### PR TITLE
fix: share single SSE subscription between wallet and ContractWatcher

### DIFF
--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -380,14 +380,19 @@ export class ContractWatcher {
 
     /**
      * Connect to the subscription.
+     *
+     * @param skipUpdate - Skip the leading `updateSubscription` call when
+     *   the caller has already established `subscriptionId`.
      */
-    private async connect(): Promise<void> {
+    private async connect(skipUpdate = false): Promise<void> {
         if (!this.isWatching) return;
 
         this.connectionState = "connecting";
 
         try {
-            await this.updateSubscription();
+            if (!skipUpdate) {
+                await this.updateSubscription();
+            }
 
             // Poll immediately after connection to sync state
             await this.pollAllContracts();
@@ -556,10 +561,30 @@ export class ContractWatcher {
     }
 
     private async tryUpdateSubscription() {
+        const hadSubscription = this.subscriptionId !== undefined;
         try {
             await this.updateSubscription();
         } catch (error) {
             // nothing, the connection will be retried later
+            return;
+        }
+
+        // Cold start: `startWatching` may have run with zero scripts,
+        // leaving `listenLoop` parked behind the reconnect timer. Kick
+        // `connect` now so streaming resumes without waiting on the
+        // backoff. `skipUpdate` avoids re-issuing `subscribeForScripts`.
+        const justGotSubscription =
+            !hadSubscription && this.subscriptionId !== undefined;
+        const listenerParked =
+            this.connectionState === "disconnected" ||
+            this.connectionState === "reconnecting";
+        if (this.isWatching && justGotSubscription && listenerParked) {
+            if (this.reconnectTimeoutId) {
+                clearTimeout(this.reconnectTimeoutId);
+                this.reconnectTimeoutId = undefined;
+            }
+            this.reconnectAttempts = 0;
+            this.connect(true).catch(() => {});
         }
     }
 

--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -584,7 +584,12 @@ export class ContractWatcher {
                 this.reconnectTimeoutId = undefined;
             }
             this.reconnectAttempts = 0;
-            this.connect(true).catch(() => {});
+            this.connect(true).catch((error) => {
+                console.warn(
+                    "ContractWatcher cold-start connect failed:",
+                    error
+                );
+            });
         }
     }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -689,6 +689,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
             // opening a second SSE stream.
             const cm = await this.getContractManager();
 
+            // Serialize annotation+notification: parallel `annotateVtxos`
+            // awaits could resolve out of order and deliver eventCallback
+            // calls in the wrong sequence (e.g. `vtxo_spent` before its
+            // matching `vtxo_received`).
+            let annotationQueue: Promise<void> = Promise.resolve();
+
             indexerStopFunc = cm.onContractEvent((event) => {
                 if (
                     event.type !== "vtxo_received" &&
@@ -705,7 +711,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
                 // `event.vtxos` carries placeholder tapscript fields from
                 // the watcher; `annotateVtxos` fills them in.
-                (async () => {
+                annotationQueue = annotationQueue.then(async () => {
                     try {
                         const annotated = await cm.annotateVtxos(event.vtxos);
                         eventCallback({
@@ -721,7 +727,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
                             error
                         );
                     }
-                })();
+                });
             });
         }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -685,69 +685,44 @@ export class ReadonlyWallet implements IReadonlyWallet {
         }
 
         if (this.indexerProvider && arkAddress) {
-            const walletScripts = await this.getWalletScripts();
+            // Share the ContractWatcher's single subscription instead of
+            // opening a second SSE stream.
+            const cm = await this.getContractManager();
 
-            const subscriptionId =
-                await this.indexerProvider.subscribeForScripts(walletScripts);
-
-            const abortController = new AbortController();
-            const subscription = this.indexerProvider.getSubscription(
-                subscriptionId,
-                abortController.signal
-            );
-
-            indexerStopFunc = async () => {
-                abortController.abort();
-                await this.indexerProvider?.unsubscribeForScripts(
-                    subscriptionId
-                );
-            };
-
-            // Handle subscription updates asynchronously without blocking.
-            // Subscription covers all wallet scripts (default + delegate) plus
-            // any additional registered contracts. Virtual outputs carry a
-            // `script` field from the indexer which the contract manager
-            // resolves to the owning contract so the extension uses the
-            // correct forfeit/intent tapscripts.
-            (async () => {
-                try {
-                    const cm = await this.getContractManager();
-                    for await (const update of subscription) {
-                        if (
-                            update.newVtxos?.length === 0 &&
-                            update.spentVtxos?.length === 0
-                        ) {
-                            continue;
-                        }
-                        // Isolate per-update annotation failures (e.g. a VTXO
-                        // arriving for a contract we haven't registered yet).
-                        // Without this a single bad update would kill the
-                        // for-await loop and silently drop every subsequent
-                        // subscription event for the session.
-                        try {
-                            // Default to `[]` so a one-sided update (e.g.
-                            // only `newVtxos`) doesn't pass `undefined` into
-                            // annotateVtxos and throw on `.length`.
-                            const [newVtxos, spentVtxos] = await Promise.all([
-                                cm.annotateVtxos(update.newVtxos ?? []),
-                                cm.annotateVtxos(update.spentVtxos ?? []),
-                            ]);
-                            eventCallback({
-                                type: "vtxo",
-                                newVtxos,
-                                spentVtxos,
-                            });
-                        } catch (error) {
-                            console.warn(
-                                "Dropping subscription update after annotation failed; next sync will reconcile:",
-                                error
-                            );
-                        }
-                    }
-                } catch (error) {
-                    console.error("Subscription error:", error);
+            indexerStopFunc = cm.onContractEvent((event) => {
+                if (
+                    event.type !== "vtxo_received" &&
+                    event.type !== "vtxo_spent"
+                ) {
+                    return;
                 }
-            })();
+                if (
+                    event.contract.type !== "default" &&
+                    event.contract.type !== "delegate"
+                ) {
+                    return;
+                }
+
+                // `event.vtxos` carries placeholder tapscript fields from
+                // the watcher; `annotateVtxos` fills them in.
+                (async () => {
+                    try {
+                        const annotated = await cm.annotateVtxos(event.vtxos);
+                        eventCallback({
+                            type: "vtxo",
+                            newVtxos:
+                                event.type === "vtxo_received" ? annotated : [],
+                            spentVtxos:
+                                event.type === "vtxo_spent" ? annotated : [],
+                        });
+                    } catch (error) {
+                        console.warn(
+                            "Dropping subscription update after annotation failed; next sync will reconcile:",
+                            error
+                        );
+                    }
+                })();
+            });
         }
 
         const stopFunc = () => {

--- a/test/contracts/watcher.test.ts
+++ b/test/contracts/watcher.test.ts
@@ -213,4 +213,35 @@ describe("ContractWatcher", () => {
             vi.useRealTimers();
         }
     });
+
+    it("opens listenLoop immediately when the first contract is added after a zero-script startWatching", async () => {
+        // Without the cold-start kick, the listener parks behind the
+        // reconnect timer and `getSubscription` is delayed by ≥1s.
+        await watcher.startWatching(() => {});
+
+        expect(mockIndexer.getSubscription).not.toHaveBeenCalled();
+        expect(watcher.getConnectionState()).not.toBe("connected");
+
+        const contract: Contract = {
+            type: "default",
+            params: createDefaultContractParams(),
+            script: TEST_DEFAULT_SCRIPT,
+            address: "address",
+            state: "active",
+            createdAt: Date.now(),
+        };
+        await watcher.addContract(contract);
+
+        // Yield so the cold-start kick reaches `getSubscription`.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(mockIndexer.getSubscription).toHaveBeenCalledTimes(1);
+        expect(mockIndexer.getSubscription).toHaveBeenCalledWith(
+            "mock-subscription-id",
+            expect.anything()
+        );
+        expect(watcher.getConnectionState()).toBe("connected");
+
+        await watcher.stopWatching();
+    });
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -21,18 +21,12 @@ import {
     IndexedDBContractRepository,
 } from "../src/repositories";
 import type { Coin, VirtualCoin } from "../src/wallet";
+import { MockEventSource } from "./mocks/eventSource";
 
 // Mock fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-// Mock EventSource
-const MockEventSource = vi.fn().mockImplementation((url: string) => ({
-    url,
-    onmessage: null,
-    onerror: null,
-    close: vi.fn(),
-}));
 vi.stubGlobal("EventSource", MockEventSource);
 
 // Shared IndexedDB repos — cleared between tests so cached VTXOs,
@@ -899,6 +893,72 @@ describe("Wallet", () => {
             );
             expect(cached).toHaveLength(1);
             expect(cached[0].isSpent).toBe(true);
+        });
+    });
+
+    describe("notifyIncomingFunds — single SSE stream", () => {
+        const mockArkInfo = {
+            signerPubkey: mockServerKeyHex,
+            forfeitPubkey: mockServerKeyHex,
+            batchExpiry: BigInt(144),
+            unilateralExitDelay: BigInt(144),
+            boardingExitDelay: BigInt(144),
+            roundInterval: BigInt(144),
+            network: "mutinynet",
+            dust: BigInt(1000),
+            forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+            checkpointTapscript:
+                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        };
+
+        it("opens exactly one getSubscription stream after notifyIncomingFunds", async () => {
+            // `subscribeForScripts` legitimately fires more than once to
+            // extend the same subscription id, so we count
+            // `getSubscription` (the actual SSE open).
+            const compressedPubKey = await mockIdentity.compressedPublicKey();
+            const readonlyIdentity =
+                ReadonlySingleKey.fromPublicKey(compressedPubKey);
+
+            const getSubscriptionSpy = vi
+                .fn<IndexerProvider["getSubscription"]>()
+                .mockImplementation(async function* () {
+                    await new Promise(() => {});
+                });
+
+            const wallet = await ReadonlyWallet.create({
+                identity: readonlyIdentity,
+                arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: vi.fn().mockResolvedValue(mockArkInfo),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider: {
+                    getVtxos: vi.fn().mockResolvedValue({ vtxos: [] }),
+                    subscribeForScripts: vi
+                        .fn()
+                        .mockResolvedValue("sub-shared"),
+                    unsubscribeForScripts: vi.fn().mockResolvedValue(undefined),
+                    getSubscription: getSubscriptionSpy,
+                } as Partial<IndexerProvider> as IndexerProvider,
+                onchainProvider: {
+                    watchAddresses: vi
+                        .fn<OnchainProvider["watchAddresses"]>()
+                        .mockResolvedValue(() => {}),
+                } as Partial<OnchainProvider> as OnchainProvider,
+                storage: {
+                    walletRepository: new InMemoryWalletRepository(),
+                    contractRepository: new InMemoryContractRepository(),
+                },
+            });
+
+            expect(getSubscriptionSpy).toHaveBeenCalledTimes(0);
+
+            const stop = await wallet.notifyIncomingFunds(() => {});
+            // Yield so the cold-start kick reaches `getSubscription`.
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(getSubscriptionSpy).toHaveBeenCalledTimes(1);
+
+            stop();
         });
     });
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -954,8 +954,20 @@ describe("Wallet", () => {
 
             expect(getSubscriptionSpy).toHaveBeenCalledTimes(0);
 
-            const stop = await wallet.notifyIncomingFunds(() => {});
+            // Boot the ContractManager up-front so its watcher is already
+            // running with an open SSE stream. Without this baseline,
+            // `notifyIncomingFunds` would lazy-init the CM itself and a
+            // regression where it opened its own subscription would still
+            // produce exactly one `getSubscription` call.
+            await wallet.getContractManager();
             // Yield so the cold-start kick reaches `getSubscription`.
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(getSubscriptionSpy).toHaveBeenCalledTimes(1);
+
+            const stop = await wallet.notifyIncomingFunds(() => {});
+            // Yield again to surface any extra stream opened by
+            // `notifyIncomingFunds`.
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             expect(getSubscriptionSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- `notifyIncomingFunds` now piggybacks on the `ContractManager` event bus instead of opening its own indexer subscription.
- Adds a cold-start kick in `ContractWatcher.tryUpdateSubscription` so the listener opens promptly when the first contract is added after a zero-script `startWatching`.

Closes #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Contract watcher: improved cold-start recovery and reconnection so streaming resumes reliably without unnecessary re-subscription; optional skip-update path avoids redundant subscription update on reconnect.
  * Incoming-funds handling: single shared subscription via contract events, annotated transaction outputs, and serialized processing to preserve event ordering.

* **Tests**
  * Added tests for watcher cold-start and incoming-funds subscription behavior; consolidated mock event source usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->