### PR TITLE
fix!: represent asset amounts as bigint (alt to #469)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,6 @@ import {
     isSubdust,
     isRecoverable,
     isExpired,
-    sumAssetAmounts,
     // Asset types
     Asset,
     Recipient,
@@ -404,7 +403,6 @@ export {
     isSubdust,
     isExpired,
     getSequence,
-    sumAssetAmounts,
 
     // Contracts
     ContractManager,

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import {
     isSubdust,
     isRecoverable,
     isExpired,
+    sumAssetAmounts,
     // Asset types
     Asset,
     Recipient,
@@ -403,6 +404,7 @@ export {
     isSubdust,
     isExpired,
     getSequence,
+    sumAssetAmounts,
 
     // Contracts
     ContractManager,

--- a/src/providers/expoIndexer.ts
+++ b/src/providers/expoIndexer.ts
@@ -33,7 +33,7 @@ function convertVtxo(vtxo: Vtxo): VirtualCoin {
         script: vtxo.script,
         assets: vtxo.assets?.map((a) => ({
             assetId: a.assetId,
-            amount: Number(a.amount),
+            amount: BigInt(a.amount),
         })),
     };
 }

--- a/src/providers/indexer.ts
+++ b/src/providers/indexer.ts
@@ -721,7 +721,7 @@ export class RestIndexerProvider implements IndexerProvider {
             : undefined;
         return {
             assetId: data.assetId ?? assetId,
-            supply: Number(data.supply ?? 0),
+            supply: BigInt(data.supply ?? 0),
             metadata,
             controlAssetId: data.controlAsset || undefined,
         };
@@ -827,7 +827,7 @@ function convertVtxo(vtxo: Vtxo): VirtualCoin {
         script: vtxo.script,
         assets: vtxo.assets?.map((a) => ({
             assetId: a.assetId,
-            amount: Number(a.amount),
+            amount: BigInt(a.amount),
         })),
     };
 }

--- a/src/repositories/migrations/walletRepositoryImpl.ts
+++ b/src/repositories/migrations/walletRepositoryImpl.ts
@@ -8,6 +8,12 @@ import {
     ExtendedVirtualCoin,
 } from "../../wallet";
 import { TapLeafScript } from "../../script/base";
+import {
+    serializeAssets,
+    deserializeAssets,
+    serializeTransaction,
+    deserializeTransaction,
+} from "../serialization";
 
 const getVtxosStorageKey = (address: string) => `vtxos:${address}`;
 const getUtxosStorageKey = (address: string) => `utxos:${address}`;
@@ -21,6 +27,7 @@ const serializeVtxo = (v: ExtendedVirtualCoin) => ({
     forfeitTapLeafScript: serializeTapLeaf(v.forfeitTapLeafScript),
     intentTapLeafScript: serializeTapLeaf(v.intentTapLeafScript),
     extraWitness: v.extraWitness?.map(hex.encode),
+    assets: serializeAssets(v.assets),
 });
 
 const serializeUtxo = (u: ExtendedCoin) => ({
@@ -38,6 +45,7 @@ const deserializeVtxo = (o: any): ExtendedVirtualCoin => ({
     forfeitTapLeafScript: deserializeTapLeaf(o.forfeitTapLeafScript),
     intentTapLeafScript: deserializeTapLeaf(o.intentTapLeafScript),
     extraWitness: o.extraWitness?.map(hex.decode),
+    assets: deserializeAssets(o.assets),
 });
 
 const deserializeUtxo = (o: any): ExtendedCoin => ({
@@ -164,7 +172,10 @@ export class WalletRepositoryImpl implements WalletRepository {
         if (!stored) return [];
 
         try {
-            return JSON.parse(stored) as ArkTransaction[];
+            const parsed = JSON.parse(stored) as Array<
+                ReturnType<typeof serializeTransaction>
+            >;
+            return parsed.map(deserializeTransaction);
         } catch (error) {
             console.error(
                 `Failed to parse transactions for address ${address}:`,
@@ -194,7 +205,7 @@ export class WalletRepositoryImpl implements WalletRepository {
         }
         await this.storage.setItem(
             getTransactionsStorageKey(address),
-            JSON.stringify(storedTransactions)
+            JSON.stringify(storedTransactions.map(serializeTransaction))
         );
     }
 

--- a/src/repositories/realm/walletRepository.ts
+++ b/src/repositories/realm/walletRepository.ts
@@ -9,6 +9,8 @@ import {
     serializeUtxo,
     deserializeVtxo,
     deserializeUtxo,
+    serializeAssets,
+    deserializeAssets,
     SerializedTapLeaf,
 } from "../serialization";
 import { scriptFromArkAddress } from "../scriptFromAddress";
@@ -197,7 +199,7 @@ export class RealmWalletRepository implements WalletRepository {
                         settled: tx.settled,
                         createdAt: tx.createdAt,
                         assetsJson: tx.assets
-                            ? JSON.stringify(tx.assets)
+                            ? JSON.stringify(serializeAssets(tx.assets))
                             : null,
                     },
                     "modified"
@@ -335,7 +337,7 @@ function txObjectToDomain(obj: any): ArkTransaction {
         createdAt: obj.createdAt,
     };
     if (obj.assetsJson) {
-        tx.assets = JSON.parse(obj.assetsJson);
+        tx.assets = deserializeAssets(JSON.parse(obj.assetsJson));
     }
     return tx;
 }

--- a/src/repositories/serialization.ts
+++ b/src/repositories/serialization.ts
@@ -1,11 +1,23 @@
 import { hex } from "@scure/base";
 import { TaprootControlBlock } from "@scure/btc-signer";
 import { TapLeafScript } from "../script/base";
-import { ExtendedCoin, ExtendedVirtualCoin } from "../wallet";
+import {
+    ArkTransaction,
+    Asset,
+    ExtendedCoin,
+    ExtendedVirtualCoin,
+} from "../wallet";
 
 export type SerializedTapLeaf = { cb: string; s: string };
 export type SerializedVtxo = ReturnType<typeof serializeVtxo>;
 export type SerializedUtxo = ReturnType<typeof serializeUtxo>;
+export type SerializedTransaction = ReturnType<typeof serializeTransaction>;
+
+// `Asset.amount` is a `bigint`, which `JSON.stringify` cannot serialize
+// (`TypeError: Do not know how to serialize a BigInt`). Persist it as a
+// decimal string so SQLite/Realm/legacy localStorage paths round-trip
+// correctly across process restarts.
+export type SerializedAsset = { assetId: string; amount: string };
 
 export const serializeTapLeaf = ([
     cb,
@@ -15,12 +27,38 @@ export const serializeTapLeaf = ([
     s: hex.encode(s),
 });
 
+export const serializeAsset = (a: Asset): SerializedAsset => ({
+    assetId: a.assetId,
+    amount: a.amount.toString(),
+});
+
+// Accept legacy persisted shapes where `amount` is a `number` — pre-bigint
+// data already on disk must keep round-tripping.
+export const deserializeAsset = (a: {
+    assetId: string;
+    amount: string | number | bigint;
+}): Asset => ({
+    assetId: a.assetId,
+    amount: typeof a.amount === "bigint" ? a.amount : BigInt(a.amount),
+});
+
+export const serializeAssets = (
+    assets: Asset[] | undefined
+): SerializedAsset[] | undefined => assets?.map(serializeAsset);
+
+export const deserializeAssets = (
+    assets:
+        | Array<{ assetId: string; amount: string | number | bigint }>
+        | undefined
+): Asset[] | undefined => assets?.map(deserializeAsset);
+
 export const serializeVtxo = (v: ExtendedVirtualCoin) => ({
     ...v,
     tapTree: hex.encode(v.tapTree),
     forfeitTapLeafScript: serializeTapLeaf(v.forfeitTapLeafScript),
     intentTapLeafScript: serializeTapLeaf(v.intentTapLeafScript),
     extraWitness: v.extraWitness?.map(hex.encode),
+    assets: serializeAssets(v.assets),
 });
 
 export const serializeUtxo = (u: ExtendedCoin) => ({
@@ -29,6 +67,11 @@ export const serializeUtxo = (u: ExtendedCoin) => ({
     forfeitTapLeafScript: serializeTapLeaf(u.forfeitTapLeafScript),
     intentTapLeafScript: serializeTapLeaf(u.intentTapLeafScript),
     extraWitness: u.extraWitness?.map(hex.encode),
+});
+
+export const serializeTransaction = (t: ArkTransaction) => ({
+    ...t,
+    assets: serializeAssets(t.assets),
 });
 
 export const deserializeTapLeaf = (t: SerializedTapLeaf): TapLeafScript => {
@@ -44,6 +87,7 @@ export const deserializeVtxo = (o: SerializedVtxo): ExtendedVirtualCoin => ({
     forfeitTapLeafScript: deserializeTapLeaf(o.forfeitTapLeafScript),
     intentTapLeafScript: deserializeTapLeaf(o.intentTapLeafScript),
     extraWitness: o.extraWitness?.map(hex.decode),
+    assets: deserializeAssets(o.assets),
 });
 
 export const deserializeUtxo = (o: SerializedUtxo): ExtendedCoin => ({
@@ -52,4 +96,11 @@ export const deserializeUtxo = (o: SerializedUtxo): ExtendedCoin => ({
     forfeitTapLeafScript: deserializeTapLeaf(o.forfeitTapLeafScript),
     intentTapLeafScript: deserializeTapLeaf(o.intentTapLeafScript),
     extraWitness: o.extraWitness?.map(hex.decode),
+});
+
+export const deserializeTransaction = (
+    o: SerializedTransaction
+): ArkTransaction => ({
+    ...o,
+    assets: deserializeAssets(o.assets),
 });

--- a/src/repositories/serialization.ts
+++ b/src/repositories/serialization.ts
@@ -37,10 +37,17 @@ export const serializeAsset = (a: Asset): SerializedAsset => ({
 export const deserializeAsset = (a: {
     assetId: string;
     amount: string | number | bigint;
-}): Asset => ({
-    assetId: a.assetId,
-    amount: typeof a.amount === "bigint" ? a.amount : BigInt(a.amount),
-});
+}): Asset => {
+    if (typeof a.amount === "number" && !Number.isSafeInteger(a.amount)) {
+        throw new Error(
+            `Unsafe legacy asset amount for ${a.assetId}; re-sync from the original source`
+        );
+    }
+    return {
+        assetId: a.assetId,
+        amount: typeof a.amount === "bigint" ? a.amount : BigInt(a.amount),
+    };
+};
 
 export const serializeAssets = (
     assets: Asset[] | undefined

--- a/src/repositories/sqlite/walletRepository.ts
+++ b/src/repositories/sqlite/walletRepository.ts
@@ -9,6 +9,8 @@ import {
     serializeUtxo,
     deserializeVtxo,
     deserializeUtxo,
+    serializeAssets,
+    deserializeAssets,
     SerializedTapLeaf,
 } from "../serialization";
 import { scriptFromArkAddress } from "../scriptFromAddress";
@@ -409,7 +411,9 @@ export class SQLiteWalletRepository implements WalletRepository {
                     tx.amount,
                     tx.settled ? 1 : 0,
                     tx.createdAt,
-                    tx.assets ? JSON.stringify(tx.assets) : null,
+                    tx.assets
+                        ? JSON.stringify(serializeAssets(tx.assets))
+                        : null,
                 ]
             );
         }
@@ -597,7 +601,7 @@ function txRowToDomain(row: TransactionRow): ArkTransaction {
         createdAt: row.created_at,
     };
     if (row.assets_json) {
-        tx.assets = JSON.parse(row.assets_json);
+        tx.assets = deserializeAssets(JSON.parse(row.assets_json));
     }
     return tx;
 }

--- a/src/utils/transactionHistory.ts
+++ b/src/utils/transactionHistory.ts
@@ -10,11 +10,11 @@ const txKey: TxKey = {
 };
 
 function collectAssets(vtxos: VirtualCoin[]): Asset[] | undefined {
-    const map = new Map<string, number>();
+    const map = new Map<string, bigint>();
     for (const vtxo of vtxos) {
         if (vtxo.assets) {
             for (const a of vtxo.assets) {
-                map.set(a.assetId, (map.get(a.assetId) ?? 0) + a.amount);
+                map.set(a.assetId, (map.get(a.assetId) ?? 0n) + a.amount);
             }
         }
     }
@@ -26,20 +26,20 @@ function subtractAssets(
     spent: VirtualCoin[],
     change: VirtualCoin[]
 ): Asset[] | undefined {
-    const map = new Map<string, number>();
+    const map = new Map<string, bigint>();
     for (const vtxo of change) {
         if (vtxo.assets) {
             for (const a of vtxo.assets) {
-                map.set(a.assetId, (map.get(a.assetId) ?? 0) + a.amount);
+                map.set(a.assetId, (map.get(a.assetId) ?? 0n) + a.amount);
             }
         }
     }
     for (const vtxo of spent) {
         if (vtxo.assets) {
             for (const a of vtxo.assets) {
-                const current = map.get(a.assetId) ?? 0;
+                const current = map.get(a.assetId) ?? 0n;
                 const remaining = current - a.amount;
-                if (remaining !== 0) {
+                if (remaining !== 0n) {
                     map.set(a.assetId, remaining);
                 } else {
                     map.delete(a.assetId);

--- a/src/wallet/asset-manager.ts
+++ b/src/wallet/asset-manager.ts
@@ -93,7 +93,7 @@ export class AssetManager
             if (!coin.assets) continue;
             for (const { assetId, amount } of coin.assets) {
                 const existing = assetChanges.get(assetId) ?? 0n;
-                assetChanges.set(assetId, existing + BigInt(amount));
+                assetChanges.set(assetId, existing + amount);
             }
         }
 
@@ -124,7 +124,7 @@ export class AssetManager
                     for (const asset of assets) {
                         if (asset.assetId !== assetId) continue;
                         changeInputs.push(
-                            AssetInput.create(inputIndex, BigInt(asset.amount))
+                            AssetInput.create(inputIndex, asset.amount)
                         );
                     }
                 }
@@ -213,11 +213,11 @@ export class AssetManager
             if (!coin.assets) continue;
             for (const { assetId, amount } of coin.assets) {
                 if (assetId === params.assetId) {
-                    assetToReissueAmount += BigInt(amount);
+                    assetToReissueAmount += amount;
                     continue;
                 }
                 const existing = assetChanges.get(assetId) ?? 0n;
-                assetChanges.set(assetId, existing + BigInt(amount));
+                assetChanges.set(assetId, existing + amount);
             }
         }
 
@@ -244,11 +244,11 @@ export class AssetManager
                 if (!coin.assets) continue;
                 for (const { assetId, amount } of coin.assets) {
                     if (assetId === params.assetId) {
-                        assetToReissueAmount += BigInt(amount);
+                        assetToReissueAmount += amount;
                         continue;
                     }
                     const existing = assetChanges.get(assetId) ?? 0n;
-                    assetChanges.set(assetId, existing + BigInt(amount));
+                    assetChanges.set(assetId, existing + amount);
                 }
             }
             selectedCoins = [...selectedCoins, ...additional.inputs];
@@ -265,9 +265,7 @@ export class AssetManager
         for (const [inputIndex, assets] of assetInputs) {
             for (const asset of assets) {
                 if (asset.assetId !== params.assetId) continue;
-                reissueInputs.push(
-                    AssetInput.create(inputIndex, BigInt(asset.amount))
-                );
+                reissueInputs.push(AssetInput.create(inputIndex, asset.amount));
             }
         }
 
@@ -293,7 +291,7 @@ export class AssetManager
                 for (const asset of assets) {
                     if (asset.assetId !== assetId) continue;
                     changeInputs.push(
-                        AssetInput.create(inputIndex, BigInt(asset.amount))
+                        AssetInput.create(inputIndex, asset.amount)
                     );
                 }
             }
@@ -370,7 +368,7 @@ export class AssetManager
             if (!coin.assets) continue;
             for (const { assetId, amount } of coin.assets) {
                 const existing = assetChanges.get(assetId) ?? 0n;
-                assetChanges.set(assetId, existing + BigInt(amount));
+                assetChanges.set(assetId, existing + amount);
             }
         }
         // subtract the amount to burn from the asset change
@@ -401,7 +399,7 @@ export class AssetManager
                 if (!coin.assets) continue;
                 for (const { assetId, amount } of coin.assets) {
                     const existing = assetChanges.get(assetId) ?? 0n;
-                    assetChanges.set(assetId, existing + BigInt(amount));
+                    assetChanges.set(assetId, existing + amount);
                 }
             }
 
@@ -418,7 +416,7 @@ export class AssetManager
                 for (const asset of assets) {
                     if (asset.assetId !== assetId) continue;
                     changeInputs.push(
-                        AssetInput.create(inputIndex, BigInt(asset.amount))
+                        AssetInput.create(inputIndex, asset.amount)
                     );
                 }
             }

--- a/src/wallet/asset-manager.ts
+++ b/src/wallet/asset-manager.ts
@@ -63,7 +63,7 @@ export class AssetManager
      * ```
      */
     async issue(params: IssuanceParams): Promise<IssuanceResult> {
-        if (params.amount <= 0) {
+        if (params.amount <= 0n) {
             throw new Error(
                 `Issue amount must be greater than 0, got ${params.amount}`
             );
@@ -100,7 +100,7 @@ export class AssetManager
         const groups: AssetGroup[] = [];
 
         // issued asset group
-        const issuedAssetOutput = AssetOutput.create(0, BigInt(params.amount));
+        const issuedAssetOutput = AssetOutput.create(0, params.amount);
         const issuedAssetGroup = AssetGroup.create(
             null,
             controlAssetRef,
@@ -181,7 +181,7 @@ export class AssetManager
      * ```
      */
     async reissue(params: ReissuanceParams): Promise<string> {
-        if (params.amount <= 0) {
+        if (params.amount <= 0n) {
             throw new Error(
                 `Reissuance amount must be greater than 0, got ${params.amount}`
             );
@@ -272,7 +272,7 @@ export class AssetManager
         }
 
         // the total output amount of the asset to reissue = new + (optional) selected amount
-        const totalAssetAmount = assetToReissueAmount + BigInt(params.amount);
+        const totalAssetAmount = assetToReissueAmount + params.amount;
         const reissueAssetIdObj = AssetId.fromString(params.assetId);
 
         // create the reissuance asset group
@@ -342,7 +342,7 @@ export class AssetManager
      * ```
      */
     async burn(params: BurnParams): Promise<string> {
-        if (params.amount <= 0) {
+        if (params.amount <= 0n) {
             throw new Error(
                 `Burn amount must be greater than 0, got ${params.amount}`
             );
@@ -358,7 +358,7 @@ export class AssetManager
         const { selected: assetCoins } = selectCoinsWithAsset(
             virtualCoins,
             params.assetId,
-            BigInt(params.amount)
+            params.amount
         );
 
         const selectedCoins = [...assetCoins];
@@ -376,7 +376,7 @@ export class AssetManager
         // subtract the amount to burn from the asset change
         assetChanges.set(
             params.assetId,
-            (assetChanges.get(params.assetId) ?? 0n) - BigInt(params.amount)
+            (assetChanges.get(params.assetId) ?? 0n) - params.amount
         );
 
         const minBtcNeeded = Number(this.wallet.dustAmount);

--- a/src/wallet/asset.ts
+++ b/src/wallet/asset.ts
@@ -109,10 +109,12 @@ export function selectCoinsWithAsset(
     // sort by asset amount (smallest first for better selection)
     coinsWithAsset.sort((a, b) => {
         const amountA =
-            a.assets?.find((asset) => asset.assetId === assetId)?.amount ?? 0;
+            a.assets?.find((asset) => asset.assetId === assetId)?.amount ?? 0n;
         const amountB =
-            b.assets?.find((asset) => asset.assetId === assetId)?.amount ?? 0;
-        return amountA - amountB;
+            b.assets?.find((asset) => asset.assetId === assetId)?.amount ?? 0n;
+        // Array.sort callback returns number; reduce the bigint diff to
+        // -1/0/1 (the only thing sort actually consults).
+        return amountA < amountB ? -1 : amountA > amountB ? 1 : 0;
     });
 
     const selected: ExtendedVirtualCoin[] = [];
@@ -123,8 +125,8 @@ export function selectCoinsWithAsset(
 
         selected.push(coin);
         const assetAmount =
-            coin.assets?.find((a) => a.assetId === assetId)?.amount ?? 0;
-        totalAssetAmount += BigInt(assetAmount);
+            coin.assets?.find((a) => a.assetId === assetId)?.amount ?? 0n;
+        totalAssetAmount += assetAmount;
     }
 
     if (totalAssetAmount < requiredAmount) {

--- a/src/wallet/asset.ts
+++ b/src/wallet/asset.ts
@@ -29,7 +29,7 @@ export function createAssetPacket(
             const existing = inputsByAssetId.get(asset.assetId);
             inputsByAssetId.set(asset.assetId, [
                 ...(existing ?? []),
-                AssetInput.create(inputIndex, BigInt(asset.amount)),
+                AssetInput.create(inputIndex, asset.amount),
             ]);
         }
     }
@@ -46,7 +46,7 @@ export function createAssetPacket(
                 const existing = outputsByAssetId.get(asset.assetId);
                 outputsByAssetId.set(asset.assetId, [
                     ...(existing ?? []),
-                    AssetOutput.create(outputIndex, BigInt(asset.amount)),
+                    AssetOutput.create(outputIndex, asset.amount),
                 ]);
             }
         }
@@ -59,7 +59,7 @@ export function createAssetPacket(
             const existing = outputsByAssetId.get(asset.assetId);
             outputsByAssetId.set(asset.assetId, [
                 ...(existing ?? []),
-                AssetOutput.create(outputIndex, BigInt(asset.amount)),
+                AssetOutput.create(outputIndex, asset.amount),
             ]);
         }
     }

--- a/src/wallet/delegator.ts
+++ b/src/wallet/delegator.ts
@@ -428,13 +428,13 @@ async function makeSignedDelegateIntent(
         for (const [, assets] of assetInputs) {
             for (const asset of assets) {
                 const existing = allAssets.get(asset.assetId) ?? 0n;
-                allAssets.set(asset.assetId, existing + BigInt(asset.amount));
+                allAssets.set(asset.assetId, existing + asset.amount);
             }
         }
 
         outputAssets = [];
         for (const [assetId, amount] of allAssets) {
-            outputAssets.push({ assetId, amount: Number(amount) });
+            outputAssets.push({ assetId, amount });
         }
     }
 

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -272,8 +272,12 @@ export interface Asset {
     /** Asset identifier. */
     assetId: string;
 
-    /** Asset amount in base units. */
-    amount: number;
+    /**
+     * Asset amount in base units. Typed as `bigint` because asset
+     * supplies routinely exceed `Number.MAX_SAFE_INTEGER` (2^53 - 1)
+     * and silently truncating in arithmetic would corrupt balances.
+     */
+    amount: bigint;
 }
 
 /**
@@ -334,8 +338,12 @@ export type AssetDetails = {
     /** Asset identifier. */
     assetId: string;
 
-    /** Total issued supply in base units. */
-    supply: number;
+    /**
+     * Total issued supply in base units. Typed as `bigint` for the
+     * same reason as {@link Asset.amount} — supplies often exceed
+     * `Number.MAX_SAFE_INTEGER`.
+     */
+    supply: bigint;
 
     /** Optional immutable metadata associated with the asset. */
     metadata?: AssetMetadata;

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -281,6 +281,26 @@ export interface Asset {
 }
 
 /**
+ * Sum the `amount` of every asset in `assets` that matches `assetId`.
+ * Convenience wrapper for the common `assets.reduce(...,
+ * 0n).filter(...)` pattern; if `assetId` is omitted, sums every asset
+ * regardless of id.
+ */
+export function sumAssetAmounts(
+    assets: Asset[] | undefined,
+    assetId?: string
+): bigint {
+    if (!assets) return 0n;
+    let total = 0n;
+    for (const a of assets) {
+        if (assetId === undefined || a.assetId === assetId) {
+            total += a.amount;
+        }
+    }
+    return total;
+}
+
+/**
  * Recipient accepted by `IWallet.send`.
  *
  * @see IWallet.send
@@ -360,7 +380,7 @@ export type AssetDetails = {
  */
 export interface IssuanceParams {
     /** Initial amount of asset to issue */
-    amount: number;
+    amount: bigint;
     /** Optional control asset ID that can be used for future reissuance */
     controlAssetId?: string;
     /** Immutable asset metadata including `ticker`, `decimals`, `icon` */
@@ -389,7 +409,7 @@ export interface ReissuanceParams {
     /** Existing asset ID, made up of genesis (Arkade) transaction ID and zero-based asset group index */
     assetId: string;
     /** Amount of asset to issue */
-    amount: number;
+    amount: bigint;
 }
 
 /**
@@ -401,7 +421,7 @@ export interface BurnParams {
     /** Existing asset ID, made up of genesis (Arkade) transaction ID and zero-based asset group index */
     assetId: string;
     /** Amount of asset to burn */
-    amount: number;
+    amount: bigint;
 }
 
 /**

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -281,26 +281,6 @@ export interface Asset {
 }
 
 /**
- * Sum the `amount` of every asset in `assets` that matches `assetId`.
- * Convenience wrapper for the common `assets.reduce(...,
- * 0n).filter(...)` pattern; if `assetId` is omitted, sums every asset
- * regardless of id.
- */
-export function sumAssetAmounts(
-    assets: Asset[] | undefined,
-    assetId?: string
-): bigint {
-    if (!assets) return 0n;
-    let total = 0n;
-    for (const a of assets) {
-        if (assetId === undefined || a.assetId === assetId) {
-            total += a.amount;
-        }
-    }
-    return total;
-}
-
-/**
  * Recipient accepted by `IWallet.send`.
  *
  * @see IWallet.send

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1091,11 +1091,11 @@ export class WalletMessageHandler
         const totalOffchain = settled + preconfirmed + recoverable;
 
         // aggregate asset balances from spendable virtual outputs
-        const assetBalances = new Map<string, number>();
+        const assetBalances = new Map<string, bigint>();
         for (const vtxo of spendableVtxos) {
             if (vtxo.assets) {
                 for (const a of vtxo.assets) {
-                    const current = assetBalances.get(a.assetId) ?? 0;
+                    const current = assetBalances.get(a.assetId) ?? 0n;
                     assetBalances.set(a.assetId, current + a.amount);
                 }
             }

--- a/src/wallet/validation.ts
+++ b/src/wallet/validation.ts
@@ -200,7 +200,7 @@ function validateAssetGroupOutput(
     packet: Packet,
     outputIndex: number,
     assetId: string,
-    expectedAmount: number
+    expectedAmount: bigint
 ): void {
     const assetGroup = packet.groups.find((group) => {
         if (group.isIssuance()) return false;
@@ -220,11 +220,10 @@ function validateAssetGroupOutput(
         throw ErrAssetOutputNotFound(assetId, outputIndex);
     }
 
-    const expectedAmountBigInt = BigInt(expectedAmount);
-    if (assetOutput.amount !== expectedAmountBigInt) {
+    if (assetOutput.amount !== expectedAmount) {
         throw ErrInvalidAssetOutputAmount(
             assetOutput.amount,
-            expectedAmountBigInt,
+            expectedAmount,
             assetId
         );
     }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -474,12 +474,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const totalOffchain = settled + preconfirmed + recoverable;
 
         // aggregate asset balances from spendable virtual outputs
-        const assetBalances = new Map<string, number>();
+        const assetBalances = new Map<string, bigint>();
         for (const vtxo of vtxos) {
             if (!isSpendable(vtxo)) continue;
             if (vtxo.assets) {
                 for (const a of vtxo.assets) {
-                    const current = assetBalances.get(a.assetId) ?? 0;
+                    const current = assetBalances.get(a.assetId) ?? 0n;
                     assetBalances.set(a.assetId, current + a.amount);
                 }
             }
@@ -1569,16 +1569,13 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             for (const [, assets] of assetInputs) {
                 for (const asset of assets) {
                     const existing = allAssets.get(asset.assetId) ?? 0n;
-                    allAssets.set(
-                        asset.assetId,
-                        existing + BigInt(asset.amount)
-                    );
+                    allAssets.set(asset.assetId, existing + asset.amount);
                 }
             }
 
             outputAssets = [];
             for (const [assetId, amount] of allAssets) {
-                outputAssets.push({ assetId, amount: Number(amount) });
+                outputAssets.push({ assetId, amount });
             }
         }
 
@@ -2407,7 +2404,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             const changeAssets: Asset[] = [];
             for (const [assetId, amount] of assetChanges) {
                 if (amount > 0n) {
-                    changeAssets.push({ assetId, amount: Number(amount) });
+                    changeAssets.push({ assetId, amount });
                 }
             }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -2213,7 +2213,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      * const txid = await wallet.send({
      *     address: 'ark1q...',
      *     amount: 1000, // (optional, default to dust) btc amount to send to the output
-     *     assets: [{ assetId: 'abc123...', amount: 50 }] // (optional) list of assets to send
+     *     assets: [{ assetId: 'abc123...', amount: 50n }] // (optional) list of assets to send
      * });
      * ```
      */
@@ -2257,7 +2257,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 continue;
             }
             for (const receiverAsset of recipient.assets) {
-                let amountToSelect = BigInt(receiverAsset.amount);
+                let amountToSelect = receiverAsset.amount;
 
                 // check if existing change covers the needed amount
                 const existingChange =
@@ -2301,10 +2301,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                                 continue;
                             }
                             const existing = assetChanges.get(a.assetId) ?? 0n;
-                            assetChanges.set(
-                                a.assetId,
-                                existing + BigInt(a.amount)
-                            );
+                            assetChanges.set(a.assetId, existing + a.amount);
                         }
                     }
                 }
@@ -2341,7 +2338,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                         const existing = assetChanges.get(asset.assetId) ?? 0n;
                         assetChanges.set(
                             asset.assetId,
-                            existing + BigInt(asset.amount)
+                            existing + asset.amount
                         );
                     }
                 }
@@ -2386,7 +2383,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                         const existing = assetChanges.get(asset.assetId) ?? 0n;
                         assetChanges.set(
                             asset.assetId,
-                            existing + BigInt(asset.amount)
+                            existing + asset.amount
                         );
                     }
                 }

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -18,7 +18,6 @@ import {
     EsploraProvider,
     InMemoryWalletRepository,
     InMemoryContractRepository,
-    sumAssetAmounts,
 } from "../../src";
 import {
     arkdExec,
@@ -1568,7 +1567,9 @@ describe("Asset integration tests", () => {
         expect(vtxosAfter.length).toBeGreaterThan(0);
 
         const allAssets = vtxosAfter.flatMap((v) => v.assets ?? []);
-        const assetTotal = sumAssetAmounts(allAssets, issueResult.assetId);
+        const assetTotal = allAssets
+            .filter((a) => a.assetId === issueResult.assetId)
+            .reduce((s, a) => s + a.amount, 0n);
         expect(assetTotal).toBe(issueAmount);
     });
 
@@ -1585,7 +1586,7 @@ describe("Asset integration tests", () => {
             await new Promise((resolve) => setTimeout(resolve, 1000));
 
             // issue an asset
-            const amount = 1000;
+            const amount = 1000n;
             const result = await alice.wallet.assetManager.issue({ amount });
 
             expect(result.arkTxId).toBeDefined();
@@ -1622,7 +1623,7 @@ describe("Asset integration tests", () => {
 
             // first issuance to create a control asset
             const firstIssueResult = await alice.wallet.assetManager.issue({
-                amount: 1,
+                amount: 1n,
             });
 
             // Wait for round completion so change VTXO is indexed
@@ -1630,7 +1631,7 @@ describe("Asset integration tests", () => {
 
             // second issuance to create a new asset using the control asset
             const secondIssueResult = await alice.wallet.assetManager.issue({
-                amount: 500,
+                amount: 500n,
                 controlAssetId: firstIssueResult.assetId,
             });
 
@@ -1674,7 +1675,7 @@ describe("Asset integration tests", () => {
         };
 
         const issueResult = await alice.wallet.assetManager.issue({
-            amount: 1000,
+            amount: 1000n,
             metadata,
         });
 
@@ -1700,7 +1701,7 @@ describe("Asset integration tests", () => {
 
         // first issuance to create a control asset
         const firstIssueResult = await alice.wallet.assetManager.issue({
-            amount: 1,
+            amount: 1n,
         });
 
         // Wait for round completion so change VTXO is indexed
@@ -1708,7 +1709,7 @@ describe("Asset integration tests", () => {
 
         // second issuance to create a new asset using the control asset
         const secondIssueResult = await alice.wallet.assetManager.issue({
-            amount: 500,
+            amount: 500n,
             controlAssetId: firstIssueResult.assetId,
         });
 
@@ -1729,10 +1730,9 @@ describe("Asset integration tests", () => {
         const vtxos = await alice.wallet.getVtxos();
         const allAssets = vtxos.flatMap((v) => v.assets ?? []);
 
-        const totalAssetAmount = sumAssetAmounts(
-            allAssets,
-            secondIssueResult.assetId
-        );
+        const totalAssetAmount = allAssets
+            .filter((a) => a.assetId === secondIssueResult.assetId)
+            .reduce((s, a) => s + a.amount, 0n);
         expect(totalAssetAmount).toBe(500n + reissueAmount);
 
         // control asset should still exist
@@ -1771,7 +1771,9 @@ describe("Asset integration tests", () => {
         // verify remaining amount
         const vtxos = await alice.wallet.getVtxos();
         const allAssets = vtxos.flatMap((v) => v.assets ?? []);
-        const remaining = sumAssetAmounts(allAssets, issueResult.assetId);
+        const remaining = allAssets
+            .filter((a) => a.assetId === issueResult.assetId)
+            .reduce((s, a) => s + a.amount, 0n);
         expect(remaining).toBe(issueAmount - burnAmount);
     });
 
@@ -1832,7 +1834,7 @@ describe("Asset integration tests", () => {
             await new Promise((resolve) => setTimeout(resolve, 1000));
 
             // alice sends some asset to bob
-            const sendAmount = 400;
+            const sendAmount = 400n;
             const sendTxid = await alice.wallet.send({
                 address: bobAddress!,
                 amount: 0,
@@ -1854,10 +1856,9 @@ describe("Asset integration tests", () => {
             // verify alice has the remaining asset as change
             const aliceVtxos = await alice.wallet.getVtxos();
             const aliceAssets = aliceVtxos.flatMap((v) => v.assets ?? []);
-            const aliceRemaining = sumAssetAmounts(
-                aliceAssets,
-                issueResult.assetId
-            );
+            const aliceRemaining = aliceAssets
+                .filter((a) => a.assetId === issueResult.assetId)
+                .reduce((s, a) => s + a.amount, 0n);
             expect(aliceRemaining).toBe(issueAmount - sendAmount);
         }
     );
@@ -1894,13 +1895,17 @@ describe("Asset integration tests", () => {
         // verify bob has all the asset
         const bobVtxos = await bob.wallet.getVtxos();
         const bobAssets = bobVtxos.flatMap((v) => v.assets ?? []);
-        const bobTotal = sumAssetAmounts(bobAssets, issueResult.assetId);
+        const bobTotal = bobAssets
+            .filter((a) => a.assetId === issueResult.assetId)
+            .reduce((s, a) => s + a.amount, 0n);
         expect(bobTotal).toBe(issueAmount);
 
         // verify alice has no more of this asset
         const aliceVtxos = await alice.wallet.getVtxos();
         const aliceAssets = aliceVtxos.flatMap((v) => v.assets ?? []);
-        const aliceTotal = sumAssetAmounts(aliceAssets, issueResult.assetId);
+        const aliceTotal = aliceAssets
+            .filter((a) => a.assetId === issueResult.assetId)
+            .reduce((s, a) => s + a.amount, 0n);
         expect(aliceTotal).toBe(0n);
     });
 
@@ -1949,7 +1954,9 @@ describe("Asset integration tests", () => {
         expect(vtxosAfter.length).toBeGreaterThan(0);
 
         const allAssets = vtxosAfter.flatMap((v) => v.assets ?? []);
-        const assetTotal = sumAssetAmounts(allAssets, issueResult.assetId);
+        const assetTotal = allAssets
+            .filter((a) => a.assetId === issueResult.assetId)
+            .reduce((s, a) => s + a.amount, 0n);
         expect(assetTotal).toBe(issueAmount);
     });
 
@@ -1982,7 +1989,7 @@ describe("Asset integration tests", () => {
             await waitFor(async () => (await wallet1.getVtxos()).length > 0);
 
             const issueResult1 = await wallet1.assetManager.issue({
-                amount: 100,
+                amount: 100n,
             });
             expect(issueResult1.assetId).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -2013,7 +2020,7 @@ describe("Asset integration tests", () => {
             await waitFor(async () => (await wallet2.getVtxos()).length >= 2);
 
             const issueResult2 = await wallet2.assetManager.issue({
-                amount: 200,
+                amount: 200n,
             });
             expect(issueResult2.assetId).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -2054,15 +2061,13 @@ describe("Asset integration tests", () => {
             // Verify alice has remaining assets as change
             const aliceVtxos2 = await wallet2.getVtxos();
             const aliceAssets2 = aliceVtxos2.flatMap((v) => v.assets ?? []);
-            const aliceRemaining1 = sumAssetAmounts(
-                aliceAssets2,
-                issueResult1.assetId
-            );
+            const aliceRemaining1 = aliceAssets2
+                .filter((a) => a.assetId === issueResult1.assetId)
+                .reduce((s, a) => s + a.amount, 0n);
             expect(aliceRemaining1).toBe(50n);
-            const aliceRemaining2 = sumAssetAmounts(
-                aliceAssets2,
-                issueResult2.assetId
-            );
+            const aliceRemaining2 = aliceAssets2
+                .filter((a) => a.assetId === issueResult2.assetId)
+                .reduce((s, a) => s + a.amount, 0n);
             expect(aliceRemaining2).toBe(100n);
 
             // Phase 3 — Remove delegator: spend via forfeit path with assets
@@ -2084,7 +2089,7 @@ describe("Asset integration tests", () => {
             await waitFor(async () => (await wallet3.getVtxos()).length >= 2);
 
             const issueResult3 = await wallet3.assetManager.issue({
-                amount: 300,
+                amount: 300n,
             });
             expect(issueResult3.assetId).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -2142,7 +2147,7 @@ describe("Asset integration tests", () => {
             await waitFor(async () => (await wallet1.getVtxos()).length > 0);
 
             const issueResult = await wallet1.assetManager.issue({
-                amount: 500,
+                amount: 500n,
             });
             expect(issueResult.assetId).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -2205,10 +2210,9 @@ describe("Asset integration tests", () => {
 
             const vtxosAfter = await wallet2.getVtxos();
             const aliceAssets = vtxosAfter.flatMap((v) => v.assets ?? []);
-            const aliceRemaining = sumAssetAmounts(
-                aliceAssets,
-                issueResult.assetId
-            );
+            const aliceRemaining = aliceAssets
+                .filter((a) => a.assetId === issueResult.assetId)
+                .reduce((s, a) => s + a.amount, 0n);
             expect(aliceRemaining).toBe(300n);
 
             // Change should land on delegate contract
@@ -2274,7 +2278,7 @@ describe("Asset integration tests", () => {
             await waitFor(async () => (await wallet2.getVtxos()).length > 0);
 
             const issueResult = await wallet2.assetManager.issue({
-                amount: 500,
+                amount: 500n,
             });
             expect(issueResult.assetId).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -2315,10 +2319,9 @@ describe("Asset integration tests", () => {
 
             const vtxosAfter = await wallet2.getVtxos();
             const aliceAssets = vtxosAfter.flatMap((v) => v.assets ?? []);
-            const aliceRemaining = sumAssetAmounts(
-                aliceAssets,
-                issueResult.assetId
-            );
+            const aliceRemaining = aliceAssets
+                .filter((a) => a.assetId === issueResult.assetId)
+                .reduce((s, a) => s + a.amount, 0n);
             expect(aliceRemaining).toBe(300n);
 
             // Change should land on delegate contract

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -18,6 +18,7 @@ import {
     EsploraProvider,
     InMemoryWalletRepository,
     InMemoryContractRepository,
+    sumAssetAmounts,
 } from "../../src";
 import {
     arkdExec,
@@ -1525,7 +1526,7 @@ describe("Asset integration tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 1000));
 
         // alice issues an asset
-        const issueAmount = 500;
+        const issueAmount = 500n;
         const issueResult = await alice.wallet.assetManager.issue({
             amount: issueAmount,
         });
@@ -1567,9 +1568,7 @@ describe("Asset integration tests", () => {
         expect(vtxosAfter.length).toBeGreaterThan(0);
 
         const allAssets = vtxosAfter.flatMap((v) => v.assets ?? []);
-        const assetTotal = allAssets
-            .filter((a) => a.assetId === issueResult.assetId)
-            .reduce((sum, a) => sum + a.amount, 0);
+        const assetTotal = sumAssetAmounts(allAssets, issueResult.assetId);
         expect(assetTotal).toBe(issueAmount);
     });
 
@@ -1649,13 +1648,13 @@ describe("Asset integration tests", () => {
                 (a) => a.assetId === secondIssueResult.assetId
             );
             expect(issuedAsset).toBeDefined();
-            expect(issuedAsset!.amount).toBe(500);
+            expect(issuedAsset!.amount).toBe(500n);
 
             const controlAsset = allAssets.find(
                 (a) => a.assetId === firstIssueResult.assetId
             );
             expect(controlAsset).toBeDefined();
-            expect(controlAsset!.amount).toBe(1);
+            expect(controlAsset!.amount).toBe(1n);
         }
     );
 
@@ -1717,7 +1716,7 @@ describe("Asset integration tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 2000));
 
         // reissue more units
-        const reissueAmount = 300;
+        const reissueAmount = 300n;
         const reissueTxid = await alice.wallet.assetManager.reissue({
             assetId: secondIssueResult.assetId,
             amount: reissueAmount,
@@ -1730,9 +1729,10 @@ describe("Asset integration tests", () => {
         const vtxos = await alice.wallet.getVtxos();
         const allAssets = vtxos.flatMap((v) => v.assets ?? []);
 
-        const totalAssetAmount = allAssets
-            .filter((a) => a.assetId === secondIssueResult.assetId)
-            .reduce((sum, a) => sum + a.amount, 0);
+        const totalAssetAmount = sumAssetAmounts(
+            allAssets,
+            secondIssueResult.assetId
+        );
         expect(totalAssetAmount).toBe(500 + reissueAmount);
 
         // control asset should still exist
@@ -1751,7 +1751,7 @@ describe("Asset integration tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 1000));
 
         // issue an asset
-        const issueAmount = 1000;
+        const issueAmount = 1000n;
         const issueResult = await alice.wallet.assetManager.issue({
             amount: issueAmount,
         });
@@ -1759,7 +1759,7 @@ describe("Asset integration tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 1000));
 
         // burn half
-        const burnAmount = 400;
+        const burnAmount = 400n;
         const burnTxid = await alice.wallet.assetManager.burn({
             assetId: issueResult.assetId,
             amount: burnAmount,
@@ -1771,9 +1771,7 @@ describe("Asset integration tests", () => {
         // verify remaining amount
         const vtxos = await alice.wallet.getVtxos();
         const allAssets = vtxos.flatMap((v) => v.assets ?? []);
-        const remaining = allAssets
-            .filter((a) => a.assetId === issueResult.assetId)
-            .reduce((sum, a) => sum + a.amount, 0);
+        const remaining = sumAssetAmounts(allAssets, issueResult.assetId);
         expect(remaining).toBe(issueAmount - burnAmount);
     });
 
@@ -1786,7 +1784,7 @@ describe("Asset integration tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 1000));
 
         // issue an asset
-        const issueAmount = 500;
+        const issueAmount = 500n;
         const issueResult = await alice.wallet.assetManager.issue({
             amount: issueAmount,
         });
@@ -1826,7 +1824,7 @@ describe("Asset integration tests", () => {
             await new Promise((resolve) => setTimeout(resolve, 1000));
 
             // alice issues an asset
-            const issueAmount = 1000;
+            const issueAmount = 1000n;
             const issueResult = await alice.wallet.assetManager.issue({
                 amount: issueAmount,
             });
@@ -1856,9 +1854,10 @@ describe("Asset integration tests", () => {
             // verify alice has the remaining asset as change
             const aliceVtxos = await alice.wallet.getVtxos();
             const aliceAssets = aliceVtxos.flatMap((v) => v.assets ?? []);
-            const aliceRemaining = aliceAssets
-                .filter((a) => a.assetId === issueResult.assetId)
-                .reduce((sum, a) => sum + a.amount, 0);
+            const aliceRemaining = sumAssetAmounts(
+                aliceAssets,
+                issueResult.assetId
+            );
             expect(aliceRemaining).toBe(issueAmount - sendAmount);
         }
     );
@@ -1875,7 +1874,7 @@ describe("Asset integration tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 1000));
 
         // alice issues an asset
-        const issueAmount = 500;
+        const issueAmount = 500n;
         const issueResult = await alice.wallet.assetManager.issue({
             amount: issueAmount,
         });
@@ -1895,18 +1894,14 @@ describe("Asset integration tests", () => {
         // verify bob has all the asset
         const bobVtxos = await bob.wallet.getVtxos();
         const bobAssets = bobVtxos.flatMap((v) => v.assets ?? []);
-        const bobTotal = bobAssets
-            .filter((a) => a.assetId === issueResult.assetId)
-            .reduce((sum, a) => sum + a.amount, 0);
+        const bobTotal = sumAssetAmounts(bobAssets, issueResult.assetId);
         expect(bobTotal).toBe(issueAmount);
 
         // verify alice has no more of this asset
         const aliceVtxos = await alice.wallet.getVtxos();
         const aliceAssets = aliceVtxos.flatMap((v) => v.assets ?? []);
-        const aliceTotal = aliceAssets
-            .filter((a) => a.assetId === issueResult.assetId)
-            .reduce((sum, a) => sum + a.amount, 0);
-        expect(aliceTotal).toBe(0);
+        const aliceTotal = sumAssetAmounts(aliceAssets, issueResult.assetId);
+        expect(aliceTotal).toBe(0n);
     });
 
     it("should settle VTXOs with assets", { timeout: 60000 }, async () => {
@@ -1918,7 +1913,7 @@ describe("Asset integration tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 1000));
 
         // alice issues an asset
-        const issueAmount = 500;
+        const issueAmount = 500n;
         const issueResult = await alice.wallet.assetManager.issue({
             amount: issueAmount,
         });
@@ -1954,9 +1949,7 @@ describe("Asset integration tests", () => {
         expect(vtxosAfter.length).toBeGreaterThan(0);
 
         const allAssets = vtxosAfter.flatMap((v) => v.assets ?? []);
-        const assetTotal = allAssets
-            .filter((a) => a.assetId === issueResult.assetId)
-            .reduce((sum, a) => sum + a.amount, 0);
+        const assetTotal = sumAssetAmounts(allAssets, issueResult.assetId);
         expect(assetTotal).toBe(issueAmount);
     });
 
@@ -2051,24 +2044,26 @@ describe("Asset integration tests", () => {
                 (a) => a.assetId === issueResult1.assetId
             );
             expect(bobAsset1).toBeDefined();
-            expect(bobAsset1!.amount).toBe(50);
+            expect(bobAsset1!.amount).toBe(50n);
             const bobAsset2 = bobAssets.find(
                 (a) => a.assetId === issueResult2.assetId
             );
             expect(bobAsset2).toBeDefined();
-            expect(bobAsset2!.amount).toBe(100);
+            expect(bobAsset2!.amount).toBe(100n);
 
             // Verify alice has remaining assets as change
             const aliceVtxos2 = await wallet2.getVtxos();
             const aliceAssets2 = aliceVtxos2.flatMap((v) => v.assets ?? []);
-            const aliceRemaining1 = aliceAssets2
-                .filter((a) => a.assetId === issueResult1.assetId)
-                .reduce((sum, a) => sum + a.amount, 0);
-            expect(aliceRemaining1).toBe(50);
-            const aliceRemaining2 = aliceAssets2
-                .filter((a) => a.assetId === issueResult2.assetId)
-                .reduce((sum, a) => sum + a.amount, 0);
-            expect(aliceRemaining2).toBe(100);
+            const aliceRemaining1 = sumAssetAmounts(
+                aliceAssets2,
+                issueResult1.assetId
+            );
+            expect(aliceRemaining1).toBe(50n);
+            const aliceRemaining2 = sumAssetAmounts(
+                aliceAssets2,
+                issueResult2.assetId
+            );
+            expect(aliceRemaining2).toBe(100n);
 
             // Phase 3 — Remove delegator: spend via forfeit path with assets
             const wallet3 = await Wallet.create({
@@ -2114,7 +2109,7 @@ describe("Asset integration tests", () => {
                 (a) => a.assetId === issueResult3.assetId
             );
             expect(bobAsset3).toBeDefined();
-            expect(bobAsset3!.amount).toBe(150);
+            expect(bobAsset3!.amount).toBe(150n);
         }
     );
 
@@ -2200,7 +2195,7 @@ describe("Asset integration tests", () => {
                 (a) => a.assetId === issueResult.assetId
             );
             expect(bobAsset).toBeDefined();
-            expect(bobAsset!.amount).toBe(200);
+            expect(bobAsset!.amount).toBe(200n);
 
             // Verify change has remaining asset on delegate contract
             await waitFor(async () => {
@@ -2210,10 +2205,11 @@ describe("Asset integration tests", () => {
 
             const vtxosAfter = await wallet2.getVtxos();
             const aliceAssets = vtxosAfter.flatMap((v) => v.assets ?? []);
-            const aliceRemaining = aliceAssets
-                .filter((a) => a.assetId === issueResult.assetId)
-                .reduce((sum, a) => sum + a.amount, 0);
-            expect(aliceRemaining).toBe(300);
+            const aliceRemaining = sumAssetAmounts(
+                aliceAssets,
+                issueResult.assetId
+            );
+            expect(aliceRemaining).toBe(300n);
 
             // Change should land on delegate contract
             const delegateContractAfter = await manager.getContractsWithVtxos({
@@ -2309,7 +2305,7 @@ describe("Asset integration tests", () => {
                 (a) => a.assetId === issueResult.assetId
             );
             expect(bobAsset).toBeDefined();
-            expect(bobAsset!.amount).toBe(200);
+            expect(bobAsset!.amount).toBe(200n);
 
             // Verify change has remaining asset on delegate contract
             await waitFor(async () => {
@@ -2319,10 +2315,11 @@ describe("Asset integration tests", () => {
 
             const vtxosAfter = await wallet2.getVtxos();
             const aliceAssets = vtxosAfter.flatMap((v) => v.assets ?? []);
-            const aliceRemaining = aliceAssets
-                .filter((a) => a.assetId === issueResult.assetId)
-                .reduce((sum, a) => sum + a.amount, 0);
-            expect(aliceRemaining).toBe(300);
+            const aliceRemaining = sumAssetAmounts(
+                aliceAssets,
+                issueResult.assetId
+            );
+            expect(aliceRemaining).toBe(300n);
 
             // Change should land on delegate contract
             const delegateContractAfter = await manager.getContractsWithVtxos({

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -1733,7 +1733,7 @@ describe("Asset integration tests", () => {
             allAssets,
             secondIssueResult.assetId
         );
-        expect(totalAssetAmount).toBe(500 + reissueAmount);
+        expect(totalAssetAmount).toBe(500n + reissueAmount);
 
         // control asset should still exist
         const controlAsset = allAssets.find(
@@ -2030,8 +2030,8 @@ describe("Asset integration tests", () => {
                 address: bobAddress,
                 amount: sendAmount,
                 assets: [
-                    { assetId: issueResult1.assetId, amount: 50 },
-                    { assetId: issueResult2.assetId, amount: 100 },
+                    { assetId: issueResult1.assetId, amount: 50n },
+                    { assetId: issueResult2.assetId, amount: 100n },
                 ],
             });
             expect(txid2).toBeDefined();
@@ -2097,7 +2097,7 @@ describe("Asset integration tests", () => {
             const txid3 = await wallet3.send({
                 address: bobAddress,
                 amount: sendAmount3,
-                assets: [{ assetId: issueResult3.assetId, amount: 150 }],
+                assets: [{ assetId: issueResult3.assetId, amount: 150n }],
             });
             expect(txid3).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -2183,7 +2183,7 @@ describe("Asset integration tests", () => {
             const txid = await wallet2.send({
                 address: bobAddress,
                 amount: sendAmount,
-                assets: [{ assetId: issueResult.assetId, amount: 200 }],
+                assets: [{ assetId: issueResult.assetId, amount: 200n }],
             });
             expect(txid).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -2293,7 +2293,7 @@ describe("Asset integration tests", () => {
             const txid = await wallet2.send({
                 address: bobAddress,
                 amount: sendAmount,
-                assets: [{ assetId: issueResult.assetId, amount: 200 }],
+                assets: [{ assetId: issueResult.assetId, amount: 200n }],
             });
             expect(txid).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/test/realm-wallet-repository.test.ts
+++ b/test/realm-wallet-repository.test.ts
@@ -232,7 +232,7 @@ function createMockVtxoWithExtras(
         intentTapLeafScript: tapLeaf,
         tapTree: new Uint8Array(32).fill(5),
         extraWitness: [new Uint8Array([0xab, 0xcd]), new Uint8Array([0xef])],
-        assets: [{ assetId: "asset-1", amount: 500 }],
+        assets: [{ assetId: "asset-1", amount: 500n }],
     };
 }
 
@@ -367,7 +367,7 @@ describe("RealmWalletRepository", () => {
             ]);
             expect(retrieved.virtualStatus.batchExpiry).toBe(1700100000);
             expect(retrieved.assets).toEqual([
-                { assetId: "asset-1", amount: 500 },
+                { assetId: "asset-1", amount: 500n },
             ]);
             // extraWitness round-trip (Uint8Array)
             expect(retrieved.extraWitness).toBeDefined();
@@ -694,8 +694,8 @@ describe("RealmWalletRepository", () => {
                 settled: true,
                 createdAt: 5000,
                 assets: [
-                    { assetId: "asset-a", amount: 100 },
-                    { assetId: "asset-b", amount: 200 },
+                    { assetId: "asset-a", amount: 100n },
+                    { assetId: "asset-b", amount: 200n },
                 ],
             };
 
@@ -705,8 +705,8 @@ describe("RealmWalletRepository", () => {
 
             expect(retrieved.settled).toBe(true);
             expect(retrieved.assets).toEqual([
-                { assetId: "asset-a", amount: 100 },
-                { assetId: "asset-b", amount: 200 },
+                { assetId: "asset-a", amount: 100n },
+                { assetId: "asset-b", amount: 200n },
             ]);
         });
 

--- a/test/sqlite-wallet-repository.test.ts
+++ b/test/sqlite-wallet-repository.test.ts
@@ -400,7 +400,7 @@ function createMockVtxoWithExtras(
         intentTapLeafScript: tapLeaf,
         tapTree: new Uint8Array(32).fill(5),
         extraWitness: [new Uint8Array([0xab, 0xcd]), new Uint8Array([0xef])],
-        assets: [{ assetId: "asset-1", amount: 500 }],
+        assets: [{ assetId: "asset-1", amount: 500n }],
         script: "5120deadbeef",
     };
 }
@@ -533,7 +533,7 @@ describe("SQLiteWalletRepository", () => {
             ]);
             expect(retrieved.virtualStatus.batchExpiry).toBe(1700100000);
             expect(retrieved.assets).toEqual([
-                { assetId: "asset-1", amount: 500 },
+                { assetId: "asset-1", amount: 500n },
             ]);
             // extraWitness round-trip (Uint8Array)
             expect(retrieved.extraWitness).toBeDefined();
@@ -858,8 +858,8 @@ describe("SQLiteWalletRepository", () => {
                 settled: true,
                 createdAt: 5000,
                 assets: [
-                    { assetId: "asset-a", amount: 100 },
-                    { assetId: "asset-b", amount: 200 },
+                    { assetId: "asset-a", amount: 100n },
+                    { assetId: "asset-b", amount: 200n },
                 ],
             };
 
@@ -869,8 +869,8 @@ describe("SQLiteWalletRepository", () => {
 
             expect(retrieved.settled).toBe(true);
             expect(retrieved.assets).toEqual([
-                { assetId: "asset-a", amount: 100 },
-                { assetId: "asset-b", amount: 200 },
+                { assetId: "asset-a", amount: 100n },
+                { assetId: "asset-b", amount: 200n },
             ]);
         });
 

--- a/test/transactionHistory.test.ts
+++ b/test/transactionHistory.test.ts
@@ -230,7 +230,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: baseDate,
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 50 }],
+                assets: [{ assetId: assetA, amount: 50n }],
             };
 
             const txs = await buildTransactionHistory([vtxo], [], new Set());
@@ -238,7 +238,7 @@ describe("buildTransactionHistory", () => {
             expect(txs).toHaveLength(1);
             expect(txs[0].type).toBe(TxType.TxReceived);
             expect(txs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: 50 },
+                { assetId: assetA, amount: 50n },
             ]);
         });
 
@@ -257,8 +257,8 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: false,
                 assets: [
-                    { assetId: assetA, amount: 10 },
-                    { assetId: assetB, amount: 20 },
+                    { assetId: assetA, amount: 10n },
+                    { assetId: assetB, amount: 20n },
                 ],
             };
 
@@ -268,8 +268,8 @@ describe("buildTransactionHistory", () => {
             expect(txs[0].type).toBe(TxType.TxReceived);
             expect(txs[0].tag).toBe("batch");
             expect(txs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: 10 },
-                { assetId: assetB, amount: 20 },
+                { assetId: assetA, amount: 10n },
+                { assetId: assetB, amount: 20n },
             ]);
         });
 
@@ -304,7 +304,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 100 }],
+                assets: [{ assetId: assetA, amount: 100n }],
             };
 
             const changeVtxo: VirtualCoin = {
@@ -316,7 +316,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 30 }],
+                assets: [{ assetId: assetA, amount: 30n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -329,7 +329,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(600);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -70 },
+                { assetId: assetA, amount: -70n },
             ]);
         });
 
@@ -346,7 +346,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 50 }],
+                assets: [{ assetId: assetA, amount: 50n }],
             };
 
             const changeVtxo: VirtualCoin = {
@@ -358,7 +358,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 50 }],
+                assets: [{ assetId: assetA, amount: 50n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -387,8 +387,8 @@ describe("buildTransactionHistory", () => {
                 isSpent: true,
                 arkTxId,
                 assets: [
-                    { assetId: assetA, amount: 40 },
-                    { assetId: assetB, amount: 60 },
+                    { assetId: assetA, amount: 40n },
+                    { assetId: assetB, amount: 60n },
                 ],
             };
 
@@ -402,8 +402,8 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(1000);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -40 },
-                { assetId: assetB, amount: -60 },
+                { assetId: assetA, amount: -40n },
+                { assetId: assetB, amount: -60n },
             ]);
         });
 
@@ -420,7 +420,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 settledBy: commitmentTxId,
-                assets: [{ assetId: assetA, amount: 80 }],
+                assets: [{ assetId: assetA, amount: 80n }],
             };
 
             const changeVtxo: VirtualCoin = {
@@ -435,7 +435,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 20 }],
+                assets: [{ assetId: assetA, amount: 20n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -449,7 +449,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs[0].tag).toBe("exit");
             expect(sentTxs[0].amount).toBe(1500);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -60 },
+                { assetId: assetA, amount: -60n },
             ]);
         });
 
@@ -466,7 +466,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 settledBy: commitmentTxId,
-                assets: [{ assetId: assetB, amount: 75 }],
+                assets: [{ assetId: assetB, amount: 75n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -480,7 +480,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs[0].tag).toBe("exit");
             expect(sentTxs[0].amount).toBe(1000);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetB, amount: -75 },
+                { assetId: assetB, amount: -75n },
             ]);
         });
 
@@ -508,7 +508,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 100 }],
+                assets: [{ assetId: assetA, amount: 100n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -521,7 +521,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(0);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: 100 },
+                { assetId: assetA, amount: 100n },
             ]);
         });
 
@@ -538,7 +538,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 50 }],
+                assets: [{ assetId: assetA, amount: 50n }],
             };
 
             const changeVtxo: VirtualCoin = {
@@ -550,7 +550,7 @@ describe("buildTransactionHistory", () => {
                 createdAt: new Date(baseDate.getTime() + 1000),
                 isUnrolled: false,
                 isSpent: false,
-                assets: [{ assetId: assetA, amount: 150 }],
+                assets: [{ assetId: assetA, amount: 150n }],
             };
 
             const txs = await buildTransactionHistory(
@@ -563,7 +563,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(0);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: 100 },
+                { assetId: assetA, amount: 100n },
             ]);
         });
 
@@ -581,7 +581,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 100 }],
+                assets: [{ assetId: assetA, amount: 100n }],
             };
 
             // Change VTXO has all BTC back but no assets (fully burned)
@@ -607,7 +607,7 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs[0].amount).toBe(0);
             // Negative = assets lost/burned
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -100 },
+                { assetId: assetA, amount: -100n },
             ]);
         });
 
@@ -627,8 +627,8 @@ describe("buildTransactionHistory", () => {
                 isSpent: true,
                 arkTxId,
                 assets: [
-                    { assetId: assetA, amount: 50 }, // will be fully burned
-                    { assetId: assetB, amount: 80 }, // 30 will be transferred
+                    { assetId: assetA, amount: 50n }, // will be fully burned
+                    { assetId: assetB, amount: 80n }, // 30 will be transferred
                 ],
             };
 
@@ -643,8 +643,8 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: false,
                 assets: [
-                    { assetId: assetB, amount: 50 }, // kept 50 of 80
-                    { assetId: assetC, amount: 200 }, // newly issued
+                    { assetId: assetB, amount: 50n }, // kept 50 of 80
+                    { assetId: assetC, amount: 200n }, // newly issued
                 ],
             };
 
@@ -658,9 +658,9 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(500);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetB, amount: -30 }, // transferred/lost
-                { assetId: assetC, amount: 200 }, // issued/gained
-                { assetId: assetA, amount: -50 }, // burned/lost
+                { assetId: assetB, amount: -30n }, // transferred/lost
+                { assetId: assetC, amount: 200n }, // issued/gained
+                { assetId: assetA, amount: -50n }, // burned/lost
             ]);
         });
 
@@ -677,7 +677,7 @@ describe("buildTransactionHistory", () => {
                 isUnrolled: false,
                 isSpent: true,
                 arkTxId,
-                assets: [{ assetId: assetA, amount: 30 }],
+                assets: [{ assetId: assetA, amount: 30n }],
             };
 
             const spentVtxo2: VirtualCoin = {
@@ -691,8 +691,8 @@ describe("buildTransactionHistory", () => {
                 isSpent: true,
                 arkTxId,
                 assets: [
-                    { assetId: assetA, amount: 20 },
-                    { assetId: assetB, amount: 10 },
+                    { assetId: assetA, amount: 20n },
+                    { assetId: assetB, amount: 10n },
                 ],
             };
 
@@ -706,8 +706,8 @@ describe("buildTransactionHistory", () => {
             expect(sentTxs).toHaveLength(1);
             expect(sentTxs[0].amount).toBe(1000);
             expect(sentTxs[0].assets).toStrictEqual([
-                { assetId: assetA, amount: -50 },
-                { assetId: assetB, amount: -10 },
+                { assetId: assetA, amount: -50n },
+                { assetId: assetB, amount: -10n },
             ]);
         });
     });


### PR DESCRIPTION
Alternative to #469. Closes #384.

Both PRs solve the same problem (asset amounts can exceed `Number.MAX_SAFE_INTEGER` and silently truncate in arithmetic). They take different paths:

| | #469 | this PR |
|---|---|---|
| `Asset.amount` | `number` (deprecated) + new `assetAmount: bigint` | `number` → `bigint` |
| `AssetDetails.supply` | `number` (deprecated) + new `assetSupply: bigint` | `number` → `bigint` |
| Read sites | Read both fields, prefer the bigint one | Read one field |
| Helper | `toSafeNumber()` clamps to `MAX_SAFE_INTEGER` | None |
| Breaking? | No | Yes (type change) |

## Approach

Just change the type. Drop `amount`/`supply` from `number` to `bigint` and let the type system surface every place that needs to switch its math to bigint. No parallel deprecated fields, no clamping helper.

## Cascade

- **`providers/{indexer,expoIndexer}`**: `Number(a.amount)` → `BigInt(a.amount)`; same for `supply`.
- **`utils/transactionHistory`**: aggregation maps become `Map<string, bigint>`, neutral element `0n`, subtraction bookkeeping uses `0n` checks. Final `Asset[]` is built directly — no number projection.
- **`wallet.getBalance`** and **`wallet-message-handler.GET_BALANCE`**: same map switch.
- **`wallet.send`** change-output asset accounting: drops the `Number(amount)` cast — the value is already a bigint.
- **`delegator.makeSignedDelegateIntent`**: drops the `BigInt(asset.amount)` conversion (already bigint), and the corresponding `Number(amount)` round-trip on output.
- **`wallet/asset.ts`** greedy selection: bigint-aware sort comparator (`amountA < amountB ? -1 : amountA > amountB ? 1 : 0`, since `Array.sort` wants a number) and drops the inner `BigInt(assetAmount)` cast.
- **`wallet/validation.ts`**: `expectedAmount` parameter typed as `bigint`; drops the local `BigInt(expectedAmount)` conversion before comparing to `assetOutput.amount` (which is already bigint).
- **`test/transactionHistory.test.ts`**: `amount: N` → `amount: Nn` on every fixture (mechanical, sed-driven).

## Trade-off vs #469

**For #469's approach**: zero break for downstream wallets that do `balance.amount + 100` etc. They keep working (with the truncation bug they already had).

**For this approach**: any caller doing arithmetic on `asset.amount` as a number gets a TS error pointing at the exact line. The fix is either to switch to bigint or — when the caller can prove the value fits — to call `Number(amount)` explicitly. Forcing the diagnosis is the point: a silent \`0\` from \`Number(huge_bigint)\` is exactly what #384 is about.

## Verification

- 1063 unit tests pass (1 skipped pre-existing)
- Lint clean
- Typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset amount precision handling across wallet operations to prevent numeric overflow and data loss in all asset-related transactions and storage.

* **Tests**
  * Updated asset amount test fixtures to reflect new precision handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->