### PR TITLE
fix(wallet): restore BatchSignableIdentity one-popup path lost in InputSignerRouter refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,6 @@ This file covers the **0.4.x** line. Pre-0.4 release history (0.3.x and
 earlier) lives in `git log` — those entries were not written in this
 style and have not been backfilled.
 
-## [Unreleased]
-
-### Bug Fixes
-
-- **`BatchSignableIdentity.signMultiple` was unreachable from
-  `Wallet.buildAndSubmitOffchainTx` after the `InputSignerRouter`
-  refactor.** The N+1 → 1 popup optimization introduced in #395 was
-  silently lost when per-input routing moved into
-  `src/wallet/inputSignerRouter.ts`: the send path called
-  `_signerRouter.sign` once per PSBT, never folding work across the
-  arkTx + N checkpoints. Restored by adding an `InputSignerRouter.classify`
-  primitive (single source of truth for routing) with a `canBatch`
-  predicate, and re-introducing the batch path in
-  `Wallet.buildAndSubmitOffchainTx` and the pending-tx recovery loop.
-  The batch path activates when the identity implements `signMultiple`
-  *and* every signable input across the bundle resolves to the baseline
-  key — i.e. no HD-rotated or other descriptor-bound contracts in scope.
-  HD/mixed sends keep using the existing sequential signing path
-  unchanged. Static single-key browser wallets (Xverse / UniSat / OKX
-  style identities) go back to one confirmation popup per send.
-
 ## [0.4.23] - 2026-05-04
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ This file covers the **0.4.x** line. Pre-0.4 release history (0.3.x and
 earlier) lives in `git log` — those entries were not written in this
 style and have not been backfilled.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **`BatchSignableIdentity.signMultiple` was unreachable from
+  `Wallet.buildAndSubmitOffchainTx` after the `InputSignerRouter`
+  refactor.** The N+1 → 1 popup optimization introduced in #395 was
+  silently lost when per-input routing moved into
+  `src/wallet/inputSignerRouter.ts`: the send path called
+  `_signerRouter.sign` once per PSBT, never folding work across the
+  arkTx + N checkpoints. Restored by adding an `InputSignerRouter.classify`
+  primitive (single source of truth for routing) with a `canBatch`
+  predicate, and re-introducing the batch path in
+  `Wallet.buildAndSubmitOffchainTx` and the pending-tx recovery loop.
+  The batch path activates when the identity implements `signMultiple`
+  *and* every signable input across the bundle resolves to the baseline
+  key — i.e. no HD-rotated or other descriptor-bound contracts in scope.
+  HD/mixed sends keep using the existing sequential signing path
+  unchanged. Static single-key browser wallets (Xverse / UniSat / OKX
+  style identities) go back to one confirmation popup per send.
+
 ## [0.4.23] - 2026-05-04
 
 ### Breaking Changes

--- a/packages/ts-sdk/src/identity/index.ts
+++ b/packages/ts-sdk/src/identity/index.ts
@@ -37,13 +37,26 @@ export interface SignRequest {
  * should implement this interface to reduce the number of confirmation popups
  * from N+1 to 1 during Arkade send transactions.
  *
- * Contract: implementations MUST return exactly one `Transaction` per request,
- * in the same order as the input array. The SDK validates this at runtime and
- * will throw if the lengths do not match.
+ * Contract:
+ * - Implementations MUST return exactly one `Transaction` per request, in the
+ *   same order as the input array. The SDK validates this at runtime and will
+ *   throw if the lengths do not match.
+ * - Implementations MUST preserve any partial signatures already present on the
+ *   input PSBTs and only ADD their own — never drop, replace, or normalize away
+ *   foreign signatures. The pending-tx recovery path
+ *   (`Wallet.finalizePendingTxs`) hands `signMultiple` checkpoint PSBTs that
+ *   already carry the server's `tapScriptSig` and relies on that server
+ *   signature surviving alongside the freshly added user signature. A provider
+ *   that discards the pre-existing server sig produces checkpoints that fail
+ *   server-side finalization, stranding the transaction in the pending state.
  */
 export interface BatchSignableIdentity extends Identity {
     /**
      * Sign multiple transactions in a single wallet interaction.
+     *
+     * Must preserve pre-existing partial signatures on each input PSBT (see the
+     * interface-level contract) and return one signed `Transaction` per request,
+     * in request order.
      *
      * @param requests - Transactions and optional input indexes to sign
      * @returns Signed transactions in the same order as the input requests

--- a/packages/ts-sdk/src/utils/arkTransaction.ts
+++ b/packages/ts-sdk/src/utils/arkTransaction.ts
@@ -328,17 +328,36 @@ export function verifyTapscriptSignatures(
 }
 
 /**
- * Merges the signed transaction with the original transaction
+ * Merges the tapscript signatures of `signedTx` onto `originalTx`, in place.
+ *
+ * Invariant: both transactions must have the same number of inputs and BOTH
+ * must carry a `tapScriptSig` on every input — the result is the per-input
+ * concatenation `originalTx.tapScriptSig ++ signedTx.tapScriptSig`. A missing
+ * signature on either side is rejected with an input-indexed error rather than
+ * silently corrupting the witness (the previous code appended `undefined` when
+ * `signedTx` was unsigned). Callers that partially sign must merge only fully
+ * co-signed inputs.
+ *
  * @param signedTx signed transaction
- * @param originalTx original transaction
+ * @param originalTx original transaction (mutated and returned)
  */
 export function combineTapscriptSigs(signedTx: Transaction, originalTx: Transaction) {
+    if (signedTx.inputsLength !== originalTx.inputsLength) {
+        throw new Error(
+            `combineTapscriptSigs: input count mismatch (signedTx ${signedTx.inputsLength}, originalTx ${originalTx.inputsLength})`,
+        );
+    }
     for (let i = 0; i < signedTx.inputsLength; i++) {
         const input = originalTx.getInput(i);
         const signedInput = signedTx.getInput(i);
-        if (!input.tapScriptSig) throw new Error("No tapScriptSig");
+        if (!input.tapScriptSig) {
+            throw new Error(`combineTapscriptSigs: originalTx input ${i} has no tapScriptSig`);
+        }
+        if (!signedInput.tapScriptSig) {
+            throw new Error(`combineTapscriptSigs: signedTx input ${i} has no tapScriptSig`);
+        }
         originalTx.updateInput(i, {
-            tapScriptSig: input.tapScriptSig?.concat(signedInput.tapScriptSig!),
+            tapScriptSig: input.tapScriptSig.concat(signedInput.tapScriptSig),
         });
     }
     return originalTx;

--- a/packages/ts-sdk/src/wallet/inputSignerRouter.ts
+++ b/packages/ts-sdk/src/wallet/inputSignerRouter.ts
@@ -139,14 +139,23 @@ export class InputSignerRouter {
     }
 
     /**
-     * Returns `true` when every signable input in `jobs` resolves to the
-     * baseline {@link Identity} key — i.e. the descriptor provider would
-     * not be invoked. Used by the wallet's send/recovery paths to pre-flight
-     * the {@link BatchSignableIdentity.signMultiple} fast path, which can
-     * only fold work a single identity key can sign.
+     * Returns `true` when every signable input across all `jobSets` resolves
+     * to the baseline {@link Identity} key — i.e. the descriptor provider
+     * would not be invoked. Used by the wallet's send/recovery paths to
+     * pre-flight the {@link BatchSignableIdentity.signMultiple} fast path,
+     * which can only fold work a single identity key can sign.
+     *
+     * Accepts several job sets (e.g. an arkTx's jobs plus one set per
+     * checkpoint) and classifies their union in a single pass. Eligibility
+     * is monotonic — the union routes entirely to the baseline key iff every
+     * set does — so this returns the same answer as ANDing the per-set
+     * results, but with one {@link classify} (one repo round-trip + one
+     * `xOnlyPublicKey` call) instead of one per set. Only the routing buckets
+     * matter here, so the input-index collisions produced by flattening jobs
+     * from different transactions are irrelevant.
      */
-    async canBatch(jobs: InputSigningJob[]): Promise<boolean> {
-        const plan = await this.classify(jobs);
+    async canBatch(...jobSets: InputSigningJob[][]): Promise<boolean> {
+        const plan = await this.classify(jobSets.flat());
         return plan.descriptorGroups.size === 0;
     }
 

--- a/packages/ts-sdk/src/wallet/inputSignerRouter.ts
+++ b/packages/ts-sdk/src/wallet/inputSignerRouter.ts
@@ -30,6 +30,22 @@ export interface InputSignerRouterDeps {
 const DESCRIPTOR_CAPABLE_CONTRACT_TYPES = new Set(["default", "delegate"]);
 
 /**
+ * Routing decision for a single tx's signable inputs: which inputs the
+ * baseline {@link Identity} signs, and which are grouped by descriptor for
+ * the {@link DescriptorProvider}.
+ */
+export interface InputRoutingPlan {
+    /** Input indexes the baseline {@link Identity} should sign. */
+    identityIndexes: number[];
+    /**
+     * Per-descriptor buckets of input indexes routed to the
+     * {@link DescriptorProvider}. Empty map ⇒ batch-eligible (every input
+     * resolves to the baseline key).
+     */
+    descriptorGroups: Map<string, number[]>;
+}
+
+/**
  * Routes PSBT inputs to the correct signer based on the owning contract.
  * Inputs whose script matches a `default`/`delegate` contract with a
  * non-baseline owner are sent to {@link DescriptorProvider}; everything
@@ -41,8 +57,24 @@ const DESCRIPTOR_CAPABLE_CONTRACT_TYPES = new Set(["default", "delegate"]);
 export class InputSignerRouter {
     constructor(private readonly deps: InputSignerRouterDeps) {}
 
-    async sign(tx: Transaction, jobs: InputSigningJob[]): Promise<Transaction> {
-        if (jobs.length === 0) return tx;
+    /**
+     * Resolve each job to its target signer without invoking signing. The
+     * returned plan is the single source of truth for both {@link sign} and
+     * the batch-eligibility predicate {@link canBatch} — callers that want
+     * to pre-flight a batch path call {@link canBatch} (which delegates
+     * here) so the routing rules never live in two places.
+     *
+     * Throws {@link MissingSigningDescriptorError} for a non-baseline
+     * default/delegate contract whose `metadata.signingDescriptor` is
+     * missing — the same condition that would later abort signing. Failing
+     * here moves the failure earlier, before any PSBT is mutated.
+     */
+    async classify(jobs: InputSigningJob[]): Promise<InputRoutingPlan> {
+        const identityIndexes: number[] = [];
+        const descriptorGroups = new Map<string, number[]>();
+        if (jobs.length === 0) {
+            return { identityIndexes, descriptorGroups };
+        }
 
         const distinctScripts = Array.from(new Set(jobs.map((j) => hex.encode(j.lookupScript))));
         const contracts = await this.deps.contractRepository.getContracts({
@@ -59,9 +91,6 @@ export class InputSignerRouter {
 
         const baselinePubKeyHex = hex.encode(await this.deps.identity.xOnlyPublicKey());
         const boardingScriptHex = hex.encode(this.deps.boardingPkScript);
-
-        const identityIndexes: number[] = [];
-        const descriptorGroups = new Map<string, number[]>();
 
         for (const job of jobs) {
             const scriptHex = hex.encode(job.lookupScript);
@@ -105,6 +134,25 @@ export class InputSignerRouter {
                 descriptorGroups.set(descriptor, [job.index]);
             }
         }
+
+        return { identityIndexes, descriptorGroups };
+    }
+
+    /**
+     * Returns `true` when every signable input in `jobs` resolves to the
+     * baseline {@link Identity} key — i.e. the descriptor provider would
+     * not be invoked. Used by the wallet's send/recovery paths to pre-flight
+     * the {@link BatchSignableIdentity.signMultiple} fast path, which can
+     * only fold work a single identity key can sign.
+     */
+    async canBatch(jobs: InputSigningJob[]): Promise<boolean> {
+        const plan = await this.classify(jobs);
+        return plan.descriptorGroups.size === 0;
+    }
+
+    async sign(tx: Transaction, jobs: InputSigningJob[]): Promise<Transaction> {
+        if (jobs.length === 0) return tx;
+        const { identityIndexes, descriptorGroups } = await this.classify(jobs);
 
         let signed = tx;
         if (identityIndexes.length > 0) {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2334,18 +2334,18 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                         const identity = this.identity;
                         const batchEligible =
                             isBatchSignable(identity) &&
-                            (
-                                await Promise.all(
-                                    checkpointJobs.map((jobs) => this._signerRouter.canBatch(jobs)),
-                                )
-                            ).every((b) => b);
+                            (await this._signerRouter.canBatch(...checkpointJobs));
 
                         let finalCheckpoints: string[];
                         if (batchEligible) {
-                            // Recovery batch: server already has its share,
-                            // we only add the user sig. signMultiple writes
-                            // directly onto the server-signed PSBTs so no
-                            // merge step is needed.
+                            // Recovery batch: these checkpoints already carry
+                            // the server's tapScriptSig. signMultiple adds the
+                            // user's share and, per the BatchSignableIdentity
+                            // contract, preserves the pre-existing server sig,
+                            // so the transactions it returns hold both. We use
+                            // those returned txs directly — no separate merge
+                            // step, unlike the send path which signs unsigned
+                            // checkpoints and merges via combineTapscriptSigs.
                             const requests = checkpointTxs.map((tx, i) => ({
                                 tx,
                                 inputIndexes: checkpointJobs[i].map((j) => j.index),
@@ -2685,10 +2685,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         const identity = this.identity;
         const batchEligible =
             isBatchSignable(identity) &&
-            (await this._signerRouter.canBatch(arkTxJobs)) &&
-            (
-                await Promise.all(checkpointJobs.map((jobs) => this._signerRouter.canBatch(jobs)))
-            ).every((b) => b);
+            (await this._signerRouter.canBatch(arkTxJobs, ...checkpointJobs));
 
         if (batchEligible) {
             // Clone so a misbehaving provider can't mutate the originals

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -21,7 +21,7 @@ import { SignerSession } from "../tree/signingSession";
 import { buildForfeitTx } from "../forfeit";
 import { validateConnectorsTxGraph, validateVtxoTxGraph } from "../tree/validation";
 import { validateBatchRecipients } from "./validation";
-import { Identity, ReadonlyIdentity } from "../identity";
+import { Identity, ReadonlyIdentity, isBatchSignable } from "../identity";
 import {
     ArkTransaction,
     Asset,
@@ -49,7 +49,12 @@ import {
 import { createAssetPacket, selectCoinsWithAsset, selectedCoinsToAssetInputs } from "./asset";
 import { VtxoScript } from "../script/base";
 import { CSVMultisigTapscript, RelativeTimelock } from "../script/tapscript";
-import { buildOffchainTx, hasBoardingTxExpired, isValidArkAddress } from "../utils/arkTransaction";
+import {
+    buildOffchainTx,
+    combineTapscriptSigs,
+    hasBoardingTxExpired,
+    isValidArkAddress,
+} from "../utils/arkTransaction";
 import {
     DEFAULT_RENEWAL_CONFIG,
     DEFAULT_SETTLEMENT_CONFIG,
@@ -2320,16 +2325,49 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
                     batchPending.push(pendingTx.arkTxid);
                     try {
-                        const finalCheckpoints = await Promise.all(
-                            pendingTx.signedCheckpointTxs.map(async (c) => {
-                                const tx = Transaction.fromPSBT(base64.decode(c));
-                                const signedCheckpoint = await this._signerRouter.sign(
-                                    tx,
-                                    this.inputSigningJobsFromWitnessUtxos(tx),
-                                );
-                                return base64.encode(signedCheckpoint.toPSBT());
-                            }),
+                        const checkpointTxs = pendingTx.signedCheckpointTxs.map((c) =>
+                            Transaction.fromPSBT(base64.decode(c)),
                         );
+                        const checkpointJobs = checkpointTxs.map((tx) =>
+                            this.inputSigningJobsFromWitnessUtxos(tx),
+                        );
+                        const identity = this.identity;
+                        const batchEligible =
+                            isBatchSignable(identity) &&
+                            (
+                                await Promise.all(
+                                    checkpointJobs.map((jobs) => this._signerRouter.canBatch(jobs)),
+                                )
+                            ).every((b) => b);
+
+                        let finalCheckpoints: string[];
+                        if (batchEligible) {
+                            // Recovery batch: server already has its share,
+                            // we only add the user sig. signMultiple writes
+                            // directly onto the server-signed PSBTs so no
+                            // merge step is needed.
+                            const requests = checkpointTxs.map((tx, i) => ({
+                                tx,
+                                inputIndexes: checkpointJobs[i].map((j) => j.index),
+                            }));
+                            const signed = await identity.signMultiple(requests);
+                            if (signed.length !== requests.length) {
+                                throw new Error(
+                                    `signMultiple returned ${signed.length} transactions, expected ${requests.length}`,
+                                );
+                            }
+                            finalCheckpoints = signed.map((tx) => base64.encode(tx.toPSBT()));
+                        } else {
+                            finalCheckpoints = await Promise.all(
+                                checkpointTxs.map(async (tx, i) => {
+                                    const signedCheckpoint = await this._signerRouter.sign(
+                                        tx,
+                                        checkpointJobs[i],
+                                    );
+                                    return base64.encode(signedCheckpoint.toPSBT());
+                                }),
+                            );
+                        }
 
                         await this.arkProvider.finalizeTx(pendingTx.arkTxid, finalCheckpoints);
                         batchFinalized.push(pendingTx.arkTxid);
@@ -2633,7 +2671,51 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             index,
             lookupScript: VtxoScript.decode(input.tapTree).pkScript,
         }));
-        const signedVirtualTx = await this._signerRouter.sign(offchainTx.arkTx, arkTxJobs);
+        const checkpointJobs = offchainTx.checkpoints.map((c) =>
+            this.inputSigningJobsFromWitnessUtxos(c),
+        );
+
+        // Batch path: when every signable input across arkTx + checkpoints
+        // resolves to the baseline identity key, a `BatchSignableIdentity`
+        // can sign all N+1 PSBTs in a single wallet popup. Stash the
+        // user-signed checkpoints, submit the unsigned ones to the server
+        // for its share, then merge server + user tapscript sigs.
+        let signedVirtualTx: Transaction;
+        let userSignedCheckpoints: Transaction[] | undefined;
+        const identity = this.identity;
+        const batchEligible =
+            isBatchSignable(identity) &&
+            (await this._signerRouter.canBatch(arkTxJobs)) &&
+            (
+                await Promise.all(checkpointJobs.map((jobs) => this._signerRouter.canBatch(jobs)))
+            ).every((b) => b);
+
+        if (batchEligible) {
+            // Clone so a misbehaving provider can't mutate the originals
+            // before submitTx. The contract on `signMultiple` is "one
+            // result per request, in input order" — validated below.
+            const requests = [
+                {
+                    tx: offchainTx.arkTx.clone(),
+                    inputIndexes: arkTxJobs.map((j) => j.index),
+                },
+                ...offchainTx.checkpoints.map((c, i) => ({
+                    tx: c.clone(),
+                    inputIndexes: checkpointJobs[i].map((j) => j.index),
+                })),
+            ];
+            const signed = await identity.signMultiple(requests);
+            if (signed.length !== requests.length) {
+                throw new Error(
+                    `signMultiple returned ${signed.length} transactions, expected ${requests.length}`,
+                );
+            }
+            const [firstSignedTx, ...signedCheckpoints] = signed;
+            signedVirtualTx = firstSignedTx;
+            userSignedCheckpoints = signedCheckpoints;
+        } else {
+            signedVirtualTx = await this._signerRouter.sign(offchainTx.arkTx, arkTxJobs);
+        }
 
         // Mark pending before submitting — if we crash between submit and
         // finalize, the next init will recover via finalizePendingTxs.
@@ -2644,16 +2726,26 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             offchainTx.checkpoints.map((c) => base64.encode(c.toPSBT())),
         );
 
-        const finalCheckpoints = await Promise.all(
-            signedCheckpointTxs.map(async (c) => {
-                const tx = Transaction.fromPSBT(base64.decode(c));
-                const signedCheckpoint = await this._signerRouter.sign(
-                    tx,
-                    this.inputSigningJobsFromWitnessUtxos(tx),
-                );
-                return base64.encode(signedCheckpoint.toPSBT());
-            }),
-        );
+        let finalCheckpoints: string[];
+        if (userSignedCheckpoints) {
+            // Merge stashed user sigs onto the server-signed checkpoints.
+            finalCheckpoints = signedCheckpointTxs.map((c, i) => {
+                const serverSigned = Transaction.fromPSBT(base64.decode(c));
+                combineTapscriptSigs(userSignedCheckpoints![i], serverSigned);
+                return base64.encode(serverSigned.toPSBT());
+            });
+        } else {
+            finalCheckpoints = await Promise.all(
+                signedCheckpointTxs.map(async (c) => {
+                    const tx = Transaction.fromPSBT(base64.decode(c));
+                    const signedCheckpoint = await this._signerRouter.sign(
+                        tx,
+                        this.inputSigningJobsFromWitnessUtxos(tx),
+                    );
+                    return base64.encode(signedCheckpoint.toPSBT());
+                }),
+            );
+        }
 
         await this.arkProvider.finalizeTx(arkTxid, finalCheckpoints);
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2728,6 +2728,16 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
         let finalCheckpoints: string[];
         if (userSignedCheckpoints) {
+            // The server must return exactly one checkpoint per user-signed
+            // checkpoint: the merge below pairs them by index, so a short
+            // response would silently drop the tail (→ incomplete finalizeTx)
+            // and a long one would throw a cryptic undefined access. Guard
+            // explicitly, mirroring the signMultiple length check above.
+            if (signedCheckpointTxs.length !== userSignedCheckpoints.length) {
+                throw new Error(
+                    `submitTx returned ${signedCheckpointTxs.length} checkpoints, expected ${userSignedCheckpoints.length}`,
+                );
+            }
             // Merge stashed user sigs onto the server-signed checkpoints.
             finalCheckpoints = signedCheckpointTxs.map((c, i) => {
                 const serverSigned = Transaction.fromPSBT(base64.decode(c));

--- a/packages/ts-sdk/test/verifySignatures.test.ts
+++ b/packages/ts-sdk/test/verifySignatures.test.ts
@@ -5,7 +5,7 @@ import { randomPrivateKeyBytes } from "@scure/btc-signer/utils.js";
 import { VtxoScript } from "../src/script/base";
 import { MultisigTapscript } from "../src/script/tapscript";
 import { SingleKey } from "../src/identity/singleKey";
-import { verifyTapscriptSignatures } from "../src/utils/arkTransaction";
+import { verifyTapscriptSignatures, combineTapscriptSigs } from "../src/utils/arkTransaction";
 
 describe("verifyTapscriptSignatures", async () => {
     // Test identities
@@ -210,4 +210,74 @@ describe("verifyTapscriptSignatures", async () => {
     // Note: Additional edge case tests (invalid signature, invalid length, missing tapLeafScript, etc.)
     // are skipped because the Transaction API doesn't allow easy manipulation of signed data.
     // The core functionality is well-tested by the positive test cases above.
+});
+
+describe("combineTapscriptSigs", async () => {
+    const serverIdentity = SingleKey.fromPrivateKey(randomPrivateKeyBytes());
+    const serverPubKey = await serverIdentity.xOnlyPublicKey();
+    const userIdentity = SingleKey.fromPrivateKey(randomPrivateKeyBytes());
+    const userPubKey = await userIdentity.xOnlyPublicKey();
+
+    // 2-of-2 collaborative leaf — mirrors a checkpoint's co-sign path.
+    const collaborative = MultisigTapscript.encode({
+        pubkeys: [serverPubKey, userPubKey],
+        type: MultisigTapscript.MultisigType.CHECKSIG,
+    });
+    const vtxoScript = new VtxoScript([collaborative.script]);
+
+    // Build a checkpoint-shaped tx (single input on the collaborative leaf),
+    // optionally signed by `signer`. Omitting the signer yields an input with
+    // no tapScriptSig — the corruption case the guards must reject.
+    function makeTx(signer?: SingleKey): Transaction {
+        const tx = new Transaction();
+        tx.addInput({
+            txid: new Uint8Array(32).fill(0),
+            index: 0,
+            witnessUtxo: { script: vtxoScript.pkScript, amount: 1000n },
+            tapLeafScript: [vtxoScript.leaves[0]],
+        });
+        tx.addOutputAddress("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", 900n);
+        if (signer) {
+            tx.signIdx(signer["key"], 0, [SigHash.DEFAULT]);
+        }
+        return tx;
+    }
+
+    it("merges both parties' sigs onto originalTx when every input is co-signed", () => {
+        const serverSigned = makeTx(serverIdentity);
+        const userSigned = makeTx(userIdentity);
+
+        combineTapscriptSigs(userSigned, serverSigned);
+
+        const pubkeys = serverSigned.getInput(0).tapScriptSig!.map(([d]) => hex.encode(d.pubKey));
+        // Server sig preserved AND user sig appended — neither dropped.
+        expect(pubkeys).toContain(hex.encode(serverPubKey));
+        expect(pubkeys).toContain(hex.encode(userPubKey));
+    });
+
+    it("throws (no silent corruption) when signedTx is missing a sig", () => {
+        const serverSigned = makeTx(serverIdentity);
+        const userUnsigned = makeTx(); // user never signed
+
+        // Previously this appended `undefined` and corrupted the witness.
+        expect(() => combineTapscriptSigs(userUnsigned, serverSigned)).toThrow(
+            /signedTx input 0 has no tapScriptSig/,
+        );
+    });
+
+    it("throws when originalTx is missing a sig", () => {
+        const serverUnsigned = makeTx();
+        const userSigned = makeTx(userIdentity);
+
+        expect(() => combineTapscriptSigs(userSigned, serverUnsigned)).toThrow(
+            /originalTx input 0 has no tapScriptSig/,
+        );
+    });
+
+    it("throws on input-count mismatch instead of out-of-bounds access", () => {
+        const userSigned = makeTx(userIdentity); // 1 input
+        const empty = new Transaction(); // 0 inputs
+
+        expect(() => combineTapscriptSigs(userSigned, empty)).toThrow(/input count mismatch/);
+    });
 });

--- a/packages/ts-sdk/test/wallet/inputSignerRouter.test.ts
+++ b/packages/ts-sdk/test/wallet/inputSignerRouter.test.ts
@@ -481,6 +481,73 @@ describe("InputSignerRouter", async () => {
                 MissingSigningDescriptorError,
             );
         });
+
+        it("unions multiple job sets and classifies them in a single repo pass", async () => {
+            const contractRepo = new InMemoryContractRepository();
+            const scriptA = taprootScript(BASELINE_REUSE_PUBKEY);
+            const scriptB = taprootScript(DELEGATE_BASELINE_PUBKEY);
+            await contractRepo.saveContract(
+                makeContract({
+                    script: hex.encode(scriptA),
+                    type: "default",
+                    params: { pubKey: baselinePubKey },
+                }),
+            );
+            await contractRepo.saveContract(
+                makeContract({
+                    script: hex.encode(scriptB),
+                    type: "delegate",
+                    params: { pubKey: baselinePubKey },
+                }),
+            );
+            // Spy after seeding so only the canBatch lookup is counted.
+            const getContracts = vi.spyOn(contractRepo, "getContracts");
+
+            const router = createRouter({ contractRepository: contractRepo });
+
+            // Mimic the wallet's call shape: an arkTx job set plus a
+            // checkpoint job set, every input baseline-owned.
+            const eligible = await router.canBatch(
+                [{ index: 0, lookupScript: scriptA }],
+                [{ index: 0, lookupScript: scriptB }],
+            );
+
+            expect(eligible).toBe(true);
+            // The whole union resolves in one classify, not one per set.
+            expect(getContracts).toHaveBeenCalledTimes(1);
+        });
+
+        it("returns false when any later job set routes to the descriptor provider", async () => {
+            const contractRepo = new InMemoryContractRepository();
+            const baselineScript = taprootScript(BASELINE_REUSE_PUBKEY);
+            const rotatedScript = taprootScript(ROTATED_A_PUBKEY);
+            await contractRepo.saveContract(
+                makeContract({
+                    script: hex.encode(baselineScript),
+                    type: "default",
+                    params: { pubKey: baselinePubKey },
+                }),
+            );
+            await contractRepo.saveContract(
+                makeContract({
+                    script: hex.encode(rotatedScript),
+                    type: "default",
+                    params: { pubKey: ROTATED_A_PUBKEY },
+                    metadata: { signingDescriptor: "tr(rotated)" },
+                }),
+            );
+
+            const router = createRouter({ contractRepository: contractRepo });
+
+            // First set is fully baseline; the rotated input hides in a
+            // later set and must still flip the whole bundle to false.
+            const eligible = await router.canBatch(
+                [{ index: 0, lookupScript: baselineScript }],
+                [{ index: 0, lookupScript: rotatedScript }],
+            );
+
+            expect(eligible).toBe(false);
+        });
     });
 
     it("keeps the first contract when the repo yields duplicates for one script", async () => {

--- a/packages/ts-sdk/test/wallet/inputSignerRouter.test.ts
+++ b/packages/ts-sdk/test/wallet/inputSignerRouter.test.ts
@@ -406,6 +406,83 @@ describe("InputSignerRouter", async () => {
         expect(result._signedByDescriptor).toEqual([descriptorA, descriptorB]);
     });
 
+    describe("canBatch", () => {
+        it("returns true when every job resolves to the baseline identity", async () => {
+            const contractRepo = new InMemoryContractRepository();
+            const script = taprootScript(BASELINE_REUSE_PUBKEY);
+            await contractRepo.saveContract(
+                makeContract({
+                    script: hex.encode(script),
+                    type: "default",
+                    params: { pubKey: baselinePubKey },
+                }),
+            );
+
+            const router = createRouter({ contractRepository: contractRepo });
+
+            const jobs: InputSigningJob[] = [
+                { index: 0, lookupScript: boardingPkScript },
+                { index: 1, lookupScript: script },
+            ];
+
+            expect(await router.canBatch(jobs)).toBe(true);
+        });
+
+        it("returns false when any job routes to the descriptor provider", async () => {
+            const contractRepo = new InMemoryContractRepository();
+            const baselineScript = taprootScript(BASELINE_REUSE_PUBKEY);
+            const rotatedScript = taprootScript(ROTATED_A_PUBKEY);
+            await contractRepo.saveContract(
+                makeContract({
+                    script: hex.encode(baselineScript),
+                    type: "default",
+                    params: { pubKey: baselinePubKey },
+                }),
+            );
+            await contractRepo.saveContract(
+                makeContract({
+                    script: hex.encode(rotatedScript),
+                    type: "default",
+                    params: { pubKey: ROTATED_A_PUBKEY },
+                    metadata: { signingDescriptor: "tr(rotated)" },
+                }),
+            );
+
+            const router = createRouter({ contractRepository: contractRepo });
+
+            const jobs: InputSigningJob[] = [
+                { index: 0, lookupScript: baselineScript },
+                { index: 1, lookupScript: rotatedScript },
+            ];
+
+            expect(await router.canBatch(jobs)).toBe(false);
+        });
+
+        it("returns true for an empty job list (degenerate batch is trivially batchable)", async () => {
+            const router = createRouter();
+            expect(await router.canBatch([])).toBe(true);
+        });
+
+        it("propagates MissingSigningDescriptorError so pre-flight catches the same failure as sign()", async () => {
+            const contractRepo = new InMemoryContractRepository();
+            const script = taprootScript(ROTATED_A_PUBKEY);
+            await contractRepo.saveContract(
+                makeContract({
+                    script: hex.encode(script),
+                    type: "default",
+                    params: { pubKey: ROTATED_A_PUBKEY },
+                    metadata: {},
+                }),
+            );
+
+            const router = createRouter({ contractRepository: contractRepo });
+
+            await expect(router.canBatch([{ index: 0, lookupScript: script }])).rejects.toThrow(
+                MissingSigningDescriptorError,
+            );
+        });
+    });
+
     it("keeps the first contract when the repo yields duplicates for one script", async () => {
         const script = taprootScript(ROTATED_A_PUBKEY);
         const scriptHex = hex.encode(script);

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -9,6 +9,9 @@ import {
     InMemoryContractRepository,
     DefaultVtxo,
     MissingSigningDescriptorError,
+    type BatchSignableIdentity,
+    type Identity,
+    type SignRequest,
 } from "../src";
 import { HDDescriptorProvider } from "../src/wallet/hdDescriptorProvider";
 import { WalletReceiveRotator } from "../src/wallet/walletReceiveRotator";
@@ -1381,5 +1384,150 @@ describe("Wallet HD rotation", () => {
             signSpy.mockRestore();
             await wallet.dispose();
         });
+    });
+});
+
+describe("Wallet batch signing (BatchSignableIdentity)", () => {
+    // Decorate an Identity with a tracked `signMultiple` that delegates
+    // each request to `base.sign`. Explicit per-method delegation —
+    // spreading `base` doesn't carry prototype methods.
+    function makeBatchSignable(base: Identity): BatchSignableIdentity & {
+        signMultipleSpy: ReturnType<typeof vi.fn>;
+        signSpy: ReturnType<typeof vi.fn>;
+    } {
+        const signSpy = vi.fn(async (tx: Transaction, idx?: number[]) => base.sign(tx, idx));
+        const signMultipleSpy = vi.fn(async (requests: SignRequest[]) =>
+            Promise.all(requests.map((r) => base.sign(r.tx, r.inputIndexes))),
+        );
+        return {
+            xOnlyPublicKey: () => base.xOnlyPublicKey(),
+            compressedPublicKey: () => base.compressedPublicKey(),
+            signerSession: () => base.signerSession(),
+            signMessage: (msg, type) => base.signMessage(msg, type),
+            sign: signSpy as unknown as Identity["sign"],
+            signMultiple: signMultipleSpy as unknown as BatchSignableIdentity["signMultiple"],
+            signSpy,
+            signMultipleSpy,
+        };
+    }
+
+    async function makeStaticBatchWallet(contractRepo?: InMemoryContractRepository) {
+        // Use a baseline SingleKey wallet (no HD rotation): every input
+        // routes to the identity, so canBatch returns true and the batch
+        // path is exercised.
+        const base = SingleKey.fromHex(
+            "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2",
+        );
+        const identity = makeBatchSignable(base);
+        const wallet = await Wallet.create({
+            identity,
+            arkServerUrl: "http://localhost:7070",
+            storage: {
+                walletRepository: new InMemoryWalletRepository(),
+                contractRepository: contractRepo ?? new InMemoryContractRepository(),
+            },
+        });
+        return { wallet, identity, base };
+    }
+
+    function makeBaselineCoin(
+        wallet: Awaited<ReturnType<typeof makeStaticBatchWallet>>["wallet"],
+    ): ExtendedVirtualCoin {
+        // Reuse the wallet's own offchainTapscript so the coin's source
+        // script matches a registered baseline contract — the router needs
+        // a contract match to route to identity (vs silently skip).
+        const tapscript = (wallet as any).offchainTapscript as DefaultVtxo.Script;
+        return {
+            txid: "11".repeat(32),
+            vout: 0,
+            value: 50_000,
+            status: { confirmed: true },
+            virtualStatus: { state: "settled" },
+            createdAt: new Date(),
+            isUnrolled: false,
+            isSpent: false,
+            script: hex.encode(tapscript.pkScript),
+            forfeitTapLeafScript: tapscript.forfeit(),
+            intentTapLeafScript: tapscript.forfeit(),
+            tapTree: tapscript.encode(),
+        };
+    }
+
+    it("buildAndSubmitOffchainTx takes the batch path: signMultiple called once with arkTx + N checkpoints", async () => {
+        const { wallet, identity } = await makeStaticBatchWallet();
+        const coin = makeBaselineCoin(wallet);
+
+        // Short-circuit at submitTx so the test focuses on the signing
+        // dispatch and doesn't have to fabricate a server tapScriptSig to
+        // satisfy `combineTapscriptSigs`. signMultiple runs *before*
+        // submitTx in the batch path, so the spy assertions below capture
+        // the full picture even though the call aborts here.
+        const sentinel = new Error("STOP_AFTER_SUBMIT");
+        vi.spyOn(wallet.arkProvider, "submitTx").mockRejectedValue(sentinel);
+
+        await expect(
+            wallet.buildAndSubmitOffchainTx(
+                [coin],
+                [
+                    {
+                        amount: BigInt(coin.value - 1000),
+                        script: wallet.arkAddress.pkScript,
+                    },
+                ],
+            ),
+        ).rejects.toBe(sentinel);
+
+        // One batch call covers arkTx + every checkpoint (here: 1 of each).
+        expect(identity.signMultipleSpy).toHaveBeenCalledTimes(1);
+        expect(identity.signMultipleSpy.mock.calls[0][0]).toHaveLength(2);
+
+        // signMultiple is the one and only user-signing entry point on
+        // this path — per-tx sign() must not be invoked.
+        expect(identity.signSpy).not.toHaveBeenCalled();
+
+        await wallet.dispose();
+    });
+
+    it("falls back to sequential when identity does not implement signMultiple", async () => {
+        // Sanity check that the batch detection is conditional — a plain
+        // Identity (no signMultiple) keeps the existing per-PSBT path.
+        const base = SingleKey.fromHex(
+            "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2",
+        );
+        const signSpy = vi.spyOn(base, "sign");
+        const wallet = await Wallet.create({
+            identity: base,
+            arkServerUrl: "http://localhost:7070",
+            storage: {
+                walletRepository: new InMemoryWalletRepository(),
+                contractRepository: new InMemoryContractRepository(),
+            },
+        });
+        const coin = makeBaselineCoin(wallet);
+
+        vi.spyOn(wallet.arkProvider, "submitTx").mockImplementation(
+            async (arkTxB64, checkpointsB64) => ({
+                arkTxid: "cc".repeat(32),
+                finalArkTx: arkTxB64,
+                signedCheckpointTxs: checkpointsB64,
+            }),
+        );
+        vi.spyOn(wallet.arkProvider, "finalizeTx").mockResolvedValue(undefined);
+
+        await wallet.buildAndSubmitOffchainTx(
+            [coin],
+            [
+                {
+                    amount: BigInt(coin.value - 1000),
+                    script: wallet.arkAddress.pkScript,
+                },
+            ],
+        );
+
+        // arkTx + 1 checkpoint → 2 sign() invocations on the fallback.
+        expect(signSpy).toHaveBeenCalledTimes(2);
+
+        signSpy.mockRestore();
+        await wallet.dispose();
     });
 });

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -9,6 +9,7 @@ import {
     InMemoryContractRepository,
     DefaultVtxo,
     MissingSigningDescriptorError,
+    buildOffchainTx,
     type BatchSignableIdentity,
     type Identity,
     type SignRequest,
@@ -1388,6 +1389,31 @@ describe("Wallet HD rotation", () => {
 });
 
 describe("Wallet batch signing (BatchSignableIdentity)", () => {
+    // The well-known generator-point key: privkey = 1, whose x-only pubkey
+    // is exactly `mockArkInfo.signerPubkey` (SERVER_PUBKEY_HEX). Lets the
+    // tests produce a REAL server `tapScriptSig` on a checkpoint's
+    // collaborative leaf, so the merge / recovery paths run against genuine
+    // signatures rather than fabricated ones.
+    const SERVER_KEY = SingleKey.fromHex(
+        "0000000000000000000000000000000000000000000000000000000000000001",
+    );
+
+    // Sign input 0 of a checkpoint PSBT with the server key on the
+    // collaborative (forfeit) leaf and return the re-encoded base64 PSBT.
+    async function serverSignCheckpoint(checkpointB64: string): Promise<string> {
+        const tx = Transaction.fromPSBT(base64.decode(checkpointB64));
+        const signed = await SERVER_KEY.sign(tx, [0]);
+        return base64.encode(signed.toPSBT());
+    }
+
+    // Pubkeys (x-only hex) that carry a tapScriptSig on the given input.
+    function tapscriptSignerPubkeysHex(psbtB64: string, inputIndex: number): string[] {
+        const tx = Transaction.fromPSBT(base64.decode(psbtB64));
+        return (tx.getInput(inputIndex).tapScriptSig ?? []).map(([data]) =>
+            hex.encode(data.pubKey),
+        );
+    }
+
     // Decorate an Identity with a tracked `signMultiple` that delegates
     // each request to `base.sign`. Explicit per-method delegation —
     // spreading `base` doesn't carry prototype methods.
@@ -1528,6 +1554,150 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
         expect(signSpy).toHaveBeenCalledTimes(2);
 
         signSpy.mockRestore();
+        await wallet.dispose();
+    });
+
+    it("batch send merge: finalized checkpoint carries BOTH server and user tapScriptSig", async () => {
+        // Covers the merge step (`combineTapscriptSigs`) the other batch
+        // test skips by aborting at submitTx. The user pre-signs the
+        // unsigned checkpoints inside signMultiple; submitTx returns them
+        // carrying the server's sig; the wallet must merge the two so the
+        // checkpoint handed to finalizeTx is signed by BOTH parties.
+        const { wallet, identity } = await makeStaticBatchWallet();
+        const coin = makeBaselineCoin(wallet);
+        const userXOnlyHex = hex.encode(await identity.xOnlyPublicKey());
+        const serverXOnlyHex = hex.encode(await SERVER_KEY.xOnlyPublicKey());
+
+        const submitSpy = vi
+            .spyOn(wallet.arkProvider, "submitTx")
+            .mockImplementation(async (arkTxB64, checkpointsB64) => ({
+                arkTxid: "ab".repeat(32),
+                finalArkTx: arkTxB64,
+                // Server adds its share to the *unsigned* checkpoints it
+                // was handed — exactly what arkd does in production.
+                signedCheckpointTxs: await Promise.all(
+                    checkpointsB64.map((c) => serverSignCheckpoint(c)),
+                ),
+            }));
+
+        let finalizedCheckpoints: string[] | undefined;
+        const finalizeSpy = vi
+            .spyOn(wallet.arkProvider, "finalizeTx")
+            .mockImplementation(async (_arkTxid, checkpoints) => {
+                finalizedCheckpoints = checkpoints;
+            });
+
+        await wallet.buildAndSubmitOffchainTx(
+            [coin],
+            [{ amount: BigInt(coin.value - 1000), script: wallet.arkAddress.pkScript }],
+        );
+
+        // Batch path taken: one signMultiple, no per-tx sign.
+        expect(identity.signMultipleSpy).toHaveBeenCalledTimes(1);
+        expect(identity.signSpy).not.toHaveBeenCalled();
+
+        expect(finalizedCheckpoints).toHaveLength(1);
+        const signers = tapscriptSignerPubkeysHex(finalizedCheckpoints![0], 0);
+        // The merge preserved the server sig AND added the user sig.
+        expect(signers).toContain(serverXOnlyHex);
+        expect(signers).toContain(userXOnlyHex);
+
+        submitSpy.mockRestore();
+        finalizeSpy.mockRestore();
+        await wallet.dispose();
+    });
+
+    it("batch send merge: rejects when the server returns a mismatched checkpoint count", async () => {
+        // The merge pairs the server's signedCheckpointTxs with the stashed
+        // userSignedCheckpoints by index. A count mismatch must throw loudly
+        // rather than silently drop the tail (short response) or blow up with
+        // a cryptic undefined access mid-merge (long response).
+        const { wallet } = await makeStaticBatchWallet();
+        const coin = makeBaselineCoin(wallet);
+
+        const submitSpy = vi
+            .spyOn(wallet.arkProvider, "submitTx")
+            .mockImplementation(async (arkTxB64, checkpointsB64) => {
+                const signed = await Promise.all(
+                    checkpointsB64.map((c) => serverSignCheckpoint(c)),
+                );
+                return {
+                    arkTxid: "ab".repeat(32),
+                    finalArkTx: arkTxB64,
+                    // One more checkpoint than the user signed → mismatch.
+                    signedCheckpointTxs: [...signed, signed[0]],
+                };
+            });
+        const finalizeSpy = vi.spyOn(wallet.arkProvider, "finalizeTx").mockResolvedValue(undefined);
+
+        await expect(
+            wallet.buildAndSubmitOffchainTx(
+                [coin],
+                [{ amount: BigInt(coin.value - 1000), script: wallet.arkAddress.pkScript }],
+            ),
+        ).rejects.toThrow(/submitTx returned 2 checkpoints, expected 1/);
+
+        // Guard fired before finalize — no malformed checkpoint reaches arkd.
+        expect(finalizeSpy).not.toHaveBeenCalled();
+
+        submitSpy.mockRestore();
+        finalizeSpy.mockRestore();
+        await wallet.dispose();
+    });
+
+    it("batch recovery: signs server-signed checkpoints once and preserves the server sig", async () => {
+        // `finalizePendingTxs` batch path is NOT a restore of #395 — it is
+        // new code that hands signMultiple a checkpoint that ALREADY carries
+        // the server's tapScriptSig and uses the result directly (no merge).
+        // It is correct only if the user signer preserves the pre-existing
+        // server sig. This locks that contract in.
+        const { wallet, identity } = await makeStaticBatchWallet();
+        const coin = makeBaselineCoin(wallet);
+        const userXOnlyHex = hex.encode(await identity.xOnlyPublicKey());
+        const serverXOnlyHex = hex.encode(await SERVER_KEY.xOnlyPublicKey());
+
+        // Build the checkpoint the same way the wallet does, then have the
+        // server (and only the server) sign it — mimics what the server
+        // returns from submitTx and persists for recovery.
+        const offchain = buildOffchainTx(
+            [{ ...coin, tapLeafScript: coin.forfeitTapLeafScript }],
+            [{ amount: BigInt(coin.value - 1000), script: wallet.arkAddress.pkScript }],
+            wallet.serverUnrollScript,
+        );
+        const serverCheckpointB64 = await serverSignCheckpoint(
+            base64.encode(offchain.checkpoints[0].toPSBT()),
+        );
+        // Sanity: the persisted checkpoint carries the server sig and NOT
+        // the user sig (recovery is responsible for adding the user share).
+        expect(tapscriptSignerPubkeysHex(serverCheckpointB64, 0)).toEqual([serverXOnlyHex]);
+
+        // Pretend a previous send was interrupted after submit.
+        await (wallet as any).setPendingTxFlag(true);
+        const getPendingSpy = vi
+            .spyOn(wallet.arkProvider, "getPendingTxs")
+            .mockResolvedValue([
+                { arkTxid: "cd".repeat(32), signedCheckpointTxs: [serverCheckpointB64] },
+            ] as never);
+        let finalizedCheckpoints: string[] | undefined;
+        const finalizeSpy = vi
+            .spyOn(wallet.arkProvider, "finalizeTx")
+            .mockImplementation(async (_arkTxid, checkpoints) => {
+                finalizedCheckpoints = checkpoints;
+            });
+
+        const result = await wallet.finalizePendingTxs([coin]);
+
+        expect(result.finalized).toEqual(["cd".repeat(32)]);
+        // One batch call covers every checkpoint of the recovered tx.
+        expect(identity.signMultipleSpy).toHaveBeenCalledTimes(1);
+
+        expect(finalizedCheckpoints).toHaveLength(1);
+        const signers = tapscriptSignerPubkeysHex(finalizedCheckpoints![0], 0);
+        expect(signers).toContain(serverXOnlyHex); // server sig survived
+        expect(signers).toContain(userXOnlyHex); // user sig added on top
+
+        getPendingSpy.mockRestore();
+        finalizeSpy.mockRestore();
         await wallet.dispose();
     });
 });


### PR DESCRIPTION
## Summary

- The N+1 → 1 popup optimization shipped in #395 was silently regressed by the `InputSignerRouter` extraction (`9a862b6b`) and the HD rotation refactor (`baa0b90e`). `Wallet.buildAndSubmitOffchainTx` calls `_signerRouter.sign` once per PSBT and the router calls `signWithDescriptor` with one request at a time, so `BatchSignableIdentity.signMultiple` was never reached on either path. Browser-wallet identities (Xverse / UniSat / OKX style) went back to N+1 confirmation popups per send.
- Extract `InputSignerRouter.classify(jobs)` as the single source of truth for routing decisions. `sign()` consumes the same plan; a new `canBatch(jobs)` predicate delegates to it. No behavior change for existing `sign()` callers.
- Restore the batch path in `buildAndSubmitOffchainTx` and the pending-tx recovery loop. When `isBatchSignable(identity)` and `canBatch` is true for every PSBT in the bundle, call `signMultiple` once with `arkTx + N checkpoints`, submit the unsigned checkpoints, then merge the stashed user sigs onto the server-signed checkpoints with `combineTapscriptSigs`. HD / mixed sends keep the sequential path unchanged.

## Why the batch path is all-or-nothing

`signMultiple` belongs to `BatchSignableIdentity`, which carries one key. If any input across the bundle would route to the `DescriptorProvider` (i.e. an HD-rotated VTXO), the identity can't sign it. `canBatch` short-circuits to the sequential fallback for those bundles. Extending batch to descriptor-rotated sends would require a new identity surface (`signMultipleWithDescriptors`) — out of scope.

## Test plan

- [x] `pnpm -F @arkade-os/sdk test:unit` — 1258 passed, 1 skipped
- [x] `pnpm -F @arkade-os/sdk lint` — clean
- [x] `pnpm -F @arkade-os/sdk tsc --noEmit -p tsconfig.json` — clean
- [x] New unit tests in `test/wallet/inputSignerRouter.test.ts` cover `canBatch` (all baseline → true; baseline + rotated → false; empty jobs → true; missing-descriptor → propagated)
- [x] New integration tests in `test/walletHdRotation.test.ts > Wallet batch signing (BatchSignableIdentity)` assert `signMultiple` is invoked exactly once with `arkTx + 1 checkpoint` for a 1-input send and that `sign()` is not invoked
- [x] Existing fallback test confirms a plain `Identity` (no `signMultiple`) takes the per-PSBT path with 2 `sign()` calls
- [ ] e2e (`pnpm test:integration` against nigiri) — not run locally; the change is gated on `isBatchSignable(identity)` which the SDK's `SeedIdentity` / `SingleKey` test identities do not implement, so e2e flows hit the unchanged sequential fallback. Confirmation popup-saving behaviour needs a real browser wallet to verify end-to-end.

## Known limits

- HD wallets that touch a rotated VTXO still get N+1 popups for that send. The batch path bails to sequential whenever any input is descriptor-routed. Restoring batch for the mixed case would need a descriptor-aware variant of `BatchSignableIdentity` — separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored batch signing for multi-signature offchain flows when all inputs use the baseline key; sequential signing remains the fallback for mixed/rotated inputs.
* **New Features**
  * Added a pre-check to detect when a transaction bundle is eligible for single-call batch signing.
* **Improvements**
  * Safer merging of user and server signatures to prevent silent witness corruption and surface mismatches.
* **Documentation**
  * Expanded contract guidance for batch-capable identities, including signature-preservation expectations.
* **Tests**
  * New and extended tests covering batch eligibility, batch signing/merge behavior, and signature-merge validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->