### PR TITLE
perf: memoize per-contract tapscripts in annotateVtxos (#521)

### DIFF
--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -19,7 +19,7 @@ import {
 import { ContractWatcher, ContractWatcherConfig } from "./contractWatcher";
 import { contractHandlers } from "./handlers";
 import { ExtendedVirtualCoin, Outpoint, VirtualCoin } from "../wallet";
-import { extendVirtualCoinForContract } from "../wallet/utils";
+import { extendVirtualCoinForContract, type ContractTapscriptCache } from "../wallet/utils";
 import { ContractFilter, ContractRepository } from "../repositories";
 import {
     advanceSyncCursor,
@@ -645,7 +645,12 @@ export class ContractManager implements IContractManager {
             byScript.set(contract.script, contract);
         }
 
-        return vtxos.map((vtxo) => extendVirtualCoinForContract(vtxo, byScript));
+        // Tapscript data is derived solely from a contract's params, so it is
+        // identical for every VTXO locked to the same contract. Memoize it per
+        // contract to avoid rebuilding the taproot tree once per VTXO — the
+        // dominant cost when annotating long spent/swept histories (see #521).
+        const tapscriptCache: ContractTapscriptCache = new Map();
+        return vtxos.map((vtxo) => extendVirtualCoinForContract(vtxo, byScript, tapscriptCache));
     }
 
     private buildContractsDbFilter(filter: GetContractsFilter): ContractFilter {

--- a/packages/ts-sdk/src/wallet/utils.ts
+++ b/packages/ts-sdk/src/wallet/utils.ts
@@ -36,7 +36,26 @@ export function extendCoin(
     };
 }
 
-function extendVtxoFromContract(vtxo: VirtualCoin, contract: Contract): ExtendedVirtualCoin {
+/**
+ * Tapscript fields derived purely from a contract's params. They are identical
+ * for every VTXO locked to the same contract, so they can be memoized per
+ * contract (see {@link ContractTapscriptCache}).
+ */
+export type ContractTapscripts = Pick<
+    ExtendedVirtualCoin,
+    "forfeitTapLeafScript" | "intentTapLeafScript" | "tapTree"
+>;
+
+/**
+ * Cache of per-contract tapscript data, keyed by `contract.script`. Building
+ * the taproot tree via `handler.createScript(contract.params)` is the dominant
+ * cost when annotating large VTXO sets; passing a shared cache across an
+ * annotation batch rebuilds it once per distinct contract instead of once per
+ * VTXO (see #521).
+ */
+export type ContractTapscriptCache = Map<string, ContractTapscripts>;
+
+function deriveContractTapscripts(contract: Contract): ContractTapscripts {
     const handler = contractHandlers.get(contract.type);
     if (!handler) {
         throw new Error(`No handler for contract type '${contract.type}'`);
@@ -45,11 +64,23 @@ function extendVtxoFromContract(vtxo: VirtualCoin, contract: Contract): Extended
         | DefaultVtxo.Script
         | DelegateVtxo.Script;
     return {
-        ...vtxo,
         forfeitTapLeafScript: script.forfeit(),
         intentTapLeafScript: script.forfeit(),
         tapTree: script.encode(),
     };
+}
+
+function extendVtxoFromContract(
+    vtxo: VirtualCoin,
+    contract: Contract,
+    cache?: ContractTapscriptCache,
+): ExtendedVirtualCoin {
+    let tapscripts = cache?.get(contract.script);
+    if (!tapscripts) {
+        tapscripts = deriveContractTapscripts(contract);
+        cache?.set(contract.script, tapscripts);
+    }
+    return { ...vtxo, ...tapscripts };
 }
 
 /**
@@ -74,6 +105,7 @@ function extendVtxoFromContract(vtxo: VirtualCoin, contract: Contract): Extended
 export function extendVirtualCoinForContract(
     vtxo: VirtualCoin,
     contractOrMap?: Contract | ReadonlyMap<string, Contract>,
+    cache?: ContractTapscriptCache,
 ): ExtendedVirtualCoin {
     const contract = resolveContract(vtxo, contractOrMap);
     if (!contract) {
@@ -81,7 +113,7 @@ export function extendVirtualCoinForContract(
             "extendVirtualCoinForContract: no contract matched vtxo.script — callers must resolve the owning contract before annotating",
         );
     }
-    return extendVtxoFromContract(vtxo, contract);
+    return extendVtxoFromContract(vtxo, contract, cache);
 }
 
 function isContractMap(

--- a/packages/ts-sdk/src/wallet/utils.ts
+++ b/packages/ts-sdk/src/wallet/utils.ts
@@ -70,17 +70,44 @@ function deriveContractTapscripts(contract: Contract): ContractTapscripts {
     };
 }
 
+function cloneTapLeafScript([
+    controlBlock,
+    script,
+]: ContractTapscripts["forfeitTapLeafScript"]): ContractTapscripts["forfeitTapLeafScript"] {
+    return [
+        {
+            version: controlBlock.version,
+            internalKey: new Uint8Array(controlBlock.internalKey),
+            merklePath: controlBlock.merklePath.map((hash) => new Uint8Array(hash)),
+        },
+        new Uint8Array(script),
+    ];
+}
+
+function cloneContractTapscripts(tapscripts: ContractTapscripts): ContractTapscripts {
+    return {
+        forfeitTapLeafScript: cloneTapLeafScript(tapscripts.forfeitTapLeafScript),
+        intentTapLeafScript: cloneTapLeafScript(tapscripts.intentTapLeafScript),
+        tapTree: new Uint8Array(tapscripts.tapTree),
+    };
+}
+
 function extendVtxoFromContract(
     vtxo: VirtualCoin,
     contract: Contract,
     cache?: ContractTapscriptCache,
 ): ExtendedVirtualCoin {
-    let tapscripts = cache?.get(contract.script);
+    if (!cache) {
+        return { ...vtxo, ...deriveContractTapscripts(contract) };
+    }
+
+    let tapscripts = cache.get(contract.script);
     if (!tapscripts) {
         tapscripts = deriveContractTapscripts(contract);
-        cache?.set(contract.script, tapscripts);
+        cache.set(contract.script, tapscripts);
     }
-    return { ...vtxo, ...tapscripts };
+
+    return { ...vtxo, ...cloneContractTapscripts(tapscripts) };
 }
 
 /**

--- a/packages/ts-sdk/test/contracts/manager.test.ts
+++ b/packages/ts-sdk/test/contracts/manager.test.ts
@@ -10,6 +10,7 @@ import {
     SubscriptionResponse,
 } from "../../src";
 import { ContractRepository } from "../../src/repositories";
+import { contractHandlers } from "../../src/contracts/handlers";
 import { hex } from "@scure/base";
 import {
     createDefaultContractParams,
@@ -595,6 +596,29 @@ describe("ContractManager", () => {
         it("throws when a vtxo's script has no registered contract", async () => {
             const orphan = createMockVtxo({ script: "ab".repeat(34) });
             await expect(manager.annotateVtxos([orphan])).rejects.toThrow();
+        });
+
+        it("builds the taproot tree once per contract, not once per VTXO (#521)", async () => {
+            await manager.createContract({
+                type: "default",
+                params: createDefaultContractParams(),
+                script: TEST_DEFAULT_SCRIPT,
+                address: "address",
+            });
+
+            const handler = contractHandlers.get("default")!;
+            const spy = vi.spyOn(handler, "createScript");
+
+            const vtxos = Array.from({ length: 100 }, (_, i) =>
+                createMockVtxo({ script: TEST_DEFAULT_SCRIPT, vout: i }),
+            );
+            const extended = await manager.annotateVtxos(vtxos);
+
+            expect(extended).toHaveLength(100);
+            // One taproot reconstruction for the whole batch, regardless of
+            // how many VTXOs share the contract.
+            expect(spy).toHaveBeenCalledTimes(1);
+            spy.mockRestore();
         });
     });
 

--- a/packages/ts-sdk/test/wallet/utils.test.ts
+++ b/packages/ts-sdk/test/wallet/utils.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 import type { Contract } from "../../src/contracts/types";
-import { extendVirtualCoinForContract } from "../../src/wallet/utils";
+import { contractHandlers } from "../../src/contracts/handlers";
+import { extendVirtualCoinForContract, type ContractTapscriptCache } from "../../src/wallet/utils";
 import {
     createDefaultContractParams,
     createDelegateContractParams,
@@ -101,5 +102,96 @@ describe("extendVirtualCoinForContract", () => {
         const map = new Map<string, Contract>([[bogus.script, bogus]]);
 
         expect(() => extendVirtualCoinForContract(vtxo, map)).toThrow(/handler/);
+    });
+});
+
+describe("extendVirtualCoinForContract tapscript memoization", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("builds the taproot tree once per distinct contract when a cache is shared", () => {
+        const handler = contractHandlers.get(defaultContract.type)!;
+        const spy = vi.spyOn(handler, "createScript");
+        const map = new Map<string, Contract>([[defaultContract.script, defaultContract]]);
+        const cache: ContractTapscriptCache = new Map();
+
+        // Many VTXOs locked to the same contract — the dominant case for a
+        // long spent/swept history (#521).
+        const vtxos = Array.from({ length: 50 }, (_, i) =>
+            createMockVtxo({ script: TEST_DEFAULT_SCRIPT, vout: i }),
+        );
+        for (const vtxo of vtxos) {
+            extendVirtualCoinForContract(vtxo, map, cache);
+        }
+
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it("builds the tree once per distinct contract, not once per VTXO", () => {
+        const defaultHandler = contractHandlers.get(defaultContract.type)!;
+        const delegateHandler = contractHandlers.get(delegateContract.type)!;
+        const defaultSpy = vi.spyOn(defaultHandler, "createScript");
+        const delegateSpy = vi.spyOn(delegateHandler, "createScript");
+        const map = new Map<string, Contract>([
+            [defaultContract.script, defaultContract],
+            [delegateContract.script, delegateContract],
+        ]);
+        const cache: ContractTapscriptCache = new Map();
+
+        for (let i = 0; i < 10; i++) {
+            extendVirtualCoinForContract(
+                createMockVtxo({ script: TEST_DEFAULT_SCRIPT, vout: i }),
+                map,
+                cache,
+            );
+            extendVirtualCoinForContract(
+                createMockVtxo({ script: TEST_DELEGATE_SCRIPT, vout: i }),
+                map,
+                cache,
+            );
+        }
+
+        expect(defaultSpy).toHaveBeenCalledTimes(1);
+        expect(delegateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("rebuilds the tree per call when no cache is passed", () => {
+        const handler = contractHandlers.get(defaultContract.type)!;
+        const spy = vi.spyOn(handler, "createScript");
+        const map = new Map<string, Contract>([[defaultContract.script, defaultContract]]);
+
+        extendVirtualCoinForContract(createMockVtxo({ script: TEST_DEFAULT_SCRIPT }), map);
+        extendVirtualCoinForContract(createMockVtxo({ script: TEST_DEFAULT_SCRIPT }), map);
+
+        expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns identical tapscript data for VTXOs sharing a contract", () => {
+        const map = new Map<string, Contract>([[defaultContract.script, defaultContract]]);
+        const cache: ContractTapscriptCache = new Map();
+
+        const a = extendVirtualCoinForContract(
+            createMockVtxo({ script: TEST_DEFAULT_SCRIPT, vout: 0 }),
+            map,
+            cache,
+        );
+        const b = extendVirtualCoinForContract(
+            createMockVtxo({ script: TEST_DEFAULT_SCRIPT, vout: 1 }),
+            map,
+            cache,
+        );
+
+        // Cached path: the memoized tapscripts must match what the uncached
+        // path produces, so annotation output is unchanged.
+        const uncached = extendVirtualCoinForContract(
+            createMockVtxo({ script: TEST_DEFAULT_SCRIPT, vout: 2 }),
+            map,
+        );
+        expect(a.tapTree).toEqual(uncached.tapTree);
+        expect(a.forfeitTapLeafScript).toEqual(uncached.forfeitTapLeafScript);
+        expect(a.intentTapLeafScript).toEqual(uncached.intentTapLeafScript);
+        expect(b.tapTree).toEqual(a.tapTree);
+        expect(b.vout).toBe(1);
     });
 });

--- a/packages/ts-sdk/test/wallet/utils.test.ts
+++ b/packages/ts-sdk/test/wallet/utils.test.ts
@@ -194,4 +194,60 @@ describe("extendVirtualCoinForContract tapscript memoization", () => {
         expect(b.tapTree).toEqual(a.tapTree);
         expect(b.vout).toBe(1);
     });
+
+    it("returns independent tapscript copies when a cache is shared", () => {
+        const map = new Map<string, Contract>([[defaultContract.script, defaultContract]]);
+        const cache: ContractTapscriptCache = new Map();
+
+        const a = extendVirtualCoinForContract(
+            createMockVtxo({ script: TEST_DEFAULT_SCRIPT, vout: 0 }),
+            map,
+            cache,
+        );
+        const b = extendVirtualCoinForContract(
+            createMockVtxo({ script: TEST_DEFAULT_SCRIPT, vout: 1 }),
+            map,
+            cache,
+        );
+        const cached = cache.get(defaultContract.script)!;
+
+        expect(a.tapTree).not.toBe(b.tapTree);
+        expect(a.tapTree).not.toBe(cached.tapTree);
+        expect(a.forfeitTapLeafScript).not.toBe(b.forfeitTapLeafScript);
+        expect(a.forfeitTapLeafScript[0]).not.toBe(b.forfeitTapLeafScript[0]);
+        expect(a.forfeitTapLeafScript[0].internalKey).not.toBe(
+            b.forfeitTapLeafScript[0].internalKey,
+        );
+        expect(a.forfeitTapLeafScript[0].merklePath[0]).not.toBe(
+            b.forfeitTapLeafScript[0].merklePath[0],
+        );
+
+        const bTapTreeByte = b.tapTree[0];
+        const bScriptByte = b.forfeitTapLeafScript[1][0];
+        const bInternalKeyByte = b.forfeitTapLeafScript[0].internalKey[0];
+        const bMerklePathByte = b.forfeitTapLeafScript[0].merklePath[0][0];
+        const bVersion = b.forfeitTapLeafScript[0].version;
+        const cachedTapTreeByte = cached.tapTree[0];
+        const cachedScriptByte = cached.forfeitTapLeafScript[1][0];
+        const cachedInternalKeyByte = cached.forfeitTapLeafScript[0].internalKey[0];
+        const cachedMerklePathByte = cached.forfeitTapLeafScript[0].merklePath[0][0];
+        const cachedVersion = cached.forfeitTapLeafScript[0].version;
+
+        a.tapTree[0] ^= 0xff;
+        a.forfeitTapLeafScript[1][0] ^= 0xff;
+        a.forfeitTapLeafScript[0].internalKey[0] ^= 0xff;
+        a.forfeitTapLeafScript[0].merklePath[0][0] ^= 0xff;
+        a.forfeitTapLeafScript[0].version ^= 1;
+
+        expect(b.tapTree[0]).toBe(bTapTreeByte);
+        expect(b.forfeitTapLeafScript[1][0]).toBe(bScriptByte);
+        expect(b.forfeitTapLeafScript[0].internalKey[0]).toBe(bInternalKeyByte);
+        expect(b.forfeitTapLeafScript[0].merklePath[0][0]).toBe(bMerklePathByte);
+        expect(b.forfeitTapLeafScript[0].version).toBe(bVersion);
+        expect(cached.tapTree[0]).toBe(cachedTapTreeByte);
+        expect(cached.forfeitTapLeafScript[1][0]).toBe(cachedScriptByte);
+        expect(cached.forfeitTapLeafScript[0].internalKey[0]).toBe(cachedInternalKeyByte);
+        expect(cached.forfeitTapLeafScript[0].merklePath[0][0]).toBe(cachedMerklePathByte);
+        expect(cached.forfeitTapLeafScript[0].version).toBe(cachedVersion);
+    });
 });


### PR DESCRIPTION
## What

`ContractManager.annotateVtxos` rebuilt the full taproot script tree via `handler.createScript(contract.params)` **once per VTXO** (`wallet/utils.ts`). Since the tapscript data (`forfeitTapLeafScript`, `intentTapLeafScript`, `tapTree`) is derived solely from a contract's params, it is identical for every VTXO locked to the same contract — so this was thousands of redundant taproot reconstructions on wallets with long spent/swept histories.

This is the first of the suggested fixes in #521 (the per-contract memoization — highest impact, smallest blast radius). It removes the dominant CPU cost the issue measured (~750 ms/page) without touching the sync/fetch logic, the repository contract, or the data-flow model.

## How

- `extendVtxoFromContract` / `extendVirtualCoinForContract` now accept an optional `ContractTapscriptCache` (keyed by `contract.script`). Tapscripts are derived once per distinct contract and reused across the batch.
- `annotateVtxos` creates one cache per call and threads it through the `.map()`.
- The cache is opt-in: all other callers (`contractWatcher`, expo wallet/task runner) pass no cache and behave exactly as before.

`contract.script` is a safe cache key: it is deterministically derived from `contract.params`, so identical scripts imply identical tapscripts.

## Scope / what this does *not* do

This is intentionally just fix #2 from the issue. The 500 ms inter-page sleep, the full-history re-fetch, and the spendable-only fast path are left for follow-ups (they carry more risk / structural change).

## Tests

- `test/wallet/utils.test.ts`: cache builds the tree once per distinct contract; rebuilds per call without a cache; cached output is identical to the uncached path.
- `test/contracts/manager.test.ts`: end-to-end via `annotateVtxos` — 100 VTXOs on one contract trigger a single `createScript`.
- Full `ts-sdk` unit suite green (1247 passed).

Refs #521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced per-contract memoization for tapscript data to avoid repeated recomputation when processing many virtual coins sharing the same contract, improving performance and memory behavior while preserving outputs.

* **Tests**
  * Added regression and unit tests ensuring tapscripts are built once per contract when cached, rebuilt when uncached, and that returned tapscript objects are independent copies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->