### PR TITLE
Unilateral exit bundle (#338 + #222 + #416)

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ for await (const step of session) {
       console.log(`Waiting for transaction ${step.txid} to be confirmed`);
       break;
     case Unroll.StepType.UNROLL:
-      console.log(`Broadcasting transaction ${step.tx.id}`);
+      console.log(`Transaction ${step.tx.id} unrolled`);
       break;
     case Unroll.StepType.DONE:
       console.log(`Unrolling complete for virtual output ${step.vtxoTxid}`);
@@ -748,6 +748,26 @@ The unrolling process works by:
 - Broadcasting each transaction that isn't already onchain
 - Waiting for confirmations between steps
 - Using P2A (Pay-to-Anchor) transactions to pay for fees
+
+Optionally, you can use `session.next()` to control the broadcasting process manually.
+
+```typescript
+const step = await session.next();
+switch (step.type) {
+  case Unroll.StepType.WAIT:
+    await step.do(); // wait for the transaction to be confirmed
+    break;
+  case Unroll.StepType.UNROLL:
+    const [parent, child] = step.pkg;
+    console.log(`Parent: ${parent}`)
+    console.log(`Child: ${child}`)
+    await step.do(); // broadcast the 1C1P package
+    break;
+  case Unroll.StepType.DONE:
+    console.log(`Unrolling complete for VTXO ${step.vtxoTxid}`);
+    break;
+  }
+```
 
 #### Step 2: Completing the Exit
 

--- a/src/script/base.ts
+++ b/src/script/base.ts
@@ -177,11 +177,11 @@ export class VtxoScript {
         for (const leaf of this.leaves) {
             try {
                 const script = scriptFromTapLeafScript(leaf);
-                if (CSVMultisigTapscript.isScriptValid(script)) {
+                if (CSVMultisigTapscript.isScriptValid(script) === true) {
                     const tapScript = CSVMultisigTapscript.decode(script);
                     paths.push(tapScript);
                 } else if (
-                    ConditionCSVMultisigTapscript.isScriptValid(script)
+                    ConditionCSVMultisigTapscript.isScriptValid(script) === true
                 ) {
                     const tapScript =
                         ConditionCSVMultisigTapscript.decode(script);

--- a/src/script/base.ts
+++ b/src/script/base.ts
@@ -176,20 +176,19 @@ export class VtxoScript {
         > = [];
         for (const leaf of this.leaves) {
             try {
-                const tapscript = CSVMultisigTapscript.decode(
-                    scriptFromTapLeafScript(leaf)
-                );
-                paths.push(tapscript);
-                continue;
-            } catch (e) {
-                try {
-                    const tapscript = ConditionCSVMultisigTapscript.decode(
-                        scriptFromTapLeafScript(leaf)
-                    );
-                    paths.push(tapscript);
-                } catch (e) {
-                    continue;
+                const script = scriptFromTapLeafScript(leaf);
+                if (CSVMultisigTapscript.isScriptValid(script)) {
+                    const tapScript = CSVMultisigTapscript.decode(script);
+                    paths.push(tapScript);
+                } else if (
+                    ConditionCSVMultisigTapscript.isScriptValid(script)
+                ) {
+                    const tapScript =
+                        ConditionCSVMultisigTapscript.decode(script);
+                    paths.push(tapScript);
                 }
+            } catch (e) {
+                console.debug("Failed to decode script", e);
             }
         }
         return paths;

--- a/src/script/tapscript.ts
+++ b/src/script/tapscript.ts
@@ -350,23 +350,14 @@ export namespace CSVMultisigTapscript {
             throw new Error("Failed to decode: script is empty");
         }
 
+        const isValid = isScriptValid(script);
+        if (isValid instanceof Error) {
+            throw isValid;
+        }
+
         const asm = Script.decode(script);
 
-        if (asm.length < 3) {
-            throw new Error(`Invalid script: too short (expected at least 3)`);
-        }
-
         const sequence = asm[0];
-        if (typeof sequence === "string") {
-            throw new Error("Invalid script: expected sequence number");
-        }
-
-        if (asm[1] !== "CHECKSEQUENCEVERIFY" || asm[2] !== "DROP") {
-            throw new Error(
-                "Invalid script: expected CHECKSEQUENCEVERIFY DROP"
-            );
-        }
-
         const multisigScript = new Uint8Array(Script.encode(asm.slice(3)));
         let multisig: MultisigTapscript.Type;
 
@@ -413,6 +404,27 @@ export namespace CSVMultisigTapscript {
     export function is(tapscript: ArkTapscript<any, any>): tapscript is Type {
         return tapscript.type === TapscriptType.CSVMultisig;
     }
+
+    export function isScriptValid(script: Uint8Array): true | Error {
+        const asm = Script.decode(script);
+
+        if (asm.length < 3) {
+            return new Error(`Invalid script: too short (expected at least 3)`);
+        }
+
+        const sequence = asm[0];
+        if (typeof sequence === "string") {
+            return new Error("Invalid script: expected sequence number");
+        }
+
+        if (asm[1] !== "CHECKSEQUENCEVERIFY" || asm[2] !== "DROP") {
+            return new Error(
+                "Invalid script: expected CHECKSEQUENCEVERIFY DROP"
+            );
+        }
+
+        return true;
+    }
 }
 
 /**
@@ -455,21 +467,17 @@ export namespace ConditionCSVMultisigTapscript {
             throw new Error("Failed to decode: script is empty");
         }
 
+        const isValid = isScriptValid(script);
+        if (isValid instanceof Error) {
+            throw isValid;
+        }
+
         const asm = Script.decode(script);
 
-        if (asm.length < 1) {
-            throw new Error(`Invalid script: too short (expected at least 1)`);
-        }
-
-        let verifyIndex = -1;
-        for (let i = asm.length - 1; i >= 0; i--) {
-            if (asm[i] === "VERIFY") {
-                verifyIndex = i;
-            }
-        }
+        let verifyIndex = getVerifyIndex(asm);
 
         if (verifyIndex === -1) {
-            throw new Error("Invalid script: missing VERIFY operation");
+            throw Error("Invalid script: missing VERIFY operation");
         }
 
         const conditionScript = new Uint8Array(
@@ -513,6 +521,33 @@ export namespace ConditionCSVMultisigTapscript {
     export function is(tapscript: ArkTapscript<any, any>): tapscript is Type {
         return tapscript.type === TapscriptType.ConditionCSVMultisig;
     }
+
+    function getVerifyIndex(asm: ScriptType) {
+        let verifyIndex = -1;
+        for (let i = asm.length - 1; i >= 0; i--) {
+            if (asm[i] === "VERIFY") {
+                verifyIndex = i;
+                return verifyIndex;
+            }
+        }
+        return verifyIndex;
+    }
+
+    export function isScriptValid(script: Uint8Array): true | Error {
+        const asm = Script.decode(script);
+
+        if (asm.length < 1) {
+            return new Error(`Invalid script: too short (expected at least 1)`);
+        }
+
+        let verifyIndex = getVerifyIndex(asm);
+
+        if (verifyIndex === -1) {
+            return new Error("Invalid script: missing VERIFY operation");
+        }
+
+        return true;
+    }
 }
 
 /**
@@ -555,21 +590,17 @@ export namespace ConditionMultisigTapscript {
             throw new Error("Failed to decode: script is empty");
         }
 
+        const isValid = isScriptValid(script);
+        if (isValid instanceof Error) {
+            throw isValid;
+        }
+
         const asm = Script.decode(script);
 
-        if (asm.length < 1) {
-            throw new Error(`Invalid script: too short (expected at least 1)`);
-        }
-
-        let verifyIndex = -1;
-        for (let i = asm.length - 1; i >= 0; i--) {
-            if (asm[i] === "VERIFY") {
-                verifyIndex = i;
-            }
-        }
+        let verifyIndex = getVerifyIndex(asm);
 
         if (verifyIndex === -1) {
-            throw new Error("Invalid script: missing VERIFY operation");
+            throw Error("Invalid script: missing VERIFY operation");
         }
 
         const conditionScript = new Uint8Array(
@@ -612,6 +643,33 @@ export namespace ConditionMultisigTapscript {
     /** Return true when the tapscript is a condition + multisig tapscript. */
     export function is(tapscript: ArkTapscript<any, any>): tapscript is Type {
         return tapscript.type === TapscriptType.ConditionMultisig;
+    }
+
+    function getVerifyIndex(asm: ScriptType) {
+        let verifyIndex = -1;
+        for (let i = asm.length - 1; i >= 0; i--) {
+            if (asm[i] === "VERIFY") {
+                verifyIndex = i;
+                return verifyIndex;
+            }
+        }
+        return verifyIndex;
+    }
+
+    export function isScriptValid(script: Uint8Array): true | Error {
+        const asm = Script.decode(script);
+
+        if (asm.length < 1) {
+            return new Error(`Invalid script: too short (expected at least 1)`);
+        }
+
+        let verifyIndex = getVerifyIndex(asm);
+
+        if (verifyIndex === -1) {
+            return new Error("Invalid script: missing VERIFY operation");
+        }
+
+        return true;
     }
 }
 
@@ -662,11 +720,12 @@ export namespace CLTVMultisigTapscript {
             throw new Error("Failed to decode: script is empty");
         }
 
-        const asm = Script.decode(script);
-
-        if (asm.length < 3) {
-            throw new Error(`Invalid script: too short (expected at least 3)`);
+        const isValid = isScriptValid(script);
+        if (isValid instanceof Error) {
+            throw isValid;
         }
+
+        const asm = Script.decode(script);
 
         const locktime = asm[0];
         if (typeof locktime === "string") {
@@ -694,8 +753,9 @@ export namespace CLTVMultisigTapscript {
         if (typeof locktime === "number") {
             absoluteTimelock = BigInt(locktime);
         } else {
-            absoluteTimelock = MinimalScriptNum.decode(locktime);
+            absoluteTimelock = MinimalScriptNum.decode(locktime as Bytes);
         }
+
         const reconstructed = encode({
             absoluteTimelock,
             ...multisig.params,
@@ -720,5 +780,28 @@ export namespace CLTVMultisigTapscript {
     /** Return true when the tapscript is a CLTV multisig tapscript. */
     export function is(tapscript: ArkTapscript<any, any>): tapscript is Type {
         return tapscript.type === TapscriptType.CLTVMultisig;
+    }
+
+    export function isScriptValid(script: Uint8Array): true | Error {
+        const asm = Script.decode(script);
+
+        if (asm.length < 3) {
+            return new Error(`Invalid script: too short (expected at least 3)`);
+        }
+
+        const locktime = asm[0];
+        if (typeof locktime === "string") {
+            return new Error(
+                "Invalid script: expected locktime as number or bytes"
+            );
+        }
+
+        if (asm[1] !== "CHECKLOCKTIMEVERIFY" || asm[2] !== "DROP") {
+            return new Error(
+                "Invalid script: expected CHECKLOCKTIMEVERIFY DROP"
+            );
+        }
+
+        return true;
     }
 }

--- a/src/wallet/unroll.ts
+++ b/src/wallet/unroll.ts
@@ -28,6 +28,7 @@ export namespace Unroll {
      */
     export type UnrollStep = {
         tx: Transaction;
+        pkg: [parent: string, child: string];
     };
 
     /**
@@ -191,10 +192,12 @@ export namespace Unroll {
                 tx.finalize();
             }
 
+            const pkg = await this.bumper.bumpP2A(tx);
             return {
                 type: StepType.UNROLL,
                 tx,
-                do: doUnroll(this.bumper, this.explorer, tx),
+                pkg,
+                do: doUnroll(this.explorer, pkg),
             };
         }
 
@@ -334,14 +337,11 @@ function sleep(ms: number): Promise<void> {
 }
 
 function doUnroll(
-    bumper: AnchorBumper,
     onchainProvider: OnchainProvider,
-    tx: Transaction
+    pkg: Unroll.UnrollStep["pkg"]
 ): () => Promise<void> {
-    return async () => {
-        const [parent, child] = await bumper.bumpP2A(tx);
-        await onchainProvider.broadcastTransaction(parent, child);
-    };
+    return () =>
+        onchainProvider.broadcastTransaction(...pkg).then(() => undefined);
 }
 
 function doWait(

--- a/src/wallet/unroll.ts
+++ b/src/wallet/unroll.ts
@@ -342,7 +342,7 @@ export async function prepareUnrollTransaction(
         throw new Error("send amount is less than dust amount");
     }
 
-    tx.addOutputAddress(outputAddress, sendAmount);
+    tx.addOutputAddress(outputAddress, sendAmount, wallet.network);
 
     const signedTx = await wallet.identity.sign(tx);
     signedTx.finalize();

--- a/src/wallet/unroll.ts
+++ b/src/wallet/unroll.ts
@@ -234,102 +234,119 @@ export namespace Unroll {
         vtxoTxids: string[],
         outputAddress: string
     ): Promise<string> {
-        const chainTip = await wallet.onchainProvider.getChainTip();
-
-        let vtxos = await wallet.getVtxos({ withUnrolled: true });
-        vtxos = vtxos.filter((vtxo) => vtxoTxids.includes(vtxo.txid));
-
-        if (vtxos.length === 0) {
-            throw new Error("No vtxos to complete unroll");
-        }
-
-        const inputs: TransactionInputUpdate[] = [];
-        let totalAmount = 0n;
-        const txWeightEstimator = TxWeightEstimator.create();
-        for (const vtxo of vtxos) {
-            if (!vtxo.isUnrolled) {
-                throw new Error(
-                    `Vtxo ${vtxo.txid}:${vtxo.vout} is not fully unrolled, use unroll first`
-                );
-            }
-
-            const txStatus = await wallet.onchainProvider.getTxStatus(
-                vtxo.txid
-            );
-            if (!txStatus.confirmed) {
-                throw new Error(`tx ${vtxo.txid} is not confirmed`);
-            }
-
-            const exit = availableExitPath(
-                { height: txStatus.blockHeight, time: txStatus.blockTime },
-                chainTip,
-                vtxo
-            );
-            if (!exit) {
-                throw new Error(
-                    `no available exit path found for vtxo ${vtxo.txid}:${vtxo.vout}`
-                );
-            }
-
-            const spendingLeaf = VtxoScript.decode(vtxo.tapTree).findLeaf(
-                hex.encode(exit.script)
-            );
-            if (!spendingLeaf) {
-                throw new Error(
-                    `spending leaf not found for vtxo ${vtxo.txid}:${vtxo.vout}`
-                );
-            }
-
-            totalAmount += BigInt(vtxo.value);
-            const sequence = timelockToSequence(exit.params.timelock);
-            inputs.push({
-                txid: vtxo.txid,
-                index: vtxo.vout,
-                tapLeafScript: [spendingLeaf],
-                sequence,
-                witnessUtxo: {
-                    amount: BigInt(vtxo.value),
-                    script: VtxoScript.decode(vtxo.tapTree).pkScript,
-                },
-                sighashType: SigHash.DEFAULT,
-            });
-            txWeightEstimator.addTapscriptInput(
-                64,
-                spendingLeaf[1].length,
-                TaprootControlBlock.encode(spendingLeaf[0]).length
-            );
-        }
-
-        const tx = new Transaction({ version: 2 });
-        for (const input of inputs) {
-            tx.addInput(input);
-        }
-
-        txWeightEstimator.addOutputAddress(outputAddress, wallet.network);
-
-        let feeRate = await wallet.onchainProvider.getFeeRate();
-        if (!feeRate || feeRate < Wallet.MIN_FEE_RATE) {
-            feeRate = Wallet.MIN_FEE_RATE;
-        }
-        const feeAmount = txWeightEstimator.vsize().fee(BigInt(feeRate));
-        if (feeAmount > totalAmount) {
-            throw new Error("fee amount is greater than the total amount");
-        }
-
-        const sendAmount = totalAmount - feeAmount;
-        if (sendAmount < BigInt(DUST_AMOUNT)) {
-            throw new Error("send amount is less than dust amount");
-        }
-
-        tx.addOutputAddress(outputAddress, sendAmount);
-
-        const signedTx = await wallet.identity.sign(tx);
-        signedTx.finalize();
-
+        const signedTx = await prepareUnrollTransaction(
+            wallet,
+            vtxoTxids,
+            outputAddress
+        );
         await wallet.onchainProvider.broadcastTransaction(signedTx.hex);
-
         return signedTx.id;
     }
+}
+
+/**
+ * Prepares the transaction that spends the CSV path to complete unrolling a VTXO.
+ * @param wallet the wallet owning the VTXO(s)
+ * @param vtxoTxIds the txids of the VTXO(s) to complete unroll
+ * @param outputAddress the address to send the unrolled funds to
+ * @throws if the VTXO(s) are not fully unrolled, if the txids are not found, if the tx is not confirmed, if no exit path is found or not available
+ * @returns the transaction spending the unrolled funds
+ */
+export async function prepareUnrollTransaction(
+    wallet: Wallet,
+    vtxoTxIds: string[],
+    outputAddress: string
+): Promise<Transaction> {
+    const chainTip = await wallet.onchainProvider.getChainTip();
+
+    let vtxos = await wallet.getVtxos({ withUnrolled: true });
+    vtxos = vtxos.filter((vtxo) => vtxoTxIds.includes(vtxo.txid));
+
+    if (vtxos.length === 0) {
+        throw new Error("No vtxos to complete unroll");
+    }
+
+    const inputs: TransactionInputUpdate[] = [];
+    let totalAmount = 0n;
+    const txWeightEstimator = TxWeightEstimator.create();
+    for (const vtxo of vtxos) {
+        if (!vtxo.isUnrolled) {
+            throw new Error(
+                `Vtxo ${vtxo.txid}:${vtxo.vout} is not fully unrolled, use unroll first`
+            );
+        }
+
+        const txStatus = await wallet.onchainProvider.getTxStatus(vtxo.txid);
+        if (!txStatus.confirmed) {
+            throw new Error(`tx ${vtxo.txid} is not confirmed`);
+        }
+
+        const exit = availableExitPath(
+            { height: txStatus.blockHeight, time: txStatus.blockTime },
+            chainTip,
+            vtxo
+        );
+        if (!exit) {
+            throw new Error(
+                `no available exit path found for vtxo ${vtxo.txid}:${vtxo.vout}`
+            );
+        }
+
+        const spendingLeaf = VtxoScript.decode(vtxo.tapTree).findLeaf(
+            hex.encode(exit.script)
+        );
+        if (!spendingLeaf) {
+            throw new Error(
+                `spending leaf not found for vtxo ${vtxo.txid}:${vtxo.vout}`
+            );
+        }
+
+        totalAmount += BigInt(vtxo.value);
+        const sequence = timelockToSequence(exit.params.timelock);
+        inputs.push({
+            txid: vtxo.txid,
+            index: vtxo.vout,
+            tapLeafScript: [spendingLeaf],
+            sequence,
+            witnessUtxo: {
+                amount: BigInt(vtxo.value),
+                script: VtxoScript.decode(vtxo.tapTree).pkScript,
+            },
+            sighashType: SigHash.DEFAULT,
+        });
+        txWeightEstimator.addTapscriptInput(
+            64,
+            spendingLeaf[1].length,
+            TaprootControlBlock.encode(spendingLeaf[0]).length
+        );
+    }
+
+    const tx = new Transaction({ version: 2 });
+    for (const input of inputs) {
+        tx.addInput(input);
+    }
+
+    txWeightEstimator.addOutputAddress(outputAddress, wallet.network);
+
+    let feeRate = await wallet.onchainProvider.getFeeRate();
+    if (!feeRate || feeRate < Wallet.MIN_FEE_RATE) {
+        feeRate = Wallet.MIN_FEE_RATE;
+    }
+    const feeAmount = txWeightEstimator.vsize().fee(BigInt(feeRate));
+    if (feeAmount > totalAmount) {
+        throw new Error("fee amount is greater than the total amount");
+    }
+
+    const sendAmount = totalAmount - feeAmount;
+    if (sendAmount < BigInt(DUST_AMOUNT)) {
+        throw new Error("send amount is less than dust amount");
+    }
+
+    tx.addOutputAddress(outputAddress, sendAmount);
+
+    const signedTx = await wallet.identity.sign(tx);
+    signedTx.finalize();
+    return signedTx;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -534,7 +534,8 @@ describe("Common", () => {
                         return b.length > 0;
                     });
 
-                    const boardingInputs = await alice.wallet.getBoardingUtxos();
+                    const boardingInputs =
+                        await alice.wallet.getBoardingUtxos();
                     expect(boardingInputs.length).toBeGreaterThanOrEqual(1);
 
                     await alice.wallet.settle({
@@ -593,18 +594,22 @@ describe("Common", () => {
                     const unrolled = virtualCoinsAfterExit[0];
                     expect(unrolled.isUnrolled).toBe(true);
 
-                    const exits = VtxoScript.decode(unrolled.tapTree).exitPaths();
+                    const exits = VtxoScript.decode(
+                        unrolled.tapTree
+                    ).exitPaths();
                     expect(exits.length).toBeGreaterThan(0);
 
-                    const txStatus = await alice.wallet.onchainProvider.getTxStatus(
-                        unrolled.txid
-                    );
+                    const txStatus =
+                        await alice.wallet.onchainProvider.getTxStatus(
+                            unrolled.txid
+                        );
                     expect(txStatus.confirmed).toBe(true);
 
                     // Keep this aligned with availableExitPath() selection logic,
                     // which currently returns the first mature exit path.
                     const exitTimelock = exits[0].params.timelock;
-                    const chainTip = await alice.wallet.onchainProvider.getChainTip();
+                    const chainTip =
+                        await alice.wallet.onchainProvider.getChainTip();
                     if (exitTimelock.type === "blocks") {
                         const requiredHeight =
                             txStatus.blockHeight + Number(exitTimelock.value);
@@ -642,7 +647,8 @@ describe("Common", () => {
                         return b.length > 0;
                     });
 
-                    const boardingInputs = await alice.wallet.getBoardingUtxos();
+                    const boardingInputs =
+                        await alice.wallet.getBoardingUtxos();
                     expect(boardingInputs.length).toBeGreaterThanOrEqual(1);
 
                     await alice.wallet.settle({
@@ -701,12 +707,15 @@ describe("Common", () => {
                     const unrolled = virtualCoinsAfterExit[0];
                     expect(unrolled.isUnrolled).toBe(true);
 
-                    const exits = VtxoScript.decode(unrolled.tapTree).exitPaths();
+                    const exits = VtxoScript.decode(
+                        unrolled.tapTree
+                    ).exitPaths();
                     expect(exits.length).toBeGreaterThan(0);
 
-                    const txStatus = await alice.wallet.onchainProvider.getTxStatus(
-                        unrolled.txid
-                    );
+                    const txStatus =
+                        await alice.wallet.onchainProvider.getTxStatus(
+                            unrolled.txid
+                        );
                     expect(txStatus.confirmed).toBe(true);
 
                     // Keep this aligned with availableExitPath() selection logic,
@@ -743,7 +752,9 @@ describe("Common", () => {
                         }
                         const finalTip =
                             await alice.wallet.onchainProvider.getChainTip();
-                        expect(finalTip.time).toBeGreaterThanOrEqual(requiredTime);
+                        expect(finalTip.time).toBeGreaterThanOrEqual(
+                            requiredTime
+                        );
                         if (initialTip.time < requiredTime) {
                             expect(blocksMined).toBeGreaterThan(0);
                         }

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -14,6 +14,7 @@ import {
     ArkAddress,
     buildOffchainTx,
     CSVMultisigTapscript,
+    VtxoScript,
     Wallet,
     EsploraProvider,
     InMemoryWalletRepository,
@@ -515,6 +516,143 @@ describe("Common", () => {
                 expect(virtualCoinsAfterExit).toHaveLength(1);
                 expect(virtualCoinsAfterExit[0].isUnrolled).toBe(true);
             });
+
+            it(
+                "should complete unroll after unilateral exit delay",
+                { timeout: 120000 },
+                async () => {
+                    const alice = await factory();
+
+                    const boardingAddress =
+                        await alice.wallet.getBoardingAddress();
+                    const offchainAddress = await alice.wallet.getAddress();
+
+                    execCommand(`nigiri faucet ${boardingAddress} 0.0001`);
+
+                    await waitFor(async () => {
+                        const b = await alice.wallet.getBoardingUtxos();
+                        return b.length > 0;
+                    });
+
+                    const boardingInputs = await alice.wallet.getBoardingUtxos();
+                    expect(boardingInputs.length).toBeGreaterThanOrEqual(1);
+
+                    await alice.wallet.settle({
+                        inputs: boardingInputs,
+                        outputs: [
+                            {
+                                address: offchainAddress!,
+                                amount: BigInt(10000),
+                            },
+                        ],
+                    });
+
+                    execCommand(`nigiri rpc --generate 1`);
+
+                    await waitFor(async () => {
+                        const v = await alice.wallet.getVtxos();
+                        return v.length > 0;
+                    });
+
+                    const virtualCoins = await alice.wallet.getVtxos();
+                    expect(virtualCoins).toHaveLength(1);
+                    const vtxo = virtualCoins[0];
+                    expect(vtxo.txid).toBeDefined();
+
+                    const onchainAlice = await OnchainWallet.create(
+                        alice.identity,
+                        "regtest"
+                    );
+
+                    execCommand(`nigiri faucet ${onchainAlice.address} 0.001`);
+                    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+                    const session = await Unroll.Session.create(
+                        { txid: vtxo.txid, vout: vtxo.vout },
+                        onchainAlice,
+                        onchainAlice.provider,
+                        new RestIndexerProvider("http://localhost:7070")
+                    );
+
+                    for await (const done of session) {
+                        switch (done.type) {
+                            case Unroll.StepType.WAIT:
+                            case Unroll.StepType.UNROLL:
+                                execCommand(`nigiri rpc --generate 1`);
+                                break;
+                        }
+                    }
+
+                    const virtualCoinsAfterExit = await alice.wallet.getVtxos({
+                        withUnrolled: true,
+                    });
+                    expect(virtualCoinsAfterExit).toHaveLength(1);
+                    const unrolled = virtualCoinsAfterExit[0];
+                    expect(unrolled.isUnrolled).toBe(true);
+
+                    const exits = VtxoScript.decode(unrolled.tapTree).exitPaths();
+                    expect(exits.length).toBeGreaterThan(0);
+
+                    const txStatus = await alice.wallet.onchainProvider.getTxStatus(
+                        unrolled.txid
+                    );
+                    expect(txStatus.confirmed).toBe(true);
+
+                    const exitTimelock = exits[0].params.timelock;
+                    if (exitTimelock.type === "blocks") {
+                        const chainTip =
+                            await alice.wallet.onchainProvider.getChainTip();
+                        const requiredHeight =
+                            txStatus.blockHeight + Number(exitTimelock.value);
+                        const remainingBlocks = Math.max(
+                            0,
+                            requiredHeight - chainTip.height
+                        );
+                        if (remainingBlocks > 0) {
+                            execCommand(
+                                `nigiri rpc --generate ${remainingBlocks}`
+                            );
+                        }
+                    } else {
+                        const requiredTime =
+                            txStatus.blockTime + Number(exitTimelock.value);
+                        for (let i = 0; i < 300; i += 1) {
+                            const chainTip =
+                                await alice.wallet.onchainProvider.getChainTip();
+                            if (chainTip.time >= requiredTime) {
+                                break;
+                            }
+                            execCommand(`nigiri rpc --generate 1`);
+                        }
+                        const finalTip =
+                            await alice.wallet.onchainProvider.getChainTip();
+                        expect(finalTip.time).toBeGreaterThanOrEqual(requiredTime);
+                    }
+
+                    const beforeBalance = await onchainAlice.getBalance();
+                    const completeTxid = await Unroll.completeUnroll(
+                        alice.wallet,
+                        [unrolled.txid],
+                        onchainAlice.address
+                    );
+                    expect(completeTxid).toBeDefined();
+
+                    execCommand(`nigiri rpc --generate 1`);
+
+                    await waitFor(async () => {
+                        const status =
+                            await alice.wallet.onchainProvider.getTxStatus(
+                                completeTxid
+                            );
+                        return status.confirmed;
+                    });
+
+                    await waitFor(async () => {
+                        const afterBalance = await onchainAlice.getBalance();
+                        return afterBalance > beforeBalance;
+                    });
+                }
+            );
 
             it("should exit collaboratively", { timeout: 60000 }, async () => {
                 const alice = await factory();

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -518,6 +518,114 @@ describe("Common", () => {
             });
 
             it(
+                "should reject complete-unroll before unilateral exit delay matures",
+                { timeout: 120000 },
+                async () => {
+                    const alice = await factory();
+
+                    const boardingAddress =
+                        await alice.wallet.getBoardingAddress();
+                    const offchainAddress = await alice.wallet.getAddress();
+
+                    execCommand(`nigiri faucet ${boardingAddress} 0.0001`);
+
+                    await waitFor(async () => {
+                        const b = await alice.wallet.getBoardingUtxos();
+                        return b.length > 0;
+                    });
+
+                    const boardingInputs = await alice.wallet.getBoardingUtxos();
+                    expect(boardingInputs.length).toBeGreaterThanOrEqual(1);
+
+                    await alice.wallet.settle({
+                        inputs: boardingInputs,
+                        outputs: [
+                            {
+                                address: offchainAddress!,
+                                amount: BigInt(10000),
+                            },
+                        ],
+                    });
+
+                    execCommand(`nigiri rpc --generate 1`);
+
+                    await waitFor(async () => {
+                        const v = await alice.wallet.getVtxos();
+                        return v.length > 0;
+                    });
+
+                    const virtualCoins = await alice.wallet.getVtxos();
+                    expect(virtualCoins).toHaveLength(1);
+                    const vtxo = virtualCoins[0];
+                    expect(vtxo.txid).toBeDefined();
+
+                    const onchainAlice = await OnchainWallet.create(
+                        alice.identity,
+                        "regtest"
+                    );
+
+                    execCommand(`nigiri faucet ${onchainAlice.address} 0.001`);
+                    await waitFor(async () => {
+                        const b = await onchainAlice.getBalance();
+                        return b > 0;
+                    });
+
+                    const session = await Unroll.Session.create(
+                        { txid: vtxo.txid, vout: vtxo.vout },
+                        onchainAlice,
+                        onchainAlice.provider,
+                        new RestIndexerProvider("http://localhost:7070")
+                    );
+
+                    for await (const done of session) {
+                        switch (done.type) {
+                            case Unroll.StepType.WAIT:
+                            case Unroll.StepType.UNROLL:
+                                execCommand(`nigiri rpc --generate 1`);
+                                break;
+                        }
+                    }
+
+                    const virtualCoinsAfterExit = await alice.wallet.getVtxos({
+                        withUnrolled: true,
+                    });
+                    expect(virtualCoinsAfterExit).toHaveLength(1);
+                    const unrolled = virtualCoinsAfterExit[0];
+                    expect(unrolled.isUnrolled).toBe(true);
+
+                    const exits = VtxoScript.decode(unrolled.tapTree).exitPaths();
+                    expect(exits.length).toBeGreaterThan(0);
+
+                    const txStatus = await alice.wallet.onchainProvider.getTxStatus(
+                        unrolled.txid
+                    );
+                    expect(txStatus.confirmed).toBe(true);
+
+                    // Keep this aligned with availableExitPath() selection logic,
+                    // which currently returns the first mature exit path.
+                    const exitTimelock = exits[0].params.timelock;
+                    const chainTip = await alice.wallet.onchainProvider.getChainTip();
+                    if (exitTimelock.type === "blocks") {
+                        const requiredHeight =
+                            txStatus.blockHeight + Number(exitTimelock.value);
+                        expect(chainTip.height).toBeLessThan(requiredHeight);
+                    } else {
+                        const requiredTime =
+                            txStatus.blockTime + Number(exitTimelock.value);
+                        expect(chainTip.time).toBeLessThan(requiredTime);
+                    }
+
+                    await expect(
+                        Unroll.completeUnroll(
+                            alice.wallet,
+                            [unrolled.txid],
+                            onchainAlice.address
+                        )
+                    ).rejects.toThrow(/no available exit path found/i);
+                }
+            );
+
+            it(
                 "should complete unroll after unilateral exit delay",
                 { timeout: 120000 },
                 async () => {

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -565,7 +565,10 @@ describe("Common", () => {
                     );
 
                     execCommand(`nigiri faucet ${onchainAlice.address} 0.001`);
-                    await new Promise((resolve) => setTimeout(resolve, 5000));
+                    await waitFor(async () => {
+                        const b = await onchainAlice.getBalance();
+                        return b > 0;
+                    });
 
                     const session = await Unroll.Session.create(
                         { txid: vtxo.txid, vout: vtxo.vout },
@@ -598,6 +601,8 @@ describe("Common", () => {
                     );
                     expect(txStatus.confirmed).toBe(true);
 
+                    // Keep this aligned with availableExitPath() selection logic,
+                    // which currently returns the first mature exit path.
                     const exitTimelock = exits[0].params.timelock;
                     if (exitTimelock.type === "blocks") {
                         const chainTip =
@@ -616,6 +621,9 @@ describe("Common", () => {
                     } else {
                         const requiredTime =
                             txStatus.blockTime + Number(exitTimelock.value);
+                        const initialTip =
+                            await alice.wallet.onchainProvider.getChainTip();
+                        let blocksMined = 0;
                         for (let i = 0; i < 300; i += 1) {
                             const chainTip =
                                 await alice.wallet.onchainProvider.getChainTip();
@@ -623,10 +631,14 @@ describe("Common", () => {
                                 break;
                             }
                             execCommand(`nigiri rpc --generate 1`);
+                            blocksMined += 1;
                         }
                         const finalTip =
                             await alice.wallet.onchainProvider.getChainTip();
                         expect(finalTip.time).toBeGreaterThanOrEqual(requiredTime);
+                        if (initialTip.time < requiredTime) {
+                            expect(blocksMined).toBeGreaterThan(0);
+                        }
                     }
 
                     const beforeBalance = await onchainAlice.getBalance();

--- a/test/e2e/ark.test.ts
+++ b/test/e2e/ark.test.ts
@@ -734,6 +734,14 @@ describe("Common", () => {
                             execCommand(
                                 `nigiri rpc --generate ${remainingBlocks}`
                             );
+                            // Wait for the onchain provider to observe the new
+                            // tip; nigiri-mined blocks are not always visible
+                            // to esplora the instant `nigiri rpc` returns.
+                            await waitFor(async () => {
+                                const tip =
+                                    await alice.wallet.onchainProvider.getChainTip();
+                                return tip.height >= requiredHeight;
+                            });
                         }
                     } else {
                         const requiredTime =


### PR DESCRIPTION
## Summary

This PR converges three open PRs around the unilateral-exit / `Unroll.completeUnroll` flow into one stack so they can land together and share CI:

- [#338](https://github.com/arkade-os/ts-sdk/pull/338) — `refactor(script)`: extract `isScriptValid` helpers and clean exit paths (Shubert Munthali)
- [#222](https://github.com/arkade-os/ts-sdk/pull/222) — `feat(unroll)`: prepare unroll transaction separately from broadcast + README + UnrollStep `pkg` (louisinger, Shubert Munthali)
- [#416](https://github.com/arkade-os/ts-sdk/pull/416) — `test(e2e)`: cover/harden complete-unroll unilateral exit path (brendio)

### Why a bundle

The three PRs touch the same area (`src/script/`, `src/wallet/unroll.ts`, e2e exit tests) and stalled separately. #222's `prepareUnrollTransaction` extraction is what the new e2e tests in #416 lean on; #338's `isScriptValid` cleanup is independent but lives in the same files exit logic decodes. Landing them together avoids three rounds of master-rebase pain — and surfaces three latent bugs that none of the PRs caught in isolation (see "Bundle-level fixes" below).

### Authorship

| Commit | Author | Source |
|--------|--------|--------|
| `refactor(script): extract isScriptValid helpers and clean exit paths` | Shubert Munthali | #338 (squashed — review fix-ups collapsed into one) |
| `add the pkg to broadcast to UnrollStep` | louisinger | #222 |
| `update README` | louisinger | #222 |
| `Prepare unroll transaction separately from broadcast (#2)` | Shubert Munthali | #222 |
| `test(e2e): cover complete-unroll unilateral exit path` | brendio | #416 |
| `test(e2e): harden complete-unroll maturity waiting` | brendio | #416 |
| `test(e2e): assert complete-unroll rejects before csv maturity` | brendio | #416 |
| `style(e2e): format unilateral exit test` | brendio | #416 |
| `fix(script): VtxoScript.exitPaths checks isScriptValid === true` | bundle integration | new |
| `fix(e2e): wait for onchain provider to observe mined exit-maturity blocks` | bundle integration | new |
| `fix(unroll): pass wallet.network to tx.addOutputAddress in completeUnroll` | bundle integration | new |

### Conflict resolutions

- **`src/script/tapscript.ts`** (#338): the squash takes the final state of #338 — `isScriptValid` returns `true | Error`, locktime check rejects only `string` opcodes (numbers are valid OP_N). The intermediate "Fixes" commit on #338 erroneously rejected numbers; that was already corrected later in #338, so the squash skips the transient regression.
- **`src/wallet/unroll.ts`** (#222 vs master): #222's extraction was rebased on master's BIP68 refactor (PR #412) and DUST_AMOUNT guard. The extracted `prepareUnrollTransaction` uses `timelockToSequence(exit.params.timelock)` for the input sequence, `txWeightEstimator.addOutputAddress(outputAddress, wallet.network)` for the output, and preserves the `sendAmount < DUST_AMOUNT` check.
- **`test/e2e/ark.test.ts`** (#416): no conflicts — applied cleanly on top of #222.

### Bundle-level fixes

These three issues only became reproducible once all three PRs were stacked — none of the source PRs caught them in isolation, and PR #416's integration job was failing on its own branch for an unrelated maturity-loop reason that masked them.

1. **`fix(script): VtxoScript.exitPaths checks isScriptValid === true`**  #338's `isScriptValid` returns `true | Error`. Two callsites in `VtxoScript.exitPaths` (`src/script/base.ts`) kept an old truthy check `if (CSVMultisigTapscript.isScriptValid(script))` — but `Error` is truthy, so a non-CSV script (e.g. `ConditionCSVMultisig`) was routed to CSV's `decode()`, which threw and got swallowed by the surrounding `catch`, never falling through to the ConditionCSV branch. Result: scripts whose only exit path lives on a ConditionCSV leaf returned an empty `exitPaths()` and `completeUnroll` failed with `no available exit path found`. #416's `should complete unroll after unilateral exit delay` test exercises exactly that leaf and caught it. Fix: change both callsites to `isScriptValid(script) === true`.
2. **`fix(e2e): wait for onchain provider to observe mined exit-maturity blocks`**  After fix 1, the same e2e still failed: the test mines the required CSV-maturity blocks via `nigiri rpc --generate` and immediately calls `completeUnroll`. nigiri returns as soon as bitcoind produces the blocks, but the esplora indexer may not have observed them yet, so `wallet.onchainProvider.getChainTip()` inside `availableExitPath` returns the pre-mining tip. The seconds branch already polls in a loop; mirror that on the blocks branch with a `waitFor` on the new height.
3. **`fix(unroll): pass wallet.network to tx.addOutputAddress in completeUnroll`**  After fixes 1 and 2, the test reached `completeUnroll` and threw `Unknown letter: "0"` from base58. `tx.addOutputAddress(outputAddress, sendAmount)` was called without a network; @scure/btc-signer defaults to bitcoin mainnet, which rejects regtest's `bcrt1...` bech32 addresses and falls through to base58, where `0` is invalid. Bug pre-dates #222 — master had the same call — but no test had ever actually exercised `completeUnroll` against a regtest address.

### What's not included

- The `Merge master` commit at the tip of #338's branch was dropped — the squash already targets current master.
- Each source PR will need to be closed (or marked superseded) once this merges.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (Prettier clean)
- [x] `pnpm test:unit` passes (1089 passed, 1 skipped)
- [x] `integration` CI green (17m02s) — including #416's new `should complete unroll after unilateral exit delay` and `should reject complete-unroll before unilateral exit delay matures` tests
- [ ] Reviewers from #338 / #222 / #416 confirm their changes survived the merge intact

Closes #338
Closes #222
Closes #416