### PR TITLE
Test/e2e unilateral exit complete unroll

### DIFF
--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -534,7 +534,8 @@ describe("Common", () => {
                         return b.length > 0;
                     });
 
-                    const boardingInputs = await alice.wallet.getBoardingUtxos();
+                    const boardingInputs =
+                        await alice.wallet.getBoardingUtxos();
                     expect(boardingInputs.length).toBeGreaterThanOrEqual(1);
 
                     await alice.wallet.settle({
@@ -593,18 +594,22 @@ describe("Common", () => {
                     const unrolled = virtualCoinsAfterExit[0];
                     expect(unrolled.isUnrolled).toBe(true);
 
-                    const exits = VtxoScript.decode(unrolled.tapTree).exitPaths();
+                    const exits = VtxoScript.decode(
+                        unrolled.tapTree
+                    ).exitPaths();
                     expect(exits.length).toBeGreaterThan(0);
 
-                    const txStatus = await alice.wallet.onchainProvider.getTxStatus(
-                        unrolled.txid
-                    );
+                    const txStatus =
+                        await alice.wallet.onchainProvider.getTxStatus(
+                            unrolled.txid
+                        );
                     expect(txStatus.confirmed).toBe(true);
 
                     // Keep this aligned with availableExitPath() selection logic,
                     // which currently returns the first mature exit path.
                     const exitTimelock = exits[0].params.timelock;
-                    const chainTip = await alice.wallet.onchainProvider.getChainTip();
+                    const chainTip =
+                        await alice.wallet.onchainProvider.getChainTip();
                     if (exitTimelock.type === "blocks") {
                         const requiredHeight =
                             txStatus.blockHeight + Number(exitTimelock.value);
@@ -642,7 +647,8 @@ describe("Common", () => {
                         return b.length > 0;
                     });
 
-                    const boardingInputs = await alice.wallet.getBoardingUtxos();
+                    const boardingInputs =
+                        await alice.wallet.getBoardingUtxos();
                     expect(boardingInputs.length).toBeGreaterThanOrEqual(1);
 
                     await alice.wallet.settle({
@@ -701,12 +707,15 @@ describe("Common", () => {
                     const unrolled = virtualCoinsAfterExit[0];
                     expect(unrolled.isUnrolled).toBe(true);
 
-                    const exits = VtxoScript.decode(unrolled.tapTree).exitPaths();
+                    const exits = VtxoScript.decode(
+                        unrolled.tapTree
+                    ).exitPaths();
                     expect(exits.length).toBeGreaterThan(0);
 
-                    const txStatus = await alice.wallet.onchainProvider.getTxStatus(
-                        unrolled.txid
-                    );
+                    const txStatus =
+                        await alice.wallet.onchainProvider.getTxStatus(
+                            unrolled.txid
+                        );
                     expect(txStatus.confirmed).toBe(true);
 
                     // Keep this aligned with availableExitPath() selection logic,
@@ -743,7 +752,9 @@ describe("Common", () => {
                         }
                         const finalTip =
                             await alice.wallet.onchainProvider.getChainTip();
-                        expect(finalTip.time).toBeGreaterThanOrEqual(requiredTime);
+                        expect(finalTip.time).toBeGreaterThanOrEqual(
+                            requiredTime
+                        );
                         if (initialTip.time < requiredTime) {
                             expect(blocksMined).toBeGreaterThan(0);
                         }

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -14,6 +14,7 @@ import {
     ArkAddress,
     buildOffchainTx,
     CSVMultisigTapscript,
+    VtxoScript,
     Wallet,
     EsploraProvider,
     InMemoryWalletRepository,
@@ -515,6 +516,143 @@ describe("Common", () => {
                 expect(virtualCoinsAfterExit).toHaveLength(1);
                 expect(virtualCoinsAfterExit[0].isUnrolled).toBe(true);
             });
+
+            it(
+                "should complete unroll after unilateral exit delay",
+                { timeout: 120000 },
+                async () => {
+                    const alice = await factory();
+
+                    const boardingAddress =
+                        await alice.wallet.getBoardingAddress();
+                    const offchainAddress = await alice.wallet.getAddress();
+
+                    execCommand(`nigiri faucet ${boardingAddress} 0.0001`);
+
+                    await waitFor(async () => {
+                        const b = await alice.wallet.getBoardingUtxos();
+                        return b.length > 0;
+                    });
+
+                    const boardingInputs = await alice.wallet.getBoardingUtxos();
+                    expect(boardingInputs.length).toBeGreaterThanOrEqual(1);
+
+                    await alice.wallet.settle({
+                        inputs: boardingInputs,
+                        outputs: [
+                            {
+                                address: offchainAddress!,
+                                amount: BigInt(10000),
+                            },
+                        ],
+                    });
+
+                    execCommand(`nigiri rpc --generate 1`);
+
+                    await waitFor(async () => {
+                        const v = await alice.wallet.getVtxos();
+                        return v.length > 0;
+                    });
+
+                    const virtualCoins = await alice.wallet.getVtxos();
+                    expect(virtualCoins).toHaveLength(1);
+                    const vtxo = virtualCoins[0];
+                    expect(vtxo.txid).toBeDefined();
+
+                    const onchainAlice = await OnchainWallet.create(
+                        alice.identity,
+                        "regtest"
+                    );
+
+                    execCommand(`nigiri faucet ${onchainAlice.address} 0.001`);
+                    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+                    const session = await Unroll.Session.create(
+                        { txid: vtxo.txid, vout: vtxo.vout },
+                        onchainAlice,
+                        onchainAlice.provider,
+                        new RestIndexerProvider("http://localhost:7070")
+                    );
+
+                    for await (const done of session) {
+                        switch (done.type) {
+                            case Unroll.StepType.WAIT:
+                            case Unroll.StepType.UNROLL:
+                                execCommand(`nigiri rpc --generate 1`);
+                                break;
+                        }
+                    }
+
+                    const virtualCoinsAfterExit = await alice.wallet.getVtxos({
+                        withUnrolled: true,
+                    });
+                    expect(virtualCoinsAfterExit).toHaveLength(1);
+                    const unrolled = virtualCoinsAfterExit[0];
+                    expect(unrolled.isUnrolled).toBe(true);
+
+                    const exits = VtxoScript.decode(unrolled.tapTree).exitPaths();
+                    expect(exits.length).toBeGreaterThan(0);
+
+                    const txStatus = await alice.wallet.onchainProvider.getTxStatus(
+                        unrolled.txid
+                    );
+                    expect(txStatus.confirmed).toBe(true);
+
+                    const exitTimelock = exits[0].params.timelock;
+                    if (exitTimelock.type === "blocks") {
+                        const chainTip =
+                            await alice.wallet.onchainProvider.getChainTip();
+                        const requiredHeight =
+                            txStatus.blockHeight + Number(exitTimelock.value);
+                        const remainingBlocks = Math.max(
+                            0,
+                            requiredHeight - chainTip.height
+                        );
+                        if (remainingBlocks > 0) {
+                            execCommand(
+                                `nigiri rpc --generate ${remainingBlocks}`
+                            );
+                        }
+                    } else {
+                        const requiredTime =
+                            txStatus.blockTime + Number(exitTimelock.value);
+                        for (let i = 0; i < 300; i += 1) {
+                            const chainTip =
+                                await alice.wallet.onchainProvider.getChainTip();
+                            if (chainTip.time >= requiredTime) {
+                                break;
+                            }
+                            execCommand(`nigiri rpc --generate 1`);
+                        }
+                        const finalTip =
+                            await alice.wallet.onchainProvider.getChainTip();
+                        expect(finalTip.time).toBeGreaterThanOrEqual(requiredTime);
+                    }
+
+                    const beforeBalance = await onchainAlice.getBalance();
+                    const completeTxid = await Unroll.completeUnroll(
+                        alice.wallet,
+                        [unrolled.txid],
+                        onchainAlice.address
+                    );
+                    expect(completeTxid).toBeDefined();
+
+                    execCommand(`nigiri rpc --generate 1`);
+
+                    await waitFor(async () => {
+                        const status =
+                            await alice.wallet.onchainProvider.getTxStatus(
+                                completeTxid
+                            );
+                        return status.confirmed;
+                    });
+
+                    await waitFor(async () => {
+                        const afterBalance = await onchainAlice.getBalance();
+                        return afterBalance > beforeBalance;
+                    });
+                }
+            );
 
             it("should exit collaboratively", { timeout: 60000 }, async () => {
                 const alice = await factory();

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -518,6 +518,114 @@ describe("Common", () => {
             });
 
             it(
+                "should reject complete-unroll before unilateral exit delay matures",
+                { timeout: 120000 },
+                async () => {
+                    const alice = await factory();
+
+                    const boardingAddress =
+                        await alice.wallet.getBoardingAddress();
+                    const offchainAddress = await alice.wallet.getAddress();
+
+                    execCommand(`nigiri faucet ${boardingAddress} 0.0001`);
+
+                    await waitFor(async () => {
+                        const b = await alice.wallet.getBoardingUtxos();
+                        return b.length > 0;
+                    });
+
+                    const boardingInputs = await alice.wallet.getBoardingUtxos();
+                    expect(boardingInputs.length).toBeGreaterThanOrEqual(1);
+
+                    await alice.wallet.settle({
+                        inputs: boardingInputs,
+                        outputs: [
+                            {
+                                address: offchainAddress!,
+                                amount: BigInt(10000),
+                            },
+                        ],
+                    });
+
+                    execCommand(`nigiri rpc --generate 1`);
+
+                    await waitFor(async () => {
+                        const v = await alice.wallet.getVtxos();
+                        return v.length > 0;
+                    });
+
+                    const virtualCoins = await alice.wallet.getVtxos();
+                    expect(virtualCoins).toHaveLength(1);
+                    const vtxo = virtualCoins[0];
+                    expect(vtxo.txid).toBeDefined();
+
+                    const onchainAlice = await OnchainWallet.create(
+                        alice.identity,
+                        "regtest"
+                    );
+
+                    execCommand(`nigiri faucet ${onchainAlice.address} 0.001`);
+                    await waitFor(async () => {
+                        const b = await onchainAlice.getBalance();
+                        return b > 0;
+                    });
+
+                    const session = await Unroll.Session.create(
+                        { txid: vtxo.txid, vout: vtxo.vout },
+                        onchainAlice,
+                        onchainAlice.provider,
+                        new RestIndexerProvider("http://localhost:7070")
+                    );
+
+                    for await (const done of session) {
+                        switch (done.type) {
+                            case Unroll.StepType.WAIT:
+                            case Unroll.StepType.UNROLL:
+                                execCommand(`nigiri rpc --generate 1`);
+                                break;
+                        }
+                    }
+
+                    const virtualCoinsAfterExit = await alice.wallet.getVtxos({
+                        withUnrolled: true,
+                    });
+                    expect(virtualCoinsAfterExit).toHaveLength(1);
+                    const unrolled = virtualCoinsAfterExit[0];
+                    expect(unrolled.isUnrolled).toBe(true);
+
+                    const exits = VtxoScript.decode(unrolled.tapTree).exitPaths();
+                    expect(exits.length).toBeGreaterThan(0);
+
+                    const txStatus = await alice.wallet.onchainProvider.getTxStatus(
+                        unrolled.txid
+                    );
+                    expect(txStatus.confirmed).toBe(true);
+
+                    // Keep this aligned with availableExitPath() selection logic,
+                    // which currently returns the first mature exit path.
+                    const exitTimelock = exits[0].params.timelock;
+                    const chainTip = await alice.wallet.onchainProvider.getChainTip();
+                    if (exitTimelock.type === "blocks") {
+                        const requiredHeight =
+                            txStatus.blockHeight + Number(exitTimelock.value);
+                        expect(chainTip.height).toBeLessThan(requiredHeight);
+                    } else {
+                        const requiredTime =
+                            txStatus.blockTime + Number(exitTimelock.value);
+                        expect(chainTip.time).toBeLessThan(requiredTime);
+                    }
+
+                    await expect(
+                        Unroll.completeUnroll(
+                            alice.wallet,
+                            [unrolled.txid],
+                            onchainAlice.address
+                        )
+                    ).rejects.toThrow(/no available exit path found/i);
+                }
+            );
+
+            it(
                 "should complete unroll after unilateral exit delay",
                 { timeout: 120000 },
                 async () => {

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -565,7 +565,10 @@ describe("Common", () => {
                     );
 
                     execCommand(`nigiri faucet ${onchainAlice.address} 0.001`);
-                    await new Promise((resolve) => setTimeout(resolve, 5000));
+                    await waitFor(async () => {
+                        const b = await onchainAlice.getBalance();
+                        return b > 0;
+                    });
 
                     const session = await Unroll.Session.create(
                         { txid: vtxo.txid, vout: vtxo.vout },
@@ -598,6 +601,8 @@ describe("Common", () => {
                     );
                     expect(txStatus.confirmed).toBe(true);
 
+                    // Keep this aligned with availableExitPath() selection logic,
+                    // which currently returns the first mature exit path.
                     const exitTimelock = exits[0].params.timelock;
                     if (exitTimelock.type === "blocks") {
                         const chainTip =
@@ -616,6 +621,9 @@ describe("Common", () => {
                     } else {
                         const requiredTime =
                             txStatus.blockTime + Number(exitTimelock.value);
+                        const initialTip =
+                            await alice.wallet.onchainProvider.getChainTip();
+                        let blocksMined = 0;
                         for (let i = 0; i < 300; i += 1) {
                             const chainTip =
                                 await alice.wallet.onchainProvider.getChainTip();
@@ -623,10 +631,14 @@ describe("Common", () => {
                                 break;
                             }
                             execCommand(`nigiri rpc --generate 1`);
+                            blocksMined += 1;
                         }
                         const finalTip =
                             await alice.wallet.onchainProvider.getChainTip();
                         expect(finalTip.time).toBeGreaterThanOrEqual(requiredTime);
+                        if (initialTip.time < requiredTime) {
+                            expect(blocksMined).toBeGreaterThan(0);
+                        }
                     }
 
                     const beforeBalance = await onchainAlice.getBalance();


### PR DESCRIPTION
### Description
This PR adds an end-to-end test for the unilateral exit completion flow, covering the path after unroll where CSV maturity must be satisfied before [completeUnroll](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

### What this adds

1. New e2e scenario in test/e2e/ark.test.ts: should complete unroll after unilateral exit delay
2. The test performs:
3. Create/fund a VTXO and settle it.
4. Run [Unroll.Session](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) until the VTXO is fully unrolled.
5. Decode the VTXO exit path timelock from tapscript.
6. Wait for CSV maturity:
7. block-based: mine remaining blocks
8. seconds-based: mine blocks until chain time reaches required timestamp
9. Call [Unroll.completeUnroll(...)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
10. Mine/confirm and assert destination onchain balance increases.

### Why

1. Reviewer feedback asked to avoid the ad-hoc unit test in #405 and prefer unilateral-exit e2e coverage.
2. This test validates real integration behavior around timelock maturity and complete-unroll broadcast/confirmation.

### Scope

1. Test-only change.
2. No SDK runtime logic changes.

### Notes

1. This branch is intended as a follow-up to the complete-unroll sequence fix.
2. If needed, it can be rebased/retargeted after #405 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering unroll behavior: verifies rejection if an unroll is attempted before the exit delay matures, and verifies successful completion after the exit delay with on-chain confirmation and balance update verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->