### PR TITLE
fix: prevent stale VTXOs from surviving sync after settlement

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1788,6 +1788,10 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
         const abortController = new AbortController();
 
+        // Optimistic mark: hide these inputs from concurrent
+        // getVtxos() callers while the settlement is in progress.
+        this._addPendingSpends(params.inputs);
+
         try {
             const stream = this.arkProvider.getEventStream(
                 abortController.signal,
@@ -1795,10 +1799,6 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             );
 
             const intentId = await this.safeRegisterIntent(intent);
-
-            // Optimistic mark: hide these inputs from concurrent
-            // getVtxos() callers while the batch is in progress.
-            this._addPendingSpends(params.inputs);
 
             const handler = this.createBatchHandler(
                 intentId,
@@ -1816,15 +1816,14 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             });
 
             await this.updateDbAfterSettle(params.inputs, commitmentTxid);
-            this._removePendingSpends(params.inputs);
 
             return commitmentTxid;
         } catch (error) {
-            this._removePendingSpends(params.inputs);
             // delete the intent to not be stuck in the queue
             await this.arkProvider.deleteIntent(deleteIntent).catch(() => {});
             throw error;
         } finally {
+            this._removePendingSpends(params.inputs);
             // close the stream
             abortController.abort();
         }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -596,6 +596,38 @@ export class ReadonlyWallet implements IReadonlyWallet {
             const extended = extendWithScript(vtxo);
             if (extended) fetchedExtended.push(extended);
         }
+        // Preserve confirmed local spend marks that the indexer hasn't
+        // caught up with yet.  Without this, a stale indexer response
+        // (isSpent=false) would overwrite the SDK's first-hand knowledge
+        // that a VTXO was consumed by a successful settle/send.
+        const cached = await this.walletRepository.getVtxos(address);
+        if (cached.length > 0) {
+            const confirmedSpent = new Map<string, ExtendedVirtualCoin>();
+            for (const v of cached) {
+                if (
+                    v.isSpent &&
+                    (v.virtualStatus.state === "spent" ||
+                        v.virtualStatus.state === "settled")
+                ) {
+                    confirmedSpent.set(`${v.txid}:${v.vout}`, v);
+                }
+            }
+            if (confirmedSpent.size > 0) {
+                for (const vtxo of fetchedExtended) {
+                    const local = confirmedSpent.get(
+                        `${vtxo.txid}:${vtxo.vout}`
+                    );
+                    if (local && !vtxo.isSpent) {
+                        vtxo.isSpent = true;
+                        vtxo.virtualStatus = local.virtualStatus;
+                        vtxo.settledBy = local.settledBy;
+                        vtxo.spentBy = local.spentBy;
+                        vtxo.arkTxId = local.arkTxId;
+                    }
+                }
+            }
+        }
+
         // Save VTXOs first, then advance cursors only on success.
         const cutoff = cursorCutoff(requestStartedAt);
         await this.walletRepository.saveVtxos(address, fetchedExtended);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -144,6 +144,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
     private _contractManagerInitializing?: Promise<ContractManager>;
     protected readonly watcherConfig?: ReadonlyWalletConfig["watcherConfig"];
     private readonly _assetManager: IReadonlyAssetManager;
+    protected _pendingSpendOutpoints = new Set<string>();
     private _syncVtxosInflight?: Promise<{
         isDelta: boolean;
         fetchedExtended: ExtendedVirtualCoin[];
@@ -464,6 +465,10 @@ export class ReadonlyWallet implements IReadonlyWallet {
             : fetchedExtended;
 
         return vtxos.filter((vtxo) => {
+            // Skip VTXOs that are being spent by an in-flight operation.
+            if (this._pendingSpendOutpoints.has(`${vtxo.txid}:${vtxo.vout}`)) {
+                return false;
+            }
             if (isSpendable(vtxo)) {
                 if (
                     !f.withRecoverable &&
@@ -1224,6 +1229,24 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      */
     private _txLock: Promise<void> = Promise.resolve();
 
+    private _addPendingSpends(inputs: ExtendedCoin[]): void {
+        for (const input of inputs) {
+            if ("virtualStatus" in input) {
+                this._pendingSpendOutpoints.add(`${input.txid}:${input.vout}`);
+            }
+        }
+    }
+
+    private _removePendingSpends(inputs: ExtendedCoin[]): void {
+        for (const input of inputs) {
+            if ("virtualStatus" in input) {
+                this._pendingSpendOutpoints.delete(
+                    `${input.txid}:${input.vout}`
+                );
+            }
+        }
+    }
+
     private _withTxLock<T>(fn: () => Promise<T>): Promise<T> {
         let release!: () => void;
         const lock = new Promise<void>((r) => (release = r));
@@ -1773,6 +1796,10 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
             const intentId = await this.safeRegisterIntent(intent);
 
+            // Optimistic mark: hide these inputs from concurrent
+            // getVtxos() callers while the batch is in progress.
+            this._addPendingSpends(params.inputs);
+
             const handler = this.createBatchHandler(
                 intentId,
                 params.inputs,
@@ -1789,9 +1816,11 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             });
 
             await this.updateDbAfterSettle(params.inputs, commitmentTxid);
+            this._removePendingSpends(params.inputs);
 
             return commitmentTxid;
         } catch (error) {
+            this._removePendingSpends(params.inputs);
             // delete the intent to not be stuck in the queue
             await this.arkProvider.deleteIntent(deleteIntent).catch(() => {});
             throw error;
@@ -2549,20 +2578,27 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
         const sentAmount = recipients.reduce((sum, r) => sum + r.amount, 0);
 
-        const { arkTxid, signedCheckpointTxs } =
-            await this.buildAndSubmitOffchainTx(selectedCoins, outputs);
+        // Optimistic mark: hide selected coins from concurrent
+        // getVtxos() callers while the offchain tx is in flight.
+        this._addPendingSpends(selectedCoins);
+        try {
+            const { arkTxid, signedCheckpointTxs } =
+                await this.buildAndSubmitOffchainTx(selectedCoins, outputs);
 
-        await this.updateDbAfterOffchainTx(
-            selectedCoins,
-            arkTxid,
-            signedCheckpointTxs,
-            sentAmount,
-            BigInt(changeAmount),
-            changeReceiver ? changeIndex : 0,
-            changeReceiver?.assets
-        );
+            await this.updateDbAfterOffchainTx(
+                selectedCoins,
+                arkTxid,
+                signedCheckpointTxs,
+                sentAmount,
+                BigInt(changeAmount),
+                changeReceiver ? changeIndex : 0,
+                changeReceiver?.assets
+            );
 
-        return arkTxid;
+            return arkTxid;
+        } finally {
+            this._removePendingSpends(selectedCoins);
+        }
     }
 
     /**

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1810,7 +1810,13 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         // the signed forfeits transactions to submit
         const signedForfeits: string[] = [];
 
-        const vtxos = await this.getVtxos();
+        // Use the inputs array directly (with type guard) instead of
+        // getVtxos() — the inputs may be in _pendingSpendOutpoints
+        // and would be filtered out by getVtxos().
+        const isVtxoInput = (
+            input: ExtendedCoin
+        ): input is ExtendedVirtualCoin => "virtualStatus" in input;
+
         let settlementPsbt = Transaction.fromPSBT(
             base64.decode(event.commitmentTx)
         );
@@ -1821,13 +1827,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         const connectorsLeaves = connectorsGraph?.leaves() || [];
 
         for (const input of inputs) {
-            // check if the input is an offchain "virtual" coin
-            const vtxo = vtxos.find(
-                (vtxo) => vtxo.txid === input.txid && vtxo.vout === input.vout
-            );
-
             // boarding utxo, we need to sign the settlement tx
-            if (!vtxo) {
+            if (!isVtxoInput(input)) {
                 for (let i = 0; i < settlementPsbt.inputsLength; i++) {
                     const settlementInput = settlementPsbt.getInput(i);
 
@@ -1856,7 +1857,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 continue;
             }
 
-            if (isRecoverable(vtxo) || isSubdust(vtxo, this.dustAmount)) {
+            if (isRecoverable(input) || isSubdust(input, this.dustAmount)) {
                 // recoverable or subdust coin, we don't need to create a forfeit tx
                 continue;
             }
@@ -1891,7 +1892,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                         txid: input.txid,
                         index: input.vout,
                         witnessUtxo: {
-                            amount: BigInt(vtxo.value),
+                            amount: BigInt(input.value),
                             script: VtxoScript.decode(input.tapTree).pkScript,
                         },
                         sighashType: SigHash.DEFAULT,

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -17,7 +17,7 @@ import { RestDelegatorProvider } from "../../src/providers/delegator";
 import { generateMnemonic } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
-export const arkdExec = "docker exec -t ark";
+export const arkdExec = "docker exec -t arkd";
 
 export interface TestArkWallet {
     wallet: Wallet;

--- a/test/e2e/vtxo-sync.test.ts
+++ b/test/e2e/vtxo-sync.test.ts
@@ -1,0 +1,111 @@
+import { expect, describe, it } from "vitest";
+import {
+    Wallet,
+    EsploraProvider,
+    SingleKey,
+    ArkNote,
+    InMemoryWalletRepository,
+    InMemoryContractRepository,
+} from "../../src";
+import { waitFor } from "./utils";
+import { execSync } from "child_process";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const generateBlocks = (n: number) => execSync(`nigiri rpc --generate ${n}`);
+const arkdContainer = (() => {
+    try {
+        execSync("docker inspect arkd", { stdio: "ignore" });
+        return "arkd";
+    } catch {
+        return "ark";
+    }
+})();
+
+function createWallet(settlementConfig: false | undefined = false) {
+    return Wallet.create({
+        identity: SingleKey.fromRandomBytes(),
+        arkServerUrl: "http://localhost:7070",
+        onchainProvider: new EsploraProvider("http://localhost:3000", {
+            forcePolling: true,
+            pollingInterval: 2000,
+        }),
+        storage: {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        },
+        settlementConfig,
+    });
+}
+
+/**
+ * This test verifies that after VtxoManager's auto-settlement round the
+ * wallet sees exactly one spendable VTXO.
+ *
+ * KNOWN BUG: when prior tests in a suite shift the block-based round
+ * timer, generateBlocks(10) can trigger a round at an offset that gives
+ * VtxoManager time to auto-register the settled VTXO for a second
+ * round.  The indexer then returns BOTH the old VTXO (committed to the
+ * pending round) and the new preconfirmed one as non-spent.  The
+ * wallet picks the stale VTXO for coin selection and arkd rejects it
+ * with INVALID_PSBT_INPUT (5): missing tapscript spend sig.
+ *
+ * This test passes in isolation (single round, 1 VTXO) but exposes the
+ * bug when run after other e2e tests that advance the block height.
+ * See: https://github.com/arkade-os/boltz-swap — the full boltz-swap
+ * suite reliably triggers the multi-VTXO condition.
+ */
+describe("VTXO sync after VtxoManager auto-settlement", () => {
+    it(
+        "wallet sees only one spendable VTXO after auto-settlement",
+        { timeout: 60_000 },
+        async () => {
+            const funder = await createWallet(false);
+            const funderAddr = await funder.getAddress();
+            const noteStr = execSync(
+                `docker exec -t ${arkdContainer} arkd note --amount 10000`
+            )
+                .toString()
+                .trim();
+            await funder.settle({
+                inputs: [ArkNote.fromString(noteStr)],
+                outputs: [{ address: funderAddr, amount: BigInt(10000) }],
+            });
+            await waitFor(
+                async () => (await funder.getBalance()).available > 0
+            );
+
+            const wallet = await createWallet(undefined);
+
+            try {
+                const address = await wallet.getAddress();
+                await funder.send({ address, amount: 5000 });
+                await waitFor(
+                    async () => (await wallet.getBalance()).available > 0
+                );
+
+                await sleep(1000);
+                generateBlocks(10);
+                await sleep(5000);
+
+                await wallet.clearSyncCursors();
+                const vtxos = await wallet.getVtxos();
+
+                expect(
+                    vtxos.length,
+                    `Expected 1 spendable VTXO but got ${vtxos.length}: ` +
+                        vtxos
+                            .map(
+                                (v) =>
+                                    `${v.txid.slice(0, 8)} ` +
+                                    `${v.virtualStatus.state} ` +
+                                    `val=${v.value}`
+                            )
+                            .join(", ")
+                ).toBe(1);
+            } finally {
+                await wallet.dispose();
+                await funder.dispose();
+            }
+        }
+    );
+});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -867,6 +867,130 @@ describe("Wallet", () => {
             expect(cached).toHaveLength(1);
             expect(cached[0].isSpent).toBe(true);
         });
+
+        it("should preserve a confirmed spend mark when the indexer still reports isSpent=false", async () => {
+            let walletScript = "";
+            const getVtxos = vi
+                .fn<IndexerProvider["getVtxos"]>()
+                // 1st call: bootstrap — returns a preconfirmed VTXO
+                .mockImplementationOnce(async (opts) => {
+                    walletScript = opts?.scripts?.[0] ?? "";
+                    return {
+                        vtxos: [createMockVtxo(walletScript)],
+                    };
+                })
+                // 2nd call: bootstrap after clearSyncCursors — indexer
+                // still returns it with isSpent=false (stale)
+                .mockImplementationOnce(async () => ({
+                    vtxos: [createMockVtxo(walletScript)],
+                }));
+
+            const { wallet, walletRepository } =
+                await createReadonlyTestWallet(getVtxos);
+
+            // First sync: VTXO cached as spendable
+            const vtxos = await wallet.getVtxos();
+            expect(vtxos).toHaveLength(1);
+
+            // Simulate a confirmed spend (as updateDbAfterSettle would)
+            const address = await wallet.getAddress();
+            const cached = await walletRepository.getVtxos(address);
+            await walletRepository.saveVtxos(address, [
+                {
+                    ...cached[0],
+                    isSpent: true,
+                    virtualStatus: {
+                        ...cached[0].virtualStatus,
+                        state: "settled",
+                    },
+                    settledBy: "cc".repeat(32),
+                },
+            ]);
+
+            // Clear cursors to force a full bootstrap on next sync
+            await wallet.clearSyncCursors();
+
+            // Next getVtxos triggers a new bootstrap; the indexer
+            // returns the VTXO with isSpent=false but the local
+            // confirmed mark should be preserved.
+            expect(await wallet.getVtxos()).toHaveLength(0);
+
+            const afterSync = await walletRepository.getVtxos(address);
+            expect(afterSync).toHaveLength(1);
+            expect(afterSync[0].isSpent).toBe(true);
+            expect(afterSync[0].virtualStatus.state).toBe("settled");
+            expect(afterSync[0].settledBy).toBe("cc".repeat(32));
+        });
+
+        it("should not preserve an unconfirmed spend mark across syncs", async () => {
+            let walletScript = "";
+            const getVtxos = vi
+                .fn<IndexerProvider["getVtxos"]>()
+                // 1st call: bootstrap
+                .mockImplementationOnce(async (opts) => {
+                    walletScript = opts?.scripts?.[0] ?? "";
+                    return {
+                        vtxos: [createMockVtxo(walletScript)],
+                    };
+                })
+                // 2nd call: bootstrap after clearSyncCursors
+                .mockImplementationOnce(async () => ({
+                    vtxos: [createMockVtxo(walletScript)],
+                }));
+
+            const { wallet, walletRepository } =
+                await createReadonlyTestWallet(getVtxos);
+
+            const vtxos = await wallet.getVtxos();
+            expect(vtxos).toHaveLength(1);
+
+            // Mark isSpent=true WITHOUT a confirmed state (no
+            // settledBy, state still "preconfirmed").  This simulates
+            // an optimistic mark that wasn't rolled back.
+            const address = await wallet.getAddress();
+            const cached = await walletRepository.getVtxos(address);
+            await walletRepository.saveVtxos(address, [
+                { ...cached[0], isSpent: true },
+            ]);
+
+            await wallet.clearSyncCursors();
+
+            // The unconfirmed mark should be overwritten by the
+            // indexer (self-healing).
+            expect(await wallet.getVtxos()).toHaveLength(1);
+        });
+
+        it("should filter out VTXOs in _pendingSpendOutpoints", async () => {
+            let walletScript = "";
+            // Use a persistent mock so delta + reconciliation calls
+            // always return the same VTXO.
+            const getVtxos = vi
+                .fn<IndexerProvider["getVtxos"]>()
+                .mockImplementation(async (opts) => {
+                    walletScript = opts?.scripts?.[0] ?? walletScript;
+                    return {
+                        vtxos: [createMockVtxo(walletScript)],
+                    };
+                });
+
+            const { wallet } = await createReadonlyTestWallet(getVtxos);
+
+            const vtxos = await wallet.getVtxos();
+            expect(vtxos).toHaveLength(1);
+
+            // Simulate an in-flight spend by adding to the set
+            const outpoint = `${vtxos[0].txid}:${vtxos[0].vout}`;
+            (wallet as any)._pendingSpendOutpoints.add(outpoint);
+
+            // The VTXO should be hidden from getVtxos.
+            const filtered = await wallet.getVtxos();
+            expect(filtered).toHaveLength(0);
+
+            // Removing from the set restores visibility.
+            (wallet as any)._pendingSpendOutpoints.delete(outpoint);
+            const restored = await wallet.getVtxos();
+            expect(restored).toHaveLength(1);
+        });
     });
 });
 


### PR DESCRIPTION
## Summary

- **Sync protection**: after a successful `settle()` or `send()`, the SDK marks input VTXOs as spent (`isSpent + state=settled/spent`). A subsequent indexer sync could overwrite this with stale data (`isSpent=false`). Now, confirmed local spend marks are preserved during sync.
- **In-flight spend tracking**: VTXOs committed to an active `settle()` or `send()` are hidden from `getVtxos()` via an in-memory set, preventing concurrent callers from selecting them for coin selection.
- **`handleSettlementFinalizationEvent` refactor**: replaced the `getVtxos()` call with a type guard on the `inputs` parameter to avoid an unnecessary sync mid-settlement and to work correctly with the pending-spend filter.

## Context

When VtxoManager auto-renews a VTXO, `updateDbAfterSettle` correctly marks the input as spent. However, the next `getVtxos()` call triggers a sync where the indexer still returns the VTXO with `isSpent=false` (server-side lag). The `saveVtxos()` merge overwrites the local mark, making the consumed VTXO appear spendable again. Coin selection picks it and arkd rejects with `INVALID_PSBT_INPUT`.

Reproducer: `test/e2e/vtxo-sync.test.ts` — passes in isolation, fails when prior e2e tests advance the block height.

## Test plan

- [x] 3 new unit tests covering sync protection, self-healing of unconfirmed marks, and pending-spend filtering
- [x] `pnpm test:unit` — 789 tests pass, no regressions
- [ ] `pnpm test:integration` — run `test/e2e/vtxo-sync.test.ts` after other e2e tests to verify the multi-VTXO condition no longer triggers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved coin visibility: VTXOs involved in in-flight operations are now optimistically hidden from available balance.

* **Bug Fixes**
  * Sync reconciliation now preserves confirmed spend marks across full syncs, preventing spendable balance regressions.

* **Tests**
  * Added end-to-end and unit tests covering VTXO sync, settlement reconciliation, and pending-spend behavior.

* **Chores**
  * Updated test tooling and submodule references (container invocation and regtest pointer).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->