### PR TITLE
Support mnemonic in Service Worker [#428]

### DIFF
--- a/src/identity/index.ts
+++ b/src/identity/index.ts
@@ -65,7 +65,21 @@ export function isBatchSignable(
 }
 
 export * from "./singleKey";
-export * from "./seedIdentity";
+// Explicit named re-export so the barrel stays a documented public surface.
+// `serializeSeedOwnedSigningIdentity` and `serializeSeedOwnedReadonlyIdentity`
+// are deliberately omitted — they are SDK-internal helpers consumed only by
+// `./serialize`, per Appendix A of the plan.
+export type {
+    NetworkOptions,
+    DescriptorOptions,
+    SeedIdentityOptions,
+    MnemonicOptions,
+} from "./seedIdentity";
+export {
+    SeedIdentity,
+    MnemonicIdentity,
+    ReadonlyDescriptorIdentity,
+} from "./seedIdentity";
 export * from "./serialize";
 
 // Descriptor utilities

--- a/src/identity/index.ts
+++ b/src/identity/index.ts
@@ -65,17 +65,8 @@ export function isBatchSignable(
 }
 
 export * from "./singleKey";
-export {
-    SeedIdentity,
-    MnemonicIdentity,
-    ReadonlyDescriptorIdentity,
-} from "./seedIdentity";
-export type {
-    SeedIdentityOptions,
-    MnemonicOptions,
-    NetworkOptions,
-    DescriptorOptions,
-} from "./seedIdentity";
+export * from "./seedIdentity";
+export * from "./serialize";
 
 // Descriptor utilities
 export {

--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -131,7 +131,11 @@ export class SeedIdentity implements Identity {
             throw new Error("Seed must be 64 bytes");
         }
 
-        seedBytes.set(this, seed);
+        // Defensive copy: `derivedKey` and `descriptor` are computed eagerly
+        // from the bytes we're about to stash, so a later mutation of the
+        // caller's buffer must not drift the serialized `seed` out of sync
+        // with the live identity state.
+        seedBytes.set(this, new Uint8Array(seed));
         this.descriptor = descriptor;
 
         const network = detectNetwork(descriptor);

--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -2,6 +2,7 @@ import { validateMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 import { pubECDSA, pubSchnorr } from "@scure/btc-signer/utils.js";
 import { SigHash } from "@scure/btc-signer";
+import { hex } from "@scure/base";
 import { Identity, ReadonlyIdentity } from ".";
 import { Transaction } from "../utils/transaction";
 import { SignerSession, TreeSignerSession } from "../tree/signingSession";
@@ -13,8 +14,28 @@ import {
     scriptExpressions,
     type Network,
 } from "@bitcoinerlab/descriptors-scure";
+import type {
+    SerializedSigningIdentity,
+    SerializedReadonlyIdentity,
+} from "./serialize";
 
 const ALL_SIGHASH = Object.values(SigHash).filter((x) => typeof x === "number");
+
+/**
+ * Secret-bearing state for seed-backed identities, held off the public
+ * instance surface. Accessed only by the SDK-internal serializer helpers
+ * below; application code cannot read these via ordinary field access.
+ *
+ * Using a module-private WeakMap (rather than `private` / `protected`)
+ * matters because TypeScript visibility is a compile-time boundary only:
+ * JavaScript consumers could still read public fields. A WeakMap removes
+ * that enumeration path entirely.
+ */
+const seedBytes = new WeakMap<SeedIdentity, Uint8Array>();
+const mnemonicMeta = new WeakMap<
+    MnemonicIdentity,
+    { mnemonic: string; passphrase?: string }
+>();
 
 /** Used for default BIP86 derivation with network selection. */
 export interface NetworkOptions {
@@ -102,7 +123,6 @@ function buildDescriptor(seed: Uint8Array, isMainnet: boolean): string {
  * ```
  */
 export class SeedIdentity implements Identity {
-    readonly seed: Uint8Array;
     private readonly derivedKey: Uint8Array;
     readonly descriptor: string;
 
@@ -111,7 +131,7 @@ export class SeedIdentity implements Identity {
             throw new Error("Seed must be 64 bytes");
         }
 
-        this.seed = seed;
+        seedBytes.set(this, seed);
         this.descriptor = descriptor;
 
         const network = detectNetwork(descriptor);
@@ -240,9 +260,6 @@ export class SeedIdentity implements Identity {
  * ```
  */
 export class MnemonicIdentity extends SeedIdentity {
-    readonly mnemonic: string;
-    readonly passphrase: string | undefined;
-
     private constructor(
         seed: Uint8Array,
         descriptor: string,
@@ -250,8 +267,7 @@ export class MnemonicIdentity extends SeedIdentity {
         passphrase: string | undefined
     ) {
         super(seed, descriptor);
-        this.mnemonic = mnemonic;
-        this.passphrase = passphrase;
+        mnemonicMeta.set(this, { mnemonic, passphrase });
     }
 
     /**
@@ -339,4 +355,57 @@ export class ReadonlyDescriptorIdentity implements ReadonlyIdentity {
     async compressedPublicKey(): Promise<Uint8Array> {
         return this.compressedPubKey;
     }
+}
+
+/**
+ * SDK-internal: serialize a seed-backed signing identity into a
+ * {@link SerializedSigningIdentity} envelope without exposing the
+ * underlying secret material on the public instance surface.
+ *
+ * Called by {@link serializeSigningIdentity}; application code should
+ * prefer that public dispatcher instead of calling this directly.
+ */
+export function serializeSeedOwnedSigningIdentity(
+    identity: SeedIdentity
+): SerializedSigningIdentity {
+    if (identity instanceof MnemonicIdentity) {
+        const meta = mnemonicMeta.get(identity);
+        if (!meta) {
+            throw new Error(
+                "MnemonicIdentity is missing internal secret state; was it constructed via MnemonicIdentity.fromMnemonic()?"
+            );
+        }
+        const envelope: SerializedSigningIdentity = {
+            type: "mnemonic",
+            mnemonic: meta.mnemonic,
+            descriptor: identity.descriptor,
+        };
+        if (meta.passphrase !== undefined) {
+            envelope.passphrase = meta.passphrase;
+        }
+        return envelope;
+    }
+    const seed = seedBytes.get(identity);
+    if (!seed) {
+        throw new Error(
+            "SeedIdentity is missing internal secret state; was it constructed via SeedIdentity.fromSeed() or the class constructor?"
+        );
+    }
+    return {
+        type: "seed",
+        seed: hex.encode(seed),
+        descriptor: identity.descriptor,
+    };
+}
+
+/**
+ * SDK-internal: downgrade a seed-backed or descriptor-backed identity
+ * into a readonly descriptor envelope. Always produces a descriptor-only
+ * shape — secret material never crosses this path, even if the input is
+ * a signing identity.
+ */
+export function serializeSeedOwnedReadonlyIdentity(
+    identity: SeedIdentity | ReadonlyDescriptorIdentity
+): SerializedReadonlyIdentity {
+    return { type: "readonly-descriptor", descriptor: identity.descriptor };
 }

--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -362,12 +362,16 @@ export class ReadonlyDescriptorIdentity implements ReadonlyIdentity {
 }
 
 /**
- * SDK-internal: serialize a seed-backed signing identity into a
+ * Serialize a seed-backed signing identity into a
  * {@link SerializedSigningIdentity} envelope without exposing the
  * underlying secret material on the public instance surface.
  *
  * Called by {@link serializeSigningIdentity}; application code should
- * prefer that public dispatcher instead of calling this directly.
+ * prefer that public dispatcher instead of calling this directly. This
+ * helper is deliberately kept out of the `src/identity` barrel so it is
+ * not part of the package's public export surface.
+ *
+ * @internal
  */
 export function serializeSeedOwnedSigningIdentity(
     identity: SeedIdentity
@@ -403,10 +407,15 @@ export function serializeSeedOwnedSigningIdentity(
 }
 
 /**
- * SDK-internal: downgrade a seed-backed or descriptor-backed identity
- * into a readonly descriptor envelope. Always produces a descriptor-only
- * shape — secret material never crosses this path, even if the input is
- * a signing identity.
+ * Downgrade a seed-backed or descriptor-backed identity into a readonly
+ * descriptor envelope. Always produces a descriptor-only shape — secret
+ * material never crosses this path, even if the input is a signing
+ * identity.
+ *
+ * Deliberately kept out of the `src/identity` barrel; consumers should go
+ * through {@link serializeReadonlyIdentity}.
+ *
+ * @internal
  */
 export function serializeSeedOwnedReadonlyIdentity(
     identity: SeedIdentity | ReadonlyDescriptorIdentity

--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -371,6 +371,18 @@ export class ReadonlyDescriptorIdentity implements ReadonlyIdentity {
  * helper is deliberately kept out of the `src/identity` barrel so it is
  * not part of the package's public export surface.
  *
+ * Secret-surface trade-off: the resulting envelope carries master-seed
+ * material — the BIP39 mnemonic (+ optional passphrase) for
+ * `MnemonicIdentity` or the raw 64-byte seed for `SeedIdentity`. A party
+ * that reads this envelope can derive any key under the HD tree, not
+ * just the key currently in use. The pre-change `SingleKey` flow only
+ * shipped one derived private key and therefore had a smaller blast
+ * radius. This is an intentional design trade to preserve class and
+ * descriptor identity across the page / service-worker boundary; the
+ * page already holds the same material so that it can re-initialize a
+ * killed worker. Transport is same-origin `postMessage` only. See the
+ * threat-model note in `src/worker/browser/README.md`.
+ *
  * @internal
  */
 export function serializeSeedOwnedSigningIdentity(

--- a/src/identity/seedIdentity.ts
+++ b/src/identity/seedIdentity.ts
@@ -102,7 +102,7 @@ function buildDescriptor(seed: Uint8Array, isMainnet: boolean): string {
  * ```
  */
 export class SeedIdentity implements Identity {
-    protected readonly seed: Uint8Array;
+    readonly seed: Uint8Array;
     private readonly derivedKey: Uint8Array;
     readonly descriptor: string;
 
@@ -240,8 +240,18 @@ export class SeedIdentity implements Identity {
  * ```
  */
 export class MnemonicIdentity extends SeedIdentity {
-    private constructor(seed: Uint8Array, descriptor: string) {
+    readonly mnemonic: string;
+    readonly passphrase: string | undefined;
+
+    private constructor(
+        seed: Uint8Array,
+        descriptor: string,
+        mnemonic: string,
+        passphrase: string | undefined
+    ) {
         super(seed, descriptor);
+        this.mnemonic = mnemonic;
+        this.passphrase = passphrase;
     }
 
     /**
@@ -265,7 +275,7 @@ export class MnemonicIdentity extends SeedIdentity {
         const descriptor = hasDescriptor(opts)
             ? opts.descriptor
             : buildDescriptor(seed, (opts as NetworkOptions).isMainnet ?? true);
-        return new MnemonicIdentity(seed, descriptor);
+        return new MnemonicIdentity(seed, descriptor, phrase, passphrase);
     }
 }
 

--- a/src/identity/serialize.ts
+++ b/src/identity/serialize.ts
@@ -131,6 +131,17 @@ export function hydrateIdentity(
             });
         case "readonly-descriptor":
             return ReadonlyDescriptorIdentity.fromDescriptor(s.descriptor);
+        default:
+            // Belt-and-suspenders: `normalizeSerializedIdentity` already
+            // rejects unknown `type` values at the wire boundary. Without
+            // this throw, an unknown type would fall through and return
+            // undefined, which callers would then cast to Identity and
+            // crash downstream with an opaque error.
+            throw new Error(
+                `Unknown serialized identity type: ${String(
+                    (s as { type: unknown }).type
+                )}`
+            );
     }
 }
 
@@ -160,7 +171,10 @@ let warnedLegacyShape = false;
 export function normalizeSerializedIdentity(
     shape: SerializedIdentity | LegacySerializedIdentity
 ): SerializedIdentity {
-    if ("type" in shape) return shape;
+    if ("type" in shape) {
+        assertValidSerializedIdentity(shape);
+        return shape;
+    }
     if (!warnedLegacyShape) {
         warnedLegacyShape = true;
         console.warn(
@@ -170,11 +184,63 @@ export function normalizeSerializedIdentity(
                 "the next major."
         );
     }
-    if ("privateKey" in shape) {
+    if ("privateKey" in shape && typeof shape.privateKey === "string") {
         return { type: "single-key", privateKey: shape.privateKey };
     }
-    if ("publicKey" in shape) {
+    if ("publicKey" in shape && typeof shape.publicKey === "string") {
         return { type: "readonly-single-key", publicKey: shape.publicKey };
     }
     throw new Error("Unrecognized serialized identity shape");
+}
+
+/**
+ * Runtime-validate that a tagged envelope carries the fields its variant
+ * requires. The SDK's own serializer produces well-formed envelopes; this
+ * guard exists so a malformed message (older SDK version mismatch,
+ * hand-built config, etc.) fails loudly at the wire boundary rather than
+ * with an opaque `"Cannot read properties of undefined"` deep inside a
+ * hydrator.
+ */
+function assertValidSerializedIdentity(s: {
+    type: unknown;
+}): asserts s is SerializedIdentity {
+    const kind = s.type;
+    const bad = (field: string, expected: string): never => {
+        throw new Error(
+            `Malformed serialized identity ({ type: ${JSON.stringify(kind)} }): ` +
+                `missing or invalid "${field}" (expected ${expected})`
+        );
+    };
+    const asStr = (key: string): string => {
+        const v = (s as Record<string, unknown>)[key];
+        return typeof v === "string" ? v : bad(key, "string");
+    };
+    switch (kind) {
+        case "single-key":
+            asStr("privateKey");
+            return;
+        case "readonly-single-key":
+            asStr("publicKey");
+            return;
+        case "seed":
+            asStr("seed");
+            asStr("descriptor");
+            return;
+        case "mnemonic": {
+            asStr("mnemonic");
+            asStr("descriptor");
+            const passphrase = (s as Record<string, unknown>).passphrase;
+            if (passphrase !== undefined && typeof passphrase !== "string") {
+                bad("passphrase", "string | undefined");
+            }
+            return;
+        }
+        case "readonly-descriptor":
+            asStr("descriptor");
+            return;
+        default:
+            throw new Error(
+                `Unknown serialized identity type: ${String(kind)}`
+            );
+    }
 }

--- a/src/identity/serialize.ts
+++ b/src/identity/serialize.ts
@@ -1,0 +1,111 @@
+import { hex } from "@scure/base";
+import type { Identity, ReadonlyIdentity } from ".";
+import { SingleKey, ReadonlySingleKey } from "./singleKey";
+
+/**
+ * Tagged envelope for a signing identity transported across the
+ * service-worker boundary. All variants are structured-clone safe
+ * (plain strings only — no functions or prototypes).
+ *
+ * Adding a new variant is a source change in every worker build; keep
+ * old variants around until all deployed workers handle them.
+ */
+export type SerializedSigningIdentity =
+    | { type: "single-key"; privateKey: string }
+    | { type: "seed"; seed: string; descriptor: string }
+    | {
+          type: "mnemonic";
+          mnemonic: string;
+          descriptor: string;
+          passphrase?: string;
+      };
+
+/**
+ * Tagged envelope for a readonly identity transported across the
+ * service-worker boundary. All variants are structured-clone safe.
+ */
+export type SerializedReadonlyIdentity =
+    | { type: "readonly-single-key"; publicKey: string }
+    | { type: "readonly-descriptor"; descriptor: string };
+
+export type SerializedIdentity =
+    | SerializedSigningIdentity
+    | SerializedReadonlyIdentity;
+
+/** Type guard — true for signing envelopes, false for readonly envelopes. */
+export function isSigningSerialized(
+    s: SerializedIdentity
+): s is SerializedSigningIdentity {
+    return (
+        s.type === "single-key" || s.type === "seed" || s.type === "mnemonic"
+    );
+}
+
+/** Identity that can expose a raw 32-byte private key via `toHex()`. */
+type HexExportableIdentity = Identity & { toHex(): string };
+
+function hasToHex(identity: Identity): identity is HexExportableIdentity {
+    return typeof (identity as { toHex?: unknown }).toHex === "function";
+}
+
+/**
+ * Serialize a signing identity into a structured-clone safe envelope for
+ * transport across the service-worker boundary.
+ *
+ * Supports SDK-owned signing identities directly. For custom identities, a
+ * duck-typed `toHex()` fallback preserves compatibility with existing
+ * `SingleKey`-like implementations.
+ */
+export function serializeSigningIdentity(
+    identity: Identity
+): SerializedSigningIdentity {
+    if (identity instanceof SingleKey) {
+        return { type: "single-key", privateKey: identity.toHex() };
+    }
+    if (hasToHex(identity)) {
+        return { type: "single-key", privateKey: identity.toHex() };
+    }
+    throw new Error(
+        "Unsupported signing identity: cannot serialize for service-worker transport"
+    );
+}
+
+/**
+ * Serialize a readonly identity into a structured-clone safe envelope.
+ *
+ * Works for any `ReadonlyIdentity` via `compressedPublicKey()`. When called
+ * with a signing identity, produces a readonly envelope (never ships signing
+ * material) — callers that need to preserve signing capability across the
+ * boundary must use {@link serializeSigningIdentity}.
+ */
+export async function serializeReadonlyIdentity(
+    identity: ReadonlyIdentity
+): Promise<SerializedReadonlyIdentity> {
+    return {
+        type: "readonly-single-key",
+        publicKey: hex.encode(await identity.compressedPublicKey()),
+    };
+}
+
+/**
+ * Rehydrate a serialized identity envelope back into an identity instance.
+ * The return type is the union of signing and readonly; use
+ * {@link isSigningSerialized} on the envelope before hydration if the caller
+ * needs to know which side it ends up on.
+ */
+export function hydrateIdentity(
+    s: SerializedIdentity
+): Identity | ReadonlyIdentity {
+    switch (s.type) {
+        case "single-key":
+            return SingleKey.fromHex(s.privateKey);
+        case "readonly-single-key":
+            return ReadonlySingleKey.fromPublicKey(hex.decode(s.publicKey));
+        case "seed":
+        case "mnemonic":
+        case "readonly-descriptor":
+            throw new Error(
+                `Serialized identity type "${s.type}" is not yet supported by hydrateIdentity`
+            );
+    }
+}

--- a/src/identity/serialize.ts
+++ b/src/identity/serialize.ts
@@ -144,3 +144,48 @@ export function hydrateIdentity(
             return ReadonlyDescriptorIdentity.fromDescriptor(s.descriptor);
     }
 }
+
+/**
+ * Legacy untagged shape emitted by page builds prior to the tagged
+ * SerializedIdentity envelope. Retained so newer workers can still accept
+ * older pages during a rolling upgrade. Slated for removal in the next major.
+ *
+ * @deprecated Use {@link SerializedIdentity}.
+ */
+export type LegacySerializedIdentity =
+    | { privateKey: string }
+    | { publicKey: string };
+
+let warnedLegacyShape = false;
+
+/**
+ * Accept either a modern {@link SerializedIdentity} envelope or a legacy
+ * `{ privateKey }` / `{ publicKey }` shape and normalize to a
+ * {@link SerializedIdentity}. Emits a one-time deprecation warning when a
+ * legacy shape is seen.
+ *
+ * Intended for the worker-side boundary; new page builds always emit tagged
+ * envelopes via {@link serializeSigningIdentity} /
+ * {@link serializeReadonlyIdentity}.
+ */
+export function normalizeSerializedIdentity(
+    shape: SerializedIdentity | LegacySerializedIdentity
+): SerializedIdentity {
+    if ("type" in shape) return shape;
+    if (!warnedLegacyShape) {
+        warnedLegacyShape = true;
+        console.warn(
+            "[ts-sdk] Received legacy serialized identity shape " +
+                "(privateKey/publicKey). Upgrade the page build to the latest " +
+                "@arkade-os/sdk — this compatibility path will be removed in " +
+                "the next major."
+        );
+    }
+    if ("privateKey" in shape) {
+        return { type: "single-key", privateKey: shape.privateKey };
+    }
+    if ("publicKey" in shape) {
+        return { type: "readonly-single-key", publicKey: shape.publicKey };
+    }
+    throw new Error("Unrecognized serialized identity shape");
+}

--- a/src/identity/serialize.ts
+++ b/src/identity/serialize.ts
@@ -168,6 +168,29 @@ let warnedLegacyShape = false;
  * envelopes via {@link serializeSigningIdentity} /
  * {@link serializeReadonlyIdentity}.
  */
+/**
+ * Map a tagged {@link SerializedIdentity} to the shape emitted on the
+ * messageBus wire.
+ *
+ * - `single-key` → legacy `{ privateKey }`
+ * - `readonly-single-key` → legacy `{ publicKey }`
+ * - every other variant → returned unchanged (those variants did not exist
+ *   before tagged envelopes, so there is no legacy shape to downgrade to).
+ *
+ * This downgrade preserves wire compatibility with workers that predate
+ * `SerializedIdentity` for the historic `SingleKey` / `ReadonlySingleKey`
+ * flows. Workers accept both shapes via {@link normalizeSerializedIdentity}.
+ *
+ * Slated for removal alongside the legacy adapter in the next major.
+ */
+export function toWireSerializedIdentity(
+    s: SerializedIdentity
+): SerializedIdentity | LegacySerializedIdentity {
+    if (s.type === "single-key") return { privateKey: s.privateKey };
+    if (s.type === "readonly-single-key") return { publicKey: s.publicKey };
+    return s;
+}
+
 export function normalizeSerializedIdentity(
     shape: SerializedIdentity | LegacySerializedIdentity
 ): SerializedIdentity {

--- a/src/identity/serialize.ts
+++ b/src/identity/serialize.ts
@@ -5,6 +5,8 @@ import {
     SeedIdentity,
     MnemonicIdentity,
     ReadonlyDescriptorIdentity,
+    serializeSeedOwnedSigningIdentity,
+    serializeSeedOwnedReadonlyIdentity,
 } from "./seedIdentity";
 
 /**
@@ -64,24 +66,11 @@ function hasToHex(identity: Identity): identity is HexExportableIdentity {
 export function serializeSigningIdentity(
     identity: Identity
 ): SerializedSigningIdentity {
-    // MnemonicIdentity must be checked before SeedIdentity (it extends it).
-    if (identity instanceof MnemonicIdentity) {
-        const envelope: SerializedSigningIdentity = {
-            type: "mnemonic",
-            mnemonic: identity.mnemonic,
-            descriptor: identity.descriptor,
-        };
-        if (identity.passphrase !== undefined) {
-            envelope.passphrase = identity.passphrase;
-        }
-        return envelope;
-    }
+    // Seed-backed identities (including MnemonicIdentity, which extends
+    // SeedIdentity) delegate to the colocated helper so secret material
+    // stays behind the WeakMap-backed internal state in seedIdentity.ts.
     if (identity instanceof SeedIdentity) {
-        return {
-            type: "seed",
-            seed: hex.encode(identity.seed),
-            descriptor: identity.descriptor,
-        };
+        return serializeSeedOwnedSigningIdentity(identity);
     }
     if (identity instanceof SingleKey) {
         return { type: "single-key", privateKey: identity.toHex() };
@@ -105,11 +94,11 @@ export function serializeSigningIdentity(
 export async function serializeReadonlyIdentity(
     identity: ReadonlyIdentity
 ): Promise<SerializedReadonlyIdentity> {
-    if (identity instanceof SeedIdentity) {
-        return { type: "readonly-descriptor", descriptor: identity.descriptor };
-    }
-    if (identity instanceof ReadonlyDescriptorIdentity) {
-        return { type: "readonly-descriptor", descriptor: identity.descriptor };
+    if (
+        identity instanceof SeedIdentity ||
+        identity instanceof ReadonlyDescriptorIdentity
+    ) {
+        return serializeSeedOwnedReadonlyIdentity(identity);
     }
     return {
         type: "readonly-single-key",

--- a/src/identity/serialize.ts
+++ b/src/identity/serialize.ts
@@ -1,6 +1,11 @@
 import { hex } from "@scure/base";
 import type { Identity, ReadonlyIdentity } from ".";
 import { SingleKey, ReadonlySingleKey } from "./singleKey";
+import {
+    SeedIdentity,
+    MnemonicIdentity,
+    ReadonlyDescriptorIdentity,
+} from "./seedIdentity";
 
 /**
  * Tagged envelope for a signing identity transported across the
@@ -59,6 +64,25 @@ function hasToHex(identity: Identity): identity is HexExportableIdentity {
 export function serializeSigningIdentity(
     identity: Identity
 ): SerializedSigningIdentity {
+    // MnemonicIdentity must be checked before SeedIdentity (it extends it).
+    if (identity instanceof MnemonicIdentity) {
+        const envelope: SerializedSigningIdentity = {
+            type: "mnemonic",
+            mnemonic: identity.mnemonic,
+            descriptor: identity.descriptor,
+        };
+        if (identity.passphrase !== undefined) {
+            envelope.passphrase = identity.passphrase;
+        }
+        return envelope;
+    }
+    if (identity instanceof SeedIdentity) {
+        return {
+            type: "seed",
+            seed: hex.encode(identity.seed),
+            descriptor: identity.descriptor,
+        };
+    }
     if (identity instanceof SingleKey) {
         return { type: "single-key", privateKey: identity.toHex() };
     }
@@ -81,6 +105,12 @@ export function serializeSigningIdentity(
 export async function serializeReadonlyIdentity(
     identity: ReadonlyIdentity
 ): Promise<SerializedReadonlyIdentity> {
+    if (identity instanceof SeedIdentity) {
+        return { type: "readonly-descriptor", descriptor: identity.descriptor };
+    }
+    if (identity instanceof ReadonlyDescriptorIdentity) {
+        return { type: "readonly-descriptor", descriptor: identity.descriptor };
+    }
     return {
         type: "readonly-single-key",
         publicKey: hex.encode(await identity.compressedPublicKey()),
@@ -102,10 +132,15 @@ export function hydrateIdentity(
         case "readonly-single-key":
             return ReadonlySingleKey.fromPublicKey(hex.decode(s.publicKey));
         case "seed":
+            return SeedIdentity.fromSeed(hex.decode(s.seed), {
+                descriptor: s.descriptor,
+            });
         case "mnemonic":
+            return MnemonicIdentity.fromMnemonic(s.mnemonic, {
+                descriptor: s.descriptor,
+                passphrase: s.passphrase,
+            });
         case "readonly-descriptor":
-            throw new Error(
-                `Serialized identity type "${s.type}" is not yet supported by hydrateIdentity`
-            );
+            return ReadonlyDescriptorIdentity.fromDescriptor(s.descriptor);
     }
 }

--- a/src/identity/serialize.ts
+++ b/src/identity/serialize.ts
@@ -157,29 +157,6 @@ let warnedLegacyShape = false;
  * envelopes via {@link serializeSigningIdentity} /
  * {@link serializeReadonlyIdentity}.
  */
-/**
- * Map a tagged {@link SerializedIdentity} to the shape emitted on the
- * messageBus wire.
- *
- * - `single-key` → legacy `{ privateKey }`
- * - `readonly-single-key` → legacy `{ publicKey }`
- * - every other variant → returned unchanged (those variants did not exist
- *   before tagged envelopes, so there is no legacy shape to downgrade to).
- *
- * This downgrade preserves wire compatibility with workers that predate
- * `SerializedIdentity` for the historic `SingleKey` / `ReadonlySingleKey`
- * flows. Workers accept both shapes via {@link normalizeSerializedIdentity}.
- *
- * Slated for removal alongside the legacy adapter in the next major.
- */
-export function toWireSerializedIdentity(
-    s: SerializedIdentity
-): SerializedIdentity | LegacySerializedIdentity {
-    if (s.type === "single-key") return { privateKey: s.privateKey };
-    if (s.type === "readonly-single-key") return { publicKey: s.publicKey };
-    return s;
-}
-
 export function normalizeSerializedIdentity(
     shape: SerializedIdentity | LegacySerializedIdentity
 ): SerializedIdentity {

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -71,7 +71,15 @@ export const DEFAULT_MESSAGE_TAG = "WALLET_UPDATER";
 export type RequestInitWallet = RequestEnvelope & {
     type: "INIT_WALLET";
     payload: {
-        key: { privateKey: string } | { publicKey: string };
+        /**
+         * Legacy per-request key material. Ignored by the current handler —
+         * identity hydration happens during INITIALIZE_MESSAGE_BUS. Retained
+         * for wire compatibility with older workers that may still read it.
+         * Slated for removal in the next major.
+         *
+         * @deprecated Identity is now carried by INITIALIZE_MESSAGE_BUS.
+         */
+        key?: { privateKey: string } | { publicKey: string } | {};
         arkServerUrl: string;
         arkServerPublicKey?: string;
     };

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -20,7 +20,12 @@ import {
 } from "..";
 import { SettlementEvent } from "../../providers/ark";
 import { hex } from "@scure/base";
-import { Identity, ReadonlyIdentity } from "../../identity";
+import {
+    Identity,
+    ReadonlyIdentity,
+    type SerializedIdentity,
+    type LegacySerializedIdentity,
+} from "../../identity";
 import { WalletRepository } from "../../repositories/walletRepository";
 import { ContractRepository } from "../../repositories/contractRepository";
 import { setupServiceWorker } from "../../worker/browser/utils";
@@ -376,13 +381,7 @@ export type ServiceWorkerWalletSetupOptions = ServiceWorkerWalletOptions & {
 };
 
 type MessageBusInitConfig = {
-    wallet:
-        | {
-              privateKey: string;
-          }
-        | {
-              publicKey: string;
-          };
+    wallet: SerializedIdentity | LegacySerializedIdentity;
     arkServer: {
         url: string;
         publicKey?: string;

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -27,7 +27,6 @@ import {
     type LegacySerializedIdentity,
     serializeReadonlyIdentity,
     serializeSigningIdentity,
-    toWireSerializedIdentity,
 } from "../../identity";
 import { WalletRepository } from "../../repositories/walletRepository";
 import { ContractRepository } from "../../repositories/contractRepository";
@@ -521,8 +520,8 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             messageTag
         );
 
-        const wireWallet = toWireSerializedIdentity(
-            await serializeReadonlyIdentity(options.identity)
+        const serializedWallet = await serializeReadonlyIdentity(
+            options.identity
         );
 
         // INIT_WALLET retains the legacy `key` payload for wire compatibility
@@ -547,7 +546,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             : (DEFAULT_MESSAGE_TIMEOUTS as Record<RequestType, number>);
 
         const busInitConfig: MessageBusInitConfig = {
-            wallet: wireWallet,
+            wallet: serializedWallet,
             arkServer: {
                 url: options.arkServerUrl,
                 publicKey: options.arkServerPublicKey,
@@ -856,7 +855,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 "Cannot re-initialize: wallet was not initialized via the SDK factory"
             );
         }
-        const wallet = toWireSerializedIdentity(await this.serializeIdentity());
+        const wallet = await this.serializeIdentity();
         this.initConfig = {
             wallet,
             arkServer: {
@@ -1365,8 +1364,7 @@ export class ServiceWorkerWallet
             );
         }
         const identity: Identity = options.identity;
-        const serialized = serializeSigningIdentity(identity);
-        const wireWallet = toWireSerializedIdentity(serialized);
+        const serializedWallet = serializeSigningIdentity(identity);
 
         const messageTag = options.walletUpdaterTag ?? DEFAULT_MESSAGE_TAG;
 
@@ -1385,7 +1383,9 @@ export class ServiceWorkerWallet
         // SingleKey-style identities can populate it. Kept optional so seed /
         // mnemonic identities simply omit it.
         const legacyPrivateKey =
-            serialized.type === "single-key" ? serialized.privateKey : null;
+            serializedWallet.type === "single-key"
+                ? serializedWallet.privateKey
+                : null;
         const initWalletPayload = {
             key: legacyPrivateKey ? { privateKey: legacyPrivateKey } : {},
             arkServerUrl: options.arkServerUrl,
@@ -1403,7 +1403,7 @@ export class ServiceWorkerWallet
             : (DEFAULT_MESSAGE_TIMEOUTS as Record<RequestType, number>);
 
         const busInitConfig: MessageBusInitConfig = {
-            wallet: wireWallet,
+            wallet: serializedWallet,
             arkServer: {
                 url: options.arkServerUrl,
                 publicKey: options.arkServerPublicKey,

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -25,6 +25,8 @@ import {
     ReadonlyIdentity,
     type SerializedIdentity,
     type LegacySerializedIdentity,
+    serializeReadonlyIdentity,
+    serializeSigningIdentity,
 } from "../../identity";
 import { WalletRepository } from "../../repositories/walletRepository";
 import { ContractRepository } from "../../repositories/contractRepository";
@@ -224,13 +226,16 @@ function getRequestDedupKey(request: WalletUpdaterRequest): string {
     return JSON.stringify(rest);
 }
 
-type PrivateKeyIdentity = Identity & { toHex(): string };
-
-const isPrivateKeyIdentity = (
+function isSigningCapable(
     identity: Identity | ReadonlyIdentity
-): identity is PrivateKeyIdentity => {
-    return typeof (identity as any).toHex === "function";
-};
+): identity is Identity {
+    const candidate = identity as Partial<Identity>;
+    return (
+        typeof candidate.signMessage === "function" &&
+        typeof candidate.sign === "function" &&
+        typeof candidate.signerSession === "function"
+    );
+}
 
 class ServiceWorkerReadonlyAssetManager implements IReadonlyAssetManager {
     constructor(
@@ -503,11 +508,14 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             messageTag
         );
 
+        const serialized = await serializeReadonlyIdentity(options.identity);
+
+        // INIT_WALLET retains the legacy `key` payload for wire compatibility
+        // with older workers; the current handler does not read it.
         const publicKey = await options.identity
             .compressedPublicKey()
             .then(hex.encode);
-
-        const initConfig = {
+        const initWalletPayload = {
             key: { publicKey },
             arkServerUrl: options.arkServerUrl,
             arkServerPublicKey: options.arkServerPublicKey,
@@ -524,12 +532,12 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             : (DEFAULT_MESSAGE_TIMEOUTS as Record<RequestType, number>);
 
         const busInitConfig: MessageBusInitConfig = {
-            wallet: initConfig.key,
+            wallet: serialized,
             arkServer: {
-                url: initConfig.arkServerUrl,
-                publicKey: initConfig.arkServerPublicKey,
+                url: options.arkServerUrl,
+                publicKey: options.arkServerPublicKey,
             },
-            delegatorUrl: initConfig.delegatorUrl,
+            delegatorUrl: options.delegatorUrl,
             indexerUrl: options.indexerUrl,
             esploraUrl: options.esploraUrl,
             watcherConfig: options.watcherConfig,
@@ -548,7 +556,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             tag: messageTag,
             type: "INIT_WALLET",
             id: getRandomId(),
-            payload: initConfig,
+            payload: initWalletPayload,
         };
 
         await wallet.sendMessage(initMessage);
@@ -556,7 +564,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         // Persist the full init config (including messageTimeouts) so
         // reinitialize() re-sends the same map to a restarted worker.
         wallet.initConfig = busInitConfig;
-        wallet.initWalletPayload = initConfig;
+        wallet.initWalletPayload = initWalletPayload;
         wallet.messageBusTimeoutMs = options.messageBusTimeoutMs;
         wallet.messageTimeouts = messageTimeouts;
 
@@ -1240,7 +1248,7 @@ export class ServiceWorkerWallet
 
     protected constructor(
         public readonly serviceWorker: ServiceWorker,
-        identity: PrivateKeyIdentity,
+        identity: Identity,
         walletRepository: WalletRepository,
         contractRepository: ContractRepository,
         messageTag: string,
@@ -1278,18 +1286,13 @@ export class ServiceWorkerWallet
             options.storage?.contractRepository ??
             new IndexedDBContractRepository();
 
-        // Extract identity and check if it can expose private key
-        const identity = isPrivateKeyIdentity(options.identity)
-            ? options.identity
-            : null;
-        if (!identity) {
+        if (!isSigningCapable(options.identity)) {
             throw new Error(
-                "ServiceWorkerWallet.create() requires a Identity that can expose a single private key"
+                "ServiceWorkerWallet.create() requires a signing Identity; got a ReadonlyIdentity"
             );
         }
-
-        // Extract private key for service worker initialization
-        const privateKey = identity.toHex();
+        const identity: Identity = options.identity;
+        const serialized = serializeSigningIdentity(identity);
 
         const messageTag = options.walletUpdaterTag ?? DEFAULT_MESSAGE_TAG;
 
@@ -1303,8 +1306,14 @@ export class ServiceWorkerWallet
             !!options.delegatorUrl
         );
 
-        const initConfig = {
-            key: { privateKey },
+        // INIT_WALLET retains the legacy `key` payload for wire compatibility
+        // with older workers; the current handler does not read it, and only
+        // SingleKey-style identities can populate it. Kept optional so seed /
+        // mnemonic identities simply omit it.
+        const legacyPrivateKey =
+            serialized.type === "single-key" ? serialized.privateKey : null;
+        const initWalletPayload = {
+            key: legacyPrivateKey ? { privateKey: legacyPrivateKey } : {},
             arkServerUrl: options.arkServerUrl,
             arkServerPublicKey: options.arkServerPublicKey,
             delegatorUrl: options.delegatorUrl,
@@ -1320,12 +1329,12 @@ export class ServiceWorkerWallet
             : (DEFAULT_MESSAGE_TIMEOUTS as Record<RequestType, number>);
 
         const busInitConfig: MessageBusInitConfig = {
-            wallet: initConfig.key,
+            wallet: serialized,
             arkServer: {
-                url: initConfig.arkServerUrl,
-                publicKey: initConfig.arkServerPublicKey,
+                url: options.arkServerUrl,
+                publicKey: options.arkServerPublicKey,
             },
-            delegatorUrl: initConfig.delegatorUrl,
+            delegatorUrl: options.delegatorUrl,
             indexerUrl: options.indexerUrl,
             esploraUrl: options.esploraUrl,
             settlementConfig: options.settlementConfig,
@@ -1343,7 +1352,7 @@ export class ServiceWorkerWallet
             tag: messageTag,
             type: "INIT_WALLET",
             id: getRandomId(),
-            payload: initConfig,
+            payload: initWalletPayload,
         };
 
         // Initialize the service worker
@@ -1352,7 +1361,7 @@ export class ServiceWorkerWallet
         // Persist the full init config (including messageTimeouts) so
         // reinitialize() re-sends the same map to a restarted worker.
         wallet.initConfig = busInitConfig;
-        wallet.initWalletPayload = initConfig;
+        wallet.initWalletPayload = initWalletPayload;
         wallet.messageBusTimeoutMs = options.messageBusTimeoutMs;
         wallet.messageTimeouts = messageTimeouts;
 

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -448,6 +448,18 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
     protected messageBusTimeoutMs?: number;
     protected messageTimeouts: Record<RequestType, number> =
         DEFAULT_MESSAGE_TIMEOUTS as Record<RequestType, number>;
+    // Denormalized from options so buildInitConfig() can rebuild the init
+    // envelope on demand for SDK-factory-created wallets. `create()` sets
+    // these immediately after construction.
+    protected arkServerUrl?: string;
+    protected arkServerPublicKey?: string;
+    protected delegatorUrl?: string;
+    protected indexerUrl?: string;
+    protected esploraUrl?: string;
+    protected watcherConfig?: Partial<
+        Omit<ContractWatcherConfig, "indexerProvider">
+    >;
+    protected settlementConfig?: SettlementConfig | false;
     private reinitPromise: Promise<void> | null = null;
     private pingPromise: Promise<void> | null = null;
     private inflightRequests = new Map<
@@ -819,17 +831,71 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         }
     }
 
+    /**
+     * Produce a serialized envelope for the wallet's identity. The base
+     * class always emits a readonly envelope; `ServiceWorkerWallet`
+     * overrides to emit a signing envelope.
+     */
+    protected async serializeIdentity(): Promise<SerializedIdentity> {
+        return serializeReadonlyIdentity(this.identity);
+    }
+
+    /**
+     * Return the cached init config, or rebuild one from live instance
+     * state when the cache was never populated. Recovery path for
+     * SDK-factory-created wallets; manual constructor bypasses do not
+     * retain enough state here and will hit the "never initialized" throw.
+     */
+    protected async buildInitConfig(): Promise<MessageBusInitConfig> {
+        if (this.initConfig) return this.initConfig;
+        if (!this.arkServerUrl) {
+            throw new Error(
+                "Cannot re-initialize: wallet was not initialized via the SDK factory"
+            );
+        }
+        const wallet = await this.serializeIdentity();
+        this.initConfig = {
+            wallet,
+            arkServer: {
+                url: this.arkServerUrl,
+                publicKey: this.arkServerPublicKey,
+            },
+            delegatorUrl: this.delegatorUrl,
+            indexerUrl: this.indexerUrl,
+            esploraUrl: this.esploraUrl,
+            watcherConfig: this.watcherConfig,
+            settlementConfig: this.settlementConfig,
+        };
+        return this.initConfig;
+    }
+
+    /** Minimal INIT_WALLET payload used on reinitialize when the cache is gone. */
+    protected buildInitWalletPayload(): RequestInitWallet["payload"] {
+        if (this.initWalletPayload) return this.initWalletPayload;
+        if (!this.arkServerUrl) {
+            throw new Error(
+                "Cannot re-initialize: wallet was not initialized via the SDK factory"
+            );
+        }
+        this.initWalletPayload = {
+            // `key` is deprecated and ignored by the current handler.
+            key: {},
+            arkServerUrl: this.arkServerUrl,
+            arkServerPublicKey: this.arkServerPublicKey,
+        };
+        return this.initWalletPayload;
+    }
+
     private async reinitialize(): Promise<void> {
         if (this.reinitPromise) return this.reinitPromise;
 
         this.reinitPromise = (async () => {
-            if (!this.initConfig || !this.initWalletPayload) {
-                throw new Error("Cannot re-initialize: missing configuration");
-            }
+            const config = await this.buildInitConfig();
+            const payload = this.buildInitWalletPayload();
 
             await initializeMessageBus(
                 this.serviceWorker,
-                this.initConfig,
+                config,
                 this.messageBusTimeoutMs
             );
 
@@ -837,7 +903,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 tag: this.messageTag,
                 type: "INIT_WALLET",
                 id: getRandomId(),
-                payload: this.initWalletPayload,
+                payload,
             };
 
             await this.sendMessageDirect(
@@ -1273,6 +1339,10 @@ export class ServiceWorkerWallet
 
     get assetManager(): IAssetManager {
         return this._assetManager;
+    }
+
+    protected async serializeIdentity(): Promise<SerializedIdentity> {
+        return serializeSigningIdentity(this.identity);
     }
 
     static async create(

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -27,6 +27,7 @@ import {
     type LegacySerializedIdentity,
     serializeReadonlyIdentity,
     serializeSigningIdentity,
+    toWireSerializedIdentity,
 } from "../../identity";
 import { WalletRepository } from "../../repositories/walletRepository";
 import { ContractRepository } from "../../repositories/contractRepository";
@@ -520,7 +521,9 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             messageTag
         );
 
-        const serialized = await serializeReadonlyIdentity(options.identity);
+        const wireWallet = toWireSerializedIdentity(
+            await serializeReadonlyIdentity(options.identity)
+        );
 
         // INIT_WALLET retains the legacy `key` payload for wire compatibility
         // with older workers; the current handler does not read it.
@@ -544,7 +547,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             : (DEFAULT_MESSAGE_TIMEOUTS as Record<RequestType, number>);
 
         const busInitConfig: MessageBusInitConfig = {
-            wallet: serialized,
+            wallet: wireWallet,
             arkServer: {
                 url: options.arkServerUrl,
                 publicKey: options.arkServerPublicKey,
@@ -853,7 +856,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 "Cannot re-initialize: wallet was not initialized via the SDK factory"
             );
         }
-        const wallet = await this.serializeIdentity();
+        const wallet = toWireSerializedIdentity(await this.serializeIdentity());
         this.initConfig = {
             wallet,
             arkServer: {
@@ -1363,6 +1366,7 @@ export class ServiceWorkerWallet
         }
         const identity: Identity = options.identity;
         const serialized = serializeSigningIdentity(identity);
+        const wireWallet = toWireSerializedIdentity(serialized);
 
         const messageTag = options.walletUpdaterTag ?? DEFAULT_MESSAGE_TAG;
 
@@ -1399,7 +1403,7 @@ export class ServiceWorkerWallet
             : (DEFAULT_MESSAGE_TIMEOUTS as Record<RequestType, number>);
 
         const busInitConfig: MessageBusInitConfig = {
-            wallet: serialized,
+            wallet: wireWallet,
             arkServer: {
                 url: options.arkServerUrl,
                 publicKey: options.arkServerPublicKey,

--- a/src/worker/browser/README.md
+++ b/src/worker/browser/README.md
@@ -188,6 +188,42 @@ page → old worker is not.
   one-time `[ts-sdk]` deprecation warning is logged when a legacy shape
   is seen; the adapter is slated for removal in the next major.
 
+### Threat model for identity transport
+
+The page↔worker boundary is same-origin only. A service worker's
+`message` listener only fires for messages posted by documents and
+workers under the same origin, so any code that can send an
+`INITIALIZE_MESSAGE_BUS` message is already running inside the page's
+trust boundary and could read the identity from page memory directly.
+
+Working assumptions:
+
+- **Page memory and worker memory are both trusted.** The SDK does not
+  attempt to isolate secrets between the two — a compromise of either
+  is a full compromise. `serializeReadonlyIdentity` does, however,
+  downgrade signing identities to readonly envelopes when called on
+  the readonly factory, so watch-only wallets never ship signing
+  material even if the caller passes a signing identity.
+- **Envelopes carry what they need to reconstruct the identity class.**
+  For `SingleKey` that is the derived 32-byte private key. For
+  `SeedIdentity` / `MnemonicIdentity` it is master-seed material — the
+  raw seed or the BIP39 mnemonic (plus optional passphrase). A reader
+  of a seed / mnemonic envelope can derive **any** key in the HD tree,
+  not just the key currently in use; the blast radius is larger than
+  the historic `SingleKey` flow. This is an intentional trade for
+  class-preserving round-trip and descriptor fidelity; the page
+  already retains the same material so it can re-initialize a killed
+  worker without prompting the user again.
+- **Secrets are not scrubbed after use.** JavaScript strings are
+  immutable and cannot be overwritten; seed `Uint8Array`s have copies
+  inside `@scure/bip39` and the HD-key library that we cannot reach.
+  The SDK does not theater-clear state it cannot actually erase.
+
+If your application's threat model is tighter than same-origin trust
+(e.g., you assume the worker may be compromised independently of the
+page), prefer `SingleKey` for single-address flows so only one derived
+key is ever in transit.
+
 ## Registering with the built-in update handshake
 
 `setupServiceWorkerOnce` now handles stale workers by:

--- a/src/worker/browser/README.md
+++ b/src/worker/browser/README.md
@@ -117,15 +117,29 @@ bus.start();
 On the client side:
 
 ```ts
+import {
+    serializeSigningIdentity,
+    serializeReadonlyIdentity,
+    SingleKey,
+    MnemonicIdentity,
+} from "@arkade-os/sdk";
+
 const sw = await MessageBus.setup("/service-worker.js");
 
-// Initialize the message bus with wallet config
+// Initialize the message bus with a tagged SerializedIdentity envelope.
+// Build one from any SDK-owned identity using the helpers:
+//   - serializeSigningIdentity(identity) for a wallet that signs.
+//   - serializeReadonlyIdentity(identity) for a watch-only wallet (always
+//     downgrades to readonly even if passed a signing identity).
+const identity = MnemonicIdentity.fromMnemonic("abandon abandon ...");
+const wallet = serializeSigningIdentity(identity);
+
 sw.postMessage({
     type: "INITIALIZE_MESSAGE_BUS",
     id: "init-1",
     tag: "INITIALIZE_MESSAGE_BUS",
     config: {
-        wallet: { privateKey: "..." },
+        wallet,
         arkServer: { url: "https://..." },
     },
 });
@@ -140,6 +154,32 @@ Notes:
 - Set `broadcast: true` on a request to fan it out to all handlers.
 - The `MessageBus` must receive `INITIALIZE_MESSAGE_BUS` before handlers process
   messages; earlier messages are dropped with a warning.
+
+### `SerializedIdentity` wire shape
+
+The `config.wallet` field carries a tagged `SerializedIdentity` envelope so
+that the worker can rehydrate the matching identity class:
+
+| Tag                    | Shape                                                             | Hydrates as                   |
+| ---------------------- | ----------------------------------------------------------------- | ----------------------------- |
+| `single-key`           | `{ type: "single-key", privateKey }`                              | `SingleKey`                   |
+| `seed`                 | `{ type: "seed", seed, descriptor }`                              | `SeedIdentity`                |
+| `mnemonic`             | `{ type: "mnemonic", mnemonic, descriptor, passphrase? }`         | `MnemonicIdentity`            |
+| `readonly-single-key`  | `{ type: "readonly-single-key", publicKey }`                      | `ReadonlySingleKey`           |
+| `readonly-descriptor`  | `{ type: "readonly-descriptor", descriptor }`                     | `ReadonlyDescriptorIdentity`  |
+
+All payloads are structured-clone safe. Signing envelopes ship the secret
+material needed for signing; readonly envelopes never do. The helpers
+`serializeSigningIdentity` / `serializeReadonlyIdentity` select the right
+variant for any SDK-owned identity class.
+
+Compatibility caveat: the untagged shapes `{ privateKey }` / `{ publicKey }`
+emitted by pre-`SerializedIdentity` page builds are still accepted by newer
+workers (a one-time `[ts-sdk]` deprecation warning is logged). New workers
+sending tagged `seed` / `mnemonic` / `readonly-descriptor` envelopes cannot
+talk to workers that predate this change — those variants require a matching
+worker build. The legacy compatibility path is slated for removal in the next
+major.
 
 ## Registering with the built-in update handshake
 

--- a/src/worker/browser/README.md
+++ b/src/worker/browser/README.md
@@ -175,26 +175,18 @@ variant for any SDK-owned identity class.
 
 ### Wire-format compatibility
 
-For reverse compatibility with workers that predate `SerializedIdentity`,
-the SDK's `ServiceWorkerWallet` / `ServiceWorkerReadonlyWallet` factories
-still emit the historic untagged `{ privateKey }` / `{ publicKey }` shapes
-on the wire for `SingleKey` / `ReadonlySingleKey` identities (via
-`toWireSerializedIdentity`). The other variants (`seed`, `mnemonic`,
-`readonly-descriptor`) are always emitted in their tagged form; they never
-had a legacy shape, so older workers cannot handle them regardless.
+Compatibility is one-way: **old page → new worker** is supported; new
+page → old worker is not.
 
-| Identity class                | Wire shape (current)                        | Works on old worker? |
-| ----------------------------- | ------------------------------------------- | -------------------- |
-| `SingleKey`                   | `{ privateKey }` (legacy)                   | yes                  |
-| `ReadonlySingleKey`           | `{ publicKey }` (legacy)                    | yes                  |
-| `SeedIdentity`                | `{ type: "seed", ... }`                     | no — new variant     |
-| `MnemonicIdentity`            | `{ type: "mnemonic", ... }`                 | no — new variant     |
-| `ReadonlyDescriptorIdentity`  | `{ type: "readonly-descriptor", ... }`      | no — new variant     |
-
-Workers accept both tagged and legacy shapes through
-`normalizeSerializedIdentity`; a one-time `[ts-sdk]` deprecation warning
-is logged when a legacy shape is seen. Both the legacy wire emission and
-the legacy-shape adapter are slated for removal in the next major.
+- Page-side: the SDK factories always emit tagged `SerializedIdentity`
+  envelopes via `serializeSigningIdentity` / `serializeReadonlyIdentity`.
+  Upgrading a page to a version of the SDK that uses tagged envelopes
+  requires a worker build that understands them.
+- Worker-side: `normalizeSerializedIdentity` still accepts the historic
+  untagged `{ privateKey }` / `{ publicKey }` shapes so an older page
+  build can initialize a newer worker during a rolling upgrade. A
+  one-time `[ts-sdk]` deprecation warning is logged when a legacy shape
+  is seen; the adapter is slated for removal in the next major.
 
 ## Registering with the built-in update handshake
 

--- a/src/worker/browser/README.md
+++ b/src/worker/browser/README.md
@@ -173,13 +173,28 @@ material needed for signing; readonly envelopes never do. The helpers
 `serializeSigningIdentity` / `serializeReadonlyIdentity` select the right
 variant for any SDK-owned identity class.
 
-Compatibility caveat: the untagged shapes `{ privateKey }` / `{ publicKey }`
-emitted by pre-`SerializedIdentity` page builds are still accepted by newer
-workers (a one-time `[ts-sdk]` deprecation warning is logged). New workers
-sending tagged `seed` / `mnemonic` / `readonly-descriptor` envelopes cannot
-talk to workers that predate this change — those variants require a matching
-worker build. The legacy compatibility path is slated for removal in the next
-major.
+### Wire-format compatibility
+
+For reverse compatibility with workers that predate `SerializedIdentity`,
+the SDK's `ServiceWorkerWallet` / `ServiceWorkerReadonlyWallet` factories
+still emit the historic untagged `{ privateKey }` / `{ publicKey }` shapes
+on the wire for `SingleKey` / `ReadonlySingleKey` identities (via
+`toWireSerializedIdentity`). The other variants (`seed`, `mnemonic`,
+`readonly-descriptor`) are always emitted in their tagged form; they never
+had a legacy shape, so older workers cannot handle them regardless.
+
+| Identity class                | Wire shape (current)                        | Works on old worker? |
+| ----------------------------- | ------------------------------------------- | -------------------- |
+| `SingleKey`                   | `{ privateKey }` (legacy)                   | yes                  |
+| `ReadonlySingleKey`           | `{ publicKey }` (legacy)                    | yes                  |
+| `SeedIdentity`                | `{ type: "seed", ... }`                     | no — new variant     |
+| `MnemonicIdentity`            | `{ type: "mnemonic", ... }`                 | no — new variant     |
+| `ReadonlyDescriptorIdentity`  | `{ type: "readonly-descriptor", ... }`      | no — new variant     |
+
+Workers accept both tagged and legacy shapes through
+`normalizeSerializedIdentity`; a one-time `[ts-sdk]` deprecation warning
+is logged when a legacy shape is seen. Both the legacy wire emission and
+the legacy-shape adapter are slated for removal in the next major.
 
 ## Registering with the built-in update handshake
 

--- a/src/worker/messageBus.ts
+++ b/src/worker/messageBus.ts
@@ -6,9 +6,16 @@ import {
 } from "./browser/service-worker-manager";
 import { ArkProvider, RestArkProvider } from "../providers/ark";
 import { RestDelegatorProvider } from "../providers/delegator";
-import { ReadonlySingleKey, SingleKey } from "../identity";
+import {
+    type Identity,
+    type ReadonlyIdentity,
+    type SerializedIdentity,
+    type LegacySerializedIdentity,
+    hydrateIdentity,
+    isSigningSerialized,
+    normalizeSerializedIdentity,
+} from "../identity";
 import { ReadonlyWallet, Wallet } from "../wallet/wallet";
-import { hex } from "@scure/base";
 import type { SettlementConfig } from "../wallet/vtxo-manager";
 import type { ContractWatcherConfig } from "../contracts/contractWatcher";
 import { ContractRepository, WalletRepository } from "../repositories";
@@ -130,13 +137,7 @@ type Initialize = {
     type: "INITIALIZE_MESSAGE_BUS";
     id: string;
     config: {
-        wallet:
-            | {
-                  privateKey: string;
-              }
-            | {
-                  publicKey: string;
-              };
+        wallet: SerializedIdentity | LegacySerializedIdentity;
         arkServer: {
             url: string;
             publicKey?: string;
@@ -362,8 +363,11 @@ export class MessageBus {
         const delegatorProvider = config.delegatorUrl
             ? new RestDelegatorProvider(config.delegatorUrl)
             : undefined;
-        if ("privateKey" in config.wallet) {
-            const identity = SingleKey.fromHex(config.wallet.privateKey);
+
+        const serialized = normalizeSerializedIdentity(config.wallet);
+
+        if (isSigningSerialized(serialized)) {
+            const identity = hydrateIdentity(serialized) as Identity;
             const wallet = await Wallet.create({
                 identity,
                 arkServerUrl: config.arkServer.url,
@@ -376,26 +380,20 @@ export class MessageBus {
                 watcherConfig: config.watcherConfig,
             });
             return { wallet, arkProvider, readonlyWallet: wallet };
-        } else if ("publicKey" in config.wallet) {
-            const identity = ReadonlySingleKey.fromPublicKey(
-                hex.decode(config.wallet.publicKey)
-            );
-            const readonlyWallet = await ReadonlyWallet.create({
-                identity,
-                arkServerUrl: config.arkServer.url,
-                arkServerPublicKey: config.arkServer.publicKey,
-                indexerUrl: config.indexerUrl,
-                esploraUrl: config.esploraUrl,
-                storage,
-                delegatorProvider,
-                watcherConfig: config.watcherConfig,
-            });
-            return { readonlyWallet, arkProvider };
-        } else {
-            throw new Error(
-                "Missing privateKey or publicKey in configuration object"
-            );
         }
+
+        const identity = hydrateIdentity(serialized) as ReadonlyIdentity;
+        const readonlyWallet = await ReadonlyWallet.create({
+            identity,
+            arkServerUrl: config.arkServer.url,
+            arkServerPublicKey: config.arkServer.publicKey,
+            indexerUrl: config.indexerUrl,
+            esploraUrl: config.esploraUrl,
+            storage,
+            delegatorProvider,
+            watcherConfig: config.watcherConfig,
+        });
+        return { readonlyWallet, arkProvider };
     }
 
     private onMessage(event: ExtendableMessageEvent) {

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -12,6 +12,7 @@ import {
     serializeReadonlyIdentity,
     hydrateIdentity,
     normalizeSerializedIdentity,
+    toWireSerializedIdentity,
     isSigningSerialized,
     type SerializedSigningIdentity,
     type SerializedReadonlyIdentity,
@@ -327,6 +328,79 @@ describe("normalizeSerializedIdentity", () => {
             }) as SerializedReadonlyIdentity;
         const rehydrated = hydrateIdentity(legacyReadonly);
         expect(rehydrated).toBeInstanceOf(ReadonlySingleKey);
+    });
+});
+
+describe("toWireSerializedIdentity", () => {
+    it("downgrades single-key to legacy { privateKey }", () => {
+        const wire = toWireSerializedIdentity({
+            type: "single-key",
+            privateKey: TEST_PRIVATE_KEY_HEX,
+        });
+        expect(wire).toEqual({ privateKey: TEST_PRIVATE_KEY_HEX });
+        expect(wire).not.toHaveProperty("type");
+    });
+
+    it("downgrades readonly-single-key to legacy { publicKey }", () => {
+        const publicKey = hex.encode(new Uint8Array(33).fill(0x02));
+        const wire = toWireSerializedIdentity({
+            type: "readonly-single-key",
+            publicKey,
+        });
+        expect(wire).toEqual({ publicKey });
+        expect(wire).not.toHaveProperty("type");
+    });
+
+    it("passes seed envelopes through unchanged", () => {
+        const envelope: SerializedSigningIdentity = {
+            type: "seed",
+            seed: hex.encode(mnemonicToSeedSync(TEST_MNEMONIC)),
+            descriptor: "tr([00000000/86'/0'/0']xpub.../0/0)",
+        };
+        expect(toWireSerializedIdentity(envelope)).toBe(envelope);
+    });
+
+    it("passes mnemonic envelopes through unchanged", () => {
+        const envelope: SerializedSigningIdentity = {
+            type: "mnemonic",
+            mnemonic: TEST_MNEMONIC,
+            descriptor: "tr([00000000/86'/0'/0']xpub.../0/0)",
+            passphrase: "secret",
+        };
+        expect(toWireSerializedIdentity(envelope)).toBe(envelope);
+    });
+
+    it("passes readonly-descriptor envelopes through unchanged", () => {
+        const envelope: SerializedReadonlyIdentity = {
+            type: "readonly-descriptor",
+            descriptor: "tr([00000000/86'/0'/0']xpub.../0/0)",
+        };
+        expect(toWireSerializedIdentity(envelope)).toBe(envelope);
+    });
+
+    it("serialize -> toWire -> normalize -> hydrate round-trips a SingleKey", async () => {
+        const original = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const wire = toWireSerializedIdentity(
+            serializeSigningIdentity(original)
+        );
+        const rehydrated = hydrateIdentity(normalizeSerializedIdentity(wire));
+        expect(rehydrated).toBeInstanceOf(SingleKey);
+        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
+            Array.from(await original.xOnlyPublicKey())
+        );
+    });
+
+    it("serialize -> toWire -> normalize -> hydrate round-trips a ReadonlySingleKey", async () => {
+        const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const original = await signing.toReadonly();
+        const wire = toWireSerializedIdentity(
+            await serializeReadonlyIdentity(original)
+        );
+        const rehydrated = hydrateIdentity(normalizeSerializedIdentity(wire));
+        expect(rehydrated).toBeInstanceOf(ReadonlySingleKey);
+        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
+            Array.from(await original.xOnlyPublicKey())
+        );
     });
 });
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -395,6 +395,89 @@ describe("normalizeSerializedIdentity", () => {
         const rehydrated = hydrateIdentity(legacyReadonly);
         expect(rehydrated).toBeInstanceOf(ReadonlySingleKey);
     });
+
+    it("rejects tagged envelopes with unknown type", () => {
+        expect(() =>
+            normalizeSerializedIdentity({
+                type: "evil",
+                privateKey: TEST_PRIVATE_KEY_HEX,
+            } as unknown as SerializedSigningIdentity)
+        ).toThrow(/Unknown serialized identity type: evil/);
+    });
+
+    it("rejects tagged envelopes missing required fields with a clear error", () => {
+        // Each variant throws with a message that names the envelope type
+        // and the missing/invalid field, not an opaque downstream error.
+        expect(() =>
+            normalizeSerializedIdentity({
+                type: "single-key",
+            } as unknown as SerializedSigningIdentity)
+        ).toThrow(/Malformed.*"single-key".*"privateKey"/);
+
+        expect(() =>
+            normalizeSerializedIdentity({
+                type: "readonly-single-key",
+            } as unknown as SerializedReadonlyIdentity)
+        ).toThrow(/Malformed.*"readonly-single-key".*"publicKey"/);
+
+        expect(() =>
+            normalizeSerializedIdentity({
+                type: "seed",
+                descriptor: "tr(...)",
+            } as unknown as SerializedSigningIdentity)
+        ).toThrow(/Malformed.*"seed".*"seed"/);
+
+        expect(() =>
+            normalizeSerializedIdentity({
+                type: "seed",
+                seed: "abcd",
+            } as unknown as SerializedSigningIdentity)
+        ).toThrow(/Malformed.*"seed".*"descriptor"/);
+
+        expect(() =>
+            normalizeSerializedIdentity({
+                type: "mnemonic",
+                descriptor: "tr(...)",
+            } as unknown as SerializedSigningIdentity)
+        ).toThrow(/Malformed.*"mnemonic".*"mnemonic"/);
+
+        expect(() =>
+            normalizeSerializedIdentity({
+                type: "mnemonic",
+                mnemonic: TEST_MNEMONIC,
+                descriptor: "tr(...)",
+                passphrase: 42,
+            } as unknown as SerializedSigningIdentity)
+        ).toThrow(/Malformed.*"mnemonic".*"passphrase"/);
+
+        expect(() =>
+            normalizeSerializedIdentity({
+                type: "readonly-descriptor",
+            } as unknown as SerializedReadonlyIdentity)
+        ).toThrow(/Malformed.*"readonly-descriptor".*"descriptor"/);
+    });
+
+    it("accepts a mnemonic envelope with undefined passphrase", () => {
+        const shape: SerializedSigningIdentity = {
+            type: "mnemonic",
+            mnemonic: TEST_MNEMONIC,
+            descriptor: "tr(...)",
+        };
+        expect(normalizeSerializedIdentity(shape)).toBe(shape);
+    });
+});
+
+describe("hydrateIdentity defensive default", () => {
+    it("throws on an unknown serialized identity type", () => {
+        // Direct call (bypassing normalize). The switch has a `default`
+        // so an unknown type can't silently produce undefined.
+        expect(() =>
+            hydrateIdentity({
+                type: "evil",
+                privateKey: "00",
+            } as unknown as SerializedSigningIdentity)
+        ).toThrow(/Unknown serialized identity type: evil/);
+    });
 });
 
 describe("isSigningSerialized", () => {

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { hex } from "@scure/base";
+import { mnemonicToSeedSync } from "@scure/bip39";
+import { SingleKey, ReadonlySingleKey } from "../src/identity/singleKey";
+import {
+    SeedIdentity,
+    MnemonicIdentity,
+    ReadonlyDescriptorIdentity,
+} from "../src/identity/seedIdentity";
+import {
+    serializeSigningIdentity,
+    serializeReadonlyIdentity,
+    hydrateIdentity,
+    normalizeSerializedIdentity,
+    isSigningSerialized,
+    type SerializedSigningIdentity,
+    type SerializedReadonlyIdentity,
+} from "../src/identity/serialize";
+
+const TEST_MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const TEST_PRIVATE_KEY_HEX =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("serializeSigningIdentity", () => {
+    it("produces a single-key envelope for SingleKey", () => {
+        const identity = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const envelope = serializeSigningIdentity(identity);
+        expect(envelope).toEqual({
+            type: "single-key",
+            privateKey: TEST_PRIVATE_KEY_HEX,
+        });
+        expect(isSigningSerialized(envelope)).toBe(true);
+    });
+
+    it("produces a seed envelope for SeedIdentity", () => {
+        const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+        const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+        const envelope = serializeSigningIdentity(identity);
+        expect(envelope.type).toBe("seed");
+        if (envelope.type !== "seed") throw new Error("unreachable");
+        expect(envelope.seed).toBe(hex.encode(seed));
+        expect(envelope.descriptor).toBe(identity.descriptor);
+    });
+
+    it("produces a mnemonic envelope for MnemonicIdentity", () => {
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+        });
+        const envelope = serializeSigningIdentity(identity);
+        expect(envelope.type).toBe("mnemonic");
+        if (envelope.type !== "mnemonic") throw new Error("unreachable");
+        expect(envelope.mnemonic).toBe(TEST_MNEMONIC);
+        expect(envelope.descriptor).toBe(identity.descriptor);
+        expect(envelope.passphrase).toBeUndefined();
+    });
+
+    it("includes passphrase in the mnemonic envelope when set", () => {
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+            passphrase: "correct horse battery staple",
+        });
+        const envelope = serializeSigningIdentity(identity);
+        if (envelope.type !== "mnemonic") throw new Error("unreachable");
+        expect(envelope.passphrase).toBe("correct horse battery staple");
+    });
+
+    it("falls back to toHex() for custom SingleKey-like identities", () => {
+        const custom = {
+            toHex: () => TEST_PRIVATE_KEY_HEX,
+            // stub the rest of Identity — unused by serializeSigningIdentity
+            xOnlyPublicKey: async () => new Uint8Array(32),
+            compressedPublicKey: async () => new Uint8Array(33),
+            sign: async () => {
+                throw new Error("unused");
+            },
+            signMessage: async () => new Uint8Array(64),
+            signerSession: () => {
+                throw new Error("unused");
+            },
+        } as unknown as Parameters<typeof serializeSigningIdentity>[0];
+        expect(serializeSigningIdentity(custom)).toEqual({
+            type: "single-key",
+            privateKey: TEST_PRIVATE_KEY_HEX,
+        });
+    });
+
+    it("throws for a signing identity with neither instanceof nor toHex", () => {
+        const opaque = {
+            xOnlyPublicKey: async () => new Uint8Array(32),
+            compressedPublicKey: async () => new Uint8Array(33),
+            sign: async () => {
+                throw new Error("unused");
+            },
+            signMessage: async () => new Uint8Array(64),
+            signerSession: () => {
+                throw new Error("unused");
+            },
+        } as unknown as Parameters<typeof serializeSigningIdentity>[0];
+        expect(() => serializeSigningIdentity(opaque)).toThrow(
+            /Unsupported signing identity/
+        );
+    });
+});
+
+describe("serializeReadonlyIdentity", () => {
+    it("produces a readonly-single-key envelope for ReadonlySingleKey", async () => {
+        const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const readonly = await signing.toReadonly();
+        const envelope = await serializeReadonlyIdentity(readonly);
+        expect(envelope.type).toBe("readonly-single-key");
+        if (envelope.type !== "readonly-single-key")
+            throw new Error("unreachable");
+        expect(envelope.publicKey).toBe(
+            hex.encode(await readonly.compressedPublicKey())
+        );
+        expect(isSigningSerialized(envelope)).toBe(false);
+    });
+
+    it("downgrades a signing SingleKey to a readonly-single-key envelope", async () => {
+        const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const envelope = await serializeReadonlyIdentity(signing);
+        expect(envelope.type).toBe("readonly-single-key");
+        if (envelope.type !== "readonly-single-key")
+            throw new Error("unreachable");
+        expect(envelope.publicKey).toBe(
+            hex.encode(await signing.compressedPublicKey())
+        );
+        expect(JSON.stringify(envelope)).not.toContain(TEST_PRIVATE_KEY_HEX);
+    });
+
+    it("produces a readonly-descriptor envelope for SeedIdentity", async () => {
+        const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+        const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+        const envelope = await serializeReadonlyIdentity(identity);
+        expect(envelope).toEqual({
+            type: "readonly-descriptor",
+            descriptor: identity.descriptor,
+        });
+        expect(JSON.stringify(envelope)).not.toContain(hex.encode(seed));
+    });
+
+    it("produces a readonly-descriptor envelope for MnemonicIdentity without phrase", async () => {
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+            passphrase: "extra secret",
+        });
+        const envelope = await serializeReadonlyIdentity(identity);
+        expect(envelope).toEqual({
+            type: "readonly-descriptor",
+            descriptor: identity.descriptor,
+        });
+        const serialized = JSON.stringify(envelope);
+        expect(serialized).not.toContain("abandon");
+        expect(serialized).not.toContain("extra secret");
+    });
+
+    it("produces a readonly-descriptor envelope for ReadonlyDescriptorIdentity", async () => {
+        const mnemonic = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+        });
+        const readonly = ReadonlyDescriptorIdentity.fromDescriptor(
+            mnemonic.descriptor
+        );
+        const envelope = await serializeReadonlyIdentity(readonly);
+        expect(envelope).toEqual({
+            type: "readonly-descriptor",
+            descriptor: mnemonic.descriptor,
+        });
+    });
+});
+
+describe("hydrateIdentity round-trip", () => {
+    it("SingleKey -> single-key -> SingleKey preserves xOnlyPublicKey", async () => {
+        const original = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const rehydrated = hydrateIdentity(serializeSigningIdentity(original));
+        expect(rehydrated).toBeInstanceOf(SingleKey);
+        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
+            Array.from(await original.xOnlyPublicKey())
+        );
+    });
+
+    it("SingleKey produces equal signMessage output after round-trip", async () => {
+        const original = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const rehydrated = hydrateIdentity(
+            serializeSigningIdentity(original)
+        ) as SingleKey;
+        const message = new Uint8Array(32).fill(7);
+        const [sigA, sigB] = await Promise.all([
+            original.signMessage(message, "ecdsa"),
+            rehydrated.signMessage(message, "ecdsa"),
+        ]);
+        expect(Array.from(sigA)).toEqual(Array.from(sigB));
+    });
+
+    it("ReadonlySingleKey -> readonly-single-key -> ReadonlySingleKey preserves pubkey", async () => {
+        const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const original = await signing.toReadonly();
+        const rehydrated = hydrateIdentity(
+            await serializeReadonlyIdentity(original)
+        );
+        expect(rehydrated).toBeInstanceOf(ReadonlySingleKey);
+        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
+            Array.from(await original.xOnlyPublicKey())
+        );
+    });
+
+    it("SeedIdentity -> seed -> SeedIdentity preserves keys and descriptor", async () => {
+        const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+        const original = SeedIdentity.fromSeed(seed, { isMainnet: true });
+        const rehydrated = hydrateIdentity(
+            serializeSigningIdentity(original)
+        ) as SeedIdentity;
+        expect(rehydrated).toBeInstanceOf(SeedIdentity);
+        expect(rehydrated.descriptor).toBe(original.descriptor);
+        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
+            Array.from(await original.xOnlyPublicKey())
+        );
+        const message = new Uint8Array(32).fill(11);
+        expect(
+            Array.from(await rehydrated.signMessage(message, "ecdsa"))
+        ).toEqual(Array.from(await original.signMessage(message, "ecdsa")));
+    });
+
+    it("MnemonicIdentity -> mnemonic -> MnemonicIdentity preserves class and keys", async () => {
+        const original = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+        });
+        const rehydrated = hydrateIdentity(
+            serializeSigningIdentity(original)
+        ) as MnemonicIdentity;
+        expect(rehydrated).toBeInstanceOf(MnemonicIdentity);
+        expect(rehydrated.mnemonic).toBe(TEST_MNEMONIC);
+        expect(rehydrated.passphrase).toBeUndefined();
+        expect(rehydrated.descriptor).toBe(original.descriptor);
+        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
+            Array.from(await original.xOnlyPublicKey())
+        );
+    });
+
+    it("MnemonicIdentity with passphrase round-trips correctly", async () => {
+        const passphrase = "extra secret";
+        const original = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+            passphrase,
+        });
+        const rehydrated = hydrateIdentity(
+            serializeSigningIdentity(original)
+        ) as MnemonicIdentity;
+        expect(rehydrated.passphrase).toBe(passphrase);
+        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
+            Array.from(await original.xOnlyPublicKey())
+        );
+    });
+
+    it("MnemonicIdentity with custom descriptor preserves the descriptor", async () => {
+        const testnetReference = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: false,
+        });
+        const original = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            descriptor: testnetReference.descriptor,
+        });
+        const rehydrated = hydrateIdentity(
+            serializeSigningIdentity(original)
+        ) as MnemonicIdentity;
+        expect(rehydrated.descriptor).toBe(testnetReference.descriptor);
+        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
+            Array.from(await testnetReference.xOnlyPublicKey())
+        );
+    });
+
+    it("SeedIdentity through readonly downgrade produces ReadonlyDescriptorIdentity", async () => {
+        const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+        const signing = SeedIdentity.fromSeed(seed, { isMainnet: true });
+        const envelope = await serializeReadonlyIdentity(signing);
+        const rehydrated = hydrateIdentity(envelope);
+        expect(rehydrated).toBeInstanceOf(ReadonlyDescriptorIdentity);
+        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
+            Array.from(await signing.xOnlyPublicKey())
+        );
+    });
+});
+
+describe("normalizeSerializedIdentity", () => {
+    it("returns tagged envelopes unchanged", () => {
+        const tagged: SerializedSigningIdentity = {
+            type: "single-key",
+            privateKey: TEST_PRIVATE_KEY_HEX,
+        };
+        expect(normalizeSerializedIdentity(tagged)).toBe(tagged);
+    });
+
+    it("maps legacy { privateKey } to a single-key envelope", () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const normalized = normalizeSerializedIdentity({
+            privateKey: TEST_PRIVATE_KEY_HEX,
+        });
+        expect(normalized).toEqual({
+            type: "single-key",
+            privateKey: TEST_PRIVATE_KEY_HEX,
+        });
+        expect(warn).toHaveBeenCalled();
+    });
+
+    it("maps legacy { publicKey } to a readonly-single-key envelope", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        const publicKey = hex.encode(new Uint8Array(33).fill(0x02));
+        expect(normalizeSerializedIdentity({ publicKey })).toEqual({
+            type: "readonly-single-key",
+            publicKey,
+        });
+    });
+
+    it("maps legacy envelopes to hydrate-compatible output", async () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        const legacyReadonly: SerializedReadonlyIdentity =
+            normalizeSerializedIdentity({
+                publicKey: hex.encode(
+                    await SingleKey.fromHex(
+                        TEST_PRIVATE_KEY_HEX
+                    ).compressedPublicKey()
+                ),
+            }) as SerializedReadonlyIdentity;
+        const rehydrated = hydrateIdentity(legacyReadonly);
+        expect(rehydrated).toBeInstanceOf(ReadonlySingleKey);
+    });
+});
+
+describe("isSigningSerialized", () => {
+    it("true for signing envelopes", () => {
+        expect(
+            isSigningSerialized({
+                type: "single-key",
+                privateKey: TEST_PRIVATE_KEY_HEX,
+            })
+        ).toBe(true);
+        expect(
+            isSigningSerialized({
+                type: "seed",
+                seed: hex.encode(mnemonicToSeedSync(TEST_MNEMONIC)),
+                descriptor: "irrelevant-for-guard",
+            })
+        ).toBe(true);
+        expect(
+            isSigningSerialized({
+                type: "mnemonic",
+                mnemonic: TEST_MNEMONIC,
+                descriptor: "irrelevant-for-guard",
+            })
+        ).toBe(true);
+    });
+
+    it("false for readonly envelopes", () => {
+        expect(
+            isSigningSerialized({
+                type: "readonly-single-key",
+                publicKey: hex.encode(new Uint8Array(33)),
+            })
+        ).toBe(false);
+        expect(
+            isSigningSerialized({
+                type: "readonly-descriptor",
+                descriptor: "irrelevant-for-guard",
+            })
+        ).toBe(false);
+    });
+});

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -296,6 +296,34 @@ describe("hydrateIdentity round-trip", () => {
         expect(Object.keys(identity)).not.toContain("seed");
     });
 
+    it("copies the seed so caller mutation after construction does not drift the envelope", () => {
+        const canonical = mnemonicToSeedSync(TEST_MNEMONIC);
+        const callerBuffer = new Uint8Array(canonical);
+        const identity = SeedIdentity.fromSeed(callerBuffer, {
+            isMainnet: true,
+        });
+        const envelopeBefore = serializeSigningIdentity(identity);
+
+        // Caller zeros their buffer after construction — the stored seed
+        // must be independent so later serialization stays consistent with
+        // the derived key / descriptor captured at construction time.
+        callerBuffer.fill(0);
+
+        expect(serializeSigningIdentity(identity)).toEqual(envelopeBefore);
+        if (envelopeBefore.type !== "seed") throw new Error("unreachable");
+        expect(envelopeBefore.seed).toBe(hex.encode(canonical));
+    });
+
+    it("MnemonicIdentity copies the derived seed through SeedIdentity construction", () => {
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+        });
+        const envelope = serializeSigningIdentity(identity);
+        // Serializing twice after construction yields the same envelope —
+        // the internal state is not an alias of a buffer that might change.
+        expect(serializeSigningIdentity(identity)).toEqual(envelope);
+    });
+
     it("MnemonicIdentity with custom descriptor preserves the descriptor", async () => {
         const testnetReference = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
             isMainnet: false,

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -12,7 +12,6 @@ import {
     serializeReadonlyIdentity,
     hydrateIdentity,
     normalizeSerializedIdentity,
-    toWireSerializedIdentity,
     isSigningSerialized,
     type SerializedSigningIdentity,
     type SerializedReadonlyIdentity,
@@ -367,79 +366,6 @@ describe("normalizeSerializedIdentity", () => {
             }) as SerializedReadonlyIdentity;
         const rehydrated = hydrateIdentity(legacyReadonly);
         expect(rehydrated).toBeInstanceOf(ReadonlySingleKey);
-    });
-});
-
-describe("toWireSerializedIdentity", () => {
-    it("downgrades single-key to legacy { privateKey }", () => {
-        const wire = toWireSerializedIdentity({
-            type: "single-key",
-            privateKey: TEST_PRIVATE_KEY_HEX,
-        });
-        expect(wire).toEqual({ privateKey: TEST_PRIVATE_KEY_HEX });
-        expect(wire).not.toHaveProperty("type");
-    });
-
-    it("downgrades readonly-single-key to legacy { publicKey }", () => {
-        const publicKey = hex.encode(new Uint8Array(33).fill(0x02));
-        const wire = toWireSerializedIdentity({
-            type: "readonly-single-key",
-            publicKey,
-        });
-        expect(wire).toEqual({ publicKey });
-        expect(wire).not.toHaveProperty("type");
-    });
-
-    it("passes seed envelopes through unchanged", () => {
-        const envelope: SerializedSigningIdentity = {
-            type: "seed",
-            seed: hex.encode(mnemonicToSeedSync(TEST_MNEMONIC)),
-            descriptor: "tr([00000000/86'/0'/0']xpub.../0/0)",
-        };
-        expect(toWireSerializedIdentity(envelope)).toBe(envelope);
-    });
-
-    it("passes mnemonic envelopes through unchanged", () => {
-        const envelope: SerializedSigningIdentity = {
-            type: "mnemonic",
-            mnemonic: TEST_MNEMONIC,
-            descriptor: "tr([00000000/86'/0'/0']xpub.../0/0)",
-            passphrase: "secret",
-        };
-        expect(toWireSerializedIdentity(envelope)).toBe(envelope);
-    });
-
-    it("passes readonly-descriptor envelopes through unchanged", () => {
-        const envelope: SerializedReadonlyIdentity = {
-            type: "readonly-descriptor",
-            descriptor: "tr([00000000/86'/0'/0']xpub.../0/0)",
-        };
-        expect(toWireSerializedIdentity(envelope)).toBe(envelope);
-    });
-
-    it("serialize -> toWire -> normalize -> hydrate round-trips a SingleKey", async () => {
-        const original = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
-        const wire = toWireSerializedIdentity(
-            serializeSigningIdentity(original)
-        );
-        const rehydrated = hydrateIdentity(normalizeSerializedIdentity(wire));
-        expect(rehydrated).toBeInstanceOf(SingleKey);
-        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
-            Array.from(await original.xOnlyPublicKey())
-        );
-    });
-
-    it("serialize -> toWire -> normalize -> hydrate round-trips a ReadonlySingleKey", async () => {
-        const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
-        const original = await signing.toReadonly();
-        const wire = toWireSerializedIdentity(
-            await serializeReadonlyIdentity(original)
-        );
-        const rehydrated = hydrateIdentity(normalizeSerializedIdentity(wire));
-        expect(rehydrated).toBeInstanceOf(ReadonlySingleKey);
-        expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
-            Array.from(await original.xOnlyPublicKey())
-        );
     });
 });
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -436,3 +436,37 @@ describe("isSigningSerialized", () => {
         ).toBe(false);
     });
 });
+
+describe("identity barrel public surface", () => {
+    it("does not re-export the SDK-internal seed-owned serializer helpers", async () => {
+        const barrel = await import("../src/identity");
+        expect(
+            (barrel as Record<string, unknown>)
+                .serializeSeedOwnedSigningIdentity
+        ).toBeUndefined();
+        expect(
+            (barrel as Record<string, unknown>)
+                .serializeSeedOwnedReadonlyIdentity
+        ).toBeUndefined();
+    });
+
+    it("still re-exports the public identity classes and types", async () => {
+        const barrel = await import("../src/identity");
+        expect(barrel.SeedIdentity).toBe(SeedIdentity);
+        expect(barrel.MnemonicIdentity).toBe(MnemonicIdentity);
+        expect(barrel.ReadonlyDescriptorIdentity).toBe(
+            ReadonlyDescriptorIdentity
+        );
+        expect(barrel.SingleKey).toBe(SingleKey);
+        expect(barrel.ReadonlySingleKey).toBe(ReadonlySingleKey);
+        expect(barrel.serializeSigningIdentity).toBe(serializeSigningIdentity);
+        expect(barrel.serializeReadonlyIdentity).toBe(
+            serializeReadonlyIdentity
+        );
+        expect(barrel.hydrateIdentity).toBe(hydrateIdentity);
+        expect(barrel.normalizeSerializedIdentity).toBe(
+            normalizeSerializedIdentity
+        );
+        expect(barrel.isSigningSerialized).toBe(isSigningSerialized);
+    });
+});

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -235,9 +235,15 @@ describe("hydrateIdentity round-trip", () => {
             serializeSigningIdentity(original)
         ) as MnemonicIdentity;
         expect(rehydrated).toBeInstanceOf(MnemonicIdentity);
-        expect(rehydrated.mnemonic).toBe(TEST_MNEMONIC);
-        expect(rehydrated.passphrase).toBeUndefined();
         expect(rehydrated.descriptor).toBe(original.descriptor);
+        // Secret state (mnemonic, passphrase) is off the public instance
+        // surface; verify it was retained by re-serializing and comparing
+        // the envelope rather than reading fields directly.
+        expect(serializeSigningIdentity(rehydrated)).toEqual({
+            type: "mnemonic",
+            mnemonic: TEST_MNEMONIC,
+            descriptor: original.descriptor,
+        });
         expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
             Array.from(await original.xOnlyPublicKey())
         );
@@ -252,10 +258,43 @@ describe("hydrateIdentity round-trip", () => {
         const rehydrated = hydrateIdentity(
             serializeSigningIdentity(original)
         ) as MnemonicIdentity;
-        expect(rehydrated.passphrase).toBe(passphrase);
+        expect(serializeSigningIdentity(rehydrated)).toEqual({
+            type: "mnemonic",
+            mnemonic: TEST_MNEMONIC,
+            descriptor: original.descriptor,
+            passphrase,
+        });
         expect(Array.from(await rehydrated.xOnlyPublicKey())).toEqual(
             Array.from(await original.xOnlyPublicKey())
         );
+    });
+
+    it("does not expose mnemonic or passphrase as public instance fields", () => {
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+            passphrase: "extra secret",
+        });
+        // Appendix A: secrets live in a module-private WeakMap, not on the
+        // instance. Property access returns undefined and enumeration does
+        // not reveal them.
+        expect(
+            (identity as unknown as Record<string, unknown>).mnemonic
+        ).toBeUndefined();
+        expect(
+            (identity as unknown as Record<string, unknown>).passphrase
+        ).toBeUndefined();
+        const ownKeys = Object.keys(identity);
+        expect(ownKeys).not.toContain("mnemonic");
+        expect(ownKeys).not.toContain("passphrase");
+    });
+
+    it("does not expose seed as a public instance field", () => {
+        const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+        const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+        expect(
+            (identity as unknown as Record<string, unknown>).seed
+        ).toBeUndefined();
+        expect(Object.keys(identity)).not.toContain("seed");
     });
 
     it("MnemonicIdentity with custom descriptor preserves the descriptor", async () => {

--- a/test/serviceWorker/wallet.test.ts
+++ b/test/serviceWorker/wallet.test.ts
@@ -4,8 +4,15 @@ import {
     ServiceWorkerReadonlyWallet,
     InMemoryContractRepository,
     InMemoryWalletRepository,
+    SingleKey,
+    ReadonlySingleKey,
+    MnemonicIdentity,
+    SeedIdentity,
+    ReadonlyDescriptorIdentity,
 } from "../../src";
 import { ServiceWorkerWallet } from "../../src/wallet/serviceWorker/wallet";
+import { mnemonicToSeedSync } from "@scure/bip39";
+import { hex } from "@scure/base";
 import {
     WalletMessageHandler,
     DEFAULT_MESSAGE_TAG,
@@ -1110,5 +1117,231 @@ describe("preflight ping", () => {
         );
         await vi.advanceTimersByTimeAsync(2_000);
         await assertion;
+    });
+});
+
+describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
+    const messageTag = DEFAULT_MESSAGE_TAG;
+    const TEST_MNEMONIC =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const TEST_PRIVATE_KEY_HEX =
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    const initResponder = (message: any) => {
+        if (message.tag === "INITIALIZE_MESSAGE_BUS") {
+            return { id: message.id, tag: "INITIALIZE_MESSAGE_BUS" };
+        }
+        if (message.type === "INIT_WALLET") {
+            return {
+                id: message.id,
+                tag: messageTag,
+                type: "WALLET_INITIALIZED",
+            };
+        }
+        return null;
+    };
+
+    const setup = () => {
+        const harness = createServiceWorkerHarness(initResponder);
+        vi.stubGlobal("navigator", {
+            serviceWorker: harness.navigatorServiceWorker,
+        } as any);
+        return harness;
+    };
+
+    const storage = () => ({
+        walletRepository: new InMemoryWalletRepository(),
+        contractRepository: new InMemoryContractRepository(),
+    });
+
+    const getInitConfigWallet = (serviceWorker: {
+        postMessage: ReturnType<typeof vi.fn>;
+    }): unknown => {
+        const call = serviceWorker.postMessage.mock.calls.find(
+            ([msg]: any) => msg?.tag === "INITIALIZE_MESSAGE_BUS"
+        );
+        expect(call).toBeDefined();
+        return call![0].config.wallet;
+    };
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("SingleKey stays on legacy { privateKey } for old-worker compatibility", async () => {
+        const { serviceWorker } = setup();
+        const identity = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+
+        await ServiceWorkerWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        const wallet = getInitConfigWallet(serviceWorker);
+        expect(wallet).toEqual({ privateKey: TEST_PRIVATE_KEY_HEX });
+        expect(wallet).not.toHaveProperty("type");
+    });
+
+    it("ReadonlySingleKey stays on legacy { publicKey } for old-worker compatibility", async () => {
+        const { serviceWorker } = setup();
+        const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const identity = await signing.toReadonly();
+        const expectedPubKey = hex.encode(await identity.compressedPublicKey());
+
+        await ServiceWorkerReadonlyWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        const wallet = getInitConfigWallet(serviceWorker);
+        expect(wallet).toEqual({ publicKey: expectedPubKey });
+        expect(wallet).not.toHaveProperty("type");
+    });
+
+    it("MnemonicIdentity emits a tagged mnemonic envelope", async () => {
+        const { serviceWorker } = setup();
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+        });
+
+        await ServiceWorkerWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        const wallet = getInitConfigWallet(serviceWorker);
+        expect(wallet).toEqual({
+            type: "mnemonic",
+            mnemonic: TEST_MNEMONIC,
+            descriptor: identity.descriptor,
+        });
+    });
+
+    it("MnemonicIdentity with passphrase includes it in the envelope", async () => {
+        const { serviceWorker } = setup();
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+            passphrase: "extra secret",
+        });
+
+        await ServiceWorkerWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        const wallet = getInitConfigWallet(serviceWorker) as {
+            type: string;
+            passphrase?: string;
+        };
+        expect(wallet.type).toBe("mnemonic");
+        expect(wallet.passphrase).toBe("extra secret");
+    });
+
+    it("SeedIdentity emits a tagged seed envelope", async () => {
+        const { serviceWorker } = setup();
+        const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+        const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+
+        await ServiceWorkerWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        const wallet = getInitConfigWallet(serviceWorker);
+        expect(wallet).toEqual({
+            type: "seed",
+            seed: hex.encode(seed),
+            descriptor: identity.descriptor,
+        });
+    });
+
+    it("ReadonlyDescriptorIdentity emits a tagged readonly-descriptor envelope", async () => {
+        const { serviceWorker } = setup();
+        const reference = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+        });
+        const identity = ReadonlyDescriptorIdentity.fromDescriptor(
+            reference.descriptor
+        );
+
+        await ServiceWorkerReadonlyWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        const wallet = getInitConfigWallet(serviceWorker);
+        expect(wallet).toEqual({
+            type: "readonly-descriptor",
+            descriptor: reference.descriptor,
+        });
+    });
+
+    it("ServiceWorkerReadonlyWallet downgrades a signing mnemonic identity to readonly-descriptor", async () => {
+        const { serviceWorker } = setup();
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+            passphrase: "extra secret",
+        });
+
+        await ServiceWorkerReadonlyWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        const wallet = getInitConfigWallet(serviceWorker);
+        expect(wallet).toEqual({
+            type: "readonly-descriptor",
+            descriptor: identity.descriptor,
+        });
+        const onWire = JSON.stringify(wallet);
+        expect(onWire).not.toContain("abandon");
+        expect(onWire).not.toContain("extra secret");
+    });
+
+    it("ServiceWorkerReadonlyWallet with a signing SingleKey downgrades to legacy { publicKey }", async () => {
+        const { serviceWorker } = setup();
+        const identity = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const expectedPubKey = hex.encode(await identity.compressedPublicKey());
+
+        await ServiceWorkerReadonlyWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        const wallet = getInitConfigWallet(serviceWorker);
+        expect(wallet).toEqual({ publicKey: expectedPubKey });
+        expect(JSON.stringify(wallet)).not.toContain(TEST_PRIVATE_KEY_HEX);
+    });
+
+    it("ServiceWorkerWallet.create rejects a ReadonlyIdentity input", async () => {
+        const { serviceWorker } = setup();
+        const readonly = ReadonlySingleKey.fromPublicKey(
+            await SingleKey.fromHex(TEST_PRIVATE_KEY_HEX).compressedPublicKey()
+        );
+
+        await expect(
+            ServiceWorkerWallet.create({
+                serviceWorker: serviceWorker as any,
+                arkServerUrl: "https://ark.test",
+                identity: readonly as any,
+                storage: storage(),
+            })
+        ).rejects.toThrow(/requires a signing Identity/);
     });
 });

--- a/test/serviceWorker/wallet.test.ts
+++ b/test/serviceWorker/wallet.test.ts
@@ -1168,7 +1168,7 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
         vi.unstubAllGlobals();
     });
 
-    it("SingleKey stays on legacy { privateKey } for old-worker compatibility", async () => {
+    it("SingleKey emits a tagged single-key envelope", async () => {
         const { serviceWorker } = setup();
         const identity = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
 
@@ -1180,11 +1180,13 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
         });
 
         const wallet = getInitConfigWallet(serviceWorker);
-        expect(wallet).toEqual({ privateKey: TEST_PRIVATE_KEY_HEX });
-        expect(wallet).not.toHaveProperty("type");
+        expect(wallet).toEqual({
+            type: "single-key",
+            privateKey: TEST_PRIVATE_KEY_HEX,
+        });
     });
 
-    it("ReadonlySingleKey stays on legacy { publicKey } for old-worker compatibility", async () => {
+    it("ReadonlySingleKey emits a tagged readonly-single-key envelope", async () => {
         const { serviceWorker } = setup();
         const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
         const identity = await signing.toReadonly();
@@ -1198,8 +1200,10 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
         });
 
         const wallet = getInitConfigWallet(serviceWorker);
-        expect(wallet).toEqual({ publicKey: expectedPubKey });
-        expect(wallet).not.toHaveProperty("type");
+        expect(wallet).toEqual({
+            type: "readonly-single-key",
+            publicKey: expectedPubKey,
+        });
     });
 
     it("MnemonicIdentity emits a tagged mnemonic envelope", async () => {
@@ -1312,7 +1316,7 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
         expect(onWire).not.toContain("extra secret");
     });
 
-    it("ServiceWorkerReadonlyWallet with a signing SingleKey downgrades to legacy { publicKey }", async () => {
+    it("ServiceWorkerReadonlyWallet with a signing SingleKey downgrades to readonly-single-key", async () => {
         const { serviceWorker } = setup();
         const identity = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
         const expectedPubKey = hex.encode(await identity.compressedPublicKey());
@@ -1325,7 +1329,10 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
         });
 
         const wallet = getInitConfigWallet(serviceWorker);
-        expect(wallet).toEqual({ publicKey: expectedPubKey });
+        expect(wallet).toEqual({
+            type: "readonly-single-key",
+            publicKey: expectedPubKey,
+        });
         expect(JSON.stringify(wallet)).not.toContain(TEST_PRIVATE_KEY_HEX);
     });
 

--- a/test/serviceWorker/worker.test.ts
+++ b/test/serviceWorker/worker.test.ts
@@ -15,6 +15,7 @@ import {
     ReadonlyDescriptorIdentity,
 } from "../../src";
 import { Wallet, ReadonlyWallet } from "../../src/wallet/wallet";
+import { serializeSigningIdentity } from "../../src/identity/serialize";
 import { mnemonicToSeedSync } from "@scure/bip39";
 import { hex } from "@scure/base";
 
@@ -511,8 +512,15 @@ describe("Worker buildServices identity hydration", () => {
             const identity = walletCreateSpy.mock.calls[0][0]
                 .identity as MnemonicIdentity;
             expect(identity).toBeInstanceOf(MnemonicIdentity);
-            expect(identity.mnemonic).toBe(TEST_MNEMONIC);
-            expect(identity.passphrase).toBe(passphrase);
+            // Mnemonic + passphrase are kept off the public instance surface
+            // (Appendix A). Verify retention by re-serializing and comparing
+            // the envelope.
+            expect(serializeSigningIdentity(identity)).toEqual({
+                type: "mnemonic",
+                mnemonic: TEST_MNEMONIC,
+                descriptor: reference.descriptor,
+                passphrase,
+            });
         });
 
         it("hydrates readonly-descriptor into a ReadonlyDescriptorIdentity", async () => {

--- a/test/serviceWorker/worker.test.ts
+++ b/test/serviceWorker/worker.test.ts
@@ -8,7 +8,15 @@ import {
 import {
     InMemoryContractRepository,
     InMemoryWalletRepository,
+    SingleKey,
+    ReadonlySingleKey,
+    SeedIdentity,
+    MnemonicIdentity,
+    ReadonlyDescriptorIdentity,
 } from "../../src";
+import { Wallet, ReadonlyWallet } from "../../src/wallet/wallet";
+import { mnemonicToSeedSync } from "@scure/bip39";
+import { hex } from "@scure/base";
 
 type TestUpdater = MessageHandler<RequestEnvelope, ResponseEnvelope>;
 
@@ -362,6 +370,162 @@ describe("Worker", () => {
             tag: "wallet",
             id: "broadcast",
             broadcast: true,
+        });
+    });
+});
+
+describe("Worker buildServices identity hydration", () => {
+    let selfMock: SelfMock;
+    let listeners: Map<string, ((event: any) => void)[]>;
+    let walletCreateSpy: ReturnType<typeof vi.spyOn>;
+    let readonlyCreateSpy: ReturnType<typeof vi.spyOn>;
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    const TEST_MNEMONIC =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const TEST_PRIVATE_KEY_HEX =
+        "153cd1982d6704b26da1a4a91baee0c27aeb7ada019adec2ea2ce5c4e717f99c";
+
+    const arkServer = {
+        url: "https://ark.example.test",
+        publicKey: "arkServerPublicKey",
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        ({ selfMock, listeners } = createSelfMock());
+        vi.stubGlobal("self", selfMock as any);
+        walletCreateSpy = vi
+            .spyOn(Wallet, "create")
+            .mockResolvedValue({ kind: "wallet-stub" } as any);
+        readonlyCreateSpy = vi
+            .spyOn(ReadonlyWallet, "create")
+            .mockResolvedValue({ kind: "readonly-stub" } as any);
+        // Silence the one-shot deprecation warning from the legacy adapter so
+        // it doesn't pollute test output.
+        warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        walletCreateSpy.mockRestore();
+        readonlyCreateSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
+
+    const startBusAndInit = async (walletConfig: unknown) => {
+        const sw = new MessageBus(
+            new InMemoryWalletRepository(),
+            new InMemoryContractRepository(),
+            { messageHandlers: [] }
+        );
+        await sw.start();
+        const source = { postMessage: vi.fn() };
+        const messageHandlers = listeners.get("message") || [];
+        expect(messageHandlers.length).toBeGreaterThan(0);
+        await messageHandlers[0]({
+            data: {
+                tag: "INITIALIZE_MESSAGE_BUS",
+                id: "init",
+                config: { wallet: walletConfig, arkServer },
+            },
+            source,
+        });
+    };
+
+    describe("legacy shapes (old page → new worker)", () => {
+        it("builds a Wallet with SingleKey from legacy { privateKey }", async () => {
+            await startBusAndInit({ privateKey: TEST_PRIVATE_KEY_HEX });
+            expect(walletCreateSpy).toHaveBeenCalledOnce();
+            expect(readonlyCreateSpy).not.toHaveBeenCalled();
+            const identity = walletCreateSpy.mock.calls[0][0].identity;
+            expect(identity).toBeInstanceOf(SingleKey);
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringMatching(/\[ts-sdk\].*legacy/i)
+            );
+        });
+
+        it("builds a ReadonlyWallet with ReadonlySingleKey from legacy { publicKey }", async () => {
+            const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+            const publicKey = hex.encode(await signing.compressedPublicKey());
+            await startBusAndInit({ publicKey });
+            expect(readonlyCreateSpy).toHaveBeenCalledOnce();
+            expect(walletCreateSpy).not.toHaveBeenCalled();
+            const identity = readonlyCreateSpy.mock.calls[0][0].identity;
+            expect(identity).toBeInstanceOf(ReadonlySingleKey);
+        });
+    });
+
+    describe("tagged envelopes (new page → new worker)", () => {
+        it("hydrates single-key into a SingleKey", async () => {
+            await startBusAndInit({
+                type: "single-key",
+                privateKey: TEST_PRIVATE_KEY_HEX,
+            });
+            expect(walletCreateSpy).toHaveBeenCalledOnce();
+            const identity = walletCreateSpy.mock.calls[0][0].identity;
+            expect(identity).toBeInstanceOf(SingleKey);
+            expect(warnSpy).not.toHaveBeenCalledWith(
+                expect.stringMatching(/\[ts-sdk\].*legacy/i)
+            );
+        });
+
+        it("hydrates readonly-single-key into a ReadonlySingleKey", async () => {
+            const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+            const publicKey = hex.encode(await signing.compressedPublicKey());
+            await startBusAndInit({ type: "readonly-single-key", publicKey });
+            expect(readonlyCreateSpy).toHaveBeenCalledOnce();
+            const identity = readonlyCreateSpy.mock.calls[0][0].identity;
+            expect(identity).toBeInstanceOf(ReadonlySingleKey);
+        });
+
+        it("hydrates seed into a SeedIdentity", async () => {
+            const seed = mnemonicToSeedSync(TEST_MNEMONIC);
+            const reference = SeedIdentity.fromSeed(seed, { isMainnet: true });
+            await startBusAndInit({
+                type: "seed",
+                seed: hex.encode(seed),
+                descriptor: reference.descriptor,
+            });
+            expect(walletCreateSpy).toHaveBeenCalledOnce();
+            const identity = walletCreateSpy.mock.calls[0][0].identity;
+            expect(identity).toBeInstanceOf(SeedIdentity);
+            expect((identity as SeedIdentity).descriptor).toBe(
+                reference.descriptor
+            );
+        });
+
+        it("hydrates mnemonic into a MnemonicIdentity with preserved passphrase", async () => {
+            const passphrase = "extra secret";
+            const reference = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+                isMainnet: true,
+                passphrase,
+            });
+            await startBusAndInit({
+                type: "mnemonic",
+                mnemonic: TEST_MNEMONIC,
+                descriptor: reference.descriptor,
+                passphrase,
+            });
+            expect(walletCreateSpy).toHaveBeenCalledOnce();
+            const identity = walletCreateSpy.mock.calls[0][0]
+                .identity as MnemonicIdentity;
+            expect(identity).toBeInstanceOf(MnemonicIdentity);
+            expect(identity.mnemonic).toBe(TEST_MNEMONIC);
+            expect(identity.passphrase).toBe(passphrase);
+        });
+
+        it("hydrates readonly-descriptor into a ReadonlyDescriptorIdentity", async () => {
+            const reference = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+                isMainnet: true,
+            });
+            await startBusAndInit({
+                type: "readonly-descriptor",
+                descriptor: reference.descriptor,
+            });
+            expect(readonlyCreateSpy).toHaveBeenCalledOnce();
+            const identity = readonlyCreateSpy.mock.calls[0][0].identity;
+            expect(identity).toBeInstanceOf(ReadonlyDescriptorIdentity);
         });
     });
 });


### PR DESCRIPTION
Addresses https://github.com/arkade-os/ts-sdk/pull/446 by implementing *Option 2* while:
- avoids breaking changes
- doesn't expose secrets

This does not mean “every possible third-party custom Identity now works.” they will be part of future improvements. This PR focuses on HD wallets support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added identity serialization and deserialization capabilities for wallet configuration and persistence.
  * Enhanced support for modern tagged identity envelope formats.

* **Improvements**
  * Strengthened security handling of sensitive identity data.
  * Maintained backward compatibility with legacy wallet configurations.

* **Documentation**
  * Updated wallet initialization guide with serialization examples and wire-format specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->