### PR TITLE
Fix reinit bug

### DIFF
--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -120,7 +120,10 @@ import type { IVtxoManager, SettlementConfig } from "../vtxo-manager";
 import type { ContractWatcherConfig } from "../../contracts/contractWatcher";
 import type { DelegateInfo } from "../../providers/delegator";
 import { getRandomId } from "../utils";
-import { ServiceWorkerTimeoutError } from "../../worker/errors";
+import {
+    MESSAGE_BUS_NOT_INITIALIZED,
+    ServiceWorkerTimeoutError,
+} from "../../worker/errors";
 
 // Check by error message content instead of instanceof because postMessage uses the
 // structured clone algorithm which strips the prototype chain — the page
@@ -128,7 +131,7 @@ import { ServiceWorkerTimeoutError } from "../../worker/errors";
 function isMessageBusNotInitializedError(error: unknown): boolean {
     return (
         error instanceof Error &&
-        error.message.includes("MessageBus not initialized")
+        error.message.includes(MESSAGE_BUS_NOT_INITIALIZED)
     );
 }
 

--- a/src/worker/errors.ts
+++ b/src/worker/errors.ts
@@ -1,13 +1,13 @@
+export const MESSAGE_BUS_NOT_INITIALIZED = "MessageBus not initialized";
+
 export class MessageBusNotInitializedError extends Error {
     constructor() {
-        super("MessageBus not initialized");
-        this.name = "MessageBusNotInitializedError";
+        super(MESSAGE_BUS_NOT_INITIALIZED);
     }
 }
 
 export class ServiceWorkerTimeoutError extends Error {
     constructor(detail: string) {
         super(detail);
-        this.name = "ServiceWorkerTimeoutError";
     }
 }

--- a/test/serviceWorker/wallet.test.ts
+++ b/test/serviceWorker/wallet.test.ts
@@ -11,6 +11,7 @@ import {
     DEFAULT_MESSAGE_TAG,
 } from "../../src/wallet/serviceWorker/wallet-message-handler";
 import {
+    MESSAGE_BUS_NOT_INITIALIZED,
     MessageBusNotInitializedError,
     ServiceWorkerTimeoutError,
 } from "../../src/worker/errors";
@@ -269,7 +270,7 @@ describe("ServiceWorkerReadonlyWallet", () => {
         ).resolves.toEqual(contract);
         await expect(manager.deleteContract("c1")).resolves.toBeUndefined();
         await expect(
-            manager.getSpendablePaths({ contractScript: "c1" })
+            manager.getSpendablePaths({ contractScript: "c1" } as any)
         ).resolves.toEqual(paths);
         await expect(manager.isWatching()).resolves.toBe(true);
 
@@ -480,7 +481,7 @@ describe("sendMessage reinitialize on SW restart", () => {
                         tag: messageTag,
                         // Across the ServiceWorker boundary the custom error is transformed in a primitive Error type
                         // and `name` is lost
-                        error: new Error("MessageBus not initialized"),
+                        error: new Error(MESSAGE_BUS_NOT_INITIALIZED),
                     };
                 }
                 if (message.type === "GET_ADDRESS") {
@@ -529,7 +530,7 @@ describe("sendMessage reinitialize on SW restart", () => {
                 return {
                     id: message.id,
                     tag: message.tag ?? messageTag,
-                    error: new Error("MessageBus not initialized"),
+                    error: new Error(MESSAGE_BUS_NOT_INITIALIZED),
                 };
             });
 
@@ -539,7 +540,7 @@ describe("sendMessage reinitialize on SW restart", () => {
 
         const wallet = createWalletWithConfig(serviceWorker as any);
         await expect(wallet.getAddress()).rejects.toThrow(
-            "MessageBus not initialized"
+            MESSAGE_BUS_NOT_INITIALIZED
         );
 
         // Should have tried 3 times (1 initial + 2 retries)
@@ -571,7 +572,7 @@ describe("sendMessage reinitialize on SW restart", () => {
                     return {
                         id: message.id,
                         tag: messageTag,
-                        error: new Error("MessageBus not initialized"),
+                        error: new Error(MESSAGE_BUS_NOT_INITIALIZED),
                     };
                 }
                 switch (message.type) {
@@ -670,7 +671,7 @@ describe("sendMessage reinitialize on SW restart", () => {
                     return {
                         id: message.id,
                         tag: messageTag,
-                        error: new Error("MessageBus not initialized"),
+                        error: new Error(MESSAGE_BUS_NOT_INITIALIZED),
                     };
                 }
                 if (message.type === "SETTLE") {


### PR DESCRIPTION

## Reinitialization Error

### To reproduce

1. open the wallet app
2. enter a wallet (init/restore)
3. open application tab in dev-tools
4. stop the service worker
5. the app enters a crash loop with `Error pinging wallet status: Failed to get status: Error: MessageBus not initialized` 

### Reason

1. the MessageBus uses `MessageBusNotInitializedError` to signal missed initialization
2. the MessageBus runs in the Service Worker
3. the service worker client `src/wallet/serviceWorker/wallet.ts:130`  uses `error.name === "MessageBusNotInitializedError"` to identify lack of initialization and reinit
4. the `name`  field is always `Error` across the service worker bridge :bug: 
5. tests worked because they don't serialize the custom error :facepalm: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error detection for message bus initialization issues in the service worker.
  * Simplified error class implementations by standardizing error message handling.

* **Tests**
  * Updated test cases to reflect changes in error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->