### PR TITLE
fix: ContractWatcher vtxo event + ContractVtxo type

### DIFF
--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -775,7 +775,10 @@ export class ContractManager implements IContractManager {
         }
 
         for (const [addr, contractVtxos] of byContract) {
-            await this.config.walletRepository.saveVtxos(addr, contractVtxos);
+            await this.config.walletRepository.saveVtxos(
+                addr,
+                contractVtxos as ExtendedVirtualCoin[]
+            );
         }
     }
 
@@ -796,7 +799,7 @@ export class ContractManager implements IContractManager {
             if (contract) {
                 await this.config.walletRepository.saveVtxos(
                     contract.address,
-                    vtxos
+                    vtxos as ExtendedVirtualCoin[]
                 );
             }
         }

--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -1,5 +1,6 @@
 import { IndexerProvider, SubscriptionResponse } from "../providers/indexer";
 import { VirtualCoin } from "../wallet";
+import { extendVirtualCoinForContract } from "../wallet/utils";
 import { WalletRepository } from "../repositories/walletRepository";
 import {
     Contract,
@@ -765,18 +766,25 @@ export class ContractWatcher {
         if (!this.eventCallback) return;
         const state = this.contracts.get(contractScript);
         if (!state) return;
+
+        const extended = [];
+        for (const v of vtxos) {
+            try {
+                const extendedVtxo = extendVirtualCoinForContract(
+                    v,
+                    state.contract
+                );
+                extended.push({ ...extendedVtxo, contractScript });
+            } catch {
+                extended.push({ ...v, contractScript });
+            }
+        }
+
         switch (eventType) {
             case "vtxo_received":
                 this.eventCallback({
                     type: "vtxo_received",
-                    vtxos: vtxos.map((v) => ({
-                        ...v,
-                        contractScript,
-                        // These fields may not be available from basic VirtualCoin
-                        forfeitTapLeafScript: undefined as any,
-                        intentTapLeafScript: undefined as any,
-                        tapTree: undefined as any,
-                    })),
+                    vtxos: extended,
                     contractScript,
                     contract: state.contract,
                     timestamp,
@@ -785,14 +793,7 @@ export class ContractWatcher {
             case "vtxo_spent":
                 this.eventCallback({
                     type: "vtxo_spent",
-                    vtxos: vtxos.map((v) => ({
-                        ...v,
-                        contractScript,
-                        // These fields may not be available from basic VirtualCoin
-                        forfeitTapLeafScript: undefined as any,
-                        intentTapLeafScript: undefined as any,
-                        tapTree: undefined as any,
-                    })),
+                    vtxos: extended,
                     contractScript,
                     contract: state.contract,
                     timestamp,

--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -776,6 +776,7 @@ export class ContractWatcher {
                 );
                 extended.push({ ...extendedVtxo, contractScript });
             } catch {
+                console.warn("failed to extend vtxo: ", v);
                 extended.push({ ...v, contractScript });
             }
         }

--- a/src/contracts/types.ts
+++ b/src/contracts/types.ts
@@ -1,6 +1,6 @@
 import { Bytes } from "@scure/btc-signer/utils.js";
-import { TapLeafScript, VtxoScript } from "../script/base";
-import { VirtualCoin, ExtendedVirtualCoin } from "../wallet";
+import { EncodedVtxoScript, TapLeafScript, VtxoScript } from "../script/base";
+import { VirtualCoin, TapLeaves } from "../wallet";
 import { ContractFilter } from "../repositories";
 
 /**
@@ -76,10 +76,11 @@ export interface Contract {
 /**
  * A virtual output that has been associated with a specific contract.
  */
-export interface ContractVtxo extends ExtendedVirtualCoin {
-    /** The contract script this virtual output belongs to. */
-    contractScript: string;
-}
+export type ContractVtxo = VirtualCoin &
+    Partial<TapLeaves & EncodedVtxoScript> & {
+        extraWitness?: Bytes[];
+        contractScript: string;
+    };
 
 /**
  * Result of path selection, including the tapleaf to use and any extra witness data.

--- a/src/wallet/delegator.ts
+++ b/src/wallet/delegator.ts
@@ -16,10 +16,12 @@ import {
     Outpoint,
     Recipient,
     SignedIntent,
+    TapLeafScript,
     Transaction,
     VirtualCoin,
     VtxoScript,
 } from "..";
+import { ContractVtxo } from "../contracts/types";
 import { DelegatorProvider } from "../providers/delegator";
 import { base64, hex } from "@scure/base";
 import { scriptFromTapLeafScript } from "../script/base";
@@ -35,13 +37,17 @@ export interface IDelegatorManager {
     /**
      * Delegate virtual outputs to the remote delegation service.
      *
+     * Vtxos that are not locked to a delegate-type contract (no tap leaf
+     * matches the delegator's pubkey) are filtered out silently, since they
+     * cannot be co-signed by the delegator.
+     *
      * @param vtxos - Virtual outputs to delegate
      * @param destination - Arkade address that should receive renewed funds
      * @param delegateAt - Optional timestamp to force a specific delegation time
      * @returns Successfully delegated and failed outpoint groups
      */
     delegate(
-        vtxos: ExtendedVirtualCoin[],
+        vtxos: ContractVtxo[],
         destination: string,
         delegateAt?: Date
     ): Promise<{
@@ -66,7 +72,7 @@ export class DelegatorManagerImpl implements IDelegatorManager {
     }
 
     async delegate(
-        vtxos: ExtendedVirtualCoin[],
+        vtxos: ContractVtxo[],
         destination: string,
         delegateAt?: Date
     ): Promise<{
@@ -83,6 +89,16 @@ export class DelegatorManagerImpl implements IDelegatorManager {
         const arkInfo = await this.arkInfoProvider.getInfo();
         const delegateInfo = await this.delegatorProvider.getDelegateInfo();
 
+        // keep only vtxos that can be signed by the delegate
+        const eligible: ExtendedVirtualCoin[] = vtxos
+            .filter(
+                (v) => findDelegateTapLeaf(v, delegateInfo.pubkey) !== undefined
+            )
+            .map((v) => v as ExtendedVirtualCoin);
+        if (eligible.length === 0) {
+            return { delegated: [], failed: [] };
+        }
+
         // if explicit delegateAt is provided, delegate all virtual outputs at once without sorting
         if (delegateAt) {
             try {
@@ -91,21 +107,24 @@ export class DelegatorManagerImpl implements IDelegatorManager {
                     this.delegatorProvider,
                     arkInfo,
                     delegateInfo,
-                    vtxos,
+                    eligible,
                     destinationScript,
                     delegateAt
                 );
             } catch (error) {
-                return { delegated: [], failed: [{ outpoints: vtxos, error }] };
+                return {
+                    delegated: [],
+                    failed: [{ outpoints: eligible, error }],
+                };
             }
-            return { delegated: vtxos, failed: [] };
+            return { delegated: eligible, failed: [] };
         }
 
         // if no explicit delegateAt is provided, sort virtual outputs by expiry and delegate in groups of the same expiry day
         const groupByExpiry: Map<number, ExtendedVirtualCoin[]> = new Map();
         let recoverableVtxos: ExtendedVirtualCoin[] = [];
 
-        for (const vtxo of vtxos) {
+        for (const vtxo of eligible) {
             if (isRecoverable(vtxo)) {
                 recoverableVtxos.push(vtxo);
                 continue;
@@ -340,23 +359,7 @@ async function makeDelegateForfeitTx(
     forfeitOutputScript: Bytes,
     identity: Identity
 ): Promise<Transaction> {
-    if (delegatePubkey.length === 66) {
-        delegatePubkey = delegatePubkey.slice(2);
-    }
-
-    const vtxoScript = VtxoScript.decode(input.tapTree);
-    const delegateTapLeaf = vtxoScript.leaves.find((tapLeaf) => {
-        const arkTapscript = decodeTapscript(scriptFromTapLeafScript(tapLeaf));
-        if (!MultisigTapscript.is(arkTapscript)) return false;
-        if (
-            !arkTapscript.params.pubkeys
-                .map(hex.encode)
-                .includes(delegatePubkey)
-        )
-            return false;
-        return true;
-    });
-
+    const delegateTapLeaf = findDelegateTapLeaf(input, delegatePubkey);
     if (!delegateTapLeaf) {
         throw new Error(
             `delegate tap leaf not found for input: ${input.txid}:${input.vout}`
@@ -480,4 +483,19 @@ function getDayTimestamp(timestamp: number): number {
     const date = new Date(timestamp);
     date.setUTCHours(0, 0, 0, 0);
     return date.getTime();
+}
+
+function findDelegateTapLeaf(
+    vtxo: { tapTree?: Bytes },
+    delegatePubkey: string
+): TapLeafScript | undefined {
+    if (!vtxo.tapTree) return undefined;
+    const pk =
+        delegatePubkey.length === 66 ? delegatePubkey.slice(2) : delegatePubkey;
+    const vtxoScript = VtxoScript.decode(vtxo.tapTree);
+    return vtxoScript.leaves.find((tapLeaf) => {
+        const arkTapscript = decodeTapscript(scriptFromTapLeafScript(tapLeaf));
+        if (!MultisigTapscript.is(arkTapscript)) return false;
+        return arkTapscript.params.pubkeys.map(hex.encode).includes(pk);
+    });
 }

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1336,9 +1336,9 @@ export class WalletMessageHandler
         const outpointSet = new Set(
             vtxoOutpoints.map((o) => `${o.txid}:${o.vout}`)
         );
-        const filtered = allVtxos.filter((v) =>
-            outpointSet.has(`${v.txid}:${v.vout}`)
-        );
+        const filtered = allVtxos
+            .filter((v) => outpointSet.has(`${v.txid}:${v.vout}`))
+            .map((v) => ({ ...v, contractScript: v.script }));
 
         const result = await delegatorManager.delegate(
             filtered,

--- a/src/wallet/vtxo-manager.ts
+++ b/src/wallet/vtxo-manager.ts
@@ -1104,13 +1104,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                         console.error("Error renewing VTXOs:", e);
                     });
                 }
-                // delegate only for "delegate" contract
-                if (delegatorManager && event.contract.type === "delegate") {
+
+                if (delegatorManager) {
                     delegatorManager
-                        .delegate(
-                            event.vtxos as ExtendedVirtualCoin[],
-                            destination
-                        )
+                        .delegate(event.vtxos, destination)
                         .catch((e) => {
                             console.error("Error delegating VTXOs:", e);
                         });

--- a/src/wallet/vtxo-manager.ts
+++ b/src/wallet/vtxo-manager.ts
@@ -1104,11 +1104,17 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                         console.error("Error renewing VTXOs:", e);
                     });
                 }
-                delegatorManager
-                    ?.delegate(event.vtxos, destination)
-                    .catch((e) => {
-                        console.error("Error delegating VTXOs:", e);
-                    });
+                // delegate only for "delegate" contract
+                if (delegatorManager && event.contract.type === "delegate") {
+                    delegatorManager
+                        .delegate(
+                            event.vtxos as ExtendedVirtualCoin[],
+                            destination
+                        )
+                        .catch((e) => {
+                            console.error("Error delegating VTXOs:", e);
+                        });
+                }
             });
 
             return stopWatching;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -517,7 +517,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const vtxos = await contractManager.getContractsWithVtxos();
 
         return vtxos
-            .flatMap((_) => _.vtxos)
+            .flatMap((_) => _.vtxos as ExtendedVirtualCoin[])
             .filter((vtxo) => {
                 if (
                     this._pendingSpendOutpoints.has(`${vtxo.txid}:${vtxo.vout}`)


### PR DESCRIPTION
* set taproot fields before emitting vtxo events using the existing `extendVirtualCoinForContract` func
* fix the ContractVtxo type to make the fields optional

@pietro909 @altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contract events now emit richer, consistently enriched VTXO data with safer fallbacks and better logging when enrichment fails.
  * Delegation now excludes ineligible VTXOs (no matching delegate tap) and returns empty results when none qualify; delegation is only attempted when the delegator is available.
* **Refactor**
  * Internal VTXO/contract handling streamlined for more consistent downstream behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->