### PR TITLE
fix(wallet): always init contract manager in script accessors

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -141,7 +141,6 @@ export class ReadonlyWallet implements IReadonlyWallet {
     private _contractManagerInitializing?: Promise<ContractManager>;
     protected readonly watcherConfig?: ReadonlyWalletConfig["watcherConfig"];
     private readonly _assetManager: IReadonlyAssetManager;
-    private _syncVtxosInflight?: Promise<void>;
     // Outpoints ("txid:vout") committed to an in-flight settle/send. Filtered
     // from getVtxos() so concurrent callers (UI, VtxoManager auto-renewal,
     // another send/settle racing the _txLock) can't reselect coins that are

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -782,24 +782,14 @@ export class ReadonlyWallet implements IReadonlyWallet {
     /**
      * Get all pkScript hex strings for the wallet's own addresses
      * (both delegate and non-delegate, current and historical).
-     * Falls back to only the current script if ContractManager is not yet initialized.
      */
     async getWalletScripts(): Promise<string[]> {
-        // Only use the contract manager if it's already initialized or
-        // currently initializing — never trigger initialization here to
-        // avoid blocking callers that don't need it.
-        if (this._contractManager || this._contractManagerInitializing) {
-            try {
-                const manager = await this.getContractManager();
-                const contracts = await manager.getContracts({
-                    type: ["default", "delegate"],
-                });
-                if (contracts.length > 0) {
-                    return contracts.map((c) => c.script);
-                }
-            } catch {
-                // fall through to current script only
-            }
+        const manager = await this.getContractManager();
+        const contracts = await manager.getContracts({
+            type: ["default", "delegate"],
+        });
+        if (contracts.length > 0) {
+            return contracts.map((c) => c.script);
         }
         return [hex.encode(this.offchainTapscript.pkScript)];
     }
@@ -817,23 +807,18 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const currentScriptHex = hex.encode(this.offchainTapscript.pkScript);
         map.set(currentScriptHex, this.offchainTapscript);
 
-        if (this._contractManager) {
-            try {
-                const contracts = await this._contractManager.getContracts({
-                    type: ["default", "delegate"],
-                });
-                for (const contract of contracts) {
-                    if (map.has(contract.script)) continue;
-                    const handler = contractHandlers.get(contract.type);
-                    if (handler) {
-                        const script = handler.createScript(contract.params) as
-                            | DefaultVtxo.Script
-                            | DelegateVtxo.Script;
-                        map.set(contract.script, script);
-                    }
-                }
-            } catch {
-                // ContractManager error — only current script in map
+        const manager = await this.getContractManager();
+        const contracts = await manager.getContracts({
+            type: ["default", "delegate"],
+        });
+        for (const contract of contracts) {
+            if (map.has(contract.script)) continue;
+            const handler = contractHandlers.get(contract.type);
+            if (handler) {
+                const script = handler.createScript(contract.params) as
+                    | DefaultVtxo.Script
+                    | DelegateVtxo.Script;
+                map.set(contract.script, script);
             }
         }
 


### PR DESCRIPTION
## Problem

`Wallet.getWalletScripts()` and `Wallet.getScriptMap()` decided whether to consult `ContractManager` by reading the internal `_contractManager` / `_contractManagerInitializing` flags directly:

- `getWalletScripts` (`src/wallet/wallet.ts:787`): only fetched contracts if the manager was already initialized or initializing, otherwise returned just the current script.
- `getScriptMap` (`src/wallet/wallet.ts:811`): only consulted the manager if `_contractManager` was already set, didn't even await an in-flight init.

Both also wrapped the manager call in a `try { ... } catch {}` that silently fell back to current-script-only.

Because `ContractManager` is lazily initialized and hydrates historical `default`/`delegate` contracts from `ContractRepository` on first call, these guards made behaviour depend on call order. On a fresh wallet:

- `notifyIncomingFunds` → `getWalletScripts()` → subscription opened against the current script only. Historical delegate/default scripts were never subscribed; VTXOs landing on them were silently missed for the life of the subscription.
- `fetchPendingTxs` and `finalizePendingTxs` → indexer queries scoped to the current script only, missing pending state on any prior wallet incarnation persisted in `ContractRepository`.

All five sibling call sites in the same class (`:481`, `:509`, `:714`, `:2598`, `:2715`) already do `await this.getContractManager()` directly and let errors bubble up.

## Solution

- Drop the flag-based guards in `getWalletScripts` and `getScriptMap`. Both now `await this.getContractManager()` unconditionally and let errors propagate, matching the sibling pattern.
- Remove the unused `_syncVtxosInflight` field on `ReadonlyWallet` (declared, never assigned or read).

No behavioural change for callers that had already triggered manager init before reaching these accessors; fresh-wallet callers now see the full set of registered contracts.

## Validation

- `pnpm exec tsc --noEmit` — clean
- `pnpm test:unit` — 1016 passed, 1 skipped
- `pnpm lint` — clean (pre-commit hook)