### PR TITLE
fix: widen RealmLike.create mode to boolean | string

### DIFF
--- a/packages/ts-sdk/src/repositories/realm/types.ts
+++ b/packages/ts-sdk/src/repositories/realm/types.ts
@@ -16,6 +16,6 @@ export interface RealmLike {
     write(callback: () => void): void;
     objects<T = Record<string, unknown>>(schemaName: string): RealmResults<T>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create(schemaName: string, values: Record<string, any>, mode?: string): void;
+    create(schemaName: string, values: Record<string, any>, mode?: boolean | string): void;
     delete(objects: unknown): void;
 }


### PR DESCRIPTION
Widen `RealmLike.create`'s `mode` param from `string` to `boolean | string` so a real `realm` `Realm` instance (whose `create` types `mode` as `boolean | UpdateMode`) is assignable to `RealmLike` without `as any`. Internal `"modified"` call sites still type-check.

Fixes #526