### PR TITLE
fix(wallet): hide in-flight VTXOs from getVtxos during settle/send

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -142,6 +142,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
     protected readonly watcherConfig?: ReadonlyWalletConfig["watcherConfig"];
     private readonly _assetManager: IReadonlyAssetManager;
     private _syncVtxosInflight?: Promise<void>;
+    // Outpoints ("txid:vout") committed to an in-flight settle/send. Filtered
+    // from getVtxos() so concurrent callers (UI, VtxoManager auto-renewal,
+    // another send/settle racing the _txLock) can't reselect coins that are
+    // already on their way out. The set is in-memory only: a process crash
+    // clears it, and a stale entry only hides a VTXO (never spends one).
+    protected _pendingSpendOutpoints = new Set<string>();
 
     get assetManager(): IReadonlyAssetManager {
         return this._assetManager;
@@ -478,6 +484,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
         return vtxos
             .flatMap((_) => _.vtxos)
             .filter((vtxo) => {
+                if (
+                    this._pendingSpendOutpoints.has(`${vtxo.txid}:${vtxo.vout}`)
+                ) {
+                    return false;
+                }
                 if (isSpendable(vtxo)) {
                     if (
                         !f.withRecoverable &&
@@ -1041,6 +1052,24 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      */
     private _txLock: Promise<void> = Promise.resolve();
 
+    private _addPendingSpends(inputs: readonly ExtendedCoin[]): void {
+        for (const input of inputs) {
+            if ("virtualStatus" in input) {
+                this._pendingSpendOutpoints.add(`${input.txid}:${input.vout}`);
+            }
+        }
+    }
+
+    private _removePendingSpends(inputs: readonly ExtendedCoin[]): void {
+        for (const input of inputs) {
+            if ("virtualStatus" in input) {
+                this._pendingSpendOutpoints.delete(
+                    `${input.txid}:${input.vout}`
+                );
+            }
+        }
+    }
+
     private _withTxLock<T>(fn: () => Promise<T>): Promise<T> {
         let release!: () => void;
         const lock = new Promise<void>((r) => (release = r));
@@ -1343,22 +1372,27 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                     });
                 }
 
-                const { arkTxid, signedCheckpointTxs } =
-                    await this.buildAndSubmitOffchainTx(
+                this._addPendingSpends(selected.inputs);
+                try {
+                    const { arkTxid, signedCheckpointTxs } =
+                        await this.buildAndSubmitOffchainTx(
+                            selected.inputs,
+                            outputs
+                        );
+
+                    await this.updateDbAfterOffchainTx(
                         selected.inputs,
-                        outputs
+                        arkTxid,
+                        signedCheckpointTxs,
+                        params.amount,
+                        selected.changeAmount,
+                        selected.changeAmount > 0n ? outputs.length - 1 : 0
                     );
 
-                await this.updateDbAfterOffchainTx(
-                    selected.inputs,
-                    arkTxid,
-                    signedCheckpointTxs,
-                    params.amount,
-                    selected.changeAmount,
-                    selected.changeAmount > 0n ? outputs.length - 1 : 0
-                );
-
-                return arkTxid;
+                    return arkTxid;
+                } finally {
+                    this._removePendingSpends(selected.inputs);
+                }
             });
         }
 
@@ -1605,6 +1639,11 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         const abortController = new AbortController();
         let stream: AsyncIterableIterator<SettlementEvent> | undefined;
 
+        // Optimistically hide these inputs from concurrent getVtxos() callers
+        // while the settlement is in flight. Set before safeRegisterIntent so
+        // there's no window between intent registration and coin-visibility.
+        this._addPendingSpends(params.inputs);
+
         try {
             stream = this.arkProvider.getEventStream(
                 abortController.signal,
@@ -1650,6 +1689,9 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             });
             throw error;
         } finally {
+            // Clear state first so a synchronous handler firing from abort()
+            // never observes a stale pending-spend set.
+            this._removePendingSpends(params.inputs);
             // close the stream — abort() fires the in-body handler if the
             // generator has started iterating; return() also releases the
             // eager resource if the body is still suspended or never ran
@@ -2407,20 +2449,27 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
         const sentAmount = recipients.reduce((sum, r) => sum + r.amount, 0);
 
-        const { arkTxid, signedCheckpointTxs } =
-            await this.buildAndSubmitOffchainTx(selectedCoins, outputs);
+        // Optimistically hide selected coins from concurrent getVtxos() while
+        // the offchain tx is in flight.
+        this._addPendingSpends(selectedCoins);
+        try {
+            const { arkTxid, signedCheckpointTxs } =
+                await this.buildAndSubmitOffchainTx(selectedCoins, outputs);
 
-        await this.updateDbAfterOffchainTx(
-            selectedCoins,
-            arkTxid,
-            signedCheckpointTxs,
-            sentAmount,
-            BigInt(changeAmount),
-            changeReceiver ? changeIndex : 0,
-            changeReceiver?.assets
-        );
+            await this.updateDbAfterOffchainTx(
+                selectedCoins,
+                arkTxid,
+                signedCheckpointTxs,
+                sentAmount,
+                BigInt(changeAmount),
+                changeReceiver ? changeIndex : 0,
+                changeReceiver?.assets
+            );
 
-        return arkTxid;
+            return arkTxid;
+        } finally {
+            this._removePendingSpends(selectedCoins);
+        }
     }
 
     /**

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1668,7 +1668,9 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         // the signed forfeits transactions to submit
         const signedForfeits: string[] = [];
 
-        const vtxos = await this.getVtxos();
+        const isVtxo = (input: ExtendedCoin): input is ExtendedVirtualCoin =>
+            "virtualStatus" in input;
+
         let settlementPsbt = Transaction.fromPSBT(
             base64.decode(event.commitmentTx)
         );
@@ -1679,13 +1681,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         const connectorsLeaves = connectorsGraph?.leaves() || [];
 
         for (const input of inputs) {
-            // check if the input is an offchain "virtual" coin
-            const vtxo = vtxos.find(
-                (vtxo) => vtxo.txid === input.txid && vtxo.vout === input.vout
-            );
-
             // boarding input, we need to sign the settlement tx
-            if (!vtxo) {
+            if (!isVtxo(input)) {
                 for (let i = 0; i < settlementPsbt.inputsLength; i++) {
                     const settlementInput = settlementPsbt.getInput(i);
 
@@ -1714,7 +1711,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 continue;
             }
 
-            if (isRecoverable(vtxo) || isSubdust(vtxo, this.dustAmount)) {
+            if (isRecoverable(input) || isSubdust(input, this.dustAmount)) {
                 // recoverable or subdust coin, we don't need to create a forfeit tx
                 continue;
             }
@@ -1749,7 +1746,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                         txid: input.txid,
                         index: input.vout,
                         witnessUtxo: {
-                            amount: BigInt(vtxo.value),
+                            amount: BigInt(input.value),
                             script: VtxoScript.decode(input.tapTree).pkScript,
                         },
                         sighashType: SigHash.DEFAULT,

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -608,7 +608,7 @@ describe("Common", () => {
                     expect(vtxoAfterSweep.spentBy).toBe("");
 
                     const settleTxid = await alice.wallet.settle({
-                        inputs: [vtxo],
+                        inputs: [vtxoAfterSweep],
                         outputs: [
                             {
                                 address: aliceOffchainAddress!,

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -901,6 +901,173 @@ describe("Wallet", () => {
         });
     });
 
+    describe("pending-spend filtering", () => {
+        const mockArkInfo = {
+            signerPubkey: mockServerKeyHex,
+            forfeitPubkey: mockServerKeyHex,
+            batchExpiry: BigInt(144),
+            unilateralExitDelay: BigInt(144),
+            boardingExitDelay: BigInt(144),
+            roundInterval: BigInt(144),
+            network: "mutinynet",
+            dust: BigInt(1000),
+            forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+            checkpointTapscript:
+                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        };
+
+        function createMockVtxo(script: string, txid: string): VirtualCoin {
+            return {
+                txid,
+                vout: 0,
+                value: 50_000,
+                status: { confirmed: false },
+                virtualStatus: {
+                    state: "preconfirmed",
+                    commitmentTxIds: ["22".repeat(32)],
+                    batchExpiry: 1767225600000,
+                },
+                spentBy: "",
+                arkTxId: "",
+                createdAt: new Date("2026-01-01T00:00:00.000Z"),
+                isUnrolled: false,
+                isSpent: false,
+                script,
+            };
+        }
+
+        async function createWalletWithVtxos(txids: string[]) {
+            const compressedPubKey = await mockIdentity.compressedPublicKey();
+            const readonlyIdentity =
+                ReadonlySingleKey.fromPublicKey(compressedPubKey);
+            const walletRepository = new InMemoryWalletRepository();
+            const contractRepository = new InMemoryContractRepository();
+
+            let walletScript = "";
+            const getVtxos = vi
+                .fn<IndexerProvider["getVtxos"]>()
+                .mockImplementation(async (opts) => {
+                    if (!walletScript && opts?.scripts?.[0]) {
+                        walletScript = opts.scripts[0];
+                    }
+                    return {
+                        vtxos: txids.map((txid) =>
+                            createMockVtxo(walletScript, txid)
+                        ),
+                    };
+                });
+
+            const wallet = await ReadonlyWallet.create({
+                identity: readonlyIdentity,
+                arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: vi.fn().mockResolvedValue(mockArkInfo),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider: {
+                    getVtxos,
+                    subscribeForScripts: vi.fn().mockResolvedValue("sub-1"),
+                    unsubscribeForScripts: vi.fn().mockResolvedValue(undefined),
+                    getSubscription: async function* () {},
+                } as Partial<IndexerProvider> as IndexerProvider,
+                onchainProvider: {} as OnchainProvider,
+                storage: {
+                    walletRepository,
+                    contractRepository,
+                },
+            });
+
+            return { wallet };
+        }
+
+        it("getVtxos excludes outpoints present in _pendingSpendOutpoints", async () => {
+            const txidA = "a".repeat(64);
+            const txidB = "b".repeat(64);
+            const { wallet } = await createWalletWithVtxos([txidA, txidB]);
+
+            expect((await wallet.getVtxos()).map((v) => v.txid).sort()).toEqual(
+                [txidA, txidB].sort()
+            );
+
+            (wallet as any)._pendingSpendOutpoints.add(`${txidA}:0`);
+            expect((await wallet.getVtxos()).map((v) => v.txid)).toEqual([
+                txidB,
+            ]);
+
+            (wallet as any)._pendingSpendOutpoints.delete(`${txidA}:0`);
+            expect((await wallet.getVtxos()).map((v) => v.txid).sort()).toEqual(
+                [txidA, txidB].sort()
+            );
+        });
+
+        it("the in-flight set is in-memory only — a fresh instance sees the VTXO again", async () => {
+            const txid = "c".repeat(64);
+            const { wallet } = await createWalletWithVtxos([txid]);
+
+            (wallet as any)._pendingSpendOutpoints.add(`${txid}:0`);
+            expect(await wallet.getVtxos()).toHaveLength(0);
+
+            // Simulating a process restart: a brand-new wallet instance over
+            // the same repositories must surface the VTXO (no persistence).
+            const { wallet: freshWallet } = await createWalletWithVtxos([txid]);
+            expect((await freshWallet.getVtxos()).map((v) => v.txid)).toEqual([
+                txid,
+            ]);
+        });
+
+        it("_addPendingSpends tracks VTXO inputs and ignores boarding UTXOs", () => {
+            const thisArg: any = { _pendingSpendOutpoints: new Set<string>() };
+            const vtxoInput = {
+                txid: "a".repeat(64),
+                vout: 0,
+                virtualStatus: {
+                    state: "preconfirmed",
+                    commitmentTxIds: [],
+                    batchExpiry: 0,
+                },
+            };
+            const boardingInput = {
+                txid: "b".repeat(64),
+                vout: 1,
+                status: { confirmed: true },
+            };
+
+            (Wallet.prototype as any)._addPendingSpends.call(thisArg, [
+                vtxoInput,
+                boardingInput,
+            ]);
+
+            expect(Array.from(thisArg._pendingSpendOutpoints)).toEqual([
+                `${vtxoInput.txid}:0`,
+            ]);
+        });
+
+        it("_removePendingSpends clears only the passed outpoints", () => {
+            const thisArg: any = {
+                _pendingSpendOutpoints: new Set<string>([
+                    `${"a".repeat(64)}:0`,
+                    `${"b".repeat(64)}:0`,
+                ]),
+            };
+            const vtxoInput = {
+                txid: "a".repeat(64),
+                vout: 0,
+                virtualStatus: {
+                    state: "preconfirmed",
+                    commitmentTxIds: [],
+                    batchExpiry: 0,
+                },
+            };
+
+            (Wallet.prototype as any)._removePendingSpends.call(thisArg, [
+                vtxoInput,
+            ]);
+
+            expect(Array.from(thisArg._pendingSpendOutpoints)).toEqual([
+                `${"b".repeat(64)}:0`,
+            ]);
+        });
+    });
+
     describe("mainnet unilateral exit delay pinning", () => {
         // If this constant changes in the SDK, update both sides intentionally —
         // changing the pinned value alters derived addresses for every mainnet


### PR DESCRIPTION
## Summary

Two related fixes in `src/wallet/wallet.ts`, rebased onto current `master`. Supersedes #418, which was written before PR #431 (the VTXO-state mitigations) rewrote the wallet. The original PR's three fixes were re-scoped down to two — the "preserve local spend marks across sync" piece was dropped because the indexer is the authoritative source on VTXO state.

## What's in this PR

### Fix 1 — `handleSettlementFinalizationEvent` uses `inputs` directly (commit 1)

Replaces `await this.getVtxos()` with a `"virtualStatus" in input` type guard. The `inputs` parameter already carries all the `ExtendedVirtualCoin` data needed to build forfeit txs; the extra `getVtxos()` call triggered a `ContractManager.syncContracts` mid-settlement for no benefit, and would actively fight Fix 2 (which filters in-flight VTXOs out of `getVtxos()`).

Same pattern is already used in `updateDbAfterSettle`. Aligns with audit finding **T6.3** (prefer type guards on the `Coin | VirtualCoin` discriminant).

### Fix 2 — optimistic pending-spend tracking (commit 2)

Add `_pendingSpendOutpoints: Set<string>` to `ReadonlyWallet`, filter those outpoints out of `getVtxos()`, and populate/clear the set around `_settleImpl`, `_sendImpl`, and `sendBitcoin`'s selectedVtxos branch.

Prevents three coin-selection races:
- UI `getVtxos()` call reselecting inputs that are already on their way out via an in-flight settle/send.
- `VtxoManager` auto-renewal firing on a `vtxo_received` event while a manual `settle()` holds the relevant inputs.
- A second auto-renewal slipping past `VtxoManager.renewalInProgress` (audit **T4.3** TOCTOU) and picking the same VTXOs the first renewal already submitted.

The set is strictly local:
- Populated **before** `safeRegisterIntent` / `buildAndSubmitOffchainTx` so there's no visibility gap.
- Cleared in `finally` — **before** `abortController.abort()` so a synchronous abort handler can't observe stale pending-spend state (preserves the **T1.0** SSE cleanup in #433).
- In-memory only: a crash self-heals on next boot. Worst case is a VTXO briefly hidden; it's never spent from stale pending-spend data.

## What this PR does **not** do

- Does not preserve confirmed local spend marks across indexer syncs. The indexer is authoritative — if it reports `isSpent=false` after a local settle, the SDK trusts the indexer and upserts. Any resulting re-selection is an indexer-freshness concern, not an SDK one.
- Does not address T1.3 (concurrency cap on `Promise.all` over inputs), T4.3 (atomic `renewalInProgress` gate), or T4.4 (`knownBoardingUtxos` outside `_txLock`) — same failure domain but distinct fixes.

## Test plan

- [x] 4 new unit tests in `test/wallet.test.ts` covering: filter application, in-memory-only self-healing, `_addPendingSpends` ignoring boarding UTXOs, `_removePendingSpends` scoping.
- [x] `pnpm test:unit` — 836 passed, 1 skipped (baseline), no regressions
- [x] `pnpm build:types` clean
- [x] `pnpm lint` clean
- [ ] Manual: run `test/e2e/` after rebase to confirm no settle-path regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coin selection to prevent concurrent reuse of coins during pending transactions.
  * Enhanced transaction settlement finalization for virtual coins with better error handling.

* **Tests**
  * Added comprehensive test coverage for pending transaction handling.
  * Updated settlement tests to validate correct state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->