### PR TITLE
Don't log VTXO renewal errors for zero items and below dust

### DIFF
--- a/src/wallet/vtxo-manager.ts
+++ b/src/wallet/vtxo-manager.ts
@@ -863,6 +863,17 @@ export class VtxoManager implements AsyncDisposable {
                 }
 
                 this.renewVtxos().catch((e) => {
+                    if (e instanceof Error) {
+                        if (e.message.includes("No VTXOs available to renew")) {
+                            // Not an error, just no VTXO eligible for renewal.
+                            return;
+                        }
+                        if (e.message.includes("is below dust threshold")) {
+                            // Not an error, just below dust threshold.
+                            // As more VTXOs are received, the threshold will be raised.
+                            return;
+                        }
+                    }
                     console.error("Error renewing VTXOs:", e);
                 });
                 delegatorManager


### PR DESCRIPTION
With the latest version of the SDK I noticed a surge of errors like:

```
console.js:654 Error renewing VTXOs: Error: Total amount 207 is below dust threshold 330

wallet-service-worker.mjs:44026 Error renewing VTXOs: Error: No VTXOs available to renew
    at XC.renewVtxos (wallet-service-worker.mjs:43883:13)
```

I don't think they should qualify as errors: no VTXOs and below dust are legit conditions for a wallet at any point in its history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for VTXO renewal operations. Expected operational conditions such as no available VTXOs or amounts below the dust threshold now return gracefully without logging false errors. This reduces unnecessary noise in error logs, improving clarity while maintaining proper error reporting for genuine renewal failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->