### PR TITLE
Use latest regtest (5f8acd3) and arkd version 0.9.1

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -1,6 +1,6 @@
 # ts-sdk arkade-regtest overrides
-ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.0
-ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.0
+ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.1
+ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.1
 
 # Skip Bitcoin Core restart — avoids nbxplorer connection loss
 BITCOIN_LOW_FEE=false

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -1,4 +1,3 @@
-import { hex } from "@scure/base";
 import {
     Wallet,
     SingleKey,
@@ -6,8 +5,6 @@ import {
     Identity,
     OnchainWallet,
     EsploraProvider,
-    RestIndexerProvider,
-    ArkAddress,
     IntentFeeConfig,
     InMemoryWalletRepository,
     InMemoryContractRepository,
@@ -45,8 +42,15 @@ export interface TestOnchainWallet {
 }
 
 export function execCommand(command: string): string {
-    command += " | grep -v WARN";
-    const result = execSync(command).toString().trim();
+    const result = execSync(command, { encoding: "utf8" })
+        .replace(/\r/g, "")
+        .split("\n")
+        .filter((line) => !line.includes("WARN"))
+        .join("\n")
+        .trim();
+    if (result.startsWith("error:")) {
+        throw new Error(result);
+    }
     return result;
 }
 
@@ -177,31 +181,13 @@ export async function createVtxo(
     return settleTxid;
 }
 
-// before each test check if the ark's cli running in the test env has at least 20_000 offchain balance
-// if not, fund it with 100.000
+// before each test, ensure the faucet wallet has fresh spendable VTXOs.
+// After rounds, existing VTXOs can become stale (balance shows them but
+// ark send can't spend them), so we always redeem a fresh note.
 export async function beforeEachFaucet(): Promise<void> {
     ensureArkCliInitialized();
-    const receiveOutput = execCommand(`${arkdExec} ark receive`);
-    const receive = JSON.parse(receiveOutput);
-    const receiveAddress = receive.offchain_address;
-
-    const { vtxos } = await new RestIndexerProvider(
-        "http://localhost:7070"
-    ).getVtxos({
-        scripts: [hex.encode(ArkAddress.decode(receiveAddress).pkScript)],
-        spendableOnly: true,
-    });
-    const offchainBalance = vtxos.reduce(
-        (sum: number, vtxo) => sum + vtxo.value,
-        0
-    );
-
-    if (offchainBalance <= 20_000) {
-        const noteStr = execCommand(`${arkdExec} arkd note --amount 200000`);
-        execCommand(
-            `${arkdExec} ark redeem-notes -n ${noteStr} --password secret`
-        );
-    }
+    const noteStr = execCommand(`${arkdExec} arkd note --amount 200000`);
+    execCommand(`${arkdExec} ark redeem-notes -n ${noteStr} --password secret`);
 }
 
 export function setFees(fees: IntentFeeConfig): void {

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -19,6 +19,21 @@ import { wordlist } from "@scure/bip39/wordlists/english.js";
 
 export const arkdExec = "docker exec -t arkd";
 
+let arkCliInitialized = false;
+
+function ensureArkCliInitialized(): void {
+    if (arkCliInitialized) return;
+    try {
+        execSync(
+            `${arkdExec} ark init --password secret --server-url localhost:7070 --explorer http://chopsticks:3000`,
+            { stdio: "pipe" }
+        );
+    } catch {
+        // already initialized — ignore
+    }
+    arkCliInitialized = true;
+}
+
 export interface TestArkWallet {
     wallet: Wallet;
     identity: Identity;
@@ -165,6 +180,7 @@ export async function createVtxo(
 // before each test check if the ark's cli running in the test env has at least 20_000 offchain balance
 // if not, fund it with 100.000
 export async function beforeEachFaucet(): Promise<void> {
+    ensureArkCliInitialized();
     const receiveOutput = execCommand(`${arkdExec} ark receive`);
     const receive = JSON.parse(receiveOutput);
     const receiveAddress = receive.offchain_address;

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -17,7 +17,7 @@ import { RestDelegatorProvider } from "../../src/providers/delegator";
 import { generateMnemonic } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
-export const arkdExec = "docker exec -t ark";
+export const arkdExec = "docker exec -t arkd";
 
 export interface TestArkWallet {
     wallet: Wallet;

--- a/test/e2e/vhtlc.test.ts
+++ b/test/e2e/vhtlc.test.ts
@@ -21,6 +21,7 @@ import {
     beforeEachFaucet,
     createTestArkWallet,
     createTestIdentity,
+    execCommand,
     faucetOffchain,
 } from "./utils";
 import { execSync } from "child_process";
@@ -71,9 +72,11 @@ describe("vhtlc", () => {
 
         // fund the vhtlc address
         const fundAmount = 1000;
-        execSync(
+        execCommand(
             `${arkdExec} ark send --to ${address} --amount ${fundAmount} --password secret`
         );
+
+        await new Promise((resolve) => setTimeout(resolve, 1000));
 
         // bob special identity to sign with the preimage
         const bobVHTLCIdentity: Identity = {

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -57,11 +57,32 @@ async function waitForBoltzPairs(maxRetries = 30, retryDelay = 2000) {
     throw new Error("Boltz ARK/BTC pairs not available after maximum retries");
 }
 
+function initArkCli() {
+    console.log("Initializing ark CLI client...");
+    try {
+        execSync(
+            "docker exec arkd ark init --password secret --server-url localhost:7070 --explorer http://chopsticks:3000",
+            { stdio: "pipe", encoding: "utf8" }
+        );
+        console.log("  ✔ ark CLI initialized");
+    } catch (e) {
+        // Already initialized is fine
+        if (e.stderr && e.stderr.includes("already initialized")) {
+            console.log("  ✔ ark CLI already initialized");
+        } else {
+            console.log(
+                "  ✔ ark CLI initialized (may have been already set up)"
+            );
+        }
+    }
+}
+
 // Run setup — arkade-regtest handles all infrastructure.
 // This script just waits for services to be ready.
 async function setup() {
     try {
         await waitForArkServer();
+        initArkCli();
         await waitForBoltzPairs();
         console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
         console.log("  ✓ regtest setup completed successfully");


### PR DESCRIPTION
Must match https://github.com/arkade-os/boltz-swap/pull/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ARK daemon and wallet container images from v0.9.0 to v0.9.1.
  * Updated regtest submodule reference.

* **Tests**
  * Test setup enhanced to ensure the ARK CLI is initialized before tests and to target the ARK daemon container for test commands, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->