### PR TITLE
test(e2e): integration tests for ElectrumOnchainProvider over regtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,91 @@ await wallet.send({ address: 'ark1q...', amount: 1000 })
 
 Identities without `signMultiple` continue to work unchanged — each checkpoint is signed individually via `sign()`.
 
+### Onchain Providers
+
+Wallets read onchain state (UTXOs, transactions, fee rates, chain tip) through an `OnchainProvider`. The SDK ships with two implementations and a single transport-agnostic interface so you can swap them without touching wallet code.
+
+| Provider | Transport | When to use |
+|---|---|---|
+| `EsploraProvider` | REST/HTTP (mempool.space-compatible) | Default for browser wallets, public mempool deployments, simple integrations. Both atomic 1P1C package broadcast and outspends are first-class. |
+| `ElectrumOnchainProvider` | WebSocket (Electrum protocol) | Self-hosted nodes (Fulcrum, electrs), low-latency subscriptions, environments where you control the backend. Required if you need to talk to an Electrum server directly. |
+
+If you don't pass a provider explicitly, `OnchainWallet` and `Wallet.create({ ... })` both default to `EsploraProvider` pointing at the URL in `ESPLORA_URL[networkName]`.
+
+#### Default URLs
+
+The SDK ships with reachable defaults for each network — bitcoin, signet, and mutinynet point at Ark Labs–operated deployments; testnet falls back to mempool.space; regtest assumes a local nigiri stack.
+
+```typescript
+import {
+  ESPLORA_URL,        // Record<NetworkName, string>
+  ELECTRUM_WS_URL,    // Record<NetworkName, string>
+  ELECTRUM_TCP_HOST,  // Record<NetworkName, string | null> — informational
+} from '@arkade-os/sdk'
+
+ESPLORA_URL.bitcoin       // "https://mempool.arkade.sh/api"
+ESPLORA_URL.signet        // "https://mempool.signet.arkade.sh/api"
+ESPLORA_URL.mutinynet     // "https://mempool.mutinynet.arkade.sh/api"
+
+ELECTRUM_WS_URL.bitcoin   // "wss://electrum.arkade.sh"
+ELECTRUM_WS_URL.signet    // "wss://electrum.signet.arkade.sh"
+ELECTRUM_WS_URL.mutinynet // "wss://electrum.mutinynet.arkade.sh"
+```
+
+#### Using Esplora (default)
+
+```typescript
+import { EsploraProvider, ESPLORA_URL, OnchainWallet } from '@arkade-os/sdk'
+
+// Use the default URL for the network
+const provider = new EsploraProvider(ESPLORA_URL.bitcoin)
+
+// Or pass nothing — OnchainWallet picks the default for you
+const wallet = await OnchainWallet.create(identity, 'bitcoin')
+
+// Or override with your own mempool/esplora instance
+const customProvider = new EsploraProvider('https://my-esplora.example/api')
+```
+
+#### Using Electrum (WebSocket)
+
+```typescript
+import { ElectrumWS } from 'ws-electrumx-client'
+import {
+  ElectrumOnchainProvider,
+  ELECTRUM_WS_URL,
+  OnchainWallet,
+  networks,
+} from '@arkade-os/sdk'
+
+const ws = new ElectrumWS(ELECTRUM_WS_URL.bitcoin)
+const provider = new ElectrumOnchainProvider(ws, networks.bitcoin)
+
+const wallet = await OnchainWallet.create(identity, 'bitcoin', provider)
+
+// Remember to close the connection when you're done
+await provider.close()
+```
+
+#### Atomic 1P1C package broadcast (TRUC / BIP 431)
+
+Both providers expose `broadcastTransaction(...txs)` that accepts either a single tx or a 1P1C package (parent first, child last). The package path is **atomic** — the parent doesn't have to independently meet mempool minfee, which is the point of TRUC relay.
+
+The Electrum provider implements this via `blockchain.transaction.broadcast_package` (Fulcrum ≥ 1.10 backed by bitcoind ≥ v28). **There is no fallback to sequential broadcast**: if the server doesn't support `broadcast_package`, the call surfaces a clear error so you can route through a different provider rather than have TRUC packages silently fail at the parent step. Ark Labs Fulcrum deployments at `electrum.arkade.sh` (and the `*.signet` / `*.mutinynet` variants) all support it.
+
+#### Server compatibility notes
+
+`ElectrumOnchainProvider` is built around methods supported by both **Fulcrum** and **electrs** (the two main Electrum server implementations):
+
+- ✅ `blockchain.scripthash.{listunspent, get_history, subscribe}`
+- ✅ `blockchain.transaction.{get, get_merkle, broadcast}`
+- ✅ `blockchain.block.header`, `blockchain.headers.subscribe`
+- ✅ `blockchain.estimatefee`, `blockchain.relayfee`
+- ⚠️ `blockchain.transaction.broadcast_package` — **Fulcrum-only**. Required for atomic 1P1C; the provider throws a descriptive error against electrs.
+- ❌ The provider does **not** call `blockchain.transaction.get` with `verbose=true` (Fulcrum-only and rejected by electrs); confirmation status is derived from `transaction.get_merkle` + raw block headers instead.
+
+Output amounts are derived from parsed raw transaction bytes (exact bigints), never from floating-point `value` fields — protocol-level money handling shouldn't depend on `Math.round(value * 1e8)`.
+
 ### Receiving Bitcoin
 
 ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,8 @@ import {
     ExplorerTransaction,
 } from "./providers/onchain";
 import {
+    ELECTRUM_TCP_HOST,
+    ELECTRUM_WS_URL,
     ElectrumOnchainProvider,
     WsElectrumChainSource,
 } from "./providers/electrum";
@@ -288,6 +290,8 @@ export {
     // Providers
     ESPLORA_URL,
     EsploraProvider,
+    ELECTRUM_WS_URL,
+    ELECTRUM_TCP_HOST,
     ElectrumOnchainProvider,
     WsElectrumChainSource,
     RestArkProvider,

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -698,44 +698,38 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         const rawTxs = await this.chain.fetchTransactions(txids);
         const rawHexByTxid = new Map(rawTxs.map((t) => [t.txID, t.hex]));
 
-        // De-duplicated header lookup. Try the batch first (fast path:
-        // 1 round-trip for the common case); fall back to per-height
-        // calls only if the batch rejects, because electrs sometimes
-        // races: a tx can show as confirmed via listunspent before its
-        // block header is indexable, which makes a batch including that
-        // height fail wholesale. The old verbose-tx code tolerated
-        // missing block_time by falling back to 0; we preserve that
-        // semantic so a fresh-block race doesn't poison the whole
-        // history mapping.
+        // De-duplicated per-height header lookup via Promise.allSettled.
+        //
+        // We deliberately avoid `fetchBlockHeaders` (which uses the library's
+        // batchRequest) here: when one element of a batch fails (e.g. a height
+        // that hits electrs's "missingheight" index-lag race), the library's
+        // `Promise.all` rejects with that one error but leaves the other
+        // in-flight requests pending. When their responses arrive later, the
+        // library rejects them too — and nobody's awaiting them, so they
+        // surface as unhandled rejections that crash the test runner.
+        //
+        // Per-height fetches with allSettled give every promise a handler,
+        // and missing block_time degrades to 0 the same way the old verbose-
+        // tx code did via `vtx.blocktime || vtx.time || 0`. Txid + confirmed
+        // status are still authoritative.
         const confirmedHeights = [
             ...new Set(history.map((h) => h.height).filter((h) => h > 0)),
         ];
         const blockTimeByHeight = new Map<number, number>();
         if (confirmedHeights.length > 0) {
-            try {
-                const headers =
-                    await this.chain.fetchBlockHeaders(confirmedHeights);
-                for (const header of headers) {
+            const settled = await Promise.allSettled(
+                confirmedHeights.map((h) => this.chain.fetchBlockHeader(h))
+            );
+            settled.forEach((res) => {
+                if (res.status === "fulfilled") {
                     blockTimeByHeight.set(
-                        header.height,
-                        parseBlockHeader(header.hex).timestamp
+                        res.value.height,
+                        parseBlockHeader(res.value.hex).timestamp
                     );
                 }
-            } catch {
-                const settled = await Promise.allSettled(
-                    confirmedHeights.map((h) => this.chain.fetchBlockHeader(h))
-                );
-                settled.forEach((res) => {
-                    if (res.status === "fulfilled") {
-                        blockTimeByHeight.set(
-                            res.value.height,
-                            parseBlockHeader(res.value.hex).timestamp
-                        );
-                    }
-                    // Failures leave the height absent from the map →
-                    // buildExplorerTx falls back to block_time = 0.
-                });
-            }
+                // Rejections leave the height absent from the map →
+                // buildExplorerTx falls back to block_time = 0.
+            });
         }
 
         return history.map((entry) =>

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -546,19 +546,45 @@ export class WsElectrumChainSource {
 }
 
 /**
- * Electrum-based implementation of the OnchainProvider interface.
- * Replaces esplora polling with electrum subscriptions where possible.
+ * Electrum-based implementation of the {@link OnchainProvider} interface.
  *
- * @example
+ * Built around the subset of the Electrum protocol that both **Fulcrum**
+ * and **electrs** support — listunspent, get_history, transaction.get
+ * (non-verbose), transaction.get_merkle, block.header,
+ * headers.subscribe, scripthash.subscribe, estimatefee, relayfee, and
+ * broadcast. The verbose form of `transaction.get` is **not** used (it's
+ * Fulcrum-only and rejected by electrs); confirmation status is derived
+ * from `transaction.get_merkle` plus parsed block headers.
+ *
+ * Output amounts are derived from parsed raw transaction bytes (exact
+ * bigints), never the floating-point `value` fields some servers return.
+ *
+ * Atomic 1P1C package broadcast (TRUC / BIP 431) is supported via
+ * Fulcrum's `blockchain.transaction.broadcast_package`. There is **no
+ * fallback** to sequential parent-then-child broadcasts — TRUC packages
+ * with a zero-fee parent would silently fail, so the call surfaces an
+ * error against servers that don't support the method.
+ *
+ * @example Default URL via {@link ELECTRUM_WS_URL}
  * ```typescript
  * import { ElectrumWS } from "ws-electrumx-client";
- * import { ElectrumOnchainProvider } from "./providers/electrum";
- * import { networks } from "./networks";
+ * import {
+ *   ElectrumOnchainProvider,
+ *   ELECTRUM_WS_URL,
+ *   networks,
+ * } from "@arkade-os/sdk";
  *
- * const ws = new ElectrumWS("wss://electrum.blockstream.info:50004");
+ * const ws = new ElectrumWS(ELECTRUM_WS_URL.bitcoin);
  * const provider = new ElectrumOnchainProvider(ws, networks.bitcoin);
  *
  * const coins = await provider.getCoins("bc1q...");
+ * await provider.close();
+ * ```
+ *
+ * @example Custom server
+ * ```typescript
+ * const ws = new ElectrumWS("wss://my-fulcrum.example:50004");
+ * const provider = new ElectrumOnchainProvider(ws, networks.bitcoin);
  * ```
  */
 export class ElectrumOnchainProvider implements OnchainProvider {

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -156,6 +156,43 @@ export class WsElectrumChainSource {
         private network: Network
     ) {}
 
+    /**
+     * Send N requests in parallel and aggregate the results, replacement
+     * for `ws.batchRequest`. The library's batchRequest is implemented as
+     * `Promise.all` over individual request promises — when one element
+     * rejects, the others remain pending. When their (often error)
+     * responses arrive later, the library rejects them too, and nobody is
+     * awaiting them: the rejections become unhandled and crash the test
+     * runner / pollute production logs.
+     *
+     * `safeBatchRequest` issues each request through `ws.request` (so each
+     * has its own request-promise lifecycle), waits for all of them via
+     * `Promise.allSettled` (every promise gets an explicit handler), and
+     * then surfaces the first error if any failed. Same wall-clock cost
+     * as the library's batch (parallel send), no orphan rejections.
+     *
+     * Use this in place of `ws.batchRequest` for any call where one or
+     * more elements may legitimately error (e.g. electrs index lag
+     * surfacing as `missingheight` for a subset of heights/txids).
+     */
+    async safeBatchRequest<T>(
+        requests: { method: string; params: unknown[] }[]
+    ): Promise<T[]> {
+        if (requests.length === 0) return [];
+        const settled = await Promise.allSettled(
+            requests.map((req) =>
+                this.ws.request<T>(
+                    req.method,
+                    ...(req.params as Parameters<typeof this.ws.request>[1][])
+                )
+            )
+        );
+        for (const r of settled) {
+            if (r.status === "rejected") throw r.reason;
+        }
+        return settled.map((r) => (r as PromiseFulfilledResult<T>).value);
+    }
+
     async fetchTransactions(
         txids: string[]
     ): Promise<{ txID: string; hex: string }[]> {
@@ -165,9 +202,7 @@ export class WsElectrumChainSource {
         }));
         for (let i = 0; i < MAX_FETCH_TRANSACTIONS_ATTEMPTS; i++) {
             try {
-                const responses = await this.ws.batchRequest<string[]>(
-                    ...requests
-                );
+                const responses = await this.safeBatchRequest<string>(requests);
                 return responses.map((hexStr, i) => ({
                     txID: txids[i],
                     hex: hexStr,
@@ -201,7 +236,7 @@ export class WsElectrumChainSource {
             method: GetTransactionMethod,
             params: [txid, true],
         }));
-        return this.ws.batchRequest<VerboseTransaction[]>(...requests);
+        return this.safeBatchRequest<VerboseTransaction>(requests);
     }
 
     /**
@@ -264,13 +299,12 @@ export class WsElectrumChainSource {
         scripts: Uint8Array[]
     ): Promise<TransactionHistory[][]> {
         const scriptsHashes = scripts.map((s) => toScriptHash(s));
-        const responses = await this.ws.batchRequest<TransactionHistory[][]>(
-            ...scriptsHashes.map((s) => ({
+        return this.safeBatchRequest<TransactionHistory[]>(
+            scriptsHashes.map((s) => ({
                 method: GetHistoryMethod,
                 params: [s],
             }))
         );
-        return responses;
     }
 
     async fetchHistory(script: Uint8Array): Promise<TransactionHistory[]> {
@@ -282,8 +316,8 @@ export class WsElectrumChainSource {
     }
 
     async fetchBlockHeaders(heights: number[]): Promise<BlockHeader[]> {
-        const responses = await this.ws.batchRequest<string[]>(
-            ...heights.map((h) => ({ method: GetBlockHeader, params: [h] }))
+        const responses = await this.safeBatchRequest<string>(
+            heights.map((h) => ({ method: GetBlockHeader, params: [h] }))
         );
         return responses.map((hexStr, i) => ({
             height: heights[i],
@@ -578,8 +612,10 @@ export class ElectrumOnchainProvider implements OnchainProvider {
 
         // Step 2: batch listunspent for all output scripthashes (1 round trip)
         // This tells us exactly which txid:vout pairs are still unspent.
-        const unspentBatch = await this.ws.batchRequest<UnspentElectrum[][]>(
-            ...validScriptHashes.map((sh) => ({
+        const unspentBatch = await this.chain.safeBatchRequest<
+            UnspentElectrum[]
+        >(
+            validScriptHashes.map((sh) => ({
                 method: ListUnspentMethod,
                 params: [sh],
             }))
@@ -609,8 +645,10 @@ export class ElectrumOnchainProvider implements OnchainProvider {
 
         if (spentIndices.length === 0) return results;
 
-        const histories = await this.ws.batchRequest<TransactionHistory[][]>(
-            ...spentScriptHashes.map((sh) => ({
+        const histories = await this.chain.safeBatchRequest<
+            TransactionHistory[]
+        >(
+            spentScriptHashes.map((sh) => ({
                 method: GetHistoryMethod,
                 params: [sh],
             }))
@@ -698,38 +736,41 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         const rawTxs = await this.chain.fetchTransactions(txids);
         const rawHexByTxid = new Map(rawTxs.map((t) => [t.txID, t.hex]));
 
-        // De-duplicated per-height header lookup via Promise.allSettled.
-        //
-        // We deliberately avoid `fetchBlockHeaders` (which uses the library's
-        // batchRequest) here: when one element of a batch fails (e.g. a height
-        // that hits electrs's "missingheight" index-lag race), the library's
-        // `Promise.all` rejects with that one error but leaves the other
-        // in-flight requests pending. When their responses arrive later, the
-        // library rejects them too — and nobody's awaiting them, so they
-        // surface as unhandled rejections that crash the test runner.
-        //
-        // Per-height fetches with allSettled give every promise a handler,
-        // and missing block_time degrades to 0 the same way the old verbose-
-        // tx code did via `vtx.blocktime || vtx.time || 0`. Txid + confirmed
-        // status are still authoritative.
+        // De-duplicated batch lookup of block headers (now safe — see
+        // safeBatchRequest above). Heights whose headers fail to resolve
+        // surface via the wrapper's first-error throw; we tolerate that
+        // here by falling back to per-height calls under Promise.allSettled
+        // so one missing header doesn't poison the whole history mapping.
+        // The old verbose-tx code had the same tolerance via
+        // `vtx.blocktime || vtx.time || 0`.
         const confirmedHeights = [
             ...new Set(history.map((h) => h.height).filter((h) => h > 0)),
         ];
         const blockTimeByHeight = new Map<number, number>();
         if (confirmedHeights.length > 0) {
-            const settled = await Promise.allSettled(
-                confirmedHeights.map((h) => this.chain.fetchBlockHeader(h))
-            );
-            settled.forEach((res) => {
-                if (res.status === "fulfilled") {
+            try {
+                const headers =
+                    await this.chain.fetchBlockHeaders(confirmedHeights);
+                for (const header of headers) {
                     blockTimeByHeight.set(
-                        res.value.height,
-                        parseBlockHeader(res.value.hex).timestamp
+                        header.height,
+                        parseBlockHeader(header.hex).timestamp
                     );
                 }
-                // Rejections leave the height absent from the map →
-                // buildExplorerTx falls back to block_time = 0.
-            });
+            } catch {
+                const settled = await Promise.allSettled(
+                    confirmedHeights.map((h) => this.chain.fetchBlockHeader(h))
+                );
+                settled.forEach((res) => {
+                    if (res.status === "fulfilled") {
+                        blockTimeByHeight.set(
+                            res.value.height,
+                            parseBlockHeader(res.value.hex).timestamp
+                        );
+                    }
+                    // Rejections leave the height absent → block_time = 0.
+                });
+            }
         }
 
         return history.map((entry) =>

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -698,21 +698,43 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         const rawTxs = await this.chain.fetchTransactions(txids);
         const rawHexByTxid = new Map(rawTxs.map((t) => [t.txID, t.hex]));
 
-        // De-duplicated batch lookup of block headers — many history
-        // entries usually share the same height, so this collapses N
-        // round-trips into 1 batch request with K ≤ N parameters.
+        // De-duplicated header lookup. Try the batch first (fast path:
+        // 1 round-trip for the common case); fall back to per-height
+        // calls only if the batch rejects, because electrs sometimes
+        // races: a tx can show as confirmed via listunspent before its
+        // block header is indexable, which makes a batch including that
+        // height fail wholesale. The old verbose-tx code tolerated
+        // missing block_time by falling back to 0; we preserve that
+        // semantic so a fresh-block race doesn't poison the whole
+        // history mapping.
         const confirmedHeights = [
             ...new Set(history.map((h) => h.height).filter((h) => h > 0)),
         ];
         const blockTimeByHeight = new Map<number, number>();
         if (confirmedHeights.length > 0) {
-            const headers =
-                await this.chain.fetchBlockHeaders(confirmedHeights);
-            for (const header of headers) {
-                blockTimeByHeight.set(
-                    header.height,
-                    parseBlockHeader(header.hex).timestamp
+            try {
+                const headers =
+                    await this.chain.fetchBlockHeaders(confirmedHeights);
+                for (const header of headers) {
+                    blockTimeByHeight.set(
+                        header.height,
+                        parseBlockHeader(header.hex).timestamp
+                    );
+                }
+            } catch {
+                const settled = await Promise.allSettled(
+                    confirmedHeights.map((h) => this.chain.fetchBlockHeader(h))
                 );
+                settled.forEach((res) => {
+                    if (res.status === "fulfilled") {
+                        blockTimeByHeight.set(
+                            res.value.height,
+                            parseBlockHeader(res.value.hex).timestamp
+                        );
+                    }
+                    // Failures leave the height absent from the map →
+                    // buildExplorerTx falls back to block_time = 0.
+                });
             }
         }
 

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -213,25 +213,29 @@ export class WsElectrumChainSource {
      * electrs in that case rejects with a "not yet in a block" error.
      */
     async fetchTxMerkle(txid: string): Promise<{ blockHeight: number } | null> {
+        let result: { block_height: number } | undefined;
         try {
-            const result = await this.ws.request<{ block_height: number }>(
+            result = await this.ws.request<{ block_height: number }>(
                 GetTransactionMerkleMethod,
                 txid
             );
-            if (
-                !result ||
-                typeof result.block_height !== "number" ||
-                result.block_height <= 0
-            ) {
-                return null;
-            }
-            return { blockHeight: result.block_height };
-        } catch {
-            // electrs raises when the tx isn't yet in a block; treat any
-            // failure as "mempool / unknown" rather than propagating —
-            // callers map a `null` here to `{confirmed: false}`.
+        } catch (err) {
+            // electrs/Fulcrum raise a specific error when the tx isn't yet in
+            // a block. Map ONLY that case to mempool/unknown; everything else
+            // (auth failure, network outage, malformed response) must surface
+            // so callers can fail rather than silently treat the tx as
+            // unconfirmed forever.
+            if (isTxNotInBlockError(err)) return null;
+            throw err;
+        }
+        if (
+            !result ||
+            typeof result.block_height !== "number" ||
+            result.block_height <= 0
+        ) {
             return null;
         }
+        return { blockHeight: result.block_height };
     }
 
     async unsubscribeScriptStatus(script: Uint8Array): Promise<void> {
@@ -723,9 +727,10 @@ export class ElectrumOnchainProvider implements OnchainProvider {
 
     /**
      * Build an ExplorerTransaction from a history entry plus the raw tx hex
-     * (when known) and a height→block_time map. Falls back to an empty
-     * vout array if the raw hex is missing or unparseable so the txid + status
-     * still surface — callers tracking by id won't lose the tx.
+     * (when known) and a height→block_time map. Parse errors propagate —
+     * silently returning an empty vout would hide real outputs (e.g. a
+     * deposit) and is far worse for protocol-level money handling than
+     * failing the whole batch.
      */
     private buildExplorerTx(
         entry: TransactionHistory,
@@ -734,26 +739,28 @@ export class ElectrumOnchainProvider implements OnchainProvider {
     ): ExplorerTransaction {
         const vout: ExplorerTransaction["vout"] = [];
         if (rawHex) {
+            let tx: Transaction;
             try {
-                const tx = Transaction.fromRaw(hex.decode(rawHex), {
+                tx = Transaction.fromRaw(hex.decode(rawHex), {
                     allowUnknownOutputs: true,
                     allowUnknownInputs: true,
                 });
-                for (let i = 0; i < tx.outputsLength; i++) {
-                    const output = tx.getOutput(i);
-                    const scriptHex = output.script
-                        ? hex.encode(output.script)
-                        : "";
-                    vout.push({
-                        scriptpubkey_address: scriptHex
-                            ? (this.chain.addressForScript(scriptHex) ?? "")
-                            : "",
-                        value: (output.amount ?? 0n).toString(),
-                    });
-                }
-            } catch {
-                // Malformed hex; leave vout empty rather than failing the
-                // whole batch — the txid + status are still useful.
+            } catch (err) {
+                throw new Error(
+                    `Failed to parse raw tx for ${entry.tx_hash}: ${err instanceof Error ? err.message : String(err)}`
+                );
+            }
+            for (let i = 0; i < tx.outputsLength; i++) {
+                const output = tx.getOutput(i);
+                const scriptHex = output.script
+                    ? hex.encode(output.script)
+                    : "";
+                vout.push({
+                    scriptpubkey_address: scriptHex
+                        ? (this.chain.addressForScript(scriptHex) ?? "")
+                        : "",
+                    value: (output.amount ?? 0n).toString(),
+                });
             }
         }
 
@@ -866,14 +873,17 @@ export class ElectrumOnchainProvider implements OnchainProvider {
 
             if (newEntries.length === 0) return;
 
-            for (const entry of newEntries) known.add(entry.tx_hash);
-            knownTxids.set(scripthash, known);
-
             // Map the new history entries through the same non-verbose
             // pipeline getTransactions uses, so subscribe-driven and
             // poll-driven callers see ExplorerTransactions of identical shape.
+            // The dedupe set is updated ONLY after delivery succeeds —
+            // otherwise a failed fetch or callback would permanently mark
+            // these txids as seen and the next notification wouldn't
+            // re-deliver them.
             const explorerTxs = await this.historyToExplorerTxs(newEntries);
             eventCallback(explorerTxs);
+            for (const entry of newEntries) known.add(entry.tx_hash);
+            knownTxids.set(scripthash, known);
         };
 
         const handleStatusChange = (scripthash: string): Promise<void> => {
@@ -935,6 +945,25 @@ function isHeaderSubscribeResult(v: unknown): v is HeaderSubscribeResult {
     if (typeof v !== "object" || v === null) return false;
     const obj = v as Record<string, unknown>;
     return typeof obj.height === "number" && typeof obj.hex === "string";
+}
+
+/**
+ * Recognise the "transaction not in a block yet" failure shape returned by
+ * electrum servers when `blockchain.transaction.get_merkle` is asked about a
+ * mempool tx. electrs surfaces this as the strings below; Fulcrum mirrors
+ * the wording. We match conservatively so genuine errors (auth, network,
+ * malformed response) still propagate.
+ */
+function isTxNotInBlockError(err: unknown): boolean {
+    const msg =
+        err instanceof Error ? err.message : typeof err === "string" ? err : "";
+    const normalized = msg.toLowerCase();
+    return (
+        normalized.includes("not yet in a block") ||
+        normalized.includes("not in a block") ||
+        normalized.includes("not in block") ||
+        normalized.includes("no confirmed transaction")
+    );
 }
 
 /**

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -13,6 +13,7 @@ const EstimateFee = "blockchain.estimatefee";
 const GetBlockHeader = "blockchain.block.header";
 const GetHistoryMethod = "blockchain.scripthash.get_history";
 const GetTransactionMethod = "blockchain.transaction.get";
+const GetTransactionMerkleMethod = "blockchain.transaction.get_merkle";
 const SubscribeStatusMethod = "blockchain.scripthash";
 const SubscribeHeadersMethod = "blockchain.headers";
 const GetRelayFeeMethod = "blockchain.relayfee";
@@ -201,6 +202,36 @@ export class WsElectrumChainSource {
             params: [txid, true],
         }));
         return this.ws.batchRequest<VerboseTransaction[]>(...requests);
+    }
+
+    /**
+     * Look up the block height of a confirmed transaction without relying
+     * on the verbose-tx endpoint. `blockchain.transaction.get_merkle` is
+     * part of the standard SPV protocol and is supported by both Fulcrum
+     * and electrs (whereas `blockchain.transaction.get` with verbose=true
+     * is Fulcrum-only). Returns `null` when the tx is in the mempool —
+     * electrs in that case rejects with a "not yet in a block" error.
+     */
+    async fetchTxMerkle(txid: string): Promise<{ blockHeight: number } | null> {
+        try {
+            const result = await this.ws.request<{ block_height: number }>(
+                GetTransactionMerkleMethod,
+                txid
+            );
+            if (
+                !result ||
+                typeof result.block_height !== "number" ||
+                result.block_height <= 0
+            ) {
+                return null;
+            }
+            return { blockHeight: result.block_height };
+        } catch {
+            // electrs raises when the tx isn't yet in a block; treat any
+            // failure as "mempool / unknown" rather than propagating —
+            // callers map a `null` here to `{confirmed: false}`.
+            return null;
+        }
     }
 
     async unsubscribeScriptStatus(script: Uint8Array): Promise<void> {
@@ -643,41 +674,95 @@ export class ElectrumOnchainProvider implements OnchainProvider {
     async getTransactions(address: string): Promise<ExplorerTransaction[]> {
         const script = this.encodeAddress(address);
         const history = await this.chain.fetchHistory(script);
-
         if (history.length === 0) return [];
-
-        const txids = history.map((h) => h.tx_hash);
-        const verboseTxs = await this.chain.fetchVerboseTransactions(txids);
-
-        return verboseTxs.map((vtx) => this.verboseToExplorer(vtx));
+        return this.historyToExplorerTxs(history);
     }
 
     /**
-     * Map an electrum verbose transaction to the ExplorerTransaction shape.
-     *
-     * Output values are derived from the raw transaction hex when available,
-     * never from the floating-point `value` field returned by the daemon.
-     * That field has 8 decimal places and `Math.round(value * 1e8)` is safe
-     * in the common case but a footgun for protocol-level money handling —
-     * the raw bytes are exact.
+     * Resolve a list of `{tx_hash, height}` entries (as returned by the
+     * scripthash history endpoint) into ExplorerTransaction shape **without
+     * using the verbose-tx endpoint**, which only Fulcrum implements. We
+     * reconstruct everything the verbose response would have given us:
+     *   - vouts ← parse the raw tx (exact sat amounts, no float precision risk)
+     *   - block_time ← batch-fetch the block headers for the heights present
+     *   - addresses ← decode each output's scriptPubKey via @scure/btc-signer
      */
-    private verboseToExplorer(vtx: VerboseTransaction): ExplorerTransaction {
-        const exactValuesByVout = parseExactSats(vtx);
+    private async historyToExplorerTxs(
+        history: TransactionHistory[]
+    ): Promise<ExplorerTransaction[]> {
+        const txids = history.map((h) => h.tx_hash);
+        const rawTxs = await this.chain.fetchTransactions(txids);
+        const rawHexByTxid = new Map(rawTxs.map((t) => [t.txID, t.hex]));
+
+        // De-duplicated batch lookup of block headers — many history
+        // entries usually share the same height, so this collapses N
+        // round-trips into 1 batch request with K ≤ N parameters.
+        const confirmedHeights = [
+            ...new Set(history.map((h) => h.height).filter((h) => h > 0)),
+        ];
+        const blockTimeByHeight = new Map<number, number>();
+        if (confirmedHeights.length > 0) {
+            const headers =
+                await this.chain.fetchBlockHeaders(confirmedHeights);
+            for (const header of headers) {
+                blockTimeByHeight.set(
+                    header.height,
+                    parseBlockHeader(header.hex).timestamp
+                );
+            }
+        }
+
+        return history.map((entry) =>
+            this.buildExplorerTx(
+                entry,
+                rawHexByTxid.get(entry.tx_hash),
+                blockTimeByHeight
+            )
+        );
+    }
+
+    /**
+     * Build an ExplorerTransaction from a history entry plus the raw tx hex
+     * (when known) and a height→block_time map. Falls back to an empty
+     * vout array if the raw hex is missing or unparseable so the txid + status
+     * still surface — callers tracking by id won't lose the tx.
+     */
+    private buildExplorerTx(
+        entry: TransactionHistory,
+        rawHex: string | undefined,
+        blockTimeByHeight: Map<number, number>
+    ): ExplorerTransaction {
+        const vout: ExplorerTransaction["vout"] = [];
+        if (rawHex) {
+            try {
+                const tx = Transaction.fromRaw(hex.decode(rawHex), {
+                    allowUnknownOutputs: true,
+                    allowUnknownInputs: true,
+                });
+                for (let i = 0; i < tx.outputsLength; i++) {
+                    const output = tx.getOutput(i);
+                    const scriptHex = output.script
+                        ? hex.encode(output.script)
+                        : "";
+                    vout.push({
+                        scriptpubkey_address: scriptHex
+                            ? (this.chain.addressForScript(scriptHex) ?? "")
+                            : "",
+                        value: (output.amount ?? 0n).toString(),
+                    });
+                }
+            } catch {
+                // Malformed hex; leave vout empty rather than failing the
+                // whole batch — the txid + status are still useful.
+            }
+        }
+
         return {
-            txid: vtx.txid,
-            vout: vtx.vout.map((v) => ({
-                scriptpubkey_address:
-                    v.scriptPubKey.address ||
-                    v.scriptPubKey.addresses?.[0] ||
-                    this.chain.addressForScript(v.scriptPubKey.hex) ||
-                    "",
-                value:
-                    exactValuesByVout?.get(v.n) ??
-                    String(Math.round(v.value * 1e8)),
-            })),
+            txid: entry.tx_hash,
+            vout,
             status: {
-                confirmed: vtx.confirmations > 0,
-                block_time: vtx.blocktime || vtx.time || 0,
+                confirmed: entry.height > 0,
+                block_time: blockTimeByHeight.get(entry.height) ?? 0,
             },
         };
     }
@@ -702,21 +787,19 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         | { confirmed: false }
         | { confirmed: true; blockTime: number; blockHeight: number }
     > {
-        const vtx = await this.chain.fetchVerboseTransaction(txid);
-        if (vtx.confirmations <= 0) {
-            return { confirmed: false };
-        }
+        // Use `transaction.get_merkle` rather than the verbose `transaction.get`
+        // because electrs (used by mempool.space, blockstream.info, and the
+        // nigiri regtest) doesn't implement verbose. get_merkle is part of the
+        // standard SPV protocol and supported by every Electrum server.
+        const merkle = await this.chain.fetchTxMerkle(txid);
+        if (!merkle) return { confirmed: false };
 
-        // Get block height from the verbose tx's blockhash
-        // We need the height, which is confirmations-based:
-        // height = tipHeight - confirmations + 1
-        const tip = await this.chain.subscribeHeaders();
-        const blockHeight = tip.height - vtx.confirmations + 1;
-
+        const header = await this.chain.fetchBlockHeader(merkle.blockHeight);
+        const { timestamp } = parseBlockHeader(header.hex);
         return {
             confirmed: true,
-            blockTime: vtx.blocktime || vtx.time || 0,
-            blockHeight,
+            blockHeight: merkle.blockHeight,
+            blockTime: timestamp,
         };
     }
 
@@ -777,18 +860,20 @@ export class ElectrumOnchainProvider implements OnchainProvider {
 
             const history = await this.chain.fetchHistory(script);
             const known = knownTxids.get(scripthash) ?? new Set<string>();
-            const newTxids = history
-                .map((h) => h.tx_hash)
-                .filter((txid) => !known.has(txid));
+            const newEntries = history.filter(
+                (entry) => !known.has(entry.tx_hash)
+            );
 
-            if (newTxids.length === 0) return;
+            if (newEntries.length === 0) return;
 
-            for (const txid of newTxids) known.add(txid);
+            for (const entry of newEntries) known.add(entry.tx_hash);
             knownTxids.set(scripthash, known);
 
-            const verboseTxs =
-                await this.chain.fetchVerboseTransactions(newTxids);
-            eventCallback(verboseTxs.map((vtx) => this.verboseToExplorer(vtx)));
+            // Map the new history entries through the same non-verbose
+            // pipeline getTransactions uses, so subscribe-driven and
+            // poll-driven callers see ExplorerTransactions of identical shape.
+            const explorerTxs = await this.historyToExplorerTxs(newEntries);
+            eventCallback(explorerTxs);
         };
 
         const handleStatusChange = (scripthash: string): Promise<void> => {
@@ -869,28 +954,4 @@ function childTxidFromHex(txHex: string): string {
         allowUnknownInputs: true,
     });
     return tx.id;
-}
-
-/**
- * Decode `vtx.hex` (when the daemon includes it) and return a map of
- * vout-index → exact sat amount as a base-10 string. Returns `null` if
- * the hex is missing or unparseable; callers should fall back to the
- * float-derived value in that case.
- */
-function parseExactSats(vtx: VerboseTransaction): Map<number, string> | null {
-    if (!vtx.hex) return null;
-    try {
-        const tx = Transaction.fromRaw(hex.decode(vtx.hex), {
-            allowUnknownOutputs: true,
-        });
-        const result = new Map<number, string>();
-        for (let i = 0; i < tx.outputsLength; i++) {
-            const output = tx.getOutput(i);
-            if (output.amount === undefined) continue;
-            result.set(i, output.amount.toString());
-        }
-        return result;
-    } catch {
-        return null;
-    }
 }

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -823,12 +823,24 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         const merkle = await this.chain.fetchTxMerkle(txid);
         if (!merkle) return { confirmed: false };
 
-        const header = await this.chain.fetchBlockHeader(merkle.blockHeight);
-        const { timestamp } = parseBlockHeader(header.hex);
+        // Header lookup can transiently race with electrs's index right
+        // after a fresh block — listunspent/get_merkle expose the new
+        // height before block.header(N) is queryable. Tolerate that the
+        // same way historyToExplorerTxs does: confirmation status and
+        // height are still authoritative; only block_time degrades.
+        let blockTime = 0;
+        try {
+            const header = await this.chain.fetchBlockHeader(
+                merkle.blockHeight
+            );
+            blockTime = parseBlockHeader(header.hex).timestamp;
+        } catch (err) {
+            if (!isMissingHeightError(err)) throw err;
+        }
         return {
             confirmed: true,
             blockHeight: merkle.blockHeight,
-            blockTime: timestamp,
+            blockTime,
         };
     }
 
@@ -967,6 +979,20 @@ function isHeaderSubscribeResult(v: unknown): v is HeaderSubscribeResult {
     if (typeof v !== "object" || v === null) return false;
     const obj = v as Record<string, unknown>;
     return typeof obj.height === "number" && typeof obj.hex === "string";
+}
+
+/**
+ * Recognise the "block header not yet indexable" failure shape returned by
+ * electrum servers (electrs in particular) when `block.header(N)` runs
+ * against a height that's already in `listunspent`/`get_merkle` but hasn't
+ * been indexed yet. Surfaced as `missingheight`. Tolerated by callers so
+ * the index-lag race doesn't poison confirmed-status reads; genuine
+ * failures (auth/network) propagate.
+ */
+function isMissingHeightError(err: unknown): boolean {
+    const msg =
+        err instanceof Error ? err.message : typeof err === "string" ? err : "";
+    return msg.toLowerCase().includes("missingheight");
 }
 
 /**

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -301,12 +301,16 @@ export class WsElectrumChainSource {
                 txid
             );
         } catch (err) {
-            // electrs/Fulcrum raise a specific error when the tx isn't yet in
-            // a block. Map ONLY that case to mempool/unknown; everything else
+            // electrs/Fulcrum raise specific errors when the tx isn't yet in
+            // a block — either "not in a block" wording, or "missingheight"
+            // when get_merkle hits the same index-lag race that block.header
+            // hits (the tx is reportedly confirmed but the height isn't
+            // queryable yet). Map both to mempool/unknown; everything else
             // (auth failure, network outage, malformed response) must surface
             // so callers can fail rather than silently treat the tx as
             // unconfirmed forever.
-            if (isTxNotInBlockError(err)) return null;
+            if (isTxNotInBlockError(err) || isMissingHeightError(err))
+                return null;
             throw err;
         }
         if (

--- a/src/providers/electrum.ts
+++ b/src/providers/electrum.ts
@@ -2,9 +2,55 @@ import { Address, OutScript, Transaction } from "@scure/btc-signer";
 import { sha256 } from "@scure/btc-signer/utils.js";
 import { hex } from "@scure/base";
 import type { ElectrumWS } from "ws-electrumx-client";
-import type { Network } from "../networks";
+import type { Network, NetworkName } from "../networks";
 import type { Coin } from "../wallet";
 import type { ExplorerTransaction, OnchainProvider } from "./onchain";
+
+/**
+ * Default WebSocket Electrum endpoints. Mainnet, mutinynet, and signet
+ * point at Ark Labs–operated Fulcrum 2.1 deployments (which support
+ * `blockchain.transaction.broadcast_package` for atomic 1P1C TRUC
+ * relay; see `ElectrumOnchainProvider.broadcastTransaction`). Testnet
+ * defaults to Blockstream's public Fulcrum because Ark doesn't host
+ * it. Regtest assumes the `electrum-ws` websocat bridge from
+ * `vulpemventures/nigiri`.
+ *
+ * @example
+ * ```typescript
+ * import { ElectrumWS } from "ws-electrumx-client";
+ * import { ELECTRUM_WS_URL, ElectrumOnchainProvider, networks } from "@arkade-os/sdk";
+ *
+ * const ws = new ElectrumWS(ELECTRUM_WS_URL.bitcoin);
+ * const provider = new ElectrumOnchainProvider(ws, networks.bitcoin);
+ * ```
+ */
+export const ELECTRUM_WS_URL: Record<NetworkName, string> = {
+    bitcoin: "wss://electrum.arkade.sh",
+    testnet: "wss://electrum.blockstream.info:60004",
+    signet: "wss://electrum.signet.arkade.sh",
+    mutinynet: "wss://electrum.mutinynet.arkade.sh",
+    regtest: "ws://localhost:50003",
+};
+
+/**
+ * Hostnames for Electrum endpoints reachable over raw TCP. Provided as
+ * a reference for Node-side consumers — the SDK's
+ * {@link ElectrumOnchainProvider} only speaks WebSocket because it has
+ * to run in browsers, so this map is informational only and not
+ * consumed by any built-in provider.
+ *
+ * Public Ark Labs Fulcrum instances expose:
+ *   - port 50001 — plain TCP (Electrum protocol)
+ *   - port 50002 — TCP + TLS (Electrum protocol)
+ *   - port 50003 — WebSocket (Electrum-over-WS, see {@link ELECTRUM_WS_URL})
+ */
+export const ELECTRUM_TCP_HOST: Record<NetworkName, string | null> = {
+    bitcoin: "electrum.arkade.sh",
+    testnet: null,
+    signet: "electrum.signet.arkade.sh",
+    mutinynet: "electrum.mutinynet.arkade.sh",
+    regtest: "localhost",
+};
 
 // Electrum protocol method names
 const BroadcastTransaction = "blockchain.transaction.broadcast";

--- a/src/providers/onchain.ts
+++ b/src/providers/onchain.ts
@@ -3,12 +3,18 @@ import { Coin } from "../wallet";
 
 /**
  * The default base URLs for esplora API providers.
+ *
+ * Mainnet, mutinynet, and signet point at Ark Labs–operated
+ * mempool deployments (mempool.space-compatible esplora API).
+ * Testnet falls back to the public mempool.space deployment
+ * because Ark doesn't host it. Regtest assumes a local nigiri
+ * stack on the standard port.
  */
 export const ESPLORA_URL: Record<NetworkName, string> = {
-    bitcoin: "https://mempool.space/api",
+    bitcoin: "https://mempool.arkade.sh/api",
     testnet: "https://mempool.space/testnet/api",
-    signet: "https://mempool.space/signet/api",
-    mutinynet: "https://mutinynet.com/api",
+    signet: "https://mempool.signet.arkade.sh/api",
+    mutinynet: "https://mempool.mutinynet.arkade.sh/api",
     regtest: "http://localhost:3000",
 };
 

--- a/test/e2e/electrum.test.ts
+++ b/test/e2e/electrum.test.ts
@@ -1,0 +1,344 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execSync } from "child_process";
+import { ElectrumWS } from "ws-electrumx-client";
+import { Address, OutScript } from "@scure/btc-signer";
+import {
+    ElectrumOnchainProvider,
+    OnchainWallet,
+    SingleKey,
+    WsElectrumChainSource,
+} from "../../src";
+import { networks } from "../../src/networks";
+
+// nigiri's electrum-ws bridge (from vulpemventures/nigiri#258) exposes the
+// existing electrs TCP endpoint as a WebSocket on this port.
+const ELECTRUM_WS_URL = "ws://localhost:50003";
+
+// Faucets propagate via electrs's mempool subscription within ~1 polling
+// interval; 5 seconds is the conservative upper bound used elsewhere in
+// the e2e suite.
+const FAUCET_PROPAGATION_MS = 5_000;
+
+function faucet(address: string, btc = 0.001): number {
+    execSync(`nigiri faucet ${address} ${btc}`);
+    return Math.round(btc * 100_000_000);
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("ElectrumOnchainProvider integration tests", () => {
+    let ws: ElectrumWS;
+    let provider: ElectrumOnchainProvider;
+    let chain: WsElectrumChainSource;
+
+    beforeAll(async () => {
+        ws = new ElectrumWS(ELECTRUM_WS_URL);
+        provider = new ElectrumOnchainProvider(ws, networks.regtest);
+        chain = new WsElectrumChainSource(ws, networks.regtest);
+        // Make sure the connection is actually open before the first test —
+        // ws-electrumx-client lazy-connects on the first request, so any
+        // setup error surfaces here rather than inside a test body.
+        const version = await ws.request<[string, string]>(
+            "server.version",
+            "ts-sdk-e2e",
+            "1.4"
+        );
+        expect(Array.isArray(version)).toBe(true);
+    }, 15_000);
+
+    afterAll(async () => {
+        await provider.close().catch(() => {});
+    });
+
+    it(
+        "exposes the regtest chain tip via the headers subscription",
+        { timeout: 10_000 },
+        async () => {
+            const tip = await provider.getChainTip();
+            // Regtest tips have non-zero height after `nigiri start` mines its
+            // genesis-plus-N blocks; assert the shape and a sane lower bound.
+            expect(tip.height).toBeGreaterThanOrEqual(0);
+            expect(typeof tip.hash).toBe("string");
+            expect(tip.hash).toMatch(/^[0-9a-f]{64}$/);
+            expect(tip.time).toBeGreaterThan(0);
+
+            // Calling twice must reuse the same subscription (cached tip),
+            // not register a new one server-side.
+            const tipAgain = await provider.getChainTip();
+            expect(tipAgain.height).toBeGreaterThanOrEqual(tip.height);
+        }
+    );
+
+    it(
+        "returns a positive sat/vB fee rate for the regtest mempool",
+        { timeout: 10_000 },
+        async () => {
+            const feeRate = await provider.getFeeRate();
+            // Regtest typically returns -1 (no estimate available) which the
+            // provider maps to undefined, OR a tiny positive integer when the
+            // chain has enough activity. Both are acceptable for this assertion.
+            if (feeRate !== undefined) {
+                expect(feeRate).toBeGreaterThanOrEqual(1);
+                expect(Number.isInteger(feeRate)).toBe(true);
+            }
+        }
+    );
+
+    it(
+        "tracks a freshly-funded address through getCoins / getTransactions / getTxStatus",
+        { timeout: 30_000 },
+        async () => {
+            const identity = SingleKey.fromRandomBytes();
+            const wallet = await OnchainWallet.create(
+                identity,
+                "regtest",
+                provider
+            );
+
+            // Fresh wallet: no coins, no history.
+            expect(await provider.getCoins(wallet.address)).toEqual([]);
+            expect(await provider.getTransactions(wallet.address)).toEqual([]);
+
+            const sats = faucet(wallet.address, 0.001);
+            await delay(FAUCET_PROPAGATION_MS);
+
+            const coins = await provider.getCoins(wallet.address);
+            expect(coins).toHaveLength(1);
+            expect(coins[0].value).toBe(sats);
+
+            const txs = await provider.getTransactions(wallet.address);
+            // Must include the faucet tx; may include further txs if other
+            // tests ran against the same regtest. Filter to ours by address.
+            const fundingTx = txs.find((tx) =>
+                tx.vout.some(
+                    (out) =>
+                        out.scriptpubkey_address === wallet.address &&
+                        Number(out.value) === sats
+                )
+            );
+            expect(fundingTx).toBeDefined();
+            expect(fundingTx!.txid).toBe(coins[0].txid);
+
+            // The faucet tx has at most 0 confirmations until the next block;
+            // either status is acceptable, just assert the shape.
+            const status = await provider.getTxStatus(coins[0].txid);
+            if (status.confirmed) {
+                expect(status.blockHeight).toBeGreaterThan(0);
+                expect(status.blockTime).toBeGreaterThan(0);
+            } else {
+                expect(status).toEqual({ confirmed: false });
+            }
+        }
+    );
+
+    it(
+        "broadcasts a single transaction and surfaces the new outpoint",
+        { timeout: 30_000 },
+        async () => {
+            // Stand up Alice with the electrum provider and Bob (recipient).
+            const alice = await OnchainWallet.create(
+                SingleKey.fromRandomBytes(),
+                "regtest",
+                provider
+            );
+            const bob = await OnchainWallet.create(
+                SingleKey.fromRandomBytes(),
+                "regtest",
+                provider
+            );
+
+            faucet(alice.address, 0.001);
+            await delay(FAUCET_PROPAGATION_MS);
+
+            // Send half the funded amount; remainder goes to fee + change.
+            await alice.send({
+                address: bob.address,
+                amount: 50_000,
+                feeRate: 2,
+            });
+            await delay(FAUCET_PROPAGATION_MS);
+
+            const bobCoins = await provider.getCoins(bob.address);
+            expect(bobCoins).toHaveLength(1);
+            expect(bobCoins[0].value).toBe(50_000);
+
+            // The send tx's outspends should mark Alice's funding output as
+            // spent (any vout pointing to Bob's coin counts).
+            const aliceFinalBalance = await alice.getBalance();
+            expect(aliceFinalBalance).toBeLessThan(100_000);
+        }
+    );
+
+    it(
+        "computes outspends correctly for a tx whose outputs are partially spent",
+        { timeout: 30_000 },
+        async () => {
+            const alice = await OnchainWallet.create(
+                SingleKey.fromRandomBytes(),
+                "regtest",
+                provider
+            );
+            const bob = await OnchainWallet.create(
+                SingleKey.fromRandomBytes(),
+                "regtest",
+                provider
+            );
+
+            faucet(alice.address, 0.001);
+            await delay(FAUCET_PROPAGATION_MS);
+
+            const aliceCoins = await provider.getCoins(alice.address);
+            expect(aliceCoins).toHaveLength(1);
+            const fundingTxid = aliceCoins[0].txid;
+
+            // Spend it; the spending tx's outputs become Bob's coin + change.
+            await alice.send({
+                address: bob.address,
+                amount: 30_000,
+                feeRate: 2,
+            });
+            await delay(FAUCET_PROPAGATION_MS);
+
+            const outspends = await provider.getTxOutspends(fundingTxid);
+            // The funded vout must report spent=true with a non-empty txid.
+            const spentOutput = outspends.find((o) => o.spent);
+            expect(spentOutput).toBeDefined();
+            expect(spentOutput!.txid).toMatch(/^[0-9a-f]{64}$/);
+            expect(spentOutput!.txid).not.toBe(fundingTxid);
+        }
+    );
+
+    it(
+        "delivers funded txs to the watchAddresses callback",
+        { timeout: 30_000 },
+        async () => {
+            const wallet = await OnchainWallet.create(
+                SingleKey.fromRandomBytes(),
+                "regtest",
+                provider
+            );
+
+            const seen: string[] = [];
+            const stop = await provider.watchAddresses(
+                [wallet.address],
+                (txs) => {
+                    for (const tx of txs) seen.push(tx.txid);
+                }
+            );
+
+            try {
+                faucet(wallet.address, 0.0005);
+                // Subscriptions deliver via electrs's mempool notification —
+                // longer wait than getCoins because it depends on electrs's
+                // own poll interval, not just nigiri's tx broadcast.
+                await delay(FAUCET_PROPAGATION_MS * 2);
+
+                expect(seen.length).toBeGreaterThanOrEqual(1);
+                // The reported txid must match the on-chain coin we can
+                // independently fetch via listunspent.
+                const coins = await provider.getCoins(wallet.address);
+                expect(seen).toContain(coins[0].txid);
+            } finally {
+                stop();
+            }
+        }
+    );
+
+    it(
+        "exposes WsElectrumChainSource.fetchHistories as a batch round-trip",
+        { timeout: 10_000 },
+        async () => {
+            const a = await OnchainWallet.create(
+                SingleKey.fromRandomBytes(),
+                "regtest",
+                provider
+            );
+            const b = await OnchainWallet.create(
+                SingleKey.fromRandomBytes(),
+                "regtest",
+                provider
+            );
+            faucet(a.address, 0.0001);
+            faucet(b.address, 0.0002);
+            await delay(FAUCET_PROPAGATION_MS);
+
+            const aScript = decodeP2trScript(a.address);
+            const bScript = decodeP2trScript(b.address);
+
+            const histories = await chain.fetchHistories([aScript, bScript]);
+            expect(histories).toHaveLength(2);
+            expect(histories[0].length).toBeGreaterThanOrEqual(1);
+            expect(histories[1].length).toBeGreaterThanOrEqual(1);
+        }
+    );
+});
+
+// Repository-coupled smoke test: exercise OnchainWallet's full read/write
+// surface against the electrum provider, mirroring the existing esplora
+// test (test/e2e/onchain.test.ts) so any divergence between providers is
+// visible side-by-side.
+describe("OnchainWallet over ElectrumOnchainProvider", () => {
+    let ws: ElectrumWS;
+    let provider: ElectrumOnchainProvider;
+
+    beforeAll(async () => {
+        ws = new ElectrumWS(ELECTRUM_WS_URL);
+        provider = new ElectrumOnchainProvider(ws, networks.regtest);
+        // Force the connection to come up before the test starts so latency
+        // stays out of the test budget.
+        await ws.request<[string, string]>(
+            "server.version",
+            "ts-sdk-e2e",
+            "1.4"
+        );
+    }, 15_000);
+
+    afterAll(async () => {
+        await provider.close().catch(() => {});
+    });
+
+    it(
+        "performs a complete onchain roundtrip payment via electrum",
+        { timeout: 30_000 },
+        async () => {
+            const alice = await OnchainWallet.create(
+                SingleKey.fromRandomBytes(),
+                "regtest",
+                provider
+            );
+            const bob = await OnchainWallet.create(
+                SingleKey.fromRandomBytes(),
+                "regtest",
+                provider
+            );
+
+            expect(await alice.getBalance()).toBe(0);
+            expect(await bob.getBalance()).toBe(0);
+
+            const sats = faucet(alice.address, 0.001);
+            await delay(FAUCET_PROPAGATION_MS);
+            expect(await alice.getBalance()).toBe(sats);
+
+            const sendAmount = 50_000;
+            await alice.send({
+                address: bob.address,
+                amount: sendAmount,
+                feeRate: 2,
+            });
+            await delay(FAUCET_PROPAGATION_MS);
+
+            expect(await bob.getBalance()).toBe(sendAmount);
+            expect(await alice.getBalance()).toBeLessThan(sats);
+        }
+    );
+});
+
+/**
+ * Decode a regtest P2TR address back to its scriptPubKey. Used to feed
+ * `WsElectrumChainSource.fetchHistories`, which takes raw scripts.
+ */
+function decodeP2trScript(address: string): Uint8Array {
+    return OutScript.encode(Address(networks.regtest).decode(address));
+}

--- a/test/e2e/electrum.test.ts
+++ b/test/e2e/electrum.test.ts
@@ -281,21 +281,24 @@ describe("ElectrumOnchainProvider integration tests", () => {
             );
             faucet(a.address, 0.0001);
             faucet(b.address, 0.0002);
-            await waitFor(async () => {
-                const [aCoins, bCoins] = await Promise.all([
-                    provider.getCoins(a.address),
-                    provider.getCoins(b.address),
-                ]);
-                return aCoins.length >= 1 && bCoins.length >= 1;
-            });
 
             const aScript = decodeP2trScript(a.address);
             const bScript = decodeP2trScript(b.address);
 
-            const histories = await chain.fetchHistories([aScript, bScript]);
-            expect(histories).toHaveLength(2);
-            expect(histories[0].length).toBeGreaterThanOrEqual(1);
-            expect(histories[1].length).toBeGreaterThanOrEqual(1);
+            // Drive the assertion via fetchHistories directly so the wait
+            // loop and the test target use the same code path. Polling
+            // sequential getCoins from two addresses in parallel under
+            // waitFor put enough concurrent strain on the WS connection in
+            // CI to occasionally trip the library's 10s request timeout.
+            let histories: Awaited<ReturnType<typeof chain.fetchHistories>>;
+            await waitFor(async () => {
+                histories = await chain.fetchHistories([aScript, bScript]);
+                return histories[0].length >= 1 && histories[1].length >= 1;
+            });
+
+            expect(histories!).toHaveLength(2);
+            expect(histories![0].length).toBeGreaterThanOrEqual(1);
+            expect(histories![1].length).toBeGreaterThanOrEqual(1);
         }
     );
 });

--- a/test/e2e/electrum.test.ts
+++ b/test/e2e/electrum.test.ts
@@ -119,13 +119,26 @@ describe("ElectrumOnchainProvider integration tests", () => {
             expect(fundingTx!.txid).toBe(coins[0].txid);
 
             // The faucet tx has at most 0 confirmations until the next block;
-            // either status is acceptable, just assert the shape.
-            const status = await provider.getTxStatus(coins[0].txid);
-            if (status.confirmed) {
-                expect(status.blockHeight).toBeGreaterThan(0);
-                expect(status.blockTime).toBeGreaterThan(0);
+            // either status is acceptable, just assert the shape. electrs
+            // can briefly race on `block.header(N)` right after a faucet —
+            // listunspent reports height>0 before the header is indexable —
+            // so retry until getTxStatus settles into a consistent state.
+            let status: Awaited<ReturnType<typeof provider.getTxStatus>>;
+            await waitFor(async () => {
+                try {
+                    status = await provider.getTxStatus(coins[0].txid);
+                    return true;
+                } catch (e) {
+                    if (/missingheight|not in block/i.test(String(e)))
+                        return false;
+                    throw e;
+                }
+            });
+            if (status!.confirmed) {
+                expect(status!.blockHeight).toBeGreaterThan(0);
+                expect(status!.blockTime).toBeGreaterThan(0);
             } else {
-                expect(status).toEqual({ confirmed: false });
+                expect(status!).toEqual({ confirmed: false });
             }
         }
     );
@@ -257,7 +270,9 @@ describe("ElectrumOnchainProvider integration tests", () => {
 
     it(
         "exposes WsElectrumChainSource.fetchHistories as a batch round-trip",
-        { timeout: 10_000 },
+        // Need headroom for waitFor's default 25s polling budget plus
+        // electrs's own indexing latency under CI load.
+        { timeout: 40_000 },
         async () => {
             const a = await OnchainWallet.create(
                 SingleKey.fromRandomBytes(),
@@ -276,7 +291,7 @@ describe("ElectrumOnchainProvider integration tests", () => {
                     provider.getCoins(a.address),
                     provider.getCoins(b.address),
                 ]);
-                return aCoins.length === 1 && bCoins.length === 1;
+                return aCoins.length >= 1 && bCoins.length >= 1;
             });
 
             const aScript = decodeP2trScript(a.address);

--- a/test/e2e/electrum.test.ts
+++ b/test/e2e/electrum.test.ts
@@ -118,27 +118,16 @@ describe("ElectrumOnchainProvider integration tests", () => {
             expect(fundingTx).toBeDefined();
             expect(fundingTx!.txid).toBe(coins[0].txid);
 
-            // The faucet tx has at most 0 confirmations until the next block;
-            // either status is acceptable, just assert the shape. electrs
-            // can briefly race on `block.header(N)` right after a faucet —
-            // listunspent reports height>0 before the header is indexable —
-            // so retry until getTxStatus settles into a consistent state.
-            let status: Awaited<ReturnType<typeof provider.getTxStatus>>;
-            await waitFor(async () => {
-                try {
-                    status = await provider.getTxStatus(coins[0].txid);
-                    return true;
-                } catch (e) {
-                    if (/missingheight|not in block/i.test(String(e)))
-                        return false;
-                    throw e;
-                }
-            });
-            if (status!.confirmed) {
-                expect(status!.blockHeight).toBeGreaterThan(0);
-                expect(status!.blockTime).toBeGreaterThan(0);
+            // The faucet tx has at most 0 confirmations until the next
+            // block; either status is acceptable. getTxStatus tolerates
+            // electrs's index-lag race on block.header(N) by returning
+            // blockTime=0 (degraded but useful), so we just assert shape.
+            const status = await provider.getTxStatus(coins[0].txid);
+            if (status.confirmed) {
+                expect(status.blockHeight).toBeGreaterThan(0);
+                expect(status.blockTime).toBeGreaterThanOrEqual(0);
             } else {
-                expect(status!).toEqual({ confirmed: false });
+                expect(status).toEqual({ confirmed: false });
             }
         }
     );

--- a/test/e2e/electrum.test.ts
+++ b/test/e2e/electrum.test.ts
@@ -9,23 +9,15 @@ import {
     WsElectrumChainSource,
 } from "../../src";
 import { networks } from "../../src/networks";
+import { waitFor } from "./utils";
 
 // nigiri's electrum-ws bridge (from vulpemventures/nigiri#258) exposes the
 // existing electrs TCP endpoint as a WebSocket on this port.
 const ELECTRUM_WS_URL = "ws://localhost:50003";
 
-// Faucets propagate via electrs's mempool subscription within ~1 polling
-// interval; 5 seconds is the conservative upper bound used elsewhere in
-// the e2e suite.
-const FAUCET_PROPAGATION_MS = 5_000;
-
 function faucet(address: string, btc = 0.001): number {
     execSync(`nigiri faucet ${address} ${btc}`);
     return Math.round(btc * 100_000_000);
-}
-
-function delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe("ElectrumOnchainProvider integration tests", () => {
@@ -102,7 +94,12 @@ describe("ElectrumOnchainProvider integration tests", () => {
             expect(await provider.getTransactions(wallet.address)).toEqual([]);
 
             const sats = faucet(wallet.address, 0.001);
-            await delay(FAUCET_PROPAGATION_MS);
+            // Poll until electrs picks up the faucet tx — tighter than a
+            // fixed sleep, and aligns with the rest of the e2e suite.
+            await waitFor(async () => {
+                const coins = await provider.getCoins(wallet.address);
+                return coins.length === 1 && coins[0].value === sats;
+            });
 
             const coins = await provider.getCoins(wallet.address);
             expect(coins).toHaveLength(1);
@@ -150,7 +147,7 @@ describe("ElectrumOnchainProvider integration tests", () => {
             );
 
             faucet(alice.address, 0.001);
-            await delay(FAUCET_PROPAGATION_MS);
+            await waitFor(async () => (await alice.getBalance()) > 0);
 
             // Send half the funded amount; remainder goes to fee + change.
             await alice.send({
@@ -158,7 +155,10 @@ describe("ElectrumOnchainProvider integration tests", () => {
                 amount: 50_000,
                 feeRate: 2,
             });
-            await delay(FAUCET_PROPAGATION_MS);
+            await waitFor(async () => {
+                const bobCoins = await provider.getCoins(bob.address);
+                return bobCoins.length === 1 && bobCoins[0].value === 50_000;
+            });
 
             const bobCoins = await provider.getCoins(bob.address);
             expect(bobCoins).toHaveLength(1);
@@ -187,7 +187,10 @@ describe("ElectrumOnchainProvider integration tests", () => {
             );
 
             faucet(alice.address, 0.001);
-            await delay(FAUCET_PROPAGATION_MS);
+            await waitFor(
+                async () =>
+                    (await provider.getCoins(alice.address)).length === 1
+            );
 
             const aliceCoins = await provider.getCoins(alice.address);
             expect(aliceCoins).toHaveLength(1);
@@ -199,7 +202,11 @@ describe("ElectrumOnchainProvider integration tests", () => {
                 amount: 30_000,
                 feeRate: 2,
             });
-            await delay(FAUCET_PROPAGATION_MS);
+            await waitFor(async () =>
+                (await provider.getTxOutspends(fundingTxid)).some(
+                    (o) => o.spent
+                )
+            );
 
             const outspends = await provider.getTxOutspends(fundingTxid);
             // The funded vout must report spent=true with a non-empty txid.
@@ -230,12 +237,14 @@ describe("ElectrumOnchainProvider integration tests", () => {
 
             try {
                 faucet(wallet.address, 0.0005);
-                // Subscriptions deliver via electrs's mempool notification —
-                // longer wait than getCoins because it depends on electrs's
-                // own poll interval, not just nigiri's tx broadcast.
-                await delay(FAUCET_PROPAGATION_MS * 2);
+                // Subscriptions deliver via electrs's mempool notification.
+                // Poll the captured array — finishes as soon as electrs
+                // pushes the notification, much shorter than a fixed sleep
+                // in the common case.
+                await waitFor(async () => seen.length >= 1, {
+                    timeout: 30_000,
+                });
 
-                expect(seen.length).toBeGreaterThanOrEqual(1);
                 // The reported txid must match the on-chain coin we can
                 // independently fetch via listunspent.
                 const coins = await provider.getCoins(wallet.address);
@@ -262,7 +271,13 @@ describe("ElectrumOnchainProvider integration tests", () => {
             );
             faucet(a.address, 0.0001);
             faucet(b.address, 0.0002);
-            await delay(FAUCET_PROPAGATION_MS);
+            await waitFor(async () => {
+                const [aCoins, bCoins] = await Promise.all([
+                    provider.getCoins(a.address),
+                    provider.getCoins(b.address),
+                ]);
+                return aCoins.length === 1 && bCoins.length === 1;
+            });
 
             const aScript = decodeP2trScript(a.address);
             const bScript = decodeP2trScript(b.address);
@@ -318,7 +333,7 @@ describe("OnchainWallet over ElectrumOnchainProvider", () => {
             expect(await bob.getBalance()).toBe(0);
 
             const sats = faucet(alice.address, 0.001);
-            await delay(FAUCET_PROPAGATION_MS);
+            await waitFor(async () => (await alice.getBalance()) === sats);
             expect(await alice.getBalance()).toBe(sats);
 
             const sendAmount = 50_000;
@@ -327,7 +342,7 @@ describe("OnchainWallet over ElectrumOnchainProvider", () => {
                 amount: sendAmount,
                 feeRate: 2,
             });
-            await delay(FAUCET_PROPAGATION_MS);
+            await waitFor(async () => (await bob.getBalance()) === sendAmount);
 
             expect(await bob.getBalance()).toBe(sendAmount);
             expect(await alice.getBalance()).toBeLessThan(sats);

--- a/test/e2e/electrum.test.ts
+++ b/test/e2e/electrum.test.ts
@@ -17,6 +17,12 @@ const ELECTRUM_WS_URL = "ws://localhost:50003";
 
 function faucet(address: string, btc = 0.001): number {
     execSync(`nigiri faucet ${address} ${btc}`);
+    // Mine a block immediately so electrs has a stable confirmed state to
+    // index. Without this the bridge can race: listunspent reports the tx
+    // at height N before block.header(N) is queryable, surfacing as
+    // "missingheight" errors. Other e2e suites mine after every state
+    // change for the same reason (settlement.test.ts etc.).
+    execSync(`nigiri rpc --generate 1`);
     return Math.round(btc * 100_000_000);
 }
 

--- a/test/e2e/electrum.test.ts
+++ b/test/e2e/electrum.test.ts
@@ -286,14 +286,22 @@ describe("ElectrumOnchainProvider integration tests", () => {
             const bScript = decodeP2trScript(b.address);
 
             // Drive the assertion via fetchHistories directly so the wait
-            // loop and the test target use the same code path. Polling
-            // sequential getCoins from two addresses in parallel under
-            // waitFor put enough concurrent strain on the WS connection in
-            // CI to occasionally trip the library's 10s request timeout.
+            // loop and the test target use the same code path. The wait
+            // also swallows the library's 10s per-request timeout — under
+            // CI load electrs occasionally wedges on get_history for the
+            // full window. Treat that as "not ready yet" and retry; only
+            // genuine errors propagate.
             let histories: Awaited<ReturnType<typeof chain.fetchHistories>>;
             await waitFor(async () => {
-                histories = await chain.fetchHistories([aScript, bScript]);
-                return histories[0].length >= 1 && histories[1].length >= 1;
+                try {
+                    histories = await chain.fetchHistories([aScript, bScript]);
+                    return histories[0].length >= 1 && histories[1].length >= 1;
+                } catch (err) {
+                    if (/request timeout|missingheight/i.test(String(err))) {
+                        return false;
+                    }
+                    throw err;
+                }
             });
 
             expect(histories!).toHaveLength(2);

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -504,8 +504,8 @@ describe("ElectrumOnchainProvider", () => {
             ]);
             // 2. fetchTransactions([txid]) — ws.batchRequest returns raw hex
             wsMock.batchRequest.mockResolvedValueOnce([txHex]);
-            // 3. fetchBlockHeaders([100]) — ws.batchRequest returns headers
-            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
+            // 3. Per-height fetchBlockHeader for height 100 — ws.request
+            wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX);
 
             const txs = await provider.getTransactions(REGTEST_ADDRESS);
             expect(txs).toHaveLength(1);
@@ -538,7 +538,7 @@ describe("ElectrumOnchainProvider", () => {
             expect(txs[0].status).toEqual({ confirmed: false, block_time: 0 });
         });
 
-        it("batches block-header lookups across history entries that share heights", async () => {
+        it("deduplicates block-header lookups across history entries that share heights", async () => {
             const { txHex } = buildTestTx();
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "tx-a", height: 200 },
@@ -546,36 +546,30 @@ describe("ElectrumOnchainProvider", () => {
                 { tx_hash: "tx-c", height: 201 },
             ]);
             wsMock.batchRequest.mockResolvedValueOnce([txHex, txHex, txHex]);
-            // Only TWO unique heights → ONE batch with two entries.
-            wsMock.batchRequest.mockResolvedValueOnce([
-                GENESIS_HEADER_HEX,
-                GENESIS_HEADER_HEX,
-            ]);
+            // Two unique heights → exactly TWO ws.request calls for headers.
+            wsMock.request
+                .mockResolvedValueOnce(GENESIS_HEADER_HEX)
+                .mockResolvedValueOnce(GENESIS_HEADER_HEX);
 
             const txs = await provider.getTransactions(REGTEST_ADDRESS);
             expect(txs).toHaveLength(3);
-            // Two batchRequest calls total: one for txs, one for headers.
-            expect(wsMock.batchRequest).toHaveBeenCalledTimes(2);
+            const headerCalls = wsMock.request.mock.calls.filter(
+                (c) => c[0] === "blockchain.block.header"
+            );
+            expect(headerCalls).toHaveLength(2);
         });
 
-        it("falls back to per-height header fetches when the batch fails (electrs index lag race)", async () => {
+        it("tolerates per-height header failures without losing the rest of the batch (electrs index lag race)", async () => {
             // electrs sometimes returns a tx as confirmed (listunspent height>0)
-            // before its block header is indexable, which makes a batched
-            // block.header request reject with "missingheight". The provider
-            // must tolerate this — the txid + status are still correct, only
-            // block_time falls back to 0 for the affected entry.
+            // before its block header is indexable. Per-height fetches via
+            // Promise.allSettled keep one failure from poisoning the others.
             const { txHex } = buildTestTx();
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "tx-good", height: 100 },
                 { tx_hash: "tx-lag", height: 999 }, // lagging height
             ]);
             wsMock.batchRequest.mockResolvedValueOnce([txHex, txHex]); // raw tx batch
-            // Header batch rejects (one height not yet indexable).
-            wsMock.batchRequest.mockRejectedValueOnce(
-                new Error("missingheight")
-            );
-            // Provider should fall back to individual fetches; one succeeds,
-            // the other still fails.
+            // One header succeeds, the other rejects with missingheight.
             wsMock.request
                 .mockResolvedValueOnce(GENESIS_HEADER_HEX) // block.header(100)
                 .mockRejectedValueOnce(new Error("missingheight")); // block.header(999)
@@ -592,6 +586,30 @@ describe("ElectrumOnchainProvider", () => {
             expect(lag.status).toEqual({ confirmed: true, block_time: 0 });
         });
 
+        it("never uses the library batchRequest for headers (avoids unhandled-rejection leak)", async () => {
+            // When one element of a batchRequest rejects, the library's
+            // Promise.all rejects with that error but leaves the other
+            // in-flight requests pending. Their later error responses
+            // surface as unhandled rejections that crash the test runner.
+            // Using per-height ws.request calls under Promise.allSettled
+            // gives every promise an explicit handler.
+            const { txHex } = buildTestTx();
+            wsMock.request.mockResolvedValueOnce([
+                { tx_hash: "tx-a", height: 100 },
+                { tx_hash: "tx-b", height: 101 },
+            ]);
+            wsMock.batchRequest.mockResolvedValueOnce([txHex, txHex]); // raw tx batch (only one batchRequest)
+            wsMock.request
+                .mockResolvedValueOnce(GENESIS_HEADER_HEX)
+                .mockResolvedValueOnce(GENESIS_HEADER_HEX);
+
+            await provider.getTransactions(REGTEST_ADDRESS);
+
+            // Exactly ONE batchRequest call (for raw txs) — headers MUST
+            // go through ws.request to avoid the unhandled-rejection leak.
+            expect(wsMock.batchRequest).toHaveBeenCalledTimes(1);
+        });
+
         it("rejects malformed addresses with a descriptive error", async () => {
             await expect(
                 provider.getTransactions("not-a-real-address")
@@ -606,7 +624,7 @@ describe("ElectrumOnchainProvider", () => {
                 { tx_hash: "txbad", height: 100 },
             ]);
             wsMock.batchRequest.mockResolvedValueOnce(["zz"]); // not valid hex
-            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
+            wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX); // header for height 100
 
             await expect(
                 provider.getTransactions(REGTEST_ADDRESS)
@@ -659,9 +677,10 @@ describe("ElectrumOnchainProvider", () => {
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "newtx", height: 100 },
             ]);
-            // 2. historyToExplorerTxs internals: raw tx batch + headers batch
+            // 2. fetchTransactions batchRequest for raw tx hex
             wsMock.batchRequest.mockResolvedValueOnce([txHex]);
-            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
+            // 3. Per-height block.header request (no longer batched)
+            wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX);
             firstCb(firstScripthash, "deadbeef");
 
             // The chain involves two awaited round-trips before the callback
@@ -722,8 +741,8 @@ describe("ElectrumOnchainProvider", () => {
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "newtx", height: 100 },
             ]);
-            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
-            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
+            wsMock.batchRequest.mockResolvedValueOnce([txHex]); // raw tx
+            wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX); // header
             cb(scripthash, "status1");
             for (let i = 0; i < 6; i++)
                 await new Promise((r) => setTimeout(r, 0));
@@ -735,7 +754,7 @@ describe("ElectrumOnchainProvider", () => {
                 { tx_hash: "newtx", height: 100 },
             ]);
             wsMock.batchRequest.mockResolvedValueOnce([txHex]);
-            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
+            wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX);
             cb(scripthash, "status2");
             for (let i = 0; i < 6; i++)
                 await new Promise((r) => setTimeout(r, 0));

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -442,6 +442,18 @@ describe("ElectrumOnchainProvider", () => {
             expect(methods).toContain("blockchain.block.header");
             expect(methods).not.toContain("blockchain.transaction.get");
         });
+
+        it("propagates non-'not in block' errors from get_merkle (no silent swallow)", async () => {
+            // Real backend errors (auth, network, malformed payload) MUST
+            // surface — silently treating them as "mempool / unconfirmed"
+            // would freeze any caller polling getTxStatus on a confirmed tx.
+            wsMock.request.mockRejectedValueOnce(
+                new Error("Authentication required")
+            );
+            await expect(provider.getTxStatus("abc")).rejects.toThrow(
+                /Authentication required/
+            );
+        });
     });
 
     describe("getTransactions", () => {
@@ -521,6 +533,21 @@ describe("ElectrumOnchainProvider", () => {
                 provider.getTransactions("not-a-real-address")
             ).rejects.toThrow(/Invalid address not-a-real-address/);
         });
+
+        it("propagates parse errors with the offending txid (no silent empty vout)", async () => {
+            // If the daemon returns gibberish for a tx, surfacing an empty
+            // vout would silently hide outputs (e.g. a deposit). Fail loud
+            // instead — let the caller decide whether to retry or skip.
+            wsMock.request.mockResolvedValueOnce([
+                { tx_hash: "txbad", height: 100 },
+            ]);
+            wsMock.batchRequest.mockResolvedValueOnce(["zz"]); // not valid hex
+            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
+
+            await expect(
+                provider.getTransactions(REGTEST_ADDRESS)
+            ).rejects.toThrow(/Failed to parse raw tx for txbad/);
+        });
     });
 
     describe("watchAddresses", () => {
@@ -586,6 +613,74 @@ describe("ElectrumOnchainProvider", () => {
 
             stop();
             expect(wsMock.unsubscribe).toHaveBeenCalledTimes(2);
+        });
+
+        it("re-delivers a tx on the next notification when delivery fails the first time", async () => {
+            // Regression: the dedupe set must not be updated until the
+            // eventCallback has fired successfully. Previously a failed
+            // historyToExplorerTxs / eventCallback would permanently mark
+            // the txid as seen and the next notification would skip it.
+            const addr = REGTEST_ADDRESS;
+            wsMock.request.mockResolvedValueOnce([]); // initial fetchHistory: empty
+
+            const subscribeCallbacks = new Map<
+                string,
+                (scripthash: string, status: string | null) => void
+            >();
+            wsMock.subscribe.mockImplementation(
+                async (
+                    method: string,
+                    cb: (s: string, status: string | null) => void,
+                    scripthash: string
+                ) => {
+                    if (method === "blockchain.scripthash") {
+                        subscribeCallbacks.set(scripthash, cb);
+                    }
+                }
+            );
+
+            // Callback throws on first invocation, succeeds on second.
+            const events: unknown[] = [];
+            let firstCallSeen = false;
+            const stop = await provider.watchAddresses([addr], (txs) => {
+                if (!firstCallSeen) {
+                    firstCallSeen = true;
+                    throw new Error("simulated downstream failure");
+                }
+                events.push(txs);
+            });
+
+            const [scripthash, cb] = [...subscribeCallbacks.entries()][0];
+            const { txHex } = buildTestTx();
+
+            // First notification: history sees newtx, parse succeeds, but
+            // the user callback throws.
+            wsMock.request.mockResolvedValueOnce([
+                { tx_hash: "newtx", height: 100 },
+            ]);
+            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
+            cb(scripthash, "status1");
+            for (let i = 0; i < 6; i++)
+                await new Promise((r) => setTimeout(r, 0));
+            expect(events).toHaveLength(0); // first call threw
+
+            // Second notification: same newtx still in history. Provider
+            // must NOT have marked it seen — should re-attempt delivery.
+            wsMock.request.mockResolvedValueOnce([
+                { tx_hash: "newtx", height: 100 },
+            ]);
+            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
+            cb(scripthash, "status2");
+            for (let i = 0; i < 6; i++)
+                await new Promise((r) => setTimeout(r, 0));
+
+            expect(events).toHaveLength(1);
+            const delivered = (events[0] as Array<{ txid: string }>)[0];
+            expect(delivered.txid).toBe("newtx");
+
+            stop();
         });
     });
 

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -404,56 +404,43 @@ describe("ElectrumOnchainProvider", () => {
     });
 
     describe("getTxStatus", () => {
-        it("returns confirmed=false for mempool txs (0 confirmations)", async () => {
-            wsMock.request.mockResolvedValueOnce({
-                txid: "abc",
-                confirmations: 0,
-                vout: [],
-                vin: [],
-            });
-            const status = await provider.getTxStatus("abc");
-            expect(status).toEqual({ confirmed: false });
-        });
-
-        it("computes block height as tipHeight - confirmations + 1", async () => {
-            wsMock.request.mockResolvedValueOnce({
-                txid: "abc",
-                confirmations: 10,
-                blocktime: 1700_000_000,
-                vout: [],
-                vin: [],
-            });
-            deliverHeadersTip(wsMock.subscribe, {
-                height: 100,
-                hex: GENESIS_HEADER_HEX,
-            });
-
-            const status = await provider.getTxStatus("abc");
-            expect(status).toEqual({
-                confirmed: true,
-                blockTime: 1700_000_000,
-                blockHeight: 91, // 100 - 10 + 1
+        it("returns confirmed=false when transaction.get_merkle is not yet available (mempool)", async () => {
+            // electrs raises an error for txs not yet in a block; fetchTxMerkle
+            // catches and returns null. Either error or a resolved {block_height: 0}
+            // path is acceptable, but error is the realistic electrs case.
+            wsMock.request.mockRejectedValueOnce(
+                new Error("Transaction not yet in a block")
+            );
+            expect(await provider.getTxStatus("abc")).toEqual({
+                confirmed: false,
             });
         });
 
-        it("falls back to time when blocktime is absent", async () => {
-            wsMock.request.mockResolvedValueOnce({
-                txid: "abc",
-                confirmations: 5,
-                time: 1650_000_000,
-                vout: [],
-                vin: [],
+        it("returns confirmed=false when transaction.get_merkle reports block_height <= 0", async () => {
+            wsMock.request.mockResolvedValueOnce({ block_height: 0 });
+            expect(await provider.getTxStatus("abc")).toEqual({
+                confirmed: false,
             });
-            deliverHeadersTip(wsMock.subscribe, {
-                height: 50,
-                hex: GENESIS_HEADER_HEX,
+        });
+
+        it("derives blockHeight from get_merkle and blockTime from the header", async () => {
+            wsMock.request
+                .mockResolvedValueOnce({ block_height: 100 }) // get_merkle
+                .mockResolvedValueOnce(GENESIS_HEADER_HEX); // block.header(100)
+
+            expect(await provider.getTxStatus("abc")).toEqual({
+                confirmed: true,
+                blockHeight: 100,
+                blockTime: GENESIS_BLOCK_TIME,
             });
 
-            const status = await provider.getTxStatus("abc");
-            expect(status).toMatchObject({
-                confirmed: true,
-                blockTime: 1650_000_000,
-            });
+            // Critical: the path must NOT use blockchain.transaction.get
+            // (which electrs rejects with "verbose transactions are
+            // currently unsupported"). Verify the methods we used.
+            const methods = wsMock.request.mock.calls.map((c) => c[0]);
+            expect(methods).toContain("blockchain.transaction.get_merkle");
+            expect(methods).toContain("blockchain.block.header");
+            expect(methods).not.toContain("blockchain.transaction.get");
         });
     });
 
@@ -464,79 +451,69 @@ describe("ElectrumOnchainProvider", () => {
             expect(txs).toEqual([]);
         });
 
-        it("maps verbose electrum txs to ExplorerTransaction shape", async () => {
-            // First call: fetchHistory (scripthash.get_history) via ws.request
+        it("maps history + raw tx + block header to ExplorerTransaction shape", async () => {
+            // buildTestTx() yields outputs of 10_000 and 20_000 sats with
+            // P2WPKH scriptPubKeys we can decode back to addresses.
+            const { txHex } = buildTestTx();
+
+            // 1. fetchHistory(script) — ws.request
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "tx1", height: 100 },
             ]);
-            // Second call: fetchVerboseTransactions via ws.batchRequest
-            wsMock.batchRequest.mockResolvedValueOnce([
-                {
-                    txid: "tx1",
-                    confirmations: 5,
-                    blocktime: 1700_000_000,
-                    vout: [
-                        {
-                            n: 0,
-                            value: 0.001, // 100_000 sat
-                            scriptPubKey: {
-                                address: "bcrt1qexample",
-                                hex: "",
-                            },
-                        },
-                    ],
-                    vin: [],
-                },
-            ]);
+            // 2. fetchTransactions([txid]) — ws.batchRequest returns raw hex
+            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            // 3. fetchBlockHeaders([100]) — ws.batchRequest returns headers
+            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
 
             const txs = await provider.getTransactions(REGTEST_ADDRESS);
-            expect(txs).toEqual([
-                {
-                    txid: "tx1",
-                    vout: [
-                        {
-                            scriptpubkey_address: "bcrt1qexample",
-                            value: "100000",
-                        },
-                    ],
-                    status: { confirmed: true, block_time: 1700_000_000 },
-                },
-            ]);
+            expect(txs).toHaveLength(1);
+            expect(txs[0].txid).toBe("tx1");
+            // Sat amounts come from the parsed raw tx (exact bigints, no float rounding).
+            expect(txs[0].vout.map((v) => v.value)).toEqual(["10000", "20000"]);
+            // Addresses come from decoding each output's scriptPubKey.
+            expect(txs[0].vout[0].scriptpubkey_address).toMatch(/^bcrt1q/);
+            expect(txs[0].vout[1].scriptpubkey_address).toMatch(/^bcrt1q/);
+            // block_time comes from parsing the block header (genesis here).
+            expect(txs[0].status).toEqual({
+                confirmed: true,
+                block_time: GENESIS_BLOCK_TIME,
+            });
+
+            // Critical: must not call the verbose-tx endpoint (electrs rejects it).
+            const methods = wsMock.request.mock.calls.map((c) => c[0]);
+            expect(methods).not.toContain("blockchain.transaction.get");
         });
 
-        it("derives exact sat amounts from vtx.hex when present (no float rounding)", async () => {
-            // buildTestTx() yields outputs of 10_000 and 20_000 sats — exact
-            // values that survive the raw-tx parse without any float math.
+        it("treats height=0 entries as unconfirmed (mempool)", async () => {
             const { txHex } = buildTestTx();
-
             wsMock.request.mockResolvedValueOnce([
-                { tx_hash: "tx-exact", height: 100 },
+                { tx_hash: "txm", height: 0 },
             ]);
+            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            // No block headers fetched: zero unique confirmed heights.
+
+            const txs = await provider.getTransactions(REGTEST_ADDRESS);
+            expect(txs[0].status).toEqual({ confirmed: false, block_time: 0 });
+        });
+
+        it("batches block-header lookups across history entries that share heights", async () => {
+            const { txHex } = buildTestTx();
+            wsMock.request.mockResolvedValueOnce([
+                { tx_hash: "tx-a", height: 200 },
+                { tx_hash: "tx-b", height: 200 },
+                { tx_hash: "tx-c", height: 201 },
+            ]);
+            wsMock.batchRequest.mockResolvedValueOnce([txHex, txHex, txHex]);
+            // Only TWO unique heights → ONE batch with two entries.
             wsMock.batchRequest.mockResolvedValueOnce([
-                {
-                    txid: "tx-exact",
-                    confirmations: 5,
-                    blocktime: 1700_000_000,
-                    hex: txHex,
-                    vout: [
-                        {
-                            n: 0,
-                            // Deliberately wrong float to prove we use the hex.
-                            value: 0.00009999,
-                            scriptPubKey: { address: "addr0", hex: "" },
-                        },
-                        {
-                            n: 1,
-                            value: 0.00019999,
-                            scriptPubKey: { address: "addr1", hex: "" },
-                        },
-                    ],
-                    vin: [],
-                },
+                GENESIS_HEADER_HEX,
+                GENESIS_HEADER_HEX,
             ]);
 
             const txs = await provider.getTransactions(REGTEST_ADDRESS);
-            expect(txs[0].vout.map((v) => v.value)).toEqual(["10000", "20000"]);
+            expect(txs).toHaveLength(3);
+            // Two batchRequest calls total: one for txs, one for headers.
+            expect(wsMock.batchRequest).toHaveBeenCalledTimes(2);
         });
 
         it("rejects malformed addresses with a descriptive error", async () => {
@@ -586,29 +563,26 @@ describe("ElectrumOnchainProvider", () => {
             const [firstScripthash, firstCb] = [
                 ...subscribeCallbacks.entries(),
             ][0];
+            const { txHex } = buildTestTx();
+            // 1. fetchHistory(script) — sees a new tx on this script
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "newtx", height: 100 },
             ]);
-            wsMock.batchRequest.mockResolvedValueOnce([
-                {
-                    txid: "newtx",
-                    confirmations: 1,
-                    blocktime: 1700_000_000,
-                    vout: [
-                        {
-                            n: 0,
-                            value: 0.0005,
-                            scriptPubKey: { address: "addrX", hex: "" },
-                        },
-                    ],
-                    vin: [],
-                },
-            ]);
+            // 2. historyToExplorerTxs internals: raw tx batch + headers batch
+            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            wsMock.batchRequest.mockResolvedValueOnce([GENESIS_HEADER_HEX]);
             firstCb(firstScripthash, "deadbeef");
 
-            // Wait for the async handleStatusChange chain to settle.
-            await new Promise((r) => setTimeout(r, 0));
+            // The chain involves two awaited round-trips before the callback
+            // fires; pump the microtask queue a few times rather than relying
+            // on a single setTimeout(0).
+            for (let i = 0; i < 5; i++) {
+                await new Promise((r) => setTimeout(r, 0));
+            }
+
             expect(events).toHaveLength(1);
+            const delivered = (events[0] as Array<{ txid: string }>)[0];
+            expect(delivered.txid).toBe("newtx");
 
             stop();
             expect(wsMock.unsubscribe).toHaveBeenCalledTimes(2);

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -68,6 +68,19 @@ function createMockWS(): {
     };
 }
 
+/**
+ * Queue N sequential responses on `wsMock.request` to mimic what
+ * `safeBatchRequest` (the in-house replacement for the library's leaky
+ * `batchRequest`) consumes — one ws.request call per batch element.
+ */
+function mockBatch<T>(
+    mock: ReturnType<typeof vi.fn>,
+    responses: T[]
+): ReturnType<typeof vi.fn> {
+    for (const r of responses) mock.mockResolvedValueOnce(r);
+    return mock;
+}
+
 // Bitcoin genesis block header (mainnet)
 const GENESIS_HEADER_HEX =
     "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c";
@@ -503,7 +516,7 @@ describe("ElectrumOnchainProvider", () => {
                 { tx_hash: "tx1", height: 100 },
             ]);
             // 2. fetchTransactions([txid]) — ws.batchRequest returns raw hex
-            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            mockBatch(wsMock.request, [txHex]);
             // 3. Per-height fetchBlockHeader for height 100 — ws.request
             wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX);
 
@@ -521,9 +534,16 @@ describe("ElectrumOnchainProvider", () => {
                 block_time: GENESIS_BLOCK_TIME,
             });
 
-            // Critical: must not call the verbose-tx endpoint (electrs rejects it).
-            const methods = wsMock.request.mock.calls.map((c) => c[0]);
-            expect(methods).not.toContain("blockchain.transaction.get");
+            // Critical: must not call the verbose form of transaction.get
+            // (electrs rejects "verbose=true" for that method). The
+            // non-verbose form is fine and IS used for raw tx hex; the
+            // marker for the verbose form is the boolean second param.
+            const verboseTxCalls = wsMock.request.mock.calls.filter(
+                (c) =>
+                    c[0] === "blockchain.transaction.get" &&
+                    c[c.length - 1] === true
+            );
+            expect(verboseTxCalls).toHaveLength(0);
         });
 
         it("treats height=0 entries as unconfirmed (mempool)", async () => {
@@ -531,7 +551,7 @@ describe("ElectrumOnchainProvider", () => {
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "txm", height: 0 },
             ]);
-            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            mockBatch(wsMock.request, [txHex]);
             // No block headers fetched: zero unique confirmed heights.
 
             const txs = await provider.getTransactions(REGTEST_ADDRESS);
@@ -545,7 +565,7 @@ describe("ElectrumOnchainProvider", () => {
                 { tx_hash: "tx-b", height: 200 },
                 { tx_hash: "tx-c", height: 201 },
             ]);
-            wsMock.batchRequest.mockResolvedValueOnce([txHex, txHex, txHex]);
+            mockBatch(wsMock.request, [txHex, txHex, txHex]);
             // Two unique heights → exactly TWO ws.request calls for headers.
             wsMock.request
                 .mockResolvedValueOnce(GENESIS_HEADER_HEX)
@@ -561,18 +581,25 @@ describe("ElectrumOnchainProvider", () => {
 
         it("tolerates per-height header failures without losing the rest of the batch (electrs index lag race)", async () => {
             // electrs sometimes returns a tx as confirmed (listunspent height>0)
-            // before its block header is indexable. Per-height fetches via
-            // Promise.allSettled keep one failure from poisoning the others.
+            // before its block header is indexable. historyToExplorerTxs
+            // tries fetchBlockHeaders first (safeBatchRequest, all-or-nothing);
+            // if that throws, falls back to per-height fetchBlockHeader under
+            // Promise.allSettled so one failure doesn't poison the rest.
             const { txHex } = buildTestTx();
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "tx-good", height: 100 },
                 { tx_hash: "tx-lag", height: 999 }, // lagging height
             ]);
-            wsMock.batchRequest.mockResolvedValueOnce([txHex, txHex]); // raw tx batch
-            // One header succeeds, the other rejects with missingheight.
+            mockBatch(wsMock.request, [txHex, txHex]); // raw tx batch
+            // First header attempt (safeBatchRequest): one succeeds,
+            // one fails — safeBatchRequest throws, triggering fallback.
             wsMock.request
                 .mockResolvedValueOnce(GENESIS_HEADER_HEX) // block.header(100)
                 .mockRejectedValueOnce(new Error("missingheight")); // block.header(999)
+            // Fallback per-height attempt: same outcome.
+            wsMock.request
+                .mockResolvedValueOnce(GENESIS_HEADER_HEX)
+                .mockRejectedValueOnce(new Error("missingheight"));
 
             const txs = await provider.getTransactions(REGTEST_ADDRESS);
             expect(txs).toHaveLength(2);
@@ -586,28 +613,25 @@ describe("ElectrumOnchainProvider", () => {
             expect(lag.status).toEqual({ confirmed: true, block_time: 0 });
         });
 
-        it("never uses the library batchRequest for headers (avoids unhandled-rejection leak)", async () => {
-            // When one element of a batchRequest rejects, the library's
-            // Promise.all rejects with that error but leaves the other
-            // in-flight requests pending. Their later error responses
-            // surface as unhandled rejections that crash the test runner.
-            // Using per-height ws.request calls under Promise.allSettled
-            // gives every promise an explicit handler.
+        it("never uses the library's leaky batchRequest (uses safeBatchRequest instead)", async () => {
+            // The library's batchRequest is implemented as Promise.all over
+            // individual request promises — when one element rejects, the
+            // others stay pending and their later rejections become
+            // unhandled (crashing the test runner). Our safeBatchRequest
+            // wraps each request in Promise.allSettled so every promise
+            // has an explicit handler. This regression test asserts that
+            // the provider's hot path never reaches the leaky primitive.
             const { txHex } = buildTestTx();
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "tx-a", height: 100 },
                 { tx_hash: "tx-b", height: 101 },
             ]);
-            wsMock.batchRequest.mockResolvedValueOnce([txHex, txHex]); // raw tx batch (only one batchRequest)
-            wsMock.request
-                .mockResolvedValueOnce(GENESIS_HEADER_HEX)
-                .mockResolvedValueOnce(GENESIS_HEADER_HEX);
+            mockBatch(wsMock.request, [txHex, txHex]); // safeBatchRequest for raw txs
+            mockBatch(wsMock.request, [GENESIS_HEADER_HEX, GENESIS_HEADER_HEX]);
 
             await provider.getTransactions(REGTEST_ADDRESS);
 
-            // Exactly ONE batchRequest call (for raw txs) — headers MUST
-            // go through ws.request to avoid the unhandled-rejection leak.
-            expect(wsMock.batchRequest).toHaveBeenCalledTimes(1);
+            expect(wsMock.batchRequest).not.toHaveBeenCalled();
         });
 
         it("rejects malformed addresses with a descriptive error", async () => {
@@ -623,7 +647,7 @@ describe("ElectrumOnchainProvider", () => {
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "txbad", height: 100 },
             ]);
-            wsMock.batchRequest.mockResolvedValueOnce(["zz"]); // not valid hex
+            mockBatch(wsMock.request, ["zz"]); // not valid hex
             wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX); // header for height 100
 
             await expect(
@@ -678,7 +702,7 @@ describe("ElectrumOnchainProvider", () => {
                 { tx_hash: "newtx", height: 100 },
             ]);
             // 2. fetchTransactions batchRequest for raw tx hex
-            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            mockBatch(wsMock.request, [txHex]);
             // 3. Per-height block.header request (no longer batched)
             wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX);
             firstCb(firstScripthash, "deadbeef");
@@ -741,7 +765,7 @@ describe("ElectrumOnchainProvider", () => {
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "newtx", height: 100 },
             ]);
-            wsMock.batchRequest.mockResolvedValueOnce([txHex]); // raw tx
+            mockBatch(wsMock.request, [txHex]); // raw tx
             wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX); // header
             cb(scripthash, "status1");
             for (let i = 0; i < 6; i++)
@@ -753,7 +777,7 @@ describe("ElectrumOnchainProvider", () => {
             wsMock.request.mockResolvedValueOnce([
                 { tx_hash: "newtx", height: 100 },
             ]);
-            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            mockBatch(wsMock.request, [txHex]);
             wsMock.request.mockResolvedValueOnce(GENESIS_HEADER_HEX);
             cb(scripthash, "status2");
             for (let i = 0; i < 6; i++)
@@ -776,10 +800,10 @@ describe("ElectrumOnchainProvider", () => {
 
         it("returns all-unspent when both outputs are in listunspent", async () => {
             // Step 1: fetchTransactions for creator tx
-            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            mockBatch(wsMock.request, [txHex]);
 
             // Step 2: listunspent for each output scripthash — both show our tx
-            wsMock.batchRequest.mockResolvedValueOnce([
+            mockBatch(wsMock.request, [
                 [
                     {
                         tx_hash: parentTxid,
@@ -812,10 +836,10 @@ describe("ElectrumOnchainProvider", () => {
             );
 
             // Step 1: fetchTransactions for creator
-            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            mockBatch(wsMock.request, [txHex]);
 
             // Step 2: listunspent — vout 0 gone, vout 1 still there
-            wsMock.batchRequest.mockResolvedValueOnce([
+            mockBatch(wsMock.request, [
                 [], // vout 0 spent
                 [
                     {
@@ -829,7 +853,7 @@ describe("ElectrumOnchainProvider", () => {
 
             // Step 3: history for the spent output's scripthash
             // history has [parent, spender] → exactly one candidate that isn't the parent
-            wsMock.batchRequest.mockResolvedValueOnce([
+            mockBatch(wsMock.request, [
                 [
                     { tx_hash: parentTxid, height: 100 },
                     { tx_hash: spenderTxid, height: 101 },
@@ -856,10 +880,10 @@ describe("ElectrumOnchainProvider", () => {
             );
 
             // Step 1: fetch parent
-            wsMock.batchRequest.mockResolvedValueOnce([txHex]);
+            mockBatch(wsMock.request, [txHex]);
 
             // Step 2: listunspent — vout 0 spent, vout 1 unspent
-            wsMock.batchRequest.mockResolvedValueOnce([
+            mockBatch(wsMock.request, [
                 [],
                 [
                     {
@@ -872,7 +896,7 @@ describe("ElectrumOnchainProvider", () => {
             ]);
 
             // Step 3: history for script 0 contains parent + two candidates
-            wsMock.batchRequest.mockResolvedValueOnce([
+            mockBatch(wsMock.request, [
                 [
                     { tx_hash: parentTxid, height: 100 },
                     { tx_hash: decoyTxid, height: 102 },
@@ -881,10 +905,7 @@ describe("ElectrumOnchainProvider", () => {
             ]);
 
             // Step 4: batch-fetch candidate txs to scan their inputs
-            wsMock.batchRequest.mockResolvedValueOnce([
-                decoyHex,
-                realSpenderHex,
-            ]);
+            mockBatch(wsMock.request, [decoyHex, realSpenderHex]);
 
             const results = await provider.getTxOutspends(parentTxid);
             expect(results[0]).toEqual({ spent: true, txid: realSpenderTxid });
@@ -919,15 +940,20 @@ describe("WsElectrumChainSource", () => {
             expect(header).toEqual({ height: 0, hex: GENESIS_HEADER_HEX });
         });
 
-        it("batches multiple heights into a single batchRequest", async () => {
-            wsMock.batchRequest.mockResolvedValueOnce(["h1", "h2", "h3"]);
+        it("issues per-height ws.request calls in parallel via safeBatchRequest", async () => {
+            mockBatch(wsMock.request, ["h1", "h2", "h3"]);
             const headers = await chain.fetchBlockHeaders([10, 20, 30]);
             expect(headers).toEqual([
                 { height: 10, hex: "h1" },
                 { height: 20, hex: "h2" },
                 { height: 30, hex: "h3" },
             ]);
-            expect(wsMock.batchRequest).toHaveBeenCalledTimes(1);
+            // Three ws.request calls, no library batchRequest.
+            const headerCalls = wsMock.request.mock.calls.filter(
+                (c) => c[0] === "blockchain.block.header"
+            );
+            expect(headerCalls).toHaveLength(3);
+            expect(wsMock.batchRequest).not.toHaveBeenCalled();
         });
     });
 
@@ -935,25 +961,33 @@ describe("WsElectrumChainSource", () => {
         it("returns empty array without calling ws when input is empty", async () => {
             const out = await chain.fetchVerboseTransactions([]);
             expect(out).toEqual([]);
+            expect(wsMock.request).not.toHaveBeenCalled();
             expect(wsMock.batchRequest).not.toHaveBeenCalled();
         });
     });
 
     describe("fetchTransactions retry on missing tx", () => {
         it("retries after a 'missingtransaction' error then succeeds", async () => {
-            wsMock.batchRequest
+            // First attempt: ws.request rejects with missingtransaction.
+            // safeBatchRequest forwards the rejection; the chain's retry
+            // loop catches it and attempts again.
+            wsMock.request
                 .mockRejectedValueOnce(
                     new Error("daemon error: missingtransaction")
                 )
-                .mockResolvedValueOnce(["0200"]);
+                .mockResolvedValueOnce("0200"); // second attempt succeeds
 
             const result = await chain.fetchTransactions(["tx1"]);
             expect(result).toEqual([{ txID: "tx1", hex: "0200" }]);
-            expect(wsMock.batchRequest).toHaveBeenCalledTimes(2);
+            // Two ws.request calls (one per attempt).
+            const txGetCalls = wsMock.request.mock.calls.filter(
+                (c) => c[0] === "blockchain.transaction.get"
+            );
+            expect(txGetCalls).toHaveLength(2);
         });
 
         it("propagates non-missing errors immediately", async () => {
-            wsMock.batchRequest.mockRejectedValueOnce(
+            wsMock.request.mockRejectedValueOnce(
                 new Error("connection refused")
             );
             await expect(chain.fetchTransactions(["tx1"])).rejects.toThrow(

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -436,6 +436,17 @@ describe("ElectrumOnchainProvider", () => {
             });
         });
 
+        it("returns confirmed=false when get_merkle hits the missingheight index-lag race", async () => {
+            // electrs can fail get_merkle with "missingheight" when the tx
+            // is reportedly confirmed but the block index isn't ready yet —
+            // same race that block.header(N) hits. Treat as not-yet-confirmed
+            // so the caller can poll again rather than throw indefinitely.
+            wsMock.request.mockRejectedValueOnce(new Error("missingheight"));
+            expect(await provider.getTxStatus("abc")).toEqual({
+                confirmed: false,
+            });
+        });
+
         it("derives blockHeight from get_merkle and blockTime from the header", async () => {
             wsMock.request
                 .mockResolvedValueOnce({ block_height: 100 }) // get_merkle

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -528,6 +528,40 @@ describe("ElectrumOnchainProvider", () => {
             expect(wsMock.batchRequest).toHaveBeenCalledTimes(2);
         });
 
+        it("falls back to per-height header fetches when the batch fails (electrs index lag race)", async () => {
+            // electrs sometimes returns a tx as confirmed (listunspent height>0)
+            // before its block header is indexable, which makes a batched
+            // block.header request reject with "missingheight". The provider
+            // must tolerate this — the txid + status are still correct, only
+            // block_time falls back to 0 for the affected entry.
+            const { txHex } = buildTestTx();
+            wsMock.request.mockResolvedValueOnce([
+                { tx_hash: "tx-good", height: 100 },
+                { tx_hash: "tx-lag", height: 999 }, // lagging height
+            ]);
+            wsMock.batchRequest.mockResolvedValueOnce([txHex, txHex]); // raw tx batch
+            // Header batch rejects (one height not yet indexable).
+            wsMock.batchRequest.mockRejectedValueOnce(
+                new Error("missingheight")
+            );
+            // Provider should fall back to individual fetches; one succeeds,
+            // the other still fails.
+            wsMock.request
+                .mockResolvedValueOnce(GENESIS_HEADER_HEX) // block.header(100)
+                .mockRejectedValueOnce(new Error("missingheight")); // block.header(999)
+
+            const txs = await provider.getTransactions(REGTEST_ADDRESS);
+            expect(txs).toHaveLength(2);
+            const good = txs.find((t) => t.txid === "tx-good")!;
+            const lag = txs.find((t) => t.txid === "tx-lag")!;
+            expect(good.status).toEqual({
+                confirmed: true,
+                block_time: GENESIS_BLOCK_TIME,
+            });
+            // The lagging entry still surfaces, just without a block_time.
+            expect(lag.status).toEqual({ confirmed: true, block_time: 0 });
+        });
+
         it("rejects malformed addresses with a descriptive error", async () => {
             await expect(
                 provider.getTransactions("not-a-real-address")

--- a/test/electrum.test.ts
+++ b/test/electrum.test.ts
@@ -454,6 +454,36 @@ describe("ElectrumOnchainProvider", () => {
                 /Authentication required/
             );
         });
+
+        it("returns confirmed=true with blockTime=0 when block.header races with index lag (missingheight)", async () => {
+            // electrs sometimes reports a tx as confirmed via get_merkle
+            // before the corresponding block header is indexable. Tolerate
+            // this — confirmation + height are still authoritative; only
+            // block_time degrades to 0 (same fallback historyToExplorerTxs
+            // uses, mirroring the old verbose-tx path's
+            // `blocktime || time || 0`).
+            wsMock.request
+                .mockResolvedValueOnce({ block_height: 200 })
+                .mockRejectedValueOnce(new Error("missingheight"));
+
+            expect(await provider.getTxStatus("abc")).toEqual({
+                confirmed: true,
+                blockHeight: 200,
+                blockTime: 0,
+            });
+        });
+
+        it("propagates non-'missingheight' errors from block.header", async () => {
+            // Same fail-loud principle as get_merkle: only the specific
+            // index-lag wording is tolerated.
+            wsMock.request
+                .mockResolvedValueOnce({ block_height: 200 })
+                .mockRejectedValueOnce(new Error("Network unreachable"));
+
+            await expect(provider.getTxStatus("abc")).rejects.toThrow(
+                /Network unreachable/
+            );
+        });
     });
 
     describe("getTransactions", () => {


### PR DESCRIPTION
## Summary

Adds end-to-end integration tests for \`ElectrumOnchainProvider\` against the nigiri regtest stack. Exercises every method on the \`OnchainProvider\` interface against a real Electrum backend so any divergence from \`EsploraProvider\` (which already has e2e coverage) surfaces side-by-side.

Mirror of \`test/e2e/onchain.test.ts\` plus electrum-specific coverage:

| Method | What is asserted |
|---|---|
| \`getChainTip\` | Header subscription is **reused** across calls (no new server-side subscription on each call) |
| \`getFeeRate\` | Accepts both \`undefined\` (regtest \`-1\`) and a positive sat/vB integer |
| \`getCoins\`, \`getTransactions\`, \`getTxStatus\` | Fund a fresh address via \`nigiri faucet\`, verify all three see it |
| \`broadcastTransaction\` | Alice-to-Bob single-tx roundtrip via \`OnchainWallet.send\` |
| \`getTxOutspends\` | Spent-output detection on a partially-consumed tx |
| \`watchAddresses\` | Funded-tx delivery via the scripthash subscription |
| \`WsElectrumChainSource.fetchHistories\` | Batch round-trip |

## Plumbing

To talk to nigiri's bitcoin Electrum endpoint from a JS client (which can't open raw TCP), this PR uses the \`electrum-ws\` websocat bridge from [vulpemventures/nigiri#258](https://github.com/vulpemventures/nigiri/pull/258), now **merged to nigiri master**. Submodule points at arkade-regtest's plain \`master\`.

## Drive-by fix: dropped verbose-tx dependency for electrs compatibility

The first round of CI on this branch failed because the provider was calling \`blockchain.transaction.get\` with \`verbose=true\`. That endpoint is Fulcrum-only — **electrs explicitly does not support it** (returns \`"verbose transactions are currently unsupported"\`). The nigiri stack uses electrs.

Refactored the three call sites that needed verbose data (\`getTransactions\`, \`getTxStatus\`, \`watchAddresses\`) to use only methods every Electrum server supports:

- Heights come from \`scripthash.get_history\` (which we already had) and \`transaction.get_merkle\` for individual lookups.
- Output values are derived from raw tx hex (parsed via \`@scure/btc-signer\`) — exact bigints, no float rounding. This was previously a footgun in the verbose-tx path's \`Math.round(value * 1e8)\`.
- Block times come from parsed block headers (batched per unique height).

The \`fetchVerboseTransaction(s)\` methods on \`WsElectrumChainSource\` remain public for callers who explicitly target Fulcrum, but the provider no longer depends on them. **Side effect: the SDK now works against electrs-based Electrum servers** (Blockstream, mempool.space, self-hosted electrs) where it previously couldn't.

## Out of scope

The 1P1C \`broadcast_package\` path isn't exercised in regtest because nigiri uses electrs (no \`broadcast_package\` support). Unit-test coverage of that path lives in \`test/electrum.test.ts\`. Once a Fulcrum-based regtest stack is available, the missing cases can be added in a follow-up.

## Test plan

- [x] \`pnpm regtest\` (clean start with the submodule's nigiri pin)
- [x] \`pnpm test:integration\` — all e2e tests pass, including \`test/e2e/electrum.test.ts\`
- [x] \`pnpm test:unit\` clean (1017 tests pass after the verbose-removal refactor)
- [x] \`pnpm lint\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More accurate on-chain confirmation info and raw-transaction-based history for precise amounts and timestamps.
* **Bug Fixes**
  * More reliable address-watch delivery (notifications retried until successfully delivered) and improved error resilience for header lookups and confirmations.
* **Tests**
  * New end-to-end and unit tests covering Electrum provider flows, mempool, history fetching, broadcasting and wallet interactions.
* **Chores**
  * Regtest environment reference updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->