### PR TITLE
hotfix: throw error on BatchFailed event if batch not joined

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -723,8 +723,8 @@ export class Wallet implements IWallet {
                 switch (event.type) {
                     // the settlement failed
                     case SettlementEventType.BatchFailed:
-                        // fail if the roundId is the one joined
-                        if (event.id === roundId) {
+                        // fail if the roundId is the one joined OR if we didn't join any round yet
+                        if (event.id === roundId || !roundId) {
                             throw new Error(event.reason);
                         }
                         break;


### PR DESCRIPTION
During settlement session, we should throw errors on **BatchFailed if we didn't join any round.** It prevents the `settle` to be stuck in case the server encounters an error before the `BatchStartedEvent`.

@bordalix @altafan @Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settlement error handling: the app now immediately reports and stops on batch failures even if no round has been joined yet, preventing ambiguous states.
  * More consistent failure messaging when a failed batch doesn’t match the active round, reducing confusion and improving reliability during settlement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->