### PR TITLE
BIP322 Intents

### DIFF
--- a/src/bip322/errors.ts
+++ b/src/bip322/errors.ts
@@ -1,0 +1,10 @@
+export class BIP322Error extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "BIP322Error";
+    }
+}
+
+export const ErrMissingInputs = new BIP322Error("missing inputs");
+export const ErrMissingData = new BIP322Error("missing data");
+export const ErrMissingWitnessUtxo = new BIP322Error("missing witness utxo");

--- a/src/bip322/index.ts
+++ b/src/bip322/index.ts
@@ -1,0 +1,173 @@
+import { OP, Transaction, Script, SigHash } from "@scure/btc-signer";
+import { TransactionInput, TransactionOutput } from "@scure/btc-signer/psbt";
+import {
+    ErrMissingData,
+    ErrMissingInputs,
+    ErrMissingWitnessUtxo,
+} from "./errors";
+import { schnorr } from "@noble/curves/secp256k1";
+import { Bytes } from "@scure/btc-signer/utils";
+import { base64 } from "@scure/base";
+
+export namespace BIP322 {
+    // BIP0322 full proof of funds is a special invalid psbt containing the inputs to prove ownership
+    // signing the proof means signing the psbt as a regular transaction
+    export type FullProof = Transaction;
+
+    // a BIP322 Signature is the raw FullProof transaction signed and finalized
+    // BIP322 signatures are base64 encoded to avoid confusion with real signed transactions
+    export type Signature = string;
+
+    // create builds a new BIP0322 "full" proof of funds unsigned transaction
+    export function create(
+        message: string,
+        inputs: TransactionInput[],
+        outputs: TransactionOutput[] = []
+    ): FullProof {
+        if (inputs.length == 0) throw ErrMissingInputs;
+        if (!validateInputs(inputs)) throw ErrMissingData;
+        if (!validateOutputs(outputs)) throw ErrMissingData;
+
+        // create the initial transaction to spend
+        const toSpend = craftToSpendTx(message, inputs[0].witnessUtxo.script);
+
+        // create the transaction to sign
+        return craftToSignTx(toSpend, inputs, outputs);
+    }
+
+    // signature finalizes and extracts the FullProof transaction into a BIP322.Signature
+    // if one of the proof's inputs has special spending conditions, a custom finalizer can be provided
+    export function signature(
+        signedProof: FullProof,
+        finalizer = (tx: FullProof) => tx.finalize()
+    ): Signature {
+        finalizer(signedProof);
+        return base64.encode(signedProof.extract());
+    }
+}
+
+const OP_RETURN_EMPTY_PKSCRIPT = new Uint8Array([OP.RETURN]);
+const ZERO_32 = new Uint8Array(32).fill(0);
+const MAX_INDEX = 0xffffffff;
+const TAG_BIP322 = "BIP0322-signed-message";
+
+type ValidatedTxInput = TransactionInput & {
+    witnessUtxo: { script: Uint8Array; amount: bigint };
+    index: number;
+    txid: Bytes;
+};
+
+type ValidatedTxOutput = TransactionOutput & {
+    amount: bigint;
+    script: Uint8Array;
+};
+
+function validateInput(input: TransactionInput): input is ValidatedTxInput {
+    if (input.index === undefined) throw ErrMissingData;
+    if (input.txid === undefined) throw ErrMissingData;
+    if (input.witnessUtxo === undefined) throw ErrMissingWitnessUtxo;
+    return true;
+}
+
+function validateInputs(
+    inputs: TransactionInput[]
+): inputs is ValidatedTxInput[] {
+    inputs.forEach(validateInput);
+    return true;
+}
+
+function validateOutput(
+    output: TransactionOutput
+): output is ValidatedTxOutput {
+    if (output.amount === undefined) throw ErrMissingData;
+    if (output.script === undefined) throw ErrMissingData;
+    return true;
+}
+
+function validateOutputs(
+    outputs: TransactionOutput[]
+): outputs is ValidatedTxOutput[] {
+    outputs.forEach(validateOutput);
+    return true;
+}
+
+// craftToSpendTx creates the initial transaction that will be spent in the proof
+function craftToSpendTx(message: string, pkScript: Uint8Array): Transaction {
+    const messageHash = hashMessage(message);
+    const tx = new Transaction();
+
+    // add input with zero hash and max index
+    tx.addInput({
+        txid: ZERO_32, // zero hash
+        index: MAX_INDEX,
+        sequence: 0,
+        finalScriptSig: Script.encode([OP.OP_0, messageHash]),
+    });
+
+    // add output with zero value and provided pkScript
+    tx.addOutput({
+        amount: 0n,
+        script: pkScript,
+    });
+
+    return tx;
+}
+
+// craftToSignTx creates the transaction that will be signed for the proof
+function craftToSignTx(
+    toSpend: Transaction,
+    inputs: ValidatedTxInput[],
+    outputs: ValidatedTxOutput[]
+): Transaction {
+    const firstInput = inputs[0];
+    const tx = new Transaction();
+
+    // add the first "toSpend" input
+    tx.addInput({
+        txid: toSpend.id,
+        index: 0,
+        sequence: firstInput.sequence,
+        witnessUtxo: {
+            script: firstInput.witnessUtxo.script,
+            amount: 0n,
+        },
+        sighashType: SigHash.ALL,
+    });
+
+    // add other inputs
+    for (const input of inputs) {
+        tx.addInput({
+            txid: input.txid,
+            index: input.index,
+            sequence: input.sequence,
+            witnessUtxo: input.witnessUtxo,
+            sighashType: SigHash.ALL,
+        });
+    }
+
+    // add the special OP_RETURN output if no outputs are provided
+    if (outputs.length === 0) {
+        outputs = [
+            {
+                amount: 0n,
+                script: OP_RETURN_EMPTY_PKSCRIPT,
+            },
+        ];
+    }
+
+    for (const output of outputs) {
+        tx.addOutput({
+            amount: output.amount,
+            script: output.script,
+        });
+    }
+
+    return tx;
+}
+
+function hashMessage(message: string): Uint8Array {
+    return schnorr.utils.taggedHash(
+        TAG_BIP322,
+        new TextEncoder().encode(message)
+    );
+}

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1091,7 +1091,7 @@ export class Wallet implements IWallet {
         onchainOutputsIndexes: number[],
         cosignerPubKeys: string[],
         notesWitnesses?: Map<number, Uint8Array[]> // index -> witness
-    ): Promise<BIP322.Signature> {
+    ): Promise<{ signature: BIP322.Signature; message: string }> {
         const nowSeconds = Math.floor(Date.now() / 1000);
         const inputTapTrees: string[] = [];
 
@@ -1125,32 +1125,47 @@ export class Wallet implements IWallet {
             },
         };
 
-        return this.makeBIP322Signature(
-            JSON.stringify(message),
+        const encodedMessage = JSON.stringify(message);
+
+        const signature = await this.makeBIP322Signature(
+            encodedMessage,
             inputs,
             tapLeafScripts,
             outputs,
             notesWitnesses
         );
+
+        return {
+            signature,
+            message: encodedMessage,
+        };
     }
 
     private async makeDeleteIntentSignature(
         inputs: TransactionInput[],
         tapLeafScripts: TapLeafScript[],
         notesWitnesses?: Map<number, Uint8Array[]> // index -> witness
-    ): Promise<BIP322.Signature> {
+    ): Promise<{ signature: BIP322.Signature; message: string }> {
         const nowSeconds = Math.floor(Date.now() / 1000);
         const message = {
             type: "delete",
             expire_at: nowSeconds + 2 * 60, // valid for 2 minutes
         };
-        return this.makeBIP322Signature(
-            JSON.stringify(message),
+
+        const encodedMessage = JSON.stringify(message);
+
+        const signature = await this.makeBIP322Signature(
+            encodedMessage,
             inputs,
             tapLeafScripts,
             undefined,
             notesWitnesses
         );
+
+        return {
+            signature,
+            message: encodedMessage,
+        };
     }
 
     private async makeBIP322Signature(

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -4,10 +4,16 @@ import {
     OutScript,
     P2TR,
     p2tr,
+    TAP_LEAF_VERSION,
     tapLeafHash,
 } from "@scure/btc-signer/payment";
 import { Transaction } from "@scure/btc-signer";
-import { TaprootControlBlock, TransactionOutput } from "@scure/btc-signer/psbt";
+import {
+    PSBTOutput,
+    TaprootControlBlock,
+    TransactionInput,
+    TransactionOutput,
+} from "@scure/btc-signer/psbt";
 import { vtxosToTxs } from "../utils/transactionHistory";
 import { BIP21 } from "../utils/bip21";
 import { ArkAddress } from "../script/address";
@@ -51,7 +57,11 @@ import {
     WalletConfig,
 } from ".";
 import { Bytes } from "@scure/btc-signer/utils";
-import { scriptFromTapLeafScript, VtxoScript } from "../script/base";
+import {
+    scriptFromTapLeafScript,
+    TapLeafScript,
+    VtxoScript,
+} from "../script/base";
 import {
     CSVMultisigTapscript,
     decodeTapscript,
@@ -60,6 +70,9 @@ import {
 import { createVirtualTx } from "../utils/psbt";
 import { ArkNote } from "../arknote";
 import { TxTree } from "../tree/vtxoTree";
+import { BIP322 } from "../bip322";
+
+const TapTreeCoder = PSBTOutput.tapTree[2];
 
 // Wallet does not store any data and rely on the Ark and onchain providers to fetch utxos and vtxos
 export class Wallet implements IWallet {
@@ -1069,4 +1082,123 @@ export class Wallet implements IWallet {
                 : undefined
         );
     }
+
+    private async makeRegisterIntentSignature(
+        inputs: TransactionInput[],
+        tapLeafScripts: TapLeafScript[],
+        tapscripts: Map<number, string[]>, // input index -> revealed tapscripts
+        outputs: TransactionOutput[],
+        onchainOutputsIndexes: number[],
+        cosignerPubKeys: string[],
+        notesWitnesses?: Map<number, Uint8Array[]> // index -> witness
+    ): Promise<BIP322.Signature> {
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        const inputTapTrees: string[] = [];
+
+        for (let i = 0; i < inputs.length; i++) {
+            const scripts = tapscripts.get(i);
+            if (!scripts) throw new Error("Tapscript not found for input");
+
+            const tapTree = TapTreeCoder.encode(
+                scripts.map((s) => {
+                    return {
+                        version: TAP_LEAF_VERSION,
+                        // TODO: allow multi-depth trees
+                        depth: 1,
+                        script: hex.decode(s),
+                    };
+                })
+            );
+
+            inputTapTrees.push(hex.encode(tapTree));
+        }
+
+        const message = {
+            type: "register",
+            valid_at: nowSeconds,
+            expire_at: nowSeconds + 2 * 60, // valid for 2 minutes
+            onchain_output_indexes: onchainOutputsIndexes,
+            input_tap_trees: inputTapTrees,
+            musig2_data: {
+                cosigners_public_keys: cosignerPubKeys,
+                signing_type: 1, // sign branch
+            },
+        };
+
+        return this.makeBIP322Signature(
+            JSON.stringify(message),
+            inputs,
+            tapLeafScripts,
+            outputs,
+            notesWitnesses
+        );
+    }
+
+    private async makeDeleteIntentSignature(
+        inputs: TransactionInput[],
+        tapLeafScripts: TapLeafScript[],
+        notesWitnesses?: Map<number, Uint8Array[]> // index -> witness
+    ): Promise<BIP322.Signature> {
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        const message = {
+            type: "delete",
+            expire_at: nowSeconds + 2 * 60, // valid for 2 minutes
+        };
+        return this.makeBIP322Signature(
+            JSON.stringify(message),
+            inputs,
+            tapLeafScripts,
+            undefined,
+            notesWitnesses
+        );
+    }
+
+    private async makeBIP322Signature(
+        message: string,
+        inputs: TransactionInput[],
+        tapLeafScripts: TapLeafScript[],
+        outputs?: TransactionOutput[],
+        notesWitnesses?: Map<number, Uint8Array[]> // index -> witnesses
+    ): Promise<BIP322.Signature> {
+        const proof = BIP322.create(message, inputs, outputs);
+
+        // add the leaf proofs for the identity to sign
+        for (let i = 0; i < proof.inputsLength; i++) {
+            const tapLeafScript =
+                i === 0 ? tapLeafScripts[0] : tapLeafScripts[i - 1];
+            proof.updateInput(i, {
+                tapLeafScript: [tapLeafScript],
+            });
+        }
+
+        const signedProof = await this.identity.sign(proof);
+        if (notesWitnesses) {
+            return BIP322.signature(
+                signedProof,
+                finalizeWithNotes(notesWitnesses)
+            );
+        }
+
+        return BIP322.signature(signedProof);
+    }
+}
+
+// finalizer function for tx spending notes
+function finalizeWithNotes(
+    notesWitnesses: Map<number, Uint8Array[]>
+): (tx: BIP322.FullProof) => void {
+    return function (tx) {
+        for (let i = 0; i < tx.inputsLength; i++) {
+            const witness = notesWitnesses.get(i);
+            if (witness) {
+                tx.updateInput(i, {
+                    finalScriptWitness: witness,
+                });
+                continue;
+            }
+
+            // not a note input, use the default finalizer
+            tx.finalizeIdx(i);
+        }
+    };
 }


### PR DESCRIPTION
This PR adds the `BIP322` namespace implementing the intent transactions building.

It also updates the Wallet with private methods crafting `BIP322.Signature` for incoming DeleteIntent and RegisterIntent RPCs (https://github.com/arkade-os/ts-sdk/issues/70)

it closes #68 

@bordalix please review