### PR TITLE
fix(wallet): reconcile VTXO_ALREADY_SPENT by outpoint, not full re-scan

### DIFF
--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -14,7 +14,7 @@ import {
 } from "./types";
 import { ContractWatcher, ContractWatcherConfig } from "./contractWatcher";
 import { contractHandlers } from "./handlers";
-import { ExtendedVirtualCoin, VirtualCoin } from "../wallet";
+import { ExtendedVirtualCoin, Outpoint, VirtualCoin } from "../wallet";
 import { extendVirtualCoinForContract } from "../wallet/utils";
 import { ContractFilter, ContractRepository } from "../repositories";
 import {
@@ -130,6 +130,22 @@ export interface IContractManager extends Disposable {
      * With options, narrows the refresh to specific scripts and/or a time window.
      */
     refreshVtxos(opts?: RefreshVtxosOptions): Promise<void>;
+
+    /**
+     * Reconcile specific outpoints with the indexer's authoritative state and
+     * upsert the result into the wallet repository.
+     *
+     * The cursor-derived delta sync filters by `created_at`, so a VTXO that
+     * was created before the cursor but spent recently won't surface in a
+     * standard `refreshVtxos()` call. This method is the surgical recovery
+     * path for that case: when something hands us a stale outpoint (e.g. the
+     * server returns `VTXO_ALREADY_SPENT` with a `vtxo_outpoint` in its
+     * error metadata), call this to pull the latest state and unblock the
+     * caller — no full re-scan, no cursor change.
+     *
+     * Outpoints not owned by any tracked contract are silently dropped.
+     */
+    refreshOutpoints(outpoints: Outpoint[]): Promise<void>;
 
     /**
      * Whether the underlying watcher is currently active.
@@ -636,6 +652,38 @@ export class ContractManager implements IContractManager {
                 ? { after: opts?.after, before: opts?.before }
                 : undefined,
         });
+    }
+
+    async refreshOutpoints(outpoints: Outpoint[]): Promise<void> {
+        if (outpoints.length === 0) return;
+
+        const { vtxos } = await this.config.indexerProvider.getVtxos({
+            outpoints,
+        });
+        if (vtxos.length === 0) return;
+
+        // Filter to outputs whose script we own. Map them to their owning
+        // contract so we can write through to the right per-address entry
+        // in the wallet repository.
+        const scripts = Array.from(new Set(vtxos.map((v) => v.script)));
+        const contracts = await this.config.contractRepository.getContracts({
+            script: scripts,
+        });
+        const scriptToContract = new Map(contracts.map((c) => [c.script, c]));
+        const owned = vtxos.filter((v) => scriptToContract.has(v.script));
+        if (owned.length === 0) return;
+
+        const annotated = await this.annotateVtxos(owned);
+        const byAddress = new Map<string, ExtendedVirtualCoin[]>();
+        for (const vtxo of annotated) {
+            const address = scriptToContract.get(vtxo.script)!.address;
+            const arr = byAddress.get(address) ?? [];
+            arr.push(vtxo);
+            byAddress.set(address, arr);
+        }
+        for (const [address, addressVtxos] of byAddress) {
+            await this.config.walletRepository.saveVtxos(address, addressVtxos);
+        }
     }
 
     /**

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -267,6 +267,16 @@ export type ResponseRefreshVtxos = ResponseEnvelope & {
     type: "REFRESH_VTXOS_SUCCESS";
 };
 
+export type RequestRefreshOutpoints = RequestEnvelope & {
+    type: "REFRESH_OUTPOINTS";
+    payload: {
+        outpoints: { txid: string; vout: number }[];
+    };
+};
+export type ResponseRefreshOutpoints = ResponseEnvelope & {
+    type: "REFRESH_OUTPOINTS_SUCCESS";
+};
+
 export type RequestGetAllSpendingPaths = RequestEnvelope & {
     type: "GET_ALL_SPENDING_PATHS";
     payload: { options: GetAllSpendingPathsOptions };
@@ -460,6 +470,7 @@ export type WalletUpdaterRequest =
     | RequestGetAllSpendingPaths
     | RequestIsContractManagerWatching
     | RequestRefreshVtxos
+    | RequestRefreshOutpoints
     | RequestSend
     | RequestGetAssetDetails
     | RequestIssue
@@ -502,6 +513,7 @@ export type WalletUpdaterResponse = ResponseEnvelope &
         | ResponseGetAllSpendingPaths
         | ResponseIsContractManagerWatching
         | ResponseRefreshVtxos
+        | ResponseRefreshOutpoints
         | ResponseContractEvent
         | ResponseSend
         | ResponseGetAssetDetails
@@ -871,6 +883,17 @@ export class WalletMessageHandler
                     return this.tagged({
                         id,
                         type: "REFRESH_VTXOS_SUCCESS",
+                    });
+                }
+                case "REFRESH_OUTPOINTS": {
+                    const manager =
+                        await this.readonlyWallet.getContractManager();
+                    const { outpoints } = (message as RequestRefreshOutpoints)
+                        .payload;
+                    await manager.refreshOutpoints(outpoints);
+                    return this.tagged({
+                        id,
+                        type: "REFRESH_OUTPOINTS_SUCCESS",
                     });
                 }
                 case "SEND": {

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -54,6 +54,7 @@ import {
     RequestInitWallet,
     RequestIsContractManagerWatching,
     RequestRefreshVtxos,
+    RequestRefreshOutpoints,
     RequestReloadWallet,
     RequestSendBitcoin,
     RequestSettle,
@@ -199,6 +200,7 @@ export const DEFAULT_MESSAGE_TIMEOUTS: Readonly<Record<RequestType, number>> = {
     UPDATE_CONTRACT: 30_000,
     DELETE_CONTRACT: 10_000,
     REFRESH_VTXOS: 30_000,
+    REFRESH_OUTPOINTS: 30_000,
 };
 
 const DEDUPABLE_REQUEST_TYPES: ReadonlySet<string> = new Set([
@@ -1271,6 +1273,18 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                     id: getRandomId(),
                     tag: messageTag,
                     payload: opts,
+                };
+                await sendContractMessage(message);
+            },
+
+            async refreshOutpoints(
+                outpoints: { txid: string; vout: number }[]
+            ): Promise<void> {
+                const message: RequestRefreshOutpoints = {
+                    type: "REFRESH_OUTPOINTS",
+                    id: getRandomId(),
+                    tag: messageTag,
+                    payload: { outpoints },
                 };
                 await sendContractMessage(message);
             },

--- a/src/wallet/vtxo-manager.ts
+++ b/src/wallet/vtxo-manager.ts
@@ -7,8 +7,10 @@ import {
     isRecoverable,
     isSpendable,
     isSubdust,
+    Outpoint,
 } from ".";
 import { ArkProvider, SettlementEvent } from "../providers/ark";
+import { maybeArkError } from "../providers/errors";
 import { hasBoardingTxExpired } from "../utils/arkTransaction";
 import { CSVMultisigTapscript } from "../script/tapscript";
 import { hex } from "@scure/base";
@@ -1095,9 +1097,13 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                             if (e.message.includes("VTXO_ALREADY_SPENT")) {
                                 // Our local VTXO cache is stale vs. the
                                 // server's authoritative view. Trigger a
-                                // throttled refresh to reconcile, then skip
-                                // — the next cycle will see fresh data.
-                                void this.maybeRefreshAfterVtxoSpent();
+                                // throttled, targeted refresh on the
+                                // offending outpoint (if the server told
+                                // us which one), then skip — the next
+                                // cycle will see fresh data.
+                                void this.maybeRefreshAfterVtxoSpent(
+                                    this.extractSpentOutpoint(e)
+                                );
                                 return;
                             }
                         }
@@ -1124,13 +1130,22 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     /**
      * VTXO_ALREADY_SPENT means the server's authoritative view of VTXO state
      * is ahead of ours — cross-instance race, pre-lock snapshot drift, or an
-     * SSE gap left stale data in the local cache. Silent-swallowing guarantees
-     * the same error on the next cycle because nothing reconciles the cache,
-     * so instead we trigger a full refreshVtxos() to advance the global sync
-     * cursor. Throttled to prevent a buggy indexer from causing a refresh
-     * storm.
+     * SSE gap left stale data in the local cache. Silent-swallowing
+     * guarantees the same error on the next cycle because nothing
+     * reconciles the cache.
+     *
+     * The cursor-derived delta sync filters by `created_at`, so a VTXO that
+     * was created before the cursor but spent recently can never be
+     * reconciled by `refreshVtxos()`. Use `refreshOutpoints` for surgical
+     * recovery: query the indexer for the specific stale outpoint and
+     * upsert its authoritative state into the wallet repository.
+     *
+     * Throttled because the same VTXO can fire repeatedly before the
+     * upsert observably propagates through the renewal selector.
      */
-    private maybeRefreshAfterVtxoSpent(): Promise<void> {
+    private maybeRefreshAfterVtxoSpent(
+        spentOutpoint?: Outpoint
+    ): Promise<void> {
         if (this.vtxoSpentRefreshPromise) {
             return this.vtxoSpentRefreshPromise;
         }
@@ -1146,7 +1161,12 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         this.vtxoSpentRefreshPromise = (async () => {
             try {
                 const contractManager = await this.wallet.getContractManager();
-                await contractManager.refreshVtxos();
+                if (spentOutpoint) {
+                    await contractManager.refreshOutpoints([spentOutpoint]);
+                } else {
+                    // No outpoint metadata — fall back to the broader refresh.
+                    await contractManager.refreshVtxos();
+                }
             } catch (e) {
                 console.error(
                     "Error refreshing VTXOs after VTXO_ALREADY_SPENT:",
@@ -1158,6 +1178,24 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         })();
 
         return this.vtxoSpentRefreshPromise;
+    }
+
+    /**
+     * Extract the offending VTXO outpoint from a `VTXO_ALREADY_SPENT` error,
+     * if the server attached one in `metadata.vtxo_outpoint`. Returns
+     * `undefined` when the error isn't a parsed ArkError, isn't this code,
+     * or doesn't carry the metadata.
+     */
+    private extractSpentOutpoint(error: unknown): Outpoint | undefined {
+        const ark = maybeArkError(error);
+        if (!ark || ark.name !== "VTXO_ALREADY_SPENT") return undefined;
+        const raw = ark.metadata?.vtxo_outpoint;
+        if (typeof raw !== "string") return undefined;
+        const [txid, voutStr] = raw.split(":");
+        if (!txid || !voutStr) return undefined;
+        const vout = Number(voutStr);
+        if (!Number.isInteger(vout) || vout < 0) return undefined;
+        return { txid, vout };
     }
 
     /** Computes the next poll delay, applying exponential backoff on failures. */
@@ -1429,11 +1467,14 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 ) {
                     // Local VTXO cache is stale vs. the server's
                     // authoritative view — not a transient failure.
-                    // Trigger a throttled refresh and skip this cycle
-                    // without bumping the failure counter, so the next
-                    // poll can retry once the cache reconciles.
+                    // Trigger a throttled, targeted refresh on the
+                    // offending outpoint and skip this cycle without
+                    // bumping the failure counter, so the next poll
+                    // can retry once the cache reconciles.
                     staleCacheSkip = true;
-                    void this.maybeRefreshAfterVtxoSpent();
+                    void this.maybeRefreshAfterVtxoSpent(
+                        this.extractSpentOutpoint(e)
+                    );
                 } else {
                     throw e;
                 }

--- a/test/contracts/manager.test.ts
+++ b/test/contracts/manager.test.ts
@@ -433,4 +433,107 @@ describe("ContractManager", () => {
             expect(stateAfter?.lastSyncTime).toBe(SEEDED_CURSOR);
         });
     });
+
+    describe("refreshOutpoints", () => {
+        it("queries the indexer by outpoint and upserts the authoritative state into the wallet repo", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const localManager = await ContractManager.create({
+                indexerProvider: mockIndexer,
+                contractRepository: repository,
+                walletRepository: walletRepo,
+                watcherConfig: {
+                    failsafePollIntervalMs: 1000,
+                    reconnectDelayMs: 500,
+                },
+            });
+            await localManager.createContract({
+                type: "default",
+                params: createDefaultContractParams(),
+                script: TEST_DEFAULT_SCRIPT,
+                address: "address",
+            });
+
+            // Indexer is the source of truth: returns the same VTXO marked
+            // spent. A cursor-derived delta sync would NOT surface this
+            // because the VTXO was created before the cursor; the surgical
+            // outpoint query bypasses that.
+            const spent = createMockVtxo({
+                txid: "aa".repeat(32),
+                script: TEST_DEFAULT_SCRIPT,
+                isSpent: true,
+            });
+            (mockIndexer.getVtxos as any).mockClear();
+            (mockIndexer.getVtxos as any).mockResolvedValue({
+                vtxos: [spent],
+            });
+
+            await localManager.refreshOutpoints([
+                { txid: spent.txid, vout: spent.vout },
+            ]);
+
+            // Outpoint-scoped indexer call.
+            expect(mockIndexer.getVtxos).toHaveBeenCalledWith({
+                outpoints: [{ txid: spent.txid, vout: spent.vout }],
+            });
+
+            // The wallet repo now reflects the spent flag for this address.
+            const stored = await walletRepo.getVtxos("address");
+            const found = stored.find(
+                (v) => v.txid === spent.txid && v.vout === spent.vout
+            );
+            expect(found).toBeDefined();
+            expect(found!.isSpent).toBe(true);
+        });
+
+        it("silently skips outpoints not owned by any tracked contract", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const localManager = await ContractManager.create({
+                indexerProvider: mockIndexer,
+                contractRepository: repository,
+                walletRepository: walletRepo,
+                watcherConfig: {
+                    failsafePollIntervalMs: 1000,
+                    reconnectDelayMs: 500,
+                },
+            });
+            // Indexer returns a VTXO at a script we don't track. The
+            // method should not throw and should not write anything.
+            (mockIndexer.getVtxos as any).mockClear();
+            (mockIndexer.getVtxos as any).mockResolvedValue({
+                vtxos: [
+                    createMockVtxo({
+                        txid: "aa".repeat(32),
+                        script: "cd".repeat(34),
+                        isSpent: true,
+                    }),
+                ],
+            });
+
+            await localManager.refreshOutpoints([
+                { txid: "aa".repeat(32), vout: 0 },
+            ]);
+
+            expect(mockIndexer.getVtxos).toHaveBeenCalled();
+            const stored = await walletRepo.getVtxos("address");
+            expect(stored).toEqual([]);
+        });
+
+        it("is a no-op for an empty outpoint list", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const localManager = await ContractManager.create({
+                indexerProvider: mockIndexer,
+                contractRepository: repository,
+                walletRepository: walletRepo,
+                watcherConfig: {
+                    failsafePollIntervalMs: 1000,
+                    reconnectDelayMs: 500,
+                },
+            });
+            (mockIndexer.getVtxos as any).mockClear();
+
+            await localManager.refreshOutpoints([]);
+
+            expect(mockIndexer.getVtxos).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/test/vtxo-manager.test.ts
+++ b/test/vtxo-manager.test.ts
@@ -2485,6 +2485,7 @@ describe("VtxoManager - VTXO_ALREADY_SPENT reconciliation", () => {
         const contractManager = {
             onContractEvent: vi.fn().mockReturnValue(() => {}),
             refreshVtxos: vi.fn().mockResolvedValue(undefined),
+            refreshOutpoints: vi.fn().mockResolvedValue(undefined),
         };
         return {
             wallet: {
@@ -2702,6 +2703,79 @@ describe("VtxoManager - VTXO_ALREADY_SPENT reconciliation", () => {
         } finally {
             await manager.dispose();
         }
+    });
+
+    // Helper: produce an error message whose body is the JSON-serialised
+    // gRPC-gateway error envelope the server actually emits, so
+    // `maybeArkError` can extract the `vtxo_outpoint` metadata.
+    const makeStructuredVtxoSpentError = (outpoint: string): Error => {
+        const body = JSON.stringify({
+            code: 3,
+            message: `VTXO_ALREADY_SPENT (6): input ${outpoint} already spent`,
+            details: [
+                {
+                    "@type": "type.googleapis.com/ark.v1.ErrorDetails",
+                    code: 6,
+                    name: "VTXO_ALREADY_SPENT",
+                    message: `VTXO_ALREADY_SPENT (6): input ${outpoint} already spent`,
+                    metadata: { vtxo_outpoint: outpoint },
+                },
+            ],
+        });
+        return new Error(body);
+    };
+
+    it("calls contractManager.refreshOutpoints() with the offending outpoint when the server attaches metadata", async () => {
+        const boarding = makeUnexpiredUtxo(10_000);
+        const vtxo = makeExpiringVtxo(5_000);
+        const { wallet, contractManager } = buildWallet([boarding], [vtxo]);
+        const outpoint =
+            "640048627268a0f1acb9920daaf5a3c6e237cafc707b007afbbd450031038e63:0";
+        (wallet.settle as any).mockRejectedValue(
+            makeStructuredVtxoSpentError(outpoint)
+        );
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle([boarding]);
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+        // Targeted recovery: just the offending outpoint, no full re-scan.
+        expect(contractManager.refreshOutpoints).toHaveBeenCalledTimes(1);
+        expect(contractManager.refreshOutpoints).toHaveBeenCalledWith([
+            {
+                txid: "640048627268a0f1acb9920daaf5a3c6e237cafc707b007afbbd450031038e63",
+                vout: 0,
+            },
+        ]);
+        expect(contractManager.refreshVtxos).not.toHaveBeenCalled();
+    });
+
+    it("falls back to refreshVtxos() when the error has no parsable outpoint metadata", async () => {
+        // Plain string error — no JSON envelope, no metadata. The fallback
+        // path is the cursor-based broad refresh.
+        const boarding = makeUnexpiredUtxo(10_000);
+        const vtxo = makeExpiringVtxo(5_000);
+        const { wallet, contractManager } = buildWallet([boarding], [vtxo]);
+        (wallet.settle as any).mockRejectedValue(
+            new Error("VTXO_ALREADY_SPENT")
+        );
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle([boarding]);
+
+        expect(contractManager.refreshOutpoints).not.toHaveBeenCalled();
+        expect(contractManager.refreshVtxos).toHaveBeenCalledTimes(1);
+        expect(contractManager.refreshVtxos).toHaveBeenCalledWith();
     });
 
     it("triggers refreshVtxos() from the event-driven renewal path on VTXO_ALREADY_SPENT", async () => {


### PR DESCRIPTION
## Summary

When the server rejects an intent with \`VTXO_ALREADY_SPENT\`, the wallet's local cache disagrees with the server's authoritative view of that one VTXO. The previous recovery path was a full \`refreshVtxos()\` sweep — but that uses a cursor-derived \`?after=\` filter on \`created_at\`, so a VTXO **created before the cursor and spent recently** can never surface there. The local cache stays stale, the renewal selector keeps picking the same stuck VTXO, and the loop repeats every \`pollIntervalMs\`.

Captured in the wild as a 60-second cycle:

- \`POST /v1/batch/registerIntent → 400 VTXO_ALREADY_SPENT (input \`6400…:0\` already spent)\`
- Wallet calls \`maybeRefreshAfterVtxoSpent\` → broad \`refreshVtxos()\`
- Same VTXO returned next cycle. Forever.

## Fix

Add a surgical recovery path that targets the offending outpoint instead of doing a full re-scan.

### \`IContractManager.refreshOutpoints(outpoints)\`

Queries the indexer by outpoint (no cursor filter), annotates with the owning contract's tapscripts, upserts into the wallet repository at that contract's address. No cursor change, no full re-scan, no traffic for vtxos we already know about.

Outpoints not owned by any tracked contract are silently dropped.

### \`maybeRefreshAfterVtxoSpent(spentOutpoint?)\`

The server attaches \`metadata.vtxo_outpoint\` to its ArkError envelope for \`VTXO_ALREADY_SPENT\`. The wallet now extracts that via \`maybeArkError\` and routes the recovery through \`refreshOutpoints([outpoint])\`. Falls back to the broader \`refreshVtxos()\` only when no outpoint metadata is available (e.g. tests using plain \`new Error('VTXO_ALREADY_SPENT')\`).

Both call sites that catch \`VTXO_ALREADY_SPENT\` in \`vtxo-manager.ts\` (event-driven renewal + periodic settle) wire up the parsed outpoint.

### Service-worker proxy

New \`REFRESH_OUTPOINTS\` message + handler so wallets running behind a service worker get the same precise recovery.

## Tests

**\`test/contracts/manager.test.ts\`** (3 new):
- happy path: queries indexer by outpoint, upserts into repo with the right contract address, the \`isSpent\` flag is visible afterward
- silent skip when the indexer returns a script we don't track
- no-op for empty input

**\`test/vtxo-manager.test.ts\`** (2 new):
- structured ArkError carrying \`vtxo_outpoint\` → \`refreshOutpoints([{txid, vout}])\` is called, \`refreshVtxos\` is NOT
- plain \`Error('VTXO_ALREADY_SPENT')\` (no metadata) → falls back to \`refreshVtxos\` (existing behaviour preserved)

## Test plan

- [x] 5 new tests; all pass
- [x] Full unit suite: 1092 tests pass (5 new on top of 1087 baseline)
- [x] Lint clean
- [x] Typecheck clean

## Related

- Companion to #476 (\`refreshVtxos\` cursor short-circuit) — that PR fixes the wasteful traffic; this one fixes the underlying \"local cache never gets the truth\" loop. Both can be merged independently in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added targeted outpoint refresh capability and service-worker messaging to request/acknowledge outpoint refreshes with a 30s timeout.
* **Bug Fixes**
  * VTXO stale/spent errors now trigger focused outpoint reconciliation instead of always performing a full refresh.
* **Tests**
  * New tests cover outpoint refresh behavior, skipping unknown scripts, and periodic-settle error handling (including parsing/fallback cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->