### PR TITLE
fix: reconcile stale VTXOs during delta sync

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -550,6 +550,22 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
         const requestStartedAt = Date.now();
         const allVtxos: VirtualCoin[] = [];
+        let deltaVtxos: VirtualCoin[] = [];
+
+        const extendWithScript = (
+            vtxo: VirtualCoin
+        ): ExtendedVirtualCoin | undefined => {
+            const vtxoScript = vtxo.script
+                ? scriptMap.get(vtxo.script)
+                : undefined;
+            if (!vtxoScript) return undefined;
+            return {
+                ...vtxo,
+                forfeitTapLeafScript: vtxoScript.forfeit(),
+                intentTapLeafScript: vtxoScript.forfeit(),
+                tapTree: vtxoScript.encode(),
+            };
+        };
 
         // Full fetch for scripts with no cursor.
         if (bootstrapScripts.length > 0) {
@@ -570,23 +586,16 @@ export class ReadonlyWallet implements IReadonlyWallet {
                     scripts: deltaScripts,
                     after: window.after,
                 });
-                allVtxos.push(...response.vtxos);
+                deltaVtxos = response.vtxos;
+                allVtxos.push(...deltaVtxos);
             }
         }
 
         // Extend every fetched VTXO and upsert into the cache.
         const fetchedExtended: ExtendedVirtualCoin[] = [];
         for (const vtxo of allVtxos) {
-            const vtxoScript = vtxo.script
-                ? scriptMap.get(vtxo.script)
-                : undefined;
-            if (!vtxoScript) continue;
-            fetchedExtended.push({
-                ...vtxo,
-                forfeitTapLeafScript: vtxoScript.forfeit(),
-                intentTapLeafScript: vtxoScript.forfeit(),
-                tapTree: vtxoScript.encode(),
-            });
+            const extended = extendWithScript(vtxo);
+            if (extended) fetchedExtended.push(extended);
         }
         // Save VTXOs first, then advance cursors only on success.
         const cutoff = cursorCutoff(requestStartedAt);
@@ -605,18 +614,10 @@ export class ReadonlyWallet implements IReadonlyWallet {
                     scripts: deltaScripts,
                     pendingOnly: true,
                 });
-            const pendingExtended: ExtendedVirtualCoin[] = [];
+            const reconciledExtended: ExtendedVirtualCoin[] = [];
             for (const vtxo of pendingVtxos) {
-                const vtxoScript = vtxo.script
-                    ? scriptMap.get(vtxo.script)
-                    : undefined;
-                if (!vtxoScript) continue;
-                pendingExtended.push({
-                    ...vtxo,
-                    forfeitTapLeafScript: vtxoScript.forfeit(),
-                    intentTapLeafScript: vtxoScript.forfeit(),
-                    tapTree: vtxoScript.encode(),
-                });
+                const extended = extendWithScript(vtxo);
+                if (extended) reconciledExtended.push(extended);
             }
 
             // Only reconcile if the pending set is complete (not
@@ -630,41 +631,78 @@ export class ReadonlyWallet implements IReadonlyWallet {
                 const pendingOutpoints = new Set(
                     pendingVtxos.map((v) => `${v.txid}:${v.vout}`)
                 );
+                const deltaOutpoints = new Set(
+                    deltaVtxos.map((v) => `${v.txid}:${v.vout}`)
+                );
 
-                // Mark locally-cached "preconfirmed" VTXOs as spent if
-                // the server no longer lists them as pending.  This
-                // happens when a preconfirmed VTXO is consumed by a
-                // round (e.g. via VtxoManager auto-settlement) between
-                // syncs: the delta fetch misses the update because the
-                // VTXO was created before the cursor, and the
-                // pendingOnly query no longer returns it.
-                //
                 // Only reconcile VTXOs belonging to delta scripts.
                 // Bootstrapped scripts already got a full fetch, so
-                // their preconfirmed state is already fresh — marking
-                // them against a pendingOnly set that only covers
-                // deltaScripts would incorrectly flag them as spent.
+                // their preconfirmed state is already fresh.
                 const deltaScriptSet = new Set(deltaScripts);
                 const cachedVtxos =
                     await this.walletRepository.getVtxos(address);
-                for (const cached of cachedVtxos) {
-                    if (
-                        cached.script &&
+
+                const unresolvedPreconfirmed = cachedVtxos.filter((cached) => {
+                    const outpoint = `${cached.txid}:${cached.vout}`;
+                    return (
+                        !!cached.script &&
                         deltaScriptSet.has(cached.script) &&
                         cached.virtualStatus.state === "preconfirmed" &&
                         !cached.isSpent &&
-                        !pendingOutpoints.has(`${cached.txid}:${cached.vout}`)
-                    ) {
-                        pendingExtended.push({
-                            ...cached,
-                            isSpent: true,
+                        !deltaOutpoints.has(outpoint) &&
+                        !pendingOutpoints.has(outpoint)
+                    );
+                });
+
+                // Only pay for a broader spendableOnly fetch when the
+                // delta window and pendingOnly frontier both fail to
+                // explain a cached preconfirmed VTXO.
+                if (unresolvedPreconfirmed.length > 0) {
+                    const { vtxos: spendableVtxos, page: spendablePage } =
+                        await this.indexerProvider.getVtxos({
+                            scripts: deltaScripts,
+                            spendableOnly: true,
                         });
+                    const spendableSetComplete =
+                        !spendablePage || spendablePage.total <= 1;
+
+                    if (spendableSetComplete) {
+                        const spendableByOutpoint = new Map(
+                            spendableVtxos.map((v) => [
+                                `${v.txid}:${v.vout}`,
+                                v,
+                            ])
+                        );
+
+                        for (const cached of unresolvedPreconfirmed) {
+                            const outpoint = `${cached.txid}:${cached.vout}`;
+                            const spendable = spendableByOutpoint.get(outpoint);
+
+                            if (!spendable) {
+                                reconciledExtended.push({
+                                    ...cached,
+                                    isSpent: true,
+                                });
+                                continue;
+                            }
+
+                            const extended = extendWithScript(spendable);
+                            if (
+                                extended &&
+                                extended.virtualStatus.state !== "preconfirmed"
+                            ) {
+                                reconciledExtended.push(extended);
+                            }
+                        }
                     }
                 }
             }
 
-            if (pendingExtended.length > 0) {
-                await this.walletRepository.saveVtxos(address, pendingExtended);
+            if (reconciledExtended.length > 0) {
+                await this.walletRepository.saveVtxos(
+                    address,
+                    reconciledExtended
+                );
             }
         }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -600,12 +600,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
         // whose state may have changed since the cursor so that
         // getVtxos()/getTransactionHistory() don't serve stale state.
         if (hasDelta) {
-            const { vtxos: pendingVtxos } = await this.indexerProvider.getVtxos(
-                {
+            const { vtxos: pendingVtxos, page: pendingPage } =
+                await this.indexerProvider.getVtxos({
                     scripts: deltaScripts,
                     pendingOnly: true,
-                }
-            );
+                });
             const pendingExtended: ExtendedVirtualCoin[] = [];
             for (const vtxo of pendingVtxos) {
                 const vtxoScript = vtxo.script
@@ -619,6 +618,51 @@ export class ReadonlyWallet implements IReadonlyWallet {
                     tapTree: vtxoScript.encode(),
                 });
             }
+
+            // Only reconcile if the pending set is complete (not
+            // paginated).  If the server truncated the response, skip
+            // rather than risk marking live VTXOs as spent based on
+            // incomplete data.
+            const pendingSetComplete = !pendingPage || pendingPage.total <= 1;
+            if (pendingSetComplete) {
+                // Build a set of outpoints the server still considers
+                // pending.
+                const pendingOutpoints = new Set(
+                    pendingVtxos.map((v) => `${v.txid}:${v.vout}`)
+                );
+
+                // Mark locally-cached "preconfirmed" VTXOs as spent if
+                // the server no longer lists them as pending.  This
+                // happens when a preconfirmed VTXO is consumed by a
+                // round (e.g. via VtxoManager auto-settlement) between
+                // syncs: the delta fetch misses the update because the
+                // VTXO was created before the cursor, and the
+                // pendingOnly query no longer returns it.
+                //
+                // Only reconcile VTXOs belonging to delta scripts.
+                // Bootstrapped scripts already got a full fetch, so
+                // their preconfirmed state is already fresh — marking
+                // them against a pendingOnly set that only covers
+                // deltaScripts would incorrectly flag them as spent.
+                const deltaScriptSet = new Set(deltaScripts);
+                const cachedVtxos =
+                    await this.walletRepository.getVtxos(address);
+                for (const cached of cachedVtxos) {
+                    if (
+                        cached.script &&
+                        deltaScriptSet.has(cached.script) &&
+                        cached.virtualStatus.state === "preconfirmed" &&
+                        !cached.isSpent &&
+                        !pendingOutpoints.has(`${cached.txid}:${cached.vout}`)
+                    ) {
+                        pendingExtended.push({
+                            ...cached,
+                            isSpent: true,
+                        });
+                    }
+                }
+            }
+
             if (pendingExtended.length > 0) {
                 await this.walletRepository.saveVtxos(address, pendingExtended);
             }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -550,7 +550,6 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
         const requestStartedAt = Date.now();
         const allVtxos: VirtualCoin[] = [];
-        let deltaVtxos: VirtualCoin[] = [];
 
         const extendWithScript = (
             vtxo: VirtualCoin
@@ -586,8 +585,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
                     scripts: deltaScripts,
                     after: window.after,
                 });
-                deltaVtxos = response.vtxos;
-                allVtxos.push(...deltaVtxos);
+                allVtxos.push(...response.vtxos);
             }
         }
 
@@ -605,103 +603,86 @@ export class ReadonlyWallet implements IReadonlyWallet {
             Object.fromEntries(allScripts.map((s) => [s, cutoff]))
         );
 
-        // For delta syncs, reconcile pending (preconfirmed/spent) VTXOs
-        // whose state may have changed since the cursor so that
-        // getVtxos()/getTransactionHistory() don't serve stale state.
+        // Delta-sync reconciliation: full re-fetch for delta scripts.
+        //
+        // The delta fetch (above) only returns VTXOs changed after the
+        // cursor, so it can miss preconfirmed VTXOs that were consumed
+        // by a round between syncs.  Rather than layering targeted
+        // queries (pendingOnly, spendableOnly) with pagination guards
+        // and set algebra, we perform a single unfiltered re-fetch for
+        // delta scripts.  This is slightly more data over the wire but
+        // gives us complete, authoritative state in one call and keeps
+        // the reconciliation logic simple.
+        //
+        // Any cached preconfirmed VTXO that is absent from the full
+        // result set is marked spent; any VTXO whose state changed
+        // (e.g. preconfirmed → confirmed) is updated in place.
         if (hasDelta) {
-            const { vtxos: pendingVtxos, page: pendingPage } =
+            const { vtxos: fullVtxos, page: fullPage } =
                 await this.indexerProvider.getVtxos({
                     scripts: deltaScripts,
-                    pendingOnly: true,
                 });
-            const reconciledExtended: ExtendedVirtualCoin[] = [];
-            for (const vtxo of pendingVtxos) {
-                const extended = extendWithScript(vtxo);
-                if (extended) reconciledExtended.push(extended);
-            }
 
-            // Only reconcile if the pending set is complete (not
-            // paginated).  If the server truncated the response, skip
-            // rather than risk marking live VTXOs as spent based on
-            // incomplete data.
-            const pendingSetComplete = !pendingPage || pendingPage.total <= 1;
-            if (pendingSetComplete) {
-                // Build a set of outpoints the server still considers
-                // pending.
-                const pendingOutpoints = new Set(
-                    pendingVtxos.map((v) => `${v.txid}:${v.vout}`)
+            // If the response is paginated we don't have a complete
+            // picture — skip reconciliation rather than act on partial
+            // data.  The next sync will retry.
+            const fullSetComplete = !fullPage || fullPage.total <= 1;
+            if (fullSetComplete) {
+                const fullOutpoints = new Map(
+                    fullVtxos.map((v) => [`${v.txid}:${v.vout}`, v])
                 );
-                const deltaOutpoints = new Set(
-                    deltaVtxos.map((v) => `${v.txid}:${v.vout}`)
-                );
-
-                // Only reconcile VTXOs belonging to delta scripts.
-                // Bootstrapped scripts already got a full fetch, so
-                // their preconfirmed state is already fresh.
                 const deltaScriptSet = new Set(deltaScripts);
                 const cachedVtxos =
                     await this.walletRepository.getVtxos(address);
 
-                const unresolvedPreconfirmed = cachedVtxos.filter((cached) => {
+                const reconciledExtended: ExtendedVirtualCoin[] = [];
+
+                for (const cached of cachedVtxos) {
+                    if (
+                        !cached.script ||
+                        !deltaScriptSet.has(cached.script) ||
+                        cached.virtualStatus.state !== "preconfirmed" ||
+                        cached.isSpent
+                    ) {
+                        continue;
+                    }
+
                     const outpoint = `${cached.txid}:${cached.vout}`;
-                    return (
-                        !!cached.script &&
-                        deltaScriptSet.has(cached.script) &&
-                        cached.virtualStatus.state === "preconfirmed" &&
-                        !cached.isSpent &&
-                        !deltaOutpoints.has(outpoint) &&
-                        !pendingOutpoints.has(outpoint)
-                    );
-                });
+                    const fresh = fullOutpoints.get(outpoint);
 
-                // Only pay for a broader spendableOnly fetch when the
-                // delta window and pendingOnly frontier both fail to
-                // explain a cached preconfirmed VTXO.
-                if (unresolvedPreconfirmed.length > 0) {
-                    const { vtxos: spendableVtxos, page: spendablePage } =
-                        await this.indexerProvider.getVtxos({
-                            scripts: deltaScripts,
-                            spendableOnly: true,
+                    if (!fresh) {
+                        // Server no longer knows about this VTXO —
+                        // it was spent between syncs.
+                        reconciledExtended.push({
+                            ...cached,
+                            isSpent: true,
                         });
-                    const spendableSetComplete =
-                        !spendablePage || spendablePage.total <= 1;
+                        continue;
+                    }
 
-                    if (spendableSetComplete) {
-                        const spendableByOutpoint = new Map(
-                            spendableVtxos.map((v) => [
-                                `${v.txid}:${v.vout}`,
-                                v,
-                            ])
-                        );
-
-                        for (const cached of unresolvedPreconfirmed) {
-                            const outpoint = `${cached.txid}:${cached.vout}`;
-                            const spendable = spendableByOutpoint.get(outpoint);
-
-                            if (!spendable) {
-                                reconciledExtended.push({
-                                    ...cached,
-                                    isSpent: true,
-                                });
-                                continue;
-                            }
-
-                            const extended = extendWithScript(spendable);
-                            if (
-                                extended &&
-                                extended.virtualStatus.state !== "preconfirmed"
-                            ) {
-                                reconciledExtended.push(extended);
-                            }
-                        }
+                    const extended = extendWithScript(fresh);
+                    if (
+                        extended &&
+                        extended.virtualStatus.state !== "preconfirmed"
+                    ) {
+                        // State transitioned (e.g. confirmed by a
+                        // round) — update the cached entry.
+                        reconciledExtended.push(extended);
                     }
                 }
-            }
 
-            if (reconciledExtended.length > 0) {
-                await this.walletRepository.saveVtxos(
-                    address,
-                    reconciledExtended
+                if (reconciledExtended.length > 0) {
+                    console.warn(
+                        `[ark-sdk] delta sync: reconciled ${reconciledExtended.length} stale preconfirmed VTXO(s) via full re-fetch`
+                    );
+                    await this.walletRepository.saveVtxos(
+                        address,
+                        reconciledExtended
+                    );
+                }
+            } else {
+                console.warn(
+                    "[ark-sdk] delta sync: skipping reconciliation — full re-fetch was paginated"
                 );
             }
         }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -595,13 +595,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
             const extended = extendWithScript(vtxo);
             if (extended) fetchedExtended.push(extended);
         }
-        // Save VTXOs first, then advance cursors only on success.
+        // Save fetched VTXOs immediately; cursors are advanced after
+        // reconciliation so that a failed or skipped reconciliation
+        // (e.g. paginated full re-fetch) retries on the next sync.
         const cutoff = cursorCutoff(requestStartedAt);
         await this.walletRepository.saveVtxos(address, fetchedExtended);
-        await advanceSyncCursors(
-            this.walletRepository,
-            Object.fromEntries(allScripts.map((s) => [s, cutoff]))
-        );
 
         // Delta-sync reconciliation: full re-fetch for delta scripts.
         //
@@ -625,7 +623,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
             // If the response is paginated we don't have a complete
             // picture — skip reconciliation rather than act on partial
-            // data.  The next sync will retry.
+            // data.  Cursors are advanced after this block, so the
+            // next sync will retry with the same window.
             const fullSetComplete = !fullPage || fullPage.total <= 1;
             if (fullSetComplete) {
                 const fullOutpoints = new Map(
@@ -686,6 +685,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
                 );
             }
         }
+
+        await advanceSyncCursors(
+            this.walletRepository,
+            Object.fromEntries(allScripts.map((s) => [s, cutoff]))
+        );
 
         return {
             isDelta: hasDelta || bootstrapScripts.length === 0,

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -595,11 +595,13 @@ export class ReadonlyWallet implements IReadonlyWallet {
             const extended = extendWithScript(vtxo);
             if (extended) fetchedExtended.push(extended);
         }
-        // Save fetched VTXOs immediately; cursors are advanced after
-        // reconciliation so that a failed or skipped reconciliation
-        // (e.g. paginated full re-fetch) retries on the next sync.
+        // Save VTXOs first, then advance cursors only on success.
         const cutoff = cursorCutoff(requestStartedAt);
         await this.walletRepository.saveVtxos(address, fetchedExtended);
+        await advanceSyncCursors(
+            this.walletRepository,
+            Object.fromEntries(allScripts.map((s) => [s, cutoff]))
+        );
 
         // Delta-sync reconciliation: full re-fetch for delta scripts.
         //
@@ -621,10 +623,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
                     scripts: deltaScripts,
                 });
 
-            // If the response is paginated we don't have a complete
-            // picture — skip reconciliation rather than act on partial
-            // data.  Cursors are advanced after this block, so the
-            // next sync will retry with the same window.
+            // Reconciliation is best-effort: if the response is
+            // paginated we don't have a complete picture, so we skip
+            // rather than act on partial data.  Wallets with enough
+            // VTXOs to exceed a single page rely solely on the
+            // cursor-based delta mechanism for state updates.
             const fullSetComplete = !fullPage || fullPage.total <= 1;
             if (fullSetComplete) {
                 const fullOutpoints = new Map(
@@ -685,11 +688,6 @@ export class ReadonlyWallet implements IReadonlyWallet {
                 );
             }
         }
-
-        await advanceSyncCursors(
-            this.walletRepository,
-            Object.fromEntries(allScripts.map((s) => [s, cutoff]))
-        );
 
         return {
             isDelta: hasDelta || bootstrapScripts.length === 0,

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -614,9 +614,9 @@ export class ReadonlyWallet implements IReadonlyWallet {
         // gives us complete, authoritative state in one call and keeps
         // the reconciliation logic simple.
         //
-        // Any cached preconfirmed VTXO that is absent from the full
+        // Any cached non-spent VTXO that is absent from the full
         // result set is marked spent; any VTXO whose state changed
-        // (e.g. preconfirmed → confirmed) is updated in place.
+        // (e.g. preconfirmed → settled) is updated in place.
         if (hasDelta) {
             const { vtxos: fullVtxos, page: fullPage } =
                 await this.indexerProvider.getVtxos({
@@ -641,7 +641,6 @@ export class ReadonlyWallet implements IReadonlyWallet {
                     if (
                         !cached.script ||
                         !deltaScriptSet.has(cached.script) ||
-                        cached.virtualStatus.state !== "preconfirmed" ||
                         cached.isSpent
                     ) {
                         continue;
@@ -663,17 +662,18 @@ export class ReadonlyWallet implements IReadonlyWallet {
                     const extended = extendWithScript(fresh);
                     if (
                         extended &&
-                        extended.virtualStatus.state !== "preconfirmed"
+                        extended.virtualStatus.state !==
+                            cached.virtualStatus.state
                     ) {
-                        // State transitioned (e.g. confirmed by a
-                        // round) — update the cached entry.
+                        // State transitioned (e.g. preconfirmed →
+                        // settled) — update the cached entry.
                         reconciledExtended.push(extended);
                     }
                 }
 
                 if (reconciledExtended.length > 0) {
                     console.warn(
-                        `[ark-sdk] delta sync: reconciled ${reconciledExtended.length} stale preconfirmed VTXO(s) via full re-fetch`
+                        `[ark-sdk] delta sync: reconciled ${reconciledExtended.length} stale VTXO(s) via full re-fetch`
                     );
                     await this.walletRepository.saveVtxos(
                         address,

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -6,13 +6,18 @@ import {
     OnchainWallet,
     RestArkProvider,
     ReadonlyWallet,
+    InMemoryWalletRepository,
+    InMemoryContractRepository,
+    type IndexerProvider,
+    type ArkProvider,
+    type OnchainProvider,
 } from "../src";
 import { ReadonlySingleKey } from "../src/identity/singleKey";
 import {
     IndexedDBWalletRepository,
     IndexedDBContractRepository,
 } from "../src/repositories";
-import type { Coin } from "../src/wallet";
+import type { Coin, VirtualCoin } from "../src/wallet";
 
 // Mock fetch
 const mockFetch = vi.fn();
@@ -684,6 +689,193 @@ describe("Wallet", () => {
 
             const balance = await readonlyWallet.getBalance();
             expect(balance.boarding.total).toBe(100000);
+        });
+    });
+
+    describe("delta-sync reconciliation", () => {
+        const mockArkInfo = {
+            signerPubkey: mockServerKeyHex,
+            forfeitPubkey: mockServerKeyHex,
+            batchExpiry: BigInt(144),
+            unilateralExitDelay: BigInt(144),
+            boardingExitDelay: BigInt(144),
+            roundInterval: BigInt(144),
+            network: "mutinynet",
+            dust: BigInt(1000),
+            forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+            checkpointTapscript:
+                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        };
+
+        async function createReadonlyTestWallet(
+            indexerProvider: IndexerProvider
+        ) {
+            const compressedPubKey = await mockIdentity.compressedPublicKey();
+            const readonlyIdentity =
+                ReadonlySingleKey.fromPublicKey(compressedPubKey);
+            const walletRepository = new InMemoryWalletRepository();
+            const contractRepository = new InMemoryContractRepository();
+
+            const wallet = await ReadonlyWallet.create({
+                identity: readonlyIdentity,
+                arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: vi.fn().mockResolvedValue(mockArkInfo),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider,
+                onchainProvider: {} as OnchainProvider,
+                storage: {
+                    walletRepository,
+                    contractRepository,
+                },
+            });
+
+            return { wallet, walletRepository };
+        }
+
+        function makeTestVtxo(
+            script: string,
+            state: "preconfirmed" | "settled" = "preconfirmed"
+        ): VirtualCoin {
+            return {
+                txid: "11".repeat(32),
+                vout: 0,
+                value: 50_000,
+                status: {
+                    confirmed: state !== "preconfirmed",
+                    isLeaf: state !== "preconfirmed",
+                },
+                virtualStatus: {
+                    state,
+                    commitmentTxIds: ["22".repeat(32)],
+                    batchExpiry: Date.now() + 60_000,
+                },
+                spentBy: "",
+                settledBy: state === "settled" ? "33".repeat(32) : undefined,
+                arkTxId: "",
+                createdAt: new Date("2026-01-01T00:00:00.000Z"),
+                isUnrolled: false,
+                isSpent: false,
+                script,
+            };
+        }
+
+        it("keeps a preconfirmed VTXO when full re-fetch still returns it", async () => {
+            let walletScript = "";
+            let callCount = 0;
+            const getVtxos = vi
+                .fn<IndexerProvider["getVtxos"]>()
+                .mockImplementation(async (opts) => {
+                    callCount += 1;
+                    const script = opts?.scripts?.[0] ?? walletScript;
+                    walletScript = script;
+
+                    switch (callCount) {
+                        case 1: // bootstrap
+                            return { vtxos: [makeTestVtxo(script)] };
+                        case 2: // delta — no changes
+                            return { vtxos: [] };
+                        case 3: // full re-fetch — VTXO still present
+                            return { vtxos: [makeTestVtxo(script)] };
+                        default:
+                            throw new Error(
+                                `unexpected getVtxos call ${callCount}`
+                            );
+                    }
+                });
+
+            const { wallet } = await createReadonlyTestWallet({
+                getVtxos,
+            } as Partial<IndexerProvider> as IndexerProvider);
+
+            expect(await wallet.getVtxos()).toHaveLength(1);
+            expect(await wallet.getVtxos()).toHaveLength(1);
+            expect(getVtxos).toHaveBeenCalledTimes(3);
+        });
+
+        it("updates VTXO state when full re-fetch shows it settled", async () => {
+            let walletScript = "";
+            let callCount = 0;
+            const getVtxos = vi
+                .fn<IndexerProvider["getVtxos"]>()
+                .mockImplementation(async (opts) => {
+                    callCount += 1;
+                    const script = opts?.scripts?.[0] ?? walletScript;
+                    walletScript = script;
+
+                    switch (callCount) {
+                        case 1: // bootstrap — preconfirmed
+                            return { vtxos: [makeTestVtxo(script)] };
+                        case 2: // delta — no changes
+                            return { vtxos: [] };
+                        case 3: // full re-fetch — now settled
+                            return { vtxos: [makeTestVtxo(script, "settled")] };
+                        default:
+                            throw new Error(
+                                `unexpected getVtxos call ${callCount}`
+                            );
+                    }
+                });
+
+            const { wallet, walletRepository } = await createReadonlyTestWallet(
+                {
+                    getVtxos,
+                } as Partial<IndexerProvider> as IndexerProvider
+            );
+
+            expect((await wallet.getVtxos())[0].virtualStatus.state).toBe(
+                "preconfirmed"
+            );
+
+            const vtxos = await wallet.getVtxos();
+            expect(vtxos).toHaveLength(1);
+            expect(vtxos[0].virtualStatus.state).toBe("settled");
+            expect(vtxos[0].isSpent).toBe(false);
+
+            const cached = await walletRepository.getVtxos(
+                await wallet.getAddress()
+            );
+            expect(cached).toHaveLength(1);
+            expect(cached[0].virtualStatus.state).toBe("settled");
+        });
+
+        it("marks a cached preconfirmed VTXO as spent when full re-fetch no longer returns it", async () => {
+            let walletScript = "";
+            let callCount = 0;
+            const getVtxos = vi
+                .fn<IndexerProvider["getVtxos"]>()
+                .mockImplementation(async (opts) => {
+                    callCount += 1;
+                    const script = opts?.scripts?.[0] ?? walletScript;
+                    walletScript = script;
+
+                    switch (callCount) {
+                        case 1: // bootstrap — preconfirmed
+                            return { vtxos: [makeTestVtxo(script)] };
+                        case 2: // delta — no changes
+                        case 3: // full re-fetch — VTXO gone
+                            return { vtxos: [] };
+                        default:
+                            throw new Error(
+                                `unexpected getVtxos call ${callCount}`
+                            );
+                    }
+                });
+
+            const { wallet, walletRepository } = await createReadonlyTestWallet(
+                {
+                    getVtxos,
+                } as Partial<IndexerProvider> as IndexerProvider
+            );
+
+            expect(await wallet.getVtxos()).toHaveLength(1);
+            expect(await wallet.getVtxos()).toEqual([]);
+
+            const cached = await walletRepository.getVtxos(
+                await wallet.getAddress()
+            );
+            expect(cached).toHaveLength(1);
+            expect(cached[0].isSpent).toBe(true);
         });
     });
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -706,9 +706,10 @@ describe("Wallet", () => {
             checkpointTapscript:
                 "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
         };
+        const mockBatchExpiry = 1767225600000;
 
         async function createReadonlyTestWallet(
-            indexerProvider: IndexerProvider
+            getVtxos: IndexerProvider["getVtxos"]
         ) {
             const compressedPubKey = await mockIdentity.compressedPublicKey();
             const readonlyIdentity =
@@ -722,7 +723,9 @@ describe("Wallet", () => {
                 arkProvider: {
                     getInfo: vi.fn().mockResolvedValue(mockArkInfo),
                 } as Partial<ArkProvider> as ArkProvider,
-                indexerProvider,
+                indexerProvider: {
+                    getVtxos,
+                } as Partial<IndexerProvider> as IndexerProvider,
                 onchainProvider: {} as OnchainProvider,
                 storage: {
                     walletRepository,
@@ -733,7 +736,7 @@ describe("Wallet", () => {
             return { wallet, walletRepository };
         }
 
-        function makeTestVtxo(
+        function createMockVtxo(
             script: string,
             state: "preconfirmed" | "settled" = "preconfirmed"
         ): VirtualCoin {
@@ -748,7 +751,7 @@ describe("Wallet", () => {
                 virtualStatus: {
                     state,
                     commitmentTxIds: ["22".repeat(32)],
-                    batchExpiry: Date.now() + 60_000,
+                    batchExpiry: mockBatchExpiry,
                 },
                 spentBy: "",
                 settledBy: state === "settled" ? "33".repeat(32) : undefined,
@@ -760,68 +763,41 @@ describe("Wallet", () => {
             };
         }
 
-        it("keeps a preconfirmed VTXO when full re-fetch still returns it", async () => {
+        it("should keep a preconfirmed VTXO when the full re-fetch still returns it", async () => {
             let walletScript = "";
-            let callCount = 0;
             const getVtxos = vi
                 .fn<IndexerProvider["getVtxos"]>()
-                .mockImplementation(async (opts) => {
-                    callCount += 1;
-                    const script = opts?.scripts?.[0] ?? walletScript;
-                    walletScript = script;
+                .mockImplementationOnce(async (opts) => {
+                    walletScript = opts?.scripts?.[0] ?? "";
+                    return { vtxos: [createMockVtxo(walletScript)] };
+                })
+                .mockResolvedValueOnce({ vtxos: [] })
+                .mockImplementationOnce(async () => ({
+                    vtxos: [createMockVtxo(walletScript)],
+                }));
 
-                    switch (callCount) {
-                        case 1: // bootstrap
-                            return { vtxos: [makeTestVtxo(script)] };
-                        case 2: // delta — no changes
-                            return { vtxos: [] };
-                        case 3: // full re-fetch — VTXO still present
-                            return { vtxos: [makeTestVtxo(script)] };
-                        default:
-                            throw new Error(
-                                `unexpected getVtxos call ${callCount}`
-                            );
-                    }
-                });
-
-            const { wallet } = await createReadonlyTestWallet({
-                getVtxos,
-            } as Partial<IndexerProvider> as IndexerProvider);
+            const { wallet } = await createReadonlyTestWallet(getVtxos);
 
             expect(await wallet.getVtxos()).toHaveLength(1);
             expect(await wallet.getVtxos()).toHaveLength(1);
             expect(getVtxos).toHaveBeenCalledTimes(3);
         });
 
-        it("updates VTXO state when full re-fetch shows it settled", async () => {
+        it("should update VTXO state when the full re-fetch shows it settled", async () => {
             let walletScript = "";
-            let callCount = 0;
             const getVtxos = vi
                 .fn<IndexerProvider["getVtxos"]>()
-                .mockImplementation(async (opts) => {
-                    callCount += 1;
-                    const script = opts?.scripts?.[0] ?? walletScript;
-                    walletScript = script;
+                .mockImplementationOnce(async (opts) => {
+                    walletScript = opts?.scripts?.[0] ?? "";
+                    return { vtxos: [createMockVtxo(walletScript)] };
+                })
+                .mockResolvedValueOnce({ vtxos: [] })
+                .mockImplementationOnce(async () => ({
+                    vtxos: [createMockVtxo(walletScript, "settled")],
+                }));
 
-                    switch (callCount) {
-                        case 1: // bootstrap — preconfirmed
-                            return { vtxos: [makeTestVtxo(script)] };
-                        case 2: // delta — no changes
-                            return { vtxos: [] };
-                        case 3: // full re-fetch — now settled
-                            return { vtxos: [makeTestVtxo(script, "settled")] };
-                        default:
-                            throw new Error(
-                                `unexpected getVtxos call ${callCount}`
-                            );
-                    }
-                });
-
-            const { wallet, walletRepository } = await createReadonlyTestWallet(
-                {
-                    getVtxos,
-                } as Partial<IndexerProvider> as IndexerProvider
-            );
+            const { wallet, walletRepository } =
+                await createReadonlyTestWallet(getVtxos);
 
             expect((await wallet.getVtxos())[0].virtualStatus.state).toBe(
                 "preconfirmed"
@@ -839,34 +815,19 @@ describe("Wallet", () => {
             expect(cached[0].virtualStatus.state).toBe("settled");
         });
 
-        it("marks a cached preconfirmed VTXO as spent when full re-fetch no longer returns it", async () => {
+        it("should mark a cached preconfirmed VTXO as spent when the full re-fetch no longer returns it", async () => {
             let walletScript = "";
-            let callCount = 0;
             const getVtxos = vi
                 .fn<IndexerProvider["getVtxos"]>()
-                .mockImplementation(async (opts) => {
-                    callCount += 1;
-                    const script = opts?.scripts?.[0] ?? walletScript;
-                    walletScript = script;
+                .mockImplementationOnce(async (opts) => {
+                    walletScript = opts?.scripts?.[0] ?? "";
+                    return { vtxos: [createMockVtxo(walletScript)] };
+                })
+                .mockResolvedValueOnce({ vtxos: [] })
+                .mockResolvedValueOnce({ vtxos: [] });
 
-                    switch (callCount) {
-                        case 1: // bootstrap — preconfirmed
-                            return { vtxos: [makeTestVtxo(script)] };
-                        case 2: // delta — no changes
-                        case 3: // full re-fetch — VTXO gone
-                            return { vtxos: [] };
-                        default:
-                            throw new Error(
-                                `unexpected getVtxos call ${callCount}`
-                            );
-                    }
-                });
-
-            const { wallet, walletRepository } = await createReadonlyTestWallet(
-                {
-                    getVtxos,
-                } as Partial<IndexerProvider> as IndexerProvider
-            );
+            const { wallet, walletRepository } =
+                await createReadonlyTestWallet(getVtxos);
 
             expect(await wallet.getVtxos()).toHaveLength(1);
             expect(await wallet.getVtxos()).toEqual([]);
@@ -878,36 +839,21 @@ describe("Wallet", () => {
             expect(cached[0].isSpent).toBe(true);
         });
 
-        it("marks a cached settled VTXO as spent when full re-fetch no longer returns it", async () => {
+        it("should mark a cached settled VTXO as spent when the full re-fetch no longer returns it", async () => {
             let walletScript = "";
-            let callCount = 0;
             const getVtxos = vi
                 .fn<IndexerProvider["getVtxos"]>()
-                .mockImplementation(async (opts) => {
-                    callCount += 1;
-                    const script = opts?.scripts?.[0] ?? walletScript;
-                    walletScript = script;
+                .mockImplementationOnce(async (opts) => {
+                    walletScript = opts?.scripts?.[0] ?? "";
+                    return {
+                        vtxos: [createMockVtxo(walletScript, "settled")],
+                    };
+                })
+                .mockResolvedValueOnce({ vtxos: [] })
+                .mockResolvedValueOnce({ vtxos: [] });
 
-                    switch (callCount) {
-                        case 1: // bootstrap — settled VTXO
-                            return {
-                                vtxos: [makeTestVtxo(script, "settled")],
-                            };
-                        case 2: // delta — no changes
-                        case 3: // full re-fetch — VTXO gone
-                            return { vtxos: [] };
-                        default:
-                            throw new Error(
-                                `unexpected getVtxos call ${callCount}`
-                            );
-                    }
-                });
-
-            const { wallet, walletRepository } = await createReadonlyTestWallet(
-                {
-                    getVtxos,
-                } as Partial<IndexerProvider> as IndexerProvider
-            );
+            const { wallet, walletRepository } =
+                await createReadonlyTestWallet(getVtxos);
 
             const vtxos = await wallet.getVtxos();
             expect(vtxos).toHaveLength(1);

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -877,6 +877,50 @@ describe("Wallet", () => {
             expect(cached).toHaveLength(1);
             expect(cached[0].isSpent).toBe(true);
         });
+
+        it("marks a cached settled VTXO as spent when full re-fetch no longer returns it", async () => {
+            let walletScript = "";
+            let callCount = 0;
+            const getVtxos = vi
+                .fn<IndexerProvider["getVtxos"]>()
+                .mockImplementation(async (opts) => {
+                    callCount += 1;
+                    const script = opts?.scripts?.[0] ?? walletScript;
+                    walletScript = script;
+
+                    switch (callCount) {
+                        case 1: // bootstrap — settled VTXO
+                            return {
+                                vtxos: [makeTestVtxo(script, "settled")],
+                            };
+                        case 2: // delta — no changes
+                        case 3: // full re-fetch — VTXO gone
+                            return { vtxos: [] };
+                        default:
+                            throw new Error(
+                                `unexpected getVtxos call ${callCount}`
+                            );
+                    }
+                });
+
+            const { wallet, walletRepository } = await createReadonlyTestWallet(
+                {
+                    getVtxos,
+                } as Partial<IndexerProvider> as IndexerProvider
+            );
+
+            const vtxos = await wallet.getVtxos();
+            expect(vtxos).toHaveLength(1);
+            expect(vtxos[0].virtualStatus.state).toBe("settled");
+
+            expect(await wallet.getVtxos()).toEqual([]);
+
+            const cached = await walletRepository.getVtxos(
+                await wallet.getAddress()
+            );
+            expect(cached).toHaveLength(1);
+            expect(cached[0].isSpent).toBe(true);
+        });
     });
 });
 


### PR DESCRIPTION
Delta sync could serve stale VTXO state because the cursor-based fetch misses VTXOs whose state changed between syncs. Two symptoms: a preconfirmed VTXO shown as spendable after being consumed by a round, and a settled VTXO shown as spendable after being spent.

Replaced the multi-step pendingOnly/spendableOnly reconciliation cascade with a single unfiltered re-fetch for delta scripts. Any cached non-spent VTXO absent from the result is marked spent; any state change is updated in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet delta-sync reconciliation to more reliably detect and mark spent coins and skip entries missing script data.
  * Reconciliation now avoids attempting stale updates when full results are paginated and surfaces a warning instead.
* **Tests**
  * Added tests covering delta-sync reconciliation: state transitions, marking stale entries as spent, and pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->