### PR TITLE
chore: rename delegator -> delegate

### DIFF
--- a/packages/boltz-swap/src/expo/background.ts
+++ b/packages/boltz-swap/src/expo/background.ts
@@ -63,6 +63,7 @@ function createBackgroundWalletShim(args: {
         getBoardingUtxos: async () => notImplemented("getBoardingUtxos"),
         getTransactionHistory: async () => notImplemented("getTransactionHistory"),
         getContractManager: async () => notImplemented("getContractManager"),
+        getDelegateManager: async () => notImplemented("getDelegateManager"),
         getDelegatorManager: async () => notImplemented("getDelegatorManager"),
         sendBitcoin: async () => notImplemented("sendBitcoin"),
         send: async () => notImplemented("send"),

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -541,30 +541,30 @@ const balance = await manager.getRecoverableBalance()
 
 Delegation allows users to outsource virtual output renewal to a third-party delegation service.
 
-Instead of the delegating user renewing virtual outputs by themself, their delegate will automatically settle them before they expire, sending the funds back to the delegator's wallet address (minus a service fee).
+Instead of the delegating user renewing virtual outputs by themselves, their delegate will automatically settle them before they expire, sending the funds back to the user's wallet address (minus a service fee).
 
 This is useful for wallets that cannot be online 24/7.
 
-When a `delegatorProvider` is configured, the wallet address includes an extra tapscript path that authorizes the delegate to co-sign renewals alongside the Arkade server.
+When a `delegateProvider` is configured, the wallet address includes an extra tapscript path that authorizes the delegate to co-sign renewals alongside the Arkade server.
 
 To run a delegation service, you'll need to set up a [Fulmine server](https://github.com/ArkLabsHQ/fulmine) with the [Delegation API](https://github.com/ArkLabsHQ/fulmine?tab=readme-ov-file#-delegate-api) enabled.
 
 #### Setting Up a Wallet with Delegation
 
 ```typescript
-import { Wallet, MnemonicIdentity, RestDelegatorProvider } from '@arkade-os/sdk'
+import { Wallet, MnemonicIdentity, RestDelegateProvider } from '@arkade-os/sdk'
 
 const wallet = await Wallet.create({
   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
-  delegatorProvider: new RestDelegatorProvider('http://localhost:7001'),
+  delegateProvider: new RestDelegateProvider('http://localhost:7001'),
 })
 ```
 
-> **Note:** Adding a `delegatorProvider` changes your wallet address because the offchain tapscript includes an additional delegation path. Funds sent to an address without delegation cannot be delegated, and vice versa.
+> **Note:** Adding a `delegateProvider` changes your wallet address because the offchain tapscript includes an additional delegation path. Funds sent to an address without delegation cannot be delegated, and vice versa.
 
 #### Delegating Virtual Outputs
 
-Once the wallet is configured with a delegate, use `wallet.delegatorManager` to delegate your virtual outputs:
+Once the wallet is configured with a delegate, use `wallet.getDelegateManager()` to delegate your virtual outputs:
 
 ```typescript
 // Get spendable virtual outputs (including recoverable)
@@ -572,8 +572,8 @@ const vtxos = await wallet.getVtxos({ withRecoverable: true })
 
 // Delegate all virtual outputs — the delegate will renew them before expiry
 const arkadeAddress = await wallet.getAddress()
-const delegatorManager = await wallet.getDelegatorManager();
-const delegationResult = await delegatorManager.delegate(vtxos, arkadeAddress)
+const delegateManager = await wallet.getDelegateManager();
+const delegationResult = await delegateManager.delegate(vtxos, arkadeAddress)
 
 console.log('Delegated:', delegationResult.delegated.length)
 console.log('Failed:', delegationResult.failed.length)
@@ -588,12 +588,12 @@ You can override this with an explicit date:
 ```typescript
 // Delegate with a specific renewal time
 const delegateAt = new Date(Date.now() + 12 * 60 * 60 * 1000) // 12 hours from now
-await delegatorManager.delegate(vtxos, arkadeAddress, delegateAt)
+await delegateManager.delegate(vtxos, arkadeAddress, delegateAt)
 ```
 
 #### Service Worker Integration
 
-When using a service worker wallet, pass the `delegatorUrl` option. The service worker will automatically delegate virtual outputs after each update:
+When using a service worker wallet, pass the `delegateUrl` option. The service worker will automatically delegate virtual outputs after each update:
 
 ```typescript
 import { ServiceWorkerWallet, MnemonicIdentity } from '@arkade-os/sdk'
@@ -601,7 +601,7 @@ import { ServiceWorkerWallet, MnemonicIdentity } from '@arkade-os/sdk'
 const wallet = await ServiceWorkerWallet.setup({
   serviceWorkerPath: '/service-worker.js',
   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
-  delegatorUrl: 'http://localhost:7001',
+  delegateUrl: 'http://localhost:7001',
 })
 ```
 
@@ -610,14 +610,14 @@ const wallet = await ServiceWorkerWallet.setup({
 You can query the delegation service directly to inspect its public key, fee, and payment address:
 
 ```typescript
-import { RestDelegatorProvider } from '@arkade-os/sdk'
+import { RestDelegateProvider } from '@arkade-os/sdk'
 
-const provider = new RestDelegatorProvider('https://delegator.example.com')
+const provider = new RestDelegateProvider('https://delegate.example.com')
 const info = await provider.getDelegateInfo()
 
 console.log('Delegate public key:', info.pubkey)
 console.log('Service fee (sats):', info.fee)
-console.log('Fee address:', info.delegatorAddress)
+console.log('Fee address:', info.delegateAddress)
 ```
 
 ### BIP-322 Message Signing

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -130,11 +130,13 @@ import {
     FeeInfo,
 } from "./providers/ark";
 import {
+    DelegateProvider,
     DelegatorProvider,
     DelegateInfo,
     DelegateOptions,
+    RestDelegateProvider,
     RestDelegatorProvider,
-} from "./providers/delegator";
+} from "./providers/delegate";
 import {
     CLTVMultisigTapscript,
     ConditionCSVMultisigTapscript,
@@ -213,7 +215,12 @@ import { WalletRepositoryImpl } from "./repositories/migrations/walletRepository
 import { ContractRepositoryImpl } from "./repositories/migrations/contractRepositoryImpl";
 import type { WalletRepository } from "./repositories/walletRepository";
 import type { ContractRepository } from "./repositories/contractRepository";
-import { DelegatorManagerImpl, IDelegatorManager } from "./wallet/delegator";
+import {
+    DelegateManagerImpl,
+    DelegatorManagerImpl,
+    IDelegateManager,
+    IDelegatorManager,
+} from "./wallet/delegate";
 
 export * from "./arkfee";
 export * as asset from "./extension/asset";
@@ -272,6 +279,7 @@ import {
     WalletMessageHandler,
     WalletNotInitializedError,
     ReadonlyWalletError,
+    DelegateNotConfiguredError,
     DelegatorNotConfiguredError,
 } from "./wallet/serviceWorker/wallet-message-handler";
 import {
@@ -295,7 +303,9 @@ export {
     DustChangeError,
     VtxoManager,
     HDDescriptorProvider,
+    DelegateManagerImpl,
     DelegatorManagerImpl,
+    RestDelegateProvider,
     RestDelegatorProvider,
 
     // Providers
@@ -327,6 +337,7 @@ export {
     WalletMessageHandler,
     WalletNotInitializedError,
     ReadonlyWalletError,
+    DelegateNotConfiguredError,
     DelegatorNotConfiguredError,
     MESSAGE_BUS_NOT_INITIALIZED,
     MessageBusNotInitializedError,
@@ -592,8 +603,10 @@ export type {
     MessageTimeouts,
     ServiceWorkerWalletMode,
 
-    // Delegator types
+    // Delegate types (Delegator* aliases deprecated)
+    IDelegateManager,
     IDelegatorManager,
+    DelegateProvider,
     DelegatorProvider,
     DelegateInfo,
     DelegateOptions,

--- a/packages/ts-sdk/src/providers/delegate.ts
+++ b/packages/ts-sdk/src/providers/delegate.ts
@@ -9,7 +9,7 @@ export interface DelegateInfo {
     pubkey: string;
     /** Delegate fee amount or expression returned by the delegate. */
     fee: string;
-    /** Address for delegate fee collection. Kept optional as it's not yet  */
+    /** Address for delegate fee collection. Sourced from `delegatorAddress` in Fulmine response, for now. */
     delegateAddress: string;
     /** @deprecated alias for @see DelegateInfo.delegateAddress */
     delegatorAddress: string;

--- a/packages/ts-sdk/src/providers/delegate.ts
+++ b/packages/ts-sdk/src/providers/delegate.ts
@@ -7,12 +7,11 @@ import { SignedIntent } from "./ark";
 export interface DelegateInfo {
     /** Delegate public key. */
     pubkey: string;
-    /** Delegate fee amount or expression returned by the delegation service. */
+    /** Delegate fee amount or expression returned by the delegate. */
     fee: string;
-    /**
-     * Address controlled by the delegation service.
-     * Naming is confusing: should be thought of as a "delegate address".
-     */
+    /** Address for delegate fee collection. Kept optional as it's not yet  */
+    delegateAddress: string;
+    /** @deprecated alias for @see DelegateInfo.delegateAddress */
     delegatorAddress: string;
 }
 
@@ -31,9 +30,9 @@ export interface DelegateOptions {
 }
 
 /**
- * Provider interface for remote delegation services.
+ * Provider interface for remote delegation service.
  */
-export interface DelegatorProvider {
+export interface DelegateProvider {
     /**
      * Request delegation for a signed register intent and its forfeit transactions.
      *
@@ -55,20 +54,23 @@ export interface DelegatorProvider {
     getDelegateInfo(): Promise<DelegateInfo>;
 }
 
+/** @deprecated alias for @see DelegateProvider */
+export type DelegatorProvider = DelegateProvider;
+
 /**
- * REST-based delegation provider implementation.
+ * REST-based delegate provider implementation.
  * @example
  * ```typescript
- * const provider = new RestDelegatorProvider('https://delegator.example.com');
+ * const provider = new RestDelegateProvider('https://delegate.example.com');
  * const info = await provider.getDelegateInfo();
  * await provider.delegate(intent, forfeitTxs);
  * ```
  */
-export class RestDelegatorProvider implements DelegatorProvider {
+export class RestDelegateProvider implements DelegateProvider {
     /**
-     * Create a REST delegation provider targeting the given base URL.
+     * Create a REST delegate provider targeting the given base URL.
      *
-     * @param url - Base URL of the delegation service
+     * @param url - Base URL of the remote delegation service.
      */
     constructor(public url: string) {}
 
@@ -114,6 +116,7 @@ export class RestDelegatorProvider implements DelegatorProvider {
      * @throws Error if the remote service returns invalid data
      */
     async getDelegateInfo(): Promise<DelegateInfo> {
+        /** TODO: Update later once Fulmine URL changed */
         const url = `${this.url}/v1/delegator/info`;
         const response = await fetch(url);
 
@@ -126,10 +129,18 @@ export class RestDelegatorProvider implements DelegatorProvider {
         if (!isDelegateInfo(data)) {
             throw new Error("Invalid delegate info");
         }
-        return data;
+        return {
+            ...data,
+            delegateAddress: data.delegateAddress || data.delegatorAddress,
+        };
     }
 }
 
+/** @deprecated alias for @see RestDelegateProvider */
+export const RestDelegatorProvider = RestDelegateProvider;
+export type RestDelegatorProvider = RestDelegateProvider;
+
+/** Note: doesn't validate `delegateAddress`, as this isn't returned by Fulmine yet. */
 function isDelegateInfo(data: unknown): data is DelegateInfo {
     return (
         !!data &&

--- a/packages/ts-sdk/src/script/delegate.ts
+++ b/packages/ts-sdk/src/script/delegate.ts
@@ -5,7 +5,7 @@ import { TapLeafScript, VtxoScript } from "./base";
 import { hex } from "@scure/base";
 
 /**
- * DelegateVtxo extends DefaultVtxo with an extra delegator path
+ * DelegateVtxo extends DefaultVtxo with an extra delegate path
  */
 export namespace DelegateVtxo {
     /**

--- a/packages/ts-sdk/src/wallet/delegate.ts
+++ b/packages/ts-sdk/src/wallet/delegate.ts
@@ -283,7 +283,8 @@ async function delegate(
         }
         amount += BigInt(coin.value) - BigInt(inputFee.value);
     }
-    const { delegateAddress, pubkey, fee } = delegateInfo;
+    const { pubkey, fee } = delegateInfo;
+    const delegateAddress = delegateInfo.delegateAddress || delegateInfo.delegatorAddress;
 
     const outputs = [];
     const delegateFee = BigInt(Number(fee));

--- a/packages/ts-sdk/src/wallet/delegate.ts
+++ b/packages/ts-sdk/src/wallet/delegate.ts
@@ -22,7 +22,7 @@ import {
     VtxoScript,
 } from "..";
 import { ContractVtxo } from "../contracts/types";
-import { DelegatorProvider } from "../providers/delegator";
+import { DelegateProvider } from "../providers/delegate";
 import { base64, hex } from "@scure/base";
 import { scriptFromTapLeafScript } from "../script/base";
 import { buildForfeitTxWithOutput } from "../forfeit";
@@ -33,13 +33,13 @@ import { getNetwork, NetworkName } from "../networks";
 import { createAssetPacket } from "./asset";
 import { Extension } from "../extension";
 
-export interface IDelegatorManager {
+export interface IDelegateManager {
     /**
      * Delegate virtual outputs to the remote delegation service.
      *
      * Vtxos that are not locked to a delegate-type contract (no tap leaf
-     * matches the delegator's pubkey) are filtered out silently, since they
-     * cannot be co-signed by the delegator.
+     * matches the delegate's pubkey) are filtered out silently, since they
+     * cannot be co-signed by the delegate.
      *
      * @param vtxos - Virtual outputs to delegate
      * @param destination - Arkade address that should receive renewed funds
@@ -59,16 +59,19 @@ export interface IDelegatorManager {
     getDelegateInfo(): Promise<DelegateInfo>;
 }
 
-export class DelegatorManagerImpl implements IDelegatorManager {
-    /** Create a delegator manager from the configured provider, Arkade info source, and wallet identity. */
+/** @deprecated alias for @see IDelegateManager */
+export type IDelegatorManager = IDelegateManager;
+
+export class DelegateManagerImpl implements IDelegateManager {
+    /** Create a delegate manager from the configured provider, Arkade info source, and wallet identity. */
     constructor(
-        readonly delegatorProvider: DelegatorProvider,
+        readonly delegateProvider: DelegateProvider,
         readonly arkInfoProvider: Pick<ArkProvider, "getInfo">,
         readonly identity: Identity,
     ) {}
 
     async getDelegateInfo(): Promise<DelegateInfo> {
-        return this.delegatorProvider.getDelegateInfo();
+        return this.delegateProvider.getDelegateInfo();
     }
 
     async delegate(
@@ -85,9 +88,9 @@ export class DelegatorManagerImpl implements IDelegatorManager {
 
         const destinationScript = ArkAddress.decode(destination).pkScript;
 
-        // fetch server and delegator info once, shared across all groups
+        // fetch server and delegate info once, shared across all groups
         const arkInfo = await this.arkInfoProvider.getInfo();
-        const delegateInfo = await this.delegatorProvider.getDelegateInfo();
+        const delegateInfo = await this.delegateProvider.getDelegateInfo();
 
         // keep only vtxos that can be signed by the delegate. The guard
         // narrows ContractVtxo (with optional taproot fields) to the
@@ -105,7 +108,7 @@ export class DelegatorManagerImpl implements IDelegatorManager {
             try {
                 await delegate(
                     this.identity,
-                    this.delegatorProvider,
+                    this.delegateProvider,
                     arkInfo,
                     delegateInfo,
                     eligible,
@@ -143,7 +146,7 @@ export class DelegatorManagerImpl implements IDelegatorManager {
             try {
                 await delegate(
                     this.identity,
-                    this.delegatorProvider,
+                    this.delegateProvider,
                     arkInfo,
                     delegateInfo,
                     recoverableVtxos,
@@ -173,7 +176,7 @@ export class DelegatorManagerImpl implements IDelegatorManager {
             groupsList.map(async ([, vtxosGroup]) =>
                 delegate(
                     this.identity,
-                    this.delegatorProvider,
+                    this.delegateProvider,
                     arkInfo,
                     delegateInfo,
                     vtxosGroup,
@@ -199,6 +202,10 @@ export class DelegatorManagerImpl implements IDelegatorManager {
     }
 }
 
+/** @deprecated alias for @see DelegateManagerImpl */
+export const DelegatorManagerImpl = DelegateManagerImpl;
+export type DelegatorManagerImpl = DelegateManagerImpl;
+
 /**
  * Delegates virtual outputs to a delegation service, allowing them to manage their renewal
  * on behalf of the wallet owner.
@@ -209,7 +216,7 @@ export class DelegatorManagerImpl implements IDelegatorManager {
  */
 async function delegate(
     identity: Identity,
-    delegatorProvider: DelegatorProvider,
+    delegateProvider: DelegateProvider,
     arkInfo: ArkInfo,
     delegateInfo: DelegateInfo,
     vtxos: ExtendedVirtualCoin[],
@@ -220,8 +227,8 @@ async function delegate(
         throw new Error("unable to delegate: no vtxos provided");
     }
 
-    if (!delegatorProvider) {
-        throw new Error("unable to delegate: delegator provider not configured");
+    if (!delegateProvider) {
+        throw new Error("unable to delegate: delegate provider not configured");
     }
 
     if (!delegateAt) {
@@ -276,15 +283,15 @@ async function delegate(
         }
         amount += BigInt(coin.value) - BigInt(inputFee.value);
     }
-    const { delegatorAddress, pubkey, fee } = delegateInfo;
+    const { delegateAddress, pubkey, fee } = delegateInfo;
 
     const outputs = [];
-    const delegatorFee = BigInt(Number(fee));
+    const delegateFee = BigInt(Number(fee));
 
-    if (delegatorFee > 0n) {
+    if (delegateFee > 0n) {
         outputs.push({
-            script: ArkAddress.decode(delegatorAddress).pkScript,
-            amount: delegatorFee,
+            script: ArkAddress.decode(delegateAddress).pkScript,
+            amount: delegateFee,
         });
     }
 
@@ -304,7 +311,7 @@ async function delegate(
     }
     amount -= BigInt(outputFee);
 
-    amount -= delegatorFee;
+    amount -= delegateFee;
     if (amount <= dust) {
         throw new Error("Amount is below dust limit, cannot delegate");
     }
@@ -343,7 +350,7 @@ async function delegate(
             }),
     );
 
-    await delegatorProvider.delegate(registerIntent, forfeits);
+    await delegateProvider.delegate(registerIntent, forfeits);
 }
 
 async function makeDelegateForfeitTx(

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -18,7 +18,7 @@ import type { VirtualCoin } from "..";
 import type { SettlementEvent } from "../../providers/ark";
 import type { Identity } from "../../identity";
 import type { IContractManager } from "../../contracts/contractManager";
-import type { IDelegatorManager } from "../delegator";
+import type { IDelegateManager } from "../delegate";
 import type { TaskQueue, TaskItem } from "../../worker/expo/taskQueue";
 import type { TaskProcessor, TaskDependencies } from "../../worker/expo/taskRunner";
 import { runTasks } from "../../worker/expo/taskRunner";
@@ -290,8 +290,13 @@ export class ExpoWallet implements IWallet {
         return this.wallet.getContractManager();
     }
 
-    getDelegatorManager(): Promise<IDelegatorManager | undefined> {
-        return this.wallet.getDelegatorManager();
+    getDelegateManager(): Promise<IDelegateManager | undefined> {
+        return this.wallet.getDelegateManager();
+    }
+
+    /** @deprecated alias for @see ExpoWallet.getDelegateManager */
+    getDelegatorManager(): Promise<IDelegateManager | undefined> {
+        return this.wallet.getDelegateManager();
     }
 
     sendBitcoin(params: SendBitcoinParams): Promise<string> {

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -10,8 +10,8 @@ import { OnchainProvider } from "../providers/onchain";
 import { ContractWatcherConfig } from "../contracts/contractWatcher";
 import { ContractRepository, WalletRepository } from "../repositories";
 import { IContractManager } from "../contracts/contractManager";
-import { IDelegatorManager } from "./delegator";
-import { DelegatorProvider } from "../providers/delegator";
+import { IDelegateManager } from "./delegate";
+import { DelegateProvider } from "../providers/delegate";
 
 /** Defaults */
 export const DEFAULT_ARKADE_SERVER_URL = "https://arkade.computer" as const;
@@ -52,7 +52,7 @@ export type WalletMode = "auto" | "static" | "hd" | DescriptorProvider;
  * derived service URLs such as `indexerUrl` and `esploraUrl`.
  *
  * Provider-based configuration supplies concrete provider instances directly,
- * including the ArkProvider, IndexerProvider, OnchainProvider, and DelegatorProvider.
+ * including the ArkProvider, IndexerProvider, OnchainProvider, and DelegateProvider.
  *
  * The wallet will use provided URLs to create default providers if custom provider
  * instances are not supplied. If optional parameters are not provided, the wallet
@@ -105,7 +105,9 @@ export interface BaseWalletConfig {
     /** Optional onchain provider instance. */
     onchainProvider?: OnchainProvider;
     /** Optional delegation service instance. */
-    delegatorProvider?: DelegatorProvider;
+    delegateProvider?: DelegateProvider;
+    /** @deprecated alias for @see BaseWalletConfig.delegateProvider */
+    delegatorProvider?: DelegateProvider;
 }
 
 /**
@@ -850,7 +852,10 @@ export interface IWallet extends IReadonlyWallet {
     assetManager: IAssetManager;
 
     /** @returns Delegation manager, when configured. */
-    getDelegatorManager(): Promise<IDelegatorManager | undefined>;
+    getDelegateManager(): Promise<IDelegateManager | undefined>;
+
+    /** @deprecated alias for @see IWallet.getDelegateManager */
+    getDelegatorManager(): Promise<IDelegateManager | undefined>;
 }
 
 /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -34,7 +34,7 @@ import {
     VirtualCoin,
     WalletBalance,
 } from "../index";
-import { DelegateInfo } from "../../providers/delegator";
+import { DelegateInfo } from "../../providers/delegate";
 import { ReadonlyWallet, Wallet } from "../wallet";
 import { extendCoin } from "../utils";
 import { MessageHandler, RequestEnvelope, ResponseEnvelope } from "../../worker/messageBus";
@@ -105,12 +105,16 @@ export class ReadonlyWalletError extends Error {
     }
 }
 
-export class DelegatorNotConfiguredError extends Error {
+export class DelegateNotConfiguredError extends Error {
     constructor() {
-        super("Delegator not configured");
-        this.name = "DelegatorNotConfiguredError";
+        super("Delegate not configured");
+        this.name = "DelegateNotConfiguredError";
     }
 }
+
+/** @deprecated alias for DelegateNotConfiguredError */
+export const DelegatorNotConfiguredError = DelegateNotConfiguredError;
+export type DelegatorNotConfiguredError = DelegateNotConfiguredError;
 
 export const DEFAULT_MESSAGE_TAG = "WALLET_UPDATER";
 
@@ -984,11 +988,11 @@ export class WalletMessageHandler
                 }
                 case "GET_DELEGATE_INFO": {
                     const wallet = this.requireWallet();
-                    const delegatorManager = await wallet.getDelegatorManager();
-                    if (!delegatorManager) {
-                        throw new DelegatorNotConfiguredError();
+                    const delegateManager = await wallet.getDelegateManager();
+                    if (!delegateManager) {
+                        throw new DelegateNotConfiguredError();
                     }
-                    const info = await delegatorManager.getDelegateInfo();
+                    const info = await delegateManager.getDelegateInfo();
                     return this.tagged({
                         id,
                         type: "DELEGATE_INFO",
@@ -1426,9 +1430,9 @@ export class WalletMessageHandler
 
     private async handleDelegate(message: RequestDelegate): Promise<ResponseDelegate> {
         const wallet = this.requireWallet();
-        const delegatorManager = await wallet.getDelegatorManager();
-        if (!delegatorManager) {
-            throw new DelegatorNotConfiguredError();
+        const delegateManager = await wallet.getDelegateManager();
+        if (!delegateManager) {
+            throw new DelegateNotConfiguredError();
         }
 
         const { vtxoOutpoints, destination, delegateAt } = message.payload;
@@ -1438,7 +1442,7 @@ export class WalletMessageHandler
             .filter((v) => outpointSet.has(`${v.txid}:${v.vout}`))
             .map((v) => ({ ...v, contractScript: v.script }));
 
-        const result = await delegatorManager.delegate(
+        const result = await delegateManager.delegate(
             filtered,
             destination,
             delegateAt !== undefined ? new Date(delegateAt) : undefined,

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -128,10 +128,10 @@ import type {
     ScanResult,
 } from "../../contracts/contractManager";
 import type { ContractState } from "../../contracts/types";
-import type { IDelegatorManager } from "../delegator";
+import type { IDelegateManager } from "../delegate";
 import type { IVtxoManager, SettlementConfig } from "../vtxo-manager";
 import type { ContractWatcherConfig } from "../../contracts/contractWatcher";
-import type { DelegateInfo } from "../../providers/delegator";
+import type { DelegateInfo } from "../../providers/delegate";
 import { getRandomId } from "../utils";
 import type { VirtualCoin } from "..";
 import { MESSAGE_BUS_NOT_INITIALIZED, ServiceWorkerTimeoutError } from "../../worker/errors";
@@ -354,11 +354,9 @@ interface ServiceWorkerWalletOptions {
     storage?: StorageConfig;
     /** Identity used to derive addresses and optionally sign operations. */
     identity: ReadonlyIdentity | Identity;
-    /**
-     * Optional delegation service URL.
-     *
-     * @deprecated Provide an explicit `DelegatorProvider` instance instead.
-     */
+    /** Optional delegation service URL. */
+    delegateUrl?: string;
+    /** @deprecated alias for @see ServiceWorkerWalletOptions.delegateUrl */
     delegatorUrl?: string;
     /**
      * Override the default tag used for messages sent to and received from the service worker.
@@ -416,6 +414,8 @@ type MessageBusInitConfig = {
         url: string;
         publicKey?: string;
     };
+    delegateUrl?: string;
+    /** @deprecated alias for @see MessageBusInitConfig.delegateUrl */
     delegatorUrl?: string;
     indexerUrl?: string;
     esploraUrl?: string;
@@ -481,6 +481,8 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
     // these immediately after construction.
     protected arkServerUrl?: string;
     protected arkServerPublicKey?: string;
+    protected delegateUrl?: string;
+    /** @deprecated alias for @see ServiceWorkerReadonlyWallet.delegateUrl */
     protected delegatorUrl?: string;
     protected indexerUrl?: string;
     protected esploraUrl?: string;
@@ -550,7 +552,8 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             key: { publicKey },
             arkServerUrl: getArkadeServerUrl(options),
             arkServerPublicKey: options.arkServerPublicKey,
-            delegatorUrl: options.delegatorUrl,
+            delegateUrl: options.delegateUrl || options.delegatorUrl,
+            delegatorUrl: options.delegateUrl || options.delegatorUrl,
         };
 
         // Precompute the merged timeout map so page-side waiting and
@@ -568,7 +571,8 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 url: getArkadeServerUrl(options),
                 publicKey: options.arkServerPublicKey,
             },
-            delegatorUrl: options.delegatorUrl,
+            delegateUrl: options.delegateUrl || options.delegatorUrl,
+            delegatorUrl: options.delegateUrl || options.delegatorUrl,
             indexerUrl: options.indexerUrl,
             esploraUrl: options.esploraUrl,
             watcherConfig: options.watcherConfig,
@@ -848,7 +852,8 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 url: this.arkServerUrl,
                 publicKey: this.arkServerPublicKey,
             },
-            delegatorUrl: this.delegatorUrl,
+            delegateUrl: this.delegateUrl || this.delegatorUrl,
+            delegatorUrl: this.delegateUrl || this.delegatorUrl,
             indexerUrl: this.indexerUrl,
             esploraUrl: this.esploraUrl,
             watcherConfig: this.watcherConfig,
@@ -1284,7 +1289,7 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
     public readonly contractRepository: ContractRepository;
     public readonly identity: Identity;
     private readonly _assetManager: IAssetManager;
-    private readonly hasDelegator: boolean;
+    private readonly hasDelegate: boolean;
 
     protected constructor(
         public readonly serviceWorker: ServiceWorker,
@@ -1292,7 +1297,7 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
         walletRepository: WalletRepository,
         contractRepository: ContractRepository,
         messageTag: string,
-        hasDelegator: boolean,
+        hasDelegate: boolean,
     ) {
         super(serviceWorker, identity, walletRepository, contractRepository, messageTag);
         this.identity = identity;
@@ -1302,7 +1307,7 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
             (msg) => this.sendMessage(msg),
             messageTag,
         );
-        this.hasDelegator = hasDelegator;
+        this.hasDelegate = hasDelegate;
     }
 
     get assetManager(): IAssetManager {
@@ -1337,7 +1342,7 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
             walletRepository,
             contractRepository,
             messageTag,
-            !!options.delegatorUrl,
+            !!(options.delegateUrl || options.delegatorUrl),
         );
 
         // INIT_WALLET retains the legacy `key` payload for wire compatibility
@@ -1350,7 +1355,8 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
             key: legacyPrivateKey ? { privateKey: legacyPrivateKey } : {},
             arkServerUrl: getArkadeServerUrl(options),
             arkServerPublicKey: options.arkServerPublicKey,
-            delegatorUrl: options.delegatorUrl,
+            delegateUrl: options.delegateUrl || options.delegatorUrl,
+            delegatorUrl: options.delegateUrl || options.delegatorUrl,
         };
 
         // Precompute the merged timeout map so page-side waiting and
@@ -1368,7 +1374,8 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
                 url: getArkadeServerUrl(options),
                 publicKey: options.arkServerPublicKey,
             },
-            delegatorUrl: options.delegatorUrl,
+            delegateUrl: options.delegateUrl || options.delegatorUrl,
+            delegatorUrl: options.delegateUrl || options.delegatorUrl,
             indexerUrl: options.indexerUrl,
             esploraUrl: options.esploraUrl,
             settlementConfig: options.settlementConfig,
@@ -1518,15 +1525,15 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
         }
     }
 
-    async getDelegatorManager(): Promise<IDelegatorManager | undefined> {
-        if (!this.hasDelegator) {
+    async getDelegateManager(): Promise<IDelegateManager | undefined> {
+        if (!this.hasDelegate) {
             return undefined;
         }
 
         const wallet = this;
         const messageTag = this.messageTag;
 
-        const manager: IDelegatorManager = {
+        const manager: IDelegateManager = {
             async delegate(vtxos, destination, delegateAt?) {
                 const message: RequestDelegate = {
                     tag: messageTag,
@@ -1573,6 +1580,11 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
         };
 
         return manager;
+    }
+
+    /** @deprecated alias for @see ServiceWorkerWallet.getDelegateManager */
+    async getDelegatorManager() {
+        return await this.getDelegateManager();
     }
 
     async getVtxoManager(): Promise<IVtxoManager> {

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -995,8 +995,8 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         }, 1000);
 
         try {
-            const [delegatorManager, contractManager, destination] = await Promise.all([
-                this.wallet.getDelegatorManager(),
+            const [delegateManager, contractManager, destination] = await Promise.all([
+                this.wallet.getDelegateManager(),
                 this.wallet.getContractManager(),
                 this.wallet.getAddress(),
             ]);
@@ -1048,8 +1048,8 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                     });
                 }
 
-                if (delegatorManager) {
-                    delegatorManager.delegate(event.vtxos, destination).catch((e) => {
+                if (delegateManager) {
+                    delegateManager.delegate(event.vtxos, destination).catch((e) => {
                         console.error("Error delegating VTXOs:", e);
                     });
                 }

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -67,12 +67,12 @@ import { extendCoin, validateRecipients } from "./utils";
 import { ArkError } from "../providers/errors";
 import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
-import { DelegatorProvider } from "../providers/delegator";
+import { DelegateProvider } from "../providers/delegate";
 import { buildTransactionHistory } from "../utils/transactionHistory";
 import { AssetManager, ReadonlyAssetManager } from "./asset-manager";
 import { Extension } from "../extension";
 import { DelegateVtxo } from "../script/delegate";
-import { DelegatorManagerImpl, findDestinationOutputIndex, IDelegatorManager } from "./delegator";
+import { DelegateManagerImpl, findDestinationOutputIndex, IDelegateManager } from "./delegate";
 import { IndexedDBContractRepository, IndexedDBWalletRepository } from "../repositories";
 import { ContractManager } from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
@@ -208,7 +208,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         readonly dustAmount: bigint,
         public readonly walletRepository: WalletRepository,
         public readonly contractRepository: ContractRepository,
-        readonly delegatorProvider?: DelegatorProvider,
+        readonly delegateProvider?: DelegateProvider,
         watcherConfig?: ReadonlyWalletConfig["watcherConfig"],
         walletContractTimelocks?: RelativeTimelock[],
     ) {
@@ -357,11 +357,15 @@ export class ReadonlyWallet implements IReadonlyWallet {
         // Generate tapscripts for offchain and boarding address
         const serverPubKey = hex.decode(info.signerPubkey).slice(1);
 
-        const delegatePubKey = config.delegatorProvider
-            ? await config.delegatorProvider
+        const delegatePubKey = config.delegateProvider
+            ? await config.delegateProvider
                   .getDelegateInfo()
                   .then((info) => hex.decode(info.pubkey).slice(1))
-            : undefined;
+            : config.delegatorProvider
+              ? await config.delegatorProvider
+                    .getDelegateInfo()
+                    .then((info) => hex.decode(info.pubkey).slice(1))
+              : undefined;
 
         const offchainOptions = {
             pubKey,
@@ -395,7 +399,9 @@ export class ReadonlyWallet implements IReadonlyWallet {
             walletRepository,
             contractRepository,
             info,
-            delegatorProvider: config.delegatorProvider,
+            delegateProvider: config.delegateProvider || config.delegatorProvider,
+            /** @deprecated alias for `delegateProvider` */
+            delegatorProvider: config.delegateProvider || config.delegatorProvider,
             walletContractTimelocks,
         };
     }
@@ -425,7 +431,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             setup.dustAmount,
             setup.walletRepository,
             setup.contractRepository,
-            setup.delegatorProvider,
+            setup.delegateProvider || setup.delegatorProvider,
             config.watcherConfig,
             setup.walletContractTimelocks,
         );
@@ -1007,7 +1013,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
     static MIN_FEE_RATE = 1; // sats/vbyte
 
     override readonly identity: Identity;
-    private readonly _delegatorManager?: IDelegatorManager;
+    private readonly _delegateManager?: IDelegateManager;
     private _vtxoManager?: VtxoManager;
     private _vtxoManagerInitializing?: Promise<VtxoManager>;
 
@@ -1218,7 +1224,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         contractRepository: ContractRepository,
         /** @deprecated Use settlementConfig */
         renewalConfig?: WalletConfig["renewalConfig"],
-        delegatorProvider?: DelegatorProvider,
+        delegateProvider?: DelegateProvider,
         watcherConfig?: WalletConfig["watcherConfig"],
         settlementConfig?: WalletConfig["settlementConfig"],
         walletContractTimelocks?: RelativeTimelock[],
@@ -1236,7 +1242,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             dustAmount,
             walletRepository,
             contractRepository,
-            delegatorProvider,
+            delegateProvider,
             watcherConfig,
             walletContractTimelocks,
         );
@@ -1265,8 +1271,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             // No config at all → enabled by default
             this.settlementConfig = { ...DEFAULT_SETTLEMENT_CONFIG };
         }
-        this._delegatorManager = delegatorProvider
-            ? new DelegatorManagerImpl(delegatorProvider, arkProvider, identity)
+        this._delegateManager = delegateProvider
+            ? new DelegateManagerImpl(delegateProvider, arkProvider, identity)
             : undefined;
         this._receiveRotator = receiveRotator;
         this._descriptorProvider = descriptorProvider;
@@ -1429,7 +1435,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             setup.walletRepository,
             setup.contractRepository,
             config.renewalConfig,
-            config.delegatorProvider,
+            config.delegateProvider || config.delegatorProvider,
             config.watcherConfig,
             config.settlementConfig,
             setup.walletContractTimelocks,
@@ -1475,15 +1481,20 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             this.dustAmount,
             this.walletRepository,
             this.contractRepository,
-            this.delegatorProvider,
+            this.delegateProvider,
             this.watcherConfig,
             this.walletContractTimelocks,
         );
     }
 
-    /** Returns the delegator manager when delegation support is configured. */
-    async getDelegatorManager(): Promise<IDelegatorManager | undefined> {
-        return this._delegatorManager;
+    /** Returns the delegate manager when delegation support is configured. */
+    async getDelegateManager(): Promise<IDelegateManager | undefined> {
+        return this._delegateManager;
+    }
+
+    /** @deprecated alias for @see Wallet.getDelegateManager */
+    async getDelegatorManager(): Promise<IDelegateManager | undefined> {
+        return this.getDelegateManager();
     }
 
     /**

--- a/packages/ts-sdk/src/worker/messageBus.ts
+++ b/packages/ts-sdk/src/worker/messageBus.ts
@@ -2,7 +2,7 @@
 
 import { getActiveServiceWorker, setupServiceWorkerOnce } from "./browser/service-worker-manager";
 import { ArkProvider, RestArkProvider } from "../providers/ark";
-import { RestDelegatorProvider } from "../providers/delegator";
+import { RestDelegateProvider } from "../providers/delegate";
 import {
     type Identity,
     type ReadonlyIdentity,
@@ -16,7 +16,6 @@ import { ReadonlyWallet, Wallet } from "../wallet/wallet";
 import type { SettlementConfig } from "../wallet/vtxo-manager";
 import type { ContractWatcherConfig } from "../contracts/contractWatcher";
 import { ContractRepository, WalletRepository } from "../repositories";
-import { getRandomId } from "../wallet/utils";
 import { MessageBusNotInitializedError, ServiceWorkerTimeoutError } from "./errors";
 
 declare const self: ServiceWorkerGlobalScope;
@@ -136,6 +135,8 @@ type Initialize = {
             url: string;
             publicKey?: string;
         };
+        delegateUrl?: string;
+        /** @deprecated alias for @see Initialize.config.delegateUrl */
         delegatorUrl?: string;
         indexerUrl?: string;
         esploraUrl?: string;
@@ -338,9 +339,11 @@ export class MessageBus {
             walletRepository: this.walletRepository,
             contractRepository: this.contractRepository,
         };
-        const delegatorProvider = config.delegatorUrl
-            ? new RestDelegatorProvider(config.delegatorUrl)
-            : undefined;
+        const delegateProvider = config.delegateUrl
+            ? new RestDelegateProvider(config.delegateUrl)
+            : config.delegatorUrl
+              ? new RestDelegateProvider(config.delegatorUrl)
+              : undefined;
 
         const serialized = normalizeSerializedIdentity(config.wallet);
 
@@ -353,7 +356,7 @@ export class MessageBus {
                 indexerUrl: config.indexerUrl,
                 esploraUrl: config.esploraUrl,
                 storage,
-                delegatorProvider,
+                delegateProvider,
                 settlementConfig: config.settlementConfig,
                 walletMode: config.walletMode,
                 watcherConfig: config.watcherConfig,
@@ -369,7 +372,7 @@ export class MessageBus {
             indexerUrl: config.indexerUrl,
             esploraUrl: config.esploraUrl,
             storage,
-            delegatorProvider,
+            delegateProvider,
             watcherConfig: config.watcherConfig,
         });
         return { readonlyWallet, arkProvider };

--- a/packages/ts-sdk/test/contracts/cross-contract-spend.test.ts
+++ b/packages/ts-sdk/test/contracts/cross-contract-spend.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { hex } from "@scure/base";
-import { InMemoryContractRepository, InMemoryWalletRepository, SingleKey, Wallet } from "../../src";
+import {
+    DelegateProvider,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    SingleKey,
+    Wallet,
+} from "../../src";
 import { ArkProvider } from "../../src/providers/ark";
-import { DelegatorProvider } from "../../src/providers/delegator";
 import { OnchainProvider } from "../../src/providers/onchain";
 import { IndexerProvider } from "../../src/providers/indexer";
 import { VirtualCoin } from "../../src/wallet";
@@ -26,7 +31,7 @@ function createMockArkProvider(): ArkProvider {
             forfeitAddress: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080",
             checkpointTapscript: "5ab27520" + serverPubKeyHex + "ac",
             dust: 450n,
-            fees: { delegatorFeeBps: 0 },
+            fees: { delegateFeeBps: 0, delegatorFeeBps: 0 },
             deprecatedSigners: [],
             digest: "",
             scheduledSession: undefined,
@@ -65,12 +70,13 @@ function createMockOnchainProvider(): OnchainProvider {
     };
 }
 
-function createMockDelegatorProvider(): DelegatorProvider {
+function createMockDelegateProvider(): DelegateProvider {
     return {
         delegate: vi.fn(),
         getDelegateInfo: vi.fn().mockResolvedValue({
             pubkey: "02" + delegatePubKeyHex,
             fee: "0",
+            delegateAddress: "delegate-address",
             delegatorAddress: "delegate-address",
         }),
     };
@@ -125,7 +131,7 @@ describe("Cross-contract spending", () => {
         const identity = SingleKey.fromHex(mockPrivKeyHex);
         const arkProvider = createMockArkProvider();
         const onchainProvider = createMockOnchainProvider();
-        const delegatorProvider = createMockDelegatorProvider();
+        const delegateProvider = createMockDelegateProvider();
         const mockIndexer = createMockIndexerProvider();
 
         // Create wallet with delegate enabled.
@@ -136,7 +142,7 @@ describe("Cross-contract spending", () => {
             arkProvider,
             indexerProvider: mockIndexer,
             onchainProvider,
-            delegatorProvider,
+            delegateProvider,
             storage: { walletRepository, contractRepository },
         });
 

--- a/packages/ts-sdk/test/contracts/delegator-lifecycle.test.ts
+++ b/packages/ts-sdk/test/contracts/delegator-lifecycle.test.ts
@@ -14,7 +14,7 @@ import {
     TEST_DELEGATE_SCRIPT,
 } from "./helpers";
 
-describe("Delegator Lifecycle", () => {
+describe("Delegate Lifecycle", () => {
     let contractRepository: InMemoryContractRepository;
     let walletRepository: InMemoryWalletRepository;
     let mockIndexer: IndexerProvider;
@@ -30,8 +30,8 @@ describe("Delegator Lifecycle", () => {
         vi.useRealTimers();
     });
 
-    it("should add delegator - persisted contracts survive re-creation", async () => {
-        // Phase 1 — No delegator: only default contract
+    it("should add delegate - persisted contracts survive re-creation", async () => {
+        // Phase 1 — No delegate: only default contract
         const manager1 = await ContractManager.create({
             indexerProvider: mockIndexer,
             contractRepository,
@@ -72,7 +72,7 @@ describe("Delegator Lifecycle", () => {
 
         manager1.dispose();
 
-        // Phase 2 — Add delegator: re-create manager with same repos, register delegate
+        // Phase 2 — Add delegate: re-create manager with same repos, register delegate
         const manager2 = await ContractManager.create({
             indexerProvider: mockIndexer,
             contractRepository,
@@ -128,7 +128,7 @@ describe("Delegator Lifecycle", () => {
         manager2.dispose();
     });
 
-    it("should remove delegator — persisted delegate contracts remain accessible", async () => {
+    it("should remove delegate — persisted delegate contracts remain accessible", async () => {
         // Setup: create both contracts
         const setupManager = await ContractManager.create({
             indexerProvider: mockIndexer,
@@ -156,7 +156,7 @@ describe("Delegator Lifecycle", () => {
         expect(await setupManager.getContracts()).toHaveLength(2);
         setupManager.dispose();
 
-        // Phase 3 — Remove delegator: re-create manager, only register default
+        // Phase 3 — Remove delegate: re-create manager, only register default
         const manager3 = await ContractManager.create({
             indexerProvider: mockIndexer,
             contractRepository,
@@ -206,7 +206,7 @@ describe("Delegator Lifecycle", () => {
             expect(cwv.vtxos).toHaveLength(1);
         }
 
-        // Both spending paths still work even without delegator service
+        // Both spending paths still work even without delegate service
         const defaultPaths = await manager3.getAllSpendingPaths({
             contractScript: TEST_DEFAULT_SCRIPT,
         });

--- a/packages/ts-sdk/test/e2e/ark.test.ts
+++ b/packages/ts-sdk/test/e2e/ark.test.ts
@@ -19,6 +19,7 @@ import {
     EsploraProvider,
     InMemoryWalletRepository,
     InMemoryContractRepository,
+    RestDelegateProvider,
 } from "../../src";
 import {
     arkdExec,
@@ -26,7 +27,6 @@ import {
     clearFees,
     createTestArkWallet,
     createTestArkWalletWithDelegate,
-    createTestArkWalletWithMnemonic,
     createTestIdentity,
     createTestOnchainWallet,
     execCommand,
@@ -35,7 +35,6 @@ import {
     setFees,
     waitFor,
 } from "./utils";
-import { RestDelegatorProvider } from "../../src/providers/delegator";
 import { hex, base64 } from "@scure/base";
 
 describe("Common", () => {
@@ -1181,8 +1180,8 @@ describe("Delegate", () => {
         const vtxoBeforeDelegate = vtxos[0];
         expect(vtxoBeforeDelegate.txid).toBeDefined();
 
-        const delegatorManager = await alice.wallet.getDelegatorManager();
-        await delegatorManager?.delegate(
+        const delegateManager = await alice.wallet.getDelegateManager();
+        await delegateManager?.delegate(
             [vtxoBeforeDelegate],
             await alice.wallet.getAddress(),
             new Date(Date.now() + 1000),
@@ -1200,11 +1199,11 @@ describe("Delegate", () => {
     });
 });
 
-describe("Delegator Lifecycle", () => {
+describe("Delegate Lifecycle", () => {
     beforeEach(beforeEachFaucet, 20000);
 
     it(
-        "should track and spend VTXOs across delegator add/remove",
+        "should track and spend VTXOs across delegate add/remove ",
         { timeout: 120000 },
         async () => {
             const walletRepository = new InMemoryWalletRepository();
@@ -1216,7 +1215,7 @@ describe("Delegator Lifecycle", () => {
                 pollingInterval: 2000,
             });
 
-            // Phase 1 — No delegator
+            // Phase 1 — No delegate
             const wallet1 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
@@ -1234,13 +1233,13 @@ describe("Delegator Lifecycle", () => {
             const balance1 = await wallet1.getBalance();
             expect(balance1.total).toBeGreaterThanOrEqual(10_000);
 
-            // Phase 2 — Add delegator
+            // Phase 2 — Add delegate
             const wallet2 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
                 onchainProvider,
                 storage: { walletRepository, contractRepository },
-                delegatorProvider: new RestDelegatorProvider("http://localhost:7012"),
+                delegateProvider: new RestDelegateProvider("http://localhost:7012"),
                 settlementConfig: false,
             });
 
@@ -1299,7 +1298,7 @@ describe("Delegator Lifecycle", () => {
             );
             expect(spentDelegateOutpoints.length).toBeGreaterThan(0);
 
-            // Phase 3 — Remove delegator
+            // Phase 3 — Remove delegate
             const wallet3 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
@@ -1373,7 +1372,7 @@ describe("Cross-contract spending", () => {
                 pollingInterval: 2000,
             });
 
-            // Step 1 — No delegator: receive 1000 to default address
+            // Step 1 — No delegate: receive 1000 to default address
             const wallet1 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
@@ -1391,13 +1390,13 @@ describe("Cross-contract spending", () => {
             const balance1 = await wallet1.getBalance();
             expect(balance1.total).toBeGreaterThanOrEqual(1_000);
 
-            // Step 2 — Enable delegator: receive 1000 to delegate address
+            // Step 2 — Enable delegate: receive 1000 to delegate address
             const wallet2 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
                 onchainProvider,
                 storage: { walletRepository, contractRepository },
-                delegatorProvider: new RestDelegatorProvider("http://localhost:7012"),
+                delegateProvider: new RestDelegateProvider("http://localhost:7012"),
                 settlementConfig: false,
             });
 
@@ -1491,7 +1490,7 @@ describe("Cross-contract spending", () => {
                 pollingInterval: 2000,
             });
 
-            // Step 1 — No delegator: receive 1000 to default address
+            // Step 1 — No delegate: receive 1000 to default address
             const wallet1 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
@@ -1503,13 +1502,13 @@ describe("Cross-contract spending", () => {
             const defaultAddress = await wallet1.getAddress();
             await wallet1.getContractManager();
 
-            // Step 2 — Enable delegator: receive 1000 to delegate address
+            // Step 2 — Enable delegate: receive 1000 to delegate address
             const wallet2 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
                 onchainProvider,
                 storage: { walletRepository, contractRepository },
-                delegatorProvider: new RestDelegatorProvider("http://localhost:7012"),
+                delegateProvider: new RestDelegateProvider("http://localhost:7012"),
                 settlementConfig: false,
             });
 
@@ -2017,7 +2016,7 @@ describe("Asset integration tests", () => {
     });
 
     it(
-        "should track and spend VTXOs with assets across delegator add/remove",
+        "should track and spend VTXOs with assets across delegate add/remove",
         { timeout: 120000 },
         async () => {
             const walletRepository = new InMemoryWalletRepository();
@@ -2029,7 +2028,7 @@ describe("Asset integration tests", () => {
                 pollingInterval: 2000,
             });
 
-            // Phase 1 — No delegator: fund and issue asset on default address
+            // Phase 1 — No delegate: fund and issue asset on default address
             const wallet1 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
@@ -2050,13 +2049,13 @@ describe("Asset integration tests", () => {
             expect(issueResult1.assetId).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));
 
-            // Phase 2 — Add delegator: fund and issue asset on delegate address
+            // Phase 2 — Add delegate: fund and issue asset on delegate address
             const wallet2 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
                 onchainProvider,
                 storage: { walletRepository, contractRepository },
-                delegatorProvider: new RestDelegatorProvider("http://localhost:7012"),
+                delegateProvider: new RestDelegateProvider("http://localhost:7012"),
                 settlementConfig: false,
             });
 
@@ -2120,7 +2119,7 @@ describe("Asset integration tests", () => {
                 .reduce((s, a) => s + a.amount, 0n);
             expect(aliceRemaining2).toBe(100n);
 
-            // Phase 3 — Remove delegator: spend via forfeit path with assets
+            // Phase 3 — Remove delegate: spend via forfeit path with assets
             const wallet3 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
@@ -2179,7 +2178,7 @@ describe("Asset integration tests", () => {
                 pollingInterval: 2000,
             });
 
-            // Step 1 — No delegator: fund default address and issue asset
+            // Step 1 — No delegate: fund default address and issue asset
             const wallet1 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
@@ -2200,13 +2199,13 @@ describe("Asset integration tests", () => {
             expect(issueResult.assetId).toBeDefined();
             await new Promise((resolve) => setTimeout(resolve, 1000));
 
-            // Step 2 — Enable delegator: fund delegate address
+            // Step 2 — Enable delegate: fund delegate address
             const wallet2 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
                 onchainProvider,
                 storage: { walletRepository, contractRepository },
-                delegatorProvider: new RestDelegatorProvider("http://localhost:7012"),
+                delegateProvider: new RestDelegateProvider("http://localhost:7012"),
                 settlementConfig: false,
             });
 
@@ -2281,7 +2280,7 @@ describe("Asset integration tests", () => {
                 pollingInterval: 2000,
             });
 
-            // Step 1 — Create wallet without delegator
+            // Step 1 — Create wallet without delegate
             const wallet1 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
@@ -2293,13 +2292,13 @@ describe("Asset integration tests", () => {
             const defaultAddress = await wallet1.getAddress();
             await wallet1.getContractManager();
 
-            // Step 2 — Enable delegator before funding
+            // Step 2 — Enable delegate before funding
             const wallet2 = await Wallet.create({
                 identity,
                 arkServerUrl: "http://localhost:7070",
                 onchainProvider,
                 storage: { walletRepository, contractRepository },
-                delegatorProvider: new RestDelegatorProvider("http://localhost:7012"),
+                delegateProvider: new RestDelegateProvider("http://localhost:7012"),
                 settlementConfig: false,
             });
 

--- a/packages/ts-sdk/test/e2e/settlement.test.ts
+++ b/packages/ts-sdk/test/e2e/settlement.test.ts
@@ -6,8 +6,8 @@ import {
     InMemoryWalletRepository,
     InMemoryContractRepository,
     ArkError,
+    RestDelegateProvider,
 } from "../../src";
-import { RestDelegatorProvider } from "../../src/providers/delegator";
 import { arkdExec, beforeEachFaucet, execCommand, waitFor } from "./utils";
 
 describe("Settlement - Auto-settle boarding UTXOs", () => {
@@ -299,12 +299,12 @@ describe("Settlement - Auto-delegation on vtxo_received", () => {
     beforeEach(beforeEachFaucet, 20000);
 
     it(
-        "should auto-delegate incoming VTXOs when settlement is enabled with delegator",
+        "should auto-delegate incoming VTXOs when settlement is enabled with delegate",
         { timeout: 120000 },
         async () => {
             const identity = SingleKey.fromRandomBytes();
 
-            // Create wallet with settlement enabled + delegator configured.
+            // Create wallet with settlement enabled + delegate configured.
             // The poll loop will auto-settle the boarding UTXO, which triggers
             // vtxo_received → auto-delegate via initializeSubscription.
             const wallet = await Wallet.create({
@@ -318,7 +318,7 @@ describe("Settlement - Auto-delegation on vtxo_received", () => {
                     walletRepository: new InMemoryWalletRepository(),
                     contractRepository: new InMemoryContractRepository(),
                 },
-                delegatorProvider: new RestDelegatorProvider("http://localhost:7012"),
+                delegateProvider: new RestDelegateProvider("http://localhost:7012"),
                 settlementConfig: {
                     pollIntervalMs: 5000,
                 },
@@ -354,7 +354,7 @@ describe("Settlement - Auto-delegation on vtxo_received", () => {
             const vtxosAfter = await wallet.getVtxos();
             const delegatedVtxo = vtxosAfter.find((v) => v.txid !== firstTxid);
             expect(delegatedVtxo).toBeDefined();
-            // With zero delegator fee, value should be preserved
+            // With zero delegate fee, value should be preserved
             expect(delegatedVtxo!.value).toBe(originalValue);
 
             await wallet.dispose();

--- a/packages/ts-sdk/test/e2e/utils.ts
+++ b/packages/ts-sdk/test/e2e/utils.ts
@@ -14,9 +14,9 @@ import {
     WalletRepository,
     ContractRepository,
     WalletMode,
+    RestDelegateProvider,
 } from "../../src";
 import { execSync } from "child_process";
-import { RestDelegatorProvider } from "../../src/providers/delegator";
 import { generateMnemonic } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
@@ -110,7 +110,7 @@ export async function createTestArkWalletWithDelegate(): Promise<TestArkWallet> 
             walletRepository: new InMemoryWalletRepository(),
             contractRepository: new InMemoryContractRepository(),
         },
-        delegatorProvider: new RestDelegatorProvider("http://localhost:7012"),
+        delegateProvider: new RestDelegateProvider("http://localhost:7012"),
         settlementConfig: false,
     });
 
@@ -304,7 +304,7 @@ export function createSharedRepos(): SharedRepos {
 }
 
 /**
- * Create a delegator-enabled wallet using a provided identity and repositories,
+ * Create a delegate-enabled wallet using a provided identity and repositories,
  * with an `ArkProvider` whose `getInfo()` overrides `unilateralExitDelay` to
  * simulate a server-side config change without restarting arkd.
  */
@@ -331,7 +331,7 @@ export async function createTestArkWalletWithDelegateAndOverride(opts: {
             walletRepository: opts.repos.walletRepository,
             contractRepository: opts.repos.contractRepository,
         },
-        delegatorProvider: new RestDelegatorProvider("http://localhost:7012"),
+        delegateProvider: new RestDelegateProvider("http://localhost:7012"),
         settlementConfig: false,
     });
 

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -321,7 +321,7 @@ describe("ServiceWorkerReadonlyWallet", () => {
 const createSWWallet = (
     serviceWorker: ServiceWorker,
     messageTag: string = DEFAULT_MESSAGE_TAG,
-    hasDelegator: boolean = false,
+    hasDelegate: boolean = false,
 ) =>
     new (ServiceWorkerWallet as any)(
         serviceWorker,
@@ -329,7 +329,7 @@ const createSWWallet = (
         new InMemoryWalletRepository(),
         new InMemoryContractRepository(),
         messageTag,
-        hasDelegator,
+        hasDelegate,
     ) as ServiceWorkerWallet;
 
 describe("ServiceWorkerWallet", () => {
@@ -340,7 +340,7 @@ describe("ServiceWorkerWallet", () => {
         vi.unstubAllGlobals();
     });
 
-    it("getDelegatorManager returns undefined when no delegator configured", async () => {
+    it("getDelegateManager returns undefined when no delegate configured", async () => {
         const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness();
 
         vi.stubGlobal("navigator", {
@@ -348,13 +348,14 @@ describe("ServiceWorkerWallet", () => {
         } as any);
 
         const wallet = createSWWallet(serviceWorker as any, messageTag, false);
-        await expect(wallet.getDelegatorManager()).resolves.toBeUndefined();
+        await expect(wallet.getDelegateManager()).resolves.toBeUndefined();
     });
 
-    it("getDelegatorManager returns a manager that proxies messages", async () => {
+    it("getDelegateManager returns a manager that proxies messages", async () => {
         const delegateInfo = {
             pubkey: "02abc",
             fee: "100",
+            delegateAddress: "tark1addr",
             delegatorAddress: "tark1addr",
         };
 
@@ -387,7 +388,7 @@ describe("ServiceWorkerWallet", () => {
         } as any);
 
         const wallet = createSWWallet(serviceWorker as any, messageTag, true);
-        const manager = await wallet.getDelegatorManager();
+        const manager = await wallet.getDelegateManager();
         expect(manager).toBeDefined();
 
         await expect(manager!.getDelegateInfo()).resolves.toEqual(delegateInfo);

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -19,7 +19,7 @@ type MockWalletOptions = {
         onContractEvent: ReturnType<typeof vi.fn>;
         refreshOutpoints?: ReturnType<typeof vi.fn>;
     };
-    delegatorManager?: {
+    delegateManager?: {
         delegate: ReturnType<typeof vi.fn>;
     };
 };
@@ -46,7 +46,7 @@ const createMockWallet = (
     return {
         getVtxos: vi.fn().mockResolvedValue(vtxos),
         getAddress: vi.fn().mockResolvedValue(arkAddress),
-        getDelegatorManager: vi.fn().mockResolvedValue(options.delegatorManager),
+        getDelegateManager: vi.fn().mockResolvedValue(options.delegateManager),
         getContractManager: vi.fn().mockResolvedValue(contractManager),
         settle: vi.fn().mockResolvedValue("mock-txid"),
         dustAmount: 1000n,
@@ -1223,6 +1223,7 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
                 .mockResolvedValue(
                     "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
                 ),
+            getDelegateManager: vi.fn().mockResolvedValue(undefined),
             getDelegatorManager: vi.fn().mockResolvedValue(undefined),
             getContractManager: vi.fn().mockResolvedValue(contractManager),
             settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -1401,6 +1402,7 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
                     .mockResolvedValue(
                         "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
                     ),
+                getDelegateManager: vi.fn().mockResolvedValue(undefined),
                 getDelegatorManager: vi.fn().mockResolvedValue(undefined),
                 getContractManager: vi.fn().mockResolvedValue({
                     onContractEvent: vi.fn().mockReturnValue(() => {}),
@@ -1448,6 +1450,7 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
                     .mockResolvedValue(
                         "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
                     ),
+                getDelegateManager: vi.fn().mockResolvedValue(undefined),
                 getDelegatorManager: vi.fn().mockResolvedValue(undefined),
                 getContractManager: vi.fn().mockResolvedValue(contractManager),
                 settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -1761,6 +1764,7 @@ describe("VtxoManager - Periodic settle cooldown", () => {
                 .mockResolvedValue(
                     "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
                 ),
+            getDelegateManager: vi.fn().mockResolvedValue(undefined),
             getDelegatorManager: vi.fn().mockResolvedValue(undefined),
             getContractManager: vi.fn().mockResolvedValue(contractManager),
             settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -2038,6 +2042,7 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
                 .mockResolvedValue(
                     "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
                 ),
+            getDelegateManager: vi.fn().mockResolvedValue(undefined),
             getDelegatorManager: vi.fn().mockResolvedValue(undefined),
             getContractManager: vi.fn().mockResolvedValue(contractManager),
             settle: vi.fn().mockResolvedValue("mock-txid"),
@@ -2298,7 +2303,7 @@ describe("VtxoManager - Cross-instance poll guard", () => {
                 .mockResolvedValue(
                     "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
                 ),
-            getDelegatorManager: vi.fn().mockResolvedValue(undefined),
+            getDelegateManager: vi.fn().mockResolvedValue(undefined),
             getContractManager: vi.fn().mockResolvedValue(contractManager),
             settle: vi.fn().mockResolvedValue("mock-txid"),
             dustAmount: 330n,
@@ -2432,6 +2437,7 @@ describe("VtxoManager - VTXO_ALREADY_SPENT reconciliation", () => {
                     .mockResolvedValue(
                         "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g",
                     ),
+                getDelegateManager: vi.fn().mockResolvedValue(undefined),
                 getDelegatorManager: vi.fn().mockResolvedValue(undefined),
                 getContractManager: vi.fn().mockResolvedValue(contractManager),
                 settle: vi.fn().mockResolvedValue("mock-txid"),

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -534,7 +534,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue(vtxos),
-            getDelegatorManager: vi.fn().mockResolvedValue({
+            getDelegateManager: vi.fn().mockResolvedValue({
                 delegate: delegateSpy,
             }),
         };
@@ -577,7 +577,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue(vtxos),
-            getDelegatorManager: vi.fn().mockResolvedValue({
+            getDelegateManager: vi.fn().mockResolvedValue({
                 delegate: delegateSpy,
             }),
         };
@@ -607,7 +607,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue(allVtxos),
-            getDelegatorManager: vi.fn().mockResolvedValue({ delegate: delegateSpy }),
+            getDelegateManager: vi.fn().mockResolvedValue({ delegate: delegateSpy }),
         };
 
         await updater.handleMessage({
@@ -623,11 +623,11 @@ describe("WalletMessageHandler handleMessage", () => {
         expect(delegateSpy).toHaveBeenCalledWith([allVtxos[0]], "dest-addr", undefined);
     });
 
-    it("DELEGATE fails when delegatorManager is not configured", async () => {
+    it("DELEGATE fails when delegateManager is not configured", async () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue([]),
-            getDelegatorManager: vi.fn().mockResolvedValue(undefined),
+            getDelegateManager: vi.fn().mockResolvedValue(undefined),
         };
 
         const response = await updater.handleMessage({
@@ -640,7 +640,7 @@ describe("WalletMessageHandler handleMessage", () => {
         } as any);
 
         expect(response.error).toBeInstanceOf(Error);
-        expect(response.error?.message).toBe("Delegator not configured");
+        expect(response.error?.message).toBe("Delegate not configured");
     });
 
     it("DELEGATE fails with readonly wallet only", async () => {
@@ -664,11 +664,12 @@ describe("WalletMessageHandler handleMessage", () => {
         const info = {
             pubkey: "02abc",
             fee: "100",
+            delegateAddress: "tark1addr",
             delegatorAddress: "tark1addr",
         };
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
-            getDelegatorManager: vi.fn().mockResolvedValue({
+            getDelegateManager: vi.fn().mockResolvedValue({
                 getDelegateInfo: vi.fn().mockResolvedValue(info),
             }),
         };
@@ -685,10 +686,10 @@ describe("WalletMessageHandler handleMessage", () => {
         });
     });
 
-    it("GET_DELEGATE_INFO fails when delegatorManager is not configured", async () => {
+    it("GET_DELEGATE_INFO fails when delegateManager is not configured", async () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
-            getDelegatorManager: vi.fn().mockResolvedValue(undefined),
+            getDelegateManager: vi.fn().mockResolvedValue(undefined),
         };
 
         const response = await updater.handleMessage({
@@ -697,7 +698,7 @@ describe("WalletMessageHandler handleMessage", () => {
         } as any);
 
         expect(response.error).toBeInstanceOf(Error);
-        expect(response.error?.message).toBe("Delegator not configured");
+        expect(response.error?.message).toBe("Delegate not configured");
     });
 
     it("handles RECOVER_VTXOS messages", async () => {

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -14,7 +14,7 @@ import {
     type IndexerProvider,
     type ArkProvider,
     type OnchainProvider,
-    type DelegatorProvider,
+    DelegateProvider,
 } from "../src";
 import { TEST_PUB_KEY, TEST_DELEGATE_PUB_KEY, TEST_SERVER_PUB_KEY } from "./contracts/helpers";
 import { DEFAULT_ARKADE_SERVER_URL } from "../src/wallet";
@@ -1146,22 +1146,24 @@ describe("Wallet", () => {
             } as Partial<OnchainProvider> as OnchainProvider;
         }
 
-        function createDelegatorProvider() {
+        function createDelegateProvider() {
             return {
                 getDelegateInfo: vi.fn().mockResolvedValue({
                     pubkey: DELEGATE_PUBKEY,
                     fee: "0",
+                    delegateAddress: "",
                     delegatorAddress: "",
                 }),
                 delegate: vi.fn().mockResolvedValue(undefined),
-            } as Partial<DelegatorProvider> as DelegatorProvider;
+            } as Partial<DelegateProvider> as DelegateProvider;
         }
 
         async function createReadonlyTestWallet(config?: {
             network?: "bitcoin" | "mutinynet";
             unilateralExitDelay?: bigint;
             exitTimelock?: { value: bigint; type: "blocks" | "seconds" };
-            delegatorProvider?: DelegatorProvider;
+            delegateProvider?: DelegateProvider;
+            delegatorProvider?: DelegateProvider;
         }) {
             const network = config?.network ?? "bitcoin";
             const compressedPubKey = await mockIdentity.compressedPublicKey();
@@ -1190,13 +1192,16 @@ describe("Wallet", () => {
                     contractRepository,
                 },
                 exitTimelock: config?.exitTimelock,
-                delegatorProvider: config?.delegatorProvider,
+                delegateProvider: config?.delegateProvider || config?.delegatorProvider,
             });
 
             return { wallet };
         }
 
-        async function createFullMainnetWallet(config?: { delegatorProvider?: DelegatorProvider }) {
+        async function createFullMainnetWallet(config?: {
+            delegateProvider?: DelegateProvider;
+            delegatorProvider?: DelegateProvider;
+        }) {
             const walletRepository = new InMemoryWalletRepository();
             const contractRepository = new InMemoryContractRepository();
 
@@ -1212,7 +1217,7 @@ describe("Wallet", () => {
                     walletRepository,
                     contractRepository,
                 },
-                delegatorProvider: config?.delegatorProvider,
+                delegateProvider: config?.delegateProvider || config?.delegatorProvider,
                 settlementConfig: false,
             });
 
@@ -1252,7 +1257,8 @@ describe("Wallet", () => {
 
         it("registers arkd and legacy default and delegate contracts on mainnet", async () => {
             const { wallet } = await createReadonlyTestWallet({
-                delegatorProvider: createDelegatorProvider(),
+                delegateProvider: createDelegateProvider(),
+                delegatorProvider: createDelegateProvider(),
             });
 
             try {
@@ -1274,7 +1280,8 @@ describe("Wallet", () => {
 
         it("passes wallet contract timelocks through Wallet.create for delegate wallets", async () => {
             const { wallet } = await createFullMainnetWallet({
-                delegatorProvider: createDelegatorProvider(),
+                delegateProvider: createDelegateProvider(),
+                delegatorProvider: createDelegateProvider(),
             });
 
             try {

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -1258,7 +1258,6 @@ describe("Wallet", () => {
         it("registers arkd and legacy default and delegate contracts on mainnet", async () => {
             const { wallet } = await createReadonlyTestWallet({
                 delegateProvider: createDelegateProvider(),
-                delegatorProvider: createDelegateProvider(),
             });
 
             try {
@@ -1281,7 +1280,6 @@ describe("Wallet", () => {
         it("passes wallet contract timelocks through Wallet.create for delegate wallets", async () => {
             const { wallet } = await createFullMainnetWallet({
                 delegateProvider: createDelegateProvider(),
-                delegatorProvider: createDelegateProvider(),
             });
 
             try {

--- a/packages/ts-sdk/test/wallet/delegator.test.ts
+++ b/packages/ts-sdk/test/wallet/delegator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { findDestinationOutputIndex } from "../../src/wallet/delegator";
+import { findDestinationOutputIndex } from "../../src/wallet/delegate";
 
 describe("findDestinationOutputIndex", () => {
     const scriptA = new Uint8Array([0x00, 0x14, 0xaa, 0xbb]);

--- a/packages/ts-sdk/test/wallet/expo/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet/expo/wallet.test.ts
@@ -41,7 +41,7 @@ const createWalletStub = () => ({
     getBoardingUtxos: vi.fn().mockResolvedValue([{ txid: "u1" }]),
     getTransactionHistory: vi.fn().mockResolvedValue([{ txid: "h1" }]),
     getContractManager: vi.fn().mockResolvedValue({ id: "manager" }),
-    getDelegatorManager: vi.fn().mockResolvedValue({ id: "delegator" }),
+    getDelegateManager: vi.fn().mockResolvedValue({ id: "delegate" }),
     sendBitcoin: vi.fn().mockResolvedValue("send-txid"),
     settle: vi.fn().mockResolvedValue("settle-txid"),
     dispose: vi.fn().mockResolvedValue(undefined),
@@ -171,8 +171,8 @@ describe("ExpoWallet", () => {
         await expect(wallet.getContractManager()).resolves.toEqual({
             id: "manager",
         });
-        await expect(wallet.getDelegatorManager()).resolves.toEqual({
-            id: "delegator",
+        await expect(wallet.getDelegateManager()).resolves.toEqual({
+            id: "delegate",
         });
         await expect(wallet.sendBitcoin({ amount: 1 } as any)).resolves.toBe("send-txid");
         await expect(wallet.settle()).resolves.toBe("settle-txid");
@@ -184,7 +184,7 @@ describe("ExpoWallet", () => {
         expect(walletStub.getBoardingUtxos).toHaveBeenCalledTimes(1);
         expect(walletStub.getTransactionHistory).toHaveBeenCalledTimes(1);
         expect(walletStub.getContractManager).toHaveBeenCalledTimes(1);
-        expect(walletStub.getDelegatorManager).toHaveBeenCalledTimes(1);
+        expect(walletStub.getDelegateManager).toHaveBeenCalledTimes(1);
         expect(walletStub.sendBitcoin).toHaveBeenCalledWith({ amount: 1 });
         expect(walletStub.settle).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
- Deprecate "delegator" methods and params, replacing with "delegate"
- Modify `getDelegateInfo` response to return `delegateAddress` alongside deprecated `delegatorAddress`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Renamed delegation surface from "delegator" to "delegate" across the SDK and tooling.
  * Wallets and service-worker integrations now expose delegate-manager APIs and accept delegate-related configuration (delegator names kept as deprecated aliases for compatibility).
  * Backward compatibility preserved: existing delegator APIs remain available as deprecated aliases.

* **Documentation**
  * README and examples updated to use "delegate" terminology and show delegate wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->