### PR TITLE
feat(boltz-swap): merge m3m4-vhtlc-multi-vtxo (multi-VTXO claim/refund)

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -568,9 +568,7 @@ export class ArkadeSwaps {
         }
 
         if (vtxos.length === 0) {
-            throw new Error(
-                `Swap ${pendingSwap.id}: no spendable virtual coins found`
-            );
+            throw new Error(`Swap ${pendingSwap.id}: no spendable virtual coins found`);
         }
 
         const unspentVtxos = vtxos.filter((vtxo) => !vtxo.isSpent);
@@ -578,10 +576,7 @@ export class ArkadeSwaps {
             throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
         }
 
-        const vhtlcIdentity = claimVHTLCIdentity(
-            this.wallet.identity,
-            preimage
-        );
+        const vhtlcIdentity = claimVHTLCIdentity(this.wallet.identity, preimage);
         const outputScript = ArkAddress.decode(address).pkScript;
 
         // Asymmetry with `refundArk` is deliberate: this path is all-or-
@@ -620,7 +615,7 @@ export class ArkadeSwaps {
                         input,
                         output,
                         arkInfo,
-                        this.arkProvider
+                        this.arkProvider,
                     );
                     usedOffchainClaim = true;
                 }
@@ -631,13 +626,10 @@ export class ArkadeSwaps {
 
         if (claimErrors.length > 0) {
             const details = claimErrors
-                .map(
-                    ({ vtxo, error }) =>
-                        `${vtxo.txid}:${vtxo.vout} (${error.message})`
-                )
+                .map(({ vtxo, error }) => `${vtxo.txid}:${vtxo.vout} (${error.message})`)
                 .join("; ");
             throw new Error(
-                `Swap ${pendingSwap.id}: failed to claim ${claimErrors.length}/${unspentVtxos.length} VTXOs: ${details}`
+                `Swap ${pendingSwap.id}: failed to claim ${claimErrors.length}/${unspentVtxos.length} VTXOs: ${details}`,
             );
         }
 
@@ -1736,9 +1728,7 @@ export class ArkadeSwaps {
      * @returns Counts of VTXOs swept vs. deferred. A `swept: 0` outcome means
      *          the call was a no-op — callers should retry after CLTV.
      */
-    async refundArk(
-        pendingSwap: BoltzChainSwap
-    ): Promise<ChainArkRefundOutcome> {
+    async refundArk(pendingSwap: BoltzChainSwap): Promise<ChainArkRefundOutcome> {
         if (!pendingSwap.response.lockupDetails.serverPublicKey)
             throw new Error(`Swap ${pendingSwap.id}: missing server public key in lockup details`);
 
@@ -1791,7 +1781,7 @@ export class ArkadeSwaps {
 
         if (vtxos.length === 0) {
             throw new Error(
-                `Swap ${pendingSwap.id}: VHTLC not found for address ${pendingSwap.response.lockupDetails.lockupAddress}`
+                `Swap ${pendingSwap.id}: VHTLC not found for address ${pendingSwap.response.lockupDetails.lockupAddress}`,
             );
         }
 
@@ -1802,8 +1792,7 @@ export class ArkadeSwaps {
 
         const outputScript = ArkAddress.decode(address).pkScript;
         const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
-        const refundLocktime =
-            pendingSwap.response.lockupDetails.timeouts!.refund;
+        const refundLocktime = pendingSwap.response.lockupDetails.timeouts!.refund;
 
         let boltzCallCount = 0;
         let sweptCount = 0;
@@ -1832,7 +1821,7 @@ export class ArkadeSwaps {
                     input,
                     output,
                     arkInfo,
-                    isRecoverableVtxo
+                    isRecoverableVtxo,
                 );
                 sweptCount++;
                 continue;
@@ -1844,7 +1833,7 @@ export class ArkadeSwaps {
                         `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
                         `(refundLocktime=${refundLocktime}, ` +
                         `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
-                        `Refund will be retried after locktime.`
+                        `Refund will be retried after locktime.`,
                 );
                 skippedCount++;
                 continue;
@@ -1874,7 +1863,7 @@ export class ArkadeSwaps {
                     input,
                     output,
                     arkInfo,
-                    this.swapProvider.refundChainSwap.bind(this.swapProvider)
+                    this.swapProvider.refundChainSwap.bind(this.swapProvider),
                 );
                 sweptCount++;
             } catch (error) {
@@ -1888,7 +1877,7 @@ export class ArkadeSwaps {
                             `refundWithoutReceiver locktime has not passed yet ` +
                             `(currentTimestamp=${Math.floor(Date.now() / 1000)}, ` +
                             `locktime=${refundLocktime}). ` +
-                            `Refund will be retried after locktime.`
+                            `Refund will be retried after locktime.`,
                     );
                     skippedCount++;
                     continue;
@@ -1896,20 +1885,14 @@ export class ArkadeSwaps {
 
                 logger.warn(
                     `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint, ` +
-                        `falling back to refundWithoutReceiver via joinBatch`
+                        `falling back to refundWithoutReceiver via joinBatch`,
                 );
                 const fallbackInput = {
                     ...vtxo,
                     tapLeafScript: refundWithoutReceiverLeaf,
                     tapTree: vhtlcScript.encode(),
                 };
-                await this.joinBatch(
-                    this.wallet.identity,
-                    fallbackInput,
-                    output,
-                    arkInfo,
-                    false
-                );
+                await this.joinBatch(this.wallet.identity, fallbackInput, output, arkInfo, false);
                 sweptCount++;
             }
         }

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -33,6 +33,7 @@ import type {
     BoltzSwap,
     ArkadeSwapsConfig,
     ArkadeSwapsCreateConfig,
+    ChainArkRefundOutcome,
     CreateLightningInvoiceRequest,
     CreateLightningInvoiceResponse,
     SendLightningPaymentRequest,
@@ -288,7 +289,7 @@ export class ArkadeSwaps {
                     await this.claimBtc(swap);
                 },
                 refundArk: async (swap: BoltzChainSwap) => {
-                    await this.refundArk(swap);
+                    return this.refundArk(swap);
                 },
                 signServerClaim: async (swap: BoltzChainSwap) => {
                     await this.signCooperativeClaimForServer(swap);
@@ -552,13 +553,13 @@ export class ArkadeSwaps {
                 `Swap ${pendingSwap.id}: VHTLC address mismatch. Expected ${lockupAddress}, got ${vhtlcAddress}`,
             );
 
-        let vtxo;
+        let vtxos: VirtualCoin[] = [];
         for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
-            const { vtxos } = await this.indexerProvider.getVtxos({
+            const result = await this.indexerProvider.getVtxos({
                 scripts: [hex.encode(vhtlcScript.pkScript)],
             });
-            if (vtxos.length > 0) {
-                vtxo = vtxos[0];
+            if (result.vtxos.length > 0) {
+                vtxos = result.vtxos;
                 break;
             }
             if (attempt < CLAIM_VTXO_RETRY_ATTEMPTS) {
@@ -566,44 +567,54 @@ export class ArkadeSwaps {
             }
         }
 
-        if (!vtxo) {
-            throw new Error(`Swap ${pendingSwap.id}: no spendable virtual coins found`);
+        if (vtxos.length === 0) {
+            throw new Error(
+                `Swap ${pendingSwap.id}: no spendable virtual coins found`
+            );
         }
 
-        if (vtxo.isSpent) {
+        const unspentVtxos = vtxos.filter((vtxo) => !vtxo.isSpent);
+        if (unspentVtxos.length === 0) {
             throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
         }
 
-        const input = {
-            ...vtxo,
-            tapLeafScript: vhtlcScript.claim(),
-            tapTree: vhtlcScript.encode(),
-        };
+        const vhtlcIdentity = claimVHTLCIdentity(
+            this.wallet.identity,
+            preimage
+        );
+        const outputScript = ArkAddress.decode(address).pkScript;
 
-        const output = {
-            amount: BigInt(vtxo.value),
-            script: ArkAddress.decode(address).pkScript,
-        };
+        let usedOffchainClaim = false;
+        for (const vtxo of unspentVtxos) {
+            const input = {
+                ...vtxo,
+                tapLeafScript: vhtlcScript.claim(),
+                tapTree: vhtlcScript.encode(),
+            };
+            const output = {
+                amount: BigInt(vtxo.value),
+                script: outputScript,
+            };
 
-        const vhtlcIdentity = claimVHTLCIdentity(this.wallet.identity, preimage);
-
-        let finalStatus: BoltzSwapStatus | undefined;
-
-        if (isRecoverable(vtxo)) {
-            await this.joinBatch(vhtlcIdentity, input, output, arkInfo);
-            finalStatus = "transaction.claimed";
-        } else {
-            await claimVHTLCwithOffchainTx(
-                vhtlcIdentity,
-                vhtlcScript,
-                serverXOnly,
-                input,
-                output,
-                arkInfo,
-                this.arkProvider,
-            );
-            finalStatus = (await this.getSwapStatus(pendingSwap.id)).status;
+            if (isRecoverable(vtxo)) {
+                await this.joinBatch(vhtlcIdentity, input, output, arkInfo);
+            } else {
+                await claimVHTLCwithOffchainTx(
+                    vhtlcIdentity,
+                    vhtlcScript,
+                    serverXOnly,
+                    input,
+                    output,
+                    arkInfo,
+                    this.arkProvider
+                );
+                usedOffchainClaim = true;
+            }
         }
+
+        const finalStatus: BoltzSwapStatus = usedOffchainClaim
+            ? (await this.getSwapStatus(pendingSwap.id)).status
+            : "transaction.claimed";
 
         // update the pending swap on storage
         await updateReverseSwapStatus(
@@ -1074,6 +1085,11 @@ export class ArkadeSwaps {
                 if (boltzCallCount > 0) {
                     await new Promise((r) => setTimeout(r, 2000));
                 }
+                // Count attempts, not successes — a thrown call still
+                // consumed Boltz's rate-limit slot, so the next attempt
+                // must observe the throttle even when the previous one
+                // failed.
+                boltzCallCount++;
                 await refundVHTLCwithOffchainTx(
                     pendingSwap.id,
                     this.wallet.identity,
@@ -1086,7 +1102,6 @@ export class ArkadeSwaps {
                     arkInfo,
                     this.swapProvider.refundSubmarineSwap.bind(this.swapProvider),
                 );
-                boltzCallCount++;
                 sweptCount++;
             } catch (error) {
                 // Only fall back for Boltz-side rejections (e.g. outpoint
@@ -1680,10 +1695,21 @@ export class ArkadeSwaps {
     }
 
     /**
-     * When an ARK to BTC swap fails, refund sats on ARK chain by claiming the VHTLC.
+     * When an ARK to BTC swap fails, refund every unspent VTXO at the chain
+     * swap's ARK lockup address.
+     *
+     * Path selection per VTXO:
+     * - CLTV has elapsed → `refundWithoutReceiver` via `joinBatch` (no Boltz).
+     * - Pre-CLTV recoverable → skipped (Boltz can't co-sign swept-batch refund).
+     * - Pre-CLTV non-recoverable → cooperative 3-of-3 refund via Boltz.
+     *
      * @param pendingSwap - The pending chain swap to refund.
+     * @returns Counts of VTXOs swept vs. deferred. A `swept: 0` outcome means
+     *          the call was a no-op — callers should retry after CLTV.
      */
-    async refundArk(pendingSwap: BoltzChainSwap): Promise<void> {
+    async refundArk(
+        pendingSwap: BoltzChainSwap
+    ): Promise<ChainArkRefundOutcome> {
         if (!pendingSwap.response.lockupDetails.serverPublicKey)
             throw new Error(`Swap ${pendingSwap.id}: missing server public key in lockup details`);
 
@@ -1712,27 +1738,6 @@ export class ArkadeSwaps {
             pendingSwap.id,
         );
 
-        const vhtlcPkScript = ArkAddress.decode(
-            pendingSwap.response.lockupDetails.lockupAddress,
-        ).pkScript;
-
-        // get spendable VTXOs from the lockup address
-        const { vtxos } = await this.indexerProvider.getVtxos({
-            scripts: [hex.encode(vhtlcPkScript)],
-        });
-
-        if (vtxos.length === 0) {
-            throw new Error(
-                `Swap ${pendingSwap.id}: VHTLC not found for address ${pendingSwap.response.lockupDetails.lockupAddress}`,
-            );
-        }
-
-        const vtxo = vtxos[0];
-
-        if (vtxo.isSpent) {
-            throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
-        }
-
         const { vhtlcAddress, vhtlcScript } = this.createVHTLCScript({
             network: arkInfo.network,
             preimageHash: hex.decode(pendingSwap.request.preimageHash),
@@ -1751,36 +1756,133 @@ export class ArkadeSwaps {
             });
         }
 
-        const isRecoverableVtxo = isRecoverable(vtxo);
+        const { vtxos } = await this.indexerProvider.getVtxos({
+            scripts: [hex.encode(vhtlcScript.pkScript)],
+        });
 
-        const input = {
-            ...vtxo,
-            tapLeafScript: isRecoverableVtxo
-                ? vhtlcScript.refundWithoutReceiver()
-                : vhtlcScript.refund(),
-            tapTree: vhtlcScript.encode(),
-        };
-
-        const output = {
-            amount: BigInt(vtxo.value),
-            script: ArkAddress.decode(address).pkScript,
-        };
-
-        if (isRecoverableVtxo) {
-            await this.joinBatch(this.wallet.identity, input, output, arkInfo);
-        } else {
-            await refundVHTLCwithOffchainTx(
-                pendingSwap.id,
-                this.wallet.identity,
-                this.arkProvider,
-                boltzXOnlyPublicKey,
-                ourXOnlyPublicKey,
-                serverXOnlyPublicKey,
-                input,
-                output,
-                arkInfo,
-                this.swapProvider.refundChainSwap.bind(this.swapProvider),
+        if (vtxos.length === 0) {
+            throw new Error(
+                `Swap ${pendingSwap.id}: VHTLC not found for address ${pendingSwap.response.lockupDetails.lockupAddress}`
             );
+        }
+
+        const unspentVtxos = vtxos.filter((vtxo) => !vtxo.isSpent);
+        if (unspentVtxos.length === 0) {
+            throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
+        }
+
+        const outputScript = ArkAddress.decode(address).pkScript;
+        const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
+        const cltvSatisfied = isSubmarineRefundLocktimeReached(
+            pendingSwap.response.lockupDetails.timeouts!.refund
+        );
+
+        let boltzCallCount = 0;
+        let sweptCount = 0;
+        let skippedCount = 0;
+
+        for (const vtxo of unspentVtxos) {
+            const isRecoverableVtxo = isRecoverable(vtxo);
+            const output = {
+                amount: BigInt(vtxo.value),
+                script: outputScript,
+            };
+
+            if (cltvSatisfied) {
+                const input = {
+                    ...vtxo,
+                    tapLeafScript: refundWithoutReceiverLeaf,
+                    tapTree: vhtlcScript.encode(),
+                };
+                await this.joinBatch(
+                    this.wallet.identity,
+                    input,
+                    output,
+                    arkInfo,
+                    isRecoverableVtxo
+                );
+                sweptCount++;
+                continue;
+            }
+
+            if (isRecoverableVtxo) {
+                logger.error(
+                    `Swap ${pendingSwap.id}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
+                        `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
+                        `(refundLocktime=${pendingSwap.response.lockupDetails.timeouts!.refund}, ` +
+                        `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
+                        `Refund will be retried after locktime.`
+                );
+                skippedCount++;
+                continue;
+            }
+
+            const input = {
+                ...vtxo,
+                tapLeafScript: vhtlcScript.refund(),
+                tapTree: vhtlcScript.encode(),
+            };
+            try {
+                if (boltzCallCount > 0) {
+                    await new Promise((r) => setTimeout(r, 2000));
+                }
+                // Count attempts, not successes — a thrown call still
+                // consumed Boltz's rate-limit slot, so the next attempt
+                // must observe the throttle even when the previous one
+                // failed.
+                boltzCallCount++;
+                await refundVHTLCwithOffchainTx(
+                    pendingSwap.id,
+                    this.wallet.identity,
+                    this.arkProvider,
+                    boltzXOnlyPublicKey,
+                    ourXOnlyPublicKey,
+                    serverXOnlyPublicKey,
+                    input,
+                    output,
+                    arkInfo,
+                    this.swapProvider.refundChainSwap.bind(this.swapProvider)
+                );
+                sweptCount++;
+            } catch (error) {
+                if (!(error instanceof BoltzRefundError)) {
+                    throw error;
+                }
+
+                if (
+                    !isSubmarineRefundLocktimeReached(
+                        pendingSwap.response.lockupDetails.timeouts!.refund
+                    )
+                ) {
+                    logger.error(
+                        `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint and ` +
+                            `refundWithoutReceiver locktime has not passed yet ` +
+                            `(currentTimestamp=${Math.floor(Date.now() / 1000)}, ` +
+                            `locktime=${pendingSwap.response.lockupDetails.timeouts!.refund}). ` +
+                            `Refund will be retried after locktime.`
+                    );
+                    skippedCount++;
+                    continue;
+                }
+
+                logger.warn(
+                    `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint, ` +
+                        `falling back to refundWithoutReceiver via joinBatch`
+                );
+                const fallbackInput = {
+                    ...vtxo,
+                    tapLeafScript: refundWithoutReceiverLeaf,
+                    tapTree: vhtlcScript.encode(),
+                };
+                await this.joinBatch(
+                    this.wallet.identity,
+                    fallbackInput,
+                    output,
+                    arkInfo,
+                    false
+                );
+                sweptCount++;
+            }
         }
 
         // update the pending swap on storage
@@ -1789,6 +1891,8 @@ export class ArkadeSwaps {
             ...pendingSwap,
             status: finalStatus.status,
         });
+
+        return { swept: sweptCount, skipped: skippedCount };
     }
 
     // =========================================================================
@@ -2825,7 +2929,7 @@ export interface IArkadeSwaps extends AsyncDisposable {
     }): Promise<ArkToBtcResponse>;
     waitAndClaimBtc(pendingSwap: BoltzChainSwap): Promise<{ txid: string }>;
     claimBtc(pendingSwap: BoltzChainSwap): Promise<void>;
-    refundArk(pendingSwap: BoltzChainSwap): Promise<void>;
+    refundArk(pendingSwap: BoltzChainSwap): Promise<ChainArkRefundOutcome>;
     btcToArk(args: {
         feeSatsPerByte?: number;
         senderLockAmount?: number;

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -584,6 +584,19 @@ export class ArkadeSwaps {
         );
         const outputScript = ArkAddress.decode(address).pkScript;
 
+        // Asymmetry with `refundArk` is deliberate: this path is all-or-
+        // throw. Each VTXO is still attempted independently (so an early
+        // failure doesn't strand later VTXOs at the lockup), and any
+        // failures are surfaced as a single aggregate error after the
+        // loop. The swap status is saved only on full success — a
+        // partial claim leaves the swap in its current Boltz-driven
+        // status (e.g. `transaction.confirmed`) so the caller / Boltz
+        // status flow can retry the whole call. We don't track a
+        // {swept, skipped} outcome here because — unlike the
+        // `swap.expired` terminal status that triggers `refundArk` —
+        // the reverse-claim path is still receiving live Boltz status
+        // transitions, and the SwapManager owns retry via those.
+        const claimErrors: { vtxo: VirtualCoin; error: Error }[] = [];
         let usedOffchainClaim = false;
         for (const vtxo of unspentVtxos) {
             const input = {
@@ -596,20 +609,36 @@ export class ArkadeSwaps {
                 script: outputScript,
             };
 
-            if (isRecoverable(vtxo)) {
-                await this.joinBatch(vhtlcIdentity, input, output, arkInfo);
-            } else {
-                await claimVHTLCwithOffchainTx(
-                    vhtlcIdentity,
-                    vhtlcScript,
-                    serverXOnly,
-                    input,
-                    output,
-                    arkInfo,
-                    this.arkProvider
-                );
-                usedOffchainClaim = true;
+            try {
+                if (isRecoverable(vtxo)) {
+                    await this.joinBatch(vhtlcIdentity, input, output, arkInfo);
+                } else {
+                    await claimVHTLCwithOffchainTx(
+                        vhtlcIdentity,
+                        vhtlcScript,
+                        serverXOnly,
+                        input,
+                        output,
+                        arkInfo,
+                        this.arkProvider
+                    );
+                    usedOffchainClaim = true;
+                }
+            } catch (error) {
+                claimErrors.push({ vtxo, error: error as Error });
             }
+        }
+
+        if (claimErrors.length > 0) {
+            const details = claimErrors
+                .map(
+                    ({ vtxo, error }) =>
+                        `${vtxo.txid}:${vtxo.vout} (${error.message})`
+                )
+                .join("; ");
+            throw new Error(
+                `Swap ${pendingSwap.id}: failed to claim ${claimErrors.length}/${unspentVtxos.length} VTXOs: ${details}`
+            );
         }
 
         const finalStatus: BoltzSwapStatus = usedOffchainClaim

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -553,13 +553,20 @@ export class ArkadeSwaps {
                 `Swap ${pendingSwap.id}: VHTLC address mismatch. Expected ${lockupAddress}, got ${vhtlcAddress}`,
             );
 
-        let vtxos: VirtualCoin[] = [];
+        // Retry while waiting for an *actionable* (unspent) VTXO to appear at
+        // the VHTLC script. A spent VTXO showing up early must not abort the
+        // wait, so we break only once the unspent subset is non-empty. The
+        // last raw response is kept so the post-retry branch can distinguish
+        // "not found" from "already spent" for diagnostics.
+        let unspentVtxos: VirtualCoin[] = [];
+        let rawVtxos: VirtualCoin[] = [];
         for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
             const result = await this.indexerProvider.getVtxos({
                 scripts: [hex.encode(vhtlcScript.pkScript)],
             });
-            if (result.vtxos.length > 0) {
-                vtxos = result.vtxos;
+            rawVtxos = result.vtxos;
+            unspentVtxos = result.vtxos.filter((vtxo) => !vtxo.isSpent);
+            if (unspentVtxos.length > 0) {
                 break;
             }
             if (attempt < CLAIM_VTXO_RETRY_ATTEMPTS) {
@@ -567,12 +574,10 @@ export class ArkadeSwaps {
             }
         }
 
-        if (vtxos.length === 0) {
-            throw new Error(`Swap ${pendingSwap.id}: no spendable virtual coins found`);
-        }
-
-        const unspentVtxos = vtxos.filter((vtxo) => !vtxo.isSpent);
         if (unspentVtxos.length === 0) {
+            if (rawVtxos.length === 0) {
+                throw new Error(`Swap ${pendingSwap.id}: no spendable virtual coins found`);
+            }
             throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
         }
 

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -1802,9 +1802,8 @@ export class ArkadeSwaps {
 
         const outputScript = ArkAddress.decode(address).pkScript;
         const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
-        const cltvSatisfied = isSubmarineRefundLocktimeReached(
-            pendingSwap.response.lockupDetails.timeouts!.refund
-        );
+        const refundLocktime =
+            pendingSwap.response.lockupDetails.timeouts!.refund;
 
         let boltzCallCount = 0;
         let sweptCount = 0;
@@ -1817,7 +1816,12 @@ export class ArkadeSwaps {
                 script: outputScript,
             };
 
-            if (cltvSatisfied) {
+            // Re-evaluate per iteration so a CLTV that elapses mid-loop
+            // is observed by every branch (recoverable + non-recoverable).
+            // `Date.now()` is cheap; the snapshot saved nothing material
+            // and could needlessly defer a recoverable VTXO whose
+            // locktime had just passed.
+            if (isSubmarineRefundLocktimeReached(refundLocktime)) {
                 const input = {
                     ...vtxo,
                     tapLeafScript: refundWithoutReceiverLeaf,
@@ -1838,7 +1842,7 @@ export class ArkadeSwaps {
                 logger.error(
                     `Swap ${pendingSwap.id}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
                         `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
-                        `(refundLocktime=${pendingSwap.response.lockupDetails.timeouts!.refund}, ` +
+                        `(refundLocktime=${refundLocktime}, ` +
                         `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
                         `Refund will be retried after locktime.`
                 );
@@ -1878,16 +1882,12 @@ export class ArkadeSwaps {
                     throw error;
                 }
 
-                if (
-                    !isSubmarineRefundLocktimeReached(
-                        pendingSwap.response.lockupDetails.timeouts!.refund
-                    )
-                ) {
+                if (!isSubmarineRefundLocktimeReached(refundLocktime)) {
                     logger.error(
                         `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint and ` +
                             `refundWithoutReceiver locktime has not passed yet ` +
                             `(currentTimestamp=${Math.floor(Date.now() / 1000)}, ` +
-                            `locktime=${pendingSwap.response.lockupDetails.timeouts!.refund}). ` +
+                            `locktime=${refundLocktime}). ` +
                             `Refund will be retried after locktime.`
                     );
                     skippedCount++;

--- a/packages/boltz-swap/src/expo/arkade-lightning.ts
+++ b/packages/boltz-swap/src/expo/arkade-lightning.ts
@@ -6,6 +6,7 @@ import type {
     ArkToBtcResponse,
     BtcToArkResponse,
     Chain,
+    ChainArkRefundOutcome,
     ChainFeesResponse,
     CreateLightningInvoiceRequest,
     CreateLightningInvoiceResponse,
@@ -325,7 +326,7 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.claimBtc(pendingSwap);
     }
 
-    refundArk(pendingSwap: BoltzChainSwap): Promise<void> {
+    refundArk(pendingSwap: BoltzChainSwap): Promise<ChainArkRefundOutcome> {
         return this.inner.refundArk(pendingSwap);
     }
 

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -17,6 +17,7 @@ import {
     ArkToBtcResponse,
     BtcToArkResponse,
     Chain,
+    type ChainArkRefundOutcome,
     ChainFeesResponse,
     type CreateLightningInvoiceRequest,
     type CreateLightningInvoiceResponse,
@@ -377,6 +378,7 @@ export type RequestRefundArk = RequestEnvelope & {
 };
 export type ResponseRefundArk = ResponseEnvelope & {
     type: "ARK_REFUND_EXECUTED";
+    payload: ChainArkRefundOutcome;
 };
 
 export type RequestSignServerClaim = RequestEnvelope & {
@@ -1038,9 +1040,16 @@ export class ArkadeSwapsMessageHandler
                     await this.handler.claimBtc(message.payload);
                     return this.tagged({ id, type: "BTC_CLAIM_EXECUTED" });
 
-                case "REFUND_ARK":
-                    await this.handler.refundArk(message.payload);
-                    return this.tagged({ id, type: "ARK_REFUND_EXECUTED" });
+                case "REFUND_ARK": {
+                    const outcome = await this.handler.refundArk(
+                        message.payload
+                    );
+                    return this.tagged({
+                        id,
+                        type: "ARK_REFUND_EXECUTED",
+                        payload: outcome,
+                    });
+                }
 
                 case "SIGN_SERVER_CLAIM":
                     await this.handler.signCooperativeClaimForServer(message.payload);

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -1041,9 +1041,7 @@ export class ArkadeSwapsMessageHandler
                     return this.tagged({ id, type: "BTC_CLAIM_EXECUTED" });
 
                 case "REFUND_ARK": {
-                    const outcome = await this.handler.refundArk(
-                        message.payload
-                    );
+                    const outcome = await this.handler.refundArk(message.payload);
                     return this.tagged({
                         id,
                         type: "ARK_REFUND_EXECUTED",

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -4,6 +4,7 @@ import {
     ArkadeSwapsConfig,
     BtcToArkResponse,
     Chain,
+    ChainArkRefundOutcome,
     ChainFeesResponse,
     CreateLightningInvoiceRequest,
     CreateLightningInvoiceResponse,
@@ -56,6 +57,7 @@ import type {
     ResponseInspectSubmarineRecovery,
     ResponseScanRecoverableSubmarineSwaps,
     ResponseRecoverAllSubmarineFunds,
+    ResponseRefundArk,
     ResponseRefundVhtlc,
     ResponseRecoverSubmarineFunds,
 } from "./arkade-swaps-message-handler";
@@ -737,13 +739,16 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         });
     }
 
-    async refundArk(pendingSwap: BoltzChainSwap): Promise<void> {
-        await this.sendMessage({
+    async refundArk(
+        pendingSwap: BoltzChainSwap
+    ): Promise<ChainArkRefundOutcome> {
+        const res = await this.sendMessage({
             id: getRandomId(),
             tag: this.messageTag,
             type: "REFUND_ARK",
             payload: pendingSwap,
         });
+        return (res as ResponseRefundArk).payload;
     }
 
     async signCooperativeClaimForServer(pendingSwap: BoltzChainSwap): Promise<void> {

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -739,9 +739,7 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         });
     }
 
-    async refundArk(
-        pendingSwap: BoltzChainSwap
-    ): Promise<ChainArkRefundOutcome> {
+    async refundArk(pendingSwap: BoltzChainSwap): Promise<ChainArkRefundOutcome> {
         const res = await this.sendMessage({
             id: getRandomId(),
             tag: this.messageTag,

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -1271,9 +1271,13 @@ export class SwapManager implements SwapManagerClient {
     private async pollAllSwaps(): Promise<void> {
         if (this.monitoredSwaps.size === 0) return;
 
-        const pollPromises = Array.from(this.monitoredSwaps.values()).map((swap) =>
-            this.pollSingleSwap(swap),
-        );
+        const pollPromises = Array.from(this.monitoredSwaps.values())
+            // Swaps with a pending refund retry are driven entirely by the
+            // refund-retry loop, not by Boltz polling. Skip them so a 404 on
+            // an already-expired swap can't trip handleSwapNotFound and tear
+            // down the in-flight retry.
+            .filter((swap) => !this.refundRetryTimers.has(swap.id))
+            .map((swap) => this.pollSingleSwap(swap));
 
         await Promise.allSettled(pollPromises);
     }
@@ -1334,6 +1338,9 @@ export class SwapManager implements SwapManagerClient {
      * Boltz endpoint).
      */
     private async handleSwapNotFound(swap: BoltzSwap): Promise<void> {
+        // A pending refund retry owns this swap's lifecycle; a transient 404
+        // must not increment the not-found counter or abort the retry.
+        if (this.refundRetryTimers.has(swap.id)) return;
         const count = (this.notFoundCounts.get(swap.id) ?? 0) + 1;
         this.notFoundCounts.set(swap.id, count);
         logger.warn(
@@ -1355,6 +1362,10 @@ export class SwapManager implements SwapManagerClient {
      * 404s without recovering anything.
      */
     private async markSwapAsUnknownToProvider(swap: BoltzSwap): Promise<void> {
+        // Never tear down a swap with a pending refund retry: clearing
+        // refundRetryTimers here would strand the deferred refund work. The
+        // retry loop owns finalization once that work completes.
+        if (this.refundRetryTimers.has(swap.id)) return;
         // Idempotency: bail if a concurrent path already removed the swap.
         if (!this.monitoredSwaps.has(swap.id)) {
             this.notFoundCounts.delete(swap.id);

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -199,10 +199,7 @@ export class SwapManager implements SwapManagerClient {
     // (refundArk returned `skipped > 0`). The swap is held in
     // `monitoredSwaps` past its terminal Boltz status until the local
     // refund completes or the manager stops.
-    private refundRetryTimers = new Map<
-        string,
-        ReturnType<typeof setTimeout>
-    >();
+    private refundRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
     // Per-swap counter of consecutive `SwapNotFoundError` responses from
     // `getSwapStatus`. Reset on any successful poll. Once a swap reaches
     // `NOT_FOUND_THRESHOLD` consecutive 404s the safety net trips and the
@@ -224,23 +221,14 @@ export class SwapManager implements SwapManagerClient {
     private swapSubscriptions = new Map<string, Set<SwapUpdateCallback>>();
 
     // Action callbacks (injected via setCallbacks)
-    private claimCallback: ((swap: BoltzReverseSwap) => Promise<void>) | null =
+    private claimCallback: ((swap: BoltzReverseSwap) => Promise<void>) | null = null;
+    private refundCallback: ((swap: BoltzSubmarineSwap) => Promise<void>) | null = null;
+    private claimArkCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
+    private claimBtcCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
+    private refundArkCallback: ((swap: BoltzChainSwap) => Promise<ChainArkRefundOutcome>) | null =
         null;
-    private refundCallback:
-        | ((swap: BoltzSubmarineSwap) => Promise<void>)
-        | null = null;
-    private claimArkCallback: ((swap: BoltzChainSwap) => Promise<void>) | null =
-        null;
-    private claimBtcCallback: ((swap: BoltzChainSwap) => Promise<void>) | null =
-        null;
-    private refundArkCallback:
-        | ((swap: BoltzChainSwap) => Promise<ChainArkRefundOutcome>)
-        | null = null;
-    private signServerClaimCallback:
-        | ((swap: BoltzChainSwap) => Promise<void>)
-        | null = null;
-    private saveSwapCallback: ((swap: BoltzSwap) => Promise<void>) | null =
-        null;
+    private signServerClaimCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
+    private saveSwapCallback: ((swap: BoltzSwap) => Promise<void>) | null = null;
 
     constructor(swapProvider: BoltzSwapProvider, config: SwapManagerConfig = {}) {
         this.swapProvider = swapProvider;
@@ -951,14 +939,11 @@ export class SwapManager implements SwapManagerClient {
                     // deferred) or finished the work; in the latter case
                     // we owe the terminal-status finalization that
                     // handleSwapStatusUpdate skipped.
-                    if (
-                        !this.refundRetryTimers.has(swap.id) &&
-                        this.isFinalStatus(swap)
-                    ) {
+                    if (!this.refundRetryTimers.has(swap.id) && this.isFinalStatus(swap)) {
                         this.finalizeMonitoredSwap(swap);
                     }
                 }
-            }, delayMs)
+            }, delayMs),
         );
     }
 
@@ -1039,32 +1024,25 @@ export class SwapManager implements SwapManagerClient {
                         // logs and emits but cannot reach the chain-
                         // specific retry path.
                         try {
-                            const outcome =
-                                await this.executeRefundArkAction(swap);
+                            const outcome = await this.executeRefundArkAction(swap);
                             if (outcome && outcome.skipped > 0) {
                                 logger.log(
-                                    `Chain swap ${swap.id}: ${outcome.skipped} VTXO(s) deferred — scheduling refund retry`
+                                    `Chain swap ${swap.id}: ${outcome.skipped} VTXO(s) deferred — scheduling refund retry`,
                                 );
-                                this.scheduleRefundRetry(
-                                    swap,
-                                    SwapManager.REFUND_RETRY_DELAY_MS
-                                );
+                                this.scheduleRefundRetry(swap, SwapManager.REFUND_RETRY_DELAY_MS);
                             }
                             this.actionExecutedListeners.forEach((listener) =>
-                                listener(swap, "refundArk")
+                                listener(swap, "refundArk"),
                             );
                         } catch (error) {
                             logger.error(
                                 `Auto-refunding ARK chain swap ${swap.id} failed; scheduling retry`,
-                                error
+                                error,
                             );
                             this.swapFailedListeners.forEach((listener) =>
-                                listener(swap, error as Error)
+                                listener(swap, error as Error),
                             );
-                            this.scheduleRefundRetry(
-                                swap,
-                                SwapManager.REFUND_RETRY_DELAY_MS
-                            );
+                            this.scheduleRefundRetry(swap, SwapManager.REFUND_RETRY_DELAY_MS);
                         }
                     }
                     if (swap.request.from === "BTC") {
@@ -1157,7 +1135,7 @@ export class SwapManager implements SwapManagerClient {
      * Execute refund action for chain swap Ark to Btc
      */
     private async executeRefundArkAction(
-        swap: BoltzChainSwap
+        swap: BoltzChainSwap,
     ): Promise<ChainArkRefundOutcome | undefined> {
         if (!this.refundArkCallback) {
             logger.error("refundArk callback not set");

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -941,6 +941,10 @@ export class SwapManager implements SwapManagerClient {
                 if (!this.isRunning) return;
                 if (!this.monitoredSwaps.has(swap.id)) return;
                 try {
+                    // `swap` is captured at scheduling time; its fields
+                    // are stable for chain refunds because swap.expired
+                    // is terminal and Boltz won't transition it again,
+                    // so the snapshot remains accurate across retries.
                     await this.executeAutonomousAction(swap);
                 } finally {
                     // The retry callback either re-scheduled itself (still

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -13,7 +13,13 @@ import {
     isChainSignableStatus,
     isChainFinalStatus,
 } from "./boltz-swap-provider";
-import { BoltzChainSwap, BoltzReverseSwap, BoltzSubmarineSwap, BoltzSwap } from "./types";
+import {
+    BoltzChainSwap,
+    BoltzReverseSwap,
+    BoltzSubmarineSwap,
+    BoltzSwap,
+    ChainArkRefundOutcome,
+} from "./types";
 import { NetworkError, SwapNotFoundError } from "./errors";
 import { logger } from "./logger";
 
@@ -137,7 +143,7 @@ export interface SwapManagerCallbacks {
     refund: (swap: BoltzSubmarineSwap) => Promise<void>;
     claimArk: (swap: BoltzChainSwap) => Promise<void>;
     claimBtc: (swap: BoltzChainSwap) => Promise<void>;
-    refundArk: (swap: BoltzChainSwap) => Promise<void>;
+    refundArk: (swap: BoltzChainSwap) => Promise<ChainArkRefundOutcome>;
     signServerClaim?: (swap: BoltzChainSwap) => Promise<void>;
     saveSwap: (swap: BoltzSwap) => Promise<void>;
 }
@@ -162,6 +168,14 @@ export class SwapManager implements SwapManagerClient {
      */
     private static readonly NOT_FOUND_THRESHOLD = 10;
 
+    /**
+     * Delay between re-attempts of a chain refund that left VTXOs deferred
+     * (e.g. pre-CLTV recoverable VTXO, or Boltz 3-of-3 rejected before CLTV
+     * has elapsed). Boltz won't send another status update once the swap
+     * is `swap.expired`, so the manager owns the local retry cadence.
+     */
+    private static readonly REFUND_RETRY_DELAY_MS = 60_000;
+
     private readonly swapProvider: BoltzSwapProvider;
     private readonly config: SwapManagerConfig;
 
@@ -181,6 +195,14 @@ export class SwapManager implements SwapManagerClient {
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     private initialPollTimer: ReturnType<typeof setTimeout> | null = null;
     private pollRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    // Per-swap retry timers for chain refunds that left work undone
+    // (refundArk returned `skipped > 0`). The swap is held in
+    // `monitoredSwaps` past its terminal Boltz status until the local
+    // refund completes or the manager stops.
+    private refundRetryTimers = new Map<
+        string,
+        ReturnType<typeof setTimeout>
+    >();
     // Per-swap counter of consecutive `SwapNotFoundError` responses from
     // `getSwapStatus`. Reset on any successful poll. Once a swap reaches
     // `NOT_FOUND_THRESHOLD` consecutive 404s the safety net trips and the
@@ -202,13 +224,23 @@ export class SwapManager implements SwapManagerClient {
     private swapSubscriptions = new Map<string, Set<SwapUpdateCallback>>();
 
     // Action callbacks (injected via setCallbacks)
-    private claimCallback: ((swap: BoltzReverseSwap) => Promise<void>) | null = null;
-    private refundCallback: ((swap: BoltzSubmarineSwap) => Promise<void>) | null = null;
-    private claimArkCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
-    private claimBtcCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
-    private refundArkCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
-    private signServerClaimCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
-    private saveSwapCallback: ((swap: BoltzSwap) => Promise<void>) | null = null;
+    private claimCallback: ((swap: BoltzReverseSwap) => Promise<void>) | null =
+        null;
+    private refundCallback:
+        | ((swap: BoltzSubmarineSwap) => Promise<void>)
+        | null = null;
+    private claimArkCallback: ((swap: BoltzChainSwap) => Promise<void>) | null =
+        null;
+    private claimBtcCallback: ((swap: BoltzChainSwap) => Promise<void>) | null =
+        null;
+    private refundArkCallback:
+        | ((swap: BoltzChainSwap) => Promise<ChainArkRefundOutcome>)
+        | null = null;
+    private signServerClaimCallback:
+        | ((swap: BoltzChainSwap) => Promise<void>)
+        | null = null;
+    private saveSwapCallback: ((swap: BoltzSwap) => Promise<void>) | null =
+        null;
 
     constructor(swapProvider: BoltzSwapProvider, config: SwapManagerConfig = {}) {
         this.swapProvider = swapProvider;
@@ -417,6 +449,10 @@ export class SwapManager implements SwapManagerClient {
             clearTimeout(timer);
         }
         this.pollRetryTimers.clear();
+        for (const timer of this.refundRetryTimers.values()) {
+            clearTimeout(timer);
+        }
+        this.refundRetryTimers.clear();
         this.notFoundCounts.clear();
     }
 
@@ -485,6 +521,11 @@ export class SwapManager implements SwapManagerClient {
         if (retryTimer) {
             clearTimeout(retryTimer);
             this.pollRetryTimers.delete(swapId);
+        }
+        const refundRetryTimer = this.refundRetryTimers.get(swapId);
+        if (refundRetryTimer) {
+            clearTimeout(refundRetryTimer);
+            this.refundRetryTimers.delete(swapId);
         }
         this.notFoundCounts.delete(swapId);
         logger.log(`Removed swap ${swapId} from monitoring`);
@@ -851,18 +892,70 @@ export class SwapManager implements SwapManagerClient {
             await this.executeAutonomousAction(swap);
         }
 
-        // Remove from monitoring if final status
+        // Remove from monitoring if final status — unless a refund retry
+        // is pending, in which case the retry callback owns finalization
+        // once the local refund work completes.
         if (this.isFinalStatus(swap)) {
-            this.monitoredSwaps.delete(swap.id);
-            this.swapSubscriptions.delete(swap.id);
-            const retryTimer = this.pollRetryTimers.get(swap.id);
-            if (retryTimer) {
-                clearTimeout(retryTimer);
-                this.pollRetryTimers.delete(swap.id);
+            if (this.refundRetryTimers.has(swap.id)) {
+                return;
             }
-            // Emit completed event to all listeners
-            this.swapCompletedListeners.forEach((listener) => listener(swap));
+            this.finalizeMonitoredSwap(swap);
         }
+    }
+
+    /**
+     * Drop a swap from monitoring and emit the terminal completion event.
+     * Shared between the on-status-update finalization path and the
+     * refund-retry finalization path (used when a previously-deferred
+     * chain refund has finished its remaining work).
+     */
+    private finalizeMonitoredSwap(swap: BoltzSwap): void {
+        if (!this.monitoredSwaps.has(swap.id)) return;
+        this.monitoredSwaps.delete(swap.id);
+        this.swapSubscriptions.delete(swap.id);
+        const retryTimer = this.pollRetryTimers.get(swap.id);
+        if (retryTimer) {
+            clearTimeout(retryTimer);
+            this.pollRetryTimers.delete(swap.id);
+        }
+        const refundRetry = this.refundRetryTimers.get(swap.id);
+        if (refundRetry) {
+            clearTimeout(refundRetry);
+            this.refundRetryTimers.delete(swap.id);
+        }
+        this.swapCompletedListeners.forEach((listener) => listener(swap));
+    }
+
+    /**
+     * Schedule another `executeAutonomousAction` run for a chain swap whose
+     * refund left VTXOs deferred. After the retry completes, if no further
+     * deferral was reported, finalize monitoring cleanup.
+     */
+    private scheduleRefundRetry(swap: BoltzChainSwap, delayMs: number): void {
+        const existing = this.refundRetryTimers.get(swap.id);
+        if (existing) clearTimeout(existing);
+        this.refundRetryTimers.set(
+            swap.id,
+            setTimeout(async () => {
+                this.refundRetryTimers.delete(swap.id);
+                if (!this.isRunning) return;
+                if (!this.monitoredSwaps.has(swap.id)) return;
+                try {
+                    await this.executeAutonomousAction(swap);
+                } finally {
+                    // The retry callback either re-scheduled itself (still
+                    // deferred) or finished the work; in the latter case
+                    // we owe the terminal-status finalization that
+                    // handleSwapStatusUpdate skipped.
+                    if (
+                        !this.refundRetryTimers.has(swap.id) &&
+                        this.isFinalStatus(swap)
+                    ) {
+                        this.finalizeMonitoredSwap(swap);
+                    }
+                }
+            }, delayMs)
+        );
     }
 
     /**
@@ -931,11 +1024,44 @@ export class SwapManager implements SwapManagerClient {
                 } else if (isChainRefundableStatus(swap.status)) {
                     if (swap.request.from === "ARK") {
                         logger.log(`Auto-refunding ARK chain swap ${swap.id}`);
-                        await this.executeRefundArkAction(swap);
-                        // Emit action executed event to all listeners
-                        this.actionExecutedListeners.forEach((listener) =>
-                            listener(swap, "refundArk"),
-                        );
+                        // Boltz won't send another status update for an
+                        // already-`swap.expired` swap, so any failure to
+                        // sweep — partial outcome OR thrown error — must
+                        // schedule a local retry, otherwise the swap
+                        // would be dropped from monitoring with funds
+                        // still stranded. The inner try/catch keeps the
+                        // retry-scheduling logic out of the broader
+                        // `executeAutonomousAction` catch below, which
+                        // logs and emits but cannot reach the chain-
+                        // specific retry path.
+                        try {
+                            const outcome =
+                                await this.executeRefundArkAction(swap);
+                            if (outcome && outcome.skipped > 0) {
+                                logger.log(
+                                    `Chain swap ${swap.id}: ${outcome.skipped} VTXO(s) deferred — scheduling refund retry`
+                                );
+                                this.scheduleRefundRetry(
+                                    swap,
+                                    SwapManager.REFUND_RETRY_DELAY_MS
+                                );
+                            }
+                            this.actionExecutedListeners.forEach((listener) =>
+                                listener(swap, "refundArk")
+                            );
+                        } catch (error) {
+                            logger.error(
+                                `Auto-refunding ARK chain swap ${swap.id} failed; scheduling retry`,
+                                error
+                            );
+                            this.swapFailedListeners.forEach((listener) =>
+                                listener(swap, error as Error)
+                            );
+                            this.scheduleRefundRetry(
+                                swap,
+                                SwapManager.REFUND_RETRY_DELAY_MS
+                            );
+                        }
                     }
                     if (swap.request.from === "BTC") {
                         // BTC-side lockup refunds are handled on-chain by
@@ -1026,13 +1152,15 @@ export class SwapManager implements SwapManagerClient {
     /**
      * Execute refund action for chain swap Ark to Btc
      */
-    private async executeRefundArkAction(swap: BoltzChainSwap): Promise<void> {
+    private async executeRefundArkAction(
+        swap: BoltzChainSwap
+    ): Promise<ChainArkRefundOutcome | undefined> {
         if (!this.refundArkCallback) {
             logger.error("refundArk callback not set");
             return;
         }
 
-        await this.refundArkCallback(swap);
+        return this.refundArkCallback(swap);
     }
 
     /**
@@ -1266,6 +1394,11 @@ export class SwapManager implements SwapManagerClient {
         if (retryTimer) {
             clearTimeout(retryTimer);
             this.pollRetryTimers.delete(swap.id);
+        }
+        const refundRetryTimer = this.refundRetryTimers.get(swap.id);
+        if (refundRetryTimer) {
+            clearTimeout(refundRetryTimer);
+            this.refundRetryTimers.delete(swap.id);
         }
         this.notFoundCounts.delete(swap.id);
 

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -197,6 +197,18 @@ export interface SubmarineRefundOutcome {
     skipped: number;
 }
 
+/** Outcome of a single `refundArk` call: how many VTXOs were swept vs. deferred. */
+export interface ChainArkRefundOutcome {
+    /** Number of VTXOs successfully refunded. */
+    swept: number;
+    /**
+     * Number of VTXOs that could not be refunded yet (e.g. recoverable VTXO
+     * pre-CLTV, or Boltz rejected and CLTV still not satisfied). The caller
+     * is expected to retry these later.
+     */
+    skipped: number;
+}
+
 /** Per-swap outcome of a bulk recovery call. */
 export interface SubmarineRecoveryResult {
     /** ID of the swap whose VHTLC we attempted to refund. */

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3848,22 +3848,15 @@ describe("ArkadeSwaps", () => {
         beforeEach(() => {
             vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
             vi.mocked(wallet.getAddress).mockResolvedValue(mock.address.ark);
-            vi.spyOn(swaps, "createVHTLCScript").mockReturnValue(
-                mockVHTLC as any
-            );
+            vi.spyOn(swaps, "createVHTLCScript").mockReturnValue(mockVHTLC as any);
         });
 
         it("claims two unspent recoverable VTXOs via joinBatch", async () => {
-            const vtxos = [
-                recoverableVtxo(txidA, 0),
-                recoverableVtxo(txidB, 1),
-            ];
+            const vtxos = [recoverableVtxo(txidA, 0), recoverableVtxo(txidB, 1)];
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: vtxos as any,
             });
-            const joinBatchSpy = vi
-                .spyOn(swaps as any, "joinBatch")
-                .mockResolvedValue(undefined);
+            const joinBatchSpy = vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
 
             await swaps.claimVHTLC(buildPendingSwap());
 
@@ -3876,21 +3869,16 @@ describe("ArkadeSwaps", () => {
                 expect.objectContaining({
                     id: mock.id,
                     status: "transaction.claimed",
-                })
+                }),
             );
         });
 
         it("claims two unspent non-recoverable VTXOs via offchain tx and saves final status once", async () => {
-            const vtxos = [
-                nonRecoverableVtxo(txidA, 0),
-                nonRecoverableVtxo(txidB, 1),
-            ];
+            const vtxos = [nonRecoverableVtxo(txidA, 0), nonRecoverableVtxo(txidB, 1)];
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: vtxos as any,
             });
-            const joinBatchSpy = vi
-                .spyOn(swaps as any, "joinBatch")
-                .mockResolvedValue(undefined);
+            const joinBatchSpy = vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
             const swapStatusSpy = vi
                 .spyOn(swapProvider, "getSwapStatus")
                 .mockResolvedValue({ status: "transaction.confirmed" });
@@ -3908,21 +3896,16 @@ describe("ArkadeSwaps", () => {
                 expect.objectContaining({
                     id: mock.id,
                     status: "transaction.confirmed",
-                })
+                }),
             );
         });
 
         it("routes mixed recoverable and non-recoverable VTXOs to the correct branch", async () => {
-            const vtxos = [
-                recoverableVtxo(txidA, 0),
-                nonRecoverableVtxo(txidB, 1),
-            ];
+            const vtxos = [recoverableVtxo(txidA, 0), nonRecoverableVtxo(txidB, 1)];
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: vtxos as any,
             });
-            const joinBatchSpy = vi
-                .spyOn(swaps as any, "joinBatch")
-                .mockResolvedValue(undefined);
+            const joinBatchSpy = vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
             vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
                 status: "transaction.confirmed",
             });
@@ -3944,13 +3927,9 @@ describe("ArkadeSwaps", () => {
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: vtxos as any,
             });
-            const joinBatchSpy = vi
-                .spyOn(swaps as any, "joinBatch")
-                .mockResolvedValue(undefined);
+            const joinBatchSpy = vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
 
-            await expect(
-                swaps.claimVHTLC(buildPendingSwap())
-            ).resolves.toBeUndefined();
+            await expect(swaps.claimVHTLC(buildPendingSwap())).resolves.toBeUndefined();
             expect(joinBatchSpy).toHaveBeenCalledTimes(1);
             expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidB);
         });
@@ -3965,15 +3944,12 @@ describe("ArkadeSwaps", () => {
             });
 
             await expect(swaps.claimVHTLC(buildPendingSwap())).rejects.toThrow(
-                /VHTLC is already spent/
+                /VHTLC is already spent/,
             );
         });
 
         it("attempts every VTXO and aggregates failures into a single throw", async () => {
-            const vtxos = [
-                recoverableVtxo(txidA, 0),
-                recoverableVtxo(txidB, 1),
-            ];
+            const vtxos = [recoverableVtxo(txidA, 0), recoverableVtxo(txidB, 1)];
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: vtxos as any,
             });
@@ -3983,7 +3959,7 @@ describe("ArkadeSwaps", () => {
                 .mockRejectedValueOnce(new Error("join failed"));
 
             await expect(swaps.claimVHTLC(buildPendingSwap())).rejects.toThrow(
-                /failed to claim 1\/2 VTXOs/
+                /failed to claim 1\/2 VTXOs/,
             );
 
             // Both VTXOs were attempted — the failure on the second VTXO
@@ -3996,10 +3972,7 @@ describe("ArkadeSwaps", () => {
         });
 
         it("still attempts later VTXOs when the first fails", async () => {
-            const vtxos = [
-                recoverableVtxo(txidA, 0),
-                recoverableVtxo(txidB, 1),
-            ];
+            const vtxos = [recoverableVtxo(txidA, 0), recoverableVtxo(txidB, 1)];
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: vtxos as any,
             });
@@ -4009,7 +3982,7 @@ describe("ArkadeSwaps", () => {
                 .mockResolvedValueOnce(undefined);
 
             await expect(swaps.claimVHTLC(buildPendingSwap())).rejects.toThrow(
-                /failed to claim 1\/2 VTXOs/
+                /failed to claim 1\/2 VTXOs/,
             );
 
             expect(joinBatchSpy).toHaveBeenCalledTimes(2);
@@ -4020,10 +3993,7 @@ describe("ArkadeSwaps", () => {
         it("retries the indexer and claims every VTXO returned on the second attempt", async () => {
             vi.useFakeTimers();
             try {
-                const vtxos = [
-                    recoverableVtxo(txidA, 0),
-                    recoverableVtxo(txidB, 1),
-                ];
+                const vtxos = [recoverableVtxo(txidA, 0), recoverableVtxo(txidB, 1)];
                 vi.spyOn(indexerProvider, "getVtxos")
                     .mockResolvedValueOnce({ vtxos: [] })
                     .mockResolvedValueOnce({ vtxos: vtxos as any });
@@ -4099,12 +4069,10 @@ describe("ArkadeSwaps", () => {
                     refundScript: new Uint8Array([1]),
                     pkScript: new Uint8Array([2]),
                     refund: () => [{}, new Uint8Array([3]), 0xc0] as any,
-                    refundWithoutReceiver: () =>
-                        [{}, new Uint8Array([4]), 0xc0] as any,
+                    refundWithoutReceiver: () => [{}, new Uint8Array([4]), 0xc0] as any,
                     encode: () => [] as any,
                 } as any,
-                vhtlcAddress:
-                    mockArkBtcChainSwap.response.lockupDetails.lockupAddress,
+                vhtlcAddress: mockArkBtcChainSwap.response.lockupDetails.lockupAddress,
             });
             vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
             vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
@@ -4113,10 +4081,7 @@ describe("ArkadeSwaps", () => {
         });
 
         it("refunds two unspent VTXOs via joinBatch when CLTV is satisfied", async () => {
-            const vtxos = [
-                nonRecoverableVtxo(txidA, 0),
-                nonRecoverableVtxo(txidB, 1),
-            ];
+            const vtxos = [nonRecoverableVtxo(txidA, 0), nonRecoverableVtxo(txidB, 1)];
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: vtxos as any,
             });
@@ -4128,9 +4093,7 @@ describe("ArkadeSwaps", () => {
             expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidA);
             expect(joinBatchSpy.mock.calls[1][1].txid).toBe(txidB);
             // refundWithoutReceiver leaf (script byte 4) was used
-            expect(joinBatchSpy.mock.calls[0][1].tapLeafScript[1]).toEqual(
-                new Uint8Array([4])
-            );
+            expect(joinBatchSpy.mock.calls[0][1].tapLeafScript[1]).toEqual(new Uint8Array([4]));
             expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
             expect(outcome).toEqual({ swept: 2, skipped: 0 });
         });
@@ -4138,10 +4101,7 @@ describe("ArkadeSwaps", () => {
         it("calls Boltz refund for two non-recoverable VTXOs pre-CLTV, with a 2s delay between calls", async () => {
             vi.useFakeTimers();
             try {
-                const vtxos = [
-                    nonRecoverableVtxo(txidA, 0),
-                    nonRecoverableVtxo(txidB, 1),
-                ];
+                const vtxos = [nonRecoverableVtxo(txidA, 0), nonRecoverableVtxo(txidB, 1)];
                 vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                     vtxos: vtxos as any,
                 });
@@ -4165,10 +4125,7 @@ describe("ArkadeSwaps", () => {
         });
 
         it("skips recoverable VTXOs pre-CLTV without calling Boltz or joinBatch", async () => {
-            const vtxos = [
-                recoverableVtxo(txidA, 0),
-                recoverableVtxo(txidB, 1),
-            ];
+            const vtxos = [recoverableVtxo(txidA, 0), recoverableVtxo(txidB, 1)];
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: vtxos as any,
             });
@@ -4183,10 +4140,7 @@ describe("ArkadeSwaps", () => {
         it("still throttles the next Boltz call by 2s after a BoltzRefundError on the previous VTXO", async () => {
             vi.useFakeTimers();
             try {
-                const vtxos = [
-                    nonRecoverableVtxo(txidA, 0),
-                    nonRecoverableVtxo(txidB, 1),
-                ];
+                const vtxos = [nonRecoverableVtxo(txidA, 0), nonRecoverableVtxo(txidB, 1)];
                 vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                     vtxos: vtxos as any,
                 });
@@ -4197,9 +4151,7 @@ describe("ArkadeSwaps", () => {
                 // fire back-to-back with the first.
                 const mockRefund = vi.mocked(refundVHTLCwithOffchainTx);
                 mockRefund
-                    .mockRejectedValueOnce(
-                        new BoltzRefundError("outpoint mismatch")
-                    )
+                    .mockRejectedValueOnce(new BoltzRefundError("outpoint mismatch"))
                     .mockResolvedValueOnce(undefined);
 
                 const promise = swaps.refundArk(buildSwap(futureRefund()));
@@ -4231,7 +4183,7 @@ describe("ArkadeSwaps", () => {
             });
 
             vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
-                new BoltzRefundError("outpoint mismatch")
+                new BoltzRefundError("outpoint mismatch"),
             );
             // Pre-CLTV at the initial check, post-CLTV at the re-check.
             const dateSpy = vi.spyOn(Date, "now");
@@ -4243,9 +4195,7 @@ describe("ArkadeSwaps", () => {
             const joinBatchSpy = vi.mocked((swaps as any).joinBatch);
             expect(joinBatchSpy).toHaveBeenCalledTimes(1);
             // fallback uses refundWithoutReceiver leaf (script byte 4)
-            expect(joinBatchSpy.mock.calls[0][1].tapLeafScript[1]).toEqual(
-                new Uint8Array([4])
-            );
+            expect(joinBatchSpy.mock.calls[0][1].tapLeafScript[1]).toEqual(new Uint8Array([4]));
             expect(joinBatchSpy.mock.calls[0][4]).toBe(false);
             expect(outcome).toEqual({ swept: 1, skipped: 0 });
         });
@@ -4256,7 +4206,7 @@ describe("ArkadeSwaps", () => {
             });
 
             vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
-                new BoltzRefundError("outpoint mismatch")
+                new BoltzRefundError("outpoint mismatch"),
             );
 
             const outcome = await swaps.refundArk(buildSwap(futureRefund()));
@@ -4271,12 +4221,12 @@ describe("ArkadeSwaps", () => {
             });
 
             vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
-                new Error("local signing failure")
+                new Error("local signing failure"),
             );
 
-            await expect(
-                swaps.refundArk(buildSwap(futureRefund()))
-            ).rejects.toThrow(/local signing failure/);
+            await expect(swaps.refundArk(buildSwap(futureRefund()))).rejects.toThrow(
+                /local signing failure/,
+            );
         });
 
         it("throws 'VHTLC not found' when no VTXOs exist at the lockup address", async () => {
@@ -4284,9 +4234,9 @@ describe("ArkadeSwaps", () => {
                 vtxos: [],
             });
 
-            await expect(
-                swaps.refundArk(buildSwap(pastRefund()))
-            ).rejects.toThrow(/VHTLC not found/);
+            await expect(swaps.refundArk(buildSwap(pastRefund()))).rejects.toThrow(
+                /VHTLC not found/,
+            );
         });
 
         it("throws 'VHTLC is already spent' when every VTXO at the address is spent", async () => {
@@ -4297,9 +4247,9 @@ describe("ArkadeSwaps", () => {
                 ] as any,
             });
 
-            await expect(
-                swaps.refundArk(buildSwap(pastRefund()))
-            ).rejects.toThrow(/VHTLC is already spent/);
+            await expect(swaps.refundArk(buildSwap(pastRefund()))).rejects.toThrow(
+                /VHTLC is already spent/,
+            );
         });
     });
 });

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -34,6 +34,7 @@ import { ripemd160 } from "@noble/hashes/legacy.js";
 import { decodeInvoice } from "../src/utils/decoding";
 import { pubECDSA } from "@scure/btc-signer/utils.js";
 import {
+    claimVHTLCwithOffchainTx,
     createVHTLCScript as createVHTLCScriptReal,
     refundVHTLCwithOffchainTx,
 } from "../src/utils/vhtlc";
@@ -52,11 +53,13 @@ vi.mock("@arkade-os/sdk", async () => {
     };
 });
 
-// Mock vhtlc utils — passthrough except refundVHTLCwithOffchainTx
+// Mock vhtlc utils — passthrough except the offchain-tx helpers, which
+// touch real Ark protocol APIs we can't reach in unit tests.
 vi.mock("../src/utils/vhtlc", async () => {
     const actual = await vi.importActual<typeof import("../src/utils/vhtlc")>("../src/utils/vhtlc");
     return {
         ...actual,
+        claimVHTLCwithOffchainTx: vi.fn().mockResolvedValue(undefined),
         refundVHTLCwithOffchainTx: vi.fn().mockResolvedValue(undefined),
     };
 });
@@ -3789,6 +3792,466 @@ describe("ArkadeSwaps", () => {
                     timeoutBlockHeights: prodTimeouts,
                 }),
             ).not.toThrow();
+        });
+    });
+
+    describe("claimVHTLC — multi-VTXO iteration", () => {
+        const preimage = randomBytes(20);
+        const txidA = hex.encode(randomBytes(32));
+        const txidB = hex.encode(randomBytes(32));
+
+        const recoverableVtxo = (txid: string, vout: number) => ({
+            txid,
+            vout,
+            value: 50000,
+            status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+            virtualStatus: { state: "swept" as const },
+            isSpent: false,
+            isUnrolled: false,
+            createdAt: new Date(),
+        });
+
+        const nonRecoverableVtxo = (txid: string, vout: number) => ({
+            txid,
+            vout,
+            value: 50000,
+            status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+            virtualStatus: { state: "settled" as const },
+            isSpent: false,
+            isUnrolled: false,
+            createdAt: new Date(),
+        });
+
+        const mockVHTLC = {
+            vhtlcAddress: mock.lockupAddress,
+            vhtlcScript: {
+                claimScript: new Uint8Array([1]),
+                pkScript: new Uint8Array([2]),
+                claim: () => [{}, new Uint8Array([3]), 0xc0] as any,
+                encode: () => [] as any,
+            },
+        };
+
+        const buildPendingSwap = (): BoltzReverseSwap => ({
+            id: mock.id,
+            type: "reverse",
+            createdAt: Date.now(),
+            preimage: hex.encode(preimage),
+            request: createReverseSwapRequest,
+            response: {
+                ...createReverseSwapResponse,
+                lockupAddress: mockVHTLC.vhtlcAddress,
+            },
+            status: "swap.created",
+        });
+
+        beforeEach(() => {
+            vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+            vi.mocked(wallet.getAddress).mockResolvedValue(mock.address.ark);
+            vi.spyOn(swaps, "createVHTLCScript").mockReturnValue(
+                mockVHTLC as any
+            );
+        });
+
+        it("claims two unspent recoverable VTXOs via joinBatch", async () => {
+            const vtxos = [
+                recoverableVtxo(txidA, 0),
+                recoverableVtxo(txidB, 1),
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+            const joinBatchSpy = vi
+                .spyOn(swaps as any, "joinBatch")
+                .mockResolvedValue(undefined);
+
+            await swaps.claimVHTLC(buildPendingSwap());
+
+            expect(joinBatchSpy).toHaveBeenCalledTimes(2);
+            expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidA);
+            expect(joinBatchSpy.mock.calls[1][1].txid).toBe(txidB);
+            expect(claimVHTLCwithOffchainTx).not.toHaveBeenCalled();
+            expect(mockSwapRepository.saveSwap).toHaveBeenCalledTimes(1);
+            expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    id: mock.id,
+                    status: "transaction.claimed",
+                })
+            );
+        });
+
+        it("claims two unspent non-recoverable VTXOs via offchain tx and saves final status once", async () => {
+            const vtxos = [
+                nonRecoverableVtxo(txidA, 0),
+                nonRecoverableVtxo(txidB, 1),
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+            const joinBatchSpy = vi
+                .spyOn(swaps as any, "joinBatch")
+                .mockResolvedValue(undefined);
+            const swapStatusSpy = vi
+                .spyOn(swapProvider, "getSwapStatus")
+                .mockResolvedValue({ status: "transaction.confirmed" });
+
+            await swaps.claimVHTLC(buildPendingSwap());
+
+            const offchainSpy = vi.mocked(claimVHTLCwithOffchainTx);
+            expect(offchainSpy).toHaveBeenCalledTimes(2);
+            expect((offchainSpy.mock.calls[0][3] as any).txid).toBe(txidA);
+            expect((offchainSpy.mock.calls[1][3] as any).txid).toBe(txidB);
+            expect(joinBatchSpy).not.toHaveBeenCalled();
+            expect(swapStatusSpy).toHaveBeenCalledTimes(1);
+            expect(mockSwapRepository.saveSwap).toHaveBeenCalledTimes(1);
+            expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    id: mock.id,
+                    status: "transaction.confirmed",
+                })
+            );
+        });
+
+        it("routes mixed recoverable and non-recoverable VTXOs to the correct branch", async () => {
+            const vtxos = [
+                recoverableVtxo(txidA, 0),
+                nonRecoverableVtxo(txidB, 1),
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+            const joinBatchSpy = vi
+                .spyOn(swaps as any, "joinBatch")
+                .mockResolvedValue(undefined);
+            vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                status: "transaction.confirmed",
+            });
+
+            await swaps.claimVHTLC(buildPendingSwap());
+
+            expect(joinBatchSpy).toHaveBeenCalledTimes(1);
+            expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidA);
+            const offchainSpy = vi.mocked(claimVHTLCwithOffchainTx);
+            expect(offchainSpy).toHaveBeenCalledTimes(1);
+            expect((offchainSpy.mock.calls[0][3] as any).txid).toBe(txidB);
+        });
+
+        it("ignores spent VTXOs but still claims the unspent ones", async () => {
+            const vtxos = [
+                { ...recoverableVtxo(txidA, 0), isSpent: true },
+                recoverableVtxo(txidB, 1),
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+            const joinBatchSpy = vi
+                .spyOn(swaps as any, "joinBatch")
+                .mockResolvedValue(undefined);
+
+            await expect(
+                swaps.claimVHTLC(buildPendingSwap())
+            ).resolves.toBeUndefined();
+            expect(joinBatchSpy).toHaveBeenCalledTimes(1);
+            expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidB);
+        });
+
+        it("throws 'VHTLC is already spent' when every returned VTXO is spent", async () => {
+            const vtxos = [
+                { ...recoverableVtxo(txidA, 0), isSpent: true },
+                { ...recoverableVtxo(txidB, 1), isSpent: true },
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+
+            await expect(swaps.claimVHTLC(buildPendingSwap())).rejects.toThrow(
+                /VHTLC is already spent/
+            );
+        });
+
+        it("retries the indexer and claims every VTXO returned on the second attempt", async () => {
+            vi.useFakeTimers();
+            try {
+                const vtxos = [
+                    recoverableVtxo(txidA, 0),
+                    recoverableVtxo(txidB, 1),
+                ];
+                vi.spyOn(indexerProvider, "getVtxos")
+                    .mockResolvedValueOnce({ vtxos: [] })
+                    .mockResolvedValueOnce({ vtxos: vtxos as any });
+                const joinBatchSpy = vi
+                    .spyOn(swaps as any, "joinBatch")
+                    .mockResolvedValue(undefined);
+
+                const promise = swaps.claimVHTLC(buildPendingSwap());
+                promise.catch(() => {});
+                await vi.advanceTimersByTimeAsync(500);
+
+                await expect(promise).resolves.toBeUndefined();
+                expect(indexerProvider.getVtxos).toHaveBeenCalledTimes(2);
+                expect(joinBatchSpy).toHaveBeenCalledTimes(2);
+                expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidA);
+                expect(joinBatchSpy.mock.calls[1][1].txid).toBe(txidB);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
+
+    describe("refundArk — multi-VTXO iteration", () => {
+        const txidA = hex.encode(randomBytes(32));
+        const txidB = hex.encode(randomBytes(32));
+
+        const recoverableVtxo = (txid: string, vout: number) => ({
+            txid,
+            vout,
+            value: 50000,
+            status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+            virtualStatus: { state: "swept" as const },
+            isSpent: false,
+            isUnrolled: false,
+            createdAt: new Date(),
+        });
+
+        const nonRecoverableVtxo = (txid: string, vout: number) => ({
+            txid,
+            vout,
+            value: 50000,
+            status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+            virtualStatus: { state: "settled" as const },
+            isSpent: false,
+            isUnrolled: false,
+            createdAt: new Date(),
+        });
+
+        const pastRefund = () => Math.floor(Date.now() / 1000) - 1;
+        const futureRefund = () => Math.floor(Date.now() / 1000) + 86400;
+
+        const buildSwap = (refund: number): BoltzChainSwap => ({
+            ...mockArkBtcChainSwap,
+            response: {
+                ...mockArkBtcChainSwap.response,
+                lockupDetails: {
+                    ...mockArkBtcChainSwap.response.lockupDetails,
+                    timeouts: {
+                        refund,
+                        unilateralClaim: 21,
+                        unilateralRefund: 42,
+                        unilateralRefundWithoutReceiver: 63,
+                    },
+                },
+            },
+        });
+
+        beforeEach(() => {
+            vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+            vi.mocked(wallet.getAddress).mockResolvedValue(mock.address.ark);
+            vi.spyOn(swaps, "createVHTLCScript").mockReturnValue({
+                vhtlcScript: {
+                    refundScript: new Uint8Array([1]),
+                    pkScript: new Uint8Array([2]),
+                    refund: () => [{}, new Uint8Array([3]), 0xc0] as any,
+                    refundWithoutReceiver: () =>
+                        [{}, new Uint8Array([4]), 0xc0] as any,
+                    encode: () => [] as any,
+                } as any,
+                vhtlcAddress:
+                    mockArkBtcChainSwap.response.lockupDetails.lockupAddress,
+            });
+            vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
+            vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                status: "transaction.refunded",
+            });
+        });
+
+        it("refunds two unspent VTXOs via joinBatch when CLTV is satisfied", async () => {
+            const vtxos = [
+                nonRecoverableVtxo(txidA, 0),
+                nonRecoverableVtxo(txidB, 1),
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+
+            const outcome = await swaps.refundArk(buildSwap(pastRefund()));
+
+            const joinBatchSpy = vi.mocked((swaps as any).joinBatch);
+            expect(joinBatchSpy).toHaveBeenCalledTimes(2);
+            expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidA);
+            expect(joinBatchSpy.mock.calls[1][1].txid).toBe(txidB);
+            // refundWithoutReceiver leaf (script byte 4) was used
+            expect(joinBatchSpy.mock.calls[0][1].tapLeafScript[1]).toEqual(
+                new Uint8Array([4])
+            );
+            expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
+            expect(outcome).toEqual({ swept: 2, skipped: 0 });
+        });
+
+        it("calls Boltz refund for two non-recoverable VTXOs pre-CLTV, with a 2s delay between calls", async () => {
+            vi.useFakeTimers();
+            try {
+                const vtxos = [
+                    nonRecoverableVtxo(txidA, 0),
+                    nonRecoverableVtxo(txidB, 1),
+                ];
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                    vtxos: vtxos as any,
+                });
+
+                const promise = swaps.refundArk(buildSwap(futureRefund()));
+                promise.catch(() => {});
+
+                // Drive the 2s inter-Boltz-call sleep under fake timers.
+                await vi.runAllTimersAsync();
+
+                const outcome = await promise;
+                const mockRefund = vi.mocked(refundVHTLCwithOffchainTx);
+                expect(mockRefund).toHaveBeenCalledTimes(2);
+                expect((mockRefund.mock.calls[0][6] as any).txid).toBe(txidA);
+                expect((mockRefund.mock.calls[1][6] as any).txid).toBe(txidB);
+                expect((swaps as any).joinBatch).not.toHaveBeenCalled();
+                expect(outcome).toEqual({ swept: 2, skipped: 0 });
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("skips recoverable VTXOs pre-CLTV without calling Boltz or joinBatch", async () => {
+            const vtxos = [
+                recoverableVtxo(txidA, 0),
+                recoverableVtxo(txidB, 1),
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+
+            const outcome = await swaps.refundArk(buildSwap(futureRefund()));
+
+            expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
+            expect((swaps as any).joinBatch).not.toHaveBeenCalled();
+            expect(outcome).toEqual({ swept: 0, skipped: 2 });
+        });
+
+        it("still throttles the next Boltz call by 2s after a BoltzRefundError on the previous VTXO", async () => {
+            vi.useFakeTimers();
+            try {
+                const vtxos = [
+                    nonRecoverableVtxo(txidA, 0),
+                    nonRecoverableVtxo(txidB, 1),
+                ];
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                    vtxos: vtxos as any,
+                });
+
+                // First call throws (pre-CLTV skip), second resolves.
+                // Boltz rate-limit slots should be counted by attempt,
+                // not by success — without that, the second call would
+                // fire back-to-back with the first.
+                const mockRefund = vi.mocked(refundVHTLCwithOffchainTx);
+                mockRefund
+                    .mockRejectedValueOnce(
+                        new BoltzRefundError("outpoint mismatch")
+                    )
+                    .mockResolvedValueOnce(undefined);
+
+                const promise = swaps.refundArk(buildSwap(futureRefund()));
+                promise.catch(() => {});
+
+                // Drain microtasks so the first call lands.
+                await vi.advanceTimersByTimeAsync(0);
+                expect(mockRefund).toHaveBeenCalledTimes(1);
+
+                // Just under the throttle window — second call must wait.
+                await vi.advanceTimersByTimeAsync(1900);
+                expect(mockRefund).toHaveBeenCalledTimes(1);
+
+                // Past the 2s deadline → second call runs.
+                await vi.advanceTimersByTimeAsync(200);
+                expect(mockRefund).toHaveBeenCalledTimes(2);
+
+                const outcome = await promise;
+                expect(outcome).toEqual({ swept: 1, skipped: 1 });
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("falls back to joinBatch when Boltz rejects and CLTV passes during the catch", async () => {
+            const futureTs = Math.floor(Date.now() / 1000) + 86400;
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: [nonRecoverableVtxo(txidA, 0)] as any,
+            });
+
+            vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
+                new BoltzRefundError("outpoint mismatch")
+            );
+            // Pre-CLTV at the initial check, post-CLTV at the re-check.
+            const dateSpy = vi.spyOn(Date, "now");
+            dateSpy.mockReturnValueOnce((futureTs - 60) * 1000);
+            dateSpy.mockReturnValueOnce((futureTs + 60) * 1000);
+
+            const outcome = await swaps.refundArk(buildSwap(futureTs));
+
+            const joinBatchSpy = vi.mocked((swaps as any).joinBatch);
+            expect(joinBatchSpy).toHaveBeenCalledTimes(1);
+            // fallback uses refundWithoutReceiver leaf (script byte 4)
+            expect(joinBatchSpy.mock.calls[0][1].tapLeafScript[1]).toEqual(
+                new Uint8Array([4])
+            );
+            expect(joinBatchSpy.mock.calls[0][4]).toBe(false);
+            expect(outcome).toEqual({ swept: 1, skipped: 0 });
+        });
+
+        it("skips when Boltz rejects and CLTV still hasn't passed", async () => {
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: [nonRecoverableVtxo(txidA, 0)] as any,
+            });
+
+            vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
+                new BoltzRefundError("outpoint mismatch")
+            );
+
+            const outcome = await swaps.refundArk(buildSwap(futureRefund()));
+
+            expect((swaps as any).joinBatch).not.toHaveBeenCalled();
+            expect(outcome).toEqual({ swept: 0, skipped: 1 });
+        });
+
+        it("re-throws non-Boltz errors from the refund offchain tx", async () => {
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: [nonRecoverableVtxo(txidA, 0)] as any,
+            });
+
+            vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
+                new Error("local signing failure")
+            );
+
+            await expect(
+                swaps.refundArk(buildSwap(futureRefund()))
+            ).rejects.toThrow(/local signing failure/);
+        });
+
+        it("throws 'VHTLC not found' when no VTXOs exist at the lockup address", async () => {
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: [],
+            });
+
+            await expect(
+                swaps.refundArk(buildSwap(pastRefund()))
+            ).rejects.toThrow(/VHTLC not found/);
+        });
+
+        it("throws 'VHTLC is already spent' when every VTXO at the address is spent", async () => {
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: [
+                    { ...nonRecoverableVtxo(txidA, 0), isSpent: true },
+                    { ...nonRecoverableVtxo(txidB, 1), isSpent: true },
+                ] as any,
+            });
+
+            await expect(
+                swaps.refundArk(buildSwap(pastRefund()))
+            ).rejects.toThrow(/VHTLC is already spent/);
         });
     });
 });

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3969,6 +3969,54 @@ describe("ArkadeSwaps", () => {
             );
         });
 
+        it("attempts every VTXO and aggregates failures into a single throw", async () => {
+            const vtxos = [
+                recoverableVtxo(txidA, 0),
+                recoverableVtxo(txidB, 1),
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+            const joinBatchSpy = vi
+                .spyOn(swaps as any, "joinBatch")
+                .mockResolvedValueOnce(undefined)
+                .mockRejectedValueOnce(new Error("join failed"));
+
+            await expect(swaps.claimVHTLC(buildPendingSwap())).rejects.toThrow(
+                /failed to claim 1\/2 VTXOs/
+            );
+
+            // Both VTXOs were attempted — the failure on the second VTXO
+            // didn't short-circuit the loop.
+            expect(joinBatchSpy).toHaveBeenCalledTimes(2);
+            expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidA);
+            expect(joinBatchSpy.mock.calls[1][1].txid).toBe(txidB);
+            // Status is not saved on partial success (all-or-throw).
+            expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+        });
+
+        it("still attempts later VTXOs when the first fails", async () => {
+            const vtxos = [
+                recoverableVtxo(txidA, 0),
+                recoverableVtxo(txidB, 1),
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+            const joinBatchSpy = vi
+                .spyOn(swaps as any, "joinBatch")
+                .mockRejectedValueOnce(new Error("first failed"))
+                .mockResolvedValueOnce(undefined);
+
+            await expect(swaps.claimVHTLC(buildPendingSwap())).rejects.toThrow(
+                /failed to claim 1\/2 VTXOs/
+            );
+
+            expect(joinBatchSpy).toHaveBeenCalledTimes(2);
+            expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidA);
+            expect(joinBatchSpy.mock.calls[1][1].txid).toBe(txidB);
+        });
+
         it("retries the indexer and claims every VTXO returned on the second attempt", async () => {
             vi.useFakeTimers();
             try {

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3935,17 +3935,27 @@ describe("ArkadeSwaps", () => {
         });
 
         it("throws 'VHTLC is already spent' when every returned VTXO is spent", async () => {
-            const vtxos = [
-                { ...recoverableVtxo(txidA, 0), isSpent: true },
-                { ...recoverableVtxo(txidB, 1), isSpent: true },
-            ];
-            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
-                vtxos: vtxos as any,
-            });
+            vi.useFakeTimers();
+            try {
+                const vtxos = [
+                    { ...recoverableVtxo(txidA, 0), isSpent: true },
+                    { ...recoverableVtxo(txidB, 1), isSpent: true },
+                ];
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                    vtxos: vtxos as any,
+                });
 
-            await expect(swaps.claimVHTLC(buildPendingSwap())).rejects.toThrow(
-                /VHTLC is already spent/,
-            );
+                // an all-spent VHTLC has no actionable VTXO, so the claim
+                // retries (CLAIM_VTXO_RETRY_ATTEMPTS) before diagnosing it as
+                // already spent — advance past the retry delays
+                const promise = swaps.claimVHTLC(buildPendingSwap());
+                promise.catch(() => {});
+                await vi.advanceTimersByTimeAsync(1000);
+
+                await expect(promise).rejects.toThrow(/VHTLC is already spent/);
+            } finally {
+                vi.useRealTimers();
+            }
         });
 
         it("attempts every VTXO and aggregates failures into a single throw", async () => {

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -1436,9 +1436,7 @@ describe("SwapManager", () => {
         it("keeps the swap monitored and schedules a retry when refundArk reports skipped > 0", async () => {
             vi.useFakeTimers();
             try {
-                const refundArk = vi
-                    .fn()
-                    .mockResolvedValueOnce({ swept: 0, skipped: 2 });
+                const refundArk = vi.fn().mockResolvedValueOnce({ swept: 0, skipped: 2 });
                 const onSwapCompleted = vi.fn();
                 swapManager = new SwapManager(swapProvider, {
                     ...swapManagerConfig,
@@ -1448,12 +1446,10 @@ describe("SwapManager", () => {
                     makeCallbacks({
                         refundArk,
                         saveSwap: vi.fn(),
-                    })
+                    }),
                 );
 
-                await swapManager.start([
-                    { ...refundableChainSwap, status: "swap.created" },
-                ]);
+                await swapManager.start([{ ...refundableChainSwap, status: "swap.created" }]);
                 mockWebSocket.onopen();
                 await triggerSwapExpired();
 
@@ -1482,12 +1478,10 @@ describe("SwapManager", () => {
                     makeCallbacks({
                         refundArk,
                         saveSwap: vi.fn(),
-                    })
+                    }),
                 );
 
-                await swapManager.start([
-                    { ...refundableChainSwap, status: "swap.created" },
-                ]);
+                await swapManager.start([{ ...refundableChainSwap, status: "swap.created" }]);
                 mockWebSocket.onopen();
                 await triggerSwapExpired();
 
@@ -1518,12 +1512,10 @@ describe("SwapManager", () => {
                 makeCallbacks({
                     refundArk,
                     saveSwap: vi.fn(),
-                })
+                }),
             );
 
-            await swapManager.start([
-                { ...refundableChainSwap, status: "swap.created" },
-            ]);
+            await swapManager.start([{ ...refundableChainSwap, status: "swap.created" }]);
             mockWebSocket.onopen();
             await triggerSwapExpired();
 
@@ -1536,20 +1528,16 @@ describe("SwapManager", () => {
         it("clears the pending retry on stop()", async () => {
             vi.useFakeTimers();
             try {
-                const refundArk = vi
-                    .fn()
-                    .mockResolvedValueOnce({ swept: 0, skipped: 1 });
+                const refundArk = vi.fn().mockResolvedValueOnce({ swept: 0, skipped: 1 });
                 swapManager = new SwapManager(swapProvider, swapManagerConfig);
                 swapManager.setCallbacks(
                     makeCallbacks({
                         refundArk,
                         saveSwap: vi.fn(),
-                    })
+                    }),
                 );
 
-                await swapManager.start([
-                    { ...refundableChainSwap, status: "swap.created" },
-                ]);
+                await swapManager.start([{ ...refundableChainSwap, status: "swap.created" }]);
                 mockWebSocket.onopen();
                 await triggerSwapExpired();
 
@@ -1567,20 +1555,16 @@ describe("SwapManager", () => {
         it("clears the pending retry on removeSwap()", async () => {
             vi.useFakeTimers();
             try {
-                const refundArk = vi
-                    .fn()
-                    .mockResolvedValueOnce({ swept: 0, skipped: 1 });
+                const refundArk = vi.fn().mockResolvedValueOnce({ swept: 0, skipped: 1 });
                 swapManager = new SwapManager(swapProvider, swapManagerConfig);
                 swapManager.setCallbacks(
                     makeCallbacks({
                         refundArk,
                         saveSwap: vi.fn(),
-                    })
+                    }),
                 );
 
-                await swapManager.start([
-                    { ...refundableChainSwap, status: "swap.created" },
-                ]);
+                await swapManager.start([{ ...refundableChainSwap, status: "swap.created" }]);
                 mockWebSocket.onopen();
                 await triggerSwapExpired();
 
@@ -1612,12 +1596,10 @@ describe("SwapManager", () => {
                     makeCallbacks({
                         refundArk,
                         saveSwap: vi.fn(),
-                    })
+                    }),
                 );
 
-                await swapManager.start([
-                    { ...refundableChainSwap, status: "swap.created" },
-                ]);
+                await swapManager.start([{ ...refundableChainSwap, status: "swap.created" }]);
                 mockWebSocket.onopen();
                 await triggerSwapExpired();
 
@@ -1658,12 +1640,10 @@ describe("SwapManager", () => {
                     makeCallbacks({
                         refundArk,
                         saveSwap: vi.fn(),
-                    })
+                    }),
                 );
 
-                await swapManager.start([
-                    { ...refundableChainSwap, status: "swap.created" },
-                ]);
+                await swapManager.start([{ ...refundableChainSwap, status: "swap.created" }]);
                 mockWebSocket.onopen();
                 await triggerSwapExpired();
 

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -1391,4 +1391,249 @@ describe("SwapManager", () => {
             expect(onSwapFailed).not.toHaveBeenCalled();
         });
     });
+
+    describe("Chain refund partial-outcome retry", () => {
+        const refundableChainSwap: BoltzChainSwap = {
+            ...mockChainSwap,
+            status: "swap.expired",
+        };
+
+        const triggerSwapExpired = async () => {
+            const message = {
+                event: "update",
+                args: [
+                    {
+                        id: refundableChainSwap.id,
+                        status: "swap.expired",
+                    },
+                ],
+            };
+            await mockWebSocket.onmessage({
+                data: JSON.stringify(message),
+            });
+        };
+
+        it("keeps the swap monitored and schedules a retry when refundArk reports skipped > 0", async () => {
+            vi.useFakeTimers();
+            try {
+                const refundArk = vi
+                    .fn()
+                    .mockResolvedValueOnce({ swept: 0, skipped: 2 });
+                const onSwapCompleted = vi.fn();
+                swapManager = new SwapManager(swapProvider, {
+                    ...swapManagerConfig,
+                    events: { onSwapCompleted },
+                });
+                swapManager.setCallbacks(
+                    makeCallbacks({
+                        refundArk,
+                        saveSwap: vi.fn(),
+                    })
+                );
+
+                await swapManager.start([
+                    { ...refundableChainSwap, status: "swap.created" },
+                ]);
+                mockWebSocket.onopen();
+                await triggerSwapExpired();
+
+                expect(refundArk).toHaveBeenCalledTimes(1);
+                const stats = await swapManager.getStats();
+                expect(stats.monitoredSwaps).toBe(1);
+                expect(onSwapCompleted).not.toHaveBeenCalled();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("re-invokes refundArk after the retry delay until it sweeps the remaining VTXOs", async () => {
+            vi.useFakeTimers();
+            try {
+                const refundArk = vi
+                    .fn()
+                    .mockResolvedValueOnce({ swept: 0, skipped: 1 })
+                    .mockResolvedValueOnce({ swept: 1, skipped: 0 });
+                const onSwapCompleted = vi.fn();
+                swapManager = new SwapManager(swapProvider, {
+                    ...swapManagerConfig,
+                    events: { onSwapCompleted },
+                });
+                swapManager.setCallbacks(
+                    makeCallbacks({
+                        refundArk,
+                        saveSwap: vi.fn(),
+                    })
+                );
+
+                await swapManager.start([
+                    { ...refundableChainSwap, status: "swap.created" },
+                ]);
+                mockWebSocket.onopen();
+                await triggerSwapExpired();
+
+                // Advance just past the retry delay (60s). The retry callback
+                // then awaits refundArk and finalizes monitoring cleanup.
+                await vi.advanceTimersByTimeAsync(60_001);
+
+                expect(refundArk).toHaveBeenCalledTimes(2);
+                const stats = await swapManager.getStats();
+                expect(stats.monitoredSwaps).toBe(0);
+                expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("removes the swap immediately and emits completed when refundArk reports no skipped VTXOs", async () => {
+            const refundArk = vi.fn().mockResolvedValue({
+                swept: 1,
+                skipped: 0,
+            });
+            const onSwapCompleted = vi.fn();
+            swapManager = new SwapManager(swapProvider, {
+                ...swapManagerConfig,
+                events: { onSwapCompleted },
+            });
+            swapManager.setCallbacks(
+                makeCallbacks({
+                    refundArk,
+                    saveSwap: vi.fn(),
+                })
+            );
+
+            await swapManager.start([
+                { ...refundableChainSwap, status: "swap.created" },
+            ]);
+            mockWebSocket.onopen();
+            await triggerSwapExpired();
+
+            expect(refundArk).toHaveBeenCalledTimes(1);
+            const stats = await swapManager.getStats();
+            expect(stats.monitoredSwaps).toBe(0);
+            expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+        });
+
+        it("clears the pending retry on stop()", async () => {
+            vi.useFakeTimers();
+            try {
+                const refundArk = vi
+                    .fn()
+                    .mockResolvedValueOnce({ swept: 0, skipped: 1 });
+                swapManager = new SwapManager(swapProvider, swapManagerConfig);
+                swapManager.setCallbacks(
+                    makeCallbacks({
+                        refundArk,
+                        saveSwap: vi.fn(),
+                    })
+                );
+
+                await swapManager.start([
+                    { ...refundableChainSwap, status: "swap.created" },
+                ]);
+                mockWebSocket.onopen();
+                await triggerSwapExpired();
+
+                expect(refundArk).toHaveBeenCalledTimes(1);
+
+                await swapManager.stop();
+                // Past the retry deadline, no further refundArk calls land.
+                await vi.advanceTimersByTimeAsync(120_000);
+                expect(refundArk).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("keeps the swap monitored and schedules a retry when refundArk throws", async () => {
+            vi.useFakeTimers();
+            try {
+                const refundArk = vi
+                    .fn()
+                    .mockRejectedValueOnce(new Error("transient refund error"))
+                    .mockResolvedValueOnce({ swept: 1, skipped: 0 });
+                const onSwapCompleted = vi.fn();
+                const onSwapFailed = vi.fn();
+                swapManager = new SwapManager(swapProvider, {
+                    ...swapManagerConfig,
+                    events: { onSwapCompleted, onSwapFailed },
+                });
+                swapManager.setCallbacks(
+                    makeCallbacks({
+                        refundArk,
+                        saveSwap: vi.fn(),
+                    })
+                );
+
+                await swapManager.start([
+                    { ...refundableChainSwap, status: "swap.created" },
+                ]);
+                mockWebSocket.onopen();
+                await triggerSwapExpired();
+
+                // Throw on the initial attempt: emit swapFailed but keep
+                // the swap monitored — a transient refund failure must
+                // not drop funds.
+                expect(refundArk).toHaveBeenCalledTimes(1);
+                expect(onSwapFailed).toHaveBeenCalledTimes(1);
+                const statsAfterThrow = await swapManager.getStats();
+                expect(statsAfterThrow.monitoredSwaps).toBe(1);
+                expect(onSwapCompleted).not.toHaveBeenCalled();
+
+                await vi.advanceTimersByTimeAsync(60_001);
+
+                expect(refundArk).toHaveBeenCalledTimes(2);
+                const stats = await swapManager.getStats();
+                expect(stats.monitoredSwaps).toBe(0);
+                expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("re-schedules indefinitely while refundArk keeps throwing", async () => {
+            vi.useFakeTimers();
+            try {
+                const refundArk = vi
+                    .fn()
+                    .mockRejectedValueOnce(new Error("transient 1"))
+                    .mockRejectedValueOnce(new Error("transient 2"))
+                    .mockResolvedValueOnce({ swept: 1, skipped: 0 });
+                const onSwapCompleted = vi.fn();
+                swapManager = new SwapManager(swapProvider, {
+                    ...swapManagerConfig,
+                    events: { onSwapCompleted },
+                });
+                swapManager.setCallbacks(
+                    makeCallbacks({
+                        refundArk,
+                        saveSwap: vi.fn(),
+                    })
+                );
+
+                await swapManager.start([
+                    { ...refundableChainSwap, status: "swap.created" },
+                ]);
+                mockWebSocket.onopen();
+                await triggerSwapExpired();
+
+                // First throw → swap monitored, retry scheduled.
+                expect(refundArk).toHaveBeenCalledTimes(1);
+
+                // Second throw after the first retry delay → still monitored.
+                await vi.advanceTimersByTimeAsync(60_001);
+                expect(refundArk).toHaveBeenCalledTimes(2);
+                const statsAfterSecond = await swapManager.getStats();
+                expect(statsAfterSecond.monitoredSwaps).toBe(1);
+
+                // Third call succeeds → swap dropped + completion emitted.
+                await vi.advanceTimersByTimeAsync(60_001);
+                expect(refundArk).toHaveBeenCalledTimes(3);
+                const stats = await swapManager.getStats();
+                expect(stats.monitoredSwaps).toBe(0);
+                expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
 });

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -1413,6 +1413,26 @@ describe("SwapManager", () => {
             });
         };
 
+        beforeEach(() => {
+            // The WebSocket `onopen` handler schedules an initial poll that
+            // calls `global.fetch` via `getSwapStatus`. Stub it here so the
+            // suite never depends on a fetch mock leaked from another block
+            // (or hits the real network), keeping these tests order-
+            // independent. The swaps are `swap.expired` once monitored, so
+            // returning that status makes every poll a no-op.
+            global.fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ status: "swap.expired" }),
+                    headers: new Headers({ "content-length": "100" }),
+                } as Response),
+            );
+        });
+
+        afterEach(() => {
+            delete (global as { fetch?: unknown }).fetch;
+        });
+
         it("keeps the swap monitored and schedules a retry when refundArk reports skipped > 0", async () => {
             vi.useFakeTimers();
             try {

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -1544,6 +1544,37 @@ describe("SwapManager", () => {
             }
         });
 
+        it("clears the pending retry on removeSwap()", async () => {
+            vi.useFakeTimers();
+            try {
+                const refundArk = vi
+                    .fn()
+                    .mockResolvedValueOnce({ swept: 0, skipped: 1 });
+                swapManager = new SwapManager(swapProvider, swapManagerConfig);
+                swapManager.setCallbacks(
+                    makeCallbacks({
+                        refundArk,
+                        saveSwap: vi.fn(),
+                    })
+                );
+
+                await swapManager.start([
+                    { ...refundableChainSwap, status: "swap.created" },
+                ]);
+                mockWebSocket.onopen();
+                await triggerSwapExpired();
+
+                expect(refundArk).toHaveBeenCalledTimes(1);
+                await swapManager.removeSwap(refundableChainSwap.id);
+
+                await vi.advanceTimersByTimeAsync(120_000);
+                // Timer was cancelled — no second call.
+                expect(refundArk).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
         it("keeps the swap monitored and schedules a retry when refundArk throws", async () => {
             vi.useFakeTimers();
             try {


### PR DESCRIPTION
## Summary

Subtree pull of 3 upstream boltz-swap commits from the `m3m4-vhtlc-multi-vtxo` branch ([standalone repo](https://github.com/arkade-os/boltz-swap)):

- `dd19a41` — Iterate all VTXOs in claimVHTLC and refundArk
- `db90da2` — claimVHTLC: aggregate per-VTXO errors instead of short-circuit
- `4c2d5d6` — Address PR review on refundArk loop

### What changes

- `claimVHTLC` now iterates every unspent VTXO at the reverse-swap lockup script (recoverable→`joinBatch`, non-recoverable→offchain claim), aggregates per-VTXO errors into a single aggregate throw, and saves swap status only on full success (asymmetric with `refundArk` because the reverse-claim path is still receiving live Boltz status transitions).
- `refundArk` now processes every unspent VTXO at the chain-swap lockup, gates the path by CLTV (rechecked per-iteration), and returns a `ChainArkRefundOutcome = { swept, skipped }` propagated through `IArkadeSwaps`, `SwapManagerCallbacks`, the Expo wrapper, and the service-worker bridge.
- `SwapManager` keeps chain swaps monitored on partial / throwing outcomes and schedules a 60s retry; the retry timer is cleared on `removeSwap()` and `stop()`.
- Fixes Boltz throttle in `refundVHTLC` / `refundArk` to count attempts so the 2s gap also applies after a `BoltzRefundError`.

### Conflict resolution

- Took the m3m4 versions of `arkade-swaps.ts` and `swap-manager.ts` wholesale, then reformatted to monorepo prettier (`printWidth: 100`, `trailingComma: "all"`).
- Auto-merged files (`expo/arkade-lightning.ts`, `serviceWorker/arkade-swaps-{message-handler,runtime}.ts`, `types.ts`, both test files) kept monorepo-specific changes (notably the `getRandomId` dedupe from `bf5a5137`).

## Test plan

- [x] `pnpm -C packages/boltz-swap typecheck` — passes
- [x] `pnpm -C packages/boltz-swap test:unit` — 361/361 tests pass (including new multi-VTXO suites in `arkade-swaps.test.ts` and refund-retry suites in `swap-manager.test.ts`)
- [x] `pnpm run lint` — clean
- [x] `pnpm run test:integration:boltz-swap` (regtest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refunds now return structured outcome data (swept vs skipped) and are surfaced end-to-end (including background worker).
  * Partial refunds are automatically retried with delayed backoff; monitoring persists across retries and shutdown/remove.
  * Claim and refund flows now iterate multiple outputs, improving success rates, throttling offchain attempts, and aggregating per-output errors.
* **Tests**
  * Added comprehensive tests for multi-output paths, throttling, fallbacks, retry scheduling and monitoring behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->