### PR TITLE
fix(types): emit ESM-compatible declaration imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "registry": "https://registry.npmjs.org/"
     },
     "scripts": {
-        "build": "rimraf dist && pnpm run build:esm && pnpm run build:expo:esm && node scripts/add-extensions.js && pnpm run build:cjs && pnpm run build:expo:cjs && pnpm run build:types && pnpm run build:expo:types && node scripts/generate-package-files.js",
+        "build": "rimraf dist && pnpm run build:esm && pnpm run build:expo:esm && pnpm run build:cjs && pnpm run build:expo:cjs && pnpm run build:types && pnpm run build:expo:types && node scripts/add-extensions.js && node scripts/generate-package-files.js",
         "build:esm": "tsc -p tsconfig.esm.json --outDir dist/esm",
         "build:cjs": "tsc -p tsconfig.cjs.json --outDir dist/cjs",
         "build:types": "tsc -p tsconfig.json --outDir dist/types --emitDeclarationOnly",

--- a/scripts/add-extensions.js
+++ b/scripts/add-extensions.js
@@ -1,12 +1,12 @@
 /**
  * ESM Import Path Fixer
  * 
- * This script adds .js extensions to all ESM imports in the compiled JavaScript files.
+ * This script adds .js extensions to relative imports in compiled output files.
  * It's necessary for Node.js ESM compatibility since Node.js requires explicit file extensions
  * in import statements when using ES modules.
  * 
  * The script:
- * 1. Finds all JS files in the ESM output directory
+ * 1. Finds files in the ESM and types output directories
  * 2. For each file, it processes all relative imports
  * 3. Adds .js extensions where needed, handling various edge cases
  */
@@ -18,7 +18,18 @@ import { glob } from 'glob';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.join(__dirname, '..');
-const esmDir = path.join(rootDir, 'dist', 'esm');
+const outputDirs = [
+  {
+    dir: path.join(rootDir, 'dist', 'esm'),
+    pattern: '**/*.js',
+    lookupExtensions: ['.js'],
+  },
+  {
+    dir: path.join(rootDir, 'dist', 'types'),
+    pattern: '**/*.d.ts',
+    lookupExtensions: ['.d.ts'],
+  },
+];
 
 /**
  * Resolves an import path to include the correct extension
@@ -26,28 +37,40 @@ const esmDir = path.join(rootDir, 'dist', 'esm');
  * @param {string} currentDir - The directory of the file containing the import
  * @returns {string} - The resolved import path with proper extension
  */
-function resolveImportPath(importPath, currentDir) {
-  // If it already has .js extension, return as is
-  if (importPath.endsWith('.js')) {
+function resolveImportPath(importPath, currentDir, lookupExtensions) {
+  // If it already has an extension, return as is
+  if (path.extname(importPath)) {
     return importPath;
   }
-  
-  // Check if the file exists with .js extension
-  const withJsExt = `${importPath}.js`;
-  const absolutePath = path.resolve(currentDir, withJsExt);
-  
-  if (fs.existsSync(absolutePath)) {
-    return withJsExt;
+
+  for (const extension of lookupExtensions) {
+    const absolutePath = path.resolve(currentDir, `${importPath}${extension}`);
+
+    if (fs.existsSync(absolutePath)) {
+      return `${importPath}.js`;
+    }
   }
-  
-  // Check if it's a directory with an index.js file
-  const indexPath = path.resolve(currentDir, `${importPath}/index.js`);
-  if (fs.existsSync(indexPath)) {
-    return `${importPath}/index.js`;
+
+  for (const extension of lookupExtensions) {
+    const indexPath = path.resolve(currentDir, `${importPath}/index${extension}`);
+    if (fs.existsSync(indexPath)) {
+      return `${importPath}/index.js`;
+    }
   }
-  
+
   // If neither exists, add .js as a fallback
   return `${importPath}.js`;
+}
+
+function addExtensionsToContent(content, currentDir, lookupExtensions) {
+  const fixSpecifier = (match, prefix, importPath, suffix) => {
+    const resolvedPath = resolveImportPath(importPath, currentDir, lookupExtensions);
+    return `${prefix}${resolvedPath}${suffix}`;
+  };
+
+  return content
+    .replace(/(from\s+['"])(\.[^'"]*)(['"])/g, fixSpecifier)
+    .replace(/(import\(\s*['"])(\.[^'"]*)(['"]\s*\))/g, fixSpecifier);
 }
 
 /**
@@ -55,36 +78,26 @@ function resolveImportPath(importPath, currentDir) {
  */
 async function addExtensions() {
   try {
-    // Find all JS files in the ESM directory
-    const files = await glob('**/*.js', { cwd: esmDir });
+    const existingOutputDirs = outputDirs.filter(({ dir }) => fs.existsSync(dir));
     let fixedImports = 0;
-    
-    for (const file of files) {
-      const filePath = path.join(esmDir, file);
-      const fileDir = path.dirname(filePath);
-      let content = fs.readFileSync(filePath, 'utf8');
-      
-      // Replace relative imports without extensions
-      const updatedContent = content.replace(
-        /from\s+['"](\.[^'"]*)['"]/g,
-        (match, importPath) => {
-          // Skip if already has an extension
-          if (importPath.endsWith('.js')) {
-            return match;
-          }
-          
-          const resolvedPath = resolveImportPath(importPath, fileDir);
+
+    for (const { dir, pattern, lookupExtensions } of existingOutputDirs) {
+      const files = await glob(pattern, { cwd: dir });
+
+      for (const file of files) {
+        const filePath = path.join(dir, file);
+        const fileDir = path.dirname(filePath);
+        const content = fs.readFileSync(filePath, 'utf8');
+        const updatedContent = addExtensionsToContent(content, fileDir, lookupExtensions);
+
+        if (content !== updatedContent) {
           fixedImports++;
-          return `from '${resolvedPath}'`;
+          fs.writeFileSync(filePath, updatedContent);
         }
-      );
-      
-      if (content !== updatedContent) {
-        fs.writeFileSync(filePath, updatedContent);
       }
     }
-    
-    console.log(`✅ Added .js extensions to ${fixedImports} ESM imports`);
+
+    console.log(`✅ Added .js extensions to imports in ${fixedImports} files`);
   } catch (error) {
     console.error('Error adding extensions:', error);
     process.exit(1);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -4,7 +4,7 @@ import { equalBytes } from "@scure/btc-signer/utils.js";
 import { Packet } from "./asset/packet";
 import { BufferReader } from "./asset/utils";
 import { ExtensionPacket, UnknownPacket } from "./packet";
-import type { TransactionOutput } from "@scure/btc-signer/psbt";
+import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import type { Transaction } from "../utils/transaction";
 
 export type { ExtensionPacket } from "./packet";

--- a/src/script/delegate.ts
+++ b/src/script/delegate.ts
@@ -1,4 +1,4 @@
-import { Bytes } from "@scure/btc-signer/utils";
+import { Bytes } from "@scure/btc-signer/utils.js";
 import { DefaultVtxo } from "./default";
 import { MultisigTapscript } from "./tapscript";
 import { TapLeafScript, VtxoScript } from "./base";

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1,6 +1,6 @@
 import { Transaction as BtcSignerTransaction } from "@scure/btc-signer";
-import { TxOpts } from "@scure/btc-signer/transaction";
-import { Bytes } from "@scure/btc-signer/utils";
+import { TxOpts } from "@scure/btc-signer/transaction.js";
+import { Bytes } from "@scure/btc-signer/utils.js";
 
 /**
  * Transaction is a wrapper around the @scure/btc-signer Transaction class.

--- a/src/wallet/delegator.ts
+++ b/src/wallet/delegator.ts
@@ -1,4 +1,4 @@
-import { TransactionOutput } from "@scure/btc-signer/psbt";
+import { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import {
     ArkAddress,
     ArkInfo,
@@ -27,7 +27,7 @@ import { base64, hex } from "@scure/base";
 import { scriptFromTapLeafScript } from "../script/base";
 import { buildForfeitTxWithOutput } from "../forfeit";
 import { Address, OutScript, SigHash } from "@scure/btc-signer";
-import { Bytes } from "@scure/btc-signer/utils";
+import { Bytes } from "@scure/btc-signer/utils.js";
 import { equalBytes } from "@scure/btc-signer/utils.js";
 import { getNetwork, NetworkName } from "../networks";
 import { createAssetPacket } from "./asset";

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -12,7 +12,7 @@ import { DefaultVtxo } from "../script/default";
 import { DelegateVtxo } from "../script/delegate";
 import { ReadonlyWallet } from "./wallet";
 import { hex } from "@scure/base";
-import { Bytes } from "@scure/btc-signer/utils";
+import { Bytes } from "@scure/btc-signer/utils.js";
 
 export const DUST_AMOUNT = 546; // sats
 


### PR DESCRIPTION
## Summary
Fixes the generated TypeScript declaration files so they work correctly in ESM/NodeNext consumers.

## What Changed
- Moved `scripts/add-extensions.js` to run after declaration files are emitted.
- Extended the extension patcher to process `dist/types/**/*.d.ts` in addition to compiled ESM JavaScript.
- Ensured emitted declaration imports use explicit `.js` specifiers, including directory imports as `index.js`.
- Updated remaining `@scure/btc-signer/*` subpath imports that are emitted into declarations to use the package’s exported `.js` subpaths.

## Why
The package is published as `"type": "module"`, but the generated `.d.ts` files contained extensionless relative imports such as:

```ts
import { Wallet } from "./wallet";
```

In TypeScript projects using `moduleResolution: "node16"` or `"nodenext"`, declaration files in ESM packages must use explicit file extensions. Without them, consumers can hit errors like:
`TS2834: Relative import paths need explicit file extensions in ECMAScript imports`

This also affects IDE/LSP resolution and linting for strict ESM consumers.

## Verification
- `pnpm run build`
- `pnpm lint`
- Verified emitted declarations pass a `NodeNext` TypeScript check with `skipLibCheck: false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to include ESM module export step for improved distribution compatibility.
  * Refactored build script to support multiple output directories with consistent import resolution.
  * Standardized internal import paths across codebase for better compatibility with package distribution formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->