### PR TITLE
fix(intent): set proof tx lockTime to 0

### DIFF
--- a/src/contracts/types.ts
+++ b/src/contracts/types.ts
@@ -94,7 +94,11 @@ export interface PathSelection {
     /** Additional witness elements, for example a preimage for HTLC-like paths. */
     extraWitness?: Bytes[];
 
-    /** Sequence number override, for example for CSV timelocks. */
+    /**
+     * nSequence for the spending input, BIP-68 encoded when the leaf
+     * uses CSV. Decode with `sequenceToTimelock`; do NOT use as an
+     * absolute `Transaction.lockTime`.
+     */
     sequence?: number;
 }
 

--- a/src/intent/index.ts
+++ b/src/intent/index.ts
@@ -250,13 +250,13 @@ function craftToSignTx(
 ): Transaction {
     const firstInput = inputs[0];
 
-    const lockTime = inputs
-        .map((input) => input.sequence || 0)
-        .reduce((a, b) => Math.max(a, b), 0);
-
+    // Proof tx is never broadcast; match BIP-322 by setting lockTime to 0.
+    // Per-input nSequence already carries any BIP-68 relative timelock for
+    // the tapscript being spent; it must not be copied into nLockTime, which
+    // has unrelated (absolute) semantics.
     const tx = new Transaction({
         version: 2,
-        lockTime,
+        lockTime: 0,
     });
 
     // add the first "toSpend" input

--- a/src/intent/index.ts
+++ b/src/intent/index.ts
@@ -250,10 +250,12 @@ function craftToSignTx(
 ): Transaction {
     const firstInput = inputs[0];
 
-    // Proof tx is never broadcast; match BIP-322 by setting lockTime to 0.
-    // Per-input nSequence already carries any BIP-68 relative timelock for
-    // the tapscript being spent; it must not be copied into nLockTime, which
-    // has unrelated (absolute) semantics.
+    // Proof tx is never broadcast onchain — toSpend references a zero-hash
+    // outpoint (see BIP-322). The tx exists only as a sighash commitment
+    // the server verifies signatures against; nLockTime and nSequence carry
+    // no consensus meaning here, they only need to match between signer and
+    // verifier. Use lockTime = 0 (BIP-322 convention) and leave each input's
+    // nSequence untouched.
     const tx = new Transaction({
         version: 2,
         lockTime: 0,

--- a/src/script/base.ts
+++ b/src/script/base.ts
@@ -71,10 +71,10 @@ export class VtxoScript {
      */
     constructor(readonly scripts: Bytes[]) {
         // reverse the scripts if the number of scripts is odd
-        // This is compatible with the arkd algorithm that computes a Taproot tree from a list of tapscripts.
-        // Reverse only here while computing the tweaked public key.
-        // Preserve the original order when re-encoding as a TapTree.
-        // Use `.slice().reverse()` instead of `.reverse()` to avoid mutating the original array.
+        // this is to be compatible with arkd algorithm computing taproot tree from list of tapscripts
+        // the scripts must be reversed only HERE while we compute the tweaked public key
+        // but the original order should be preserved while encoding as taptree
+        // note: .slice().reverse() is used instead of .reverse() to avoid mutating the original array
         const list =
             scripts.length % 2 !== 0 ? scripts.slice().reverse() : scripts;
 

--- a/src/script/base.ts
+++ b/src/script/base.ts
@@ -199,12 +199,23 @@ export class VtxoScript {
 export type EncodedVtxoScript = { tapTree: Bytes };
 
 /**
- * Extract the relative sequence value encoded in a CSV-based tapleaf, if present.
+ * Extract the timelock value encoded in a timelocked tapleaf, if any.
+ *
+ * The return value is unit-ambiguous: for a CSV leaf it is a BIP-68
+ * nSequence (relative timelock); for a CLTV leaf it is an absolute
+ * nLockTime. Callers must know which leaf shape they are inspecting to
+ * interpret the number correctly, and must not copy a CSV result into
+ * `Transaction.lockTime` (or vice versa).
  *
  * @param tapLeafScript - Tapleaf script to inspect
- * @returns Relative sequence number, or `undefined` when no CSV path is present
+ * @returns The encoded timelock value, or `undefined` when neither a CSV
+ *          nor CLTV path is present
  * @see VtxoScript.exitPaths
  */
+// TODO(next-major): return a discriminated union
+// (`{ kind: "relative", nSequence } | { kind: "absolute", lockTime }`)
+// so callers can't conflate the two. Deferred because changing the
+// return type is a breaking change.
 export function getSequence(tapLeafScript: TapLeafScript): number | undefined {
     let sequence: number | undefined = undefined;
 

--- a/test/intent.test.ts
+++ b/test/intent.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { Intent } from "../src/intent";
+
+describe("Intent", () => {
+    // Minimal P2TR-shaped pkscript (OP_1 <32-byte x-only key>). The Intent
+    // builder doesn't execute scripts; it only needs a witnessUtxo.
+    const witnessUtxo = {
+        script: new Uint8Array([0x51, 0x20, ...new Uint8Array(32).fill(1)]),
+        amount: 1000n,
+    };
+
+    const zeroTxid = new Uint8Array(32);
+
+    describe("craftToSignTx lockTime", () => {
+        it("sets lockTime = 0 when a BIP-68 nSequence is present on an input", () => {
+            // 4195486 = 0x40_049E = seconds flag (bit 22) + 1182 (=605184s).
+            // This is a valid BIP-68 nSequence for a CSV leaf and must NOT
+            // be copied into tx.lockTime (which is absolute nLockTime).
+            const input = {
+                txid: zeroTxid,
+                index: 0,
+                sequence: 4195486,
+                witnessUtxo,
+            };
+
+            const proof = Intent.create("hello", [input]);
+
+            expect(proof.lockTime).toBe(0);
+            // Per-input nSequence must still carry the BIP-68 value.
+            // Index 0 is the to_spend-referencing input; ownership input is at index 1.
+            expect(proof.getInput(1).sequence).toBe(4195486);
+        });
+
+        it("sets lockTime = 0 regardless of large input.sequence values", () => {
+            const input = {
+                txid: zeroTxid,
+                index: 0,
+                sequence: 0xfffffffe,
+                witnessUtxo,
+            };
+
+            const proof = Intent.create("msg", [input]);
+
+            expect(proof.lockTime).toBe(0);
+        });
+
+        it("sets lockTime = 0 when no input.sequence is set", () => {
+            const input = {
+                txid: zeroTxid,
+                index: 0,
+                witnessUtxo,
+            };
+
+            const proof = Intent.create("msg", [input]);
+
+            expect(proof.lockTime).toBe(0);
+        });
+
+        it("sets lockTime = 0 across multiple inputs with mixed sequences", () => {
+            const inputs = [
+                {
+                    txid: zeroTxid,
+                    index: 0,
+                    sequence: 4195486,
+                    witnessUtxo,
+                },
+                {
+                    txid: new Uint8Array(32).fill(2),
+                    index: 1,
+                    sequence: 144,
+                    witnessUtxo,
+                },
+            ];
+
+            const proof = Intent.create("msg", inputs);
+
+            expect(proof.lockTime).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

`craftToSignTx` was deriving `tx.lockTime` from the max of per-input nSequence values, which conflated BIP-68 relative timelocks (CSV leaves) with absolute nLockTime. A VTXO with the typical 605184s CSV timelock produced `lockTime = 4195486` on the signed proof.

Matches BIP-322 and `arkd`'s reference builder by hardcoding `lockTime = 0`. Per-input nSequence continues to carry the CSV value on the PSBT input. `arkd`'s `Verify` does not inspect `LockTime`, so the change is not breaking at the wire level.

Also adds a docstring on `PathSelection.sequence` and a TODO on `getSequence` for a future discriminated-union refactor.

## Test plan
- [x] `pnpm test:unit` (47 files, 790 tests)
- [ ] Regression check against arkd on regtest (register / delete / get-pending-tx intents)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified sequence field documentation for relative timelock handling.

* **Tests**
  * Added test suite validating transaction lockTime behavior.

* **Improvements**
  * Refined transaction locking time calculation for timelock inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->