### PR TITLE
Quiet SSE reconnect errors

### DIFF
--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -7,6 +7,7 @@ import {
     ContractEventCallback,
     ContractEvent,
 } from "./types";
+import { isEventSourceError } from "../providers/utils";
 
 /**
  * Configuration for the ContractWatcher.
@@ -400,7 +401,13 @@ export class ContractWatcher {
                 // indefinitely and block the caller.
                 // Error management must be implemented to ensure the connection
                 // is restored and events are fired.
-                console.error(e);
+                if (isEventSourceError(e)) {
+                    console.debug(
+                        "ContractWatcher subscription disconnected; reconnecting"
+                    );
+                } else {
+                    console.error(e);
+                }
                 this.connectionState = "disconnected";
                 this.eventCallback?.({
                     type: "connection_reset",

--- a/src/providers/ark.ts
+++ b/src/providers/ark.ts
@@ -2,7 +2,7 @@ import { TxTreeNode } from "../tree/txTree";
 import { TreeNonces, TreePartialSigs } from "../tree/signingSession";
 import { hex } from "@scure/base";
 import { Vtxo } from "./indexer";
-import { eventSourceIterator } from "./utils";
+import { eventSourceIterator, isEventSourceError } from "./utils";
 import { maybeArkError } from "./errors";
 import type { IntentFeeConfig } from "../arkfee";
 import { Intent } from "../intent";
@@ -583,8 +583,9 @@ export class RestArkProvider implements ArkProvider {
                         }
                     } catch (error) {
                         if (
-                            error instanceof Error &&
-                            error.name === "AbortError"
+                            signal?.aborted ||
+                            (error instanceof Error &&
+                                error.name === "AbortError")
                         ) {
                             break;
                         }
@@ -593,6 +594,10 @@ export class RestArkProvider implements ArkProvider {
                         if (isFetchTimeoutError(error)) {
                             console.debug("Timeout error ignored");
                             continue;
+                        }
+
+                        if (isEventSourceError(error)) {
+                            throw error;
                         }
 
                         console.error("Event stream error:", error);
@@ -658,7 +663,10 @@ export class RestArkProvider implements ArkProvider {
                     eventSource.close();
                 }
             } catch (error) {
-                if (error instanceof Error && error.name === "AbortError") {
+                if (
+                    signal?.aborted ||
+                    (error instanceof Error && error.name === "AbortError")
+                ) {
                     break;
                 }
 
@@ -666,6 +674,10 @@ export class RestArkProvider implements ArkProvider {
                 if (isFetchTimeoutError(error)) {
                     console.debug("Timeout error ignored");
                     continue;
+                }
+
+                if (isEventSourceError(error)) {
+                    throw error;
                 }
 
                 console.error("Transaction stream error:", error);

--- a/src/providers/indexer.ts
+++ b/src/providers/indexer.ts
@@ -1,7 +1,7 @@
 import { hex } from "@scure/base";
 import { AssetDetails, AssetMetadata, Outpoint, VirtualCoin } from "../wallet";
 import { isFetchTimeoutError } from "./ark";
-import { eventSourceIterator } from "./utils";
+import { eventSourceIterator, isEventSourceError } from "./utils";
 import { MetadataList } from "../extension/asset";
 
 export type PaginationOptions = {
@@ -524,7 +524,10 @@ export class RestIndexerProvider implements IndexerProvider {
                     eventSource.close();
                 }
             } catch (error) {
-                if (error instanceof Error && error.name === "AbortError") {
+                if (
+                    abortSignal?.aborted ||
+                    (error instanceof Error && error.name === "AbortError")
+                ) {
                     break;
                 }
 
@@ -532,6 +535,10 @@ export class RestIndexerProvider implements IndexerProvider {
                 if (isFetchTimeoutError(error)) {
                     console.debug("Timeout error ignored");
                     continue;
+                }
+
+                if (isEventSourceError(error)) {
+                    throw error;
                 }
 
                 console.error("Subscription error:", error);

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -7,7 +7,6 @@
 export function eventSourceIterator(
     eventSource: EventSource
 ): AsyncGenerator<MessageEvent, void, unknown> {
-    const eventSourceConnecting = 0;
     const messageQueue: MessageEvent[] = [];
     const errorQueue: Error[] = [];
     let messageResolve: ((value: MessageEvent) => void) | null = null;
@@ -23,12 +22,6 @@ export function eventSourceIterator(
     };
 
     const errorHandler = () => {
-        // EventSource emits "error" for transient disconnects while it is
-        // already retrying. Do not turn those into fatal SDK errors.
-        if (eventSource.readyState === eventSourceConnecting) {
-            return;
-        }
-
         const error = new Error("EventSource error");
         error.name = "EventSourceError";
         if (errorResolve) {

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -7,6 +7,7 @@
 export function eventSourceIterator(
     eventSource: EventSource
 ): AsyncGenerator<MessageEvent, void, unknown> {
+    const eventSourceConnecting = 0;
     const messageQueue: MessageEvent[] = [];
     const errorQueue: Error[] = [];
     let messageResolve: ((value: MessageEvent) => void) | null = null;
@@ -22,6 +23,12 @@ export function eventSourceIterator(
     };
 
     const errorHandler = () => {
+        // EventSource emits "error" for transient disconnects while it is
+        // already retrying. Do not turn those into fatal SDK errors.
+        if (eventSource.readyState === eventSourceConnecting) {
+            return;
+        }
+
         const error = new Error("EventSource error");
         error.name = "EventSourceError";
         if (errorResolve) {
@@ -73,4 +80,8 @@ export function eventSourceIterator(
             eventSource.removeEventListener("error", errorHandler);
         }
     })();
+}
+
+export function isEventSourceError(error: unknown): error is Error {
+    return error instanceof Error && error.name === "EventSourceError";
 }

--- a/test/providers-utils.test.ts
+++ b/test/providers-utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    eventSourceIterator,
+    isEventSourceError,
+} from "../src/providers/utils";
+
+class ControlledEventSource {
+    readyState = 1;
+    private listeners = new Map<string, Set<(event: unknown) => void>>();
+
+    addEventListener(type: string, handler: (event: unknown) => void) {
+        if (!this.listeners.has(type)) {
+            this.listeners.set(type, new Set());
+        }
+        this.listeners.get(type)!.add(handler);
+    }
+
+    removeEventListener(type: string, handler: (event: unknown) => void) {
+        this.listeners.get(type)?.delete(handler);
+    }
+
+    emitMessage(data: string) {
+        this.emit("message", { data });
+    }
+
+    emitError(readyState: number) {
+        this.readyState = readyState;
+        this.emit("error", new Event("error"));
+    }
+
+    private emit(type: string, event: unknown) {
+        for (const handler of this.listeners.get(type) ?? []) {
+            handler(event);
+        }
+    }
+}
+
+describe("eventSourceIterator", () => {
+    it("ignores transient EventSource errors while the source is reconnecting", async () => {
+        const eventSource = new ControlledEventSource();
+        const iterator = eventSourceIterator(
+            eventSource as unknown as EventSource
+        );
+        const next = iterator.next();
+        const settled = vi.fn();
+        void next.then(settled, settled);
+
+        eventSource.emitError(0);
+        await Promise.resolve();
+
+        expect(settled).not.toHaveBeenCalled();
+
+        eventSource.emitMessage("ok");
+        await expect(next).resolves.toEqual({
+            done: false,
+            value: { data: "ok" },
+        });
+
+        await iterator.return?.();
+    });
+
+    it("surfaces closed EventSource errors as EventSourceError", async () => {
+        const eventSource = new ControlledEventSource();
+        const iterator = eventSourceIterator(
+            eventSource as unknown as EventSource
+        );
+        const next = iterator.next();
+
+        eventSource.emitError(2);
+
+        await expect(next).rejects.toMatchObject({
+            name: "EventSourceError",
+            message: "EventSource error",
+        });
+
+        await next.catch((error) => {
+            expect(isEventSourceError(error)).toBe(true);
+        });
+    });
+});

--- a/test/providers-utils.test.ts
+++ b/test/providers-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
     eventSourceIterator,
     isEventSourceError,
@@ -36,27 +36,23 @@ class ControlledEventSource {
 }
 
 describe("eventSourceIterator", () => {
-    it("ignores transient EventSource errors while the source is reconnecting", async () => {
+    it("surfaces reconnecting EventSource errors as EventSourceError", async () => {
         const eventSource = new ControlledEventSource();
         const iterator = eventSourceIterator(
             eventSource as unknown as EventSource
         );
         const next = iterator.next();
-        const settled = vi.fn();
-        void next.then(settled, settled);
 
         eventSource.emitError(0);
-        await Promise.resolve();
 
-        expect(settled).not.toHaveBeenCalled();
-
-        eventSource.emitMessage("ok");
-        await expect(next).resolves.toEqual({
-            done: false,
-            value: { data: "ok" },
+        await expect(next).rejects.toMatchObject({
+            name: "EventSourceError",
+            message: "EventSource error",
         });
 
-        await iterator.return?.();
+        await next.catch((error) => {
+            expect(isEventSourceError(error)).toBe(true);
+        });
     });
 
     it("surfaces closed EventSource errors as EventSourceError", async () => {


### PR DESCRIPTION
## Problem

The SDK logs noisy `EventSourceError` messages when indexer subscriptions reset. The error is logged once inside the provider and again by `ContractWatcher`, even though the watcher already handles subscription resets by scheduling a reconnect.

## Solution

Keep EventSource errors fatal to the async iterator so dead or invalid subscriptions still reject instead of hanging, but avoid treating expected `EventSourceError` resets as hard console errors in the provider/watcher logging path. The watcher still emits `connection_reset` and reconnects.

## Validation

- `pnpm vitest run test/providers-utils.test.ts test/ark-provider.test.ts test/contracts/watcher.test.ts`
- `pnpm -s lint`
- `pnpm -s build`
- `pnpm -s test:unit`