### PR TITLE
fix: Handle issuance in TxHistory

### DIFF
--- a/src/utils/transactionHistory.ts
+++ b/src/utils/transactionHistory.ts
@@ -27,20 +27,20 @@ function subtractAssets(
     change: VirtualCoin[]
 ): Asset[] | undefined {
     const map = new Map<string, number>();
-    for (const vtxo of spent) {
+    for (const vtxo of change) {
         if (vtxo.assets) {
             for (const a of vtxo.assets) {
                 map.set(a.assetId, (map.get(a.assetId) ?? 0) + a.amount);
             }
         }
     }
-    for (const vtxo of change) {
+    for (const vtxo of spent) {
         if (vtxo.assets) {
             for (const a of vtxo.assets) {
                 const current = map.get(a.assetId) ?? 0;
                 const remaining = current - a.amount;
                 if (remaining !== 0) {
-                    map.set(a.assetId, Math.abs(remaining));
+                    map.set(a.assetId, remaining);
                 } else {
                     map.delete(a.assetId);
                 }
@@ -214,7 +214,7 @@ export async function buildTransactionHistory(
                     }
                 } else {
                     // forfeitAmount > 0 && settledAmount == 0 --> collaborative exit without any offchain change
-                    const assets = collectAssets(forfeitVtxos);
+                    const assets = subtractAssets(forfeitVtxos, []);
                     sent.push({
                         key: { ...txKey, commitmentTxid: vtxo.settledBy },
                         tag: "exit",


### PR DESCRIPTION
instead of removing the asset in case change > spent, we should add it because it is a valid issuance/reissuance.

@Kukks @pietro909 please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset reconciliation in transaction history so sent/returned assets and forfeitures are calculated and preserved correctly, preventing loss or misattribution of non-zero asset balances.

* **Tests**
  * Added extensive tests covering issuance, reissuance, burns, mixed operations, and multi-input aggregation to validate asset history and net sent amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->