### PR TITLE
fix @noble/curves imports

### DIFF
--- a/src/bip322/index.ts
+++ b/src/bip322/index.ts
@@ -5,7 +5,7 @@ import {
     ErrMissingInputs,
     ErrMissingWitnessUtxo,
 } from "./errors";
-import { schnorr } from "@noble/curves/secp256k1";
+import { schnorr } from "@noble/curves/secp256k1.js";
 import { Bytes } from "@scure/btc-signer/utils";
 import { base64 } from "@scure/base";
 

--- a/src/musig2/keys.ts
+++ b/src/musig2/keys.ts
@@ -1,5 +1,5 @@
 import * as musig from "@scure/btc-signer/musig2";
-import { schnorr } from "@noble/curves/secp256k1";
+import { schnorr } from "@noble/curves/secp256k1.js";
 
 interface KeyAggOptions {
     taprootTweak?: Uint8Array;

--- a/src/musig2/sign.ts
+++ b/src/musig2/sign.ts
@@ -1,8 +1,8 @@
 import * as musig from "@scure/btc-signer/musig2";
-import { bytesToNumberBE } from "@noble/curves/utils";
+import { bytesToNumberBE } from "@noble/curves/utils.js";
 import { Point } from "@noble/secp256k1";
 import { aggregateKeys } from "./keys";
-import { schnorr } from "@noble/curves/secp256k1";
+import { schnorr } from "@noble/curves/secp256k1.js";
 
 // Add this error type for decode failures
 export class PartialSignatureError extends Error {

--- a/src/tree/signingSession.ts
+++ b/src/tree/signingSession.ts
@@ -1,7 +1,7 @@
 import * as musig2 from "../musig2";
 import { Script, SigHash, Transaction } from "@scure/btc-signer";
 import { hex } from "@scure/base";
-import { schnorr, secp256k1 } from "@noble/curves/secp256k1";
+import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
 import { randomPrivateKeyBytes, sha256x2 } from "@scure/btc-signer/utils";
 import { CosignerPublicKey, getArkPsbtFields } from "../utils/unknownFields";
 import { TxTree } from "./txTree";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated internal module import paths for cryptography components to use explicit .js extensions.
  * Consolidated imports without altering logic, control flow, or error handling.
  * No changes to public APIs.
  * No user-facing changes; existing functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->