### PR TITLE
fix(wallet): pin mainnet unilateral exit delay to 605184s

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -109,6 +109,11 @@ import {
     updateWalletState,
 } from "../utils/syncCursors";
 
+// Hardcoded unilateral exit delay for mainnet (~7 days in seconds).
+// Pinned here so that address derivation stays stable for existing mainnet
+// wallets even after the server lowers the delay it advertises.
+const MAINNET_UNILATERAL_EXIT_DELAY = 605184n;
+
 export type IncomingFunds =
     | {
           type: "utxo";
@@ -267,10 +272,18 @@ export class ReadonlyWallet implements IReadonlyWallet {
             }
         }
 
+        // On mainnet, pin the unilateral exit delay to the historical value so
+        // that addresses derived by existing wallets remain stable even if the
+        // server starts advertising a shorter delay.
+        const unilateralExitDelay =
+            info.network === "bitcoin"
+                ? MAINNET_UNILATERAL_EXIT_DELAY
+                : info.unilateralExitDelay;
+
         // create unilateral exit timelock
         const exitTimelock: RelativeTimelock = config.exitTimelock ?? {
-            value: info.unilateralExitDelay,
-            type: info.unilateralExitDelay < 512n ? "blocks" : "seconds",
+            value: unilateralExitDelay,
+            type: unilateralExitDelay < 512n ? "blocks" : "seconds",
         };
 
         // validate boarding timelock passed in config if any

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -868,6 +868,61 @@ describe("Wallet", () => {
             expect(cached[0].isSpent).toBe(true);
         });
     });
+
+    describe("mainnet unilateral exit delay pinning", () => {
+        // If this constant changes in the SDK, update both sides intentionally —
+        // changing the pinned value alters derived addresses for every mainnet
+        // wallet.
+        const MAINNET_PINNED_DELAY = 605184n;
+
+        const mockMainnetInfo = (unilateralExitDelay: bigint) => ({
+            signerPubkey: mockServerKeyHex,
+            forfeitPubkey: mockServerKeyHex,
+            batchExpiry: BigInt(144),
+            unilateralExitDelay,
+            roundInterval: BigInt(144),
+            network: "bitcoin",
+            forfeitAddress: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            checkpointTapscript:
+                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        });
+
+        it("pins the exit timelock to 605184s on mainnet even when the server advertises a shorter delay", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(mockMainnetInfo(86528n)),
+            });
+
+            const wallet = await Wallet.create({
+                identity: mockIdentity,
+                arkServerUrl: "http://localhost:7070",
+            });
+
+            expect(wallet.offchainTapscript.options.csvTimelock).toEqual({
+                value: MAINNET_PINNED_DELAY,
+                type: "seconds",
+            });
+        });
+
+        it("lets an explicit config.exitTimelock override the mainnet pin", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(mockMainnetInfo(86528n)),
+            });
+
+            // bip68 seconds must be multiples of 512.
+            const override = { value: 1024n, type: "seconds" as const };
+            const wallet = await Wallet.create({
+                identity: mockIdentity,
+                arkServerUrl: "http://localhost:7070",
+                exitTimelock: override,
+            });
+
+            expect(wallet.offchainTapscript.options.csvTimelock).toEqual(
+                override
+            );
+        });
+    });
 });
 
 describe("ReadonlyWallet", () => {


### PR DESCRIPTION
## Summary
- Hardcode the unilateral exit delay to `605184n` seconds (~7 days) when the Ark server reports network `bitcoin` (mainnet), regardless of what it advertises.
- Non-mainnet networks keep using `info.unilateralExitDelay` from the server.
- `boardingExitDelay` is unchanged.

## Why
The Ark server is about to lower its advertised unilateral exit delay from ~7 days (605184s) to ~1 day (86528s). Existing mainnet wallets have derived their offchain tapscripts with the old value, and the delay is part of the script — switching to the new value would produce different addresses and break continuity for existing users. Pinning the historical value on mainnet keeps derivation stable.

## Test plan
- [x] `pnpm test:unit` — all 790 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm run build` — succeeds
- [ ] Manual smoke check against mainnet after server drops to 86528: verify derived offchain address matches the pre-change address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unilateral exit delay handling in wallet configuration to apply network-specific values when calculating exit timelocks.
  * Enhanced timelock type derivation to correctly align with network-appropriate delay configurations, ensuring accurate behavior for Bitcoin mainnet environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->