### PR TITLE
fix: use exit() instead of forfeit() for intentTapLeafScript

### DIFF
--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -23,7 +23,7 @@ export function extendVirtualCoin(
     return {
         ...vtxo,
         forfeitTapLeafScript: wallet.offchainTapscript.forfeit(),
-        intentTapLeafScript: wallet.offchainTapscript.forfeit(),
+        intentTapLeafScript: wallet.offchainTapscript.exit(),
         tapTree: wallet.offchainTapscript.encode(),
     };
 }
@@ -35,7 +35,7 @@ export function extendCoin(
     return {
         ...utxo,
         forfeitTapLeafScript: wallet.boardingTapscript.forfeit(),
-        intentTapLeafScript: wallet.boardingTapscript.forfeit(),
+        intentTapLeafScript: wallet.boardingTapscript.exit(),
         tapTree: wallet.boardingTapscript.encode(),
     };
 }
@@ -54,7 +54,7 @@ export function extendVtxoFromContract(
     return {
         ...vtxo,
         forfeitTapLeafScript: script.forfeit(),
-        intentTapLeafScript: script.forfeit(),
+        intentTapLeafScript: script.exit(),
         tapTree: script.encode(),
     };
 }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -585,7 +585,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             fetchedExtended.push({
                 ...vtxo,
                 forfeitTapLeafScript: vtxoScript.forfeit(),
-                intentTapLeafScript: vtxoScript.forfeit(),
+                intentTapLeafScript: vtxoScript.exit(),
                 tapTree: vtxoScript.encode(),
             });
         }
@@ -616,7 +616,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
                 pendingExtended.push({
                     ...vtxo,
                     forfeitTapLeafScript: vtxoScript.forfeit(),
-                    intentTapLeafScript: vtxoScript.forfeit(),
+                    intentTapLeafScript: vtxoScript.exit(),
                     tapTree: vtxoScript.encode(),
                 });
             }
@@ -2122,7 +2122,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 allExtended.push({
                     ...vtxo,
                     forfeitTapLeafScript: vtxoScript.forfeit(),
-                    intentTapLeafScript: vtxoScript.forfeit(),
+                    intentTapLeafScript: vtxoScript.exit(),
                     tapTree: vtxoScript.encode(),
                 });
             }
@@ -2634,7 +2634,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                     vout: changeVout,
                     createdAt: new Date(createdAt),
                     forfeitTapLeafScript: this.offchainTapscript.forfeit(),
-                    intentTapLeafScript: this.offchainTapscript.forfeit(),
+                    intentTapLeafScript: this.offchainTapscript.exit(),
                     isUnrolled: false,
                     isSpent: false,
                     tapTree: this.offchainTapscript.encode(),


### PR DESCRIPTION
## Summary

- `intentTapLeafScript` was incorrectly assigned `vtxoScript.forfeit()` (2-of-2 multisig, no timelock) instead of `vtxoScript.exit()` (CSV timelock leaf) in all 7 construction sites across `src/wallet/wallet.ts` and `src/wallet/utils.ts`
- This caused `getSequence()` in intent proof construction to always return `undefined` (no timelock to decode), and produced incorrect tapscript control blocks

Closes #414

## Test plan

- [x] Unit tests pass
- [x] Build succeeds
- [ ] Run integration tests against regtest to verify intent proofs work end-to-end


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated wallet transaction processing to correctly configure virtual transaction outputs during sync operations, pending transaction reconciliation, and transaction finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->