### PR TITLE
Move `setupServiceWorker` outside of WalletServiceWorker class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
 } from "./wallet/index";
 import { Wallet } from "./wallet/wallet";
 import { ServiceWorkerWallet } from "./wallet/serviceWorker/wallet";
+import { setupServiceWorker } from "./wallet/serviceWorker/utils";
 import { Worker } from "./wallet/serviceWorker/worker";
 import { Request } from "./wallet/serviceWorker/request";
 import { Response } from "./wallet/serviceWorker/response";
@@ -53,9 +54,7 @@ import { VtxoRepository } from "./wallet/serviceWorker/db/vtxo";
 import { networks } from "./networks";
 
 export {
-    // Classes
     Wallet,
-    ServiceWorkerWallet,
     InMemoryKey,
 
     // Providers
@@ -73,7 +72,9 @@ export {
     TxType,
 
     // Service Worker
+    setupServiceWorker,
     Worker,
+    ServiceWorkerWallet,
     Request,
     Response,
 

--- a/src/wallet/serviceWorker/utils.ts
+++ b/src/wallet/serviceWorker/utils.ts
@@ -1,0 +1,53 @@
+export async function setupServiceWorker(path: string): Promise<ServiceWorker> {
+    // check if service workers are supported
+    if (!("serviceWorker" in navigator)) {
+        throw new Error("Service workers are not supported in this browser");
+    }
+
+    // check for existing registration
+    const existingRegistration =
+        await navigator.serviceWorker.getRegistration(path);
+    let registration: ServiceWorkerRegistration;
+
+    if (existingRegistration) {
+        registration = existingRegistration;
+        // Force unregister and re-register to ensure we get the latest version
+        await existingRegistration.unregister();
+    }
+
+    registration = await navigator.serviceWorker.register(path);
+
+    // Handle updates
+    registration.addEventListener("updatefound", () => {
+        const newWorker = registration.installing;
+        if (!newWorker) return;
+
+        newWorker.addEventListener("statechange", () => {
+            if (
+                newWorker.state === "activated" &&
+                navigator.serviceWorker.controller
+            ) {
+                console.info("Service worker activated, reloading...");
+                window.location.reload();
+            }
+        });
+    });
+
+    const serviceWorker =
+        registration.active || registration.waiting || registration.installing;
+    if (!serviceWorker) {
+        throw new Error("Failed to get service worker instance");
+    }
+    // wait for the service worker to be ready
+    if (serviceWorker.state !== "activated") {
+        await new Promise<void>((resolve) => {
+            if (!serviceWorker) return resolve();
+            serviceWorker.addEventListener("statechange", () => {
+                if (serviceWorker.state === "activated") {
+                    resolve();
+                }
+            });
+        });
+    }
+    return serviceWorker;
+}

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -28,19 +28,7 @@ class UnexpectedResponseError extends Error {
 
 // ServiceWorkerWallet is a wallet that uses a service worker as "backend" to handle the wallet logic
 export class ServiceWorkerWallet implements IWallet {
-    private serviceWorker?: ServiceWorker;
-
-    static async create(svcWorkerPath: string): Promise<ServiceWorkerWallet> {
-        try {
-            const wallet = new ServiceWorkerWallet();
-            await wallet.setupServiceWorker(svcWorkerPath);
-            return wallet;
-        } catch (error) {
-            throw new Error(
-                `Failed to initialize service worker wallet: ${error}`
-            );
-        }
-    }
+    constructor(public readonly serviceWorker: ServiceWorker) {}
 
     async getStatus(): Promise<Response.WalletStatus["status"]> {
         const message: Request.GetStatus = {
@@ -96,78 +84,10 @@ export class ServiceWorkerWallet implements IWallet {
         await this.sendMessage(message);
     }
 
-    // register the service worker
-    private async setupServiceWorker(path: string): Promise<void> {
-        // check if service workers are supported
-        if (!("serviceWorker" in navigator)) {
-            throw new Error(
-                "Service workers are not supported in this browser"
-            );
-        }
-
-        try {
-            // check for existing registration
-            const existingRegistration =
-                await navigator.serviceWorker.getRegistration(path);
-            let registration: ServiceWorkerRegistration;
-
-            if (existingRegistration) {
-                registration = existingRegistration;
-                // Force unregister and re-register to ensure we get the latest version
-                await existingRegistration.unregister();
-            }
-
-            registration = await navigator.serviceWorker.register(path);
-
-            // Handle updates
-            registration.addEventListener("updatefound", () => {
-                const newWorker = registration.installing;
-                if (!newWorker) return;
-
-                newWorker.addEventListener("statechange", () => {
-                    if (
-                        newWorker.state === "activated" &&
-                        navigator.serviceWorker.controller
-                    ) {
-                        console.info("Service worker activated, reloading...");
-                        window.location.reload();
-                    }
-                });
-            });
-
-            const sw =
-                registration.active ||
-                registration.waiting ||
-                registration.installing;
-            if (!sw) {
-                throw new Error("Failed to get service worker instance");
-            }
-            this.serviceWorker = sw;
-
-            // wait for the service worker to be ready
-            if (this.serviceWorker?.state !== "activated") {
-                await new Promise<void>((resolve) => {
-                    if (!this.serviceWorker) return resolve();
-                    this.serviceWorker.addEventListener("statechange", () => {
-                        if (this.serviceWorker?.state === "activated") {
-                            resolve();
-                        }
-                    });
-                });
-            }
-        } catch (error) {
-            throw new Error(`Failed to setup service worker: ${error}`);
-        }
-    }
-
     // send a message and wait for a response
     private async sendMessage<T extends Request.Base>(
         message: T
     ): Promise<Response.Base> {
-        if (!this.serviceWorker) {
-            throw new Error("Service worker not initialized");
-        }
-
         return new Promise((resolve, reject) => {
             const messageHandler = (event: MessageEvent) => {
                 const response = event.data as Response.Base;
@@ -191,11 +111,7 @@ export class ServiceWorkerWallet implements IWallet {
             };
 
             navigator.serviceWorker.addEventListener("message", messageHandler);
-            if (this.serviceWorker) {
-                this.serviceWorker.postMessage(message);
-            } else {
-                reject(new Error("Service worker not initialized"));
-            }
+            this.serviceWorker.postMessage(message);
         });
     }
 
@@ -371,11 +287,7 @@ export class ServiceWorkerWallet implements IWallet {
                     "message",
                     messageHandler
                 );
-                if (this.serviceWorker) {
-                    this.serviceWorker.postMessage(message);
-                } else {
-                    reject(new Error("Service worker not initialized"));
-                }
+                this.serviceWorker.postMessage(message);
             });
         } catch (error) {
             throw new Error(`Settlement failed: ${error}`);


### PR DESCRIPTION
This PR removes the service worker update and registration logic from the `WalletServiceWorker`. Letting to handle custom registration.

`setupServiceWorker` is still exported as utility function.

@Kukks @bordalix  @evalthis please review

