### PR TITLE
SubscribeForAddress: fix timeouts error

### DIFF
--- a/src/providers/ark.ts
+++ b/src/providers/ark.ts
@@ -600,6 +600,13 @@ export class RestArkProvider implements ArkProvider {
                     buffer = lines[lines.length - 1];
                 }
             } catch (error) {
+                // ignore timeout errors, they're expected when the server is not sending anything for 5 min
+                // these timeouts are set by builtin fetch function
+                if (isFetchTimeoutError(error)) {
+                    console.debug("Timeout error ignored");
+                    continue;
+                }
+
                 console.error("Address subscription error:", error);
                 throw error;
             }
@@ -925,4 +932,18 @@ namespace ProtoTypes {
         connectors: Tree;
         stage: string; // RoundStage as string
     }
+}
+
+function isFetchTimeoutError(err: any): boolean {
+    const checkError = (error: any) => {
+        return (
+            error instanceof Error &&
+            (error.name === "HeadersTimeoutError" ||
+                error.name === "BodyTimeoutError" ||
+                (error as any).code === "UND_ERR_HEADERS_TIMEOUT" ||
+                (error as any).code === "UND_ERR_BODY_TIMEOUT")
+        );
+    };
+
+    return checkError(err) || checkError((err as any).cause);
 }


### PR DESCRIPTION
`fetch` function [throws HeadersTimeoutError and/or BodyTimeoutError](https://github.com/nodejs/undici/issues/1272) once the server is not sending any event after 5 minutes. It is not configurable but ignoring them do not prevent to keep listening for events.

Thus, we catch and ignore them in `RestArkProvider.subscribeForAddress` method.

It closes #103 

@tiero @bordalix @Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription reliability by gracefully handling fetch timeout errors, ensuring temporary network issues do not interrupt address subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->