### PR TITLE
chore: override @ungap/structured-clone to >=1.3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   esbuild: '>=0.25.0'
   brace-expansion: ^2.0.2
   minimatch: 9.0.3
+  '@ungap/structured-clone': '>=1.3.1'
 
 importers:
 
@@ -1540,9 +1541,8 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -5340,7 +5340,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@ungap/structured-clone@1.3.0': {}
+  '@ungap/structured-clone@1.3.1': {}
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.3.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
@@ -6054,7 +6054,7 @@ snapshots:
       '@expo/metro': 54.2.0
       '@expo/metro-config': 55.0.9(expo@55.0.4)(typescript@5.9.2)
       '@expo/vector-icons': 15.1.1(expo-font@55.0.4(expo@55.0.4)(react-native@0.84.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4)
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       babel-preset-expo: 55.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@55.0.4)(react-refresh@0.14.2)
       expo-asset: 55.0.8(expo@55.0.4)(react-native@0.84.1(@babel/core@7.29.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.2)
       expo-constants: 55.0.7(expo@55.0.4)(react-native@0.84.1(@babel/core@7.29.0)(react@19.2.4))(typescript@5.9.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ overrides:
   esbuild: ">=0.25.0"
   brace-expansion: ^2.0.2
   minimatch: 9.0.3
+  "@ungap/structured-clone": ">=1.3.1"
 
 onlyBuiltDependencies:
   - better-sqlite3


### PR DESCRIPTION
## Summary

Adds a pnpm override pinning `@ungap/structured-clone` to `>=1.3.1`. The 1.3.0 release is flagged with [CWE-502](https://cwe.mitre.org/data/definitions/502.html) (deserialization of untrusted data); 1.3.1 is the safe patch. Pulled in transitively via `expo`.

## Changes

- `pnpm-workspace.yaml`: add the override entry
- `pnpm-lock.yaml`: regenerated — now resolves `@ungap/structured-clone@1.3.1`

Closes #497.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm run lint` + `pnpm run test:unit` pass via pre-commit hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to require a specific minimum dependency version for enhanced compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->