### PR TITLE
fix: set lockupDetails.timeouts for restored chain swaps

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -79,7 +79,7 @@ import {
 } from "./utils/boltz-swap-tx";
 import { decodeInvoice, getInvoicePaymentHash } from "./utils/decoding";
 import { normalizeToXOnlyKey } from "./utils/signatures";
-import { extractInvoiceAmount, extractTimeLockFromLeafOutput } from "./utils/restoration";
+import { extractInvoiceAmount, resolveVhtlcTimeouts } from "./utils/restoration";
 import { SwapManager, SwapManagerClient } from "./swap-manager";
 import {
     saveSwap,
@@ -2768,20 +2768,7 @@ export class ArkadeSwaps {
                         onchainAmount: amount,
                         lockupAddress,
                         refundPublicKey: serverPublicKey,
-                        timeoutBlockHeights: timeoutBlockHeights ?? {
-                            refund: extractTimeLockFromLeafOutput(
-                                tree.refundWithoutBoltzLeaf?.output ?? "",
-                            ),
-                            unilateralClaim: extractTimeLockFromLeafOutput(
-                                tree.unilateralClaimLeaf?.output ?? "",
-                            ),
-                            unilateralRefund: extractTimeLockFromLeafOutput(
-                                tree.unilateralRefundLeaf?.output ?? "",
-                            ),
-                            unilateralRefundWithoutReceiver: extractTimeLockFromLeafOutput(
-                                tree.unilateralRefundWithoutBoltzLeaf?.output ?? "",
-                            ),
-                        },
+                        timeoutBlockHeights: resolveVhtlcTimeouts(tree, timeoutBlockHeights),
                     },
                     status,
                     type: "reverse",
@@ -2819,28 +2806,21 @@ export class ArkadeSwaps {
                         address: lockupAddress,
                         expectedAmount: amount,
                         claimPublicKey: serverPublicKey,
-                        timeoutBlockHeights: timeoutBlockHeights ?? {
-                            refund: extractTimeLockFromLeafOutput(
-                                tree.refundWithoutBoltzLeaf?.output ?? "",
-                            ),
-                            unilateralClaim: extractTimeLockFromLeafOutput(
-                                tree.unilateralClaimLeaf?.output ?? "",
-                            ),
-                            unilateralRefund: extractTimeLockFromLeafOutput(
-                                tree.unilateralRefundLeaf?.output ?? "",
-                            ),
-                            unilateralRefundWithoutReceiver: extractTimeLockFromLeafOutput(
-                                tree.unilateralRefundWithoutBoltzLeaf?.output ?? "",
-                            ),
-                        },
+                        timeoutBlockHeights: resolveVhtlcTimeouts(tree, timeoutBlockHeights),
                     },
                 } as BoltzSubmarineSwap);
             } else if (isRestoredChainSwap(swap)) {
                 const refundDetails = swap.refundDetails;
                 if (!refundDetails) continue;
 
-                const { amount, lockupAddress, serverPublicKey, timeoutBlockHeight } =
-                    refundDetails;
+                const {
+                    amount,
+                    lockupAddress,
+                    serverPublicKey,
+                    timeoutBlockHeight,
+                    tree,
+                    timeoutBlockHeights,
+                } = refundDetails;
 
                 chainSwaps.push({
                     id,
@@ -2868,6 +2848,7 @@ export class ArkadeSwaps {
                             lockupAddress,
                             serverPublicKey,
                             timeoutBlockHeight,
+                            timeouts: resolveVhtlcTimeouts(tree, timeoutBlockHeights),
                         },
                     },
                 } as BoltzChainSwap);

--- a/packages/boltz-swap/src/boltz-swap-provider.ts
+++ b/packages/boltz-swap/src/boltz-swap-provider.ts
@@ -211,7 +211,7 @@ export const isChainSwapClaimable = (swap: BoltzSwap): swap is BoltzChainSwap =>
 
 // API call types and validators
 
-type TimeoutBlockHeights = {
+export type TimeoutBlockHeights = {
     refund: number;
     unilateralClaim: number;
     unilateralRefund: number;

--- a/packages/boltz-swap/src/utils/restoration.ts
+++ b/packages/boltz-swap/src/utils/restoration.ts
@@ -1,6 +1,7 @@
 import { hex } from "@scure/base";
 import { Script } from "@scure/btc-signer";
 import { FeesResponse } from "../types";
+import type { Tree, TimeoutBlockHeights } from "../boltz-swap-provider";
 import bip68 from "bip68";
 
 /**
@@ -66,4 +67,39 @@ export function extractInvoiceAmount(amountSats: number | undefined, fees: FeesR
     if (miner >= amountSats) return 0;
 
     return Math.ceil((amountSats - miner) / (1 - percentage / 100));
+}
+
+/**
+ * Resolves a VHTLC's timeouts for a restored swap: prefers the server-provided
+ * `timeoutBlockHeights`, otherwise derives them from the tree leaves.
+ *
+ * Returns `undefined` when any locktime is missing/zero (an incomplete restore
+ * response, since `extractTimeLockFromLeafOutput` yields 0 for an empty or
+ * unparseable leaf). Building a VHTLC from zeroed timeouts would fail the
+ * downstream address-match check with a cryptic error; returning `undefined`
+ * instead lets callers' explicit "missing/incomplete timeouts" guards fire.
+ */
+export function resolveVhtlcTimeouts(
+    tree: Tree,
+    timeoutBlockHeights?: TimeoutBlockHeights,
+): TimeoutBlockHeights | undefined {
+    const resolved = timeoutBlockHeights ?? {
+        refund: extractTimeLockFromLeafOutput(tree.refundWithoutBoltzLeaf?.output ?? ""),
+        unilateralClaim: extractTimeLockFromLeafOutput(tree.unilateralClaimLeaf?.output ?? ""),
+        unilateralRefund: extractTimeLockFromLeafOutput(tree.unilateralRefundLeaf?.output ?? ""),
+        unilateralRefundWithoutReceiver: extractTimeLockFromLeafOutput(
+            tree.unilateralRefundWithoutBoltzLeaf?.output ?? "",
+        ),
+    };
+
+    if (
+        !resolved.refund ||
+        !resolved.unilateralClaim ||
+        !resolved.unilateralRefund ||
+        !resolved.unilateralRefundWithoutReceiver
+    ) {
+        return undefined;
+    }
+
+    return resolved;
 }

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -2668,6 +2668,50 @@ describe("ArkadeSwaps", () => {
             },
         };
 
+        // Server-provided timeouts (the common path: Boltz returns these directly).
+        const serverTimeouts = {
+            refund: 1700000000,
+            unilateralClaim: 266752,
+            unilateralRefund: 432128,
+            unilateralRefundWithoutReceiver: 518656,
+        };
+
+        // A real Boltz Ark VHTLC tree (hex reused from boltz-swap-provider.test.ts)
+        // whose leaves decode to the known timeouts below — exercises the
+        // tree-derived fallback when the response omits `timeoutBlockHeights`.
+        const realVhtlcTree = {
+            claimLeaf: {
+                version: 0,
+                output: "a914709b098708fed95c0d8c19fda64f630887f4f4988769200da6a9cbcebd245df8ac2f7e6520f2fd46e2da3990a74f701db1df92ffe3a9daad20e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+            },
+            refundLeaf: {
+                version: 0,
+                output: "20c432d8c2f7191f2ffe380cdcd995d53492aa1af60a92f1be6698971c03ee5d6dad200da6a9cbcebd245df8ac2f7e6520f2fd46e2da3990a74f701db1df92ffe3a9daad20e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+            },
+            refundWithoutBoltzLeaf: {
+                version: 0,
+                output: "044d5a3969b17520c432d8c2f7191f2ffe380cdcd995d53492aa1af60a92f1be6698971c03ee5d6dad20e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+            },
+            unilateralClaimLeaf: {
+                version: 0,
+                output: "a914709b098708fed95c0d8c19fda64f630887f4f498876903130040b275200da6a9cbcebd245df8ac2f7e6520f2fd46e2da3990a74f701db1df92ffe3a9daac",
+            },
+            unilateralRefundLeaf: {
+                version: 0,
+                output: "03260040b27520c432d8c2f7191f2ffe380cdcd995d53492aa1af60a92f1be6698971c03ee5d6dad200da6a9cbcebd245df8ac2f7e6520f2fd46e2da3990a74f701db1df92ffe3a9daac",
+            },
+            unilateralRefundWithoutBoltzLeaf: {
+                version: 0,
+                output: "034b0040b27520c432d8c2f7191f2ffe380cdcd995d53492aa1af60a92f1be6698971c03ee5d6dac",
+            },
+        };
+        const derivedTimeouts = {
+            refund: 1765366349,
+            unilateralClaim: 9728,
+            unilateralRefund: 19456,
+            unilateralRefundWithoutReceiver: 38400,
+        };
+
         it("should include terminal swaps in results without extra API fetches", async () => {
             const restoreSpy = vi
                 .spyOn(swapProvider, "restoreSwaps")
@@ -2743,6 +2787,90 @@ describe("ArkadeSwaps", () => {
             await swaps.restoreSwaps();
 
             expect(getPreimageSpy).not.toHaveBeenCalled();
+        });
+
+        it("populates chain lockupDetails.timeouts from server-provided timeoutBlockHeights", async () => {
+            const chainWithTimeouts = {
+                ...pendingChain,
+                refundDetails: {
+                    ...mockDetails,
+                    tree: mockTree,
+                    timeoutBlockHeights: serverTimeouts,
+                },
+            };
+            vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([chainWithTimeouts]);
+            vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+            const result = await swaps.restoreSwaps();
+
+            // Without this, refundArk() throws "missing timeouts in lockup details".
+            expect(result.chainSwaps[0].response.lockupDetails.timeouts).toEqual(serverTimeouts);
+        });
+
+        it("derives chain lockupDetails.timeouts from the VHTLC tree when timeoutBlockHeights is absent", async () => {
+            const chainDerived = {
+                ...pendingChain,
+                refundDetails: { ...mockDetails, tree: realVhtlcTree },
+            };
+            vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([chainDerived]);
+            vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+            const result = await swaps.restoreSwaps();
+
+            expect(result.chainSwaps[0].response.lockupDetails.timeouts).toEqual(derivedTimeouts);
+        });
+
+        it("leaves chain lockupDetails.timeouts undefined when the tree is incomplete (zero-guard)", async () => {
+            // pendingChain uses the empty mockTree and carries no timeoutBlockHeights,
+            // so every derived locktime is 0 — the guard must skip rather than build a
+            // VHTLC with zeroed timeouts (which would fail refundArk's address check).
+            vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([pendingChain]);
+            vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+            const result = await swaps.restoreSwaps();
+
+            expect(result.chainSwaps[0].response.lockupDetails.timeouts).toBeUndefined();
+        });
+
+        it("applies the same timeouts resolution to restored reverse and submarine swaps", async () => {
+            const reverseDerived = {
+                ...pendingReverse,
+                id: "rev-derived",
+                claimDetails: { ...mockDetails, tree: realVhtlcTree },
+            };
+            const submarineDerived = {
+                ...pendingSubmarine,
+                id: "sub-derived",
+                refundDetails: { ...mockDetails, tree: realVhtlcTree },
+            };
+            vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([
+                reverseDerived,
+                submarineDerived,
+                pendingReverse, // empty tree -> undefined
+                pendingSubmarine, // empty tree -> undefined
+            ]);
+            vi.spyOn(swapProvider, "getSwapPreimage").mockResolvedValue({
+                preimage: hex.encode(randomBytes(32)),
+            });
+            vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+            const result = await swaps.restoreSwaps();
+
+            const byId = <T extends { id: string }>(swaps: T[], id: string) =>
+                swaps.find((s) => s.id === id)!;
+
+            expect(byId(result.reverseSwaps, "rev-derived").response.timeoutBlockHeights).toEqual(
+                derivedTimeouts,
+            );
+            expect(
+                byId(result.reverseSwaps, "rev-pending").response.timeoutBlockHeights,
+            ).toBeUndefined();
+            expect(byId(result.submarineSwaps, "sub-derived").response.timeoutBlockHeights).toEqual(
+                derivedTimeouts,
+            );
+            expect(
+                byId(result.submarineSwaps, "sub-pending").response.timeoutBlockHeights,
+            ).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
## Summary

`ArkadeSwaps.restoreSwaps()` rebuilt chain swaps without `response.lockupDetails.timeouts`. Because `refundArk()` hard-requires that field, any ARK→BTC chain swap recovered via restore (after a restart) could reach a refundable state but threw `missing timeouts in lockup details` and could never be refunded. The reverse and submarine restore branches already populated the equivalent timeouts; only the chain branch was missed.

Fixes #524.

## Changes

- Add a shared `resolveVhtlcTimeouts(tree, timeoutBlockHeights?)` helper (`src/utils/restoration.ts`) that prefers the server-provided timeouts, otherwise derives them from the VHTLC tree leaves, and returns `undefined` when any locktime is missing/zero (incomplete restore response).
- Set `lockupDetails.timeouts` in the chain branch of `restoreSwaps()` — the actual fix.
- Route the reverse and submarine branches through the same helper, collapsing two duplicated inline blocks.
- Export `TimeoutBlockHeights` so the helper can reference it.

### Zero-guard

`extractTimeLockFromLeafOutput` returns `0` for a missing/unparseable leaf. Rather than build a VHTLC from zeroed timeouts (which fails `refundArk`'s address-match check with a cryptic error), the helper returns `undefined` so each consumer's explicit guard fires legibly:
- chain → `missing timeouts in lockup details`
- reverse → `incomplete reverse swap response`
- submarine → `incomplete submarine swap response`

## Test plan

- New `restoreSwaps` cases: chain server-provided path, chain tree-derived path (real VHTLC hex), chain zero-guard → `undefined`, and reverse/submarine parity.
- `pnpm -C packages/boltz-swap test:unit` — 370 passing.
- `pnpm run build` (incl. dts type-check) and `pnpm run lint` — clean.
