### PR TITLE
feat: make `opts` optional when creating identity

### DIFF
--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -48,7 +48,7 @@ function detectNetwork(descriptor: string): Network {
     return descriptor.includes("tpub") ? networks.testnet : networks.bitcoin;
 }
 
-function hasDescriptor(opts: SeedIdentityOptions): opts is DescriptorOptions {
+function hasDescriptor(opts: SeedIdentityOptions = {}): opts is DescriptorOptions {
     return "descriptor" in opts && typeof opts.descriptor === "string";
 }
 
@@ -147,7 +147,7 @@ export class SeedIdentity implements Identity {
      * @param seed - 64-byte seed (typically from mnemonicToSeedSync)
      * @param opts - Network selection or custom descriptor.
      */
-    static fromSeed(seed: Uint8Array, opts: SeedIdentityOptions): SeedIdentity {
+    static fromSeed(seed: Uint8Array, opts: SeedIdentityOptions = {}): SeedIdentity {
         const descriptor = hasDescriptor(opts)
             ? opts.descriptor
             : buildDescriptor(seed, (opts as NetworkOptions).isMainnet ?? true);
@@ -246,7 +246,7 @@ export class MnemonicIdentity extends SeedIdentity {
      */
     static fromMnemonic(
         phrase: string,
-        opts: MnemonicOptions
+        opts: MnemonicOptions = {}
     ): MnemonicIdentity {
         if (!validateMnemonic(phrase, wordlist)) {
             throw new Error("Invalid mnemonic");

--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -48,7 +48,9 @@ function detectNetwork(descriptor: string): Network {
     return descriptor.includes("tpub") ? networks.testnet : networks.bitcoin;
 }
 
-function hasDescriptor(opts: SeedIdentityOptions = {}): opts is DescriptorOptions {
+function hasDescriptor(
+    opts: SeedIdentityOptions = {}
+): opts is DescriptorOptions {
     return "descriptor" in opts && typeof opts.descriptor === "string";
 }
 
@@ -147,7 +149,10 @@ export class SeedIdentity implements Identity {
      * @param seed - 64-byte seed (typically from mnemonicToSeedSync)
      * @param opts - Network selection or custom descriptor.
      */
-    static fromSeed(seed: Uint8Array, opts: SeedIdentityOptions = {}): SeedIdentity {
+    static fromSeed(
+        seed: Uint8Array,
+        opts: SeedIdentityOptions = {}
+    ): SeedIdentity {
         const descriptor = hasDescriptor(opts)
             ? opts.descriptor
             : buildDescriptor(seed, (opts as NetworkOptions).isMainnet ?? true);

--- a/test/seedIdentity.test.ts
+++ b/test/seedIdentity.test.ts
@@ -21,12 +21,6 @@ describe("SeedIdentity", () => {
             expect(xOnlyPubKey).toHaveLength(32);
         });
 
-        it("should require network selection", () => {
-            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
-            // @ts-expect-error opts is required
-            expect(() => SeedIdentity.fromSeed(seed)).toThrow();
-        });
-
         it("should derive different keys for mainnet vs testnet", async () => {
             const seed = mnemonicToSeedSync(TEST_MNEMONIC);
 
@@ -207,13 +201,6 @@ describe("MnemonicIdentity", () => {
             const xOnlyPubKey = await identity.xOnlyPublicKey();
             expect(xOnlyPubKey).toBeInstanceOf(Uint8Array);
             expect(xOnlyPubKey).toHaveLength(32);
-        });
-
-        it("should require network selection", () => {
-            // @ts-expect-error opts is required
-            expect(() =>
-                MnemonicIdentity.fromMnemonic(TEST_MNEMONIC)
-            ).toThrow();
         });
 
         it("should produce same key as SeedIdentity.fromSeed with equivalent seed", async () => {


### PR DESCRIPTION
Allow `fromSeed` and `fromMnemonic` to be used without including an `opts` argument (default to empty object).

Fixes https://github.com/arkade-os/ts-sdk/issues/377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Identity creation functions now accept optional configuration parameters with sensible defaults, enabling simplified initialization for common usage scenarios without requiring explicit settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->