### PR TITLE
fix(vtxo): gate persisted VTXOs by owning script (Tier 1 of #480)

### DIFF
--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -23,6 +23,10 @@ import {
     cursorCutoff,
     getSyncCursor,
 } from "../utils/syncCursors";
+import {
+    filterVtxosForScript,
+    warnAndFilterVtxosForScript,
+} from "./vtxoOwnership";
 
 const DEFAULT_PAGE_SIZE = 500;
 
@@ -686,7 +690,10 @@ export class ContractManager implements IContractManager {
         const res = await Promise.all(
             contracts.map(({ script, address }) =>
                 this.config.walletRepository.getVtxos(address).then((vtxos) =>
-                    vtxos.map(
+                    // Address buckets may carry legacy duplicate rows from
+                    // other contracts that once shared the same address —
+                    // gate by script so the wrong-script row never wins.
+                    filterVtxosForScript(vtxos, script).map(
                         (vtxo) =>
                             ({
                                 ...vtxo,
@@ -786,9 +793,19 @@ export class ContractManager implements IContractManager {
         }
 
         for (const [addr, contractVtxos] of byContract) {
+            // The bucket is keyed by contract address, so the script filter
+            // here is the same as the contract's. Skip wrong-script rows
+            // rather than crash the reconcile loop.
+            const contract = contracts.find((c) => c.address === addr)!;
+            const filtered = warnAndFilterVtxosForScript(
+                contractVtxos,
+                contract.script,
+                "ContractManager.reconcilePendingFrontier"
+            );
+            if (filtered.length === 0) continue;
             await this.config.walletRepository.saveVtxos(
                 addr,
-                contractVtxos as ExtendedVirtualCoin[]
+                filtered as ExtendedVirtualCoin[]
             );
         }
     }
@@ -808,9 +825,15 @@ export class ContractManager implements IContractManager {
             result.set(contractScript, vtxos);
             const contract = contracts.find((c) => c.script === contractScript);
             if (contract) {
+                const filtered = warnAndFilterVtxosForScript(
+                    vtxos,
+                    contract.script,
+                    "ContractManager.fetchContractVxosFromIndexer"
+                );
+                if (filtered.length === 0) continue;
                 await this.config.walletRepository.saveVtxos(
                     contract.address,
-                    vtxos as ExtendedVirtualCoin[]
+                    filtered as ExtendedVirtualCoin[]
                 );
             }
         }

--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -9,6 +9,7 @@ import {
     ContractEvent,
 } from "./types";
 import { isEventSourceError } from "../providers/utils";
+import { filterVtxosForScript } from "./vtxoOwnership";
 
 /**
  * Configuration for the ContractWatcher.
@@ -281,8 +282,13 @@ export class ContractWatcher {
                 return true;
             })
             .map(async (state): Promise<[[string, ContractVtxo[]]] | []> => {
-                // Use contract address as cache key
-                const cached = await repo.getVtxos(state.contract.address);
+                // Use contract address as cache key. Legacy address buckets
+                // can contain rows from other contracts; gate by script before
+                // converting so a wrong-script row never reaches the watcher.
+                const cached = filterVtxosForScript(
+                    await repo.getVtxos(state.contract.address),
+                    state.contract.script
+                );
                 if (cached.length > 0) {
                     // Convert to ContractVtxo with contractScript
                     const contractVtxos: ContractVtxo[] = cached.map((v) => ({

--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -182,8 +182,14 @@ export class ContractWatcher {
      */
     private async seedLastKnownVtxos(state: ContractState): Promise<void> {
         try {
-            const cached = await this.config.walletRepository.getVtxos(
-                state.contract.address
+            // Apply the same script gate used by getContractVtxos so a legacy
+            // wrong-script row in the address bucket can't seed the baseline
+            // and then look "spent" on the first poll.
+            const cached = filterVtxosForScript(
+                await this.config.walletRepository.getVtxos(
+                    state.contract.address
+                ),
+                state.contract.script
             );
             for (const vtxo of cached) {
                 if (vtxo.isSpent) continue;

--- a/src/contracts/vtxoOwnership.ts
+++ b/src/contracts/vtxoOwnership.ts
@@ -1,0 +1,74 @@
+import type { VirtualCoin } from "../wallet";
+
+/**
+ * Tier 1 helpers that enforce VTXO ownership at call sites that already know
+ * the intended contract script. Address-keyed repositories may still hand back
+ * legacy duplicate rows under the wrong bucket; these helpers gate reads and
+ * writes so a wrong-script row never wins.
+ *
+ * `script` is the authoritative ownership key. Equality is strict: a missing
+ * or empty `vtxo.script` never matches.
+ */
+
+export function vtxoOutpoint(vtxo: Pick<VirtualCoin, "txid" | "vout">): string {
+    return `${vtxo.txid}:${vtxo.vout}`;
+}
+
+export function isVtxoForScript(
+    vtxo: Pick<VirtualCoin, "script">,
+    script: string
+): boolean {
+    return !!vtxo.script && vtxo.script === script;
+}
+
+export function filterVtxosForScript<T extends Pick<VirtualCoin, "script">>(
+    vtxos: T[],
+    script: string
+): T[] {
+    return vtxos.filter((v) => isVtxoForScript(v, script));
+}
+
+/**
+ * Background/indexer sync flavour: drop wrong-script rows and log enough
+ * context to identify each rejection. Returns only matching rows so the
+ * caller can keep going.
+ */
+export function warnAndFilterVtxosForScript<
+    T extends Pick<VirtualCoin, "txid" | "vout" | "script">,
+>(vtxos: T[], script: string, context: string): T[] {
+    const matches: T[] = [];
+    const rejected: string[] = [];
+    for (const v of vtxos) {
+        if (isVtxoForScript(v, script)) {
+            matches.push(v);
+        } else {
+            rejected.push(`${vtxoOutpoint(v)}(script=${v.script ?? ""})`);
+        }
+    }
+    if (rejected.length > 0) {
+        console.warn(
+            `${context}: dropped ${rejected.length} wrong-script VTXO(s) for script ${script}: ${rejected.join(", ")}`
+        );
+    }
+    return matches;
+}
+
+/**
+ * User-initiated transaction/signing flavour: throw before persisting or
+ * signing inconsistent ownership state. Silently skipping here would hide a
+ * serious bug in the wallet's spend path.
+ */
+export function validateVtxosForScript(
+    vtxos: Array<Pick<VirtualCoin, "txid" | "vout" | "script">>,
+    script: string,
+    context: string
+): void {
+    const mismatches = vtxos.filter((v) => !isVtxoForScript(v, script));
+    if (mismatches.length === 0) return;
+    const detail = mismatches
+        .map((v) => `${vtxoOutpoint(v)}(script=${v.script ?? ""})`)
+        .join(", ");
+    throw new Error(
+        `${context}: refusing to persist ${mismatches.length} VTXO(s) whose script does not match ${script}: ${detail}`
+    );
+}

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1505,20 +1505,21 @@ export class WalletMessageHandler
         }
 
         // Also check the wallet's primary address. Decode it to its script
-        // and apply the same script gate; if the address can't be decoded we
-        // skip the bucket rather than admit unvalidated rows.
+        // and apply the same script gate. Failing to decode the wallet's own
+        // address is a structural bug — surfacing the error is safer than
+        // silently dropping the primary bucket and zeroing the user's
+        // visible balance.
         const walletAddress = await this.readonlyWallet.getAddress();
-        let walletScript: string | undefined;
+        let walletScript: string;
         try {
             walletScript = scriptFromArkAddress(walletAddress);
-        } catch {
-            walletScript = undefined;
+        } catch (e) {
+            throw new Error(
+                `WalletMessageHandler.getVtxosFromRepo: failed to derive script from wallet address ${walletAddress}: ${e instanceof Error ? e.message : String(e)}`
+            );
         }
-        if (walletScript) {
-            const walletVtxos =
-                await this.walletRepository.getVtxos(walletAddress);
-            addVtxos(filterVtxosForScript(walletVtxos, walletScript));
-        }
+        const walletVtxos = await this.walletRepository.getVtxos(walletAddress);
+        addVtxos(filterVtxosForScript(walletVtxos, walletScript));
 
         return allVtxos;
     }

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -44,6 +44,11 @@ import {
 } from "../../worker/messageBus";
 import { Transaction } from "../../utils/transaction";
 import { buildTransactionHistory } from "../../utils/transactionHistory";
+import {
+    filterVtxosForScript,
+    warnAndFilterVtxosForScript,
+} from "../../contracts/vtxoOwnership";
+import { scriptFromArkAddress } from "../../repositories/scriptFromAddress";
 
 export class WalletNotInitializedError extends Error {
     constructor() {
@@ -1186,11 +1191,46 @@ export class WalletMessageHandler
 
                     if (newVtxos.length + spentVtxos.length === 0) return;
 
-                    // save virtual outputs using unified repository
-                    await this.walletRepository?.saveVtxos(address, [
-                        ...newVtxos,
-                        ...spentVtxos,
-                    ]);
+                    // Save virtual outputs using unified repository. The
+                    // event may carry rows for several scripts (other
+                    // contracts the wallet watches), so split by script and
+                    // save each bucket under its own contract address rather
+                    // than saving a mixed-script array under one address.
+                    const byScript = new Map<string, ExtendedVirtualCoin[]>();
+                    for (const v of [...newVtxos, ...spentVtxos]) {
+                        if (!v.script) continue;
+                        const arr = byScript.get(v.script) ?? [];
+                        arr.push(v);
+                        byScript.set(v.script, arr);
+                    }
+                    let walletScript: string | undefined;
+                    try {
+                        walletScript = scriptFromArkAddress(address);
+                    } catch {
+                        walletScript = undefined;
+                    }
+                    const cm = await this.readonlyWallet!.getContractManager();
+                    const contracts = await cm.getContracts();
+                    const addrByScript = new Map(
+                        contracts.map((c) => [c.script, c.address])
+                    );
+                    for (const [script, vtxos] of byScript) {
+                        const filtered = warnAndFilterVtxosForScript(
+                            vtxos,
+                            script,
+                            "WalletMessageHandler.notifyIncomingFunds"
+                        );
+                        if (filtered.length === 0) continue;
+                        const targetAddress =
+                            script === walletScript
+                                ? address
+                                : addrByScript.get(script);
+                        if (!targetAddress) continue;
+                        await this.walletRepository?.saveVtxos(
+                            targetAddress,
+                            filtered
+                        );
+                    }
 
                     // notify all clients about the virtual output state update
                     this.scheduleForNextTick(() =>
@@ -1443,20 +1483,34 @@ export class WalletMessageHandler
             }
         };
 
-        // Aggregate virtual outputs from all contract addresses
+        // Aggregate virtual outputs from all contract addresses. Address
+        // buckets may carry legacy duplicate rows from other contracts; gate
+        // each bucket by its owning contract script before deduplication so a
+        // wrong-script row never wins the txid:vout race.
         const manager = await this.readonlyWallet.getContractManager();
         const contracts = await manager.getContracts();
         for (const contract of contracts) {
             const vtxos = await this.walletRepository.getVtxos(
                 contract.address
             );
-            addVtxos(vtxos);
+            addVtxos(filterVtxosForScript(vtxos, contract.script));
         }
 
-        // Also check the wallet's primary address
+        // Also check the wallet's primary address. Decode it to its script
+        // and apply the same script gate; if the address can't be decoded we
+        // skip the bucket rather than admit unvalidated rows.
         const walletAddress = await this.readonlyWallet.getAddress();
-        const walletVtxos = await this.walletRepository.getVtxos(walletAddress);
-        addVtxos(walletVtxos);
+        let walletScript: string | undefined;
+        try {
+            walletScript = scriptFromArkAddress(walletAddress);
+        } catch {
+            walletScript = undefined;
+        }
+        if (walletScript) {
+            const walletVtxos =
+                await this.walletRepository.getVtxos(walletAddress);
+            addVtxos(filterVtxosForScript(walletVtxos, walletScript));
+        }
 
         return allVtxos;
     }

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1198,7 +1198,15 @@ export class WalletMessageHandler
                     // than saving a mixed-script array under one address.
                     const byScript = new Map<string, ExtendedVirtualCoin[]>();
                     for (const v of [...newVtxos, ...spentVtxos]) {
-                        if (!v.script) continue;
+                        if (!v.script) {
+                            // Without a script we can't route the row to the
+                            // right contract bucket; surface the drop instead
+                            // of silently losing the VTXO.
+                            console.warn(
+                                `WalletMessageHandler.notifyIncomingFunds: dropping VTXO without script ${v.txid}:${v.vout}`
+                            );
+                            continue;
+                        }
                         const arr = byScript.get(v.script) ?? [];
                         arr.push(v);
                         byScript.set(v.script, arr);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -2619,7 +2619,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             }
 
             const createdAt = Date.now();
-            const addr = this.arkAddress.encode();
+            const primaryAddr = this.arkAddress.encode();
 
             // Only save a change virtual output for preconfirmed coins (those with a batchExpiry).
             // Inputs without a batchExpiry are already settled/unrolled and don't need tracking.
@@ -2648,20 +2648,60 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 };
             }
 
-            const toSave = changeVtxo
-                ? [...spentVtxos, changeVtxo]
-                : spentVtxos;
-            // User-initiated send path: a wrong-script row here means the
-            // wallet is about to record ownership against the wrong contract
-            // — fail loudly rather than persist inconsistent state.
-            validateVtxosForScript(
-                toSave,
-                hex.encode(this.offchainTapscript.pkScript),
-                "Wallet.updateDbAfterOffchainTx"
+            // Route spent rows to their owning contract bucket. The wallet's
+            // primary contract is registered with the manager at boot, so
+            // `addrByScript` already includes it; in a multi-contract spend
+            // each input may belong to a different contract.
+            const contracts = await cm.getContracts();
+            const addrByScript = new Map(
+                contracts.map((c) => [c.script, c.address])
             );
-            await this.walletRepository.saveVtxos(addr, toSave);
 
-            await this.walletRepository.saveTransactions(addr, [
+            const spentByScript = new Map<string, ExtendedVirtualCoin[]>();
+            for (const v of spentVtxos) {
+                if (!v.script) {
+                    throw new Error(
+                        `Wallet.updateDbAfterOffchainTx: spent VTXO ${v.txid}:${v.vout} has no script`
+                    );
+                }
+                const arr = spentByScript.get(v.script) ?? [];
+                arr.push(v);
+                spentByScript.set(v.script, arr);
+            }
+
+            const byAddress = new Map<string, ExtendedVirtualCoin[]>();
+            for (const [script, vtxos] of spentByScript) {
+                // User-initiated send path: a wrong-script row here means the
+                // wallet is about to record ownership against the wrong
+                // contract — fail loudly rather than persist inconsistent state.
+                validateVtxosForScript(
+                    vtxos,
+                    script,
+                    "Wallet.updateDbAfterOffchainTx"
+                );
+                const targetAddr = addrByScript.get(script);
+                if (!targetAddr) {
+                    throw new Error(
+                        `Wallet.updateDbAfterOffchainTx: no contract owns script ${script}`
+                    );
+                }
+                const bucket = byAddress.get(targetAddr) ?? [];
+                bucket.push(...vtxos);
+                byAddress.set(targetAddr, bucket);
+            }
+
+            // Change is always primary-script by construction.
+            if (changeVtxo) {
+                const bucket = byAddress.get(primaryAddr) ?? [];
+                bucket.push(changeVtxo);
+                byAddress.set(primaryAddr, bucket);
+            }
+
+            for (const [addr, vtxos] of byAddress) {
+                await this.walletRepository.saveVtxos(addr, vtxos);
+            }
+
+            await this.walletRepository.saveTransactions(primaryAddr, [
                 {
                     key: {
                         boardingTxid: "",
@@ -2676,6 +2716,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             ]);
         } catch (e) {
             console.warn("error saving offchain tx to repository", e);
+            throw e;
         }
     }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -101,6 +101,7 @@ import { ContractManager } from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
 import { timelockToSequence } from "../utils/timelock";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
+import { validateVtxosForScript } from "../contracts/vtxoOwnership";
 
 export const getArkadeServerUrl = ({
     arkServerUrl,
@@ -2647,10 +2648,18 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 };
             }
 
-            await this.walletRepository.saveVtxos(
-                addr,
-                changeVtxo ? [...spentVtxos, changeVtxo] : spentVtxos
+            const toSave = changeVtxo
+                ? [...spentVtxos, changeVtxo]
+                : spentVtxos;
+            // User-initiated send path: a wrong-script row here means the
+            // wallet is about to record ownership against the wrong contract
+            // — fail loudly rather than persist inconsistent state.
+            validateVtxosForScript(
+                toSave,
+                hex.encode(this.offchainTapscript.pkScript),
+                "Wallet.updateDbAfterOffchainTx"
             );
+            await this.walletRepository.saveVtxos(addr, toSave);
 
             await this.walletRepository.saveTransactions(addr, [
                 {
@@ -2718,6 +2727,13 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             }
 
             if (spentVtxos.length > 0) {
+                // Settle path is also user-initiated — refuse to record a
+                // settle against the wrong script.
+                validateVtxosForScript(
+                    spentVtxos,
+                    hex.encode(this.offchainTapscript.pkScript),
+                    "Wallet.updateDbAfterSettle"
+                );
                 await this.walletRepository.saveVtxos(addr, spentVtxos);
             }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -2726,7 +2726,6 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         commitmentTxid: string
     ): Promise<void> {
         try {
-            const addr = this.arkAddress.encode();
             const boardingAddress = await this.getBoardingAddress();
 
             const spentVtxos: ExtendedVirtualCoin[] = [];
@@ -2768,14 +2767,51 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             }
 
             if (spentVtxos.length > 0) {
-                // Settle path is also user-initiated — refuse to record a
-                // settle against the wrong script.
-                validateVtxosForScript(
-                    spentVtxos,
-                    hex.encode(this.offchainTapscript.pkScript),
-                    "Wallet.updateDbAfterSettle"
+                // Route settled rows to their owning contract bucket. In a
+                // multi-contract settle the inputs may belong to several
+                // contracts; the wallet's primary contract is registered with
+                // the manager at boot, so its address is in `addrByScript`
+                // alongside the rest.
+                const contracts = await cm.getContracts();
+                const addrByScript = new Map(
+                    contracts.map((c) => [c.script, c.address])
                 );
-                await this.walletRepository.saveVtxos(addr, spentVtxos);
+
+                const byAddress = new Map<string, ExtendedVirtualCoin[]>();
+                const byScript = new Map<string, ExtendedVirtualCoin[]>();
+                for (const v of spentVtxos) {
+                    if (!v.script) {
+                        throw new Error(
+                            `Wallet.updateDbAfterSettle: spent VTXO ${v.txid}:${v.vout} has no script`
+                        );
+                    }
+                    const arr = byScript.get(v.script) ?? [];
+                    arr.push(v);
+                    byScript.set(v.script, arr);
+                }
+
+                for (const [script, vtxos] of byScript) {
+                    // User-initiated settle path: refuse to record a settle
+                    // against the wrong script.
+                    validateVtxosForScript(
+                        vtxos,
+                        script,
+                        "Wallet.updateDbAfterSettle"
+                    );
+                    const targetAddr = addrByScript.get(script);
+                    if (!targetAddr) {
+                        throw new Error(
+                            `Wallet.updateDbAfterSettle: no contract owns script ${script}`
+                        );
+                    }
+                    const bucket = byAddress.get(targetAddr) ?? [];
+                    bucket.push(...vtxos);
+                    byAddress.set(targetAddr, bucket);
+                }
+
+                for (const [bucketAddr, vtxos] of byAddress) {
+                    await this.walletRepository.saveVtxos(bucketAddr, vtxos);
+                }
             }
 
             if (boardingUtxoToRemove.size > 0) {
@@ -2795,6 +2831,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             }
         } catch (e) {
             console.warn("error updating repository after settle", e);
+            throw e;
         }
     }
 }

--- a/src/worker/expo/processors/contractPollProcessor.ts
+++ b/src/worker/expo/processors/contractPollProcessor.ts
@@ -1,6 +1,7 @@
 import type { TaskItem, TaskResult } from "../taskQueue";
 import type { TaskProcessor, TaskDependencies } from "../taskRunner";
 import type { ExtendedVirtualCoin } from "../../../wallet";
+import { warnAndFilterVtxosForScript } from "../../../contracts/vtxoOwnership";
 
 export const CONTRACT_POLL_TASK_TYPE = "contract-poll";
 
@@ -60,8 +61,16 @@ export const contractPollProcessor: TaskProcessor = {
                 pageIndex++;
             }
 
-            await walletRepository.saveVtxos(contract.address, allVtxos);
-            vtxosSaved += allVtxos.length;
+            // Skip wrong-script rows (legacy duplicates or indexer drift)
+            // before persisting; the loop must keep going for the remaining
+            // contracts even when one row is rejected.
+            const filtered = warnAndFilterVtxosForScript(
+                allVtxos,
+                contract.script,
+                "contractPollProcessor"
+            );
+            await walletRepository.saveVtxos(contract.address, filtered);
+            vtxosSaved += filtered.length;
             contractsProcessed++;
         }
 

--- a/test/contracts/helpers.ts
+++ b/test/contracts/helpers.ts
@@ -67,6 +67,12 @@ export const testDefaultScript = new DefaultVtxo.Script({
     serverPubKey: TEST_SERVER_PUB_KEY,
 });
 export const TEST_DEFAULT_SCRIPT = hex.encode(testDefaultScript.pkScript);
+// Real Arkade address whose pkScript decodes to TEST_DEFAULT_SCRIPT. Use this
+// as the wallet's primary address in tests so script-aware code paths can
+// derive a script via scriptFromArkAddress and match VTXOs by default script.
+export const TEST_DEFAULT_ARK_ADDRESS = testDefaultScript
+    .address("ark", TEST_SERVER_PUB_KEY)
+    .encode();
 
 // Create a valid delegate contract script
 export const testDelegateScript = new DelegateVtxo.Script({

--- a/test/contracts/manager.test.ts
+++ b/test/contracts/manager.test.ts
@@ -14,6 +14,7 @@ import { hex } from "@scure/base";
 import {
     createDefaultContractParams,
     createMockContractVtxo,
+    createMockExtendedVtxo,
     createMockIndexerProvider,
     createMockVtxo,
     TEST_DEFAULT_SCRIPT,
@@ -432,5 +433,131 @@ describe("ContractManager", () => {
             const stateAfter = await repo.getWalletState();
             expect(stateAfter?.lastSyncTime).toBe(SEEDED_CURSOR);
         });
+    });
+
+    // Regression: an address bucket can hold a row whose `script` belongs
+    // to a different contract (legacy duplicate). `getContractsWithVtxos`
+    // must filter each contract's bucket by its own `script` before mapping
+    // to ContractVtxo, otherwise the wrong-script row leaks into the wrong
+    // contract's view.
+    it("getContractsWithVtxos drops wrong-script rows from a contract's address bucket", async () => {
+        const altParams = DefaultContractHandler.serializeParams({
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: {
+                type: "blocks",
+                value: DefaultVtxo.Script.DEFAULT_TIMELOCK.value + 1n,
+            },
+        });
+        const altScript = hex.encode(
+            DefaultContractHandler.createScript(altParams).pkScript
+        );
+
+        const walletRepo = new InMemoryWalletRepository();
+        const localManager = await ContractManager.create({
+            indexerProvider: createMockIndexerProvider(),
+            contractRepository: new InMemoryContractRepository(),
+            walletRepository: walletRepo,
+            watcherConfig: {
+                failsafePollIntervalMs: 1000,
+                reconnectDelayMs: 500,
+            },
+        });
+
+        const contractA = await localManager.createContract({
+            type: "default",
+            params: createDefaultContractParams(),
+            script: TEST_DEFAULT_SCRIPT,
+            address: "contract-A-addr",
+        });
+        const contractB = await localManager.createContract({
+            type: "default",
+            params: altParams,
+            script: altScript,
+            address: "contract-B-addr",
+        });
+
+        // Seed contract A's bucket with a row whose script actually
+        // belongs to contract B — the live bug we're guarding against.
+        const wrongScriptRow = createMockExtendedVtxo({
+            txid: "ee".repeat(32),
+            vout: 0,
+            virtualStatus: { state: "settled" },
+            isSpent: false,
+            script: contractB.script,
+        });
+        // Seed contract B's bucket with the script-matching row at the
+        // same outpoint, marked spent so we can prove the spent row wins
+        // over the unspent wrong-script duplicate.
+        const correctRow = createMockExtendedVtxo({
+            txid: "ee".repeat(32),
+            vout: 0,
+            virtualStatus: { state: "settled" },
+            isSpent: true,
+            script: contractB.script,
+        });
+        await walletRepo.saveVtxos(contractA.address, [wrongScriptRow]);
+        await walletRepo.saveVtxos(contractB.address, [correctRow]);
+
+        const result = await localManager.getContractsWithVtxos();
+        const a = result.find((c) => c.contract.script === contractA.script);
+        const b = result.find((c) => c.contract.script === contractB.script);
+
+        // Contract A must not return a row whose script is contract B's.
+        expect(
+            a?.vtxos.find((v) => v.txid === "ee".repeat(32))
+        ).toBeUndefined();
+        // Contract B returns its own script-matching row.
+        const bRow = b?.vtxos.find((v) => v.txid === "ee".repeat(32));
+        expect(bRow).toBeDefined();
+        expect(bRow?.isSpent).toBe(true);
+
+        localManager.dispose();
+    });
+
+    it("fetchContractVxosFromIndexer skips wrong-script rows without crashing the sync", async () => {
+        const walletRepo = new InMemoryWalletRepository();
+        const indexer = createMockIndexerProvider();
+        const goodVtxo = createMockContractVtxo(TEST_DEFAULT_SCRIPT, {
+            txid: "aa".repeat(32),
+            virtualStatus: { state: "settled" },
+        });
+        // A row coming back tagged with the wrong script (e.g. indexer
+        // mis-routing) must be dropped, not persisted under the contract's
+        // address bucket.
+        const badVtxo = createMockContractVtxo(TEST_DEFAULT_SCRIPT, {
+            txid: "bb".repeat(32),
+            virtualStatus: { state: "settled" },
+            script: "ff".repeat(34),
+        });
+        (indexer.getVtxos as any).mockResolvedValue({
+            vtxos: [goodVtxo, badVtxo],
+        });
+
+        const localManager = await ContractManager.create({
+            indexerProvider: indexer,
+            contractRepository: new InMemoryContractRepository(),
+            walletRepository: walletRepo,
+            watcherConfig: {
+                failsafePollIntervalMs: 1000,
+                reconnectDelayMs: 500,
+            },
+        });
+
+        await expect(
+            localManager.createContract({
+                type: "default",
+                params: createDefaultContractParams(),
+                script: TEST_DEFAULT_SCRIPT,
+                address: "contract-addr",
+            })
+        ).resolves.toBeDefined();
+
+        const saved = await walletRepo.getVtxos("contract-addr");
+        // The badVtxo must have been filtered out; the good one persists.
+        expect(saved.find((v) => v.txid === "aa".repeat(32))).toBeDefined();
+        expect(saved.find((v) => v.txid === "bb".repeat(32))).toBeUndefined();
+
+        localManager.dispose();
     });
 });

--- a/test/contracts/vtxoOwnership.test.ts
+++ b/test/contracts/vtxoOwnership.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+    filterVtxosForScript,
+    isVtxoForScript,
+    validateVtxosForScript,
+    vtxoOutpoint,
+    warnAndFilterVtxosForScript,
+} from "../../src/contracts/vtxoOwnership";
+
+const row = (script: string, txid = "aa".repeat(32), vout = 0) => ({
+    txid,
+    vout,
+    script,
+});
+
+describe("vtxoOwnership", () => {
+    describe("isVtxoForScript", () => {
+        it("matches when scripts are equal", () => {
+            expect(isVtxoForScript({ script: "abc" }, "abc")).toBe(true);
+        });
+        it("rejects when scripts differ", () => {
+            expect(isVtxoForScript({ script: "abc" }, "xyz")).toBe(false);
+        });
+        it("rejects empty script", () => {
+            expect(isVtxoForScript({ script: "" }, "")).toBe(false);
+        });
+    });
+
+    describe("filterVtxosForScript", () => {
+        it("keeps only matching-script rows", () => {
+            const out = filterVtxosForScript(
+                [row("a"), row("b"), row("a")],
+                "a"
+            );
+            expect(out).toHaveLength(2);
+            expect(out.every((v) => v.script === "a")).toBe(true);
+        });
+    });
+
+    describe("warnAndFilterVtxosForScript", () => {
+        let warnSpy: ReturnType<typeof vi.spyOn>;
+        beforeEach(() => {
+            warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        });
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        it("returns matches and warns about rejected outpoints", () => {
+            const good = row("a", "aa".repeat(32), 0);
+            const bad = row("b", "bb".repeat(32), 1);
+            const out = warnAndFilterVtxosForScript(
+                [good, bad],
+                "a",
+                "test-context"
+            );
+            expect(out).toEqual([good]);
+            expect(warnSpy).toHaveBeenCalledOnce();
+            const msg = warnSpy.mock.calls[0][0] as string;
+            expect(msg).toContain("test-context");
+            expect(msg).toContain(vtxoOutpoint(bad));
+        });
+
+        it("does not warn when all rows match", () => {
+            const out = warnAndFilterVtxosForScript([row("a")], "a", "ctx");
+            expect(out).toHaveLength(1);
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("validateVtxosForScript", () => {
+        it("throws on a wrong-script row, naming the outpoint and context", () => {
+            const good = row("a");
+            const bad = row("b", "bb".repeat(32), 1);
+            expect(() =>
+                validateVtxosForScript([good, bad], "a", "Wallet.ctx")
+            ).toThrowError(/Wallet\.ctx/);
+            expect(() =>
+                validateVtxosForScript([good, bad], "a", "Wallet.ctx")
+            ).toThrowError(new RegExp(vtxoOutpoint(bad)));
+        });
+
+        it("returns silently when every row matches", () => {
+            expect(() =>
+                validateVtxosForScript([row("a"), row("a")], "a", "ctx")
+            ).not.toThrow();
+        });
+    });
+});

--- a/test/wallet-message-handler.test.ts
+++ b/test/wallet-message-handler.test.ts
@@ -8,6 +8,8 @@ import { InMemoryWalletRepository } from "../src";
 import {
     createMockExtendedVtxo,
     createMockIndexerProvider,
+    TEST_DEFAULT_ARK_ADDRESS,
+    TEST_DEFAULT_SCRIPT,
 } from "./contracts/helpers";
 const baseMessage = (id: string = "1") => ({
     id,
@@ -1141,7 +1143,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
         walletRepo = new InMemoryWalletRepository();
 
         (updater as any).readonlyWallet = {
-            getAddress: vi.fn().mockResolvedValue("wallet-address"),
+            getAddress: vi.fn().mockResolvedValue(TEST_DEFAULT_ARK_ADDRESS),
             getBoardingAddress: vi.fn().mockResolvedValue("boarding-address"),
             getBoardingUtxos: vi.fn().mockResolvedValue([]),
             getBoardingTxs: vi.fn().mockResolvedValue({
@@ -1174,7 +1176,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
             value: 50000,
             virtualStatus: { state: "settled" },
         });
-        await walletRepo.saveVtxos("wallet-address", [vtxo]);
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [vtxo]);
 
         const response = await updater.handleMessage({
             ...baseMessage(),
@@ -1207,7 +1209,10 @@ describe("WalletMessageHandler repo-backed reads", () => {
             value: 50000,
             virtualStatus: { state: "swept" },
         });
-        await walletRepo.saveVtxos("wallet-address", [settled, recoverable]);
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [
+            settled,
+            recoverable,
+        ]);
 
         const response = await updater.handleMessage({
             ...baseMessage(),
@@ -1232,7 +1237,10 @@ describe("WalletMessageHandler repo-backed reads", () => {
             value: 50000,
             virtualStatus: { state: "preconfirmed" },
         });
-        await walletRepo.saveVtxos("wallet-address", [settled, preconfirmed]);
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [
+            settled,
+            preconfirmed,
+        ]);
 
         const response = await updater.handleMessage({
             ...baseMessage(),
@@ -1258,7 +1266,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
             virtualStatus: { state: "settled" },
             createdAt: new Date(),
         });
-        await walletRepo.saveVtxos("wallet-address", [vtxo]);
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [vtxo]);
 
         const response = await updater.handleMessage({
             ...baseMessage(),
@@ -1283,11 +1291,13 @@ describe("WalletMessageHandler repo-backed reads", () => {
             txid: "aa".repeat(32),
             value: 10000,
             virtualStatus: { state: "settled" },
+            script: "s1",
         });
         const vtxo2 = createMockExtendedVtxo({
             txid: "bb".repeat(32),
             value: 20000,
             virtualStatus: { state: "settled" },
+            script: "s2",
         });
         await walletRepo.saveVtxos("contract-1", [vtxo1]);
         await walletRepo.saveVtxos("contract-2", [vtxo2]);
@@ -1314,6 +1324,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
                 txid: "aa".repeat(32),
                 value: 10000,
                 virtualStatus: { state: "settled" },
+                script: "s1",
             }),
         ]);
         await walletRepo.saveVtxos("contract-2", [
@@ -1321,6 +1332,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
                 txid: "bb".repeat(32),
                 value: 20000,
                 virtualStatus: { state: "settled" },
+                script: "s2",
             }),
         ]);
 
@@ -1339,7 +1351,9 @@ describe("WalletMessageHandler repo-backed reads", () => {
     });
 
     it("GET_VTXOS deduplicates across wallet and contract addresses", async () => {
-        const contracts = [{ address: "wallet-address", script: "s1" }];
+        const contracts = [
+            { address: TEST_DEFAULT_ARK_ADDRESS, script: TEST_DEFAULT_SCRIPT },
+        ];
         setupHandler(contracts);
 
         const vtxo = createMockExtendedVtxo({
@@ -1348,7 +1362,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
             virtualStatus: { state: "settled" },
         });
         // Save same VTXO under both keys (contract address = wallet address)
-        await walletRepo.saveVtxos("wallet-address", [vtxo]);
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [vtxo]);
 
         const response = await updater.handleMessage({
             ...baseMessage(),
@@ -1378,7 +1392,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
             value: 20000,
             virtualStatus: { state: "swept" },
         });
-        await walletRepo.saveVtxos("wallet-address", [
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [
             preconfirmed,
             settled,
             swept,
@@ -1540,7 +1554,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
             value: 10000,
             virtualStatus: { state: "settled" },
         });
-        await walletRepo.saveVtxos("wallet-address", [initial]);
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [initial]);
 
         // Simulate subscription update by saving new VTXOs
         const newVtxo = createMockExtendedVtxo({
@@ -1548,7 +1562,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
             value: 20000,
             virtualStatus: { state: "settled" },
         });
-        await walletRepo.saveVtxos("wallet-address", [newVtxo]);
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [newVtxo]);
 
         const response = await updater.handleMessage({
             ...baseMessage(),
@@ -1561,5 +1575,52 @@ describe("WalletMessageHandler repo-backed reads", () => {
                 settled: 30000,
             },
         });
+    });
+
+    // Regression: legacy address buckets can hold rows whose `script`
+    // belongs to a different contract. The aggregator must filter each
+    // bucket by the owning contract's script before deduping by txid:vout
+    // so a wrong-script duplicate cannot win the dedupe over the correct
+    // row stored under another bucket.
+    it("GET_VTXOS skips wrong-script rows and prefers script-matching ones across legacy duplicates", async () => {
+        const contracts = [
+            { address: "contract-A-addr", script: "scriptA" },
+            { address: "contract-B-addr", script: "scriptB" },
+        ];
+        setupHandler(contracts);
+
+        // Stale row under contract A's address bucket but actually locked
+        // to contract B's script — left behind by a legacy save under the
+        // wrong bucket. Must be ignored by the contract-A read.
+        const stale = createMockExtendedVtxo({
+            txid: "ee".repeat(32),
+            vout: 0,
+            value: 1000,
+            virtualStatus: { state: "settled" },
+            isSpent: false,
+            script: "scriptB",
+        });
+        // Correct row under contract B's bucket with the same outpoint and
+        // contract B's script. Marked spent — proves the read returns the
+        // script-matching row regardless of its lifecycle state, instead of
+        // the stale unspent row from the wrong bucket.
+        const correct = createMockExtendedVtxo({
+            txid: "ee".repeat(32),
+            vout: 0,
+            value: 1000,
+            virtualStatus: { state: "settled" },
+            isSpent: true,
+            script: "scriptB",
+        });
+        await walletRepo.saveVtxos("contract-A-addr", [stale]);
+        await walletRepo.saveVtxos("contract-B-addr", [correct]);
+
+        const all = await (updater as any).getVtxosFromRepo();
+        const matched = all.filter(
+            (v: any) => v.txid === "ee".repeat(32) && v.vout === 0
+        );
+        expect(matched).toHaveLength(1);
+        expect(matched[0].script).toBe("scriptB");
+        expect(matched[0].isSpent).toBe(true);
     });
 });

--- a/test/wallet-message-handler.test.ts
+++ b/test/wallet-message-handler.test.ts
@@ -467,7 +467,7 @@ describe("WalletMessageHandler handleMessage", () => {
 
     it("read operations work with readonly wallet only", async () => {
         (updater as any).readonlyWallet = {
-            getAddress: vi.fn().mockResolvedValue("bc1-readonly"),
+            getAddress: vi.fn().mockResolvedValue(TEST_DEFAULT_ARK_ADDRESS),
             getBoardingAddress: vi.fn().mockResolvedValue("bc1-boarding"),
             getBoardingTxs: vi.fn().mockResolvedValue({
                 boardingTxs: [],
@@ -491,7 +491,7 @@ describe("WalletMessageHandler handleMessage", () => {
         } as any);
         expect(addrRes).toMatchObject({
             type: "ADDRESS",
-            payload: { address: "bc1-readonly" },
+            payload: { address: TEST_DEFAULT_ARK_ADDRESS },
         });
 
         const boardingRes = await updater.handleMessage({
@@ -954,7 +954,7 @@ describe("WalletMessageHandler handleMessage", () => {
     it("eagerly starts VtxoManager on wallet initialization", async () => {
         const getVtxoManagerSpy = vi.fn().mockResolvedValue({});
         (updater as any).readonlyWallet = {
-            getAddress: vi.fn().mockResolvedValue("bc1-test"),
+            getAddress: vi.fn().mockResolvedValue(TEST_DEFAULT_ARK_ADDRESS),
             getBoardingAddress: vi.fn().mockResolvedValue("bc1-boarding"),
             getBoardingTxs: vi.fn().mockResolvedValue({
                 boardingTxs: [],
@@ -992,7 +992,7 @@ describe("WalletMessageHandler handleMessage", () => {
 
     it("does not start VtxoManager for readonly wallets", async () => {
         (updater as any).readonlyWallet = {
-            getAddress: vi.fn().mockResolvedValue("bc1-test"),
+            getAddress: vi.fn().mockResolvedValue(TEST_DEFAULT_ARK_ADDRESS),
             getBoardingAddress: vi.fn().mockResolvedValue("bc1-boarding"),
             getBoardingTxs: vi.fn().mockResolvedValue({
                 boardingTxs: [],
@@ -1622,5 +1622,19 @@ describe("WalletMessageHandler repo-backed reads", () => {
         expect(matched).toHaveLength(1);
         expect(matched[0].script).toBe("scriptB");
         expect(matched[0].isSpent).toBe(true);
+    });
+
+    it("GET_VTXOS fails fast when the wallet's primary address can't be decoded", async () => {
+        setupHandler();
+        // Override the readonly wallet to return a malformed address that
+        // scriptFromArkAddress cannot decode. Before the fix this silently
+        // dropped the wallet's primary bucket and zeroed the visible balance.
+        (updater as any).readonlyWallet.getAddress = vi
+            .fn()
+            .mockResolvedValue("not-a-valid-ark-address");
+
+        await expect((updater as any).getVtxosFromRepo()).rejects.toThrow(
+            /failed to derive script from wallet address/
+        );
     });
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -2119,3 +2119,194 @@ describe("Wallet.updateDbAfterOffchainTx", () => {
         expect(saveVtxos).not.toHaveBeenCalled();
     });
 });
+
+describe("Wallet.updateDbAfterSettle", () => {
+    const PRIMARY_SCRIPT = "ab".repeat(34);
+    const PRIMARY_ADDR = "ark1primaryaddress";
+    const DELEGATE_SCRIPT = "cd".repeat(34);
+    const DELEGATE_ADDR = "ark1delegateaddress";
+    const BOARDING_ADDR = "bc1boardingaddr";
+
+    const makeThisArg = (overrides: {
+        annotateVtxos: ReturnType<typeof vi.fn>;
+        contracts: { script: string; address: string }[];
+        currentBoardingUtxos?: any[];
+    }) => {
+        const saveVtxos = vi.fn().mockResolvedValue(undefined);
+        const saveUtxos = vi.fn().mockResolvedValue(undefined);
+        const deleteUtxos = vi.fn().mockResolvedValue(undefined);
+        const getUtxos = vi
+            .fn()
+            .mockResolvedValue(overrides.currentBoardingUtxos ?? []);
+        const getContracts = vi.fn().mockResolvedValue(overrides.contracts);
+        const getContractManager = vi.fn().mockResolvedValue({
+            annotateVtxos: overrides.annotateVtxos,
+            getContracts,
+        });
+        return {
+            thisArg: {
+                walletRepository: {
+                    saveVtxos,
+                    saveUtxos,
+                    deleteUtxos,
+                    getUtxos,
+                },
+                getContractManager,
+                getBoardingAddress: vi.fn().mockResolvedValue(BOARDING_ADDR),
+            } as any,
+            saveVtxos,
+            saveUtxos,
+            deleteUtxos,
+            getUtxos,
+        };
+    };
+
+    const makeVtxoInput = (script: string, suffix: string): ExtendedCoin =>
+        ({
+            txid: suffix.repeat(64).slice(0, 64),
+            vout: 0,
+            value: 5_000,
+            status: { confirmed: true },
+            virtualStatus: { state: "preconfirmed" },
+            createdAt: new Date(),
+            isUnrolled: false,
+            isSpent: false,
+            script,
+            forfeitTapLeafScript: [new Uint8Array(32), new Uint8Array(33)],
+            intentTapLeafScript: [new Uint8Array(32), new Uint8Array(34)],
+            tapTree: new Uint8Array(64),
+        }) as ExtendedCoin;
+
+    const makeBoardingInput = (suffix: string): ExtendedCoin =>
+        ({
+            txid: suffix.repeat(64).slice(0, 64),
+            vout: 0,
+            value: 10_000,
+            status: { confirmed: true },
+        }) as ExtendedCoin;
+
+    it("saves single-contract settle rows under the primary bucket", async () => {
+        const input = makeVtxoInput(PRIMARY_SCRIPT, "1");
+        const annotateVtxos = vi.fn().mockResolvedValue([input]);
+        const { thisArg, saveVtxos } = makeThisArg({
+            annotateVtxos,
+            contracts: [{ script: PRIMARY_SCRIPT, address: PRIMARY_ADDR }],
+        });
+
+        await (Wallet.prototype as any).updateDbAfterSettle.call(
+            thisArg,
+            [input],
+            "commitment-tx"
+        );
+
+        expect(saveVtxos).toHaveBeenCalledTimes(1);
+        const [addr, vtxos] = saveVtxos.mock.calls[0];
+        expect(addr).toBe(PRIMARY_ADDR);
+        expect(vtxos).toHaveLength(1);
+        expect(vtxos[0].virtualStatus.state).toBe("settled");
+        expect(vtxos[0].settledBy).toBe("commitment-tx");
+        expect(vtxos[0].isSpent).toBe(true);
+    });
+
+    it("routes multi-contract settle rows to their owning contract buckets", async () => {
+        const primaryInput = makeVtxoInput(PRIMARY_SCRIPT, "1");
+        const delegateInput = makeVtxoInput(DELEGATE_SCRIPT, "2");
+        const annotateVtxos = vi
+            .fn()
+            .mockResolvedValue([primaryInput, delegateInput]);
+        const { thisArg, saveVtxos } = makeThisArg({
+            annotateVtxos,
+            contracts: [
+                { script: PRIMARY_SCRIPT, address: PRIMARY_ADDR },
+                { script: DELEGATE_SCRIPT, address: DELEGATE_ADDR },
+            ],
+        });
+
+        await (Wallet.prototype as any).updateDbAfterSettle.call(
+            thisArg,
+            [primaryInput, delegateInput],
+            "commitment-tx"
+        );
+
+        expect(saveVtxos).toHaveBeenCalledTimes(2);
+        const calls = new Map(
+            saveVtxos.mock.calls.map(([addr, vtxos]: any) => [addr, vtxos])
+        );
+        expect(calls.get(PRIMARY_ADDR)).toHaveLength(1);
+        expect(calls.get(PRIMARY_ADDR)[0].script).toBe(PRIMARY_SCRIPT);
+        expect(calls.get(DELEGATE_ADDR)).toHaveLength(1);
+        expect(calls.get(DELEGATE_ADDR)[0].script).toBe(DELEGATE_SCRIPT);
+    });
+
+    it("removes settled boarding inputs even when no vtxo rows are settled", async () => {
+        const boardingInput = makeBoardingInput("b");
+        const otherUtxo = {
+            txid: "c".repeat(64),
+            vout: 0,
+            value: 1000,
+            status: { confirmed: true },
+        };
+        const annotateVtxos = vi.fn().mockResolvedValue([]);
+        const { thisArg, saveVtxos, deleteUtxos, saveUtxos, getUtxos } =
+            makeThisArg({
+                annotateVtxos,
+                contracts: [{ script: PRIMARY_SCRIPT, address: PRIMARY_ADDR }],
+                currentBoardingUtxos: [
+                    { txid: boardingInput.txid, vout: 0, value: 10_000 },
+                    otherUtxo,
+                ],
+            });
+
+        await (Wallet.prototype as any).updateDbAfterSettle.call(
+            thisArg,
+            [boardingInput],
+            "commitment-tx"
+        );
+
+        expect(saveVtxos).not.toHaveBeenCalled();
+        expect(getUtxos).toHaveBeenCalledWith(BOARDING_ADDR);
+        expect(deleteUtxos).toHaveBeenCalledWith(BOARDING_ADDR);
+        expect(saveUtxos).toHaveBeenCalledWith(BOARDING_ADDR, [otherUtxo]);
+    });
+
+    it("rethrows when a settled VTXO has no script", async () => {
+        const input = makeVtxoInput(PRIMARY_SCRIPT, "1");
+        const annotateVtxos = vi
+            .fn()
+            .mockResolvedValue([{ ...input, script: undefined }]);
+        const { thisArg, saveVtxos } = makeThisArg({
+            annotateVtxos,
+            contracts: [{ script: PRIMARY_SCRIPT, address: PRIMARY_ADDR }],
+        });
+
+        await expect(
+            (Wallet.prototype as any).updateDbAfterSettle.call(
+                thisArg,
+                [input],
+                "commitment-tx"
+            )
+        ).rejects.toThrow(/has no script/);
+
+        expect(saveVtxos).not.toHaveBeenCalled();
+    });
+
+    it("rethrows when a settled VTXO references an unknown contract", async () => {
+        const input = makeVtxoInput(PRIMARY_SCRIPT, "1");
+        const orphan = { ...input, script: "ee".repeat(34) };
+        const annotateVtxos = vi.fn().mockResolvedValue([orphan]);
+        const { thisArg, saveVtxos } = makeThisArg({
+            annotateVtxos,
+            contracts: [{ script: PRIMARY_SCRIPT, address: PRIMARY_ADDR }],
+        });
+
+        await expect(
+            (Wallet.prototype as any).updateDbAfterSettle.call(
+                thisArg,
+                [orphan],
+                "commitment-tx"
+            )
+        ).rejects.toThrow(/no contract owns script/);
+
+        expect(saveVtxos).not.toHaveBeenCalled();
+    });
+});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1899,3 +1899,223 @@ describe("Wallet._settleImpl", () => {
         batchJoinSpy.mockRestore();
     });
 });
+
+describe("Wallet.updateDbAfterOffchainTx", () => {
+    const PRIMARY_SCRIPT = "ab".repeat(34);
+    const PRIMARY_ADDR = "ark1primaryaddress";
+    const DELEGATE_SCRIPT = "cd".repeat(34);
+    const DELEGATE_ADDR = "ark1delegateaddress";
+
+    const primaryPkScript = hex.decode(PRIMARY_SCRIPT);
+
+    const makeThisArg = (overrides: {
+        annotateVtxos: ReturnType<typeof vi.fn>;
+        contracts: { script: string; address: string }[];
+        saveVtxos?: ReturnType<typeof vi.fn>;
+        saveTransactions?: ReturnType<typeof vi.fn>;
+    }) => {
+        const saveVtxos =
+            overrides.saveVtxos ?? vi.fn().mockResolvedValue(undefined);
+        const saveTransactions =
+            overrides.saveTransactions ?? vi.fn().mockResolvedValue(undefined);
+        const getContracts = vi.fn().mockResolvedValue(overrides.contracts);
+        const getContractManager = vi.fn().mockResolvedValue({
+            annotateVtxos: overrides.annotateVtxos,
+            getContracts,
+        });
+        const offchainTapscript: any = {
+            pkScript: primaryPkScript,
+            forfeit: () => [new Uint8Array(32), new Uint8Array(33)],
+            encode: () => new Uint8Array(64),
+        };
+        const arkAddress = { encode: () => PRIMARY_ADDR };
+        return {
+            thisArg: {
+                arkAddress,
+                offchainTapscript,
+                walletRepository: { saveVtxos, saveTransactions },
+                getContractManager,
+            } as any,
+            saveVtxos,
+            saveTransactions,
+            getContracts,
+        };
+    };
+
+    const makeSpentInput = (script: string, suffix: string): VirtualCoin => ({
+        txid: suffix.repeat(64).slice(0, 64),
+        vout: 0,
+        value: 5_000,
+        status: { confirmed: true },
+        virtualStatus: { state: "preconfirmed", batchExpiry: 1_700_000_000 },
+        createdAt: new Date(),
+        isUnrolled: false,
+        isSpent: false,
+        script,
+    });
+
+    const annotated = (input: VirtualCoin): any => ({
+        ...input,
+        forfeitTapLeafScript: [new Uint8Array(32), new Uint8Array(33)],
+        intentTapLeafScript: [new Uint8Array(32), new Uint8Array(34)],
+        tapTree: new Uint8Array(64),
+    });
+
+    it("saves single-contract spend rows and the change row under the primary bucket", async () => {
+        const input = makeSpentInput(PRIMARY_SCRIPT, "1");
+        const annotateVtxos = vi.fn().mockResolvedValue([annotated(input)]);
+        const { thisArg, saveVtxos, saveTransactions } = makeThisArg({
+            annotateVtxos,
+            contracts: [{ script: PRIMARY_SCRIPT, address: PRIMARY_ADDR }],
+        });
+
+        await (Wallet.prototype as any).updateDbAfterOffchainTx.call(
+            thisArg,
+            [input],
+            "ark-tx-id",
+            [], // empty checkpoints → loop takes the no-PSBT branch
+            1_000, // sentAmount
+            4_000n, // changeAmount
+            1 // changeVout
+        );
+
+        expect(saveVtxos).toHaveBeenCalledTimes(1);
+        const [addr, vtxos] = saveVtxos.mock.calls[0];
+        expect(addr).toBe(PRIMARY_ADDR);
+        expect(vtxos).toHaveLength(2); // spent + change
+        expect(vtxos[0].txid).toBe(input.txid);
+        expect(vtxos[0].isSpent).toBe(true);
+        expect(vtxos[0].script).toBe(PRIMARY_SCRIPT);
+        expect(vtxos[1].txid).toBe("ark-tx-id");
+        expect(vtxos[1].vout).toBe(1);
+        expect(vtxos[1].script).toBe(PRIMARY_SCRIPT);
+
+        expect(saveTransactions).toHaveBeenCalledTimes(1);
+        expect(saveTransactions.mock.calls[0][0]).toBe(PRIMARY_ADDR);
+    });
+
+    it("routes multi-contract spend rows to their owning contract buckets", async () => {
+        const primaryInput = makeSpentInput(PRIMARY_SCRIPT, "1");
+        const delegateInput = makeSpentInput(DELEGATE_SCRIPT, "2");
+        const annotateVtxos = vi
+            .fn()
+            .mockResolvedValue([
+                annotated(primaryInput),
+                annotated(delegateInput),
+            ]);
+        const { thisArg, saveVtxos } = makeThisArg({
+            annotateVtxos,
+            contracts: [
+                { script: PRIMARY_SCRIPT, address: PRIMARY_ADDR },
+                { script: DELEGATE_SCRIPT, address: DELEGATE_ADDR },
+            ],
+        });
+
+        await (Wallet.prototype as any).updateDbAfterOffchainTx.call(
+            thisArg,
+            [primaryInput, delegateInput],
+            "ark-tx-id",
+            [],
+            1_000,
+            0n, // no change → only spent rows
+            0
+        );
+
+        expect(saveVtxos).toHaveBeenCalledTimes(2);
+        const calls = new Map(
+            saveVtxos.mock.calls.map(([addr, vtxos]: any) => [addr, vtxos])
+        );
+        expect(calls.get(PRIMARY_ADDR)).toHaveLength(1);
+        expect(calls.get(PRIMARY_ADDR)[0].script).toBe(PRIMARY_SCRIPT);
+        expect(calls.get(DELEGATE_ADDR)).toHaveLength(1);
+        expect(calls.get(DELEGATE_ADDR)[0].script).toBe(DELEGATE_SCRIPT);
+    });
+
+    it("aggregates change with primary-bucket spent rows in a single save", async () => {
+        const primaryInput = makeSpentInput(PRIMARY_SCRIPT, "1");
+        const delegateInput = makeSpentInput(DELEGATE_SCRIPT, "2");
+        const annotateVtxos = vi
+            .fn()
+            .mockResolvedValue([
+                annotated(primaryInput),
+                annotated(delegateInput),
+            ]);
+        const { thisArg, saveVtxos } = makeThisArg({
+            annotateVtxos,
+            contracts: [
+                { script: PRIMARY_SCRIPT, address: PRIMARY_ADDR },
+                { script: DELEGATE_SCRIPT, address: DELEGATE_ADDR },
+            ],
+        });
+
+        await (Wallet.prototype as any).updateDbAfterOffchainTx.call(
+            thisArg,
+            [primaryInput, delegateInput],
+            "ark-tx-id",
+            [],
+            1_000,
+            4_000n,
+            1
+        );
+
+        expect(saveVtxos).toHaveBeenCalledTimes(2);
+        const calls = new Map(
+            saveVtxos.mock.calls.map(([addr, vtxos]: any) => [addr, vtxos])
+        );
+        // Primary bucket gets the primary spent row + the change row.
+        expect(calls.get(PRIMARY_ADDR)).toHaveLength(2);
+        expect(calls.get(DELEGATE_ADDR)).toHaveLength(1);
+    });
+
+    it("rethrows when a spent VTXO has no script", async () => {
+        const input = makeSpentInput(PRIMARY_SCRIPT, "1");
+        const annotateVtxos = vi
+            .fn()
+            .mockResolvedValue([{ ...annotated(input), script: undefined }]);
+        const { thisArg, saveVtxos } = makeThisArg({
+            annotateVtxos,
+            contracts: [{ script: PRIMARY_SCRIPT, address: PRIMARY_ADDR }],
+        });
+
+        await expect(
+            (Wallet.prototype as any).updateDbAfterOffchainTx.call(
+                thisArg,
+                [input],
+                "ark-tx-id",
+                [],
+                1_000,
+                0n,
+                0
+            )
+        ).rejects.toThrow(/has no script/);
+
+        expect(saveVtxos).not.toHaveBeenCalled();
+    });
+
+    it("rethrows when a spent VTXO references an unknown contract", async () => {
+        const input = makeSpentInput(PRIMARY_SCRIPT, "1");
+        const orphan = {
+            ...annotated(input),
+            script: "ee".repeat(34),
+        };
+        const annotateVtxos = vi.fn().mockResolvedValue([orphan]);
+        const { thisArg, saveVtxos } = makeThisArg({
+            annotateVtxos,
+            contracts: [{ script: PRIMARY_SCRIPT, address: PRIMARY_ADDR }],
+        });
+
+        await expect(
+            (Wallet.prototype as any).updateDbAfterOffchainTx.call(
+                thisArg,
+                [input],
+                "ark-tx-id",
+                [],
+                1_000,
+                0n,
+                0
+            )
+        ).rejects.toThrow(/no contract owns script/);
+
+        expect(saveVtxos).not.toHaveBeenCalled();
+    });
+});

--- a/test/worker/expo/processors/contractPollProcessor.test.ts
+++ b/test/worker/expo/processors/contractPollProcessor.test.ts
@@ -32,8 +32,11 @@ describe("contractPollProcessor", () => {
         const firstPageVtxos = Array.from({ length: 100 }, (_, i) => ({
             txid: `tx-${i}`,
             vout: i,
+            script: "script-a",
         }));
-        const secondPageVtxos = [{ txid: "tx-100", vout: 100 }];
+        const secondPageVtxos = [
+            { txid: "tx-100", vout: 100, script: "script-a" },
+        ];
 
         const contractRepository = {
             getContracts: vi.fn().mockResolvedValue([contractA, contractB]),


### PR DESCRIPTION
Adds vtxoOwnership helpers and applies them at every contract-scoped read/write site so legacy address buckets cannot leak wrong-script rows or win `txid:vout` dedup. 

Background sync writers warn-and-skip; user- initiated wallet write paths throw. 
No repository or schema changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect attribution of virtual outputs to contracts; outputs are now properly validated and mapped only to their correct owning contract, even when multiple contracts share the same address.
  * Enhanced validation across wallet and contract operations to ensure data consistency and prevent legacy outputs from being persisted with wrong associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->