### PR TITLE
feat: require csvTimelock to be specified

### DIFF
--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -53,9 +53,7 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
     },
 
     deserializeParams(params: Record<string, string>): DefaultContractParams {
-        const csvTimelock = params.csvTimelock
-            ? sequenceToTimelock(Number(params.csvTimelock))
-            : DefaultVtxo.Script.DEFAULT_TIMELOCK;
+        const csvTimelock = sequenceToTimelock(Number(params.csvTimelock));
         return {
             pubKey: extractPubKeyBytes(params.pubKey),
             serverPubKey: extractPubKeyBytes(params.serverPubKey),

--- a/packages/ts-sdk/src/contracts/handlers/delegate.ts
+++ b/packages/ts-sdk/src/contracts/handlers/delegate.ts
@@ -1,6 +1,5 @@
 import { hex } from "@scure/base";
 import { DelegateVtxo } from "../../script/delegate";
-import { DefaultVtxo } from "../../script/default";
 import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
@@ -46,9 +45,7 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
     },
 
     deserializeParams(params: Record<string, string>): DelegateContractParams {
-        const csvTimelock = params.csvTimelock
-            ? sequenceToTimelock(Number(params.csvTimelock))
-            : DefaultVtxo.Script.DEFAULT_TIMELOCK;
+        const csvTimelock = sequenceToTimelock(Number(params.csvTimelock));
         return {
             pubKey: hex.decode(params.pubKey),
             serverPubKey: hex.decode(params.serverPubKey),

--- a/packages/ts-sdk/src/script/default.ts
+++ b/packages/ts-sdk/src/script/default.ts
@@ -17,7 +17,7 @@ export namespace DefaultVtxo {
     export interface Options {
         pubKey: Bytes;
         serverPubKey: Bytes;
-        csvTimelock?: RelativeTimelock;
+        csvTimelock: RelativeTimelock;
     }
 
     /**
@@ -27,6 +27,10 @@ export namespace DefaultVtxo {
      * const vtxoScript = new DefaultVtxo.Script({
      *     pubKey: new Uint8Array(32),
      *     serverPubKey: new Uint8Array(32),
+     *     csvTimelock: {
+     *         value: 605184n,
+     *         type: "seconds"
+     *     }
      * });
      *
      * console.log("script pub key:", vtxoScript.pkScript)
@@ -43,7 +47,7 @@ export namespace DefaultVtxo {
 
         /** Create the default virtual output script with one forfeit path and one exit path. */
         constructor(readonly options: Options) {
-            const { pubKey, serverPubKey, csvTimelock = Script.DEFAULT_TIMELOCK } = options;
+            const { pubKey, serverPubKey, csvTimelock } = options;
 
             const forfeitScript = MultisigTapscript.encode({
                 pubkeys: [pubKey, serverPubKey],

--- a/packages/ts-sdk/src/script/delegate.ts
+++ b/packages/ts-sdk/src/script/delegate.ts
@@ -23,6 +23,10 @@ export namespace DelegateVtxo {
      *     pubKey: new Uint8Array(32),
      *     serverPubKey: new Uint8Array(32),
      *     delegatePubKey: new Uint8Array(32),
+     *     csvTimelock: {
+     *         value: 605184n,
+     *         type: "seconds"
+     *     }
      * });
      *
      * console.log("script pub key:", vtxoScript.pkScript)

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -14,7 +14,6 @@ import type {
     ExtendedVirtualCoin,
     Recipient,
 } from "..";
-import type { VirtualCoin } from "..";
 import type { SettlementEvent } from "../../providers/ark";
 import type { Identity } from "../../identity";
 import type { IContractManager } from "../../contracts/contractManager";
@@ -24,7 +23,6 @@ import type { TaskProcessor, TaskDependencies } from "../../worker/expo/taskRunn
 import { runTasks } from "../../worker/expo/taskRunner";
 import { contractPollProcessor, CONTRACT_POLL_TASK_TYPE } from "../../worker/expo/processors";
 import { extendVirtualCoinForContract, getRandomId } from "../utils";
-import { DefaultVtxo } from "../../script/default";
 import type { PersistedBackgroundConfig } from "./background";
 import type { AsyncStorageTaskQueue } from "../../worker/expo/asyncStorageTaskQueue";
 
@@ -177,9 +175,7 @@ export class ExpoWallet implements IWallet {
                     : undefined);
 
             if (arkServerUrl) {
-                const timelock =
-                    wallet.offchainTapscript.options.csvTimelock ??
-                    DefaultVtxo.Script.DEFAULT_TIMELOCK;
+                const timelock = wallet.offchainTapscript.options.csvTimelock;
 
                 const bgConfig: PersistedBackgroundConfig = {
                     arkServerUrl,

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -239,10 +239,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         this.walletContractTimelocks =
             walletContractTimelocks && walletContractTimelocks.length > 0
                 ? dedupeTimelocks(walletContractTimelocks)
-                : [
-                      this.offchainTapscript.options.csvTimelock ??
-                          DefaultVtxo.Script.DEFAULT_TIMELOCK,
-                  ];
+                : [this.offchainTapscript.options.csvTimelock];
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
+++ b/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
@@ -1,6 +1,5 @@
 import { equalBytes } from "@scure/btc-signer/utils.js";
 import { hex } from "@scure/base";
-
 import { deriveDescriptorLeafPubKey } from "../identity/descriptor";
 import { DescriptorProvider } from "../identity/descriptorProvider";
 import { isHDCapableIdentity } from "../identity/hdCapableIdentity";
@@ -512,7 +511,7 @@ export class WalletReceiveRotator {
             .encode();
 
         const manager = await wallet.getContractManager();
-        const csvTimelock = newTapscript.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK;
+        const csvTimelock = newTapscript.options.csvTimelock;
         const csvTimelockStr = timelockToSequence(csvTimelock).toString();
         const serverPubKeyHex = hex.encode(newTapscript.options.serverPubKey);
 

--- a/packages/ts-sdk/test/contracts/helpers.ts
+++ b/packages/ts-sdk/test/contracts/helpers.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { vi } from "vitest";
 
 import {
     ContractVtxo,
@@ -64,6 +64,7 @@ export const createDelegateContractParams = () =>
 export const testDefaultScript = new DefaultVtxo.Script({
     pubKey: TEST_PUB_KEY,
     serverPubKey: TEST_SERVER_PUB_KEY,
+    csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
 });
 export const TEST_DEFAULT_SCRIPT = hex.encode(testDefaultScript.pkScript);
 // Real Arkade address whose pkScript decodes to TEST_DEFAULT_SCRIPT. Use this
@@ -78,6 +79,7 @@ export const testDelegateScript = new DelegateVtxo.Script({
     pubKey: TEST_PUB_KEY,
     serverPubKey: TEST_SERVER_PUB_KEY,
     delegatePubKey: TEST_DELEGATE_PUB_KEY,
+    csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
 });
 export const TEST_DELEGATE_SCRIPT = hex.encode(testDelegateScript.pkScript);
 

--- a/packages/ts-sdk/test/contracts/manager.test.ts
+++ b/packages/ts-sdk/test/contracts/manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import {
     ContractManager,
@@ -31,6 +31,7 @@ import {
 const SECOND_DEFAULT_SCRIPT_TAPSCRIPT = new DefaultVtxo.Script({
     pubKey: TEST_DELEGATE_PUB_KEY,
     serverPubKey: TEST_SERVER_PUB_KEY,
+    csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
 });
 const SECOND_DEFAULT_SCRIPT = hex.encode(SECOND_DEFAULT_SCRIPT_TAPSCRIPT.pkScript);
 const SECOND_DEFAULT_PARAMS = DefaultContractHandler.serializeParams({

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -2042,10 +2042,12 @@ describe("Wallet.updateDbAfterOffchainTx", () => {
         const tapscriptOld = new DefaultVtxo.Script({
             pubKey: TEST_PUB_KEY,
             serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
         });
         const tapscriptNew = new DefaultVtxo.Script({
             pubKey: TEST_DELEGATE_PUB_KEY,
             serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
         });
         // Sanity: the two tapscripts produce distinguishable outputs.
         // Without this, any assertion below would be vacuously true.


### PR DESCRIPTION
- Require `csvTimelock` to be specified when constructing `DefaultVtxo.Script` (and downstream `DelegateVtxo.Script`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * csvTimelock is now required when configuring script timelocks; previous automatic fallback to a default timelock has been removed. Update configurations to provide explicit timelock values.

* **Documentation**
  * Examples and docs updated to show explicit csvTimelock entries with required type and value.

* **Tests**
  * Test fixtures updated to include explicit csvTimelock values to match the new required behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->