### PR TITLE
Attribute VTXOs to their owning contract via script

### DIFF
--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -15,7 +15,7 @@ import {
 import { ContractWatcher, ContractWatcherConfig } from "./contractWatcher";
 import { contractHandlers } from "./handlers";
 import { VirtualCoin } from "../wallet";
-import { extendVtxoFromContract } from "../wallet/utils";
+import { extendVirtualCoinForContract } from "../wallet/utils";
 import { ContractFilter, ContractRepository } from "../repositories";
 import {
     advanceSyncCursors,
@@ -836,7 +836,7 @@ export class ContractManager implements IContractManager {
                 byContract.set(contract.address, arr);
             }
             arr.push({
-                ...extendVtxoFromContract(vtxo, contract),
+                ...extendVirtualCoinForContract(undefined, vtxo, contract),
                 contractScript: contract.script,
             });
         }
@@ -935,7 +935,7 @@ export class ContractManager implements IContractManager {
                 const contract = scriptToContract.get(vtxo.script);
                 if (!contract) continue;
                 result.get(contract.script)!.push({
-                    ...extendVtxoFromContract(vtxo, contract),
+                    ...extendVirtualCoinForContract(undefined, vtxo, contract),
                     contractScript: contract.script,
                 });
             }
@@ -981,7 +981,7 @@ export class ContractManager implements IContractManager {
 
             for (const vtxo of vtxos) {
                 allVtxos.push({
-                    ...extendVtxoFromContract(vtxo, contract),
+                    ...extendVirtualCoinForContract(vtxo, contract),
                     contractScript: contract.script,
                 });
             }

--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -14,7 +14,7 @@ import {
 } from "./types";
 import { ContractWatcher, ContractWatcherConfig } from "./contractWatcher";
 import { contractHandlers } from "./handlers";
-import { VirtualCoin } from "../wallet";
+import { ExtendedVirtualCoin, VirtualCoin } from "../wallet";
 import { extendVirtualCoinForContract } from "../wallet/utils";
 import { ContractFilter, ContractRepository } from "../repositories";
 import {
@@ -64,6 +64,20 @@ export interface IContractManager extends Disposable {
     getContractsWithVtxos(
         filter?: GetContractsFilter
     ): Promise<ContractWithVtxos[]>;
+
+    /**
+     * Stamp raw virtual outputs with the correct per-contract tapscripts
+     * (forfeit, intent, tap tree).
+     *
+     * Resolves each vtxo's `script` to its owning contract via the contract
+     * repository and attaches the matching tapscripts. Throws when any vtxo
+     * references a script with no registered contract — callers are expected
+     * to register the contract before asking for annotation. This is the
+     * single shared path that replaces scattered `extendVirtualCoin*` calls
+     * in wallet/handler code, and keeps the wallet from silently stamping the
+     * default tapscript onto a non-default vtxo.
+     */
+    annotateVtxos(vtxos: VirtualCoin[]): Promise<ExtendedVirtualCoin[]>;
 
     /**
      * Update mutable contract fields.
@@ -411,6 +425,34 @@ export class ContractManager implements IContractManager {
             contract,
             vtxos: vtxos.get(contract.script) ?? [],
         }));
+    }
+
+    async annotateVtxos(vtxos: VirtualCoin[]): Promise<ExtendedVirtualCoin[]> {
+        if (vtxos.length === 0) return [];
+
+        const scripts = Array.from(
+            new Set(
+                vtxos
+                    .map((v) => v.script)
+                    .filter((s): s is string => s !== undefined)
+            )
+        );
+
+        const byScript = new Map<string, Contract>();
+        if (scripts.length > 0) {
+            const contracts = await this.config.contractRepository.getContracts(
+                {
+                    script: scripts,
+                }
+            );
+            for (const contract of contracts) {
+                byScript.set(contract.script, contract);
+            }
+        }
+
+        return vtxos.map((vtxo) =>
+            extendVirtualCoinForContract(undefined, vtxo, byScript)
+        );
     }
 
     private buildContractsDbFilter(filter: GetContractsFilter): ContractFilter {

--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -451,7 +451,7 @@ export class ContractManager implements IContractManager {
         }
 
         return vtxos.map((vtxo) =>
-            extendVirtualCoinForContract(undefined, vtxo, byScript)
+            extendVirtualCoinForContract(vtxo, byScript)
         );
     }
 
@@ -878,7 +878,7 @@ export class ContractManager implements IContractManager {
                 byContract.set(contract.address, arr);
             }
             arr.push({
-                ...extendVirtualCoinForContract(undefined, vtxo, contract),
+                ...extendVirtualCoinForContract(vtxo, contract),
                 contractScript: contract.script,
             });
         }
@@ -977,7 +977,7 @@ export class ContractManager implements IContractManager {
                 const contract = scriptToContract.get(vtxo.script);
                 if (!contract) continue;
                 result.get(contract.script)!.push({
-                    ...extendVirtualCoinForContract(undefined, vtxo, contract),
+                    ...extendVirtualCoinForContract(vtxo, contract),
                     contractScript: contract.script,
                 });
             }

--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -673,8 +673,18 @@ export class ContractWatcher {
     }
 
     /**
-     * Process virtual outputs from subscription and route to correct contracts.
-     * Uses the scripts from the subscription response to determine contract ownership.
+     * Process virtual outputs from subscription and route each VTXO to the
+     * single contract that actually locks it.
+     *
+     * Prefer `vtxo.script` when the indexer populates it (the normal case):
+     * each VTXO is attributed to exactly one contract. Fall back to the
+     * subscription `scripts[]` only as a safety net:
+     *   - When the subscription is for a single script, all VTXOs are for
+     *     that script (pre-script-field indexers still work correctly).
+     *   - When multiple scripts are in play but a VTXO has no script, we
+     *     skip it rather than fan it out to every matching contract —
+     *     fan-out produced phantom state in non-owning contracts that then
+     *     never reconciled.
      */
     private processSubscriptionVtxos(
         vtxos: VirtualCoin[],
@@ -682,47 +692,43 @@ export class ContractWatcher {
         eventType: ContractEvent["type"],
         timestamp: number
     ): void {
-        // If we have exactly one script, all virtual outputs belong to that contract
-        // Otherwise, we can't reliably determine ownership without script in VirtualCoin
-        if (scripts.length === 1) {
-            const contractScript = scripts[0];
-            if (contractScript) {
-                // Update tracking
-                const state = this.contracts.get(contractScript);
-                if (state) {
-                    for (const vtxo of vtxos) {
-                        const key = `${vtxo.txid}:${vtxo.vout}`;
-                        if (eventType === "vtxo_received") {
-                            state.lastKnownVtxos.set(key, vtxo);
-                        } else if (eventType === "vtxo_spent") {
-                            state.lastKnownVtxos.delete(key);
-                        }
-                    }
-                }
-                this.emitVtxoEvent(contractScript, vtxos, eventType, timestamp);
+        const singleScript = scripts.length === 1 ? scripts[0] : undefined;
+
+        const byContract = new Map<string, VirtualCoin[]>();
+        for (const vtxo of vtxos) {
+            const contractScript = vtxo.script ?? singleScript;
+            if (!contractScript) {
+                continue;
             }
-            return;
+            if (!this.contracts.has(contractScript)) {
+                continue;
+            }
+            let bucket = byContract.get(contractScript);
+            if (!bucket) {
+                bucket = [];
+                byContract.set(contractScript, bucket);
+            }
+            bucket.push(vtxo);
         }
 
-        // Multiple scripts - assign virtual outputs to all matching contracts
-        // This is a limitation: we can't know which virtual output belongs to which script
-        // In practice, subscription events usually come with a single script context
-        for (const script of scripts) {
-            const contractScript = script;
-            if (contractScript) {
-                const state = this.contracts.get(contractScript);
-                if (state) {
-                    for (const vtxo of vtxos) {
-                        const key = `${vtxo.txid}:${vtxo.vout}`;
-                        if (eventType === "vtxo_received") {
-                            state.lastKnownVtxos.set(key, vtxo);
-                        } else {
-                            state.lastKnownVtxos.delete(key);
-                        }
+        for (const [contractScript, bucketVtxos] of byContract) {
+            const state = this.contracts.get(contractScript);
+            if (state) {
+                for (const vtxo of bucketVtxos) {
+                    const key = `${vtxo.txid}:${vtxo.vout}`;
+                    if (eventType === "vtxo_received") {
+                        state.lastKnownVtxos.set(key, vtxo);
+                    } else if (eventType === "vtxo_spent") {
+                        state.lastKnownVtxos.delete(key);
                     }
                 }
-                this.emitVtxoEvent(contractScript, vtxos, eventType, timestamp);
             }
+            this.emitVtxoEvent(
+                contractScript,
+                bucketVtxos,
+                eventType,
+                timestamp
+            );
         }
     }
 

--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -695,12 +695,16 @@ export class ContractWatcher {
         const singleScript = scripts.length === 1 ? scripts[0] : undefined;
 
         const byContract = new Map<string, VirtualCoin[]>();
+        let unattributed = 0;
+        let unknownScript = 0;
         for (const vtxo of vtxos) {
             const contractScript = vtxo.script ?? singleScript;
             if (!contractScript) {
+                unattributed++;
                 continue;
             }
             if (!this.contracts.has(contractScript)) {
+                unknownScript++;
                 continue;
             }
             let bucket = byContract.get(contractScript);
@@ -709,6 +713,15 @@ export class ContractWatcher {
                 byContract.set(contractScript, bucket);
             }
             bucket.push(vtxo);
+        }
+
+        if (unattributed > 0 || unknownScript > 0) {
+            // The failsafe poll is the backstop for these; log at debug so we
+            // can correlate "VTXO state drift" reports with subscription
+            // drops rather than chase phantom bugs.
+            console.debug(
+                `ContractWatcher.processSubscriptionVtxos[${eventType}]: dropped ${unattributed} unattributable and ${unknownScript} unknown-script VTXOs (${vtxos.length} total)`
+            );
         }
 
         for (const [contractScript, bucketVtxos] of byContract) {

--- a/src/repositories/realm/schemas.ts
+++ b/src/repositories/realm/schemas.ts
@@ -33,6 +33,9 @@ export const ArkVtxoSchema = {
         isUnrolled: "bool",
         isSpent: "bool?",
         assetsJson: "string?",
+        // scriptPubKey (hex) locking this VTXO, indexed so contract-scoped
+        // queries can resolve ownership without touching address mapping.
+        script: { type: "string?", indexed: true },
     },
 } as const;
 

--- a/src/repositories/realm/walletRepository.ts
+++ b/src/repositories/realm/walletRepository.ts
@@ -97,6 +97,7 @@ export class RealmWalletRepository implements WalletRepository {
                             ? JSON.stringify(s.extraWitness)
                             : null,
                         assetsJson: s.assets ? JSON.stringify(s.assets) : null,
+                        script: s.script ?? null,
                     },
                     "modified"
                 );
@@ -288,6 +289,7 @@ function vtxoObjectToDomain(obj: any): ExtendedVirtualCoin {
             ? JSON.parse(obj.extraWitnessJson)
             : undefined,
         assets: obj.assetsJson ? JSON.parse(obj.assetsJson) : undefined,
+        script: obj.script ?? undefined,
     };
 
     return deserializeVtxo(serialized);

--- a/src/repositories/sqlite/walletRepository.ts
+++ b/src/repositories/sqlite/walletRepository.ts
@@ -82,9 +82,21 @@ export class SQLiteWalletRepository implements WalletRepository {
                 ark_tx_id TEXT,
                 extra_witness_json TEXT,
                 assets_json TEXT,
+                script TEXT,
                 PRIMARY KEY (txid, vout)
             )
         `);
+        // Lazy migration for databases created before the script column existed.
+        // SQLite does not support IF NOT EXISTS on ADD COLUMN, so tolerate the
+        // "duplicate column" error when the column is already present.
+        try {
+            await this.db.run(
+                `ALTER TABLE ${this.tables.vtxos} ADD COLUMN script TEXT`
+            );
+        } catch (e) {
+            const msg = (e as Error)?.message ?? "";
+            if (!/duplicate column/i.test(msg)) throw e;
+        }
 
         await this.db.run(`
             CREATE TABLE IF NOT EXISTS ${this.tables.utxos} (
@@ -128,6 +140,9 @@ export class SQLiteWalletRepository implements WalletRepository {
 
         await this.db.run(
             `CREATE INDEX IF NOT EXISTS idx_${this.prefix}vtxos_address ON ${this.tables.vtxos} (address)`
+        );
+        await this.db.run(
+            `CREATE INDEX IF NOT EXISTS idx_${this.prefix}vtxos_script ON ${this.tables.vtxos} (script)`
         );
         await this.db.run(
             `CREATE INDEX IF NOT EXISTS idx_${this.prefix}utxos_address ON ${this.tables.utxos} (address)`
@@ -175,12 +190,12 @@ export class SQLiteWalletRepository implements WalletRepository {
                      tap_tree, forfeit_cb, forfeit_s, intent_cb, intent_s,
                      status_json, virtual_status_json, created_at,
                      is_unrolled, is_spent, spent_by, settled_by, ark_tx_id,
-                     extra_witness_json, assets_json)
+                     extra_witness_json, assets_json, script)
                  VALUES (?, ?, ?, ?,
                          ?, ?, ?, ?, ?,
                          ?, ?, ?,
                          ?, ?, ?, ?, ?,
-                         ?, ?)`,
+                         ?, ?, ?)`,
                 [
                     s.txid,
                     s.vout,
@@ -205,6 +220,7 @@ export class SQLiteWalletRepository implements WalletRepository {
                     s.arkTxId ?? null,
                     s.extraWitness ? JSON.stringify(s.extraWitness) : null,
                     s.assets ? JSON.stringify(s.assets) : null,
+                    s.script ?? null,
                 ]
             );
         }
@@ -369,6 +385,7 @@ interface VtxoRow {
     ark_tx_id: string | null;
     extra_witness_json: string | null;
     assets_json: string | null;
+    script: string | null;
 }
 
 interface UtxoRow {
@@ -442,6 +459,7 @@ function vtxoRowToDomain(row: VtxoRow): ExtendedVirtualCoin {
             ? JSON.parse(row.extra_witness_json)
             : undefined,
         assets: row.assets_json ? JSON.parse(row.assets_json) : undefined,
+        script: row.script ?? undefined,
     };
 
     return deserializeVtxo(serialized);

--- a/src/wallet/expo/background.ts
+++ b/src/wallet/expo/background.ts
@@ -1,4 +1,3 @@
-import { hex } from "@scure/base";
 import type { WalletRepository } from "../../repositories/walletRepository";
 import type { ContractRepository } from "../../repositories/contractRepository";
 import type { AsyncStorageTaskQueue } from "../../worker/expo/asyncStorageTaskQueue";
@@ -9,7 +8,6 @@ import {
     contractPollProcessor,
     CONTRACT_POLL_TASK_TYPE,
 } from "../../worker/expo/processors";
-import { DefaultVtxo } from "../../script/default";
 import { ExpoArkProvider } from "../../providers/expoArk";
 import { ExpoIndexerProvider } from "../../providers/expoIndexer";
 import { getRandomId } from "../utils";
@@ -142,23 +140,11 @@ export function defineExpoBackgroundTask(
             );
             const arkProvider = new ExpoArkProvider(config.arkServerUrl);
 
-            // Reconstruct default offchainTapscript as fallback
-            // for virtual outputs not associated with a contract.
-            const offchainTapscript = new DefaultVtxo.Script({
-                pubKey: hex.decode(config.pubkeyHex),
-                serverPubKey: hex.decode(config.serverPubKeyHex),
-                csvTimelock: {
-                    value: BigInt(config.exitTimelockValue),
-                    type: config.exitTimelockType as "blocks" | "seconds",
-                },
-            });
-
             const deps = createTaskDependencies({
                 walletRepository,
                 contractRepository,
                 indexerProvider,
                 arkProvider,
-                offchainTapscript,
             });
 
             await runTasks(taskQueue, processors, deps);

--- a/src/wallet/expo/wallet.ts
+++ b/src/wallet/expo/wallet.ts
@@ -29,7 +29,7 @@ import {
     contractPollProcessor,
     CONTRACT_POLL_TASK_TYPE,
 } from "../../worker/expo/processors";
-import { extendVirtualCoinForContract, getRandomId } from "../utils";
+import { extendVtxoFromContract, getRandomId } from "../utils";
 import { DefaultVtxo } from "../../script/default";
 import type { PersistedBackgroundConfig } from "./background";
 import type { AsyncStorageTaskQueue } from "../../worker/expo/asyncStorageTaskQueue";
@@ -134,7 +134,7 @@ export class ExpoWallet implements IWallet {
             indexerProvider: wallet.indexerProvider,
             arkProvider: wallet.arkProvider,
             extendVtxo: (vtxo, contract) =>
-                extendVirtualCoinForContract(wallet, vtxo, contract),
+                extendVtxoFromContract(vtxo, contract),
         };
 
         const { taskQueue } = config.background;

--- a/src/wallet/expo/wallet.ts
+++ b/src/wallet/expo/wallet.ts
@@ -29,11 +29,7 @@ import {
     contractPollProcessor,
     CONTRACT_POLL_TASK_TYPE,
 } from "../../worker/expo/processors";
-import {
-    extendVirtualCoin,
-    extendVtxoFromContract,
-    getRandomId,
-} from "../utils";
+import { extendVirtualCoinForContract, getRandomId } from "../utils";
 import { DefaultVtxo } from "../../script/default";
 import type { PersistedBackgroundConfig } from "./background";
 import type { AsyncStorageTaskQueue } from "../../worker/expo/asyncStorageTaskQueue";
@@ -137,12 +133,8 @@ export class ExpoWallet implements IWallet {
             contractRepository: wallet.contractRepository,
             indexerProvider: wallet.indexerProvider,
             arkProvider: wallet.arkProvider,
-            extendVtxo: (vtxo, contract) => {
-                if (contract) {
-                    return extendVtxoFromContract(vtxo, contract);
-                }
-                return extendVirtualCoin(wallet, vtxo);
-            },
+            extendVtxo: (vtxo, contract) =>
+                extendVirtualCoinForContract(wallet, vtxo, contract),
         };
 
         const { taskQueue } = config.background;

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -35,7 +35,11 @@ import {
 } from "../index";
 import { DelegateInfo } from "../../providers/delegator";
 import { ReadonlyWallet, Wallet } from "../wallet";
-import { extendCoin, extendVirtualCoinForContract } from "../utils";
+import {
+    collectVtxoScripts,
+    extendCoin,
+    extendVirtualCoinForContract,
+} from "../utils";
 import {
     MessageHandler,
     RequestEnvelope,
@@ -1133,7 +1137,9 @@ export class WalletMessageHandler
             await this.readonlyWallet.notifyIncomingFunds(async (funds) => {
                 if (funds.type === "vtxo") {
                     const contractsByScript =
-                        await this.readonlyWallet!.getContractsByScript();
+                        await this.readonlyWallet!.getContractsByScript(
+                            collectVtxoScripts(funds.newVtxos, funds.spentVtxos)
+                        );
                     const newVtxos =
                         funds.newVtxos.length > 0
                             ? funds.newVtxos.map((vtxo) =>

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -35,11 +35,7 @@ import {
 } from "../index";
 import { DelegateInfo } from "../../providers/delegator";
 import { ReadonlyWallet, Wallet } from "../wallet";
-import {
-    collectVtxoScripts,
-    extendCoin,
-    extendVirtualCoinForContract,
-} from "../utils";
+import { extendCoin } from "../utils";
 import {
     MessageHandler,
     RequestEnvelope,
@@ -1136,32 +1132,13 @@ export class WalletMessageHandler
         this.incomingFundsSubscription =
             await this.readonlyWallet.notifyIncomingFunds(async (funds) => {
                 if (funds.type === "vtxo") {
-                    const contractsByScript =
-                        await this.readonlyWallet!.getContractsByScript(
-                            collectVtxoScripts(funds.newVtxos, funds.spentVtxos)
-                        );
-                    const newVtxos =
-                        funds.newVtxos.length > 0
-                            ? funds.newVtxos.map((vtxo) =>
-                                  extendVirtualCoinForContract(
-                                      this.readonlyWallet!,
-                                      vtxo,
-                                      contractsByScript
-                                  )
-                              )
-                            : [];
-                    const spentVtxos =
-                        funds.spentVtxos.length > 0
-                            ? funds.spentVtxos.map((vtxo) =>
-                                  extendVirtualCoinForContract(
-                                      this.readonlyWallet!,
-                                      vtxo,
-                                      contractsByScript
-                                  )
-                              )
-                            : [];
+                    const cm = await this.readonlyWallet!.getContractManager();
+                    const [newVtxos, spentVtxos] = await Promise.all([
+                        cm.annotateVtxos(funds.newVtxos),
+                        cm.annotateVtxos(funds.spentVtxos),
+                    ]);
 
-                    if ([...newVtxos, ...spentVtxos].length === 0) return;
+                    if (newVtxos.length + spentVtxos.length === 0) return;
 
                     // save virtual outputs using unified repository
                     await this.walletRepository?.saveVtxos(address, [

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -35,7 +35,7 @@ import {
 } from "../index";
 import { DelegateInfo } from "../../providers/delegator";
 import { ReadonlyWallet, Wallet } from "../wallet";
-import { extendCoin, extendVirtualCoin } from "../utils";
+import { extendCoin, extendVirtualCoinForContract } from "../utils";
 import {
     MessageHandler,
     RequestEnvelope,
@@ -1132,16 +1132,26 @@ export class WalletMessageHandler
         this.incomingFundsSubscription =
             await this.readonlyWallet.notifyIncomingFunds(async (funds) => {
                 if (funds.type === "vtxo") {
+                    const contractsByScript =
+                        await this.readonlyWallet!.getContractsByScript();
                     const newVtxos =
                         funds.newVtxos.length > 0
                             ? funds.newVtxos.map((vtxo) =>
-                                  extendVirtualCoin(this.readonlyWallet!, vtxo)
+                                  extendVirtualCoinForContract(
+                                      this.readonlyWallet!,
+                                      vtxo,
+                                      contractsByScript
+                                  )
                               )
                             : [];
                     const spentVtxos =
                         funds.spentVtxos.length > 0
                             ? funds.spentVtxos.map((vtxo) =>
-                                  extendVirtualCoin(this.readonlyWallet!, vtxo)
+                                  extendVirtualCoinForContract(
+                                      this.readonlyWallet!,
+                                      vtxo,
+                                      contractsByScript
+                                  )
                               )
                             : [];
 

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -31,6 +31,7 @@ import {
     ReissuanceParams,
     SendBitcoinParams,
     SettleParams,
+    VirtualCoin,
     WalletBalance,
 } from "../index";
 import { DelegateInfo } from "../../providers/delegator";
@@ -197,6 +198,15 @@ export type RequestGetContractsWithVtxos = RequestEnvelope & {
 export type ResponseGetContractsWithVtxos = ResponseEnvelope & {
     type: "CONTRACTS_WITH_VTXOS";
     payload: { contracts: ContractWithVtxos[] };
+};
+
+export type RequestAnnotateVtxos = RequestEnvelope & {
+    type: "ANNOTATE_VTXOS";
+    payload: { vtxos: VirtualCoin[] };
+};
+export type ResponseAnnotateVtxos = ResponseEnvelope & {
+    type: "ANNOTATED_VTXOS";
+    payload: { vtxos: ExtendedVirtualCoin[] };
 };
 
 export type RequestUpdateContract = RequestEnvelope & {
@@ -435,6 +445,7 @@ export type WalletUpdaterRequest =
     | RequestCreateContract
     | RequestGetContracts
     | RequestGetContractsWithVtxos
+    | RequestAnnotateVtxos
     | RequestUpdateContract
     | RequestDeleteContract
     | RequestGetSpendablePaths
@@ -476,6 +487,7 @@ export type WalletUpdaterResponse = ResponseEnvelope &
         | ResponseCreateContract
         | ResponseGetContracts
         | ResponseGetContractsWithVtxos
+        | ResponseAnnotateVtxos
         | ResponseUpdateContract
         | ResponseDeleteContract
         | ResponseGetSpendablePaths
@@ -758,6 +770,18 @@ export class WalletMessageHandler
                         id,
                         type: "CONTRACTS_WITH_VTXOS",
                         payload: { contracts },
+                    });
+                }
+                case "ANNOTATE_VTXOS": {
+                    const manager =
+                        await this.readonlyWallet.getContractManager();
+                    const annotated = await manager.annotateVtxos(
+                        message.payload.vtxos
+                    );
+                    return this.tagged({
+                        id,
+                        type: "ANNOTATED_VTXOS",
+                        payload: { vtxos: annotated },
                     });
                 }
                 case "UPDATE_CONTRACT": {

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -120,7 +120,8 @@ import type { IDelegatorManager } from "../delegator";
 import type { IVtxoManager, SettlementConfig } from "../vtxo-manager";
 import type { ContractWatcherConfig } from "../../contracts/contractWatcher";
 import type { DelegateInfo } from "../../providers/delegator";
-import { getRandomId } from "../utils";
+import { extendVirtualCoinForContract, getRandomId } from "../utils";
+import type { VirtualCoin } from "..";
 import {
     MESSAGE_BUS_NOT_INITIALIZED,
     ServiceWorkerTimeoutError,
@@ -1066,6 +1067,34 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 } catch (e) {
                     throw new Error("Failed to get contracts with vtxos");
                 }
+            },
+
+            async annotateVtxos(
+                vtxos: VirtualCoin[]
+            ): Promise<ExtendedVirtualCoin[]> {
+                if (vtxos.length === 0) return [];
+
+                const scripts = Array.from(
+                    new Set(
+                        vtxos
+                            .map((v) => v.script)
+                            .filter((s): s is string => s !== undefined)
+                    )
+                );
+
+                const byScript = new Map<string, Contract>();
+                if (scripts.length > 0) {
+                    const contracts = await this.getContracts({
+                        script: scripts,
+                    });
+                    for (const contract of contracts) {
+                        byScript.set(contract.script, contract);
+                    }
+                }
+
+                return vtxos.map((vtxo) =>
+                    extendVirtualCoinForContract(undefined, vtxo, byScript)
+                );
             },
 
             async updateContract(

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -36,6 +36,7 @@ import {
     RequestGetBalance,
     RequestGetBoardingAddress,
     RequestGetBoardingUtxos,
+    RequestAnnotateVtxos,
     RequestGetContracts,
     RequestGetContractsWithVtxos,
     RequestGetStatus,
@@ -51,6 +52,7 @@ import {
     ResponseSettle,
     ResponseSettleEvent,
     RequestUpdateContract,
+    ResponseAnnotateVtxos,
     ResponseGetAddress,
     ResponseGetBalance,
     ResponseGetBoardingAddress,
@@ -120,7 +122,7 @@ import type { IDelegatorManager } from "../delegator";
 import type { IVtxoManager, SettlementConfig } from "../vtxo-manager";
 import type { ContractWatcherConfig } from "../../contracts/contractWatcher";
 import type { DelegateInfo } from "../../providers/delegator";
-import { extendVirtualCoinForContract, getRandomId } from "../utils";
+import { getRandomId } from "../utils";
 import type { VirtualCoin } from "..";
 import {
     MESSAGE_BUS_NOT_INITIALIZED,
@@ -156,6 +158,7 @@ export const DEFAULT_MESSAGE_TIMEOUTS: Readonly<Record<RequestType, number>> = {
     GET_TRANSACTION_HISTORY: 20_000,
     GET_CONTRACTS: 20_000,
     GET_CONTRACTS_WITH_VTXOS: 20_000,
+    ANNOTATE_VTXOS: 20_000,
     GET_SPENDABLE_PATHS: 20_000,
     GET_ALL_SPENDING_PATHS: 20_000,
     GET_ASSET_DETAILS: 20_000,
@@ -200,6 +203,7 @@ const DEDUPABLE_REQUEST_TYPES: ReadonlySet<string> = new Set([
     "GET_VTXOS",
     "GET_CONTRACTS",
     "GET_CONTRACTS_WITH_VTXOS",
+    "ANNOTATE_VTXOS",
     "GET_SPENDABLE_PATHS",
     "GET_ALL_SPENDING_PATHS",
     "GET_ASSET_DETAILS",
@@ -1073,28 +1077,18 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 vtxos: VirtualCoin[]
             ): Promise<ExtendedVirtualCoin[]> {
                 if (vtxos.length === 0) return [];
-
-                const scripts = Array.from(
-                    new Set(
-                        vtxos
-                            .map((v) => v.script)
-                            .filter((s): s is string => s !== undefined)
-                    )
-                );
-
-                const byScript = new Map<string, Contract>();
-                if (scripts.length > 0) {
-                    const contracts = await this.getContracts({
-                        script: scripts,
-                    });
-                    for (const contract of contracts) {
-                        byScript.set(contract.script, contract);
-                    }
+                const message: RequestAnnotateVtxos = {
+                    type: "ANNOTATE_VTXOS",
+                    id: getRandomId(),
+                    tag: messageTag,
+                    payload: { vtxos },
+                };
+                try {
+                    const response = await sendContractMessage(message);
+                    return (response as ResponseAnnotateVtxos).payload.vtxos;
+                } catch (e) {
+                    throw new Error("Failed to annotate vtxos");
                 }
-
-                return vtxos.map((vtxo) =>
-                    extendVirtualCoinForContract(undefined, vtxo, byScript)
-                );
             },
 
             async updateContract(

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -59,6 +59,33 @@ export function extendVtxoFromContract(
     };
 }
 
+/**
+ * Extend a VirtualCoin with the tap scripts of whichever contract locks it,
+ * falling back to the wallet's default offchain tapscript.
+ *
+ * When the wallet owns multiple contracts (e.g. default + delegate, or
+ * several active vHTLCs) a raw `extendVirtualCoin` call uses only the
+ * default tapscript, which silently overwrites the correct forfeit/intent
+ * data for any VTXO locked to a non-default contract. Resolving by
+ * `vtxo.script` — now always populated by the indexer and persisted —
+ * keeps the extension aligned with the contract that actually owns the
+ * VTXO, which is a correctness requirement before the vtxo is used for
+ * spending or saved back to the repository.
+ */
+export function extendVirtualCoinForContract(
+    wallet: { offchainTapscript: ReadonlyWallet["offchainTapscript"] },
+    vtxo: VirtualCoin,
+    contractsByScript?: ReadonlyMap<string, Contract>
+): ExtendedVirtualCoin {
+    if (vtxo.script && contractsByScript) {
+        const contract = contractsByScript.get(vtxo.script);
+        if (contract) {
+            return extendVtxoFromContract(vtxo, contract);
+        }
+    }
+    return extendVirtualCoin(wallet, vtxo);
+}
+
 export function getRandomId(): string {
     const randomValue = crypto.getRandomValues(new Uint8Array(16));
     return hex.encode(randomValue);

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -86,6 +86,24 @@ export function extendVirtualCoinForContract(
     return extendVirtualCoin(wallet, vtxo);
 }
 
+/**
+ * Collect the unique, defined `script` values from one or more batches of
+ * virtual outputs. Callers pass the result to `getContractsByScript` so the
+ * contract lookup is scoped to the scripts actually being processed rather
+ * than every contract the wallet has ever created.
+ */
+export function collectVtxoScripts(
+    ...batches: readonly (readonly { script?: string }[])[]
+): string[] {
+    const scripts = new Set<string>();
+    for (const batch of batches) {
+        for (const vtxo of batch) {
+            if (vtxo.script) scripts.add(vtxo.script);
+        }
+    }
+    return [...scripts];
+}
+
 export function getRandomId(): string {
     const randomValue = crypto.getRandomValues(new Uint8Array(16));
     return hex.encode(randomValue);

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -16,6 +16,13 @@ import { Bytes } from "@scure/btc-signer/utils";
 
 export const DUST_AMOUNT = 546; // sats
 
+/**
+ * @deprecated Prefer {@link extendVirtualCoinForContract}, which resolves the
+ * owning contract's tapscripts when the wallet holds VTXOs from multiple
+ * contracts. This helper unconditionally stamps the wallet's default
+ * tapscript onto every VTXO and is only safe for wallets whose VTXOs all
+ * belong to the default contract.
+ */
 export function extendVirtualCoin(
     wallet: { offchainTapscript: ReadonlyWallet["offchainTapscript"] },
     vtxo: VirtualCoin
@@ -40,6 +47,13 @@ export function extendCoin(
     };
 }
 
+/**
+ * @deprecated Internal primitive — call {@link extendVirtualCoinForContract}
+ * and pass the `Contract` (or a `ReadonlyMap<script, Contract>`) as the third
+ * argument instead. The unified helper routes through this primitive when a
+ * contract resolves and falls back to the wallet's default tapscript
+ * otherwise.
+ */
 export function extendVtxoFromContract(
     vtxo: VirtualCoin,
     contract: Contract
@@ -61,29 +75,66 @@ export function extendVtxoFromContract(
 
 /**
  * Extend a VirtualCoin with the tap scripts of whichever contract locks it,
- * falling back to the wallet's default offchain tapscript.
+ * falling back to the wallet's default offchain tapscript when no contract
+ * can be resolved.
  *
- * When the wallet owns multiple contracts (e.g. default + delegate, or
- * several active vHTLCs) a raw `extendVirtualCoin` call uses only the
- * default tapscript, which silently overwrites the correct forfeit/intent
- * data for any VTXO locked to a non-default contract. Resolving by
- * `vtxo.script` — now always populated by the indexer and persisted —
- * keeps the extension aligned with the contract that actually owns the
- * VTXO, which is a correctness requirement before the vtxo is used for
- * spending or saved back to the repository.
+ * The third argument accepts either form, so each callsite passes what it
+ * already has:
+ * - a single `Contract` (when the caller already knows the owning contract,
+ *   e.g. the contract manager iterating its own `scriptToContract` map), or
+ * - a `ReadonlyMap<script, Contract>` (when the caller resolves by
+ *   `vtxo.script`, populated by the indexer).
+ *
+ * `wallet` may be `undefined` when the caller guarantees a contract always
+ * resolves (no need for the default-tapscript fallback). When both no
+ * contract resolves and no wallet is provided, this throws rather than
+ * returning a silently-defaulted extension.
+ *
+ * When the wallet owns multiple contracts (default + delegate, several active
+ * vHTLCs, etc.), a raw {@link extendVirtualCoin} call uses only the default
+ * tapscript, which silently overwrites the correct forfeit/intent data for
+ * any VTXO locked to a non-default contract. Resolving by `vtxo.script` keeps
+ * the extension aligned with the owning contract, which is a correctness
+ * requirement before the vtxo is used for spending or saved back to the
+ * repository.
  */
 export function extendVirtualCoinForContract(
-    wallet: { offchainTapscript: ReadonlyWallet["offchainTapscript"] },
+    wallet:
+        | { offchainTapscript: ReadonlyWallet["offchainTapscript"] }
+        | undefined,
     vtxo: VirtualCoin,
-    contractsByScript?: ReadonlyMap<string, Contract>
+    contractOrMap?: Contract | ReadonlyMap<string, Contract>
 ): ExtendedVirtualCoin {
-    if (vtxo.script && contractsByScript) {
-        const contract = contractsByScript.get(vtxo.script);
-        if (contract) {
-            return extendVtxoFromContract(vtxo, contract);
-        }
+    const contract = resolveContract(vtxo, contractOrMap);
+    if (contract) {
+        return extendVtxoFromContract(vtxo, contract);
+    }
+    if (!wallet) {
+        throw new Error(
+            "extendVirtualCoinForContract: no contract matched vtxo.script and no wallet fallback was provided"
+        );
     }
     return extendVirtualCoin(wallet, vtxo);
+}
+
+function isContractMap(
+    value: Contract | ReadonlyMap<string, Contract>
+): value is ReadonlyMap<string, Contract> {
+    // A `Contract` is a plain object with a string `type`. `ReadonlyMap` is
+    // an interface so `instanceof Map` is not enough to narrow it — but a
+    // contract has no `get` method, so duck-typing on that is unambiguous.
+    return typeof (value as { get?: unknown }).get === "function";
+}
+
+function resolveContract(
+    vtxo: VirtualCoin,
+    contractOrMap?: Contract | ReadonlyMap<string, Contract>
+): Contract | undefined {
+    if (!contractOrMap) return undefined;
+    if (isContractMap(contractOrMap)) {
+        return vtxo.script ? contractOrMap.get(vtxo.script) : undefined;
+    }
+    return contractOrMap;
 }
 
 /**

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -16,25 +16,6 @@ import { Bytes } from "@scure/btc-signer/utils";
 
 export const DUST_AMOUNT = 546; // sats
 
-/**
- * @deprecated Prefer {@link extendVirtualCoinForContract}, which resolves the
- * owning contract's tapscripts when the wallet holds VTXOs from multiple
- * contracts. This helper unconditionally stamps the wallet's default
- * tapscript onto every VTXO and is only safe for wallets whose VTXOs all
- * belong to the default contract.
- */
-export function extendVirtualCoin(
-    wallet: { offchainTapscript: ReadonlyWallet["offchainTapscript"] },
-    vtxo: VirtualCoin
-): ExtendedVirtualCoin {
-    return {
-        ...vtxo,
-        forfeitTapLeafScript: wallet.offchainTapscript.forfeit(),
-        intentTapLeafScript: wallet.offchainTapscript.forfeit(),
-        tapTree: wallet.offchainTapscript.encode(),
-    };
-}
-
 export function extendCoin(
     wallet: { boardingTapscript: ReadonlyWallet["boardingTapscript"] },
     utxo: Coin
@@ -48,11 +29,11 @@ export function extendCoin(
 }
 
 /**
- * @deprecated Internal primitive — call {@link extendVirtualCoinForContract}
- * and pass the `Contract` (or a `ReadonlyMap<script, Contract>`) as the third
- * argument instead. The unified helper routes through this primitive when a
- * contract resolves and falls back to the wallet's default tapscript
- * otherwise.
+ * Internal primitive — prefer {@link extendVirtualCoinForContract}, which
+ * resolves the owning contract via a script→Contract map (or accepts a single
+ * `Contract` directly) and throws when resolution fails. Leaving this
+ * exported for the handful of callsites that already hold a `Contract` and
+ * only need the raw annotation.
  */
 export function extendVtxoFromContract(
     vtxo: VirtualCoin,
@@ -74,47 +55,35 @@ export function extendVtxoFromContract(
 }
 
 /**
- * Extend a VirtualCoin with the tap scripts of whichever contract locks it,
- * falling back to the wallet's default offchain tapscript when no contract
- * can be resolved.
+ * Extend a VirtualCoin with the tap scripts of whichever contract locks it.
  *
- * The third argument accepts either form, so each callsite passes what it
+ * The second argument accepts either form, so each callsite passes what it
  * already has:
  * - a single `Contract` (when the caller already knows the owning contract,
  *   e.g. the contract manager iterating its own `scriptToContract` map), or
  * - a `ReadonlyMap<script, Contract>` (when the caller resolves by
  *   `vtxo.script`, populated by the indexer).
  *
- * `wallet` may be `undefined` when the caller guarantees a contract always
- * resolves (no need for the default-tapscript fallback). When both no
- * contract resolves and no wallet is provided, this throws rather than
- * returning a silently-defaulted extension.
- *
- * When the wallet owns multiple contracts (default + delegate, several active
- * vHTLCs, etc.), a raw {@link extendVirtualCoin} call uses only the default
- * tapscript, which silently overwrites the correct forfeit/intent data for
- * any VTXO locked to a non-default contract. Resolving by `vtxo.script` keeps
- * the extension aligned with the owning contract, which is a correctness
- * requirement before the vtxo is used for spending or saved back to the
- * repository.
+ * Throws when no contract can be resolved — there is intentionally no
+ * default-tapscript fallback. When the wallet owns multiple contracts
+ * (default + delegate, several active vHTLCs, etc.) a default-tapscript path
+ * silently stamps every VTXO with the same forfeit/intent data, overwriting
+ * the correct data for any VTXO locked to a non-default contract. Callers
+ * must feed a Contract or a populated script→Contract map; otherwise the
+ * caller (typically `ContractManager.annotateVtxos`) should fetch the owning
+ * contract first.
  */
 export function extendVirtualCoinForContract(
-    wallet:
-        | { offchainTapscript: ReadonlyWallet["offchainTapscript"] }
-        | undefined,
     vtxo: VirtualCoin,
     contractOrMap?: Contract | ReadonlyMap<string, Contract>
 ): ExtendedVirtualCoin {
     const contract = resolveContract(vtxo, contractOrMap);
-    if (contract) {
-        return extendVtxoFromContract(vtxo, contract);
-    }
-    if (!wallet) {
+    if (!contract) {
         throw new Error(
-            "extendVirtualCoinForContract: no contract matched vtxo.script and no wallet fallback was provided"
+            "extendVirtualCoinForContract: no contract matched vtxo.script — callers must resolve the owning contract before annotating"
         );
     }
-    return extendVirtualCoin(wallet, vtxo);
+    return extendVtxoFromContract(vtxo, contract);
 }
 
 function isContractMap(

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -79,7 +79,11 @@ import { TxTree } from "../tree/txTree";
 import { ConditionWitness, VtxoTaprootTree } from "../utils/unknownFields";
 import { WalletRepository } from "../repositories/walletRepository";
 import { ContractRepository } from "../repositories/contractRepository";
-import { extendCoin, extendVirtualCoin, validateRecipients } from "./utils";
+import {
+    extendCoin,
+    extendVirtualCoinForContract,
+    validateRecipients,
+} from "./utils";
 import { ArkError } from "../providers/errors";
 import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
@@ -98,6 +102,7 @@ import {
     IndexedDBWalletRepository,
 } from "../repositories";
 import { ContractManager } from "../contracts/contractManager";
+import type { Contract } from "../contracts/types";
 import { contractHandlers } from "../contracts/handlers";
 import { timelockToSequence } from "../contracts/handlers/helpers";
 import {
@@ -906,11 +911,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
             };
 
             // Handle subscription updates asynchronously without blocking.
-            // Note: subscription covers all wallet scripts (default + delegate),
-            // but we can't determine which script each virtual output belongs to from the
-            // subscription event. Virtual outputs are extended with the current offchainTapscript;
-            // this is for notification/display only — not for spending.
-            // For correct extension metadata, use getVtxos() which queries per-script.
+            // Subscription covers all wallet scripts (default + delegate) plus
+            // any additional registered contracts. Virtual outputs carry a
+            // `script` field from the indexer, which we map back to the owning
+            // contract so the extension uses the correct forfeit/intent
+            // tapscripts. Falls back to the wallet's default offchainTapscript
+            // only when a VTXO can't be attributed to a known contract.
             (async () => {
                 try {
                     for await (const update of subscription) {
@@ -918,13 +924,23 @@ export class ReadonlyWallet implements IReadonlyWallet {
                             update.newVtxos?.length > 0 ||
                             update.spentVtxos?.length > 0
                         ) {
+                            const contractsByScript =
+                                await this.getContractsByScript();
                             eventCallback({
                                 type: "vtxo",
                                 newVtxos: update.newVtxos.map((vtxo) =>
-                                    extendVirtualCoin(this, vtxo)
+                                    extendVirtualCoinForContract(
+                                        this,
+                                        vtxo,
+                                        contractsByScript
+                                    )
                                 ),
                                 spentVtxos: update.spentVtxos.map((vtxo) =>
-                                    extendVirtualCoin(this, vtxo)
+                                    extendVirtualCoinForContract(
+                                        this,
+                                        vtxo,
+                                        contractsByScript
+                                    )
                                 ),
                             });
                         }
@@ -987,6 +1003,27 @@ export class ReadonlyWallet implements IReadonlyWallet {
             }
         }
         return [hex.encode(this.offchainTapscript.pkScript)];
+    }
+
+    /**
+     * Return a script → Contract index covering every contract known to the
+     * wallet. Callers use this to attribute incoming virtual outputs (via
+     * their `script`) back to the correct contract so they can be extended
+     * with the right tap scripts. Returns an empty map when the contract
+     * manager is not initialised to avoid triggering initialisation from
+     * hot paths.
+     */
+    async getContractsByScript(): Promise<ReadonlyMap<string, Contract>> {
+        if (!this._contractManager && !this._contractManagerInitializing) {
+            return new Map();
+        }
+        try {
+            const manager = await this.getContractManager();
+            const contracts = await manager.getContracts();
+            return new Map(contracts.map((c) => [c.script, c]));
+        } catch {
+            return new Map();
+        }
     }
 
     /**
@@ -2712,8 +2749,13 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 inputs.length,
                 signedCheckpointTxs.length
             );
+            const contractsByScript = await this.getContractsByScript();
             for (const [inputIndex, input] of inputs.entries()) {
-                const vtxo = extendVirtualCoin(this, input);
+                const vtxo = extendVirtualCoinForContract(
+                    this,
+                    input,
+                    contractsByScript
+                );
 
                 if (
                     inputIndex < safeLength &&
@@ -2827,10 +2869,15 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 input: ExtendedCoin
             ): input is ExtendedVirtualCoin => "virtualStatus" in input;
 
+            const contractsByScript = await this.getContractsByScript();
             for (const input of inputs) {
                 if (isVtxo(input)) {
                     // virtual output = mark it settled
-                    const vtxo = extendVirtualCoin(this, input);
+                    const vtxo = extendVirtualCoinForContract(
+                        this,
+                        input,
+                        contractsByScript
+                    );
                     if (vtxo.arkTxId) {
                         inputArkTxIds.add(vtxo.arkTxId);
                     }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -80,6 +80,7 @@ import { ConditionWitness, VtxoTaprootTree } from "../utils/unknownFields";
 import { WalletRepository } from "../repositories/walletRepository";
 import { ContractRepository } from "../repositories/contractRepository";
 import {
+    collectVtxoScripts,
     extendCoin,
     extendVirtualCoinForContract,
     validateRecipients,
@@ -925,7 +926,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
                             update.spentVtxos?.length > 0
                         ) {
                             const contractsByScript =
-                                await this.getContractsByScript();
+                                await this.getContractsByScript(
+                                    collectVtxoScripts(
+                                        update.newVtxos,
+                                        update.spentVtxos
+                                    )
+                                );
                             eventCallback({
                                 type: "vtxo",
                                 newVtxos: update.newVtxos.map((vtxo) =>
@@ -1006,20 +1012,24 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }
 
     /**
-     * Return a script → Contract index covering every contract known to the
-     * wallet. Callers use this to attribute incoming virtual outputs (via
-     * their `script`) back to the correct contract so they can be extended
-     * with the right tap scripts. Returns an empty map when the contract
-     * manager is not initialised to avoid triggering initialisation from
-     * hot paths.
+     * Return a script → Contract index restricted to the requested scripts.
+     * Callers use this to attribute virtual outputs (via their `script`) to
+     * the owning contract so they can be extended with the right tap
+     * scripts. Returns an empty map when there are no scripts to resolve or
+     * when the contract manager is not yet initialised (so hot paths don't
+     * trigger initialisation).
      */
-    async getContractsByScript(): Promise<ReadonlyMap<string, Contract>> {
+    async getContractsByScript(
+        scripts: Iterable<string>
+    ): Promise<ReadonlyMap<string, Contract>> {
         if (!this._contractManager && !this._contractManagerInitializing) {
             return new Map();
         }
+        const unique = Array.from(new Set(scripts));
+        if (unique.length === 0) return new Map();
         try {
             const manager = await this.getContractManager();
-            const contracts = await manager.getContracts();
+            const contracts = await manager.getContracts({ script: unique });
             return new Map(contracts.map((c) => [c.script, c]));
         } catch {
             return new Map();
@@ -2749,7 +2759,9 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 inputs.length,
                 signedCheckpointTxs.length
             );
-            const contractsByScript = await this.getContractsByScript();
+            const contractsByScript = await this.getContractsByScript(
+                collectVtxoScripts(inputs)
+            );
             for (const [inputIndex, input] of inputs.entries()) {
                 const vtxo = extendVirtualCoinForContract(
                     this,
@@ -2869,7 +2881,9 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 input: ExtendedCoin
             ): input is ExtendedVirtualCoin => "virtualStatus" in input;
 
-            const contractsByScript = await this.getContractsByScript();
+            const contractsByScript = await this.getContractsByScript(
+                collectVtxoScripts(inputs.filter(isVtxo))
+            );
             for (const input of inputs) {
                 if (isVtxo(input)) {
                     // virtual output = mark it settled

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -79,12 +79,7 @@ import { TxTree } from "../tree/txTree";
 import { ConditionWitness, VtxoTaprootTree } from "../utils/unknownFields";
 import { WalletRepository } from "../repositories/walletRepository";
 import { ContractRepository } from "../repositories/contractRepository";
-import {
-    collectVtxoScripts,
-    extendCoin,
-    extendVirtualCoinForContract,
-    validateRecipients,
-} from "./utils";
+import { extendCoin, validateRecipients } from "./utils";
 import { ArkError } from "../providers/errors";
 import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
@@ -103,7 +98,6 @@ import {
     IndexedDBWalletRepository,
 } from "../repositories";
 import { ContractManager } from "../contracts/contractManager";
-import type { Contract } from "../contracts/types";
 import { contractHandlers } from "../contracts/handlers";
 import { timelockToSequence } from "../contracts/handlers/helpers";
 import {
@@ -914,40 +908,25 @@ export class ReadonlyWallet implements IReadonlyWallet {
             // Handle subscription updates asynchronously without blocking.
             // Subscription covers all wallet scripts (default + delegate) plus
             // any additional registered contracts. Virtual outputs carry a
-            // `script` field from the indexer, which we map back to the owning
-            // contract so the extension uses the correct forfeit/intent
-            // tapscripts. Falls back to the wallet's default offchainTapscript
-            // only when a VTXO can't be attributed to a known contract.
+            // `script` field from the indexer which the contract manager
+            // resolves to the owning contract so the extension uses the
+            // correct forfeit/intent tapscripts.
             (async () => {
                 try {
+                    const cm = await this.getContractManager();
                     for await (const update of subscription) {
                         if (
                             update.newVtxos?.length > 0 ||
                             update.spentVtxos?.length > 0
                         ) {
-                            const contractsByScript =
-                                await this.getContractsByScript(
-                                    collectVtxoScripts(
-                                        update.newVtxos,
-                                        update.spentVtxos
-                                    )
-                                );
+                            const [newVtxos, spentVtxos] = await Promise.all([
+                                cm.annotateVtxos(update.newVtxos),
+                                cm.annotateVtxos(update.spentVtxos),
+                            ]);
                             eventCallback({
                                 type: "vtxo",
-                                newVtxos: update.newVtxos.map((vtxo) =>
-                                    extendVirtualCoinForContract(
-                                        this,
-                                        vtxo,
-                                        contractsByScript
-                                    )
-                                ),
-                                spentVtxos: update.spentVtxos.map((vtxo) =>
-                                    extendVirtualCoinForContract(
-                                        this,
-                                        vtxo,
-                                        contractsByScript
-                                    )
-                                ),
+                                newVtxos,
+                                spentVtxos,
                             });
                         }
                     }
@@ -1009,35 +988,6 @@ export class ReadonlyWallet implements IReadonlyWallet {
             }
         }
         return [hex.encode(this.offchainTapscript.pkScript)];
-    }
-
-    /**
-     * Return a script → Contract index restricted to the requested scripts.
-     * Callers use this to attribute virtual outputs (via their `script`) to
-     * the owning contract so they can be extended with the right tap
-     * scripts. Returns an empty map when there are no scripts to resolve or
-     * when the contract manager is not yet initialised (so hot paths don't
-     * trigger initialisation).
-     */
-    async getContractsByScript(
-        scripts: Iterable<string>
-    ): Promise<ReadonlyMap<string, Contract>> {
-        if (!this._contractManager && !this._contractManagerInitializing) {
-            return new Map();
-        }
-        const unique = Array.from(new Set(scripts));
-        if (unique.length === 0) return new Map();
-        try {
-            const manager = await this.getContractManager();
-            const contracts = await manager.getContracts({ script: unique });
-            return new Map(contracts.map((c) => [c.script, c]));
-        } catch (error) {
-            console.warn(
-                "getContractsByScript failed; falling back to default tapscript for these VTXOs",
-                error
-            );
-            return new Map();
-        }
     }
 
     /**
@@ -2763,16 +2713,9 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 inputs.length,
                 signedCheckpointTxs.length
             );
-            const contractsByScript = await this.getContractsByScript(
-                collectVtxoScripts(inputs)
-            );
-            for (const [inputIndex, input] of inputs.entries()) {
-                const vtxo = extendVirtualCoinForContract(
-                    this,
-                    input,
-                    contractsByScript
-                );
-
+            const cm = await this.getContractManager();
+            const annotatedInputs = await cm.annotateVtxos(inputs);
+            for (const [inputIndex, vtxo] of annotatedInputs.entries()) {
                 if (
                     inputIndex < safeLength &&
                     signedCheckpointTxs[inputIndex]
@@ -2885,17 +2828,18 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 input: ExtendedCoin
             ): input is ExtendedVirtualCoin => "virtualStatus" in input;
 
-            const contractsByScript = await this.getContractsByScript(
-                collectVtxoScripts(inputs.filter(isVtxo))
+            const vtxoInputs = inputs.filter(isVtxo);
+            const cm = await this.getContractManager();
+            const annotatedVtxos = await cm.annotateVtxos(vtxoInputs);
+            const annotatedByKey = new Map(
+                annotatedVtxos.map((v) => [`${v.txid}:${v.vout}`, v])
             );
             for (const input of inputs) {
                 if (isVtxo(input)) {
                     // virtual output = mark it settled
-                    const vtxo = extendVirtualCoinForContract(
-                        this,
-                        input,
-                        contractsByScript
-                    );
+                    const vtxo = annotatedByKey.get(
+                        `${input.txid}:${input.vout}`
+                    )!;
                     if (vtxo.arkTxId) {
                         inputArkTxIds.add(vtxo.arkTxId);
                     }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1031,7 +1031,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
             const manager = await this.getContractManager();
             const contracts = await manager.getContracts({ script: unique });
             return new Map(contracts.map((c) => [c.script, c]));
-        } catch {
+        } catch (error) {
+            console.warn(
+                "getContractsByScript failed; falling back to default tapscript for these VTXOs",
+                error
+            );
             return new Map();
         }
     }

--- a/src/worker/expo/taskRunner.ts
+++ b/src/worker/expo/taskRunner.ts
@@ -6,11 +6,7 @@ import type { ArkProvider } from "../../providers/ark";
 import type { ExtendedVirtualCoin, VirtualCoin } from "../../wallet";
 import type { Contract } from "../../contracts/types";
 import type { ReadonlyWallet } from "../../wallet/wallet";
-import {
-    getRandomId,
-    extendVirtualCoin,
-    extendVtxoFromContract,
-} from "../../wallet/utils";
+import { getRandomId, extendVirtualCoinForContract } from "../../wallet/utils";
 
 /**
  * Shared dependencies injected into every processor at runtime.
@@ -139,11 +135,7 @@ export function createTaskDependencies(
         contractRepository,
         indexerProvider,
         arkProvider,
-        extendVtxo: (vtxo: VirtualCoin, contract?: Contract) => {
-            if (contract) {
-                return extendVtxoFromContract(vtxo, contract);
-            }
-            return extendVirtualCoin({ offchainTapscript }, vtxo);
-        },
+        extendVtxo: (vtxo: VirtualCoin, contract?: Contract) =>
+            extendVirtualCoinForContract({ offchainTapscript }, vtxo, contract),
     };
 }

--- a/src/worker/expo/taskRunner.ts
+++ b/src/worker/expo/taskRunner.ts
@@ -5,18 +5,22 @@ import type { IndexerProvider } from "../../providers/indexer";
 import type { ArkProvider } from "../../providers/ark";
 import type { ExtendedVirtualCoin, VirtualCoin } from "../../wallet";
 import type { Contract } from "../../contracts/types";
-import type { ReadonlyWallet } from "../../wallet/wallet";
-import { getRandomId, extendVirtualCoinForContract } from "../../wallet/utils";
+import { getRandomId, extendVtxoFromContract } from "../../wallet/utils";
 
 /**
  * Shared dependencies injected into every processor at runtime.
+ *
+ * `extendVtxo` requires the owning contract — processors must resolve each
+ * vtxo's `script` to a known contract (via the contract repository) before
+ * calling this. The strict signature prevents the footgun where a missing
+ * contract silently falls back to the wallet's default tapscript.
  */
 export interface TaskDependencies {
     walletRepository: WalletRepository;
     contractRepository: ContractRepository;
     indexerProvider: IndexerProvider;
     arkProvider: ArkProvider;
-    extendVtxo: (vtxo: VirtualCoin, contract?: Contract) => ExtendedVirtualCoin;
+    extendVtxo: (vtxo: VirtualCoin, contract: Contract) => ExtendedVirtualCoin;
 }
 
 /**
@@ -107,7 +111,6 @@ export interface CreateTaskDependenciesOptions {
     contractRepository: ContractRepository;
     indexerProvider: IndexerProvider;
     arkProvider: ArkProvider;
-    offchainTapscript: ReadonlyWallet["offchainTapscript"];
 }
 
 /**
@@ -122,20 +125,9 @@ export interface CreateTaskDependenciesOptions {
 export function createTaskDependencies(
     options: CreateTaskDependenciesOptions
 ): TaskDependencies {
-    const {
-        walletRepository,
-        contractRepository,
-        indexerProvider,
-        arkProvider,
-        offchainTapscript,
-    } = options;
-
     return {
-        walletRepository,
-        contractRepository,
-        indexerProvider,
-        arkProvider,
-        extendVtxo: (vtxo: VirtualCoin, contract?: Contract) =>
-            extendVirtualCoinForContract({ offchainTapscript }, vtxo, contract),
+        ...options,
+        extendVtxo: (vtxo: VirtualCoin, contract: Contract) =>
+            extendVtxoFromContract(vtxo, contract),
     };
 }

--- a/test/contracts/manager.test.ts
+++ b/test/contracts/manager.test.ts
@@ -318,4 +318,32 @@ describe("ContractManager", () => {
 
         vi.advanceTimersByTime(3000);
     });
+
+    describe("annotateVtxos", () => {
+        it("returns empty array for empty input", async () => {
+            const extended = await manager.annotateVtxos([]);
+            expect(extended).toEqual([]);
+        });
+
+        it("stamps the owning contract's tapscripts via vtxo.script", async () => {
+            await manager.createContract({
+                type: "default",
+                params: createDefaultContractParams(),
+                script: TEST_DEFAULT_SCRIPT,
+                address: "address",
+            });
+
+            const vtxo = createMockVtxo({ script: TEST_DEFAULT_SCRIPT });
+            const [extended] = await manager.annotateVtxos([vtxo]);
+
+            expect(extended.forfeitTapLeafScript).toBeDefined();
+            expect(extended.intentTapLeafScript).toBeDefined();
+            expect(extended.tapTree).toBeDefined();
+        });
+
+        it("throws when a vtxo's script has no registered contract", async () => {
+            const orphan = createMockVtxo({ script: "ab".repeat(34) });
+            await expect(manager.annotateVtxos([orphan])).rejects.toThrow();
+        });
+    });
 });

--- a/test/sqlite-wallet-repository.test.ts
+++ b/test/sqlite-wallet-repository.test.ts
@@ -138,6 +138,25 @@ function createMockSQLExecutor(): SQLExecutor {
                 return;
             }
 
+            // ALTER TABLE ADD COLUMN is used for lazy migrations. Simulate
+            // the real SQLite behaviour: if the column already exists, raise
+            // a "duplicate column" error so the impl's catch branch matches.
+            const alterMatch = trimmed.match(
+                /^ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)/i
+            );
+            if (alterMatch) {
+                const [, tableName, colName] = alterMatch;
+                const t = tables.get(tableName);
+                if (!t) throw new Error(`Table ${tableName} does not exist`);
+                const sample = t.rows.values().next();
+                if (!sample.done && colName in (sample.value as object)) {
+                    throw new Error(`duplicate column name: ${colName}`);
+                }
+                // Column did not exist — nothing structural to track in the
+                // mock since rows are plain objects; new writes populate it.
+                return;
+            }
+
             throw new Error(`Unsupported SQL in run(): ${trimmed}`);
         },
 
@@ -272,6 +291,7 @@ function createMockVtxoWithExtras(
         tapTree: new Uint8Array(32).fill(5),
         extraWitness: [new Uint8Array([0xab, 0xcd]), new Uint8Array([0xef])],
         assets: [{ assetId: "asset-1", amount: 500 }],
+        script: "5120deadbeef",
     };
 }
 
@@ -410,6 +430,8 @@ describe("SQLiteWalletRepository", () => {
             expect(retrieved.extraWitness!.length).toBe(2);
             expect(hex.encode(retrieved.extraWitness![0])).toBe("abcd");
             expect(hex.encode(retrieved.extraWitness![1])).toBe("ef");
+            // script (hex scriptPubKey) round-trip
+            expect(retrieved.script).toBe("5120deadbeef");
         });
 
         it("should round-trip tap tree and leaf scripts", async () => {

--- a/test/wallet/utils.test.ts
+++ b/test/wallet/utils.test.ts
@@ -1,31 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { hex } from "@scure/base";
 
 import type { Contract } from "../../src/contracts/types";
 import {
     extendVirtualCoinForContract,
     collectVtxoScripts,
 } from "../../src/wallet/utils";
-import { DefaultVtxo } from "../../src/script/default";
 import {
     createDefaultContractParams,
     createDelegateContractParams,
     createMockVtxo,
     TEST_DEFAULT_SCRIPT,
     TEST_DELEGATE_SCRIPT,
-    TEST_PUB_KEY,
-    TEST_SERVER_PUB_KEY,
 } from "../contracts/helpers";
-
-// A wallet stub carrying only what the helper consumes: the offchain
-// tapscript used as the default fallback when no contract resolves.
-const fallbackWallet = {
-    offchainTapscript: new DefaultVtxo.Script({
-        pubKey: TEST_PUB_KEY,
-        serverPubKey: TEST_SERVER_PUB_KEY,
-    }),
-};
-const FALLBACK_SCRIPT = hex.encode(fallbackWallet.offchainTapscript.pkScript);
 
 const defaultContract: Contract = {
     type: "default",
@@ -53,64 +39,42 @@ describe("extendVirtualCoinForContract", () => {
             [delegateContract.script, delegateContract],
         ]);
 
-        const extended = extendVirtualCoinForContract(
-            fallbackWallet,
-            vtxo,
-            map
-        );
+        const extended = extendVirtualCoinForContract(vtxo, map);
 
-        // The extension must use the delegate tapscript, not the fallback
-        // default one — otherwise multi-contract VTXOs get silently stamped
-        // with the wrong forfeit/intent data.
-        expect(extended.tapTree).not.toEqual(
-            fallbackWallet.offchainTapscript.encode()
-        );
+        // The extension uses the delegate contract's tapscript, not the
+        // default one — multi-contract VTXOs must not be stamped with the
+        // wrong forfeit/intent data.
+        expect(extended.tapTree).toBeDefined();
+        expect(extended.forfeitTapLeafScript).toBeDefined();
     });
 
-    it("falls back to the wallet default when vtxo.script has no entry in the map", () => {
+    it("throws when vtxo.script has no entry in the map", () => {
         const vtxo = createMockVtxo({ script: "deadbeef".repeat(8) });
         const map = new Map<string, Contract>([
             [delegateContract.script, delegateContract],
         ]);
 
-        const extended = extendVirtualCoinForContract(
-            fallbackWallet,
-            vtxo,
-            map
-        );
-
-        expect(extended.tapTree).toEqual(
-            fallbackWallet.offchainTapscript.encode()
-        );
-        expect(extended.forfeitTapLeafScript).toEqual(
-            fallbackWallet.offchainTapscript.forfeit()
+        expect(() => extendVirtualCoinForContract(vtxo, map)).toThrow(
+            /no contract matched/
         );
     });
 
-    it("falls back to the wallet default when vtxo.script is missing", () => {
+    it("throws when vtxo.script is missing", () => {
         const vtxo = createMockVtxo(); // no script
         const map = new Map<string, Contract>([
             [delegateContract.script, delegateContract],
         ]);
 
-        const extended = extendVirtualCoinForContract(
-            fallbackWallet,
-            vtxo,
-            map
-        );
-
-        expect(extended.tapTree).toEqual(
-            fallbackWallet.offchainTapscript.encode()
+        expect(() => extendVirtualCoinForContract(vtxo, map)).toThrow(
+            /no contract matched/
         );
     });
 
-    it("falls back to the wallet default when no third argument is provided", () => {
+    it("throws when no second argument is provided", () => {
         const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
 
-        const extended = extendVirtualCoinForContract(fallbackWallet, vtxo);
-
-        expect(extended.tapTree).toEqual(
-            fallbackWallet.offchainTapscript.encode()
+        expect(() => extendVirtualCoinForContract(vtxo)).toThrow(
+            /no contract matched/
         );
     });
 
@@ -119,45 +83,24 @@ describe("extendVirtualCoinForContract", () => {
         // caller is asserting ownership, so no map lookup happens.
         const vtxo = createMockVtxo({ script: "cafebabe".repeat(8) });
 
-        const extended = extendVirtualCoinForContract(
-            fallbackWallet,
-            vtxo,
-            delegateContract
-        );
-
-        expect(extended.tapTree).not.toEqual(
-            fallbackWallet.offchainTapscript.encode()
-        );
-    });
-
-    it("throws when no contract resolves and no wallet is provided", () => {
-        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
-
-        expect(() =>
-            extendVirtualCoinForContract(undefined, vtxo, new Map())
-        ).toThrow(/no contract matched/);
-    });
-
-    it("does not throw when a contract resolves even if wallet is undefined", () => {
-        // The contract-manager call path passes `undefined` for wallet because
-        // it only ever calls with a contract in hand — the fallback should
-        // never run, so no wallet is needed.
-        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
-
-        const extended = extendVirtualCoinForContract(
-            undefined,
-            vtxo,
-            delegateContract
-        );
+        const extended = extendVirtualCoinForContract(vtxo, delegateContract);
 
         expect(extended.tapTree).toBeDefined();
         expect(extended.forfeitTapLeafScript).toBeDefined();
     });
 
+    it("throws when the map is empty", () => {
+        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
+
+        expect(() => extendVirtualCoinForContract(vtxo, new Map())).toThrow(
+            /no contract matched/
+        );
+    });
+
     it("routes two VTXOs from different contracts to different tapscripts", () => {
-        // The correctness regression this helper prevents: when a wallet holds
-        // VTXOs from multiple contracts, the default-tapscript path silently
-        // stamps every VTXO with the same forfeit/intent data.
+        // The correctness regression this helper prevents: with a shared
+        // default-tapscript path, every VTXO was stamped with the same
+        // forfeit/intent data regardless of the owning contract.
         const defaultVtxo = createMockVtxo({ script: TEST_DEFAULT_SCRIPT });
         const delegateVtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
         const map = new Map<string, Contract>([
@@ -165,13 +108,8 @@ describe("extendVirtualCoinForContract", () => {
             [delegateContract.script, delegateContract],
         ]);
 
-        const extendedDefault = extendVirtualCoinForContract(
-            fallbackWallet,
-            defaultVtxo,
-            map
-        );
+        const extendedDefault = extendVirtualCoinForContract(defaultVtxo, map);
         const extendedDelegate = extendVirtualCoinForContract(
-            fallbackWallet,
             delegateVtxo,
             map
         );
@@ -187,16 +125,8 @@ describe("extendVirtualCoinForContract", () => {
         };
         const map = new Map<string, Contract>([[bogus.script, bogus]]);
 
-        expect(() =>
-            extendVirtualCoinForContract(fallbackWallet, vtxo, map)
-        ).toThrow(/handler/);
-    });
-
-    // Satisfy lint: `FALLBACK_SCRIPT` is referenced from the helpers above,
-    // but we also keep it here so a failing diff highlights a fallback regression.
-    it("sanity: fallback tapscript hash matches the wallet stub", () => {
-        expect(FALLBACK_SCRIPT).toBe(
-            hex.encode(fallbackWallet.offchainTapscript.pkScript)
+        expect(() => extendVirtualCoinForContract(vtxo, map)).toThrow(
+            /handler/
         );
     });
 });

--- a/test/wallet/utils.test.ts
+++ b/test/wallet/utils.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+
+import type { Contract } from "../../src/contracts/types";
+import {
+    extendVirtualCoinForContract,
+    collectVtxoScripts,
+} from "../../src/wallet/utils";
+import { DefaultVtxo } from "../../src/script/default";
+import {
+    createDefaultContractParams,
+    createDelegateContractParams,
+    createMockVtxo,
+    TEST_DEFAULT_SCRIPT,
+    TEST_DELEGATE_SCRIPT,
+    TEST_PUB_KEY,
+    TEST_SERVER_PUB_KEY,
+} from "../contracts/helpers";
+
+// A wallet stub carrying only what the helper consumes: the offchain
+// tapscript used as the default fallback when no contract resolves.
+const fallbackWallet = {
+    offchainTapscript: new DefaultVtxo.Script({
+        pubKey: TEST_PUB_KEY,
+        serverPubKey: TEST_SERVER_PUB_KEY,
+    }),
+};
+const FALLBACK_SCRIPT = hex.encode(fallbackWallet.offchainTapscript.pkScript);
+
+const defaultContract: Contract = {
+    type: "default",
+    params: createDefaultContractParams(),
+    script: TEST_DEFAULT_SCRIPT,
+    address: "ark1default",
+    state: "active",
+    createdAt: Date.now(),
+};
+
+const delegateContract: Contract = {
+    type: "delegate",
+    params: createDelegateContractParams(),
+    script: TEST_DELEGATE_SCRIPT,
+    address: "ark1delegate",
+    state: "active",
+    createdAt: Date.now(),
+};
+
+describe("extendVirtualCoinForContract", () => {
+    it("resolves via map when vtxo.script matches a known contract", () => {
+        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
+        const map = new Map<string, Contract>([
+            [defaultContract.script, defaultContract],
+            [delegateContract.script, delegateContract],
+        ]);
+
+        const extended = extendVirtualCoinForContract(
+            fallbackWallet,
+            vtxo,
+            map
+        );
+
+        // The extension must use the delegate tapscript, not the fallback
+        // default one — otherwise multi-contract VTXOs get silently stamped
+        // with the wrong forfeit/intent data.
+        expect(extended.tapTree).not.toEqual(
+            fallbackWallet.offchainTapscript.encode()
+        );
+    });
+
+    it("falls back to the wallet default when vtxo.script has no entry in the map", () => {
+        const vtxo = createMockVtxo({ script: "deadbeef".repeat(8) });
+        const map = new Map<string, Contract>([
+            [delegateContract.script, delegateContract],
+        ]);
+
+        const extended = extendVirtualCoinForContract(
+            fallbackWallet,
+            vtxo,
+            map
+        );
+
+        expect(extended.tapTree).toEqual(
+            fallbackWallet.offchainTapscript.encode()
+        );
+        expect(extended.forfeitTapLeafScript).toEqual(
+            fallbackWallet.offchainTapscript.forfeit()
+        );
+    });
+
+    it("falls back to the wallet default when vtxo.script is missing", () => {
+        const vtxo = createMockVtxo(); // no script
+        const map = new Map<string, Contract>([
+            [delegateContract.script, delegateContract],
+        ]);
+
+        const extended = extendVirtualCoinForContract(
+            fallbackWallet,
+            vtxo,
+            map
+        );
+
+        expect(extended.tapTree).toEqual(
+            fallbackWallet.offchainTapscript.encode()
+        );
+    });
+
+    it("falls back to the wallet default when no third argument is provided", () => {
+        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(fallbackWallet, vtxo);
+
+        expect(extended.tapTree).toEqual(
+            fallbackWallet.offchainTapscript.encode()
+        );
+    });
+
+    it("uses a directly-passed Contract without consulting vtxo.script", () => {
+        // vtxo.script intentionally mismatches — with a direct Contract the
+        // caller is asserting ownership, so no map lookup happens.
+        const vtxo = createMockVtxo({ script: "cafebabe".repeat(8) });
+
+        const extended = extendVirtualCoinForContract(
+            fallbackWallet,
+            vtxo,
+            delegateContract
+        );
+
+        expect(extended.tapTree).not.toEqual(
+            fallbackWallet.offchainTapscript.encode()
+        );
+    });
+
+    it("throws when no contract resolves and no wallet is provided", () => {
+        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
+
+        expect(() =>
+            extendVirtualCoinForContract(undefined, vtxo, new Map())
+        ).toThrow(/no contract matched/);
+    });
+
+    it("does not throw when a contract resolves even if wallet is undefined", () => {
+        // The contract-manager call path passes `undefined` for wallet because
+        // it only ever calls with a contract in hand — the fallback should
+        // never run, so no wallet is needed.
+        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(
+            undefined,
+            vtxo,
+            delegateContract
+        );
+
+        expect(extended.tapTree).toBeDefined();
+        expect(extended.forfeitTapLeafScript).toBeDefined();
+    });
+
+    it("routes two VTXOs from different contracts to different tapscripts", () => {
+        // The correctness regression this helper prevents: when a wallet holds
+        // VTXOs from multiple contracts, the default-tapscript path silently
+        // stamps every VTXO with the same forfeit/intent data.
+        const defaultVtxo = createMockVtxo({ script: TEST_DEFAULT_SCRIPT });
+        const delegateVtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
+        const map = new Map<string, Contract>([
+            [defaultContract.script, defaultContract],
+            [delegateContract.script, delegateContract],
+        ]);
+
+        const extendedDefault = extendVirtualCoinForContract(
+            fallbackWallet,
+            defaultVtxo,
+            map
+        );
+        const extendedDelegate = extendVirtualCoinForContract(
+            fallbackWallet,
+            delegateVtxo,
+            map
+        );
+
+        expect(extendedDefault.tapTree).not.toEqual(extendedDelegate.tapTree);
+    });
+
+    it("throws for an unknown contract type in the map", () => {
+        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
+        const bogus: Contract = {
+            ...delegateContract,
+            type: "not-a-real-type",
+        };
+        const map = new Map<string, Contract>([[bogus.script, bogus]]);
+
+        expect(() =>
+            extendVirtualCoinForContract(fallbackWallet, vtxo, map)
+        ).toThrow(/handler/);
+    });
+
+    // Satisfy lint: `FALLBACK_SCRIPT` is referenced from the helpers above,
+    // but we also keep it here so a failing diff highlights a fallback regression.
+    it("sanity: fallback tapscript hash matches the wallet stub", () => {
+        expect(FALLBACK_SCRIPT).toBe(
+            hex.encode(fallbackWallet.offchainTapscript.pkScript)
+        );
+    });
+});
+
+describe("collectVtxoScripts", () => {
+    it("returns a unique, ordered-by-insertion list across batches", () => {
+        const scripts = collectVtxoScripts(
+            [{ script: "a" }, { script: "b" }, { script: "a" }],
+            [{ script: "c" }, { script: "b" }]
+        );
+
+        expect(scripts).toEqual(["a", "b", "c"]);
+    });
+
+    it("drops entries without a script", () => {
+        const scripts = collectVtxoScripts([
+            { script: "a" },
+            {},
+            { script: undefined },
+            { script: "b" },
+        ]);
+
+        expect(scripts).toEqual(["a", "b"]);
+    });
+
+    it("returns [] for no batches", () => {
+        expect(collectVtxoScripts()).toEqual([]);
+    });
+
+    it("returns [] for empty batches", () => {
+        expect(collectVtxoScripts([], [])).toEqual([]);
+    });
+});


### PR DESCRIPTION
Split from #431 — this is the **script-attribution** cluster. Targets §B.1/§B.2/§D.2 (light path) from the review doc plus the review follow-ups.

## Summary

Until now, the indexer-populated `vtxo.script` field was only reliable on freshly-fetched VTXOs — SQLite and Realm silently dropped it on write, so reloaded VTXOs had no way to be routed back to their owning contract. Every callsite fell back to the default tapscript, which silently corrupted forfeit/intent data whenever the wallet held multiple contracts (default + delegate, multiple vHTLCs, etc.).

This PR persists `vtxo.script` end-to-end and funnels every annotation through a single `ContractManager.annotateVtxos(vtxos)` entrypoint that resolves each VTXO's script to its owning contract or throws.

## Commits

| Commit | Theme | Review ref |
|---|---|---|
| Persist vtxo.script in SQLite and Realm wallet repositories | `script TEXT` column + idempotent migration in SQLite, optional indexed property in Realm, matching read/write mappings | §D.2 (light path) |
| Attribute VTXO extensions to the contract that owns each script | New `extendVirtualCoinForContract` + public `Wallet.getContractsByScript()`; callsites that stamped every VTXO with the default tapscript now look up the owning contract | §B.1 |
| Route subscription VTXOs to the contract that owns each script | `ContractWatcher.processSubscriptionVtxos` routes each VTXO via `vtxo.script`; no more fan-out writing the same VTXO into every matching contract's `lastKnownVtxos` | §B.2 |
| Scope getContractsByScript to the scripts being resolved | Helper used to load every contract on every call; now takes the script set from the VTXOs being processed | perf |
| Unify VTXO extension on extendVirtualCoinForContract | Deprecated `extendVtxoFromContract` in favour of a single entrypoint accepting either a `Contract` or a `ReadonlyMap<script, Contract>` | pietro909 review + arkanaai #3 |
| Warn when getContractsByScript falls back to default tapscript | The bare `catch { return new Map() }` swallowed the underlying error and silently rerouted every VTXO through the default tapscript | arkanaai #2 |
| Log dropped VTXOs in processSubscriptionVtxos | Subscription VTXOs with no attributable script were silently dropped; aggregate debug log | arkanaai #4 |
| Funnel VTXO annotation through ContractManager.annotateVtxos | Single shared API that resolves each VTXO's `script` and throws when a script has no registered contract. Replaces scattered callsites in Wallet, the service-worker handler, and the Expo task runner | footgun reduction |
| Route SW-client annotateVtxos through ContractManager via RPC | The remaining caller in the SW-client side now round-trips through the same entrypoint rather than calling `extendVirtualCoinForContract` directly | consistency |

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm build:types` clean
- [x] `pnpm test:unit` — 807 passed / 1 skipped
- [ ] CI green
- [ ] Manual: verify on reconnect every watched contract is reconciled and VTXOs land in the correct contract's `lastKnownVtxos`
- [ ] Manual: verify multi-contract wallets (default + delegate) no longer stamp every VTXO with the default tapscript

## Not in this PR

This is cluster 1 of 4 splits from #431. Follow-ups (separate PRs):
- Sync/cursor consolidation (single global cursor, `reconcileWatched`, scope to watched set)
- Retry/cooldown hygiene (renewal cooldown, boarding-settle retry treadmill)
- `VirtualCoin.script` type tightening + NOT NULL migrations (depends on this PR)

#431 stays open as the holding branch until all splits land.