### PR TITLE
fix: do not register/unregister SW if working in chrome extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "bip68": "1.0.4"
   },
   "devDependencies": {
-    "rimraf": "^5.0.0",
     "@eslint/js": "^9.17.0",
+    "@types/chrome": "0.0.326",
     "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "8.18.2",
     "@typescript-eslint/parser": "8.18.2",
@@ -72,6 +72,7 @@
     "husky": "9.1.7",
     "lint-staged": "15.3.0",
     "prettier": "3.4.2",
+    "rimraf": "^5.0.0",
     "typescript": "5.7.2",
     "vitest": "2.1.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@eslint/js':
         specifier: ^9.17.0
         version: 9.17.0
+      '@types/chrome':
+        specifier: 0.0.326
+        version: 0.0.326
       '@types/node':
         specifier: 22.10.2
         version: 22.10.2
@@ -585,11 +588,23 @@ packages:
   '@scure/btc-signer@1.8.1':
     resolution: {integrity: sha512-8nX9T++dFyKpvqksNHfSi9CgRsGnHAQtCdIQ1y1GmbCGLpV97v4MUyemUUT6uDumKL3oo3m4niyY6A32nmdLuQ==}
 
+  '@types/chrome@0.0.326':
+    resolution: {integrity: sha512-WS7jKf3ZRZFHOX7dATCZwqNJgdfiSF0qBRFxaO0LhIOvTNBrfkab26bsZwp6EBpYtqp8loMHJTnD6vDTLWPKYw==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1844,9 +1859,22 @@ snapshots:
       '@scure/base': 1.2.6
       micro-packed: 0.7.3
 
+  '@types/chrome@0.0.326':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
   '@types/estree@1.0.6': {}
 
   '@types/estree@1.0.7': {}
+
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
+  '@types/har-format@1.2.16': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -105,6 +105,28 @@ export class ServiceWorkerWallet implements IWallet {
             );
         }
 
+        // In Chrome extensions, we can't register or unregister service workers
+        // so we just get the existing registration
+        if (chrome?.runtime?.id) {
+            try {
+                const registration =
+                    await navigator.serviceWorker.getRegistration(path);
+                if (!registration) {
+                    throw new Error("Service worker registration not found");
+                }
+                const sw = registration.active;
+                if (!sw) {
+                    throw new Error("Failed to get service worker instance");
+                }
+                this.serviceWorker = sw;
+            } catch (error) {
+                throw new Error(
+                    `Failed to get service worker registration: ${error}`
+                );
+            }
+            return;
+        }
+
         try {
             // check for existing registration
             const existingRegistration =


### PR DESCRIPTION
Currently, ServiceWorkerWallet is designed to run in a web page environment. However, it is also possible to run it inside a browser extension. In that case, you cannot use the register or unregister API.