### PR TITLE
refactor(timelock): centralise BIP68 encode/decode helpers

### DIFF
--- a/src/contracts/handlers/default.ts
+++ b/src/contracts/handlers/default.ts
@@ -9,9 +9,11 @@ import {
 } from "../types";
 import {
     isCsvSpendable,
+} from "./helpers";
+import {
     sequenceToTimelock,
     timelockToSequence,
-} from "./helpers";
+} from "../../utils/timelock";
 
 /**
  * Typed parameters for DefaultVtxo contracts.

--- a/src/contracts/handlers/default.ts
+++ b/src/contracts/handlers/default.ts
@@ -7,11 +7,8 @@ import {
     PathContext,
     PathSelection,
 } from "../types";
-import {
-    isCsvSpendable,
-    sequenceToTimelock,
-    timelockToSequence,
-} from "./helpers";
+import { isCsvSpendable } from "./helpers";
+import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 import {
     normalizeToDescriptor,
     extractPubKey,

--- a/src/contracts/handlers/delegate.ts
+++ b/src/contracts/handlers/delegate.ts
@@ -10,9 +10,11 @@ import {
 } from "../types";
 import {
     isCsvSpendable,
+} from "./helpers";
+import {
     sequenceToTimelock,
     timelockToSequence,
-} from "./helpers";
+} from "../../utils/timelock";
 
 /**
  * Typed parameters for DelegateVtxo contracts.

--- a/src/contracts/handlers/delegate.ts
+++ b/src/contracts/handlers/delegate.ts
@@ -8,11 +8,8 @@ import {
     PathContext,
     PathSelection,
 } from "../types";
-import {
-    isCsvSpendable,
-    sequenceToTimelock,
-    timelockToSequence,
-} from "./helpers";
+import { isCsvSpendable } from "./helpers";
+import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 
 /**
  * Typed parameters for DelegateVtxo contracts.

--- a/src/contracts/handlers/helpers.ts
+++ b/src/contracts/handlers/helpers.ts
@@ -1,23 +1,5 @@
-import { RelativeTimelock } from "../../script/tapscript";
-import {
-    timelockToSequence as timelockToSequenceImpl,
-    sequenceToTimelock as sequenceToTimelockImpl,
-} from "../../utils/timelock";
+import { sequenceToTimelock } from "../../utils/timelock";
 import { Contract, PathContext } from "../types";
-
-/**
- * Convert RelativeTimelock to BIP68 sequence number.
- */
-export function timelockToSequence(timelock: RelativeTimelock): number {
-    return timelockToSequenceImpl(timelock);
-}
-
-/**
- * Convert BIP68 sequence number back to RelativeTimelock.
- */
-export function sequenceToTimelock(sequence: number): RelativeTimelock {
-    return sequenceToTimelockImpl(sequence);
-}
 
 /**
  * Resolve wallet's role from explicit role or by matching pubkey.

--- a/src/contracts/handlers/helpers.ts
+++ b/src/contracts/handlers/helpers.ts
@@ -1,30 +1,22 @@
 import { RelativeTimelock } from "../../script/tapscript";
-import * as bip68 from "bip68";
+import {
+    timelockToSequence as timelockToSequenceImpl,
+    sequenceToTimelock as sequenceToTimelockImpl,
+} from "../../utils/timelock";
 import { Contract, PathContext } from "../types";
 
 /**
  * Convert RelativeTimelock to BIP68 sequence number.
  */
 export function timelockToSequence(timelock: RelativeTimelock): number {
-    return bip68.encode(
-        timelock.type === "blocks"
-            ? { blocks: Number(timelock.value) }
-            : { seconds: Number(timelock.value) }
-    );
+    return timelockToSequenceImpl(timelock);
 }
 
 /**
  * Convert BIP68 sequence number back to RelativeTimelock.
  */
 export function sequenceToTimelock(sequence: number): RelativeTimelock {
-    const decoded = bip68.decode(sequence);
-    if ("blocks" in decoded && decoded.blocks !== undefined) {
-        return { type: "blocks", value: BigInt(decoded.blocks) };
-    }
-    if ("seconds" in decoded && decoded.seconds !== undefined) {
-        return { type: "seconds", value: BigInt(decoded.seconds) };
-    }
-    throw new Error(`Invalid BIP68 sequence: ${sequence}`);
+    return sequenceToTimelockImpl(sequence);
 }
 
 /**

--- a/src/contracts/handlers/helpers.ts
+++ b/src/contracts/handlers/helpers.ts
@@ -1,8 +1,4 @@
-import { RelativeTimelock } from "../../script/tapscript";
-import {
-    timelockToSequence as timelockToSequenceImpl,
-    sequenceToTimelock as sequenceToTimelockImpl,
-} from "../../utils/timelock";
+import { sequenceToTimelock } from "../../utils/timelock";
 import { Contract, PathContext } from "../types";
 import { isDescriptor, extractPubKey } from "../../identity/descriptor";
 
@@ -20,20 +16,6 @@ function extractRawPubKey(value: string): string | undefined {
     } catch {
         return undefined;
     }
-}
-
-/**
- * Convert RelativeTimelock to BIP68 sequence number.
- */
-export function timelockToSequence(timelock: RelativeTimelock): number {
-    return timelockToSequenceImpl(timelock);
-}
-
-/**
- * Convert BIP68 sequence number back to RelativeTimelock.
- */
-export function sequenceToTimelock(sequence: number): RelativeTimelock {
-    return sequenceToTimelockImpl(sequence);
 }
 
 /**

--- a/src/contracts/handlers/helpers.ts
+++ b/src/contracts/handlers/helpers.ts
@@ -1,5 +1,8 @@
 import { RelativeTimelock } from "../../script/tapscript";
-import * as bip68 from "bip68";
+import {
+    timelockToSequence as timelockToSequenceImpl,
+    sequenceToTimelock as sequenceToTimelockImpl,
+} from "../../utils/timelock";
 import { Contract, PathContext } from "../types";
 import { isDescriptor, extractPubKey } from "../../identity/descriptor";
 
@@ -23,25 +26,14 @@ function extractRawPubKey(value: string): string | undefined {
  * Convert RelativeTimelock to BIP68 sequence number.
  */
 export function timelockToSequence(timelock: RelativeTimelock): number {
-    return bip68.encode(
-        timelock.type === "blocks"
-            ? { blocks: Number(timelock.value) }
-            : { seconds: Number(timelock.value) }
-    );
+    return timelockToSequenceImpl(timelock);
 }
 
 /**
  * Convert BIP68 sequence number back to RelativeTimelock.
  */
 export function sequenceToTimelock(sequence: number): RelativeTimelock {
-    const decoded = bip68.decode(sequence);
-    if ("blocks" in decoded && decoded.blocks !== undefined) {
-        return { type: "blocks", value: BigInt(decoded.blocks) };
-    }
-    if ("seconds" in decoded && decoded.seconds !== undefined) {
-        return { type: "seconds", value: BigInt(decoded.seconds) };
-    }
-    throw new Error(`Invalid BIP68 sequence: ${sequence}`);
+    return sequenceToTimelockImpl(sequence);
 }
 
 /**

--- a/src/contracts/handlers/vhtlc.ts
+++ b/src/contracts/handlers/vhtlc.ts
@@ -11,9 +11,11 @@ import {
     isCltvSatisfied,
     isCsvSpendable,
     resolveRole,
+} from "./helpers";
+import {
     sequenceToTimelock,
     timelockToSequence,
-} from "./helpers";
+} from "../../utils/timelock";
 
 /**
  * Typed parameters for VHTLC contracts.

--- a/src/contracts/handlers/vhtlc.ts
+++ b/src/contracts/handlers/vhtlc.ts
@@ -7,13 +7,8 @@ import {
     PathContext,
     PathSelection,
 } from "../types";
-import {
-    isCltvSatisfied,
-    isCsvSpendable,
-    resolveRole,
-    sequenceToTimelock,
-    timelockToSequence,
-} from "./helpers";
+import { isCltvSatisfied, isCsvSpendable, resolveRole } from "./helpers";
+import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 
 /**
  * Typed parameters for VHTLC contracts.

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,10 +260,7 @@ import type {
     VHTLCContractParams,
 } from "./contracts";
 import { IContractManager } from "./contracts/contractManager";
-import {
-    timelockToSequence,
-    sequenceToTimelock,
-} from "./contracts/handlers/helpers";
+import { timelockToSequence, sequenceToTimelock } from "./utils/timelock";
 import { closeDatabase, openDatabase } from "./repositories/indexedDB/manager";
 import {
     WalletMessageHandler,

--- a/src/script/base.ts
+++ b/src/script/base.ts
@@ -6,12 +6,12 @@ import {
     TAPROOT_UNSPENDABLE_KEY,
     NETWORK,
 } from "@scure/btc-signer";
-import * as bip68 from "bip68";
 import { TAP_LEAF_VERSION } from "@scure/btc-signer/payment.js";
 import { PSBTOutput } from "@scure/btc-signer/psbt.js";
 import { Bytes } from "@scure/btc-signer/utils.js";
 import { hex } from "@scure/base";
 import { ArkAddress } from "./address";
+import { timelockToSequence } from "../utils/timelock";
 import {
     CLTVMultisigTapscript,
     ConditionCSVMultisigTapscript,
@@ -227,11 +227,7 @@ export function getSequence(tapLeafScript: TapLeafScript): number | undefined {
         );
         try {
             const params = CSVMultisigTapscript.decode(script).params;
-            sequence = bip68.encode(
-                params.timelock.type === "blocks"
-                    ? { blocks: Number(params.timelock.value) }
-                    : { seconds: Number(params.timelock.value) }
-            );
+            sequence = timelockToSequence(params.timelock);
         } catch {
             const params = CLTVMultisigTapscript.decode(script).params;
             sequence = Number(params.absoluteTimelock);

--- a/src/script/base.ts
+++ b/src/script/base.ts
@@ -6,12 +6,12 @@ import {
     TAPROOT_UNSPENDABLE_KEY,
     NETWORK,
 } from "@scure/btc-signer";
-import * as bip68 from "bip68";
 import { TAP_LEAF_VERSION } from "@scure/btc-signer/payment.js";
 import { PSBTOutput } from "@scure/btc-signer/psbt.js";
 import { Bytes } from "@scure/btc-signer/utils.js";
 import { hex } from "@scure/base";
 import { ArkAddress } from "./address";
+import { timelockToSequence } from "../utils/timelock";
 import {
     CLTVMultisigTapscript,
     ConditionCSVMultisigTapscript,
@@ -158,11 +158,7 @@ export function getSequence(tapLeafScript: TapLeafScript): number | undefined {
         );
         try {
             const params = CSVMultisigTapscript.decode(script).params;
-            sequence = bip68.encode(
-                params.timelock.type === "blocks"
-                    ? { blocks: Number(params.timelock.value) }
-                    : { seconds: Number(params.timelock.value) }
-            );
+            sequence = timelockToSequence(params.timelock);
         } catch {
             const params = CLTVMultisigTapscript.decode(script).params;
             sequence = Number(params.absoluteTimelock);

--- a/src/script/tapscript.ts
+++ b/src/script/tapscript.ts
@@ -1,7 +1,7 @@
-import * as bip68 from "bip68";
 import { Script, ScriptNum, ScriptType, p2tr_ms } from "@scure/btc-signer";
 import { Bytes } from "@scure/btc-signer/utils.js";
 import { hex } from "@scure/base";
+import { sequenceToTimelock, timelockToSequence } from "../utils/timelock";
 
 const MinimalScriptNum = ScriptNum(undefined, true);
 
@@ -323,13 +323,7 @@ export namespace CSVMultisigTapscript {
         }
 
         const sequence = MinimalScriptNum.encode(
-            BigInt(
-                bip68.encode(
-                    params.timelock.type === "blocks"
-                        ? { blocks: Number(params.timelock.value) }
-                        : { seconds: Number(params.timelock.value) }
-                )
-            )
+            BigInt(timelockToSequence(params.timelock))
         );
 
         const asm: ScriptType = [
@@ -392,12 +386,7 @@ export namespace CSVMultisigTapscript {
                 MinimalScriptNum.decode(sequence as Uint8Array)
             );
         }
-        const decodedTimelock = bip68.decode(sequenceNum);
-
-        const timelock: RelativeTimelock =
-            decodedTimelock.blocks !== undefined
-                ? { type: "blocks", value: BigInt(decodedTimelock.blocks) }
-                : { type: "seconds", value: BigInt(decodedTimelock.seconds!) };
+        const timelock = sequenceToTimelock(sequenceNum);
 
         const reconstructed = encode({
             timelock,

--- a/src/script/tapscript.ts
+++ b/src/script/tapscript.ts
@@ -1,7 +1,7 @@
-import * as bip68 from "bip68";
 import { Script, ScriptNum, ScriptType, p2tr_ms } from "@scure/btc-signer";
 import { Bytes } from "@scure/btc-signer/utils.js";
 import { hex } from "@scure/base";
+import { sequenceToTimelock, timelockToSequence } from "../utils/timelock";
 
 const MinimalScriptNum = ScriptNum(undefined, true);
 
@@ -319,13 +319,7 @@ export namespace CSVMultisigTapscript {
         }
 
         const sequence = MinimalScriptNum.encode(
-            BigInt(
-                bip68.encode(
-                    params.timelock.type === "blocks"
-                        ? { blocks: Number(params.timelock.value) }
-                        : { seconds: Number(params.timelock.value) }
-                )
-            )
+            BigInt(timelockToSequence(params.timelock))
         );
 
         const asm: ScriptType = [
@@ -387,12 +381,7 @@ export namespace CSVMultisigTapscript {
                 MinimalScriptNum.decode(sequence as Uint8Array)
             );
         }
-        const decodedTimelock = bip68.decode(sequenceNum);
-
-        const timelock: RelativeTimelock =
-            decodedTimelock.blocks !== undefined
-                ? { type: "blocks", value: BigInt(decodedTimelock.blocks) }
-                : { type: "seconds", value: BigInt(decodedTimelock.seconds!) };
+        const timelock = sequenceToTimelock(sequenceNum);
 
         const reconstructed = encode({
             timelock,

--- a/src/utils/timelock.ts
+++ b/src/utils/timelock.ts
@@ -1,5 +1,5 @@
 import * as bip68 from "bip68";
-import { RelativeTimelock } from "../script/tapscript";
+import type { RelativeTimelock } from "../script/tapscript";
 
 /**
  * Convert RelativeTimelock to BIP68 sequence number.

--- a/src/utils/timelock.ts
+++ b/src/utils/timelock.ts
@@ -1,0 +1,27 @@
+import * as bip68 from "bip68";
+import { RelativeTimelock } from "../script/tapscript";
+
+/**
+ * Convert RelativeTimelock to BIP68 sequence number.
+ */
+export function timelockToSequence(timelock: RelativeTimelock): number {
+    return bip68.encode(
+        timelock.type === "blocks"
+            ? { blocks: Number(timelock.value) }
+            : { seconds: Number(timelock.value) }
+    );
+}
+
+/**
+ * Convert BIP68 sequence number back to RelativeTimelock.
+ */
+export function sequenceToTimelock(sequence: number): RelativeTimelock {
+    const decoded = bip68.decode(sequence);
+    if ("blocks" in decoded && decoded.blocks !== undefined) {
+        return { type: "blocks", value: BigInt(decoded.blocks) };
+    }
+    if ("seconds" in decoded && decoded.seconds !== undefined) {
+        return { type: "seconds", value: BigInt(decoded.seconds) };
+    }
+    throw new Error(`Invalid BIP68 sequence: ${sequence}`);
+}

--- a/src/utils/unknownFields.ts
+++ b/src/utils/unknownFields.ts
@@ -1,7 +1,7 @@
-import * as bip68 from "bip68";
 import { RawWitness, ScriptNum, Transaction } from "@scure/btc-signer";
 import { TransactionInputUpdate } from "@scure/btc-signer/psbt.js";
 import { hex } from "@scure/base";
+import { sequenceToTimelock } from "./timelock";
 
 /**
  * ArkPsbtFieldKey are the available key names for the Arkade PSBT custom fields.
@@ -186,11 +186,7 @@ export const VtxoTreeExpiry: ArkPsbtFieldCoder<{
                 return null;
             const v = ScriptNum(6, true).decode(unknown[1]);
             if (!v) return null;
-            const { blocks, seconds } = bip68.decode(Number(v));
-            return {
-                type: blocks ? "blocks" : "seconds",
-                value: BigInt(blocks ?? seconds ?? 0),
-            };
+            return sequenceToTimelock(Number(v));
         }),
 };
 

--- a/src/utils/unknownFields.ts
+++ b/src/utils/unknownFields.ts
@@ -1,7 +1,7 @@
-import * as bip68 from "bip68";
 import { RawWitness, ScriptNum, Transaction } from "@scure/btc-signer";
 import { TransactionInputUpdate } from "@scure/btc-signer/psbt.js";
 import { hex } from "@scure/base";
+import { sequenceToTimelock } from "./timelock";
 
 /**
  * ArkPsbtFieldKey is the key values for ark psbt fields.
@@ -186,11 +186,7 @@ export const VtxoTreeExpiry: ArkPsbtFieldCoder<{
                 return null;
             const v = ScriptNum(6, true).decode(unknown[1]);
             if (!v) return null;
-            const { blocks, seconds } = bip68.decode(Number(v));
-            return {
-                type: blocks ? "blocks" : "seconds",
-                value: BigInt(blocks ?? seconds ?? 0),
-            };
+            return sequenceToTimelock(Number(v));
         }),
 };
 

--- a/src/wallet/unroll.ts
+++ b/src/wallet/unroll.ts
@@ -1,7 +1,7 @@
 import { base64, hex } from "@scure/base";
 import { SigHash, TaprootControlBlock } from "@scure/btc-signer";
 import { TransactionInputUpdate } from "@scure/btc-signer/psbt.js";
-import { timelockToSequence } from "../contracts/handlers/helpers";
+import { timelockToSequence } from "../utils/timelock";
 import { ChainTx, ChainTxType, IndexerProvider } from "../providers/indexer";
 import { AnchorBumper } from "../utils/anchor";
 import { OnchainProvider } from "../providers/onchain";

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -99,7 +99,7 @@ import {
 } from "../repositories";
 import { ContractManager } from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
-import { timelockToSequence } from "../contracts/handlers/helpers";
+import { timelockToSequence } from "../utils/timelock";
 import {
     advanceSyncCursors,
     clearSyncCursors,

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -99,7 +99,7 @@ import {
 } from "../repositories";
 import { ContractManager } from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
-import { timelockToSequence } from "../contracts/handlers/helpers";
+import { timelockToSequence } from "../utils/timelock";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
 
 export const getArkadeServerUrl = ({

--- a/test/contracts/handlers.test.ts
+++ b/test/contracts/handlers.test.ts
@@ -17,7 +17,7 @@ import {
     TEST_SERVER_PUB_KEY,
     TEST_DELEGATE_PUB_KEY,
 } from "./helpers";
-import { timelockToSequence } from "../../src/contracts/handlers/helpers";
+import { timelockToSequence } from "../../src/utils/timelock";
 
 describe("Contract Registry", () => {
     it("should have default handler registered", () => {

--- a/test/contracts/handlers.test.ts
+++ b/test/contracts/handlers.test.ts
@@ -19,10 +19,8 @@ import {
     TEST_SERVER_PUB_KEY_HEX,
     TEST_DELEGATE_PUB_KEY,
 } from "./helpers";
-import {
-    resolveRole,
-    timelockToSequence,
-} from "../../src/contracts/handlers/helpers";
+import { resolveRole } from "../../src/contracts/handlers/helpers";
+import { timelockToSequence } from "../../src/utils/timelock";
 
 describe("Contract Registry", () => {
     it("should have default handler registered", () => {

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../src/repositories";
 import type { Coin, VirtualCoin } from "../src/wallet";
 import { MockEventSource } from "./mocks/eventSource";
-import { timelockToSequence } from "../src/contracts/handlers/helpers";
+import { timelockToSequence } from "../src/utils/timelock";
 
 // Mock fetch
 const mockFetch = vi.fn();


### PR DESCRIPTION
1. Move BIP68 timelock conversion logic to a shared utility.
2. Reuse the utility from contracts helpers and script base.
3. No functional behaviour change intended; this is dedup/maintainability only.
As suggested in https://github.com/arkade-os/ts-sdk/pull/405#pullrequestreview-4095146296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated timelock ↔ sequence conversion into a dedicated utility, removed the old low-level dependency, and updated usages across the codebase; no user-facing behavior or public APIs changed.
* **Tests**
  * Adjusted tests to import and use the new utility location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->