### PR TITLE
Export MESSAGE_BUS_NOT_INITIALIZED error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -247,6 +247,7 @@ import {
     DelegatorNotConfiguredError,
 } from "./wallet/serviceWorker/wallet-message-handler";
 import {
+    MESSAGE_BUS_NOT_INITIALIZED,
     MessageBusNotInitializedError,
     ServiceWorkerTimeoutError,
 } from "./worker/errors";
@@ -292,6 +293,7 @@ export {
     WalletNotInitializedError,
     ReadonlyWalletError,
     DelegatorNotConfiguredError,
+    MESSAGE_BUS_NOT_INITIALIZED,
     MessageBusNotInitializedError,
     ServiceWorkerTimeoutError,
     ServiceWorkerWallet,


### PR DESCRIPTION
Needed for boltz-swap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Expanded the public API to include a new error-related constant, making it available for import alongside existing error exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->