### PR TITLE
test: asset e2e tests for delegator lifecycle and cross-contract spending

### DIFF
--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -2177,16 +2177,6 @@ describe("Asset integration tests", () => {
                 ),
             });
 
-            // Fund default address and issue asset after delegation is set up
-            faucetOffchain(defaultAddress, 1_000);
-            await waitFor(async () => (await wallet1.getVtxos()).length > 0);
-
-            const issueResult = await wallet2.assetManager.issue({
-                amount: 500,
-            });
-            expect(issueResult.assetId).toBeDefined();
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-
             const delegateAddress = await wallet2.getAddress();
             expect(delegateAddress).not.toBe(defaultAddress);
 
@@ -2196,6 +2186,16 @@ describe("Asset integration tests", () => {
                 type: ["default", "delegate"],
             });
             expect(contracts).toHaveLength(2);
+
+            // Fund default address and issue asset after delegation is set up
+            faucetOffchain(defaultAddress, 1_000);
+            await waitFor(async () => (await wallet2.getVtxos()).length > 0);
+
+            const issueResult = await wallet2.assetManager.issue({
+                amount: 500,
+            });
+            expect(issueResult.assetId).toBeDefined();
+            await new Promise((resolve) => setTimeout(resolve, 1000));
 
             faucetOffchain(delegateAddress, 1_000);
             await waitFor(async () => (await wallet2.getVtxos()).length >= 2);


### PR DESCRIPTION
## Summary
- Extends asset integration tests to cover the same delegator and cross-contract scenarios recently added for plain sats in #330
- Adds 3 new e2e tests:
  - **Delegator lifecycle with assets**: issue assets across delegator add/remove phases, verify assets preserved through cross-pool sends and forfeit path spending
  - **Cross-contract spending with assets**: issue asset on default contract, enable delegator, send requiring both VTXO pools with assets, verify asset change lands on delegate contract
  - **Cross-contract spending with assets (funded after delegation)**: same scenario but funding occurs after delegation is configured

## Test plan
- [ ] Run e2e tests with `pnpm test:e2e` against a local nigiri + arkd environment
- [ ] Verify asset amounts are correctly split between sender change and receiver
- [ ] Verify assets survive cross-contract and forfeit-path spending