### PR TITLE
fix: suppress duplicate history entries for swept boarding deposits

### DIFF
--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -74,6 +74,7 @@ export async function buildTransactionHistory(
             // it's translated into a received batch transaction
             if (
                 !commitmentsToIgnore.has(vtxo.virtualStatus.commitmentTxIds![0]) &&
+                (!vtxo.settledBy || !commitmentsToIgnore.has(vtxo.settledBy)) &&
                 fromOldestVtxo.filter((v) => v.settledBy === vtxo.virtualStatus.commitmentTxIds![0])
                     .length === 0
             ) {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -638,7 +638,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             const tx: ArkTransaction = {
                 key: {
                     boardingTxid: utxo.txid,
-                    commitmentTxid: "",
+                    commitmentTxid: utxo.virtualStatus.commitmentTxIds?.[0] ?? "",
                     arkTxid: "",
                 },
                 amount: utxo.value,

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -165,6 +165,61 @@ describe("buildTransactionHistory", () => {
     });
 
     describe("Receive transactions", () => {
+        it("should suppress duplicate batch received entries for boarding sweeps", async () => {
+            const boardingTxid = "boarding-txid";
+            const sweepTxid = "sweep-txid-onchain";
+            const indexerCommitmentTxid = "sweep-txid-indexer"; // Differing IDs should still be handled
+            const amount = 1000;
+            const baseDate = new Date("2026-05-28T10:00:00Z");
+
+            // 1. Boarding transaction as returned by the improved getBoardingTxs()
+            const boardingTx: ArkTransaction = {
+                key: {
+                    boardingTxid: boardingTxid,
+                    commitmentTxid: sweepTxid,
+                    arkTxid: "",
+                },
+                amount: amount,
+                type: TxType.TxReceived,
+                settled: true,
+                createdAt: baseDate.getTime(),
+            };
+
+            // 2. Leaf VTXO as returned by the indexer
+            const leafVtxo: VirtualCoin = {
+                txid: "leaf-vtxo-txid",
+                vout: 0,
+                value: amount,
+                status: {
+                    confirmed: true,
+                    isLeaf: true,
+                },
+                virtualStatus: {
+                    state: "settled",
+                    commitmentTxIds: [indexerCommitmentTxid],
+                },
+                settledBy: sweepTxid, // This matches the on-chain sweep txid
+                createdAt: new Date(baseDate.getTime() + 60000),
+                isUnrolled: false,
+                isSpent: false,
+            };
+
+            const commitmentsToIgnore = new Set<string>([sweepTxid]);
+
+            const transactions = await buildTransactionHistory(
+                [leafVtxo],
+                [boardingTx],
+                commitmentsToIgnore,
+            );
+
+            const receivedTxs = transactions.filter((tx) => tx.type === TxType.TxReceived);
+
+            // Expect only 1 entry: the enriched boarding entry
+            expect(receivedTxs).toHaveLength(1);
+            expect(receivedTxs[0].key.boardingTxid).toBe(boardingTxid);
+            expect(receivedTxs[0].key.commitmentTxid).toBe(sweepTxid);
+        });
+
         it("should create a receive transaction for a new vtxo", async () => {
             const arkTxId = "receive-ark-tx-id";
             const baseDate = new Date("2025-10-31T20:00:00Z");


### PR DESCRIPTION
## Problem
Users reported that `getTransactionHistory()` returned two RECEIVED entries for a single boarding/refill event that has been swept. This was caused by an ID mismatch between the on-chain sweep transaction ID (used in `commitmentsToIgnore`) and the indexer's batch commitment ID (checked in `buildTransactionHistory`).

## Solution
1. **Improved De-duplication**: Updated `buildTransactionHistory` to also check `vtxo.settledBy` against `commitmentsToIgnore`. The `settledBy` field correctly carries the on-chain sweep transaction ID.
2. **Enriched Boarding Entries**: Updated `getBoardingTxs` to populate the `commitmentTxid` field in the `ArkTransaction` object. This fulfills the `TxKey` contract and provides a better correlation between the boarding event and its sweep.

## Testing
- Added a regression test in `packages/ts-sdk/test/transactionHistory.test.ts` that simulates the ID mismatch.
- Verified that a single, enriched `RECEIVED` entry is returned.
- Existing transaction history tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate transaction entries appearing in transaction history under certain wallet operation conditions
  * Enhanced transaction reference identification to improve accuracy and consistency of transaction data across wallet operations
  * Refined filtering logic to prevent erroneous entries in transaction history

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->