### PR TITLE
fix: accept Expo SDK 55 unified versions in peer ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,9 +144,9 @@
     "peerDependencies": {
         "@react-native-async-storage/async-storage": ">=1.0.0",
         "expo": ">=54.0.0",
-        "expo-background-task": "~1.0.10",
-        "expo-sqlite": "~16.0.10",
-        "expo-task-manager": "~14.0.9"
+        "expo-background-task": "~1.0.10 || >=55.0.0",
+        "expo-sqlite": "~16.0.10 || >=55.0.0",
+        "expo-task-manager": "~14.0.9 || >=55.0.0"
     },
     "peerDependenciesMeta": {
         "expo": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,13 +44,13 @@ importers:
         specifier: '>=54.0.0'
         version: 54.0.33(@babel/core@7.29.0)(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4)
       expo-background-task:
-        specifier: ~1.0.10
+        specifier: ~1.0.10 || >=55.0.0
         version: 1.0.10(expo@54.0.33(@babel/core@7.29.0)(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))
       expo-sqlite:
-        specifier: ~16.0.10
+        specifier: ~16.0.10 || >=55.0.0
         version: 16.0.10(expo@54.0.33(@babel/core@7.29.0)(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4)
       expo-task-manager:
-        specifier: ~14.0.9
+        specifier: ~14.0.9 || >=55.0.0
         version: 14.0.9(expo@54.0.33(@babel/core@7.29.0)(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(react@19.2.4))
       ws-electrumx-client:
         specifier: 1.0.5
@@ -1380,6 +1380,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}


### PR DESCRIPTION
## Summary

Expo SDK 55 ships `expo-sqlite`, `expo-background-task`, and `expo-task-manager` under unified majors (`55.0.x`), so consumers on SDK 55 hit unmet-peer warnings against our `~16.0.10` / `~1.0.10` / `~14.0.9` ranges.

Widen each range to `<legacy> || >=55.0.0` so both SDK 54 (current lockfile) and SDK 55+ consumers satisfy the peer. These peers are already declared `optional`, so consumers without Expo are unaffected. Required APIs (`openDatabaseSync`, `defineTask`, `BackgroundTaskResult`, …) are unchanged in `55.0.x`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated peer dependency requirements for expo-background-task, expo-sqlite, and expo-task-manager to support Expo versions 55.0.0 and later while maintaining backward compatibility with previous versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->