### PR TITLE
Fix Phantom example signPSBT and Prettier setup

### DIFF
--- a/examples/phantom-example/package.json
+++ b/examples/phantom-example/package.json
@@ -1,28 +1,30 @@
 {
-  "name": "phantom-example",
-  "private": true,
-  "version": "0.0.0",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "lint": "eslint .",
-    "preview": "vite preview"
-  },
-  "dependencies": {
-    "@arkade-os/sdk": "workspace:*",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1"
-  },
-  "devDependencies": {
-    "@eslint/js": "^9.33.0",
-    "@types/react": "^19.1.10",
-    "@types/react-dom": "^19.1.7",
-    "@vitejs/plugin-react": "^5.0.0",
-    "eslint": "^9.33.0",
-    "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-react-refresh": "^0.4.20",
-    "globals": "^16.3.0",
-    "vite": "^7.1.2"
-  }
+    "name": "phantom-example",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "lint": "eslint .",
+        "preview": "vite preview"
+    },
+    "dependencies": {
+        "@arkade-os/sdk": "workspace:*",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1"
+    },
+    "devDependencies": {
+        "@eslint/js": "^9.33.0",
+        "@types/react": "^19.1.10",
+        "@types/react-dom": "^19.1.7",
+        "@vitejs/plugin-react": "^5.0.0",
+        "eslint": "^9.33.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.20",
+        "globals": "^16.3.0",
+        "vite": "^7.1.2",
+        "babel-plugin-react-compiler": "latest",
+        "prettier": "latest"
+    }
 }

--- a/examples/phantom-example/src/App.jsx
+++ b/examples/phantom-example/src/App.jsx
@@ -1,75 +1,81 @@
-import { useState } from 'react';
-import './App.css';
-import { OnchainWallet, networks } from '@arkade-os/sdk';
-import { Transaction } from '@scure/btc-signer';
+import { useState } from "react";
+import "./App.css";
+import { OnchainWallet, networks } from "@arkade-os/sdk";
+import { Transaction } from "@scure/btc-signer";
 
 function App() {
-  const [address, setAddress] = useState(null);
-  const [txid, setTxid] = useState(null);
+    const [address, setAddress] = useState(null);
+    const [txid, setTxid] = useState(null);
 
-  const createAndSignTransaction = async () => {
-    try {
-      const provider = window.phantom.bitcoin;
-      const pubkey = await provider.getPublicKey();
+    const createAndSignTransaction = async () => {
+        try {
+            const provider = window.phantom.bitcoin;
+            const pubkey = await provider.getPublicKey();
 
-      const phantomIdentity = {
-        xOnlyPublicKey: () => pubkey,
-        sign: async (tx) => {
-          const psbt = tx.toPSBT();
-          const signedPsbt = await provider.signTransaction(psbt);
-          return Transaction.fromPSBT(signedPsbt);
+            const phantomIdentity = {
+                xOnlyPublicKey: () => pubkey,
+                sign: async (tx) => {
+                    const psbtBytes = tx.toPSBT();
+                    const signedPsbt = await provider.signPSBT(psbtBytes, {
+                        inputsToSign: [{ index: 0, publicKey: pubkey }],
+                    });
+                    return Transaction.fromPSBT(signedPsbt);
+                },
+            };
+
+            const wallet = new OnchainWallet(phantomIdentity, "mainnet");
+            const txid = await wallet.send({
+                amount: 1000,
+                address: address,
+            });
+
+            setTxid(txid);
+        } catch (error) {
+            console.error("Error creating and signing transaction:", error);
+            alert(
+                "Error creating and signing transaction. See console for details."
+            );
         }
-      };
+    };
 
-      const wallet = new OnchainWallet(phantomIdentity, 'mainnet');
-      const txid = await wallet.send({
-        amount: 1000,
-        address: address,
-      });
+    const connectWallet = async () => {
+        if (window.phantom && window.phantom.bitcoin) {
+            try {
+                const provider = window.phantom.bitcoin;
+                const accounts = await provider.requestAccounts();
+                setAddress(accounts[0]);
+            } catch (error) {
+                console.error("Error connecting to Phantom:", error);
+            }
+        } else {
+            alert("Phantom wallet not found. Please install it.");
+        }
+    };
 
-      setTxid(txid);
-    } catch (error) {
-      console.error('Error creating and signing transaction:', error);
-      alert('Error creating and signing transaction. See console for details.');
-    }
-  };
-
-  const connectWallet = async () => {
-    if (window.phantom && window.phantom.bitcoin) {
-      try {
-        const provider = window.phantom.bitcoin;
-        const accounts = await provider.requestAccounts();
-        setAddress(accounts[0]);
-      } catch (error) {
-        console.error('Error connecting to Phantom:', error);
-      }
-    } else {
-      alert('Phantom wallet not found. Please install it.');
-    }
-  };
-
-  return (
-    <div className="App">
-      <header className="App-header">
-        <h1>Arkade SDK Phantom Example</h1>
-        {address ? (
-          <div>
-            <p>Connected Address:</p>
-            <p>{address}</p>
-            <button onClick={createAndSignTransaction}>Create & Sign Transaction</button>
-            {txid && (
-              <div>
-                <p>Transaction ID:</p>
-                <pre>{txid}</pre>
-              </div>
-            )}
-          </div>
-        ) : (
-          <button onClick={connectWallet}>Connect to Phantom</button>
-        )}
-      </header>
-    </div>
-  );
+    return (
+        <div className="App">
+            <header className="App-header">
+                <h1>Arkade SDK Phantom Example</h1>
+                {address ? (
+                    <div>
+                        <p>Connected Address:</p>
+                        <p>{address}</p>
+                        <button onClick={createAndSignTransaction}>
+                            Create & Sign Transaction
+                        </button>
+                        {txid && (
+                            <div>
+                                <p>Transaction ID:</p>
+                                <pre>{txid}</pre>
+                            </div>
+                        )}
+                    </div>
+                ) : (
+                    <button onClick={connectWallet}>Connect to Phantom</button>
+                )}
+            </header>
+        </div>
+    );
 }
 
 export default App;

--- a/examples/phantom-example/vite.config.js
+++ b/examples/phantom-example/vite.config.js
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import reactCompiler from "babel-plugin-react-compiler";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+    plugins: [
+        react({
+            babel: {
+                plugins: [reactCompiler],
+            },
+        }),
+    ],
+});


### PR DESCRIPTION
## Summary
- add Prettier and React compiler plugin to phantom example
- sign PSBT bytes with Phantom provider
- configure Vite React plugin for React 19 compiler

## Testing
- `pnpm prettier --write examples`
- `pnpm prettier --check src test examples`
- `pnpm test` *(fails: Command failed: nigiri ark balance)*

------
https://chatgpt.com/codex/tasks/task_b_68a4f80e6300832c8df33028da8d5a77