### PR TITLE
add the package to broadcast to UnrollStep

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ for await (const step of session) {
       console.log(`Waiting for transaction ${step.txid} to be confirmed`);
       break;
     case Unroll.StepType.UNROLL:
-      console.log(`Broadcasting transaction ${step.tx.id}`);
+      console.log(`Transaction ${step.tx.id} unrolled`);
       break;
     case Unroll.StepType.DONE:
       console.log(`Unrolling complete for VTXO ${step.vtxoTxid}`);
@@ -224,6 +224,26 @@ The unrolling process works by:
 - Broadcasting each transaction that isn't already on-chain
 - Waiting for confirmations between steps
 - Using P2A (Pay-to-Anchor) transactions to pay for fees
+
+Optionally, you can use `session.next()` to control the broadcasting process manually.
+
+```typescript
+const step = await session.next();
+switch (step.type) {
+  case Unroll.StepType.WAIT:
+    await step.do(); // wait for the transaction to be confirmed
+    break;
+  case Unroll.StepType.UNROLL:
+    const [parent, child] = step.pkg;
+    console.log(`Parent: ${parent}`)
+    console.log(`Child: ${child}`)
+    await step.do(); // broadcast the 1C1P package
+    break;
+  case Unroll.StepType.DONE:
+    console.log(`Unrolling complete for VTXO ${step.vtxoTxid}`);
+    break;
+  }
+```
 
 #### Step 2: Completing the Exit
 

--- a/src/wallet/unroll.ts
+++ b/src/wallet/unroll.ts
@@ -230,96 +230,113 @@ export namespace Unroll {
         vtxoTxids: string[],
         outputAddress: string
     ): Promise<string> {
-        const chainTip = await wallet.onchainProvider.getChainTip();
-
-        let vtxos = await wallet.getVtxos({ withUnrolled: true });
-        vtxos = vtxos.filter((vtxo) => vtxoTxids.includes(vtxo.txid));
-
-        if (vtxos.length === 0) {
-            throw new Error("No vtxos to complete unroll");
-        }
-
-        const inputs: TransactionInputUpdate[] = [];
-        let totalAmount = 0n;
-        const txWeightEstimator = TxWeightEstimator.create();
-        for (const vtxo of vtxos) {
-            if (!vtxo.isUnrolled) {
-                throw new Error(
-                    `Vtxo ${vtxo.txid}:${vtxo.vout} is not fully unrolled, use unroll first`
-                );
-            }
-
-            const txStatus = await wallet.onchainProvider.getTxStatus(
-                vtxo.txid
-            );
-            if (!txStatus.confirmed) {
-                throw new Error(`tx ${vtxo.txid} is not confirmed`);
-            }
-
-            const exit = availableExitPath(
-                { height: txStatus.blockHeight, time: txStatus.blockTime },
-                chainTip,
-                vtxo
-            );
-            if (!exit) {
-                throw new Error(
-                    `no available exit path found for vtxo ${vtxo.txid}:${vtxo.vout}`
-                );
-            }
-
-            const spendingLeaf = VtxoScript.decode(vtxo.tapTree).findLeaf(
-                hex.encode(exit.script)
-            );
-            if (!spendingLeaf) {
-                throw new Error(
-                    `spending leaf not found for vtxo ${vtxo.txid}:${vtxo.vout}`
-                );
-            }
-
-            totalAmount += BigInt(vtxo.value);
-            inputs.push({
-                txid: vtxo.txid,
-                index: vtxo.vout,
-                tapLeafScript: [spendingLeaf],
-                sequence: 0xffffffff - 1,
-                witnessUtxo: {
-                    amount: BigInt(vtxo.value),
-                    script: VtxoScript.decode(vtxo.tapTree).pkScript,
-                },
-                sighashType: SigHash.DEFAULT,
-            });
-            txWeightEstimator.addTapscriptInput(
-                64,
-                spendingLeaf[1].length,
-                TaprootControlBlock.encode(spendingLeaf[0]).length
-            );
-        }
-
-        const tx = new Transaction({ version: 2 });
-        for (const input of inputs) {
-            tx.addInput(input);
-        }
-
-        txWeightEstimator.addP2TROutput();
-
-        let feeRate = await wallet.onchainProvider.getFeeRate();
-        if (!feeRate || feeRate < Wallet.MIN_FEE_RATE) {
-            feeRate = Wallet.MIN_FEE_RATE;
-        }
-        const feeAmount = txWeightEstimator.vsize().fee(BigInt(feeRate));
-        if (feeAmount > totalAmount) {
-            throw new Error("fee amount is greater than the total amount");
-        }
-
-        tx.addOutputAddress(outputAddress, totalAmount - feeAmount);
-
-        const signedTx = await wallet.identity.sign(tx);
-        signedTx.finalize();
-
+        const signedTx = await prepareUnrollTransaction(
+            wallet,
+            vtxoTxids,
+            outputAddress
+        );
         await wallet.onchainProvider.broadcastTransaction(signedTx.hex);
-
         return signedTx.id;
     }
+}
+
+/**
+ * Prepares the transaction that spends the CSV path to complete unrolling a VTXO.
+ * @param wallet the wallet owning the VTXO(s)
+ * @param vtxoTxIds the txids of the VTXO(s) to complete unroll
+ * @param outputAddress the address to send the unrolled funds to
+ * @throws if the VTXO(s) are not fully unrolled, if the txids are not found, if the tx is not confirmed, if no exit path is found or not available
+ * @returns the transaction spending the unrolled funds
+ */
+export async function prepareUnrollTransaction(
+    wallet: Wallet,
+    vtxoTxIds: string[],
+    outputAddress: string
+): Promise<Transaction> {
+    const chainTip = await wallet.onchainProvider.getChainTip();
+
+    let vtxos = await wallet.getVtxos({ withUnrolled: true });
+    vtxos = vtxos.filter((vtxo) => vtxoTxIds.includes(vtxo.txid));
+
+    if (vtxos.length === 0) {
+        throw new Error("No vtxos to complete unroll");
+    }
+
+    const inputs: TransactionInputUpdate[] = [];
+    let totalAmount = 0n;
+    const txWeightEstimator = TxWeightEstimator.create();
+    for (const vtxo of vtxos) {
+        if (!vtxo.isUnrolled) {
+            throw new Error(
+                `Vtxo ${vtxo.txid}:${vtxo.vout} is not fully unrolled, use unroll first`
+            );
+        }
+
+        const txStatus = await wallet.onchainProvider.getTxStatus(vtxo.txid);
+        if (!txStatus.confirmed) {
+            throw new Error(`tx ${vtxo.txid} is not confirmed`);
+        }
+
+        const exit = availableExitPath(
+            { height: txStatus.blockHeight, time: txStatus.blockTime },
+            chainTip,
+            vtxo
+        );
+        if (!exit) {
+            throw new Error(
+                `no available exit path found for vtxo ${vtxo.txid}:${vtxo.vout}`
+            );
+        }
+
+        const spendingLeaf = VtxoScript.decode(vtxo.tapTree).findLeaf(
+            hex.encode(exit.script)
+        );
+        if (!spendingLeaf) {
+            throw new Error(
+                `spending leaf not found for vtxo ${vtxo.txid}:${vtxo.vout}`
+            );
+        }
+
+        totalAmount += BigInt(vtxo.value);
+        inputs.push({
+            txid: vtxo.txid,
+            index: vtxo.vout,
+            tapLeafScript: [spendingLeaf],
+            sequence: 0xffffffff - 1,
+            witnessUtxo: {
+                amount: BigInt(vtxo.value),
+                script: VtxoScript.decode(vtxo.tapTree).pkScript,
+            },
+            sighashType: SigHash.DEFAULT,
+        });
+        txWeightEstimator.addTapscriptInput(
+            64,
+            spendingLeaf[1].length,
+            TaprootControlBlock.encode(spendingLeaf[0]).length
+        );
+    }
+
+    const tx = new Transaction({ version: 2 });
+    for (const input of inputs) {
+        tx.addInput(input);
+    }
+
+    txWeightEstimator.addP2TROutput();
+
+    let feeRate = await wallet.onchainProvider.getFeeRate();
+    if (!feeRate || feeRate < Wallet.MIN_FEE_RATE) {
+        feeRate = Wallet.MIN_FEE_RATE;
+    }
+    const feeAmount = txWeightEstimator.vsize().fee(BigInt(feeRate));
+    if (feeAmount > totalAmount) {
+        throw new Error("fee amount is greater than the total amount");
+    }
+
+    tx.addOutputAddress(outputAddress, totalAmount - feeAmount);
+
+    const signedTx = await wallet.identity.sign(tx);
+    signedTx.finalize();
+    return signedTx;
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
add the 1C1P package to broadcast to `Unroll.UnrollStep`

```js
const step = await unrollSession.next()
if (step.type === Unroll.StepType.UNROLL) {
   const [parent, child] = step.pkg
    // optionally broadcast with "do"
    await step.do()
}
```

@tiero @supertestnet please review


it closes #219 
it closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual broadcasting control for unroll sessions — callers can drive WAIT → UNROLL → DONE flow and inspect package details before sending.
* **Bug Fix / Logging**
  * Updated transaction log wording to indicate when a transaction has been unrolled.
* **Documentation**
  * README expanded with a manual control example showing the new flow and package extraction.
* **Refactor**
  * Streamlined unroll transaction preparation and broadcasting for clearer, reusable workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->