### PR TITLE
notify also when user empties wallet

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1061,7 +1061,10 @@ export class Wallet implements IWallet {
             (async () => {
                 try {
                     for await (const update of subscription) {
-                        if (update.newVtxos?.length > 0) {
+                        if (
+                            update.newVtxos?.length > 0 ||
+                            update.spentVtxos?.length > 0
+                        ) {
                             eventCallback({
                                 type: "vtxo",
                                 newVtxos: update.newVtxos.map((vtxo) =>


### PR DESCRIPTION
when user empties the wallet, it was not being notified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet transaction tracking to emit notifications when both new virtual transactions arrive and existing ones are spent, ensuring more complete visibility into account activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->