### PR TITLE
fix(wallet): auto-renew swept and expiring vtxos during background

### DIFF
--- a/src/wallet/vtxo-manager.ts
+++ b/src/wallet/vtxo-manager.ts
@@ -61,6 +61,18 @@ function assertSweepCapable(
     }
 }
 
+/**
+ * Return whether a wallet exposes the surface required for VTXO renewal.
+ *
+ * Renewal re-submits existing VTXOs via `settle()`, so a wallet that can't
+ * settle can't renew. IWallet declares `settle` at the type level, but this
+ * runtime guard keeps auto-renewal paths safe when a proxy or subclass omits
+ * it.
+ */
+function isRenewCapable(wallet: IWallet): boolean {
+    return typeof wallet.settle === "function";
+}
+
 /** Default renewal threshold in seconds (3 days). */
 export const DEFAULT_THRESHOLD_SECONDS = 3 * 24 * 60 * 60;
 
@@ -981,14 +993,17 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 ]);
 
             const stopWatching = contractManager.onContractEvent((event) => {
+                // Mirror the filter used by renewVtxos so the trigger set can't
+                // be broader than the action set — otherwise a vtxo_spent event
+                // for a fully-spent vtxo would fire a no-op renewal and burn
+                // the cooldown.
                 const shouldRenew =
                     event.type === "vtxo_received" ||
                     (event.type === "vtxo_spent" &&
                         event.vtxos.some(
                             (vtxo) =>
-                                vtxo.virtualStatus.state === "swept" ||
                                 isRecoverable(vtxo) ||
-                                isExpired(vtxo)
+                                (isSpendable(vtxo) && isExpired(vtxo))
                         ));
 
                 if (shouldRenew) {
@@ -1041,6 +1056,9 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     }
 
     private async maybeRenewVtxos(): Promise<void> {
+        if (!isRenewCapable(this.wallet)) {
+            return;
+        }
         if (!this.shouldAttemptRenewal()) {
             return;
         }

--- a/src/wallet/vtxo-manager.ts
+++ b/src/wallet/vtxo-manager.ts
@@ -965,8 +965,8 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             return undefined;
         }
 
-        // Start polling for boarding inputs independently of contract manager
-        // SSE setup. Use a short delay to let the wallet finish construction.
+        // Start polling for wallet settlement tasks independently of contract
+        // manager SSE setup. Use a short delay to let the wallet finish construction.
         this.startupPollTimeoutId = setTimeout(() => {
             if (this.disposed) return;
             this.startBoardingUtxoPoll();
@@ -981,58 +981,82 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 ]);
 
             const stopWatching = contractManager.onContractEvent((event) => {
-                if (event.type !== "vtxo_received") {
-                    return;
-                }
-
-                const msSinceLastRenewal =
-                    Date.now() - this.lastRenewalTimestamp;
                 const shouldRenew =
-                    !this.renewalInProgress &&
-                    msSinceLastRenewal >= VtxoManager.RENEWAL_COOLDOWN_MS;
+                    event.type === "vtxo_received" ||
+                    (event.type === "vtxo_spent" &&
+                        event.vtxos.some(
+                            (vtxo) =>
+                                vtxo.virtualStatus.state === "swept" ||
+                                isRecoverable(vtxo) ||
+                                isExpired(vtxo)
+                        ));
 
                 if (shouldRenew) {
-                    this.renewVtxos().catch((e) => {
-                        if (e instanceof Error) {
-                            if (
-                                e.message.includes(
-                                    "No VTXOs available to renew"
-                                )
-                            ) {
-                                // Not an error, just no virtual outputs eligible for renewal.
-                                return;
-                            }
-                            if (e.message.includes("is below dust threshold")) {
-                                // Not an error, just below dust threshold.
-                                // As more virtual outputs are received, the threshold will be raised.
-                                return;
-                            }
-                            if (
-                                e.message.includes("VTXO_ALREADY_REGISTERED") ||
-                                e.message.includes("VTXO_ALREADY_SPENT") ||
-                                e.message.includes("duplicated input")
-                            ) {
-                                // Virtual output is already being used in a concurrent
-                                // user-initiated operation. Skip silently — the
-                                // wallet's tx lock serializes these, but the
-                                // renewal will retry on the next cycle.
-                                return;
-                            }
-                        }
+                    this.maybeRenewVtxos().catch((e) => {
                         console.error("Error renewing VTXOs:", e);
                     });
                 }
-                delegatorManager
-                    ?.delegate(event.vtxos, destination)
-                    .catch((e) => {
-                        console.error("Error delegating VTXOs:", e);
-                    });
+
+                if (event.type === "vtxo_received") {
+                    delegatorManager
+                        ?.delegate(event.vtxos, destination)
+                        .catch((e) => {
+                            console.error("Error delegating VTXOs:", e);
+                        });
+                }
             });
 
             return stopWatching;
         } catch (e) {
             console.error("Error renewing VTXOs from VtxoManager", e);
             return undefined;
+        }
+    }
+
+    private shouldAttemptRenewal(): boolean {
+        const msSinceLastRenewal = Date.now() - this.lastRenewalTimestamp;
+        return (
+            !this.renewalInProgress &&
+            msSinceLastRenewal >= VtxoManager.RENEWAL_COOLDOWN_MS
+        );
+    }
+
+    private isIgnorableRenewalError(error: unknown): boolean {
+        return (
+            error instanceof Error &&
+            (this.isNoopRenewalError(error) ||
+                error.message.includes("VTXO_ALREADY_REGISTERED") ||
+                error.message.includes("VTXO_ALREADY_SPENT") ||
+                error.message.includes("duplicated input") ||
+                error.message.includes("Renewal already in progress"))
+        );
+    }
+
+    private isNoopRenewalError(error: unknown): boolean {
+        return (
+            error instanceof Error &&
+            (error.message.includes("No VTXOs available to renew") ||
+                error.message.includes("is below dust threshold"))
+        );
+    }
+
+    private async maybeRenewVtxos(): Promise<void> {
+        if (!this.shouldAttemptRenewal()) {
+            return;
+        }
+
+        try {
+            await this.renewVtxos();
+        } catch (error) {
+            if (this.isIgnorableRenewalError(error)) {
+                if (this.isNoopRenewalError(error)) {
+                    // A no-op renewal still means we checked recently, so apply
+                    // the cooldown to avoid repeated scans on every event.
+                    this.lastRenewalTimestamp = Date.now();
+                }
+                return;
+            }
+            throw error;
         }
     }
 
@@ -1052,8 +1076,9 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
     /**
      * Starts a polling loop that:
-     * 1. Auto-settles new boarding inputs into Arkade
-     * 2. Sweeps expired boarding inputs (when boardingUtxoSweep is enabled)
+     * 1. Auto-renews expiring or recoverable VTXOs
+     * 2. Auto-settles new boarding inputs into Arkade
+     * 3. Sweeps expired boarding inputs (when boardingUtxoSweep is enabled)
      *
      * Uses setTimeout chaining (not setInterval) so a slow/blocked poll
      * cannot stack up and the next delay can incorporate backoff.
@@ -1072,8 +1097,6 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     }
 
     private async pollBoardingUtxos(): Promise<void> {
-        // Guard: wallet must support boarding input + sweep operations
-        if (!isSweepCapable(this.wallet)) return;
         // Skip if disposed or a previous poll is still running
         if (this.disposed) return;
         if (this.pollInProgress) return;
@@ -1087,39 +1110,53 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         let hadError = false;
 
         try {
-            // Fetch boarding inputs once for the entire poll cycle so that
-            // settle and sweep don't each hit the network independently.
-            const boardingUtxos = await this.wallet.getBoardingUtxos();
-
-            // Settle new (unexpired) boarding inputs first, then sweep expired ones.
-            // Sequential to avoid racing for the same inputs.
             try {
-                await this.settleBoardingUtxos(boardingUtxos);
+                await this.maybeRenewVtxos();
             } catch (e) {
                 hadError = true;
-                console.error("Error auto-settling boarding UTXOs:", e);
+                console.error("Error auto-renewing VTXOs:", e);
             }
 
-            const sweepEnabled =
-                this.settlementConfig !== false &&
-                (this.settlementConfig?.boardingUtxoSweep ??
-                    DEFAULT_SETTLEMENT_CONFIG.boardingUtxoSweep);
-            if (sweepEnabled) {
+            if (isSweepCapable(this.wallet)) {
                 try {
-                    await this.sweepExpiredBoardingUtxos(boardingUtxos);
-                } catch (e) {
-                    if (
-                        !(e instanceof Error) ||
-                        !e.message.includes("No expired boarding UTXOs")
-                    ) {
+                    // Fetch boarding inputs once for the entire poll cycle so that
+                    // settle and sweep don't each hit the network independently.
+                    const boardingUtxos = await this.wallet.getBoardingUtxos();
+
+                    // Settle new (unexpired) boarding inputs first, then sweep expired ones.
+                    // Sequential to avoid racing for the same inputs.
+                    try {
+                        await this.settleBoardingUtxos(boardingUtxos);
+                    } catch (e) {
                         hadError = true;
-                        console.error("Error auto-sweeping boarding UTXOs:", e);
+                        console.error("Error auto-settling boarding UTXOs:", e);
                     }
+
+                    const sweepEnabled =
+                        this.settlementConfig !== false &&
+                        (this.settlementConfig?.boardingUtxoSweep ??
+                            DEFAULT_SETTLEMENT_CONFIG.boardingUtxoSweep);
+                    if (sweepEnabled) {
+                        try {
+                            await this.sweepExpiredBoardingUtxos(boardingUtxos);
+                        } catch (e) {
+                            if (
+                                !(e instanceof Error) ||
+                                !e.message.includes("No expired boarding UTXOs")
+                            ) {
+                                hadError = true;
+                                console.error(
+                                    "Error auto-sweeping boarding UTXOs:",
+                                    e
+                                );
+                            }
+                        }
+                    }
+                } catch (e) {
+                    hadError = true;
+                    console.error("Error fetching boarding UTXOs:", e);
                 }
             }
-        } catch (e) {
-            hadError = true;
-            console.error("Error fetching boarding UTXOs:", e);
         } finally {
             if (hadError) {
                 this.consecutivePollFailures++;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -149,6 +149,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
     private _contractManagerInitializing?: Promise<ContractManager>;
     protected readonly watcherConfig?: ReadonlyWalletConfig["watcherConfig"];
     private readonly _assetManager: IReadonlyAssetManager;
+    protected readonly pendingSettledBoardingOutpoints = new Set<string>();
     private _syncVtxosInflight?: Promise<{
         isDelta: boolean;
         fetchedExtended: ExtendedVirtualCoin[];
@@ -831,9 +832,25 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const boardingUtxos =
             await this.onchainProvider.getCoins(boardingAddress);
 
-        const utxos = boardingUtxos.map((utxo) => {
-            return extendCoin(this, utxo);
-        });
+        const fetchedOutpoints = new Set(
+            boardingUtxos.map((utxo) => `${utxo.txid}:${utxo.vout}`)
+        );
+        for (const outpoint of this.pendingSettledBoardingOutpoints) {
+            if (!fetchedOutpoints.has(outpoint)) {
+                this.pendingSettledBoardingOutpoints.delete(outpoint);
+            }
+        }
+
+        const utxos = boardingUtxos
+            .filter(
+                (utxo) =>
+                    !this.pendingSettledBoardingOutpoints.has(
+                        `${utxo.txid}:${utxo.vout}`
+                    )
+            )
+            .map((utxo) => {
+                return extendCoin(this, utxo);
+            });
 
         // Save boarding inputs using unified repository
         await this.walletRepository.saveUtxos(boardingAddress, utxos);
@@ -2845,7 +2862,9 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                     });
                 } else {
                     // boarding input = remove it
-                    boardingUtxoToRemove.add(`${input.txid}:${input.vout}`);
+                    const outpoint = `${input.txid}:${input.vout}`;
+                    boardingUtxoToRemove.add(outpoint);
+                    this.pendingSettledBoardingOutpoints.add(outpoint);
                 }
             }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1195,6 +1195,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         manager?.dispose();
         this._contractManager = undefined;
         this._contractManagerInitializing = undefined;
+        this.pendingSettledBoardingOutpoints.clear();
     }
 
     /** Async-dispose hook that forwards to `dispose()`. */

--- a/test/vtxo-manager.test.ts
+++ b/test/vtxo-manager.test.ts
@@ -1357,6 +1357,7 @@ describe("SettlementConfig", () => {
                 _vtxoManagerInitializing?: Promise<unknown>;
                 _contractManager?: { dispose(): void };
                 _contractManagerInitializing?: Promise<unknown>;
+                pendingSettledBoardingOutpoints: Set<string>;
             };
 
             wallet._vtxoManager = {
@@ -1365,6 +1366,7 @@ describe("SettlementConfig", () => {
             wallet._contractManager = {
                 dispose: contractManagerDispose,
             };
+            wallet.pendingSettledBoardingOutpoints = new Set<string>();
 
             await wallet.dispose();
 

--- a/test/vtxo-manager.test.ts
+++ b/test/vtxo-manager.test.ts
@@ -377,6 +377,209 @@ describe("VtxoManager - Lifecycle", () => {
 
         expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
+
+    it("should auto-renew on swept vtxo_spent events", async () => {
+        let onContractEvent:
+            | ((event: {
+                  type: "vtxo_spent";
+                  vtxos: ExtendedVirtualCoin[];
+                  contractScript: string;
+                  contract: any;
+                  timestamp: number;
+              }) => void)
+            | undefined;
+        const contractManager = {
+            onContractEvent: vi.fn().mockImplementation((callback) => {
+                onContractEvent = callback;
+                return () => {};
+            }),
+        };
+        const wallet = createMockWallet(
+            [createMockVtxo(5000, "swept", false)],
+            "arkade1test",
+            { contractManager }
+        );
+        const manager = new VtxoManager(wallet, undefined, {});
+
+        await flushMicrotasks();
+        onContractEvent?.({
+            type: "vtxo_spent",
+            vtxos: [createMockVtxo(5000, "swept", false)],
+            contractScript: "script",
+            contract: {} as any,
+            timestamp: Date.now(),
+        });
+        await flushMicrotasks();
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+
+        await manager.dispose();
+    });
+
+    it("should not auto-renew on plain settled vtxo_spent events", async () => {
+        let onContractEvent:
+            | ((event: {
+                  type: "vtxo_spent";
+                  vtxos: ExtendedVirtualCoin[];
+                  contractScript: string;
+                  contract: any;
+                  timestamp: number;
+              }) => void)
+            | undefined;
+        const contractManager = {
+            onContractEvent: vi.fn().mockImplementation((callback) => {
+                onContractEvent = callback;
+                return () => {};
+            }),
+        };
+        const wallet = createMockWallet(
+            [createMockVtxo(5000, "settled", false)],
+            "arkade1test",
+            { contractManager }
+        );
+        const manager = new VtxoManager(wallet, undefined, {});
+
+        await flushMicrotasks();
+        onContractEvent?.({
+            type: "vtxo_spent",
+            vtxos: [createMockVtxo(5000, "settled", false)],
+            contractScript: "script",
+            contract: {} as any,
+            timestamp: Date.now(),
+        });
+        await flushMicrotasks();
+
+        expect(wallet.getVtxos).not.toHaveBeenCalled();
+        expect(wallet.settle).not.toHaveBeenCalled();
+
+        await manager.dispose();
+    });
+
+    it("should apply cooldown after a no-op renewal check", async () => {
+        let onContractEvent:
+            | ((event: {
+                  type: "vtxo_received";
+                  vtxos: ExtendedVirtualCoin[];
+                  contractScript: string;
+                  contract: any;
+                  timestamp: number;
+              }) => void)
+            | undefined;
+        const contractManager = {
+            onContractEvent: vi.fn().mockImplementation((callback) => {
+                onContractEvent = callback;
+                return () => {};
+            }),
+        };
+        const wallet = createMockWallet(
+            [createMockVtxo(5000, "settled", false)],
+            "arkade1test",
+            { contractManager }
+        );
+        const manager = new VtxoManager(wallet, undefined, {});
+
+        await flushMicrotasks();
+        onContractEvent?.({
+            type: "vtxo_received",
+            vtxos: [createMockVtxo(5000, "settled", false)],
+            contractScript: "script",
+            contract: {} as any,
+            timestamp: Date.now(),
+        });
+        await flushMicrotasks();
+
+        onContractEvent?.({
+            type: "vtxo_received",
+            vtxos: [createMockVtxo(5000, "settled", false)],
+            contractScript: "script",
+            contract: {} as any,
+            timestamp: Date.now(),
+        });
+        await flushMicrotasks();
+
+        expect(wallet.getVtxos).toHaveBeenCalledTimes(1);
+        expect(wallet.settle).not.toHaveBeenCalled();
+
+        await manager.dispose();
+    });
+
+    it("should auto-renew during background polling without contract events", async () => {
+        vi.useFakeTimers();
+        try {
+            const now = Date.now();
+            const wallet = createMockWallet([
+                {
+                    txid: "tx1",
+                    vout: 0,
+                    value: 5000,
+                    createdAt: new Date(now - 100_000),
+                    virtualStatus: {
+                        state: "settled",
+                        batchExpiry: now + 5_000,
+                    },
+                    status: { confirmed: true },
+                    isUnrolled: false,
+                    isSpent: false,
+                } as ExtendedVirtualCoin,
+            ]);
+            const manager = new VtxoManager(wallet, undefined, {
+                pollIntervalMs: 1_000,
+            });
+
+            await flushMicrotasks();
+            await vi.advanceTimersByTimeAsync(1_000);
+            await flushMicrotasks();
+
+            expect(wallet.settle).toHaveBeenCalledTimes(1);
+
+            await manager.dispose();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("should back off background polling when boarding fetch fails", async () => {
+        vi.useFakeTimers();
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+        try {
+            const getBoardingUtxos = vi
+                .fn()
+                .mockRejectedValue(new Error("fetch failed"));
+            const wallet = {
+                ...createMockWallet([], "arkade1test"),
+                getBoardingUtxos,
+                boardingTapscript: {} as any,
+                onchainProvider: {} as any,
+                network: {} as any,
+            } as IWallet;
+            const manager = new VtxoManager(wallet, undefined, {
+                pollIntervalMs: 1_000,
+            });
+
+            await flushMicrotasks();
+            await vi.advanceTimersByTimeAsync(1_000);
+            await flushMicrotasks();
+
+            expect(getBoardingUtxos).toHaveBeenCalledTimes(1);
+
+            await vi.advanceTimersByTimeAsync(1_000);
+            await flushMicrotasks();
+
+            expect(getBoardingUtxos).toHaveBeenCalledTimes(1);
+
+            await vi.advanceTimersByTimeAsync(1_000);
+            await flushMicrotasks();
+
+            expect(getBoardingUtxos).toHaveBeenCalledTimes(2);
+
+            await manager.dispose();
+        } finally {
+            consoleError.mockRestore();
+            vi.useRealTimers();
+        }
+    });
 });
 
 describe("VtxoManager - Renewal utilities", () => {

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -169,6 +169,66 @@ describe("Wallet", () => {
             expect(balance.recoverable).toBe(0);
             expect(balance.total).toBe(150000);
         });
+
+        it("should ignore locally settled boarding UTXOs while the provider lags", async () => {
+            const staleBoardingUtxo: Coin = {
+                txid: hex.encode(new Uint8Array(32).fill(9)),
+                vout: 0,
+                value: 100000,
+                status: {
+                    confirmed: true,
+                    block_height: 100,
+                    block_hash: hex.encode(new Uint8Array(32).fill(8)),
+                    block_time: 1600000000,
+                },
+            };
+            const mockArkInfo = {
+                signerPubkey: mockServerKeyHex,
+                forfeitPubkey: mockServerKeyHex,
+                batchExpiry: BigInt(144),
+                unilateralExitDelay: BigInt(144),
+                boardingExitDelay: BigInt(144),
+                roundInterval: BigInt(144),
+                network: "mutinynet",
+                dust: BigInt(1000),
+                forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+                checkpointTapscript:
+                    "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+            };
+            const onchainProvider = {
+                getCoins: vi.fn().mockResolvedValue([staleBoardingUtxo]),
+            } as Partial<OnchainProvider> as OnchainProvider;
+            const indexerProvider = {
+                getVtxos: vi.fn().mockResolvedValue({ vtxos: [] }),
+            } as Partial<IndexerProvider> as IndexerProvider;
+            const wallet = await Wallet.create({
+                identity: mockIdentity,
+                arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: vi.fn().mockResolvedValue(mockArkInfo),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider,
+                onchainProvider,
+                storage: {
+                    walletRepository: new InMemoryWalletRepository(),
+                    contractRepository: new InMemoryContractRepository(),
+                },
+                settlementConfig: false,
+            });
+
+            const boardingUtxos = await wallet.getBoardingUtxos();
+            expect(boardingUtxos).toHaveLength(1);
+
+            await (wallet as any).updateDbAfterSettle(
+                boardingUtxos,
+                "11".repeat(32)
+            );
+
+            const balance = await wallet.getBalance();
+            expect(balance.boarding.total).toBe(0);
+
+            await wallet.dispose();
+        });
     });
 
     describe("getCoins", () => {


### PR DESCRIPTION
Extend background settlement polling to renew swept and expiring VTXOs, and add regression coverage for renewal triggers, cooldown handling, and polling backoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Auto-renewal now guarded to run only when the wallet supports settlement; renewal can trigger on received or spent events (recoverable/expired) and runs earlier in polling (renew → settle → sweep).
  * Polling no longer aborts when sweep support is absent; docs updated.

* **Bug Fixes**
  * Delegation limited to received events.
  * Boarding UTXOs removed by settlement are tracked so balances ignore locally-settled entries.

* **Tests**
  * Added lifecycle and polling tests for renewal, cooldowns, backoff, and boarding/settlement handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->