### PR TITLE
Fix event binding and timeouts

### DIFF
--- a/src/worker/messageBus.ts
+++ b/src/worker/messageBus.ts
@@ -117,6 +117,7 @@ export class MessageBus {
         wallet?: Wallet;
         readonlyWallet: ReadonlyWallet;
     }>;
+    private readonly boundOnMessage = this.onMessage.bind(this);
 
     constructor(
         private readonly walletRepository: WalletRepository,
@@ -142,7 +143,7 @@ export class MessageBus {
         if (this.debug) console.log("MessageBus starting");
 
         // Hook message routing
-        self.addEventListener("message", this.onMessage.bind(this));
+        self.addEventListener("message", this.boundOnMessage);
 
         // activate service worker immediately
         self.addEventListener("install", () => {
@@ -168,7 +169,7 @@ export class MessageBus {
             this.tickTimeout = null;
         }
 
-        self.removeEventListener("message", this.onMessage.bind(this));
+        self.removeEventListener("message", this.boundOnMessage);
 
         await Promise.all(
             Array.from(this.handlers.values()).map((updater) => updater.stop())
@@ -330,6 +331,9 @@ export class MessageBus {
             if (this.debug) {
                 console.log("Init Command received");
             }
+            // Intentionally not wrapped with withTimeout: initialization
+            // performs network calls (buildServices) and handler startup
+            // that may legitimately exceed the message timeout.
             await this.waitForInit(event.data.config);
             event.source?.postMessage({ id, tag });
             if (this.debug) {
@@ -434,10 +438,12 @@ export class MessageBus {
         }
     }
 
-    private withTimeout<T>(
-        promise: Promise<T>,
-        label: string
-    ): Promise<T> {
+    /**
+     * Race `promise` against a timeout. Note: this does NOT cancel the
+     * underlying work — the original promise keeps running. This is safe
+     * here because only the caller (not the handler) posts the response.
+     */
+    private withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
         if (this.messageTimeoutMs <= 0) return promise;
         return new Promise((resolve, reject) => {
             const timer = self.setTimeout(() => {


### PR DESCRIPTION
  - Fix service worker lifetime management: call `event.waitUntil()` on incoming messages so the browser doesn't terminate the SW mid-operation                                                                                                                   
  - Add configurable timeout (`messageTimeoutMs`, default 30s) to all `handleMessage` and tick calls to prevent hung handlers from blocking responses indefinitely                                                                                                  
  - Fix `removeEventListener` in `stop()` - previously used a new `.bind()` reference each time, so the listener was never actually removed    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout protection for message operations to prevent indefinite waits and improve system responsiveness during message processing.

* **Bug Fixes**
  * Improved message processing reliability with enhanced safeguards for initialization failures and better error recovery when operations take longer than expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->