### PR TITLE
Identity decrypt

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "release:cleanup": "bash scripts/release.sh --cleanup"
     },
     "dependencies": {
+        "@noble/ciphers": "2.0.1",
         "@noble/curves": "2.0.0",
         "@noble/secp256k1": "3.0.0",
         "@scure/base": "2.0.0",
@@ -96,8 +97,8 @@
         "@types/node": "24.3.1",
         "@vitest/coverage-v8": "3.2.4",
         "esbuild": "^0.25.9",
-        "expo": "~52.0.47",
         "eventsource": "4.0.0",
+        "expo": "~52.0.47",
         "glob": "11.0.3",
         "husky": "9.1.7",
         "prettier": "3.6.2",
@@ -116,7 +117,7 @@
     ],
     "author": "Ark Labs",
     "license": "MIT",
-    "packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321",
+    "packageManager": "pnpm@10.20.0",
     "engines": {
         "node": ">=20.0.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@arkade-os/sdk",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "Bitcoin wallet SDK with Taproot and Ark integration",
     "type": "module",
     "main": "./dist/cjs/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     dependencies:
+      '@noble/ciphers':
+        specifier: 2.0.1
+        version: 2.0.1
       '@noble/curves':
         specifier: 2.0.0
         version: 2.0.0
@@ -1104,6 +1107,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@noble/ciphers@2.0.1':
+    resolution: {integrity: sha512-xHK3XHPUW8DTAobU+G0XT+/w+JLM7/8k1UFdB5xg/zTFPnFCobhftzw8wl4Lw2aq/Rvir5pxfZV5fEazmeCJ2g==}
+    engines: {node: '>= 20.19.0'}
 
   '@noble/curves@2.0.0':
     resolution: {integrity: sha512-RiwZZeJnsTnhT+/gg2KvITJZhK5oagQrpZo+yQyd3mv3D5NAG2qEeEHpw7IkXRlpkoD45wl2o4ydHAvY9wyEfw==}
@@ -5303,6 +5310,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@noble/ciphers@2.0.1': {}
 
   '@noble/curves@2.0.0':
     dependencies:

--- a/src/identity/index.ts
+++ b/src/identity/index.ts
@@ -11,6 +11,8 @@ export interface Identity {
     ): Promise<Uint8Array>;
     // if inputIndexes is not provided, try to sign all inputs
     sign(tx: Transaction, inputIndexes?: number[]): Promise<Transaction>;
+    // decrypt data encrypted with the corresponding public key
+    decrypt(pubkey: string, data: string): string;
 }
 
 export * from "./singleKey";


### PR DESCRIPTION
Adds support for nip04 decrypt in Identity.

It will be useful to decrypt stored messages on Nostr.

@tiero @louisinger do you think this makes sense?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced public-key-based decryption functionality to the identity management system, allowing secure decryption of encrypted data through identity objects

* **Chores**
  * Version incremented to 0.3.4
  * Package manager updated to pnpm 10.20.0
  * Added new dependencies to support enhanced cryptographic operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->