### PR TITLE
register intent after opening the stream

### DIFF
--- a/src/providers/ark.ts
+++ b/src/providers/ark.ts
@@ -482,7 +482,7 @@ export class RestArkProvider implements ArkProvider {
         }
     }
 
-    async *getEventStream(
+    getEventStream(
         signal: AbortSignal,
         topics: string[]
     ): AsyncIterableIterator<SettlementEvent> {
@@ -492,53 +492,67 @@ export class RestArkProvider implements ArkProvider {
                 ? `?${topics.map((topic) => `topics=${encodeURIComponent(topic)}`).join("&")}`
                 : "";
 
-        while (!signal?.aborted) {
-            try {
-                const eventSource = new EventSource(url + queryParams);
+        // Create first EventSource eagerly so events are buffered
+        // before the caller starts iterating, preventing race conditions
+        // where the server emits events before iteration begins.
+        const eagerEventSource = new EventSource(url + queryParams);
+        const eagerIterator = eventSourceIterator(eagerEventSource);
 
-                // Set up abort handling
-                const abortHandler = () => {
-                    eventSource.close();
-                };
-                signal?.addEventListener("abort", abortHandler);
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
+        return (async function* () {
+            let firstIteration = true;
+            while (!signal?.aborted) {
+                const eventSource = firstIteration
+                    ? eagerEventSource
+                    : new EventSource(url + queryParams);
+                const iterator = firstIteration
+                    ? eagerIterator
+                    : eventSourceIterator(eventSource);
+                firstIteration = false;
 
                 try {
-                    for await (const event of eventSourceIterator(
-                        eventSource
-                    )) {
-                        if (signal?.aborted) break;
+                    const abortHandler = () => {
+                        eventSource.close();
+                    };
+                    signal?.addEventListener("abort", abortHandler);
 
-                        try {
-                            const data = JSON.parse(event.data);
-                            const settlementEvent =
-                                this.parseSettlementEvent(data);
-                            if (settlementEvent) {
-                                yield settlementEvent;
+                    try {
+                        for await (const event of iterator) {
+                            if (signal?.aborted) break;
+
+                            try {
+                                const data = JSON.parse(event.data);
+                                const settlementEvent =
+                                    self.parseSettlementEvent(data);
+                                if (settlementEvent) {
+                                    yield settlementEvent;
+                                }
+                            } catch (err) {
+                                console.error("Failed to parse event:", err);
+                                throw err;
                             }
-                        } catch (err) {
-                            console.error("Failed to parse event:", err);
-                            throw err;
                         }
+                    } finally {
+                        signal?.removeEventListener("abort", abortHandler);
+                        eventSource.close();
                     }
-                } finally {
-                    signal?.removeEventListener("abort", abortHandler);
-                    eventSource.close();
-                }
-            } catch (error) {
-                if (error instanceof Error && error.name === "AbortError") {
-                    break;
-                }
+                } catch (error) {
+                    if (error instanceof Error && error.name === "AbortError") {
+                        break;
+                    }
 
-                // ignore timeout errors, they're expected when the server is not sending anything for 5 min
-                if (isFetchTimeoutError(error)) {
-                    console.debug("Timeout error ignored");
-                    continue;
-                }
+                    // ignore timeout errors, they're expected when the server is not sending anything for 5 min
+                    if (isFetchTimeoutError(error)) {
+                        console.debug("Timeout error ignored");
+                        continue;
+                    }
 
-                console.error("Event stream error:", error);
-                throw error;
+                    console.error("Event stream error:", error);
+                    throw error;
+                }
             }
-        }
+        })();
     }
 
     async *getTransactionsStream(signal: AbortSignal): AsyncIterableIterator<{

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,4 +1,10 @@
-export async function* eventSourceIterator(
+/**
+ * Creates an async iterator over EventSource messages that attaches listeners
+ * eagerly (at call time) rather than lazily (at first .next() call).
+ * This ensures events are buffered immediately, preventing race conditions
+ * where events arrive before iteration begins.
+ */
+export function eventSourceIterator(
     eventSource: EventSource
 ): AsyncGenerator<MessageEvent, void, unknown> {
     const messageQueue: MessageEvent[] = [];
@@ -26,41 +32,45 @@ export async function* eventSourceIterator(
         }
     };
 
+    // Attach listeners immediately so events are buffered
+    // even before the caller starts iterating
     eventSource.addEventListener("message", messageHandler);
     eventSource.addEventListener("error", errorHandler);
 
-    try {
-        while (true) {
-            // if we have queued messages, yield the first one, remove it from the queue
-            if (messageQueue.length > 0) {
-                yield messageQueue.shift()!;
-                continue;
-            }
-
-            // if we have queued errors, throw the first one, remove it from the queue
-            if (errorQueue.length > 0) {
-                const error = errorQueue.shift()!;
-                throw error;
-            }
-
-            // wait for the next message or error
-            const result = await new Promise<MessageEvent>(
-                (resolve, reject) => {
-                    messageResolve = resolve;
-                    errorResolve = reject;
+    return (async function* () {
+        try {
+            while (true) {
+                // if we have queued messages, yield the first one, remove it from the queue
+                if (messageQueue.length > 0) {
+                    yield messageQueue.shift()!;
+                    continue;
                 }
-            ).finally(() => {
-                messageResolve = null;
-                errorResolve = null;
-            });
 
-            if (result) {
-                yield result;
+                // if we have queued errors, throw the first one, remove it from the queue
+                if (errorQueue.length > 0) {
+                    const error = errorQueue.shift()!;
+                    throw error;
+                }
+
+                // wait for the next message or error
+                const result = await new Promise<MessageEvent>(
+                    (resolve, reject) => {
+                        messageResolve = resolve;
+                        errorResolve = reject;
+                    }
+                ).finally(() => {
+                    messageResolve = null;
+                    errorResolve = null;
+                });
+
+                if (result) {
+                    yield result;
+                }
             }
+        } finally {
+            // clean up
+            eventSource.removeEventListener("message", messageHandler);
+            eventSource.removeEventListener("error", errorHandler);
         }
-    } finally {
-        // clean up
-        eventSource.removeEventListener("message", messageHandler);
-        eventSource.removeEventListener("error", errorHandler);
-    }
+    })();
 }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1100,26 +1100,6 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 topics
             );
 
-            // Prime the async generator to ensure the EventSource connection
-            // is established before registering the intent. Without this,
-            // the generator body (which creates the EventSource) doesn't
-            // execute until Batch.join starts iterating, creating a race
-            // where the server emits batch_started before we're listening.
-            //
-            // Calling .next() without awaiting starts the generator body
-            // (which creates the EventSource), but doesn't block since
-            // the generator will suspend at its first yield.
-            const firstNext = stream.next();
-
-            // Wrap the stream to replay the primed first result
-            const primedStream = (async function* () {
-                const first = await firstNext;
-                if (!first.done) {
-                    yield first.value;
-                }
-                yield* stream;
-            })();
-
             const intentId = await this.safeRegisterIntent(intent);
 
             const handler = this.createBatchHandler(
@@ -1129,7 +1109,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 session
             );
 
-            const commitmentTxid = await Batch.join(primedStream, handler, {
+            const commitmentTxid = await Batch.join(stream, handler, {
                 abortController,
                 skipVtxoTreeSigning: !hasOffchainOutputs,
                 eventCallback: eventCallback


### PR DESCRIPTION
Closes #310 

@louisinger please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reordered event-stream setup so streams are initialized before registration/handler creation, and introduced eager buffering and explicit cleanup for event sources.
* **Bug Fixes**
  * Reduced race conditions and missed/out-of-order events by improving stream instantiation, parsing error handling, and abort/cleanup semantics for more reliable wallet sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->