### PR TITLE
fix(wallet): skip unconfirmed boarding UTXOs during settle

### DIFF
--- a/src/wallet/vtxo-manager.ts
+++ b/src/wallet/vtxo-manager.ts
@@ -1243,6 +1243,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         const unsettledBoarding = boardingUtxos.filter(
             (u) =>
+                u.status.confirmed &&
                 !this.knownBoardingUtxos.has(`${u.txid}:${u.vout}`) &&
                 !expiredSet.has(`${u.txid}:${u.vout}`)
         );

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1422,6 +1422,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
             const boardingUtxos = (await this.getBoardingUtxos()).filter(
                 (utxo) =>
+                    utxo.status.confirmed &&
                     !hasBoardingTxExpired(
                         utxo,
                         boardingTimelock,

--- a/test/vtxo-manager.test.ts
+++ b/test/vtxo-manager.test.ts
@@ -1938,6 +1938,87 @@ describe("VtxoManager - Periodic settle cooldown", () => {
             nowSpy.mockRestore();
         }
     });
+
+    // Regression: issue #438 — settling an unconfirmed boarding UTXO would hit
+    // the server which rejects with INVALID_PSBT_INPUT, and the resulting
+    // failure would bump the exponential-backoff counter. Filtering them out
+    // pre-flight means no settle call happens and no cooldown is armed.
+    const makeUnconfirmedUtxo = (value: number, vout = 0): ExtendedCoin =>
+        ({
+            txid: `unconfirmed-boarding-${value}-${vout}`,
+            vout,
+            value,
+            status: {
+                confirmed: false,
+            },
+        }) as ExtendedCoin;
+
+    it("skips unconfirmed boarding UTXOs without calling settle or bumping backoff", async () => {
+        const baseNow = new Date("2026-01-01T00:00:00Z").getTime();
+        const nowSpy = vi.spyOn(Date, "now").mockReturnValue(baseNow);
+
+        try {
+            const unconfirmed = makeUnconfirmedUtxo(10_000);
+            const wallet = buildBoardingWallet([unconfirmed]);
+            const manager = new VtxoManager(wallet, undefined, {
+                boardingUtxoSweep: false,
+                pollIntervalMs: 60_000,
+            });
+            manager.dispose();
+
+            await (manager as any).runPeriodicSettle([unconfirmed]);
+
+            expect(wallet.settle).not.toHaveBeenCalled();
+            expect((manager as any).lastPeriodicSettleTimestamp).toBe(0);
+            expect((manager as any).consecutivePeriodicSettleFailures).toBe(0);
+            // The unconfirmed UTXO must NOT be marked as known — once it
+            // confirms, the next poll should pick it up.
+            expect(
+                (manager as any).knownBoardingUtxos.has(
+                    `${unconfirmed.txid}:${unconfirmed.vout}`
+                )
+            ).toBe(false);
+        } finally {
+            nowSpy.mockRestore();
+        }
+    });
+
+    it("settles only the confirmed subset when a mix is present", async () => {
+        const baseNow = new Date("2026-01-01T00:00:00Z").getTime();
+        const nowSpy = vi.spyOn(Date, "now").mockReturnValue(baseNow);
+
+        try {
+            const confirmed = makeUnexpiredUtxo(10_000, 0);
+            const unconfirmed = makeUnconfirmedUtxo(5_000, 1);
+            const wallet = buildBoardingWallet([confirmed, unconfirmed]);
+            const manager = new VtxoManager(wallet, undefined, {
+                boardingUtxoSweep: false,
+                pollIntervalMs: 60_000,
+            });
+            manager.dispose();
+
+            await (manager as any).runPeriodicSettle([confirmed, unconfirmed]);
+
+            expect(wallet.settle).toHaveBeenCalledTimes(1);
+            const callArgs = (wallet.settle as any).mock.calls[0][0];
+            // Only the confirmed UTXO should be in the inputs.
+            expect(callArgs.inputs).toHaveLength(1);
+            expect(callArgs.inputs[0].txid).toBe(confirmed.txid);
+            // Known set only tracks the one we actually tried to settle.
+            expect(
+                (manager as any).knownBoardingUtxos.has(
+                    `${confirmed.txid}:${confirmed.vout}`
+                )
+            ).toBe(true);
+            expect(
+                (manager as any).knownBoardingUtxos.has(
+                    `${unconfirmed.txid}:${unconfirmed.vout}`
+                )
+            ).toBe(false);
+        } finally {
+            nowSpy.mockRestore();
+        }
+    });
 });
 
 describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {


### PR DESCRIPTION
## Summary

Fixes #438. `VtxoManager.runPeriodicSettle` and `Wallet._settleImpl` were including boarding UTXOs whose funding tx was still unconfirmed. The Ark server rejects these with `INVALID_PSBT_INPUT (5): failed to validate boarding input: tx ... not confirmed`, and on the periodic-poll path every rejection bumped the exponential-backoff counter — delaying legitimate settle attempts and polluting the console until the funding tx confirmed (~10 min).

The fix adds `utxo.status.confirmed` to the pre-flight filters in both call sites. Since the failure never happens, the backoff counter is no longer affected.

## Changes

- `src/wallet/vtxo-manager.ts` — `runPeriodicSettle`: filter `unsettledBoarding` on `u.status.confirmed`.
- `src/wallet/wallet.ts` — `_settleImpl`: filter `boardingUtxos` on `utxo.status.confirmed`.
- `test/vtxo-manager.test.ts` — 2 new regression tests:
  - unconfirmed-only: no settle call, `consecutivePeriodicSettleFailures` stays at 0, UTXO NOT marked as known (so it's picked up when it confirms)
  - mixed: only the confirmed UTXO enters the settle intent; known-set tracks only the one we actually submitted

## Notes

- `utxo.status.confirmed` is part of the `Status` interface on every `Coin`, and `Wallet.getBalance()` already branches on it (wallet.ts:408), so no new field is being introduced.
- No separate backoff-counter change is required: the issue's point about not bumping backoff on `INVALID_PSBT_INPUT` is resolved as a side effect of the pre-flight filter — there's no failure to count.
- Unconfirmed UTXOs remain untouched in `knownBoardingUtxos`, so once they confirm the next poll settles them normally.

## Test plan

- [x] New unit tests pass — `npx vitest run test/vtxo-manager.test.ts` (82 tests)
- [x] Full non-e2e suite passes — 828 tests, 1 pre-existing skip
- [x] `prettier --check` clean
- [x] `tsc --noEmit` clean

Fixes #438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Wallet settlement now requires boarding inputs to be confirmed on-chain before processing, preventing settlement attempts on unconfirmed UTXOs and improving transaction stability.

* **Tests**
  * Added regression tests to verify settlement behavior with unconfirmed inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->