### PR TITLE
feat: default to bitcoin mainnet + arkade.computer

### DIFF
--- a/src/contracts/arkcontract.ts
+++ b/src/contracts/arkcontract.ts
@@ -1,6 +1,7 @@
 import { hex } from "@scure/base";
 import { Contract } from "./types";
 import { contractHandlers } from "./handlers";
+import { DEFAULT_ARKADE_HRP } from "../wallet";
 
 /**
  * Prefix for arkcontract strings.
@@ -162,7 +163,7 @@ export function contractFromArkContract(
 export function contractFromArkContractWithAddress(
     encoded: string,
     serverPubKey: Uint8Array,
-    addressPrefix: string,
+    addressPrefix: string = DEFAULT_ARKADE_HRP,
     options: {
         label?: string;
         state?: "active" | "inactive";

--- a/src/script/address.ts
+++ b/src/script/address.ts
@@ -1,6 +1,7 @@
 import { bech32m } from "@scure/base";
 import { Bytes } from "@scure/btc-signer/utils.js";
 import { Script } from "@scure/btc-signer/script.js";
+import { DEFAULT_ARKADE_HRP } from "../wallet";
 
 /**
  * ArkAddress allows creating and decoding bech32m-encoded Arkade addresses.
@@ -45,7 +46,7 @@ export class ArkAddress {
     constructor(
         readonly serverPubKey: Bytes,
         readonly vtxoTaprootKey: Bytes,
-        readonly hrp: string,
+        readonly hrp: string = DEFAULT_ARKADE_HRP,
         readonly version: number = 0
     ) {
         if (serverPubKey.length !== 32) {

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -12,6 +12,11 @@ import { IContractManager } from "../contracts/contractManager";
 import { IDelegatorManager } from "./delegator";
 import { DelegatorProvider } from "../providers/delegator";
 
+/** Defaults */
+export const DEFAULT_ARKADE_SERVER_URL = "https://arkade.computer" as const;
+export const DEFAULT_ARKADE_HRP = "ark";
+export const DEFAULT_NETWORK_NAME = "bitcoin";
+
 /**
  * Base configuration options shared by all wallet types.
  *
@@ -22,9 +27,6 @@ import { DelegatorProvider } from "../providers/delegator";
  *
  * Provider-based configuration supplies concrete provider instances directly,
  * including the ArkProvider, IndexerProvider, OnchainProvider, and DelegatorProvider.
- *
- * At least one of the following must be provided:
- * - arkServerUrl OR arkProvider
  *
  * The wallet will use provided URLs to create default providers if custom provider
  * instances are not supplied. If optional parameters are not provided, the wallet

--- a/src/wallet/onchain.ts
+++ b/src/wallet/onchain.ts
@@ -1,6 +1,6 @@
 import { p2tr } from "@scure/btc-signer";
 import { P2TR } from "@scure/btc-signer/payment.js";
-import { Coin, SendBitcoinParams } from ".";
+import { Coin, DEFAULT_NETWORK_NAME, SendBitcoinParams } from ".";
 import { Identity } from "../identity";
 import { getNetwork, Network, NetworkName } from "../networks";
 import {
@@ -60,7 +60,7 @@ export class OnchainWallet implements AnchorBumper {
      */
     static async create(
         identity: Identity,
-        networkName: NetworkName,
+        networkName: NetworkName = DEFAULT_NETWORK_NAME,
         provider?: OnchainProvider
     ): Promise<OnchainWallet> {
         const pubkey = await identity.xOnlyPublicKey();

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -136,6 +136,7 @@ import {
     MESSAGE_BUS_NOT_INITIALIZED,
     ServiceWorkerTimeoutError,
 } from "../../worker/errors";
+import { getArkadeServerUrl } from "../wallet";
 
 // Check by error message content instead of instanceof because postMessage uses the
 // structured clone algorithm which strips the prototype chain — the page
@@ -532,7 +533,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             .then(hex.encode);
         const initWalletPayload = {
             key: { publicKey },
-            arkServerUrl: options.arkServerUrl || DEFAULT_ARKADE_SERVER_URL,
+            arkServerUrl: getArkadeServerUrl(options),
             arkServerPublicKey: options.arkServerPublicKey,
             delegatorUrl: options.delegatorUrl,
         };
@@ -549,7 +550,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         const busInitConfig: MessageBusInitConfig = {
             wallet: serializedWallet,
             arkServer: {
-                url: options.arkServerUrl || DEFAULT_ARKADE_SERVER_URL,
+                url: getArkadeServerUrl(options),
                 publicKey: options.arkServerPublicKey,
             },
             delegatorUrl: options.delegatorUrl,
@@ -1389,7 +1390,7 @@ export class ServiceWorkerWallet
                 : null;
         const initWalletPayload = {
             key: legacyPrivateKey ? { privateKey: legacyPrivateKey } : {},
-            arkServerUrl: options.arkServerUrl || DEFAULT_ARKADE_SERVER_URL,
+            arkServerUrl: getArkadeServerUrl(options),
             arkServerPublicKey: options.arkServerPublicKey,
             delegatorUrl: options.delegatorUrl,
         };
@@ -1406,7 +1407,7 @@ export class ServiceWorkerWallet
         const busInitConfig: MessageBusInitConfig = {
             wallet: serializedWallet,
             arkServer: {
-                url: options.arkServerUrl || DEFAULT_ARKADE_SERVER_URL,
+                url: getArkadeServerUrl(options),
                 publicKey: options.arkServerPublicKey,
             },
             delegatorUrl: options.delegatorUrl,

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -17,6 +17,7 @@ import {
     ReissuanceParams,
     BurnParams,
     Recipient,
+    DEFAULT_ARKADE_SERVER_URL,
 } from "..";
 import { SettlementEvent } from "../../providers/ark";
 import { hex } from "@scure/base";
@@ -329,7 +330,7 @@ interface ServiceWorkerWalletOptions {
     /** Optional Arkade server public key used to construct and validate Arkade addresses. */
     arkServerPublicKey?: string;
     /** Base URL of the Arkade server. */
-    arkServerUrl: string;
+    arkServerUrl?: string;
     /** Optional override for the indexer URL. */
     indexerUrl?: string;
     /** Optional override for the Esplora API URL. */
@@ -531,7 +532,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             .then(hex.encode);
         const initWalletPayload = {
             key: { publicKey },
-            arkServerUrl: options.arkServerUrl,
+            arkServerUrl: options.arkServerUrl || DEFAULT_ARKADE_SERVER_URL,
             arkServerPublicKey: options.arkServerPublicKey,
             delegatorUrl: options.delegatorUrl,
         };
@@ -548,7 +549,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         const busInitConfig: MessageBusInitConfig = {
             wallet: serializedWallet,
             arkServer: {
-                url: options.arkServerUrl,
+                url: options.arkServerUrl || DEFAULT_ARKADE_SERVER_URL,
                 publicKey: options.arkServerPublicKey,
             },
             delegatorUrl: options.delegatorUrl,
@@ -1388,7 +1389,7 @@ export class ServiceWorkerWallet
                 : null;
         const initWalletPayload = {
             key: legacyPrivateKey ? { privateKey: legacyPrivateKey } : {},
-            arkServerUrl: options.arkServerUrl,
+            arkServerUrl: options.arkServerUrl || DEFAULT_ARKADE_SERVER_URL,
             arkServerPublicKey: options.arkServerPublicKey,
             delegatorUrl: options.delegatorUrl,
         };
@@ -1405,7 +1406,7 @@ export class ServiceWorkerWallet
         const busInitConfig: MessageBusInitConfig = {
             wallet: serializedWallet,
             arkServer: {
-                url: options.arkServerUrl,
+                url: options.arkServerUrl || DEFAULT_ARKADE_SERVER_URL,
                 publicKey: options.arkServerPublicKey,
             },
             delegatorUrl: options.delegatorUrl,

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -33,6 +33,7 @@ import {
     ArkTransaction,
     Asset,
     Coin,
+    DEFAULT_ARKADE_SERVER_URL,
     ExtendedCoin,
     ExtendedVirtualCoin,
     GetVtxosFilter,
@@ -230,12 +231,9 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const arkProvider =
             config.arkProvider ||
             (() => {
-                if (!config.arkServerUrl) {
-                    throw new Error(
-                        "Either arkProvider or arkServerUrl must be provided"
-                    );
-                }
-                return new RestArkProvider(config.arkServerUrl);
+                return new RestArkProvider(
+                    config.arkServerUrl || DEFAULT_ARKADE_SERVER_URL
+                );
             })();
 
         // Extract arkServerUrl from provider if not explicitly provided

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -102,6 +102,12 @@ import { contractHandlers } from "../contracts/handlers";
 import { timelockToSequence } from "../contracts/handlers/helpers";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
 
+export const getArkadeServerUrl = ({
+    arkServerUrl,
+}: {
+    arkServerUrl?: string;
+}) => arkServerUrl || DEFAULT_ARKADE_SERVER_URL;
+
 // Historical unilateral exit delay for mainnet (~7 days in seconds).
 // Kept so existing wallets can still discover and spend VTXOs sent to the
 // legacy address after arkd starts advertising a different delay.
@@ -231,9 +237,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const arkProvider =
             config.arkProvider ||
             (() => {
-                return new RestArkProvider(
-                    config.arkServerUrl || DEFAULT_ARKADE_SERVER_URL
-                );
+                return new RestArkProvider(getArkadeServerUrl(config));
             })();
 
         // Extract arkServerUrl from provider if not explicitly provided

--- a/test/address.test.ts
+++ b/test/address.test.ts
@@ -1,9 +1,23 @@
 import { describe, it, expect } from "vitest";
 import { ArkAddress } from "../src";
+import { DEFAULT_ARKADE_HRP } from "../src/wallet";
 import fixtures from "./fixtures/encoding.json";
 import { hex } from "@scure/base";
 
 describe("ArkAddress", () => {
+    it("defaults to the mainnet Arkade HRP", () => {
+        const serverPubKey = new Uint8Array(32).fill(1);
+        const vtxoTaprootKey = new Uint8Array(32).fill(2);
+
+        const address = new ArkAddress(serverPubKey, vtxoTaprootKey);
+        const encoded = address.encode();
+
+        expect(address.hrp).toBe(DEFAULT_ARKADE_HRP);
+        expect(encoded.startsWith(`${DEFAULT_ARKADE_HRP}1`)).toBe(true);
+        const decoded = ArkAddress.decode(encoded);
+        expect(decoded.hrp).toBe(DEFAULT_ARKADE_HRP);
+    });
+
     describe("valid addresses", () => {
         fixtures.address.valid.forEach((fixture) => {
             it(`should correctly decode and encode address ${fixture.addr}`, () => {

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -4,8 +4,10 @@ import {
     encodeArkContract,
     decodeArkContract,
     contractFromArkContract,
+    contractFromArkContractWithAddress,
     isArkContract,
 } from "../src/contracts";
+import { DEFAULT_ARKADE_HRP } from "../src/wallet";
 import type { Contract } from "../src/contracts";
 import { InMemoryContractRepository } from "../src/repositories/inMemory/contractRepository";
 import type { IndexerProvider } from "../src/providers/indexer";
@@ -17,6 +19,7 @@ import {
     createDefaultContractParams,
     createMockIndexerProvider,
     TEST_DEFAULT_SCRIPT,
+    TEST_SERVER_PUB_KEY,
 } from "./contracts/helpers";
 
 describe("Contracts", () => {
@@ -72,6 +75,26 @@ describe("Contracts", () => {
             expect(contract.type).toBe("default");
             expect(contract.params.pubKey).toBe("abc");
             expect(contract.state).toBe("active");
+        });
+
+        it("should default derived contract addresses to the mainnet Arkade HRP", () => {
+            const encoded = encodeArkContract({
+                type: "default",
+                params: createDefaultContractParams(),
+                script: "",
+                address: "",
+                state: "active",
+                createdAt: 0,
+            });
+
+            const contract = contractFromArkContractWithAddress(
+                encoded,
+                TEST_SERVER_PUB_KEY
+            );
+
+            expect(contract.address.startsWith(`${DEFAULT_ARKADE_HRP}1`)).toBe(
+                true
+            );
         });
 
         it("should throw for unknown contract type", () => {

--- a/test/serviceWorker/wallet.test.ts
+++ b/test/serviceWorker/wallet.test.ts
@@ -10,6 +10,7 @@ import {
     SeedIdentity,
     ReadonlyDescriptorIdentity,
 } from "../../src";
+import { DEFAULT_ARKADE_SERVER_URL } from "../../src/wallet";
 import { ServiceWorkerWallet } from "../../src/wallet/serviceWorker/wallet";
 import { mnemonicToSeedSync } from "@scure/bip39";
 import { hex } from "@scure/base";
@@ -1164,6 +1165,26 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
         return call![0].config.wallet;
     };
 
+    const getInitializeMessage = (serviceWorker: {
+        postMessage: ReturnType<typeof vi.fn>;
+    }): any => {
+        const call = serviceWorker.postMessage.mock.calls.find(
+            ([msg]: any) => msg?.tag === "INITIALIZE_MESSAGE_BUS"
+        );
+        expect(call).toBeDefined();
+        return call![0];
+    };
+
+    const getInitWalletMessage = (serviceWorker: {
+        postMessage: ReturnType<typeof vi.fn>;
+    }): any => {
+        const call = serviceWorker.postMessage.mock.calls.find(
+            ([msg]: any) => msg?.type === "INIT_WALLET"
+        );
+        expect(call).toBeDefined();
+        return call![0];
+    };
+
     afterEach(() => {
         vi.unstubAllGlobals();
     });
@@ -1184,6 +1205,43 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
             type: "single-key",
             privateKey: TEST_PRIVATE_KEY_HEX,
         });
+    });
+
+    it("ServiceWorkerWallet.create uses the default Arkade server URL when omitted", async () => {
+        const { serviceWorker } = setup();
+        const identity = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+
+        await ServiceWorkerWallet.create({
+            serviceWorker: serviceWorker as any,
+            identity,
+            storage: storage(),
+        });
+
+        expect(getInitializeMessage(serviceWorker).config.arkServer.url).toBe(
+            DEFAULT_ARKADE_SERVER_URL
+        );
+        expect(getInitWalletMessage(serviceWorker).payload.arkServerUrl).toBe(
+            DEFAULT_ARKADE_SERVER_URL
+        );
+    });
+
+    it("ServiceWorkerReadonlyWallet.create uses the default Arkade server URL when omitted", async () => {
+        const { serviceWorker } = setup();
+        const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const identity = await signing.toReadonly();
+
+        await ServiceWorkerReadonlyWallet.create({
+            serviceWorker: serviceWorker as any,
+            identity,
+            storage: storage(),
+        });
+
+        expect(getInitializeMessage(serviceWorker).config.arkServer.url).toBe(
+            DEFAULT_ARKADE_SERVER_URL
+        );
+        expect(getInitWalletMessage(serviceWorker).payload.arkServerUrl).toBe(
+            DEFAULT_ARKADE_SERVER_URL
+        );
     });
 
     it("ReadonlySingleKey emits a tagged readonly-single-key envelope", async () => {

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -15,6 +15,7 @@ import {
     type OnchainProvider,
     type DelegatorProvider,
 } from "../src";
+import { DEFAULT_ARKADE_SERVER_URL } from "../src/wallet";
 import type { ExtendedCoin } from "../src/wallet";
 import { ReadonlySingleKey } from "../src/identity/singleKey";
 import {
@@ -49,6 +50,15 @@ describe("Wallet", () => {
         mockFetch.mockReset();
         await sharedRepo.clear();
         await sharedContractRepo.clear();
+    });
+
+    describe("create", () => {
+        it("defaults OnchainWallet to the bitcoin network", async () => {
+            const wallet = await OnchainWallet.create(mockIdentity);
+
+            expect(wallet.network.bech32).toBe("bc");
+            expect(wallet.address.startsWith("bc1p")).toBe(true);
+        });
     });
 
     describe("getBalance", () => {
@@ -1502,6 +1512,31 @@ describe("ReadonlyWallet", () => {
 
         const boardingAddress = await readonlyWallet.getBoardingAddress();
         expect(boardingAddress).toBeDefined();
+    });
+
+    it("should create ReadonlyWallet with the default Arkade server URL", async () => {
+        const key = SingleKey.fromRandomBytes();
+        const compressedPubKey = await key.compressedPublicKey();
+        const readonlyIdentity =
+            ReadonlySingleKey.fromPublicKey(compressedPubKey);
+
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockArkInfo),
+        });
+
+        const readonlyWallet = await ReadonlyWallet.create({
+            identity: readonlyIdentity,
+            storage: {
+                walletRepository: new InMemoryWalletRepository(),
+                contractRepository: new InMemoryContractRepository(),
+            },
+        });
+
+        expect(readonlyWallet).toBeInstanceOf(ReadonlyWallet);
+        expect(mockFetch).toHaveBeenCalledWith(
+            `${DEFAULT_ARKADE_SERVER_URL}/v1/info`
+        );
     });
 
     it("should query balance with ReadonlyWallet", async () => {


### PR DESCRIPTION
- default `ArkAddress` human readable prefix to 'ark'
- default `OnchainWallet` network name to 'bitcoin'
- export `DEFAULT_ARKADE_SERVER_URL` from wallet/index
- default `arkServerUrl` to `DEFAULT_ARKADE_SERVER_URL` in `ReadonlyWallet`
- make `arkServerUrl` optional for `ServiceWorkerWalletOptions`
- default `arkServerUrl` to `DEFAULT_ARKADE_SERVER_URL` in `initWalletPayload` and `busInitConfig` in `ServiceWorkerWallet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallets default to the "bitcoin" network and a standard address prefix when not specified.
  * Arkade server URL is optional and now falls back to a default Arkade URL.
* **Bug Fixes / Reliability**
  * Wallet initialization no longer errors when server/provider info is omitted.
* **Tests**
  * Added coverage verifying default HRP, network, and server URL fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->