### PR TITLE
arkTransaction: support two OP_RETURN outputs

### DIFF
--- a/src/utils/arkTransaction.ts
+++ b/src/utils/arkTransaction.ts
@@ -50,13 +50,28 @@ export function buildOffchainTx(
     outputs: TransactionOutput[],
     serverUnrollScript: CSVMultisigTapscript.Type
 ): OffchainTx {
+    // TODO: use arkd /info
+    const MAX_OP_RETURN = 2;
+
+    let countOpReturn = 0;
     let hasExtensionOutput = false;
     for (const [index, output] of outputs.entries()) {
         if (!output.script) throw new Error(`missing output script ${index}`);
         const isExtension = Extension.isExtension(output.script);
+        const isOpReturn =
+            isExtension || Script.decode(output.script)[0] === "RETURN";
+        if (isOpReturn) {
+            countOpReturn++;
+        }
         if (!isExtension) continue;
         if (hasExtensionOutput) throw new Error("multiple extension outputs");
         hasExtensionOutput = true;
+    }
+
+    if (countOpReturn > MAX_OP_RETURN) {
+        throw new Error(
+            `too many OP_RETURN outputs: ${countOpReturn} > ${MAX_OP_RETURN}`
+        );
     }
 
     const checkpoints = inputs.map((input) =>


### PR DESCRIPTION
Allow multiple OP_RETURN outputs thanks to https://github.com/arkade-os/arkd/pull/983
Still check for multiple extension outputs (only 1 extension allowed).

@pietro909 please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened transaction validation: enforces a maximum of two special/return-style outputs and prevents more than one special extension output.
  * Ensures transactions with an extension output ignore unrelated outputs, reducing false-positive invalidations and preventing malformed transaction configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->