### PR TITLE
fix(serviceWorker): exempt streaming messages from timeouts

### DIFF
--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -613,6 +613,19 @@ export class WalletMessageHandler
         } as WalletUpdaterResponse;
     }
 
+    // Flows that surrender control to the Ark server and the other participants
+    // in a batch round: quiet gaps between protocol events can easily exceed
+    // the bus-level messageTimeoutMs. Liveness is covered out-of-band by the
+    // page-side PING / MESSAGE_BUS_NOT_INITIALIZED path triggered by concurrent
+    // short requests (GET_STATUS, GET_BALANCE, ...).
+    isLongRunning(message: WalletUpdaterRequest): boolean {
+        return (
+            message.type === "SETTLE" ||
+            message.type === "RECOVER_VTXOS" ||
+            message.type === "RENEW_VTXOS"
+        );
+    }
+
     async handleMessage(
         message: WalletUpdaterRequest
     ): Promise<WalletUpdaterResponse> {

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -167,7 +167,10 @@ export const DEFAULT_MESSAGE_TIMEOUTS: Readonly<Record<RequestType, number>> = {
     GET_RECOVERABLE_BALANCE: 20_000,
     RELOAD_WALLET: 20_000,
 
-    // Transactions — need more headroom
+    // Transactions — need more headroom.
+    // SETTLE / RECOVER_VTXOS / RENEW_VTXOS go through the streaming path and
+    // are treated as long-running on both sides of the bus: the values below
+    // are retained only for type completeness and are never enforced.
     SEND_BITCOIN: 50_000,
     SEND: 50_000,
     SETTLE: 50_000,
@@ -638,38 +641,23 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
 
     // Like sendMessageDirect but supports streaming responses: intermediate
     // messages are forwarded via onEvent while the promise resolves on the
-    // first response for which isComplete returns true. The timeout resets
-    // on every intermediate event so long-running but progressing operations
-    // don't time out prematurely.
+    // first response for which isComplete returns true. No inactivity deadline:
+    // settlement-class flows surrender control to remote peers and can sit
+    // idle for long stretches between protocol events. Service-worker death
+    // is detected out-of-band via concurrent short requests that surface
+    // MESSAGE_BUS_NOT_INITIALIZED.
     private sendMessageStreaming(
         request: WalletUpdaterRequest,
         onEvent: (response: WalletUpdaterResponse) => void,
-        isComplete: (response: WalletUpdaterResponse) => boolean,
-        timeoutMs: number
+        isComplete: (response: WalletUpdaterResponse) => boolean
     ): Promise<WalletUpdaterResponse> {
         return new Promise((resolve, reject) => {
-            const resetTimeout = () => {
-                clearTimeout(timeoutId);
-                timeoutId = setTimeout(() => {
-                    cleanup();
-                    reject(
-                        new ServiceWorkerTimeoutError(
-                            `Service worker message timed out (${request.type})`
-                        )
-                    );
-                }, timeoutMs);
-            };
-
             const cleanup = () => {
-                clearTimeout(timeoutId);
                 navigator.serviceWorker.removeEventListener(
                     "message",
                     messageHandler
                 );
             };
-
-            let timeoutId: ReturnType<typeof setTimeout>;
-            resetTimeout();
 
             const messageHandler = (
                 event: MessageEvent<WalletUpdaterResponse>
@@ -687,7 +675,6 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                     cleanup();
                     resolve(response);
                 } else {
-                    resetTimeout();
                     onEvent(response);
                 }
             };
@@ -805,15 +792,13 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             }
         }
 
-        const timeoutMs = this.getTimeoutForRequest(request);
         const maxRetries = 2;
         for (let attempt = 0; ; attempt++) {
             try {
                 return await this.sendMessageStreaming(
                     request,
                     onEvent,
-                    isComplete,
-                    timeoutMs
+                    isComplete
                 );
             } catch (error: any) {
                 if (

--- a/src/worker/messageBus.ts
+++ b/src/worker/messageBus.ts
@@ -73,6 +73,16 @@ export interface MessageHandler<
      * Handle routed messages from the clients
      **/
     handleMessage(message: REQ): Promise<RES | null>;
+
+    /**
+     * Optional opt-out from the bus-level message timeout.
+     *
+     * Long-running flows (e.g. settlement) surrender control to remote peers
+     * and can legitimately sit idle for longer than `messageTimeoutMs`. When
+     * this returns true, the bus awaits `handleMessage` without a deadline.
+     * Defaults to false.
+     */
+    isLongRunning?(message: REQ): boolean;
 }
 
 type Options = {
@@ -403,12 +413,12 @@ export class MessageBus {
         if (broadcast) {
             const updaters = Array.from(this.handlers.values());
             const results = await Promise.allSettled(
-                updaters.map((updater) =>
-                    this.withTimeout(
-                        updater.handleMessage(event.data),
-                        updater.messageTag
-                    )
-                )
+                updaters.map((updater) => {
+                    const handlerPromise = updater.handleMessage(event.data);
+                    return updater.isLongRunning?.(event.data)
+                        ? handlerPromise
+                        : this.withTimeout(handlerPromise, updater.messageTag);
+                })
             );
 
             results.forEach((result, index) => {
@@ -446,10 +456,10 @@ export class MessageBus {
         }
 
         try {
-            const response = await this.withTimeout(
-                updater.handleMessage(event.data),
-                tag
-            );
+            const handlerPromise = updater.handleMessage(event.data);
+            const response = updater.isLongRunning?.(event.data)
+                ? await handlerPromise
+                : await this.withTimeout(handlerPromise, tag);
             if (this.debug)
                 console.log(`[${tag}] outgoing response:`, response);
             if (response) {


### PR DESCRIPTION
Settlement and other batch-round flows surrender control to the Ark server and peers.

Both page and worker now skip the timeout for:

- SETTLE
-  RECOVER_VTXOS
-  RENEW_VTXOS
 
Service Worker death is still detected out-of-band via the existing PING / MESSAGE_BUS_NOT_INITIALIZED path on short concurrent requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Long-running wallet operations (settle, recover, and renew transactions) are no longer subject to request timeouts and can now complete without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->