### PR TITLE
ServiceWorkerWallet.sign : allow unknown PSBT fields

### DIFF
--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -344,7 +344,10 @@ export class ServiceWorkerWallet implements IWallet, Identity {
         try {
             const response = await this.sendMessage(message);
             if (Response.isSignSuccess(response)) {
-                return Transaction.fromPSBT(base64.decode(response.tx));
+                return Transaction.fromPSBT(base64.decode(response.tx), {
+                    allowUnknown: true,
+                    allowUnknownInputs: true,
+                });
             }
             throw new UnexpectedResponseError(response);
         } catch (error) {

--- a/src/wallet/serviceWorker/worker.ts
+++ b/src/wallet/serviceWorker/worker.ts
@@ -580,7 +580,10 @@ export class Worker {
         }
 
         try {
-            const tx = Transaction.fromPSBT(base64.decode(message.tx));
+            const tx = Transaction.fromPSBT(base64.decode(message.tx), {
+                allowUnknown: true,
+                allowUnknownInputs: true,
+            });
             const signedTx = await this.wallet.identity.sign(
                 tx,
                 message.inputIndexes


### PR DESCRIPTION
fix: `ServiceWorkerWallet.sign` doesn't allow to set unknown field after the signature step. `allowUnknown = true` is required.

@bordalix please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when signing transactions by accepting PSBTs with unknown fields or inputs, reducing errors with non-standard or extended transaction formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->