### PR TITLE
feat(providers): electrum onchain provider (production-ready, supersedes #359)

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
         "@scure/base": "2.0.0",
         "@scure/bip39": "2.0.1",
         "@scure/btc-signer": "2.0.1",
-        "bip68": "1.0.4"
+        "bip68": "1.0.4",
+        "ws-electrumx-client": "^1.0.5"
     },
     "devDependencies": {
         "@types/better-sqlite3": "7.6.13",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
         "@scure/bip39": "2.0.1",
         "@scure/btc-signer": "2.0.1",
         "bip68": "1.0.4",
-        "ws-electrumx-client": "^1.0.5"
+        "ws-electrumx-client": "1.0.5"
     },
     "devDependencies": {
         "@types/better-sqlite3": "7.6.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       expo-task-manager:
         specifier: ~14.0.9
         version: 14.0.9(expo@54.0.33(@babel/core@7.29.0)(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))
+      ws-electrumx-client:
+        specifier: ^1.0.5
+        version: 1.0.5
     devDependencies:
       '@types/better-sqlite3':
         specifier: 7.6.13
@@ -2308,6 +2311,11 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -3656,6 +3664,10 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  ws-electrumx-client@1.0.5:
+    resolution: {integrity: sha512-pBjfFqb9j2FBz7NPbnd8r2lOYanEw8ACzfKxOtHCgEGqre5QiTax5XHLVgbsiOvST0vmsHAiMtkJPvsZm77PIQ==}
+    engines: {node: '>=10'}
 
   ws@6.2.3:
     resolution: {integrity: sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==}
@@ -6312,6 +6324,10 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic-ws@5.0.0(ws@8.19.0):
+    dependencies:
+      ws: 8.19.0
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-instrument@5.2.1:
@@ -7861,6 +7877,14 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  ws-electrumx-client@1.0.5:
+    dependencies:
+      isomorphic-ws: 5.0.0(ws@8.19.0)
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   ws@6.2.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         specifier: ~14.0.9
         version: 14.0.9(expo@54.0.33(@babel/core@7.29.0)(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))
       ws-electrumx-client:
-        specifier: ^1.0.5
+        specifier: 1.0.5
         version: 1.0.5
     devDependencies:
       '@types/better-sqlite3':

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,11 @@ import {
     ElectrumOnchainProvider,
     WsElectrumChainSource,
 } from "./providers/electrum";
+import type {
+    TransactionHistory as ElectrumTransactionHistory,
+    BlockHeader as ElectrumBlockHeader,
+    Unspent as ElectrumUnspent,
+} from "./providers/electrum";
 import {
     RestArkProvider,
     ArkProvider,
@@ -466,6 +471,9 @@ export type {
     Output,
     TxNotification,
     ExplorerTransaction,
+    ElectrumTransactionHistory,
+    ElectrumBlockHeader,
+    ElectrumUnspent,
     BatchFinalizationEvent,
     BatchFinalizedEvent,
     BatchFailedEvent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,10 @@ import {
     ExplorerTransaction,
 } from "./providers/onchain";
 import {
+    ElectrumOnchainProvider,
+    WsElectrumChainSource,
+} from "./providers/electrum";
+import {
     RestArkProvider,
     ArkProvider,
     SettlementEvent,
@@ -279,6 +283,8 @@ export {
     // Providers
     ESPLORA_URL,
     EsploraProvider,
+    ElectrumOnchainProvider,
+    WsElectrumChainSource,
     RestArkProvider,
     RestIndexerProvider,
 

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -1,0 +1,213 @@
+import { Address, OutScript, Transaction } from "@scure/btc-signer";
+import { sha256 } from "@scure/btc-signer/utils.js";
+import { hex } from "@scure/base";
+import type { ElectrumWS } from "ws-electrumx-client";
+import type { Network } from "../networks";
+
+const BroadcastTransaction = "blockchain.transaction.broadcast"; // returns txid
+const EstimateFee = "blockchain.estimatefee"; // returns fee rate in sats/kBytes
+const GetBlockHeader = "blockchain.block.header"; // returns block header as hex string
+const GetHistoryMethod = "blockchain.scripthash.get_history";
+const GetTransactionMethod = "blockchain.transaction.get"; // returns hex string
+const SubscribeStatusMethod = "blockchain.scripthash"; // ElectrumWS automatically adds '.subscribe'
+const GetRelayFeeMethod = "blockchain.relayfee";
+const ListUnspentMethod = "blockchain.scripthash.listunspent";
+
+const MISSING_TRANSACTION = "missingtransaction";
+const MAX_FETCH_TRANSACTIONS_ATTEMPTS = 5;
+
+export type TransactionHistory = {
+    tx_hash: string;
+    height: number;
+};
+
+export type BlockHeader = {
+    height: number;
+    hex: string;
+};
+
+export type Unspent = {
+    txid: string;
+    vout: number;
+    witnessUtxo: {
+        script: Uint8Array;
+        value: bigint;
+    };
+};
+
+type UnspentElectrum = {
+    height: number;
+    tx_pos: number;
+    tx_hash: string;
+};
+
+/**
+ * WebSocket-based Electrum chain source using ws-electrumx-client.
+ * Provides methods for querying transaction history, fetching transactions,
+ * subscribing to script status updates, and broadcasting transactions.
+ *
+ * @example
+ * ```typescript
+ * import { ElectrumWS } from "ws-electrumx-client";
+ * import { WsElectrumChainSource } from "./providers/electrum";
+ * import { networks } from "./networks";
+ *
+ * const ws = new ElectrumWS("wss://electrum.blockstream.info:50004");
+ * const chain = new WsElectrumChainSource(ws, networks.bitcoin);
+ *
+ * const history = await chain.fetchHistories([script]);
+ * await chain.close();
+ * ```
+ */
+export class WsElectrumChainSource {
+    constructor(
+        private ws: ElectrumWS,
+        private network: Network
+    ) {}
+
+    async fetchTransactions(
+        txids: string[]
+    ): Promise<{ txID: string; hex: string }[]> {
+        const requests = txids.map((txid) => ({
+            method: GetTransactionMethod,
+            params: [txid],
+        }));
+        for (let i = 0; i < MAX_FETCH_TRANSACTIONS_ATTEMPTS; i++) {
+            try {
+                const responses = await this.ws.batchRequest<string[]>(
+                    ...requests
+                );
+                return responses.map((hexStr, i) => ({
+                    txID: txids[i],
+                    hex: hexStr,
+                }));
+            } catch (e) {
+                const msg =
+                    e instanceof Error ? e.message : String(e);
+                if (msg.toLowerCase().includes(MISSING_TRANSACTION)) {
+                    console.warn("missing transaction error, retrying");
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                    continue;
+                }
+                throw e;
+            }
+        }
+        throw new Error("Unable to fetch transactions: " + txids);
+    }
+
+    async unsubscribeScriptStatus(script: Uint8Array): Promise<void> {
+        await this.ws
+            .unsubscribe(SubscribeStatusMethod, toScriptHash(script))
+            .catch(() => {});
+    }
+
+    async subscribeScriptStatus(
+        script: Uint8Array,
+        callback: (scripthash: string, status: string | null) => void
+    ): Promise<void> {
+        const scriptHash = toScriptHash(script);
+        await this.ws.subscribe(
+            SubscribeStatusMethod,
+            (scripthash: unknown, status: unknown) => {
+                if (scripthash === scriptHash) {
+                    callback(scripthash as string, status as string | null);
+                }
+            },
+            scriptHash
+        );
+    }
+
+    async fetchHistories(
+        scripts: Uint8Array[]
+    ): Promise<TransactionHistory[][]> {
+        const scriptsHashes = scripts.map((s) => toScriptHash(s));
+        const responses = await this.ws.batchRequest<TransactionHistory[][]>(
+            ...scriptsHashes.map((s) => ({
+                method: GetHistoryMethod,
+                params: [s],
+            }))
+        );
+        return responses;
+    }
+
+    async fetchBlockHeaders(heights: number[]): Promise<BlockHeader[]> {
+        const responses = await this.ws.batchRequest<string[]>(
+            ...heights.map((h) => ({ method: GetBlockHeader, params: [h] }))
+        );
+        return responses.map((hexStr, i) => ({
+            height: heights[i],
+            hex: hexStr,
+        }));
+    }
+
+    async estimateFees(targetNumberBlocks: number): Promise<number> {
+        const feeRate = await this.ws.request<number>(
+            EstimateFee,
+            targetNumberBlocks
+        );
+        return feeRate;
+    }
+
+    async broadcastTransaction(txHex: string): Promise<string> {
+        return this.ws.request<string>(BroadcastTransaction, txHex);
+    }
+
+    async getRelayFee(): Promise<number> {
+        return this.ws.request<number>(GetRelayFeeMethod);
+    }
+
+    async close(): Promise<void> {
+        try {
+            await this.ws.close("close");
+        } catch (e) {
+            console.debug("error closing ws:", e);
+        }
+    }
+
+    waitForAddressReceivesTx(addr: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const script = OutScript.encode(Address(this.network).decode(addr));
+            this.subscribeScriptStatus(script, (_, status) => {
+                if (status !== null) {
+                    resolve();
+                }
+            }).catch(reject);
+        });
+    }
+
+    async listUnspents(addr: string): Promise<Unspent[]> {
+        const script = OutScript.encode(Address(this.network).decode(addr));
+        const scriptHash = toScriptHash(script);
+        const unspentsFromElectrum = await this.ws.request<UnspentElectrum[]>(
+            ListUnspentMethod,
+            scriptHash
+        );
+        const txs = await this.fetchTransactions(
+            unspentsFromElectrum.map((u) => u.tx_hash)
+        );
+
+        return unspentsFromElectrum.map((u, index) => {
+            const tx = Transaction.fromRaw(hex.decode(txs[index].hex), {
+                allowUnknownOutputs: true,
+            });
+            const output = tx.getOutput(u.tx_pos);
+            if (!output.script || output.amount === undefined) {
+                throw new Error(
+                    `Missing output data for ${u.tx_hash}:${u.tx_pos}`
+                );
+            }
+            return {
+                txid: u.tx_hash,
+                vout: u.tx_pos,
+                witnessUtxo: {
+                    script: output.script,
+                    value: output.amount,
+                },
+            };
+        });
+    }
+}
+
+function toScriptHash(script: Uint8Array): string {
+    return hex.encode(sha256(script).reverse());
+}

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -486,9 +486,7 @@ export class ElectrumOnchainProvider implements OnchainProvider {
 
         // Step 4 (rare): batch-fetch all ambiguous candidate txs at once
         if (ambiguousIndices.length > 0) {
-            const allCandidateTxids = [
-                ...new Set(ambiguousCandidates.flat()),
-            ];
+            const allCandidateTxids = [...new Set(ambiguousCandidates.flat())];
             const fetched =
                 await this.chain.fetchTransactions(allCandidateTxids);
             const txMap = new Map(fetched.map((t) => [t.txID, t.hex]));
@@ -672,6 +670,11 @@ export class ElectrumOnchainProvider implements OnchainProvider {
                 this.chain.unsubscribeScriptStatus(script).catch(() => {});
             }
         };
+    }
+
+    /** Close the underlying WebSocket connection. */
+    async close(): Promise<void> {
+        await this.chain.close();
     }
 }
 

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -56,6 +56,10 @@ type VerboseTransaction = {
     blockhash?: string;
     blocktime?: number;
     time?: number;
+    /** Raw transaction hex. Bitcoin Core's getrawtransaction <tx> 1 always
+     *  includes this; we use it to derive exact satoshi amounts instead of
+     *  multiplying the floating-point `value` field by 1e8. */
+    hex?: string;
     vout: {
         n: number;
         value: number;
@@ -127,6 +131,12 @@ function parseBlockHeader(headerHex: string): {
  * ```
  */
 export class WsElectrumChainSource {
+    // Cached chain tip kept fresh by the headers subscription. Initialized
+    // lazily on first call to subscribeHeaders().
+    private cachedTip: HeaderSubscribeResult | null = null;
+    private headersSubscribePromise: Promise<HeaderSubscribeResult> | null =
+        null;
+
     constructor(
         private ws: ElectrumWS,
         private network: Network
@@ -238,10 +248,47 @@ export class WsElectrumChainSource {
         return { height, hex: headerHex };
     }
 
+    /**
+     * Returns the current chain tip and keeps it fresh via a single
+     * server-side subscription. Subsequent calls return the cached tip
+     * (updated by background notifications) without round-tripping to the
+     * server. Previously each call issued `blockchain.headers.subscribe` as
+     * a regular request, leaving a stale subscription on the server every
+     * time — under polling that adds up. ws-electrumx-client deduplicates
+     * `subscribe()` by method+params, so registering once is enough.
+     */
     async subscribeHeaders(): Promise<HeaderSubscribeResult> {
-        return this.ws.request<HeaderSubscribeResult>(
-            SubscribeHeadersMethod + ".subscribe"
+        if (this.cachedTip) return this.cachedTip;
+        if (this.headersSubscribePromise) return this.headersSubscribePromise;
+
+        this.headersSubscribePromise = new Promise<HeaderSubscribeResult>(
+            (resolve, reject) => {
+                let resolved = false;
+                this.ws
+                    .subscribe(SubscribeHeadersMethod, (header: unknown) => {
+                        if (!isHeaderSubscribeResult(header)) return;
+                        this.cachedTip = header;
+                        if (!resolved) {
+                            resolved = true;
+                            resolve(header);
+                        }
+                    })
+                    .catch((err) => {
+                        if (!resolved) {
+                            resolved = true;
+                            reject(err);
+                        }
+                    });
+            }
         );
+
+        try {
+            return await this.headersSubscribePromise;
+        } catch (err) {
+            // Allow the next call to retry from scratch.
+            this.headersSubscribePromise = null;
+            throw err;
+        }
     }
 
     async estimateFees(targetNumberBlocks: number): Promise<number> {
@@ -351,7 +398,7 @@ export class ElectrumOnchainProvider implements OnchainProvider {
     }
 
     async getCoins(address: string): Promise<Coin[]> {
-        const script = OutScript.encode(Address(this.network).decode(address));
+        const script = this.encodeAddress(address);
         const scriptHash = toScriptHash(script);
         const unspents = await this.ws.request<UnspentElectrum[]>(
             ListUnspentMethod,
@@ -390,7 +437,7 @@ export class ElectrumOnchainProvider implements OnchainProvider {
             await this.chain.broadcastTransaction(txs[0]);
             return this.chain.broadcastTransaction(txs[1]);
         }
-        throw new Error("Only 1 or 1C1P package can be broadcast");
+        throw new Error("Only 1 or 1P1C package can be broadcast");
     }
 
     async getTxOutspends(
@@ -522,7 +569,7 @@ export class ElectrumOnchainProvider implements OnchainProvider {
     }
 
     async getTransactions(address: string): Promise<ExplorerTransaction[]> {
-        const script = OutScript.encode(Address(this.network).decode(address));
+        const script = this.encodeAddress(address);
         const history = await this.chain.fetchHistory(script);
 
         if (history.length === 0) return [];
@@ -530,7 +577,21 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         const txids = history.map((h) => h.tx_hash);
         const verboseTxs = await this.chain.fetchVerboseTransactions(txids);
 
-        return verboseTxs.map((vtx) => ({
+        return verboseTxs.map((vtx) => this.verboseToExplorer(vtx));
+    }
+
+    /**
+     * Map an electrum verbose transaction to the ExplorerTransaction shape.
+     *
+     * Output values are derived from the raw transaction hex when available,
+     * never from the floating-point `value` field returned by the daemon.
+     * That field has 8 decimal places and `Math.round(value * 1e8)` is safe
+     * in the common case but a footgun for protocol-level money handling —
+     * the raw bytes are exact.
+     */
+    private verboseToExplorer(vtx: VerboseTransaction): ExplorerTransaction {
+        const exactValuesByVout = parseExactSats(vtx);
+        return {
             txid: vtx.txid,
             vout: vtx.vout.map((v) => ({
                 scriptpubkey_address:
@@ -538,13 +599,29 @@ export class ElectrumOnchainProvider implements OnchainProvider {
                     v.scriptPubKey.addresses?.[0] ||
                     this.chain.addressForScript(v.scriptPubKey.hex) ||
                     "",
-                value: String(Math.round(v.value * 1e8)),
+                value:
+                    exactValuesByVout?.get(v.n) ??
+                    String(Math.round(v.value * 1e8)),
             })),
             status: {
                 confirmed: vtx.confirmations > 0,
                 block_time: vtx.blocktime || vtx.time || 0,
             },
-        }));
+        };
+    }
+
+    /**
+     * Decode `address` into its scriptPubKey, throwing a clear error if the
+     * input is malformed. @scure/btc-signer raises a generic decode error
+     * which is hard to map back to user input — this wraps it.
+     */
+    private encodeAddress(address: string): Uint8Array {
+        try {
+            return OutScript.encode(Address(this.network).decode(address));
+        } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            throw new Error(`Invalid address ${address}: ${reason}`);
+        }
     }
 
     async getTxStatus(
@@ -590,26 +667,25 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         addresses: string[],
         eventCallback: (txs: ExplorerTransaction[]) => void
     ): Promise<() => void> {
-        const scripts = addresses.map((addr) =>
-            OutScript.encode(Address(this.network).decode(addr))
-        );
+        const scripts = addresses.map((addr) => this.encodeAddress(addr));
         const scriptHashes = scripts.map(toScriptHash);
 
-        // Track known history per script to detect new txs
+        // Track known history per script to detect new txs.
         const knownTxids = new Map<string, Set<string>>();
 
-        // Initialize with current history
-        for (let i = 0; i < scripts.length; i++) {
-            const history = await this.chain.fetchHistory(scripts[i]);
+        // Initialize known-set in parallel — for a wallet watching many
+        // addresses this avoids n sequential round trips on first call.
+        const initialHistories = await Promise.all(
+            scripts.map((s) => this.chain.fetchHistory(s))
+        );
+        initialHistories.forEach((history, i) => {
             knownTxids.set(
                 scriptHashes[i],
                 new Set(history.map((h) => h.tx_hash))
             );
-        }
+        });
 
-        // Subscribe to each script hash
         const handleStatusChange = async (scripthash: string) => {
-            // Find which script this is
             const scriptIndex = scriptHashes.indexOf(scripthash);
             if (scriptIndex === -1) return;
 
@@ -622,49 +698,30 @@ export class ElectrumOnchainProvider implements OnchainProvider {
 
             if (newTxids.length === 0) return;
 
-            // Update known set
             for (const txid of newTxids) {
                 known.add(txid);
             }
             knownTxids.set(scripthash, known);
 
-            // Fetch verbose transactions for new txids
             const verboseTxs =
                 await this.chain.fetchVerboseTransactions(newTxids);
-
-            const explorerTxs: ExplorerTransaction[] = verboseTxs.map(
-                (vtx) => ({
-                    txid: vtx.txid,
-                    vout: vtx.vout.map((v) => ({
-                        scriptpubkey_address:
-                            v.scriptPubKey.address ||
-                            v.scriptPubKey.addresses?.[0] ||
-                            this.chain.addressForScript(v.scriptPubKey.hex) ||
-                            "",
-                        value: String(Math.round(v.value * 1e8)),
-                    })),
-                    status: {
-                        confirmed: vtx.confirmations > 0,
-                        block_time: vtx.blocktime || vtx.time || 0,
-                    },
-                })
-            );
-
-            eventCallback(explorerTxs);
+            eventCallback(verboseTxs.map((vtx) => this.verboseToExplorer(vtx)));
         };
 
-        for (let i = 0; i < scripts.length; i++) {
-            await this.chain.subscribeScriptStatus(
-                scripts[i],
-                (scripthash, status) => {
-                    if (status !== null) {
-                        handleStatusChange(scripthash).catch(console.error);
+        // Register all subscriptions in parallel.
+        await Promise.all(
+            scripts.map((script) =>
+                this.chain.subscribeScriptStatus(
+                    script,
+                    (scripthash, status) => {
+                        if (status !== null) {
+                            handleStatusChange(scripthash).catch(console.error);
+                        }
                     }
-                }
-            );
-        }
+                )
+            )
+        );
 
-        // Return cleanup function
         return () => {
             for (const script of scripts) {
                 this.chain.unsubscribeScriptStatus(script).catch(() => {});
@@ -680,4 +737,34 @@ export class ElectrumOnchainProvider implements OnchainProvider {
 
 function toScriptHash(script: Uint8Array): string {
     return hex.encode(sha256(script).reverse());
+}
+
+function isHeaderSubscribeResult(v: unknown): v is HeaderSubscribeResult {
+    if (typeof v !== "object" || v === null) return false;
+    const obj = v as Record<string, unknown>;
+    return typeof obj.height === "number" && typeof obj.hex === "string";
+}
+
+/**
+ * Decode `vtx.hex` (when the daemon includes it) and return a map of
+ * vout-index → exact sat amount as a base-10 string. Returns `null` if
+ * the hex is missing or unparseable; callers should fall back to the
+ * float-derived value in that case.
+ */
+function parseExactSats(vtx: VerboseTransaction): Map<number, string> | null {
+    if (!vtx.hex) return null;
+    try {
+        const tx = Transaction.fromRaw(hex.decode(vtx.hex), {
+            allowUnknownOutputs: true,
+        });
+        const result = new Map<number, string>();
+        for (let i = 0; i < tx.outputsLength; i++) {
+            const output = tx.getOutput(i);
+            if (output.amount === undefined) continue;
+            result.set(i, output.amount.toString());
+        }
+        return result;
+    } catch {
+        return null;
+    }
 }

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -3,22 +3,30 @@ import { sha256 } from "@scure/btc-signer/utils.js";
 import { hex } from "@scure/base";
 import type { ElectrumWS } from "ws-electrumx-client";
 import type { Network } from "../networks";
+import type { Coin } from "../wallet";
+import type { ExplorerTransaction, OnchainProvider } from "./onchain";
 
-const BroadcastTransaction = "blockchain.transaction.broadcast"; // returns txid
-const EstimateFee = "blockchain.estimatefee"; // returns fee rate in sats/kBytes
-const GetBlockHeader = "blockchain.block.header"; // returns block header as hex string
+// Electrum protocol method names
+const BroadcastTransaction = "blockchain.transaction.broadcast";
+const EstimateFee = "blockchain.estimatefee";
+const GetBlockHeader = "blockchain.block.header";
 const GetHistoryMethod = "blockchain.scripthash.get_history";
-const GetTransactionMethod = "blockchain.transaction.get"; // returns hex string
-const SubscribeStatusMethod = "blockchain.scripthash"; // ElectrumWS automatically adds '.subscribe'
+const GetTransactionMethod = "blockchain.transaction.get";
+const SubscribeStatusMethod = "blockchain.scripthash";
+const SubscribeHeadersMethod = "blockchain.headers";
 const GetRelayFeeMethod = "blockchain.relayfee";
 const ListUnspentMethod = "blockchain.scripthash.listunspent";
 
 const MISSING_TRANSACTION = "missingtransaction";
 const MAX_FETCH_TRANSACTIONS_ATTEMPTS = 5;
 
+// Bitcoin block header is 80 bytes
+const BLOCK_HEADER_SIZE = 80;
+
 export type TransactionHistory = {
     tx_hash: string;
     height: number;
+    fee?: number;
 };
 
 export type BlockHeader = {
@@ -39,12 +47,71 @@ type UnspentElectrum = {
     height: number;
     tx_pos: number;
     tx_hash: string;
+    value: number;
+};
+
+type VerboseTransaction = {
+    txid: string;
+    confirmations: number;
+    blockhash?: string;
+    blocktime?: number;
+    time?: number;
+    vout: {
+        n: number;
+        value: number;
+        scriptPubKey: {
+            addresses?: string[];
+            address?: string;
+            hex: string;
+        };
+    }[];
+    vin: {
+        txid: string;
+        vout: number;
+    }[];
+};
+
+type HeaderSubscribeResult = {
+    height: number;
+    hex: string;
 };
 
 /**
+ * Parse a raw block header (80 bytes hex = 160 chars) to extract fields.
+ * Bitcoin block header layout:
+ *   - version: 4 bytes (LE)
+ *   - prevHash: 32 bytes
+ *   - merkleRoot: 32 bytes
+ *   - timestamp: 4 bytes (LE)
+ *   - bits: 4 bytes
+ *   - nonce: 4 bytes
+ */
+function parseBlockHeader(headerHex: string): {
+    hash: string;
+    timestamp: number;
+} {
+    const headerBytes = hex.decode(headerHex);
+    if (headerBytes.length !== BLOCK_HEADER_SIZE) {
+        throw new Error(
+            `Invalid block header size: ${headerBytes.length}, expected ${BLOCK_HEADER_SIZE}`
+        );
+    }
+
+    // timestamp is at offset 68 (4+32+32), 4 bytes little-endian
+    const view = new DataView(headerBytes.buffer, headerBytes.byteOffset);
+    const timestamp = view.getUint32(68, true);
+
+    // block hash = double SHA256 of header, reversed
+    const hash1 = sha256(headerBytes);
+    const hash2 = sha256(hash1);
+    const hashStr = hex.encode(new Uint8Array(hash2).reverse());
+
+    return { hash: hashStr, timestamp };
+}
+
+/**
  * WebSocket-based Electrum chain source using ws-electrumx-client.
- * Provides methods for querying transaction history, fetching transactions,
- * subscribing to script status updates, and broadcasting transactions.
+ * Provides low-level methods for the Electrum protocol.
  *
  * @example
  * ```typescript
@@ -82,8 +149,7 @@ export class WsElectrumChainSource {
                     hex: hexStr,
                 }));
             } catch (e) {
-                const msg =
-                    e instanceof Error ? e.message : String(e);
+                const msg = e instanceof Error ? e.message : String(e);
                 if (msg.toLowerCase().includes(MISSING_TRANSACTION)) {
                     console.warn("missing transaction error, retrying");
                     await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -93,6 +159,25 @@ export class WsElectrumChainSource {
             }
         }
         throw new Error("Unable to fetch transactions: " + txids);
+    }
+
+    async fetchVerboseTransaction(txid: string): Promise<VerboseTransaction> {
+        return this.ws.request<VerboseTransaction>(
+            GetTransactionMethod,
+            txid,
+            true
+        );
+    }
+
+    async fetchVerboseTransactions(
+        txids: string[]
+    ): Promise<VerboseTransaction[]> {
+        if (txids.length === 0) return [];
+        const requests = txids.map((txid) => ({
+            method: GetTransactionMethod,
+            params: [txid, true],
+        }));
+        return this.ws.batchRequest<VerboseTransaction[]>(...requests);
     }
 
     async unsubscribeScriptStatus(script: Uint8Array): Promise<void> {
@@ -130,6 +215,14 @@ export class WsElectrumChainSource {
         return responses;
     }
 
+    async fetchHistory(script: Uint8Array): Promise<TransactionHistory[]> {
+        const scriptHash = toScriptHash(script);
+        return this.ws.request<TransactionHistory[]>(
+            GetHistoryMethod,
+            scriptHash
+        );
+    }
+
     async fetchBlockHeaders(heights: number[]): Promise<BlockHeader[]> {
         const responses = await this.ws.batchRequest<string[]>(
             ...heights.map((h) => ({ method: GetBlockHeader, params: [h] }))
@@ -138,6 +231,17 @@ export class WsElectrumChainSource {
             height: heights[i],
             hex: hexStr,
         }));
+    }
+
+    async fetchBlockHeader(height: number): Promise<BlockHeader> {
+        const headerHex = await this.ws.request<string>(GetBlockHeader, height);
+        return { height, hex: headerHex };
+    }
+
+    async subscribeHeaders(): Promise<HeaderSubscribeResult> {
+        return this.ws.request<HeaderSubscribeResult>(
+            SubscribeHeadersMethod + ".subscribe"
+        );
     }
 
     async estimateFees(targetNumberBlocks: number): Promise<number> {
@@ -205,6 +309,302 @@ export class WsElectrumChainSource {
                 },
             };
         });
+    }
+
+    /**
+     * Get the address string for a script output, if decodable.
+     */
+    addressForScript(scriptHex: string): string | undefined {
+        try {
+            const script = hex.decode(scriptHex);
+            return Address(this.network).encode(OutScript.decode(script));
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+/**
+ * Electrum-based implementation of the OnchainProvider interface.
+ * Replaces esplora polling with electrum subscriptions where possible.
+ *
+ * @example
+ * ```typescript
+ * import { ElectrumWS } from "ws-electrumx-client";
+ * import { ElectrumOnchainProvider } from "./providers/electrum";
+ * import { networks } from "./networks";
+ *
+ * const ws = new ElectrumWS("wss://electrum.blockstream.info:50004");
+ * const provider = new ElectrumOnchainProvider(ws, networks.bitcoin);
+ *
+ * const coins = await provider.getCoins("bc1q...");
+ * ```
+ */
+export class ElectrumOnchainProvider implements OnchainProvider {
+    private chain: WsElectrumChainSource;
+
+    constructor(
+        private ws: ElectrumWS,
+        private network: Network
+    ) {
+        this.chain = new WsElectrumChainSource(ws, network);
+    }
+
+    async getCoins(address: string): Promise<Coin[]> {
+        const script = OutScript.encode(Address(this.network).decode(address));
+        const scriptHash = toScriptHash(script);
+        const unspents = await this.ws.request<UnspentElectrum[]>(
+            ListUnspentMethod,
+            scriptHash
+        );
+
+        return unspents.map((u) => ({
+            txid: u.tx_hash,
+            vout: u.tx_pos,
+            value: u.value,
+            status: {
+                confirmed: u.height > 0,
+                block_height: u.height > 0 ? u.height : undefined,
+            },
+        }));
+    }
+
+    async getFeeRate(): Promise<number | undefined> {
+        // electrum returns BTC/kB, we need sat/vB
+        // 1 BTC = 100_000_000 sat, 1 kB = 1000 bytes
+        // sat/vB = (BTC/kB) * 100_000_000 / 1000 = (BTC/kB) * 100_000
+        const feePerKb = await this.chain.estimateFees(1);
+        if (feePerKb < 0) {
+            // -1 means the daemon cannot estimate
+            return undefined;
+        }
+        return Math.max(1, Math.ceil(feePerKb * 100_000));
+    }
+
+    async broadcastTransaction(...txs: string[]): Promise<string> {
+        if (txs.length === 1) {
+            return this.chain.broadcastTransaction(txs[0]);
+        }
+        if (txs.length === 2) {
+            // Broadcast parent first, then child (electrum doesn't support package relay)
+            await this.chain.broadcastTransaction(txs[0]);
+            return this.chain.broadcastTransaction(txs[1]);
+        }
+        throw new Error("Only 1 or 1C1P package can be broadcast");
+    }
+
+    async getTxOutspends(
+        txid: string
+    ): Promise<{ spent: boolean; txid: string }[]> {
+        // Get the raw transaction to find its outputs
+        const [txResult] = await this.chain.fetchTransactions([txid]);
+        const tx = Transaction.fromRaw(hex.decode(txResult.hex), {
+            allowUnknownOutputs: true,
+        });
+
+        const results: { spent: boolean; txid: string }[] = [];
+
+        for (let i = 0; i < tx.outputsLength; i++) {
+            const output = tx.getOutput(i);
+            if (!output.script) {
+                results.push({ spent: false, txid: "" });
+                continue;
+            }
+
+            const outScriptHash = toScriptHash(output.script);
+            const history = await this.ws.request<TransactionHistory[]>(
+                GetHistoryMethod,
+                outScriptHash
+            );
+
+            // Find a spending tx: any tx in the history that is NOT the original tx
+            // and spends this output
+            let spentByTxid = "";
+            let isSpent = false;
+
+            for (const entry of history) {
+                if (entry.tx_hash === txid) continue;
+                // Fetch this tx and check if it spends our output
+                const [spenderResult] = await this.chain.fetchTransactions([
+                    entry.tx_hash,
+                ]);
+                const spenderTx = Transaction.fromRaw(
+                    hex.decode(spenderResult.hex),
+                    {
+                        allowUnknownOutputs: true,
+                        allowUnknownInputs: true,
+                    }
+                );
+                for (let j = 0; j < spenderTx.inputsLength; j++) {
+                    const input = spenderTx.getInput(j);
+                    if (
+                        input.txid &&
+                        hex.encode(input.txid) === txid &&
+                        input.index === i
+                    ) {
+                        isSpent = true;
+                        spentByTxid = entry.tx_hash;
+                        break;
+                    }
+                }
+                if (isSpent) break;
+            }
+
+            results.push({ spent: isSpent, txid: spentByTxid });
+        }
+
+        return results;
+    }
+
+    async getTransactions(address: string): Promise<ExplorerTransaction[]> {
+        const script = OutScript.encode(Address(this.network).decode(address));
+        const history = await this.chain.fetchHistory(script);
+
+        if (history.length === 0) return [];
+
+        const txids = history.map((h) => h.tx_hash);
+        const verboseTxs = await this.chain.fetchVerboseTransactions(txids);
+
+        return verboseTxs.map((vtx) => ({
+            txid: vtx.txid,
+            vout: vtx.vout.map((v) => ({
+                scriptpubkey_address:
+                    v.scriptPubKey.address ||
+                    v.scriptPubKey.addresses?.[0] ||
+                    this.chain.addressForScript(v.scriptPubKey.hex) ||
+                    "",
+                value: String(Math.round(v.value * 1e8)),
+            })),
+            status: {
+                confirmed: vtx.confirmations > 0,
+                block_time: vtx.blocktime || vtx.time || 0,
+            },
+        }));
+    }
+
+    async getTxStatus(
+        txid: string
+    ): Promise<
+        | { confirmed: false }
+        | { confirmed: true; blockTime: number; blockHeight: number }
+    > {
+        const vtx = await this.chain.fetchVerboseTransaction(txid);
+        if (vtx.confirmations <= 0) {
+            return { confirmed: false };
+        }
+
+        // Get block height from the verbose tx's blockhash
+        // We need the height, which is confirmations-based:
+        // height = tipHeight - confirmations + 1
+        const tip = await this.chain.subscribeHeaders();
+        const blockHeight = tip.height - vtx.confirmations + 1;
+
+        return {
+            confirmed: true,
+            blockTime: vtx.blocktime || vtx.time || 0,
+            blockHeight,
+        };
+    }
+
+    async getChainTip(): Promise<{
+        height: number;
+        time: number;
+        hash: string;
+    }> {
+        const tip = await this.chain.subscribeHeaders();
+        const { hash, timestamp } = parseBlockHeader(tip.hex);
+
+        return {
+            height: tip.height,
+            time: timestamp,
+            hash,
+        };
+    }
+
+    async watchAddresses(
+        addresses: string[],
+        eventCallback: (txs: ExplorerTransaction[]) => void
+    ): Promise<() => void> {
+        const scripts = addresses.map((addr) =>
+            OutScript.encode(Address(this.network).decode(addr))
+        );
+        const scriptHashes = scripts.map(toScriptHash);
+
+        // Track known history per script to detect new txs
+        const knownTxids = new Map<string, Set<string>>();
+
+        // Initialize with current history
+        for (let i = 0; i < scripts.length; i++) {
+            const history = await this.chain.fetchHistory(scripts[i]);
+            knownTxids.set(
+                scriptHashes[i],
+                new Set(history.map((h) => h.tx_hash))
+            );
+        }
+
+        // Subscribe to each script hash
+        const handleStatusChange = async (scripthash: string) => {
+            // Find which script this is
+            const scriptIndex = scriptHashes.indexOf(scripthash);
+            if (scriptIndex === -1) return;
+
+            const script = scripts[scriptIndex];
+            const history = await this.chain.fetchHistory(script);
+            const known = knownTxids.get(scripthash) || new Set();
+            const newTxids = history
+                .map((h) => h.tx_hash)
+                .filter((txid) => !known.has(txid));
+
+            if (newTxids.length === 0) return;
+
+            // Update known set
+            for (const txid of newTxids) {
+                known.add(txid);
+            }
+            knownTxids.set(scripthash, known);
+
+            // Fetch verbose transactions for new txids
+            const verboseTxs =
+                await this.chain.fetchVerboseTransactions(newTxids);
+
+            const explorerTxs: ExplorerTransaction[] = verboseTxs.map(
+                (vtx) => ({
+                    txid: vtx.txid,
+                    vout: vtx.vout.map((v) => ({
+                        scriptpubkey_address:
+                            v.scriptPubKey.address ||
+                            v.scriptPubKey.addresses?.[0] ||
+                            this.chain.addressForScript(v.scriptPubKey.hex) ||
+                            "",
+                        value: String(Math.round(v.value * 1e8)),
+                    })),
+                    status: {
+                        confirmed: vtx.confirmations > 0,
+                        block_time: vtx.blocktime || vtx.time || 0,
+                    },
+                })
+            );
+
+            eventCallback(explorerTxs);
+        };
+
+        for (let i = 0; i < scripts.length; i++) {
+            await this.chain.subscribeScriptStatus(
+                scripts[i],
+                (scripthash, status) => {
+                    if (status !== null) {
+                        handleStatusChange(scripthash).catch(console.error);
+                    }
+                }
+            );
+        }
+
+        // Return cleanup function
+        return () => {
+            for (const script of scripts) {
+                this.chain.unsubscribeScriptStatus(script).catch(() => {});
+            }
+        };
     }
 }
 

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -8,6 +8,7 @@ import type { ExplorerTransaction, OnchainProvider } from "./onchain";
 
 // Electrum protocol method names
 const BroadcastTransaction = "blockchain.transaction.broadcast";
+const BroadcastPackageMethod = "blockchain.transaction.broadcast_package";
 const EstimateFee = "blockchain.estimatefee";
 const GetBlockHeader = "blockchain.block.header";
 const GetHistoryMethod = "blockchain.scripthash.get_history";
@@ -78,6 +79,18 @@ type VerboseTransaction = {
 type HeaderSubscribeResult = {
     height: number;
     hex: string;
+};
+
+/**
+ * Server response for `blockchain.transaction.broadcast_package` (verbose=false).
+ * `errors` is null/undefined on success and populated when at least one
+ * transaction in the package was rejected by the mempool. The exact error
+ * shape mirrors bitcoind's `submitpackage` RPC and varies across Core
+ * versions.
+ */
+type BroadcastPackageResult = {
+    success: boolean;
+    errors?: Array<Record<string, unknown>> | null;
 };
 
 /**
@@ -303,6 +316,48 @@ export class WsElectrumChainSource {
         return this.ws.request<string>(BroadcastTransaction, txHex);
     }
 
+    /**
+     * Submit a package of raw transactions atomically via Fulcrum's
+     * `blockchain.transaction.broadcast_package` method, the on-the-wire
+     * equivalent of bitcoind's `submitpackage` RPC.
+     *
+     * Required for TRUC (BIP 431) 1P1C relay where the parent has zero
+     * (or below-minfee) fee and depends on the child to pay for both via
+     * CPFP — sequential broadcast cannot work in that case because the
+     * parent would be rejected from the mempool on its own.
+     *
+     * @param txHexes - Topologically sorted raw transactions; child must
+     *                  be the last element. Currently must be a 1P1C pair
+     *                  (length 2). Parents may not depend on each other.
+     * @returns The child transaction id (the last entry in the array),
+     *          computed locally — `broadcast_package` itself returns
+     *          `{success, errors}` rather than a txid.
+     * @throws If the server does not implement `broadcast_package` (e.g.
+     *         ElectrumX, or older Fulcrum, or Fulcrum backed by bitcoind
+     *         < v28.0.0). Callers must surface this clearly to users —
+     *         this method does NOT silently fall back to sequential
+     *         broadcasts because doing so would let TRUC packages fail
+     *         in subtle ways.
+     * @throws If the server returns `success=false`, surfacing the
+     *         underlying mempool rejection in the error message.
+     */
+    async broadcastPackage(txHexes: string[]): Promise<string> {
+        const result = await this.ws.request<BroadcastPackageResult>(
+            BroadcastPackageMethod,
+            txHexes,
+            false
+        );
+        if (!result.success) {
+            const detail = result.errors
+                ? JSON.stringify(result.errors)
+                : "unknown error";
+            throw new Error(`Package broadcast rejected: ${detail}`);
+        }
+        // The child txid is not in the response — derive it from the raw
+        // bytes (double-SHA256 of the serialized tx, reversed).
+        return childTxidFromHex(txHexes[txHexes.length - 1]);
+    }
+
     async getRelayFee(): Promise<number> {
         return this.ws.request<number>(GetRelayFeeMethod);
     }
@@ -428,14 +483,31 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         return Math.max(1, Math.ceil(feePerKb * 100_000));
     }
 
+    /**
+     * Broadcast a single transaction or a TRUC (BIP 431) 1P1C package
+     * atomically.
+     *
+     * **Server requirements for 1P1C packages:** the backing Electrum
+     * server must implement `blockchain.transaction.broadcast_package`
+     * (Fulcrum ≥ 1.10) and be backed by bitcoind ≥ v28.0.0. ElectrumX
+     * does not implement this method. There is **no fallback** to
+     * sequential parent-then-child broadcast: TRUC packages typically
+     * have a zero-fee parent and would be rejected from the mempool on
+     * their own, so a fallback would silently fail in subtle ways.
+     * Callers receiving a "method not found" error here should route
+     * through a different provider for that submission.
+     *
+     * @param txs - One transaction (single broadcast) or two
+     *              topologically-sorted transactions (parent first,
+     *              child last) for 1P1C package relay.
+     * @returns The broadcast txid (or the child txid for 1P1C packages).
+     */
     async broadcastTransaction(...txs: string[]): Promise<string> {
         if (txs.length === 1) {
             return this.chain.broadcastTransaction(txs[0]);
         }
         if (txs.length === 2) {
-            // Broadcast parent first, then child (electrum doesn't support package relay)
-            await this.chain.broadcastTransaction(txs[0]);
-            return this.chain.broadcastTransaction(txs[1]);
+            return this.chain.broadcastPackage(txs);
         }
         throw new Error("Only 1 or 1P1C package can be broadcast");
     }
@@ -743,6 +815,17 @@ function isHeaderSubscribeResult(v: unknown): v is HeaderSubscribeResult {
     if (typeof v !== "object" || v === null) return false;
     const obj = v as Record<string, unknown>;
     return typeof obj.height === "number" && typeof obj.hex === "string";
+}
+
+/**
+ * Compute the txid of a serialized transaction. Bitcoin's txid is the
+ * double-SHA256 of the serialized tx bytes, with the result interpreted
+ * little-endian (i.e. reversed when displayed as hex). `broadcast_package`
+ * does not return the child txid, so we derive it from the raw bytes.
+ */
+function childTxidFromHex(txHex: string): string {
+    const bytes = hex.decode(txHex);
+    return hex.encode(sha256(sha256(bytes)).reverse());
 }
 
 /**

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -741,6 +741,12 @@ export class ElectrumOnchainProvider implements OnchainProvider {
     ): Promise<() => void> {
         const scripts = addresses.map((addr) => this.encodeAddress(addr));
         const scriptHashes = scripts.map(toScriptHash);
+        // O(1) scripthash → script lookup, kept in sync with the
+        // scripts/scriptHashes arrays. Server notifications hit this on
+        // every push, so the previous indexOf was O(n) per event.
+        const scriptByHash = new Map<string, Uint8Array>(
+            scriptHashes.map((h, i) => [h, scripts[i]])
+        );
 
         // Track known history per script to detect new txs.
         const knownTxids = new Map<string, Set<string>>();
@@ -757,22 +763,27 @@ export class ElectrumOnchainProvider implements OnchainProvider {
             );
         });
 
-        const handleStatusChange = async (scripthash: string) => {
-            const scriptIndex = scriptHashes.indexOf(scripthash);
-            if (scriptIndex === -1) return;
+        // Per-scripthash mutex serializing concurrent notifications so
+        // two pushes for the same address can't fetch history in parallel
+        // and emit duplicate events. Each call chains onto the previous
+        // one's tail; failures are swallowed to keep the chain alive.
+        const inFlight = new Map<string, Promise<void>>();
 
-            const script = scripts[scriptIndex];
+        const processStatusChange = async (
+            scripthash: string
+        ): Promise<void> => {
+            const script = scriptByHash.get(scripthash);
+            if (!script) return;
+
             const history = await this.chain.fetchHistory(script);
-            const known = knownTxids.get(scripthash) || new Set();
+            const known = knownTxids.get(scripthash) ?? new Set<string>();
             const newTxids = history
                 .map((h) => h.tx_hash)
                 .filter((txid) => !known.has(txid));
 
             if (newTxids.length === 0) return;
 
-            for (const txid of newTxids) {
-                known.add(txid);
-            }
+            for (const txid of newTxids) known.add(txid);
             knownTxids.set(scripthash, known);
 
             const verboseTxs =
@@ -780,19 +791,43 @@ export class ElectrumOnchainProvider implements OnchainProvider {
             eventCallback(verboseTxs.map((vtx) => this.verboseToExplorer(vtx)));
         };
 
-        // Register all subscriptions in parallel.
-        await Promise.all(
-            scripts.map((script) =>
-                this.chain.subscribeScriptStatus(
-                    script,
-                    (scripthash, status) => {
-                        if (status !== null) {
-                            handleStatusChange(scripthash).catch(console.error);
+        const handleStatusChange = (scripthash: string): Promise<void> => {
+            const previous = inFlight.get(scripthash) ?? Promise.resolve();
+            const next = previous.then(() => processStatusChange(scripthash));
+            // Keep the chain alive even when one link rejects.
+            inFlight.set(
+                scripthash,
+                next.catch(() => undefined)
+            );
+            return next;
+        };
+
+        // Register all subscriptions in parallel; if any one fails, tear
+        // down the others so we don't leak server-side subscriptions on
+        // a connection the caller never gets a stop() handle for.
+        const subscribed: Uint8Array[] = [];
+        try {
+            await Promise.all(
+                scripts.map(async (script) => {
+                    await this.chain.subscribeScriptStatus(
+                        script,
+                        (scripthash, status) => {
+                            if (status !== null) {
+                                handleStatusChange(scripthash).catch(
+                                    console.error
+                                );
+                            }
                         }
-                    }
-                )
-            )
-        );
+                    );
+                    subscribed.push(script);
+                })
+            );
+        } catch (err) {
+            await Promise.allSettled(
+                subscribed.map((s) => this.chain.unsubscribeScriptStatus(s))
+            );
+            throw err;
+        }
 
         return () => {
             for (const script of scripts) {
@@ -818,14 +853,22 @@ function isHeaderSubscribeResult(v: unknown): v is HeaderSubscribeResult {
 }
 
 /**
- * Compute the txid of a serialized transaction. Bitcoin's txid is the
- * double-SHA256 of the serialized tx bytes, with the result interpreted
- * little-endian (i.e. reversed when displayed as hex). `broadcast_package`
- * does not return the child txid, so we derive it from the raw bytes.
+ * Compute the txid of a serialized transaction. For segwit transactions
+ * (every Ark transaction), the broadcast hex includes witness data, but
+ * the txid is the double-SHA256 of the legacy (witness-stripped)
+ * serialization. Hashing the raw broadcast bytes directly would yield
+ * the wtxid instead — silently breaking any caller that tracks the tx
+ * by id (round settlement, forfeit monitoring, exit paths).
+ *
+ * Delegating to `Transaction.fromRaw(...).id` lets @scure/btc-signer
+ * handle the witness-stripping correctly.
  */
 function childTxidFromHex(txHex: string): string {
-    const bytes = hex.decode(txHex);
-    return hex.encode(sha256(sha256(bytes)).reverse());
+    const tx = Transaction.fromRaw(hex.decode(txHex), {
+        allowUnknownOutputs: true,
+        allowUnknownInputs: true,
+    });
+    return tx.id;
 }
 
 /**

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -396,61 +396,128 @@ export class ElectrumOnchainProvider implements OnchainProvider {
     async getTxOutspends(
         txid: string
     ): Promise<{ spent: boolean; txid: string }[]> {
-        // Get the raw transaction to find its outputs
+        // Step 1: fetch the creating tx to get its output scripts (1 round trip)
         const [txResult] = await this.chain.fetchTransactions([txid]);
         const tx = Transaction.fromRaw(hex.decode(txResult.hex), {
             allowUnknownOutputs: true,
         });
 
-        const results: { spent: boolean; txid: string }[] = [];
-
-        for (let i = 0; i < tx.outputsLength; i++) {
+        const outputCount = tx.outputsLength;
+        const outputScriptHashes: (string | undefined)[] = [];
+        for (let i = 0; i < outputCount; i++) {
             const output = tx.getOutput(i);
-            if (!output.script) {
-                results.push({ spent: false, txid: "" });
-                continue;
-            }
-
-            const outScriptHash = toScriptHash(output.script);
-            const history = await this.ws.request<TransactionHistory[]>(
-                GetHistoryMethod,
-                outScriptHash
+            outputScriptHashes.push(
+                output.script ? toScriptHash(output.script) : undefined
             );
+        }
 
-            // Find a spending tx: any tx in the history that is NOT the original tx
-            // and spends this output
-            let spentByTxid = "";
-            let isSpent = false;
+        const validScriptHashes = outputScriptHashes.filter(
+            (h): h is string => h !== undefined
+        );
 
-            for (const entry of history) {
-                if (entry.tx_hash === txid) continue;
-                // Fetch this tx and check if it spends our output
-                const [spenderResult] = await this.chain.fetchTransactions([
-                    entry.tx_hash,
-                ]);
-                const spenderTx = Transaction.fromRaw(
-                    hex.decode(spenderResult.hex),
-                    {
-                        allowUnknownOutputs: true,
-                        allowUnknownInputs: true,
-                    }
-                );
-                for (let j = 0; j < spenderTx.inputsLength; j++) {
-                    const input = spenderTx.getInput(j);
-                    if (
-                        input.txid &&
-                        hex.encode(input.txid) === txid &&
-                        input.index === i
-                    ) {
-                        isSpent = true;
-                        spentByTxid = entry.tx_hash;
-                        break;
-                    }
+        const results: { spent: boolean; txid: string }[] = Array.from(
+            { length: outputCount },
+            () => ({ spent: false, txid: "" })
+        );
+
+        if (validScriptHashes.length === 0) return results;
+
+        // Step 2: batch listunspent for all output scripthashes (1 round trip)
+        // This tells us exactly which txid:vout pairs are still unspent.
+        const unspentBatch = await this.ws.batchRequest<UnspentElectrum[][]>(
+            ...validScriptHashes.map((sh) => ({
+                method: ListUnspentMethod,
+                params: [sh],
+            }))
+        );
+
+        const unspentSet = new Set<string>();
+        let validIdx = 0;
+        for (let i = 0; i < outputCount; i++) {
+            if (outputScriptHashes[i] !== undefined) {
+                for (const u of unspentBatch[validIdx]) {
+                    unspentSet.add(`${u.tx_hash}:${u.tx_pos}`);
                 }
-                if (isSpent) break;
+                validIdx++;
             }
+        }
 
-            results.push({ spent: isSpent, txid: spentByTxid });
+        // Step 3: batch get_history only for spent outputs (1 round trip)
+        const spentIndices: number[] = [];
+        const spentScriptHashes: string[] = [];
+        for (let i = 0; i < outputCount; i++) {
+            const sh = outputScriptHashes[i];
+            if (sh && !unspentSet.has(`${txid}:${i}`)) {
+                spentIndices.push(i);
+                spentScriptHashes.push(sh);
+            }
+        }
+
+        if (spentIndices.length === 0) return results;
+
+        const histories = await this.ws.batchRequest<TransactionHistory[][]>(
+            ...spentScriptHashes.map((sh) => ({
+                method: GetHistoryMethod,
+                params: [sh],
+            }))
+        );
+
+        // For each spent output find the spender in its history.
+        // Common case: history has exactly 2 entries (creating + spending tx).
+        // Ambiguous case (same script reused): batch-fetch all candidates at once.
+        const ambiguousIndices: number[] = [];
+        const ambiguousCandidates: string[][] = [];
+
+        for (let j = 0; j < spentIndices.length; j++) {
+            const i = spentIndices[j];
+            const candidates = histories[j]
+                .map((h) => h.tx_hash)
+                .filter((hash) => hash !== txid);
+
+            if (candidates.length === 1) {
+                // Fast path: one candidate = the spender
+                results[i] = { spent: true, txid: candidates[0] };
+            } else if (candidates.length > 1) {
+                ambiguousIndices.push(i);
+                ambiguousCandidates.push(candidates);
+            }
+            // candidates.length === 0 → mempool eviction, treat as unspent
+        }
+
+        // Step 4 (rare): batch-fetch all ambiguous candidate txs at once
+        if (ambiguousIndices.length > 0) {
+            const allCandidateTxids = [
+                ...new Set(ambiguousCandidates.flat()),
+            ];
+            const fetched =
+                await this.chain.fetchTransactions(allCandidateTxids);
+            const txMap = new Map(fetched.map((t) => [t.txID, t.hex]));
+
+            for (let j = 0; j < ambiguousIndices.length; j++) {
+                const i = ambiguousIndices[j];
+                for (const candidateTxid of ambiguousCandidates[j]) {
+                    const rawHex = txMap.get(candidateTxid);
+                    if (!rawHex) continue;
+                    const candidateTx = Transaction.fromRaw(
+                        hex.decode(rawHex),
+                        { allowUnknownOutputs: true, allowUnknownInputs: true }
+                    );
+                    let found = false;
+                    for (let k = 0; k < candidateTx.inputsLength; k++) {
+                        const input = candidateTx.getInput(k);
+                        if (
+                            input.txid &&
+                            hex.encode(input.txid) === txid &&
+                            input.index === i
+                        ) {
+                            results[i] = { spent: true, txid: candidateTxid };
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (found) break;
+                }
+            }
         }
 
         return results;

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -77,6 +77,46 @@ const GENESIS_BLOCK_TIME = 1231006505;
 
 const REGTEST_ADDRESS = "bcrt1q679zsd45msawvr7782r0twvmukns3drlstjt77";
 
+// Build a tx that carries a (fake) witness, so the segwit serialization
+// differs from the legacy one. Used to verify that childTxidFromHex
+// returns the txid (legacy hash) rather than the wtxid (witness hash) —
+// silently emitting the wtxid would break every downstream caller that
+// tracks the tx by id.
+function buildSegwitTxWithWitness(): {
+    txHex: string;
+    expectedTxid: string;
+    expectedWtxid: string;
+} {
+    const tx = new Transaction({
+        allowUnknownOutputs: true,
+        allowUnknownInputs: true,
+    });
+    // Inputs and outputs must be added BEFORE the witness — @scure/btc-signer
+    // locks the output set once any input is finalized.
+    tx.addInput({
+        txid: hex.decode(
+            "0000000000000000000000000000000000000000000000000000000000000005"
+        ),
+        index: 0,
+        sequence: 0xffffffff,
+    });
+    tx.addOutput({
+        script: p2wpkhScript(new Uint8Array(20).fill(0x77)),
+        amount: 12_345n,
+    });
+    tx.updateInput(0, {
+        finalScriptWitness: [
+            new Uint8Array(64).fill(0x99), // signature-shaped bytes
+            new Uint8Array(33).fill(0x02), // pubkey-shaped bytes
+        ],
+    });
+    return {
+        txHex: tx.hex,
+        expectedTxid: tx.id,
+        expectedWtxid: tx.hash,
+    };
+}
+
 // Build a tx with 2 distinct P2WPKH outputs we can reason about.
 function buildTestTx(): { txHex: string; scripts: Uint8Array[] } {
     const hash1 = new Uint8Array(20).fill(0xaa);
@@ -217,14 +257,20 @@ describe("ElectrumOnchainProvider", () => {
             );
         });
 
-        it("broadcasts a 1P1C package atomically via broadcast_package and returns the child txid", async () => {
-            // Use a real, parseable child tx so we can assert the expected
-            // child txid is the locally-derived double-SHA256 (broadcast_package
-            // doesn't return one — atomic submit only reports success/errors).
-            const { txHex: childHex } = buildTestTx();
-            const expectedChildTxid = hex.encode(
-                sha256(sha256(hex.decode(childHex))).reverse()
-            );
+        it("broadcasts a 1P1C package atomically via broadcast_package and returns the child txid (segwit witness-stripped)", async () => {
+            // Use a tx that actually has witness data so the segwit
+            // serialization differs from the legacy one. broadcast_package
+            // doesn't return a txid; we must derive the *txid* (legacy
+            // hash) — emitting the wtxid would silently break downstream
+            // tracking on every Ark transaction.
+            const {
+                txHex: childHex,
+                expectedTxid,
+                expectedWtxid,
+            } = buildSegwitTxWithWitness();
+            // Sanity check: the test fixture must actually exercise the
+            // bug path (id != hash means witness data is present).
+            expect(expectedTxid).not.toBe(expectedWtxid);
 
             wsMock.request.mockResolvedValueOnce({
                 success: true,
@@ -236,7 +282,8 @@ describe("ElectrumOnchainProvider", () => {
                 childHex
             );
 
-            expect(result).toBe(expectedChildTxid);
+            expect(result).toBe(expectedTxid);
+            expect(result).not.toBe(expectedWtxid);
             expect(wsMock.request).toHaveBeenCalledTimes(1);
             const [method, txArray, verbose] = wsMock.request.mock.calls[0];
             expect(method).toBe("blockchain.transaction.broadcast_package");
@@ -794,11 +841,14 @@ describe("WsElectrumChainSource", () => {
     });
 
     describe("broadcastPackage", () => {
-        it("returns the locally-derived child txid on success", async () => {
-            const { txHex: childHex } = buildTestTx();
-            const expectedTxid = hex.encode(
-                sha256(sha256(hex.decode(childHex))).reverse()
-            );
+        it("returns the locally-derived txid (witness-stripped) on success", async () => {
+            const {
+                txHex: childHex,
+                expectedTxid,
+                expectedWtxid,
+            } = buildSegwitTxWithWitness();
+            expect(expectedTxid).not.toBe(expectedWtxid);
+
             wsMock.request.mockResolvedValueOnce({
                 success: true,
                 errors: null,

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -1,0 +1,603 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Transaction } from "@scure/btc-signer";
+import { sha256 } from "@scure/btc-signer/utils.js";
+import { hex } from "@scure/base";
+import type { ElectrumWS } from "ws-electrumx-client";
+import { ElectrumOnchainProvider, WsElectrumChainSource } from "../src";
+import { networks } from "../src/networks";
+
+/**
+ * Build a P2WPKH scriptPubKey (OP_0 + 20-byte pushdata + hash160).
+ * We hand-assemble the script rather than using p2wpkh(), because the
+ * helper expects a 33-byte compressed pubkey we don't need here —
+ * toScriptHash only cares about the script bytes.
+ */
+function p2wpkhScript(hash160: Uint8Array): Uint8Array {
+    if (hash160.length !== 20) {
+        throw new Error("expected 20-byte hash");
+    }
+    const out = new Uint8Array(22);
+    out[0] = 0x00; // OP_0
+    out[1] = 0x14; // push 20 bytes
+    out.set(hash160, 2);
+    return out;
+}
+
+/**
+ * Minimal mock of ElectrumWS — only the methods used by the provider.
+ * Tests drive it by calling `.mockResolvedValueOnce()` on `request`/`batchRequest`
+ * in the same order the production code invokes them.
+ */
+type MockElectrumWS = Pick<
+    ElectrumWS,
+    "request" | "batchRequest" | "subscribe" | "unsubscribe" | "close"
+>;
+
+function createMockWS(): {
+    ws: MockElectrumWS;
+    request: ReturnType<typeof vi.fn>;
+    batchRequest: ReturnType<typeof vi.fn>;
+    subscribe: ReturnType<typeof vi.fn>;
+    unsubscribe: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+} {
+    const request = vi.fn();
+    const batchRequest = vi.fn();
+    const subscribe = vi.fn().mockResolvedValue(undefined);
+    const unsubscribe = vi.fn().mockResolvedValue(undefined);
+    const close = vi.fn().mockResolvedValue(undefined);
+    return {
+        ws: {
+            request,
+            batchRequest,
+            subscribe,
+            unsubscribe,
+            close,
+        } as unknown as MockElectrumWS,
+        request,
+        batchRequest,
+        subscribe,
+        unsubscribe,
+        close,
+    };
+}
+
+// Bitcoin genesis block header (mainnet)
+const GENESIS_HEADER_HEX =
+    "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c";
+const GENESIS_BLOCK_HASH =
+    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+const GENESIS_BLOCK_TIME = 1231006505;
+
+const REGTEST_ADDRESS = "bcrt1q679zsd45msawvr7782r0twvmukns3drlstjt77";
+
+// Build a tx with 2 distinct P2WPKH outputs we can reason about.
+function buildTestTx(): { txHex: string; scripts: Uint8Array[] } {
+    const hash1 = new Uint8Array(20).fill(0xaa);
+    const hash2 = new Uint8Array(20).fill(0xbb);
+    const script1 = p2wpkhScript(hash1);
+    const script2 = p2wpkhScript(hash2);
+
+    const tx = new Transaction({
+        allowUnknownOutputs: true,
+        allowUnknownInputs: true,
+    });
+    tx.addInput({
+        txid: hex.decode(
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        ),
+        index: 0,
+        sequence: 0xffffffff,
+    });
+    tx.addOutput({ script: script1, amount: 10_000n });
+    tx.addOutput({ script: script2, amount: 20_000n });
+
+    return {
+        txHex: hex.encode(tx.toBytes(false, false)),
+        scripts: [script1, script2],
+    };
+}
+
+const SPENDER_HASH = new Uint8Array(20).fill(0xcc);
+const SPENDER_SCRIPT = p2wpkhScript(SPENDER_HASH);
+
+function toScriptHash(script: Uint8Array): string {
+    return hex.encode(sha256(script).reverse());
+}
+
+// Build a tx that spends output `vout` of `parentTxid`.
+function buildSpendingTx(parentTxid: string, vout: number): string {
+    const tx = new Transaction({
+        allowUnknownOutputs: true,
+        allowUnknownInputs: true,
+    });
+    tx.addInput({
+        txid: hex.decode(parentTxid),
+        index: vout,
+        sequence: 0xffffffff,
+    });
+    tx.addOutput({ script: SPENDER_SCRIPT, amount: 5_000n });
+    return hex.encode(tx.toBytes(false, false));
+}
+
+describe("ElectrumOnchainProvider", () => {
+    let wsMock: ReturnType<typeof createMockWS>;
+    let provider: ElectrumOnchainProvider;
+
+    beforeEach(() => {
+        wsMock = createMockWS();
+        provider = new ElectrumOnchainProvider(
+            wsMock.ws as unknown as ElectrumWS,
+            networks.regtest
+        );
+    });
+
+    describe("getCoins", () => {
+        it("maps listunspent results to Coin shape", async () => {
+            wsMock.request.mockResolvedValueOnce([
+                {
+                    tx_hash: "abcd1234",
+                    tx_pos: 0,
+                    value: 100_000,
+                    height: 500,
+                },
+                {
+                    tx_hash: "ef567890",
+                    tx_pos: 1,
+                    value: 50_000,
+                    height: 0, // mempool
+                },
+            ]);
+
+            const coins = await provider.getCoins(REGTEST_ADDRESS);
+
+            expect(wsMock.request).toHaveBeenCalledTimes(1);
+            expect(wsMock.request.mock.calls[0][0]).toBe(
+                "blockchain.scripthash.listunspent"
+            );
+            expect(coins).toEqual([
+                {
+                    txid: "abcd1234",
+                    vout: 0,
+                    value: 100_000,
+                    status: { confirmed: true, block_height: 500 },
+                },
+                {
+                    txid: "ef567890",
+                    vout: 1,
+                    value: 50_000,
+                    status: { confirmed: false, block_height: undefined },
+                },
+            ]);
+        });
+
+        it("returns empty array when no unspents", async () => {
+            wsMock.request.mockResolvedValueOnce([]);
+            const coins = await provider.getCoins(REGTEST_ADDRESS);
+            expect(coins).toEqual([]);
+        });
+    });
+
+    describe("getFeeRate", () => {
+        it("converts BTC/kB to sat/vB with Math.max(1, ceil) guard", async () => {
+            wsMock.request.mockResolvedValueOnce(0.00002);
+            expect(await provider.getFeeRate()).toBe(2);
+        });
+
+        it("rounds up fractional rates", async () => {
+            wsMock.request.mockResolvedValueOnce(0.000015);
+            expect(await provider.getFeeRate()).toBe(2);
+        });
+
+        it("returns at least 1 sat/vB even for tiny rates", async () => {
+            wsMock.request.mockResolvedValueOnce(0.000000001);
+            expect(await provider.getFeeRate()).toBe(1);
+        });
+
+        it("returns undefined when daemon cannot estimate (-1)", async () => {
+            wsMock.request.mockResolvedValueOnce(-1);
+            expect(await provider.getFeeRate()).toBeUndefined();
+        });
+    });
+
+    describe("broadcastTransaction", () => {
+        it("broadcasts a single tx", async () => {
+            wsMock.request.mockResolvedValueOnce("deadbeef");
+            const txid = await provider.broadcastTransaction("0200000000");
+            expect(txid).toBe("deadbeef");
+            expect(wsMock.request).toHaveBeenCalledTimes(1);
+            expect(wsMock.request.mock.calls[0][0]).toBe(
+                "blockchain.transaction.broadcast"
+            );
+        });
+
+        it("broadcasts 1P1C package sequentially (parent then child)", async () => {
+            wsMock.request
+                .mockResolvedValueOnce("parentTxid")
+                .mockResolvedValueOnce("childTxid");
+            const result = await provider.broadcastTransaction(
+                "parentHex",
+                "childHex"
+            );
+            expect(result).toBe("childTxid");
+            expect(wsMock.request).toHaveBeenCalledTimes(2);
+            expect(wsMock.request.mock.calls[0][1]).toBe("parentHex");
+            expect(wsMock.request.mock.calls[1][1]).toBe("childHex");
+        });
+
+        it("throws for 3+ transactions", async () => {
+            await expect(
+                provider.broadcastTransaction("a", "b", "c")
+            ).rejects.toThrow("Only 1 or 1C1P package can be broadcast");
+        });
+    });
+
+    describe("getChainTip", () => {
+        it("parses block header for hash, timestamp, height", async () => {
+            wsMock.request.mockResolvedValueOnce({
+                height: 0,
+                hex: GENESIS_HEADER_HEX,
+            });
+
+            const tip = await provider.getChainTip();
+            expect(tip.height).toBe(0);
+            expect(tip.time).toBe(GENESIS_BLOCK_TIME);
+            expect(tip.hash).toBe(GENESIS_BLOCK_HASH);
+        });
+    });
+
+    describe("getTxStatus", () => {
+        it("returns confirmed=false for mempool txs (0 confirmations)", async () => {
+            wsMock.request.mockResolvedValueOnce({
+                txid: "abc",
+                confirmations: 0,
+                vout: [],
+                vin: [],
+            });
+            const status = await provider.getTxStatus("abc");
+            expect(status).toEqual({ confirmed: false });
+        });
+
+        it("computes block height as tipHeight - confirmations + 1", async () => {
+            wsMock.request
+                .mockResolvedValueOnce({
+                    txid: "abc",
+                    confirmations: 10,
+                    blocktime: 1700_000_000,
+                    vout: [],
+                    vin: [],
+                })
+                .mockResolvedValueOnce({
+                    height: 100,
+                    hex: GENESIS_HEADER_HEX,
+                });
+
+            const status = await provider.getTxStatus("abc");
+            expect(status).toEqual({
+                confirmed: true,
+                blockTime: 1700_000_000,
+                blockHeight: 91, // 100 - 10 + 1
+            });
+        });
+
+        it("falls back to time when blocktime is absent", async () => {
+            wsMock.request
+                .mockResolvedValueOnce({
+                    txid: "abc",
+                    confirmations: 5,
+                    time: 1650_000_000,
+                    vout: [],
+                    vin: [],
+                })
+                .mockResolvedValueOnce({
+                    height: 50,
+                    hex: GENESIS_HEADER_HEX,
+                });
+
+            const status = await provider.getTxStatus("abc");
+            expect(status).toMatchObject({
+                confirmed: true,
+                blockTime: 1650_000_000,
+            });
+        });
+    });
+
+    describe("getTransactions", () => {
+        it("returns empty array when history is empty", async () => {
+            wsMock.request.mockResolvedValueOnce([]);
+            const txs = await provider.getTransactions(REGTEST_ADDRESS);
+            expect(txs).toEqual([]);
+        });
+
+        it("maps verbose electrum txs to ExplorerTransaction shape", async () => {
+            // First call: fetchHistory (scripthash.get_history) via ws.request
+            wsMock.request.mockResolvedValueOnce([
+                { tx_hash: "tx1", height: 100 },
+            ]);
+            // Second call: fetchVerboseTransactions via ws.batchRequest
+            wsMock.batchRequest.mockResolvedValueOnce([
+                {
+                    txid: "tx1",
+                    confirmations: 5,
+                    blocktime: 1700_000_000,
+                    vout: [
+                        {
+                            n: 0,
+                            value: 0.001, // 100_000 sat
+                            scriptPubKey: {
+                                address: "bcrt1qexample",
+                                hex: "",
+                            },
+                        },
+                    ],
+                    vin: [],
+                },
+            ]);
+
+            const txs = await provider.getTransactions(REGTEST_ADDRESS);
+            expect(txs).toEqual([
+                {
+                    txid: "tx1",
+                    vout: [
+                        {
+                            scriptpubkey_address: "bcrt1qexample",
+                            value: "100000",
+                        },
+                    ],
+                    status: { confirmed: true, block_time: 1700_000_000 },
+                },
+            ]);
+        });
+    });
+
+    describe("getTxOutspends", () => {
+        const { txHex, scripts } = buildTestTx();
+        const parentTxid = hex.encode(
+            sha256(sha256(hex.decode(txHex))).reverse()
+        );
+        const scriptHashes = scripts.map(toScriptHash);
+
+        it("returns all-unspent when both outputs are in listunspent", async () => {
+            // Step 1: fetchTransactions for creator tx
+            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+
+            // Step 2: listunspent for each output scripthash — both show our tx
+            wsMock.batchRequest.mockResolvedValueOnce([
+                [
+                    {
+                        tx_hash: parentTxid,
+                        tx_pos: 0,
+                        value: 10_000,
+                        height: 100,
+                    },
+                ],
+                [
+                    {
+                        tx_hash: parentTxid,
+                        tx_pos: 1,
+                        value: 20_000,
+                        height: 100,
+                    },
+                ],
+            ]);
+
+            const results = await provider.getTxOutspends(parentTxid);
+            expect(results).toEqual([
+                { spent: false, txid: "" },
+                { spent: false, txid: "" },
+            ]);
+        });
+
+        it("resolves simple spent case via single history candidate", async () => {
+            const spenderHex = buildSpendingTx(parentTxid, 0);
+            const spenderTxid = hex.encode(
+                sha256(sha256(hex.decode(spenderHex))).reverse()
+            );
+
+            // Step 1: fetchTransactions for creator
+            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+
+            // Step 2: listunspent — vout 0 gone, vout 1 still there
+            wsMock.batchRequest.mockResolvedValueOnce([
+                [], // vout 0 spent
+                [
+                    {
+                        tx_hash: parentTxid,
+                        tx_pos: 1,
+                        value: 20_000,
+                        height: 100,
+                    },
+                ],
+            ]);
+
+            // Step 3: history for the spent output's scripthash
+            // history has [parent, spender] → exactly one candidate that isn't the parent
+            wsMock.batchRequest.mockResolvedValueOnce([
+                [
+                    { tx_hash: parentTxid, height: 100 },
+                    { tx_hash: spenderTxid, height: 101 },
+                ],
+            ]);
+
+            const results = await provider.getTxOutspends(parentTxid);
+            expect(results[0]).toEqual({ spent: true, txid: spenderTxid });
+            expect(results[1]).toEqual({ spent: false, txid: "" });
+        });
+
+        it("disambiguates reused-script history by scanning candidate inputs", async () => {
+            // Create two candidate spenders — only one actually spends vout 0
+            const realSpenderHex = buildSpendingTx(parentTxid, 0);
+            const realSpenderTxid = hex.encode(
+                sha256(sha256(hex.decode(realSpenderHex))).reverse()
+            );
+            const decoyHex = buildSpendingTx(
+                "0000000000000000000000000000000000000000000000000000000000000099",
+                3
+            );
+            const decoyTxid = hex.encode(
+                sha256(sha256(hex.decode(decoyHex))).reverse()
+            );
+
+            // Step 1: fetch parent
+            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+
+            // Step 2: listunspent — vout 0 spent, vout 1 unspent
+            wsMock.batchRequest.mockResolvedValueOnce([
+                [],
+                [
+                    {
+                        tx_hash: parentTxid,
+                        tx_pos: 1,
+                        value: 20_000,
+                        height: 100,
+                    },
+                ],
+            ]);
+
+            // Step 3: history for script 0 contains parent + two candidates
+            wsMock.batchRequest.mockResolvedValueOnce([
+                [
+                    { tx_hash: parentTxid, height: 100 },
+                    { tx_hash: decoyTxid, height: 102 },
+                    { tx_hash: realSpenderTxid, height: 103 },
+                ],
+            ]);
+
+            // Step 4: batch-fetch candidate txs to scan their inputs
+            wsMock.batchRequest.mockResolvedValueOnce([
+                decoyHex,
+                realSpenderHex,
+            ]);
+
+            const results = await provider.getTxOutspends(parentTxid);
+            expect(results[0]).toEqual({ spent: true, txid: realSpenderTxid });
+            expect(results[1]).toEqual({ spent: false, txid: "" });
+        });
+    });
+
+    describe("close", () => {
+        it("delegates to underlying ws close()", async () => {
+            await provider.close();
+            expect(wsMock.close).toHaveBeenCalledTimes(1);
+        });
+    });
+});
+
+describe("WsElectrumChainSource", () => {
+    let wsMock: ReturnType<typeof createMockWS>;
+    let chain: WsElectrumChainSource;
+
+    beforeEach(() => {
+        wsMock = createMockWS();
+        chain = new WsElectrumChainSource(
+            wsMock.ws as unknown as ElectrumWS,
+            networks.regtest
+        );
+    });
+
+    describe("fetchBlockHeader / fetchBlockHeaders", () => {
+        it("returns {height, hex} from single request", async () => {
+            wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX);
+            const header = await chain.fetchBlockHeader(0);
+            expect(header).toEqual({ height: 0, hex: GENESIS_HEADER_HEX });
+        });
+
+        it("batches multiple heights into a single batchRequest", async () => {
+            wsMock.batchRequest.mockResolvedValueOnce(["h1", "h2", "h3"]);
+            const headers = await chain.fetchBlockHeaders([10, 20, 30]);
+            expect(headers).toEqual([
+                { height: 10, hex: "h1" },
+                { height: 20, hex: "h2" },
+                { height: 30, hex: "h3" },
+            ]);
+            expect(wsMock.batchRequest).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("fetchVerboseTransactions", () => {
+        it("returns empty array without calling ws when input is empty", async () => {
+            const out = await chain.fetchVerboseTransactions([]);
+            expect(out).toEqual([]);
+            expect(wsMock.batchRequest).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("fetchTransactions retry on missing tx", () => {
+        it("retries after a 'missingtransaction' error then succeeds", async () => {
+            wsMock.batchRequest
+                .mockRejectedValueOnce(
+                    new Error("daemon error: missingtransaction")
+                )
+                .mockResolvedValueOnce(["0200"]);
+
+            const result = await chain.fetchTransactions(["tx1"]);
+            expect(result).toEqual([{ txID: "tx1", hex: "0200" }]);
+            expect(wsMock.batchRequest).toHaveBeenCalledTimes(2);
+        });
+
+        it("propagates non-missing errors immediately", async () => {
+            wsMock.batchRequest.mockRejectedValueOnce(
+                new Error("connection refused")
+            );
+            await expect(chain.fetchTransactions(["tx1"])).rejects.toThrow(
+                "connection refused"
+            );
+        });
+    });
+
+    describe("getRelayFee / estimateFees", () => {
+        it("returns electrum relay fee as-is (BTC/kB)", async () => {
+            wsMock.request.mockResolvedValueOnce(0.00001);
+            expect(await chain.getRelayFee()).toBe(0.00001);
+        });
+
+        it("requests estimatefee with target block count", async () => {
+            wsMock.request.mockResolvedValueOnce(0.0002);
+            const rate = await chain.estimateFees(6);
+            expect(rate).toBe(0.0002);
+            expect(wsMock.request).toHaveBeenCalledWith(
+                "blockchain.estimatefee",
+                6
+            );
+        });
+    });
+
+    describe("broadcastTransaction", () => {
+        it("forwards tx hex to electrum broadcast method", async () => {
+            wsMock.request.mockResolvedValueOnce("broadcasttxid");
+            expect(await chain.broadcastTransaction("rawhex")).toBe(
+                "broadcasttxid"
+            );
+            expect(wsMock.request).toHaveBeenCalledWith(
+                "blockchain.transaction.broadcast",
+                "rawhex"
+            );
+        });
+    });
+
+    describe("addressForScript", () => {
+        it("decodes a valid P2WPKH script to an address", async () => {
+            const hash = new Uint8Array(20).fill(0x01);
+            const script = p2wpkhScript(hash);
+            const addr = chain.addressForScript(hex.encode(script));
+            expect(addr).toBeDefined();
+            expect(addr).toMatch(/^bcrt1q/);
+        });
+
+        it("returns undefined for unparseable scripts", async () => {
+            expect(chain.addressForScript("00")).toBeUndefined();
+        });
+    });
+
+    describe("close", () => {
+        it("calls ws.close('close')", async () => {
+            await chain.close();
+            expect(wsMock.close).toHaveBeenCalledWith("close");
+        });
+
+        it("swallows errors from ws.close", async () => {
+            wsMock.close.mockRejectedValueOnce(new Error("already closed"));
+            await expect(chain.close()).resolves.toBeUndefined();
+        });
+    });
+});

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -217,18 +217,60 @@ describe("ElectrumOnchainProvider", () => {
             );
         });
 
-        it("broadcasts 1P1C package sequentially (parent then child)", async () => {
-            wsMock.request
-                .mockResolvedValueOnce("parentTxid")
-                .mockResolvedValueOnce("childTxid");
+        it("broadcasts a 1P1C package atomically via broadcast_package and returns the child txid", async () => {
+            // Use a real, parseable child tx so we can assert the expected
+            // child txid is the locally-derived double-SHA256 (broadcast_package
+            // doesn't return one — atomic submit only reports success/errors).
+            const { txHex: childHex } = buildTestTx();
+            const expectedChildTxid = hex.encode(
+                sha256(sha256(hex.decode(childHex))).reverse()
+            );
+
+            wsMock.request.mockResolvedValueOnce({
+                success: true,
+                errors: null,
+            });
+
             const result = await provider.broadcastTransaction(
                 "parentHex",
-                "childHex"
+                childHex
             );
-            expect(result).toBe("childTxid");
-            expect(wsMock.request).toHaveBeenCalledTimes(2);
-            expect(wsMock.request.mock.calls[0][1]).toBe("parentHex");
-            expect(wsMock.request.mock.calls[1][1]).toBe("childHex");
+
+            expect(result).toBe(expectedChildTxid);
+            expect(wsMock.request).toHaveBeenCalledTimes(1);
+            const [method, txArray, verbose] = wsMock.request.mock.calls[0];
+            expect(method).toBe("blockchain.transaction.broadcast_package");
+            // Parent first, child last — topological order required by the protocol.
+            expect(txArray).toEqual(["parentHex", childHex]);
+            expect(verbose).toBe(false);
+        });
+
+        it("surfaces the server error when broadcast_package returns success=false", async () => {
+            wsMock.request.mockResolvedValueOnce({
+                success: false,
+                errors: [{ txid: "abc", error: "min relay fee not met" }],
+            });
+
+            await expect(
+                provider.broadcastTransaction("parentHex", "childHex")
+            ).rejects.toThrow(/min relay fee not met/);
+        });
+
+        it("propagates 'method not found' errors instead of silently falling back", async () => {
+            // A server that doesn't implement broadcast_package (ElectrumX,
+            // older Fulcrum, or Fulcrum on bitcoind < v28) — we MUST NOT
+            // silently downgrade to sequential broadcast because TRUC
+            // packages would fail in subtle ways.
+            const methodNotFound = new Error(
+                "unknown method 'blockchain.transaction.broadcast_package'"
+            );
+            wsMock.request.mockRejectedValueOnce(methodNotFound);
+
+            await expect(
+                provider.broadcastTransaction("parentHex", "childHex")
+            ).rejects.toThrow(/broadcast_package/);
+            // Critical: only one ws.request call — no sequential fallback.
+            expect(wsMock.request).toHaveBeenCalledTimes(1);
         });
 
         it("throws for 3+ transactions", async () => {
@@ -747,6 +789,46 @@ describe("WsElectrumChainSource", () => {
             expect(wsMock.request).toHaveBeenCalledWith(
                 "blockchain.transaction.broadcast",
                 "rawhex"
+            );
+        });
+    });
+
+    describe("broadcastPackage", () => {
+        it("returns the locally-derived child txid on success", async () => {
+            const { txHex: childHex } = buildTestTx();
+            const expectedTxid = hex.encode(
+                sha256(sha256(hex.decode(childHex))).reverse()
+            );
+            wsMock.request.mockResolvedValueOnce({
+                success: true,
+                errors: null,
+            });
+
+            expect(await chain.broadcastPackage(["parentHex", childHex])).toBe(
+                expectedTxid
+            );
+            expect(wsMock.request).toHaveBeenCalledWith(
+                "blockchain.transaction.broadcast_package",
+                ["parentHex", childHex],
+                false
+            );
+        });
+
+        it("throws with the underlying error when success=false", async () => {
+            wsMock.request.mockResolvedValueOnce({
+                success: false,
+                errors: [{ error: "txn-mempool-conflict" }],
+            });
+
+            await expect(chain.broadcastPackage(["a", "b"])).rejects.toThrow(
+                /txn-mempool-conflict/
+            );
+        });
+
+        it("throws 'unknown error' when success=false but errors is missing", async () => {
+            wsMock.request.mockResolvedValueOnce({ success: false });
+            await expect(chain.broadcastPackage(["a", "b"])).rejects.toThrow(
+                /unknown error/
             );
         });
     });

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Transaction } from "@scure/btc-signer";
+import { Address, OutScript, Transaction } from "@scure/btc-signer";
 import { sha256 } from "@scure/btc-signer/utils.js";
 import { hex } from "@scure/base";
 import type { ElectrumWS } from "ws-electrumx-client";
 import { ElectrumOnchainProvider, WsElectrumChainSource } from "../src";
 import { networks } from "../src/networks";
+
+function regtestAddressFromHash(hash160: Uint8Array): string {
+    return Address(networks.regtest).encode(
+        OutScript.decode(p2wpkhScript(hash160))
+    );
+}
 
 /**
  * Build a P2WPKH scriptPubKey (OP_0 + 20-byte pushdata + hash160).
@@ -228,13 +234,33 @@ describe("ElectrumOnchainProvider", () => {
         it("throws for 3+ transactions", async () => {
             await expect(
                 provider.broadcastTransaction("a", "b", "c")
-            ).rejects.toThrow("Only 1 or 1C1P package can be broadcast");
+            ).rejects.toThrow(/Only 1 or 1P1C package/);
         });
     });
 
+    /**
+     * Configure the headers subscription mock so subscribe() invokes its
+     * callback with the given tip immediately. Mirrors how ws-electrumx-client
+     * delivers initial subscribe responses (and ongoing notifications) via
+     * the registered callback.
+     */
+    function deliverHeadersTip(
+        subscribeMock: ReturnType<typeof vi.fn>,
+        tip: { height: number; hex: string }
+    ): void {
+        subscribeMock.mockImplementationOnce(
+            async (
+                method: string,
+                cb: (header: { height: number; hex: string }) => void
+            ) => {
+                if (method === "blockchain.headers") cb(tip);
+            }
+        );
+    }
+
     describe("getChainTip", () => {
         it("parses block header for hash, timestamp, height", async () => {
-            wsMock.request.mockResolvedValueOnce({
+            deliverHeadersTip(wsMock.subscribe, {
                 height: 0,
                 hex: GENESIS_HEADER_HEX,
             });
@@ -243,6 +269,48 @@ describe("ElectrumOnchainProvider", () => {
             expect(tip.height).toBe(0);
             expect(tip.time).toBe(GENESIS_BLOCK_TIME);
             expect(tip.hash).toBe(GENESIS_BLOCK_HASH);
+        });
+
+        it("reuses the cached tip across calls (one server subscription)", async () => {
+            deliverHeadersTip(wsMock.subscribe, {
+                height: 42,
+                hex: GENESIS_HEADER_HEX,
+            });
+
+            await provider.getChainTip();
+            await provider.getChainTip();
+            await provider.getChainTip();
+
+            // Only one subscription registered for the whole sequence —
+            // previously each call sent a fresh blockchain.headers.subscribe
+            // request that the server treated as a new subscription.
+            expect(wsMock.subscribe).toHaveBeenCalledTimes(1);
+        });
+
+        it("updates the cached tip when the server pushes a new header", async () => {
+            // Stash the callback so we can fire a notification later.
+            let pushHeader:
+                | ((h: { height: number; hex: string }) => void)
+                | undefined;
+            wsMock.subscribe.mockImplementationOnce(
+                async (
+                    _method: string,
+                    cb: (h: { height: number; hex: string }) => void
+                ) => {
+                    pushHeader = cb;
+                    cb({ height: 100, hex: GENESIS_HEADER_HEX });
+                }
+            );
+
+            const tip1 = await provider.getChainTip();
+            expect(tip1.height).toBe(100);
+
+            // Server pushes a new tip via the same subscription.
+            pushHeader!({ height: 101, hex: GENESIS_HEADER_HEX });
+
+            const tip2 = await provider.getChainTip();
+            expect(tip2.height).toBe(101);
+            expect(wsMock.subscribe).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -259,18 +327,17 @@ describe("ElectrumOnchainProvider", () => {
         });
 
         it("computes block height as tipHeight - confirmations + 1", async () => {
-            wsMock.request
-                .mockResolvedValueOnce({
-                    txid: "abc",
-                    confirmations: 10,
-                    blocktime: 1700_000_000,
-                    vout: [],
-                    vin: [],
-                })
-                .mockResolvedValueOnce({
-                    height: 100,
-                    hex: GENESIS_HEADER_HEX,
-                });
+            wsMock.request.mockResolvedValueOnce({
+                txid: "abc",
+                confirmations: 10,
+                blocktime: 1700_000_000,
+                vout: [],
+                vin: [],
+            });
+            deliverHeadersTip(wsMock.subscribe, {
+                height: 100,
+                hex: GENESIS_HEADER_HEX,
+            });
 
             const status = await provider.getTxStatus("abc");
             expect(status).toEqual({
@@ -281,18 +348,17 @@ describe("ElectrumOnchainProvider", () => {
         });
 
         it("falls back to time when blocktime is absent", async () => {
-            wsMock.request
-                .mockResolvedValueOnce({
-                    txid: "abc",
-                    confirmations: 5,
-                    time: 1650_000_000,
-                    vout: [],
-                    vin: [],
-                })
-                .mockResolvedValueOnce({
-                    height: 50,
-                    hex: GENESIS_HEADER_HEX,
-                });
+            wsMock.request.mockResolvedValueOnce({
+                txid: "abc",
+                confirmations: 5,
+                time: 1650_000_000,
+                vout: [],
+                vin: [],
+            });
+            deliverHeadersTip(wsMock.subscribe, {
+                height: 50,
+                hex: GENESIS_HEADER_HEX,
+            });
 
             const status = await provider.getTxStatus("abc");
             expect(status).toMatchObject({
@@ -347,6 +413,116 @@ describe("ElectrumOnchainProvider", () => {
                     status: { confirmed: true, block_time: 1700_000_000 },
                 },
             ]);
+        });
+
+        it("derives exact sat amounts from vtx.hex when present (no float rounding)", async () => {
+            // buildTestTx() yields outputs of 10_000 and 20_000 sats — exact
+            // values that survive the raw-tx parse without any float math.
+            const { txHex } = buildTestTx();
+
+            wsMock.request.mockResolvedValueOnce([
+                { tx_hash: "tx-exact", height: 100 },
+            ]);
+            wsMock.batchRequest.mockResolvedValueOnce([
+                {
+                    txid: "tx-exact",
+                    confirmations: 5,
+                    blocktime: 1700_000_000,
+                    hex: txHex,
+                    vout: [
+                        {
+                            n: 0,
+                            // Deliberately wrong float to prove we use the hex.
+                            value: 0.00009999,
+                            scriptPubKey: { address: "addr0", hex: "" },
+                        },
+                        {
+                            n: 1,
+                            value: 0.00019999,
+                            scriptPubKey: { address: "addr1", hex: "" },
+                        },
+                    ],
+                    vin: [],
+                },
+            ]);
+
+            const txs = await provider.getTransactions(REGTEST_ADDRESS);
+            expect(txs[0].vout.map((v) => v.value)).toEqual(["10000", "20000"]);
+        });
+
+        it("rejects malformed addresses with a descriptive error", async () => {
+            await expect(
+                provider.getTransactions("not-a-real-address")
+            ).rejects.toThrow(/Invalid address not-a-real-address/);
+        });
+    });
+
+    describe("watchAddresses", () => {
+        it("registers script subscriptions in parallel and emits new txs via callback", async () => {
+            // Derive a second valid regtest address from a known hash so we
+            // exercise the parallel-subscribe path with two distinct script
+            // hashes (without depending on any external fixture).
+            const addr1 = REGTEST_ADDRESS;
+            const addr2 = regtestAddressFromHash(new Uint8Array(20).fill(0x42));
+
+            // Initial fetchHistory for each address — empty (no known txids).
+            wsMock.request.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+            const subscribeCallbacks = new Map<
+                string,
+                (scripthash: string, status: string | null) => void
+            >();
+            wsMock.subscribe.mockImplementation(
+                async (
+                    method: string,
+                    cb: (s: string, status: string | null) => void,
+                    scripthash: string
+                ) => {
+                    if (method === "blockchain.scripthash") {
+                        subscribeCallbacks.set(scripthash, cb);
+                    }
+                }
+            );
+
+            const events: unknown[] = [];
+            const stop = await provider.watchAddresses([addr1, addr2], (txs) =>
+                events.push(txs)
+            );
+
+            // Both subscribes must have been registered before resolving.
+            expect(subscribeCallbacks.size).toBe(2);
+
+            // Server pushes a status update for addr1 — provider must refetch
+            // history and report the new tx via callback.
+            const [firstScripthash, firstCb] = [
+                ...subscribeCallbacks.entries(),
+            ][0];
+            wsMock.request.mockResolvedValueOnce([
+                { tx_hash: "newtx", height: 100 },
+            ]);
+            wsMock.batchRequest.mockResolvedValueOnce([
+                {
+                    txid: "newtx",
+                    confirmations: 1,
+                    blocktime: 1700_000_000,
+                    vout: [
+                        {
+                            n: 0,
+                            value: 0.0005,
+                            scriptPubKey: { address: "addrX", hex: "" },
+                        },
+                    ],
+                    vin: [],
+                },
+            ]);
+            firstCb(firstScripthash, "deadbeef");
+
+            // Wait for the async handleStatusChange chain to settle.
+            await new Promise((r) => setTimeout(r, 0));
+            expect(events).toHaveLength(1);
+
+            stop();
+            expect(wsMock.unsubscribe).toHaveBeenCalledTimes(2);
         });
     });
 


### PR DESCRIPTION
Supersedes #359 (draft by @louisinger). Rebased onto post–docker-compose-removal master (the submodule split in 33bdd76b made #359 unmergeable), adds unit tests, and completes the provider for production.

## Changes from #359

Three commits preserved with original @louisinger authorship:
- `0d28dd03` — `feat: add WsElectrumChainSource in providers using ws-electrumx-client`
- `b7aa81d7` — `feat: add ElectrumOnchainProvider implementing OnchainProvider interface` (docker-compose.yml change dropped; arkade-regtest submodule now owns compose)
- `a3643201` — `perf: optimize getTxOutspends from O(outputs×history×fetch) to O(4 round trips)`

One commit added on top:
- `262ff005` — `test: add unit tests for ElectrumOnchainProvider and close() helper` + adds a `close()` method to `ElectrumOnchainProvider` so callers can tear down the underlying WebSocket.

## What's in this PR

- `WsElectrumChainSource` — low-level wrapper over `ws-electrumx-client` covering the full electrum RPC surface used by the SDK (history, listunspent, verbose tx, block headers, subscriptions, broadcast, fee estimation, relay fee).
- `ElectrumOnchainProvider` implementing `OnchainProvider`: replaces esplora polling with `scripthash.subscribe` push, converts BTC/kB → sat/vB fee, sequential 1P1C broadcast (electrum has no package relay), 4-round-trip `getTxOutspends`.
- Exports both classes from `src/index.ts`.
- New dep: `ws-electrumx-client@^1.0.5`.

## Test plan

Unit tests (31 new tests passing, 875 total):
- [x] `getCoins` happy + empty paths
- [x] `getFeeRate` BTC/kB→sat/vB conversion + floor(1) guard + daemon-cannot-estimate (-1)
- [x] `broadcastTransaction` single + 1P1C package + rejects 3+
- [x] `getChainTip` parses genesis header (hash + timestamp verified against known-good values)
- [x] `getTxStatus` mempool + confirmed + blocktime/time fallback
- [x] `getTransactions` empty + verbose-tx mapping
- [x] `getTxOutspends` all-unspent + single-spender + ambiguous reused-script disambiguation
- [x] `WsElectrumChainSource` missing-tx retry, empty-input short-circuits, address decoding, close error swallowing

Live smoke test against `wss://electrum.arkade.sh` (mainnet, block 946339):
- [x] `getChainTip` returns current tip with correct parsed hash and block time
- [x] `getFeeRate` / `getRelayFee` return sane sat/vB values
- [x] `fetchBlockHeader` + `fetchBlockHeaders` (single + batch)
- [x] `getCoins` on a known bech32m address
- [x] `getTransactions` returns paginated history with proper ExplorerTransaction shape
- [x] `getTxStatus` on a confirmed tx returns correct height/time
- [x] `getTxOutspends` returns correct spent/unspent with spender txids
- [x] `close()` cleanly tears down the WebSocket

## Notes

- CI: depends on master's CI pipeline; this branch targets master cleanly now.
- @louisinger's docker-compose websocat bridge entry was dropped — that work belongs in `arkade-regtest` (the submodule that replaced docker-compose in 33bdd76b), tracked separately.
- Credit for the entire provider design and three original commits belongs to @louisinger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Electrum WebSocket on-chain provider with real-time chain tip, transaction retrieval (verbose/raw), broadcasting (single tx and package), fee estimation, address watching, unspent listing, tx status, and subscription-backed updates.
  * Public exports for the Electrum provider and related types.

* **Tests**
  * Comprehensive test suite validating header/tx fetching, fee conversion, broadcasting flows, address watching, unspent resolution, retries, and subscription behavior.

* **Chores**
  * Added a runtime dependency to support the Electrum provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->