### PR TITLE
fix(vtxo): script-scoped repository methods across backends (Tier 2 of #480)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,10 @@ docs/
 .idea
 .claude/
 *.sqlite
+
+# Debug 
 *.har
+*.idb
 
 # AI
 TASKS.md

--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -25,6 +25,8 @@ import {
 } from "../utils/syncCursors";
 import {
     filterVtxosForScript,
+    getVtxosForContract,
+    saveVtxosForContract,
     warnAndFilterVtxosForScript,
 } from "./vtxoOwnership";
 
@@ -680,13 +682,27 @@ export class ContractManager implements IContractManager {
         const annotated = await this.annotateVtxos(owned);
         const byAddress = new Map<string, ExtendedVirtualCoin[]>();
         for (const vtxo of annotated) {
-            const address = scriptToContract.get(vtxo.script)!.address;
+            const contract = scriptToContract.get(vtxo.script);
+            if (!contract) continue;
+            const address = contract.address;
             const arr = byAddress.get(address) ?? [];
             arr.push(vtxo);
             byAddress.set(address, arr);
         }
         for (const [address, addressVtxos] of byAddress) {
-            await this.config.walletRepository.saveVtxos(address, addressVtxos);
+            const contract = contracts.find((c) => c.address === address);
+            if (contract) {
+                await saveVtxosForContract(
+                    this.config.walletRepository,
+                    contract,
+                    addressVtxos
+                );
+            } else {
+                await this.config.walletRepository.saveVtxos(
+                    address,
+                    addressVtxos
+                );
+            }
         }
     }
 
@@ -736,16 +752,16 @@ export class ContractManager implements IContractManager {
         contracts: Contract[]
     ): Promise<ContractVtxo[]> {
         const res = await Promise.all(
-            contracts.map(({ script, address }) =>
-                this.config.walletRepository.getVtxos(address).then((vtxos) =>
-                    // Address buckets may carry legacy duplicate rows from
-                    // other contracts that once shared the same address —
-                    // gate by script so the wrong-script row never wins.
-                    filterVtxosForScript(vtxos, script).map(
+            contracts.map((contract) =>
+                getVtxosForContract(
+                    this.config.walletRepository,
+                    contract
+                ).then((vtxos) =>
+                    vtxos.map(
                         (vtxo) =>
                             ({
                                 ...vtxo,
-                                contractScript: script,
+                                contractScript: contract.script,
                             }) as ContractVtxo
                     )
                 )
@@ -851,8 +867,9 @@ export class ContractManager implements IContractManager {
                 "ContractManager.reconcilePendingFrontier"
             );
             if (filtered.length === 0) continue;
-            await this.config.walletRepository.saveVtxos(
-                addr,
+            await saveVtxosForContract(
+                this.config.walletRepository,
+                contract,
                 filtered as ExtendedVirtualCoin[]
             );
         }
@@ -879,8 +896,9 @@ export class ContractManager implements IContractManager {
                     "ContractManager.fetchContractVxosFromIndexer"
                 );
                 if (filtered.length === 0) continue;
-                await this.config.walletRepository.saveVtxos(
-                    contract.address,
+                await saveVtxosForContract(
+                    this.config.walletRepository,
+                    contract,
                     filtered as ExtendedVirtualCoin[]
                 );
             }

--- a/src/contracts/contractWatcher.ts
+++ b/src/contracts/contractWatcher.ts
@@ -9,7 +9,7 @@ import {
     ContractEvent,
 } from "./types";
 import { isEventSourceError } from "../providers/utils";
-import { filterVtxosForScript } from "./vtxoOwnership";
+import { filterVtxosForScript, getVtxosForContract } from "./vtxoOwnership";
 
 /**
  * Configuration for the ContractWatcher.
@@ -185,11 +185,9 @@ export class ContractWatcher {
             // Apply the same script gate used by getContractVtxos so a legacy
             // wrong-script row in the address bucket can't seed the baseline
             // and then look "spent" on the first poll.
-            const cached = filterVtxosForScript(
-                await this.config.walletRepository.getVtxos(
-                    state.contract.address
-                ),
-                state.contract.script
+            const cached = await getVtxosForContract(
+                this.config.walletRepository,
+                state.contract
             );
             for (const vtxo of cached) {
                 if (vtxo.isSpent) continue;
@@ -291,10 +289,7 @@ export class ContractWatcher {
                 // Use contract address as cache key. Legacy address buckets
                 // can contain rows from other contracts; gate by script before
                 // converting so a wrong-script row never reaches the watcher.
-                const cached = filterVtxosForScript(
-                    await repo.getVtxos(state.contract.address),
-                    state.contract.script
-                );
+                const cached = await getVtxosForContract(repo, state.contract);
                 if (cached.length > 0) {
                     // Convert to ContractVtxo with contractScript
                     const contractVtxos: ContractVtxo[] = cached.map((v) => ({

--- a/src/contracts/vtxoOwnership.ts
+++ b/src/contracts/vtxoOwnership.ts
@@ -96,10 +96,12 @@ export async function saveVtxosForContract(
     contract: Pick<Contract, "script" | "address">,
     vtxos: ExtendedVirtualCoin[]
 ): Promise<void> {
-    return repo.saveVtxosForScript
-        ? repo.saveVtxosForScript(
-              { script: contract.script, address: contract.address },
-              vtxos
-          )
-        : repo.saveVtxos(contract.address, vtxos);
+    if (repo.saveVtxosForScript) {
+        return repo.saveVtxosForScript(
+            { script: contract.script, address: contract.address },
+            vtxos
+        );
+    }
+    validateVtxosForScript(vtxos, contract.script, "saveVtxosForContract");
+    return repo.saveVtxos(contract.address, vtxos);
 }

--- a/src/contracts/vtxoOwnership.ts
+++ b/src/contracts/vtxoOwnership.ts
@@ -1,4 +1,6 @@
-import type { VirtualCoin } from "../wallet";
+import type { ExtendedVirtualCoin, VirtualCoin } from "../wallet";
+import type { WalletRepository } from "../repositories/walletRepository";
+import type { Contract } from "./types";
 
 /**
  * Tier 1 helpers that enforce VTXO ownership at call sites that already know
@@ -71,4 +73,33 @@ export function validateVtxosForScript(
     throw new Error(
         `${context}: refusing to persist ${mismatches.length} VTXO(s) whose script does not match ${script}: ${detail}`
     );
+}
+
+/**
+ * Tier 2 dispatch helpers: route to script-scoped repository methods when
+ * available, falling back to Tier 1 address-based filtering otherwise.
+ */
+export async function getVtxosForContract(
+    repo: WalletRepository,
+    contract: Pick<Contract, "script" | "address">
+): Promise<ExtendedVirtualCoin[]> {
+    return repo.getVtxosForScript
+        ? repo.getVtxosForScript(contract.script)
+        : filterVtxosForScript(
+              await repo.getVtxos(contract.address),
+              contract.script
+          );
+}
+
+export async function saveVtxosForContract(
+    repo: WalletRepository,
+    contract: Pick<Contract, "script" | "address">,
+    vtxos: ExtendedVirtualCoin[]
+): Promise<void> {
+    return repo.saveVtxosForScript
+        ? repo.saveVtxosForScript(
+              { script: contract.script, address: contract.address },
+              vtxos
+          )
+        : repo.saveVtxos(contract.address, vtxos);
 }

--- a/src/repositories/inMemory/walletRepository.ts
+++ b/src/repositories/inMemory/walletRepository.ts
@@ -3,7 +3,12 @@ import {
     ExtendedCoin,
     ExtendedVirtualCoin,
 } from "../../wallet";
-import { WalletRepository, WalletState } from "../walletRepository";
+import {
+    WalletRepository,
+    WalletState,
+    VtxoRepositoryKey,
+} from "../walletRepository";
+import { isVtxoForScript } from "../../contracts/vtxoOwnership";
 
 /**
  * In-memory implementation of WalletRepository.
@@ -36,6 +41,51 @@ export class InMemoryWalletRepository implements WalletRepository {
 
     async deleteVtxos(address: string): Promise<void> {
         this.vtxosByAddress.delete(address);
+    }
+
+    async getVtxosForScript(script: string): Promise<ExtendedVirtualCoin[]> {
+        const allMatches: ExtendedVirtualCoin[] = [];
+        for (const bucket of this.vtxosByAddress.values()) {
+            for (const vtxo of bucket) {
+                if (isVtxoForScript(vtxo, script)) {
+                    allMatches.push(vtxo);
+                }
+            }
+        }
+        // Dedup by outpoint (last-write-wins across address buckets)
+        return mergeByKey(
+            [],
+            allMatches,
+            (item) => `${item.txid}:${item.vout}`
+        );
+    }
+
+    async saveVtxosForScript(
+        key: VtxoRepositoryKey,
+        vtxos: ExtendedVirtualCoin[]
+    ): Promise<void> {
+        if (!key.address) {
+            throw new Error("InMemoryWalletRepository requires an address");
+        }
+        for (const vtxo of vtxos) {
+            if (!isVtxoForScript(vtxo, key.script)) {
+                throw new Error(
+                    `VTXO ${vtxo.txid}:${vtxo.vout} script mismatch: expected ${key.script}, got ${vtxo.script}`
+                );
+            }
+        }
+        return this.saveVtxos(key.address, vtxos);
+    }
+
+    async deleteVtxosForScript(script: string): Promise<void> {
+        for (const [address, bucket] of this.vtxosByAddress.entries()) {
+            const next = bucket.filter((v) => !isVtxoForScript(v, script));
+            if (next.length === 0) {
+                this.vtxosByAddress.delete(address);
+            } else {
+                this.vtxosByAddress.set(address, next);
+            }
+        }
     }
 
     async getUtxos(address: string): Promise<ExtendedCoin[]> {

--- a/src/repositories/indexedDB/walletRepository.ts
+++ b/src/repositories/indexedDB/walletRepository.ts
@@ -237,7 +237,7 @@ export class IndexedDBWalletRepository implements WalletRepository {
             });
         } catch (error) {
             console.error(`Failed to get VTXOs for script ${script}:`, error);
-            return [];
+            throw error;
         }
     }
 

--- a/src/repositories/indexedDB/walletRepository.ts
+++ b/src/repositories/indexedDB/walletRepository.ts
@@ -24,7 +24,7 @@ import { closeDatabase, openDatabase } from "./manager";
 import { initDatabase } from "./schema";
 import { scriptFromArkAddress } from "../scriptFromAddress";
 import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
-import { isVtxoForScript, vtxoOutpoint } from "../../contracts/vtxoOwnership";
+import { isVtxoForScript } from "../../contracts/vtxoOwnership";
 
 /**
  * IndexedDB-based implementation of WalletRepository.

--- a/src/repositories/indexedDB/walletRepository.ts
+++ b/src/repositories/indexedDB/walletRepository.ts
@@ -3,7 +3,11 @@ import {
     ExtendedVirtualCoin,
     ArkTransaction,
 } from "../../wallet";
-import { WalletRepository, WalletState } from "../walletRepository";
+import {
+    WalletRepository,
+    WalletState,
+    VtxoRepositoryKey,
+} from "../walletRepository";
 import {
     STORE_VTXOS,
     STORE_UTXOS,
@@ -20,6 +24,7 @@ import { closeDatabase, openDatabase } from "./manager";
 import { initDatabase } from "./schema";
 import { scriptFromArkAddress } from "../scriptFromAddress";
 import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
+import { isVtxoForScript, vtxoOutpoint } from "../../contracts/vtxoOwnership";
 
 /**
  * IndexedDB-based implementation of WalletRepository.
@@ -178,6 +183,103 @@ export class IndexedDBWalletRepository implements WalletRepository {
                 `Failed to clear VTXOs for address ${address}:`,
                 error
             );
+            throw error;
+        }
+    }
+
+    async getVtxosForScript(script: string): Promise<ExtendedVirtualCoin[]> {
+        try {
+            const db = await this.getDB();
+            return new Promise((resolve, reject) => {
+                const transaction = db.transaction([STORE_VTXOS], "readonly");
+                const store = transaction.objectStore(STORE_VTXOS);
+                const index = store.index("script");
+                const request: IDBRequest<
+                    (SerializedVtxo & { address: string })[]
+                > = index.getAll(script);
+
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => {
+                    const results = request.result || [];
+                    try {
+                        // Defensive filter: only rows whose script matches.
+                        const matching = results.filter(
+                            (r) => r.script === script
+                        );
+
+                        // Dedup same outpoint rows across address buckets.
+                        // Work on raw rows so the address field is available
+                        // for the canonicality tiebreaker.
+                        const byOutpoint = new Map<
+                            string,
+                            SerializedVtxo & { address: string }
+                        >();
+                        for (const row of matching) {
+                            const outpoint = `${row.txid}:${row.vout}`;
+                            const existing = byOutpoint.get(outpoint);
+                            if (!existing) {
+                                byOutpoint.set(outpoint, row);
+                                continue;
+                            }
+                            if (shouldReplaceVtxo(existing, row)) {
+                                byOutpoint.set(outpoint, row);
+                            }
+                        }
+                        resolve(
+                            Array.from(byOutpoint.values()).map(
+                                deserializeVtxoWithBackfill
+                            )
+                        );
+                    } catch (err) {
+                        reject(err);
+                    }
+                };
+            });
+        } catch (error) {
+            console.error(`Failed to get VTXOs for script ${script}:`, error);
+            return [];
+        }
+    }
+
+    async saveVtxosForScript(
+        key: VtxoRepositoryKey,
+        vtxos: ExtendedVirtualCoin[]
+    ): Promise<void> {
+        if (!key.address) {
+            throw new Error("IndexedDBWalletRepository requires an address");
+        }
+        for (const vtxo of vtxos) {
+            if (!isVtxoForScript(vtxo, key.script)) {
+                throw new Error(
+                    `VTXO ${vtxo.txid}:${vtxo.vout} script mismatch: expected ${key.script}, got ${vtxo.script}`
+                );
+            }
+        }
+        return this.saveVtxos(key.address, vtxos);
+    }
+
+    async deleteVtxosForScript(script: string): Promise<void> {
+        try {
+            const db = await this.getDB();
+            return new Promise((resolve, reject) => {
+                const transaction = db.transaction([STORE_VTXOS], "readwrite");
+                const store = transaction.objectStore(STORE_VTXOS);
+                const index = store.index("script");
+                const request = index.openCursor(IDBKeyRange.only(script));
+
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => {
+                    const cursor = request.result;
+                    if (cursor) {
+                        cursor.delete();
+                        cursor.continue();
+                    } else {
+                        resolve();
+                    }
+                };
+            });
+        } catch (error) {
+            console.error(`Failed to clear VTXOs for script ${script}:`, error);
             throw error;
         }
     }
@@ -436,4 +538,44 @@ function deserializeVtxoWithBackfill(
         o = { ...o, script: scriptFromArkAddress(o.address) };
     }
     return deserializeVtxo(o);
+}
+
+type RawVtxoRow = SerializedVtxo & { address: string };
+
+function isCanonicalRow(row: RawVtxoRow): boolean {
+    try {
+        return scriptFromArkAddress(row.address) === row.script;
+    } catch {
+        return false;
+    }
+}
+
+function shouldReplaceVtxo(
+    existing: RawVtxoRow,
+    incoming: RawVtxoRow
+): boolean {
+    const existingCanonical = isCanonicalRow(existing);
+    const incomingCanonical = isCanonicalRow(incoming);
+
+    if (incomingCanonical && !existingCanonical) return true;
+    if (existingCanonical && !incomingCanonical) return false;
+
+    // Tie on canonicality, check lifecycle completeness
+    const existingWeight = getLifecycleWeight(existing);
+    const incomingWeight = getLifecycleWeight(incoming);
+
+    if (incomingWeight > existingWeight) return true;
+    if (existingWeight > incomingWeight) return false;
+
+    // Tie on weight, stable sort by address
+    return incoming.address < existing.address;
+}
+
+function getLifecycleWeight(v: RawVtxoRow): number {
+    let weight = 0;
+    if (v.isSpent !== undefined) weight += 1;
+    if (v.spentBy) weight += 2;
+    if (v.settledBy) weight += 2;
+    if (v.arkTxId) weight += 2;
+    return weight;
 }

--- a/src/repositories/realm/walletRepository.ts
+++ b/src/repositories/realm/walletRepository.ts
@@ -3,7 +3,11 @@ import {
     ExtendedCoin,
     ExtendedVirtualCoin,
 } from "../../wallet";
-import { WalletRepository, WalletState } from "../walletRepository";
+import {
+    WalletRepository,
+    WalletState,
+    VtxoRepositoryKey,
+} from "../walletRepository";
 import {
     serializeVtxo,
     serializeUtxo,
@@ -14,6 +18,7 @@ import {
     SerializedTapLeaf,
 } from "../serialization";
 import { scriptFromArkAddress } from "../scriptFromAddress";
+import { isVtxoForScript } from "../../contracts/vtxoOwnership";
 import { RealmLike } from "./types";
 
 /**
@@ -114,6 +119,41 @@ export class RealmWalletRepository implements WalletRepository {
             const toDelete = this.realm
                 .objects("ArkVtxo")
                 .filtered("address == $0", address);
+            this.realm.delete(toDelete);
+        });
+    }
+
+    async getVtxosForScript(script: string): Promise<ExtendedVirtualCoin[]> {
+        await this.ensureInit();
+        const results = this.realm
+            .objects("ArkVtxo")
+            .filtered("script == $0", script);
+        return [...results].map(vtxoObjectToDomain);
+    }
+
+    async saveVtxosForScript(
+        key: VtxoRepositoryKey,
+        vtxos: ExtendedVirtualCoin[]
+    ): Promise<void> {
+        if (!key.address) {
+            throw new Error("RealmWalletRepository requires an address");
+        }
+        for (const vtxo of vtxos) {
+            if (!isVtxoForScript(vtxo, key.script)) {
+                throw new Error(
+                    `VTXO ${vtxo.txid}:${vtxo.vout} script mismatch: expected ${key.script}, got ${vtxo.script}`
+                );
+            }
+        }
+        return this.saveVtxos(key.address, vtxos);
+    }
+
+    async deleteVtxosForScript(script: string): Promise<void> {
+        await this.ensureInit();
+        this.realm.write(() => {
+            const toDelete = this.realm
+                .objects("ArkVtxo")
+                .filtered("script == $0", script);
             this.realm.delete(toDelete);
         });
     }

--- a/src/repositories/sqlite/walletRepository.ts
+++ b/src/repositories/sqlite/walletRepository.ts
@@ -3,7 +3,11 @@ import {
     ExtendedCoin,
     ExtendedVirtualCoin,
 } from "../../wallet";
-import { WalletRepository, WalletState } from "../walletRepository";
+import {
+    WalletRepository,
+    WalletState,
+    VtxoRepositoryKey,
+} from "../walletRepository";
 import {
     serializeVtxo,
     serializeUtxo,
@@ -15,6 +19,7 @@ import {
 } from "../serialization";
 import { scriptFromArkAddress } from "../scriptFromAddress";
 import { SQLExecutor } from "./types";
+import { isVtxoForScript } from "../../contracts/vtxoOwnership";
 
 interface SQLiteWalletRepositoryOptions {
     /** Table name prefix (default: "ark_") */
@@ -329,6 +334,39 @@ export class SQLiteWalletRepository implements WalletRepository {
             `DELETE FROM ${this.tables.vtxos} WHERE address = ?`,
             [address]
         );
+    }
+
+    async getVtxosForScript(script: string): Promise<ExtendedVirtualCoin[]> {
+        await this.ensureInit();
+        const rows = await this.db.all<VtxoRow>(
+            `SELECT * FROM ${this.tables.vtxos} WHERE script = ?`,
+            [script]
+        );
+        return rows.map(vtxoRowToDomain);
+    }
+
+    async saveVtxosForScript(
+        key: VtxoRepositoryKey,
+        vtxos: ExtendedVirtualCoin[]
+    ): Promise<void> {
+        if (!key.address) {
+            throw new Error("SQLiteWalletRepository requires an address");
+        }
+        for (const vtxo of vtxos) {
+            if (!isVtxoForScript(vtxo, key.script)) {
+                throw new Error(
+                    `VTXO ${vtxo.txid}:${vtxo.vout} script mismatch: expected ${key.script}, got ${vtxo.script}`
+                );
+            }
+        }
+        return this.saveVtxos(key.address, vtxos);
+    }
+
+    async deleteVtxosForScript(script: string): Promise<void> {
+        await this.ensureInit();
+        await this.db.run(`DELETE FROM ${this.tables.vtxos} WHERE script = ?`, [
+            script,
+        ]);
     }
 
     // ── UTXO management ────────────────────────────────────────────────

--- a/src/repositories/walletRepository.ts
+++ b/src/repositories/walletRepository.ts
@@ -25,6 +25,13 @@ export type CommitmentTxRecord = {
     createdAt: number;
 };
 
+export interface VtxoRepositoryKey {
+    /** Authoritative ownership key. */
+    script: string;
+    /** Legacy storage bucket. Required by all current backends; throw if absent. */
+    address?: string;
+}
+
 export interface WalletRepository extends AsyncDisposable {
     readonly version: 1;
 
@@ -39,6 +46,27 @@ export interface WalletRepository extends AsyncDisposable {
     saveVtxos(address: string, vtxos: ExtendedVirtualCoin[]): Promise<void>;
     /** Delete stored virtual outputs for an address. */
     deleteVtxos(address: string): Promise<void>;
+
+    /**
+     * Fetch stored virtual outputs for a script.
+     * @optional SDK backends implement this; custom backends fall back to Tier 1.
+     */
+    getVtxosForScript?(script: string): Promise<ExtendedVirtualCoin[]>;
+
+    /**
+     * Save virtual outputs for a script.
+     * @optional SDK backends implement this; custom backends fall back to Tier 1.
+     */
+    saveVtxosForScript?(
+        key: VtxoRepositoryKey,
+        vtxos: ExtendedVirtualCoin[]
+    ): Promise<void>;
+
+    /**
+     * Delete stored virtual outputs for a script.
+     * @optional SDK backends implement this; custom backends fall back to Tier 1.
+     */
+    deleteVtxosForScript?(script: string): Promise<void>;
 
     /** Fetch stored boarding inputs for an address. */
     getUtxos(address: string): Promise<ExtendedCoin[]>;

--- a/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -46,6 +46,8 @@ import { Transaction } from "../../utils/transaction";
 import { buildTransactionHistory } from "../../utils/transactionHistory";
 import {
     filterVtxosForScript,
+    getVtxosForContract,
+    saveVtxosForContract,
     warnAndFilterVtxosForScript,
 } from "../../contracts/vtxoOwnership";
 import { scriptFromArkAddress } from "../../repositories/scriptFromAddress";
@@ -1257,10 +1259,13 @@ export class WalletMessageHandler
                                 ? address
                                 : addrByScript.get(script);
                         if (!targetAddress) continue;
-                        await this.walletRepository?.saveVtxos(
-                            targetAddress,
-                            filtered
-                        );
+                        if (this.walletRepository) {
+                            await saveVtxosForContract(
+                                this.walletRepository,
+                                { script, address: targetAddress },
+                                filtered
+                            );
+                        }
                     }
 
                     // notify all clients about the virtual output state update
@@ -1521,10 +1526,9 @@ export class WalletMessageHandler
         const manager = await this.readonlyWallet.getContractManager();
         const contracts = await manager.getContracts();
         for (const contract of contracts) {
-            const vtxos = await this.walletRepository.getVtxos(
-                contract.address
+            addVtxos(
+                await getVtxosForContract(this.walletRepository, contract)
             );
-            addVtxos(filterVtxosForScript(vtxos, contract.script));
         }
 
         // Also check the wallet's primary address. Decode it to its script

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -101,7 +101,10 @@ import { ContractManager } from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
 import { timelockToSequence } from "../utils/timelock";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
-import { validateVtxosForScript } from "../contracts/vtxoOwnership";
+import {
+    validateVtxosForScript,
+    saveVtxosForContract,
+} from "../contracts/vtxoOwnership";
 
 export const getArkadeServerUrl = ({
     arkServerUrl,
@@ -2669,7 +2672,6 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 spentByScript.set(v.script, arr);
             }
 
-            const byAddress = new Map<string, ExtendedVirtualCoin[]>();
             for (const [script, vtxos] of spentByScript) {
                 // User-initiated send path: a wrong-script row here means the
                 // wallet is about to record ownership against the wrong
@@ -2685,20 +2687,20 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                         `Wallet.updateDbAfterOffchainTx: no contract owns script ${script}`
                     );
                 }
-                const bucket = byAddress.get(targetAddr) ?? [];
-                bucket.push(...vtxos);
-                byAddress.set(targetAddr, bucket);
+                await saveVtxosForContract(
+                    this.walletRepository,
+                    { script, address: targetAddr },
+                    vtxos
+                );
             }
 
             // Change is always primary-script by construction.
             if (changeVtxo) {
-                const bucket = byAddress.get(primaryAddr) ?? [];
-                bucket.push(changeVtxo);
-                byAddress.set(primaryAddr, bucket);
-            }
-
-            for (const [addr, vtxos] of byAddress) {
-                await this.walletRepository.saveVtxos(addr, vtxos);
+                await saveVtxosForContract(
+                    this.walletRepository,
+                    { script: changeVtxo.script!, address: primaryAddr },
+                    [changeVtxo]
+                );
             }
 
             await this.walletRepository.saveTransactions(primaryAddr, [
@@ -2777,7 +2779,6 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                     contracts.map((c) => [c.script, c.address])
                 );
 
-                const byAddress = new Map<string, ExtendedVirtualCoin[]>();
                 const byScript = new Map<string, ExtendedVirtualCoin[]>();
                 for (const v of spentVtxos) {
                     if (!v.script) {
@@ -2804,13 +2805,11 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                             `Wallet.updateDbAfterSettle: no contract owns script ${script}`
                         );
                     }
-                    const bucket = byAddress.get(targetAddr) ?? [];
-                    bucket.push(...vtxos);
-                    byAddress.set(targetAddr, bucket);
-                }
-
-                for (const [bucketAddr, vtxos] of byAddress) {
-                    await this.walletRepository.saveVtxos(bucketAddr, vtxos);
+                    await saveVtxosForContract(
+                        this.walletRepository,
+                        { script, address: targetAddr },
+                        vtxos
+                    );
                 }
             }
 

--- a/src/worker/expo/processors/contractPollProcessor.ts
+++ b/src/worker/expo/processors/contractPollProcessor.ts
@@ -1,7 +1,10 @@
 import type { TaskItem, TaskResult } from "../taskQueue";
 import type { TaskProcessor, TaskDependencies } from "../taskRunner";
 import type { ExtendedVirtualCoin } from "../../../wallet";
-import { warnAndFilterVtxosForScript } from "../../../contracts/vtxoOwnership";
+import {
+    warnAndFilterVtxosForScript,
+    saveVtxosForContract,
+} from "../../../contracts/vtxoOwnership";
 
 export const CONTRACT_POLL_TASK_TYPE = "contract-poll";
 
@@ -69,7 +72,7 @@ export const contractPollProcessor: TaskProcessor = {
                 contract.script,
                 "contractPollProcessor"
             );
-            await walletRepository.saveVtxos(contract.address, filtered);
+            await saveVtxosForContract(walletRepository, contract, filtered);
             vtxosSaved += filtered.length;
             contractsProcessed++;
         }

--- a/test/repositories/walletRepository.test.ts
+++ b/test/repositories/walletRepository.test.ts
@@ -37,7 +37,7 @@ const walletRepositoryImplementations: Array<
 // WalletRepository tests
 describe.each(walletRepositoryImplementations)(
     "WalletRepository: $name",
-    ({ factory }) => {
+    ({ factory, name }) => {
         let repository: WalletRepository;
         const testAddress = "test-address-123";
 
@@ -111,6 +111,103 @@ describe.each(walletRepositoryImplementations)(
                 expect(retrieved2).toHaveLength(1);
                 expect(retrieved2[0].txid).toBe("tx2");
             });
+        });
+
+        describe("Script-scoped VTXO management", () => {
+            it("should return empty array when no VTXOs exist for script", async () => {
+                const vtxos = await repository.getVtxosForScript!("script1");
+                expect(vtxos).toEqual([]);
+            });
+
+            it("should save and retrieve VTXOs by script", async () => {
+                const script1 = "script1";
+                const address1 = "address1";
+                const vtxo1 = {
+                    ...createMockVtxo("tx1", 0, 10000),
+                    script: script1,
+                };
+
+                await repository.saveVtxosForScript!(
+                    { script: script1, address: address1 },
+                    [vtxo1]
+                );
+                const retrieved = await repository.getVtxosForScript!(script1);
+
+                expect(retrieved).toHaveLength(1);
+                expect(retrieved[0].txid).toBe("tx1");
+                expect(retrieved[0].script).toBe(script1);
+            });
+
+            it("should throw when saving VTXO with mismatched script", async () => {
+                const script1 = "script1";
+                const address1 = "address1";
+                const vtxo1 = {
+                    ...createMockVtxo("tx1", 0, 10000),
+                    script: "wrong-script",
+                };
+
+                await expect(
+                    repository.saveVtxosForScript!(
+                        { script: script1, address: address1 },
+                        [vtxo1]
+                    )
+                ).rejects.toThrow();
+            });
+
+            it("should delete VTXOs by script across address buckets", async () => {
+                const script1 = "script1";
+                const address1 = "address1";
+                const address2 = "address2";
+                const vtxo1 = {
+                    ...createMockVtxo("tx1", 0, 10000),
+                    script: script1,
+                };
+                const vtxo2 = {
+                    ...createMockVtxo("tx2", 0, 20000),
+                    script: script1,
+                };
+
+                await repository.saveVtxos(address1, [vtxo1]);
+                await repository.saveVtxos(address2, [vtxo2]);
+
+                await repository.deleteVtxosForScript!(script1);
+
+                expect(await repository.getVtxosForScript!(script1)).toEqual(
+                    []
+                );
+                expect(await repository.getVtxos(address1)).toEqual([]);
+                expect(await repository.getVtxos(address2)).toEqual([]);
+            });
+
+            if (name.includes("IndexedDB")) {
+                it("should dedup same outpoint across address buckets in getVtxosForScript", async () => {
+                    const script1 = "script1";
+                    const address1 = "address1";
+                    const address2 = "address2";
+                    const txid = "tx1";
+                    const vout = 0;
+
+                    // vtxo1 is canonical for address1
+                    const vtxo1 = {
+                        ...createMockVtxo(txid, vout, 10000),
+                        script: script1,
+                        address: address1,
+                    };
+                    // vtxo2 is a duplicate in address2 bucket
+                    const vtxo2 = {
+                        ...createMockVtxo(txid, vout, 10000),
+                        script: script1,
+                        address: address2,
+                    };
+
+                    await repository.saveVtxos(address1, [vtxo1]);
+                    await repository.saveVtxos(address2, [vtxo2]);
+
+                    const retrieved =
+                        await repository.getVtxosForScript!(script1);
+                    expect(retrieved).toHaveLength(1);
+                });
+            }
         });
 
         describe("UTXO management", () => {

--- a/test/sqlite-wallet-repository.test.ts
+++ b/test/sqlite-wallet-repository.test.ts
@@ -645,6 +645,86 @@ describe("SQLiteWalletRepository", () => {
 
             expect(retrieved.isSpent).toBeUndefined();
         });
+
+        describe("Script-scoped VTXO management", () => {
+            it("should return empty array when no VTXOs exist for script", async () => {
+                const vtxos = await repository.getVtxosForScript("script1");
+                expect(vtxos).toEqual([]);
+            });
+
+            it("should save and retrieve VTXOs by script", async () => {
+                const script1 = "script1";
+                const address1 = "address1";
+                const vtxo1 = {
+                    ...createMockVtxo("tx1", 0, 10000),
+                    script: script1,
+                };
+
+                await repository.saveVtxosForScript(
+                    { script: script1, address: address1 },
+                    [vtxo1]
+                );
+                const retrieved = await repository.getVtxosForScript(script1);
+
+                expect(retrieved).toHaveLength(1);
+                expect(retrieved[0].txid).toBe("tx1");
+                expect(retrieved[0].script).toBe(script1);
+            });
+
+            it("should throw when saving VTXO with mismatched script", async () => {
+                const script1 = "script1";
+                const address1 = "address1";
+                const vtxo1 = {
+                    ...createMockVtxo("tx1", 0, 10000),
+                    script: "wrong-script",
+                };
+
+                await expect(
+                    repository.saveVtxosForScript(
+                        { script: script1, address: address1 },
+                        [vtxo1]
+                    )
+                ).rejects.toThrow();
+            });
+
+            it("should delete VTXOs by script", async () => {
+                const script1 = "script1";
+                const address1 = "address1";
+                const vtxo1 = {
+                    ...createMockVtxo("tx1", 0, 10000),
+                    script: script1,
+                };
+
+                await repository.saveVtxos(address1, [vtxo1]);
+                await repository.deleteVtxosForScript(script1);
+
+                expect(await repository.getVtxosForScript(script1)).toEqual([]);
+            });
+
+            it("should read by script, not address", async () => {
+                const address1 = "address1";
+                const scriptA = "scriptA";
+                const scriptB = "scriptB";
+                const vtxoA = {
+                    ...createMockVtxo("tx1", 0, 10000),
+                    script: scriptA,
+                };
+                const vtxoB = {
+                    ...createMockVtxo("tx2", 0, 20000),
+                    script: scriptB,
+                };
+
+                await repository.saveVtxos(address1, [vtxoA, vtxoB]);
+
+                const resultA = await repository.getVtxosForScript(scriptA);
+                const resultB = await repository.getVtxosForScript(scriptB);
+
+                expect(resultA).toHaveLength(1);
+                expect(resultA[0].txid).toBe("tx1");
+                expect(resultB).toHaveLength(1);
+                expect(resultB[0].txid).toBe("tx2");
+            });
+        });
     });
 
     // ── UTXO management ────────────────────────────────────────────────

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1979,16 +1979,28 @@ describe("Wallet.updateDbAfterOffchainTx", () => {
             1 // changeVout
         );
 
-        expect(saveVtxos).toHaveBeenCalledTimes(1);
-        const [addr, vtxos] = saveVtxos.mock.calls[0];
-        expect(addr).toBe(PRIMARY_ADDR);
-        expect(vtxos).toHaveLength(2); // spent + change
-        expect(vtxos[0].txid).toBe(input.txid);
-        expect(vtxos[0].isSpent).toBe(true);
-        expect(vtxos[0].script).toBe(PRIMARY_SCRIPT);
-        expect(vtxos[1].txid).toBe("ark-tx-id");
-        expect(vtxos[1].vout).toBe(1);
-        expect(vtxos[1].script).toBe(PRIMARY_SCRIPT);
+        // Per-script saves: one for the spent row, one for the change row.
+        expect(saveVtxos).toHaveBeenCalledTimes(2);
+        expect(saveVtxos).toHaveBeenCalledWith(
+            PRIMARY_ADDR,
+            expect.arrayContaining([
+                expect.objectContaining({
+                    txid: input.txid,
+                    isSpent: true,
+                    script: PRIMARY_SCRIPT,
+                }),
+            ])
+        );
+        expect(saveVtxos).toHaveBeenCalledWith(
+            PRIMARY_ADDR,
+            expect.arrayContaining([
+                expect.objectContaining({
+                    txid: "ark-tx-id",
+                    vout: 1,
+                    script: PRIMARY_SCRIPT,
+                }),
+            ])
+        );
 
         expect(saveTransactions).toHaveBeenCalledTimes(1);
         expect(saveTransactions.mock.calls[0][0]).toBe(PRIMARY_ADDR);
@@ -2031,7 +2043,7 @@ describe("Wallet.updateDbAfterOffchainTx", () => {
         expect(calls.get(DELEGATE_ADDR)[0].script).toBe(DELEGATE_SCRIPT);
     });
 
-    it("aggregates change with primary-bucket spent rows in a single save", async () => {
+    it("saves change separately from primary-bucket spent rows", async () => {
         const primaryInput = makeSpentInput(PRIMARY_SCRIPT, "1");
         const delegateInput = makeSpentInput(DELEGATE_SCRIPT, "2");
         const annotateVtxos = vi
@@ -2058,13 +2070,20 @@ describe("Wallet.updateDbAfterOffchainTx", () => {
             1
         );
 
-        expect(saveVtxos).toHaveBeenCalledTimes(2);
-        const calls = new Map(
-            saveVtxos.mock.calls.map(([addr, vtxos]: any) => [addr, vtxos])
+        // Per-script saves: primary spent, delegate spent, change (primary script).
+        expect(saveVtxos).toHaveBeenCalledTimes(3);
+        expect(saveVtxos).toHaveBeenCalledWith(
+            PRIMARY_ADDR,
+            expect.arrayContaining([
+                expect.objectContaining({ script: PRIMARY_SCRIPT }),
+            ])
         );
-        // Primary bucket gets the primary spent row + the change row.
-        expect(calls.get(PRIMARY_ADDR)).toHaveLength(2);
-        expect(calls.get(DELEGATE_ADDR)).toHaveLength(1);
+        expect(saveVtxos).toHaveBeenCalledWith(
+            DELEGATE_ADDR,
+            expect.arrayContaining([
+                expect.objectContaining({ script: DELEGATE_SCRIPT }),
+            ])
+        );
     });
 
     it("rethrows when a spent VTXO has no script", async () => {


### PR DESCRIPTION
## Summary

- Adds optional `getVtxosForScript`, `saveVtxosForScript`, and `deleteVtxosForScript` methods to the `WalletRepository` interface (no breaking change — existing custom implementations continue to work via Tier 1 fallbacks).
- Implements the three methods in all SDK-provided backends: in-memory, IndexedDB, SQLite, and Realm.
- Adds `getVtxosForContract` / `saveVtxosForContract` dispatch helpers in `vtxoOwnership.ts`; migrates all contract-aware call sites in `ContractManager`, `ContractWatcher`, `contractPollProcessor`, `wallet-message-handler`, and `Wallet` to use them.
- IndexedDB dedup tiebreaker (`shouldReplaceVtxo`) guards `scriptFromArkAddress` decode failures so a row with an undecodable address is treated as non-canonical rather than crashing the entire script-scoped read.
- No schema changes, no migration required, no version bump.

Part of #480.

## Test plan

- [x] `pnpm lint && pnpm test:unit` passes
- [x] Conformance tests in `test/repositories/walletRepository.test.ts` cover all three new methods for InMemory and IndexedDB, including the duplicate-outpoint dedup case
- [x] SQLite script-scoped tests in `test/sqlite-wallet-repository.test.ts` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized how virtual transaction outputs are managed internally to support script-based organization alongside address-based storage.

* **Tests**
  * Added comprehensive test coverage for script-scoped virtual output operations across repository implementations.

* **Chores**
  * Updated `.gitignore` to exclude debug artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->