### PR TITLE
feat: output descriptors in contract params

### DIFF
--- a/src/contracts/handlers/default.ts
+++ b/src/contracts/handlers/default.ts
@@ -12,14 +12,26 @@ import {
     sequenceToTimelock,
     timelockToSequence,
 } from "./helpers";
+import {
+    normalizeToDescriptor,
+    extractPubKey,
+} from "../../identity/descriptor";
 
 /**
  * Typed parameters for DefaultVtxo contracts.
+ * pubKey and serverPubKey are descriptor strings (e.g. "tr(hex)" or "tr([fp/path']xpub/0/{index})").
  */
 export interface DefaultContractParams {
-    pubKey: Uint8Array;
-    serverPubKey: Uint8Array;
+    pubKey: string;
+    serverPubKey: string;
     csvTimelock: RelativeTimelock;
+}
+
+/**
+ * Extract pubkey bytes from a descriptor or hex string.
+ */
+function extractPubKeyBytes(value: string): Uint8Array {
+    return hex.decode(extractPubKey(value));
 }
 
 /**
@@ -37,13 +49,17 @@ export const DefaultContractHandler: ContractHandler<
 
     createScript(params: Record<string, string>): DefaultVtxo.Script {
         const typed = this.deserializeParams(params);
-        return new DefaultVtxo.Script(typed);
+        return new DefaultVtxo.Script({
+            pubKey: extractPubKeyBytes(typed.pubKey),
+            serverPubKey: extractPubKeyBytes(typed.serverPubKey),
+            csvTimelock: typed.csvTimelock,
+        });
     },
 
     serializeParams(params: DefaultContractParams): Record<string, string> {
         return {
-            pubKey: hex.encode(params.pubKey),
-            serverPubKey: hex.encode(params.serverPubKey),
+            pubKey: params.pubKey,
+            serverPubKey: params.serverPubKey,
             csvTimelock: timelockToSequence(params.csvTimelock).toString(),
         };
     },
@@ -53,8 +69,8 @@ export const DefaultContractHandler: ContractHandler<
             ? sequenceToTimelock(Number(params.csvTimelock))
             : DefaultVtxo.Script.DEFAULT_TIMELOCK;
         return {
-            pubKey: hex.decode(params.pubKey),
-            serverPubKey: hex.decode(params.serverPubKey),
+            pubKey: normalizeToDescriptor(params.pubKey),
+            serverPubKey: normalizeToDescriptor(params.serverPubKey),
             csvTimelock,
         };
     },

--- a/src/contracts/handlers/helpers.ts
+++ b/src/contracts/handlers/helpers.ts
@@ -1,6 +1,17 @@
 import { RelativeTimelock } from "../../script/tapscript";
 import * as bip68 from "bip68";
 import { Contract, PathContext } from "../types";
+import { isDescriptor, extractPubKey } from "../../identity/descriptor";
+
+/**
+ * Extract raw hex pubkey from a value that may be a descriptor or raw hex.
+ */
+function extractRawPubKey(value: string): string {
+    if (isDescriptor(value)) {
+        return extractPubKey(value);
+    }
+    return value;
+}
 
 /**
  * Convert RelativeTimelock to BIP68 sequence number.
@@ -39,12 +50,21 @@ export function resolveRole(
         return context.role;
     }
 
-    // Try to match wallet pubkey against contract params
-    if (context.walletPubKey) {
-        if (context.walletPubKey === contract.params.sender) {
+    // Try to match wallet descriptor/pubkey against contract params
+    const walletKey = context.walletDescriptor ?? context.walletPubKey;
+    if (walletKey) {
+        const rawWalletKey = extractRawPubKey(walletKey);
+        const senderKey = contract.params.sender
+            ? extractRawPubKey(contract.params.sender)
+            : undefined;
+        const receiverKey = contract.params.receiver
+            ? extractRawPubKey(contract.params.receiver)
+            : undefined;
+
+        if (senderKey && rawWalletKey === senderKey) {
             return "sender";
         }
-        if (context.walletPubKey === contract.params.receiver) {
+        if (receiverKey && rawWalletKey === receiverKey) {
             return "receiver";
         }
     }

--- a/src/contracts/types.ts
+++ b/src/contracts/types.ts
@@ -112,8 +112,15 @@ export interface PathContext {
     blockHeight?: number;
 
     /**
-     * Wallet's public key (x-only, 32 bytes hex).
+     * Wallet's descriptor for signing.
+     * Format: tr(pubkey) for static keys, tr([fingerprint/path']xpub/0/{index}) for HD.
      * Used by handlers to determine wallet's role in multi-party contracts.
+     */
+    walletDescriptor?: string;
+
+    /**
+     * Wallet's public key (x-only, 32 bytes hex).
+     * @deprecated Use walletDescriptor instead.
      */
     walletPubKey?: string;
 

--- a/src/identity/descriptor.ts
+++ b/src/identity/descriptor.ts
@@ -1,26 +1,10 @@
-/**
- * Descriptor utility functions for working with output descriptors.
- *
- * Output descriptors provide a standardized way to represent Bitcoin addresses
- * and their spending conditions. This module supports:
- * - Simple descriptors: tr(pubkey) — for static/external keys
- * - HD descriptors: tr([fingerprint/path']xpub/derivation) — for HD wallets
- *
- * Uses @kukks/bitcoin-descriptors for parsing — no manual regex.
- *
- * @module
- */
-
-import { defaultFactory, networks } from "@kukks/bitcoin-descriptors";
-import type { Network } from "@kukks/bitcoin-descriptors";
+import {
+    expand,
+    networks,
+    type Network,
+} from "@bitcoinerlab/descriptors-scure";
 import { hex } from "@scure/base";
 
-const { expand } = defaultFactory;
-
-/**
- * Infer the network from a descriptor string.
- * tpub → testnet, xpub or raw hex → mainnet (default).
- */
 function inferNetwork(descriptor: string): Network {
     return descriptor.includes("tpub") ? networks.testnet : networks.bitcoin;
 }

--- a/src/identity/descriptor.ts
+++ b/src/identity/descriptor.ts
@@ -6,8 +6,24 @@
  * - Simple descriptors: tr(pubkey) — for static/external keys
  * - HD descriptors: tr([fingerprint/path']xpub/derivation) — for HD wallets
  *
+ * Uses @kukks/bitcoin-descriptors for parsing — no manual regex.
+ *
  * @module
  */
+
+import { defaultFactory, networks } from "@kukks/bitcoin-descriptors";
+import type { Network } from "@kukks/bitcoin-descriptors";
+import { hex } from "@scure/base";
+
+const { expand } = defaultFactory;
+
+/**
+ * Infer the network from a descriptor string.
+ * tpub → testnet, xpub or raw hex → mainnet (default).
+ */
+function inferNetwork(descriptor: string): Network {
+    return descriptor.includes("tpub") ? networks.testnet : networks.bitcoin;
+}
 
 /**
  * Check if a string is a descriptor (starts with "tr(").
@@ -29,7 +45,7 @@ export function normalizeToDescriptor(value: string): string {
 
 /**
  * Extract the public key from a simple descriptor.
- * For simple descriptors (tr(64-hex-chars)), extracts the pubkey directly.
+ * For simple descriptors (tr(pubkey)), extracts the pubkey using the library.
  * For HD descriptors, throws — use DescriptorProvider to derive the key.
  */
 export function extractPubKey(descriptor: string): string {
@@ -37,15 +53,30 @@ export function extractPubKey(descriptor: string): string {
         return descriptor;
     }
 
-    const simpleMatch = descriptor.match(/^tr\(([0-9a-fA-F]{64})\)$/);
-    if (simpleMatch) {
-        return simpleMatch[1];
+    const network = inferNetwork(descriptor);
+    const expansion = expand({ descriptor, network });
+
+    if (!expansion.expansionMap) {
+        throw new Error(
+            "Cannot extract pubkey from descriptor: expansion failed."
+        );
     }
 
-    throw new Error(
-        "Cannot extract pubkey from HD descriptor without derivation. " +
-            "Use DescriptorProvider to derive the key from the xpub."
-    );
+    const key = expansion.expansionMap["@0"];
+
+    // HD descriptors (have a bip32 key) require DescriptorProvider for derivation
+    if (key?.bip32) {
+        throw new Error(
+            "Cannot extract pubkey from HD descriptor without derivation. " +
+                "Use DescriptorProvider to derive the key from the xpub."
+        );
+    }
+
+    if (!key?.pubkey) {
+        throw new Error("Cannot extract pubkey from descriptor: no key found.");
+    }
+
+    return hex.encode(key.pubkey);
 }
 
 /** Parsed HD descriptor components. */
@@ -64,18 +95,51 @@ export interface ParsedHDDescriptor {
 export function parseHDDescriptor(
     descriptor: string
 ): ParsedHDDescriptor | null {
-    const match = descriptor.match(
-        /^tr\(\[([0-9a-fA-F]{8})\/([^\]]+)\]([a-zA-Z0-9]+)\/(.+)\)$/
-    );
-
-    if (!match) {
+    if (!isDescriptor(descriptor)) {
         return null;
     }
 
+    let expansion;
+    try {
+        const network = inferNetwork(descriptor);
+        expansion = expand({ descriptor, network });
+    } catch {
+        return null;
+    }
+
+    if (!expansion.expansionMap) {
+        return null;
+    }
+
+    const key = expansion.expansionMap["@0"];
+    if (!key) {
+        return null;
+    }
+
+    // HD descriptors have originPath and keyPath; simple pubkey descriptors do not
+    if (!key.masterFingerprint || !key.originPath || !key.keyPath) {
+        return null;
+    }
+
+    // Extract xpub from the key expression: strip origin prefix and key path suffix
+    const keyExpr = key.keyExpression;
+    const originEnd = keyExpr.indexOf("]");
+    const afterOrigin = originEnd >= 0 ? keyExpr.slice(originEnd + 1) : keyExpr;
+    const keyPathStart = afterOrigin.indexOf(key.keyPath);
+    const xpub =
+        keyPathStart > 0 ? afterOrigin.slice(0, keyPathStart) : afterOrigin;
+
+    // keyPath comes back as "/0/5" — strip leading slash for our format
+    const derivationPath = key.keyPath.startsWith("/")
+        ? key.keyPath.slice(1)
+        : key.keyPath;
+
     return {
-        fingerprint: match[1],
-        basePath: match[2],
-        xpub: match[3],
-        derivationPath: match[4],
+        fingerprint: hex.encode(key.masterFingerprint),
+        basePath: key.originPath.startsWith("/")
+            ? key.originPath.slice(1)
+            : key.originPath,
+        xpub,
+        derivationPath,
     };
 }

--- a/src/identity/descriptor.ts
+++ b/src/identity/descriptor.ts
@@ -1,0 +1,81 @@
+/**
+ * Descriptor utility functions for working with output descriptors.
+ *
+ * Output descriptors provide a standardized way to represent Bitcoin addresses
+ * and their spending conditions. This module supports:
+ * - Simple descriptors: tr(pubkey) — for static/external keys
+ * - HD descriptors: tr([fingerprint/path']xpub/derivation) — for HD wallets
+ *
+ * @module
+ */
+
+/**
+ * Check if a string is a descriptor (starts with "tr(").
+ */
+export function isDescriptor(value: string): boolean {
+    return value.startsWith("tr(");
+}
+
+/**
+ * Normalize a value to descriptor format.
+ * If already a descriptor, return as-is. If hex pubkey, wrap as tr(pubkey).
+ */
+export function normalizeToDescriptor(value: string): string {
+    if (isDescriptor(value)) {
+        return value;
+    }
+    return `tr(${value})`;
+}
+
+/**
+ * Extract the public key from a simple descriptor.
+ * For simple descriptors (tr(64-hex-chars)), extracts the pubkey directly.
+ * For HD descriptors, throws — use DescriptorProvider to derive the key.
+ */
+export function extractPubKey(descriptor: string): string {
+    if (!isDescriptor(descriptor)) {
+        return descriptor;
+    }
+
+    const simpleMatch = descriptor.match(/^tr\(([0-9a-fA-F]{64})\)$/);
+    if (simpleMatch) {
+        return simpleMatch[1];
+    }
+
+    throw new Error(
+        "Cannot extract pubkey from HD descriptor without derivation. " +
+            "Use DescriptorProvider to derive the key from the xpub."
+    );
+}
+
+/** Parsed HD descriptor components. */
+export interface ParsedHDDescriptor {
+    fingerprint: string;
+    basePath: string;
+    xpub: string;
+    derivationPath: string;
+}
+
+/**
+ * Parse an HD descriptor into its components.
+ * HD descriptors have the format: tr([fingerprint/path']xpub/derivation)
+ * Returns null if the descriptor is not in HD format.
+ */
+export function parseHDDescriptor(
+    descriptor: string
+): ParsedHDDescriptor | null {
+    const match = descriptor.match(
+        /^tr\(\[([0-9a-fA-F]{8})\/([^\]]+)\]([a-zA-Z0-9]+)\/(.+)\)$/
+    );
+
+    if (!match) {
+        return null;
+    }
+
+    return {
+        fingerprint: match[1],
+        basePath: match[2],
+        xpub: match[3],
+        derivationPath: match[4],
+    };
+}

--- a/src/identity/descriptorProvider.ts
+++ b/src/identity/descriptorProvider.ts
@@ -1,0 +1,37 @@
+import { Transaction } from "../utils/transaction";
+
+/** A signing request for a transaction with optional specific input indexes. */
+export interface DescriptorSigningRequest {
+    /** Transaction to sign */
+    tx: Transaction;
+    /** Specific input indexes to sign (signs all if omitted) */
+    inputIndexes?: number[];
+}
+
+/**
+ * Provider interface for descriptor-based signing.
+ *
+ * Implementations include:
+ * - StaticDescriptorProvider: wraps a legacy Identity with a single key
+ * - SeedIdentity: HD wallet with multi-index derivation (implements this directly)
+ */
+export interface DescriptorProvider {
+    /** Returns the current signing descriptor. */
+    getSigningDescriptor(): string;
+
+    /** Checks if a descriptor belongs to this provider. */
+    isOurs(descriptor: string): boolean;
+
+    /** Signs transactions using the key derived from the descriptor. */
+    signWithDescriptor(
+        descriptor: string,
+        requests: DescriptorSigningRequest[]
+    ): Promise<Transaction[]>;
+
+    /** Signs a message using the key derived from the descriptor. */
+    signMessageWithDescriptor(
+        descriptor: string,
+        message: Uint8Array,
+        type?: "schnorr" | "ecdsa"
+    ): Promise<Uint8Array>;
+}

--- a/src/identity/descriptorProvider.ts
+++ b/src/identity/descriptorProvider.ts
@@ -1,7 +1,9 @@
 import { Transaction } from "../utils/transaction";
 
-/** A signing request for a transaction with optional specific input indexes. */
+/** A signing request that pairs a descriptor with a transaction. */
 export interface DescriptorSigningRequest {
+    /** Descriptor identifying which key to sign with */
+    descriptor: string;
     /** Transaction to sign */
     tx: Transaction;
     /** Specific input indexes to sign (signs all if omitted) */
@@ -22,9 +24,8 @@ export interface DescriptorProvider {
     /** Checks if a descriptor belongs to this provider. */
     isOurs(descriptor: string): boolean;
 
-    /** Signs transactions using the key derived from the descriptor. */
+    /** Signs transactions, each with its own descriptor-derived key. */
     signWithDescriptor(
-        descriptor: string,
         requests: DescriptorSigningRequest[]
     ): Promise<Transaction[]>;
 

--- a/src/identity/index.ts
+++ b/src/identity/index.ts
@@ -47,4 +47,35 @@ export function isBatchSignable(
 }
 
 export * from "./singleKey";
-export * from "./seedIdentity";
+export {
+    SeedIdentity,
+    MnemonicIdentity,
+    ReadonlySeedIdentity,
+    ReadonlyDescriptorIdentity,
+} from "./seedIdentity";
+export type {
+    SeedIdentityOptions,
+    MnemonicOptions,
+    NetworkOptions,
+    DescriptorOptions,
+    SigningRequest,
+    SeedIdentityJSON,
+} from "./seedIdentity";
+
+// Descriptor utilities
+export {
+    isDescriptor,
+    normalizeToDescriptor,
+    extractPubKey,
+    parseHDDescriptor,
+} from "./descriptor";
+export type { ParsedHDDescriptor } from "./descriptor";
+
+// Descriptor provider interface
+export type {
+    DescriptorProvider,
+    DescriptorSigningRequest,
+} from "./descriptorProvider";
+
+// Static descriptor provider (wrapper for legacy Identity)
+export { StaticDescriptorProvider } from "./staticDescriptorProvider";

--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -95,7 +95,7 @@ function buildDescriptor(seed: Uint8Array, isMainnet: boolean): string {
  */
 function buildWildcardDescriptor(seed: Uint8Array, isMainnet: boolean): string {
     const network = isMainnet ? networks.bitcoin : networks.testnet;
-    const masterNode = BIP32.fromSeed(seed, network);
+    const masterNode = HDKey.fromMasterSeed(seed, network.bip32);
     return scriptExpressions.trBIP32({
         masterNode,
         network,
@@ -216,7 +216,7 @@ export class SeedIdentity implements Identity {
         const seed = mnemonicToSeedSync(phrase, passphrase);
         const descriptor = hasDescriptor(opts)
             ? opts.descriptor
-            : buildDescriptor(seed, (opts as NetworkOptions).isMainnet);
+            : buildDescriptor(seed, (opts as NetworkOptions).isMainnet ?? true);
         return new SeedIdentity(seed, descriptor, phrase);
     }
 
@@ -271,7 +271,7 @@ export class SeedIdentity implements Identity {
      */
     toJSON(): SeedIdentityJSON {
         const network = detectNetwork(this.descriptor);
-        const masterNode = BIP32.fromSeed(this.seed, network);
+        const masterNode = HDKey.fromMasterSeed(this.seed, network.bip32);
         const templateDescriptor = scriptExpressions.trBIP32({
             masterNode,
             network,
@@ -307,7 +307,7 @@ export class SeedIdentity implements Identity {
             throw new Error("Index must be non-negative");
         }
         const network = detectNetwork(this.descriptor);
-        const masterNode = BIP32.fromSeed(this.seed, network);
+        const masterNode = HDKey.fromMasterSeed(this.seed, network.bip32);
         return scriptExpressions.trBIP32({
             masterNode,
             network,
@@ -493,25 +493,17 @@ export class SeedIdentity implements Identity {
      */
     private derivePrivateKeyFromDescriptor(descriptor: string): Uint8Array {
         const network = detectNetwork(descriptor);
-        const masterNode = BIP32.fromSeed(this.seed, network);
+        const masterNode = HDKey.fromMasterSeed(this.seed, network.bip32);
         const expansion = expand({ descriptor, network });
         const keyInfo = expansion.expansionMap?.["@0"];
-        if (!keyInfo?.originPath) {
-            throw new Error("Invalid descriptor: missing origin path");
+        if (!keyInfo?.path) {
+            throw new Error("Invalid descriptor: missing derivation path");
         }
-        const accountNode = masterNode.derivePath(`m${keyInfo.originPath}`);
-        // keyPath is like "/0/5", extract the index
-        const keyPath = keyInfo.keyPath;
-        if (!keyPath) {
-            throw new Error("Invalid descriptor: missing key path");
-        }
-        const segments = keyPath.split("/").filter(Boolean);
-        const childIndex = segments[segments.length - 1];
-        const addressNode = accountNode.derivePath(`m/0/${childIndex}`);
-        if (!addressNode.privateKey) {
+        const derivedNode = masterNode.derive(keyInfo.path);
+        if (!derivedNode.privateKey) {
             throw new Error("Failed to derive private key");
         }
-        return addressNode.privateKey;
+        return derivedNode.privateKey;
     }
 }
 
@@ -581,9 +573,12 @@ export class MnemonicIdentity extends SeedIdentity {
 export class ReadonlySeedIdentity implements ReadonlyIdentity {
     private readonly xOnlyPubKey: Uint8Array;
     private readonly compressedPubKey: Uint8Array;
-    /** The account-level BIP32 node extracted from the descriptor. */
     private readonly accountBip32:
-        | ReturnType<typeof BIP32.fromSeed>
+        | {
+              derivePath(path: string): { publicKey: Uint8Array };
+              toBase58(): string;
+              publicKey: Uint8Array;
+          }
         | undefined;
 
     private constructor(readonly descriptor: string) {

--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -41,9 +41,10 @@ export type MnemonicOptions = SeedIdentityOptions & {
 };
 
 /**
- * A signing request pairs a transaction with optional input indexes to sign.
+ * A signing request pairs a descriptor with a transaction and optional input indexes.
  */
 export interface SigningRequest {
+    descriptor: string;
     tx: Transaction;
     inputIndexes?: number[];
 }
@@ -345,30 +346,36 @@ export class SeedIdentity implements Identity {
     }
 
     /**
-     * Signs one or more transactions using the private key derived at the
-     * index embedded in the given descriptor.
+     * Signs one or more transactions, each using the private key derived
+     * from its own descriptor.
      *
-     * @param descriptor - A concrete descriptor belonging to this identity
-     * @param requests - Array of signing requests
-     * @returns Array of signed transactions
-     * @throws If the descriptor does not belong to this identity
+     * @param requests - Array of signing requests, each with its own descriptor
+     * @returns Array of signed transactions (same order as requests)
+     * @throws If any descriptor does not belong to this identity
      */
     async signWithDescriptor(
-        descriptor: string,
         requests: SigningRequest[]
     ): Promise<Transaction[]> {
-        if (!this.isOurs(descriptor)) {
-            throw new Error("Descriptor does not belong to this identity");
-        }
-
         if (requests.length === 0) {
             return [];
         }
 
-        const privateKey = this.derivePrivateKeyFromDescriptor(descriptor);
+        const keyCache = new Map<string, Uint8Array>();
         const results: Transaction[] = [];
 
         for (const request of requests) {
+            if (!this.isOurs(request.descriptor)) {
+                throw new Error("Descriptor does not belong to this identity");
+            }
+
+            let privateKey = keyCache.get(request.descriptor);
+            if (!privateKey) {
+                privateKey = this.derivePrivateKeyFromDescriptor(
+                    request.descriptor
+                );
+                keyCache.set(request.descriptor, privateKey);
+            }
+
             const txCpy = request.tx.clone();
 
             if (!request.inputIndexes) {

--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -2,6 +2,7 @@ import { validateMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 import { pubECDSA, pubSchnorr } from "@scure/btc-signer/utils.js";
 import { SigHash } from "@scure/btc-signer";
+import { hex } from "@scure/base";
 import { Identity, ReadonlyIdentity } from ".";
 import { Transaction } from "../utils/transaction";
 import { SignerSession, TreeSignerSession } from "../tree/signingSession";
@@ -40,6 +41,23 @@ export type MnemonicOptions = SeedIdentityOptions & {
 };
 
 /**
+ * A signing request pairs a transaction with optional input indexes to sign.
+ */
+export interface SigningRequest {
+    tx: Transaction;
+    inputIndexes?: number[];
+}
+
+/**
+ * JSON representation of a SeedIdentity for serialization.
+ */
+export interface SeedIdentityJSON {
+    mnemonic?: string;
+    seed?: string;
+    descriptor: string;
+}
+
+/**
  * Detects the network from a descriptor string by checking for tpub (testnet)
  * vs xpub (mainnet) key prefix.
  * @internal
@@ -67,6 +85,23 @@ function buildDescriptor(seed: Uint8Array, isMainnet: boolean): string {
         account: 0,
         change: 0,
         index: 0,
+    });
+}
+
+/**
+ * Builds a BIP86 Taproot wildcard descriptor template from a seed and network flag.
+ * Uses `*` as the index for ranged descriptors.
+ * @internal
+ */
+function buildWildcardDescriptor(seed: Uint8Array, isMainnet: boolean): string {
+    const network = isMainnet ? networks.bitcoin : networks.testnet;
+    const masterNode = BIP32.fromSeed(seed, network);
+    return scriptExpressions.trBIP32({
+        masterNode,
+        network,
+        account: 0,
+        change: 0,
+        index: "*",
     });
 }
 
@@ -101,16 +136,22 @@ export class SeedIdentity implements Identity {
     protected readonly seed: Uint8Array;
     private readonly derivedKey: Uint8Array;
     readonly descriptor: string;
+    /** The mnemonic phrase, if this identity was created from one. */
+    readonly mnemonic?: string;
+    /** Whether this identity uses mainnet (true) or testnet (false). */
+    readonly isMainnet: boolean;
 
-    constructor(seed: Uint8Array, descriptor: string) {
+    constructor(seed: Uint8Array, descriptor: string, mnemonic?: string) {
         if (seed.length !== 64) {
             throw new Error("Seed must be 64 bytes");
         }
 
         this.seed = seed;
         this.descriptor = descriptor;
+        this.mnemonic = mnemonic;
 
         const network = detectNetwork(descriptor);
+        this.isMainnet = network === networks.bitcoin;
 
         // Parse and validate the descriptor using the library
         const expansion = expand({ descriptor, network });
@@ -157,6 +198,233 @@ export class SeedIdentity implements Identity {
             ? opts.descriptor
             : buildDescriptor(seed, (opts as NetworkOptions).isMainnet ?? true);
         return new SeedIdentity(seed, descriptor);
+    }
+
+    /**
+     * Creates a SeedIdentity from a BIP39 mnemonic phrase.
+     *
+     * Convenience static that stores the mnemonic for later serialization.
+     *
+     * @param phrase - BIP39 mnemonic phrase (12 or 24 words)
+     * @param opts - Network selection or custom descriptor, plus optional passphrase
+     */
+    static fromMnemonic(phrase: string, opts: MnemonicOptions): SeedIdentity {
+        if (!validateMnemonic(phrase, wordlist)) {
+            throw new Error("Invalid mnemonic");
+        }
+        const passphrase = opts.passphrase;
+        const seed = mnemonicToSeedSync(phrase, passphrase);
+        const descriptor = hasDescriptor(opts)
+            ? opts.descriptor
+            : buildDescriptor(seed, (opts as NetworkOptions).isMainnet);
+        return new SeedIdentity(seed, descriptor, phrase);
+    }
+
+    /**
+     * Restores a SeedIdentity from a JSON object.
+     *
+     * The JSON must contain either `mnemonic` or `seed` (hex), plus a `descriptor`.
+     * When the descriptor uses a wildcard (`*`), it is resolved to index 0 for the
+     * identity's default key.
+     *
+     * @param json - Serialized identity containing `{mnemonic?, seed?, descriptor}`
+     */
+    static fromJSON(json: SeedIdentityJSON): SeedIdentity {
+        if (!json.descriptor) {
+            throw new Error("Missing descriptor in JSON");
+        }
+
+        let seed: Uint8Array;
+        let mnemonic: string | undefined;
+
+        if (json.mnemonic) {
+            if (!validateMnemonic(json.mnemonic, wordlist)) {
+                throw new Error("Invalid mnemonic");
+            }
+            mnemonic = json.mnemonic;
+            seed = mnemonicToSeedSync(json.mnemonic);
+        } else if (json.seed) {
+            seed = hex.decode(json.seed);
+        } else {
+            throw new Error("JSON must contain either mnemonic or seed");
+        }
+
+        // If descriptor has wildcard, resolve to index 0
+        let descriptor = json.descriptor;
+        if (descriptor.includes("*")) {
+            const network = detectNetwork(descriptor);
+            // Expand with index 0 to get a concrete descriptor
+            const expansion = expand({ descriptor, network, index: 0 });
+            descriptor = expansion.canonicalExpression;
+        }
+
+        return new SeedIdentity(seed, descriptor, mnemonic);
+    }
+
+    /**
+     * Serializes this identity to a JSON object.
+     *
+     * The descriptor is stored as a wildcard template (e.g. `.../0/*`)
+     * so it can be used to derive any child index on restore.
+     *
+     * @returns JSON containing `{mnemonic?, seed?, descriptor}`
+     */
+    toJSON(): SeedIdentityJSON {
+        const network = detectNetwork(this.descriptor);
+        const masterNode = BIP32.fromSeed(this.seed, network);
+        const templateDescriptor = scriptExpressions.trBIP32({
+            masterNode,
+            network,
+            account: 0,
+            change: 0,
+            index: "*",
+        });
+
+        const result: SeedIdentityJSON = {
+            descriptor: templateDescriptor,
+        };
+
+        if (this.mnemonic) {
+            result.mnemonic = this.mnemonic;
+        } else {
+            result.seed = hex.encode(this.seed);
+        }
+
+        return result;
+    }
+
+    /**
+     * Derives a concrete signing descriptor at the given child index.
+     *
+     * For example, `deriveSigningDescriptor(5)` produces a descriptor like:
+     * `tr([fp/86'/coinType'/0']xpub.../0/5)`
+     *
+     * @param index - Non-negative child index
+     * @returns A concrete taproot descriptor for the given index
+     */
+    deriveSigningDescriptor(index: number): string {
+        if (index < 0) {
+            throw new Error("Index must be non-negative");
+        }
+        const network = detectNetwork(this.descriptor);
+        const masterNode = BIP32.fromSeed(this.seed, network);
+        return scriptExpressions.trBIP32({
+            masterNode,
+            network,
+            account: 0,
+            change: 0,
+            index,
+        });
+    }
+
+    /**
+     * Checks whether a given descriptor belongs to this identity by comparing
+     * the account-level xpub.
+     *
+     * @param descriptor - The descriptor to check
+     * @returns `true` if the descriptor was derived from the same HD account
+     */
+    isOurs(descriptor: string): boolean {
+        try {
+            const network = detectNetwork(descriptor);
+            const expansion = expand({ descriptor, network });
+            const keyInfo = expansion.expansionMap?.["@0"];
+            if (!keyInfo?.bip32) return false;
+
+            // Compare with our own account xpub
+            const ownNetwork = detectNetwork(this.descriptor);
+            const ownExpansion = expand({
+                descriptor: this.descriptor,
+                network: ownNetwork,
+            });
+            const ownKeyInfo = ownExpansion.expansionMap?.["@0"];
+            return keyInfo.bip32.toBase58() === ownKeyInfo?.bip32?.toBase58();
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Signs one or more transactions using the private key derived at the
+     * index embedded in the given descriptor.
+     *
+     * @param descriptor - A concrete descriptor belonging to this identity
+     * @param requests - Array of signing requests
+     * @returns Array of signed transactions
+     * @throws If the descriptor does not belong to this identity
+     */
+    async signWithDescriptor(
+        descriptor: string,
+        requests: SigningRequest[]
+    ): Promise<Transaction[]> {
+        if (!this.isOurs(descriptor)) {
+            throw new Error("Descriptor does not belong to this identity");
+        }
+
+        if (requests.length === 0) {
+            return [];
+        }
+
+        const privateKey = this.derivePrivateKeyFromDescriptor(descriptor);
+        const results: Transaction[] = [];
+
+        for (const request of requests) {
+            const txCpy = request.tx.clone();
+
+            if (!request.inputIndexes) {
+                try {
+                    if (!txCpy.sign(privateKey, ALL_SIGHASH)) {
+                        throw new Error("Failed to sign transaction");
+                    }
+                } catch (e) {
+                    if (
+                        e instanceof Error &&
+                        e.message.includes("No inputs signed")
+                    ) {
+                        // ignore
+                    } else {
+                        throw e;
+                    }
+                }
+                results.push(txCpy);
+            } else {
+                for (const inputIndex of request.inputIndexes) {
+                    if (!txCpy.signIdx(privateKey, inputIndex, ALL_SIGHASH)) {
+                        throw new Error(`Failed to sign input #${inputIndex}`);
+                    }
+                }
+                results.push(txCpy);
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Signs a message using the private key derived at the index embedded
+     * in the given descriptor.
+     *
+     * @param descriptor - A concrete descriptor belonging to this identity
+     * @param message - The message bytes to sign
+     * @param signatureType - "schnorr" or "ecdsa" (default: "schnorr")
+     * @returns The signature bytes
+     * @throws If the descriptor does not belong to this identity
+     */
+    async signMessageWithDescriptor(
+        descriptor: string,
+        message: Uint8Array,
+        signatureType: "schnorr" | "ecdsa" = "schnorr"
+    ): Promise<Uint8Array> {
+        if (!this.isOurs(descriptor)) {
+            throw new Error("Descriptor does not belong to this identity");
+        }
+
+        const privateKey = this.derivePrivateKeyFromDescriptor(descriptor);
+
+        if (signatureType === "ecdsa") {
+            return signAsync(message, privateKey, { prehash: false });
+        }
+        return schnorr.signAsync(message, privateKey);
     }
 
     async xOnlyPublicKey(): Promise<Uint8Array> {
@@ -214,8 +482,36 @@ export class SeedIdentity implements Identity {
     /**
      * Converts to a watch-only identity that cannot sign.
      */
-    async toReadonly(): Promise<ReadonlyDescriptorIdentity> {
-        return ReadonlyDescriptorIdentity.fromDescriptor(this.descriptor);
+    async toReadonly(): Promise<ReadonlySeedIdentity> {
+        return ReadonlySeedIdentity.fromDescriptor(this.descriptor);
+    }
+
+    /**
+     * Derives a private key from a concrete descriptor by extracting its
+     * derivation index and computing the child key from the seed.
+     * @internal
+     */
+    private derivePrivateKeyFromDescriptor(descriptor: string): Uint8Array {
+        const network = detectNetwork(descriptor);
+        const masterNode = BIP32.fromSeed(this.seed, network);
+        const expansion = expand({ descriptor, network });
+        const keyInfo = expansion.expansionMap?.["@0"];
+        if (!keyInfo?.originPath) {
+            throw new Error("Invalid descriptor: missing origin path");
+        }
+        const accountNode = masterNode.derivePath(`m${keyInfo.originPath}`);
+        // keyPath is like "/0/5", extract the index
+        const keyPath = keyInfo.keyPath;
+        if (!keyPath) {
+            throw new Error("Invalid descriptor: missing key path");
+        }
+        const segments = keyPath.split("/").filter(Boolean);
+        const childIndex = segments[segments.length - 1];
+        const addressNode = accountNode.derivePath(`m/0/${childIndex}`);
+        if (!addressNode.privateKey) {
+            throw new Error("Failed to derive private key");
+        }
+        return addressNode.privateKey;
     }
 }
 
@@ -272,16 +568,23 @@ export class MnemonicIdentity extends SeedIdentity {
  * watch-only wallets or when sharing identity information without
  * exposing private keys.
  *
+ * Supports HD wallet methods for deriving public keys at arbitrary
+ * child indexes and checking descriptor ownership.
+ *
  * @example
  * ```typescript
  * const descriptor = "tr([fingerprint/86'/0'/0']xpub.../0/0)";
- * const readonly = ReadonlyDescriptorIdentity.fromDescriptor(descriptor);
+ * const readonly = ReadonlySeedIdentity.fromDescriptor(descriptor);
  * const pubKey = await readonly.xOnlyPublicKey();
  * ```
  */
-export class ReadonlyDescriptorIdentity implements ReadonlyIdentity {
+export class ReadonlySeedIdentity implements ReadonlyIdentity {
     private readonly xOnlyPubKey: Uint8Array;
     private readonly compressedPubKey: Uint8Array;
+    /** The account-level BIP32 node extracted from the descriptor. */
+    private readonly accountBip32:
+        | ReturnType<typeof BIP32.fromSeed>
+        | undefined;
 
     private constructor(readonly descriptor: string) {
         const network = detectNetwork(descriptor);
@@ -307,15 +610,152 @@ export class ReadonlyDescriptorIdentity implements ReadonlyIdentity {
                 "Cannot determine compressed public key parity from descriptor"
             );
         }
+
+        // Store the account-level bip32 node for HD methods
+        this.accountBip32 = keyInfo.bip32;
     }
 
     /**
-     * Creates a ReadonlyDescriptorIdentity from an output descriptor.
+     * Creates a ReadonlySeedIdentity from an output descriptor.
      *
      * @param descriptor - Taproot descriptor: tr([fingerprint/path']xpub.../child/path)
      */
-    static fromDescriptor(descriptor: string): ReadonlyDescriptorIdentity {
-        return new ReadonlyDescriptorIdentity(descriptor);
+    static fromDescriptor(descriptor: string): ReadonlySeedIdentity {
+        return new ReadonlySeedIdentity(descriptor);
+    }
+
+    /**
+     * Restores a ReadonlySeedIdentity from a JSON object.
+     *
+     * @param json - Object containing `{descriptor}`
+     */
+    static fromJSON(json: { descriptor: string }): ReadonlySeedIdentity {
+        if (!json.descriptor) {
+            throw new Error("Missing descriptor in JSON");
+        }
+        // If descriptor has wildcard, resolve to index 0
+        let descriptor = json.descriptor;
+        if (descriptor.includes("*")) {
+            const network = detectNetwork(descriptor);
+            const expansion = expand({ descriptor, network, index: 0 });
+            descriptor = expansion.canonicalExpression;
+        }
+        return new ReadonlySeedIdentity(descriptor);
+    }
+
+    /**
+     * Serializes this identity to a JSON object.
+     *
+     * The descriptor is stored as a wildcard template (e.g. `.../0/*`)
+     * when possible, so it can derive any child index on restore.
+     *
+     * @returns JSON containing `{descriptor}`
+     */
+    toJSON(): { descriptor: string } {
+        // Build a wildcard descriptor from the account bip32 node
+        if (this.accountBip32) {
+            const network = detectNetwork(this.descriptor);
+            // Extract the origin path and fingerprint from the descriptor
+            const expansion = expand({ descriptor: this.descriptor, network });
+            const keyInfo = expansion.expansionMap?.["@0"];
+            if (keyInfo?.originPath) {
+                // Build wildcard from the xpub base58 and origin info
+                const masterFp = keyInfo.masterFingerprint
+                    ? hex.encode(keyInfo.masterFingerprint)
+                    : "00000000";
+                const xpub = keyInfo.bip32!.toBase58();
+                return {
+                    descriptor: `tr([${masterFp}${keyInfo.originPath}]${xpub}/0/*)`,
+                };
+            }
+        }
+        return { descriptor: this.descriptor };
+    }
+
+    /**
+     * Derives a concrete signing descriptor at the given child index.
+     *
+     * @param index - Non-negative child index
+     * @returns A concrete taproot descriptor for the given index
+     */
+    deriveSigningDescriptor(index: number): string {
+        if (index < 0) {
+            throw new Error("Index must be non-negative");
+        }
+        if (!this.accountBip32) {
+            throw new Error("No BIP32 account node available");
+        }
+        const network = detectNetwork(this.descriptor);
+        const expansion = expand({ descriptor: this.descriptor, network });
+        const keyInfo = expansion.expansionMap?.["@0"];
+        if (!keyInfo?.masterFingerprint || !keyInfo?.originPath) {
+            throw new Error("Descriptor missing origin information");
+        }
+        const masterFp = hex.encode(keyInfo.masterFingerprint);
+        const xpub = keyInfo.bip32!.toBase58();
+        return `tr([${masterFp}${keyInfo.originPath}]${xpub}/0/${index})`;
+    }
+
+    /**
+     * Checks whether a given descriptor belongs to this identity by comparing
+     * the account-level xpub.
+     *
+     * @param descriptor - The descriptor to check
+     * @returns `true` if the descriptor was derived from the same HD account
+     */
+    isOurs(descriptor: string): boolean {
+        try {
+            const network = detectNetwork(descriptor);
+            const expansion = expand({ descriptor, network });
+            const keyInfo = expansion.expansionMap?.["@0"];
+            if (!keyInfo?.bip32) return false;
+
+            // Compare with our own account xpub
+            const ownNetwork = detectNetwork(this.descriptor);
+            const ownExpansion = expand({
+                descriptor: this.descriptor,
+                network: ownNetwork,
+            });
+            const ownKeyInfo = ownExpansion.expansionMap?.["@0"];
+            return keyInfo.bip32.toBase58() === ownKeyInfo?.bip32?.toBase58();
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the x-only (Schnorr) public key at the given child index.
+     *
+     * @param index - Non-negative child index
+     */
+    async xOnlyPublicKeyAtIndex(index: number): Promise<Uint8Array> {
+        if (index < 0) {
+            throw new Error("Index must be non-negative");
+        }
+        const desc = this.deriveSigningDescriptor(index);
+        const network = detectNetwork(desc);
+        const expansion = expand({ descriptor: desc, network });
+        const keyInfo = expansion.expansionMap?.["@0"];
+        if (!keyInfo?.pubkey) {
+            throw new Error("Failed to derive public key at index");
+        }
+        return keyInfo.pubkey;
+    }
+
+    /**
+     * Returns the 33-byte compressed public key at the given child index.
+     *
+     * @param index - Non-negative child index
+     */
+    async compressedPublicKeyAtIndex(index: number): Promise<Uint8Array> {
+        if (index < 0) {
+            throw new Error("Index must be non-negative");
+        }
+        if (!this.accountBip32) {
+            throw new Error("No BIP32 account node available");
+        }
+        const childNode = this.accountBip32.derivePath(`0/${index}`);
+        return childNode.publicKey;
     }
 
     async xOnlyPublicKey(): Promise<Uint8Array> {
@@ -326,3 +766,6 @@ export class ReadonlyDescriptorIdentity implements ReadonlyIdentity {
         return this.compressedPubKey;
     }
 }
+
+/** @deprecated Use {@link ReadonlySeedIdentity} instead. */
+export { ReadonlySeedIdentity as ReadonlyDescriptorIdentity };

--- a/src/identity/staticDescriptorProvider.ts
+++ b/src/identity/staticDescriptorProvider.ts
@@ -1,0 +1,77 @@
+import { hex } from "@scure/base";
+import { Identity } from ".";
+import {
+    DescriptorProvider,
+    DescriptorSigningRequest,
+} from "./descriptorProvider";
+import { normalizeToDescriptor, extractPubKey } from "./descriptor";
+import { Transaction } from "../utils/transaction";
+
+/**
+ * Wraps a legacy Identity (single-key) as a DescriptorProvider.
+ * The descriptor is always a simple tr(pubkey) format.
+ */
+export class StaticDescriptorProvider implements DescriptorProvider {
+    private readonly identity: Identity;
+    private readonly descriptor: string;
+    private readonly pubKeyHex: string;
+
+    constructor(identity: Identity, pubKeyHex: string) {
+        this.identity = identity;
+        this.pubKeyHex = pubKeyHex;
+        this.descriptor = `tr(${pubKeyHex})`;
+    }
+
+    static async create(identity: Identity): Promise<StaticDescriptorProvider> {
+        const pubKey = await identity.xOnlyPublicKey();
+        return new StaticDescriptorProvider(identity, hex.encode(pubKey));
+    }
+
+    getSigningDescriptor(): string {
+        return this.descriptor;
+    }
+
+    isOurs(descriptor: string): boolean {
+        const normalized = normalizeToDescriptor(descriptor);
+        try {
+            const pubKey = extractPubKey(normalized);
+            return pubKey.toLowerCase() === this.pubKeyHex.toLowerCase();
+        } catch {
+            return false;
+        }
+    }
+
+    async signWithDescriptor(
+        descriptor: string,
+        requests: DescriptorSigningRequest[]
+    ): Promise<Transaction[]> {
+        if (!this.isOurs(descriptor)) {
+            throw new Error(
+                `Descriptor ${descriptor} does not belong to this provider`
+            );
+        }
+
+        const results: Transaction[] = [];
+        for (const request of requests) {
+            const signed = await this.identity.sign(
+                request.tx,
+                request.inputIndexes
+            );
+            results.push(signed);
+        }
+        return results;
+    }
+
+    async signMessageWithDescriptor(
+        descriptor: string,
+        message: Uint8Array,
+        type: "schnorr" | "ecdsa" = "schnorr"
+    ): Promise<Uint8Array> {
+        if (!this.isOurs(descriptor)) {
+            throw new Error(
+                `Descriptor ${descriptor} does not belong to this provider`
+            );
+        }
+        return this.identity.signMessage(message, type);
+    }
+}

--- a/src/identity/staticDescriptorProvider.ts
+++ b/src/identity/staticDescriptorProvider.ts
@@ -42,17 +42,15 @@ export class StaticDescriptorProvider implements DescriptorProvider {
     }
 
     async signWithDescriptor(
-        descriptor: string,
         requests: DescriptorSigningRequest[]
     ): Promise<Transaction[]> {
-        if (!this.isOurs(descriptor)) {
-            throw new Error(
-                `Descriptor ${descriptor} does not belong to this provider`
-            );
-        }
-
         const results: Transaction[] = [];
         for (const request of requests) {
+            if (!this.isOurs(request.descriptor)) {
+                throw new Error(
+                    `Descriptor ${request.descriptor} does not belong to this provider`
+                );
+            }
             const signed = await this.identity.sign(
                 request.tx,
                 request.inputIndexes

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,15 @@ import {
     SeedIdentity,
     MnemonicIdentity,
     ReadonlyDescriptorIdentity,
+    ReadonlySeedIdentity,
 } from "./identity/seedIdentity";
 import type {
     SeedIdentityOptions,
     MnemonicOptions,
     NetworkOptions,
     DescriptorOptions,
+    SigningRequest,
+    SeedIdentityJSON,
 } from "./identity/seedIdentity";
 import {
     Identity,
@@ -270,6 +273,7 @@ export {
     MnemonicIdentity,
     ReadonlyDescriptorIdentity,
     isBatchSignable,
+    ReadonlySeedIdentity,
     OnchainWallet,
     Ramps,
     VtxoManager,
@@ -438,6 +442,8 @@ export type {
     MnemonicOptions,
     NetworkOptions,
     DescriptorOptions,
+    SigningRequest,
+    SeedIdentityJSON,
 
     // Indexer types
     IndexerProvider,

--- a/test/contracts/handlers.test.ts
+++ b/test/contracts/handlers.test.ts
@@ -14,7 +14,9 @@ import {
     createDelegateContractParams,
     createMockVtxo,
     TEST_PUB_KEY,
+    TEST_PUB_KEY_HEX,
     TEST_SERVER_PUB_KEY,
+    TEST_SERVER_PUB_KEY_HEX,
     TEST_DELEGATE_PUB_KEY,
 } from "./helpers";
 import { timelockToSequence } from "../../src/contracts/handlers/helpers";
@@ -72,11 +74,11 @@ describe("DefaultContractHandler", () => {
 
     it("should create script from params", () => {
         const params = {
-            pubKey: hex.encode(TEST_PUB_KEY),
-            serverPubKey: hex.encode(TEST_SERVER_PUB_KEY),
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
             csvTimelock: DefaultContractHandler.serializeParams({
-                pubKey: TEST_PUB_KEY,
-                serverPubKey: TEST_SERVER_PUB_KEY,
+                pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+                serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
                 csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
             }).csvTimelock,
         };
@@ -89,8 +91,8 @@ describe("DefaultContractHandler", () => {
 
     it("should serialize and deserialize params", () => {
         const original = {
-            pubKey: TEST_PUB_KEY,
-            serverPubKey: TEST_SERVER_PUB_KEY,
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
             csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
         };
 
@@ -98,10 +100,9 @@ describe("DefaultContractHandler", () => {
         const deserialized =
             DefaultContractHandler.deserializeParams(serialized);
 
-        expect(deserialized.pubKey).toBeInstanceOf(Uint8Array);
-        expect(deserialized.serverPubKey).toBeInstanceOf(Uint8Array);
-        expect(Array.from(deserialized.pubKey)).toEqual(
-            Array.from(TEST_PUB_KEY)
+        expect(deserialized.pubKey).toBe(`tr(${TEST_PUB_KEY_HEX})`);
+        expect(deserialized.serverPubKey).toBe(
+            `tr(${TEST_SERVER_PUB_KEY_HEX})`
         );
     });
 
@@ -223,8 +224,8 @@ describe("DefaultContractHandler", () => {
 
     it("should omit sequence on exit path when csvTimelock is missing", () => {
         const params = {
-            pubKey: hex.encode(TEST_PUB_KEY),
-            serverPubKey: hex.encode(TEST_SERVER_PUB_KEY),
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
         };
         const script = DefaultContractHandler.createScript(params);
         const contract: Contract = {

--- a/test/contracts/handlers/default.test.ts
+++ b/test/contracts/handlers/default.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { DefaultContractHandler } from "../../../src/contracts/handlers/default";
+import { DefaultVtxo } from "../../../src";
+
+const TEST_PUB_KEY_HEX =
+    "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const TEST_SERVER_PUB_KEY_HEX =
+    "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+
+describe("DefaultContractHandler descriptor support", () => {
+    it("should normalize hex pubkey to descriptor on deserialize", () => {
+        const params = DefaultContractHandler.deserializeParams({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+        });
+        expect(params.pubKey).toBe(`tr(${TEST_PUB_KEY_HEX})`);
+        expect(params.serverPubKey).toBe(`tr(${TEST_SERVER_PUB_KEY_HEX})`);
+    });
+
+    it("should keep descriptors unchanged on deserialize", () => {
+        const params = DefaultContractHandler.deserializeParams({
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
+        });
+        expect(params.pubKey).toBe(`tr(${TEST_PUB_KEY_HEX})`);
+        expect(params.serverPubKey).toBe(`tr(${TEST_SERVER_PUB_KEY_HEX})`);
+    });
+
+    it("should store descriptors directly on serialize", () => {
+        const serialized = DefaultContractHandler.serializeParams({
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
+        });
+        expect(serialized.pubKey).toBe(`tr(${TEST_PUB_KEY_HEX})`);
+        expect(serialized.serverPubKey).toBe(`tr(${TEST_SERVER_PUB_KEY_HEX})`);
+    });
+
+    it("should create script from descriptor params", () => {
+        const serialized = DefaultContractHandler.serializeParams({
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
+        });
+        const script = DefaultContractHandler.createScript(serialized);
+        expect(script).toBeDefined();
+        expect(script.pkScript).toBeDefined();
+    });
+
+    it("should create script from legacy hex params", () => {
+        const script = DefaultContractHandler.createScript({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+        });
+        expect(script).toBeDefined();
+        expect(script.pkScript).toBeDefined();
+    });
+
+    it("should produce identical pkScript from descriptor and hex params", () => {
+        const hexScript = DefaultContractHandler.createScript({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+        });
+        const descScript = DefaultContractHandler.createScript({
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
+        });
+        expect(hexScript.pkScript).toEqual(descScript.pkScript);
+    });
+
+    it("should round-trip serialize/deserialize with descriptors", () => {
+        const original = {
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
+        };
+        const serialized = DefaultContractHandler.serializeParams(original);
+        const deserialized =
+            DefaultContractHandler.deserializeParams(serialized);
+        expect(deserialized.pubKey).toBe(original.pubKey);
+        expect(deserialized.serverPubKey).toBe(original.serverPubKey);
+    });
+
+    it("should upgrade legacy hex to descriptor on deserialize", () => {
+        const deserialized = DefaultContractHandler.deserializeParams({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+            csvTimelock: "65536",
+        });
+        expect(deserialized.pubKey).toBe(`tr(${TEST_PUB_KEY_HEX})`);
+    });
+});

--- a/test/contracts/helpers.ts
+++ b/test/contracts/helpers.ts
@@ -28,9 +28,13 @@ export const createMockIndexerProvider = (): IndexerProvider => ({
     unsubscribeForScripts: vi.fn().mockResolvedValue(undefined),
 });
 
-// Test keys for creating valid contracts
-export const TEST_PUB_KEY = new Uint8Array(32).fill(1);
-export const TEST_SERVER_PUB_KEY = new Uint8Array(32).fill(2);
+// Test keys for creating valid contracts (valid secp256k1 x-only public keys)
+export const TEST_PUB_KEY_HEX =
+    "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+export const TEST_SERVER_PUB_KEY_HEX =
+    "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+export const TEST_PUB_KEY = hex.decode(TEST_PUB_KEY_HEX);
+export const TEST_SERVER_PUB_KEY = hex.decode(TEST_SERVER_PUB_KEY_HEX);
 // Real-looking x-only pubkey (needed for 3-key multisig in DelegateVtxo)
 export const TEST_DELEGATE_PUB_KEY = hex.decode(
     "f8352deebdf5658d95875d89656112b1dd150f176c702eea4f91a91527e48e26"
@@ -39,8 +43,8 @@ export const TEST_DELEGATE_PUB_KEY = hex.decode(
 // Helper to create valid default contract params
 export const createDefaultContractParams = () =>
     DefaultContractHandler.serializeParams({
-        pubKey: TEST_PUB_KEY,
-        serverPubKey: TEST_SERVER_PUB_KEY,
+        pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+        serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
         csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
     });
 

--- a/test/contracts/manager.test.ts
+++ b/test/contracts/manager.test.ts
@@ -16,8 +16,8 @@ import {
     createMockIndexerProvider,
     createMockVtxo,
     TEST_DEFAULT_SCRIPT,
-    TEST_PUB_KEY,
-    TEST_SERVER_PUB_KEY,
+    TEST_PUB_KEY_HEX,
+    TEST_SERVER_PUB_KEY_HEX,
 } from "./helpers";
 
 vi.useFakeTimers();
@@ -71,8 +71,8 @@ describe("ContractManager", () => {
         });
 
         const altParams = DefaultContractHandler.serializeParams({
-            pubKey: TEST_PUB_KEY,
-            serverPubKey: TEST_SERVER_PUB_KEY,
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
             csvTimelock: {
                 type: "blocks",
                 value: DefaultVtxo.Script.DEFAULT_TIMELOCK.value + 1n,

--- a/test/descriptor.test.ts
+++ b/test/descriptor.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+    isDescriptor,
+    normalizeToDescriptor,
+    extractPubKey,
+    parseHDDescriptor,
+} from "../src/identity/descriptor";
+
+describe("isDescriptor", () => {
+    it("should return true for simple descriptor", () => {
+        expect(isDescriptor("tr(abc123def456)")).toBe(true);
+    });
+    it("should return true for HD descriptor", () => {
+        expect(
+            isDescriptor("tr([12345678/86'/0'/0']xpubABCDEF123456/0/5)")
+        ).toBe(true);
+    });
+    it("should return false for hex pubkey", () => {
+        expect(isDescriptor("abc123def456")).toBe(false);
+    });
+    it("should return false for empty string", () => {
+        expect(isDescriptor("")).toBe(false);
+    });
+});
+
+describe("normalizeToDescriptor", () => {
+    it("should return descriptor unchanged", () => {
+        expect(normalizeToDescriptor("tr(abc123)")).toBe("tr(abc123)");
+    });
+    it("should wrap hex pubkey as tr(pubkey)", () => {
+        expect(normalizeToDescriptor("abc123")).toBe("tr(abc123)");
+    });
+    it("should wrap 64-char hex pubkey", () => {
+        const pubkey = "a".repeat(64);
+        expect(normalizeToDescriptor(pubkey)).toBe(`tr(${pubkey})`);
+    });
+    it("should not double-wrap descriptors", () => {
+        expect(normalizeToDescriptor("tr(abc123)")).toBe("tr(abc123)");
+    });
+});
+
+describe("extractPubKey", () => {
+    it("should extract pubkey from simple descriptor", () => {
+        const pubkey = "a".repeat(64);
+        expect(extractPubKey(`tr(${pubkey})`)).toBe(pubkey);
+    });
+    it("should return hex pubkey unchanged", () => {
+        const pubkey = "a".repeat(64);
+        expect(extractPubKey(pubkey)).toBe(pubkey);
+    });
+    it("should throw for HD descriptor", () => {
+        expect(() =>
+            extractPubKey("tr([12345678/86'/0'/0']xpubABCDEF/0/5)")
+        ).toThrow("Cannot extract pubkey from HD descriptor");
+    });
+    it("should handle uppercase hex", () => {
+        const pubkey = "A".repeat(64);
+        expect(extractPubKey(`tr(${pubkey})`)).toBe(pubkey);
+    });
+    it("should throw for short pubkey in descriptor", () => {
+        expect(() => extractPubKey("tr(abc123)")).toThrow(
+            "Cannot extract pubkey from HD descriptor"
+        );
+    });
+});
+
+describe("parseHDDescriptor", () => {
+    it("should parse valid HD descriptor with mainnet path", () => {
+        const result = parseHDDescriptor(
+            "tr([12345678/86'/0'/0']xpubDCtest123/0/5)"
+        );
+        expect(result).not.toBeNull();
+        expect(result!.fingerprint).toBe("12345678");
+        expect(result!.basePath).toBe("86'/0'/0'");
+        expect(result!.xpub).toBe("xpubDCtest123");
+        expect(result!.derivationPath).toBe("0/5");
+    });
+    it("should parse valid HD descriptor with testnet path", () => {
+        const result = parseHDDescriptor(
+            "tr([abcdef12/86'/1'/0']tpubDCtest456/0/10)"
+        );
+        expect(result).not.toBeNull();
+        expect(result!.fingerprint).toBe("abcdef12");
+        expect(result!.basePath).toBe("86'/1'/0'");
+        expect(result!.xpub).toBe("tpubDCtest456");
+        expect(result!.derivationPath).toBe("0/10");
+    });
+    it("should return null for simple descriptor", () => {
+        expect(parseHDDescriptor(`tr(${"a".repeat(64)})`)).toBeNull();
+    });
+    it("should return null for invalid format", () => {
+        expect(parseHDDescriptor("invalid")).toBeNull();
+    });
+    it("should return null for raw hex", () => {
+        expect(parseHDDescriptor("a".repeat(64))).toBeNull();
+    });
+    it("should handle real-world xpub format", () => {
+        const result = parseHDDescriptor(
+            "tr([73c5da0a/86'/0'/0']xpub6CUGRUonZSQ4TWtTMmzXdrXDtyPWm/0/0)"
+        );
+        expect(result).not.toBeNull();
+        expect(result!.fingerprint).toBe("73c5da0a");
+        expect(result!.xpub).toBe("xpub6CUGRUonZSQ4TWtTMmzXdrXDtyPWm");
+    });
+});

--- a/test/descriptor.test.ts
+++ b/test/descriptor.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect } from "vitest";
+import { mnemonicToSeedSync } from "@scure/bip39";
+import {
+    scureBIP32 as BIP32,
+    networks,
+    scriptExpressions,
+} from "@kukks/bitcoin-descriptors";
+import { hex } from "@scure/base";
 import {
     isDescriptor,
     normalizeToDescriptor,
@@ -6,17 +13,49 @@ import {
     parseHDDescriptor,
 } from "../src/identity/descriptor";
 
+const TEST_MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+/** Generate a real HD descriptor from the test mnemonic. */
+function makeDescriptor(opts: {
+    isMainnet?: boolean;
+    change?: number;
+    index?: number;
+}): string {
+    const { isMainnet = true, change = 0, index = 0 } = opts;
+    const network = isMainnet ? networks.bitcoin : networks.testnet;
+    const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+    const masterNode = BIP32.fromSeed(seed, network);
+    return scriptExpressions.trBIP32({
+        masterNode,
+        network,
+        account: 0,
+        change,
+        index,
+    });
+}
+
+/** Get x-only pubkey hex for a derived key. */
+function getXOnlyPubKey(isMainnet = true): string {
+    const network = isMainnet ? networks.bitcoin : networks.testnet;
+    const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+    const root = BIP32.fromSeed(seed, network);
+    const account = root.derivePath(isMainnet ? "m/86'/0'/0'" : "m/86'/1'/0'");
+    const child = account.derive(0).derive(0);
+    return hex.encode(child.publicKey.slice(1));
+}
+
 describe("isDescriptor", () => {
     it("should return true for simple descriptor", () => {
-        expect(isDescriptor("tr(abc123def456)")).toBe(true);
+        const pubkey = getXOnlyPubKey();
+        expect(isDescriptor(`tr(${pubkey})`)).toBe(true);
     });
     it("should return true for HD descriptor", () => {
-        expect(
-            isDescriptor("tr([12345678/86'/0'/0']xpubABCDEF123456/0/5)")
-        ).toBe(true);
+        const desc = makeDescriptor({ index: 5 });
+        expect(isDescriptor(desc)).toBe(true);
     });
     it("should return false for hex pubkey", () => {
-        expect(isDescriptor("abc123def456")).toBe(false);
+        expect(isDescriptor(getXOnlyPubKey())).toBe(false);
     });
     it("should return false for empty string", () => {
         expect(isDescriptor("")).toBe(false);
@@ -25,81 +64,79 @@ describe("isDescriptor", () => {
 
 describe("normalizeToDescriptor", () => {
     it("should return descriptor unchanged", () => {
-        expect(normalizeToDescriptor("tr(abc123)")).toBe("tr(abc123)");
+        const pubkey = getXOnlyPubKey();
+        const desc = `tr(${pubkey})`;
+        expect(normalizeToDescriptor(desc)).toBe(desc);
     });
     it("should wrap hex pubkey as tr(pubkey)", () => {
-        expect(normalizeToDescriptor("abc123")).toBe("tr(abc123)");
-    });
-    it("should wrap 64-char hex pubkey", () => {
-        const pubkey = "a".repeat(64);
+        const pubkey = getXOnlyPubKey();
         expect(normalizeToDescriptor(pubkey)).toBe(`tr(${pubkey})`);
     });
     it("should not double-wrap descriptors", () => {
-        expect(normalizeToDescriptor("tr(abc123)")).toBe("tr(abc123)");
+        const desc = makeDescriptor({ index: 0 });
+        expect(normalizeToDescriptor(desc)).toBe(desc);
     });
 });
 
 describe("extractPubKey", () => {
     it("should extract pubkey from simple descriptor", () => {
-        const pubkey = "a".repeat(64);
+        const pubkey = getXOnlyPubKey();
         expect(extractPubKey(`tr(${pubkey})`)).toBe(pubkey);
     });
     it("should return hex pubkey unchanged", () => {
-        const pubkey = "a".repeat(64);
+        const pubkey = getXOnlyPubKey();
         expect(extractPubKey(pubkey)).toBe(pubkey);
     });
     it("should throw for HD descriptor", () => {
-        expect(() =>
-            extractPubKey("tr([12345678/86'/0'/0']xpubABCDEF/0/5)")
-        ).toThrow("Cannot extract pubkey from HD descriptor");
-    });
-    it("should handle uppercase hex", () => {
-        const pubkey = "A".repeat(64);
-        expect(extractPubKey(`tr(${pubkey})`)).toBe(pubkey);
-    });
-    it("should throw for short pubkey in descriptor", () => {
-        expect(() => extractPubKey("tr(abc123)")).toThrow(
+        const desc = makeDescriptor({ index: 5 });
+        expect(() => extractPubKey(desc)).toThrow(
             "Cannot extract pubkey from HD descriptor"
         );
+    });
+    it("should handle uppercase hex", () => {
+        const pubkey = getXOnlyPubKey().toUpperCase();
+        expect(extractPubKey(`tr(${pubkey})`)).toBe(pubkey.toLowerCase());
+    });
+    it("should throw for invalid descriptor content", () => {
+        expect(() => extractPubKey("tr(abc123)")).toThrow();
     });
 });
 
 describe("parseHDDescriptor", () => {
     it("should parse valid HD descriptor with mainnet path", () => {
-        const result = parseHDDescriptor(
-            "tr([12345678/86'/0'/0']xpubDCtest123/0/5)"
-        );
+        const desc = makeDescriptor({ index: 5 });
+        const result = parseHDDescriptor(desc);
         expect(result).not.toBeNull();
-        expect(result!.fingerprint).toBe("12345678");
+        expect(result!.fingerprint).toBe("73c5da0a");
         expect(result!.basePath).toBe("86'/0'/0'");
-        expect(result!.xpub).toBe("xpubDCtest123");
         expect(result!.derivationPath).toBe("0/5");
+        expect(result!.xpub).toMatch(/^xpub/);
     });
     it("should parse valid HD descriptor with testnet path", () => {
-        const result = parseHDDescriptor(
-            "tr([abcdef12/86'/1'/0']tpubDCtest456/0/10)"
-        );
+        const desc = makeDescriptor({ isMainnet: false, index: 10 });
+        const result = parseHDDescriptor(desc);
         expect(result).not.toBeNull();
-        expect(result!.fingerprint).toBe("abcdef12");
+        expect(result!.fingerprint).toBe("73c5da0a");
         expect(result!.basePath).toBe("86'/1'/0'");
-        expect(result!.xpub).toBe("tpubDCtest456");
         expect(result!.derivationPath).toBe("0/10");
+        expect(result!.xpub).toMatch(/^tpub/);
     });
     it("should return null for simple descriptor", () => {
-        expect(parseHDDescriptor(`tr(${"a".repeat(64)})`)).toBeNull();
+        const pubkey = getXOnlyPubKey();
+        expect(parseHDDescriptor(`tr(${pubkey})`)).toBeNull();
     });
     it("should return null for invalid format", () => {
         expect(parseHDDescriptor("invalid")).toBeNull();
     });
     it("should return null for raw hex", () => {
-        expect(parseHDDescriptor("a".repeat(64))).toBeNull();
+        expect(parseHDDescriptor(getXOnlyPubKey())).toBeNull();
     });
-    it("should handle real-world xpub format", () => {
-        const result = parseHDDescriptor(
-            "tr([73c5da0a/86'/0'/0']xpub6CUGRUonZSQ4TWtTMmzXdrXDtyPWm/0/0)"
-        );
+    it("should extract correct xpub from mainnet descriptor", () => {
+        const desc = makeDescriptor({ index: 0 });
+        const result = parseHDDescriptor(desc);
         expect(result).not.toBeNull();
-        expect(result!.fingerprint).toBe("73c5da0a");
-        expect(result!.xpub).toBe("xpub6CUGRUonZSQ4TWtTMmzXdrXDtyPWm");
+        expect(result!.xpub).toBe(
+            "xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ"
+        );
     });
 });

--- a/test/descriptor.test.ts
+++ b/test/descriptor.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { mnemonicToSeedSync } from "@scure/bip39";
 import {
-    scureBIP32 as BIP32,
+    HDKey,
     networks,
     scriptExpressions,
-} from "@kukks/bitcoin-descriptors";
+} from "@bitcoinerlab/descriptors-scure";
 import { hex } from "@scure/base";
 import {
     isDescriptor,
@@ -25,7 +25,7 @@ function makeDescriptor(opts: {
     const { isMainnet = true, change = 0, index = 0 } = opts;
     const network = isMainnet ? networks.bitcoin : networks.testnet;
     const seed = mnemonicToSeedSync(TEST_MNEMONIC);
-    const masterNode = BIP32.fromSeed(seed, network);
+    const masterNode = HDKey.fromMasterSeed(seed, network.bip32);
     return scriptExpressions.trBIP32({
         masterNode,
         network,
@@ -39,10 +39,10 @@ function makeDescriptor(opts: {
 function getXOnlyPubKey(isMainnet = true): string {
     const network = isMainnet ? networks.bitcoin : networks.testnet;
     const seed = mnemonicToSeedSync(TEST_MNEMONIC);
-    const root = BIP32.fromSeed(seed, network);
-    const account = root.derivePath(isMainnet ? "m/86'/0'/0'" : "m/86'/1'/0'");
-    const child = account.derive(0).derive(0);
-    return hex.encode(child.publicKey.slice(1));
+    const root = HDKey.fromMasterSeed(seed, network.bip32);
+    const account = root.derive(isMainnet ? "m/86'/0'/0'" : "m/86'/1'/0'");
+    const child = account.deriveChild(0).deriveChild(0);
+    return hex.encode(child.publicKey!.slice(1));
 }
 
 describe("isDescriptor", () => {

--- a/test/seedIdentity.test.ts
+++ b/test/seedIdentity.test.ts
@@ -3,8 +3,11 @@ import {
     SeedIdentity,
     MnemonicIdentity,
     ReadonlyDescriptorIdentity,
+    ReadonlySeedIdentity,
 } from "../src/identity/seedIdentity";
+import type { SigningRequest } from "../src/identity/seedIdentity";
 import { mnemonicToSeedSync } from "@scure/bip39";
+import { hex } from "@scure/base";
 import { schnorr, verifyAsync } from "@noble/secp256k1";
 
 const TEST_MNEMONIC =
@@ -375,5 +378,580 @@ describe("module exports", () => {
         expect(typeof ReadonlyDescriptorIdentity.fromDescriptor).toBe(
             "function"
         );
+    });
+
+    it("should export ReadonlySeedIdentity from identity module", async () => {
+        const { ReadonlySeedIdentity } = await import("../src/identity");
+        expect(ReadonlySeedIdentity).toBeDefined();
+        expect(typeof ReadonlySeedIdentity.fromDescriptor).toBe("function");
+    });
+
+    it("should export SigningRequest type from identity module", async () => {
+        // SigningRequest is a type, so we just verify it compiles
+        const req: SigningRequest = { tx: null as any };
+        expect(req).toBeDefined();
+    });
+});
+
+// ============================================================
+// New tests: SeedIdentity HD wallet methods
+// ============================================================
+
+describe("SeedIdentity HD methods", () => {
+    describe("deriveSigningDescriptor", () => {
+        it("should produce a valid descriptor at index 0", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const desc = identity.deriveSigningDescriptor(0);
+
+            expect(desc).toMatch(
+                /^tr\(\[[\da-f]{8}\/86'\/0'\/0'\]xpub.+\/0\/0\)$/
+            );
+        });
+
+        it("should produce a valid descriptor at index 5", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const desc = identity.deriveSigningDescriptor(5);
+
+            expect(desc).toMatch(/\/0\/5\)$/);
+        });
+
+        it("should use testnet coin type in descriptor", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: false });
+            const desc = identity.deriveSigningDescriptor(0);
+
+            expect(desc).toMatch(/\/86'\/1'\/0'\]/);
+            expect(desc).toMatch(/tpub/);
+        });
+
+        it("should throw for negative index", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+            expect(() => identity.deriveSigningDescriptor(-1)).toThrow(
+                "Index must be non-negative"
+            );
+        });
+
+        it("should produce different descriptors for different indexes", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+            const desc0 = identity.deriveSigningDescriptor(0);
+            const desc1 = identity.deriveSigningDescriptor(1);
+            const desc5 = identity.deriveSigningDescriptor(5);
+
+            expect(desc0).not.toBe(desc1);
+            expect(desc0).not.toBe(desc5);
+            expect(desc1).not.toBe(desc5);
+        });
+
+        it("should match the identity default descriptor at index 0", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const desc = identity.deriveSigningDescriptor(0);
+
+            expect(desc).toBe(identity.descriptor);
+        });
+    });
+
+    describe("isOurs", () => {
+        it("should return true for own descriptor at index 0", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+            expect(identity.isOurs(identity.descriptor)).toBe(true);
+        });
+
+        it("should return true for own descriptor at any index", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const desc5 = identity.deriveSigningDescriptor(5);
+            const desc42 = identity.deriveSigningDescriptor(42);
+
+            expect(identity.isOurs(desc5)).toBe(true);
+            expect(identity.isOurs(desc42)).toBe(true);
+        });
+
+        it("should return false for a different seed", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+            const otherSeed = mnemonicToSeedSync(TEST_MNEMONIC, "different");
+            const otherIdentity = SeedIdentity.fromSeed(otherSeed, {
+                isMainnet: true,
+            });
+
+            expect(identity.isOurs(otherIdentity.descriptor)).toBe(false);
+        });
+
+        it("should return false for cross-network descriptor", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const mainnet = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const testnet = SeedIdentity.fromSeed(seed, { isMainnet: false });
+
+            // mainnet identity checking a testnet descriptor
+            expect(mainnet.isOurs(testnet.descriptor)).toBe(false);
+        });
+
+        it("should return false for invalid format", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+            expect(identity.isOurs("invalid")).toBe(false);
+            expect(identity.isOurs("")).toBe(false);
+        });
+    });
+
+    describe("signMessageWithDescriptor", () => {
+        it("should sign a message via descriptor at index 0", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const desc0 = identity.deriveSigningDescriptor(0);
+            const message = new Uint8Array(32).fill(42);
+
+            const signature = await identity.signMessageWithDescriptor(
+                desc0,
+                message,
+                "schnorr"
+            );
+            expect(signature).toBeInstanceOf(Uint8Array);
+            expect(signature).toHaveLength(64);
+
+            // Verify the signature against the public key at index 0
+            const pubKey = await identity.xOnlyPublicKey();
+            const isValid = await schnorr.verifyAsync(
+                signature,
+                message,
+                pubKey
+            );
+            expect(isValid).toBe(true);
+        });
+
+        it("should throw for a foreign descriptor", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+            const otherSeed = mnemonicToSeedSync(TEST_MNEMONIC, "other");
+            const otherIdentity = SeedIdentity.fromSeed(otherSeed, {
+                isMainnet: true,
+            });
+
+            const message = new Uint8Array(32).fill(42);
+            await expect(
+                identity.signMessageWithDescriptor(
+                    otherIdentity.descriptor,
+                    message
+                )
+            ).rejects.toThrow("Descriptor does not belong to this identity");
+        });
+
+        it("should produce different signatures for different indexes", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const message = new Uint8Array(32).fill(42);
+
+            const desc0 = identity.deriveSigningDescriptor(0);
+            const desc5 = identity.deriveSigningDescriptor(5);
+
+            const sig0 = await identity.signMessageWithDescriptor(
+                desc0,
+                message,
+                "schnorr"
+            );
+            const sig5 = await identity.signMessageWithDescriptor(
+                desc5,
+                message,
+                "schnorr"
+            );
+
+            expect(Array.from(sig0)).not.toEqual(Array.from(sig5));
+        });
+    });
+
+    describe("signWithDescriptor", () => {
+        it("should throw for a foreign descriptor", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+            const otherSeed = mnemonicToSeedSync(TEST_MNEMONIC, "other");
+            const otherIdentity = SeedIdentity.fromSeed(otherSeed, {
+                isMainnet: true,
+            });
+
+            await expect(
+                identity.signWithDescriptor(otherIdentity.descriptor, [
+                    { tx: null as any },
+                ])
+            ).rejects.toThrow("Descriptor does not belong to this identity");
+        });
+
+        it("should handle empty requests array", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+            const results = await identity.signWithDescriptor(
+                identity.descriptor,
+                []
+            );
+            expect(results).toEqual([]);
+        });
+    });
+
+    describe("isMainnet", () => {
+        it("should be true for mainnet identity", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            expect(identity.isMainnet).toBe(true);
+        });
+
+        it("should be false for testnet identity", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: false });
+            expect(identity.isMainnet).toBe(false);
+        });
+    });
+});
+
+// ============================================================
+// New tests: SeedIdentity serialization
+// ============================================================
+
+describe("SeedIdentity serialization", () => {
+    describe("toJSON", () => {
+        it("should include mnemonic when created via fromMnemonic", () => {
+            const identity = SeedIdentity.fromMnemonic(TEST_MNEMONIC, {
+                isMainnet: true,
+            });
+            const json = identity.toJSON();
+
+            expect(json.mnemonic).toBe(TEST_MNEMONIC);
+            expect(json.seed).toBeUndefined();
+            expect(json.descriptor).toBeDefined();
+        });
+
+        it("should include seed hex when created via fromSeed", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const json = identity.toJSON();
+
+            expect(json.mnemonic).toBeUndefined();
+            expect(json.seed).toBe(hex.encode(seed));
+            expect(json.descriptor).toBeDefined();
+        });
+
+        it("should produce a wildcard descriptor with /0/*", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const json = identity.toJSON();
+
+            expect(json.descriptor).toMatch(/\/0\/\*\)$/);
+        });
+    });
+
+    describe("fromJSON", () => {
+        it("should restore from mnemonic JSON", async () => {
+            const original = SeedIdentity.fromMnemonic(TEST_MNEMONIC, {
+                isMainnet: true,
+            });
+            const json = original.toJSON();
+            const restored = SeedIdentity.fromJSON(json);
+
+            const origPubKey = await original.xOnlyPublicKey();
+            const restoredPubKey = await restored.xOnlyPublicKey();
+            expect(Array.from(restoredPubKey)).toEqual(Array.from(origPubKey));
+            expect(restored.mnemonic).toBe(TEST_MNEMONIC);
+        });
+
+        it("should restore from seed JSON", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const original = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const json = original.toJSON();
+            const restored = SeedIdentity.fromJSON(json);
+
+            const origPubKey = await original.xOnlyPublicKey();
+            const restoredPubKey = await restored.xOnlyPublicKey();
+            expect(Array.from(restoredPubKey)).toEqual(Array.from(origPubKey));
+            expect(restored.mnemonic).toBeUndefined();
+        });
+
+        it("should infer mainnet from descriptor coin type", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const mainnet = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const testnet = SeedIdentity.fromSeed(seed, { isMainnet: false });
+
+            const restoredMainnet = SeedIdentity.fromJSON(mainnet.toJSON());
+            const restoredTestnet = SeedIdentity.fromJSON(testnet.toJSON());
+
+            expect(restoredMainnet.isMainnet).toBe(true);
+            expect(restoredTestnet.isMainnet).toBe(false);
+        });
+
+        it("should throw on xpub mismatch", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const json = identity.toJSON();
+            // Use a different seed to cause mismatch
+            const otherSeed = mnemonicToSeedSync(TEST_MNEMONIC, "different");
+            json.seed = hex.encode(otherSeed);
+            delete (json as any).mnemonic;
+
+            expect(() => SeedIdentity.fromJSON(json)).toThrow("xpub mismatch");
+        });
+
+        it("should throw on missing mnemonic and seed", () => {
+            expect(() =>
+                SeedIdentity.fromJSON({ descriptor: "tr(xpub.../0/0)" } as any)
+            ).toThrow("JSON must contain either mnemonic or seed");
+        });
+    });
+
+    describe("SeedIdentity.fromMnemonic", () => {
+        it("should store the mnemonic on the identity", () => {
+            const identity = SeedIdentity.fromMnemonic(TEST_MNEMONIC, {
+                isMainnet: true,
+            });
+            expect(identity.mnemonic).toBe(TEST_MNEMONIC);
+        });
+
+        it("should produce same key as MnemonicIdentity.fromMnemonic", async () => {
+            const fromSeed = SeedIdentity.fromMnemonic(TEST_MNEMONIC, {
+                isMainnet: true,
+            });
+            const fromMnemonic = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+                isMainnet: true,
+            });
+
+            const pubKey1 = await fromSeed.xOnlyPublicKey();
+            const pubKey2 = await fromMnemonic.xOnlyPublicKey();
+            expect(Array.from(pubKey1)).toEqual(Array.from(pubKey2));
+        });
+
+        it("should throw for invalid mnemonic", () => {
+            expect(() =>
+                SeedIdentity.fromMnemonic("invalid mnemonic words here", {
+                    isMainnet: false,
+                })
+            ).toThrow("Invalid mnemonic");
+        });
+    });
+});
+
+// ============================================================
+// New tests: ReadonlySeedIdentity
+// ============================================================
+
+describe("ReadonlySeedIdentity", () => {
+    describe("fromDescriptor", () => {
+        it("should create identity from descriptor", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            const identityPubKey = await identity.xOnlyPublicKey();
+            const readonlyPubKey = await readonly.xOnlyPublicKey();
+            expect(Array.from(readonlyPubKey)).toEqual(
+                Array.from(identityPubKey)
+            );
+        });
+    });
+
+    describe("fromJSON / toJSON", () => {
+        it("should serialize and restore via JSON", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const original = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+            const json = original.toJSON();
+            expect(json.descriptor).toBeDefined();
+
+            // The serialized descriptor should have wildcard
+            expect(json.descriptor).toMatch(/\/0\/\*\)$/);
+
+            // Restore from JSON — wildcard gets resolved to index 0
+            const restored = ReadonlySeedIdentity.fromJSON(json);
+            const origPubKey = await original.xOnlyPublicKey();
+            const restoredPubKey = await restored.xOnlyPublicKey();
+            expect(Array.from(restoredPubKey)).toEqual(Array.from(origPubKey));
+        });
+    });
+
+    describe("deriveSigningDescriptor", () => {
+        it("should match SeedIdentity deriveSigningDescriptor", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            const fullDesc = identity.deriveSigningDescriptor(3);
+            const readonlyDesc = readonly.deriveSigningDescriptor(3);
+            expect(readonlyDesc).toBe(fullDesc);
+        });
+
+        it("should produce descriptor at index 0 matching the identity descriptor", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            expect(readonly.deriveSigningDescriptor(0)).toBe(
+                identity.descriptor
+            );
+        });
+
+        it("should throw for negative index", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            expect(() => readonly.deriveSigningDescriptor(-1)).toThrow(
+                "Index must be non-negative"
+            );
+        });
+    });
+
+    describe("isOurs", () => {
+        it("should return true for own descriptors", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            expect(readonly.isOurs(identity.descriptor)).toBe(true);
+            expect(readonly.isOurs(identity.deriveSigningDescriptor(5))).toBe(
+                true
+            );
+        });
+
+        it("should return false for foreign descriptors", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            const otherSeed = mnemonicToSeedSync(TEST_MNEMONIC, "other");
+            const other = SeedIdentity.fromSeed(otherSeed, {
+                isMainnet: true,
+            });
+            expect(readonly.isOurs(other.descriptor)).toBe(false);
+        });
+
+        it("should return false for invalid descriptor", () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            expect(readonly.isOurs("invalid")).toBe(false);
+        });
+    });
+
+    describe("xOnlyPublicKeyAtIndex", () => {
+        it("should return 32-byte key at index 0 matching xOnlyPublicKey", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            const pubKey = await readonly.xOnlyPublicKeyAtIndex(0);
+            const defaultPubKey = await readonly.xOnlyPublicKey();
+            expect(pubKey).toHaveLength(32);
+            expect(Array.from(pubKey)).toEqual(Array.from(defaultPubKey));
+        });
+
+        it("should return different keys for different indexes", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            const pubKey0 = await readonly.xOnlyPublicKeyAtIndex(0);
+            const pubKey5 = await readonly.xOnlyPublicKeyAtIndex(5);
+            expect(Array.from(pubKey0)).not.toEqual(Array.from(pubKey5));
+        });
+    });
+
+    describe("compressedPublicKeyAtIndex", () => {
+        it("should return 33-byte key at index 0 matching compressedPublicKey", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            const pubKey = await readonly.compressedPublicKeyAtIndex(0);
+            const defaultPubKey = await readonly.compressedPublicKey();
+            expect(pubKey).toHaveLength(33);
+            expect(Array.from(pubKey)).toEqual(Array.from(defaultPubKey));
+        });
+
+        it("should return different keys for different indexes", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            const readonly = ReadonlySeedIdentity.fromDescriptor(
+                identity.descriptor
+            );
+
+            const pubKey0 = await readonly.compressedPublicKeyAtIndex(0);
+            const pubKey5 = await readonly.compressedPublicKeyAtIndex(5);
+            expect(Array.from(pubKey0)).not.toEqual(Array.from(pubKey5));
+        });
+    });
+});
+
+// ============================================================
+// Backwards compatibility
+// ============================================================
+
+describe("backwards compatibility", () => {
+    it("xOnlyPublicKey() should match deriveSigningDescriptor(0) key", async () => {
+        const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+        const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+        const desc0 = identity.deriveSigningDescriptor(0);
+
+        // The default xOnlyPublicKey is the key at index 0
+        expect(desc0).toBe(identity.descriptor);
+
+        const defaultPubKey = await identity.xOnlyPublicKey();
+
+        // Create a readonly from desc0 and compare
+        const readonly0 = ReadonlySeedIdentity.fromDescriptor(desc0);
+        const pubKeyFromDesc = await readonly0.xOnlyPublicKey();
+        expect(Array.from(pubKeyFromDesc)).toEqual(Array.from(defaultPubKey));
+    });
+
+    it("existing sign() API still works", async () => {
+        const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+        const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+        const message = new Uint8Array(32).fill(99);
+
+        const signature = await identity.signMessage(message);
+        expect(signature).toBeInstanceOf(Uint8Array);
+        expect(signature).toHaveLength(64);
+    });
+
+    it("ReadonlyDescriptorIdentity alias still works", () => {
+        expect(ReadonlyDescriptorIdentity).toBe(ReadonlySeedIdentity);
+    });
+
+    it("ReadonlyDescriptorIdentity alias is available from identity module", async () => {
+        const { ReadonlyDescriptorIdentity, ReadonlySeedIdentity } =
+            await import("../src/identity");
+        expect(ReadonlyDescriptorIdentity).toBe(ReadonlySeedIdentity);
     });
 });

--- a/test/seedIdentity.test.ts
+++ b/test/seedIdentity.test.ts
@@ -582,8 +582,8 @@ describe("SeedIdentity HD methods", () => {
             });
 
             await expect(
-                identity.signWithDescriptor(otherIdentity.descriptor, [
-                    { tx: null as any },
+                identity.signWithDescriptor([
+                    { descriptor: otherIdentity.descriptor, tx: null as any },
                 ])
             ).rejects.toThrow("Descriptor does not belong to this identity");
         });
@@ -592,10 +592,7 @@ describe("SeedIdentity HD methods", () => {
             const seed = mnemonicToSeedSync(TEST_MNEMONIC);
             const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
 
-            const results = await identity.signWithDescriptor(
-                identity.descriptor,
-                []
-            );
+            const results = await identity.signWithDescriptor([]);
             expect(results).toEqual([]);
         });
     });

--- a/test/staticDescriptorProvider.test.ts
+++ b/test/staticDescriptorProvider.test.ts
@@ -110,16 +110,18 @@ describe("StaticDescriptorProvider", () => {
 
     describe("signWithDescriptor", () => {
         it("should handle empty requests array", async () => {
-            const results = await provider.signWithDescriptor(
-                `tr(${pubKeyHex})`,
-                []
-            );
+            const results = await provider.signWithDescriptor([]);
             expect(results).toEqual([]);
         });
 
         it("should throw for foreign descriptor", async () => {
             await expect(
-                provider.signWithDescriptor("tr(" + "b".repeat(64) + ")", [])
+                provider.signWithDescriptor([
+                    {
+                        descriptor: "tr(" + "b".repeat(64) + ")",
+                        tx: null as any,
+                    },
+                ])
             ).rejects.toThrow("does not belong");
         });
     });

--- a/test/staticDescriptorProvider.test.ts
+++ b/test/staticDescriptorProvider.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { hex } from "@scure/base";
+import { StaticDescriptorProvider } from "../src/identity/staticDescriptorProvider";
+import { SingleKey } from "../src/identity/singleKey";
+
+// Well-known test private key (32 bytes, all 0x01)
+const TEST_PRIVKEY = new Uint8Array(32).fill(1);
+
+describe("StaticDescriptorProvider", () => {
+    let provider: StaticDescriptorProvider;
+    let pubKeyHex: string;
+
+    beforeEach(async () => {
+        const identity = SingleKey.fromPrivateKey(TEST_PRIVKEY);
+        provider = await StaticDescriptorProvider.create(identity);
+        const pubKey = await identity.xOnlyPublicKey();
+        pubKeyHex = hex.encode(pubKey);
+    });
+
+    describe("create", () => {
+        it("should create from Identity", () => {
+            expect(provider).toBeInstanceOf(StaticDescriptorProvider);
+        });
+    });
+
+    describe("getSigningDescriptor", () => {
+        it("should return tr(<pubkey>) format", () => {
+            const descriptor = provider.getSigningDescriptor();
+            expect(descriptor).toBe(`tr(${pubKeyHex})`);
+        });
+
+        it("should return consistent descriptor", () => {
+            expect(provider.getSigningDescriptor()).toBe(
+                provider.getSigningDescriptor()
+            );
+        });
+    });
+
+    describe("isOurs", () => {
+        it("should return true for own descriptor", () => {
+            expect(provider.isOurs(`tr(${pubKeyHex})`)).toBe(true);
+        });
+
+        it("should return true for raw hex pubkey", () => {
+            expect(provider.isOurs(pubKeyHex)).toBe(true);
+        });
+
+        it("should return true for uppercase hex", () => {
+            expect(provider.isOurs(pubKeyHex.toUpperCase())).toBe(true);
+        });
+
+        it("should return true for tr(UPPERCASE)", () => {
+            expect(provider.isOurs(`tr(${pubKeyHex.toUpperCase()})`)).toBe(
+                true
+            );
+        });
+
+        it("should return false for different pubkey", () => {
+            expect(provider.isOurs("tr(" + "b".repeat(64) + ")")).toBe(false);
+        });
+
+        it("should return false for HD descriptor", () => {
+            expect(
+                provider.isOurs("tr([12345678/86'/0'/0']xpubSomething/0/5)")
+            ).toBe(false);
+        });
+    });
+
+    describe("signMessageWithDescriptor", () => {
+        it("should sign with schnorr by default", async () => {
+            const message = new Uint8Array(32).fill(42);
+            const signature = await provider.signMessageWithDescriptor(
+                `tr(${pubKeyHex})`,
+                message
+            );
+            expect(signature).toBeInstanceOf(Uint8Array);
+            expect(signature).toHaveLength(64);
+        });
+
+        it("should sign with ecdsa", async () => {
+            const message = new Uint8Array(32).fill(42);
+            const signature = await provider.signMessageWithDescriptor(
+                `tr(${pubKeyHex})`,
+                message,
+                "ecdsa"
+            );
+            expect(signature).toBeInstanceOf(Uint8Array);
+            expect(signature).toHaveLength(64);
+        });
+
+        it("should accept raw hex pubkey", async () => {
+            const message = new Uint8Array(32).fill(42);
+            const signature = await provider.signMessageWithDescriptor(
+                pubKeyHex,
+                message
+            );
+            expect(signature).toHaveLength(64);
+        });
+
+        it("should throw for foreign descriptor", async () => {
+            const message = new Uint8Array(32).fill(42);
+            await expect(
+                provider.signMessageWithDescriptor(
+                    "tr(" + "b".repeat(64) + ")",
+                    message
+                )
+            ).rejects.toThrow("does not belong");
+        });
+    });
+
+    describe("signWithDescriptor", () => {
+        it("should handle empty requests array", async () => {
+            const results = await provider.signWithDescriptor(
+                `tr(${pubKeyHex})`,
+                []
+            );
+            expect(results).toEqual([]);
+        });
+
+        it("should throw for foreign descriptor", async () => {
+            await expect(
+                provider.signWithDescriptor("tr(" + "b".repeat(64) + ")", [])
+            ).rejects.toThrow("does not belong");
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add descriptor utility functions for output descriptor parsing (`descriptor.ts`)
- Add `DescriptorProvider` interface for descriptor-based signing abstraction
- Add `StaticDescriptorProvider` to wrap legacy `Identity` as a `DescriptorProvider`
- Extend `SeedIdentity` with HD wallet methods: `deriveSigningDescriptor`, `isOurs`, `signWithDescriptor`, `signMessageWithDescriptor`, `toJSON`/`fromJSON`
- Add `ReadonlySeedIdentity` with HD derivation and serialization support
- Update `DefaultContractHandler` to use descriptor strings instead of `Uint8Array` for pubkeys
- Add `walletDescriptor` to `PathContext` (deprecating `walletPubKey`)
- Migrate descriptor parsing from `@kukks/bitcoin-descriptors` to `@bitcoinerlab/descriptors-scure`

## Test plan
- [x] Unit tests for descriptor utilities (isDescriptor, normalizeToDescriptor, extractPubKey, parseHDDescriptor)
- [x] Unit tests for SeedIdentity HD methods (deriveSigningDescriptor, isOurs, signWithDescriptor, signMessageWithDescriptor)
- [x] Unit tests for SeedIdentity JSON serialization/deserialization
- [x] Unit tests for ReadonlySeedIdentity (fromDescriptor, fromJSON, toJSON, deriveSigningDescriptor, isOurs)
- [x] Unit tests for StaticDescriptorProvider
- [x] Unit tests for DefaultContractHandler descriptor support (serialize, deserialize, createScript)
- [x] All 863 existing unit tests pass with no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Descriptor-aware identities and signing: detect/normalize descriptors, extract pubkeys, per-descriptor signing, and a static descriptor provider.
  * HD/indexed wallet support: derive per-index signing descriptors, export/import identity JSON, and sign specific inputs or descriptors.

* **Refactor**
  * Public key params now use descriptor/hex string formats and preserve descriptor strings across serialize/deserialize and script generation.

* **Tests**
  * Comprehensive descriptor, identity, provider, and handler tests added/updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->