### PR TITLE
Use collab path to sign intent

### DIFF
--- a/src/arknote/index.ts
+++ b/src/arknote/index.ts
@@ -35,7 +35,6 @@ export class ArkNote implements ExtendedCoin {
     readonly txid: string;
     readonly vout = 0;
     readonly forfeitTapLeafScript: TapLeafScript;
-    readonly intentTapLeafScript: TapLeafScript;
     readonly tapTree: Bytes;
     readonly status: Status;
     readonly extraWitness?: Bytes[] | undefined;
@@ -53,7 +52,6 @@ export class ArkNote implements ExtendedCoin {
         this.txid = hex.encode(new Uint8Array(preimageHash).reverse());
         this.tapTree = this.vtxoScript.encode();
         this.forfeitTapLeafScript = leaf;
-        this.intentTapLeafScript = leaf;
         this.value = value;
         this.status = { confirmed: true };
         this.extraWitness = [this.preimage];

--- a/src/repositories/walletRepository.ts
+++ b/src/repositories/walletRepository.ts
@@ -29,7 +29,6 @@ const serializeVtxo = (v: ExtendedVirtualCoin) => ({
     ...v,
     tapTree: toHex(v.tapTree),
     forfeitTapLeafScript: serializeTapLeaf(v.forfeitTapLeafScript),
-    intentTapLeafScript: serializeTapLeaf(v.intentTapLeafScript),
     extraWitness: v.extraWitness?.map(toHex),
 });
 
@@ -37,7 +36,6 @@ const serializeUtxo = (u: ExtendedCoin) => ({
     ...u,
     tapTree: toHex(u.tapTree),
     forfeitTapLeafScript: serializeTapLeaf(u.forfeitTapLeafScript),
-    intentTapLeafScript: serializeTapLeaf(u.intentTapLeafScript),
     extraWitness: u.extraWitness?.map(toHex),
 });
 
@@ -52,7 +50,6 @@ const deserializeVtxo = (o: any): ExtendedVirtualCoin => ({
     createdAt: new Date(o.createdAt),
     tapTree: fromHex(o.tapTree),
     forfeitTapLeafScript: deserializeTapLeaf(o.forfeitTapLeafScript),
-    intentTapLeafScript: deserializeTapLeaf(o.intentTapLeafScript),
     extraWitness: o.extraWitness?.map(fromHex),
 });
 
@@ -60,7 +57,6 @@ const deserializeUtxo = (o: any): ExtendedCoin => ({
     ...o,
     tapTree: fromHex(o.tapTree),
     forfeitTapLeafScript: deserializeTapLeaf(o.forfeitTapLeafScript),
-    intentTapLeafScript: deserializeTapLeaf(o.intentTapLeafScript),
     extraWitness: o.extraWitness?.map(fromHex),
 });
 

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -148,7 +148,6 @@ export interface ArkTransaction {
 // ExtendedCoin and ExtendedVirtualCoin contains the utxo/vtxo data along with the vtxo script locking it
 export type TapLeaves = {
     forfeitTapLeafScript: TapLeafScript;
-    intentTapLeafScript: TapLeafScript;
 };
 
 export type ExtendedCoin = TapLeaves &

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -13,7 +13,6 @@ export function extendVirtualCoin(
     return {
         ...vtxo,
         forfeitTapLeafScript: wallet.offchainTapscript.forfeit(),
-        intentTapLeafScript: wallet.offchainTapscript.exit(),
         tapTree: wallet.offchainTapscript.encode(),
     };
 }
@@ -22,7 +21,6 @@ export function extendCoin(wallet: Wallet, utxo: Coin): ExtendedCoin {
     return {
         ...utxo,
         forfeitTapLeafScript: wallet.boardingTapscript.forfeit(),
-        intentTapLeafScript: wallet.boardingTapscript.exit(),
         tapTree: wallet.boardingTapscript.encode(),
     };
 }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -661,7 +661,6 @@ export class Wallet implements IWallet {
                     vout: outputs.length - 1,
                     createdAt: new Date(createdAt),
                     forfeitTapLeafScript: this.offchainTapscript.forfeit(),
-                    intentTapLeafScript: this.offchainTapscript.exit(),
                     isUnrolled: false,
                     isSpent: false,
                     tapTree: this.offchainTapscript.encode(),
@@ -1509,7 +1508,7 @@ export class Wallet implements IWallet {
                     script: vtxoScript.pkScript,
                 },
                 sequence,
-                tapLeafScript: [input.intentTapLeafScript],
+                tapLeafScript: [input.forfeitTapLeafScript],
                 unknown,
             });
         }
@@ -1522,7 +1521,7 @@ function getSequence(coin: ExtendedCoin): number | undefined {
     let sequence: number | undefined = undefined;
 
     try {
-        const scriptWithLeafVersion = coin.intentTapLeafScript[1];
+        const scriptWithLeafVersion = coin.forfeitTapLeafScript[1];
         const script = scriptWithLeafVersion.subarray(
             0,
             scriptWithLeafVersion.length - 1

--- a/test/vtxo-manager.test.ts
+++ b/test/vtxo-manager.test.ts
@@ -37,7 +37,6 @@ const createMockVtxo = (
         createdAt: new Date(),
         isUnrolled: false,
         forfeitTapLeafScript: [new Uint8Array(), new Uint8Array()],
-        intentTapLeafScript: [new Uint8Array(), new Uint8Array()],
         tapTree: new Uint8Array(),
     } as any;
 };


### PR DESCRIPTION
Use forfeit tapscript instead of exit to sign intent psbt.

@Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined wallet infrastructure by consolidating and removing redundant internal fields while standardizing field references across coin utilities, transaction handling, serialization, and offchain processing. These architectural improvements enhance code consistency and maintainability throughout the system while maintaining complete backward compatibility with existing public APIs and user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->