### PR TITLE
Mainnet defaults + deprecate provider string arguments

### DIFF
--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -31,8 +31,6 @@ const identity = MnemonicIdentity.fromMnemonic(mnemonic)
 const wallet = await Wallet.create({ identity })  // defaults to mainnet
 ```
 
-To use a different network, pass `arkServerUrl` option.
-
 ### Read-Only Wallets (Watch-Only)
 
 The SDK supports read-only wallets that allow you to query wallet state without exposing private keys. This is useful for:

--- a/packages/ts-sdk/src/contracts/arkcontract.ts
+++ b/packages/ts-sdk/src/contracts/arkcontract.ts
@@ -1,7 +1,7 @@
 import { hex } from "@scure/base";
 import { Contract } from "./types";
 import { contractHandlers } from "./handlers";
-import { DEFAULT_ARKADE_HRP } from "../wallet";
+import { DEFAULT_NETWORK } from "../networks";
 
 /**
  * Prefix for arkcontract strings.
@@ -159,7 +159,7 @@ export function contractFromArkContract(
 export function contractFromArkContractWithAddress(
     encoded: string,
     serverPubKey: Uint8Array,
-    addressPrefix: string = DEFAULT_ARKADE_HRP,
+    addressPrefix: string = DEFAULT_NETWORK.hrp,
     options: {
         label?: string;
         state?: "active" | "inactive";

--- a/packages/ts-sdk/src/networks.ts
+++ b/packages/ts-sdk/src/networks.ts
@@ -35,3 +35,7 @@ function withArkPrefix(network: Omit<Network, "hrp">, prefix: string): Network {
         hrp: prefix,
     };
 }
+
+export const DEFAULT_ARKADE_SERVER_URL = "https://arkade.computer" as const;
+export const DEFAULT_NETWORK = networks.bitcoin;
+export const DEFAULT_NETWORK_NAME = "bitcoin" as const satisfies NetworkName;

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -6,6 +6,7 @@ import { eventSourceIterator, isEventSourceError } from "./utils";
 import { maybeArkError } from "./errors";
 import type { IntentFeeConfig } from "../arkfee";
 import { Intent } from "../intent";
+import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
 
 /** Output requested during settlement or transaction submission. */
 export type Output = {
@@ -252,7 +253,7 @@ export interface ArkProvider {
  * ```
  */
 export class RestArkProvider implements ArkProvider {
-    constructor(public serverUrl: string) {}
+    constructor(public serverUrl: string = DEFAULT_ARKADE_SERVER_URL) {}
 
     async getInfo(): Promise<ArkInfo> {
         const url = `${this.serverUrl}/v1/info`;

--- a/packages/ts-sdk/src/providers/expoArk.ts
+++ b/packages/ts-sdk/src/providers/expoArk.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
 import { RestArkProvider, SettlementEvent, TxNotification, isFetchTimeoutError } from "./ark";
 import { getExpoFetch, sseStreamIterator } from "./expoUtils";
 
@@ -15,7 +16,7 @@ import { getExpoFetch, sseStreamIterator } from "./expoUtils";
  * ```
  */
 export class ExpoArkProvider extends RestArkProvider {
-    constructor(serverUrl: string) {
+    constructor(serverUrl: string = DEFAULT_ARKADE_SERVER_URL) {
         super(serverUrl);
     }
 

--- a/packages/ts-sdk/src/providers/expoIndexer.ts
+++ b/packages/ts-sdk/src/providers/expoIndexer.ts
@@ -2,6 +2,7 @@ import { RestIndexerProvider, SubscriptionResponse, Vtxo } from "./indexer";
 import { isFetchTimeoutError } from "./ark";
 import { VirtualCoin } from "../wallet";
 import { getExpoFetch, sseStreamIterator } from "./expoUtils";
+import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
 
 // Helper function to convert Vtxo to VirtualCoin (same as in indexer.ts)
 function convertVtxo(vtxo: Vtxo): VirtualCoin {
@@ -46,7 +47,7 @@ function convertVtxo(vtxo: Vtxo): VirtualCoin {
  * ```
  */
 export class ExpoIndexerProvider extends RestIndexerProvider {
-    constructor(serverUrl: string) {
+    constructor(serverUrl: string = DEFAULT_ARKADE_SERVER_URL) {
         super(serverUrl);
     }
 

--- a/packages/ts-sdk/src/providers/indexer.ts
+++ b/packages/ts-sdk/src/providers/indexer.ts
@@ -3,6 +3,7 @@ import { AssetDetails, AssetMetadata, Outpoint, VirtualCoin } from "../wallet";
 import { isFetchTimeoutError } from "./ark";
 import { eventSourceIterator, isEventSourceError } from "./utils";
 import { MetadataList } from "../extension/asset";
+import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
 
 export type PaginationOptions = {
     pageIndex?: number;
@@ -296,7 +297,7 @@ export interface IndexerProvider {
  * ```
  */
 export class RestIndexerProvider implements IndexerProvider {
-    constructor(public serverUrl: string) {}
+    constructor(public serverUrl: string = DEFAULT_ARKADE_SERVER_URL) {}
 
     async getVtxoTree(
         batchOutpoint: Outpoint,

--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -1,4 +1,4 @@
-import type { NetworkName } from "../networks";
+import { DEFAULT_NETWORK_NAME, type NetworkName } from "../networks";
 import { Coin } from "../wallet";
 
 /**
@@ -129,7 +129,7 @@ export class EsploraProvider implements OnchainProvider {
     readonly forcePolling: boolean;
 
     constructor(
-        private baseUrl: string,
+        private baseUrl: string = ESPLORA_URL[DEFAULT_NETWORK_NAME],
         opts?: {
             /** Polling interval in milliseconds. */
             pollingInterval?: number;

--- a/packages/ts-sdk/src/script/address.ts
+++ b/packages/ts-sdk/src/script/address.ts
@@ -1,7 +1,7 @@
 import { bech32m } from "@scure/base";
 import { Bytes } from "@scure/btc-signer/utils.js";
 import { Script } from "@scure/btc-signer/script.js";
-import { DEFAULT_ARKADE_HRP } from "../wallet";
+import { DEFAULT_NETWORK } from "../networks";
 
 /**
  * ArkAddress allows creating and decoding bech32m-encoded Arkade addresses.
@@ -46,7 +46,7 @@ export class ArkAddress {
     constructor(
         readonly serverPubKey: Bytes,
         readonly vtxoTaprootKey: Bytes,
-        readonly hrp: string = DEFAULT_ARKADE_HRP,
+        readonly hrp: string = DEFAULT_NETWORK.hrp,
         readonly version: number = 0,
     ) {
         if (serverPubKey.length !== 32) {

--- a/packages/ts-sdk/src/script/base.ts
+++ b/packages/ts-sdk/src/script/base.ts
@@ -17,6 +17,7 @@ import {
     ConditionCSVMultisigTapscript,
     CSVMultisigTapscript,
 } from "./tapscript";
+import { DEFAULT_NETWORK } from "../networks";
 
 export type TapLeafScript = [
     {
@@ -118,7 +119,7 @@ export class VtxoScript {
      * @returns Arkade address for this script
      * @see ArkAddress
      */
-    address(prefix: string, serverPubKey: Bytes): ArkAddress {
+    address(prefix: string = DEFAULT_NETWORK.hrp, serverPubKey: Bytes): ArkAddress {
         return new ArkAddress(serverPubKey, this.tweakedPublicKey, prefix);
     }
 
@@ -133,7 +134,7 @@ export class VtxoScript {
      * @returns Taproot onchain address
      * @see address
      */
-    onchainAddress(network: typeof NETWORK): string {
+    onchainAddress(network: typeof NETWORK = DEFAULT_NETWORK): string {
         return Address(network).encode({
             type: "tr",
             pubkey: this.tweakedPublicKey,

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -99,8 +99,8 @@ export function warnOnRemovedBackgroundFields(bg: unknown): void {
  *
  * const wallet = await ExpoWallet.setup({
  *     identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *     arkProvider: new RestArkProvider('https://arkade.computer'),
- *     onchainProvider: new EsploraProvider('https://mempool.space/api')
+ *     arkProvider: new RestArkProvider(),
+ *     onchainProvider: new EsploraProvider(),
  *     storage: { ... },
  *     background: {
  *         taskQueue: new AsyncStorageTaskQueue(AsyncStorage),

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -99,8 +99,8 @@ export function warnOnRemovedBackgroundFields(bg: unknown): void {
  *
  * const wallet = await ExpoWallet.setup({
  *     identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *     arkServerUrl: 'https://arkade.computer',
- *     esploraUrl: 'https://mempool.space/api',
+ *     arkProvider: new RestArkProvider('https://arkade.computer'),
+ *     onchainProvider: new EsploraProvider('https://mempool.space/api')
  *     storage: { ... },
  *     background: {
  *         taskQueue: new AsyncStorageTaskQueue(AsyncStorage),
@@ -171,7 +171,7 @@ export class ExpoWallet implements IWallet {
         // without a network call. Only works with AsyncStorageTaskQueue.
         if ("persistConfig" in taskQueue) {
             const arkServerUrl =
-                config.arkServerUrl ??
+                config.arkServerUrl ||
                 (wallet.arkProvider instanceof RestArkProvider
                     ? wallet.arkProvider.serverUrl
                     : undefined);

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -117,19 +117,12 @@ export interface BaseWalletConfig {
  *
  * @example
  * ```typescript
- * // URL-based configuration
- * const wallet = await ReadonlyWallet.create({
- *   identity: ReadonlySingleKey.fromPublicKey(pubkey),
- *   arkProvider: new RestArkProvider('https://arkade.computer')
- *   onchainProvider: new EsploraProvider('https://mempool.space/api')
- * });
- *
  * // Provider-based configuration (e.g., for Expo/React Native)
  * const wallet = await ReadonlyWallet.create({
  *   identity: ReadonlySingleKey.fromPublicKey(pubkey),
- *   arkProvider: new ExpoArkProvider('https://arkade.computer'),
- *   indexerProvider: new ExpoIndexerProvider('https://arkade.computer'),
- *   onchainProvider: new EsploraProvider('https://mempool.space/api')
+ *   arkProvider: new ExpoArkProvider(),
+ *   indexerProvider: new ExpoIndexerProvider(),
+ *   onchainProvider: new EsploraProvider()
  * });
  * ```
  */
@@ -156,18 +149,18 @@ export interface ReadonlyWalletConfig extends BaseWalletConfig {
  *
  * @example
  * ```typescript
- * // Provider-based configuration (e.g., for Expo/React Native)
+ * // Provider-based configuration
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkProvider: new ExpoArkProvider('https://arkade.computer'),
- *   indexerProvider: new ExpoIndexerProvider('https://arkade.computer'),
- *   onchainProvider: new EsploraProvider('https://mempool.space/api')
+ *   arkProvider: new ExpoArkProvider(),
+ *   indexerProvider: new ExpoIndexerProvider(),
+ *   onchainProvider: new EsploraProvider()
  * });
  *
  * // With settlement configuration
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkProvider: new RestArkProvider('https://arkade.computer'),
+ *   arkProvider: new RestArkProvider(),
  *   settlementConfig: {
  *     vtxoThreshold: 60 * 60 * 24, // 24 hours in seconds
  *     boardingUtxoSweep: true,

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -13,11 +13,6 @@ import { IContractManager } from "../contracts/contractManager";
 import { IDelegatorManager } from "./delegator";
 import { DelegatorProvider } from "../providers/delegator";
 
-/** Defaults */
-export const DEFAULT_ARKADE_SERVER_URL = "https://arkade.computer" as const;
-export const DEFAULT_ARKADE_HRP = "ark" as const;
-export const DEFAULT_NETWORK_NAME = "bitcoin" as const;
-
 /**
  * Wallet receive-address strategy.
  *

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -43,7 +43,7 @@ export type WalletMode = "auto" | "static" | "hd" | DescriptorProvider;
  *
  * Supports URL-based and provider-based configuration.
  *
- * URL-based configuration starts from `arkServerUrl` and can optionally override
+ * @deprecated URL-based configuration starts from `arkServerUrl` and can optionally override
  * derived service URLs such as `indexerUrl` and `esploraUrl`.
  *
  * Provider-based configuration supplies concrete provider instances directly,
@@ -120,8 +120,8 @@ export interface BaseWalletConfig {
  * // URL-based configuration
  * const wallet = await ReadonlyWallet.create({
  *   identity: ReadonlySingleKey.fromPublicKey(pubkey),
- *   arkServerUrl: 'https://arkade.computer',
- *   esploraUrl: 'https://mempool.space/api'
+ *   arkProvider: new RestArkProvider('https://arkade.computer')
+ *   onchainProvider: new EsploraProvider('https://mempool.space/api')
  * });
  *
  * // Provider-based configuration (e.g., for Expo/React Native)
@@ -156,13 +156,6 @@ export interface ReadonlyWalletConfig extends BaseWalletConfig {
  *
  * @example
  * ```typescript
- * // URL-based configuration
- * const wallet = await Wallet.create({
- *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkServerUrl: 'https://arkade.computer',
- *   esploraUrl: 'https://mempool.space/api'
- * });
- *
  * // Provider-based configuration (e.g., for Expo/React Native)
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
@@ -174,7 +167,7 @@ export interface ReadonlyWalletConfig extends BaseWalletConfig {
  * // With settlement configuration
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkServerUrl: 'https://arkade.computer',
+ *   arkProvider: new RestArkProvider('https://arkade.computer'),
  *   settlementConfig: {
  *     vtxoThreshold: 60 * 60 * 24, // 24 hours in seconds
  *     boardingUtxoSweep: true,

--- a/packages/ts-sdk/src/wallet/onchain.ts
+++ b/packages/ts-sdk/src/wallet/onchain.ts
@@ -1,8 +1,8 @@
 import { p2tr } from "@scure/btc-signer";
 import { P2TR } from "@scure/btc-signer/payment.js";
-import { Coin, DEFAULT_NETWORK_NAME, SendBitcoinParams } from ".";
+import { Coin, SendBitcoinParams } from ".";
 import { Identity } from "../identity";
-import { getNetwork, Network, NetworkName } from "../networks";
+import { DEFAULT_NETWORK_NAME, getNetwork, Network, NetworkName } from "../networks";
 import { ESPLORA_URL, EsploraProvider, OnchainProvider } from "../providers/onchain";
 import { AnchorBumper, findP2AOutput, P2A } from "../utils/anchor";
 import { TxWeightEstimator } from "../utils/txSizeEstimator";

--- a/packages/ts-sdk/src/wallet/onchain.ts
+++ b/packages/ts-sdk/src/wallet/onchain.ts
@@ -51,7 +51,6 @@ export class OnchainWallet implements AnchorBumper {
      * @param networkName - Bitcoin network name, @see NetworkName
      * @param provider - Optional onchain provider override, @see OnchainProvider
      * @returns Configured onchain wallet
-     * @defaultValue `provider = new EsploraProvider('https://mempool.space/api')`
      * @throws Error if the configured identity cannot produce a valid x-only public key
      */
     static async create(

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -17,7 +17,6 @@ import {
     ReissuanceParams,
     BurnParams,
     Recipient,
-    DEFAULT_ARKADE_SERVER_URL,
 } from "..";
 import { SettlementEvent } from "../../providers/ark";
 import { hex } from "@scure/base";

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -153,13 +153,13 @@ export interface RenewalConfig {
  * // Default behavior: virtual output renewal at 3 days, boarding sweep enabled, polling every minute
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkServerUrl: 'https://arkade.computer',
+ *   arkProvider: new RestArkProvider('https://arkade.computer'),
  * });
  *
  * // Custom expiry threshold of 24 hours
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkServerUrl: 'https://arkade.computer',
+ *   arkProvider: new RestArkProvider('https://arkade.computer'),
  *   settlementConfig: {
  *     vtxoThreshold: 60 * 60 * 24, // 24 hours in seconds
  *   },
@@ -168,7 +168,7 @@ export interface RenewalConfig {
  * // Explicitly disable
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkServerUrl: 'https://arkade.computer',
+ *   arkProvider: new RestArkProvider('https://arkade.computer'),
  *   settlementConfig: false,
  * });
  * ```
@@ -225,7 +225,7 @@ export const DEFAULT_RENEWAL_CONFIG: Required<Omit<RenewalConfig, "enabled">> = 
  * ```typescript
  * const wallet = await Wallet.create({
  *   identity,
- *   arkServerUrl: 'https://arkade.computer',
+ *   arkProvider: new RestArkProvider('https://arkade.computer'),
  *   settlementConfig: DEFAULT_SETTLEMENT_CONFIG,
  * })
  * ```
@@ -392,7 +392,7 @@ export function getExpiringAndRecoverableVtxos(
  * ```typescript
  * const wallet = await Wallet.create({
  *   identity,
- *   arkServerUrl: 'https://arkade.computer',
+ *   arkProvider: new RestArkProvider('https://arkade.computer'),
  *   settlementConfig: {
  *      // Seconds before virtual output expiry to trigger renewal
  *      vtxoThreshold: 259_200, // 3 days
@@ -640,7 +640,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * ```typescript
      * const wallet = await Wallet.create({
      *  identity,
-     *  arkServerUrl: 'https://arkade.computer',
+     *  arkProvider: new RestArkProvider('https://arkade.computer'),
      *  settlementConfig: {
      *      vtxoThreshold: 86_400 // 24 hours
      *  },
@@ -829,7 +829,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * ```typescript
      * const wallet = await Wallet.create({
      *   identity,
-     *   arkServerUrl: 'https://arkade.computer',
+     *   arkProvider: new RestArkProvider('https://arkade.computer'),
      *   settlementConfig: {
      *     boardingUtxoSweep: true,
      *   },

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -98,7 +98,7 @@ async function runWithCrossInstanceLock(name: string, fn: () => Promise<void>): 
 }
 
 /** Default renewal threshold in seconds (3 days). */
-export const DEFAULT_THRESHOLD_SECONDS = 3 * 24 * 60 * 60;
+export const DEFAULT_THRESHOLD_SECONDS = 259_200;
 
 /**
  * Default renewal threshold in milliseconds (3 days).
@@ -153,13 +153,13 @@ export interface RenewalConfig {
  * // Default behavior: virtual output renewal at 3 days, boarding sweep enabled, polling every minute
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkProvider: new RestArkProvider('https://arkade.computer'),
+ *   arkProvider: new RestArkProvider(),
  * });
  *
  * // Custom expiry threshold of 24 hours
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkProvider: new RestArkProvider('https://arkade.computer'),
+ *   arkProvider: new RestArkProvider(),
  *   settlementConfig: {
  *     vtxoThreshold: 60 * 60 * 24, // 24 hours in seconds
  *   },
@@ -168,7 +168,7 @@ export interface RenewalConfig {
  * // Explicitly disable
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkProvider: new RestArkProvider('https://arkade.computer'),
+ *   arkProvider: new RestArkProvider(),
  *   settlementConfig: false,
  * });
  * ```
@@ -225,8 +225,12 @@ export const DEFAULT_RENEWAL_CONFIG: Required<Omit<RenewalConfig, "enabled">> = 
  * ```typescript
  * const wallet = await Wallet.create({
  *   identity,
- *   arkProvider: new RestArkProvider('https://arkade.computer'),
- *   settlementConfig: DEFAULT_SETTLEMENT_CONFIG,
+ *   arkProvider: new RestArkProvider(),
+ *   settlementConfig: {
+ *     vtxoThreshold: 259_200,
+ *     boardingUtxoSweep: true,
+ *     pollIntervalMs: 60_000,
+ *   },
  * })
  * ```
  */
@@ -392,7 +396,7 @@ export function getExpiringAndRecoverableVtxos(
  * ```typescript
  * const wallet = await Wallet.create({
  *   identity,
- *   arkProvider: new RestArkProvider('https://arkade.computer'),
+ *   arkProvider: new RestArkProvider(),
  *   settlementConfig: {
  *      // Seconds before virtual output expiry to trigger renewal
  *      vtxoThreshold: 259_200, // 3 days
@@ -640,7 +644,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * ```typescript
      * const wallet = await Wallet.create({
      *  identity,
-     *  arkProvider: new RestArkProvider('https://arkade.computer'),
+     *  arkProvider: new RestArkProvider(),
      *  settlementConfig: {
      *      vtxoThreshold: 86_400 // 24 hours
      *  },
@@ -829,7 +833,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * ```typescript
      * const wallet = await Wallet.create({
      *   identity,
-     *   arkProvider: new RestArkProvider('https://arkade.computer'),
+     *   arkProvider: new RestArkProvider(),
      *   settlementConfig: {
      *     boardingUtxoSweep: true,
      *   },

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -979,10 +979,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
  * // Create a wallet with providers
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkProvider: new RestArkProvider('https://arkade.computer'),
- *   onchainProvider: new EsploraProvider('https://mempool.space/api')
+ *   arkProvider: new RestArkProvider(),
+ *   onchainProvider: new EsploraProvider()
  * });
  *
+ * // Use custom providers and/or URLs (e.g., for Expo/React Native)
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
  *   arkProvider: new ExpoArkProvider('https://arkade.computer'),
@@ -1375,7 +1376,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      * ```typescript
      * const wallet = await Wallet.create({
      *   identity,
-     *   arkProvider: new RestArkProvider('https://arkade.computer'),
+     *   arkProvider: new RestArkProvider(),
      * });
      * ```
      */

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -257,7 +257,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const arkadeServerUrl = getArkadeServerUrl(config);
 
         // Use provided arkProvider instance or create a new one from arkServerUrl
-        const arkProvider = config.arkProvider ?? new RestArkProvider(arkadeServerUrl);
+        const arkProvider = config.arkProvider || new RestArkProvider(arkadeServerUrl);
 
         // Resolve the indexer provider. If a full instance is supplied, use it
         // directly. Otherwise pick a URL with priority:
@@ -976,19 +976,18 @@ export class ReadonlyWallet implements IReadonlyWallet {
  *
  * @example
  * ```typescript
- * // Create a wallet with URL configuration
+ * // Create a wallet with providers
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
- *   arkServerUrl: 'https://arkade.computer',
- *   esploraUrl: 'https://mempool.space/api'
+ *   arkProvider: new RestArkProvider('https://arkade.computer'),
+ *   onchainProvider: new EsploraProvider('https://mempool.space/api')
  * });
  *
- * // Or with custom provider instances (e.g., for Expo/React Native)
  * const wallet = await Wallet.create({
  *   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
  *   arkProvider: new ExpoArkProvider('https://arkade.computer'),
  *   indexerProvider: new ExpoIndexerProvider('https://arkade.computer'),
- *   esploraUrl: 'https://mempool.space/api'
+ *   onchainProvider: new EsploraProvider('https://mempool.space/api')
  * });
  *
  * // Get addresses
@@ -1376,7 +1375,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      * ```typescript
      * const wallet = await Wallet.create({
      *   identity,
-     *   arkServerUrl: 'https://arkade.computer',
+     *   arkProvider: new RestArkProvider('https://arkade.computer'),
      * });
      * ```
      */

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2,10 +2,10 @@ import { base64, hex } from "@scure/base";
 import { tapLeafHash } from "@scure/btc-signer/payment.js";
 import { Address, OutScript, SigHash, Transaction } from "@scure/btc-signer";
 import { TransactionOutput } from "@scure/btc-signer/psbt.js";
-import { Bytes, equalBytes, sha256 } from "@scure/btc-signer/utils.js";
+import { Bytes, sha256 } from "@scure/btc-signer/utils.js";
 import { ArkAddress } from "../script/address";
 import { DefaultVtxo } from "../script/default";
-import { getNetwork, Network, NetworkName } from "../networks";
+import { DEFAULT_ARKADE_SERVER_URL, getNetwork, Network, NetworkName } from "../networks";
 import { ESPLORA_URL, EsploraProvider, OnchainProvider } from "../providers/onchain";
 import {
     ArkProvider,
@@ -26,7 +26,6 @@ import {
     ArkTransaction,
     Asset,
     Coin,
-    DEFAULT_ARKADE_SERVER_URL,
     ExtendedCoin,
     ExtendedVirtualCoin,
     GetVtxosFilter,

--- a/packages/ts-sdk/src/worker/expo/README.md
+++ b/packages/ts-sdk/src/worker/expo/README.md
@@ -55,8 +55,8 @@ import { SingleKey } from "@arkade-os/sdk";
 
 const wallet = await ExpoWallet.setup({
     identity: SingleKey.fromHex(privateKey),
-    arkServerUrl,
-    esploraUrl,
+    arkProvider: new RestArkProvider('https://arkade.computer'),
+    onchainProvider: new EsploraProvider('https://mempool.space/api'),
     storage: { walletRepository, contractRepository },
     background: {
         taskQueue, // same instance from step 1

--- a/packages/ts-sdk/src/worker/expo/README.md
+++ b/packages/ts-sdk/src/worker/expo/README.md
@@ -51,12 +51,12 @@ The wallet surface matches the browser version. `ExpoWallet.setup()` persists co
 ```ts
 import { ExpoWallet } from "@arkade-os/sdk/wallet/expo";
 import { registerExpoBackgroundTask } from "@arkade-os/sdk/wallet/expo/background";
-import { SingleKey } from "@arkade-os/sdk";
+import { MnemonicIdentity, EsploraProvider, RestArkProvider } from "@arkade-os/sdk";
 
 const wallet = await ExpoWallet.setup({
-    identity: SingleKey.fromHex(privateKey),
-    arkProvider: new RestArkProvider('https://arkade.computer'),
-    onchainProvider: new EsploraProvider('https://mempool.space/api'),
+    identity: MnemonicIdentity.fromMnemonic("abandon abandon..."),
+    arkProvider: new RestArkProvider(),
+    onchainProvider: new EsploraProvider(),
     storage: { walletRepository, contractRepository },
     background: {
         taskQueue, // same instance from step 1

--- a/packages/ts-sdk/test/address.test.ts
+++ b/packages/ts-sdk/test/address.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { ArkAddress } from "../src";
-import { DEFAULT_ARKADE_HRP } from "../src/wallet";
 import fixtures from "./fixtures/encoding.json";
 import { hex } from "@scure/base";
+import { DEFAULT_NETWORK } from "../src/networks";
 
 describe("ArkAddress", () => {
     it("defaults to the mainnet Arkade HRP", () => {
@@ -12,10 +12,10 @@ describe("ArkAddress", () => {
         const address = new ArkAddress(serverPubKey, vtxoTaprootKey);
         const encoded = address.encode();
 
-        expect(address.hrp).toBe(DEFAULT_ARKADE_HRP);
-        expect(encoded.startsWith(`${DEFAULT_ARKADE_HRP}1`)).toBe(true);
+        expect(address.hrp).toBe(DEFAULT_NETWORK.hrp);
+        expect(encoded.startsWith(`${DEFAULT_NETWORK.hrp}1`)).toBe(true);
         const decoded = ArkAddress.decode(encoded);
-        expect(decoded.hrp).toBe(DEFAULT_ARKADE_HRP);
+        expect(decoded.hrp).toBe(DEFAULT_NETWORK.hrp);
     });
 
     describe("valid addresses", () => {

--- a/packages/ts-sdk/test/contracts.test.ts
+++ b/packages/ts-sdk/test/contracts.test.ts
@@ -7,7 +7,6 @@ import {
     contractFromArkContractWithAddress,
     isArkContract,
 } from "../src/contracts";
-import { DEFAULT_ARKADE_HRP } from "../src/wallet";
 import type { Contract } from "../src/contracts";
 import { InMemoryContractRepository } from "../src/repositories/inMemory/contractRepository";
 import type { IndexerProvider } from "../src/providers/indexer";
@@ -18,6 +17,7 @@ import {
     TEST_DEFAULT_SCRIPT,
     TEST_SERVER_PUB_KEY,
 } from "./contracts/helpers";
+import { DEFAULT_NETWORK } from "../src/networks";
 
 describe("Contracts", () => {
     describe("ArkContract encoding/decoding", () => {
@@ -83,7 +83,7 @@ describe("Contracts", () => {
 
             const contract = contractFromArkContractWithAddress(encoded, TEST_SERVER_PUB_KEY);
 
-            expect(contract.address.startsWith(`${DEFAULT_ARKADE_HRP}1`)).toBe(true);
+            expect(contract.address.startsWith(`${DEFAULT_NETWORK.hrp}1`)).toBe(true);
         });
 
         it("should throw for unknown contract type", () => {

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -10,7 +10,6 @@ import {
     SeedIdentity,
     ReadonlyDescriptorIdentity,
 } from "../../src";
-import { DEFAULT_ARKADE_SERVER_URL } from "../../src/wallet";
 import { ServiceWorkerWallet } from "../../src/wallet/serviceWorker/wallet";
 import { mnemonicToSeedSync } from "@scure/bip39";
 import { hex } from "@scure/base";
@@ -18,11 +17,8 @@ import {
     WalletMessageHandler,
     DEFAULT_MESSAGE_TAG,
 } from "../../src/wallet/serviceWorker/wallet-message-handler";
-import {
-    MESSAGE_BUS_NOT_INITIALIZED,
-    MessageBusNotInitializedError,
-    ServiceWorkerTimeoutError,
-} from "../../src/worker/errors";
+import { MESSAGE_BUS_NOT_INITIALIZED, ServiceWorkerTimeoutError } from "../../src/worker/errors";
+import { DEFAULT_ARKADE_SERVER_URL } from "../../src/networks";
 
 type MessageHandler = (event: { data: any }) => void;
 

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -17,13 +17,13 @@ import {
     type DelegatorProvider,
 } from "../src";
 import { TEST_PUB_KEY, TEST_DELEGATE_PUB_KEY, TEST_SERVER_PUB_KEY } from "./contracts/helpers";
-import { DEFAULT_ARKADE_SERVER_URL } from "../src/wallet";
 import type { ExtendedCoin } from "../src/wallet";
 import { ReadonlySingleKey } from "../src/identity/singleKey";
 import { IndexedDBWalletRepository, IndexedDBContractRepository } from "../src/repositories";
 import type { Coin, VirtualCoin } from "../src/wallet";
 import { MockEventSource } from "./mocks/eventSource";
 import { timelockToSequence } from "../src/utils/timelock";
+import { DEFAULT_ARKADE_SERVER_URL } from "../src/networks";
 
 // Mock fetch
 const mockFetch = vi.fn();


### PR DESCRIPTION
Builds on https://github.com/arkade-os/ts-sdk/pull/511

- Move default network constants into networks
- Default human-readable prefix for address() and onchainAddress() to mainnet
- Deprecate arkServerUrl, indexerUrl, and esploraUrl from wallet configs (excluding service worker wallet)
- Default -ArkProvider, -IndexerProvider and EsploraProvider base URLs to mainnet
