### PR TITLE
hotfix transaction signing

### DIFF
--- a/src/identity/singleKey.ts
+++ b/src/identity/singleKey.ts
@@ -9,7 +9,6 @@ import { Identity } from ".";
 import { SignerSession, TreeSignerSession } from "../tree/signingSession";
 import { schnorr, sign } from "@noble/secp256k1";
 
-const ZERO_32 = new Uint8Array(32).fill(0);
 const ALL_SIGHASH = Object.values(SigHash).filter((x) => typeof x === "number");
 
 /**
@@ -63,7 +62,7 @@ export class SingleKey implements Identity {
 
         if (!inputIndexes) {
             try {
-                if (!txCpy.sign(this.key, ALL_SIGHASH, ZERO_32)) {
+                if (!txCpy.sign(this.key, ALL_SIGHASH)) {
                     throw new Error("Failed to sign transaction");
                 }
             } catch (e) {
@@ -80,7 +79,7 @@ export class SingleKey implements Identity {
         }
 
         for (const inputIndex of inputIndexes) {
-            if (!txCpy.signIdx(this.key, inputIndex, ALL_SIGHASH, ZERO_32)) {
+            if (!txCpy.signIdx(this.key, inputIndex, ALL_SIGHASH)) {
                 throw new Error(`Failed to sign input #${inputIndex}`);
             }
         }


### PR DESCRIPTION
remove the ZERO_32 argument in SingleKey identity signing calls. reuising a nonce can lead to secret key leaks.

@bordalix @tiero please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined transaction signing by removing an unnecessary parameter, improving clarity and maintainability.
  * Preserves existing behavior; no action required from users and no changes to workflows.
  * Enhances forward compatibility with signing operations and reduces potential edge-case inconsistencies.
  * Minor internal cleanup to simplify logic without altering results or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->