### PR TITLE
fix: isolate expo-task-manager/expo-background-task to /wallet/expo/background

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
             "import": "./dist/esm/wallet/expo/index.js",
             "require": "./dist/cjs/wallet/expo/index.js",
             "default": "./dist/esm/wallet/expo/index.js"
+        },
+        "./wallet/expo/background": {
+            "types": "./dist/types/wallet/expo/background.d.ts",
+            "import": "./dist/esm/wallet/expo/background.js",
+            "require": "./dist/cjs/wallet/expo/background.js",
+            "default": "./dist/esm/wallet/expo/background.js"
         }
     },
     "files": [

--- a/src/wallet/expo/background.ts
+++ b/src/wallet/expo/background.ts
@@ -1,3 +1,25 @@
+/**
+ * Expo background task entrypoint — `@arkade-os/sdk/wallet/expo/background`.
+ *
+ * This subpath is the **only** module in the package that touches
+ * `expo-task-manager` / `expo-background-task`. It is split out from
+ * `/wallet/expo` on purpose: those packages have no web platform and
+ * are declared as optional peer dependencies, so importing them from
+ * `/wallet/expo` would regress react-native-web / Node consumers who
+ * only need the foreground APIs.
+ *
+ * The imports are static (not lazy `require()`) because Metro's static
+ * dependency collector cannot see modules hidden behind `__require()`
+ * in the ESM build — without static imports the packages never enter
+ * the bundle graph and resolution fails at runtime. See
+ * https://github.com/arkade-os/ts-sdk/issues/486 for details.
+ *
+ * Consumers install the peers in their Expo app:
+ *   npx expo install expo-task-manager expo-background-task
+ */
+import * as TaskManager from "expo-task-manager";
+import * as BackgroundTask from "expo-background-task";
+
 import type { WalletRepository } from "../../repositories/walletRepository";
 import type { ContractRepository } from "../../repositories/contractRepository";
 import type { AsyncStorageTaskQueue } from "../../worker/expo/asyncStorageTaskQueue";
@@ -11,52 +33,6 @@ import {
 import { ExpoArkProvider } from "../../providers/expoArk";
 import { ExpoIndexerProvider } from "../../providers/expoIndexer";
 import { getRandomId } from "../utils";
-
-// ── Inline type declarations for optional Expo packages ──────────
-// These avoid a hard build-time dependency on expo-background-task
-// and expo-task-manager (they are optional peerDependencies).
-
-interface TaskManagerModule {
-    defineTask(
-        taskName: string,
-        executor: (body: {
-            data: unknown;
-            error: { code: string | number; message: string } | null;
-            executionInfo: { eventId: string; taskName: string };
-        }) => Promise<unknown>
-    ): void;
-}
-
-interface BackgroundTaskModule {
-    BackgroundTaskResult: { Success: 1; Failed: 2 };
-    registerTaskAsync(
-        taskName: string,
-        options?: { minimumInterval?: number }
-    ): Promise<void>;
-    unregisterTaskAsync(taskName: string): Promise<void>;
-}
-
-function requireTaskManager(): TaskManagerModule {
-    try {
-        return require("expo-task-manager") as TaskManagerModule;
-    } catch {
-        throw new Error(
-            "expo-task-manager is required for background tasks. " +
-                "Install it with: npx expo install expo-task-manager"
-        );
-    }
-}
-
-function requireBackgroundTask(): BackgroundTaskModule {
-    try {
-        return require("expo-background-task") as BackgroundTaskModule;
-    } catch {
-        throw new Error(
-            "expo-background-task is required for background tasks. " +
-                "Install it with: npx expo install expo-background-task"
-        );
-    }
-}
 
 // ── Persisted config ─────────────────────────────────────────────
 
@@ -92,13 +68,17 @@ export interface DefineBackgroundTaskOptions {
 /**
  * Define the Expo background task handler.
  *
- * **Must be called at module/global scope** (before React mounts).
- * Internally calls `TaskManager.defineTask()`.
+ * **Must be called at module/global scope** (before React mounts) so
+ * Expo's TaskManager can resume the task on cold start.
+ *
+ * Pair with @see registerExpoBackgroundTask to activate the OS
+ * scheduler — `ExpoWallet.setup()` no longer registers the task for
+ * you.
  *
  * @example
  * ```ts
- * // At the top of your app entry file
- * import { defineExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo";
+ * // App entry (e.g. _layout.tsx) — module scope
+ * import { defineExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo/background";
  * import { AsyncStorageTaskQueue } from "@arkade-os/sdk/worker/expo";
  * import AsyncStorage from "@react-native-async-storage/async-storage";
  *
@@ -114,9 +94,6 @@ export function defineExpoBackgroundTask(
     taskName: string,
     options: DefineBackgroundTaskOptions
 ): void {
-    const TaskManager = requireTaskManager();
-    const BackgroundTask = requireBackgroundTask();
-
     const {
         taskQueue,
         walletRepository,
@@ -134,7 +111,6 @@ export function defineExpoBackgroundTask(
                 return BackgroundTask.BackgroundTaskResult.Success;
             }
 
-            // Reconstruct providers
             const indexerProvider = new ExpoIndexerProvider(
                 config.arkServerUrl
             );
@@ -181,16 +157,19 @@ export function defineExpoBackgroundTask(
 /**
  * Activate the OS-level background task scheduler.
  *
- * Call this after @see defineExpoBackgroundTask (typically inside
- * @see ExpoWallet.setup or in a React component after wallet init).
+ * Call once after @see defineExpoBackgroundTask — typically right after
+ * `ExpoWallet.setup()`. Safe to call again to update the interval.
  *
- * @param minimumInterval - Minimum interval in minutes (default 15).
+ * @param taskName - The task name passed to {@link defineExpoBackgroundTask}.
+ * @param options.minimumInterval - Minimum interval in **minutes** (default
+ *   15, the floor enforced by `expo-background-task`).
+ *
+ * @see https://docs.expo.dev/versions/latest/sdk/background-task/#backgroundtaskoptions
  */
 export async function registerExpoBackgroundTask(
     taskName: string,
     options?: { minimumInterval?: number }
 ): Promise<void> {
-    const BackgroundTask = requireBackgroundTask();
     await BackgroundTask.registerTaskAsync(taskName, {
         minimumInterval: (options?.minimumInterval ?? 15) * 60,
     });
@@ -198,10 +177,13 @@ export async function registerExpoBackgroundTask(
 
 /**
  * Unregister the background task from the OS scheduler.
+ *
+ * `ExpoWallet.dispose()` does **not** call this — the OS-level task
+ * lifecycle is the consumer's responsibility, matching the explicit
+ * `register` step.
  */
 export async function unregisterExpoBackgroundTask(
     taskName: string
 ): Promise<void> {
-    const BackgroundTask = requireBackgroundTask();
     await BackgroundTask.unregisterTaskAsync(taskName);
 }

--- a/src/wallet/expo/expo-modules.d.ts
+++ b/src/wallet/expo/expo-modules.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Ambient declarations for `expo-task-manager` and `expo-background-task`.
+ *
+ * Why this file exists: these modules are required at runtime by
+ * `src/wallet/expo/background.ts` but are intentionally declared as
+ * **optional** peer dependencies — they have no web platform and are
+ * only needed by Expo Android/iOS consumers. This file lets `tsc`
+ * type-check the subset of their APIs we actually use, without
+ * pulling the packages into the build.
+ *
+ * Consumers install them in their own Expo app:
+ *   npx expo install expo-task-manager expo-background-task
+ */
+
+declare module "expo-task-manager" {
+    export function defineTask(
+        taskName: string,
+        executor: (body: {
+            data: unknown;
+            error: { code: string | number; message: string } | null;
+            executionInfo: { eventId: string; taskName: string };
+        }) => Promise<unknown>
+    ): void;
+}
+
+declare module "expo-background-task" {
+    export const BackgroundTaskResult: { Success: 1; Failed: 2 };
+    export function registerTaskAsync(
+        taskName: string,
+        options?: { minimumInterval?: number }
+    ): Promise<void>;
+    export function unregisterTaskAsync(taskName: string): Promise<void>;
+}

--- a/src/wallet/expo/index.ts
+++ b/src/wallet/expo/index.ts
@@ -1,11 +1,16 @@
+/**
+ * Expo/React Native entrypoint for `@arkade-os/sdk/wallet/expo`.
+ *
+ * Foreground-only APIs. For the background-task helpers, import from
+ * `@arkade-os/sdk/wallet/expo/background` — that subpath is split out
+ * so non-Expo consumers (react-native-web, Node) don't pull
+ * `expo-task-manager` / `expo-background-task` into their bundle
+ * graph. See https://github.com/arkade-os/ts-sdk/issues/486.
+ *
+ * ```ts
+ * import { ExpoWallet } from "@arkade-os/sdk/wallet/expo";
+ * import { defineExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo/background";
+ * ```
+ */
 export { ExpoWallet } from "./wallet";
 export type { ExpoWalletConfig, ExpoBackgroundConfig } from "./wallet";
-export {
-    defineExpoBackgroundTask,
-    registerExpoBackgroundTask,
-    unregisterExpoBackgroundTask,
-} from "./background";
-export type {
-    DefineBackgroundTaskOptions,
-    PersistedBackgroundConfig,
-} from "./background";

--- a/src/wallet/expo/wallet.ts
+++ b/src/wallet/expo/wallet.ts
@@ -36,18 +36,22 @@ import type { AsyncStorageTaskQueue } from "../../worker/expo/asyncStorageTaskQu
 
 /**
  * Background processing configuration for @see ExpoWallet.
+ *
+ * OS-level task registration is **not** part of this config — call
+ * `registerExpoBackgroundTask` from `@arkade-os/sdk/wallet/expo/background`
+ * explicitly. Splitting that step out keeps `/wallet/expo` free of the
+ * `expo-task-manager` / `expo-background-task` dependencies, so
+ * react-native-web and Node consumers can use `ExpoWallet` without
+ * those native packages. See
+ * https://github.com/arkade-os/ts-sdk/issues/486 for details.
  */
 export interface ExpoBackgroundConfig {
-    /** Identifier registered with expo-background-task. */
-    taskName: string;
     /** Persistence layer for foreground ↔ background handoff. */
     taskQueue: TaskQueue;
     /** Processors to run on each tick. Defaults to `[contractPollProcessor]`. */
     processors?: TaskProcessor[];
     /** If set, automatically polls at this interval (ms) while the app is in the foreground. */
     foregroundIntervalMs?: number;
-    /** If set, registers the background task with the OS at this interval (minutes, min 15). */
-    minimumBackgroundInterval?: number;
 }
 
 /**
@@ -58,15 +62,45 @@ export interface ExpoWalletConfig extends WalletConfig {
 }
 
 /**
+ * Catches JS callers still passing the pre-fix-#486 fields: TypeScript
+ * blocks these at compile time, but compiled JS silently dropped them
+ * and consumers would never realize the OS task wasn't scheduled.
+ *
+ * @internal Exported for tests; not part of the public API surface.
+ */
+export function warnOnRemovedBackgroundFields(bg: unknown): void {
+    if (!bg || typeof bg !== "object") return;
+    const removed: string[] = [];
+    if ("taskName" in bg) removed.push("taskName");
+    if ("minimumBackgroundInterval" in bg) {
+        removed.push("minimumBackgroundInterval");
+    }
+    if (removed.length === 0) return;
+    console.warn(
+        `[ark-sdk] ExpoWallet.setup: ignoring removed background field(s): ${removed.join(", ")}. ` +
+            'OS-task registration moved to "@arkade-os/sdk/wallet/expo/background". ' +
+            "See https://github.com/arkade-os/ts-sdk/issues/486"
+    );
+}
+
+/**
  * Expo/React Native wallet with built-in background task processing.
  *
  * Wraps a standard @see Wallet and adds a lightweight task queue
  * for keeping contract/VTXO state fresh while the app is active and
  * across Expo BackgroundTask wakes.
  *
+ * OS-level task registration is the consumer's responsibility — call
+ * `registerExpoBackgroundTask` from
+ * `@arkade-os/sdk/wallet/expo/background` after `setup()`. Keeping
+ * registration out of `setup()` lets this entrypoint avoid pulling
+ * `expo-task-manager` / `expo-background-task` into the `/wallet/expo`
+ * bundle.
+ *
  * @example
  * ```ts
  * import { ExpoWallet } from "@arkade-os/sdk/wallet/expo";
+ * import { registerExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo/background";
  * import { AsyncStorageTaskQueue } from "@arkade-os/sdk/worker/expo";
  *
  * const wallet = await ExpoWallet.setup({
@@ -75,12 +109,13 @@ export interface ExpoWalletConfig extends WalletConfig {
  *     esploraUrl: 'https://mempool.space/api',
  *     storage: { ... },
  *     background: {
- *         taskName: "ark-background-poll",
  *         taskQueue: new AsyncStorageTaskQueue(AsyncStorage),
  *         foregroundIntervalMs: 20_000,
- *         minimumBackgroundInterval: 15,
  *     },
  * });
+ *
+ * // Activate the OS scheduler (Expo Android/iOS only)
+ * await registerExpoBackgroundTask("ark-background-poll", { minimumInterval: 15 });
  *
  * const balance = await wallet.getBalance();
  * ```
@@ -91,20 +126,17 @@ export class ExpoWallet implements IWallet {
     readonly indexerProvider: Wallet["indexerProvider"];
 
     private foregroundIntervalId?: ReturnType<typeof setInterval>;
-    private readonly taskName: string;
 
     private constructor(
         private readonly wallet: Wallet,
         private readonly taskQueue: TaskQueue,
         private readonly processors: TaskProcessor[],
         private readonly deps: TaskDependencies,
-        taskName: string,
         foregroundIntervalMs?: number
     ) {
         this.identity = wallet.identity;
         this.arkProvider = wallet.arkProvider;
         this.indexerProvider = wallet.indexerProvider;
-        this.taskName = taskName;
 
         if (foregroundIntervalMs && foregroundIntervalMs > 0) {
             this.startForegroundPolling(foregroundIntervalMs);
@@ -112,16 +144,21 @@ export class ExpoWallet implements IWallet {
     }
 
     /**
-     * Create an ExpoWallet with background task support.
+     * Create an ExpoWallet with foreground/background queue handoff.
      *
      * 1. Creates the inner @see Wallet via `Wallet.create()`.
      * 2. Wires up processors (defaults to @see contractPollProcessor).
      * 3. Persists background config for the background handler (if the queue supports it).
      * 4. Seeds the task queue with a `contract-poll` task.
-     * 5. Registers the background task with the OS scheduler (if `minimumBackgroundInterval` is set).
-     * 6. Starts foreground polling if `foregroundIntervalMs` is set.
+     * 5. Starts the foreground interval if `foregroundIntervalMs` is set.
+     *
+     * OS-level scheduling lives in
+     * `@arkade-os/sdk/wallet/expo/background` and is invoked separately
+     * by the consumer.
      */
     static async setup(config: ExpoWalletConfig): Promise<ExpoWallet> {
+        warnOnRemovedBackgroundFields(config.background);
+
         const wallet = await Wallet.create(config);
 
         const processors = config.background.processors ?? [
@@ -176,27 +213,11 @@ export class ExpoWallet implements IWallet {
             taskQueue,
             processors,
             deps,
-            config.background.taskName,
             config.background.foregroundIntervalMs
         );
 
         // Seed the queue so the first tick (or background wake) has work to do
         await expoWallet.seedContractPollTask();
-
-        // Activate OS-level background scheduling
-        if (config.background.minimumBackgroundInterval) {
-            try {
-                const { registerExpoBackgroundTask } = await import(
-                    "./background"
-                );
-                await registerExpoBackgroundTask(config.background.taskName, {
-                    minimumInterval:
-                        config.background.minimumBackgroundInterval,
-                });
-            } catch {
-                // expo-background-task not installed — foreground-only mode
-            }
-        }
 
         return expoWallet;
     }
@@ -238,21 +259,17 @@ export class ExpoWallet implements IWallet {
     // ── Lifecycle ────────────────────────────────────────────────────
 
     /**
-     * Stop foreground polling and unregister the background task.
+     * Stop foreground polling and dispose the inner wallet.
+     *
+     * Does **not** unregister the OS background task — call
+     * `unregisterExpoBackgroundTask` from
+     * `@arkade-os/sdk/wallet/expo/background` yourself, matching the
+     * explicit `register` step.
      */
     async dispose(): Promise<void> {
         if (this.foregroundIntervalId) {
             clearInterval(this.foregroundIntervalId);
             this.foregroundIntervalId = undefined;
-        }
-
-        try {
-            const { unregisterExpoBackgroundTask } = await import(
-                "./background"
-            );
-            await unregisterExpoBackgroundTask(this.taskName);
-        } catch {
-            // expo-background-task not installed — nothing to unregister
         }
 
         await this.wallet.dispose();

--- a/src/worker/expo/README.md
+++ b/src/worker/expo/README.md
@@ -2,6 +2,25 @@
 
 Expo/React Native cannot run a long-lived service worker. Background work is executed by the OS every ~15 minutes for a short window, and foreground/background never overlap. The SDK therefore keeps all orchestration inside a single service and uses a lightweight task queue (AsyncStorage-backed in production, in-memory for tests) to hand off work/results across wakes.
 
+> [!WARNING]
+> **Change since 0.4.27** — fix for [#486](https://github.com/arkade-os/ts-sdk/issues/486).
+>
+> Background-task helpers moved from `@arkade-os/sdk/wallet/expo` to
+> `@arkade-os/sdk/wallet/expo/background`. OS-level registration is no
+> longer performed by `ExpoWallet.setup()` — call
+> `registerExpoBackgroundTask` explicitly. The split keeps the
+> `expo-task-manager` / `expo-background-task` imports out of
+> `/wallet/expo`, so they stay invisible to Metro's static dependency
+> collector only on the subpath that needs them.
+>
+> | Before | After |
+> | --- | --- |
+> | `import { defineExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo"` | `import { defineExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo/background"` |
+> | `background: { taskName, taskQueue, foregroundIntervalMs, minimumBackgroundInterval }` | `background: { taskQueue, foregroundIntervalMs }` + explicit `await registerExpoBackgroundTask(taskName, { minimumInterval })` |
+> | `dispose()` unregistered the OS task | Call `unregisterExpoBackgroundTask(taskName)` yourself |
+>
+> TypeScript callers get a compile error on the removed fields. **JS callers must update manually** — the old fields are silently ignored and the OS task will never run.
+
 ## Usage
 
 ### 1. Define the background task (global scope)
@@ -12,7 +31,7 @@ Expo/React Native cannot run a long-lived service worker. Background work is exe
 // App entry point (e.g., _layout.tsx or index.ts) — GLOBAL SCOPE
 import "@/polyfills/indexeddb";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { defineExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo";
+import { defineExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo/background";
 import { AsyncStorageTaskQueue } from "@arkade-os/sdk/worker/expo";
 import { IndexedDBWalletRepository, IndexedDBContractRepository } from "@arkade-os/sdk";
 
@@ -27,10 +46,11 @@ defineExpoBackgroundTask("ark-background-poll", {
 
 ### 2. Set up the wallet (in a React component/provider)
 
-The wallet surface matches the browser version. `ExpoWallet.setup()` persists config for background rehydration and registers the OS scheduler.
+The wallet surface matches the browser version. `ExpoWallet.setup()` persists config for background rehydration; the OS scheduler is activated separately with `registerExpoBackgroundTask`.
 
 ```ts
 import { ExpoWallet } from "@arkade-os/sdk/wallet/expo";
+import { registerExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo/background";
 import { SingleKey } from "@arkade-os/sdk";
 
 const wallet = await ExpoWallet.setup({
@@ -39,16 +59,31 @@ const wallet = await ExpoWallet.setup({
     esploraUrl,
     storage: { walletRepository, contractRepository },
     background: {
-        taskName: "ark-background-poll",
         taskQueue,                          // same instance from step 1
         foregroundIntervalMs: 20_000,       // poll every 20s while app is active
-        minimumBackgroundInterval: 15,      // OS wakes every 15+ min
     },
 });
 
+// Activate the OS scheduler (Expo Android/iOS only).
+// Must use the same task name passed to defineExpoBackgroundTask above.
+await registerExpoBackgroundTask("ark-background-poll", { minimumInterval: 15 });
+
 // Use like a regular wallet:
 const balance = await wallet.getBalance();
+
+// On logout / wallet reset / app teardown:
+import { unregisterExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo/background";
+await wallet.dispose();
+await unregisterExpoBackgroundTask("ark-background-poll");
 ```
+
+> [!IMPORTANT]
+> The OS-task helpers (`defineExpoBackgroundTask`,
+> `registerExpoBackgroundTask`, `unregisterExpoBackgroundTask`) live
+> under `@arkade-os/sdk/wallet/expo/background`. That subpath is the
+> **only** module that imports `expo-task-manager` /
+> `expo-background-task`; keeping it isolated lets react-native-web and
+> Node consumers use `/wallet/expo` without those native packages.
 
 ## Architecture
 
@@ -69,8 +104,8 @@ const balance = await wallet.getBalance();
 Setup (one-time):
   defineExpoBackgroundTask() registers the handler at global scope
   ExpoWallet.setup() persists wallet config to AsyncStorageTaskQueue
-  ExpoWallet.setup() registers the task with the OS scheduler
   ExpoWallet.setup() seeds a contract-poll task in the inbox
+  registerExpoBackgroundTask() activates the OS scheduler (caller invokes)
 
 Foreground (app active):
   setInterval calls runForegroundPoll()

--- a/test/wallet/expo/background.test.ts
+++ b/test/wallet/expo/background.test.ts
@@ -1,13 +1,31 @@
-import Module from "module";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CONTRACT_POLL_TASK_TYPE } from "../../../src/worker/expo/processors";
 
-const defineTaskMock = vi.fn();
-const registerTaskAsyncMock = vi.fn();
-const unregisterTaskAsyncMock = vi.fn();
-const runTasksMock = vi.fn();
-const expoIndexerProviderCtorMock = vi.fn();
-const expoArkProviderCtorMock = vi.fn();
+const {
+    defineTaskMock,
+    registerTaskAsyncMock,
+    unregisterTaskAsyncMock,
+    runTasksMock,
+    expoIndexerProviderCtorMock,
+    expoArkProviderCtorMock,
+} = vi.hoisted(() => ({
+    defineTaskMock: vi.fn(),
+    registerTaskAsyncMock: vi.fn(),
+    unregisterTaskAsyncMock: vi.fn(),
+    runTasksMock: vi.fn(),
+    expoIndexerProviderCtorMock: vi.fn(),
+    expoArkProviderCtorMock: vi.fn(),
+}));
+
+vi.mock("expo-task-manager", () => ({
+    defineTask: defineTaskMock,
+}));
+
+vi.mock("expo-background-task", () => ({
+    BackgroundTaskResult: { Success: 1, Failed: 2 },
+    registerTaskAsync: registerTaskAsyncMock,
+    unregisterTaskAsync: unregisterTaskAsyncMock,
+}));
 
 vi.mock("../../../src/worker/expo/taskRunner", async () => {
     const actual = await vi.importActual<any>(
@@ -37,34 +55,9 @@ const loadBackground = async () =>
     import("../../../src/wallet/expo/background");
 
 describe("expo background task helpers", () => {
-    const originalRequire = Module.prototype.require;
-
     beforeEach(() => {
         vi.resetModules();
         vi.clearAllMocks();
-
-        Module.prototype.require = function patchedRequire(
-            this: unknown,
-            id: string
-        ) {
-            if (id === "expo-task-manager") {
-                return {
-                    defineTask: defineTaskMock,
-                };
-            }
-            if (id === "expo-background-task") {
-                return {
-                    BackgroundTaskResult: { Success: 1, Failed: 2 },
-                    registerTaskAsync: registerTaskAsyncMock,
-                    unregisterTaskAsync: unregisterTaskAsyncMock,
-                };
-            }
-            return originalRequire.call(this, id);
-        };
-    });
-
-    afterEach(() => {
-        Module.prototype.require = originalRequire;
     });
 
     it("defines and executes the background task happy path", async () => {

--- a/test/wallet/expo/wallet.test.ts
+++ b/test/wallet/expo/wallet.test.ts
@@ -4,8 +4,6 @@ import { CONTRACT_POLL_TASK_TYPE } from "../../../src/worker/expo/processors";
 
 const walletCreateMock = vi.fn();
 const runTasksMock = vi.fn();
-const registerExpoBackgroundTaskMock = vi.fn();
-const unregisterExpoBackgroundTaskMock = vi.fn();
 
 vi.mock("../../../src/wallet/wallet", () => ({
     Wallet: {
@@ -22,11 +20,6 @@ vi.mock("../../../src/worker/expo/taskRunner", async () => {
         runTasks: runTasksMock,
     };
 });
-
-vi.mock("../../../src/wallet/expo/background", () => ({
-    registerExpoBackgroundTask: registerExpoBackgroundTaskMock,
-    unregisterExpoBackgroundTask: unregisterExpoBackgroundTaskMock,
-}));
 
 const loadExpoWallet = async () => import("../../../src/wallet/expo/wallet");
 
@@ -70,7 +63,7 @@ describe("ExpoWallet", () => {
         vi.useRealTimers();
     });
 
-    it("setup persists background config, seeds tasks, and registers background task", async () => {
+    it("setup persists background config and seeds tasks", async () => {
         const taskQueue = new QueueWithConfig();
         const walletStub = createWalletStub();
         walletCreateMock.mockResolvedValue(walletStub);
@@ -83,9 +76,7 @@ describe("ExpoWallet", () => {
             esploraUrl: "https://esplora.example",
             storage: {} as any,
             background: {
-                taskName: "ark-background-poll",
                 taskQueue: taskQueue as any,
-                minimumBackgroundInterval: 20,
             },
         } as any);
 
@@ -99,12 +90,6 @@ describe("ExpoWallet", () => {
         });
         expect(await taskQueue.getTasks(CONTRACT_POLL_TASK_TYPE)).toHaveLength(
             1
-        );
-        expect(registerExpoBackgroundTaskMock).toHaveBeenCalledWith(
-            "ark-background-poll",
-            {
-                minimumInterval: 20,
-            }
         );
 
         await wallet.dispose();
@@ -141,7 +126,6 @@ describe("ExpoWallet", () => {
             esploraUrl: "https://esplora.example",
             storage: {} as any,
             background: {
-                taskName: "ark-foreground-poll",
                 taskQueue,
                 foregroundIntervalMs: 1_000,
             },
@@ -164,9 +148,6 @@ describe("ExpoWallet", () => {
         const callsBefore = runTasksMock.mock.calls.length;
         await vi.advanceTimersByTimeAsync(1_000);
         expect(runTasksMock).toHaveBeenCalledTimes(callsBefore);
-        expect(unregisterExpoBackgroundTaskMock).toHaveBeenCalledWith(
-            "ark-foreground-poll"
-        );
     });
 
     it("delegates wallet methods to the inner wallet", async () => {
@@ -182,7 +163,6 @@ describe("ExpoWallet", () => {
             esploraUrl: "https://esplora.example",
             storage: {} as any,
             background: {
-                taskName: "ark-delegation",
                 taskQueue,
             },
         } as any);
@@ -224,8 +204,70 @@ describe("ExpoWallet", () => {
 
         await wallet.dispose();
         expect(walletStub.dispose).toHaveBeenCalledTimes(1);
-        expect(unregisterExpoBackgroundTaskMock).toHaveBeenCalledWith(
-            "ark-delegation"
-        );
+    });
+});
+
+describe("warnOnRemovedBackgroundFields", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it("does not warn when neither removed field is present", async () => {
+        const { warnOnRemovedBackgroundFields } = await loadExpoWallet();
+        warnOnRemovedBackgroundFields({
+            taskQueue: {},
+            foregroundIntervalMs: 20_000,
+        });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("warns and names taskName when present (pre-fix-#486 field)", async () => {
+        const { warnOnRemovedBackgroundFields } = await loadExpoWallet();
+        warnOnRemovedBackgroundFields({
+            taskName: "ark-background-poll",
+            taskQueue: {},
+        });
+        expect(warnSpy).toHaveBeenCalledOnce();
+        const msg = String(warnSpy.mock.calls[0][0]);
+        expect(msg).toContain("taskName");
+        expect(msg).toContain("@arkade-os/sdk/wallet/expo/background");
+    });
+
+    it("warns and names minimumBackgroundInterval when present", async () => {
+        const { warnOnRemovedBackgroundFields } = await loadExpoWallet();
+        warnOnRemovedBackgroundFields({
+            taskQueue: {},
+            minimumBackgroundInterval: 15,
+        });
+        expect(warnSpy).toHaveBeenCalledOnce();
+        const msg = String(warnSpy.mock.calls[0][0]);
+        expect(msg).toContain("minimumBackgroundInterval");
+    });
+
+    it("lists both removed fields in a single warning when both present", async () => {
+        const { warnOnRemovedBackgroundFields } = await loadExpoWallet();
+        warnOnRemovedBackgroundFields({
+            taskName: "ark-background-poll",
+            minimumBackgroundInterval: 15,
+            taskQueue: {},
+        });
+        expect(warnSpy).toHaveBeenCalledOnce();
+        const msg = String(warnSpy.mock.calls[0][0]);
+        expect(msg).toContain("taskName");
+        expect(msg).toContain("minimumBackgroundInterval");
+    });
+
+    it("does not throw on null / undefined / non-object inputs", async () => {
+        const { warnOnRemovedBackgroundFields } = await loadExpoWallet();
+        expect(() => warnOnRemovedBackgroundFields(null)).not.toThrow();
+        expect(() => warnOnRemovedBackgroundFields(undefined)).not.toThrow();
+        expect(() => warnOnRemovedBackgroundFields("nonsense")).not.toThrow();
+        expect(warnSpy).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
- Fix #486: `defineExpoBackgroundTask` (and `registerExpoBackgroundTask` / `unregisterExpoBackgroundTask`) failed at JS startup because lazy `require()` in `/wallet/expo` was invisible to Metro's static dependency collector, so `expo-task-manager` / `expo-background-task` never entered the bundle graph.
- Split task helpers into a new `@arkade-os/sdk/wallet/expo/background` subpath that uses **static** imports. `/wallet/expo` itself no longer references the optional Expo packages — react-native-web and Node consumers are unaffected.
- Drop OS-task registration from `ExpoWallet.setup()` / `.dispose()`. Consumers call `registerExpoBackgroundTask` / `unregisterExpoBackgroundTask` explicitly.
- README migration callout + teardown example updated.

## Testing

Direct port of arkade-os/boltz-swap#146, whose validated build pattern is in production in Trixie Wallet. Test changes:

- `test/wallet/expo/background.test.ts` rewritten to mock `expo-task-manager` / `expo-background-task` via `vi.hoisted` + `vi.mock` — the previous `Module.prototype.require` patching does not intercept static imports.
- `test/wallet/expo/wallet.test.ts` drops the `taskName` / `minimumBackgroundInterval` mocks (those fields are gone) and adds coverage for the new `warnOnRemovedBackgroundFields` JS-caller guard.
- Smoke-check after `pnpm build`: grep'ing `dist/{esm,cjs}/wallet/expo/{index,wallet}.js` shows zero runtime imports of `expo-task-manager` / `expo-background-task` — only `/wallet/expo/background.{js,cjs}` pulls them in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background helpers moved to a dedicated subpath and published so consumers can import OS registration helpers directly.
  * Added ambient TypeScript types for Expo background-task APIs.

* **Documentation**
  * Updated Expo background setup, examples, and architecture notes to show explicit register/unregister calls and new import paths.
  * Wallet setup examples updated to reflect removed config fields.

* **Breaking / API Changes**
  * Wallet no longer auto-registers OS background tasks; background config no longer accepts taskName or minimumBackgroundInterval.
  * Added runtime warning for removed legacy background fields.

* **Tests**
  * Background-task tests refactored to use static mocks; added tests for the removal-warning helper.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->