### PR TITLE
docs: monorepo cleanup pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,18 @@ pnpm -C packages/boltz-swap vitest run test/swap-manager.test.ts
 pnpm -C packages/ts-sdk vitest run -t "test name pattern"
 
 # Integration tests (require Docker regtest stack)
-pnpm run regtest:up           # Start nigiri + Docker services
-pnpm run regtest:setup        # Initialize wallets and shared test fixtures
-pnpm run test:integration     # Run integration tests for both packages
-pnpm run regtest:test         # Run setup + integration tests for both packages
-pnpm run regtest:down         # Stop Docker services
-pnpm run regtest:reset        # Reset Docker volumes
+# `test:integration` runs each package's full cycle (reset + up + setup + test)
+# via `scripts/regtest.sh <pkg> cycle`, using packages/<pkg>/.env.regtest.
+pnpm run test:integration              # Both packages, end-to-end
+pnpm run test:integration:ts-sdk       # ts-sdk only
+pnpm run test:integration:boltz-swap   # boltz-swap only
+
+# Per-package stack control (replace :ts-sdk with :boltz-swap for the other)
+pnpm run regtest:up:ts-sdk
+pnpm run regtest:setup:ts-sdk
+pnpm run regtest:test:ts-sdk
+pnpm run regtest:down:ts-sdk
+pnpm run regtest:reset:ts-sdk
 
 # Release
 pnpm run release              # Release both packages at the same version
@@ -54,7 +60,7 @@ pnpm run release:dry-run -- <version>  # Preview a lockstep release
 ### Workspace Structure
 
 ```
-config/              # Shared configs (tsconfig.base.json, vitest.base.ts, eslint.base.cjs)
+config/              # Shared configs (tsconfig.base.json, vitest.base.ts)
 packages/
   ts-sdk/            # @arkade-os/sdk — core Bitcoin wallet SDK
   boltz-swap/        # @arkade-os/boltz-swap — Boltz submarine swaps (depends on ts-sdk)
@@ -65,7 +71,7 @@ scripts/
 
 ### `@arkade-os/sdk` (packages/ts-sdk)
 
-Dual ESM/CJS build via `tsc` (separate tsconfig per format) with post-processing (`add-extensions.js` for ESM imports, `generate-package-files.js` for subpath exports).
+Multi-entry dual ESM/CJS build via `tsup` (see `tsup.config.ts`). Subpath exports cover adapters, repositories (sqlite/realm), the Expo worker, and the Expo wallet (including its background-task entry).
 
 Key layers:
 - **Wallet** (`src/wallet/`) — `Wallet` (signing), `ReadonlyWallet` (watch-only), `OnchainWallet` (on-chain UTXOs). Service worker variants communicate via `MessageBus`.
@@ -95,7 +101,6 @@ Git submodule pointing to [arkade-regtest](https://github.com/ArkLabsHQ/arkade-r
 Packages extend shared base configs from `config/`:
 - `tsconfig.json` extends `../../config/tsconfig.base.json`
 - `vitest.config.ts` merges with `../../config/vitest.base.ts`
-- ESLint configs extend `../../config/eslint.base.cjs`
 
 ### Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,7 @@ Packages extend shared base configs from `config/`:
 - ts-sdk uses `test/polyfill.js` (IndexedDB shim + EventSource polyfill for Node)
 - boltz-swap uses `test/setup.ts`
 - Integration tests live in `test/e2e/` within each package and require the Docker regtest stack
+
+## Local Scratch Files
+
+`.gitignore` excludes `*.agents.md`, `TASKS.md`, `CLAUDE.md`, `REVIEW.md`, and `.claude/`. These are local scratch notes — drafts, review snapshots, AI session state — and are **not** authoritative project guidance. Authoritative guidance lives in this `AGENTS.md` (and the package READMEs); treat anything in an ignored file as transient context that may be stale or contradict the codebase.

--- a/README.md
+++ b/README.md
@@ -70,10 +70,14 @@ pnpm run regtest:reset:ts-sdk   # Remove containers and volumes
 
 ### Documentation
 
+TypeDoc-generated API docs for `@arkade-os/sdk` are written to the repo-root `docs/` directory (the source for [arkade-os.github.io/ts-sdk](https://arkade-os.github.io/ts-sdk/)).
+
 ```bash
-pnpm -C packages/ts-sdk run docs:build   # Build TypeScript API docs
-pnpm -C packages/ts-sdk run docs:open    # Open in browser
+pnpm -C packages/ts-sdk run docs:build   # Build into ./docs at the repo root
+pnpm -C packages/ts-sdk run docs:open    # Open ./docs/index.html in the browser
 ```
+
+After regenerating, sanity-check that source links in the generated HTML point to monorepo-style paths (e.g. `packages/ts-sdk/src/...`) before publishing.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,29 @@ pnpm -C packages/ts-sdk vitest run -t "test name pattern"
 
 ### Integration tests
 
-Integration tests use the shared [arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest) environment (git submodule):
+Integration tests use the shared [arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest) environment (git submodule). Each package runs against its own regtest stack via a per-package override file:
+
+- `packages/ts-sdk/.env.regtest`
+- `packages/boltz-swap/.env.regtest`
+
+#### All packages
 
 ```bash
-pnpm run regtest:up      # Start nigiri + arkd, boltz, LND, fulmine, etc.
-pnpm run regtest:setup   # Initialize wallets and shared test fixtures
-pnpm run test:integration # Run e2e tests for all packages against regtest
-pnpm run regtest:test    # Run setup + e2e tests
-pnpm run regtest:down    # Stop the stack
-pnpm run regtest:reset   # Stop and remove volumes
+pnpm run test:integration   # Runs test:integration:ts-sdk, then test:integration:boltz-swap
+```
+
+Each script invokes `scripts/regtest.sh <pkg> cycle`, where `cycle` means `reset + up + setup + test` against that package's stack.
+
+#### Single package
+
+Per-package commands let you control the stack directly. Replace `:ts-sdk` with `:boltz-swap` for the other package.
+
+```bash
+pnpm run regtest:up:ts-sdk      # Start the package's regtest stack
+pnpm run regtest:setup:ts-sdk   # Initialize wallets and fixtures
+pnpm run regtest:test:ts-sdk    # Run the package's e2e suite (assumes stack is up)
+pnpm run regtest:down:ts-sdk    # Stop the stack (preserves data)
+pnpm run regtest:reset:ts-sdk   # Remove containers and volumes
 ```
 
 ### Documentation

--- a/packages/boltz-swap/README.md
+++ b/packages/boltz-swap/README.md
@@ -242,18 +242,18 @@ Custom implementations must set `readonly version = 1` — TypeScript will error
 
 > [!WARNING]
 > If you previously used the v1 `StorageAdapter`-based repositories, migrate
-> data before use:
+> data before use. `migrateToSwapRepository` copies legacy `reverseSwaps` and
+> `submarineSwaps` collections from the old `ContractRepository` into the new
+> `SwapRepository`. It writes its own swap-specific migration flag, so it is
+> idempotent and safe to call on every startup — do not gate it on the
+> wallet-side `getMigrationStatus`.
 >
 > ```typescript
 > import { IndexedDbSwapRepository, migrateToSwapRepository } from '@arkade-os/boltz-swap'
-> import { getMigrationStatus } from '@arkade-os/sdk'
 > import { IndexedDBStorageAdapter } from '@arkade-os/sdk/adapters/indexedDB'
 >
 > const oldStorage = new IndexedDBStorageAdapter('arkade-service-worker', 1)
-> const status = await getMigrationStatus('wallet', oldStorage)
-> if (status !== 'not-needed') {
->   await migrateToSwapRepository(oldStorage, new IndexedDbSwapRepository())
-> }
+> await migrateToSwapRepository(oldStorage, new IndexedDbSwapRepository())
 > ```
 
 ## Expo / React Native
@@ -283,16 +283,14 @@ Expo/React Native cannot run a long-lived Service Worker, and background work is
 npx expo install expo-task-manager expo-background-task
 npx expo install @react-native-async-storage/async-storage expo-secure-store
 npx expo install expo-crypto
-npx expo install expo-sqlite && npm install indexeddbshim
+npx expo install expo-sqlite
 ```
 
-- If you rely on the default IndexedDB-backed repositories in Expo, call `setupExpoDb()` **before any SDK/boltz-swap import**:
-
-```ts
-import { setupExpoDb } from "@arkade-os/sdk/adapters/expo-db";
-
-setupExpoDb();
-```
+- For persistence on Expo, prefer the SQLite-backed repositories
+  (`@arkade-os/boltz-swap/repositories/sqlite` and
+  `@arkade-os/sdk/repositories/sqlite`) on top of `expo-sqlite`, or the Realm
+  repositories on top of `realm`. There is no SDK-shipped IndexedDB helper
+  for Expo.
 
 - Expo requires a `crypto.getRandomValues()` polyfill for cryptographic operations:
 
@@ -310,13 +308,20 @@ global.crypto.getRandomValues = Crypto.getRandomValues;
 // App entry point (e.g., _layout.tsx) — GLOBAL SCOPE
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
+import * as SQLite from "expo-sqlite";
 import { SingleKey } from "@arkade-os/sdk";
 import { AsyncStorageTaskQueue } from "@arkade-os/sdk/worker/expo";
-import { IndexedDbSwapRepository } from "@arkade-os/boltz-swap";
+import { SQLiteSwapRepository } from "@arkade-os/boltz-swap/repositories/sqlite";
 import { defineExpoSwapBackgroundTask } from "@arkade-os/boltz-swap/expo/background";
 
 const swapTaskQueue = new AsyncStorageTaskQueue(AsyncStorage, "ark:swap-queue");
-const swapRepository = new IndexedDbSwapRepository();
+
+const swapDb = SQLite.openDatabaseSync("ark-swaps.db");
+const swapRepository = new SQLiteSwapRepository({
+  run: (sql, params) => swapDb.runAsync(sql, params ?? []),
+  get: (sql, params) => swapDb.getFirstAsync(sql, params ?? []),
+  all: (sql, params) => swapDb.getAllAsync(sql, params ?? []),
+});
 
 defineExpoSwapBackgroundTask("ark-swap-poll", {
   taskQueue: swapTaskQueue,

--- a/packages/boltz-swap/README.md
+++ b/packages/boltz-swap/README.md
@@ -424,11 +424,7 @@ import {
 
 ### Releasing
 
-Package-local releases are disabled. Maintainers release this package from the repository root together with the rest of the monorepo.
-
-```bash
-pnpm run release
-```
+Package-local releases are disabled. Releases happen from the repository root in lockstep with the rest of the monorepo; see the [root README](../../README.md#releasing).
 
 ## License
 

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -369,7 +369,7 @@ The wallet's `assetManager` lets you create and manage assets on Arkade. The `se
 ```typescript
 // Issue a new asset (non-reissuable by default)
 const { assetId: controlAssetId } = await wallet.assetManager.issue({
-  amount: 1,
+  amount: 1n,
   metadata: {
     ticker: 'ctrl-MTK'
   }
@@ -377,7 +377,7 @@ const { assetId: controlAssetId } = await wallet.assetManager.issue({
 
 // Issue a new asset referencing the control asset
 const { assetId } = await wallet.assetManager.issue({
-  amount: 500,
+  amount: 500n,
   controlAssetId,
   metadata: {
     ticker: 'MTK'
@@ -387,19 +387,19 @@ const { assetId } = await wallet.assetManager.issue({
 // Reissue more supply of the asset (requires ownership of the control asset)
 const reissuanceTxId = await wallet.assetManager.reissue({
   assetId,
-  amount: 500,
+  amount: 500n,
 })
 
 // Burn some of the asset
 const burnTxId = await wallet.assetManager.burn({
   assetId,
-  amount: 200,
+  amount: 200n,
 })
 
 // Send asset to another Arkade address
 const sendTxId = await wallet.send({
   address: 'ark1q...',
-  assets: [{ assetId, amount: 100 }],
+  assets: [{ assetId, amount: 100n }],
 })
 
 // Check remaining balance
@@ -653,12 +653,12 @@ const history = await wallet.getTransactionHistory()
         arkTxid: string;
     };
     type: "SENT" | "RECEIVED";
-    amount: number;
+    amount: number;       // BTC amount in satoshis
     settled: boolean;
     createdAt: number;
     assets?: Array<{
         assetId: string,
-        amount: number
+        amount: bigint    // asset amount in base units
     }>
 }
 */
@@ -896,20 +896,11 @@ The `StorageAdapter` API is deprecated. Use repositories instead. If you omit `s
 > next call to `getMigrationStatus` can detect the partial migration. Old data
 > is never deleted — re-running migration after a rollback is safe.
 >
-> Anything related to contract repository migration must be handled by the package which created them. The SDK doesn't manage contracts in V1. Data remains untouched and persisted in the same old location.
->
-> If you persisted custom data in the ContractRepository via its `setContractData` method,
-> or a custom collection via `saveToContractCollection`, you'll need to migrate it manually:
->
-> ```typescript
-> // Custom data stored in the ContractRepository
-> const oldStorage = new IndexedDBStorageAdapter('legacy-wallet', 1)
-> const oldRepo = new ContractRepositoryImpl(storageAdapter)
-> const customContract = await oldRepo.getContractData('my-contract', 'status')
-> await contractRepository.setContractData('my-contract', 'status', customData)
-> const customCollection = await oldRepo.getContractCollection('swaps')
-> await contractRepository.saveToContractCollection('swaps', customCollection)
-> ```
+> Anything related to contract repository migration must be handled by the
+> package that created the contracts. The SDK doesn't manage external contracts
+> in V1; data persisted by other packages remains untouched in its original
+> location. For example, see `@arkade-os/boltz-swap`'s `migrateToSwapRepository`
+> for migrating legacy `reverseSwaps` / `submarineSwaps` collections.
 
 #### Repository Versioning
 
@@ -1213,25 +1204,19 @@ The watcher features:
 
 ### Repository Pattern
 
-Access low-level data management through repositories:
+Most users don't need to touch repositories directly — `Wallet` and `ContractManager` already read and write through them. They are documented here for advanced integrations (custom storage backends, offline-first apps, repository inspection).
 
 ```typescript
-// Virtual output management (automatically cached for performance)
+// Wallet repository — VTXOs, UTXOs, transaction history, settings
 const addr = await wallet.getAddress()
 const vtxos = await wallet.walletRepository.getVtxos(addr)
-await wallet.walletRepository.saveVtxos(addr, vtxos)
+const utxos = await wallet.walletRepository.getUtxos(addr)
+const history = await wallet.walletRepository.getTransactionHistory(addr)
 
-// Contract data for SDK integrations
-await wallet.contractRepository.setContractData('my-contract', 'status', 'active')
-const status = await wallet.contractRepository.getContractData('my-contract', 'status')
-
-// Collection management for related data
-await wallet.contractRepository.saveToContractCollection(
-  'swaps',
-  { id: 'swap-1', amount: 50000, type: 'reverse' },
-  'id' // key field
-)
-const swaps = await wallet.contractRepository.getContractCollection('swaps')
+// Contract repository — script-keyed contracts (default address, VHTLCs, etc.)
+const contracts = await wallet.contractRepository.getContracts({ type: 'vhtlc' })
+await wallet.contractRepository.saveContract(myContract)
+await wallet.contractRepository.deleteContract(myContract.script)
 ```
 
 _For complete API documentation, visit our [TypeDoc documentation](https://arkade-os.github.io/ts-sdk/)._

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -1238,73 +1238,24 @@ _For complete API documentation, visit our [TypeDoc documentation](https://arkad
 
 ## Development
 
-### Requirements
+This package is developed inside the [arkade-os/ts-sdk](../..) monorepo. See the [root README](../../README.md) for repo-wide setup (`pnpm install`, submodule init, lint) and the integration test workflow against the shared regtest stack.
 
-- [pnpm](https://pnpm.io/) - Package manager
-- [nigiri](https://github.com/vulpemventures/nigiri) - For running integration tests with a local Bitcoin regtest network
-
-### Setup
-
-1. Install dependencies:
-
-   ```bash
-   pnpm install
-   pnpm format
-   pnpm lint
-   ```
-
-1. Install nigiri for integration tests:
-
-   ```bash
-   curl https://getnigiri.vulpem.com | bash
-   ```
-
-### Running Tests
+Common package-local commands (run from the repo root):
 
 ```bash
-# Run all tests
-pnpm test
-
-# Run unit tests only
-pnpm test:unit
-
-# Run integration tests with ark provided by nigiri
-nigiri start --ark
-pnpm test:setup # Run setup script for integration tests
-pnpm test:integration
-nigiri stop --delete
-
-# Run integration tests with ark provided by docker (requires nigiri)
-nigiri start
-pnpm test:up-docker
-pnpm test:setup-docker # Run setup script for integration tests
-pnpm test:integration-docker
-pnpm test:down-docker
-nigiri stop --delete
-
-# Watch mode for development
-pnpm test:watch
-
-# Run tests with coverage
-pnpm test:coverage
+pnpm -C packages/ts-sdk run typecheck    # Type-check the SDK
+pnpm -C packages/ts-sdk test:unit        # Unit tests, excluding e2e
+pnpm -C packages/ts-sdk test:watch       # Vitest watch mode
+pnpm -C packages/ts-sdk test:coverage    # Coverage report
+pnpm -C packages/ts-sdk docs:build       # Build TypeDoc API docs
+pnpm -C packages/ts-sdk docs:open        # Open API docs in the browser
 ```
 
-### Building the documentation
-
-```bash
-# Build the TypeScript documentation
-pnpm docs:build
-# Open the docs in the browser
-pnpm docs:open
-```
+For integration tests, use the root commands (`pnpm run test:integration:ts-sdk` and the `regtest:*:ts-sdk` family) — see the root README.
 
 ### Releasing
 
-Package-local releases are disabled. Maintainers release this package from the repository root together with the rest of the monorepo.
-
-```bash
-pnpm run release
-```
+Package-local releases are disabled. Releases happen from the repository root in lockstep with the rest of the monorepo; see the [root README](../../README.md#releasing).
 
 ## License
 

--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -141,7 +141,7 @@
         "smoke:dist": "node scripts/smoke-dist.mjs",
         "typecheck": "tsc --noEmit",
         "docs:build": "pnpm run typecheck && pnpm typedoc",
-        "docs:open": "open ./docs/index.html",
+        "docs:open": "open ../../docs/index.html",
         "test": "vitest run",
         "test:master": "ARK_ENV=master vitest run",
         "test:unit": "vitest run --exclude test/e2e",

--- a/packages/ts-sdk/src/worker/README.md
+++ b/packages/ts-sdk/src/worker/README.md
@@ -1,0 +1,10 @@
+# Worker
+
+Platform-specific background processing for the SDK. Both implementations share a common pattern (pluggable handlers, periodic scheduling, repository/provider injection) but differ in orchestration and communication, because the browser and Expo/React Native runtimes constrain background work differently.
+
+| Platform              | Directory                         | Orchestrator                                                           | Communication                               |
+| --------------------- | --------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------- |
+| **Browser**           | [`browser/`](./browser/README.md) | `MessageBus` inside a Service Worker                                   | `postMessage` between SW and window clients |
+| **Expo/React Native** | [`expo/`](./expo/README.md)       | `runTasks()` driven by a foreground interval and an OS background wake | `AsyncStorageTaskQueue` inbox/outbox        |
+
+See the platform READMEs for architecture details, runtime flow, and usage examples. `messageBus.ts` in this directory defines the shared `MessageBus` / `MessageHandler` primitives that the browser worker uses directly and that the Expo wallet wraps in its own service.

--- a/packages/ts-sdk/typedoc.json
+++ b/packages/ts-sdk/typedoc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["./src/index.ts"],
-  "out": "./docs",
+  "out": "../../docs",
   "exclude": [
     "**/*.test.ts",
     "**/*.spec.ts",


### PR DESCRIPTION
## Summary

Pass over the monorepo docs to fix broken commands and stale API references found during a review. Out of scope: `CHANGELOG.md` and package changelog files.

## Changes

- **Root commands & architecture** — replace non-existent `regtest:up/setup/down/reset` with per-package variants; document `scripts/regtest.sh <pkg> cycle` and per-package `.env.regtest`; drop stale `config/eslint.base.cjs`; correct SDK build description (`tsc` → `tsup`).
- **Package dev sections** — drop obsolete `nigiri` / `test:up-docker` block from the SDK README; point both package READMEs at the root for setup and integration.
- **SDK API examples** — bigint literals for `assetManager.issue/reissue/burn` and asset sends; `assets[].amount: bigint` in the transaction history shape; rewrite the Repository Pattern section against the current `ContractRepository` (`getContracts`/`saveContract`/`deleteContract`) and drop the dead `setContractData`/`saveToContractCollection` migration snippet.
- **boltz-swap Expo & migration** — remove the non-existent `setupExpoDb` / `@arkade-os/sdk/adapters/expo-db` prerequisite and `indexeddbshim` install; recommend `SQLiteSwapRepository` for Expo and use it in the background-task example; call `migrateToSwapRepository` directly (don't gate on `getMigrationStatus('wallet', ...)`).
- **TypeDoc output** — point `packages/ts-sdk/typedoc.json` at `../../docs` so the repo-root `docs/` is the canonical GH Pages source; align `docs:open`; note the location in the root README.
- **Misc** — populate previously-empty `packages/ts-sdk/src/worker/README.md` as a short index; add a note in `AGENTS.md` that `.gitignored` scratch files (`*.agents.md`, `TASKS.md`, `CLAUDE.md`, `REVIEW.md`, `.claude/`) are not authoritative.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm -C packages/ts-sdk run typecheck` — no errors
- [x] `pnpm -C packages/boltz-swap run typecheck` — no errors
- [x] `pnpm -C packages/ts-sdk run docs:build` — emits to repo-root `docs/`; spot-checked source links now use monorepo paths (`packages/ts-sdk/src/...`)
- [x] Pre-commit unit tests passed on every commit (303 boltz-swap + ts-sdk suites)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing workflow and monorepo command guidance for integration tests
  * Enhanced swap migration and Expo setup instructions with platform-specific details
  * Clarified SDK usage examples for asset handling
  * Documented worker architecture and platform-specific background processing approaches
  * Revised build and release process documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->