### PR TITLE
feat(sw): ServiceWorkerWallet.restore() with AggregateError round-trip

### DIFF
--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -55,6 +55,49 @@ export class WalletNotInitializedError extends Error {
     }
 }
 
+/**
+ * Type-guard for a {@link SerializedAggregateError} object that has survived
+ * the postMessage boundary. Used on the page side of the RESTORE_WALLET path
+ * to detect a worker-side AggregateError and reconstruct it.
+ */
+export function isSerializedAggregateError(value: unknown): value is SerializedAggregateError {
+    if (!value || typeof value !== "object") return false;
+    const v = value as Partial<SerializedAggregateError>;
+    return (
+        v.name === "AggregateError" &&
+        typeof v.message === "string" &&
+        Array.isArray(v.errors) &&
+        v.errors.every((e) => e && typeof e.name === "string" && typeof e.message === "string")
+    );
+}
+
+/** Worker-side serializer for a real {@link AggregateError}. */
+export function serializeAggregateError(error: AggregateError): SerializedAggregateError {
+    const errors: { name: string; message: string }[] = [];
+    for (const child of error.errors ?? []) {
+        if (child instanceof Error) {
+            errors.push({ name: child.name, message: child.message });
+        } else {
+            errors.push({ name: "Error", message: String(child) });
+        }
+    }
+    return {
+        name: "AggregateError",
+        message: error.message,
+        errors,
+    };
+}
+
+/** Page-side reconstructor: rebuild an {@link AggregateError} from the wire form. */
+export function deserializeAggregateError(payload: SerializedAggregateError): AggregateError {
+    const errs = payload.errors.map((e) => {
+        const err = new Error(e.message);
+        err.name = e.name;
+        return err;
+    });
+    return new AggregateError(errs, payload.message);
+}
+
 export class ReadonlyWalletError extends Error {
     constructor() {
         super("Read-only wallet: operation requires signing");
@@ -448,6 +491,27 @@ export type ResponseSweepExpiredBoardingUtxos = ResponseEnvelope & {
     payload: { txid: string };
 };
 
+export type RequestRestoreWallet = RequestEnvelope & {
+    type: "RESTORE_WALLET";
+    payload: { gapLimit?: number };
+};
+export type ResponseRestoreWallet = ResponseEnvelope & {
+    type: "RESTORE_WALLET_SUCCESS";
+};
+
+/**
+ * Wire envelope used to transmit an AggregateError across the postMessage
+ * boundary. `AggregateError` and its `.errors` array are not portable enough
+ * to rely on raw structured-clone behaviour across target browsers, so the
+ * RESTORE_WALLET path serializes/reconstructs explicitly. Non-Error entries
+ * are converted to Error on the worker side.
+ */
+export type SerializedAggregateError = {
+    name: "AggregateError";
+    message: string;
+    errors: { name: string; message: string }[];
+};
+
 // WalletUpdater
 export type WalletUpdaterRequest =
     | RequestInitWallet
@@ -486,7 +550,8 @@ export type WalletUpdaterRequest =
     | RequestGetExpiringVtxos
     | RequestRenewVtxos
     | RequestGetExpiredBoardingUtxos
-    | RequestSweepExpiredBoardingUtxos;
+    | RequestSweepExpiredBoardingUtxos
+    | RequestRestoreWallet;
 
 export type WalletUpdaterResponse = ResponseEnvelope &
     (
@@ -533,6 +598,7 @@ export type WalletUpdaterResponse = ResponseEnvelope &
         | ResponseRenewVtxosEvent
         | ResponseGetExpiredBoardingUtxos
         | ResponseSweepExpiredBoardingUtxos
+        | ResponseRestoreWallet
     );
 
 export class WalletMessageHandler
@@ -640,7 +706,11 @@ export class WalletMessageHandler
         return (
             message.type === "SETTLE" ||
             message.type === "RECOVER_VTXOS" ||
-            message.type === "RENEW_VTXOS"
+            message.type === "RENEW_VTXOS" ||
+            // HD restore walks the index range with one indexer round-trip per
+            // step until it hits gapLimit consecutive unused indices. The bus
+            // deadline must not race the scan; liveness stays covered by PING.
+            message.type === "RESTORE_WALLET"
         );
     }
 
@@ -1006,6 +1076,28 @@ export class WalletMessageHandler
                         id,
                         type: "SWEEP_EXPIRED_BOARDING_UTXOS_SUCCESS",
                         payload: { txid },
+                    });
+                }
+                case "RESTORE_WALLET": {
+                    const wallet = this.requireWallet();
+                    try {
+                        await wallet.restore(message.payload);
+                    } catch (error: unknown) {
+                        // AggregateError loses its prototype across postMessage
+                        // and `.errors` is not portable enough to round-trip
+                        // raw — serialize explicitly so the page can rebuild
+                        // it. Other errors fall through to the generic catch.
+                        if (error instanceof AggregateError) {
+                            return this.tagged({
+                                id,
+                                error: serializeAggregateError(error) as unknown as Error,
+                            });
+                        }
+                        throw error;
+                    }
+                    return this.tagged({
+                        id,
+                        type: "RESTORE_WALLET_SUCCESS",
                     });
                 }
                 default:

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -107,7 +107,10 @@ import {
     ResponseGetExpiredBoardingUtxos,
     RequestSweepExpiredBoardingUtxos,
     ResponseSweepExpiredBoardingUtxos,
+    RequestRestoreWallet,
     DEFAULT_MESSAGE_TAG,
+    deserializeAggregateError,
+    isSerializedAggregateError,
 } from "./wallet-message-handler";
 import type {
     Contract,
@@ -185,6 +188,10 @@ export const DEFAULT_MESSAGE_TIMEOUTS: Readonly<Record<RequestType, number>> = {
     RECOVER_VTXOS: 50_000,
     RENEW_VTXOS: 50_000,
     SWEEP_EXPIRED_BOARDING_UTXOS: 50_000,
+    // RESTORE_WALLET is a streaming/long-running path (sendMessageWithEvents)
+    // like SETTLE; the value here is kept for type completeness and is never
+    // enforced as an inactivity deadline.
+    RESTORE_WALLET: 50_000,
 
     // Misc writes
     INIT_WALLET: 30_000,
@@ -1442,6 +1449,39 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
             return (response as ResponseSettle).payload.txid;
         } catch (error) {
             throw new Error(`Settlement failed: ${error}`);
+        }
+    }
+
+    /**
+     * Explicitly recover this wallet's contracts and balance on a fresh repo.
+     * Mirrors {@link Wallet.restore} but drives the scan inside the service
+     * worker — the materialize() callback used by `scanContracts` cannot
+     * cross the postMessage boundary, so the entire flow runs worker-side
+     * and only the gapLimit / outcome cross the wire.
+     *
+     * Uses the streaming send path so the bus deadline does not race a
+     * long indexer-bound scan. AggregateError thrown by the worker is
+     * reconstructed here so callers can inspect `.errors`.
+     */
+    async restore(opts?: { gapLimit?: number }): Promise<void> {
+        const message: RequestRestoreWallet = {
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "RESTORE_WALLET",
+            payload: opts ?? {},
+        };
+
+        try {
+            await this.sendMessageWithEvents(
+                message,
+                () => {},
+                (resp) => resp.type === "RESTORE_WALLET_SUCCESS",
+            );
+        } catch (error: unknown) {
+            if (isSerializedAggregateError(error)) {
+                throw deserializeAggregateError(error);
+            }
+            throw error;
         }
     }
 

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -28,11 +28,20 @@ type MessageHandler = (event: { data: any }) => void;
 
 // Simulate the structured clone algorithm that postMessage uses: Error
 // subclasses lose their prototype chain and arrive as plain Error objects,
-// but name and message are preserved as own properties.
-function structuredCloneError(error: Error): Error {
-    const cloned = new Error(error.message);
-    cloned.name = error.name;
-    return cloned;
+// but name and message are preserved as own properties. Plain objects in
+// the error envelope (e.g., the RESTORE_WALLET path's serialized
+// AggregateError) survive structured clone with all enumerable own
+// properties intact, so we deep-clone them via JSON to preserve fidelity.
+function structuredCloneError(error: any): any {
+    if (error instanceof Error) {
+        const cloned = new Error(error.message);
+        cloned.name = error.name;
+        return cloned;
+    }
+    if (error && typeof error === "object") {
+        return JSON.parse(JSON.stringify(error));
+    }
+    return error;
 }
 
 function structuredCloneResponse(response: any): any {
@@ -400,6 +409,111 @@ describe("ServiceWorkerWallet", () => {
                 type: "DELEGATE",
             }),
         );
+    });
+
+    it("restore() forwards gapLimit and resolves on RESTORE_WALLET_SUCCESS", async () => {
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => {
+            if (message.type === "RESTORE_WALLET") {
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    type: "RESTORE_WALLET_SUCCESS",
+                };
+            }
+            return null;
+        });
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const wallet = createSWWallet(serviceWorker as any, messageTag);
+        await expect(wallet.restore({ gapLimit: 30 })).resolves.toBeUndefined();
+        expect(serviceWorker.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tag: messageTag,
+                type: "RESTORE_WALLET",
+                payload: { gapLimit: 30 },
+            }),
+        );
+    });
+
+    it("restore() defaults to an empty payload when called without options", async () => {
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => ({
+            id: message.id,
+            tag: messageTag,
+            type: "RESTORE_WALLET_SUCCESS",
+        }));
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const wallet = createSWWallet(serviceWorker as any, messageTag);
+        await expect(wallet.restore()).resolves.toBeUndefined();
+        expect(serviceWorker.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "RESTORE_WALLET",
+                payload: {},
+            }),
+        );
+    });
+
+    it("restore() reconstructs a worker-side AggregateError on the page", async () => {
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => {
+            if (message.type !== "RESTORE_WALLET") return null;
+            return {
+                id: message.id,
+                tag: messageTag,
+                error: {
+                    name: "AggregateError",
+                    message: "restore failed",
+                    errors: [
+                        { name: "HandlerAError", message: "handler-a-failed" },
+                        { name: "Error", message: "handler-b-failed" },
+                    ],
+                },
+            };
+        });
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const wallet = createSWWallet(serviceWorker as any, messageTag);
+        let caught: unknown;
+        try {
+            await wallet.restore({ gapLimit: 20 });
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught).toBeInstanceOf(AggregateError);
+        const agg = caught as AggregateError;
+        expect(agg.message).toBe("restore failed");
+        expect(agg.errors).toHaveLength(2);
+        expect(agg.errors[0]).toBeInstanceOf(Error);
+        expect((agg.errors[0] as Error).name).toBe("HandlerAError");
+        expect((agg.errors[0] as Error).message).toBe("handler-a-failed");
+        expect((agg.errors[1] as Error).message).toBe("handler-b-failed");
+    });
+
+    it("restore() propagates non-AggregateError failures as-is", async () => {
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => {
+            if (message.type !== "RESTORE_WALLET") return null;
+            return {
+                id: message.id,
+                tag: messageTag,
+                error: new Error("boom"),
+            };
+        });
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const wallet = createSWWallet(serviceWorker as any, messageTag);
+        await expect(wallet.restore()).rejects.toThrow("boom");
     });
 });
 

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -927,6 +927,110 @@ describe("WalletMessageHandler handleMessage", () => {
         });
     });
 
+    it("handles RESTORE_WALLET messages and forwards gapLimit", async () => {
+        const restoreSpy = vi.fn().mockResolvedValue(undefined);
+        (updater as any).readonlyWallet = {};
+        (updater as any).wallet = { restore: restoreSpy };
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "RESTORE_WALLET",
+            payload: { gapLimit: 50 },
+        } as any);
+
+        expect(restoreSpy).toHaveBeenCalledWith({ gapLimit: 50 });
+        expect(response).toMatchObject({
+            tag: updater.messageTag,
+            id: "1",
+            type: "RESTORE_WALLET_SUCCESS",
+        });
+    });
+
+    it("handles RESTORE_WALLET messages without gapLimit", async () => {
+        const restoreSpy = vi.fn().mockResolvedValue(undefined);
+        (updater as any).readonlyWallet = {};
+        (updater as any).wallet = { restore: restoreSpy };
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "RESTORE_WALLET",
+            payload: {},
+        } as any);
+
+        expect(restoreSpy).toHaveBeenCalledWith({});
+        expect(response).toMatchObject({
+            tag: updater.messageTag,
+            type: "RESTORE_WALLET_SUCCESS",
+        });
+    });
+
+    it("RESTORE_WALLET serializes AggregateError into a structured envelope", async () => {
+        const child1 = new Error("handler-a-failed");
+        child1.name = "HandlerAError";
+        const child2 = new Error("handler-b-failed");
+        const aggregate = new AggregateError([child1, child2], "restore failed");
+        (updater as any).readonlyWallet = {};
+        (updater as any).wallet = {
+            restore: vi.fn().mockRejectedValue(aggregate),
+        };
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "RESTORE_WALLET",
+            payload: { gapLimit: 20 },
+        } as any);
+
+        expect(response.error).toMatchObject({
+            name: "AggregateError",
+            message: "restore failed",
+            errors: [
+                { name: "HandlerAError", message: "handler-a-failed" },
+                { name: "Error", message: "handler-b-failed" },
+            ],
+        });
+    });
+
+    it("RESTORE_WALLET propagates non-AggregateError failures through the standard error path", async () => {
+        const err = new Error("oh no");
+        (updater as any).readonlyWallet = {};
+        (updater as any).wallet = {
+            restore: vi.fn().mockRejectedValue(err),
+        };
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "RESTORE_WALLET",
+            payload: {},
+        } as any);
+
+        expect(response.error).toBeInstanceOf(Error);
+        expect(response.error?.message).toBe("oh no");
+    });
+
+    it("RESTORE_WALLET rejects on readonly wallet", async () => {
+        (updater as any).readonlyWallet = {};
+        // wallet is NOT set — readonly only
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "RESTORE_WALLET",
+            payload: {},
+        } as any);
+
+        expect(response.error).toBeInstanceOf(Error);
+        expect(response.error?.message).toBe("Read-only wallet: operation requires signing");
+    });
+
+    it("isLongRunning returns true for RESTORE_WALLET", () => {
+        expect(
+            updater.isLongRunning({
+                ...baseMessage(),
+                type: "RESTORE_WALLET",
+                payload: {},
+            } as any),
+        ).toBe(true);
+    });
+
     it("eagerly starts VtxoManager on wallet initialization", async () => {
         const getVtxoManagerSpy = vi.fn().mockResolvedValue({});
         (updater as any).readonlyWallet = {


### PR DESCRIPTION
Stacked on top of #492 

## Summary

Follow-up to #492. Adds `ServiceWorkerWallet.restore({ gapLimit? })` so SW  wallets reach parity with `Wallet.restore()`.

 - New `RESTORE_WALLET` message; dispatcher runs `wallet.restore()` entirely worker-side (the `materialize()` callback never crosses the postMessage boundary).
  - Marked long-running on both sides so the bus deadline does not race the indexer-bound HD gap scan.
  - Explicit `AggregateError` round-trip: worker serializes to `{ name, message, errors: [{ name, message }] }`, page reconstructs before rejecting. Non-Aggregate errors fall through the standard path.
  - Signing-only entrypoint. `IWallet`, `IReadonlyWallet`, `ServiceWorkerReadonlyWallet`, and `ExpoWallet` are untouched —
    readonly callers still hit `ReadonlyWalletError`. The `scanContracts` proxy rejection in the SW contract-manager stays as
    the low-level guardrail.

  ## Out of scope

  - `ServiceWorkerReadonlyWallet.restore()` — needs a readonly variant of `Wallet.restore()` first.
  - Intermediate progress events — restore stays atomic from the caller's perspective.
  - Browser/SW e2e — existing regtest restore coverage is Node-only `Wallet.restore()` and does not exercise the worker transport.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added wallet restoration method enabling users to recover wallet contract and balance information with an optional gap limit configuration.
  * Enhanced error handling for wallet operations, including improved serialization of aggregate errors in service worker communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->