### PR TITLE
fix: represent asset amounts as `bigint`

### DIFF
--- a/src/providers/expoIndexer.ts
+++ b/src/providers/expoIndexer.ts
@@ -2,6 +2,7 @@ import { RestIndexerProvider, SubscriptionResponse, Vtxo } from "./indexer";
 import { isFetchTimeoutError } from "./ark";
 import { VirtualCoin } from "../wallet";
 import { getExpoFetch, sseStreamIterator } from "./expoUtils";
+import { toSafeNumber } from "../utils/safeNumber";
 
 // Helper function to convert Vtxo to VirtualCoin (same as in indexer.ts)
 function convertVtxo(vtxo: Vtxo): VirtualCoin {
@@ -33,7 +34,8 @@ function convertVtxo(vtxo: Vtxo): VirtualCoin {
         script: vtxo.script,
         assets: vtxo.assets?.map((a) => ({
             assetId: a.assetId,
-            amount: Number(a.amount),
+            amount: toSafeNumber(a.amount),
+            assetAmount: BigInt(a.amount),
         })),
     };
 }

--- a/src/providers/indexer.ts
+++ b/src/providers/indexer.ts
@@ -3,6 +3,7 @@ import { AssetDetails, AssetMetadata, Outpoint, VirtualCoin } from "../wallet";
 import { isFetchTimeoutError } from "./ark";
 import { eventSourceIterator, isEventSourceError } from "./utils";
 import { MetadataList } from "../extension/asset";
+import { toSafeNumber } from "../utils/safeNumber";
 
 export type PaginationOptions = {
     pageIndex?: number;
@@ -721,7 +722,8 @@ export class RestIndexerProvider implements IndexerProvider {
             : undefined;
         return {
             assetId: data.assetId ?? assetId,
-            supply: Number(data.supply ?? 0),
+            supply: toSafeNumber(data.supply ?? 0),
+            assetSupply: BigInt(data.supply ?? 0),
             metadata,
             controlAssetId: data.controlAsset || undefined,
         };
@@ -827,7 +829,8 @@ function convertVtxo(vtxo: Vtxo): VirtualCoin {
         script: vtxo.script,
         assets: vtxo.assets?.map((a) => ({
             assetId: a.assetId,
-            amount: Number(a.amount),
+            amount: toSafeNumber(a.amount),
+            assetAmount: BigInt(a.amount),
         })),
     };
 }

--- a/src/utils/safeNumber.ts
+++ b/src/utils/safeNumber.ts
@@ -1,0 +1,11 @@
+/** Used for parsing asset amounts */
+export const toSafeNumber = (value: string | bigint | number): number => {
+    const num = Number(value);
+
+    if (!Number.isFinite(num)) return Number.MAX_SAFE_INTEGER;
+
+    if (num > Number.MAX_SAFE_INTEGER) return Number.MAX_SAFE_INTEGER;
+    if (num < Number.MIN_SAFE_INTEGER) return Number.MIN_SAFE_INTEGER;
+
+    return num;
+};

--- a/src/utils/transactionHistory.ts
+++ b/src/utils/transactionHistory.ts
@@ -1,4 +1,5 @@
 import { ArkTransaction, Asset, TxKey, TxType, VirtualCoin } from "../wallet";
+import { toSafeNumber } from "./safeNumber";
 
 type ExtendedArkTransaction = ArkTransaction & {
     tag: "offchain" | "boarding" | "exit" | "batch";
@@ -10,36 +11,40 @@ const txKey: TxKey = {
 };
 
 function collectAssets(vtxos: VirtualCoin[]): Asset[] | undefined {
-    const map = new Map<string, number>();
+    const map = new Map<string, bigint>();
     for (const vtxo of vtxos) {
         if (vtxo.assets) {
             for (const a of vtxo.assets) {
-                map.set(a.assetId, (map.get(a.assetId) ?? 0) + a.amount);
+                map.set(a.assetId, (map.get(a.assetId) ?? 0n) + a.assetAmount);
             }
         }
     }
     if (map.size === 0) return undefined;
-    return Array.from(map, ([assetId, amount]) => ({ assetId, amount }));
+    return Array.from(map, ([assetId, assetAmount]) => ({
+        assetId,
+        amount: toSafeNumber(assetAmount),
+        assetAmount,
+    }));
 }
 
 function subtractAssets(
     spent: VirtualCoin[],
     change: VirtualCoin[]
 ): Asset[] | undefined {
-    const map = new Map<string, number>();
+    const map = new Map<string, bigint>();
     for (const vtxo of change) {
         if (vtxo.assets) {
             for (const a of vtxo.assets) {
-                map.set(a.assetId, (map.get(a.assetId) ?? 0) + a.amount);
+                map.set(a.assetId, (map.get(a.assetId) ?? 0n) + a.assetAmount);
             }
         }
     }
     for (const vtxo of spent) {
         if (vtxo.assets) {
             for (const a of vtxo.assets) {
-                const current = map.get(a.assetId) ?? 0;
-                const remaining = current - a.amount;
-                if (remaining !== 0) {
+                const current = map.get(a.assetId) ?? 0n;
+                const remaining = current - a.assetAmount;
+                if (remaining !== 0n) {
                     map.set(a.assetId, remaining);
                 } else {
                     map.delete(a.assetId);
@@ -48,7 +53,11 @@ function subtractAssets(
         }
     }
     if (map.size === 0) return undefined;
-    return Array.from(map, ([assetId, amount]) => ({ assetId, amount }));
+    return Array.from(map, ([assetId, assetAmount]) => ({
+        assetId,
+        amount: toSafeNumber(assetAmount),
+        assetAmount,
+    }));
 }
 
 /**

--- a/src/wallet/delegator.ts
+++ b/src/wallet/delegator.ts
@@ -32,6 +32,7 @@ import { equalBytes } from "@scure/btc-signer/utils.js";
 import { getNetwork, NetworkName } from "../networks";
 import { createAssetPacket } from "./asset";
 import { Extension } from "../extension";
+import { toSafeNumber } from "../utils/safeNumber";
 
 export interface IDelegatorManager {
     /**
@@ -428,13 +429,17 @@ async function makeSignedDelegateIntent(
         for (const [, assets] of assetInputs) {
             for (const asset of assets) {
                 const existing = allAssets.get(asset.assetId) ?? 0n;
-                allAssets.set(asset.assetId, existing + BigInt(asset.amount));
+                allAssets.set(asset.assetId, existing + asset.assetAmount);
             }
         }
 
         outputAssets = [];
-        for (const [assetId, amount] of allAssets) {
-            outputAssets.push({ assetId, amount: Number(amount) });
+        for (const [assetId, assetAmount] of allAssets) {
+            outputAssets.push({
+                assetId,
+                amount: toSafeNumber(assetAmount),
+                assetAmount,
+            });
         }
     }
 

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -272,8 +272,15 @@ export interface Asset {
     /** Asset identifier. */
     assetId: string;
 
-    /** Asset amount in base units. */
+    /**
+     * Asset amount in base units.
+     * @deprecated (unsuitable for large values)
+     * @see Asset.assetAmount
+     */
     amount: number;
+
+    /** Asset amount in base units. */
+    assetAmount: bigint;
 }
 
 /**
@@ -334,8 +341,15 @@ export type AssetDetails = {
     /** Asset identifier. */
     assetId: string;
 
-    /** Total issued supply in base units. */
+    /**
+     * Total issued supply in base units.
+     * @deprecated (unsuitable for large values)
+     * @see AssetDetails.assetSupply
+     */
     supply: number;
+
+    /** Total issued supply in base units. */
+    assetSupply: bigint;
 
     /** Optional immutable metadata associated with the asset. */
     metadata?: AssetMetadata;

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -44,6 +44,7 @@ import {
 } from "../../worker/messageBus";
 import { Transaction } from "../../utils/transaction";
 import { buildTransactionHistory } from "../../utils/transactionHistory";
+import { toSafeNumber } from "../../utils/safeNumber";
 
 export class WalletNotInitializedError extends Error {
     constructor() {
@@ -1091,17 +1092,21 @@ export class WalletMessageHandler
         const totalOffchain = settled + preconfirmed + recoverable;
 
         // aggregate asset balances from spendable virtual outputs
-        const assetBalances = new Map<string, number>();
+        const assetBalances = new Map<string, bigint>();
         for (const vtxo of spendableVtxos) {
             if (vtxo.assets) {
                 for (const a of vtxo.assets) {
-                    const current = assetBalances.get(a.assetId) ?? 0;
-                    assetBalances.set(a.assetId, current + a.amount);
+                    const current = assetBalances.get(a.assetId) ?? 0n;
+                    assetBalances.set(a.assetId, current + a.assetAmount);
                 }
             }
         }
         const assets = Array.from(assetBalances.entries()).map(
-            ([assetId, amount]) => ({ assetId, amount })
+            ([assetId, assetAmount]) => ({
+                assetId,
+                amount: toSafeNumber(assetAmount),
+                assetAmount,
+            })
         );
 
         return {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -100,6 +100,7 @@ import { ContractManager } from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
 import { timelockToSequence } from "../contracts/handlers/helpers";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
+import { toSafeNumber } from "../utils/safeNumber";
 
 // Historical unilateral exit delay for mainnet (~7 days in seconds).
 // Kept so existing wallets can still discover and spend VTXOs sent to the
@@ -474,20 +475,21 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const totalOffchain = settled + preconfirmed + recoverable;
 
         // aggregate asset balances from spendable virtual outputs
-        const assetBalances = new Map<string, number>();
+        const assetBalances = new Map<string, bigint>();
         for (const vtxo of vtxos) {
             if (!isSpendable(vtxo)) continue;
             if (vtxo.assets) {
                 for (const a of vtxo.assets) {
-                    const current = assetBalances.get(a.assetId) ?? 0;
-                    assetBalances.set(a.assetId, current + a.amount);
+                    const current = assetBalances.get(a.assetId) ?? 0n;
+                    assetBalances.set(a.assetId, current + a.assetAmount);
                 }
             }
         }
         const assets = Array.from(assetBalances.entries()).map(
-            ([assetId, amount]) => ({
+            ([assetId, assetAmount]) => ({
                 assetId,
-                amount,
+                amount: toSafeNumber(assetAmount),
+                assetAmount,
             })
         );
 
@@ -1577,8 +1579,12 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             }
 
             outputAssets = [];
-            for (const [assetId, amount] of allAssets) {
-                outputAssets.push({ assetId, amount: Number(amount) });
+            for (const [assetId, assetAmount] of allAssets) {
+                outputAssets.push({
+                    assetId,
+                    amount: toSafeNumber(assetAmount),
+                    assetAmount,
+                });
             }
         }
 
@@ -2405,9 +2411,13 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         let changeIndex = 0;
         if (changeAmount > 0) {
             const changeAssets: Asset[] = [];
-            for (const [assetId, amount] of assetChanges) {
-                if (amount > 0n) {
-                    changeAssets.push({ assetId, amount: Number(amount) });
+            for (const [assetId, assetAmount] of assetChanges) {
+                if (assetAmount > 0n) {
+                    changeAssets.push({
+                        assetId,
+                        amount: toSafeNumber(assetAmount),
+                        assetAmount,
+                    });
                 }
             }
 

--- a/test/transactionHistory.test.ts
+++ b/test/transactionHistory.test.ts
@@ -230,7 +230,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: baseDate,
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 50 }],
+                assets: [{ assetId: assetA, amount: 50, assetAmount: 50n }],
             };
 
             const txs = await buildTransactionHistory([vtxo], [], new Set());
@@ -238,7 +238,7 @@ describe("buildTransactionHistory", () => {
             expect(txs).toHaveLength(1);
             expect(txs[0].type).toBe(TxType.TxReceived);
             expect(txs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: 50 },
+                { assetId: assetA, amount: 50, assetAmount: 50n },
             ]);
         });
 
@@ -257,8 +257,8 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: false,
                 assets: [
-                    { assetId: assetA, amount: 10 },
-                    { assetId: assetB, amount: 20 },
+                    { assetId: assetA, amount: 10, assetAmount: 10n },
+                    { assetId: assetB, amount: 20, assetAmount: 20n },
                 ],
             };
 
@@ -268,8 +268,8 @@ describe("buildTransactionHistory", () => {
             expect(txs[0].type).toBe(TxType.TxReceived);
             expect(txs[0].tag).toBe("batch");
             expect(txs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: 10 },
-                { assetId: assetB, amount: 20 },
+                { assetId: assetA, amount: 10, assetAmount: 10n },
+                { assetId: assetB, amount: 20, assetAmount: 20n },
             ]);
         });
 
@@ -304,7 +304,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 100 }],
+                assets: [{ assetId: assetA, amount: 100, assetAmount: 100n }],
             };
 
             const changeVtxo: VirtualCoin = {
@@ -316,7 +316,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 30 }],
+                assets: [{ assetId: assetA, amount: 30, assetAmount: 30n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -329,7 +329,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(600);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -70 },
+                { assetId: assetA, amount: -70, assetAmount: -70n },
             ]);
         });
 
@@ -346,7 +346,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 50 }],
+                assets: [{ assetId: assetA, amount: 50, assetAmount: 50n }],
             };
 
             const changeVtxo: VirtualCoin = {
@@ -358,7 +358,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 50 }],
+                assets: [{ assetId: assetA, amount: 50, assetAmount: 50n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -387,8 +387,8 @@ describe("buildTransactionHistory", () => {
                 isSpent: true,
                 arkTxId,
                 assets: [
-                    { assetId: assetA, amount: 40 },
-                    { assetId: assetB, amount: 60 },
+                    { assetId: assetA, amount: 40, assetAmount: 40n },
+                    { assetId: assetB, amount: 60, assetAmount: 60n },
                 ],
             };
 
@@ -402,8 +402,8 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(1000);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -40 },
-                { assetId: assetB, amount: -60 },
+                { assetId: assetA, amount: -40, assetAmount: -40n },
+                { assetId: assetB, amount: -60, assetAmount: -60n },
             ]);
         });
 
@@ -420,7 +420,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 settledBy: commitmentTxId,
-                assets: [{ assetId: assetA, amount: 80 }],
+                assets: [{ assetId: assetA, amount: 80, assetAmount: 80n }],
             };
 
             const changeVtxo: VirtualCoin = {
@@ -435,7 +435,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 20 }],
+                assets: [{ assetId: assetA, amount: 20, assetAmount: 20n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -449,7 +449,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs[0].tag).toBe("exit");
             expect(sentTxs[0].amount).toBe(1500);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -60 },
+                { assetId: assetA, amount: -60, assetAmount: -60n },
             ]);
         });
 
@@ -466,7 +466,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 settledBy: commitmentTxId,
-                assets: [{ assetId: assetB, amount: 75 }],
+                assets: [{ assetId: assetB, amount: 75, assetAmount: 75n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -480,7 +480,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs[0].tag).toBe("exit");
             expect(sentTxs[0].amount).toBe(1000);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetB, amount: -75 },
+                { assetId: assetB, amount: -75, assetAmount: -75n },
             ]);
         });
 
@@ -508,7 +508,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 100 }],
+                assets: [{ assetId: assetA, amount: 100, assetAmount: 100n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -521,7 +521,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(0);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: 100 },
+                { assetId: assetA, amount: 100, assetAmount: 100n },
             ]);
         });
 
@@ -538,7 +538,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 50 }],
+                assets: [{ assetId: assetA, amount: 50, assetAmount: 50n }],
             };
 
             const changeVtxo: VirtualCoin = {
@@ -550,7 +550,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 150 }],
+                assets: [{ assetId: assetA, amount: 150, assetAmount: 150n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -563,7 +563,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(0);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: 100 },
+                { assetId: assetA, amount: 100, assetAmount: 100n },
             ]);
         });
 
@@ -581,7 +581,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 100 }],
+                assets: [{ assetId: assetA, amount: 100, assetAmount: 100n }],
             };
 
             // Change VTXO has all BTC back but no assets (fully burned)
@@ -607,7 +607,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs[0].amount).toBe(0);
             // Negative = assets lost/burned
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -100 },
+                { assetId: assetA, amount: -100, assetAmount: -100n },
             ]);
         });
 
@@ -627,8 +627,8 @@ describe("buildTransactionHistory", () => {
                 isSpent: true,
                 arkTxId,
                 assets: [
-                    { assetId: assetA, amount: 50 }, // will be fully burned
-                    { assetId: assetB, amount: 80 }, // 30 will be transferred
+                    { assetId: assetA, amount: 50, assetAmount: 50n }, // will be fully burned
+                    { assetId: assetB, amount: 80, assetAmount: 80n }, // 30 will be transferred
                 ],
             };
 
@@ -643,8 +643,8 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: false,
                 assets: [
-                    { assetId: assetB, amount: 50 }, // kept 50 of 80
-                    { assetId: assetC, amount: 200 }, // newly issued
+                    { assetId: assetB, amount: 50, assetAmount: 50n }, // kept 50 of 80
+                    { assetId: assetC, amount: 200, assetAmount: 200n }, // newly issued
                 ],
             };
 
@@ -658,9 +658,9 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(500);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetB, amount: -30 }, // transferred/lost
-                { assetId: assetC, amount: 200 }, // issued/gained
-                { assetId: assetA, amount: -50 }, // burned/lost
+                { assetId: assetB, amount: -30, assetAmount: -30n }, // transferred/lost
+                { assetId: assetC, amount: 200, assetAmount: 200n }, // issued/gained
+                { assetId: assetA, amount: -50, assetAmount: -50n }, // burned/lost
             ]);
         });
 
@@ -677,7 +677,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 30 }],
+                assets: [{ assetId: assetA, amount: 30, assetAmount: 30n }],
             };
 
             const spentVtxo2: VirtualCoin = {
@@ -691,8 +691,8 @@ describe("buildTransactionHistory", () => {
                 isSpent: true,
                 arkTxId,
                 assets: [
-                    { assetId: assetA, amount: 20 },
-                    { assetId: assetB, amount: 10 },
+                    { assetId: assetA, amount: 20, assetAmount: 20n },
+                    { assetId: assetB, amount: 10, assetAmount: 10n },
                 ],
             };
 
@@ -706,8 +706,8 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(1000);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -50 },
-                { assetId: assetB, amount: -10 },
+                { assetId: assetA, amount: -50, assetAmount: -50n },
+                { assetId: assetB, amount: -10, assetAmount: -10n },
             ]);
         });
     });


### PR DESCRIPTION
Closes https://github.com/arkade-os/ts-sdk/issues/384

- creates `toSafeNumber` util for converting strings/bigints to in-range `Number`
- add `assetAmount` to `Asset` type as `bigint`, marking `amount` as deprecated
- add `assetSupply` to `AssetDetails` type as `bigint`, marking `supply` as deprecated
- does _**not**_ change `VtxoAsset.amount` as it is already `string`
- ensure functions that relied on these use `assetAmount` or `assetSupply` as source of truth, while returning the base `amount`/`supply` for backwards compatibility
- updates relevant `transactionHistory` tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `assetAmount` (bigint) and `assetSupply` (bigint) fields for more precise asset quantity handling with support for large values.

* **Deprecations**
  * Marked `amount` and `supply` number fields as deprecated; use `assetAmount` and `assetSupply` respectively for accurate large-value representation.

* **Bug Fixes**
  * Improved numeric handling to prevent loss of precision when dealing with large asset quantities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->