### PR TITLE
fix: handle fees in vtxo-manager

### DIFF
--- a/src/wallet/ramps.ts
+++ b/src/wallet/ramps.ts
@@ -174,7 +174,7 @@ export class Ramps {
                 weight: 0,
                 birth: vtxo.createdAt,
                 expiry: vtxo.virtualStatus.batchExpiry
-                    ? new Date(vtxo.virtualStatus.batchExpiry * 1000)
+                    ? new Date(vtxo.virtualStatus.batchExpiry)
                     : undefined,
             });
             if (inputFee.satoshis >= vtxo.value) {

--- a/src/wallet/vtxo-manager.ts
+++ b/src/wallet/vtxo-manager.ts
@@ -1372,10 +1372,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 weight: 0,
                 birth: v.createdAt,
                 expiry: v.virtualStatus.batchExpiry
-                    ? new Date(v.virtualStatus.batchExpiry * 1000)
-                    : new Date(),
+                    ? new Date(v.virtualStatus.batchExpiry)
+                    : undefined,
             });
-            if (inputFee.value >= BigInt(v.value)) {
+            if (inputFee.satoshis >= v.value) {
                 continue;
             }
             filteredVtxos.push(v);

--- a/src/wallet/vtxo-manager.ts
+++ b/src/wallet/vtxo-manager.ts
@@ -8,13 +8,15 @@ import {
     isSpendable,
     isSubdust,
 } from ".";
-import { SettlementEvent } from "../providers/ark";
+import { ArkProvider, SettlementEvent } from "../providers/ark";
 import { hasBoardingTxExpired } from "../utils/arkTransaction";
 import { CSVMultisigTapscript } from "../script/tapscript";
 import { hex } from "@scure/base";
 import { getSequence } from "../script/base";
 import { Transaction } from "../utils/transaction";
 import { TxWeightEstimator } from "../utils/txSizeEstimator";
+import { Estimator } from "../arkfee";
+import { ArkAddress } from "../script/address";
 import type { OnchainProvider } from "../providers/onchain";
 import type { Network } from "../networks";
 import type { DefaultVtxo } from "../script/default";
@@ -26,6 +28,7 @@ import type { DefaultVtxo } from "../script/default";
 interface SweepCapableWallet extends IReadonlyWallet {
     boardingTapscript: DefaultVtxo.Script;
     onchainProvider: OnchainProvider;
+    arkProvider: ArkProvider;
     network: Network;
 }
 
@@ -41,6 +44,7 @@ function isSweepCapable(
     return (
         "boardingTapscript" in wallet &&
         "onchainProvider" in wallet &&
+        "arkProvider" in wallet &&
         "network" in wallet
     );
 }
@@ -56,7 +60,7 @@ function assertSweepCapable(
 ): asserts wallet is IWallet & SweepCapableWallet {
     if (!isSweepCapable(wallet)) {
         throw new Error(
-            "Boarding UTXO sweep requires a Wallet instance with boardingTapscript, onchainProvider, and network"
+            "Boarding UTXO sweep requires a Wallet instance with boardingTapscript, onchainProvider, arkProvider, and network"
         );
     }
 }
@@ -1016,6 +1020,11 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         return this.getSweepWallet().onchainProvider;
     }
 
+    /** Returns the Ark provider for intent fee and server info lookups. */
+    private getArkProvider() {
+        return this.getSweepWallet().arkProvider;
+    }
+
     /** Returns the Bitcoin network configuration from the wallet. */
     private getNetwork() {
         return this.getSweepWallet().network;
@@ -1331,19 +1340,63 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         }
 
         const dustAmount = getDustAmount(this.wallet);
-        const boardingTotal = unsettledBoarding.reduce(
-            (sum, u) => sum + BigInt(u.value),
-            0n
-        );
-        const vtxoTotal = expiringVtxos.reduce(
-            (sum, v) => sum + BigInt(v.value),
-            0n
-        );
-        const totalAmount = boardingTotal + vtxoTotal;
-        if (totalAmount < dustAmount) return;
+
+        // Fetch server intent-fee config so each input/output can be priced.
+        // Without this, settle sends `outputAmount = sum(inputs)` and the
+        // server rejects with INTENT_INSUFFICIENT_FEE whenever the operator
+        // charges non-zero intent fees.
+        const { fees } = await this.getArkProvider().getInfo();
+        const estimator = new Estimator(fees.intentFee);
+
+        let totalAmount = 0n;
+
+        const filteredBoarding: ExtendedCoin[] = [];
+        for (const u of unsettledBoarding) {
+            const inputFee = estimator.evalOnchainInput({
+                amount: BigInt(u.value),
+            });
+            if (inputFee.value >= BigInt(u.value)) {
+                // Fee exceeds input value — including it would drain the output.
+                continue;
+            }
+            filteredBoarding.push(u);
+            totalAmount += BigInt(u.value) - BigInt(inputFee.satoshis);
+        }
+
+        const filteredVtxos: ExtendedVirtualCoin[] = [];
+        for (const v of expiringVtxos) {
+            const inputFee = estimator.evalOffchainInput({
+                amount: BigInt(v.value),
+                type:
+                    v.virtualStatus.state === "swept" ? "recoverable" : "vtxo",
+                weight: 0,
+                birth: v.createdAt,
+                expiry: v.virtualStatus.batchExpiry
+                    ? new Date(v.virtualStatus.batchExpiry * 1000)
+                    : new Date(),
+            });
+            if (inputFee.value >= BigInt(v.value)) {
+                continue;
+            }
+            filteredVtxos.push(v);
+            totalAmount += BigInt(v.value) - BigInt(inputFee.satoshis);
+        }
+
+        if (filteredBoarding.length === 0 && filteredVtxos.length === 0) {
+            return;
+        }
 
         const arkAddress = await this.wallet.getAddress();
-        const includesVtxos = expiringVtxos.length > 0;
+
+        const outputFee = estimator.evalOffchainOutput({
+            amount: totalAmount,
+            script: hex.encode(ArkAddress.decode(arkAddress).pkScript),
+        });
+        totalAmount -= BigInt(outputFee.satoshis);
+
+        if (totalAmount < dustAmount) return;
+
+        const includesVtxos = filteredVtxos.length > 0;
 
         // Block the event-driven renewal path while this settle is in flight
         // when VTXOs are part of the intent. Mirrors renewVtxos()'s guard so
@@ -1357,12 +1410,12 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         try {
             try {
                 await this.wallet.settle({
-                    inputs: [...unsettledBoarding, ...expiringVtxos],
+                    inputs: [...filteredBoarding, ...filteredVtxos],
                     outputs: [{ address: arkAddress, amount: totalAmount }],
                 });
 
                 // Mark boarding inputs as known only after successful settle.
-                for (const u of unsettledBoarding) {
+                for (const u of filteredBoarding) {
                     this.knownBoardingUtxos.add(`${u.txid}:${u.vout}`);
                 }
                 success = true;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1491,10 +1491,10 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                     weight: 0,
                     birth: vtxo.createdAt,
                     expiry: vtxo.virtualStatus.batchExpiry
-                        ? new Date(vtxo.virtualStatus.batchExpiry * 1000)
-                        : new Date(),
+                        ? new Date(vtxo.virtualStatus.batchExpiry)
+                        : undefined,
                 });
-                if (inputFee.value >= vtxo.value) {
+                if (inputFee.satoshis >= vtxo.value) {
                     // skip if fees are greater than the virtual output value
                     continue;
                 }

--- a/test/vtxo-manager.test.ts
+++ b/test/vtxo-manager.test.ts
@@ -26,7 +26,7 @@ type MockWalletOptions = {
 // Mock wallet implementation
 const createMockWallet = (
     vtxos: ExtendedVirtualCoin[] = [],
-    arkAddress = "arkade1test",
+    arkAddress = "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
     options: MockWalletOptions = {}
 ): IWallet => {
     const contractManager = options.contractManager ?? {
@@ -342,7 +342,11 @@ describe("VtxoManager - Lifecycle", () => {
         const contractManager = {
             onContractEvent: vi.fn().mockReturnValue(unsubscribe),
         };
-        const wallet = createMockWallet([], "arkade1test", { contractManager });
+        const wallet = createMockWallet(
+            [],
+            "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
+            { contractManager }
+        );
 
         new VtxoManager(wallet, undefined, {});
         await flushMicrotasks();
@@ -355,7 +359,11 @@ describe("VtxoManager - Lifecycle", () => {
         const contractManager = {
             onContractEvent: vi.fn().mockReturnValue(() => {}),
         };
-        const wallet = createMockWallet([], "arkade1test", { contractManager });
+        const wallet = createMockWallet(
+            [],
+            "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
+            { contractManager }
+        );
 
         new VtxoManager(wallet, undefined, false);
         await flushMicrotasks();
@@ -369,7 +377,11 @@ describe("VtxoManager - Lifecycle", () => {
         const contractManager = {
             onContractEvent: vi.fn().mockReturnValue(unsubscribe),
         };
-        const wallet = createMockWallet([], "arkade1test", { contractManager });
+        const wallet = createMockWallet(
+            [],
+            "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
+            { contractManager }
+        );
         const manager = new VtxoManager(wallet, undefined, {});
 
         await flushMicrotasks();
@@ -1224,7 +1236,11 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
 
         return {
             getVtxos: vi.fn().mockResolvedValue([]),
-            getAddress: vi.fn().mockResolvedValue("arkade1test"),
+            getAddress: vi
+                .fn()
+                .mockResolvedValue(
+                    "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g"
+                ),
             getDelegatorManager: vi.fn().mockResolvedValue(undefined),
             getContractManager: vi.fn().mockResolvedValue(contractManager),
             settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -1251,6 +1267,9 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
                     time: Math.floor(Date.now() / 1000),
                     hash: "0".repeat(64),
                 }),
+            },
+            arkProvider: {
+                getInfo: vi.fn().mockResolvedValue({ fees: { intentFee: {} } }),
             },
             network: {
                 bech32: "bcrt",
@@ -1395,7 +1414,11 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
             // A minimal IWallet that lacks boardingTapscript/onchainProvider/network
             const minimalWallet = {
                 getVtxos: vi.fn().mockResolvedValue([]),
-                getAddress: vi.fn().mockResolvedValue("arkade1test"),
+                getAddress: vi
+                    .fn()
+                    .mockResolvedValue(
+                        "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g"
+                    ),
                 getDelegatorManager: vi.fn().mockResolvedValue(undefined),
                 getContractManager: vi.fn().mockResolvedValue({
                     onContractEvent: vi.fn().mockReturnValue(() => {}),
@@ -1447,7 +1470,11 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
 
             return {
                 getVtxos: vi.fn().mockResolvedValue([]),
-                getAddress: vi.fn().mockResolvedValue("arkade1test"),
+                getAddress: vi
+                    .fn()
+                    .mockResolvedValue(
+                        "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g"
+                    ),
                 getDelegatorManager: vi.fn().mockResolvedValue(undefined),
                 getContractManager: vi.fn().mockResolvedValue(contractManager),
                 settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -1476,6 +1503,11 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
                         time: Math.floor(Date.now() / 1000),
                         hash: "0".repeat(64),
                     }),
+                },
+                arkProvider: {
+                    getInfo: vi
+                        .fn()
+                        .mockResolvedValue({ fees: { intentFee: {} } }),
                 },
                 network: {
                     bech32: "bcrt",
@@ -1757,7 +1789,11 @@ describe("VtxoManager - Periodic settle cooldown", () => {
         };
         return {
             getVtxos: vi.fn().mockResolvedValue([]),
-            getAddress: vi.fn().mockResolvedValue("arkade1test"),
+            getAddress: vi
+                .fn()
+                .mockResolvedValue(
+                    "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g"
+                ),
             getDelegatorManager: vi.fn().mockResolvedValue(undefined),
             getContractManager: vi.fn().mockResolvedValue(contractManager),
             settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -1775,6 +1811,9 @@ describe("VtxoManager - Periodic settle cooldown", () => {
                     time: Math.floor(Date.now() / 1000),
                     hash: "0".repeat(64),
                 }),
+            },
+            arkProvider: {
+                getInfo: vi.fn().mockResolvedValue({ fees: { intentFee: {} } }),
             },
             network: {
                 bech32: "bcrt",
@@ -2043,7 +2082,11 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
         };
         return {
             getVtxos: vi.fn().mockResolvedValue(vtxos),
-            getAddress: vi.fn().mockResolvedValue("arkade1test"),
+            getAddress: vi
+                .fn()
+                .mockResolvedValue(
+                    "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g"
+                ),
             getDelegatorManager: vi.fn().mockResolvedValue(undefined),
             getContractManager: vi.fn().mockResolvedValue(contractManager),
             settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -2061,6 +2104,9 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
                     time: Math.floor(Date.now() / 1000),
                     hash: "0".repeat(64),
                 }),
+            },
+            arkProvider: {
+                getInfo: vi.fn().mockResolvedValue({ fees: { intentFee: {} } }),
             },
             network: {
                 bech32: "bcrt",
@@ -2127,6 +2173,57 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
         // Output amount is the sum of both inputs.
         expect(call.outputs).toHaveLength(1);
         expect(call.outputs[0].amount).toBe(15_000n);
+    });
+
+    it("subtracts the server intent fee from the output so settle is not rejected with INTENT_INSUFFICIENT_FEE", async () => {
+        const boarding = makeUnexpiredUtxo(10_000);
+        const wallet = buildWallet([boarding], []);
+        // Server charges 200 sats per onchain input and 50 sats per offchain output.
+        (wallet.arkProvider.getInfo as any).mockResolvedValue({
+            fees: {
+                intentFee: {
+                    onchainInput: "200.0",
+                    offchainOutput: "50.0",
+                },
+            },
+        });
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle([boarding]);
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+        const call = (wallet.settle as any).mock.calls[0][0];
+        expect(call.inputs).toEqual([boarding]);
+        // 10_000 boarding - 200 input fee - 50 output fee = 9_750
+        expect(call.outputs[0].amount).toBe(9_750n);
+    });
+
+    it("skips a boarding UTXO whose onchain intent fee is greater than its value", async () => {
+        const tiny = makeUnexpiredUtxo(100);
+        const normal = makeUnexpiredUtxo(10_000, 1);
+        const wallet = buildWallet([tiny, normal], []);
+        (wallet.arkProvider.getInfo as any).mockResolvedValue({
+            fees: { intentFee: { onchainInput: "200.0" } },
+        });
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle([tiny, normal]);
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+        const call = (wallet.settle as any).mock.calls[0][0];
+        // Tiny boarding UTXO is dropped (fee 200 >= value 100); only the 10k one settles.
+        expect(call.inputs).toEqual([normal]);
+        expect(call.outputs[0].amount).toBe(10_000n - 200n);
     });
 
     it("settles VTXOs alone when no unsettled boarding UTXOs are present", async () => {
@@ -2248,7 +2345,11 @@ describe("VtxoManager - Cross-instance poll guard", () => {
         };
         return {
             getVtxos: vi.fn().mockResolvedValue([]),
-            getAddress: vi.fn().mockResolvedValue("arkade1test"),
+            getAddress: vi
+                .fn()
+                .mockResolvedValue(
+                    "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g"
+                ),
             getDelegatorManager: vi.fn().mockResolvedValue(undefined),
             getContractManager: vi.fn().mockResolvedValue(contractManager),
             settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -2266,6 +2367,9 @@ describe("VtxoManager - Cross-instance poll guard", () => {
                     time: Math.floor(Date.now() / 1000),
                     hash: "0".repeat(64),
                 }),
+            },
+            arkProvider: {
+                getInfo: vi.fn().mockResolvedValue({ fees: { intentFee: {} } }),
             },
             network: {
                 bech32: "bcrt",
@@ -2385,7 +2489,11 @@ describe("VtxoManager - VTXO_ALREADY_SPENT reconciliation", () => {
         return {
             wallet: {
                 getVtxos: vi.fn().mockResolvedValue(vtxos),
-                getAddress: vi.fn().mockResolvedValue("arkade1test"),
+                getAddress: vi
+                    .fn()
+                    .mockResolvedValue(
+                        "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g"
+                    ),
                 getDelegatorManager: vi.fn().mockResolvedValue(undefined),
                 getContractManager: vi.fn().mockResolvedValue(contractManager),
                 settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -2403,6 +2511,11 @@ describe("VtxoManager - VTXO_ALREADY_SPENT reconciliation", () => {
                         time: Math.floor(Date.now() / 1000),
                         hash: "0".repeat(64),
                     }),
+                },
+                arkProvider: {
+                    getInfo: vi
+                        .fn()
+                        .mockResolvedValue({ fees: { intentFee: {} } }),
                 },
                 network: {
                     bech32: "bcrt",


### PR DESCRIPTION
* handle intent fees in vtxo manager
* skip non economical input (fees greater than amount) <- TODO handle this gracefuly by sending notification ?

@Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settlement fee calculation to filter out inputs where onchain fees exceed their value.
  * Enhanced fee handling to properly account for server-provided intent fees and output fees in settlement logic.
  * Added dust checks to prevent uneconomical transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->