### PR TITLE
chore: deprecate URL string args in wallet config

### DIFF
--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -67,11 +67,24 @@ export type WalletMode = "auto" | "static" | "hd" | DescriptorProvider;
  * @see StorageConfig
  */
 export interface BaseWalletConfig {
-    /** Base URL of the Arkade server. */
+    /**
+     * Base URL of the Arkade server.
+     *
+     * @deprecated Pass an explicit `arkProvider` instance instead. URL-based
+     * configuration will be removed in a future major version.
+     */
     arkServerUrl?: string;
-    /** Optional override for the indexer URL. */
+    /**
+     * Optional override for the indexer URL.
+     *
+     * @deprecated Pass an explicit `indexerProvider` instance instead.
+     */
     indexerUrl?: string;
-    /** Optional override for the Esplora API URL. */
+    /**
+     * Optional override for the Esplora API URL.
+     *
+     * @deprecated Pass an explicit `onchainProvider` instance instead.
+     */
     esploraUrl?: string;
 
     /** Optional Arkade server public key used to construct and validate Arkade addresses. */

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -321,11 +321,24 @@ class ServiceWorkerAssetManager extends ServiceWorkerReadonlyAssetManager implem
 interface ServiceWorkerWalletOptions {
     /** Optional Arkade server public key used to construct and validate Arkade addresses. */
     arkServerPublicKey?: string;
-    /** Base URL of the Arkade server. */
+    /**
+     * Base URL of the Arkade server.
+     *
+     * @deprecated Provide an explicit provider via the worker config instead.
+     * URL-based configuration will be removed in a future major version.
+     */
     arkServerUrl?: string;
-    /** Optional override for the indexer URL. */
+    /**
+     * Optional override for the indexer URL.
+     *
+     * @deprecated Provide an explicit provider via the worker config instead.
+     */
     indexerUrl?: string;
-    /** Optional override for the Esplora API URL. */
+    /**
+     * Optional override for the Esplora API URL.
+     *
+     * @deprecated Provide an explicit provider via the worker config instead.
+     */
     esploraUrl?: string;
     /**
      * Repository-backed storage configuration overrides.
@@ -334,7 +347,11 @@ interface ServiceWorkerWalletOptions {
     storage?: StorageConfig;
     /** Identity used to derive addresses and optionally sign operations. */
     identity: ReadonlyIdentity | Identity;
-    /** Optional delegation service URL. */
+    /**
+     * Optional delegation service URL.
+     *
+     * @deprecated Provide an explicit `DelegatorProvider` instance instead.
+     */
     delegatorUrl?: string;
     /**
      * Override the default tag used for messages sent to and received from the service worker.


### PR DESCRIPTION
## Summary

Marks the URL-string fields on wallet config as `@deprecated` in favour of explicit provider instances. Runtime behaviour is unchanged — the URLs still construct the default providers internally — so this is non-breaking and existing integrations keep working.

## Changes

- `BaseWalletConfig.arkServerUrl` / `indexerUrl` / `esploraUrl` — point callers at `arkProvider` / `indexerProvider` / `onchainProvider`.
- `ServiceWorkerWalletOptions` — same three fields plus `delegatorUrl` (recommend explicit `DelegatorProvider`).

Refs #466 (decision confirmed by @gringokiwi in the issue thread).

## Out of scope

- TypeDoc / API-reference rebuild — handled separately per the issue.
- Eventual removal in a future major version.
- Issue #342 (expose `notifyIncomingFunds` on the interface) is a separate follow-up — adding it to `IReadonlyWallet` requires wiring it through the ServiceWorker message bus and is not a one-liner.

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm -C packages/ts-sdk exec tsc --noEmit` clean
- [x] `pnpm run test:unit` pass (via pre-commit hook)