### PR TITLE
Remove getDefaultAddress

### DIFF
--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -46,7 +46,6 @@ const DEFAULT_PAGE_SIZE = 500;
  *   indexerProvider,
  *   contractRepository,
  *   walletRepository,
- *   getDefaultAddress,
  * });
  *
  * const unsubscribe = manager.onContractEvent((event) => {
@@ -207,9 +206,6 @@ export interface ContractManagerConfig {
     /** The wallet repository for VTXO storage (single source of truth) */
     walletRepository: WalletRepository;
 
-    /** Function to get the wallet's default Ark address */
-    getDefaultAddress: () => Promise<string>;
-
     /** Watcher configuration */
     watcherConfig?: Partial<ContractWatcherConfig>;
 }
@@ -235,7 +231,6 @@ export type CreateContractParams = Omit<Contract, "createdAt" | "state"> & {
  * const manager = new ContractManager({
  *   indexerProvider: wallet.indexerProvider,
  *   contractRepository: wallet.contractRepository,
- *   getDefaultAddress: () => wallet.getAddress(),
  * });
  *
  * // Initialize (loads persisted contracts)

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1045,7 +1045,6 @@ export class ReadonlyWallet implements IReadonlyWallet {
             indexerProvider: this.indexerProvider,
             contractRepository: this.contractRepository,
             walletRepository: this.walletRepository,
-            getDefaultAddress: () => this.getAddress(),
             watcherConfig: this.watcherConfig,
         });
 

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -94,7 +94,6 @@ describe("Contracts", () => {
             manager = await ContractManager.create({
                 indexerProvider: mockIndexer,
                 contractRepository: repository,
-                getDefaultAddress: async () => "default-address",
                 walletRepository: new InMemoryWalletRepository(),
             });
         });
@@ -146,7 +145,6 @@ describe("Contracts", () => {
             manager = await ContractManager.create({
                 indexerProvider: mockIndexer,
                 contractRepository: repository,
-                getDefaultAddress: async () => "default-address",
                 walletRepository: new InMemoryWalletRepository(),
             });
         });

--- a/test/contracts/delegator-lifecycle.test.ts
+++ b/test/contracts/delegator-lifecycle.test.ts
@@ -36,7 +36,6 @@ describe("Delegator Lifecycle", () => {
             indexerProvider: mockIndexer,
             contractRepository,
             walletRepository,
-            getDefaultAddress: async () => "default-address",
             watcherConfig: {
                 failsafePollIntervalMs: 1000,
                 reconnectDelayMs: 500,
@@ -78,7 +77,6 @@ describe("Delegator Lifecycle", () => {
             indexerProvider: mockIndexer,
             contractRepository,
             walletRepository,
-            getDefaultAddress: async () => "delegate-address",
             watcherConfig: {
                 failsafePollIntervalMs: 1000,
                 reconnectDelayMs: 500,
@@ -138,7 +136,6 @@ describe("Delegator Lifecycle", () => {
             indexerProvider: mockIndexer,
             contractRepository,
             walletRepository,
-            getDefaultAddress: async () => "default-address",
             watcherConfig: {
                 failsafePollIntervalMs: 1000,
                 reconnectDelayMs: 500,
@@ -166,7 +163,6 @@ describe("Delegator Lifecycle", () => {
             indexerProvider: mockIndexer,
             contractRepository,
             walletRepository,
-            getDefaultAddress: async () => "default-address",
             watcherConfig: {
                 failsafePollIntervalMs: 1000,
                 reconnectDelayMs: 500,

--- a/test/contracts/manager.test.ts
+++ b/test/contracts/manager.test.ts
@@ -34,7 +34,6 @@ describe("ContractManager", () => {
         manager = await ContractManager.create({
             indexerProvider: mockIndexer,
             contractRepository: repository,
-            getDefaultAddress: async () => "default-address",
             walletRepository: new InMemoryWalletRepository(),
             watcherConfig: {
                 failsafePollIntervalMs: 1000,
@@ -160,7 +159,6 @@ describe("ContractManager", () => {
         const newManager = await ContractManager.create({
             indexerProvider: mockIndexer,
             contractRepository: repository,
-            getDefaultAddress: async () => "default-address",
             walletRepository: new InMemoryWalletRepository(),
         });
 
@@ -199,7 +197,6 @@ describe("ContractManager", () => {
         const newManager = await ContractManager.create({
             indexerProvider: mockIndexer,
             contractRepository: repository,
-            getDefaultAddress: async () => "default-address",
             walletRepository: walletRepo,
         });
 
@@ -245,7 +242,6 @@ describe("ContractManager", () => {
         await ContractManager.create({
             indexerProvider: mockIndexer,
             contractRepository: repository,
-            getDefaultAddress: async () => "default-address",
             walletRepository: walletRepo,
         });
 


### PR DESCRIPTION
`getDefaultAddress()` shouldn't be used. It's only mentioned in ContractManager configuration and never used there. No reason to expose it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified ContractManager configuration by removing the `getDefaultAddress` callback requirement; the system now handles default address resolution internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->