### PR TITLE
Harden SSE iterator cleanup on abort and return

### DIFF
--- a/src/providers/ark.ts
+++ b/src/providers/ark.ts
@@ -552,21 +552,24 @@ export class RestArkProvider implements ArkProvider {
         // leak the underlying SSE connection. `return()` is overridden below
         // so that closing the generator also closes the connection even when
         // the body is currently suspended at an await point.
-        let eventSource: EventSource | null = null;
+        let iterator: ReturnType<typeof eventSourceIterator> | null = null;
+        const closeIterator = () => iterator?.close();
 
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this;
         const gen = (async function* () {
-            const abortHandler = () => eventSource?.close();
+            const abortHandler = closeIterator;
             signal?.addEventListener("abort", abortHandler);
 
             try {
                 while (!signal?.aborted) {
-                    eventSource = new EventSource(url + queryParams);
-                    const iterator = eventSourceIterator(eventSource);
+                    const currentIterator = eventSourceIterator(
+                        new EventSource(url + queryParams)
+                    );
+                    iterator = currentIterator;
 
                     try {
-                        for await (const event of iterator) {
+                        for await (const event of currentIterator) {
                             if (signal?.aborted) break;
 
                             try {
@@ -603,87 +606,104 @@ export class RestArkProvider implements ArkProvider {
                         console.error("Event stream error:", error);
                         throw error;
                     } finally {
-                        eventSource.close();
+                        currentIterator.close();
+                        iterator = null;
                     }
                 }
             } finally {
                 signal?.removeEventListener("abort", abortHandler);
-                eventSource?.close();
+                closeIterator();
             }
         })();
 
         const origReturn = gen.return.bind(gen);
         gen.return = (value) => {
-            eventSource?.close();
+            closeIterator();
             return origReturn(value);
         };
 
         return gen;
     }
 
-    async *getTransactionsStream(signal: AbortSignal): AsyncIterableIterator<{
+    getTransactionsStream(signal: AbortSignal): AsyncIterableIterator<{
         commitmentTx?: TxNotification;
         arkTx?: TxNotification;
     }> {
         const url = `${this.serverUrl}/v1/txs`;
+        let iterator: ReturnType<typeof eventSourceIterator> | null = null;
+        const closeIterator = () => iterator?.close();
 
-        while (!signal?.aborted) {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
+        const gen = (async function* () {
+            const abortHandler = closeIterator;
+            signal?.addEventListener("abort", abortHandler);
+
             try {
-                const eventSource = new EventSource(url);
+                while (!signal?.aborted) {
+                    try {
+                        const currentIterator = eventSourceIterator(
+                            new EventSource(url)
+                        );
+                        iterator = currentIterator;
 
-                // Set up abort handling
-                const abortHandler = () => {
-                    eventSource.close();
-                };
-                signal?.addEventListener("abort", abortHandler);
+                        for await (const event of currentIterator) {
+                            if (signal?.aborted) break;
 
-                try {
-                    for await (const event of eventSourceIterator(
-                        eventSource
-                    )) {
-                        if (signal?.aborted) break;
-
-                        try {
-                            const data = JSON.parse(event.data);
-                            const txNotification =
-                                this.parseTransactionNotification(data);
-                            if (txNotification) {
-                                yield txNotification;
+                            try {
+                                const data = JSON.parse(event.data);
+                                const txNotification =
+                                    self.parseTransactionNotification(data);
+                                if (txNotification) {
+                                    yield txNotification;
+                                }
+                            } catch (err) {
+                                console.error(
+                                    "Failed to parse transaction notification:",
+                                    err
+                                );
+                                throw err;
                             }
-                        } catch (err) {
-                            console.error(
-                                "Failed to parse transaction notification:",
-                                err
-                            );
-                            throw err;
                         }
+                    } catch (error) {
+                        if (
+                            signal?.aborted ||
+                            (error instanceof Error &&
+                                error.name === "AbortError")
+                        ) {
+                            break;
+                        }
+
+                        // ignore timeout errors, they're expected when the server is not sending anything for 5 min
+                        if (isFetchTimeoutError(error)) {
+                            console.debug("Timeout error ignored");
+                            continue;
+                        }
+
+                        if (isEventSourceError(error)) {
+                            throw error;
+                        }
+
+                        console.error("Transaction stream error:", error);
+                        throw error;
+                    } finally {
+                        closeIterator();
+                        iterator = null;
                     }
-                } finally {
-                    signal?.removeEventListener("abort", abortHandler);
-                    eventSource.close();
                 }
-            } catch (error) {
-                if (
-                    signal?.aborted ||
-                    (error instanceof Error && error.name === "AbortError")
-                ) {
-                    break;
-                }
-
-                // ignore timeout errors, they're expected when the server is not sending anything for 5 min
-                if (isFetchTimeoutError(error)) {
-                    console.debug("Timeout error ignored");
-                    continue;
-                }
-
-                if (isEventSourceError(error)) {
-                    throw error;
-                }
-
-                console.error("Transaction stream error:", error);
-                throw error;
+            } finally {
+                signal?.removeEventListener("abort", abortHandler);
+                closeIterator();
             }
-        }
+        })();
+
+        const origReturn = gen.return.bind(gen);
+        gen.return = (value) => {
+            closeIterator();
+            return origReturn(value);
+        };
+
+        return gen;
     }
 
     async getPendingTxs(

--- a/src/providers/indexer.ts
+++ b/src/providers/indexer.ts
@@ -470,81 +470,95 @@ export class RestIndexerProvider implements IndexerProvider {
         return data;
     }
 
-    async *getSubscription(
+    getSubscription(
         subscriptionId: string,
         abortSignal: AbortSignal
     ): AsyncIterableIterator<SubscriptionResponse> {
         const url = `${this.serverUrl}/v1/indexer/script/subscription/${subscriptionId}`;
+        let iterator: ReturnType<typeof eventSourceIterator> | null = null;
+        const closeIterator = () => iterator?.close();
 
-        while (!abortSignal?.aborted) {
+        const gen = (async function* () {
+            const abortHandler = closeIterator;
+            abortSignal?.addEventListener("abort", abortHandler);
+
             try {
-                const eventSource = new EventSource(url);
+                while (!abortSignal?.aborted) {
+                    try {
+                        const currentIterator = eventSourceIterator(
+                            new EventSource(url)
+                        );
+                        iterator = currentIterator;
 
-                // Set up abort handling
-                const abortHandler = () => {
-                    eventSource.close();
-                };
-                abortSignal?.addEventListener("abort", abortHandler);
+                        for await (const event of currentIterator) {
+                            if (abortSignal?.aborted) break;
 
-                try {
-                    for await (const event of eventSourceIterator(
-                        eventSource
-                    )) {
-                        if (abortSignal?.aborted) break;
-
-                        try {
-                            const data = JSON.parse(event.data);
-                            if (data.event) {
-                                yield {
-                                    txid: data.event.txid,
-                                    scripts: data.event.scripts || [],
-                                    newVtxos: (data.event.newVtxos || []).map(
-                                        convertVtxo
-                                    ),
-                                    spentVtxos: (
-                                        data.event.spentVtxos || []
-                                    ).map(convertVtxo),
-                                    sweptVtxos: (
-                                        data.event.sweptVtxos || []
-                                    ).map(convertVtxo),
-                                    tx: data.event.tx,
-                                    checkpointTxs: data.event.checkpointTxs,
-                                };
+                            try {
+                                const data = JSON.parse(event.data);
+                                if (data.event) {
+                                    yield {
+                                        txid: data.event.txid,
+                                        scripts: data.event.scripts || [],
+                                        newVtxos: (
+                                            data.event.newVtxos || []
+                                        ).map(convertVtxo),
+                                        spentVtxos: (
+                                            data.event.spentVtxos || []
+                                        ).map(convertVtxo),
+                                        sweptVtxos: (
+                                            data.event.sweptVtxos || []
+                                        ).map(convertVtxo),
+                                        tx: data.event.tx,
+                                        checkpointTxs: data.event.checkpointTxs,
+                                    };
+                                }
+                            } catch (err) {
+                                console.error(
+                                    "Failed to parse subscription event:",
+                                    err
+                                );
+                                throw err;
                             }
-                        } catch (err) {
-                            console.error(
-                                "Failed to parse subscription event:",
-                                err
-                            );
-                            throw err;
                         }
+                    } catch (error) {
+                        if (
+                            abortSignal?.aborted ||
+                            (error instanceof Error &&
+                                error.name === "AbortError")
+                        ) {
+                            break;
+                        }
+
+                        // ignore timeout errors, they're expected when the server is not sending anything for 5 min
+                        if (isFetchTimeoutError(error)) {
+                            console.debug("Timeout error ignored");
+                            continue;
+                        }
+
+                        if (isEventSourceError(error)) {
+                            throw error;
+                        }
+
+                        console.error("Subscription error:", error);
+                        throw error;
+                    } finally {
+                        closeIterator();
+                        iterator = null;
                     }
-                } finally {
-                    abortSignal?.removeEventListener("abort", abortHandler);
-                    eventSource.close();
                 }
-            } catch (error) {
-                if (
-                    abortSignal?.aborted ||
-                    (error instanceof Error && error.name === "AbortError")
-                ) {
-                    break;
-                }
-
-                // ignore timeout errors, they're expected when the server is not sending anything for 5 min
-                if (isFetchTimeoutError(error)) {
-                    console.debug("Timeout error ignored");
-                    continue;
-                }
-
-                if (isEventSourceError(error)) {
-                    throw error;
-                }
-
-                console.error("Subscription error:", error);
-                throw error;
+            } finally {
+                abortSignal?.removeEventListener("abort", abortHandler);
+                closeIterator();
             }
-        }
+        })();
+
+        const origReturn = gen.return.bind(gen);
+        gen.return = (value) => {
+            closeIterator();
+            return origReturn(value);
+        };
+
+        return gen;
     }
 
     async getVirtualTxs(

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,32 +1,78 @@
+export type ManagedEventSourceIterator = AsyncGenerator<
+    MessageEvent,
+    void,
+    unknown
+> & {
+    close(): void;
+};
+
+function createAbortError(): Error {
+    const error = new Error("EventSource closed");
+    error.name = "AbortError";
+    return error;
+}
+
 /**
- * Creates an async iterator over EventSource messages that attaches listeners
- * eagerly (at call time) rather than lazily (at first .next() call).
- * This ensures events are buffered immediately, preventing race conditions
- * where events arrive before iteration begins.
+ * Creates a close-aware EventSource async iterator.
+ *
+ * Listeners attach eagerly so events are buffered before the first next() call.
+ * close() closes the EventSource, removes listeners, and wakes any pending
+ * next() even when the browser does not emit an error from EventSource.close().
  */
 export function eventSourceIterator(
     eventSource: EventSource
-): AsyncGenerator<MessageEvent, void, unknown> {
+): ManagedEventSourceIterator {
     const messageQueue: MessageEvent[] = [];
     const errorQueue: Error[] = [];
     let messageResolve: ((value: MessageEvent) => void) | null = null;
     let errorResolve: ((error: Error) => void) | null = null;
+    let closed = false;
+    let cleanedUp = false;
+
+    const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        eventSource.removeEventListener("message", messageHandler);
+        eventSource.removeEventListener("error", errorHandler);
+    };
+
+    const close = () => {
+        if (closed) return;
+        closed = true;
+        messageQueue.length = 0;
+        errorQueue.length = 0;
+        eventSource.close();
+        cleanup();
+
+        if (errorResolve) {
+            const reject = errorResolve;
+            messageResolve = null;
+            errorResolve = null;
+            reject(createAbortError());
+        }
+    };
 
     const messageHandler = (event: MessageEvent) => {
+        if (closed) return;
         if (messageResolve) {
-            messageResolve(event);
+            const resolve = messageResolve;
             messageResolve = null;
+            errorResolve = null;
+            resolve(event);
         } else {
             messageQueue.push(event);
         }
     };
 
     const errorHandler = () => {
+        if (closed) return;
         const error = new Error("EventSource error");
         error.name = "EventSourceError";
         if (errorResolve) {
-            errorResolve(error);
+            const reject = errorResolve;
+            messageResolve = null;
             errorResolve = null;
+            reject(error);
         } else {
             errorQueue.push(error);
         }
@@ -37,9 +83,9 @@ export function eventSourceIterator(
     eventSource.addEventListener("message", messageHandler);
     eventSource.addEventListener("error", errorHandler);
 
-    return (async function* () {
+    const gen = (async function* () {
         try {
-            while (true) {
+            while (!closed) {
                 // if we have queued messages, yield the first one, remove it from the queue
                 if (messageQueue.length > 0) {
                     yield messageQueue.shift()!;
@@ -63,16 +109,26 @@ export function eventSourceIterator(
                     errorResolve = null;
                 });
 
-                if (result) {
+                if (!closed && result) {
                     yield result;
                 }
             }
         } finally {
-            // clean up
-            eventSource.removeEventListener("message", messageHandler);
-            eventSource.removeEventListener("error", errorHandler);
+            closed = true;
+            cleanup();
+            eventSource.close();
         }
     })();
+
+    const origReturn = gen.return.bind(gen);
+    const managed = gen as ManagedEventSourceIterator;
+    managed.close = close;
+    managed.return = (value?: void | PromiseLike<void>) => {
+        close();
+        return origReturn(value);
+    };
+
+    return managed;
 }
 
 export function isEventSourceError(error: unknown): error is Error {

--- a/test/ark-provider.test.ts
+++ b/test/ark-provider.test.ts
@@ -1,50 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { RestArkProvider } from "../src/providers/ark";
-
-class MockEventSource {
-    static instances: MockEventSource[] = [];
-    static reset() {
-        MockEventSource.instances = [];
-    }
-
-    url: string;
-    closed = false;
-    private listeners = new Map<string, Set<(e: unknown) => void>>();
-
-    constructor(url: string) {
-        this.url = url;
-        MockEventSource.instances.push(this);
-    }
-
-    addEventListener(type: string, handler: (e: unknown) => void) {
-        if (!this.listeners.has(type)) {
-            this.listeners.set(type, new Set());
-        }
-        this.listeners.get(type)!.add(handler);
-    }
-
-    removeEventListener(type: string, handler: (e: unknown) => void) {
-        this.listeners.get(type)?.delete(handler);
-    }
-
-    close() {
-        if (this.closed) return;
-        this.closed = true;
-        // Mirror real EventSource behavior so that consumers suspended on
-        // `await` inside the iterator unblock instead of parking forever.
-        const handlers = this.listeners.get("error");
-        if (handlers) {
-            for (const handler of handlers) handler(new Event("error"));
-        }
-    }
-}
+import { MockEventSource } from "./mocks/eventSource";
 
 describe("RestArkProvider.getEventStream", () => {
     beforeEach(() => {
         MockEventSource.reset();
         vi.stubGlobal("EventSource", MockEventSource);
-        // Silence the informational console.error from the generator's
-        // error branch when the mock's close() emits a synthetic error.
+        // Keep test output focused if a failure path logs while unwinding.
         vi.spyOn(console, "error").mockImplementation(() => {});
     });
 

--- a/test/indexer-provider.test.ts
+++ b/test/indexer-provider.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RestIndexerProvider } from "../src";
+import { MockEventSource } from "./mocks/eventSource";
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -7,6 +8,10 @@ global.fetch = mockFetch;
 describe("RestIndexerProvider", () => {
     beforeEach(() => {
         mockFetch.mockReset();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
     });
 
     describe("getVtxos", () => {
@@ -127,6 +132,55 @@ describe("RestIndexerProvider", () => {
             ).rejects.toThrow("before must be greater than after");
 
             expect(mockFetch).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("getSubscription", () => {
+        beforeEach(() => {
+            MockEventSource.reset();
+            vi.stubGlobal("EventSource", MockEventSource);
+        });
+
+        it("aborts a pending subscription even when EventSource.close emits nothing", async () => {
+            const provider = new RestIndexerProvider("http://localhost:7070");
+            const ac = new AbortController();
+            const subscription = provider.getSubscription("sub-id", ac.signal);
+
+            const pending = subscription.next();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(MockEventSource.instances).toHaveLength(1);
+            expect(MockEventSource.instances[0].closed).toBe(false);
+
+            ac.abort();
+
+            expect(MockEventSource.instances[0].closed).toBe(true);
+            await expect(pending).resolves.toMatchObject({ done: true });
+            expect(MockEventSource.instances[0].listenerCount("message")).toBe(
+                0
+            );
+            expect(MockEventSource.instances[0].listenerCount("error")).toBe(0);
+        });
+
+        it("return closes a pending subscription even when EventSource.close emits nothing", async () => {
+            const provider = new RestIndexerProvider("http://localhost:7070");
+            const ac = new AbortController();
+            const subscription = provider.getSubscription("sub-id", ac.signal);
+
+            const pending = subscription.next();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(MockEventSource.instances).toHaveLength(1);
+
+            const returned = subscription.return?.();
+
+            expect(MockEventSource.instances[0].closed).toBe(true);
+            await expect(pending).resolves.toMatchObject({ done: true });
+            await expect(returned).resolves.toMatchObject({ done: true });
+            expect(MockEventSource.instances[0].listenerCount("message")).toBe(
+                0
+            );
+            expect(MockEventSource.instances[0].listenerCount("error")).toBe(0);
         });
     });
 });

--- a/test/mocks/eventSource.ts
+++ b/test/mocks/eventSource.ts
@@ -1,0 +1,51 @@
+export class MockEventSource {
+    static instances: MockEventSource[] = [];
+
+    static reset() {
+        MockEventSource.instances = [];
+    }
+
+    readonly url: string;
+    readyState = 1;
+    closed = false;
+    private listeners = new Map<string, Set<(event: unknown) => void>>();
+
+    constructor(url = "") {
+        this.url = url;
+        MockEventSource.instances.push(this);
+    }
+
+    addEventListener(type: string, handler: (event: unknown) => void) {
+        if (!this.listeners.has(type)) {
+            this.listeners.set(type, new Set());
+        }
+        this.listeners.get(type)!.add(handler);
+    }
+
+    removeEventListener(type: string, handler: (event: unknown) => void) {
+        this.listeners.get(type)?.delete(handler);
+    }
+
+    listenerCount(type: string) {
+        return this.listeners.get(type)?.size ?? 0;
+    }
+
+    close() {
+        this.closed = true;
+    }
+
+    emitMessage(data: string) {
+        this.emit("message", { data });
+    }
+
+    emitError(readyState: number) {
+        this.readyState = readyState;
+        this.emit("error", new Event("error"));
+    }
+
+    private emit(type: string, event: unknown) {
+        for (const handler of this.listeners.get(type) ?? []) {
+            handler(event);
+        }
+    }
+}

--- a/test/providers-utils.test.ts
+++ b/test/providers-utils.test.ts
@@ -3,41 +3,11 @@ import {
     eventSourceIterator,
     isEventSourceError,
 } from "../src/providers/utils";
-
-class ControlledEventSource {
-    readyState = 1;
-    private listeners = new Map<string, Set<(event: unknown) => void>>();
-
-    addEventListener(type: string, handler: (event: unknown) => void) {
-        if (!this.listeners.has(type)) {
-            this.listeners.set(type, new Set());
-        }
-        this.listeners.get(type)!.add(handler);
-    }
-
-    removeEventListener(type: string, handler: (event: unknown) => void) {
-        this.listeners.get(type)?.delete(handler);
-    }
-
-    emitMessage(data: string) {
-        this.emit("message", { data });
-    }
-
-    emitError(readyState: number) {
-        this.readyState = readyState;
-        this.emit("error", new Event("error"));
-    }
-
-    private emit(type: string, event: unknown) {
-        for (const handler of this.listeners.get(type) ?? []) {
-            handler(event);
-        }
-    }
-}
+import { MockEventSource } from "./mocks/eventSource";
 
 describe("eventSourceIterator", () => {
     it("surfaces reconnecting EventSource errors as EventSourceError", async () => {
-        const eventSource = new ControlledEventSource();
+        const eventSource = new MockEventSource();
         const iterator = eventSourceIterator(
             eventSource as unknown as EventSource
         );
@@ -56,7 +26,7 @@ describe("eventSourceIterator", () => {
     });
 
     it("surfaces closed EventSource errors as EventSourceError", async () => {
-        const eventSource = new ControlledEventSource();
+        const eventSource = new MockEventSource();
         const iterator = eventSourceIterator(
             eventSource as unknown as EventSource
         );
@@ -72,5 +42,42 @@ describe("eventSourceIterator", () => {
         await next.catch((error) => {
             expect(isEventSourceError(error)).toBe(true);
         });
+    });
+
+    it("close wakes a pending next without relying on an EventSource error", async () => {
+        const eventSource = new MockEventSource();
+        const iterator = eventSourceIterator(
+            eventSource as unknown as EventSource
+        );
+        const next = iterator.next();
+
+        iterator.close();
+
+        await expect(next).rejects.toMatchObject({
+            name: "AbortError",
+            message: "EventSource closed",
+        });
+        expect(eventSource.closed).toBe(true);
+        expect(eventSource.listenerCount("message")).toBe(0);
+        expect(eventSource.listenerCount("error")).toBe(0);
+    });
+
+    it("return closes the EventSource and wakes a pending next", async () => {
+        const eventSource = new MockEventSource();
+        const iterator = eventSourceIterator(
+            eventSource as unknown as EventSource
+        );
+        const next = iterator.next();
+
+        const returned = iterator.return();
+
+        await expect(next).rejects.toMatchObject({
+            name: "AbortError",
+            message: "EventSource closed",
+        });
+        await expect(returned).resolves.toMatchObject({ done: true });
+        expect(eventSource.closed).toBe(true);
+        expect(eventSource.listenerCount("message")).toBe(0);
+        expect(eventSource.listenerCount("error")).toBe(0);
     });
 });


### PR DESCRIPTION
This PR hardens SSE stream cleanup by making `eventSourceIterator` close-aware. Closing now removes listeners, closes the underlying EventSource, and wakes pending `next()` calls even when `EventSource.close()` does not emit an error.

It also applies the same cleanup pattern across Ark and Indexer streams and adds tests for abort/return behavior with cilent `EventSource.close()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved stream lifecycle management for data providers with enhanced cancellation and cleanup handling when streams are aborted or terminated.

* **Tests**
  * Added test mocking infrastructure and expanded coverage for streaming operations, including cancellation and resource cleanup verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->