### PR TITLE
Add boarding contract type

### DIFF
--- a/packages/ts-sdk/scripts/smoke-dist.mjs
+++ b/packages/ts-sdk/scripts/smoke-dist.mjs
@@ -17,7 +17,7 @@
 //      ./dist/index.cjs and ./dist/contracts/handlers/index.cjs by
 //      relative path, assert object identity for `contractHandlers`
 //      and that the registered handler types are exactly
-//      default,delegate,vhtlc.
+//      boarding,default,delegate,vhtlc.
 //   4. ESM singleton: same but via `await import("...")` with
 //      --input-type=module.
 //   5. Public package-name resolution: build a consumer dir with
@@ -138,7 +138,7 @@ section("contractHandlers singleton: CJS + ESM");
 
 const runNode = (args, cwd) => spawnSync(process.execPath, args, { cwd, encoding: "utf8" });
 
-const expectedTypes = "default,delegate,vhtlc";
+const expectedTypes = "boarding,default,delegate,vhtlc";
 
 const cjsSingleton = `
 const root = require("./dist/index.cjs");

--- a/packages/ts-sdk/src/contracts/handlers/boarding.ts
+++ b/packages/ts-sdk/src/contracts/handlers/boarding.ts
@@ -42,15 +42,18 @@ export type BoardingContractParams = DefaultContractParams;
  * Identity & the default/boarding collision: a contract's `script` (pkScript)
  * is its unique identity — a script owns exactly one repository row. `boarding`
  * is a first-class type with its own row **when its script is distinct** from
- * the wallet's `default` baseline (the usual case, since boardingExitDelay and
- * unilateralExitDelay differ). When those delays coincide the boarding script
- * is byte-identical to the default script; the single shared row may then carry
- * **either** `type` (`default` or `boarding`), and the funds are equally
- * spendable through the shared `DefaultVtxo.Script` paths regardless. Consumers
- * therefore must NOT rely on `contract.type === "boarding"` to identify the
- * boarding purpose in that collision case — resolve the boarding script via
- * `wallet.getBoardingAddress()` / `wallet.boardingTapscript` (which never depend
- * on the persisted contract's type) and match by script when needed.
+ * the wallet's `default` baseline — the real-world case, since a sound Ark
+ * server keeps boardingExitDelay strictly longer than unilateralExitDelay (equal
+ * delays would expose the provider to a double-spend). Should those delays ever
+ * coincide (a misconfigured/malicious server), the boarding script is
+ * byte-identical to the default script and the wallet coalesces the single
+ * shared row onto the `default` type ("default wins"; see `ensureWalletContract`)
+ * rather than persisting a second row. Either way the funds are equally spendable
+ * through the shared `DefaultVtxo.Script` paths. Consumers must NOT rely on
+ * `contract.type === "boarding"` to identify the boarding purpose — resolve the
+ * boarding script via `wallet.getBoardingAddress()` / `wallet.boardingTapscript`
+ * (which never depend on the persisted contract's type) and match by script when
+ * needed.
  */
 export const BoardingContractHandler: ContractHandler<BoardingContractParams, DefaultVtxo.Script> =
     {

--- a/packages/ts-sdk/src/contracts/handlers/boarding.ts
+++ b/packages/ts-sdk/src/contracts/handlers/boarding.ts
@@ -38,6 +38,19 @@ export type BoardingContractParams = DefaultContractParams;
  * selection for HD wallets is owned by the wallet / address-provider
  * layer, which hands this handler an already-derived pubkey. As a result
  * `isDiscoverable(BoardingContractHandler)` is `false`.
+ *
+ * Identity & the default/boarding collision: a contract's `script` (pkScript)
+ * is its unique identity — a script owns exactly one repository row. `boarding`
+ * is a first-class type with its own row **when its script is distinct** from
+ * the wallet's `default` baseline (the usual case, since boardingExitDelay and
+ * unilateralExitDelay differ). When those delays coincide the boarding script
+ * is byte-identical to the default script; the single shared row may then carry
+ * **either** `type` (`default` or `boarding`), and the funds are equally
+ * spendable through the shared `DefaultVtxo.Script` paths regardless. Consumers
+ * therefore must NOT rely on `contract.type === "boarding"` to identify the
+ * boarding purpose in that collision case — resolve the boarding script via
+ * `wallet.getBoardingAddress()` / `wallet.boardingTapscript` (which never depend
+ * on the persisted contract's type) and match by script when needed.
  */
 export const BoardingContractHandler: ContractHandler<BoardingContractParams, DefaultVtxo.Script> =
     {

--- a/packages/ts-sdk/src/contracts/handlers/boarding.ts
+++ b/packages/ts-sdk/src/contracts/handlers/boarding.ts
@@ -1,0 +1,81 @@
+import { DefaultVtxo } from "../../script/default";
+import { Contract, ContractHandler, PathContext, PathSelection } from "../types";
+import { DefaultContractHandler, DefaultContractParams } from "./default";
+
+/**
+ * Typed parameters for boarding contracts.
+ *
+ * Boarding reuses the exact `default` contract parameter shape
+ * (`pubKey` / `serverPubKey` / `csvTimelock`) rather than inventing
+ * boarding-specific names — the boarding semantics come from the
+ * contract type and from populating `csvTimelock` with the server's
+ * boarding-exit delay (`ArkInfo.boardingExitDelay`) instead of the
+ * offchain unilateral-exit delay.
+ */
+export type BoardingContractParams = DefaultContractParams;
+
+/**
+ * Handler for the boarding contract (registered type `boarding`).
+ *
+ * The boarding contract derives the on-chain Bitcoin address used to
+ * board funds onto Arkade. It shares the exact `DefaultVtxo.Script`
+ * shape with the `default` contract — a Taproot output co-owned by the
+ * wallet and the Ark server, with a CSV exit path back to the wallet —
+ * and therefore reuses the `default` handler's path logic (forfeit via
+ * server cooperation, exit after the boarding CSV).
+ *
+ * Boarding semantics come entirely from the contract type and from
+ * sourcing the CSV timelock from the server's boarding-exit delay
+ * (`ArkInfo.boardingExitDelay`), not from renamed parameters. The
+ * offchain `default` contract is built from `ArkInfo.unilateralExitDelay`
+ * instead, so the two share a script shape but differ in their CSV
+ * timelock value. Parameters round-trip through the same
+ * `timelockToSequence` / `sequenceToTimelock` helpers and BIP68 sequence
+ * encoding as `default` / `delegate`.
+ *
+ * Unlike `default` / `delegate`, the boarding handler deliberately does
+ * **not** implement {@link Discoverable.discoverAt}: branch/index
+ * selection for HD wallets is owned by the wallet / address-provider
+ * layer, which hands this handler an already-derived pubkey. As a result
+ * `isDiscoverable(BoardingContractHandler)` is `false`.
+ */
+export const BoardingContractHandler: ContractHandler<BoardingContractParams, DefaultVtxo.Script> =
+    {
+        type: "boarding",
+
+        createScript(params: Record<string, string>): DefaultVtxo.Script {
+            return DefaultContractHandler.createScript(params);
+        },
+
+        serializeParams(params: BoardingContractParams): Record<string, string> {
+            return DefaultContractHandler.serializeParams(params);
+        },
+
+        deserializeParams(params: Record<string, string>): BoardingContractParams {
+            return DefaultContractHandler.deserializeParams(params);
+        },
+
+        selectPath(
+            script: DefaultVtxo.Script,
+            contract: Contract,
+            context: PathContext,
+        ): PathSelection | null {
+            return DefaultContractHandler.selectPath(script, contract, context);
+        },
+
+        getAllSpendingPaths(
+            script: DefaultVtxo.Script,
+            contract: Contract,
+            context: PathContext,
+        ): PathSelection[] {
+            return DefaultContractHandler.getAllSpendingPaths(script, contract, context);
+        },
+
+        getSpendablePaths(
+            script: DefaultVtxo.Script,
+            contract: Contract,
+            context: PathContext,
+        ): PathSelection[] {
+            return DefaultContractHandler.getSpendablePaths(script, contract, context);
+        },
+    };

--- a/packages/ts-sdk/src/contracts/handlers/index.ts
+++ b/packages/ts-sdk/src/contracts/handlers/index.ts
@@ -5,13 +5,17 @@ export { DelegateContractHandler } from "./delegate";
 export type { DelegateContractParams } from "./delegate";
 export { VHTLCContractHandler } from "./vhtlc";
 export type { VHTLCContractParams } from "./vhtlc";
+export { BoardingContractHandler } from "./boarding";
+export type { BoardingContractParams } from "./boarding";
 
 // Register built-in handlers
 import { contractHandlers } from "./registry";
 import { DefaultContractHandler } from "./default";
 import { DelegateContractHandler } from "./delegate";
 import { VHTLCContractHandler } from "./vhtlc";
+import { BoardingContractHandler } from "./boarding";
 
 contractHandlers.register(DefaultContractHandler);
 contractHandlers.register(DelegateContractHandler);
 contractHandlers.register(VHTLCContractHandler);
+contractHandlers.register(BoardingContractHandler);

--- a/packages/ts-sdk/src/contracts/index.ts
+++ b/packages/ts-sdk/src/contracts/index.ts
@@ -9,6 +9,8 @@ export { DelegateContractHandler } from "./handlers";
 export type { DelegateContractParams } from "./handlers";
 export { VHTLCContractHandler } from "./handlers";
 export type { VHTLCContractParams } from "./handlers";
+export { BoardingContractHandler } from "./handlers";
+export type { BoardingContractParams } from "./handlers";
 
 // arkcontract string codec
 export {

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -249,6 +249,8 @@ import { DelegateContractHandler } from "./contracts/handlers/delegate";
 import type { DelegateContractParams } from "./contracts/handlers/delegate";
 import { VHTLCContractHandler } from "./contracts/handlers/vhtlc";
 import type { VHTLCContractParams } from "./contracts/handlers/vhtlc";
+import { BoardingContractHandler } from "./contracts/handlers/boarding";
+import type { BoardingContractParams } from "./contracts/handlers/boarding";
 import {
     encodeArkContract,
     decodeArkContract,
@@ -442,6 +444,7 @@ export {
     DefaultContractHandler,
     DelegateContractHandler,
     VHTLCContractHandler,
+    BoardingContractHandler,
     encodeArkContract,
     decodeArkContract,
     contractFromArkContract,
@@ -599,6 +602,7 @@ export type {
     DefaultContractParams,
     DelegateContractParams,
     VHTLCContractParams,
+    BoardingContractParams,
     Discoverable,
     DiscoveryDeps,
     DiscoveredContract,

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -75,6 +75,7 @@ import { DelegateManagerImpl, findDestinationOutputIndex, IDelegateManager } fro
 import { IndexedDBContractRepository, IndexedDBWalletRepository } from "../repositories";
 import { ContractManager } from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
+import { BoardingContractHandler } from "../contracts/handlers/boarding";
 import { timelockToSequence } from "../utils/timelock";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
 import { validateVtxosForScript, saveVtxosForContract } from "../contracts/vtxoOwnership";
@@ -374,9 +375,18 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const offchainTapscript = !delegatePubKey
             ? new DefaultVtxo.Script(offchainOptions)
             : new DelegateVtxo.Script({ ...offchainOptions, delegatePubKey });
-        const boardingTapscript = new DefaultVtxo.Script({
-            ...offchainOptions,
-            csvTimelock: boardingTimelock,
+        // Source the boarding script from the registered `boarding` handler so
+        // wallet setup derives it through the contract type rather than ad-hoc
+        // construction. The handler returns a DefaultVtxo.Script byte-identical
+        // to the previous inline construction for equivalent params (the CSV
+        // timelock round-trips through the same BIP68 sequence encoding the
+        // script bytes already use), so getBoardingAddress() and pkScript are
+        // unchanged. Contract-manager initialization persists a matching
+        // `boarding` contract from these same params.
+        const boardingTapscript = BoardingContractHandler.createScript({
+            pubKey: hex.encode(pubKey),
+            serverPubKey: hex.encode(serverPubKey),
+            csvTimelock: timelockToSequence(boardingTimelock).toString(),
         });
 
         const walletRepository =
@@ -951,6 +961,46 @@ export class ReadonlyWallet implements IReadonlyWallet {
                     state: "active",
                 });
             }
+        }
+
+        // Boarding contract: persisted from the same handler-produced boarding
+        // script the wallet uses (this.boardingTapscript). Created `active` so
+        // ContractWatcher monitors the boarding Arkade address and any VTXOs
+        // that land on the (valid) boarding script are visible and spendable
+        // through the normal contract paths — even though the SDK does not
+        // promote the boarding Arkade address as an L2 receive address.
+        // getBoardingAddress() does not depend on this contract (it derives from
+        // this.boardingTapscript directly), keeping the lazy contract-manager
+        // lifecycle intact.
+        //
+        // Create-if-missing (idempotent): contracts are keyed by script. When
+        // boardingExitDelay coincides with a baseline (default/delegate)
+        // timelock, the boarding script is byte-identical to that baseline
+        // contract's script, so we cannot — and need not — persist a second
+        // `boarding`-typed row for it: the script is already persisted and
+        // watched via the baseline contract, so funds landing on it stay
+        // visible/spendable. Re-running initialization is likewise a no-op once
+        // the boarding contract exists.
+        const boardingScriptHex = hex.encode(this.boardingTapscript.pkScript);
+        const boardingCsvTimelock =
+            this.boardingTapscript.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK;
+        const [existingForBoardingScript] = await manager.getContracts({
+            script: boardingScriptHex,
+        });
+        if (!existingForBoardingScript) {
+            await manager.createContract({
+                type: "boarding",
+                params: {
+                    pubKey: hex.encode(this.boardingTapscript.options.pubKey),
+                    serverPubKey: hex.encode(this.boardingTapscript.options.serverPubKey),
+                    csvTimelock: timelockToSequence(boardingCsvTimelock).toString(),
+                },
+                script: boardingScriptHex,
+                address: this.boardingTapscript
+                    .address(this.network.hrp, this.arkServerPublicKey)
+                    .encode(),
+                state: "active",
+            });
         }
 
         return manager;

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -74,6 +74,7 @@ import { DelegateVtxo } from "../script/delegate";
 import { DelegateManagerImpl, findDestinationOutputIndex, IDelegateManager } from "./delegate";
 import { IndexedDBContractRepository, IndexedDBWalletRepository } from "../repositories";
 import { ContractManager } from "../contracts/contractManager";
+import type { CreateContractParams } from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
 import { BoardingContractHandler } from "../contracts/handlers/boarding";
 import { timelockToSequence } from "../utils/timelock";
@@ -137,6 +138,73 @@ function dedupeTimelocks(timelocks: RelativeTimelock[]): RelativeTimelock[] {
     }
 
     return deduped;
+}
+
+/**
+ * Whether two wallet baseline contract types may legitimately share a single
+ * repository row when their scripts collide.
+ *
+ * Contracts are keyed by their pkScript (`script` is the unique identity), so a
+ * given script can own exactly one row. `default` and `boarding` are both built
+ * from the same `DefaultVtxo.Script` shape and differ only by CSV timelock
+ * value; when the offchain unilateral-exit delay and the boarding-exit delay
+ * coincide, the two derive a byte-identical script and either type may own the
+ * row. Same-type is trivially compatible. Every other pairing (e.g. a
+ * `delegate` script, which carries an extra leaf and cannot collide under
+ * normal semantics) is incompatible and signals a real script/params mismatch.
+ *
+ * @internal Exported for unit tests; not part of the public API surface.
+ */
+export function areSameScriptBaselineTypesCompatible(
+    existingType: string,
+    requestedType: string,
+): boolean {
+    if (existingType === requestedType) return true;
+    return (
+        (existingType === "default" && requestedType === "boarding") ||
+        (existingType === "boarding" && requestedType === "default")
+    );
+}
+
+/**
+ * Register a wallet baseline contract (`default` / `boarding`) idempotently,
+ * tolerating a same-script collision with a compatible baseline type.
+ *
+ * Because contracts are keyed by script, when `default` and `boarding` resolve
+ * to the same pkScript (coinciding CSV timelocks) the script can only have one
+ * row — and that existing row already satisfies the wallet invariant: it is
+ * persisted, created `active` (so watched), and its spend paths are valid (both
+ * types share the `DefaultVtxo.Script` forfeit/exit surface). In that case we
+ * accept the existing row instead of creating a duplicate or throwing.
+ *
+ * Resolution:
+ * - no existing row for the script → create it;
+ * - existing row of the same type → {@link ContractManager.createContract} is a
+ *   no-op (idempotent), so re-running initialization never duplicates;
+ * - existing row of a *compatible* baseline type → accept it (no second row);
+ * - existing row of an *incompatible* type → fall through to `createContract`,
+ *   which throws its descriptive script/type mismatch error.
+ *
+ * Used only for the wallet's own `default` / `boarding` baseline contracts;
+ * `delegate` creation stays strict (its script cannot collide with the others).
+ *
+ * @internal Exported for unit tests; not part of the public API surface.
+ */
+export async function ensureWalletContract(
+    manager: ContractManager,
+    params: CreateContractParams,
+): Promise<void> {
+    const [existing] = await manager.getContracts({ script: params.script });
+    if (
+        existing &&
+        existing.type !== params.type &&
+        areSameScriptBaselineTypesCompatible(existing.type, params.type)
+    ) {
+        // Compatible collision: the existing row already persists and watches
+        // this exact script, so the baseline purpose is fully served.
+        return;
+    }
+    await manager.createContract(params);
 }
 
 export type IncomingFunds =
@@ -925,7 +993,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
             });
             const defaultScriptHex = hex.encode(defaultScript.pkScript);
 
-            await manager.createContract({
+            // Use ensureWalletContract (not a strict createContract) so a
+            // default baseline whose script collides with an already-persisted
+            // `boarding` row — possible across boots when the server's
+            // unilateral-exit delay shifts to match a prior boarding-exit delay
+            // — accepts that row instead of throwing a type mismatch.
+            await ensureWalletContract(manager, {
                 type: "default",
                 params: {
                     pubKey: hex.encode(defaultScript.options.pubKey),
@@ -973,35 +1046,29 @@ export class ReadonlyWallet implements IReadonlyWallet {
         // this.boardingTapscript directly), keeping the lazy contract-manager
         // lifecycle intact.
         //
-        // Create-if-missing (idempotent): contracts are keyed by script. When
-        // boardingExitDelay coincides with a baseline (default/delegate)
-        // timelock, the boarding script is byte-identical to that baseline
-        // contract's script, so we cannot — and need not — persist a second
-        // `boarding`-typed row for it: the script is already persisted and
-        // watched via the baseline contract, so funds landing on it stay
-        // visible/spendable. Re-running initialization is likewise a no-op once
-        // the boarding contract exists.
+        // Create-if-missing via ensureWalletContract (idempotent): contracts
+        // are keyed by script. When boardingExitDelay coincides with a baseline
+        // `default` timelock, the boarding script is byte-identical to that
+        // default contract's script, so we cannot — and need not — persist a
+        // second row for it: the script is already persisted and watched via
+        // the default contract, so funds landing on it stay visible/spendable.
+        // Re-running initialization is likewise a no-op once the row exists.
         const boardingScriptHex = hex.encode(this.boardingTapscript.pkScript);
         const boardingCsvTimelock =
             this.boardingTapscript.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK;
-        const [existingForBoardingScript] = await manager.getContracts({
+        await ensureWalletContract(manager, {
+            type: "boarding",
+            params: {
+                pubKey: hex.encode(this.boardingTapscript.options.pubKey),
+                serverPubKey: hex.encode(this.boardingTapscript.options.serverPubKey),
+                csvTimelock: timelockToSequence(boardingCsvTimelock).toString(),
+            },
             script: boardingScriptHex,
+            address: this.boardingTapscript
+                .address(this.network.hrp, this.arkServerPublicKey)
+                .encode(),
+            state: "active",
         });
-        if (!existingForBoardingScript) {
-            await manager.createContract({
-                type: "boarding",
-                params: {
-                    pubKey: hex.encode(this.boardingTapscript.options.pubKey),
-                    serverPubKey: hex.encode(this.boardingTapscript.options.serverPubKey),
-                    csvTimelock: timelockToSequence(boardingCsvTimelock).toString(),
-                },
-                script: boardingScriptHex,
-                address: this.boardingTapscript
-                    .address(this.network.hrp, this.arkServerPublicKey)
-                    .encode(),
-                state: "active",
-            });
-        }
 
         return manager;
     }

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -148,10 +148,12 @@ function dedupeTimelocks(timelocks: RelativeTimelock[]): RelativeTimelock[] {
  * given script can own exactly one row. `default` and `boarding` are both built
  * from the same `DefaultVtxo.Script` shape and differ only by CSV timelock
  * value; when the offchain unilateral-exit delay and the boarding-exit delay
- * coincide, the two derive a byte-identical script and either type may own the
- * row. Same-type is trivially compatible. Every other pairing (e.g. a
- * `delegate` script, which carries an extra leaf and cannot collide under
- * normal semantics) is incompatible and signals a real script/params mismatch.
+ * coincide, the two derive a byte-identical script and may share a single row
+ * (the wallet coalesces such a collision onto `default` — see
+ * {@link ensureWalletContract}). Same-type is trivially compatible. Every other
+ * pairing (e.g. a `delegate` script, which carries an extra leaf and cannot
+ * collide under normal semantics) is incompatible and signals a real
+ * script/params mismatch.
  *
  * @internal Exported for unit tests; not part of the public API surface.
  */
@@ -168,20 +170,27 @@ export function areSameScriptBaselineTypesCompatible(
 
 /**
  * Register a wallet baseline contract (`default` / `boarding`) idempotently,
- * tolerating a same-script collision with a compatible baseline type.
+ * coalescing a same-script collision onto the `default` type.
  *
- * Because contracts are keyed by script, when `default` and `boarding` resolve
- * to the same pkScript (coinciding CSV timelocks) the script can only have one
- * row — and that existing row already satisfies the wallet invariant: it is
- * persisted, created `active` (so watched), and its spend paths are valid (both
- * types share the `DefaultVtxo.Script` forfeit/exit surface). In that case we
- * accept the existing row instead of creating a duplicate or throwing.
+ * Contracts are keyed by script, so when `default` and `boarding` resolve to the
+ * same pkScript the script can own only one row. This collision is degenerate: a
+ * sound Ark server keeps `boardingExitDelay` strictly longer than the offchain
+ * unilateral-exit delay (equal delays would expose the provider to a
+ * double-spend), so in practice the two scripts differ and the boarding row
+ * keeps its own identity. They can coincide only against a misconfigured /
+ * malicious server — and even then the wallet must stay usable, so we coalesce
+ * rather than throw.
  *
- * Resolution:
+ * Resolution ("default wins" on a shared script):
  * - no existing row for the script → create it;
  * - existing row of the same type → {@link ContractManager.createContract} is a
  *   no-op (idempotent), so re-running initialization never duplicates;
- * - existing row of a *compatible* baseline type → accept it (no second row);
+ * - requested `default`, existing `boarding` (compatible) → promote the row to
+ *   `default`. The shared script is also the wallet's live offchain baseline, so
+ *   typing it `default` keeps it visible to the type-gated consumers
+ *   (`notifyIncomingFunds`, `getWalletScripts`, `getScriptMap`);
+ * - requested `boarding`, existing `default` (compatible) → accept as-is (the
+ *   shared script is already canonical);
  * - existing row of an *incompatible* type → fall through to `createContract`,
  *   which throws its descriptive script/type mismatch error.
  *
@@ -200,8 +209,15 @@ export async function ensureWalletContract(
         existing.type !== params.type &&
         areSameScriptBaselineTypesCompatible(existing.type, params.type)
     ) {
-        // Compatible collision: the existing row already persists and watches
-        // this exact script, so the baseline purpose is fully served.
+        // Compatible collision (degenerate; sound servers keep the delays
+        // distinct). The script already persists and is watched, so the baseline
+        // purpose is served. Coalesce onto `default` ("default wins") so a shared
+        // script that is also the wallet's live offchain baseline stays
+        // discoverable through the type-gated consumers; otherwise the existing
+        // row is already `default`, so accept it as-is.
+        if (params.type === "default" && existing.type === "boarding") {
+            await manager.updateContract(params.script, { type: "default" });
+        }
         return;
     }
     await manager.createContract(params);
@@ -995,9 +1011,10 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
             // Use ensureWalletContract (not a strict createContract) so a
             // default baseline whose script collides with an already-persisted
-            // `boarding` row — possible across boots when the server's
-            // unilateral-exit delay shifts to match a prior boarding-exit delay
-            // — accepts that row instead of throwing a type mismatch.
+            // `boarding` row promotes that row to `default` ("default wins")
+            // instead of throwing a type mismatch. Degenerate guard only: a
+            // sound server keeps the unilateral-exit and boarding-exit delays
+            // distinct, so these scripts never actually collide.
             await ensureWalletContract(manager, {
                 type: "default",
                 params: {
@@ -1047,12 +1064,14 @@ export class ReadonlyWallet implements IReadonlyWallet {
         // lifecycle intact.
         //
         // Create-if-missing via ensureWalletContract (idempotent): contracts
-        // are keyed by script. When boardingExitDelay coincides with a baseline
-        // `default` timelock, the boarding script is byte-identical to that
-        // default contract's script, so we cannot — and need not — persist a
-        // second row for it: the script is already persisted and watched via
-        // the default contract, so funds landing on it stay visible/spendable.
-        // Re-running initialization is likewise a no-op once the row exists.
+        // are keyed by script. In the degenerate case where boardingExitDelay
+        // coincides with a baseline `default` timelock (a misconfigured server;
+        // sound servers keep them distinct), the boarding script is
+        // byte-identical to that default contract's script, so we cannot — and
+        // need not — persist a second row: the shared script is already
+        // persisted and watched as a `default` contract ("default wins"), so
+        // funds landing on it stay visible/spendable. Re-running initialization
+        // is likewise a no-op once the row exists.
         const boardingScriptHex = hex.encode(this.boardingTapscript.pkScript);
         const boardingCsvTimelock =
             this.boardingTapscript.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK;

--- a/packages/ts-sdk/test/contracts/handlers/boarding.test.ts
+++ b/packages/ts-sdk/test/contracts/handlers/boarding.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+import { BoardingContractHandler } from "../../../src/contracts/handlers/boarding";
+import { DefaultContractHandler } from "../../../src/contracts/handlers/default";
+import {
+    contractHandlers,
+    DefaultVtxo,
+    BoardingContractHandler as RootBoardingContractHandler,
+} from "../../../src";
+import { isDiscoverable } from "../../../src/contracts/types";
+import { sequenceToTimelock, timelockToSequence } from "../../../src/utils/timelock";
+
+const TEST_PUB_KEY_HEX = "5b3a7b5e8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f";
+const TEST_PUB_KEY = hex.decode(TEST_PUB_KEY_HEX);
+const TEST_SERVER_PUB_KEY_HEX = "9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b";
+const TEST_SERVER_PUB_KEY = hex.decode(TEST_SERVER_PUB_KEY_HEX);
+
+// Boarding-exit delay sourced from ArkInfo.boardingExitDelay (seconds),
+// distinct from the offchain unilateral-exit delay used by `default`.
+const BOARDING_EXIT_DELAY = { value: 86016n, type: "seconds" as const };
+const UNILATERAL_EXIT_DELAY = { value: 512n, type: "seconds" as const };
+
+const boardingParams = (csvTimelock = BOARDING_EXIT_DELAY) => ({
+    pubKey: TEST_PUB_KEY_HEX,
+    serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+    csvTimelock: timelockToSequence(csvTimelock).toString(),
+});
+
+describe("BoardingContractHandler registration", () => {
+    it("is registered under type 'boarding'", () => {
+        expect(contractHandlers.has("boarding")).toBe(true);
+        const handler = contractHandlers.get("boarding");
+        expect(handler).toBeDefined();
+        expect(handler?.type).toBe("boarding");
+    });
+
+    it("registers the exported handler object instance", () => {
+        expect(BoardingContractHandler.type).toBe("boarding");
+        expect(contractHandlers.get("boarding")).toBe(BoardingContractHandler);
+    });
+
+    it("is exported from the package root (the only public entrypoint)", () => {
+        // package.json exposes only "." for the core API, so consumers must be
+        // able to import the built-in handler from the root entry like the
+        // default/delegate/vhtlc handlers.
+        expect(RootBoardingContractHandler).toBe(BoardingContractHandler);
+        expect(RootBoardingContractHandler.type).toBe("boarding");
+    });
+});
+
+describe("BoardingContractHandler.createScript", () => {
+    it("matches the boardingTapscript construction (DefaultVtxo.Script) for the boarding timelock", () => {
+        // The current/legacy wallet-setup construction of boardingTapscript.
+        const legacy = new DefaultVtxo.Script({
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: BOARDING_EXIT_DELAY,
+        });
+
+        const fromHandler = BoardingContractHandler.createScript(boardingParams());
+
+        expect(fromHandler).toBeInstanceOf(DefaultVtxo.Script);
+        expect(hex.encode(fromHandler.pkScript)).toEqual(hex.encode(legacy.pkScript));
+    });
+
+    it("produces a DefaultVtxo.Script with forfeit and exit leaves", () => {
+        const script = BoardingContractHandler.createScript(boardingParams());
+        expect(script.forfeit()).toBeDefined();
+        expect(script.exit()).toBeDefined();
+    });
+
+    it("sources the CSV timelock from the boarding delay, not the unilateral exit delay", () => {
+        const boarding = BoardingContractHandler.createScript(boardingParams(BOARDING_EXIT_DELAY));
+        const offchain = DefaultContractHandler.createScript({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+            csvTimelock: timelockToSequence(UNILATERAL_EXIT_DELAY).toString(),
+        });
+
+        // Same pubkeys, different CSV timelock value → different pkScript.
+        expect(hex.encode(boarding.pkScript)).not.toEqual(hex.encode(offchain.pkScript));
+
+        // Boarding built from the boarding delay matches default built from the
+        // same boarding delay — they share a script shape, differing only by the
+        // CSV value. This pins that boarding adds no new timelock semantics.
+        const defaultWithBoardingDelay = DefaultContractHandler.createScript(boardingParams());
+        expect(hex.encode(boarding.pkScript)).toEqual(
+            hex.encode(defaultWithBoardingDelay.pkScript),
+        );
+    });
+});
+
+describe("BoardingContractHandler on-chain & Arkade address derivation", () => {
+    it("derives the on-chain boarding address from the handler script (matches legacy boardingTapscript)", () => {
+        const network = { bech32: "bcrt", hrp: "tark" } as any;
+        const legacy = new DefaultVtxo.Script({
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: BOARDING_EXIT_DELAY,
+        });
+        const fromHandler = BoardingContractHandler.createScript(boardingParams());
+
+        expect(fromHandler.onchainAddress(network)).toEqual(legacy.onchainAddress(network));
+    });
+
+    it("derives the Arkade address matching DefaultVtxo.Script for the same hrp/server key/params", () => {
+        const hrp = "tark";
+        const legacy = new DefaultVtxo.Script({
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: BOARDING_EXIT_DELAY,
+        });
+        const fromHandler = BoardingContractHandler.createScript(boardingParams());
+
+        expect(fromHandler.address(hrp, TEST_SERVER_PUB_KEY).encode()).toEqual(
+            legacy.address(hrp, TEST_SERVER_PUB_KEY).encode(),
+        );
+    });
+});
+
+describe("BoardingContractHandler param serialize/deserialize", () => {
+    it("round-trips params using the same timelock helpers as default", () => {
+        const typed = {
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: BOARDING_EXIT_DELAY,
+        };
+
+        const serialized = BoardingContractHandler.serializeParams(typed);
+        expect(serialized).toEqual(DefaultContractHandler.serializeParams(typed));
+        expect(serialized.csvTimelock).toEqual(timelockToSequence(BOARDING_EXIT_DELAY).toString());
+
+        const deserialized = BoardingContractHandler.deserializeParams(serialized);
+        expect(Array.from(deserialized.pubKey)).toEqual(Array.from(TEST_PUB_KEY));
+        expect(Array.from(deserialized.serverPubKey)).toEqual(Array.from(TEST_SERVER_PUB_KEY));
+        expect(deserialized.csvTimelock).toEqual(BOARDING_EXIT_DELAY);
+    });
+
+    it("produces an identical pkScript after a serialize round trip", () => {
+        const typed = {
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: BOARDING_EXIT_DELAY,
+        };
+        const serialized = BoardingContractHandler.serializeParams(typed);
+        const script1 = BoardingContractHandler.createScript(serialized);
+
+        const reserialized = BoardingContractHandler.serializeParams(
+            BoardingContractHandler.deserializeParams(serialized),
+        );
+        const script2 = BoardingContractHandler.createScript(reserialized);
+
+        expect(hex.encode(script2.pkScript)).toEqual(hex.encode(script1.pkScript));
+    });
+
+    it("falls back to the default timelock when csvTimelock is missing", () => {
+        const script = BoardingContractHandler.createScript({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+        });
+        const expected = new DefaultVtxo.Script({
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
+        });
+        expect(hex.encode(script.pkScript)).toEqual(hex.encode(expected.pkScript));
+    });
+
+    it("throws on invalid pubkey params", () => {
+        expect(() =>
+            BoardingContractHandler.createScript({
+                pubKey: "not-hex",
+                serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+                csvTimelock: timelockToSequence(BOARDING_EXIT_DELAY).toString(),
+            }),
+        ).toThrow();
+    });
+
+    it("uses the same BIP68 sequence round-trip as default/delegate", () => {
+        const seq = timelockToSequence(BOARDING_EXIT_DELAY);
+        expect(sequenceToTimelock(seq)).toEqual(BOARDING_EXIT_DELAY);
+    });
+});
+
+describe("BoardingContractHandler is not discoverable", () => {
+    it("does not implement discoverAt", () => {
+        expect((BoardingContractHandler as { discoverAt?: unknown }).discoverAt).toBeUndefined();
+    });
+
+    it("isDiscoverable(BoardingContractHandler) is false", () => {
+        expect(isDiscoverable(BoardingContractHandler)).toBe(false);
+        // sanity: the default handler IS discoverable, proving the guard works
+        expect(isDiscoverable(DefaultContractHandler)).toBe(true);
+    });
+
+    it("is excluded from the scanner's discoverable handler set", () => {
+        const discoverables = contractHandlers
+            .getRegisteredTypes()
+            .map((t) => contractHandlers.get(t))
+            .filter(isDiscoverable)
+            .map((h) => h!.type);
+        expect(discoverables).not.toContain("boarding");
+    });
+});
+
+describe("BoardingContractHandler spend paths reuse the default surface", () => {
+    const params = boardingParams();
+    const script = BoardingContractHandler.createScript(params);
+    const contract = {
+        type: "boarding",
+        params,
+        script: hex.encode(script.pkScript),
+        address: "address",
+        state: "active" as const,
+        createdAt: 0,
+    };
+
+    it("selects the forfeit path when collaborative", () => {
+        const path = BoardingContractHandler.selectPath(script, contract, {
+            collaborative: true,
+            currentTime: 0,
+        });
+        expect(path?.leaf).toBeDefined();
+    });
+
+    it("selects the exit path (with sequence) after the boarding CSV matures", () => {
+        const paths = BoardingContractHandler.getSpendablePaths(script, contract, {
+            collaborative: false,
+            currentTime: Date.now(),
+            blockHeight: 300,
+            vtxo: {
+                txid: "00".repeat(32),
+                vout: 0,
+                value: 1000,
+                status: { confirmed: true, block_height: 100, block_time: 1 },
+                virtualStatus: { state: "settled" },
+                createdAt: new Date(),
+            } as any,
+        });
+        expect(paths).toHaveLength(1);
+        expect(paths[0].sequence).toEqual(Number(params.csvTimelock));
+    });
+});

--- a/packages/ts-sdk/test/e2e/contract-params-change.test.ts
+++ b/packages/ts-sdk/test/e2e/contract-params-change.test.ts
@@ -36,7 +36,9 @@ describe("Contract params change", () => {
 
                 const firstManager = await first.wallet.getContractManager();
                 const contractsAfterFirst = await firstManager.getContracts();
-                expect(contractsAfterFirst).toHaveLength(2);
+                // default + delegate (both csv = unilateralExitDelay) + boarding
+                // (csv = boardingExitDelay, a distinct server delay).
+                expect(contractsAfterFirst).toHaveLength(3);
 
                 const oldDelegate = contractsAfterFirst.find((c) => c.type === "delegate");
                 const oldDefault = contractsAfterFirst.find((c) => c.type === "default");
@@ -76,7 +78,10 @@ describe("Contract params change", () => {
 
                 const secondManager = await second.wallet.getContractManager();
                 const contractsAfterSecond = await secondManager.getContracts();
-                expect(contractsAfterSecond).toHaveLength(4);
+                // Old default + old delegate (persisted) + new default + new
+                // delegate (new unilateralExitDelay) + the single boarding
+                // contract, whose boardingExitDelay never changed.
+                expect(contractsAfterSecond).toHaveLength(5);
 
                 const delegateContracts = contractsAfterSecond.filter((c) => c.type === "delegate");
                 const defaultContracts = contractsAfterSecond.filter((c) => c.type === "default");

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -117,6 +117,13 @@ describe("Wallet", () => {
             //    the wallet's default contract (includeSpent=true)
             // 4. ContractWatcher.subscribeForScripts for the wallet's script
             // 5. getContractsWithVtxos -> syncContracts delta fetch
+            //
+            // boardingExitDelay equals unilateralExitDelay here, so the
+            // boarding script is byte-identical to the default baseline
+            // contract's script. Contract-manager init creates the boarding
+            // contract create-if-missing, so it is skipped (the script is
+            // already persisted/watched via the default contract) and the
+            // fetch sequence above is unchanged.
 
             mockFetch
                 .mockResolvedValueOnce({
@@ -127,6 +134,7 @@ describe("Wallet", () => {
                             forfeitPubkey: mockServerKeyHex,
                             batchExpiry: BigInt(144),
                             unilateralExitDelay: BigInt(144),
+                            boardingExitDelay: BigInt(144),
                             roundInterval: BigInt(144),
                             network: "mutinynet",
                             forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",

--- a/packages/ts-sdk/test/wallet/boarding-contract.test.ts
+++ b/packages/ts-sdk/test/wallet/boarding-contract.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi } from "vitest";
+import { Wallet } from "../../src/wallet/wallet";
+import { InMemoryWalletRepository } from "../../src/repositories/inMemory/walletRepository";
+import { InMemoryContractRepository } from "../../src/repositories/inMemory/contractRepository";
+import { SingleKey } from "../../src/identity/singleKey";
+import { DefaultVtxo } from "../../src/script/default";
+import { contractHandlers } from "../../src/contracts/handlers";
+import { isDiscoverable } from "../../src/contracts/types";
+import { timelockToSequence } from "../../src/utils/timelock";
+import { hex } from "@scure/base";
+
+// Valid secp256k1 server pubkey (33-byte compressed, generator point) and a
+// real CSV-multisig checkpoint tapscript — both lifted from the proven
+// test/helpers/restoreWallet.ts harness so Wallet.create() parses cleanly.
+const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const CHECKPOINT_TAPSCRIPT =
+    "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac";
+
+// boardingExitDelay is a seconds-type relative timelock and must be a multiple
+// of 512 (BIP68 seconds granularity; bip68.encode throws otherwise). 604672 =
+// 1181 * 512 (~7 days). unilateralExitDelay is a small block delay, so the
+// offchain `default` baseline script never collides with the boarding script.
+function makeInfo(overrides: Partial<any> = {}) {
+    return {
+        signerPubkey: SERVER_PUBKEY_HEX,
+        forfeitPubkey: SERVER_PUBKEY_HEX,
+        network: "mutinynet",
+        batchExpiry: 144n,
+        unilateralExitDelay: 144n,
+        boardingExitDelay: 604672n,
+        roundInterval: 144n,
+        dust: 1000n,
+        forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+        checkpointTapscript: CHECKPOINT_TAPSCRIPT,
+        ...overrides,
+    };
+}
+
+function makeIdleIndexer() {
+    return {
+        getVtxos: vi.fn(async () => ({ vtxos: [] })),
+        subscribeForScripts: vi.fn(async () => "sub-id"),
+        unsubscribeForScripts: vi.fn(async () => {}),
+        // Idle subscription stream: resolves only when the watcher aborts, so
+        // it never emits and keeps the contract watcher quiet during tests.
+        getSubscription: vi.fn(async function* (_subId: string, abortSignal: AbortSignal) {
+            await new Promise<void>((resolve) => {
+                if (abortSignal?.aborted) return resolve();
+                abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+            });
+        }),
+        watchAddresses: vi.fn(async () => () => {}),
+    } as any;
+}
+
+function makeIdleOnchain() {
+    return {
+        getCoins: vi.fn(async () => []),
+        getTransactions: vi.fn(async () => []),
+        getTxOutspends: vi.fn(async () => []),
+        getTxStatus: vi.fn(async () => ({ confirmed: false })),
+        getChainTip: vi.fn(async () => ({ height: 0, hash: "", time: 0 })),
+        broadcastTransaction: vi.fn(async () => "txid"),
+        watchAddresses: vi.fn(async () => () => {}),
+    } as any;
+}
+
+async function makeWallet(infoOverrides: Partial<any> = {}) {
+    const identity = SingleKey.fromHex("1".repeat(64));
+    const info = makeInfo(infoOverrides);
+
+    const arkProvider = { getInfo: vi.fn(async () => info) } as any;
+    const indexerProvider = makeIdleIndexer();
+    const onchainProvider = makeIdleOnchain();
+
+    const wallet = await Wallet.create({
+        identity,
+        // Disable background settlement so no renewal loop races our
+        // contract-manager assertions.
+        settlementConfig: false,
+        arkProvider,
+        indexerProvider,
+        onchainProvider,
+        storage: {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        },
+    });
+
+    return { wallet, info, identity, arkProvider, indexerProvider, onchainProvider };
+}
+
+describe("boarding contract: getBoardingAddress backward compatibility", () => {
+    it("returns the address derived directly from a DefaultVtxo.Script for the same keys/timelock", async () => {
+        const { wallet, info } = await makeWallet();
+
+        const serverPubKey = hex.decode(info.signerPubkey).slice(1);
+        const pubKey = await wallet.identity.xOnlyPublicKey();
+        // Reconstruct the pre-change boardingTapscript exactly: DefaultVtxo.Script
+        // with csvTimelock sourced from boardingExitDelay.
+        const legacy = new DefaultVtxo.Script({
+            pubKey,
+            serverPubKey,
+            csvTimelock: {
+                value: info.boardingExitDelay,
+                type: info.boardingExitDelay < 512n ? "blocks" : "seconds",
+            },
+        });
+
+        const expected = legacy.onchainAddress(wallet.network);
+        expect(await wallet.getBoardingAddress()).toEqual(expected);
+    });
+
+    it("derives getBoardingAddress from boardingTapscript without loading the persisted contract", async () => {
+        const { wallet } = await makeWallet();
+        // No contract-manager access here: getBoardingAddress must not trigger
+        // contract-manager initialization.
+        const address = await wallet.getBoardingAddress();
+        expect(address).toEqual(wallet.boardingTapscript.onchainAddress(wallet.network));
+    });
+});
+
+describe("boarding contract: wallet.boardingTapscript source", () => {
+    it("is sourced from BoardingContractHandler.createScript and remains a DefaultVtxo.Script", async () => {
+        const { wallet, info } = await makeWallet();
+
+        expect(wallet.boardingTapscript).toBeInstanceOf(DefaultVtxo.Script);
+
+        // Rebuild the script the way wallet setup does — via the boarding
+        // handler from the resolved pubkey, server key, and boarding timelock —
+        // and confirm it is byte-identical to wallet.boardingTapscript.
+        const handler = contractHandlers.get("boarding")!;
+        const serverPubKey = hex.decode(info.signerPubkey).slice(1);
+        const pubKey = await wallet.identity.xOnlyPublicKey();
+        const boardingTimelock = {
+            value: info.boardingExitDelay,
+            type: info.boardingExitDelay < 512n ? ("blocks" as const) : ("seconds" as const),
+        };
+        const fromHandler = handler.createScript({
+            pubKey: hex.encode(pubKey),
+            serverPubKey: hex.encode(serverPubKey),
+            csvTimelock: timelockToSequence(boardingTimelock).toString(),
+        });
+
+        expect(hex.encode(fromHandler.pkScript)).toEqual(
+            hex.encode(wallet.boardingTapscript.pkScript),
+        );
+    });
+});
+
+describe("boarding contract: persistence through the contract-manager path", () => {
+    it("creates and persists an active boarding contract matching wallet.boardingTapscript", async () => {
+        const { wallet } = await makeWallet();
+        const manager = await wallet.getContractManager();
+
+        const boarding = await manager.getContracts({ type: ["boarding"] });
+        expect(boarding).toHaveLength(1);
+
+        const contract = boarding[0];
+        expect(contract.type).toBe("boarding");
+        expect(contract.state).toBe("active");
+        // Contract.script is the boarding pkScript; matches wallet.boardingTapscript.
+        expect(contract.script).toEqual(hex.encode(wallet.boardingTapscript.pkScript));
+        // Contract.address holds the Arkade address derived from the script.
+        expect(contract.address).toEqual(
+            wallet.boardingTapscript
+                .address(wallet.network.hrp, wallet.arkServerPublicKey)
+                .encode(),
+        );
+        // The script re-derived from the persisted params matches the stored script.
+        const handler = contractHandlers.get(contract.type)!;
+        expect(hex.encode(handler.createScript(contract.params).pkScript)).toEqual(contract.script);
+    });
+
+    it("can be re-read through the repository", async () => {
+        const { wallet } = await makeWallet();
+        await wallet.getContractManager();
+
+        const fromRepo = await wallet.contractRepository.getContracts({ type: ["boarding"] });
+        expect(fromRepo).toHaveLength(1);
+        expect(fromRepo[0].script).toEqual(hex.encode(wallet.boardingTapscript.pkScript));
+    });
+
+    it("registers the boarding script with the ContractWatcher (subscribes via the indexer)", async () => {
+        const { wallet, indexerProvider } = await makeWallet();
+        await wallet.getContractManager();
+
+        const subscribedScripts = indexerProvider.subscribeForScripts.mock.calls.flatMap(
+            (call: any[]) => call[0] ?? [],
+        );
+        expect(subscribedScripts).toContain(hex.encode(wallet.boardingTapscript.pkScript));
+    });
+
+    it("is idempotent: re-initializing does not duplicate the boarding contract", async () => {
+        const { wallet } = await makeWallet();
+
+        const m1 = await wallet.getContractManager();
+        const before = await m1.getContracts({ type: ["boarding"] });
+        expect(before).toHaveLength(1);
+
+        // Force a fresh initialization pass against the same repository.
+        await wallet.dispose();
+        const m2 = await wallet.getContractManager();
+        const after = await m2.getContracts({ type: ["boarding"] });
+        expect(after).toHaveLength(1);
+        expect(after[0].script).toEqual(before[0].script);
+    });
+});
+
+describe("boarding contract: VTXO annotation and spend paths", () => {
+    it("annotates a VTXO landing on the boarding script to the boarding contract with spendable paths", async () => {
+        const { wallet } = await makeWallet();
+        const manager = await wallet.getContractManager();
+
+        const boardingScript = hex.encode(wallet.boardingTapscript.pkScript);
+        const vtxo = {
+            txid: "ab".repeat(32),
+            vout: 0,
+            value: 5000,
+            status: { confirmed: true, block_height: 100, block_time: 1 },
+            virtualStatus: { state: "settled" as const },
+            createdAt: new Date(),
+            script: boardingScript,
+        };
+
+        // Sanity: the persisted boarding contract is keyed by exactly this script.
+        const persisted = await wallet.contractRepository.getContracts({ type: ["boarding"] });
+        expect(persisted.map((c) => c.script)).toContain(boardingScript);
+
+        const annotated = await manager.annotateVtxos([vtxo as any]);
+        expect(annotated).toHaveLength(1);
+        // Annotated VTXO carries the taproot tree for the boarding script.
+        expect(annotated[0].tapTree).toBeDefined();
+
+        // The boarding contract yields a collaborative (forfeit) spend path.
+        const handler = contractHandlers.get("boarding")!;
+        const contract = (await manager.getContracts({ type: ["boarding"] }))[0];
+        const script = handler.createScript(contract.params);
+        const paths = handler.getSpendablePaths(script, contract, {
+            collaborative: true,
+            currentTime: Date.now(),
+        });
+        expect(paths.length).toBeGreaterThanOrEqual(1);
+    });
+});
+
+describe("boarding contract: not discoverable", () => {
+    it("is not part of the discoverable handler set", () => {
+        const handler = contractHandlers.get("boarding");
+        expect(isDiscoverable(handler)).toBe(false);
+    });
+});
+
+describe("boarding contract: server boarding-exit-delay change", () => {
+    it("promotes the latest boarding script while keeping the old boarding contract persisted and watched", async () => {
+        const sharedWalletRepo = new InMemoryWalletRepository();
+        const sharedContractRepo = new InMemoryContractRepository();
+        const identity = SingleKey.fromHex("1".repeat(64));
+
+        const build = async (boardingExitDelay: bigint) => {
+            const info = makeInfo({ boardingExitDelay });
+            const arkProvider = { getInfo: vi.fn(async () => info) } as any;
+            const indexerProvider = makeIdleIndexer();
+            const onchainProvider = makeIdleOnchain();
+            const wallet = await Wallet.create({
+                identity,
+                settlementConfig: false,
+                arkProvider,
+                indexerProvider,
+                onchainProvider,
+                storage: {
+                    walletRepository: sharedWalletRepo,
+                    contractRepository: sharedContractRepo,
+                },
+            });
+            return { wallet, indexerProvider };
+        };
+
+        // First boot: boarding delay A (604672 = 1181 * 512, ~7 days).
+        const a = await build(604672n);
+        const scriptA = hex.encode(a.wallet.boardingTapscript.pkScript);
+        await a.wallet.getContractManager();
+        await a.wallet.dispose();
+
+        // Second boot: server advertises a different boarding delay B
+        // (1209344 = 2362 * 512, ~14 days).
+        const b = await build(1209344n);
+        const scriptB = hex.encode(b.wallet.boardingTapscript.pkScript);
+        const managerB = await b.wallet.getContractManager();
+
+        // Distinct scripts → distinct boarding contracts.
+        expect(scriptB).not.toEqual(scriptA);
+
+        // getBoardingAddress promotes the latest (B) script.
+        expect(await b.wallet.getBoardingAddress()).toEqual(
+            b.wallet.boardingTapscript.onchainAddress(b.wallet.network),
+        );
+
+        // Both boarding contracts remain persisted and active.
+        const boardingContracts = await managerB.getContracts({ type: ["boarding"] });
+        const scripts = boardingContracts.map((c) => c.script);
+        expect(scripts).toContain(scriptA);
+        expect(scripts).toContain(scriptB);
+        expect(boardingContracts.every((c) => c.state === "active")).toBe(true);
+
+        // The new boarding script is registered with the watcher on boot B.
+        const subscribed = b.indexerProvider.subscribeForScripts.mock.calls.flatMap(
+            (call: any[]) => call[0] ?? [],
+        );
+        expect(subscribed).toContain(scriptB);
+
+        await b.wallet.dispose();
+    });
+});
+
+describe("boarding contract: HD key selection stays wallet-owned", () => {
+    it("persists a boarding contract whose pubkey is the wallet-resolved key, not allocated by the handler", async () => {
+        const { wallet } = await makeWallet();
+        const manager = await wallet.getContractManager();
+
+        const walletPubKey = await wallet.identity.xOnlyPublicKey();
+        const boarding = (await manager.getContracts({ type: ["boarding"] }))[0];
+        expect(boarding.params.pubKey).toEqual(hex.encode(walletPubKey));
+        // Same key the wallet's boardingTapscript uses — one resolved key shared.
+        expect(boarding.params.pubKey).toEqual(hex.encode(wallet.boardingTapscript.options.pubKey));
+    });
+});

--- a/packages/ts-sdk/test/wallet/boarding-contract.test.ts
+++ b/packages/ts-sdk/test/wallet/boarding-contract.test.ts
@@ -435,16 +435,24 @@ describe("ensureWalletContract", () => {
         }
     });
 
-    it("collision direction B: existing boarding, then default accepts the row (no duplicate, watched)", async () => {
+    it("collision direction B: existing boarding, then default promotes the row to default (default wins)", async () => {
         const { manager, indexerProvider } = await makeManager();
         try {
+            // Stale `boarding` row persisted first (an earlier boot where the
+            // boarding script did not collide with any default baseline).
             await ensureWalletContract(manager, baselineParams("boarding"));
+            // A later boot's default baseline now resolves to the same script.
             await ensureWalletContract(manager, baselineParams("default"));
 
             const rows = await manager.getContracts({ script: sharedScript });
             expect(rows).toHaveLength(1);
-            expect(rows[0].type).toBe("boarding");
+            // Promoted to `default` so the shared script — also the wallet's
+            // live offchain baseline — stays visible to the type-gated
+            // consumers (notifyIncomingFunds, getWalletScripts, getScriptMap).
+            expect(rows[0].type).toBe("default");
             expect(rows[0].state).toBe("active");
+            // No boarding-typed row remains for the shared script.
+            expect(await manager.getContracts({ type: ["boarding"] })).toHaveLength(0);
             expect(subscribedScripts(indexerProvider)).toContain(sharedScript);
         } finally {
             manager.dispose();

--- a/packages/ts-sdk/test/wallet/boarding-contract.test.ts
+++ b/packages/ts-sdk/test/wallet/boarding-contract.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
-import { Wallet } from "../../src/wallet/wallet";
+import {
+    Wallet,
+    areSameScriptBaselineTypesCompatible,
+    ensureWalletContract,
+} from "../../src/wallet/wallet";
 import { InMemoryWalletRepository } from "../../src/repositories/inMemory/walletRepository";
 import { InMemoryContractRepository } from "../../src/repositories/inMemory/contractRepository";
 import { SingleKey } from "../../src/identity/singleKey";
 import { DefaultVtxo } from "../../src/script/default";
+import { ContractManager } from "../../src/contracts/contractManager";
 import { contractHandlers } from "../../src/contracts/handlers";
+import { DefaultContractHandler } from "../../src/contracts/handlers/default";
 import { isDiscoverable } from "../../src/contracts/types";
 import { timelockToSequence } from "../../src/utils/timelock";
 import { hex } from "@scure/base";
@@ -323,5 +329,176 @@ describe("boarding contract: HD key selection stays wallet-owned", () => {
         expect(boarding.params.pubKey).toEqual(hex.encode(walletPubKey));
         // Same key the wallet's boardingTapscript uses — one resolved key shared.
         expect(boarding.params.pubKey).toEqual(hex.encode(wallet.boardingTapscript.options.pubKey));
+    });
+});
+
+describe("areSameScriptBaselineTypesCompatible", () => {
+    it("treats default <-> boarding as compatible (both directions)", () => {
+        expect(areSameScriptBaselineTypesCompatible("default", "boarding")).toBe(true);
+        expect(areSameScriptBaselineTypesCompatible("boarding", "default")).toBe(true);
+    });
+
+    it("treats same type as compatible", () => {
+        for (const t of ["default", "boarding", "delegate", "vhtlc"]) {
+            expect(areSameScriptBaselineTypesCompatible(t, t)).toBe(true);
+        }
+    });
+
+    it("treats every other pairing as incompatible", () => {
+        const incompatible: [string, string][] = [
+            ["default", "delegate"],
+            ["boarding", "delegate"],
+            ["default", "vhtlc"],
+            ["boarding", "vhtlc"],
+            ["delegate", "vhtlc"],
+        ];
+        for (const [a, b] of incompatible) {
+            expect(areSameScriptBaselineTypesCompatible(a, b)).toBe(false);
+            expect(areSameScriptBaselineTypesCompatible(b, a)).toBe(false);
+        }
+    });
+});
+
+describe("ensureWalletContract", () => {
+    // Shared (params -> script) pair. boarding and default handlers derive a
+    // byte-identical script from identical params, so the same script/params
+    // can back either type — exactly the collision this helper resolves.
+    const PK = "5b3a7b5e8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f";
+    const SPK = "9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b";
+    const sharedParams = {
+        pubKey: PK,
+        serverPubKey: SPK,
+        csvTimelock: timelockToSequence({ value: 86016n, type: "seconds" }).toString(),
+    };
+    const sharedScript = hex.encode(DefaultContractHandler.createScript(sharedParams).pkScript);
+
+    async function makeManager() {
+        const indexerProvider = makeIdleIndexer();
+        const contractRepository = new InMemoryContractRepository();
+        const manager = await ContractManager.create({
+            indexerProvider,
+            contractRepository,
+            walletRepository: new InMemoryWalletRepository(),
+            watcherConfig: { failsafePollIntervalMs: 1000, reconnectDelayMs: 500 },
+        });
+        return { manager, indexerProvider, contractRepository };
+    }
+
+    const baselineParams = (type: string) => ({
+        type,
+        params: sharedParams,
+        script: sharedScript,
+        address: "addr",
+        state: "active" as const,
+    });
+
+    const subscribedScripts = (indexerProvider: any): string[] =>
+        indexerProvider.subscribeForScripts.mock.calls.flatMap((call: any[]) => call[0] ?? []);
+
+    it("creates the contract when no row exists for the script", async () => {
+        const { manager } = await makeManager();
+        try {
+            await ensureWalletContract(manager, baselineParams("boarding"));
+            const rows = await manager.getContracts({ script: sharedScript });
+            expect(rows).toHaveLength(1);
+            expect(rows[0].type).toBe("boarding");
+        } finally {
+            manager.dispose();
+        }
+    });
+
+    it("is idempotent for the same type (no duplicate row)", async () => {
+        const { manager } = await makeManager();
+        try {
+            await ensureWalletContract(manager, baselineParams("boarding"));
+            await ensureWalletContract(manager, baselineParams("boarding"));
+            expect(await manager.getContracts({ script: sharedScript })).toHaveLength(1);
+        } finally {
+            manager.dispose();
+        }
+    });
+
+    it("collision direction A: existing default, then boarding accepts the row (no duplicate, watched)", async () => {
+        const { manager, indexerProvider } = await makeManager();
+        try {
+            await ensureWalletContract(manager, baselineParams("default"));
+            await ensureWalletContract(manager, baselineParams("boarding"));
+
+            const rows = await manager.getContracts({ script: sharedScript });
+            // Assert by script, not type: the script owns exactly one row.
+            expect(rows).toHaveLength(1);
+            expect(rows[0].type).toBe("default");
+            expect(rows[0].state).toBe("active");
+            expect(subscribedScripts(indexerProvider)).toContain(sharedScript);
+        } finally {
+            manager.dispose();
+        }
+    });
+
+    it("collision direction B: existing boarding, then default accepts the row (no duplicate, watched)", async () => {
+        const { manager, indexerProvider } = await makeManager();
+        try {
+            await ensureWalletContract(manager, baselineParams("boarding"));
+            await ensureWalletContract(manager, baselineParams("default"));
+
+            const rows = await manager.getContracts({ script: sharedScript });
+            expect(rows).toHaveLength(1);
+            expect(rows[0].type).toBe("boarding");
+            expect(rows[0].state).toBe("active");
+            expect(subscribedScripts(indexerProvider)).toContain(sharedScript);
+        } finally {
+            manager.dispose();
+        }
+    });
+
+    it("still throws on a genuinely incompatible existing type for the same script", async () => {
+        const { manager, contractRepository } = await makeManager();
+        try {
+            // Seed an incompatible (vhtlc) row directly at the shared script,
+            // bypassing createContract's params validation.
+            await contractRepository.saveContract({
+                type: "vhtlc",
+                params: sharedParams,
+                script: sharedScript,
+                address: "addr",
+                state: "active",
+                createdAt: 0,
+            });
+
+            await expect(
+                ensureWalletContract(manager, baselineParams("default")),
+            ).rejects.toThrow();
+
+            // No duplicate row was created.
+            expect(await manager.getContracts({ script: sharedScript })).toHaveLength(1);
+        } finally {
+            manager.dispose();
+        }
+    });
+});
+
+describe("boarding contract: default/boarding script collision (boardingExitDelay == unilateralExitDelay)", () => {
+    it("init succeeds, keeps one row for the shared script, and does not force a separate boarding row", async () => {
+        // unilateralExitDelay defaults to 144 (blocks) in makeInfo; matching the
+        // boarding delay makes the boarding script byte-identical to the default
+        // baseline script.
+        const { wallet } = await makeWallet({ boardingExitDelay: 144n });
+        const manager = await wallet.getContractManager();
+
+        const boardingScript = hex.encode(wallet.boardingTapscript.pkScript);
+        const rows = await manager.getContracts({ script: boardingScript });
+
+        // Assert by script: exactly one row owns the shared script.
+        expect(rows).toHaveLength(1);
+        expect(rows[0].state).toBe("active");
+        // The default baseline is created first, so it owns the colliding row;
+        // no second `boarding`-typed row is forced.
+        expect(rows[0].type).toBe("default");
+        expect(await manager.getContracts({ type: ["boarding"] })).toHaveLength(0);
+
+        // getBoardingAddress still resolves from the (shared) boarding script.
+        expect(await wallet.getBoardingAddress()).toEqual(
+            wallet.boardingTapscript.onchainAddress(wallet.network),
+        );
     });
 });


### PR DESCRIPTION
Adds a registered `boarding` contract handler and derives the on-chain boarding address from it, replacing the ad-hoc `boardingTapscript` plumbing. The boarding address and the `getBoardingAddress()` API are unchanged.

## What
- `BoardingContractHandler` (type `boarding`), reusing the `default` `DefaultVtxo.Script` shape and spend paths; sources its CSV timelock from `ArkInfo.boardingExitDelay`. Not discoverable (HD index selection stays wallet-owned).
- Exported from the package root (`@arkade-os/sdk`) alongside the other built-in handlers.
- Wallet setup sources `boardingTapscript` from the handler; contract-manager init persists a matching `active` boarding contract so its Arkade address is watched.
- `script` is the unique contract identity. When `boardingExitDelay` coincides with the offchain unilateral-exit delay, the boarding script is byte-identical to the `default` baseline; `ensureWalletContract` accepts the existing row in either direction instead of creating a duplicate or throwing. `default`/`boarding` are the only compatible pair; `delegate` stays strict.

## Notes
- Backward compatible: the contract-derived boarding script produces a byte-identical pkScript/address.
- In the collision case the single shared row may carry either type — consumers must not rely on `type === "boarding"` to identify boarding purpose; resolve via `getBoardingAddress()` / `boardingTapscript`.

## Tests
- New unit coverage for the handler (registration, script/address byte-identity, serde, not-discoverable, root export) and wallet integration (persistence, watcher registration, idempotency, server-delay change, both collision directions).
- Full non-e2e unit suite, typecheck, lint, and build pass.

Manually tested on *mutinynet*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boarding contract handler to the TypeScript SDK, now available through the public API alongside existing contract handlers.
  * Enhanced wallet with idempotent contract initialization logic for improved baseline contract collision handling.
  * Boarding contracts are now fully integrated into the wallet's contract lifecycle and management.

* **Tests**
  * Added comprehensive test suites for boarding contract functionality and wallet integration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/ts-sdk/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->