### PR TITLE
fix: resolve waitForIncomingFunds on actual incoming funds

### DIFF
--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2994,15 +2994,31 @@ export function selectVirtualCoins(
  */
 export async function waitForIncomingFunds(wallet: Wallet): Promise<IncomingFunds> {
     let stopFunc: (() => void) | undefined;
+    let settled = false;
 
     return new Promise<IncomingFunds>((resolve) => {
         wallet
-            .notifyIncomingFunds((coins: IncomingFunds) => {
-                resolve(coins);
-                if (stopFunc) stopFunc();
+            .notifyIncomingFunds((funds: IncomingFunds) => {
+                // `notifyIncomingFunds` also fires for purely outgoing activity:
+                // a `vtxo_spent` event carries `newVtxos: []`, and an onchain tx
+                // that only spends from the boarding address yields empty
+                // `coins`. Those hold no incoming funds, so skip them and keep
+                // waiting — otherwise this one-shot helper can resolve on the
+                // spent half of a self-send before the matching `vtxo_received`
+                // arrives, returning an empty result.
+                const hasFunds =
+                    funds.type === "utxo" ? funds.coins.length > 0 : funds.newVtxos.length > 0;
+                if (settled || !hasFunds) return;
+
+                settled = true;
+                resolve(funds);
+                stopFunc?.();
             })
             .then((stop) => {
                 stopFunc = stop;
+                // The callback may have already resolved before the subscription
+                // handle was available; tear it down now so we don't leak it.
+                if (settled) stop();
             });
     });
 }


### PR DESCRIPTION
## What happened

The e2e test `should finalize pending transactions` was flaky (failed ~1-in-2 locally). Diagnostics confirmed `finalizePendingTxs` worked correctly every time — the failure was at `expect(incomingFunds).toHaveLength(1)`.

`waitForIncomingFunds` resolves on the first `notifyIncomingFunds` callback. But that callback also fires for purely *outgoing* activity: a `vtxo_spent` event carries `newVtxos: []`, and an onchain spend yields empty `coins`. The test does a self-send, which emits both a `vtxo_spent` (input) and a `vtxo_received` (output) in separate subscription messages. When the spent one landed first, the helper resolved with an empty result.

This corrects the earlier guess in #534 (a `hasPendingTx` flag race): both `toHaveLength(1)` assertions produce the identical error string, and the actual failing one is the incoming-funds check, not the finalize check. The flag is intact throughout.

## Fix

`waitForIncomingFunds` now skips notifications that carry no incoming funds and keeps waiting for the real `vtxo_received` (or non-empty `coins`). A "wait for incoming funds" helper resolving on a pure outgoing event was a genuine wart — this fixes it for all callers, not just the test.

## Verification

30/30 passing against the regtest stack (was ~1-in-2 failing before). No rebuild needed — the e2e suite imports from source.

Closes #534.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced the reliability of wallet fund notifications through improved filtering of transaction events and strengthened subscription lifecycle management to prevent resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->