### PR TITLE
fix(boltz-swap): address CodeRabbit comments on PR #502

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -2338,7 +2338,16 @@ export class ArkadeSwaps {
         // Subtract-then-floor instead of multiply-then-divide: the original
         // `floor * 10000` form loses precision once `floor` exceeds
         // ~9e11 sats (above MAX_SAFE_INTEGER after multiply by 10000).
-        return Math.floor(floor - (floor * slippageBps) / 10000);
+        const effectiveFloor = Math.floor(floor - (floor * slippageBps) / 10000);
+        // Reject when slippage (or a tiny baseline) drives the floor to 0:
+        // a 0 floor lets any positive Boltz quote through, silently restoring
+        // the blind-accept behaviour this guard exists to prevent.
+        if (effectiveFloor < 1) {
+            throw new TypeError(
+                `Invalid quote configuration: maxSlippageBps=${slippageBps} reduces floor ${floor} below 1 sat`,
+            );
+        }
+        return effectiveFloor;
     }
 
     private async resolveQuoteFloor(swapId: string, options?: QuoteSwapOptions): Promise<number> {

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -2391,7 +2391,17 @@ export class ArkadeSwaps {
     }
 
     private validateQuote(amount: number, effectiveFloor: number): void {
-        if (!(amount > 0)) {
+        // Guard against non-finite / fractional / above-MAX_SAFE_INTEGER values
+        // before the `> 0` and `< floor` comparisons: Infinity passes `> 0` and
+        // fails `< floor`, so without this check it would slip through to
+        // postChainQuote. Satoshi amounts must be safe positive integers.
+        if (!Number.isSafeInteger(amount)) {
+            throw new QuoteRejectedError({
+                reason: "non_safe_integer",
+                quotedAmount: amount,
+            });
+        }
+        if (amount <= 0) {
             throw new QuoteRejectedError({
                 reason: "non_positive",
                 quotedAmount: amount,

--- a/packages/boltz-swap/src/errors.ts
+++ b/packages/boltz-swap/src/errors.ts
@@ -166,15 +166,20 @@ export class TransactionRefundedError extends SwapError {
 }
 
 /** Reason a `quoteSwap` was rejected before being posted to Boltz. */
-export type QuoteRejectionReason = "below_floor" | "non_positive" | "no_baseline";
+export type QuoteRejectionReason =
+    | "below_floor"
+    | "non_positive"
+    | "non_safe_integer"
+    | "no_baseline";
 
 // Discriminated by `reason` so each rejection mode statically requires its own
 // metadata: below_floor demands both `quotedAmount` and `floor`, non_positive
-// demands `quotedAmount`, no_baseline carries neither.
+// and non_safe_integer demand `quotedAmount`, no_baseline carries neither.
 type QuoteRejectedOptions = ErrorOptions &
     (
         | { reason: "below_floor"; quotedAmount: number; floor: number }
         | { reason: "non_positive"; quotedAmount: number }
+        | { reason: "non_safe_integer"; quotedAmount: number }
         | { reason: "no_baseline" }
     );
 
@@ -205,6 +210,8 @@ export class QuoteRejectedError extends SwapError {
                 return `Boltz quote ${options.quotedAmount} is below acceptable floor ${options.floor}`;
             case "non_positive":
                 return `Boltz quote ${options.quotedAmount} is not positive`;
+            case "non_safe_integer":
+                return `Boltz quote ${options.quotedAmount} is not a safe positive satoshi integer`;
             case "no_baseline":
                 return "Cannot accept quote: no minAcceptableAmount and no stored pending swap";
         }
@@ -272,6 +279,7 @@ export class QuoteRejectedError extends SwapError {
                     message,
                 });
             case "non_positive":
+            case "non_safe_integer":
                 if (quotedAmount === null) return null;
                 return new QuoteRejectedError({
                     reason,
@@ -289,6 +297,7 @@ const QUOTE_REJECTION_TRANSPORT_PREFIX = "QUOTE_REJECTED::";
 const QUOTE_REJECTION_REASONS: ReadonlySet<QuoteRejectionReason> = new Set([
     "below_floor",
     "non_positive",
+    "non_safe_integer",
     "no_baseline",
 ]);
 

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -1408,6 +1408,24 @@ describe("ArkadeSwaps", () => {
                 expect(postSpy).not.toHaveBeenCalled();
             });
 
+            it.each([
+                ["Infinity", Infinity],
+                ["NaN", NaN],
+                ["fractional", 1500.5],
+                ["above MAX_SAFE_INTEGER", Number.MAX_SAFE_INTEGER + 2],
+            ])("acceptSwapQuote rejects amount %s as non-safe-integer", async (_label, value) => {
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+                await expect(
+                    swaps.acceptSwapQuote(mock.id, value, {
+                        minAcceptableAmount: 1000,
+                    }),
+                ).rejects.toMatchObject({
+                    name: "QuoteRejectedError",
+                    reason: "non_safe_integer",
+                });
+                expect(postSpy).not.toHaveBeenCalled();
+            });
+
             it("acceptSwapQuote rejects an amount below the floor and does not post", async () => {
                 const postSpy = vi.spyOn(swapProvider, "postChainQuote");
                 await expect(

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -1464,6 +1464,19 @@ describe("ArkadeSwaps", () => {
                 ).rejects.toThrow(TypeError);
                 expect(postSpy).not.toHaveBeenCalled();
             });
+
+            it("acceptSwapQuote rejects when slippage drives the effective floor below 1 sat", async () => {
+                // 100% slippage would collapse the floor to 0 and let any
+                // positive Boltz quote through — must be rejected up front.
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+                await expect(
+                    swaps.acceptSwapQuote(mock.id, 1, {
+                        minAcceptableAmount: 1000,
+                        maxSlippageBps: 10000,
+                    }),
+                ).rejects.toThrow(TypeError);
+                expect(postSpy).not.toHaveBeenCalled();
+            });
         });
 
         describe("verifyChainSwap", () => {

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -1440,30 +1440,39 @@ describe("ArkadeSwaps", () => {
             });
 
             it("autopilot SwapError wrap preserves the underlying QuoteRejectedError as cause", async () => {
-                mockSwapRepository.getAllSwaps.mockResolvedValueOnce([mockArkBtcChainSwap]);
+                // Drive the real `transaction.lockupFailed` handler in
+                // `waitAndClaimBtc` so the SwapError wrap that lives there
+                // actually executes. Manually constructing SwapError in the
+                // test would still pass even if the production code dropped
+                // `cause`, so it has to come from the production path.
                 vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
                     amount: 1,
                 });
                 const postSpy = vi.spyOn(swapProvider, "postChainQuote");
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(async (_id, callback) => {
+                    setTimeout(() => callback("transaction.lockupFailed", {}), 10);
+                });
 
                 let caught: unknown;
                 try {
-                    await swaps.quoteSwap(mock.id);
+                    await swaps.waitAndClaimBtc(mockArkBtcChainSwap);
                 } catch (e) {
                     caught = e;
                 }
+                // Production wrap shape.
+                expect(caught).toBeInstanceOf(SwapError);
                 expect(caught).toMatchObject({
+                    name: "SwapError",
+                    isRefundable: true,
+                });
+                expect((caught as SwapError).message).toMatch(/Failed to renegotiate quote/);
+                // Inner QuoteRejectedError must survive the wrap so callers
+                // can branch on the rejection reason.
+                const cause = (caught as SwapError).cause;
+                expect(cause).toMatchObject({
                     name: "QuoteRejectedError",
                     reason: "below_floor",
                 });
-                // Wrap the QuoteRejectedError the same shape the autopilot does;
-                // assert cause survives so callers can branch on the inner type.
-                const wrapped = new SwapError({
-                    message: `Failed: ${(caught as Error).message}`,
-                    isRefundable: true,
-                    cause: caught,
-                });
-                expect(wrapped.cause).toBe(caught);
                 expect(postSpy).not.toHaveBeenCalled();
             });
 


### PR DESCRIPTION
## Summary

Addresses the three CodeRabbit comments left on #502.

- **fix #1** (`36937074`): `resolveEffectiveFloor` now throws `TypeError` when `maxSlippageBps` (or a tiny baseline) drives the effective floor below 1 sat. Without this, `maxSlippageBps: 10000` silently restored blind-accept behaviour.
- **fix #2** (`0789d942`): `validateQuote` rejects non-finite, fractional, and `> MAX_SAFE_INTEGER` amounts via a new `non_safe_integer` rejection reason. `Infinity` previously slipped past `> 0` and the `< floor` check straight into `postChainQuote`. Transport-roundtrip path updated to match.
- **test #3** (`5c36b5a5`): the autopilot-cause regression test now drives `monitorSwap` → `transaction.lockupFailed` so the real `SwapError` wrap in `waitAndClaimBtc` executes. The previous version constructed `SwapError` manually and would have passed even if production code dropped `cause`.

## Test plan

- [x] `pnpm test:unit` — 342 boltz-swap tests pass (4 new)
- [x] CI green on the PR