### PR TITLE
Use Go 1.25.7

### DIFF
--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.25.6 AS builder
+FROM golang:1.25.7 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/wallet.Dockerfile
+++ b/wallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.25.6 AS builder
+FROM golang:1.25.7 AS builder
 
 ARG VERSION
 ARG TARGETOS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go build environment from version 1.25.6 to 1.25.7 for server and wallet services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->