### PR TITLE
feat: allow spending specific vtxos

### DIFF
--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -131,6 +131,7 @@ export interface SendBitcoinParams {
     amount: number;
     feeRate?: number;
     memo?: string;
+    selectedVtxos?: VirtualCoin[];
 }
 
 export interface Recipient {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -788,7 +788,23 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             withRecoverable: false,
         });
 
-        const selected = selectVirtualCoins(virtualCoins, params.amount);
+        let selected;
+        if (params.selectedVtxos) {
+            const selectedVtxoSum = params.selectedVtxos
+                .map((v) => v.value)
+                .reduce((a, b) => a + b, 0);
+            if (selectedVtxoSum < params.amount) {
+                throw new Error("Selected VTXOs do not cover specified amount");
+            }
+            const changeAmount = selectedVtxoSum - params.amount;
+
+            selected = {
+                inputs: params.selectedVtxos,
+                changeAmount: BigInt(changeAmount),
+            };
+        } else {
+            selected = selectVirtualCoins(virtualCoins, params.amount);
+        }
 
         const selectedLeaf = this.offchainTapscript.forfeit();
         if (!selectedLeaf) {


### PR DESCRIPTION
We extend `sendBitcoin(..)``by a new optional paramter: `selectedVtxos?: {inputs: VirtualCoin[], changeAmount: number};`.

This allows the caller to spend sepcific VTXOs.

Note: If `params.amount` equals the sum of all selected VTXOs, the remainder will be returned as change output. If the sum of all selected VTXOs does not cover `params.amount` an error is returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional transaction output selection when sending bitcoin. Users can now explicitly specify which outputs to include in payments for greater control. The wallet validates that selected outputs cover the required amount and automatically selects suitable outputs if none are specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->