### PR TITLE
chore: bump @kukks/bitcoin-descriptors to 3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         "release:cleanup": "bash scripts/release.sh --cleanup"
     },
     "dependencies": {
-        "@kukks/bitcoin-descriptors": "3.2.2",
+        "@kukks/bitcoin-descriptors": "3.2.3",
         "@marcbachmann/cel-js": "7.3.1",
         "@noble/curves": "2.0.0",
         "@noble/secp256k1": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@kukks/bitcoin-descriptors':
-        specifier: 3.2.2
-        version: 3.2.2(@bitcoinerlab/miniscript@1.4.3)
+        specifier: 3.2.3
+        version: 3.2.3(@bitcoinerlab/miniscript@1.4.3)
       '@marcbachmann/cel-js':
         specifier: 7.3.1
         version: 7.3.1
@@ -951,8 +951,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kukks/bitcoin-descriptors@3.2.2':
-    resolution: {integrity: sha512-xQr5348LsthNn3uaScGNCCWM8vslSaWHqgWCeF9/RzEp6do+D5nAHp7vKZDqq2xwdhgBpYyBbwcy5yYiiv3NVg==}
+  '@kukks/bitcoin-descriptors@3.2.3':
+    resolution: {integrity: sha512-oa37RYwnbd6WIRgZTr44ifUYrrQCESvM/K4ITXPU54HywDlin4y57fJzj1h+g3koBdz/dUP4DpE8qhzVGefLeQ==}
     peerDependencies:
       '@bitcoinerlab/miniscript': ^1.4.3
     peerDependenciesMeta:
@@ -4805,7 +4805,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kukks/bitcoin-descriptors@3.2.2(@bitcoinerlab/miniscript@1.4.3)':
+  '@kukks/bitcoin-descriptors@3.2.3(@bitcoinerlab/miniscript@1.4.3)':
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1


### PR DESCRIPTION
## Summary
- Bumps `@kukks/bitcoin-descriptors` from `3.2.2` to `3.2.3`
- Fixes Vite browser builds broken by Node-only `createRequire` in the `3.2.2` release
- The `3.2.3` release replaces `createRequire` with dynamic `import()` for browser-compatible lazy loading of the optional miniscript peer dependency

## Context
See: https://github.com/Kukks/descriptors/pull/3

## Test plan
- [x] `pnpm install` succeeds
- [x] Pre-commit hooks pass (lint + unit tests)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bitcoin-descriptors dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->