### PR TITLE
Merge boltz-swap master (post-v0.3.32) into packages/boltz-swap/

### DIFF
--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -1686,6 +1686,7 @@ export class ArkadeSwaps {
                                     message: `Failed to renegotiate quote: ${err.message}`,
                                     isRefundable: true,
                                     pendingSwap: swap,
+                                    cause: err,
                                 })
                             );
                         });
@@ -2084,6 +2085,7 @@ export class ArkadeSwaps {
                                     message: `Failed to renegotiate quote: ${err.message}`,
                                     isRefundable: false, // TODO btc refund not implemented yet
                                     pendingSwap: swap,
+                                    cause: err,
                                 })
                             );
                         });
@@ -2585,7 +2587,10 @@ export class ArkadeSwaps {
         this.validateQuoteOptions(options);
         const floor = await this.resolveQuoteFloor(swapId, options);
         const slippageBps = options?.maxSlippageBps ?? 0;
-        return Math.floor((floor * (10000 - slippageBps)) / 10000);
+        // Subtract-then-floor instead of multiply-then-divide: the original
+        // `floor * 10000` form loses precision once `floor` exceeds
+        // ~9e11 sats (above MAX_SAFE_INTEGER after multiply by 10000).
+        return Math.floor(floor - (floor * slippageBps) / 10000);
     }
 
     private async resolveQuoteFloor(
@@ -2612,9 +2617,12 @@ export class ArkadeSwaps {
     private validateQuoteOptions(options?: QuoteSwapOptions): void {
         if (options?.minAcceptableAmount !== undefined) {
             const v = options.minAcceptableAmount;
-            if (!Number.isInteger(v) || v < 0) {
+            // Reject 0: it would short-circuit the floor to 0 and let any
+            // positive Boltz quote through, silently restoring the old
+            // blind-accept behaviour the guard is meant to prevent.
+            if (!Number.isInteger(v) || v <= 0) {
                 throw new TypeError(
-                    `Invalid minAcceptableAmount: ${v} — must be a non-negative integer`
+                    `Invalid minAcceptableAmount: ${v} — must be a positive integer`
                 );
             }
         }

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -181,6 +181,19 @@ const isSubmarineRefundLocktimeReached = (refundTimestamp: number): boolean =>
 const CLAIM_VTXO_RETRY_ATTEMPTS = 3;
 const CLAIM_VTXO_RETRY_DELAY_MS = 500;
 
+// Build the QuoteSwapOptions for an autopilot renegotiation. The type marks
+// `claimDetails.amount` as required, but a swap restored from older persisted
+// formats may lack it — in that case, fall through without a floor (the
+// repository lookup will then resolve no_baseline and abort the renegotiation).
+const quoteOptionsForSwap = (
+    swap: BoltzChainSwap
+): QuoteSwapOptions | undefined => {
+    const amount = swap.response?.claimDetails?.amount;
+    return typeof amount === "number"
+        ? { minAcceptableAmount: amount }
+        : undefined;
+};
+
 /**
  * Unified entry point for Lightning and chain swaps between Arkade, Lightning Network, and Bitcoin.
  *
@@ -1664,10 +1677,10 @@ export class ArkadeSwaps {
                         break;
                     case "transaction.lockupFailed":
                         await updateSwapStatus();
-                        await this.quoteSwap(swap.response.id, {
-                            minAcceptableAmount:
-                                swap.response.claimDetails.amount,
-                        }).catch((err) => {
+                        await this.quoteSwap(
+                            swap.response.id,
+                            quoteOptionsForSwap(swap)
+                        ).catch((err) => {
                             reject(
                                 new SwapError({
                                     message: `Failed to renegotiate quote: ${err.message}`,
@@ -2062,10 +2075,10 @@ export class ArkadeSwaps {
                         break;
                     case "transaction.lockupFailed":
                         await updateSwapStatus();
-                        await this.quoteSwap(swap.response.id, {
-                            minAcceptableAmount:
-                                swap.response.claimDetails.amount,
-                        }).catch((err) => {
+                        await this.quoteSwap(
+                            swap.response.id,
+                            quoteOptionsForSwap(swap)
+                        ).catch((err) => {
                             reject(
                                 new SwapError({
                                     message: `Failed to renegotiate quote: ${err.message}`,
@@ -2587,10 +2600,13 @@ export class ArkadeSwaps {
             type: "chain",
         });
         const stored = swaps[0];
-        if (!stored) {
+        // Defensive: persisted swaps from older formats may not have a
+        // populated claimDetails.amount even though the type marks it required.
+        const amount = stored?.response?.claimDetails?.amount;
+        if (typeof amount !== "number") {
             throw new QuoteRejectedError({ reason: "no_baseline" });
         }
-        return stored.response.claimDetails.amount;
+        return amount;
     }
 
     private validateQuoteOptions(options?: QuoteSwapOptions): void {

--- a/src/arkade-swaps.ts
+++ b/src/arkade-swaps.ts
@@ -7,6 +7,7 @@ import {
     TransactionLockupFailedError,
     TransactionRefundedError,
     BoltzRefundError,
+    QuoteRejectedError,
 } from "./errors";
 import {
     ArkAddress,
@@ -1663,7 +1664,10 @@ export class ArkadeSwaps {
                         break;
                     case "transaction.lockupFailed":
                         await updateSwapStatus();
-                        await this.quoteSwap(swap.response.id).catch((err) => {
+                        await this.quoteSwap(swap.response.id, {
+                            minAcceptableAmount:
+                                swap.response.claimDetails.amount,
+                        }).catch((err) => {
                             reject(
                                 new SwapError({
                                     message: `Failed to renegotiate quote: ${err.message}`,
@@ -2058,7 +2062,10 @@ export class ArkadeSwaps {
                         break;
                     case "transaction.lockupFailed":
                         await updateSwapStatus();
-                        await this.quoteSwap(swap.response.id).catch((err) => {
+                        await this.quoteSwap(swap.response.id, {
+                            minAcceptableAmount:
+                                swap.response.claimDetails.amount,
+                        }).catch((err) => {
                             reject(
                                 new SwapError({
                                     message: `Failed to renegotiate quote: ${err.message}`,
@@ -2492,14 +2499,133 @@ export class ArkadeSwaps {
     }
 
     /**
-     * Renegotiates the quote for an existing swap.
+     * Renegotiates the quote for an existing chain swap. Convenience wrapper
+     * over `getSwapQuote` + `acceptSwapQuote` with a safety floor.
+     *
+     * The floor is resolved in order:
+     *   1. `options.minAcceptableAmount` if provided.
+     *   2. The original `response.claimDetails.amount` of the stored
+     *      pending swap (Boltz-confirmed server-lock amount at creation).
+     *   3. Otherwise throws `QuoteRejectedError({ reason: "no_baseline" })`.
+     *
+     * `options.maxSlippageBps` (default 0) relaxes the floor by basis points.
+     * Quotes ≤ 0 are always rejected. On rejection the acceptance is NOT
+     * posted to Boltz.
+     *
+     * Prefer `getSwapQuote` / `acceptSwapQuote` for callers that want to
+     * inspect the quote before committing.
+     *
      * @param swapId - The ID of the swap.
+     * @param options - Optional floor and slippage configuration.
      * @returns The accepted quote amount.
+     * @throws QuoteRejectedError if the quote is non-positive, below the
+     *     effective floor, or no baseline is available.
      */
-    async quoteSwap(swapId: string): Promise<number> {
-        const { amount } = await this.swapProvider.getChainQuote(swapId);
+    async quoteSwap(
+        swapId: string,
+        options?: QuoteSwapOptions
+    ): Promise<number> {
+        const effectiveFloor = await this.resolveEffectiveFloor(
+            swapId,
+            options
+        );
+        const amount = await this.getSwapQuote(swapId);
+        this.validateQuote(amount, effectiveFloor);
         await this.swapProvider.postChainQuote(swapId, { amount });
         return amount;
+    }
+
+    /**
+     * Fetches a renegotiated quote from Boltz without accepting it.
+     * Pair with `acceptSwapQuote` to commit a specific value.
+     */
+    async getSwapQuote(swapId: string): Promise<number> {
+        const { amount } = await this.swapProvider.getChainQuote(swapId);
+        return amount;
+    }
+
+    /**
+     * Accepts a quote amount for an existing chain swap, after validating it
+     * against the configured floor. See `quoteSwap` for floor-resolution rules.
+     *
+     * @throws QuoteRejectedError if `amount` ≤ 0, below the effective floor,
+     *     or no baseline is available.
+     */
+    async acceptSwapQuote(
+        swapId: string,
+        amount: number,
+        options?: QuoteSwapOptions
+    ): Promise<number> {
+        const effectiveFloor = await this.resolveEffectiveFloor(
+            swapId,
+            options
+        );
+        this.validateQuote(amount, effectiveFloor);
+        await this.swapProvider.postChainQuote(swapId, { amount });
+        return amount;
+    }
+
+    private async resolveEffectiveFloor(
+        swapId: string,
+        options?: QuoteSwapOptions
+    ): Promise<number> {
+        this.validateQuoteOptions(options);
+        const floor = await this.resolveQuoteFloor(swapId, options);
+        const slippageBps = options?.maxSlippageBps ?? 0;
+        return Math.floor((floor * (10000 - slippageBps)) / 10000);
+    }
+
+    private async resolveQuoteFloor(
+        swapId: string,
+        options?: QuoteSwapOptions
+    ): Promise<number> {
+        if (options?.minAcceptableAmount !== undefined) {
+            return options.minAcceptableAmount;
+        }
+        const swaps = await this.swapRepository.getAllSwaps<BoltzChainSwap>({
+            id: swapId,
+            type: "chain",
+        });
+        const stored = swaps[0];
+        if (!stored) {
+            throw new QuoteRejectedError({ reason: "no_baseline" });
+        }
+        return stored.response.claimDetails.amount;
+    }
+
+    private validateQuoteOptions(options?: QuoteSwapOptions): void {
+        if (options?.minAcceptableAmount !== undefined) {
+            const v = options.minAcceptableAmount;
+            if (!Number.isInteger(v) || v < 0) {
+                throw new TypeError(
+                    `Invalid minAcceptableAmount: ${v} — must be a non-negative integer`
+                );
+            }
+        }
+        if (options?.maxSlippageBps !== undefined) {
+            const v = options.maxSlippageBps;
+            if (!Number.isInteger(v) || v < 0 || v > 10000) {
+                throw new TypeError(
+                    `Invalid maxSlippageBps: ${v} — must be an integer in [0, 10000]`
+                );
+            }
+        }
+    }
+
+    private validateQuote(amount: number, effectiveFloor: number): void {
+        if (!(amount > 0)) {
+            throw new QuoteRejectedError({
+                reason: "non_positive",
+                quotedAmount: amount,
+            });
+        }
+        if (amount < effectiveFloor) {
+            throw new QuoteRejectedError({
+                reason: "below_floor",
+                quotedAmount: amount,
+                floor: effectiveFloor,
+            });
+        }
     }
 
     // =========================================================================
@@ -2908,6 +3034,22 @@ export class ArkadeSwaps {
     }
 }
 
+/** Options controlling acceptance of a renegotiated chain-swap quote. */
+export type QuoteSwapOptions = {
+    /**
+     * Hard floor on the accepted quote (in sats). When provided, skips the
+     * repository lookup. Pass the original `response.claimDetails.amount`
+     * to require the renegotiated amount to be no worse than what Boltz
+     * confirmed at swap creation.
+     */
+    minAcceptableAmount?: number;
+    /**
+     * Slippage tolerance in basis points, applied to the floor. Default 0
+     * (strict). E.g. 100 allows accepting quotes within 1% below the floor.
+     */
+    maxSlippageBps?: number;
+};
+
 /** @deprecated Use ArkadeSwapsConfig instead */
 export type ArkadeLightningConfig = ArkadeSwapsConfig;
 
@@ -2986,7 +3128,13 @@ export interface IArkadeSwaps extends AsyncDisposable {
         swap: BoltzChainSwap;
         arkInfo: ArkInfo;
     }): Promise<boolean>;
-    quoteSwap(swapId: string): Promise<number>;
+    quoteSwap(swapId: string, options?: QuoteSwapOptions): Promise<number>;
+    getSwapQuote(swapId: string): Promise<number>;
+    acceptSwapQuote(
+        swapId: string,
+        amount: number,
+        options?: QuoteSwapOptions
+    ): Promise<number>;
     joinBatch(
         identity: Identity,
         input: ArkTxInput,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -156,6 +156,122 @@ export class TransactionRefundedError extends SwapError {
     }
 }
 
+/** Reason a `quoteSwap` was rejected before being posted to Boltz. */
+export type QuoteRejectionReason =
+    | "below_floor"
+    | "non_positive"
+    | "no_baseline";
+
+interface QuoteRejectedOptions extends ErrorOptions {
+    reason: QuoteRejectionReason;
+    quotedAmount?: number;
+    floor?: number;
+}
+
+/**
+ * Thrown when a Boltz-returned chain-swap quote fails local validation
+ * (below the acceptable floor, non-positive, or missing a baseline to
+ * compare against). The acceptance is never posted on failure.
+ */
+export class QuoteRejectedError extends SwapError {
+    public readonly reason: QuoteRejectionReason;
+    public readonly quotedAmount?: number;
+    public readonly floor?: number;
+
+    constructor(options: QuoteRejectedOptions) {
+        super({
+            message:
+                options.message ??
+                QuoteRejectedError.defaultMessage(options),
+            ...options,
+        });
+        this.name = "QuoteRejectedError";
+        this.reason = options.reason;
+        this.quotedAmount = options.quotedAmount;
+        this.floor = options.floor;
+    }
+
+    private static defaultMessage(options: QuoteRejectedOptions): string {
+        switch (options.reason) {
+            case "below_floor":
+                return `Boltz quote ${options.quotedAmount} is below acceptable floor ${options.floor}`;
+            case "non_positive":
+                return `Boltz quote ${options.quotedAmount} is not positive`;
+            case "no_baseline":
+                return "Cannot accept quote: no minAcceptableAmount and no stored pending swap";
+        }
+    }
+
+    /**
+     * Serialize into a plain `Error` whose `.message` carries the full
+     * rejection payload as JSON behind a marker prefix. Structured clone
+     * (used by `postMessage` between page and service worker) preserves
+     * `Error.message` reliably but strips custom `.name` and own properties,
+     * so we move the typed data into the message field for transport.
+     */
+    toTransportError(): Error {
+        return new Error(
+            QUOTE_REJECTION_TRANSPORT_PREFIX +
+                JSON.stringify({
+                    reason: this.reason,
+                    message: this.message,
+                    quotedAmount: this.quotedAmount,
+                    floor: this.floor,
+                })
+        );
+    }
+
+    /**
+     * Inverse of `toTransportError`. Returns a real `QuoteRejectedError` if
+     * `error` carries the transport prefix, else `null`.
+     */
+    static fromTransportError(error: unknown): QuoteRejectedError | null {
+        if (
+            !(error instanceof Error) ||
+            !error.message.startsWith(QUOTE_REJECTION_TRANSPORT_PREFIX)
+        ) {
+            return null;
+        }
+        const payload = error.message.slice(
+            QUOTE_REJECTION_TRANSPORT_PREFIX.length
+        );
+        let data: {
+            reason?: unknown;
+            message?: unknown;
+            quotedAmount?: unknown;
+            floor?: unknown;
+        };
+        try {
+            data = JSON.parse(payload);
+        } catch {
+            return null;
+        }
+        if (
+            typeof data.reason !== "string" ||
+            !QUOTE_REJECTION_REASONS.has(data.reason as QuoteRejectionReason)
+        ) {
+            return null;
+        }
+        return new QuoteRejectedError({
+            reason: data.reason as QuoteRejectionReason,
+            message: typeof data.message === "string" ? data.message : undefined,
+            quotedAmount:
+                typeof data.quotedAmount === "number"
+                    ? data.quotedAmount
+                    : undefined,
+            floor: typeof data.floor === "number" ? data.floor : undefined,
+        });
+    }
+}
+
+const QUOTE_REJECTION_TRANSPORT_PREFIX = "QUOTE_REJECTED::";
+
+const QUOTE_REJECTION_REASONS: ReadonlySet<QuoteRejectionReason> = new Set([
+    "below_floor",
+    "non_positive",
+    "no_baseline",
+]);
+
 /**
  * Thrown when the Boltz API rejects a refund request
  * (e.g. outpoint mismatch after an Ark round).

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,6 +10,12 @@ interface ErrorOptions {
     isRefundable?: boolean;
     /** The associated pending swap, if available. */
     pendingSwap?: BoltzSwap;
+    /**
+     * Underlying cause. Preserved on the resulting `Error.cause`, so callers
+     * that wrap a typed error (e.g. autopilot wrapping `QuoteRejectedError`)
+     * can still recover the inner instance for programmatic branching.
+     */
+    cause?: unknown;
 }
 
 /**
@@ -25,7 +31,10 @@ export class SwapError extends Error {
     public pendingSwap?: BoltzSwap;
 
     constructor(options: ErrorOptions = {}) {
-        super(options.message ?? "Error during swap.");
+        super(
+            options.message ?? "Error during swap.",
+            options.cause !== undefined ? { cause: options.cause } : undefined
+        );
         this.name = "SwapError";
         this.isClaimable = options.isClaimable ?? false;
         this.isRefundable = options.isRefundable ?? false;
@@ -185,8 +194,7 @@ export class QuoteRejectedError extends SwapError {
     constructor(options: QuoteRejectedOptions) {
         super({
             message:
-                options.message ??
-                QuoteRejectedError.defaultMessage(options),
+                options.message ?? QuoteRejectedError.defaultMessage(options),
             ...options,
         });
         this.name = "QuoteRejectedError";

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -162,11 +162,15 @@ export type QuoteRejectionReason =
     | "non_positive"
     | "no_baseline";
 
-interface QuoteRejectedOptions extends ErrorOptions {
-    reason: QuoteRejectionReason;
-    quotedAmount?: number;
-    floor?: number;
-}
+// Discriminated by `reason` so each rejection mode statically requires its own
+// metadata: below_floor demands both `quotedAmount` and `floor`, non_positive
+// demands `quotedAmount`, no_baseline carries neither.
+type QuoteRejectedOptions = ErrorOptions &
+    (
+        | { reason: "below_floor"; quotedAmount: number; floor: number }
+        | { reason: "non_positive"; quotedAmount: number }
+        | { reason: "no_baseline" }
+    );
 
 /**
  * Thrown when a Boltz-returned chain-swap quote fails local validation
@@ -187,8 +191,9 @@ export class QuoteRejectedError extends SwapError {
         });
         this.name = "QuoteRejectedError";
         this.reason = options.reason;
-        this.quotedAmount = options.quotedAmount;
-        this.floor = options.floor;
+        this.quotedAmount =
+            "quotedAmount" in options ? options.quotedAmount : undefined;
+        this.floor = "floor" in options ? options.floor : undefined;
     }
 
     private static defaultMessage(options: QuoteRejectedOptions): string {
@@ -252,15 +257,31 @@ export class QuoteRejectedError extends SwapError {
         ) {
             return null;
         }
-        return new QuoteRejectedError({
-            reason: data.reason as QuoteRejectionReason,
-            message: typeof data.message === "string" ? data.message : undefined,
-            quotedAmount:
-                typeof data.quotedAmount === "number"
-                    ? data.quotedAmount
-                    : undefined,
-            floor: typeof data.floor === "number" ? data.floor : undefined,
-        });
+        const message =
+            typeof data.message === "string" ? data.message : undefined;
+        const reason = data.reason as QuoteRejectionReason;
+        const quotedAmount =
+            typeof data.quotedAmount === "number" ? data.quotedAmount : null;
+        const floor = typeof data.floor === "number" ? data.floor : null;
+        switch (reason) {
+            case "below_floor":
+                if (quotedAmount === null || floor === null) return null;
+                return new QuoteRejectedError({
+                    reason,
+                    quotedAmount,
+                    floor,
+                    message,
+                });
+            case "non_positive":
+                if (quotedAmount === null) return null;
+                return new QuoteRejectedError({
+                    reason,
+                    quotedAmount,
+                    message,
+                });
+            case "no_baseline":
+                return new QuoteRejectedError({ reason, message });
+        }
     }
 }
 

--- a/src/expo/arkade-lightning.ts
+++ b/src/expo/arkade-lightning.ts
@@ -1,5 +1,5 @@
 import type { TaskItem } from "@arkade-os/sdk/worker/expo";
-import type { IArkadeSwaps } from "../arkade-swaps";
+import type { IArkadeSwaps, QuoteSwapOptions } from "../arkade-swaps";
 import { ArkadeSwaps } from "../arkade-swaps";
 import type { SwapManagerClient } from "../swap-manager";
 import type {
@@ -406,8 +406,20 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.verifyChainSwap(args);
     }
 
-    quoteSwap(swapId: string): Promise<number> {
-        return this.inner.quoteSwap(swapId);
+    quoteSwap(swapId: string, options?: QuoteSwapOptions): Promise<number> {
+        return this.inner.quoteSwap(swapId, options);
+    }
+
+    getSwapQuote(swapId: string): Promise<number> {
+        return this.inner.getSwapQuote(swapId);
+    }
+
+    acceptSwapQuote(
+        swapId: string,
+        amount: number,
+        options?: QuoteSwapOptions
+    ): Promise<number> {
+        return this.inner.acceptSwapQuote(swapId, amount, options);
     }
 
     joinBatch(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { ArkadeSwaps } from "./arkade-swaps";
+export type { QuoteSwapOptions } from "./arkade-swaps";
 export {
     BoltzSwapProvider,
     BoltzSwapStatus,
@@ -39,7 +40,9 @@ export {
     SwapNotFoundError,
     TransactionFailedError,
     BoltzRefundError,
+    QuoteRejectedError,
 } from "./errors";
+export type { QuoteRejectionReason } from "./errors";
 export {
     decodeInvoice,
     getInvoicePaymentHash,

--- a/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -38,7 +38,20 @@ import {
     IndexerProvider,
     RestIndexerProvider,
 } from "@arkade-os/sdk";
-import { ArkadeSwaps } from "../arkade-swaps";
+import { ArkadeSwaps, type QuoteSwapOptions } from "../arkade-swaps";
+import { QuoteRejectedError } from "../errors";
+
+// Wrap thrown errors at the SW boundary: structured clone (used by postMessage)
+// strips custom Error subclass identity — `name` becomes "Error" and own
+// properties like `reason`/`quotedAmount`/`floor` are dropped. Serialize the
+// rejection payload into the Error.message field, which IS preserved across
+// the clone, then the runtime reconstructs the typed error on the other side.
+function toQuoteTransportError(error: unknown): unknown {
+    if (error instanceof QuoteRejectedError) {
+        return error.toTransportError();
+    }
+    return error;
+}
 import type { SwapManagerClient } from "../swap-manager";
 
 export const DEFAULT_MESSAGE_TAG = "ARKADE_SWAPS_UPDATER";
@@ -395,10 +408,28 @@ export type ResponseVerifyChainSwap = ResponseEnvelope & {
 
 export type RequestQuoteSwap = RequestEnvelope & {
     type: "QUOTE_SWAP";
-    payload: { swapId: string };
+    payload: { swapId: string; options?: QuoteSwapOptions };
 };
 export type ResponseQuoteSwap = ResponseEnvelope & {
     type: "SWAP_QUOTED";
+    payload: { amount: number };
+};
+
+export type RequestGetSwapQuote = RequestEnvelope & {
+    type: "GET_SWAP_QUOTE";
+    payload: { swapId: string };
+};
+export type ResponseGetSwapQuote = ResponseEnvelope & {
+    type: "SWAP_QUOTE_RETRIEVED";
+    payload: { amount: number };
+};
+
+export type RequestAcceptSwapQuote = RequestEnvelope & {
+    type: "ACCEPT_SWAP_QUOTE";
+    payload: { swapId: string; amount: number; options?: QuoteSwapOptions };
+};
+export type ResponseAcceptSwapQuote = ResponseEnvelope & {
+    type: "SWAP_QUOTE_ACCEPTED";
     payload: { amount: number };
 };
 
@@ -521,6 +552,8 @@ export type ArkadeSwapsUpdaterRequest =
     | RequestSignServerClaim
     | RequestVerifyChainSwap
     | RequestQuoteSwap
+    | RequestGetSwapQuote
+    | RequestAcceptSwapQuote
     | RequestSwapManagerStart
     | RequestSwapManagerStop
     | RequestSwapManagerAddSwap
@@ -568,6 +601,8 @@ export type ArkadeSwapsUpdaterResponse =
     | ResponseSignServerClaim
     | ResponseVerifyChainSwap
     | ResponseQuoteSwap
+    | ResponseGetSwapQuote
+    | ResponseAcceptSwapQuote
     | ResponseSwapManagerStart
     | ResponseSwapManagerStop
     | ResponseSwapManagerAddSwap
@@ -1079,14 +1114,51 @@ export class ArkadeSwapsMessageHandler
                 }
 
                 case "QUOTE_SWAP": {
-                    const amount = await this.handler.quoteSwap(
-                        message.payload.swapId
-                    );
-                    return this.tagged({
-                        id,
-                        type: "SWAP_QUOTED",
-                        payload: { amount },
-                    });
+                    try {
+                        const amount = await this.handler.quoteSwap(
+                            message.payload.swapId,
+                            message.payload.options
+                        );
+                        return this.tagged({
+                            id,
+                            type: "SWAP_QUOTED",
+                            payload: { amount },
+                        });
+                    } catch (e) {
+                        throw toQuoteTransportError(e);
+                    }
+                }
+
+                case "GET_SWAP_QUOTE": {
+                    try {
+                        const amount = await this.handler.getSwapQuote(
+                            message.payload.swapId
+                        );
+                        return this.tagged({
+                            id,
+                            type: "SWAP_QUOTE_RETRIEVED",
+                            payload: { amount },
+                        });
+                    } catch (e) {
+                        throw toQuoteTransportError(e);
+                    }
+                }
+
+                case "ACCEPT_SWAP_QUOTE": {
+                    try {
+                        const amount = await this.handler.acceptSwapQuote(
+                            message.payload.swapId,
+                            message.payload.amount,
+                            message.payload.options
+                        );
+                        return this.tagged({
+                            id,
+                            type: "SWAP_QUOTE_ACCEPTED",
+                            payload: { amount },
+                        });
+                    } catch (e) {
+                        throw toQuoteTransportError(e);
+                    }
                 }
 
                 /* --- SwapManager methods --- */

--- a/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/src/serviceWorker/arkade-swaps-runtime.ts
@@ -107,6 +107,10 @@ function isHandlerNotInitializedError(error: unknown): boolean {
 // back into a real typed error so SW callers can `instanceof`-check and
 // branch on `.reason` exactly like in-process callers.
 function rethrowIfQuoteRejected(error: unknown): void {
+    // If a real QuoteRejectedError reached us without going through the SW
+    // transport (e.g. in-process testing or a direct throw), preserve it
+    // verbatim instead of going through the encode/decode round trip.
+    if (error instanceof QuoteRejectedError) throw error;
     const rebuilt = QuoteRejectedError.fromTransportError(error);
     if (rebuilt) throw rebuilt;
 }

--- a/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/src/serviceWorker/arkade-swaps-runtime.ts
@@ -41,6 +41,8 @@ import type {
     ResponseGetPendingReverseSwaps,
     ResponseGetPendingSubmarineSwaps,
     ResponseQuoteSwap,
+    ResponseGetSwapQuote,
+    ResponseAcceptSwapQuote,
     ResponseGetSwapHistory,
     ResponseGetSwapStatus,
     ResponseRestoreSwaps,
@@ -66,7 +68,8 @@ import {
     type VHTLC,
 } from "@arkade-os/sdk";
 import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
-import { IArkadeSwaps } from "../arkade-swaps";
+import { IArkadeSwaps, type QuoteSwapOptions } from "../arkade-swaps";
+import { QuoteRejectedError } from "../errors";
 import type { VhtlcTimeouts } from "../utils/vhtlc";
 import { IndexedDbSwapRepository } from "../repositories/IndexedDb/swap-repository";
 import {
@@ -94,6 +97,18 @@ function isHandlerNotInitializedError(error: unknown): boolean {
         error instanceof Error &&
         error.message.includes(HANDLER_NOT_INITIALIZED)
     );
+}
+
+// postMessage structured clone normalises `Error.name` to "Error" and drops
+// custom own properties on Error subclasses, so we cannot recover a
+// QuoteRejectedError by inspecting `name` or `reason` after the round trip.
+// The SW handler instead encodes rejections into the Error.message field via
+// `QuoteRejectedError.toTransportError()`; this helper decodes the message
+// back into a real typed error so SW callers can `instanceof`-check and
+// branch on `.reason` exactly like in-process callers.
+function rethrowIfQuoteRejected(error: unknown): void {
+    const rebuilt = QuoteRejectedError.fromTransportError(error);
+    if (rebuilt) throw rebuilt;
 }
 
 const DEFAULT_MESSAGE_TIMEOUT_MS = 30_000;
@@ -833,17 +848,55 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         }
     }
 
-    async quoteSwap(swapId: string): Promise<number> {
+    async quoteSwap(
+        swapId: string,
+        options?: QuoteSwapOptions
+    ): Promise<number> {
         try {
             const res = await this.sendMessage({
                 id: getRandomId(),
                 tag: this.messageTag,
                 type: "QUOTE_SWAP",
-                payload: { swapId },
+                payload: { swapId, options },
             });
             return (res as ResponseQuoteSwap).payload.amount;
         } catch (e) {
+            rethrowIfQuoteRejected(e);
             throw new Error("Cannot quote swap", { cause: e });
+        }
+    }
+
+    async getSwapQuote(swapId: string): Promise<number> {
+        try {
+            const res = await this.sendMessage({
+                id: getRandomId(),
+                tag: this.messageTag,
+                type: "GET_SWAP_QUOTE",
+                payload: { swapId },
+            });
+            return (res as ResponseGetSwapQuote).payload.amount;
+        } catch (e) {
+            rethrowIfQuoteRejected(e);
+            throw new Error("Cannot get swap quote", { cause: e });
+        }
+    }
+
+    async acceptSwapQuote(
+        swapId: string,
+        amount: number,
+        options?: QuoteSwapOptions
+    ): Promise<number> {
+        try {
+            const res = await this.sendMessage({
+                id: getRandomId(),
+                tag: this.messageTag,
+                type: "ACCEPT_SWAP_QUOTE",
+                payload: { swapId, amount, options },
+            });
+            return (res as ResponseAcceptSwapQuote).payload.amount;
+        } catch (e) {
+            rethrowIfQuoteRejected(e);
+            throw new Error("Cannot accept swap quote", { cause: e });
         }
     }
 

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -1254,21 +1254,204 @@ describe("ArkadeSwaps", () => {
         });
 
         describe("quoteSwap", () => {
-            it("should quote a chain swap", async () => {
+            it("accepts a quote at or above the stored claimDetails.amount", async () => {
                 // arrange
+                mockSwapRepository.getAllSwaps.mockResolvedValueOnce([
+                    mockArkBtcChainSwap,
+                ]);
                 vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
                     amount: mock.amount,
                 });
-                vi.spyOn(swapProvider, "postChainQuote").mockResolvedValueOnce(
-                    {}
-                );
+                const postSpy = vi
+                    .spyOn(swapProvider, "postChainQuote")
+                    .mockResolvedValueOnce({});
 
                 // act
                 const amount = await swaps.quoteSwap(mock.id);
 
                 // assert
                 expect(amount).toEqual(mock.amount);
+                expect(postSpy).toHaveBeenCalledWith(mock.id, {
+                    amount: mock.amount,
+                });
             });
+
+            it("accepts when explicit minAcceptableAmount matches the quote", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
+                    amount: 1000,
+                });
+                const postSpy = vi
+                    .spyOn(swapProvider, "postChainQuote")
+                    .mockResolvedValueOnce({});
+
+                // act
+                const amount = await swaps.quoteSwap(mock.id, {
+                    minAcceptableAmount: 1000,
+                });
+
+                // assert
+                expect(amount).toEqual(1000);
+                expect(postSpy).toHaveBeenCalledOnce();
+            });
+
+            it("rejects a quote below the explicit floor and does not post", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
+                    amount: 999,
+                });
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+
+                // act & assert
+                await expect(
+                    swaps.quoteSwap(mock.id, { minAcceptableAmount: 1000 })
+                ).rejects.toMatchObject({
+                    name: "QuoteRejectedError",
+                    reason: "below_floor",
+                });
+                expect(postSpy).not.toHaveBeenCalled();
+            });
+
+            it("rejects a non-positive quote and does not post", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
+                    amount: 0,
+                });
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+
+                // act & assert
+                await expect(
+                    swaps.quoteSwap(mock.id, { minAcceptableAmount: 1000 })
+                ).rejects.toMatchObject({
+                    name: "QuoteRejectedError",
+                    reason: "non_positive",
+                });
+                expect(postSpy).not.toHaveBeenCalled();
+            });
+
+            it("applies maxSlippageBps to the floor", async () => {
+                // arrange — 100 bps = 1%, floor 1000 → effective 990
+                vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
+                    amount: 991,
+                });
+                vi.spyOn(swapProvider, "postChainQuote").mockResolvedValueOnce(
+                    {}
+                );
+
+                // act
+                const amount = await swaps.quoteSwap(mock.id, {
+                    minAcceptableAmount: 1000,
+                    maxSlippageBps: 100,
+                });
+
+                // assert
+                expect(amount).toEqual(991);
+            });
+
+            it("rejects when below floor even with slippage applied", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
+                    amount: 989,
+                });
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+
+                // act & assert
+                await expect(
+                    swaps.quoteSwap(mock.id, {
+                        minAcceptableAmount: 1000,
+                        maxSlippageBps: 100,
+                    })
+                ).rejects.toMatchObject({
+                    name: "QuoteRejectedError",
+                    reason: "below_floor",
+                });
+                expect(postSpy).not.toHaveBeenCalled();
+            });
+
+            it("throws no_baseline without hitting Boltz when no options and no stored swap", async () => {
+                // arrange
+                mockSwapRepository.getAllSwaps.mockResolvedValueOnce([]);
+                const getQuoteSpy = vi.spyOn(swapProvider, "getChainQuote");
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+
+                // act & assert
+                await expect(swaps.quoteSwap(mock.id)).rejects.toMatchObject({
+                    name: "QuoteRejectedError",
+                    reason: "no_baseline",
+                });
+                expect(getQuoteSpy).not.toHaveBeenCalled();
+                expect(postSpy).not.toHaveBeenCalled();
+            });
+
+            it("getSwapQuote returns the quote without posting", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
+                    amount: mock.amount,
+                });
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+
+                // act
+                const amount = await swaps.getSwapQuote(mock.id);
+
+                // assert
+                expect(amount).toEqual(mock.amount);
+                expect(postSpy).not.toHaveBeenCalled();
+            });
+
+            it("acceptSwapQuote posts the user-supplied amount", async () => {
+                // arrange
+                const postSpy = vi
+                    .spyOn(swapProvider, "postChainQuote")
+                    .mockResolvedValueOnce({});
+
+                // act
+                const amount = await swaps.acceptSwapQuote(mock.id, 1234, {
+                    minAcceptableAmount: 1000,
+                });
+
+                // assert
+                expect(amount).toEqual(1234);
+                expect(postSpy).toHaveBeenCalledWith(mock.id, {
+                    amount: 1234,
+                });
+            });
+
+            it.each([
+                ["NaN", NaN],
+                ["non-integer", 1000.5],
+                ["negative", -1],
+                ["Infinity", Infinity],
+            ])(
+                "rejects invalid minAcceptableAmount (%s)",
+                async (_label, value) => {
+                    const getQuoteSpy = vi.spyOn(swapProvider, "getChainQuote");
+                    await expect(
+                        swaps.quoteSwap(mock.id, {
+                            minAcceptableAmount: value as number,
+                        })
+                    ).rejects.toThrow(TypeError);
+                    expect(getQuoteSpy).not.toHaveBeenCalled();
+                }
+            );
+
+            it.each([
+                ["NaN", NaN],
+                ["above 10000", 10001],
+                ["negative", -1],
+                ["non-integer", 50.5],
+            ])(
+                "rejects invalid maxSlippageBps (%s)",
+                async (_label, value) => {
+                    const getQuoteSpy = vi.spyOn(swapProvider, "getChainQuote");
+                    await expect(
+                        swaps.quoteSwap(mock.id, {
+                            minAcceptableAmount: 1000,
+                            maxSlippageBps: value as number,
+                        })
+                    ).rejects.toThrow(TypeError);
+                    expect(getQuoteSpy).not.toHaveBeenCalled();
+                }
+            );
         });
 
         describe("verifyChainSwap", () => {
@@ -1755,20 +1938,43 @@ describe("ArkadeSwaps", () => {
         });
 
         describe("quoteSwap", () => {
-            it("should quote a chain swap", async () => {
-                // arrange
+            it("anchors the floor on response.claimDetails.amount, not top-level amount (BTC→ARK sender-path)", async () => {
+                // arrange — sender-path swap: top-level amount = senderLockAmount (user lock,
+                // larger than the receive-side after Boltz fees) but the Boltz-confirmed
+                // server-lock amount on the receive side lives in claimDetails.amount.
+                // The quote returned by Boltz is on the receive side; anchoring on the
+                // top-level field would reject every honest renegotiation here.
+                const RECEIVE_AMOUNT = 50_000;
+                const SENDER_LOCK_AMOUNT = 55_000;
+                const senderPathSwap: BoltzChainSwap = {
+                    ...mockBtcArkChainSwap,
+                    amount: SENDER_LOCK_AMOUNT,
+                    response: {
+                        ...createBtcArkChainSwapResponse,
+                        claimDetails: {
+                            ...createBtcArkChainSwapResponse.claimDetails,
+                            amount: RECEIVE_AMOUNT,
+                        },
+                    },
+                };
+                mockSwapRepository.getAllSwaps.mockResolvedValueOnce([
+                    senderPathSwap,
+                ]);
                 vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
-                    amount: mock.amount,
+                    amount: RECEIVE_AMOUNT,
                 });
-                vi.spyOn(swapProvider, "postChainQuote").mockResolvedValueOnce(
-                    {}
-                );
+                const postSpy = vi
+                    .spyOn(swapProvider, "postChainQuote")
+                    .mockResolvedValueOnce({});
 
-                // act
+                // act — would throw below_floor if code read top-level amount
                 const amount = await swaps.quoteSwap(mock.id);
 
                 // assert
-                expect(amount).toEqual(mock.amount);
+                expect(amount).toEqual(RECEIVE_AMOUNT);
+                expect(postSpy).toHaveBeenCalledWith(mock.id, {
+                    amount: RECEIVE_AMOUNT,
+                });
             });
         });
 

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -1452,6 +1452,43 @@ describe("ArkadeSwaps", () => {
                     expect(getQuoteSpy).not.toHaveBeenCalled();
                 }
             );
+
+            it.each([
+                ["NaN", NaN],
+                ["non-integer", 1000.5],
+                ["negative", -1],
+                ["Infinity", Infinity],
+            ])(
+                "acceptSwapQuote rejects invalid minAcceptableAmount (%s)",
+                async (_label, value) => {
+                    const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+                    await expect(
+                        swaps.acceptSwapQuote(mock.id, 1234, {
+                            minAcceptableAmount: value as number,
+                        })
+                    ).rejects.toThrow(TypeError);
+                    expect(postSpy).not.toHaveBeenCalled();
+                }
+            );
+
+            it.each([
+                ["NaN", NaN],
+                ["above 10000", 10001],
+                ["negative", -1],
+                ["non-integer", 50.5],
+            ])(
+                "acceptSwapQuote rejects invalid maxSlippageBps (%s)",
+                async (_label, value) => {
+                    const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+                    await expect(
+                        swaps.acceptSwapQuote(mock.id, 1234, {
+                            minAcceptableAmount: 1000,
+                            maxSlippageBps: value as number,
+                        })
+                    ).rejects.toThrow(TypeError);
+                    expect(postSpy).not.toHaveBeenCalled();
+                }
+            );
         });
 
         describe("verifyChainSwap", () => {

--- a/test/arkade-swaps.test.ts
+++ b/test/arkade-swaps.test.ts
@@ -37,7 +37,7 @@ import {
     createVHTLCScript as createVHTLCScriptReal,
     refundVHTLCwithOffchainTx,
 } from "../src/utils/vhtlc";
-import { BoltzRefundError } from "../src/errors";
+import { BoltzRefundError, SwapError } from "../src/errors";
 
 // Mock the @arkade-os/sdk modules
 vi.mock("@arkade-os/sdk", async () => {
@@ -1420,6 +1420,7 @@ describe("ArkadeSwaps", () => {
                 ["NaN", NaN],
                 ["non-integer", 1000.5],
                 ["negative", -1],
+                ["zero", 0],
                 ["Infinity", Infinity],
             ])(
                 "rejects invalid minAcceptableAmount (%s)",
@@ -1439,24 +1440,22 @@ describe("ArkadeSwaps", () => {
                 ["above 10000", 10001],
                 ["negative", -1],
                 ["non-integer", 50.5],
-            ])(
-                "rejects invalid maxSlippageBps (%s)",
-                async (_label, value) => {
-                    const getQuoteSpy = vi.spyOn(swapProvider, "getChainQuote");
-                    await expect(
-                        swaps.quoteSwap(mock.id, {
-                            minAcceptableAmount: 1000,
-                            maxSlippageBps: value as number,
-                        })
-                    ).rejects.toThrow(TypeError);
-                    expect(getQuoteSpy).not.toHaveBeenCalled();
-                }
-            );
+            ])("rejects invalid maxSlippageBps (%s)", async (_label, value) => {
+                const getQuoteSpy = vi.spyOn(swapProvider, "getChainQuote");
+                await expect(
+                    swaps.quoteSwap(mock.id, {
+                        minAcceptableAmount: 1000,
+                        maxSlippageBps: value as number,
+                    })
+                ).rejects.toThrow(TypeError);
+                expect(getQuoteSpy).not.toHaveBeenCalled();
+            });
 
             it.each([
                 ["NaN", NaN],
                 ["non-integer", 1000.5],
                 ["negative", -1],
+                ["zero", 0],
                 ["Infinity", Infinity],
             ])(
                 "acceptSwapQuote rejects invalid minAcceptableAmount (%s)",
@@ -1470,6 +1469,62 @@ describe("ArkadeSwaps", () => {
                     expect(postSpy).not.toHaveBeenCalled();
                 }
             );
+
+            it("acceptSwapQuote rejects a non-positive amount and does not post", async () => {
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+                await expect(
+                    swaps.acceptSwapQuote(mock.id, 0, {
+                        minAcceptableAmount: 1000,
+                    })
+                ).rejects.toMatchObject({
+                    name: "QuoteRejectedError",
+                    reason: "non_positive",
+                });
+                expect(postSpy).not.toHaveBeenCalled();
+            });
+
+            it("acceptSwapQuote rejects an amount below the floor and does not post", async () => {
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+                await expect(
+                    swaps.acceptSwapQuote(mock.id, 999, {
+                        minAcceptableAmount: 1000,
+                    })
+                ).rejects.toMatchObject({
+                    name: "QuoteRejectedError",
+                    reason: "below_floor",
+                });
+                expect(postSpy).not.toHaveBeenCalled();
+            });
+
+            it("autopilot SwapError wrap preserves the underlying QuoteRejectedError as cause", async () => {
+                mockSwapRepository.getAllSwaps.mockResolvedValueOnce([
+                    mockArkBtcChainSwap,
+                ]);
+                vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
+                    amount: 1,
+                });
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+
+                let caught: unknown;
+                try {
+                    await swaps.quoteSwap(mock.id);
+                } catch (e) {
+                    caught = e;
+                }
+                expect(caught).toMatchObject({
+                    name: "QuoteRejectedError",
+                    reason: "below_floor",
+                });
+                // Wrap the QuoteRejectedError the same shape the autopilot does;
+                // assert cause survives so callers can branch on the inner type.
+                const wrapped = new SwapError({
+                    message: `Failed: ${(caught as Error).message}`,
+                    isRefundable: true,
+                    cause: caught,
+                });
+                expect(wrapped.cause).toBe(caught);
+                expect(postSpy).not.toHaveBeenCalled();
+            });
 
             it.each([
                 ["NaN", NaN],

--- a/test/serviceWorker/arkade-swaps-runtime.test.ts
+++ b/test/serviceWorker/arkade-swaps-runtime.test.ts
@@ -1095,6 +1095,25 @@ describe("quote rejection error reconstruction", () => {
         );
     });
 
+    it("getSwapQuote reconstructs a typed QuoteRejectedError when the SW raises one", async () => {
+        const original = new QuoteRejectedError({ reason: "no_baseline" });
+        const { navigatorServiceWorker, serviceWorker } = respondWithError(
+            "GET_SWAP_QUOTE",
+            original
+        );
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        await expect(runtime.getSwapQuote("swap-5")).rejects.toBeInstanceOf(
+            QuoteRejectedError
+        );
+        await expect(runtime.getSwapQuote("swap-5")).rejects.toMatchObject({
+            reason: "no_baseline",
+        });
+    });
+
     it("survives the realistic structured clone (Error.name lost, props dropped)", async () => {
         // Sanity check that our reconstruction does NOT depend on the
         // properties the structured clone actually strips. We replicate the

--- a/test/serviceWorker/arkade-swaps-runtime.test.ts
+++ b/test/serviceWorker/arkade-swaps-runtime.test.ts
@@ -14,6 +14,7 @@ import {
     MESSAGE_BUS_NOT_INITIALIZED,
     ServiceWorkerTimeoutError,
 } from "@arkade-os/sdk";
+import { QuoteRejectedError } from "../../src/errors";
 
 class FakeServiceWorker {
     listeners: ((e: MessageEvent) => void)[] = [];
@@ -291,9 +292,11 @@ describe("SwArkadeSwapsRuntime enrich methods", () => {
 type MessageHandler = (event: { data: any }) => void;
 
 function structuredCloneError(error: Error): Error {
-    const cloned = new Error(error.message);
-    cloned.name = error.name;
-    return cloned;
+    // Match real structuredClone semantics: Error subclasses lose their
+    // identity (name → "Error") and own enumerable properties are dropped.
+    // Only `message` (and `stack`) survive the round trip. The runtime must
+    // therefore reconstruct any typed errors from the message field alone.
+    return new Error(error.message);
 }
 
 function structuredCloneResponse(response: any): any {
@@ -1007,5 +1010,117 @@ describe("preflight ping", () => {
         );
         await vi.advanceTimersByTimeAsync(2_000);
         await assertion;
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Quote rejection error reconstruction across the SW boundary
+// ---------------------------------------------------------------------------
+
+describe("quote rejection error reconstruction", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    // The SW message handler calls `QuoteRejectedError.toTransportError()`
+    // before throwing, encoding the typed payload into the Error.message
+    // field. The test harness mimics that here so the round trip is realistic.
+    const respondWithError = (type: string, error: Error) =>
+        createServiceWorkerHarness((message) => {
+            if (message.type !== type) return null;
+            const transport =
+                error instanceof QuoteRejectedError
+                    ? error.toTransportError()
+                    : error;
+            return { id: message.id, tag: TAG, error: transport };
+        });
+
+    it("quoteSwap reconstructs a typed QuoteRejectedError with reason and metadata", async () => {
+        const original = new QuoteRejectedError({
+            reason: "below_floor",
+            quotedAmount: 999,
+            floor: 1000,
+        });
+        const { navigatorServiceWorker, serviceWorker } = respondWithError(
+            "QUOTE_SWAP",
+            original
+        );
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        await expect(runtime.quoteSwap("swap-1")).rejects.toMatchObject({
+            name: "QuoteRejectedError",
+            reason: "below_floor",
+            quotedAmount: 999,
+            floor: 1000,
+        });
+        await expect(runtime.quoteSwap("swap-1")).rejects.toBeInstanceOf(
+            QuoteRejectedError
+        );
+    });
+
+    it("acceptSwapQuote reconstructs no_baseline QuoteRejectedError", async () => {
+        const original = new QuoteRejectedError({ reason: "no_baseline" });
+        const { navigatorServiceWorker, serviceWorker } = respondWithError(
+            "ACCEPT_SWAP_QUOTE",
+            original
+        );
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        await expect(
+            runtime.acceptSwapQuote("swap-2", 1000)
+        ).rejects.toBeInstanceOf(QuoteRejectedError);
+        await expect(
+            runtime.acceptSwapQuote("swap-2", 1000)
+        ).rejects.toMatchObject({ reason: "no_baseline" });
+    });
+
+    it("getSwapQuote wraps generic errors in 'Cannot get swap quote'", async () => {
+        const { navigatorServiceWorker, serviceWorker } = respondWithError(
+            "GET_SWAP_QUOTE",
+            new Error("network down")
+        );
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        await expect(runtime.getSwapQuote("swap-3")).rejects.toThrow(
+            /Cannot get swap quote/
+        );
+    });
+
+    it("survives the realistic structured clone (Error.name lost, props dropped)", async () => {
+        // Sanity check that our reconstruction does NOT depend on the
+        // properties the structured clone actually strips. We replicate the
+        // browser-faithful clone (name → "Error", own props gone) by piping
+        // the transport-error through the test harness's structuredCloneError.
+        const original = new QuoteRejectedError({
+            reason: "below_floor",
+            quotedAmount: 500,
+            floor: 1000,
+        });
+        const transport = original.toTransportError();
+        const { navigatorServiceWorker, serviceWorker } =
+            createServiceWorkerHarness((message) => {
+                if (message.type !== "QUOTE_SWAP") return null;
+                return { id: message.id, tag: TAG, error: transport };
+            });
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        await expect(runtime.quoteSwap("swap-4")).rejects.toMatchObject({
+            name: "QuoteRejectedError",
+            reason: "below_floor",
+            quotedAmount: 500,
+            floor: 1000,
+        });
     });
 });


### PR DESCRIPTION
# Aligning the monorepo to latest boltz-swap for first release

## :warning:  Important 

I will *not* address comments about the code being migrated: I'll create separate PRs for it. The reason being that this PR doesn't change anything in the logic.

## Summary

Subtree pull of 4 upstream boltz-swap commits (PR [arkade-os/boltz-swap#151](https://github.com/arkade-os/boltz-swap/pull/151)) adding a `quoteSwap` guard against adversarial Boltz quotes.

What lands:
- `QuoteRejectedError` (typed, with `reason` discriminator: `below_floor` / `non_positive` / `no_baseline`) plus SW-boundary transport encoding so structured clone preserves the typed shape
- `getSwapQuote` / `acceptSwapQuote` on `ArkadeSwaps` and `ServiceWorkerArkadeSwaps` for callers that want to inspect a quote before posting
- `quoteSwap` now refuses any chain-swap renegotiation below the original `claimDetails.amount` (or explicit `minAcceptableAmount`), with optional bps slippage
- `cause: err` propagated on the two renegotiate `SwapError`s

## Conflict resolution

- `src/index.ts` — kept monorepo's `export type { BoltzSwapStatus }`, added new `QuoteSwapOptions` type export
- `src/arkade-swaps.ts` — added `cause: err` to both renegotiate-quote `SwapError` calls, kept trailing-comma style
- `src/serviceWorker/*` and tests — adopted upstream additions; reformatted to prettier@100 / `trailingComma=all`

## Test plan

- [x] `pnpm -C packages/boltz-swap test:unit` — 337/337 passing
- [x] `pnpm -C packages/boltz-swap exec tsc --noEmit` — clean
- [x] `pnpm -C packages/boltz-swap exec prettier --check src test` — clean
- [x] `pnpm -C packages/boltz-swap build` — clean (ESM + DTS)
- [x] Integration tests (`pnpm run test:integration:boltz-swap`) — to verify on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quote renegotiation with configurable acceptance floor and slippage options
  * New swap quote retrieval and acceptance methods
  * Enhanced quote validation with minimum threshold checks

* **Bug Fixes**
  * Improved error handling with better context preservation and typed error information for quote operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->