### PR TITLE
chore: fix tsconfig errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
     "compilerOptions": {
         "target": "es2020",
-        "lib": ["es2022", "dom", "dom.iterable"],
+        "lib": ["esnext","es2022","dom","dom.iterable"],
         "module": "esnext",
         "moduleResolution": "node",
+        "ignoreDeprecations": "6.0",
         "strict": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
@@ -11,6 +12,7 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "declaration": true,
+        "rootDir": "./",
         "declarationDir": "./dist/types",
         "outDir": "./dist/esm"
     },


### PR DESCRIPTION
- adds `esnext` as lib (needed for `disponse` + `asyncDispose`)
- adds `ignoreDeprecations: 6.0` (necessary to keep moduleResolution: node)
- adds `rootDir: ./` (needed for `declarationDir` and `outDir` to work outside of `./src`)