### PR TITLE
Fix BIP21 amount validation

### DIFF
--- a/packages/ts-sdk/src/utils/bip21.ts
+++ b/packages/ts-sdk/src/utils/bip21.ts
@@ -112,8 +112,11 @@ export class BIP21 {
                 if (!value) continue;
 
                 if (key === "amount") {
+                    if (!/^\d+(?:\.\d+)?$/.test(value)) {
+                        continue;
+                    }
                     const amount = Number(value);
-                    if (!isFinite(amount)) {
+                    if (!isFinite(amount) || !Number.isSafeInteger(Math.trunc(amount))) {
                         continue;
                     }
                     if (amount < 0) {

--- a/packages/ts-sdk/test/bip21.test.ts
+++ b/packages/ts-sdk/test/bip21.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { BIP21 } from "../src/utils/bip21";
+
+describe("BIP21", () => {
+    it("parses valid amount values", () => {
+        const result = BIP21.parse("bitcoin:bc1qexample?amount=1.25");
+
+        expect(result.params.amount).toBe(1.25);
+    });
+
+    it("ignores malformed amount values", () => {
+        const result = BIP21.parse("bitcoin:bc1qexample?amount=1abc");
+
+        expect(result.params.amount).toBeUndefined();
+    });
+
+    it("ignores unsafe amount values", () => {
+        const result = BIP21.parse("bitcoin:bc1qexample?amount=9007199254740992");
+
+        expect(result.params.amount).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Fixes BIP21 amount parsing so malformed and unsafe amount values are ignored instead of accepted. Adds focused coverage for valid, malformed, and unsafe amount inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced amount validation in BIP21 URI parsing to reject malformed and unsafe numeric values.

* **Tests**
  * Added test coverage for BIP21 URI parsing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->