### PR TITLE
fix wallet returned status

### DIFF
--- a/src/wallet/serviceWorker/utils.ts
+++ b/src/wallet/serviceWorker/utils.ts
@@ -24,11 +24,10 @@ export async function setupServiceWorker(path: string): Promise<ServiceWorker> {
         throw new Error("Failed to get service worker instance");
     }
     // wait for the service worker to be ready
-    if (serviceWorker.state !== "activated") {
-        await new Promise<void>((resolve) => {
-            if (!serviceWorker) return resolve();
-            serviceWorker.addEventListener("activate", () => resolve());
-        });
-    }
-    return serviceWorker;
+    return new Promise<ServiceWorker>((resolve) => {
+        if (serviceWorker.state === "activated") return resolve(serviceWorker);
+        serviceWorker.addEventListener("activate", () =>
+            resolve(serviceWorker)
+        );
+    });
 }

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -62,7 +62,10 @@ export class ServiceWorkerWallet implements IWallet, Identity {
         };
         const response = await this.sendMessage(message);
         if (Response.isWalletStatus(response)) {
-            return response.status;
+            const { status } = response;
+            status.walletInitialized &&=
+                this.cachedXOnlyPublicKey !== undefined;
+            return status;
         }
         throw new UnexpectedResponseError(response);
     }
@@ -80,7 +83,8 @@ export class ServiceWorkerWallet implements IWallet, Identity {
 
         if (
             Response.isWalletStatus(response) &&
-            response.status.walletInitialized
+            response.status.walletInitialized &&
+            this.cachedXOnlyPublicKey !== undefined
         ) {
             if (failIfInitialized) {
                 throw new Error("Wallet already initialized");


### PR DESCRIPTION
@louisinger I think I found the bug.

The wallet returns one boolean as state, when in fact it has 3 states:
- no service worker defined
- service worker running but not private key (i.e. locked)
- service worker running with private key (i.e. unlocked)

First bug:
- when returning the status, is only returned true if sw was running, not considering if it was unlocked
- now it also checks if it nows the private key and only return if BOTH conditions are true

Second bug:
- when calling for init, if the sw was already running we were not passing it the private key
- now we check if it's running and unlocked, or else we pass it the private key again

Wallet is working like a charm with this changes

We should publish a new release with this fixes