### PR TITLE
[codex] Fix duplicate boarding refill history entries

### DIFF
--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -9,6 +9,20 @@ const txKey: TxKey = {
     arkTxid: "",
 };
 
+function consumeBoardingReceive(
+    boardingTxs: ArkTransaction[],
+    predicate: (tx: ArkTransaction) => boolean,
+): boolean {
+    const index = boardingTxs.findIndex(predicate);
+    if (index === -1) return false;
+    boardingTxs.splice(index, 1);
+    return true;
+}
+
+function isSettledBoardingReceive(tx: ArkTransaction): boolean {
+    return tx.type === TxType.TxReceived && tx.settled && tx.key.boardingTxid !== "";
+}
+
 function collectAssets(vtxos: VirtualCoin[]): Asset[] | undefined {
     const map = new Map<string, bigint>();
     for (const vtxo of vtxos) {
@@ -64,6 +78,9 @@ export async function buildTransactionHistory(
     getTxCreatedAt?: (txid: string) => Promise<number | undefined>,
 ): Promise<ExtendedArkTransaction[]> {
     const fromOldestVtxo = [...vtxos].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    const unmatchedSettledBoardingTxs = allBoardingTxs
+        .filter(isSettledBoardingReceive)
+        .sort((a, b) => a.createdAt - b.createdAt);
 
     const sent: ExtendedArkTransaction[] = [];
     let received: ExtendedArkTransaction[] = [];
@@ -72,25 +89,44 @@ export async function buildTransactionHistory(
         if (vtxo.status.isLeaf) {
             // If this virtual output is a leaf and it's not the settlement of a boarding or there's no virtual output refreshed by it,
             // it's translated into a received batch transaction
-            if (
-                !commitmentsToIgnore.has(vtxo.virtualStatus.commitmentTxIds![0]) &&
-                (!vtxo.settledBy || !commitmentsToIgnore.has(vtxo.settledBy)) &&
+            const commitmentTxid = vtxo.virtualStatus.commitmentTxIds![0];
+            const vtxoCreatedAt = vtxo.createdAt.getTime();
+            const ignoredCommitment =
+                commitmentsToIgnore.has(commitmentTxid) ||
+                (!!vtxo.settledBy && commitmentsToIgnore.has(vtxo.settledBy));
+
+            if (ignoredCommitment) {
+                consumeBoardingReceive(
+                    unmatchedSettledBoardingTxs,
+                    (tx) =>
+                        tx.createdAt <= vtxoCreatedAt &&
+                        (tx.key.commitmentTxid === commitmentTxid ||
+                            tx.key.commitmentTxid === vtxo.settledBy),
+                );
+            } else if (
                 fromOldestVtxo.filter((v) => v.settledBy === vtxo.virtualStatus.commitmentTxIds![0])
                     .length === 0
             ) {
-                const assets = collectAssets([vtxo]);
-                received.push({
-                    key: {
-                        ...txKey,
-                        commitmentTxid: vtxo.virtualStatus.commitmentTxIds![0],
-                    },
-                    tag: "batch",
-                    type: TxType.TxReceived,
-                    amount: vtxo.value,
-                    settled: vtxo.status.isLeaf || vtxo.isSpent!,
-                    createdAt: vtxo.createdAt.getTime(),
-                    ...(assets && { assets }),
-                });
+                const duplicateBoardingReceive = consumeBoardingReceive(
+                    unmatchedSettledBoardingTxs,
+                    (tx) => tx.amount === vtxo.value && tx.createdAt <= vtxoCreatedAt,
+                );
+
+                if (!duplicateBoardingReceive) {
+                    const assets = collectAssets([vtxo]);
+                    received.push({
+                        key: {
+                            ...txKey,
+                            commitmentTxid,
+                        },
+                        tag: "batch",
+                        type: TxType.TxReceived,
+                        amount: vtxo.value,
+                        settled: vtxo.status.isLeaf || vtxo.isSpent!,
+                        createdAt: vtxoCreatedAt,
+                        ...(assets && { assets }),
+                    });
+                }
             }
         } else if (fromOldestVtxo.filter((v) => v.arkTxId === vtxo.txid).length === 0) {
             // If this virtual output is preconfirmed and does not spend any other virtual outputs,

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -220,6 +220,178 @@ describe("buildTransactionHistory", () => {
             expect(receivedTxs[0].key.commitmentTxid).toBe(sweepTxid);
         });
 
+        it("should suppress duplicate boarding batch receives when the boarding commitment id is missing", async () => {
+            const boardingTxid = "boarding-txid";
+            const indexerCommitmentTxid =
+                "ebf6bebe7b510934cf2ed3c167f77ea06d19cc104edf8b66e4721a103e0ed4f3";
+            const amount = 84960;
+            const baseDate = new Date("2026-05-27T20:00:00Z");
+
+            const boardingTx: ArkTransaction = {
+                key: {
+                    boardingTxid,
+                    commitmentTxid: "",
+                    arkTxid: "",
+                },
+                amount,
+                type: TxType.TxReceived,
+                settled: true,
+                createdAt: baseDate.getTime(),
+            };
+
+            const leafVtxo: VirtualCoin = {
+                txid: "86e31825f6a50d88c71eca33c7b4830d0aae4f320c12b12df0053c7b341cd4f3",
+                vout: 0,
+                value: amount,
+                status: {
+                    confirmed: true,
+                    isLeaf: true,
+                },
+                virtualStatus: {
+                    state: "settled",
+                    commitmentTxIds: [indexerCommitmentTxid],
+                },
+                settledBy: "",
+                createdAt: new Date(baseDate.getTime() + 104000),
+                isUnrolled: false,
+                isSpent: false,
+            };
+
+            const transactions = await buildTransactionHistory(
+                [leafVtxo],
+                [boardingTx],
+                new Set<string>(),
+            );
+
+            const receivedTxs = transactions.filter((tx) => tx.type === TxType.TxReceived);
+
+            expect(receivedTxs).toHaveLength(1);
+            expect(receivedTxs[0].key.boardingTxid).toBe(boardingTxid);
+            expect(
+                receivedTxs.some(
+                    (tx) =>
+                        tx.key.boardingTxid === "" &&
+                        tx.key.commitmentTxid === indexerCommitmentTxid,
+                ),
+            ).toBe(false);
+        });
+
+        it("should suppress duplicate boarding batch receives when settledBy is missing", async () => {
+            const boardingTxid = "boarding-txid";
+            const sweepTxid = "onchain-sweep-txid";
+            const indexerCommitmentTxid =
+                "ebf6bebe7b510934cf2ed3c167f77ea06d19cc104edf8b66e4721a103e0ed4f3";
+            const amount = 84960;
+            const baseDate = new Date("2026-05-27T20:00:00Z");
+
+            const boardingTx: ArkTransaction = {
+                key: {
+                    boardingTxid,
+                    commitmentTxid: sweepTxid,
+                    arkTxid: "",
+                },
+                amount,
+                type: TxType.TxReceived,
+                settled: true,
+                createdAt: baseDate.getTime(),
+            };
+
+            const leafVtxo: VirtualCoin = {
+                txid: "86e31825f6a50d88c71eca33c7b4830d0aae4f320c12b12df0053c7b341cd4f3",
+                vout: 0,
+                value: amount,
+                status: {
+                    confirmed: true,
+                    isLeaf: true,
+                },
+                virtualStatus: {
+                    state: "settled",
+                    commitmentTxIds: [indexerCommitmentTxid],
+                },
+                settledBy: "",
+                createdAt: new Date(baseDate.getTime() + 104000),
+                isUnrolled: false,
+                isSpent: false,
+            };
+
+            const transactions = await buildTransactionHistory(
+                [leafVtxo],
+                [boardingTx],
+                new Set<string>([sweepTxid]),
+            );
+
+            const receivedTxs = transactions.filter((tx) => tx.type === TxType.TxReceived);
+
+            expect(receivedTxs).toHaveLength(1);
+            expect(receivedTxs[0].key.boardingTxid).toBe(boardingTxid);
+            expect(
+                receivedTxs.some(
+                    (tx) =>
+                        tx.key.boardingTxid === "" &&
+                        tx.key.commitmentTxid === indexerCommitmentTxid,
+                ),
+            ).toBe(false);
+        });
+
+        it("should only suppress one same-amount batch receive per settled boarding entry", async () => {
+            const amount = 84960;
+            const baseDate = new Date("2026-05-27T20:00:00Z");
+            const boardingTx: ArkTransaction = {
+                key: {
+                    boardingTxid: "boarding-txid",
+                    commitmentTxid: "onchain-sweep-txid",
+                    arkTxid: "",
+                },
+                amount,
+                type: TxType.TxReceived,
+                settled: true,
+                createdAt: baseDate.getTime(),
+            };
+            const boardingSweepLeaf: VirtualCoin = {
+                txid: "boarding-sweep-vtxo",
+                vout: 0,
+                value: amount,
+                status: { confirmed: true, isLeaf: true },
+                virtualStatus: {
+                    state: "settled",
+                    commitmentTxIds: ["indexer-boarding-commitment"],
+                },
+                settledBy: "",
+                createdAt: new Date(baseDate.getTime() + 60000),
+                isUnrolled: false,
+                isSpent: false,
+            };
+            const independentReceiveLeaf: VirtualCoin = {
+                txid: "independent-receive-vtxo",
+                vout: 0,
+                value: amount,
+                status: { confirmed: true, isLeaf: true },
+                virtualStatus: {
+                    state: "settled",
+                    commitmentTxIds: ["independent-receive-commitment"],
+                },
+                settledBy: "",
+                createdAt: new Date(baseDate.getTime() + 120000),
+                isUnrolled: false,
+                isSpent: false,
+            };
+
+            const transactions = await buildTransactionHistory(
+                [boardingSweepLeaf, independentReceiveLeaf],
+                [boardingTx],
+                new Set<string>(["onchain-sweep-txid"]),
+            );
+
+            const receivedTxs = transactions.filter((tx) => tx.type === TxType.TxReceived);
+
+            expect(receivedTxs).toHaveLength(2);
+            expect(
+                receivedTxs.some(
+                    (tx) => tx.key.commitmentTxid === "independent-receive-commitment",
+                ),
+            ).toBe(true);
+        });
+
         it("should create a receive transaction for a new vtxo", async () => {
             const arkTxId = "receive-ark-tx-id";
             const baseDate = new Date("2025-10-31T20:00:00Z");


### PR DESCRIPTION
## Summary

Fixes duplicate transaction history entries for boarding/refill receives when the indexer leaf VTXO cannot be correlated back to the boarding transaction by `settledBy` or commitment id.

## Root Cause

The previous fix handled the ID-correlated path, but the live indexer payload can return a settled leaf with an empty `settledBy` and a commitment id that does not match the boarding sweep transaction. In that case, `buildTransactionHistory` still emitted a separate batch receive for the same boarding amount.

## Changes

- Track settled boarding receive rows that can suppress one matching batch receive.
- Preserve the existing ID-based suppression when `commitmentTxid` or `settledBy` are available.
- Add regression coverage for missing boarding commitment id, missing `settledBy`, and same-amount independent receives.

## Validation

- `pnpm --dir packages/ts-sdk exec vitest run test/transactionHistory.test.ts`
- `pnpm --dir packages/ts-sdk exec prettier --check src/utils/transactionHistory.ts test/transactionHistory.test.ts`
- `pnpm --dir packages/ts-sdk exec tsc --noEmit`
- Commit hook: monorepo lint and workspace unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced transaction history processing to eliminate duplicate entries and improve accuracy when handling certain transaction scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->