### PR TITLE
chore: improve typedoc comments, use `as const` for default constants

### DIFF
--- a/src/script/address.ts
+++ b/src/script/address.ts
@@ -34,10 +34,10 @@ import { DEFAULT_ARKADE_HRP } from "../wallet";
  */
 export class ArkAddress {
     /**
-     * Create an Arkade address from its server key, vtxo taproot public key, and prefix.
+     * Create an Arkade address from its server public key, Taproot output key, and prefix.
      *
      * @param serverPubKey - 32-byte Arkade server public key
-     * @param vtxoTaprootKey - 32-byte tweaked vtxo taproot public key
+     * @param vtxoTaprootKey - 32-byte Taproot output key (a.k.a. tweaked public key)
      * @param hrp - Bech32 human-readable prefix
      * @param version - Address version byte
      * @defaultValue `version = 0`

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -14,8 +14,8 @@ import { DelegatorProvider } from "../providers/delegator";
 
 /** Defaults */
 export const DEFAULT_ARKADE_SERVER_URL = "https://arkade.computer" as const;
-export const DEFAULT_ARKADE_HRP = "ark";
-export const DEFAULT_NETWORK_NAME = "bitcoin";
+export const DEFAULT_ARKADE_HRP = "ark" as const;
+export const DEFAULT_NETWORK_NAME = "bitcoin" as const;
 
 /**
  * Base configuration options shared by all wallet types.
@@ -512,24 +512,27 @@ export interface Coin extends Outpoint {
  * @see VirtualStatus
  */
 export interface VirtualCoin extends Coin {
-    /** Virtual output status */
-    virtualStatus: VirtualStatus;
-    /** Transaction id that spent this virtual output, when known. */
-    spentBy?: string;
-    /** Settlement transaction associated with this virtual output, when known. */
-    settledBy?: string;
-    /** Arkade transaction id that created or spent this virtual output, when known. */
-    arkTxId?: string;
     /** Creation time of the virtual output. */
     createdAt: Date;
-    /** Whether this virtual output has been unrolled to onchain outputs. */
-    isUnrolled: boolean;
-    /** Whether this virtual output is already spent. */
-    isSpent?: boolean;
-    /** Assets carried by this virtual output, if any. */
-    assets?: Asset[];
     /** The scriptPubKey (hex) locking this virtual output, as returned by the indexer. */
     script: string;
+    /** Whether this virtual output has been broadcasted onchain via an unroll (unilateral exit). */
+    isUnrolled: boolean;
+    /**
+     * Whether this virtual output is already spent (boolean helper for `spentBy`).
+     * This is not set to true if the virtual output is unrolled or swept, only when it's spent offchain.
+     */
+    isSpent?: boolean;
+    /** ID of the onchain commitment transaction that settled this output, if applicable. */
+    settledBy?: string;
+    /** ID of the offchain checkpoint transaction that spent this output, if applicable. */
+    spentBy?: string;
+    /** ID of the offchain Arkade transaction that spent the above checkpoint output, if applicable. */
+    arkTxId?: string;
+    /** Virtual output status */
+    virtualStatus: VirtualStatus;
+    /** Assets carried by this virtual output, if any. */
+    assets?: Asset[];
 }
 
 /** Wallet transaction direction. */


### PR DESCRIPTION
update per https://arklabshq.slack.com/archives/C07NCLU403B/p1776420435361069?thread_ts=1774626705.210579&cid=C07NCLU403B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified JSDoc descriptions for improved code documentation.

* **Refactor**
  * Enhanced type safety with string literal typing for constants and reorganized interface property ordering for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->