### PR TITLE
fix(worker): enforce one-response-per-message delivery guarantees

### DIFF
--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -393,6 +393,7 @@ type MessageBusInitConfig = {
     timeoutMs?: number;
     settlementConfig?: SettlementConfig | false;
     watcherConfig?: Partial<Omit<ContractWatcherConfig, "indexerProvider">>;
+    messageTimeouts?: Record<string, number>;
 };
 
 const initializeMessageBus = (
@@ -514,21 +515,32 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             delegatorUrl: options.delegatorUrl,
         };
 
+        // Precompute the merged timeout map so page-side waiting and
+        // worker-side enforcement are derived from the same source.
+        const messageTimeouts = options.messageTimeouts
+            ? ({
+                  ...DEFAULT_MESSAGE_TIMEOUTS,
+                  ...options.messageTimeouts,
+              } as Record<RequestType, number>)
+            : (DEFAULT_MESSAGE_TIMEOUTS as Record<RequestType, number>);
+
+        const busInitConfig: MessageBusInitConfig = {
+            wallet: initConfig.key,
+            arkServer: {
+                url: initConfig.arkServerUrl,
+                publicKey: initConfig.arkServerPublicKey,
+            },
+            delegatorUrl: initConfig.delegatorUrl,
+            indexerUrl: options.indexerUrl,
+            esploraUrl: options.esploraUrl,
+            watcherConfig: options.watcherConfig,
+            messageTimeouts,
+        };
+
         // Bootstrap the MessageBus in the service worker
         await initializeMessageBus(
             options.serviceWorker,
-            {
-                wallet: initConfig.key,
-                arkServer: {
-                    url: initConfig.arkServerUrl,
-                    publicKey: initConfig.arkServerPublicKey,
-                },
-                delegatorUrl: initConfig.delegatorUrl,
-                indexerUrl: options.indexerUrl,
-                esploraUrl: options.esploraUrl,
-                timeoutMs: options.messageBusTimeoutMs,
-                watcherConfig: options.watcherConfig,
-            },
+            { ...busInitConfig, timeoutMs: options.messageBusTimeoutMs },
             options.messageBusTimeoutMs
         );
 
@@ -542,25 +554,12 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
 
         await wallet.sendMessage(initMessage);
 
-        wallet.initConfig = {
-            wallet: initConfig.key,
-            arkServer: {
-                url: initConfig.arkServerUrl,
-                publicKey: initConfig.arkServerPublicKey,
-            },
-            delegatorUrl: initConfig.delegatorUrl,
-            indexerUrl: options.indexerUrl,
-            esploraUrl: options.esploraUrl,
-            watcherConfig: options.watcherConfig,
-        };
+        // Persist the full init config (including messageTimeouts) so
+        // reinitialize() re-sends the same map to a restarted worker.
+        wallet.initConfig = busInitConfig;
         wallet.initWalletPayload = initConfig;
         wallet.messageBusTimeoutMs = options.messageBusTimeoutMs;
-        if (options.messageTimeouts) {
-            wallet.messageTimeouts = {
-                ...DEFAULT_MESSAGE_TIMEOUTS,
-                ...options.messageTimeouts,
-            } as Record<RequestType, number>;
-        }
+        wallet.messageTimeouts = messageTimeouts;
 
         return wallet;
     }
@@ -1312,21 +1311,32 @@ export class ServiceWorkerWallet
             delegatorUrl: options.delegatorUrl,
         };
 
+        // Precompute the merged timeout map so page-side waiting and
+        // worker-side enforcement are derived from the same source.
+        const messageTimeouts = options.messageTimeouts
+            ? ({
+                  ...DEFAULT_MESSAGE_TIMEOUTS,
+                  ...options.messageTimeouts,
+              } as Record<RequestType, number>)
+            : (DEFAULT_MESSAGE_TIMEOUTS as Record<RequestType, number>);
+
+        const busInitConfig: MessageBusInitConfig = {
+            wallet: initConfig.key,
+            arkServer: {
+                url: initConfig.arkServerUrl,
+                publicKey: initConfig.arkServerPublicKey,
+            },
+            delegatorUrl: initConfig.delegatorUrl,
+            indexerUrl: options.indexerUrl,
+            esploraUrl: options.esploraUrl,
+            settlementConfig: options.settlementConfig,
+            watcherConfig: options.watcherConfig,
+            messageTimeouts,
+        };
+
         await initializeMessageBus(
             options.serviceWorker,
-            {
-                wallet: initConfig.key,
-                arkServer: {
-                    url: initConfig.arkServerUrl,
-                    publicKey: initConfig.arkServerPublicKey,
-                },
-                delegatorUrl: initConfig.delegatorUrl,
-                indexerUrl: options.indexerUrl,
-                esploraUrl: options.esploraUrl,
-                timeoutMs: options.messageBusTimeoutMs,
-                settlementConfig: options.settlementConfig,
-                watcherConfig: options.watcherConfig,
-            },
+            { ...busInitConfig, timeoutMs: options.messageBusTimeoutMs },
             options.messageBusTimeoutMs
         );
         // Initialize the service worker with the config
@@ -1340,26 +1350,12 @@ export class ServiceWorkerWallet
         // Initialize the service worker
         await wallet.sendMessage(initMessage);
 
-        wallet.initConfig = {
-            wallet: initConfig.key,
-            arkServer: {
-                url: initConfig.arkServerUrl,
-                publicKey: initConfig.arkServerPublicKey,
-            },
-            delegatorUrl: initConfig.delegatorUrl,
-            indexerUrl: options.indexerUrl,
-            esploraUrl: options.esploraUrl,
-            settlementConfig: options.settlementConfig,
-            watcherConfig: options.watcherConfig,
-        };
+        // Persist the full init config (including messageTimeouts) so
+        // reinitialize() re-sends the same map to a restarted worker.
+        wallet.initConfig = busInitConfig;
         wallet.initWalletPayload = initConfig;
         wallet.messageBusTimeoutMs = options.messageBusTimeoutMs;
-        if (options.messageTimeouts) {
-            wallet.messageTimeouts = {
-                ...DEFAULT_MESSAGE_TIMEOUTS,
-                ...options.messageTimeouts,
-            } as Record<RequestType, number>;
-        }
+        wallet.messageTimeouts = messageTimeouts;
 
         return wallet;
     }

--- a/src/worker/messageBus.ts
+++ b/src/worker/messageBus.ts
@@ -93,7 +93,9 @@ type Options = {
      * Per-operation timeout overrides. Keys are either message types
      * (e.g. "SETTLE") or handler tags (e.g. "WALLET_UPDATER"). Message-type
      * matches take precedence over tag matches. Unspecified operations use
-     * `messageTimeoutMs`.
+     * `messageTimeoutMs`. These are treated as defaults: any map supplied
+     * via `INITIALIZE_MESSAGE_BUS` overrides per-key and is re-applied on
+     * every (re-)init.
      */
     messageTimeoutOverrides?: Record<string, number>;
     debug?: boolean;
@@ -144,6 +146,12 @@ type Initialize = {
         esploraUrl?: string;
         settlementConfig?: SettlementConfig | false;
         watcherConfig?: Partial<Omit<ContractWatcherConfig, "indexerProvider">>;
+        /**
+         * Page-supplied per-operation timeout map. Keys are message types
+         * (e.g. "SETTLE"). Overrides constructor-supplied
+         * `messageTimeoutOverrides` per-key; re-applied on every init.
+         */
+        messageTimeouts?: Record<string, number>;
     };
 };
 
@@ -151,6 +159,7 @@ export class MessageBus {
     private handlers: Map<string, MessageHandler>;
     private tickIntervalMs: number;
     private messageTimeoutMs: number;
+    private readonly constructorTimeoutOverrides: Record<string, number>;
     private messageTimeoutOverrides: Record<string, number>;
     private lateDeliveries = new Set<LateDelivery>();
     private running = false;
@@ -183,7 +192,8 @@ export class MessageBus {
         this.handlers = new Map(messageHandlers.map((u) => [u.messageTag, u]));
         this.tickIntervalMs = tickIntervalMs;
         this.messageTimeoutMs = messageTimeoutMs;
-        this.messageTimeoutOverrides = messageTimeoutOverrides;
+        this.constructorTimeoutOverrides = { ...messageTimeoutOverrides };
+        this.messageTimeoutOverrides = { ...this.constructorTimeoutOverrides };
         this.debug = debug;
         this.buildServicesFn = buildServices ?? this.buildServices.bind(this);
     }
@@ -317,6 +327,13 @@ export class MessageBus {
                 )
             );
         }
+        // Recompute the active timeout map from scratch so a prior init's
+        // keys cannot linger after re-init with a smaller map.
+        this.messageTimeoutOverrides = {
+            ...this.constructorTimeoutOverrides,
+            ...(config.messageTimeouts ?? {}),
+        };
+
         const services = await this.buildServicesFn(config);
         // Start all handlers
         for (const updater of this.handlers.values()) {

--- a/src/worker/messageBus.ts
+++ b/src/worker/messageBus.ts
@@ -634,10 +634,21 @@ export class MessageBus {
         messageType: string | undefined,
         handlerTag: string
     ): number {
-        if (messageType && messageType in this.messageTimeoutOverrides) {
+        if (
+            messageType &&
+            Object.prototype.hasOwnProperty.call(
+                this.messageTimeoutOverrides,
+                messageType
+            )
+        ) {
             return this.messageTimeoutOverrides[messageType];
         }
-        if (handlerTag in this.messageTimeoutOverrides) {
+        if (
+            Object.prototype.hasOwnProperty.call(
+                this.messageTimeoutOverrides,
+                handlerTag
+            )
+        ) {
             return this.messageTimeoutOverrides[handlerTag];
         }
         return this.messageTimeoutMs;

--- a/src/worker/messageBus.ts
+++ b/src/worker/messageBus.ts
@@ -79,6 +79,13 @@ type Options = {
     messageHandlers: MessageHandler[];
     tickIntervalMs?: number;
     messageTimeoutMs?: number;
+    /**
+     * Per-operation timeout overrides. Keys are either message types
+     * (e.g. "SETTLE") or handler tags (e.g. "WALLET_UPDATER"). Message-type
+     * matches take precedence over tag matches. Unspecified operations use
+     * `messageTimeoutMs`.
+     */
+    messageTimeoutOverrides?: Record<string, number>;
     debug?: boolean;
     buildServices?: (config: Initialize["config"]) => Promise<{
         arkProvider: ArkProvider;
@@ -86,6 +93,14 @@ type Options = {
         readonlyWallet: ReadonlyWallet;
     }>;
 };
+
+/**
+ * Grace period after a handler times out during which late handler
+ * completion is still delivered to the client. Once this expires,
+ * the bus sends an "Operation abandoned" error so the message id
+ * never goes silent indefinitely.
+ */
+const LATE_DELIVERY_GRACE_MS = 5 * 60_000;
 
 type Initialize = {
     type: "INITIALIZE_MESSAGE_BUS";
@@ -114,6 +129,7 @@ export class MessageBus {
     private handlers: Map<string, MessageHandler>;
     private tickIntervalMs: number;
     private messageTimeoutMs: number;
+    private messageTimeoutOverrides: Record<string, number>;
     private running = false;
     private tickTimeout: number | null = null;
     private tickInProgress = false;
@@ -136,6 +152,7 @@ export class MessageBus {
             messageHandlers,
             tickIntervalMs = 10_000,
             messageTimeoutMs = 30_000,
+            messageTimeoutOverrides = {},
             debug = false,
             buildServices,
         }: Options
@@ -143,6 +160,7 @@ export class MessageBus {
         this.handlers = new Map(messageHandlers.map((u) => [u.messageTag, u]));
         this.tickIntervalMs = tickIntervalMs;
         this.messageTimeoutMs = messageTimeoutMs;
+        this.messageTimeoutOverrides = messageTimeoutOverrides;
         this.debug = debug;
         this.buildServicesFn = buildServices ?? this.buildServices.bind(this);
     }
@@ -213,9 +231,11 @@ export class MessageBus {
 
             for (const updater of this.handlers.values()) {
                 try {
+                    const tickLabel = `${updater.messageTag}:tick`;
                     const response = await this.withTimeout(
                         updater.tick(now),
-                        `${updater.messageTag}:tick`
+                        this.resolveTimeoutMs(tickLabel, updater.messageTag),
+                        tickLabel
                     );
                     if (this.debug)
                         console.log(
@@ -400,39 +420,67 @@ export class MessageBus {
             return;
         }
 
+        const messageType = this.extractMessageType(event.data);
+
         if (broadcast) {
             const updaters = Array.from(this.handlers.values());
+            const entries = updaters.map((updater) => {
+                const label = this.labelFor(messageType, updater.messageTag);
+                const timeoutMs = this.resolveTimeoutMs(
+                    messageType,
+                    updater.messageTag
+                );
+                const handlerPromise = updater.handleMessage(event.data);
+                const raced = this.withTimeout(
+                    handlerPromise,
+                    timeoutMs,
+                    label
+                );
+                return { updater, handlerPromise, raced };
+            });
+
             const results = await Promise.allSettled(
-                updaters.map((updater) =>
-                    this.withTimeout(
-                        updater.handleMessage(event.data),
-                        updater.messageTag
-                    )
-                )
+                entries.map((e) => e.raced)
             );
 
             results.forEach((result, index) => {
-                const updater = updaters[index];
+                const { updater, handlerPromise } = entries[index];
+                const handlerTag = updater.messageTag;
+                const context = { id, tag: handlerTag, messageType };
                 if (result.status === "fulfilled") {
                     const response = result.value;
-                    if (response) {
-                        event.source?.postMessage(response);
-                    }
+                    // Always deliver a response so the caller's message id
+                    // never goes silent. Handlers returning null/undefined
+                    // get an explicit ack envelope.
+                    this.deliverResponse(
+                        event.source,
+                        response ?? { id, tag: handlerTag },
+                        context
+                    );
                 } else {
                     if (this.debug)
                         console.error(
-                            `[${updater.messageTag}] handleMessage failed`,
+                            `[${handlerTag}] handleMessage failed`,
                             result.reason
                         );
-                    const error =
-                        result.reason instanceof Error
-                            ? result.reason
-                            : new Error(String(result.reason));
-                    event.source?.postMessage({
-                        id,
-                        tag: updater.messageTag,
-                        error,
-                    });
+                    const error = toError(result.reason);
+                    this.deliverResponse(
+                        event.source,
+                        { id, tag: handlerTag, error },
+                        context
+                    );
+                    // If the error was a timeout, keep watching the
+                    // underlying handler and surface its eventual result
+                    // under the same id.
+                    if (result.reason instanceof ServiceWorkerTimeoutError) {
+                        this.attachLateDelivery(
+                            handlerPromise,
+                            event.source,
+                            id,
+                            handlerTag,
+                            messageType
+                        );
+                    }
                 }
             });
             return;
@@ -442,41 +490,76 @@ export class MessageBus {
         if (!updater) {
             if (this.debug)
                 console.warn(`[${tag}] unknown message tag, ignoring message`);
+            this.deliverResponse(
+                event.source,
+                {
+                    id,
+                    tag,
+                    error: new Error(`Unknown handler tag: ${tag}`),
+                },
+                { id, tag, messageType }
+            );
             return;
         }
 
+        const label = this.labelFor(messageType, tag);
+        const timeoutMs = this.resolveTimeoutMs(messageType, tag);
+        const handlerPromise = updater.handleMessage(event.data);
+        const context = { id, tag, messageType };
         try {
             const response = await this.withTimeout(
-                updater.handleMessage(event.data),
-                tag
+                handlerPromise,
+                timeoutMs,
+                label
             );
             if (this.debug)
                 console.log(`[${tag}] outgoing response:`, response);
-            if (response) {
-                event.source?.postMessage(response);
-            }
+            // Always deliver a response so the caller's message id never
+            // goes silent. A handler returning null/undefined yields an
+            // explicit ack envelope.
+            this.deliverResponse(
+                event.source,
+                response ?? { id, tag },
+                context
+            );
         } catch (err) {
             if (this.debug) console.error(`[${tag}] handleMessage failed`, err);
-            const error = err instanceof Error ? err : new Error(String(err));
-            event.source?.postMessage({ id, tag, error });
+            const error = toError(err);
+            this.deliverResponse(event.source, { id, tag, error }, context);
+            // When we abandoned the handler via timeout, keep watching it
+            // so the client's message id eventually gets a final response.
+            if (err instanceof ServiceWorkerTimeoutError) {
+                this.attachLateDelivery(
+                    handlerPromise,
+                    event.source,
+                    id,
+                    tag,
+                    messageType
+                );
+            }
         }
     }
 
     /**
      * Race `promise` against a timeout. Note: this does NOT cancel the
-     * underlying work — the original promise keeps running. This is safe
-     * here because only the caller (not the handler) posts the response.
+     * underlying work — the original promise keeps running. Call
+     * `attachLateDelivery` after catching the timeout to surface the
+     * eventual result so the message id does not go silent.
      */
-    private withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
-        if (this.messageTimeoutMs <= 0) return promise;
+    private withTimeout<T>(
+        promise: Promise<T>,
+        timeoutMs: number,
+        label: string
+    ): Promise<T> {
+        if (timeoutMs <= 0) return promise;
         return new Promise((resolve, reject) => {
             const timer = self.setTimeout(() => {
                 reject(
                     new ServiceWorkerTimeoutError(
-                        `Message handler timed out after ${this.messageTimeoutMs}ms (${label})`
+                        `Message handler timed out after ${timeoutMs}ms (${label})`
                     )
                 );
-            }, this.messageTimeoutMs);
+            }, timeoutMs);
             promise.then(
                 (val) => {
                     self.clearTimeout(timer);
@@ -488,6 +571,118 @@ export class MessageBus {
                 }
             );
         });
+    }
+
+    /**
+     * Extract the declared `type` from a request envelope (e.g. "SETTLE").
+     * Not every envelope carries a type (PING/INIT are special cased
+     * earlier), so this returns undefined for envelopes that lack one.
+     */
+    private extractMessageType(data: RequestEnvelope): string | undefined {
+        const maybeType = (data as RequestEnvelope & { type?: unknown }).type;
+        return typeof maybeType === "string" ? maybeType : undefined;
+    }
+
+    /**
+     * Resolve the timeout for an operation. Message-type overrides take
+     * precedence over handler-tag overrides, with the bus-wide default
+     * (`messageTimeoutMs`) as the final fallback.
+     */
+    private resolveTimeoutMs(
+        messageType: string | undefined,
+        handlerTag: string
+    ): number {
+        if (messageType && messageType in this.messageTimeoutOverrides) {
+            return this.messageTimeoutOverrides[messageType];
+        }
+        if (handlerTag in this.messageTimeoutOverrides) {
+            return this.messageTimeoutOverrides[handlerTag];
+        }
+        return this.messageTimeoutMs;
+    }
+
+    /**
+     * Build a human-readable label for timeout errors. Format:
+     * `"<MESSAGE_TYPE> via <HANDLER_TAG>"` when both are known, else the
+     * handler tag alone. Used so timeout errors name the operation the
+     * client actually triggered (e.g. SETTLE) rather than just the
+     * handler that received it (e.g. WALLET_UPDATER).
+     */
+    private labelFor(
+        messageType: string | undefined,
+        handlerTag: string
+    ): string {
+        return messageType ? `${messageType} via ${handlerTag}` : handlerTag;
+    }
+
+    /**
+     * Post a response to the originating client. When `source` is null
+     * (client tab closed, detached frame, etc.) the response cannot be
+     * delivered; we log the drop in debug mode so it is not invisible.
+     */
+    private deliverResponse(
+        source: ExtendableMessageEvent["source"],
+        response: ResponseEnvelope,
+        context: { id?: string; tag: string; messageType?: string }
+    ): void {
+        if (!source) {
+            if (this.debug)
+                console.warn(
+                    `[${context.tag}] cannot deliver response: event.source is null`,
+                    {
+                        id: context.id,
+                        messageType: context.messageType,
+                    }
+                );
+            return;
+        }
+        source.postMessage(response);
+    }
+
+    /**
+     * After a handler times out the client has already received a timeout
+     * error, but the handler keeps running. Attach a follow-up so the
+     * handler's eventual result (or error) is delivered under the same
+     * message id, or — if the handler never completes within
+     * {@link LATE_DELIVERY_GRACE_MS} — an "Operation abandoned" error is
+     * sent so the client's listener (if still attached) does not hang.
+     */
+    private attachLateDelivery(
+        handlerPromise: Promise<ResponseEnvelope | null>,
+        source: ExtendableMessageEvent["source"],
+        id: string,
+        tag: string,
+        messageType: string | undefined
+    ): void {
+        const context = { id, tag, messageType };
+        const deadline = self.setTimeout(() => {
+            this.deliverResponse(
+                source,
+                {
+                    id,
+                    tag,
+                    error: new Error(
+                        `Operation abandoned: handler did not complete within ${LATE_DELIVERY_GRACE_MS}ms after timeout (${this.labelFor(messageType, tag)})`
+                    ),
+                },
+                context
+            );
+        }, LATE_DELIVERY_GRACE_MS);
+
+        handlerPromise.then(
+            (response) => {
+                self.clearTimeout(deadline);
+                this.deliverResponse(source, response ?? { id, tag }, context);
+            },
+            (err) => {
+                self.clearTimeout(deadline);
+                this.deliverResponse(
+                    source,
+                    { id, tag, error: toError(err) },
+                    context
+                );
+            }
+        );
     }
 
     /**
@@ -512,4 +707,8 @@ export class MessageBus {
         await setupServiceWorkerOnce(path);
         return getActiveServiceWorker(path);
     }
+}
+
+function toError(value: unknown): Error {
+    return value instanceof Error ? value : new Error(String(value));
 }

--- a/src/worker/messageBus.ts
+++ b/src/worker/messageBus.ts
@@ -123,7 +123,7 @@ const LATE_DELIVERY_GRACE_MS = 5 * 60_000;
  */
 type LateDelivery = {
     settled: boolean;
-    deadline: ReturnType<typeof setTimeout>;
+    deadline: number;
 };
 
 type Initialize = {

--- a/src/worker/messageBus.ts
+++ b/src/worker/messageBus.ts
@@ -112,6 +112,18 @@ type Options = {
  */
 const LATE_DELIVERY_GRACE_MS = 5 * 60_000;
 
+/**
+ * Tracks one in-flight late-delivery watcher (a handler that has already
+ * timed out but is still running). The `settled` flag guards against
+ * double-delivery when the grace-period deadline and the handler's own
+ * completion race; `stop()` iterates every live record, flips `settled`,
+ * and clears the deadline so no response is posted after shutdown.
+ */
+type LateDelivery = {
+    settled: boolean;
+    deadline: ReturnType<typeof setTimeout>;
+};
+
 type Initialize = {
     type: "INITIALIZE_MESSAGE_BUS";
     id: string;
@@ -140,6 +152,7 @@ export class MessageBus {
     private tickIntervalMs: number;
     private messageTimeoutMs: number;
     private messageTimeoutOverrides: Record<string, number>;
+    private lateDeliveries = new Set<LateDelivery>();
     private running = false;
     private tickTimeout: number | null = null;
     private tickInProgress = false;
@@ -208,6 +221,12 @@ export class MessageBus {
             self.clearTimeout(this.tickTimeout);
             this.tickTimeout = null;
         }
+
+        for (const record of this.lateDeliveries) {
+            record.settled = true;
+            self.clearTimeout(record.deadline);
+        }
+        this.lateDeliveries.clear();
 
         self.removeEventListener("message", this.boundOnMessage);
 
@@ -661,27 +680,40 @@ export class MessageBus {
         messageType: string | undefined
     ): void {
         const context = { id, tag, messageType };
-        const deadline = self.setTimeout(() => {
-            this.deliverResponse(
-                source,
-                {
-                    id,
-                    tag,
-                    error: new Error(
-                        `Operation abandoned: handler did not complete within ${LATE_DELIVERY_GRACE_MS}ms after timeout (${this.labelFor(messageType, tag)})`
-                    ),
-                },
-                context
-            );
-        }, LATE_DELIVERY_GRACE_MS);
+        const record: LateDelivery = {
+            settled: false,
+            deadline: self.setTimeout(() => {
+                if (record.settled) return;
+                record.settled = true;
+                this.lateDeliveries.delete(record);
+                this.deliverResponse(
+                    source,
+                    {
+                        id,
+                        tag,
+                        error: new Error(
+                            `Operation abandoned: handler did not complete within ${LATE_DELIVERY_GRACE_MS}ms after timeout (${this.labelFor(messageType, tag)})`
+                        ),
+                    },
+                    context
+                );
+            }, LATE_DELIVERY_GRACE_MS),
+        };
+        this.lateDeliveries.add(record);
 
         handlerPromise.then(
             (response) => {
-                self.clearTimeout(deadline);
+                if (record.settled) return;
+                record.settled = true;
+                self.clearTimeout(record.deadline);
+                this.lateDeliveries.delete(record);
                 this.deliverResponse(source, response ?? { id, tag }, context);
             },
             (err) => {
-                self.clearTimeout(deadline);
+                if (record.settled) return;
+                record.settled = true;
+                self.clearTimeout(record.deadline);
+                this.lateDeliveries.delete(record);
                 this.deliverResponse(
                     source,
                     { id, tag, error: toError(err) },

--- a/src/worker/messageBus.ts
+++ b/src/worker/messageBus.ts
@@ -413,7 +413,11 @@ export class MessageBus {
         const { id, tag, broadcast } = event.data as RequestEnvelope;
 
         if (tag === "PING") {
-            event.source?.postMessage({ id, tag: "PONG" });
+            this.deliverResponse(
+                event.source,
+                { id, tag: "PONG" },
+                { id, tag: "PONG" }
+            );
             return;
         }
 
@@ -425,7 +429,7 @@ export class MessageBus {
             // performs network calls (buildServices) and handler startup
             // that may legitimately exceed the message timeout.
             await this.waitForInit(event.data.config);
-            event.source?.postMessage({ id, tag });
+            this.deliverResponse(event.source, { id, tag }, { id, tag });
             if (this.debug) {
                 console.log("MessageBus initialized");
             }
@@ -442,11 +446,16 @@ export class MessageBus {
             // hanging forever. This happens when the browser kills and restarts
             // the service worker — the new instance has initialized=false and
             // messages arrive before INITIALIZE_MESSAGE_BUS is re-sent.
-            event.source?.postMessage({
-                id,
-                tag: tag ?? "unknown",
-                error: new MessageBusNotInitializedError(),
-            });
+            const fallbackTag = tag ?? "unknown";
+            this.deliverResponse(
+                event.source,
+                {
+                    id,
+                    tag: fallbackTag,
+                    error: new MessageBusNotInitializedError(),
+                },
+                { id, tag: fallbackTag }
+            );
             return;
         }
 
@@ -456,13 +465,18 @@ export class MessageBus {
                     "Invalid message received, missing required fields:",
                     event.data
                 );
-            event.source?.postMessage({
-                id,
-                tag: tag ?? "unknown",
-                error: new TypeError(
-                    "Invalid message received, missing required fields"
-                ),
-            });
+            const fallbackTag = tag ?? "unknown";
+            this.deliverResponse(
+                event.source,
+                {
+                    id,
+                    tag: fallbackTag,
+                    error: new TypeError(
+                        "Invalid message received, missing required fields"
+                    ),
+                },
+                { id, tag: fallbackTag }
+            );
             return;
         }
 

--- a/test/serviceWorker/worker.test.ts
+++ b/test/serviceWorker/worker.test.ts
@@ -150,7 +150,7 @@ describe("Worker", () => {
         });
     });
 
-    it("ignores messages with unknown tags", async () => {
+    it("responds with an error for messages with unknown tags (no silent drop)", async () => {
         const handleMessage = vi.fn().mockResolvedValue(null);
         const updater: TestUpdater = {
             messageTag: "known",
@@ -182,7 +182,13 @@ describe("Worker", () => {
         });
 
         expect(handleMessage).not.toHaveBeenCalled();
-        expect(source.postMessage).not.toHaveBeenCalled();
+        // Every message must produce exactly one response (issue #448).
+        expect(source.postMessage).toHaveBeenCalledTimes(1);
+        const sent = source.postMessage.mock.calls[0][0];
+        expect(sent.id).toBe("1");
+        expect(sent.tag).toBe("unknown");
+        expect(sent.error).toBeInstanceOf(Error);
+        expect(sent.error.message).toMatch(/Unknown handler tag/);
     });
 
     it("handles init message", async () => {

--- a/test/worker/messageBus.test.ts
+++ b/test/worker/messageBus.test.ts
@@ -3,27 +3,110 @@ import {
     InMemoryWalletRepository,
     InMemoryContractRepository,
 } from "../../src";
-import { MessageBus } from "../../src/worker/messageBus";
+import {
+    MessageBus,
+    MessageHandler,
+    RequestEnvelope,
+    ResponseEnvelope,
+} from "../../src/worker/messageBus";
+import { ServiceWorkerTimeoutError } from "../../src/worker/errors";
+
+type StubbedSelf = {
+    addEventListener: ReturnType<typeof vi.fn>;
+    removeEventListener: ReturnType<typeof vi.fn>;
+    skipWaiting: ReturnType<typeof vi.fn>;
+    clients: {
+        claim: ReturnType<typeof vi.fn>;
+        matchAll: ReturnType<typeof vi.fn>;
+    };
+    setTimeout: typeof setTimeout;
+    clearTimeout: typeof clearTimeout;
+};
+
+let messageHandler: (event: {
+    data: RequestEnvelope | { type: string; id?: string; config?: unknown };
+    source: { postMessage: (m: unknown) => void } | null;
+    waitUntil: (p: Promise<unknown>) => unknown;
+}) => Promise<void>;
+
+function installSelfStub(): StubbedSelf {
+    const selfMock: StubbedSelf = {
+        addEventListener: vi.fn((type: string, handler: Function) => {
+            if (type === "message")
+                messageHandler = handler as typeof messageHandler;
+        }),
+        removeEventListener: vi.fn(),
+        skipWaiting: vi.fn(),
+        clients: {
+            claim: vi.fn(),
+            matchAll: vi.fn().mockResolvedValue([]),
+        },
+        // Use globalThis so these work with vi.useFakeTimers() for timeout tests
+        setTimeout: ((fn: () => void, ms: number) =>
+            globalThis.setTimeout(fn, ms)) as unknown as typeof setTimeout,
+        clearTimeout: ((id: unknown) =>
+            globalThis.clearTimeout(
+                id as Parameters<typeof globalThis.clearTimeout>[0]
+            )) as unknown as typeof clearTimeout,
+    };
+    vi.stubGlobal("self", selfMock);
+    return selfMock;
+}
+
+class TestHandler implements MessageHandler {
+    readonly messageTag: string;
+    handleMessage =
+        vi.fn<(message: RequestEnvelope) => Promise<ResponseEnvelope | null>>();
+    tick = vi
+        .fn<(now: number) => Promise<ResponseEnvelope[]>>()
+        .mockResolvedValue([]);
+    start = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    stop = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    constructor(tag = "TEST_HANDLER") {
+        this.messageTag = tag;
+    }
+}
+
+async function createAndInitBus(options: {
+    handlers: MessageHandler[];
+    messageTimeoutMs?: number;
+    messageTimeoutOverrides?: Record<string, number>;
+    debug?: boolean;
+}) {
+    const bus = new MessageBus(
+        new InMemoryWalletRepository(),
+        new InMemoryContractRepository(),
+        {
+            messageHandlers: options.handlers,
+            messageTimeoutMs: options.messageTimeoutMs ?? 30_000,
+            messageTimeoutOverrides: options.messageTimeoutOverrides,
+            debug: options.debug ?? false,
+            // Bypass the real buildServices — it tries to talk to networks.
+            buildServices: async () => ({}) as never,
+        }
+    );
+    await bus.start();
+    const initSource = { postMessage: vi.fn() };
+    await messageHandler({
+        data: {
+            type: "INITIALIZE_MESSAGE_BUS",
+            id: "init-1",
+            tag: "INITIALIZE_MESSAGE_BUS",
+            config: {
+                wallet: { publicKey: "00".repeat(33) },
+                arkServer: { url: "http://localhost" },
+            },
+        } as never,
+        source: initSource as never,
+        waitUntil: (p: Promise<unknown>) => p,
+    });
+    return bus;
+}
 
 describe("MessageBus PING/PONG", () => {
-    let messageHandler: Function;
-
     beforeEach(() => {
-        const selfMock = {
-            addEventListener: vi.fn((type: string, handler: Function) => {
-                if (type === "message") messageHandler = handler;
-            }),
-            removeEventListener: vi.fn(),
-            skipWaiting: vi.fn(),
-            clients: {
-                claim: vi.fn(),
-                matchAll: vi.fn().mockResolvedValue([]),
-            },
-            setTimeout: (fn: Function, ms: number) =>
-                setTimeout(fn, ms) as unknown as number,
-            clearTimeout: (id: number) => clearTimeout(id),
-        };
-        vi.stubGlobal("self", selfMock);
+        installSelfStub();
     });
 
     afterEach(() => {
@@ -42,7 +125,7 @@ describe("MessageBus PING/PONG", () => {
         await messageHandler({
             data: { id: "ping-1", tag: "PING" },
             source: { postMessage },
-            waitUntil: vi.fn((p: Promise<any>) => p),
+            waitUntil: (p) => p,
         });
 
         expect(postMessage).toHaveBeenCalledWith({
@@ -61,21 +144,494 @@ describe("MessageBus PING/PONG", () => {
         );
         await bus.start();
 
-        // Don't send INITIALIZE_MESSAGE_BUS — bus is uninitialized
-
         const postMessage = vi.fn();
         await messageHandler({
             data: { id: "ping-2", tag: "PING" },
             source: { postMessage },
-            waitUntil: vi.fn((p: Promise<any>) => p),
+            waitUntil: (p) => p,
         });
 
         expect(postMessage).toHaveBeenCalledWith({
             id: "ping-2",
             tag: "PONG",
         });
-        // Should not have sent an error (which the !initialized gate would)
         expect(postMessage).toHaveBeenCalledTimes(1);
+
+        await bus.stop();
+    });
+});
+
+describe("MessageBus delivery guarantees (issue #448)", () => {
+    let handler: TestHandler;
+
+    beforeEach(() => {
+        installSelfStub();
+        handler = new TestHandler();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it("responds with an error when the message tag has no registered handler", async () => {
+        const bus = await createAndInitBus({ handlers: [handler] });
+        const postMessage = vi.fn();
+
+        await messageHandler({
+            data: { id: "m1", tag: "DOES_NOT_EXIST" },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        expect(postMessage).toHaveBeenCalledTimes(1);
+        const sent = postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.id).toBe("m1");
+        expect(sent.tag).toBe("DOES_NOT_EXIST");
+        expect(sent.error).toBeInstanceOf(Error);
+        expect(sent.error?.message).toMatch(/Unknown handler tag/);
+
+        await bus.stop();
+    });
+
+    it("delivers an ack envelope when a handler returns null", async () => {
+        handler.handleMessage.mockResolvedValueOnce(null);
+        const bus = await createAndInitBus({ handlers: [handler] });
+        const postMessage = vi.fn();
+
+        await messageHandler({
+            data: { id: "m2", tag: handler.messageTag },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        expect(postMessage).toHaveBeenCalledTimes(1);
+        expect(postMessage).toHaveBeenCalledWith({
+            id: "m2",
+            tag: handler.messageTag,
+        });
+
+        await bus.stop();
+    });
+
+    it("delivers an ack envelope when a handler returns undefined", async () => {
+        handler.handleMessage.mockResolvedValueOnce(
+            undefined as unknown as ResponseEnvelope
+        );
+        const bus = await createAndInitBus({ handlers: [handler] });
+        const postMessage = vi.fn();
+
+        await messageHandler({
+            data: { id: "m3", tag: handler.messageTag },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        expect(postMessage).toHaveBeenCalledWith({
+            id: "m3",
+            tag: handler.messageTag,
+        });
+
+        await bus.stop();
+    });
+
+    it("delivers the handler's response verbatim when it is truthy", async () => {
+        handler.handleMessage.mockResolvedValueOnce({
+            id: "m4",
+            tag: handler.messageTag,
+            payload: { ok: true },
+        } as ResponseEnvelope);
+        const bus = await createAndInitBus({ handlers: [handler] });
+        const postMessage = vi.fn();
+
+        await messageHandler({
+            data: { id: "m4", tag: handler.messageTag, type: "GET_BALANCE" },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ id: "m4", payload: { ok: true } })
+        );
+
+        await bus.stop();
+    });
+
+    it("reports timeout errors with message type and handler tag in the label", async () => {
+        vi.useFakeTimers();
+        handler.handleMessage.mockReturnValueOnce(new Promise(() => {}));
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 100,
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m5",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(150);
+        await processed;
+
+        const sent = postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.id).toBe("m5");
+        expect(sent.tag).toBe(handler.messageTag);
+        expect(sent.error).toBeInstanceOf(ServiceWorkerTimeoutError);
+        expect(sent.error?.message).toContain("SETTLE via TEST_HANDLER");
+        expect(sent.error?.message).toContain("100ms");
+
+        await bus.stop();
+    });
+
+    it("falls back to the handler tag in the label when no message type is provided", async () => {
+        vi.useFakeTimers();
+        handler.handleMessage.mockReturnValueOnce(new Promise(() => {}));
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 50,
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: { id: "m6", tag: handler.messageTag },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(100);
+        await processed;
+
+        const sent = postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.error?.message).toContain("(TEST_HANDLER)");
+        expect(sent.error?.message).not.toContain(" via ");
+
+        await bus.stop();
+    });
+
+    it("honours per-message-type timeout overrides", async () => {
+        vi.useFakeTimers();
+        handler.handleMessage.mockReturnValueOnce(new Promise(() => {}));
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 30_000,
+            messageTimeoutOverrides: { SETTLE: 100 },
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m7",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        // The override (100ms) should fire long before the default (30s).
+        await vi.advanceTimersByTimeAsync(150);
+        await processed;
+
+        const sent = postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.error?.message).toContain("100ms");
+
+        await bus.stop();
+    });
+
+    it("honours per-handler-tag timeout overrides when no message-type override matches", async () => {
+        vi.useFakeTimers();
+        handler.handleMessage.mockReturnValueOnce(new Promise(() => {}));
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 30_000,
+            messageTimeoutOverrides: { TEST_HANDLER: 80 },
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m8",
+                tag: handler.messageTag,
+                type: "GET_BALANCE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(120);
+        await processed;
+
+        const sent = postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.error?.message).toContain("80ms");
+
+        await bus.stop();
+    });
+
+    it("prefers message-type override over handler-tag override when both match", async () => {
+        vi.useFakeTimers();
+        handler.handleMessage.mockReturnValueOnce(new Promise(() => {}));
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 30_000,
+            messageTimeoutOverrides: {
+                TEST_HANDLER: 30_000,
+                SETTLE: 60,
+            },
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m9",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(100);
+        await processed;
+
+        const sent = postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.error?.message).toContain("60ms");
+
+        await bus.stop();
+    });
+
+    it("delivers late handler result under the original id after a timeout", async () => {
+        vi.useFakeTimers();
+        let resolveLate: ((r: ResponseEnvelope) => void) | undefined;
+        handler.handleMessage.mockReturnValueOnce(
+            new Promise<ResponseEnvelope>((resolve) => {
+                resolveLate = resolve;
+            })
+        );
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 50,
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m10",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(100);
+        await processed;
+
+        // First response: the timeout error
+        expect(postMessage).toHaveBeenCalledTimes(1);
+        expect(
+            (postMessage.mock.calls[0][0] as ResponseEnvelope).error
+        ).toBeInstanceOf(ServiceWorkerTimeoutError);
+
+        // Handler now completes late
+        resolveLate!({
+            id: "m10",
+            tag: handler.messageTag,
+            payload: { settled: true },
+        } as ResponseEnvelope);
+        // Flush the microtasks that deliver the late response (the handler's
+        // .then continuations). Do not use runAllTimersAsync here because
+        // the bus's recurring tick timer would never settle.
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Second response: the late result with the same id
+        expect(postMessage).toHaveBeenCalledTimes(2);
+        expect(postMessage.mock.calls[1][0]).toEqual(
+            expect.objectContaining({
+                id: "m10",
+                payload: { settled: true },
+            })
+        );
+
+        await bus.stop();
+    });
+
+    it("delivers late handler error under the original id after a timeout", async () => {
+        vi.useFakeTimers();
+        let rejectLate: ((e: Error) => void) | undefined;
+        handler.handleMessage.mockReturnValueOnce(
+            new Promise<ResponseEnvelope>((_, reject) => {
+                rejectLate = reject;
+            })
+        );
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 50,
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m11",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(100);
+        await processed;
+
+        rejectLate!(new Error("late failure"));
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(postMessage).toHaveBeenCalledTimes(2);
+        const lateResponse = postMessage.mock.calls[1][0] as ResponseEnvelope;
+        expect(lateResponse.id).toBe("m11");
+        expect(lateResponse.tag).toBe(handler.messageTag);
+        expect(lateResponse.error?.message).toBe("late failure");
+
+        await bus.stop();
+    });
+
+    it("sends an 'Operation abandoned' error if the handler never completes within the grace window", async () => {
+        vi.useFakeTimers();
+        handler.handleMessage.mockReturnValueOnce(new Promise(() => {}));
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 50,
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m12",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(100);
+        await processed;
+
+        // Advance past the 5-minute grace window.
+        await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
+
+        expect(postMessage).toHaveBeenCalledTimes(2);
+        const abandoned = postMessage.mock.calls[1][0] as ResponseEnvelope;
+        expect(abandoned.id).toBe("m12");
+        expect(abandoned.tag).toBe(handler.messageTag);
+        expect(abandoned.error?.message).toMatch(/Operation abandoned/);
+
+        await bus.stop();
+    });
+
+    it("does not throw and logs when the originating client (event.source) is null", async () => {
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            debug: true,
+        });
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        handler.handleMessage.mockResolvedValueOnce({
+            id: "m13",
+            tag: handler.messageTag,
+        } as ResponseEnvelope);
+
+        await messageHandler({
+            data: { id: "m13", tag: handler.messageTag },
+            source: null,
+            waitUntil: (p) => p,
+        });
+
+        expect(warnSpy).toHaveBeenCalled();
+        const [msg] =
+            warnSpy.mock.calls.find(
+                (call) =>
+                    typeof call[0] === "string" &&
+                    call[0].includes("cannot deliver response")
+            ) ?? [];
+        expect(msg).toBeDefined();
+
+        warnSpy.mockRestore();
+        await bus.stop();
+    });
+
+    it("broadcasts to every handler and acks handlers that return null", async () => {
+        const handlerA = new TestHandler("A_HANDLER");
+        const handlerB = new TestHandler("B_HANDLER");
+        handlerA.handleMessage.mockResolvedValueOnce({
+            id: "bc1",
+            tag: "A_HANDLER",
+            payload: { fromA: true },
+        } as ResponseEnvelope);
+        handlerB.handleMessage.mockResolvedValueOnce(null);
+
+        const bus = await createAndInitBus({
+            handlers: [handlerA, handlerB],
+        });
+        const postMessage = vi.fn();
+
+        await messageHandler({
+            data: { id: "bc1", tag: "BROADCAST", broadcast: true },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        expect(postMessage).toHaveBeenCalledTimes(2);
+        // Order follows handler registration; A resolves with payload, B acks.
+        expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: "bc1",
+                tag: "A_HANDLER",
+                payload: { fromA: true },
+            })
+        );
+        expect(postMessage).toHaveBeenCalledWith({
+            id: "bc1",
+            tag: "B_HANDLER",
+        });
+
+        await bus.stop();
+    });
+
+    it("surfaces per-handler errors in broadcast mode without suppressing others", async () => {
+        const handlerA = new TestHandler("A_HANDLER");
+        const handlerB = new TestHandler("B_HANDLER");
+        handlerA.handleMessage.mockRejectedValueOnce(new Error("A failed"));
+        handlerB.handleMessage.mockResolvedValueOnce({
+            id: "bc2",
+            tag: "B_HANDLER",
+            payload: { ok: true },
+        } as ResponseEnvelope);
+
+        const bus = await createAndInitBus({
+            handlers: [handlerA, handlerB],
+        });
+        const postMessage = vi.fn();
+
+        await messageHandler({
+            data: { id: "bc2", tag: "BROADCAST", broadcast: true },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        expect(postMessage).toHaveBeenCalledTimes(2);
+        const aResponse = postMessage.mock.calls.find(
+            (c) => (c[0] as ResponseEnvelope).tag === "A_HANDLER"
+        )?.[0] as ResponseEnvelope;
+        expect(aResponse.error?.message).toBe("A failed");
+        const bResponse = postMessage.mock.calls.find(
+            (c) => (c[0] as ResponseEnvelope).tag === "B_HANDLER"
+        )?.[0] as ResponseEnvelope;
+        expect(bResponse.payload).toEqual({ ok: true });
 
         await bus.stop();
     });

--- a/test/worker/messageBus.test.ts
+++ b/test/worker/messageBus.test.ts
@@ -534,6 +534,130 @@ describe("MessageBus delivery guarantees (issue #448)", () => {
         await bus.stop();
     });
 
+    it("does not deliver a third response when the handler resolves after the abandoned deadline", async () => {
+        vi.useFakeTimers();
+        let resolveLate: ((r: ResponseEnvelope) => void) | undefined;
+        handler.handleMessage.mockReturnValueOnce(
+            new Promise<ResponseEnvelope>((resolve) => {
+                resolveLate = resolve;
+            })
+        );
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 50,
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m14",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(100);
+        await processed;
+        // Advance past the grace window — abandoned error fires.
+        await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
+        expect(postMessage).toHaveBeenCalledTimes(2);
+
+        // Handler now completes very late; must NOT produce a third response.
+        resolveLate!({
+            id: "m14",
+            tag: handler.messageTag,
+            payload: { settled: true },
+        } as ResponseEnvelope);
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(postMessage).toHaveBeenCalledTimes(2);
+
+        await bus.stop();
+    });
+
+    it("does not deliver a third response when the handler rejects after the abandoned deadline", async () => {
+        vi.useFakeTimers();
+        let rejectLate: ((e: Error) => void) | undefined;
+        handler.handleMessage.mockReturnValueOnce(
+            new Promise<ResponseEnvelope>((_, reject) => {
+                rejectLate = reject;
+            })
+        );
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 50,
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m15",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(100);
+        await processed;
+        await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
+        expect(postMessage).toHaveBeenCalledTimes(2);
+
+        rejectLate!(new Error("very late failure"));
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(postMessage).toHaveBeenCalledTimes(2);
+
+        await bus.stop();
+    });
+
+    it("does not deliver late responses after bus.stop()", async () => {
+        vi.useFakeTimers();
+        let resolveLate: ((r: ResponseEnvelope) => void) | undefined;
+        handler.handleMessage.mockReturnValueOnce(
+            new Promise<ResponseEnvelope>((resolve) => {
+                resolveLate = resolve;
+            })
+        );
+        const bus = await createAndInitBus({
+            handlers: [handler],
+            messageTimeoutMs: 50,
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "m16",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        await vi.advanceTimersByTimeAsync(100);
+        await processed;
+        // One response delivered so far: the timeout error.
+        expect(postMessage).toHaveBeenCalledTimes(1);
+
+        await bus.stop();
+        const countAtStop = postMessage.mock.calls.length;
+
+        // Neither the grace deadline nor a late handler settle should post now.
+        await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
+        resolveLate!({
+            id: "m16",
+            tag: handler.messageTag,
+            payload: { settled: true },
+        } as ResponseEnvelope);
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(postMessage).toHaveBeenCalledTimes(countAtStop);
+    });
+
     it("does not throw and logs when the originating client (event.source) is null", async () => {
         const bus = await createAndInitBus({
             handlers: [handler],

--- a/test/worker/messageBus.test.ts
+++ b/test/worker/messageBus.test.ts
@@ -373,6 +373,131 @@ describe("MessageBus delivery guarantees (issue #448)", () => {
         await bus.stop();
     });
 
+    it("prefers INIT-supplied messageTimeouts over constructor overrides", async () => {
+        vi.useFakeTimers();
+        handler.handleMessage.mockReturnValueOnce(new Promise(() => {}));
+        // Constructor sets SETTLE to 5s; INIT will override it to 100ms.
+        const bus = new MessageBus(
+            new InMemoryWalletRepository(),
+            new InMemoryContractRepository(),
+            {
+                messageHandlers: [handler],
+                messageTimeoutMs: 30_000,
+                messageTimeoutOverrides: { SETTLE: 5_000 },
+                buildServices: async () => ({}) as never,
+            }
+        );
+        await bus.start();
+        const initSource = { postMessage: vi.fn() };
+        await messageHandler({
+            data: {
+                type: "INITIALIZE_MESSAGE_BUS",
+                id: "init-prec",
+                tag: "INITIALIZE_MESSAGE_BUS",
+                config: {
+                    wallet: { publicKey: "00".repeat(33) },
+                    arkServer: { url: "http://localhost" },
+                    messageTimeouts: { SETTLE: 100 },
+                },
+            } as never,
+            source: initSource as never,
+            waitUntil: (p: Promise<unknown>) => p,
+        });
+        const postMessage = vi.fn();
+
+        const processed = messageHandler({
+            data: {
+                id: "prec-1",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        // INIT's 100ms should fire long before the constructor's 5s.
+        await vi.advanceTimersByTimeAsync(150);
+        await processed;
+
+        const sent = postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.error?.message).toContain("100ms");
+
+        await bus.stop();
+    });
+
+    it("recomputes the active timeout map on every init (no stale keys)", async () => {
+        vi.useFakeTimers();
+        const bus = new MessageBus(
+            new InMemoryWalletRepository(),
+            new InMemoryContractRepository(),
+            {
+                messageHandlers: [handler],
+                messageTimeoutMs: 30_000,
+                buildServices: async () => ({}) as never,
+            }
+        );
+        await bus.start();
+
+        // First init introduces a SETTLE override.
+        const initSource = { postMessage: vi.fn() };
+        await messageHandler({
+            data: {
+                type: "INITIALIZE_MESSAGE_BUS",
+                id: "init-a",
+                tag: "INITIALIZE_MESSAGE_BUS",
+                config: {
+                    wallet: { publicKey: "00".repeat(33) },
+                    arkServer: { url: "http://localhost" },
+                    messageTimeouts: { SETTLE: 100 },
+                },
+            } as never,
+            source: initSource as never,
+            waitUntil: (p: Promise<unknown>) => p,
+        });
+
+        // Re-init without SETTLE in the new map — the previous override
+        // must not persist.
+        await messageHandler({
+            data: {
+                type: "INITIALIZE_MESSAGE_BUS",
+                id: "init-b",
+                tag: "INITIALIZE_MESSAGE_BUS",
+                config: {
+                    wallet: { publicKey: "00".repeat(33) },
+                    arkServer: { url: "http://localhost" },
+                    messageTimeouts: { GET_BALANCE: 200 },
+                },
+            } as never,
+            source: initSource as never,
+            waitUntil: (p: Promise<unknown>) => p,
+        });
+
+        handler.handleMessage.mockReturnValueOnce(new Promise(() => {}));
+        const postMessage = vi.fn();
+        const processed = messageHandler({
+            data: {
+                id: "recompute-1",
+                tag: handler.messageTag,
+                type: "SETTLE",
+            } as RequestEnvelope & { type: string },
+            source: { postMessage },
+            waitUntil: (p) => p,
+        });
+
+        // With SETTLE no longer overridden, the bus default (30s) applies.
+        // Advance past the old 100ms override — no response should be posted.
+        await vi.advanceTimersByTimeAsync(500);
+        expect(postMessage).not.toHaveBeenCalled();
+
+        // Advance past the default 30s and confirm the default fires.
+        await vi.advanceTimersByTimeAsync(30_000);
+        await processed;
+        const sent = postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.error?.message).toContain("30000ms");
+
+        await bus.stop();
+    });
+
     it("prefers message-type override over handler-tag override when both match", async () => {
         vi.useFakeTimers();
         handler.handleMessage.mockReturnValueOnce(new Promise(() => {}));


### PR DESCRIPTION
Closes #448.

## Summary

The `MessageBus` had no delivery guarantee — six paths could silently drop responses, leaving the caller's message id without a final response. This change enforces the invariant: **every message produces exactly one final response**.

### Fixes applied to `src/worker/messageBus.ts`

1. **Handler result discarded after timeout** — the handler promise is now retained after `withTimeout` rejects. When the handler eventually completes (success or error), the result is delivered under the original message id. If the handler does not complete within `LATE_DELIVERY_GRACE_MS` (5 minutes), an explicit `Operation abandoned` error is sent so listeners still attached do not hang forever.
2. **Unknown tag → silent drop** — now replies `{id, tag, error: Error("Unknown handler tag: ...")}` instead of `return`.
3. **Handler returns null/undefined → silent skip** — now emits an explicit ack envelope `{id, tag}`. Applied to both unicast and broadcast paths.
4. **`event.source` null → silent drop** — centralised via `deliverResponse(...)` which logs in `debug` mode so the drop isn't invisible.
5. **Timeout error label names handler tag, not message type** — errors now read `"Message handler timed out after Xms (SETTLE via WALLET_UPDATER)"` rather than `"(WALLET_UPDATER)"`, so the operation the client triggered is obvious at a glance.
6. **No per-operation timeout configuration** — new `messageTimeoutOverrides?: Record<string, number>` option on `MessageBus`. Keys can be message types (e.g. `SETTLE`) or handler tags (e.g. `WALLET_UPDATER`); message-type matches take precedence over tag matches; unspecified operations use `messageTimeoutMs`.

### Notes

- Client-side keep-listening-after-timeout support (mentioned as a follow-up in the issue) is **out of scope** for this PR. This change is server-side only so the infrastructure is correct even if no client listens for the late response.
- The existing `test/serviceWorker/worker.test.ts` test `ignores messages with unknown tags` encoded the old silent-drop behaviour; it has been updated to assert the new error-response contract.
- **This PR will need rebasing after #446 merges.** Both PRs touch the same broadcast-path (lines 407-412) and unicast-path (lines 449-452) regions of `src/worker/messageBus.ts`. The rebase is mechanical — #446 adds an `isLongRunning()` opt-out around the `withTimeout` call, and this PR changes the call shape; they'll combine cleanly.

## Test plan

- [x] `pnpm run test:unit` — all 859 tests pass (+6 new tests for the fixes, +1 updated for the changed unknown-tag contract).
- [x] `pnpm run lint` — prettier clean.
- [x] TypeScript check — no errors.
- [x] CI passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable per-operation message timeout overrides enabling flexible timeout management for different operation types and scenarios.

* **Bug Fixes**
  * Fixed silent failures by ensuring all service requests receive explicit response envelopes, including acknowledgments.
  * Enhanced timeout error handling with grace-period support for late-arriving responses before final abandonment.
  * Improved consistency of timeout behavior enforcement across wallet initialization and reinitialization cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->