### PR TITLE
SubmitTx: persist tx and mark vtxo spent

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -634,6 +634,7 @@ export class Wallet implements IWallet {
                     forfeitTapLeafScript: this.offchainTapscript.forfeit(),
                     intentTapLeafScript: this.offchainTapscript.exit(),
                     isUnrolled: false,
+                    isSpent: false,
                     tapTree: this.offchainTapscript.encode(),
                     value: Number(selected.changeAmount),
                     virtualStatus: {


### PR DESCRIPTION
This PR updates the database after every offchain tx and mark the inputs as spent.

@altafan @bordalix please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction reliability: the wallet now ensures a transaction ID is always returned even if background persistence encounters issues.
  * Better handling of spent outputs and change: change outputs are created and persisted when applicable, and spent outputs are recorded more robustly; repository errors are logged without blocking the transaction response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->