### PR TITLE
feat(vtxo-manager): per-call threshold on renewVtxos

### DIFF
--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -85,7 +85,7 @@ import { SignerSession, TreeNonces, TreePartialSigs } from "./tree/signingSessio
 import { DustChangeError, Ramps } from "./wallet/ramps";
 import { HDDescriptorProvider } from "./wallet/hdDescriptorProvider";
 import { isVtxoExpiringSoon, VtxoManager } from "./wallet/vtxo-manager";
-import type { IVtxoManager, SettlementConfig } from "./wallet/vtxo-manager";
+import type { IVtxoManager, RenewVtxosOptions, SettlementConfig } from "./wallet/vtxo-manager";
 import {
     ServiceWorkerWallet,
     ServiceWorkerReadonlyWallet,
@@ -547,6 +547,7 @@ export type {
     GetVtxosFilter,
     SettlementConfig,
     IVtxoManager,
+    RenewVtxosOptions,
 
     // Asset types
     IReadonlyAssetManager,

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -36,6 +36,7 @@ import {
 } from "../index";
 import { DelegateInfo } from "../../providers/delegate";
 import { ReadonlyWallet, Wallet } from "../wallet";
+import type { RenewVtxosOptions } from "../vtxo-manager";
 import { extendCoin } from "../utils";
 import { MessageHandler, RequestEnvelope, ResponseEnvelope } from "../../worker/messageBus";
 import { Transaction } from "../../utils/transaction";
@@ -473,6 +474,7 @@ export type ResponseGetExpiringVtxos = ResponseEnvelope & {
 
 export type RequestRenewVtxos = RequestEnvelope & {
     type: "RENEW_VTXOS";
+    payload?: RenewVtxosOptions;
 };
 export type ResponseRenewVtxos = ResponseEnvelope & {
     type: "RENEW_VTXOS_SUCCESS";
@@ -1055,7 +1057,7 @@ export class WalletMessageHandler
                                 payload: e,
                             }),
                         );
-                    });
+                    }, message.payload);
                     return this.tagged({
                         id,
                         type: "RENEW_VTXOS_SUCCESS",

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -128,7 +128,7 @@ import type {
 } from "../../contracts/contractManager";
 import type { ContractState } from "../../contracts/types";
 import type { IDelegateManager } from "../delegate";
-import type { IVtxoManager, SettlementConfig } from "../vtxo-manager";
+import type { IVtxoManager, RenewVtxosOptions, SettlementConfig } from "../vtxo-manager";
 import type { ContractWatcherConfig } from "../../contracts/contractWatcher";
 import type { DelegateInfo } from "../../providers/delegate";
 import { getRandomId } from "../utils";
@@ -1659,11 +1659,15 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
                 }
             },
 
-            async renewVtxos(eventCallback?: (event: SettlementEvent) => void): Promise<string> {
+            async renewVtxos(
+                eventCallback?: (event: SettlementEvent) => void,
+                options?: RenewVtxosOptions,
+            ): Promise<string> {
                 const message: RequestRenewVtxos = {
                     tag: messageTag,
                     type: "RENEW_VTXOS",
                     id: getRandomId(),
+                    payload: options,
                 };
                 try {
                     const response = await wallet.sendMessageWithEvents(

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -379,6 +379,20 @@ export function getExpiringAndRecoverableVtxos(
 }
 
 /**
+ * Optional arguments for {@link IVtxoManager.renewVtxos}.
+ */
+export interface RenewVtxosOptions {
+    /**
+     * Override the renewal threshold for this call only, in seconds.
+     *
+     * When provided, takes precedence over `SettlementConfig.vtxoThreshold`
+     * and the default (3 days). Useful for renewing only VTXOs that are
+     * more urgently expiring than the globally configured threshold.
+     */
+    thresholdSeconds?: number;
+}
+
+/**
  * VtxoManager is a unified class for managing virtual output lifecycle operations including
  * recovery of swept/expired virtual outputs and renewal to prevent expiration.
  *
@@ -435,7 +449,10 @@ export interface IVtxoManager {
 
     getExpiringVtxos(thresholdMs?: number): Promise<ExtendedVirtualCoin[]>;
 
-    renewVtxos(eventCallback?: (event: SettlementEvent) => void): Promise<string>;
+    renewVtxos(
+        eventCallback?: (event: SettlementEvent) => void,
+        options?: RenewVtxosOptions,
+    ): Promise<string>;
 
     getExpiredBoardingUtxos(): Promise<ExtendedCoin[]>;
 
@@ -689,6 +706,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * primary way to prevent virtual outputs from expiring.
      *
      * @param eventCallback - Optional callback for settlement events
+     * @param options - Optional per-call overrides; see {@link RenewVtxosOptions}
      * @returns Settlement transaction ID
      * @throws Error if no virtual outputs available to renew
      * @throws Error if total amount is below dust threshold
@@ -704,9 +722,15 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * const txid = await manager.renewVtxos((event) => {
      *   console.log('Settlement event:', event.type);
      * });
+     *
+     * // Renew only VTXOs that expire within 6 hours
+     * const txid = await manager.renewVtxos(undefined, { thresholdSeconds: 6 * 60 * 60 });
      * ```
      */
-    async renewVtxos(eventCallback?: (event: SettlementEvent) => void): Promise<string> {
+    async renewVtxos(
+        eventCallback?: (event: SettlementEvent) => void,
+        options?: RenewVtxosOptions,
+    ): Promise<string> {
         if (this.renewalInProgress) {
             throw new Error("Renewal already in progress");
         }
@@ -715,12 +739,19 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         try {
             // Get all virtual outputs (including recoverable ones)
-            // Use default threshold to bypass settlementConfig gate (manual API should always work)
-            const threshold =
+            // Resolution order: explicit options.thresholdSeconds > settlementConfig.vtxoThreshold > default.
+            // Manual API should always work, so we bypass the settlementConfig === false gate.
+            let threshold: number;
+            if (options?.thresholdSeconds !== undefined) {
+                threshold = options.thresholdSeconds * 1000;
+            } else if (
                 this.settlementConfig !== false &&
                 this.settlementConfig?.vtxoThreshold !== undefined
-                    ? this.settlementConfig.vtxoThreshold * 1000
-                    : DEFAULT_RENEWAL_CONFIG.thresholdMs;
+            ) {
+                threshold = this.settlementConfig.vtxoThreshold * 1000;
+            } else {
+                threshold = DEFAULT_RENEWAL_CONFIG.thresholdMs;
+            }
             let vtxos = await this.getExpiringVtxos(threshold);
 
             if (vtxos.length === 0) {

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -731,6 +731,25 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         eventCallback?: (event: SettlementEvent) => void,
         options?: RenewVtxosOptions,
     ): Promise<string> {
+        // Validate the per-call override before touching any state. The payload
+        // can arrive over the worker MessageBus, so `thresholdSeconds` is not
+        // guaranteed to be a number at runtime despite its type. Reject
+        // NaN/Infinity/non-positive values, which would otherwise corrupt the
+        // expiry threshold (and a 0/<=100ms threshold silently reverts to the
+        // 3-day default via the guard in isVtxoExpiringSoon).
+        if (options?.thresholdSeconds !== undefined) {
+            const { thresholdSeconds } = options;
+            if (
+                typeof thresholdSeconds !== "number" ||
+                !Number.isFinite(thresholdSeconds) ||
+                thresholdSeconds <= 0
+            ) {
+                throw new TypeError(
+                    `Invalid thresholdSeconds: expected a positive finite number, got ${String(thresholdSeconds)}`,
+                );
+            }
+        }
+
         if (this.renewalInProgress) {
             throw new Error("Renewal already in progress");
         }

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -854,6 +854,32 @@ describe("WalletMessageHandler handleMessage", () => {
         });
     });
 
+    it("handles RENEW_VTXOS messages with a thresholdSeconds payload", async () => {
+        const thresholdSeconds = 3600;
+        const vtxoManager = {
+            renewVtxos: vi.fn().mockResolvedValue("renew-txid"),
+        };
+        (updater as any).readonlyWallet = {};
+        (updater as any).wallet = {
+            getVtxoManager: vi.fn().mockResolvedValue(vtxoManager),
+        };
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "RENEW_VTXOS",
+            payload: { thresholdSeconds },
+        } as any);
+
+        expect(vtxoManager.renewVtxos).toHaveBeenCalledWith(expect.any(Function), {
+            thresholdSeconds,
+        });
+        expect(response).toMatchObject({
+            tag: updater.messageTag,
+            type: "RENEW_VTXOS_SUCCESS",
+            payload: { txid: "renew-txid" },
+        });
+    });
+
     it("RENEW_VTXOS forwards settlement events via tick", async () => {
         const event = { type: "batch_finalized", id: "b2" };
         const vtxoManager = {

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -846,7 +846,7 @@ describe("WalletMessageHandler handleMessage", () => {
             type: "RENEW_VTXOS",
         } as any);
 
-        expect(vtxoManager.renewVtxos).toHaveBeenCalledWith(expect.any(Function));
+        expect(vtxoManager.renewVtxos).toHaveBeenCalledWith(expect.any(Function), undefined);
         expect(response).toMatchObject({
             tag: updater.messageTag,
             type: "RENEW_VTXOS_SUCCESS",


### PR DESCRIPTION
## Summary

`IVtxoManager.renewVtxos()` now accepts an optional `{ thresholdSeconds }` second argument that overrides the renewal threshold for that call only. Useful when a caller wants to renew only VTXOs that are more urgently expiring than the globally-configured `SettlementConfig.vtxoThreshold`.

Resolution order:

1. `options.thresholdSeconds` (new)
2. `SettlementConfig.vtxoThreshold`
3. `DEFAULT_THRESHOLD_SECONDS` (3 days)

The new option is propagated through the ServiceWorker message bus.

Closes #388.

## Changes

- `src/wallet/vtxo-manager.ts`: new `RenewVtxosOptions` type; updated `IVtxoManager.renewVtxos` + `VtxoManager.renewVtxos`.
- `src/wallet/serviceWorker/wallet-message-handler.ts`: `RequestRenewVtxos` carries optional payload; handler forwards it.
- `src/wallet/serviceWorker/wallet.ts`: SW `VtxoManager` proxy forwards options in the message.
- `src/index.ts`: re-exports `RenewVtxosOptions`.
- `test/wallet-message-handler.test.ts`: assertion updated for the new arg.

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm -C packages/ts-sdk exec tsc --noEmit` clean
- [x] `pnpm run test:unit` — 1228/1228 pass (1 pre-existing skip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-call renewal threshold override: you can now pass an optional threshold when triggering VTXO renewal to customize behavior without changing global settings.

* **Bug Fixes**
  * Service-worker request/handling updated to forward optional renewal options correctly.
  * Invalid threshold values now raise a clear error instead of proceeding silently.

* **Tests**
  * Coverage added for optional threshold payload and call signatures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->