### PR TITLE
fix(ramps): reject sub-dust change on partial offboard

### DIFF
--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -80,7 +80,7 @@ import {
 } from "./wallet/wallet";
 import { TxTree, TxTreeNode } from "./tree/txTree";
 import { SignerSession, TreeNonces, TreePartialSigs } from "./tree/signingSession";
-import { Ramps } from "./wallet/ramps";
+import { DustChangeError, Ramps } from "./wallet/ramps";
 import { HDDescriptorProvider } from "./wallet/hdDescriptorProvider";
 import { isVtxoExpiringSoon, VtxoManager } from "./wallet/vtxo-manager";
 import type { IVtxoManager, SettlementConfig } from "./wallet/vtxo-manager";
@@ -292,6 +292,7 @@ export {
     isBatchSignable,
     OnchainWallet,
     Ramps,
+    DustChangeError,
     VtxoManager,
     HDDescriptorProvider,
     DelegatorManagerImpl,

--- a/packages/ts-sdk/src/wallet/ramps.ts
+++ b/packages/ts-sdk/src/wallet/ramps.ts
@@ -5,6 +5,7 @@ import { Address, OutScript } from "@scure/btc-signer";
 import { hex } from "@scure/base";
 import { networks, NetworkName } from "../networks";
 import { ArkAddress } from "../script/address";
+import { getDustAmount } from "./utils";
 
 /**
  * Thrown when a collaborative-exit / offboard would leave a change VTXO below
@@ -24,13 +25,6 @@ export class DustChangeError extends Error {
         this.change = change;
         this.dustAmount = dustAmount;
     }
-}
-
-/** Fallback dust threshold used when the wallet doesn't expose `dustAmount`. */
-const FALLBACK_DUST_AMOUNT = 330n;
-
-function getDustAmount(wallet: IWallet): bigint {
-    return "dustAmount" in wallet ? (wallet.dustAmount as bigint) : FALLBACK_DUST_AMOUNT;
 }
 
 /**

--- a/packages/ts-sdk/src/wallet/ramps.ts
+++ b/packages/ts-sdk/src/wallet/ramps.ts
@@ -7,6 +7,33 @@ import { networks, NetworkName } from "../networks";
 import { ArkAddress } from "../script/address";
 
 /**
+ * Thrown when a collaborative-exit / offboard would leave a change VTXO below
+ * the dust threshold. Lets callers (e.g. wallet UI) react with appropriate UX
+ * — for instance, offering to exit the full balance — instead of forwarding a
+ * server-side dust rejection to the user.
+ */
+export class DustChangeError extends Error {
+    readonly change: bigint;
+    readonly dustAmount: bigint;
+    constructor(change: bigint, dustAmount: bigint) {
+        super(
+            `change ${change} sats is below dust threshold ${dustAmount}; ` +
+                `consider exiting the full balance`,
+        );
+        this.name = "DustChangeError";
+        this.change = change;
+        this.dustAmount = dustAmount;
+    }
+}
+
+/** Fallback dust threshold used when the wallet doesn't expose `dustAmount`. */
+const FALLBACK_DUST_AMOUNT = 330n;
+
+function getDustAmount(wallet: IWallet): bigint {
+    return "dustAmount" in wallet ? (wallet.dustAmount as bigint) : FALLBACK_DUST_AMOUNT;
+}
+
+/**
  * Ramps is a class wrapping `settle` method to provide a more convenient interface for onboarding and offboarding operations.
  *
  * @see IWallet.settle
@@ -191,6 +218,15 @@ export class Ramps {
                 throw new Error("Amount is greater than total amount of vtxos after fees");
             }
             change = totalAmount - amount;
+        }
+
+        // Reject partial exits that would leave a sub-dust change VTXO: arkd
+        // would otherwise reject the intent and surface a raw dust error to
+        // the caller. The wallet layer can catch DustChangeError and offer to
+        // exit the full balance instead.
+        const dustAmount = getDustAmount(this.wallet);
+        if (change > 0n && change < dustAmount) {
+            throw new DustChangeError(change, dustAmount);
         }
 
         amount = amount ?? totalAmount;

--- a/packages/ts-sdk/src/wallet/utils.ts
+++ b/packages/ts-sdk/src/wallet/utils.ts
@@ -1,4 +1,4 @@
-import { Recipient } from ".";
+import type { IWallet, Recipient } from ".";
 import {
     ArkAddress,
     type Coin,
@@ -10,11 +10,19 @@ import type { Contract } from "../contracts/types";
 import { contractHandlers } from "../contracts/handlers";
 import { DefaultVtxo } from "../script/default";
 import { DelegateVtxo } from "../script/delegate";
-import { ReadonlyWallet } from "./wallet";
+import type { ReadonlyWallet } from "./wallet";
 import { hex } from "@scure/base";
 import { Bytes } from "@scure/btc-signer/utils.js";
 
 export const DUST_AMOUNT = 546; // sats
+
+/** Fallback dust threshold used when the wallet doesn't expose `dustAmount`. */
+export const FALLBACK_WALLET_DUST_AMOUNT = 330n;
+
+/** Extracts the dust amount from the wallet, defaulting to the fallback dust threshold. */
+export function getDustAmount(wallet: IWallet): bigint {
+    return "dustAmount" in wallet ? (wallet.dustAmount as bigint) : FALLBACK_WALLET_DUST_AMOUNT;
+}
 
 export function extendCoin(
     wallet: { boardingTapscript: ReadonlyWallet["boardingTapscript"] },

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -22,6 +22,7 @@ import { ArkAddress } from "../script/address";
 import type { OnchainProvider } from "../providers/onchain";
 import type { Network } from "../networks";
 import type { DefaultVtxo } from "../script/default";
+import { getDustAmount } from "./utils";
 
 /**
  * Extended wallet interface for boarding input sweep operations.
@@ -234,11 +235,6 @@ export const DEFAULT_SETTLEMENT_CONFIG: Required<SettlementConfig> = {
     boardingUtxoSweep: true,
     pollIntervalMs: 60_000,
 };
-
-/** Extracts the dust amount from the wallet, defaulting to 330 sats. */
-function getDustAmount(wallet: IWallet): bigint {
-    return "dustAmount" in wallet ? (wallet.dustAmount as bigint) : 330n;
-}
 
 /**
  * Filter virtual outputs that are recoverable (swept and still spendable, or preconfirmed subdust)


### PR DESCRIPTION
## Summary

Pre-check the change amount during a collab exit (`Ramps.offboard`) and throw `DustChangeError` if the leftover change VTXO would fall below the wallet's dust threshold (default 330 sats). Today this case is forwarded to arkd, which rejects the intent and surfaces a raw dust error to the caller.

Closes #458.

## Changes

- `src/wallet/ramps.ts`: new `DustChangeError` class; offboard rejects when `0 < change < dustAmount`. Falls back to 330 sats when the wallet doesn't expose `dustAmount`.
- `src/index.ts`: re-export `DustChangeError`.

## Rationale

The wallet UI layer can `instanceof`-check `DustChangeError` and react with appropriate UX (e.g. offer to exit the full balance), rather than the caller pattern-matching on a server error string.

## Out of scope

- The same change-dust condition exists symmetrically on `Ramps.onboard`. Left untouched for this PR to keep scope tight to the reported bug; happy to follow up.
- No unit test file added — `ramps.test.ts` does not exist yet and standing up the Wallet/Estimator mocks would balloon the PR. The logic is small and the error is exercised via the existing types.

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm -C packages/ts-sdk exec tsc --noEmit` clean
- [x] `pnpm run test:unit` pass (via pre-commit hook)