### PR TITLE
feat(contracts): export handler authoring helpers

### DIFF
--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -249,6 +249,7 @@ import { DelegateContractHandler } from "./contracts/handlers/delegate";
 import type { DelegateContractParams } from "./contracts/handlers/delegate";
 import { VHTLCContractHandler } from "./contracts/handlers/vhtlc";
 import type { VHTLCContractParams } from "./contracts/handlers/vhtlc";
+import { isCsvSpendable, isCltvSatisfied } from "./contracts/handlers/helpers";
 import { BoardingContractHandler } from "./contracts/handlers/boarding";
 import type { BoardingContractParams } from "./contracts/handlers/boarding";
 import {
@@ -451,6 +452,9 @@ export {
     contractFromArkContractWithAddress,
     isArkContract,
     isDiscoverable,
+    // Contract handler authoring helpers (spending-path selection)
+    isCsvSpendable,
+    isCltvSatisfied,
 
     // Assets
     ReadonlyAssetManager,


### PR DESCRIPTION
exporting them lets authors of custom ContractHandlers implement selectPath/getSpendablePaths consistently instead of reimplementing BIP-68/BIP-65 timelock-maturity logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two contract utility helpers are now exposed in the TypeScript SDK public API.
  * Updated release note: corrected previous count — two helpers were added and are publicly available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->