### PR TITLE
Fix ScriptNum minimal encoding, improve vhtlc tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         environment:
             - ARKD_ROUND_INTERVAL=10
             - ARKD_NETWORK=regtest
-            - ARKD_LOG_LEVEL=6
+            - ARKD_LOG_LEVEL=5
             - ARKD_VTXO_TREE_EXPIRY=20
             - ARKD_TX_BUILDER_TYPE=covenantless
             - ARKD_ESPLORA_URL=http://chopsticks:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         environment:
             - ARKD_ROUND_INTERVAL=10
             - ARKD_NETWORK=regtest
-            - ARKD_LOG_LEVEL=5
+            - ARKD_LOG_LEVEL=6
             - ARKD_VTXO_TREE_EXPIRY=20
             - ARKD_TX_BUILDER_TYPE=covenantless
             - ARKD_ESPLORA_URL=http://chopsticks:3000

--- a/src/script/tapscript.ts
+++ b/src/script/tapscript.ts
@@ -4,6 +4,8 @@ import { Script, ScriptNum, ScriptType } from "@scure/btc-signer/script";
 import { p2tr_ms } from "@scure/btc-signer/payment";
 import { hex } from "@scure/base";
 
+const MinimalScriptNum = ScriptNum(undefined, true);
+
 /**
  * RelativeTimelock lets to create timelocked with CHECKSEQUENCEVERIFY script.
  *
@@ -317,7 +319,7 @@ export namespace CSVMultisigTapscript {
             }
         }
 
-        const sequence = ScriptNum().encode(
+        const sequence = MinimalScriptNum.encode(
             BigInt(
                 bip68.encode(
                     params.timelock.type === "blocks"
@@ -327,7 +329,11 @@ export namespace CSVMultisigTapscript {
             )
         );
 
-        const asm: ScriptType = [sequence, "CHECKSEQUENCEVERIFY", "DROP"];
+        const asm: ScriptType = [
+            sequence.length === 1 ? sequence[0] : sequence,
+            "CHECKSEQUENCEVERIFY",
+            "DROP",
+        ];
         const multisigScript = MultisigTapscript.encode(params);
         const script = new Uint8Array([
             ...Script.encode(asm),
@@ -374,7 +380,7 @@ export namespace CSVMultisigTapscript {
             );
         }
 
-        const sequenceNum = Number(ScriptNum().decode(sequence));
+        const sequenceNum = Number(MinimalScriptNum.decode(sequence));
         const decodedTimelock = bip68.decode(sequenceNum);
 
         const timelock: RelativeTimelock =
@@ -622,8 +628,12 @@ export namespace CLTVMultisigTapscript {
     } & MultisigTapscript.Params;
 
     export function encode(params: Params): Type {
-        const locktime = ScriptNum().encode(params.absoluteTimelock);
-        const asm: ScriptType = [locktime, "CHECKLOCKTIMEVERIFY", "DROP"];
+        const locktime = MinimalScriptNum.encode(params.absoluteTimelock);
+        const asm: ScriptType = [
+            locktime.length === 1 ? locktime[0] : locktime,
+            "CHECKLOCKTIMEVERIFY",
+            "DROP",
+        ];
         const timelockedScript = Script.encode(asm);
 
         const script = new Uint8Array([
@@ -671,7 +681,7 @@ export namespace CLTVMultisigTapscript {
             );
         }
 
-        const absoluteTimelock = ScriptNum().decode(locktime);
+        const absoluteTimelock = MinimalScriptNum.decode(locktime);
 
         const reconstructed = encode({
             absoluteTimelock,

--- a/test/e2e/indexer.test.ts
+++ b/test/e2e/indexer.test.ts
@@ -1,5 +1,10 @@
-import { expect, describe, it } from "vitest";
-import { faucetOffchain, createTestArkWallet, createVtxo } from "./utils";
+import { expect, describe, it, beforeEach } from "vitest";
+import {
+    faucetOffchain,
+    createTestArkWallet,
+    createVtxo,
+    beforeEachFaucet,
+} from "./utils";
 import {
     ArkAddress,
     Outpoint,
@@ -12,6 +17,8 @@ import { hex } from "@scure/base";
 import { sha256x2 } from "@scure/btc-signer/utils";
 
 describe("Indexer provider", () => {
+    beforeEach(beforeEachFaucet);
+
     it("should inspect a VTXO", { timeout: 60000 }, async () => {
         // Create fresh wallet instance for this test
         const alice = await createTestArkWallet();

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -92,3 +92,21 @@ export async function createVtxo(
 
     return settleTxid;
 }
+
+// before each test check if the ark's cli running in the test env has at least 20_000 offchain balance
+// if not, fund it with 2 * 20_000
+export function beforeEachFaucet(): void {
+    const balanceOutput = execSync(`${arkdExec} ark balance`).toString();
+    const balance = JSON.parse(balanceOutput);
+    const offchainBalance = balance.offchain_balance.total;
+
+    if (offchainBalance <= 20_000) {
+        for (let i = 0; i < 2; i++) {
+            const note = execSync(`${arkdExec} arkd note --amount 20_000`);
+            const noteStr = note.toString().trim();
+            execSync(
+                `${arkdExec} ark redeem-notes -n ${noteStr} --password secret`
+            );
+        }
+    }
+}

--- a/test/e2e/vhtlc.test.ts
+++ b/test/e2e/vhtlc.test.ts
@@ -1,0 +1,257 @@
+import { expect, describe, it, beforeEach } from "vitest";
+import * as bip68 from "bip68";
+import { base64, hex } from "@scure/base";
+import { Transaction } from "@scure/btc-signer";
+import {
+    buildOffchainTx,
+    ConditionWitness,
+    CSVMultisigTapscript,
+    Identity,
+    networks,
+    OnchainWallet,
+    RestArkProvider,
+    RestIndexerProvider,
+    setArkPsbtField,
+    Unroll,
+    VHTLC,
+} from "../../src";
+import {
+    arkdExec,
+    beforeEachFaucet,
+    createTestIdentity,
+    X_ONLY_PUBLIC_KEY,
+} from "./utils";
+import { hash160 } from "@scure/btc-signer/utils";
+import { execSync } from "child_process";
+
+describe("vhtlc", () => {
+    beforeEach(beforeEachFaucet);
+
+    it("should claim", { timeout: 60000 }, async () => {
+        const alice = createTestIdentity();
+        const bob = createTestIdentity();
+
+        const preimage = new TextEncoder().encode("preimage");
+        const preimageHash = hash160(preimage);
+
+        const vhtlcScript = new VHTLC.Script({
+            preimageHash,
+            sender: alice.xOnlyPublicKey(),
+            receiver: bob.xOnlyPublicKey(),
+            server: X_ONLY_PUBLIC_KEY,
+            refundLocktime: BigInt(1000),
+            unilateralClaimDelay: {
+                type: "blocks",
+                value: 100n,
+            },
+            unilateralRefundDelay: {
+                type: "blocks",
+                value: 50n,
+            },
+            unilateralRefundWithoutReceiverDelay: {
+                type: "blocks",
+                value: 50n,
+            },
+        });
+
+        const address = vhtlcScript
+            .address(networks.regtest.hrp, X_ONLY_PUBLIC_KEY)
+            .encode();
+
+        // fund the vhtlc address
+        const fundAmount = 1000;
+        execSync(
+            `${arkdExec} ark send --to ${address} --amount ${fundAmount} --password secret`
+        );
+
+        // bob special identity to sign with the preimage
+        const bobVHTLCIdentity: Identity = {
+            sign: async (tx: Transaction, inputIndexes?: number[]) => {
+                const cpy = tx.clone();
+                setArkPsbtField(cpy, 0, ConditionWitness, [preimage]);
+                return bob.sign(cpy, inputIndexes);
+            },
+            xOnlyPublicKey: bob.xOnlyPublicKey,
+            signerSession: bob.signerSession,
+        };
+
+        const arkProvider = new RestArkProvider("http://localhost:7070");
+        const indexerProvider = new RestIndexerProvider(
+            "http://localhost:7070"
+        );
+
+        const spendableVtxosResponse = await indexerProvider.getVtxos({
+            scripts: [hex.encode(vhtlcScript.pkScript)],
+            spendableOnly: true,
+        });
+        expect(spendableVtxosResponse.vtxos).toHaveLength(1);
+
+        const infos = await arkProvider.getInfo();
+        const serverUnrollScript = CSVMultisigTapscript.encode({
+            timelock: {
+                type: infos.unilateralExitDelay < 512 ? "blocks" : "seconds",
+                value: infos.unilateralExitDelay,
+            },
+            pubkeys: [X_ONLY_PUBLIC_KEY],
+        });
+
+        const vtxo = spendableVtxosResponse.vtxos[0];
+
+        const { arkTx, checkpoints } = buildOffchainTx(
+            [
+                {
+                    ...vtxo,
+                    tapLeafScript: vhtlcScript.claim(),
+                    tapTree: vhtlcScript.encode(),
+                },
+            ],
+            [
+                {
+                    script: vhtlcScript.pkScript,
+                    amount: BigInt(fundAmount),
+                },
+            ],
+            serverUnrollScript
+        );
+
+        const signedArkTx = await bobVHTLCIdentity.sign(arkTx);
+        const { arkTxid, finalArkTx, signedCheckpointTxs } =
+            await arkProvider.submitTx(
+                base64.encode(signedArkTx.toPSBT()),
+                checkpoints.map((c) => base64.encode(c.toPSBT()))
+            );
+
+        expect(arkTxid).toBeDefined();
+        expect(finalArkTx).toBeDefined();
+        expect(signedCheckpointTxs).toBeDefined();
+        expect(signedCheckpointTxs.length).toBe(checkpoints.length);
+
+        const finalCheckpoints = await Promise.all(
+            signedCheckpointTxs.map(async (c) => {
+                const tx = Transaction.fromPSBT(base64.decode(c), {
+                    allowUnknown: true,
+                });
+                const signedCheckpoint = await bobVHTLCIdentity.sign(tx, [0]);
+                return base64.encode(signedCheckpoint.toPSBT());
+            })
+        );
+
+        await arkProvider.finalizeTx(arkTxid, finalCheckpoints);
+    });
+
+    it("should unilaterally claim", { timeout: 300_000 }, async () => {
+        const alice = createTestIdentity();
+        const bob = createTestIdentity();
+
+        const preimage = new TextEncoder().encode("preimage");
+        const preimageHash = hash160(preimage);
+
+        const vhtlcScript = new VHTLC.Script({
+            preimageHash,
+            sender: alice.xOnlyPublicKey(),
+            receiver: bob.xOnlyPublicKey(),
+            server: X_ONLY_PUBLIC_KEY,
+            refundLocktime: BigInt(1000),
+            unilateralClaimDelay: {
+                type: "blocks",
+                value: 9n,
+            },
+            unilateralRefundDelay: {
+                type: "blocks",
+                value: 50n,
+            },
+            unilateralRefundWithoutReceiverDelay: {
+                type: "blocks",
+                value: 50n,
+            },
+        });
+
+        const address = vhtlcScript
+            .address(networks.regtest.hrp, X_ONLY_PUBLIC_KEY)
+            .encode();
+
+        // fund the vhtlc address
+        const fundAmount = 20000;
+        execSync(
+            `${arkdExec} ark send --to ${address} --amount ${fundAmount} --password secret`
+        );
+
+        const indexerProvider = new RestIndexerProvider(
+            "http://localhost:7070"
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        const spendableVtxosResponse = await indexerProvider.getVtxos({
+            scripts: [hex.encode(vhtlcScript.pkScript)],
+            spendableOnly: true,
+        });
+        expect(spendableVtxosResponse.vtxos).toHaveLength(1);
+
+        const vtxo = spendableVtxosResponse.vtxos[0];
+        const onchainBob = new OnchainWallet(bob, "regtest");
+
+        execSync(`nigiri faucet ${onchainBob.address} 0.001`);
+
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+
+        const session = await Unroll.Session.create(
+            vtxo,
+            onchainBob,
+            onchainBob.provider,
+            indexerProvider
+        );
+
+        for await (const done of session) {
+            switch (done.type) {
+                case Unroll.StepType.WAIT:
+                case Unroll.StepType.UNROLL:
+                    execSync(
+                        `nigiri rpc generatetoaddress 1 $(nigiri rpc getnewaddress)`
+                    );
+                    break;
+            }
+        }
+
+        const tx = new Transaction({ allowUnknownInputs: true });
+        tx.addInput({
+            index: vtxo.vout,
+            txid: vtxo.txid,
+            witnessUtxo: {
+                amount: BigInt(vtxo.value),
+                script: vhtlcScript.pkScript,
+            },
+            tapLeafScript: [vhtlcScript.unilateralClaim()],
+            sequence: bip68.encode({ blocks: 9, seconds: undefined }),
+        });
+        tx.addOutputAddress(
+            onchainBob.address,
+            BigInt(vtxo.value) - 1000n,
+            onchainBob.network
+        );
+        const signedTx = await bob.sign(tx);
+        signedTx.finalize();
+
+        const currentWitness = signedTx.getInput(0).finalScriptWitness;
+        signedTx.updateInput(0, {
+            finalScriptWitness: [
+                currentWitness![0],
+                preimage,
+                ...currentWitness!.slice(1),
+            ],
+        });
+
+        // should fail now cause the utxo is locked by CSV
+        await expect(
+            onchainBob.provider.broadcastTransaction(signedTx.hex)
+        ).rejects.toThrow();
+
+        // generate 10 blocks to make the exit path available
+        execSync(`nigiri rpc generatetoaddress 10 $(nigiri rpc getnewaddress)`);
+
+        const txid = await onchainBob.provider.broadcastTransaction(
+            signedTx.hex
+        );
+        expect(txid).toBeDefined();
+    });
+});

--- a/test/e2e/vhtlc.test.ts
+++ b/test/e2e/vhtlc.test.ts
@@ -209,6 +209,10 @@ describe("vhtlc", () => {
                     execSync(
                         `nigiri rpc generatetoaddress 1 $(nigiri rpc getnewaddress)`
                     );
+                    await new Promise((resolve) => setTimeout(resolve, 2000)); // give time for the checkpoint to be created
+                    execSync(
+                        `nigiri rpc generatetoaddress 1 $(nigiri rpc getnewaddress)`
+                    );
                     break;
             }
         }

--- a/test/setup.js
+++ b/test/setup.js
@@ -94,9 +94,10 @@ async function setupArkServer() {
             .toString()
             .trim();
         console.log("Funding arkd address:", arkdAddress);
-        await execCommand(`nigiri faucet ${arkdAddress}`);
-        await execCommand(`nigiri faucet ${arkdAddress}`);
-        await execCommand(`nigiri faucet ${arkdAddress}`);
+
+        for (let i = 0; i < 10; i++) {
+            await execCommand(`nigiri faucet ${arkdAddress}`);
+        }
 
         // Wait for transaction to be confirmed
         await sleep(5000);
@@ -106,19 +107,14 @@ async function setupArkServer() {
             `${arkdExec} ark init --server-url http://localhost:7070 --explorer http://chopsticks:3000 --password secret --network regtest`
         );
 
-        // Get ark boarding address and fund it
-        const arkReceiveOutput = (
-            await execCommand(`${arkdExec} ark receive`)
-        ).toString();
-        const boardingAddress = JSON.parse(arkReceiveOutput).boarding_address;
-        console.log("Funding boarding address:", boardingAddress);
-        await execCommand(`nigiri faucet ${boardingAddress}`);
-
-        // Wait for transaction to be confirmed
-        await sleep(5000);
+        // fund the ark-cli with 1 vtxo worth of 20_000
+        const note = await execCommand(`${arkdExec} arkd note --amount 20_000`);
+        const noteStr = note.toString().trim();
+        const cmd = `${arkdExec} ark redeem-notes -n ${noteStr} --password secret`;
+        await execCommand(cmd);
 
         // Settle the funds and wait for completion
-        await execCommand(`${arkdExec} ark settle --password secret`);
+
         console.log("Settlement completed successfully");
 
         console.log("Ark server and client setup completed successfully");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    fileParallelism: false,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
This PR ensures numbers are using the minimal encoding in bitcoin script.
It also adds a unilateralClaim test and `vhtlc.test.ts` file.

@bordalix @tiero @altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced end-to-end tests for virtual Hashed Time-Locked Contracts (VHTLC), covering both standard and unilateral claim scenarios.

* **Bug Fixes**
  * Ensured minimal encoding is used for numeric values in timelock scripts, improving compatibility with Bitcoin-like networks.

* **Tests**
  * Added a utility to automatically top up test balances before each test.
  * Improved test reliability by disabling parallel execution and adjusting test setup routines.
  * Removed a redundant VHTLC claim test and updated test lifecycle hooks for more consistent test environments.
  * Added global setup steps to ensure sufficient test balances and inserted delays for asynchronous processing in tests.

* **Chores**
  * Updated funding procedures in test setup scripts for more efficient and reliable test initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->