### PR TITLE
Fix subscription

### DIFF
--- a/src/providers/ark.ts
+++ b/src/providers/ark.ts
@@ -830,13 +830,18 @@ namespace ProtoTypes {
 
 export function isFetchTimeoutError(err: any): boolean {
     const checkError = (error: any) => {
+        if (!(error instanceof Error)) return false;
+
+        // TODO: get something more robust than this
+        const isCloudflare524 =
+            error.name === "TypeError" && error.message === "Failed to fetch";
+
         return (
-            error instanceof Error &&
-            (error.name === "HeadersTimeoutError" ||
-                error.name === "BodyTimeoutError" ||
-                error.name === "TypeError" ||
-                (error as any).code === "UND_ERR_HEADERS_TIMEOUT" ||
-                (error as any).code === "UND_ERR_BODY_TIMEOUT")
+            isCloudflare524 ||
+            error.name === "HeadersTimeoutError" ||
+            error.name === "BodyTimeoutError" ||
+            (error as any).code === "UND_ERR_HEADERS_TIMEOUT" ||
+            (error as any).code === "UND_ERR_BODY_TIMEOUT"
         );
     };
 


### PR DESCRIPTION
It's hard to identify timeout errors from fetch, but we will assume by context and error description that this is a timeout error (tipically a http code 524 by cloudflare), which will not break the outer while loop, making it re-connect after initial timeout.

TODO: we should find a more robust way to identify a timeout error.

https://github.com/user-attachments/assets/f0c90f71-a27e-44d8-a64f-5bdbd960a25d

@altafan please review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of fetch timeout errors, including better handling of specific Cloudflare timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->