### PR TITLE
stop managing service worker updates

### DIFF
--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -119,28 +119,28 @@ export class ServiceWorkerWallet implements IWallet {
             registration = await navigator.serviceWorker.register(path);
 
             // Handle updates
-            registration.addEventListener("updatefound", () => {
-                console.info(
-                    "@arklabs/wallet-sdk: Service worker auto-update..."
-                );
-                const newWorker = registration.installing;
-                if (!newWorker) return;
-
-                newWorker.addEventListener("statechange", () => {
-                    if (
-                        newWorker.state === "installed" &&
-                        navigator.serviceWorker.controller
-                    ) {
-                        console.info(
-                            "@arklabs/wallet-sdk: Service worker updated, reloading..."
-                        );
-                        window.location.reload();
-                    }
-                });
-            });
+            // registration.addEventListener("updatefound", () => {
+            //     console.info(
+            //         "@arklabs/wallet-sdk: Service worker auto-update..."
+            //     );
+            //     const newWorker = registration.installing;
+            //     if (!newWorker) return;
+            //
+            //     newWorker.addEventListener("statechange", () => {
+            //         if (
+            //             newWorker.state === "installed" &&
+            //             navigator.serviceWorker.controller
+            //         ) {
+            //             console.info(
+            //                 "@arklabs/wallet-sdk: Service worker updated, reloading..."
+            //             );
+            //             window.location.reload();
+            //         }
+            //     });
+            // });
 
             // Check for updates
-            await registration.update();
+            // await registration.update();
 
             const sw =
                 registration.active ||

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -134,9 +134,6 @@ export class ServiceWorkerWallet implements IWallet {
                 });
             });
 
-            // Check for updates
-            // await registration.update();
-
             const sw =
                 registration.active ||
                 registration.waiting ||

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -119,25 +119,20 @@ export class ServiceWorkerWallet implements IWallet {
             registration = await navigator.serviceWorker.register(path);
 
             // Handle updates
-            // registration.addEventListener("updatefound", () => {
-            //     console.info(
-            //         "@arklabs/wallet-sdk: Service worker auto-update..."
-            //     );
-            //     const newWorker = registration.installing;
-            //     if (!newWorker) return;
-            //
-            //     newWorker.addEventListener("statechange", () => {
-            //         if (
-            //             newWorker.state === "installed" &&
-            //             navigator.serviceWorker.controller
-            //         ) {
-            //             console.info(
-            //                 "@arklabs/wallet-sdk: Service worker updated, reloading..."
-            //             );
-            //             window.location.reload();
-            //         }
-            //     });
-            // });
+            registration.addEventListener("updatefound", () => {
+                const newWorker = registration.installing;
+                if (!newWorker) return;
+
+                newWorker.addEventListener("statechange", () => {
+                    if (
+                        newWorker.state === "activated" &&
+                        navigator.serviceWorker.controller
+                    ) {
+                        console.info("Service worker activated, reloading...");
+                        window.location.reload();
+                    }
+                });
+            });
 
             // Check for updates
             // await registration.update();

--- a/src/wallet/serviceWorker/worker.ts
+++ b/src/wallet/serviceWorker/worker.ts
@@ -26,13 +26,23 @@ export class Worker {
         ) => void = () => {}
     ) {}
 
-    async start() {
+    async start(withServiceWorkerUpdate = true) {
         self.addEventListener(
             "message",
             async (event: ExtendableMessageEvent) => {
                 await this.handleMessage(event);
             }
         );
+        if (withServiceWorkerUpdate) {
+            // activate service worker immediately
+            self.addEventListener("install", () => {
+                self.skipWaiting();
+            });
+            // take control of clients immediately
+            self.addEventListener("activate", () => {
+                self.clients.claim();
+            });
+        }
     }
 
     async clear() {


### PR DESCRIPTION
Fixes the infernal loop of service worker auto updating and reloading the page.

Commented all the code that manages service worker updates as a quick fix.

Let's leave this for the developer to manage, as he would maybe want to add more functionalities to his service worker, and having this management on the SDK could clash with the developer's will.

On the developer's side he could do something like this on his service worker:

```js
import { Worker } from '@arkade-os/ts-sdk'

const worker = new Worker()
worker.start().catch(console.error)

declare const self: ServiceWorkerGlobalScope

// activate service worker immediately
self.addEventListener('install', () => {
  self.skipWaiting()
})

// take control of clients immediately
self.addEventListener('activate', () => {
  self.clients.claim()
})
```

@tiero @louisinger I would like to hear your opinions.