### PR TITLE
add asset packet to last output of intent

### DIFF
--- a/src/wallet/delegator.ts
+++ b/src/wallet/delegator.ts
@@ -392,9 +392,9 @@ async function makeSignedDelegateIntent(
 
     let outputAssets: Asset[] | undefined;
 
-    // find our own output by matching the destination script
-    const assetOutputIndex = outputs.findIndex(
-        (o) => o.script && equalBytes(o.script, destinationScript)
+    const assetOutputIndex = findDestinationOutputIndex(
+        outputs,
+        destinationScript
     );
 
     if (assetInputs.size > 0) {
@@ -444,6 +444,19 @@ async function makeSignedDelegateIntent(
         proof: base64.encode(signedProof.toPSBT()),
         message,
     };
+}
+
+/**
+ * Finds the index of the output whose script matches the destination script.
+ * Returns -1 if no match is found.
+ */
+export function findDestinationOutputIndex(
+    outputs: TransactionOutput[],
+    destinationScript: Bytes
+): number {
+    return outputs.findIndex(
+        (o) => o.script && equalBytes(o.script, destinationScript)
+    );
 }
 
 function getDayTimestamp(timestamp: number): number {

--- a/test/wallet/delegator.test.ts
+++ b/test/wallet/delegator.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { findDestinationOutputIndex } from "../../src/wallet/delegator";
+
+describe("findDestinationOutputIndex", () => {
+    const scriptA = new Uint8Array([0x00, 0x14, 0xaa, 0xbb]);
+    const scriptB = new Uint8Array([0x00, 0x14, 0xcc, 0xdd]);
+    const scriptC = new Uint8Array([0x00, 0x14, 0xee, 0xff]);
+
+    it("should find the destination output when it is the last output", () => {
+        const outputs = [
+            { script: scriptA, amount: 1000n },
+            { script: scriptB, amount: 5000n },
+        ];
+        expect(findDestinationOutputIndex(outputs, scriptB)).toBe(1);
+    });
+
+    it("should find the destination output when it is the first output", () => {
+        const outputs = [
+            { script: scriptB, amount: 5000n },
+            { script: scriptA, amount: 1000n },
+        ];
+        expect(findDestinationOutputIndex(outputs, scriptB)).toBe(0);
+    });
+
+    it("should find the destination output in the middle", () => {
+        const outputs = [
+            { script: scriptA, amount: 1000n },
+            { script: scriptB, amount: 5000n },
+            { script: scriptC, amount: 3000n },
+        ];
+        expect(findDestinationOutputIndex(outputs, scriptB)).toBe(1);
+    });
+
+    it("should return -1 when no output matches", () => {
+        const outputs = [
+            { script: scriptA, amount: 1000n },
+            { script: scriptC, amount: 3000n },
+        ];
+        expect(findDestinationOutputIndex(outputs, scriptB)).toBe(-1);
+    });
+
+    it("should return -1 for empty outputs", () => {
+        expect(findDestinationOutputIndex([], scriptA)).toBe(-1);
+    });
+
+    it("should skip outputs with undefined script", () => {
+        const outputs = [{ amount: 1000n }, { script: scriptA, amount: 5000n }];
+        expect(findDestinationOutputIndex(outputs, scriptA)).toBe(1);
+    });
+
+    it("should not match outputs with different-length scripts", () => {
+        const shortScript = new Uint8Array([0x00, 0x14]);
+        const outputs = [{ script: shortScript, amount: 1000n }];
+        expect(findDestinationOutputIndex(outputs, scriptA)).toBe(-1);
+    });
+
+    it("should return the first match when duplicates exist", () => {
+        const outputs = [
+            { script: scriptA, amount: 1000n },
+            { script: scriptB, amount: 2000n },
+            { script: scriptB, amount: 3000n },
+        ];
+        expect(findDestinationOutputIndex(outputs, scriptB)).toBe(1);
+    });
+});


### PR DESCRIPTION
@Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Asset routing during delegation now targets the specified destination address rather than a fallback output, making delegation behavior predictable.
  * Transactions that include assets will now surface a clear error if no transaction output matches the requested destination, preventing silent misrouting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->