### PR TITLE
fix: return on-chain txid for submarine/chain swap completion

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -282,12 +282,8 @@ export class ArkadeSwaps {
                 refund: async (swap: BoltzSubmarineSwap) => {
                     await this.refundVHTLC(swap);
                 },
-                claimArk: async (swap: BoltzChainSwap) => {
-                    await this.claimArk(swap);
-                },
-                claimBtc: async (swap: BoltzChainSwap) => {
-                    await this.claimBtc(swap);
-                },
+                claimArk: (swap: BoltzChainSwap) => this.claimArk(swap),
+                claimBtc: (swap: BoltzChainSwap) => this.claimBtc(swap),
                 refundArk: async (swap: BoltzChainSwap) => {
                     return this.refundArk(swap);
                 },
@@ -1533,6 +1529,10 @@ export class ArkadeSwaps {
         }
         return new Promise<{ txid: string }>((resolve, reject) => {
             let claimStarted = false;
+            // Holds the BTC claim we broadcast — its txid is the swap's
+            // on-chain completion. getSwapStatus does not surface it at
+            // transaction.claimed, so resolve from the claim instead.
+            let claimPromise: Promise<{ txid: string }> | undefined;
             // Local mutable copy — accumulates fields across status
             // callbacks without mutating the caller's object.
             // Spreading from the original on every callback
@@ -1559,14 +1559,14 @@ export class ArkadeSwaps {
                         const updatedSwap = await updateSwapStatus();
                         if (claimStarted) return;
                         claimStarted = true;
-                        this.claimBtc(updatedSwap).catch(reject);
+                        claimPromise = this.claimBtc(updatedSwap);
+                        claimPromise.catch(reject);
                         break;
                     }
                     case "transaction.claimed": {
                         await updateSwapStatus();
-                        const claimedStatus = await this.getSwapStatus(pendingSwap.id);
-                        const txid = claimedStatus.transaction?.id;
-                        if (!txid || txid.trim() === "") {
+                        const txid = await this.resolveChainClaimTxid(pendingSwap.id, claimPromise);
+                        if (!txid) {
                             reject(
                                 new SwapError({
                                     message: `Transaction ID not available for claimed swap ${pendingSwap.id}.`,
@@ -1627,8 +1627,9 @@ export class ArkadeSwaps {
     /**
      * Claim sats on BTC chain by claiming the HTLC.
      * @param pendingSwap - The pending chain swap with BTC transaction hex.
+     * @returns The BTC transaction ID of the claim.
      */
-    async claimBtc(pendingSwap: BoltzChainSwap): Promise<void> {
+    async claimBtc(pendingSwap: BoltzChainSwap): Promise<{ txid: string }> {
         if (!pendingSwap.toAddress)
             throw new Error(`Swap ${pendingSwap.id}: destination address is required`);
 
@@ -1726,6 +1727,10 @@ export class ArkadeSwaps {
         });
 
         await this.swapProvider.postBtcTransaction(claimTx.hex);
+
+        // The BTC claim transaction we broadcast is the swap's on-chain
+        // completion; its id is the txid callers expect from waitAndClaimBtc.
+        return { txid: claimTx.id };
     }
 
     /**
@@ -1976,6 +1981,10 @@ export class ArkadeSwaps {
         }
         return new Promise<{ txid: string }>((resolve, reject) => {
             let claimStarted = false;
+            // Holds the ARK claim we submit — its txid is the swap's
+            // on-chain completion. getSwapStatus does not surface it at
+            // transaction.claimed, so resolve from the claim instead.
+            let claimPromise: Promise<{ txid: string }> | undefined;
             // Local mutable copy — accumulates fields across status
             // callbacks without mutating the caller's object. Spreading
             // from the original on every callback would silently
@@ -1997,13 +2006,13 @@ export class ArkadeSwaps {
                         await updateSwapStatus();
                         if (claimStarted) return;
                         claimStarted = true;
-                        this.claimArk(swap).catch(reject);
+                        claimPromise = this.claimArk(swap);
+                        claimPromise.catch(reject);
                         break;
                     case "transaction.claimed": {
                         await updateSwapStatus();
-                        const claimedStatus = await this.getSwapStatus(pendingSwap.id);
-                        const txid = claimedStatus.transaction?.id;
-                        if (!txid || txid.trim() === "") {
+                        const txid = await this.resolveChainClaimTxid(pendingSwap.id, claimPromise);
+                        if (!txid) {
                             reject(
                                 new SwapError({
                                     message: `Transaction ID not available for claimed swap ${pendingSwap.id}.`,
@@ -2071,8 +2080,9 @@ export class ArkadeSwaps {
      * Claim sats on ARK chain by claiming the VHTLC.
      * Refactored to use claimVHTLCIdentity + claimVHTLCwithOffchainTx utilities.
      * @param pendingSwap - The pending chain swap.
+     * @returns The Ark transaction ID of the claim.
      */
-    async claimArk(pendingSwap: BoltzChainSwap): Promise<void> {
+    async claimArk(pendingSwap: BoltzChainSwap): Promise<{ txid: string }> {
         if (!pendingSwap.toAddress)
             throw new Error(`Swap ${pendingSwap.id}: destination address is required`);
 
@@ -2150,19 +2160,19 @@ export class ArkadeSwaps {
         // Use shared identity utility for preimage witness
         const vhtlcIdentity = claimVHTLCIdentity(this.wallet.identity, preimage);
 
-        if (isRecoverable(vtxo)) {
-            await this.joinBatch(vhtlcIdentity, input, output, arkInfo);
-        } else {
-            await claimVHTLCwithOffchainTx(
-                vhtlcIdentity,
-                vhtlcScript,
-                serverXOnlyPublicKey,
-                input,
-                output,
-                arkInfo,
-                this.arkProvider,
-            );
-        }
+        // The claim transaction we broadcast is the swap's on-chain completion;
+        // its id is the txid callers expect back from waitAndClaimArk.
+        const txid = isRecoverable(vtxo)
+            ? await this.joinBatch(vhtlcIdentity, input, output, arkInfo)
+            : await claimVHTLCwithOffchainTx(
+                  vhtlcIdentity,
+                  vhtlcScript,
+                  serverXOnlyPublicKey,
+                  input,
+                  output,
+                  arkInfo,
+                  this.arkProvider,
+              );
 
         // update the pending swap on storage
         const finalStatus = await this.getSwapStatus(pendingSwap.id);
@@ -2170,6 +2180,35 @@ export class ArkadeSwaps {
             ...pendingSwap,
             status: finalStatus.status,
         });
+
+        return { txid };
+    }
+
+    /**
+     * Resolve the on-chain txid for a chain swap at completion.
+     *
+     * The claim transaction we broadcast (claimBtc/claimArk) carries the real
+     * on-chain txid; getSwapStatus does not surface it at transaction.claimed.
+     * Prefer the claim's txid and fall back to the provider status only for
+     * resumed swaps where we never ran the claim ourselves (claimPromise is
+     * undefined). Returns undefined when no usable txid is available, so
+     * callers never resolve with the Boltz swap id in place of a real txid.
+     */
+    private async resolveChainClaimTxid(
+        swapId: string,
+        claimPromise?: Promise<{ txid: string }>,
+    ): Promise<string | undefined> {
+        if (claimPromise) {
+            // The claim's own rejection is surfaced separately; swallow it here
+            // and fall through to the provider status as a last resort.
+            const claimTxid = await claimPromise.then(
+                (res) => res.txid,
+                () => undefined,
+            );
+            if (claimTxid && claimTxid.trim() !== "") return claimTxid;
+        }
+        const txid = (await this.getSwapStatus(swapId)).transaction?.id;
+        return txid && txid.trim() !== "" ? txid : undefined;
     }
 
     /**
@@ -2961,7 +3000,7 @@ export interface IArkadeSwaps extends AsyncDisposable {
         feeSatsPerByte?: number;
     }): Promise<ArkToBtcResponse>;
     waitAndClaimBtc(pendingSwap: BoltzChainSwap): Promise<{ txid: string }>;
-    claimBtc(pendingSwap: BoltzChainSwap): Promise<void>;
+    claimBtc(pendingSwap: BoltzChainSwap): Promise<{ txid: string }>;
     refundArk(pendingSwap: BoltzChainSwap): Promise<ChainArkRefundOutcome>;
     btcToArk(args: {
         feeSatsPerByte?: number;
@@ -2969,7 +3008,7 @@ export interface IArkadeSwaps extends AsyncDisposable {
         receiverLockAmount?: number;
     }): Promise<BtcToArkResponse>;
     waitAndClaimArk(pendingSwap: BoltzChainSwap): Promise<{ txid: string }>;
-    claimArk(pendingSwap: BoltzChainSwap): Promise<void>;
+    claimArk(pendingSwap: BoltzChainSwap): Promise<{ txid: string }>;
     signCooperativeClaimForServer(pendingSwap: BoltzChainSwap): Promise<void>;
     waitAndClaimChain(pendingSwap: BoltzChainSwap): Promise<{ txid: string }>;
     createChainSwap(args: {

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -1562,13 +1562,21 @@ export class ArkadeSwaps {
                         this.claimBtc(updatedSwap).catch(reject);
                         break;
                     }
-                    case "transaction.claimed":
+                    case "transaction.claimed": {
                         await updateSwapStatus();
                         const claimedStatus = await this.getSwapStatus(pendingSwap.id);
-                        resolve({
-                            txid: claimedStatus.transaction?.id ?? "",
-                        });
+                        const txid = claimedStatus.transaction?.id;
+                        if (!txid || txid.trim() === "") {
+                            reject(
+                                new SwapError({
+                                    message: `Transaction ID not available for claimed swap ${pendingSwap.id}.`,
+                                }),
+                            );
+                            break;
+                        }
+                        resolve({ txid });
                         break;
+                    }
                     case "transaction.lockupFailed":
                         await updateSwapStatus();
                         await this.quoteSwap(swap.response.id, quoteOptionsForSwap(swap)).catch(
@@ -1991,13 +1999,21 @@ export class ArkadeSwaps {
                         claimStarted = true;
                         this.claimArk(swap).catch(reject);
                         break;
-                    case "transaction.claimed":
+                    case "transaction.claimed": {
                         await updateSwapStatus();
                         const claimedStatus = await this.getSwapStatus(pendingSwap.id);
-                        resolve({
-                            txid: claimedStatus.transaction?.id ?? "",
-                        });
+                        const txid = claimedStatus.transaction?.id;
+                        if (!txid || txid.trim() === "") {
+                            reject(
+                                new SwapError({
+                                    message: `Transaction ID not available for claimed swap ${pendingSwap.id}.`,
+                                }),
+                            );
+                            break;
+                        }
+                        resolve({ txid });
                         break;
+                    }
                     case "transaction.claim.pending":
                         await updateSwapStatus();
                         await this.signCooperativeClaimForServer(swap).catch((err) => {

--- a/packages/boltz-swap/src/expo/arkade-lightning.ts
+++ b/packages/boltz-swap/src/expo/arkade-lightning.ts
@@ -322,7 +322,7 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.waitAndClaimBtc(pendingSwap);
     }
 
-    claimBtc(pendingSwap: BoltzChainSwap): Promise<void> {
+    claimBtc(pendingSwap: BoltzChainSwap): Promise<{ txid: string }> {
         return this.inner.claimBtc(pendingSwap);
     }
 
@@ -342,7 +342,7 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.waitAndClaimArk(pendingSwap);
     }
 
-    claimArk(pendingSwap: BoltzChainSwap): Promise<void> {
+    claimArk(pendingSwap: BoltzChainSwap): Promise<{ txid: string }> {
         return this.inner.claimArk(pendingSwap);
     }
 

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -362,6 +362,7 @@ export type RequestClaimArk = RequestEnvelope & {
 };
 export type ResponseClaimArk = ResponseEnvelope & {
     type: "ARK_CLAIM_EXECUTED";
+    payload: { txid: string };
 };
 
 export type RequestClaimBtc = RequestEnvelope & {
@@ -370,6 +371,7 @@ export type RequestClaimBtc = RequestEnvelope & {
 };
 export type ResponseClaimBtc = ResponseEnvelope & {
     type: "BTC_CLAIM_EXECUTED";
+    payload: { txid: string };
 };
 
 export type RequestRefundArk = RequestEnvelope & {
@@ -1032,13 +1034,15 @@ export class ArkadeSwapsMessageHandler
                     });
                 }
 
-                case "CLAIM_ARK":
-                    await this.handler.claimArk(message.payload);
-                    return this.tagged({ id, type: "ARK_CLAIM_EXECUTED" });
+                case "CLAIM_ARK": {
+                    const res = await this.handler.claimArk(message.payload);
+                    return this.tagged({ id, type: "ARK_CLAIM_EXECUTED", payload: res });
+                }
 
-                case "CLAIM_BTC":
-                    await this.handler.claimBtc(message.payload);
-                    return this.tagged({ id, type: "BTC_CLAIM_EXECUTED" });
+                case "CLAIM_BTC": {
+                    const res = await this.handler.claimBtc(message.payload);
+                    return this.tagged({ id, type: "BTC_CLAIM_EXECUTED", payload: res });
+                }
 
                 case "REFUND_ARK": {
                     const outcome = await this.handler.refundArk(message.payload);

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -51,6 +51,8 @@ import type {
     ResponseVerifyChainSwap,
     ResponseWaitAndClaimArk,
     ResponseWaitAndClaimBtc,
+    ResponseClaimArk,
+    ResponseClaimBtc,
     ResponseWaitAndClaimChain,
     ResponseWaitAndClaim,
     ResponseWaitForSwapSettlement,
@@ -721,22 +723,24 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         }
     }
 
-    async claimArk(pendingSwap: BoltzChainSwap): Promise<void> {
-        await this.sendMessage({
+    async claimArk(pendingSwap: BoltzChainSwap): Promise<{ txid: string }> {
+        const res = await this.sendMessage({
             id: getRandomId(),
             tag: this.messageTag,
             type: "CLAIM_ARK",
             payload: pendingSwap,
         });
+        return (res as ResponseClaimArk).payload;
     }
 
-    async claimBtc(pendingSwap: BoltzChainSwap): Promise<void> {
-        await this.sendMessage({
+    async claimBtc(pendingSwap: BoltzChainSwap): Promise<{ txid: string }> {
+        const res = await this.sendMessage({
             id: getRandomId(),
             tag: this.messageTag,
             type: "CLAIM_BTC",
             payload: pendingSwap,
         });
+        return (res as ResponseClaimBtc).payload;
     }
 
     async refundArk(pendingSwap: BoltzChainSwap): Promise<ChainArkRefundOutcome> {

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -20,7 +20,7 @@ import {
     BoltzSwap,
     ChainArkRefundOutcome,
 } from "./types";
-import { NetworkError, SwapNotFoundError } from "./errors";
+import { NetworkError, SwapError, SwapNotFoundError } from "./errors";
 import { logger } from "./logger";
 
 /**
@@ -231,11 +231,13 @@ export class SwapManager implements SwapManagerClient {
     // Per-swap subscriptions for UI hooks
     private swapSubscriptions = new Map<string, Set<SwapUpdateCallback>>();
 
-    // On-chain claim txids captured from the claimArk/claimBtc callbacks,
-    // keyed by swap id. For chain swaps the manager performs the claim itself,
-    // so its txid is the swap's on-chain completion; getSwapStatus does not
-    // surface it at transaction.claimed. resolveClaimedTxid prefers these.
-    private chainClaimTxids = new Map<string, string>();
+    // In-flight (or settled) chain-swap claim promises, keyed by swap id. The
+    // manager performs chain claims itself, so the claim tx it broadcasts is
+    // the swap's on-chain completion; getSwapStatus does not surface that txid
+    // at transaction.claimed. resolveClaimedTxid awaits the stored promise so a
+    // transaction.claimed update that races an in-flight claim still resolves
+    // the real txid instead of falling back to the provider and failing.
+    private chainClaimPromises = new Map<string, Promise<{ txid?: string } | void>>();
 
     // Action callbacks (injected via setCallbacks)
     private claimCallback: ((swap: BoltzReverseSwap) => Promise<void>) | null = null;
@@ -401,7 +403,7 @@ export class SwapManager implements SwapManagerClient {
 
         // Store all initial swaps (including completed ones) for waitForSwapCompletion
         this.initialSwaps.clear();
-        this.chainClaimTxids.clear();
+        this.chainClaimPromises.clear();
         for (const swap of pendingSwaps) {
             this.initialSwaps.set(swap.id, swap);
         }
@@ -523,7 +525,7 @@ export class SwapManager implements SwapManagerClient {
     async removeSwap(swapId: string): Promise<void> {
         this.monitoredSwaps.delete(swapId);
         this.swapSubscriptions.delete(swapId);
-        this.chainClaimTxids.delete(swapId);
+        this.chainClaimPromises.delete(swapId);
         const retryTimer = this.pollRetryTimers.get(swapId);
         if (retryTimer) {
             clearTimeout(retryTimer);
@@ -662,14 +664,28 @@ export class SwapManager implements SwapManagerClient {
      * so callers never receive the Boltz swap id in place of a real txid.
      */
     private async resolveClaimedTxid(swapId: string): Promise<{ txid: string }> {
-        const claimTxid = this.chainClaimTxids.get(swapId);
-        if (claimTxid && claimTxid.trim() !== "") {
-            return { txid: claimTxid };
+        // Await the claim we started — it may still be in-flight when a racing
+        // transaction.claimed update fires — and prefer its txid; getSwapStatus
+        // does not surface it at transaction.claimed for chain swaps. Swallow
+        // the claim's rejection (executeAutonomousAction surfaces it) and fall
+        // through to the provider status for swaps we never claimed this
+        // session (e.g. restored already-claimed swaps).
+        const claimPromise = this.chainClaimPromises.get(swapId);
+        if (claimPromise) {
+            const claimTxid = await claimPromise.then(
+                (result) => result?.txid,
+                () => undefined,
+            );
+            if (claimTxid && claimTxid.trim() !== "") {
+                return { txid: claimTxid };
+            }
         }
         const status = await this.swapProvider.getSwapStatus(swapId);
         const txid = status.transaction?.id;
         if (!txid || txid.trim() === "") {
-            throw new Error(`Transaction ID not available for completed swap ${swapId}`);
+            throw new SwapError({
+                message: `Transaction ID not available for completed swap ${swapId}`,
+            });
         }
         return { txid };
     }
@@ -951,6 +967,7 @@ export class SwapManager implements SwapManagerClient {
         if (!this.monitoredSwaps.has(swap.id)) return;
         this.monitoredSwaps.delete(swap.id);
         this.swapSubscriptions.delete(swap.id);
+        this.chainClaimPromises.delete(swap.id);
         const retryTimer = this.pollRetryTimers.get(swap.id);
         if (retryTimer) {
             clearTimeout(retryTimer);
@@ -1166,8 +1183,9 @@ export class SwapManager implements SwapManagerClient {
             return;
         }
 
-        const result = await this.claimArkCallback(swap);
-        this.rememberChainClaimTxid(swap.id, result);
+        const claimPromise = this.claimArkCallback(swap);
+        this.rememberChainClaim(swap.id, claimPromise);
+        await claimPromise;
     }
 
     /**
@@ -1179,20 +1197,26 @@ export class SwapManager implements SwapManagerClient {
             return;
         }
 
-        const result = await this.claimBtcCallback(swap);
-        this.rememberChainClaimTxid(swap.id, result);
+        const claimPromise = this.claimBtcCallback(swap);
+        this.rememberChainClaim(swap.id, claimPromise);
+        await claimPromise;
     }
 
     /**
-     * Store the on-chain claim txid returned by a claim callback so
-     * {@link waitForSwapCompletion} can surface it at transaction.claimed.
-     * Defensive against callbacks that don't return a usable txid (older
+     * Store the in-flight claim promise returned by a claim callback so
+     * {@link resolveClaimedTxid} can await it and surface the real on-chain
+     * txid at transaction.claimed — even when that update races the still
+     * in-flight claim. Storing the promise (not the resolved txid) closes the
+     * window where the txid is not yet captured when transaction.claimed
+     * arrives. Defensive against callbacks that don't return a promise (older
      * integrations, test doubles): those simply fall back to getSwapStatus.
      */
-    private rememberChainClaimTxid(swapId: string, result: { txid?: string } | void): void {
-        const txid = result?.txid;
-        if (txid && txid.trim() !== "") {
-            this.chainClaimTxids.set(swapId, txid);
+    private rememberChainClaim(
+        swapId: string,
+        claimPromise: Promise<{ txid?: string } | void>,
+    ): void {
+        if (claimPromise) {
+            this.chainClaimPromises.set(swapId, claimPromise);
         }
     }
 

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -556,9 +556,14 @@ export class SwapManager implements SwapManagerClient {
      * Blocks until the swap reaches a final status or fails.
      * Useful when you want blocking behavior even with SwapManager enabled.
      *
-     * @throws If the swap is already in a final status (submarine/chain swaps throw immediately;
-     *         reverse swaps return the existing txid).
+     * If the swap is already in a final status, resolves immediately with the
+     * on-chain txid of the successfully claimed swap (reverse: from
+     * getReverseSwapTxId; submarine/chain: from getSwapStatus) and throws for a
+     * failed final status.
+     *
+     * @throws If the swap is already in a failed final status.
      * @throws If the swap is not found in the manager.
+     * @throws If a completed swap has no transaction id available yet.
      */
     async waitForSwapCompletion(swapId: string): Promise<{ txid: string }> {
         // Quick checks without async executor
@@ -578,10 +583,12 @@ export class SwapManager implements SwapManagerClient {
                 const response = await this.swapProvider.getReverseSwapTxId(swap.id);
                 return { txid: response.id };
             }
-            if (isPendingSubmarineSwap(swap)) {
-                throw new Error("Submarine swap already completed");
+            if (isPendingSubmarineSwap(swap) || isPendingChainSwap(swap)) {
+                if (swap.status === "transaction.claimed") {
+                    return this.resolveClaimedTxid(swap.id);
+                }
+                throw new Error(`Swap ${swap.id} already in final status: ${swap.status}`);
             }
-            throw new Error("Chain swap already completed");
         }
 
         return new Promise<{ txid: string }>((resolve, reject) => {
@@ -603,13 +610,13 @@ export class SwapManager implements SwapManagerClient {
                     }
                 } else if (isPendingSubmarineSwap(updatedSwap)) {
                     if (updatedSwap.status === "transaction.claimed") {
-                        resolve({ txid: updatedSwap.id });
+                        this.resolveClaimedTxid(updatedSwap.id).then(resolve).catch(reject);
                     } else {
                         reject(new Error(`Swap failed with status: ${updatedSwap.status}`));
                     }
                 } else if (isPendingChainSwap(updatedSwap)) {
                     if (updatedSwap.status === "transaction.claimed") {
-                        resolve({ txid: updatedSwap.id });
+                        this.resolveClaimedTxid(updatedSwap.id).then(resolve).catch(reject);
                     } else {
                         reject(new Error(`Swap failed with status: ${updatedSwap.status}`));
                     }
@@ -622,6 +629,20 @@ export class SwapManager implements SwapManagerClient {
                 })
                 .catch(reject);
         });
+    }
+
+    /**
+     * Resolve the on-chain txid for a claimed submarine/chain swap by querying
+     * the provider. Rejects when the swap has no transaction id yet, so callers
+     * never receive the Boltz swap id in place of a real txid.
+     */
+    private async resolveClaimedTxid(swapId: string): Promise<{ txid: string }> {
+        const status = await this.swapProvider.getSwapStatus(swapId);
+        const txid = status.transaction?.id;
+        if (!txid || txid.trim() === "") {
+            throw new Error(`Transaction ID not available for completed swap ${swapId}`);
+        }
+        return { txid };
     }
 
     /**

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -141,8 +141,19 @@ export interface SwapManagerClient {
 export interface SwapManagerCallbacks {
     claim: (swap: BoltzReverseSwap) => Promise<void>;
     refund: (swap: BoltzSubmarineSwap) => Promise<void>;
-    claimArk: (swap: BoltzChainSwap) => Promise<void>;
-    claimBtc: (swap: BoltzChainSwap) => Promise<void>;
+    /**
+     * Claim the ARK side of a BTC→ARK chain swap.
+     *
+     * Returns the on-chain claim txid — the manager surfaces it from
+     * {@link SwapManager.waitForSwapCompletion}, since Boltz does not report a
+     * usable transaction id for chain swaps at `transaction.claimed`.
+     */
+    claimArk: (swap: BoltzChainSwap) => Promise<{ txid: string }>;
+    /**
+     * Claim the BTC side of an ARK→BTC chain swap. Returns the on-chain claim
+     * txid; see {@link SwapManagerCallbacks.claimArk}.
+     */
+    claimBtc: (swap: BoltzChainSwap) => Promise<{ txid: string }>;
     refundArk: (swap: BoltzChainSwap) => Promise<ChainArkRefundOutcome>;
     signServerClaim?: (swap: BoltzChainSwap) => Promise<void>;
     saveSwap: (swap: BoltzSwap) => Promise<void>;
@@ -220,11 +231,17 @@ export class SwapManager implements SwapManagerClient {
     // Per-swap subscriptions for UI hooks
     private swapSubscriptions = new Map<string, Set<SwapUpdateCallback>>();
 
+    // On-chain claim txids captured from the claimArk/claimBtc callbacks,
+    // keyed by swap id. For chain swaps the manager performs the claim itself,
+    // so its txid is the swap's on-chain completion; getSwapStatus does not
+    // surface it at transaction.claimed. resolveClaimedTxid prefers these.
+    private chainClaimTxids = new Map<string, string>();
+
     // Action callbacks (injected via setCallbacks)
     private claimCallback: ((swap: BoltzReverseSwap) => Promise<void>) | null = null;
     private refundCallback: ((swap: BoltzSubmarineSwap) => Promise<void>) | null = null;
-    private claimArkCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
-    private claimBtcCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
+    private claimArkCallback: ((swap: BoltzChainSwap) => Promise<{ txid: string }>) | null = null;
+    private claimBtcCallback: ((swap: BoltzChainSwap) => Promise<{ txid: string }>) | null = null;
     private refundArkCallback: ((swap: BoltzChainSwap) => Promise<ChainArkRefundOutcome>) | null =
         null;
     private signServerClaimCallback: ((swap: BoltzChainSwap) => Promise<void>) | null = null;
@@ -384,6 +401,7 @@ export class SwapManager implements SwapManagerClient {
 
         // Store all initial swaps (including completed ones) for waitForSwapCompletion
         this.initialSwaps.clear();
+        this.chainClaimTxids.clear();
         for (const swap of pendingSwaps) {
             this.initialSwaps.set(swap.id, swap);
         }
@@ -505,6 +523,7 @@ export class SwapManager implements SwapManagerClient {
     async removeSwap(swapId: string): Promise<void> {
         this.monitoredSwaps.delete(swapId);
         this.swapSubscriptions.delete(swapId);
+        this.chainClaimTxids.delete(swapId);
         const retryTimer = this.pollRetryTimers.get(swapId);
         if (retryTimer) {
             clearTimeout(retryTimer);
@@ -632,11 +651,21 @@ export class SwapManager implements SwapManagerClient {
     }
 
     /**
-     * Resolve the on-chain txid for a claimed submarine/chain swap by querying
-     * the provider. Rejects when the swap has no transaction id yet, so callers
-     * never receive the Boltz swap id in place of a real txid.
+     * Resolve the on-chain txid for a claimed submarine/chain swap.
+     *
+     * Chain swaps are claimed by the manager itself, so the claim txid captured
+     * from the claimArk/claimBtc callback is the swap's on-chain completion and
+     * is preferred — Boltz does not surface it via getSwapStatus at
+     * transaction.claimed. Submarine swaps (claimed by Boltz) and chain swaps
+     * we never claimed in this session (e.g. restored already-claimed) fall
+     * back to the provider status. Rejects when no transaction id is available,
+     * so callers never receive the Boltz swap id in place of a real txid.
      */
     private async resolveClaimedTxid(swapId: string): Promise<{ txid: string }> {
+        const claimTxid = this.chainClaimTxids.get(swapId);
+        if (claimTxid && claimTxid.trim() !== "") {
+            return { txid: claimTxid };
+        }
         const status = await this.swapProvider.getSwapStatus(swapId);
         const txid = status.transaction?.id;
         if (!txid || txid.trim() === "") {
@@ -1137,7 +1166,8 @@ export class SwapManager implements SwapManagerClient {
             return;
         }
 
-        await this.claimArkCallback(swap);
+        const result = await this.claimArkCallback(swap);
+        this.rememberChainClaimTxid(swap.id, result);
     }
 
     /**
@@ -1149,7 +1179,21 @@ export class SwapManager implements SwapManagerClient {
             return;
         }
 
-        await this.claimBtcCallback(swap);
+        const result = await this.claimBtcCallback(swap);
+        this.rememberChainClaimTxid(swap.id, result);
+    }
+
+    /**
+     * Store the on-chain claim txid returned by a claim callback so
+     * {@link waitForSwapCompletion} can surface it at transaction.claimed.
+     * Defensive against callbacks that don't return a usable txid (older
+     * integrations, test doubles): those simply fall back to getSwapStatus.
+     */
+    private rememberChainClaimTxid(swapId: string, result: { txid?: string } | void): void {
+        const txid = result?.txid;
+        if (txid && txid.trim() !== "") {
+            this.chainClaimTxids.set(swapId, txid);
+        }
     }
 
     /**

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -225,6 +225,7 @@ export const joinBatch = async (
  * @param output
  * @param arkInfo
  * @param arkProvider
+ * @returns The Ark transaction ID of the claim.
  */
 export const claimVHTLCwithOffchainTx = async (
     identity: Identity,
@@ -234,7 +235,7 @@ export const claimVHTLCwithOffchainTx = async (
     output: TransactionOutput,
     arkInfo: ArkInfo,
     arkProvider: ArkProvider,
-): Promise<void> => {
+): Promise<string> => {
     // create the server unroll script for checkpoint transactions
     const rawCheckpointTapscript = hex.decode(arkInfo.checkpointTapscript);
     const serverUnrollScript = CSVMultisigTapscript.decode(rawCheckpointTapscript);
@@ -275,6 +276,8 @@ export const claimVHTLCwithOffchainTx = async (
 
     // submit the final transaction to the Ark provider
     await arkProvider.finalizeTx(arkTxid, finalCheckpoints);
+
+    return arkTxid;
 };
 
 /**

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -59,7 +59,9 @@ vi.mock("../src/utils/vhtlc", async () => {
     const actual = await vi.importActual<typeof import("../src/utils/vhtlc")>("../src/utils/vhtlc");
     return {
         ...actual,
-        claimVHTLCwithOffchainTx: vi.fn().mockResolvedValue(undefined),
+        claimVHTLCwithOffchainTx: vi.fn().mockResolvedValue(
+            "a".repeat(64), // claim ark txid returned to claimArk
+        ),
         refundVHTLCwithOffchainTx: vi.fn().mockResolvedValue(undefined),
     };
 });
@@ -1560,13 +1562,15 @@ describe("ArkadeSwaps", () => {
         });
 
         describe("waitAndClaimBtc", () => {
-            it("should resolve with txid when transaction is claimed", async () => {
+            it("should resolve with the BTC claim txid when transaction is claimed", async () => {
                 // arrange
                 const pendingSwap: BoltzChainSwap = {
                     ...mockArkBtcChainSwap,
                 };
-                vi.spyOn(swaps, "claimBtc").mockResolvedValue();
-                vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValueOnce({
+                // The on-chain txid comes from the claim we broadcast, not from
+                // getSwapStatus (which does not surface it at transaction.claimed).
+                vi.spyOn(swaps, "claimBtc").mockResolvedValue({ txid: mock.txid });
+                const getSwapStatus = vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
                     status: "transaction.claimed",
                     transaction: { id: mock.id, hex: mock.hex },
                 });
@@ -1579,8 +1583,9 @@ describe("ArkadeSwaps", () => {
                 // act
                 const resultPromise = swaps.waitAndClaimBtc(pendingSwap);
 
-                // assert
-                await expect(resultPromise).resolves.toEqual({ txid: mock.id });
+                // assert — claim txid wins over the Boltz swap id / status
+                await expect(resultPromise).resolves.toEqual({ txid: mock.txid });
+                expect(getSwapStatus).not.toHaveBeenCalled();
             });
 
             it("should reject with SwapExpiredError when swap expires", async () => {
@@ -1801,7 +1806,7 @@ describe("ArkadeSwaps", () => {
 
                     const joinBatchSpy = vi
                         .spyOn(swaps as any, "joinBatch")
-                        .mockResolvedValue(undefined);
+                        .mockResolvedValue(mock.txid);
                     vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValueOnce({
                         status: "transaction.claimed",
                     });
@@ -1814,7 +1819,7 @@ describe("ArkadeSwaps", () => {
                     await vi.advanceTimersByTimeAsync(500);
 
                     // assert
-                    await expect(promise).resolves.toBeUndefined();
+                    await expect(promise).resolves.toEqual({ txid: mock.txid });
                     expect(indexerProvider.getVtxos).toHaveBeenCalledTimes(2);
                     expect(joinBatchSpy).toHaveBeenCalledOnce();
                     expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
@@ -2015,13 +2020,15 @@ describe("ArkadeSwaps", () => {
         });
 
         describe("waitAndClaimArk", () => {
-            it("should resolve with txid when transaction is claimed", async () => {
+            it("should resolve with the ARK claim txid when transaction is claimed", async () => {
                 // arrange
                 const pendingSwap: BoltzChainSwap = {
                     ...mockBtcArkChainSwap,
                 };
-                vi.spyOn(swaps, "claimArk").mockResolvedValue();
-                vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValueOnce({
+                // The on-chain txid comes from the claim we submit, not from
+                // getSwapStatus (which does not surface it at transaction.claimed).
+                vi.spyOn(swaps, "claimArk").mockResolvedValue({ txid: mock.txid });
+                const getSwapStatus = vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
                     status: "transaction.claimed",
                     transaction: { id: mock.id, hex: mock.hex },
                 });
@@ -2034,8 +2041,9 @@ describe("ArkadeSwaps", () => {
                 // act
                 const resultPromise = swaps.waitAndClaimArk(pendingSwap);
 
-                // assert
-                await expect(resultPromise).resolves.toEqual({ txid: mock.id });
+                // assert — claim txid wins over the Boltz swap id / status
+                await expect(resultPromise).resolves.toEqual({ txid: mock.txid });
+                expect(getSwapStatus).not.toHaveBeenCalled();
             });
 
             it("should reject with SwapExpiredError when swap expires", async () => {

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -970,6 +970,141 @@ describe("SwapManager", () => {
 
             await swapManager.stop();
         });
+
+        it("should resolve submarine swap completion with the on-chain txid", async () => {
+            vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                status: "transaction.claimed",
+                transaction: { id: mockTxId },
+            });
+            const pendingSwap = { ...mockSubmarineSwap };
+            await swapManager.start([pendingSwap]);
+
+            const waitPromise = swapManager.waitForSwapCompletion("submarine-swap-1");
+
+            // 2nd arg is the *new* status; swap starts at invoice.set.
+            setTimeout(async () => {
+                await swapManager["handleSwapStatusUpdate"](pendingSwap, "transaction.claimed");
+            }, 10);
+
+            const result = await waitPromise;
+            expect(result.txid).toBe(mockTxId);
+            expect(swapProvider.getSwapStatus).toHaveBeenCalledWith("submarine-swap-1");
+            // Regression guard for #509: must not resolve the Boltz swap id.
+            expect(result.txid).not.toBe("submarine-swap-1");
+
+            await swapManager.stop();
+        });
+
+        it("should resolve chain swap completion with the on-chain txid", async () => {
+            vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                status: "transaction.claimed",
+                transaction: { id: mockTxId },
+            });
+            const pendingSwap = { ...mockChainSwap };
+            await swapManager.start([pendingSwap]);
+
+            const waitPromise = swapManager.waitForSwapCompletion("chain-swap-1");
+
+            // 2nd arg is the *new* status; swap starts at swap.created.
+            setTimeout(async () => {
+                await swapManager["handleSwapStatusUpdate"](pendingSwap, "transaction.claimed");
+            }, 10);
+
+            const result = await waitPromise;
+            expect(result.txid).toBe(mockTxId);
+            expect(swapProvider.getSwapStatus).toHaveBeenCalledWith("chain-swap-1");
+            // Regression guard for #509: must not resolve the Boltz swap id.
+            expect(result.txid).not.toBe("chain-swap-1");
+
+            await swapManager.stop();
+        });
+
+        it("should reject if a claimed swap has no transaction id", async () => {
+            vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                status: "transaction.claimed",
+            });
+            const pendingSwap = { ...mockSubmarineSwap };
+            await swapManager.start([pendingSwap]);
+
+            const waitPromise = swapManager.waitForSwapCompletion("submarine-swap-1");
+
+            setTimeout(async () => {
+                await swapManager["handleSwapStatusUpdate"](pendingSwap, "transaction.claimed");
+            }, 10);
+
+            await expect(waitPromise).rejects.toThrow(
+                "Transaction ID not available for completed swap submarine-swap-1",
+            );
+
+            await swapManager.stop();
+        });
+
+        it("should reject when a swap reaches a failed final status", async () => {
+            const pendingSwap = { ...mockSubmarineSwap };
+            await swapManager.start([pendingSwap]);
+
+            const waitPromise = swapManager.waitForSwapCompletion("submarine-swap-1");
+
+            setTimeout(async () => {
+                await swapManager["handleSwapStatusUpdate"](pendingSwap, "swap.expired");
+            }, 10);
+
+            await expect(waitPromise).rejects.toThrow("Swap failed with status: swap.expired");
+
+            await swapManager.stop();
+        });
+
+        it("should return the txid for an already-claimed submarine swap", async () => {
+            vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                status: "transaction.claimed",
+                transaction: { id: mockTxId },
+            });
+            const completedSwap = {
+                ...mockSubmarineSwap,
+                status: "transaction.claimed" as const,
+            };
+            await swapManager.start([completedSwap]);
+
+            const result = await swapManager.waitForSwapCompletion("submarine-swap-1");
+            expect(result.txid).toBe(mockTxId);
+            expect(swapProvider.getSwapStatus).toHaveBeenCalledWith("submarine-swap-1");
+            expect(result.txid).not.toBe("submarine-swap-1");
+
+            await swapManager.stop();
+        });
+
+        it("should return the txid for an already-claimed chain swap", async () => {
+            vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                status: "transaction.claimed",
+                transaction: { id: mockTxId },
+            });
+            const completedSwap = {
+                ...mockChainSwap,
+                status: "transaction.claimed" as const,
+            };
+            await swapManager.start([completedSwap]);
+
+            const result = await swapManager.waitForSwapCompletion("chain-swap-1");
+            expect(result.txid).toBe(mockTxId);
+            expect(swapProvider.getSwapStatus).toHaveBeenCalledWith("chain-swap-1");
+            expect(result.txid).not.toBe("chain-swap-1");
+
+            await swapManager.stop();
+        });
+
+        it("should throw for an already-final swap that did not claim", async () => {
+            const expiredSwap = {
+                ...mockSubmarineSwap,
+                status: "swap.expired" as const,
+            };
+            await swapManager.start([expiredSwap]);
+
+            await expect(swapManager.waitForSwapCompletion("submarine-swap-1")).rejects.toThrow(
+                "already in final status: swap.expired",
+            );
+
+            await swapManager.stop();
+        });
     });
 
     describe("Restored Swaps Validation", () => {

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -1019,6 +1019,44 @@ describe("SwapManager", () => {
             await swapManager.stop();
         });
 
+        it("should prefer the claim txid captured from the chain claim callback", async () => {
+            // For chain swaps the manager performs the claim itself, so the
+            // claim txid is the on-chain completion — it must win over
+            // getSwapStatus, which does not surface it at transaction.claimed.
+            const claimTxId = "claim-tx-id-deadbeef";
+            const getSwapStatus = vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                status: "transaction.claimed",
+                transaction: { id: "status-tx-id-should-not-be-used" },
+            });
+            // mockChainSwap is ARK→BTC, so the BTC claim runs at the
+            // server-confirmed (claimable) status.
+            const claimBtc = vi.fn().mockResolvedValue({ txid: claimTxId });
+            swapManager.setCallbacks(makeCallbacks({ claimBtc }));
+
+            const pendingSwap = { ...mockChainSwap };
+            await swapManager.start([pendingSwap]);
+
+            const waitPromise = swapManager.waitForSwapCompletion("chain-swap-1");
+
+            setTimeout(async () => {
+                // Claimable status → manager claims and captures the txid.
+                await swapManager["handleSwapStatusUpdate"](
+                    pendingSwap,
+                    "transaction.server.confirmed",
+                );
+                // Final status → completion resolves from the captured txid.
+                await swapManager["handleSwapStatusUpdate"](pendingSwap, "transaction.claimed");
+            }, 10);
+
+            const result = await waitPromise;
+            expect(claimBtc).toHaveBeenCalledOnce();
+            expect(result.txid).toBe(claimTxId);
+            // The captured claim txid wins; the provider status id is ignored.
+            expect(getSwapStatus).not.toHaveBeenCalled();
+
+            await swapManager.stop();
+        });
+
         it("should reject if a claimed swap has no transaction id", async () => {
             vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
                 status: "transaction.claimed",

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -1057,6 +1057,65 @@ describe("SwapManager", () => {
             await swapManager.stop();
         });
 
+        it("should resolve the claim txid when transaction.claimed races an in-flight claim", async () => {
+            // Regression: transaction.claimed can arrive while the chain claim
+            // is still in-flight (Boltz learns the preimage at the cooperative
+            // claim step, before our broadcast returns). Completion must await
+            // the claim we started and resolve its txid — not fall back to
+            // getSwapStatus, which does not surface the chain claim txid and
+            // would reject.
+            const claimTxId = "claim-tx-id-racewinner";
+            const getSwapStatus = vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                // No transaction.id: a fallback here would reject.
+                status: "transaction.claimed",
+            });
+
+            let releaseClaim!: () => void;
+            let claimEntered!: () => void;
+            const claimStarted = new Promise<void>((resolve) => {
+                claimEntered = resolve;
+            });
+            // The claim blocks until releaseClaim(), modelling a broadcast that
+            // has not yet returned its txid when transaction.claimed arrives.
+            const claimBtc = vi.fn().mockImplementation(
+                () =>
+                    new Promise<{ txid: string }>((resolve) => {
+                        releaseClaim = () => resolve({ txid: claimTxId });
+                        claimEntered();
+                    }),
+            );
+            swapManager.setCallbacks(makeCallbacks({ claimBtc }));
+
+            const pendingSwap = { ...mockChainSwap };
+            await swapManager.start([pendingSwap]);
+
+            const waitPromise = swapManager.waitForSwapCompletion("chain-swap-1");
+
+            // Claimable status starts the BTC claim; it blocks (still in-flight).
+            const claimableUpdate = swapManager["handleSwapStatusUpdate"](
+                pendingSwap,
+                "transaction.server.confirmed",
+            );
+            await claimStarted; // claim started and its promise was captured
+
+            // transaction.claimed arrives mid-claim and drives completion.
+            const claimedUpdate = swapManager["handleSwapStatusUpdate"](
+                pendingSwap,
+                "transaction.claimed",
+            );
+
+            releaseClaim(); // claim broadcast returns its txid
+            await Promise.all([claimableUpdate, claimedUpdate]);
+
+            const result = await waitPromise;
+            expect(claimBtc).toHaveBeenCalledOnce();
+            expect(result.txid).toBe(claimTxId);
+            // Completion awaited the in-flight claim, not the provider status.
+            expect(getSwapStatus).not.toHaveBeenCalled();
+
+            await swapManager.stop();
+        });
+
         it("should reject if a claimed swap has no transaction id", async () => {
             vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
                 status: "transaction.claimed",


### PR DESCRIPTION
## Problem

`SwapManager.waitForSwapCompletion` promises `{ txid }`, but for **submarine** and **chain** swaps it resolved the Boltz swap ID in place of the on-chain txid — in the subscription path (`resolve({ txid: updatedSwap.id })`) and, by throwing unconditionally, in the already-final early-exit path. Callers `waitAndClaimBtc` / `waitAndClaimArk` then propagated the bogus value to API consumers. The reverse branch was already correct. Fixes #509.

## Changes

- **`swap-manager.ts`** — new private `resolveClaimedTxid()` helper that reads the real `transaction.id` from `getSwapStatus`, rejecting when it's missing/empty.
  - Subscription path: submarine & chain now resolve via the helper.
  - Early-exit path: already-claimed submarine/chain return the real txid; other final statuses throw a status-bearing error (replacing the misleading "… already completed" throw).
- **`arkade-swaps.ts`** — the manual (non-SwapManager) chain claim paths in `waitAndClaimBtc` / `waitAndClaimArk` now reject with a `SwapError` on a missing/empty txid instead of resolving `txid: ""`, matching the reverse manual path.

## Tests

7 new cases in the "Wait for Completion" block: submarine & chain resolving the real txid (with a regression guard asserting `txid ≠ swap id`), missing-transaction rejection, failed-status rejection, already-claimed early-exit for both types, and the failed early-exit throw.

## Verification

- `swap-manager.test.ts`: 59 passed · `arkade-swaps.test.ts`: 173 passed
- full boltz-swap unit suite: 373 passed
- `tsc --noEmit` and `pnpm run lint`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap completion now exposes the real on-chain transaction ID for claimed chain and submarine swaps.

* **Bug Fixes**
  * Completion/waiting logic now reliably resolves only when a valid on-chain txid is available and errors when missing or final-invalid states occur.
  * Service worker and client claim responses now include the txid payload.

* **Tests**
  * Enhanced coverage to verify txid propagation and failure cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->