### PR TITLE
chore: bump @kukks/bitcoin-descriptors to 3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         "release:cleanup": "bash scripts/release.sh --cleanup"
     },
     "dependencies": {
-        "@kukks/bitcoin-descriptors": "3.1.0",
+        "@kukks/bitcoin-descriptors": "3.2.2",
         "@marcbachmann/cel-js": "7.3.1",
         "@noble/curves": "2.0.0",
         "@noble/secp256k1": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@kukks/bitcoin-descriptors':
-        specifier: 3.1.0
-        version: 3.1.0
+        specifier: 3.2.2
+        version: 3.2.2(@bitcoinerlab/miniscript@1.4.3)
       '@marcbachmann/cel-js':
         specifier: 7.3.1
         version: 7.3.1
@@ -951,8 +951,13 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kukks/bitcoin-descriptors@3.1.0':
-    resolution: {integrity: sha512-7HOCZjufw3DIIDebx7/ZOeol6khkWoccM6vzee6t5bXOJoj/6ISdssEDhjxDgy88in/I39pKz+kzFukxK5eqVw==}
+  '@kukks/bitcoin-descriptors@3.2.2':
+    resolution: {integrity: sha512-xQr5348LsthNn3uaScGNCCWM8vslSaWHqgWCeF9/RzEp6do+D5nAHp7vKZDqq2xwdhgBpYyBbwcy5yYiiv3NVg==}
+    peerDependencies:
+      '@bitcoinerlab/miniscript': ^1.4.3
+    peerDependenciesMeta:
+      '@bitcoinerlab/miniscript':
+        optional: true
 
   '@marcbachmann/cel-js@7.3.1':
     resolution: {integrity: sha512-P6o26TvjStT8V8+8EF+yq9Pp7ZFV00bpiUMbssr76XbIZGxaB+NNWeBp6WNxOrR9gp0JPzvJueCKHpOs5LE9PQ==}
@@ -4319,6 +4324,7 @@ snapshots:
   '@bitcoinerlab/miniscript@1.4.3':
     dependencies:
       bip68: 1.0.4
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -4799,14 +4805,15 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kukks/bitcoin-descriptors@3.1.0':
+  '@kukks/bitcoin-descriptors@3.2.2(@bitcoinerlab/miniscript@1.4.3)':
     dependencies:
-      '@bitcoinerlab/miniscript': 1.4.3
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1
       '@scure/base': 2.0.0
       '@scure/bip32': 2.0.1
       '@scure/btc-signer': 2.0.1
+    optionalDependencies:
+      '@bitcoinerlab/miniscript': 1.4.3
 
   '@marcbachmann/cel-js@7.3.1': {}
 


### PR DESCRIPTION
## Summary
- Bumps `@kukks/bitcoin-descriptors` from 3.1.0 to 3.2.2
- `@bitcoinerlab/miniscript` is now an optional peer dependency in descriptors — ts-sdk doesn't use miniscript descriptors, so this reduces the install footprint with no code changes

## Test plan
- [x] Pre-commit hooks passed (prettier + vitest unit tests)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a third-party dependency to a newer version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->