### PR TITLE
Support hardcoded exit delay and arkd info when they differ

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -817,7 +817,6 @@ export class ReadonlyWallet implements IReadonlyWallet {
     /**
      * Get all pkScript hex strings for the wallet's own addresses
      * (both delegate and non-delegate, current and historical).
-     * Falls back to locally-derived wallet scripts if ContractManager is not yet initialized.
      */
     async getWalletScripts(): Promise<string[]> {
         const manager = await this.getContractManager();

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -101,10 +101,31 @@ import { contractHandlers } from "../contracts/handlers";
 import { timelockToSequence } from "../contracts/handlers/helpers";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
 
-// Hardcoded unilateral exit delay for mainnet (~7 days in seconds).
-// Pinned here so that address derivation stays stable for existing mainnet
-// wallets even after the server lowers the delay it advertises.
+// Historical unilateral exit delay for mainnet (~7 days in seconds).
+// Kept so existing wallets can still discover and spend VTXOs sent to the
+// legacy address after arkd starts advertising a different delay.
 const MAINNET_UNILATERAL_EXIT_DELAY = 605184n;
+
+function delayToTimelock(delay: bigint): RelativeTimelock {
+    return {
+        value: delay,
+        type: delay < 512n ? "blocks" : "seconds",
+    };
+}
+
+function dedupeTimelocks(timelocks: RelativeTimelock[]): RelativeTimelock[] {
+    const seen = new Set<string>();
+    const deduped: RelativeTimelock[] = [];
+
+    for (const timelock of timelocks) {
+        const sequence = timelockToSequence(timelock).toString();
+        if (seen.has(sequence)) continue;
+        seen.add(sequence);
+        deduped.push(timelock);
+    }
+
+    return deduped;
+}
 
 export type IncomingFunds =
     | {
@@ -141,6 +162,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
     private _contractManagerInitializing?: Promise<ContractManager>;
     protected readonly watcherConfig?: ReadonlyWalletConfig["watcherConfig"];
     private readonly _assetManager: IReadonlyAssetManager;
+    private _syncVtxosInflight?: Promise<void>;
+    readonly walletContractTimelocks: RelativeTimelock[];
     // Outpoints ("txid:vout") committed to an in-flight settle/send. Filtered
     // from getVtxos() so concurrent callers (UI, VtxoManager auto-renewal,
     // another send/settle racing the _txLock) can't reselect coins that are
@@ -164,7 +187,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
         public readonly walletRepository: WalletRepository,
         public readonly contractRepository: ContractRepository,
         readonly delegatorProvider?: DelegatorProvider,
-        watcherConfig?: ReadonlyWalletConfig["watcherConfig"]
+        watcherConfig?: ReadonlyWalletConfig["watcherConfig"],
+        walletContractTimelocks?: RelativeTimelock[]
     ) {
         // Guard: detect identity/server network mismatch for descriptor-based identities.
         // This duplicates the check in setupWalletConfig() so that subclasses
@@ -183,6 +207,15 @@ export class ReadonlyWallet implements IReadonlyWallet {
         }
         this.watcherConfig = watcherConfig;
         this._assetManager = new ReadonlyAssetManager(this.indexerProvider);
+        // Defensive for direct-construction callers; setupWalletConfig already
+        // passes a deduped list through the public create() factories.
+        this.walletContractTimelocks =
+            walletContractTimelocks && walletContractTimelocks.length > 0
+                ? dedupeTimelocks(walletContractTimelocks)
+                : [
+                      this.offchainTapscript.options.csvTimelock ??
+                          DefaultVtxo.Script.DEFAULT_TIMELOCK,
+                  ];
     }
 
     /**
@@ -265,19 +298,20 @@ export class ReadonlyWallet implements IReadonlyWallet {
             }
         }
 
-        // On mainnet, pin the unilateral exit delay to the historical value so
-        // that addresses derived by existing wallets remain stable even if the
-        // server starts advertising a shorter delay.
-        const unilateralExitDelay =
-            info.network === "bitcoin"
-                ? MAINNET_UNILATERAL_EXIT_DELAY
-                : info.unilateralExitDelay;
+        const arkdExitTimelock = delayToTimelock(info.unilateralExitDelay);
 
         // create unilateral exit timelock
-        const exitTimelock: RelativeTimelock = config.exitTimelock ?? {
-            value: unilateralExitDelay,
-            type: unilateralExitDelay < 512n ? "blocks" : "seconds",
-        };
+        const exitTimelock: RelativeTimelock =
+            config.exitTimelock ?? arkdExitTimelock;
+
+        const walletContractTimelocks = config.exitTimelock
+            ? [exitTimelock]
+            : dedupeTimelocks([
+                  arkdExitTimelock,
+                  ...(info.network === "bitcoin"
+                      ? [delayToTimelock(MAINNET_UNILATERAL_EXIT_DELAY)]
+                      : []),
+              ]);
 
         // validate boarding timelock passed in config if any
         if (config.boardingTimelock) {
@@ -339,6 +373,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             contractRepository,
             info,
             delegatorProvider: config.delegatorProvider,
+            walletContractTimelocks,
         };
     }
 
@@ -368,7 +403,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
             setup.walletRepository,
             setup.contractRepository,
             setup.delegatorProvider,
-            config.watcherConfig
+            config.watcherConfig,
+            setup.walletContractTimelocks
         );
     }
 
@@ -380,8 +416,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }
 
     /**
-     * Get the contract script for the wallet's default address.
-     * This is the pkScript hex, used to identify the wallet in ContractManager.
+     * Get the pkScript hex for the wallet's primary offchain address.
+     * For the full wallet-owned script set registered in ContractManager, use getWalletScripts().
      */
     get defaultContractScript(): string {
         return hex.encode(this.offchainTapscript.pkScript);
@@ -781,16 +817,14 @@ export class ReadonlyWallet implements IReadonlyWallet {
     /**
      * Get all pkScript hex strings for the wallet's own addresses
      * (both delegate and non-delegate, current and historical).
+     * Falls back to locally-derived wallet scripts if ContractManager is not yet initialized.
      */
     async getWalletScripts(): Promise<string[]> {
         const manager = await this.getContractManager();
         const contracts = await manager.getContracts({
             type: ["default", "delegate"],
         });
-        if (contracts.length > 0) {
             return contracts.map((c) => c.script);
-        }
-        return [hex.encode(this.offchainTapscript.pkScript)];
     }
 
     /**
@@ -801,10 +835,6 @@ export class ReadonlyWallet implements IReadonlyWallet {
         Map<string, DefaultVtxo.Script | DelegateVtxo.Script>
     > {
         const map = new Map<string, DefaultVtxo.Script | DelegateVtxo.Script>();
-
-        // Always include the current script
-        const currentScriptHex = hex.encode(this.offchainTapscript.pkScript);
-        map.set(currentScriptHex, this.offchainTapscript);
 
         const manager = await this.getContractManager();
         const contracts = await manager.getContracts({
@@ -891,76 +921,58 @@ export class ReadonlyWallet implements IReadonlyWallet {
             watcherConfig: this.watcherConfig,
         });
 
-        // Register the wallet's current address as a contract
-        const csvTimelock =
-            this.offchainTapscript.options.csvTimelock ??
-            DefaultVtxo.Script.DEFAULT_TIMELOCK;
-        const csvTimelockStr = timelockToSequence(csvTimelock).toString();
-
-        const isDelegateScript =
-            this.offchainTapscript instanceof DelegateVtxo.Script;
-
-        if (isDelegateScript) {
-            const delegateScript = this
-                .offchainTapscript as DelegateVtxo.Script;
-
-            // Register the delegate contract (current address)
-            await manager.createContract({
-                type: "delegate",
-                params: {
-                    pubKey: hex.encode(delegateScript.options.pubKey),
-                    serverPubKey: hex.encode(
-                        delegateScript.options.serverPubKey
-                    ),
-                    delegatePubKey: hex.encode(
-                        delegateScript.options.delegatePubKey
-                    ),
-                    csvTimelock: csvTimelockStr,
-                },
-                script: this.defaultContractScript,
-                address: await this.getAddress(),
-                state: "active",
-            });
-
-            // Also register the non-delegate version so old virtual outputs remain visible
-            const nonDelegateScript = new DefaultVtxo.Script({
-                pubKey: delegateScript.options.pubKey,
-                serverPubKey: delegateScript.options.serverPubKey,
+        for (const csvTimelock of this.walletContractTimelocks) {
+            const csvTimelockStr = timelockToSequence(csvTimelock).toString();
+            const defaultScript = new DefaultVtxo.Script({
+                pubKey: this.offchainTapscript.options.pubKey,
+                serverPubKey: this.offchainTapscript.options.serverPubKey,
                 csvTimelock,
             });
+
             await manager.createContract({
                 type: "default",
                 params: {
-                    pubKey: hex.encode(delegateScript.options.pubKey),
+                    pubKey: hex.encode(defaultScript.options.pubKey),
                     serverPubKey: hex.encode(
-                        delegateScript.options.serverPubKey
+                        defaultScript.options.serverPubKey
                     ),
                     csvTimelock: csvTimelockStr,
                 },
-                script: hex.encode(nonDelegateScript.pkScript),
-                address: nonDelegateScript
+                script: hex.encode(defaultScript.pkScript),
+                address: defaultScript
                     .address(this.network.hrp, this.arkServerPublicKey)
                     .encode(),
                 state: "active",
             });
-        } else {
-            // Register the default contract (current address)
-            await manager.createContract({
-                type: "default",
-                params: {
-                    pubKey: hex.encode(this.offchainTapscript.options.pubKey),
-                    serverPubKey: hex.encode(
-                        this.offchainTapscript.options.serverPubKey
-                    ),
-                    csvTimelock: csvTimelockStr,
-                },
-                script: this.defaultContractScript,
-                address: await this.getAddress(),
-                state: "active",
-            });
 
-            // Any old "delegate" contract from a prior wallet incarnation
-            // is already loaded by ContractManager.initialize() from ContractRepository
+            if (this.offchainTapscript instanceof DelegateVtxo.Script) {
+                const delegateScript = new DelegateVtxo.Script({
+                    pubKey: this.offchainTapscript.options.pubKey,
+                    serverPubKey: this.offchainTapscript.options.serverPubKey,
+                    delegatePubKey:
+                        this.offchainTapscript.options.delegatePubKey,
+                    csvTimelock,
+                });
+
+                await manager.createContract({
+                    type: "delegate",
+                    params: {
+                        pubKey: hex.encode(delegateScript.options.pubKey),
+                        serverPubKey: hex.encode(
+                            delegateScript.options.serverPubKey
+                        ),
+                        delegatePubKey: hex.encode(
+                            delegateScript.options.delegatePubKey
+                        ),
+                        csvTimelock: csvTimelockStr,
+                    },
+                    script: hex.encode(delegateScript.pkScript),
+                    address: delegateScript
+                        .address(this.network.hrp, this.arkServerPublicKey)
+                        .encode(),
+                    state: "active",
+                });
+            }
         }
 
         return manager;
@@ -1094,7 +1106,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         renewalConfig?: WalletConfig["renewalConfig"],
         delegatorProvider?: DelegatorProvider,
         watcherConfig?: WalletConfig["watcherConfig"],
-        settlementConfig?: WalletConfig["settlementConfig"]
+        settlementConfig?: WalletConfig["settlementConfig"],
+        walletContractTimelocks?: RelativeTimelock[]
     ) {
         super(
             identity,
@@ -1108,7 +1121,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             walletRepository,
             contractRepository,
             delegatorProvider,
-            watcherConfig
+            watcherConfig,
+            walletContractTimelocks
         );
         this.identity = identity;
 
@@ -1246,7 +1260,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             config.renewalConfig,
             config.delegatorProvider,
             config.watcherConfig,
-            config.settlementConfig
+            config.settlementConfig,
+            setup.walletContractTimelocks
         );
 
         await wallet.getVtxoManager();
@@ -1289,7 +1304,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             this.walletRepository,
             this.contractRepository,
             this.delegatorProvider,
-            this.watcherConfig
+            this.watcherConfig,
+            this.walletContractTimelocks
         );
     }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -824,7 +824,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const contracts = await manager.getContracts({
             type: ["default", "delegate"],
         });
-            return contracts.map((c) => c.script);
+        return contracts.map((c) => c.script);
     }
 
     /**

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -13,6 +13,7 @@ import {
     type IndexerProvider,
     type ArkProvider,
     type OnchainProvider,
+    type DelegatorProvider,
 } from "../src";
 import type { ExtendedCoin } from "../src/wallet";
 import { ReadonlySingleKey } from "../src/identity/singleKey";
@@ -21,6 +22,7 @@ import {
     IndexedDBContractRepository,
 } from "../src/repositories";
 import type { Coin, VirtualCoin } from "../src/wallet";
+import { timelockToSequence } from "../src/contracts/handlers/helpers";
 
 // Mock fetch
 const mockFetch = vi.fn();
@@ -1069,58 +1071,351 @@ describe("Wallet", () => {
         });
     });
 
-    describe("mainnet unilateral exit delay pinning", () => {
-        // If this constant changes in the SDK, update both sides intentionally —
-        // changing the pinned value alters derived addresses for every mainnet
-        // wallet.
-        const MAINNET_PINNED_DELAY = 605184n;
+    describe("mainnet unilateral exit delay compatibility", () => {
+        const MAINNET_LEGACY_DELAY = 605184n;
+        const ARKD_DELAY = 86528n;
+        const MUTINYNET_DELAY = 144n;
+        const DELEGATE_PUBKEY = mockServerKeyHex;
 
-        const mockMainnetInfo = (unilateralExitDelay: bigint) => ({
+        const mockArkInfo = (
+            network: "bitcoin" | "mutinynet",
+            unilateralExitDelay: bigint
+        ) => ({
             signerPubkey: mockServerKeyHex,
             forfeitPubkey: mockServerKeyHex,
             batchExpiry: BigInt(144),
             unilateralExitDelay,
+            boardingExitDelay: BigInt(144),
             roundInterval: BigInt(144),
-            network: "bitcoin",
-            forfeitAddress: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            network,
+            dust: BigInt(330),
+            forfeitAddress:
+                network === "bitcoin"
+                    ? "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+                    : "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
             checkpointTapscript:
                 "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
         });
 
-        it("pins the exit timelock to 605184s on mainnet even when the server advertises a shorter delay", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockMainnetInfo(86528n)),
+        function sequence(value: bigint, type: "blocks" | "seconds") {
+            return timelockToSequence({ value, type }).toString();
+        }
+
+        function contractSummaries(
+            contracts: { type: string; params: Record<string, string> }[]
+        ) {
+            return contracts
+                .map(
+                    (contract) =>
+                        `${contract.type}:${contract.params.csvTimelock}`
+                )
+                .sort();
+        }
+
+        function createIndexerProvider() {
+            return {
+                getVtxos: vi.fn().mockResolvedValue({ vtxos: [] }),
+                subscribeForScripts: vi.fn().mockResolvedValue("sub-1"),
+                unsubscribeForScripts: vi.fn().mockResolvedValue(undefined),
+                getSubscription: async function* () {},
+            } as Partial<IndexerProvider> as IndexerProvider;
+        }
+
+        function createOnchainProvider() {
+            return {
+                getCoins: vi.fn().mockResolvedValue([]),
+                getFeeRate: vi.fn().mockResolvedValue(1),
+                broadcastTransaction: vi.fn().mockResolvedValue(""),
+                getTxOutspends: vi.fn().mockResolvedValue([]),
+                getTransactions: vi.fn().mockResolvedValue([]),
+                getTxStatus: vi.fn().mockResolvedValue({ confirmed: false }),
+                getChainTip: vi.fn().mockResolvedValue({
+                    height: 1,
+                    time: 1,
+                    hash: "00".repeat(32),
+                }),
+                watchAddresses: vi.fn().mockResolvedValue(() => {}),
+            } as Partial<OnchainProvider> as OnchainProvider;
+        }
+
+        function createDelegatorProvider() {
+            return {
+                getDelegateInfo: vi.fn().mockResolvedValue({
+                    pubkey: DELEGATE_PUBKEY,
+                    fee: "0",
+                    delegatorAddress: "",
+                }),
+                delegate: vi.fn().mockResolvedValue(undefined),
+            } as Partial<DelegatorProvider> as DelegatorProvider;
+        }
+
+        async function createReadonlyTestWallet(config?: {
+            network?: "bitcoin" | "mutinynet";
+            unilateralExitDelay?: bigint;
+            exitTimelock?: { value: bigint; type: "blocks" | "seconds" };
+            delegatorProvider?: DelegatorProvider;
+        }) {
+            const network = config?.network ?? "bitcoin";
+            const compressedPubKey = await mockIdentity.compressedPublicKey();
+            const readonlyIdentity =
+                ReadonlySingleKey.fromPublicKey(compressedPubKey);
+            const walletRepository = new InMemoryWalletRepository();
+            const contractRepository = new InMemoryContractRepository();
+
+            const wallet = await ReadonlyWallet.create({
+                identity: readonlyIdentity,
+                arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: vi
+                        .fn()
+                        .mockResolvedValue(
+                            mockArkInfo(
+                                network,
+                                config?.unilateralExitDelay ??
+                                    (network === "bitcoin"
+                                        ? ARKD_DELAY
+                                        : MUTINYNET_DELAY)
+                            )
+                        ),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider: createIndexerProvider(),
+                onchainProvider: createOnchainProvider(),
+                storage: {
+                    walletRepository,
+                    contractRepository,
+                },
+                exitTimelock: config?.exitTimelock,
+                delegatorProvider: config?.delegatorProvider,
             });
+
+            return { wallet };
+        }
+
+        async function createFullMainnetWallet(config?: {
+            delegatorProvider?: DelegatorProvider;
+        }) {
+            const walletRepository = new InMemoryWalletRepository();
+            const contractRepository = new InMemoryContractRepository();
 
             const wallet = await Wallet.create({
                 identity: mockIdentity,
                 arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: vi
+                        .fn()
+                        .mockResolvedValue(mockArkInfo("bitcoin", ARKD_DELAY)),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider: createIndexerProvider(),
+                onchainProvider: createOnchainProvider(),
+                storage: {
+                    walletRepository,
+                    contractRepository,
+                },
+                delegatorProvider: config?.delegatorProvider,
+                settlementConfig: false,
             });
 
-            expect(wallet.offchainTapscript.options.csvTimelock).toEqual({
-                value: MAINNET_PINNED_DELAY,
-                type: "seconds",
-            });
+            return { wallet };
+        }
+
+        it("uses the arkd exit timelock as the mainnet offchain address delay", async () => {
+            const { wallet } = await createReadonlyTestWallet();
+
+            try {
+                expect(wallet.offchainTapscript.options.csvTimelock).toEqual({
+                    value: ARKD_DELAY,
+                    type: "seconds",
+                });
+            } finally {
+                await wallet.dispose();
+            }
         });
 
-        it("lets an explicit config.exitTimelock override the mainnet pin", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockMainnetInfo(86528n)),
+        it("registers arkd and legacy default contracts on mainnet", async () => {
+            const { wallet } = await createReadonlyTestWallet();
+
+            try {
+                const manager = await wallet.getContractManager();
+                const contracts = await manager.getContracts({
+                    type: ["default", "delegate"],
+                });
+
+                expect(contractSummaries(contracts)).toEqual([
+                    `default:${sequence(ARKD_DELAY, "seconds")}`,
+                    `default:${sequence(MAINNET_LEGACY_DELAY, "seconds")}`,
+                ]);
+            } finally {
+                await wallet.dispose();
+            }
+        });
+
+        it("registers arkd and legacy default and delegate contracts on mainnet", async () => {
+            const { wallet } = await createReadonlyTestWallet({
+                delegatorProvider: createDelegatorProvider(),
             });
 
-            // bip68 seconds must be multiples of 512.
+            try {
+                const manager = await wallet.getContractManager();
+                const contracts = await manager.getContracts({
+                    type: ["default", "delegate"],
+                });
+
+                expect(contractSummaries(contracts)).toEqual([
+                    `default:${sequence(ARKD_DELAY, "seconds")}`,
+                    `default:${sequence(MAINNET_LEGACY_DELAY, "seconds")}`,
+                    `delegate:${sequence(ARKD_DELAY, "seconds")}`,
+                    `delegate:${sequence(MAINNET_LEGACY_DELAY, "seconds")}`,
+                ]);
+            } finally {
+                await wallet.dispose();
+            }
+        });
+
+        it("passes wallet contract timelocks through Wallet.create for delegate wallets", async () => {
+            const { wallet } = await createFullMainnetWallet({
+                delegatorProvider: createDelegatorProvider(),
+            });
+
+            try {
+                expect(wallet.offchainTapscript.options.csvTimelock).toEqual({
+                    value: ARKD_DELAY,
+                    type: "seconds",
+                });
+                expect(
+                    wallet.walletContractTimelocks.map((timelock) =>
+                        timelockToSequence(timelock).toString()
+                    )
+                ).toEqual([
+                    sequence(ARKD_DELAY, "seconds"),
+                    sequence(MAINNET_LEGACY_DELAY, "seconds"),
+                ]);
+
+                const manager = await wallet.getContractManager();
+                const contracts = await manager.getContracts({
+                    type: ["default", "delegate"],
+                });
+
+                expect(contractSummaries(contracts)).toEqual([
+                    `default:${sequence(ARKD_DELAY, "seconds")}`,
+                    `default:${sequence(MAINNET_LEGACY_DELAY, "seconds")}`,
+                    `delegate:${sequence(ARKD_DELAY, "seconds")}`,
+                    `delegate:${sequence(MAINNET_LEGACY_DELAY, "seconds")}`,
+                ]);
+            } finally {
+                await wallet.dispose();
+            }
+        });
+
+        it("lets an explicit config.exitTimelock override compatibility registration", async () => {
             const override = { value: 1024n, type: "seconds" as const };
-            const wallet = await Wallet.create({
-                identity: mockIdentity,
-                arkServerUrl: "http://localhost:7070",
+            const { wallet } = await createReadonlyTestWallet({
                 exitTimelock: override,
             });
 
             expect(wallet.offchainTapscript.options.csvTimelock).toEqual(
                 override
             );
+
+            try {
+                const manager = await wallet.getContractManager();
+                const contracts = await manager.getContracts({
+                    type: ["default", "delegate"],
+                });
+
+                expect(contractSummaries(contracts)).toEqual([
+                    `default:${sequence(override.value, override.type)}`,
+                ]);
+            } finally {
+                await wallet.dispose();
+            }
+        });
+
+        it("dedupes the legacy delay when arkd advertises the legacy value", async () => {
+            const { wallet } = await createReadonlyTestWallet({
+                unilateralExitDelay: MAINNET_LEGACY_DELAY,
+            });
+
+            try {
+                const manager = await wallet.getContractManager();
+                const contracts = await manager.getContracts({
+                    type: ["default", "delegate"],
+                });
+
+                expect(contractSummaries(contracts)).toEqual([
+                    `default:${sequence(MAINNET_LEGACY_DELAY, "seconds")}`,
+                ]);
+            } finally {
+                await wallet.dispose();
+            }
+        });
+
+        it("includes arkd and legacy scripts before ContractManager is initialized", async () => {
+            const { wallet } = await createReadonlyTestWallet();
+
+            try {
+                const fallbackScripts = await wallet.getWalletScripts();
+
+                expect((wallet as any)._contractManager).toBeUndefined();
+                expect(new Set(fallbackScripts).size).toBe(2);
+
+                const manager = await wallet.getContractManager();
+                const contracts = await manager.getContracts({
+                    type: "default",
+                });
+
+                expect(fallbackScripts.sort()).toEqual(
+                    contracts.map((contract) => contract.script).sort()
+                );
+            } finally {
+                await wallet.dispose();
+            }
+        });
+
+        it("includes delegate and default scripts in getScriptMap before ContractManager is initialized", async () => {
+            const { wallet } = await createReadonlyTestWallet({
+                delegatorProvider: createDelegatorProvider(),
+            });
+
+            try {
+                const scriptMap = await wallet.getScriptMap();
+
+                expect((wallet as any)._contractManager).toBeUndefined();
+                expect(scriptMap.size).toBe(4);
+
+                const manager = await wallet.getContractManager();
+                const contracts = await manager.getContracts({
+                    type: ["default", "delegate"],
+                });
+
+                expect([...scriptMap.keys()].sort()).toEqual(
+                    contracts.map((contract) => contract.script).sort()
+                );
+            } finally {
+                await wallet.dispose();
+            }
+        });
+
+        it("does not register legacy mainnet delay variants on mutinynet", async () => {
+            const { wallet } = await createReadonlyTestWallet({
+                network: "mutinynet",
+            });
+
+            try {
+                expect(wallet.walletContractTimelocks).toEqual([
+                    { value: MUTINYNET_DELAY, type: "blocks" },
+                ]);
+
+                const manager = await wallet.getContractManager();
+                const contracts = await manager.getContracts({
+                    type: ["default", "delegate"],
+                });
+
+                expect(contractSummaries(contracts)).toEqual([
+                    `default:${sequence(MUTINYNET_DELAY, "blocks")}`,
+                ]);
+            } finally {
+                await wallet.dispose();
+            }
         });
     });
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1349,52 +1349,6 @@ describe("Wallet", () => {
             }
         });
 
-        it("includes arkd and legacy scripts before ContractManager is initialized", async () => {
-            const { wallet } = await createReadonlyTestWallet();
-
-            try {
-                const fallbackScripts = await wallet.getWalletScripts();
-
-                expect((wallet as any)._contractManager).toBeUndefined();
-                expect(new Set(fallbackScripts).size).toBe(2);
-
-                const manager = await wallet.getContractManager();
-                const contracts = await manager.getContracts({
-                    type: "default",
-                });
-
-                expect(fallbackScripts.sort()).toEqual(
-                    contracts.map((contract) => contract.script).sort()
-                );
-            } finally {
-                await wallet.dispose();
-            }
-        });
-
-        it("includes delegate and default scripts in getScriptMap before ContractManager is initialized", async () => {
-            const { wallet } = await createReadonlyTestWallet({
-                delegatorProvider: createDelegatorProvider(),
-            });
-
-            try {
-                const scriptMap = await wallet.getScriptMap();
-
-                expect((wallet as any)._contractManager).toBeUndefined();
-                expect(scriptMap.size).toBe(4);
-
-                const manager = await wallet.getContractManager();
-                const contracts = await manager.getContracts({
-                    type: ["default", "delegate"],
-                });
-
-                expect([...scriptMap.keys()].sort()).toEqual(
-                    contracts.map((contract) => contract.script).sort()
-                );
-            } finally {
-                await wallet.dispose();
-            }
-        });
-
         it("does not register legacy mainnet delay variants on mutinynet", async () => {
             const { wallet } = await createReadonlyTestWallet({
                 network: "mutinynet",


### PR DESCRIPTION
## Summary

  - Use arkd’s advertised `unilateralExitDelay` as the wallet’s primary offchain tapscript delay.
  - Keep the historical mainnet delay (`605184s`) as a compatibility script so existing mainnet wallet funds remain discoverable and spendable.
  - Register all wallet-owned `default` scripts, plus matching `delegate` scripts when delegation is configured.
  - Update pre-ContractManager script discovery so `getWalletScripts()` and `getScriptMap()` include all locally-derived wallet script variants.

  ## Behavior

  Mainnet wallets without `config.exitTimelock` now use the arkd delay for `offchainTapscript` / `getAddress()`, while ContractManager also registers the legacy mainnet delay variant.

  When delegation is configured and arkd’s delay differs from the legacy delay, the wallet registers:

  - `default` with arkd delay
  - `delegate` with arkd delay
  - `default` with legacy mainnet delay
  - `delegate` with legacy mainnet delay

  `config.exitTimelock` remains an authoritative override and registers only the override delay.

## Opinionated change

About [this comment](https://github.com/arkade-os/ts-sdk/pull/456#pullrequestreview-4186894014): 

> Outstanding from prior review (still unresolved):
>
> getWalletScripts() (src/wallet/wallet.ts:823-826) — no try/catch, returns [] on empty contracts. If ContractManager > init fails (DB error, storage quota), callers like fetchPendingTxs() lose visibility of all VTXOs.
>
> getScriptMap() (src/wallet/wallet.ts:835) — same: removed the map.set(currentScriptHex, this.offchainTapscript) > safety net. ContractManager failure → empty map → wallet can't decode any of its own VTXOs.

The ContractManager is the sole source of truth and it's a critical part: **if it doesn't work, the app cannot work properly**. Hence the failure must bubble up and there are no fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced wallet compatibility with improved support for multiple exit delay configurations, enabling better adaptation across different network environments.
  * Expanded contract registration to include legacy timelock variants for enhanced backward compatibility.

* **Bug Fixes**
  * Improved wallet initialization to correctly handle exit delays from server advertisements and user configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->