### PR TITLE
fix: tolerate trailing TLV bytes in asset packet parser

### DIFF
--- a/src/asset/packet.ts
+++ b/src/asset/packet.ts
@@ -196,6 +196,10 @@ function extractRawPacketFromScript(script: Uint8Array): Uint8Array {
     const tlvData = payload.slice(ARKADE_MAGIC.length);
 
     // Scan for the asset marker byte — it may not be the first record.
+    // Prefer non-empty candidates: a 0x00 byte embedded in another record's
+    // value may accidentally parse as count=0 (empty packet). If that happens
+    // we save it as a fallback and keep scanning for a non-empty match.
+    let emptyFallback: Uint8Array | null = null;
     for (let i = 0; i < tlvData.length; i++) {
         if (tlvData[i] !== MARKER_ASSET_PAYLOAD) continue;
 
@@ -203,14 +207,26 @@ function extractRawPacketFromScript(script: Uint8Array): Uint8Array {
         if (candidate.length === 0) continue;
 
         try {
-            parseAssetGroups(new BufferReader(candidate));
-            return candidate;
+            const groups = parseAssetGroups(new BufferReader(candidate));
+            if (groups.length > 0) {
+                // Non-empty: this is definitely the real asset marker.
+                return candidate;
+            }
+            // count=0: could be a genuine empty asset record, or a false
+            // positive from a 0x00 byte inside a preceding TLV record's value.
+            // Save as fallback and keep scanning for a non-empty record.
+            if (emptyFallback === null) {
+                emptyFallback = candidate;
+            }
         } catch {
             // False positive — 0x00 byte is part of another record.
             continue;
         }
     }
 
+    if (emptyFallback !== null) {
+        return emptyFallback;
+    }
     throw new Error("asset marker not found in TLV stream");
 }
 

--- a/test/asset.test.ts
+++ b/test/asset.test.ts
@@ -656,6 +656,36 @@ describe("Packet", () => {
             });
         });
 
+        describe("false marker embedded in preceding TLV record", () => {
+            it("should prefer non-empty candidate over false empty match", () => {
+                // A preceding TLV record with value 0x00 creates a false
+                // "0x00 0x00" sequence. The scanner must prefer the non-empty
+                // candidate (real asset data) over the empty count=0 parse.
+                //
+                // Layout: ARK + [0x02 0x00] + [0x00 asset_data]
+                //   0x02 = fake type, 0x00 = its value (false marker)
+                //   0x00 = real asset marker, then real groups
+                const injected =
+                    "6a1741524b" +       // OP_RETURN + push + "ARK"
+                    "0200" +             // fake TLV record (type 0x02, value 0x00)
+                    "0001020200000001010000c0de810a"; // real asset record
+
+                const packet = Packet.fromString(injected);
+                expect(packet).toBeDefined();
+                expect(packet.groups).toHaveLength(1);
+            });
+
+            it("should recognize false-marker script as asset packet", () => {
+                const injected =
+                    "6a1741524b" +
+                    "0200" +
+                    "0001020200000001010000c0de810a";
+                const script = hex.decode(injected);
+
+                expect(Packet.isAssetPacket(script)).toBe(true);
+            });
+        });
+
         describe("arbitrary TLV record order", () => {
             it("should find asset record when another record precedes it", () => {
                 // Original: 6a 12 41524b 00 01020200000001010000c0de810a


### PR DESCRIPTION
## Summary

The asset packet parser in `Packet.fromReader` strictly rejected any unread bytes remaining after parsing all asset groups:

```ts
if (reader.remaining() > 0) {
    throw new Error(`invalid packet length, left ${reader.remaining()} unknown bytes to read`);
}
```

This is incorrect for a TLV (Type-Length-Value) encoded format. The TLV spec is designed for forward compatibility: a parser should read the types it knows about and **ignore** any unknown trailing records. Newer protocol versions may append additional TLV fields, and older parsers must tolerate them gracefully.

In practice this bug causes failures when the `arkd` server includes additional TLV data in asset packets that the TypeScript SDK does not yet recognize.

## Changes

- **`src/asset/packet.ts`**: Remove the trailing bytes check in `Packet.fromReader`. After reading all expected asset groups, any remaining bytes in the buffer are now silently ignored.
- **`test/asset.test.ts`**: Add two tests that verify parsing succeeds when trailing TLV bytes are present after the asset groups (via `fromString` and `fromTxOut`).

## References

- The same fix was applied to the Go SDK in arkade-os/arkd#945
- The same bug also exists in the .NET SDK (`dotnet-sdk`) and will need a similar fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Packets now tolerate trailing unknown bytes after asset groups and correctly handle arbitrary TLV record ordering to avoid misclassification.

* **New Features**
  * Improved asset-packet detection that scans for valid payload markers and verifies candidates to reduce false positives, preserving empty candidates when appropriate.

* **Tests**
  * Added tests validating parsing with trailing TLV bytes, false marker scenarios, and reordered/unknown TLV records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->