### PR TITLE
Boarding HD rotation + default/boarding collision fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,21 @@ This file provides guidance to AI coding assistants when working with code in th
 
 **arkade-monorepo** — A pnpm workspace monorepo for the Arkade Bitcoin wallet ecosystem. Contains two published packages: `@arkade-os/sdk` (Bitcoin wallet SDK with Taproot/Ark protocol) and `@arkade-os/boltz-swap` (Lightning/chain swaps via Boltz). Both target browser, Node.js, and React Native (Expo).
 
+## Reference Implementation & Technical Direction
+
+**The .NET Ark SDK (`NArk`, ArkLabsHQ) is the reference implementation for this TypeScript SDK** —
+for feature parity and, more broadly, for technical direction and architecture. When designing a new
+feature, refactoring, or resolving an ambiguity about how something *should* work, check how `NArk`
+does it and align with it unless there's a TypeScript- or platform-specific reason to diverge (and
+note the reason when you do). A local checkout typically lives alongside this repo at `../dotnet-sdk`.
+
+Context for why this matters: this TypeScript SDK began as a fairly literal port of the Go SDK. That
+origin left it carrying Go idioms and structural choices that don't fit TypeScript well, so parts of
+the codebase are shaped by the translation rather than by what's idiomatic or best for this platform.
+Treat such patterns as legacy to be improved, not as precedent to extend. The `NArk` codebase is the
+better-architected, more deliberately designed expression of the same domain; prefer its structure
+and naming when they conflict with the inherited Go-shaped patterns here.
+
 ## Commands
 
 ```bash

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -37,6 +37,34 @@ import {
 const DEFAULT_PAGE_SIZE = 500;
 
 /**
+ * Whether two *different* contract types may legitimately share a single
+ * repository row when their derived scripts collide (byte-identical pkScript).
+ *
+ * Contracts are keyed by their pkScript (`script` is the unique identity), so a
+ * given script can own exactly one row. `default` and `boarding` are both built
+ * from the same `DefaultVtxo.Script` shape and differ only by CSV-timelock
+ * value; when the server's offchain unilateral-exit delay and its boarding-exit
+ * delay coincide (a degenerate / misconfigured server — a sound server keeps
+ * them distinct), the two derive a byte-identical script and must share a
+ * single row. {@link ContractManager.upsertContract} resolves such a collision
+ * first-wins (keep the existing row, don't throw). Every other distinct pairing
+ * (e.g. `default` ↔ `vhtlc`, or a `delegate` script — which carries an extra
+ * leaf and cannot collide under sound semantics) signals a real script/params
+ * mismatch and still throws.
+ *
+ * This is a pure *type-pair* rule with no notion of HD index or "baseline":
+ * `upsertContract` sees only the two type strings, so a `default` ↔ `boarding`
+ * collision coalesces at ANY index, including rotated ones — exactly what
+ * equal-delay restore needs (see
+ * docs/hd-wallets_onchain_rotation_collision_fix.md §5.1).
+ *
+ * @internal Exported for unit tests; not part of the public API surface.
+ */
+export function areCoalescibleContractTypes(a: string, b: string): boolean {
+    return (a === "default" && b === "boarding") || (a === "boarding" && b === "default");
+}
+
+/**
  * Hard upper bound on the HD index range probed by {@link scanContracts}.
  * Safety valve: a buggy or malicious `Discoverable` handler that returns a
  * hit at every index would otherwise keep the gap window open forever and
@@ -501,12 +529,31 @@ export class ContractManager implements IContractManager {
             );
         }
 
-        // Check if contract already exists and verify it's the same type to avoid silent mismatches
+        // A script is its own unique identity, so at most one row per script.
         const [existing] = await this.getContracts({ script: params.script });
         if (existing) {
+            // Same type → idempotent no-op (re-registering is a no-op).
             if (existing.type === params.type) return { contract: existing, persisted: false };
+            // Degenerate equal-delay collision: a `default` and a `boarding`
+            // script are byte-identical when the server's unilateral-exit and
+            // boarding-exit delays coincide. Tolerate it FIRST-WINS — keep the
+            // existing row exactly as-is (no overwrite, no type promotion, no
+            // throw) and report it was not (re)persisted. This mirrors NArk's
+            // script-keyed dedup (one row per script) and is the single source
+            // of truth for the collision, covering both `createContract` (init)
+            // and `persistAndWatchContract` (the restore scan). Because it never
+            // mutates the row it also preserves the watcher invariant: the
+            // winning row was registered with the watcher when first persisted,
+            // so event callbacks always see the authoritative type — there is no
+            // promote-then-forget-the-watcher gap. See
+            // docs/hd-wallets_onchain_rotation_collision_fix.md §5.1.
+            if (areCoalescibleContractTypes(existing.type, params.type)) {
+                return { contract: existing, persisted: false };
+            }
+            // Any other same-script/different-type collision is a real bug or
+            // hash anomaly — surface it loudly.
             throw new Error(
-                `Contract with script ${params.script} already exists with with type ${existing.type}.`,
+                `Contract with script ${params.script} already exists with type ${existing.type}.`,
             );
         }
 
@@ -546,10 +593,28 @@ export class ContractManager implements IContractManager {
                 `scanContracts: gapLimit must be a positive integer (got ${String(opts.gapLimit)})`,
             );
         }
-        const discoverables = contractHandlers
+        const registered = contractHandlers
             .getRegisteredTypes()
             .map((t) => contractHandlers.get(t))
             .filter(isDiscoverable);
+
+        // Probe `boarding` before `default`/`delegate`. This ordering is
+        // LOAD-BEARING, not cosmetic: each hit is persisted immediately and
+        // `upsertContract` resolves a same-script collision FIRST-WINS, so the
+        // iteration order IS the tie-break. In the degenerate equal-delay case
+        // a rotated index can carry BOTH an on-chain boarding UTXO and an L2
+        // VTXO at the same (byte-identical) script; probing boarding first
+        // resolves that collision to a `boarding` row, which keeps the on-chain
+        // UTXO visible to the type-gated `getBoardingUtxos` while the VTXO stays
+        // visible via the type-agnostic `getVtxos`. Resolving to `default` would
+        // hide the on-chain boarding UTXO (the original Finding #1 bug). The
+        // stable partition preserves the relative order of all non-boarding
+        // handlers. A future reorder must not regress this; a unit test pins it.
+        // See docs/hd-wallets_onchain_rotation_collision_fix.md §5.2.
+        const discoverables = [
+            ...registered.filter((h) => h.type === "boarding"),
+            ...registered.filter((h) => h.type !== "boarding"),
+        ];
 
         const maxIdx = opts.hd ? SCAN_MAX_INDEX : 0;
         const handlerErrors: HandlerError[] = [];

--- a/packages/ts-sdk/src/contracts/handlers/boarding.ts
+++ b/packages/ts-sdk/src/contracts/handlers/boarding.ts
@@ -1,6 +1,11 @@
+import { hex } from "@scure/base";
 import { DefaultVtxo } from "../../script/default";
-import { Contract, ContractHandler, PathContext, PathSelection } from "../types";
+import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
+import type { DiscoveredContract, DiscoveryDeps } from "../types";
 import { DefaultContractHandler, DefaultContractParams } from "./default";
+import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
+import { timelockToSequence } from "../../utils/timelock";
+import { WALLET_RECEIVE_SOURCE } from "../metadata";
 
 /**
  * Typed parameters for boarding contracts.
@@ -33,11 +38,15 @@ export type BoardingContractParams = DefaultContractParams;
  * `timelockToSequence` / `sequenceToTimelock` helpers and BIP68 sequence
  * encoding as `default` / `delegate`.
  *
- * Unlike `default` / `delegate`, the boarding handler deliberately does
- * **not** implement {@link Discoverable.discoverAt}: branch/index
- * selection for HD wallets is owned by the wallet / address-provider
- * layer, which hands this handler an already-derived pubkey. As a result
- * `isDiscoverable(BoardingContractHandler)` is `false`.
+ * Like `default` / `delegate`, the boarding handler implements
+ * {@link Discoverable.discoverAt} so `wallet.restore()` can rediscover
+ * used boarding indices from authoritative on-chain data. It differs from
+ * the L2 handlers in its source of truth: boarding probes the **on-chain**
+ * UTXO set at its P2TR address (`OnchainProvider.getCoins`) rather than the
+ * Ark indexer, and builds its candidate from the boarding-exit CSV
+ * (`deps.boardingTimelock`) instead of the unilateral-exit matrix
+ * (`deps.csvTimelocks`). When boarding discovery is not plumbed (no
+ * `deps.boardingTimelock` / `deps.onchainNetwork`) `discoverAt` no-ops.
  *
  * Identity & the default/boarding collision: a contract's `script` (pkScript)
  * is its unique identity — a script owns exactly one repository row. `boarding`
@@ -55,43 +64,124 @@ export type BoardingContractParams = DefaultContractParams;
  * (which never depend on the persisted contract's type) and match by script when
  * needed.
  */
-export const BoardingContractHandler: ContractHandler<BoardingContractParams, DefaultVtxo.Script> =
-    {
-        type: "boarding",
+export const BoardingContractHandler: ContractHandler<BoardingContractParams, DefaultVtxo.Script> &
+    Discoverable = {
+    type: "boarding",
 
-        createScript(params: Record<string, string>): DefaultVtxo.Script {
-            return DefaultContractHandler.createScript(params);
-        },
+    createScript(params: Record<string, string>): DefaultVtxo.Script {
+        return DefaultContractHandler.createScript(params);
+    },
 
-        serializeParams(params: BoardingContractParams): Record<string, string> {
-            return DefaultContractHandler.serializeParams(params);
-        },
+    serializeParams(params: BoardingContractParams): Record<string, string> {
+        return DefaultContractHandler.serializeParams(params);
+    },
 
-        deserializeParams(params: Record<string, string>): BoardingContractParams {
-            return DefaultContractHandler.deserializeParams(params);
-        },
+    deserializeParams(params: Record<string, string>): BoardingContractParams {
+        return DefaultContractHandler.deserializeParams(params);
+    },
 
-        selectPath(
-            script: DefaultVtxo.Script,
-            contract: Contract,
-            context: PathContext,
-        ): PathSelection | null {
-            return DefaultContractHandler.selectPath(script, contract, context);
-        },
+    selectPath(
+        script: DefaultVtxo.Script,
+        contract: Contract,
+        context: PathContext,
+    ): PathSelection | null {
+        return DefaultContractHandler.selectPath(script, contract, context);
+    },
 
-        getAllSpendingPaths(
-            script: DefaultVtxo.Script,
-            contract: Contract,
-            context: PathContext,
-        ): PathSelection[] {
-            return DefaultContractHandler.getAllSpendingPaths(script, contract, context);
-        },
+    getAllSpendingPaths(
+        script: DefaultVtxo.Script,
+        contract: Contract,
+        context: PathContext,
+    ): PathSelection[] {
+        return DefaultContractHandler.getAllSpendingPaths(script, contract, context);
+    },
 
-        getSpendablePaths(
-            script: DefaultVtxo.Script,
-            contract: Contract,
-            context: PathContext,
-        ): PathSelection[] {
-            return DefaultContractHandler.getSpendablePaths(script, contract, context);
-        },
-    };
+    getSpendablePaths(
+        script: DefaultVtxo.Script,
+        contract: Contract,
+        context: PathContext,
+    ): PathSelection[] {
+        return DefaultContractHandler.getSpendablePaths(script, contract, context);
+    },
+
+    /**
+     * Probe the on-chain UTXO set for a boarding output at this HD index.
+     *
+     * Boarding's source of truth is the **current** on-chain coin set
+     * (`OnchainProvider.getCoins`), not the Ark indexer: a boarded (spent)
+     * boarding output becomes an L2 VTXO at the receive index, so the
+     * indexer probe already keeps the gap window open for it; only an
+     * *unspent* boarding output needs the on-chain probe (see plan §2).
+     *
+     * No-ops (returns `[]`) when boarding discovery is not plumbed — i.e.
+     * `deps.boardingTimelock` or `deps.onchainNetwork` is absent — so the
+     * scanner unit harness (which sets neither) is unaffected.
+     *
+     * Equal-delay collision coalescing ("default wins", plan §6-I.3): when
+     * the boarding script is byte-identical to a `default` script at this
+     * index (a degenerate server with `boardingExitDelay ===
+     * unilateralExitDelay`), this emits the hit as a `default` contract
+     * rather than a conflicting `boarding` row, so the restore scan's strict
+     * `upsertContract` never aborts on a same-script/different-type clash.
+     */
+    async discoverAt(
+        index: number,
+        descriptor: string,
+        deps: DiscoveryDeps,
+    ): Promise<DiscoveredContract[]> {
+        if (!deps.boardingTimelock || !deps.onchainNetwork) return [];
+
+        const pubKey = deriveDescriptorLeafPubKey(descriptor);
+        const script = new DefaultVtxo.Script({
+            pubKey,
+            serverPubKey: deps.serverPubKey,
+            csvTimelock: deps.boardingTimelock,
+        });
+        const onchainAddress = script.onchainAddress(deps.onchainNetwork);
+
+        const coins = await deps.onchainProvider.getCoins(onchainAddress);
+        if (coins.length === 0) return [];
+
+        const scriptHex = hex.encode(script.pkScript);
+        // Coalesce onto `default` when the boarding script collides with a
+        // `default` candidate at this index. Scripts are byte-identical iff
+        // the boarding-exit sequence equals one of the unilateral-exit
+        // sequences (same pubKey + serverPubKey + sequence). A `delegate`
+        // script carries an extra leaf and can never collide.
+        const boardingSeq = timelockToSequence(deps.boardingTimelock);
+        const collidesWithDefault = deps.csvTimelocks.some(
+            (tl) => timelockToSequence(tl) === boardingSeq,
+        );
+        const type = collidesWithDefault ? "default" : "boarding";
+
+        return [
+            {
+                type,
+                params: {
+                    pubKey: hex.encode(pubKey),
+                    serverPubKey: hex.encode(deps.serverPubKey),
+                    csvTimelock: boardingSeq.toString(),
+                },
+                script: scriptHex,
+                // The persisted row's `address` is the *Ark* address (not the
+                // on-chain P2TR), matching the row registered at init so the
+                // ContractWatcher keeps monitoring the same L2 script and the
+                // VTXO repository bucket lines up (plan §6-I.4). The P2TR is
+                // recomputed from params only for the `getCoins` probe.
+                address: script.address(deps.network.hrp, deps.serverPubKey).encode(),
+                // Tag rotated rows (index > 0) so boot resolution can find the
+                // newest boarding address and descriptor-aware signing can
+                // recover the per-index key (plan §6-II/§6-III.3). The index-0
+                // baseline stays untagged, matching `default`/`delegate`.
+                ...(index > 0
+                    ? {
+                          metadata: {
+                              source: WALLET_RECEIVE_SOURCE,
+                              signingDescriptor: descriptor,
+                          },
+                      }
+                    : {}),
+            },
+        ];
+    },
+};

--- a/packages/ts-sdk/src/contracts/handlers/boarding.ts
+++ b/packages/ts-sdk/src/contracts/handlers/boarding.ts
@@ -44,8 +44,7 @@ export type BoardingContractParams = DefaultContractParams;
  * the L2 handlers in its source of truth: boarding probes the **on-chain**
  * UTXO set at its P2TR address (`OnchainProvider.getCoins`) rather than the
  * Ark indexer, and builds its candidate from the boarding-exit CSV
- * (`deps.boardingTimelock`) instead of the unilateral-exit matrix
- * (`deps.csvTimelocks`). When boarding discovery is not plumbed (no
+ * (`deps.boardingTimelock`). When boarding discovery is not plumbed (no
  * `deps.boardingTimelock` / `deps.onchainNetwork`) `discoverAt` no-ops.
  *
  * Identity & the default/boarding collision: a contract's `script` (pkScript)
@@ -55,14 +54,17 @@ export type BoardingContractParams = DefaultContractParams;
  * server keeps boardingExitDelay strictly longer than unilateralExitDelay (equal
  * delays would expose the provider to a double-spend). Should those delays ever
  * coincide (a misconfigured/malicious server), the boarding script is
- * byte-identical to the default script and the wallet coalesces the single
- * shared row onto the `default` type ("default wins"; see `ensureWalletContract`)
- * rather than persisting a second row. Either way the funds are equally spendable
- * through the shared `DefaultVtxo.Script` paths. Consumers must NOT rely on
- * `contract.type === "boarding"` to identify the boarding purpose — resolve the
- * boarding script via `wallet.getBoardingAddress()` / `wallet.boardingTapscript`
- * (which never depend on the persisted contract's type) and match by script when
- * needed.
+ * byte-identical to the default script. `discoverAt` does NOT pre-coalesce that
+ * collision: it always emits `type: "boarding"`, and the single shared row is
+ * resolved FIRST-WINS at the persistence layer
+ * ({@link ContractManager.upsertContract}) — whichever purpose is persisted
+ * first keeps the row, and the scan deliberately probes boarding first
+ * (see docs/hd-wallets_onchain_rotation_collision_fix.md §5.1–5.2). Either way
+ * the funds are equally spendable through the shared `DefaultVtxo.Script` paths.
+ * Consumers must NOT rely on `contract.type === "boarding"` to identify the
+ * boarding purpose — resolve the boarding script via
+ * `wallet.getBoardingAddress()` / `wallet.boardingTapscript` (which never depend
+ * on the persisted contract's type) and match by script when needed.
  */
 export const BoardingContractHandler: ContractHandler<BoardingContractParams, DefaultVtxo.Script> &
     Discoverable = {
@@ -117,12 +119,12 @@ export const BoardingContractHandler: ContractHandler<BoardingContractParams, De
      * `deps.boardingTimelock` or `deps.onchainNetwork` is absent — so the
      * scanner unit harness (which sets neither) is unaffected.
      *
-     * Equal-delay collision coalescing ("default wins", plan §6-I.3): when
-     * the boarding script is byte-identical to a `default` script at this
-     * index (a degenerate server with `boardingExitDelay ===
-     * unilateralExitDelay`), this emits the hit as a `default` contract
-     * rather than a conflicting `boarding` row, so the restore scan's strict
-     * `upsertContract` never aborts on a same-script/different-type clash.
+     * Always emits `type: "boarding"`, even in the degenerate equal-delay case
+     * where the boarding script is byte-identical to a `default` script at this
+     * index (`boardingExitDelay === unilateralExitDelay`). The collision is no
+     * longer pre-judged in discovery; it is tolerated FIRST-WINS at the
+     * persistence layer ({@link ContractManager.upsertContract}). `deps.csvTimelocks`
+     * is intentionally not read here.
      */
     async discoverAt(
         index: number,
@@ -143,20 +145,17 @@ export const BoardingContractHandler: ContractHandler<BoardingContractParams, De
         if (coins.length === 0) return [];
 
         const scriptHex = hex.encode(script.pkScript);
-        // Coalesce onto `default` when the boarding script collides with a
-        // `default` candidate at this index. Scripts are byte-identical iff
-        // the boarding-exit sequence equals one of the unilateral-exit
-        // sequences (same pubKey + serverPubKey + sequence). A `delegate`
-        // script carries an extra leaf and can never collide.
         const boardingSeq = timelockToSequence(deps.boardingTimelock);
-        const collidesWithDefault = deps.csvTimelocks.some(
-            (tl) => timelockToSequence(tl) === boardingSeq,
-        );
-        const type = collidesWithDefault ? "default" : "boarding";
 
+        // Always `type: "boarding"` (see method doc). The equal-delay
+        // same-script collision is resolved first-wins at persistence, and the
+        // scan probes boarding before default so a both-purpose rotated index
+        // resolves to a `boarding` row — keeping both the on-chain UTXO and any
+        // L2 VTXO recoverable (docs/hd-wallets_onchain_rotation_collision_fix.md
+        // §5.2, §5.4).
         return [
             {
-                type,
+                type: "boarding",
                 params: {
                     pubKey: hex.encode(pubKey),
                     serverPubKey: hex.encode(deps.serverPubKey),

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -5,6 +5,7 @@ import { ContractFilter } from "../repositories";
 import type { RelativeTimelock } from "../script/tapscript";
 import type { IndexerProvider } from "../providers/indexer";
 import type { OnchainProvider } from "../providers/onchain";
+import type { Network } from "../networks";
 
 /**
  * Contract state indicating whether it should be actively monitored.
@@ -257,10 +258,31 @@ export interface DiscoveredContract {
 export interface DiscoveryDeps {
     indexerProvider: IndexerProvider;
     onchainProvider: OnchainProvider;
+    /**
+     * Ark-address network data. The `{ hrp }` shape is all the L2
+     * (`default`/`delegate`) discovery path needs to render an Ark address.
+     */
     network: { hrp: string };
+    /**
+     * Full Bitcoin network descriptor for on-chain (P2TR) address
+     * rendering. Required by the boarding discovery probe, which derives an
+     * on-chain Taproot address via {@link VtxoScript.onchainAddress} — the
+     * `{ hrp }`-only {@link DiscoveryDeps.network} lacks the `bech32` data
+     * that needs. Absent only when no boarding discovery is plumbed (e.g.
+     * the scanner unit harness), in which case boarding `discoverAt` no-ops.
+     */
+    onchainNetwork?: Network;
     serverPubKey: Uint8Array;
     /** Relative timelocks the wallet treats as its baseline matrix. */
     csvTimelocks: RelativeTimelock[];
+    /**
+     * Boarding-exit CSV timelock. Distinct from {@link DiscoveryDeps.csvTimelocks}
+     * (the unilateral-exit matrix): boarding scripts source their CSV from the
+     * server's boarding-exit delay. Present only when boarding discovery is
+     * plumbed; when absent, boarding `discoverAt` no-ops (so the scanner unit
+     * harness, which never sets it, is unaffected).
+     */
+    boardingTimelock?: RelativeTimelock;
     /** Present only for delegate wallets. */
     delegatePubKey?: Uint8Array;
 }

--- a/packages/ts-sdk/src/wallet/inputSignerRouter.ts
+++ b/packages/ts-sdk/src/wallet/inputSignerRouter.ts
@@ -27,7 +27,7 @@ export interface InputSignerRouterDeps {
     boardingPkScript: Uint8Array;
 }
 
-const DESCRIPTOR_CAPABLE_CONTRACT_TYPES = new Set(["default", "delegate"]);
+const DESCRIPTOR_CAPABLE_CONTRACT_TYPES = new Set(["default", "delegate", "boarding"]);
 
 /**
  * Routing decision for a single tx's signable inputs: which inputs the
@@ -47,12 +47,18 @@ export interface InputRoutingPlan {
 
 /**
  * Routes PSBT inputs to the correct signer based on the owning contract.
- * Inputs whose script matches a `default`/`delegate` contract with a
- * non-baseline owner are sent to {@link DescriptorProvider}; everything
- * else (baseline-owned contracts, non-default/non-delegate contracts,
- * and the boarding script) is sent to {@link Identity}. Inputs with no
+ * Inputs whose script matches a `default`/`delegate`/`boarding` contract with
+ * a non-baseline owner are sent to {@link DescriptorProvider}; everything
+ * else (baseline-owned contracts, other contract types, and the index-0
+ * boarding fallback script) is sent to {@link Identity}. Inputs with no
  * matching contract and no boarding match are silently skipped, matching
  * how the wallet historically handled cosigner/connector inputs.
+ *
+ * Boarding participates in descriptor-aware signing (plan §6-III.3): a
+ * *rotated* boarding UTXO is locked to its HD index's pubkey, so it must be
+ * signed with the key derived at that index, not the baseline identity key.
+ * The `pubKey === baseline` early-out below keeps index-0 / static boarding on
+ * the identity path, so the no-rotation case is byte-for-byte unchanged.
  */
 export class InputSignerRouter {
     constructor(private readonly deps: InputSignerRouterDeps) {}
@@ -123,7 +129,7 @@ export class InputSignerRouter {
             if (typeof descriptor !== "string" || descriptor.length === 0) {
                 throw new MissingSigningDescriptorError(
                     contract.script,
-                    contract.type as "default" | "delegate",
+                    contract.type as "default" | "delegate" | "boarding",
                 );
             }
 

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1362,14 +1362,22 @@ export class WalletMessageHandler
         const vtxos = await this.getVtxosFromRepo();
 
         // Fetch boarding inputs across the full boarding-address set (current +
-        // historical rotated; plan §6-IV.2). Clear each stale bucket first so
-        // spent coins drop, then let getBoardingUtxos re-fetch and re-save each
-        // address bucket with the correct per-UTXO tapscript.
+        // historical rotated; plan §6-IV.2). Fetch FIRST: getBoardingUtxos
+        // re-fetches each boarding address from the onchain provider and saves
+        // it, so a transient failure throws here before we touch the cache and
+        // the previous snapshot survives (offline-first). saveUtxos merges, so
+        // only once the fetch succeeds do we prune spent coins the merge would
+        // otherwise keep — per address, mirroring updateDbAfterSettle.
         const boardingAddresses = await this.readonlyWallet.getBoardingAddresses();
+        const fresh = await this.readonlyWallet.getBoardingUtxos();
+        const freshKeys = new Set(fresh.map((u) => `${u.txid}:${u.vout}`));
         for (const addr of boardingAddresses) {
+            const cached = await this.walletRepository.getUtxos(addr);
+            const kept = cached.filter((u) => freshKeys.has(`${u.txid}:${u.vout}`));
+            if (kept.length === cached.length) continue; // nothing stale
             await this.walletRepository.deleteUtxos(addr);
+            if (kept.length > 0) await this.walletRepository.saveUtxos(addr, kept);
         }
-        await this.readonlyWallet.getBoardingUtxos();
 
         // Build transaction history from cached virtual outputs (no indexer call)
         const address = await this.readonlyWallet.getAddress();

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -37,7 +37,6 @@ import {
 import { DelegateInfo } from "../../providers/delegate";
 import { ReadonlyWallet, Wallet } from "../wallet";
 import type { RenewVtxosOptions } from "../vtxo-manager";
-import { extendCoin } from "../utils";
 import { MessageHandler, RequestEnvelope, ResponseEnvelope } from "../../worker/messageBus";
 import { Transaction } from "../../utils/transaction";
 import { buildTransactionHistory } from "../../utils/transactionHistory";
@@ -1316,12 +1315,14 @@ export class WalletMessageHandler
                     );
                 }
                 if (funds.type === "utxo") {
-                    const utxos = funds.coins.map((utxo) => extendCoin(this.readonlyWallet!, utxo));
-                    const boardingAddress = await this.readonlyWallet!.getBoardingAddress();
-                    // save boarding inputs using unified repository
-                    // TODO: remove UTXOs by address
-                    //  await this.walletRepository.clearUtxos(boardingAddress);
-                    await this.walletRepository?.saveUtxos(boardingAddress, utxos);
+                    // A deposit may land on the current OR a previous boarding
+                    // address (per-derivation rotation, plan §6-IV.2). The
+                    // notified `coins` carry no address, so re-fetch + re-cache
+                    // the full boarding-address set via getBoardingUtxos, which
+                    // buckets each UTXO under the address it sits on with the
+                    // correct per-UTXO tapscript — instead of assuming the
+                    // current boarding address.
+                    const utxos = await this.readonlyWallet!.getBoardingUtxos();
 
                     // notify all clients about the boarding input state update
                     this.scheduleForNextTick(() =>
@@ -1360,14 +1361,15 @@ export class WalletMessageHandler
         // Read virtual outputs from repository (now populated by contract manager)
         const vtxos = await this.getVtxosFromRepo();
 
-        // Fetch boarding inputs and save using unified repository
-        const boardingAddress = await this.readonlyWallet.getBoardingAddress();
-        const coins = await this.readonlyWallet.onchainProvider.getCoins(boardingAddress);
-        await this.walletRepository.deleteUtxos(boardingAddress);
-        await this.walletRepository.saveUtxos(
-            boardingAddress,
-            coins.map((utxo) => extendCoin(this.readonlyWallet!, utxo)),
-        );
+        // Fetch boarding inputs across the full boarding-address set (current +
+        // historical rotated; plan §6-IV.2). Clear each stale bucket first so
+        // spent coins drop, then let getBoardingUtxos re-fetch and re-save each
+        // address bucket with the correct per-UTXO tapscript.
+        const boardingAddresses = await this.readonlyWallet.getBoardingAddresses();
+        for (const addr of boardingAddresses) {
+            await this.walletRepository.deleteUtxos(addr);
+        }
+        await this.readonlyWallet.getBoardingUtxos();
 
         // Build transaction history from cached virtual outputs (no indexer call)
         const address = await this.readonlyWallet.getAddress();

--- a/packages/ts-sdk/src/wallet/signingErrors.ts
+++ b/packages/ts-sdk/src/wallet/signingErrors.ts
@@ -1,6 +1,6 @@
 /**
- * Thrown when a rotated contract (default or delegate) is missing the
- * metadata.signingDescriptor required to route it to a descriptor-aware
+ * Thrown when a rotated contract (default, delegate, or boarding) is missing
+ * the metadata.signingDescriptor required to route it to a descriptor-aware
  * signer.
  */
 export class MissingSigningDescriptorError extends Error {
@@ -8,7 +8,7 @@ export class MissingSigningDescriptorError extends Error {
 
     constructor(
         readonly contractScript: string,
-        readonly contractType: "default" | "delegate",
+        readonly contractType: "default" | "delegate" | "boarding",
     ) {
         super(
             `Cannot sign input for ${contractType} contract ${contractScript}: ` +

--- a/packages/ts-sdk/src/wallet/utils.ts
+++ b/packages/ts-sdk/src/wallet/utils.ts
@@ -24,16 +24,39 @@ export function getDustAmount(wallet: IWallet): bigint {
     return "dustAmount" in wallet ? (wallet.dustAmount as bigint) : FALLBACK_WALLET_DUST_AMOUNT;
 }
 
-export function extendCoin(
-    wallet: { boardingTapscript: ReadonlyWallet["boardingTapscript"] },
+/**
+ * Annotate an on-chain boarding {@link Coin} with the forfeit/intent leaves
+ * and tap tree of a *specific* boarding tapscript — the one the UTXO actually
+ * sits on, resolved by scriptPubKey.
+ *
+ * Under per-derivation boarding rotation (plan §6-II) a wallet can hold
+ * unspent boarding UTXOs at several historical boarding addresses at once, so
+ * the spending path must NOT assume the single current `boardingTapscript`;
+ * each UTXO is extended with the tapscript of its own address (plan §6-III.2).
+ */
+export function extendCoinWithTapscript(
+    boardingTapscript: DefaultVtxo.Script,
     utxo: Coin,
 ): ExtendedCoin {
     return {
         ...utxo,
-        forfeitTapLeafScript: wallet.boardingTapscript.forfeit(),
-        intentTapLeafScript: wallet.boardingTapscript.forfeit(),
-        tapTree: wallet.boardingTapscript.encode(),
+        forfeitTapLeafScript: boardingTapscript.forfeit(),
+        intentTapLeafScript: boardingTapscript.forfeit(),
+        tapTree: boardingTapscript.encode(),
     };
+}
+
+/**
+ * Annotate a boarding {@link Coin} with the wallet's *current* boarding
+ * tapscript. Kept for callers that only ever deal with the current boarding
+ * address; the multi-address spending path uses {@link extendCoinWithTapscript}
+ * with the per-UTXO tapscript instead.
+ */
+export function extendCoin(
+    wallet: { boardingTapscript: ReadonlyWallet["boardingTapscript"] },
+    utxo: Coin,
+): ExtendedCoin {
+    return extendCoinWithTapscript(wallet.boardingTapscript, utxo);
 }
 
 /**

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -14,7 +14,7 @@ import { maybeArkError } from "../providers/errors";
 import { hasBoardingTxExpired } from "../utils/arkTransaction";
 import { CSVMultisigTapscript } from "../script/tapscript";
 import { hex } from "@scure/base";
-import { getSequence } from "../script/base";
+import { getSequence, scriptFromTapLeafScript, VtxoScript } from "../script/base";
 import { Transaction } from "../utils/transaction";
 import { TxWeightEstimator } from "../utils/txSizeEstimator";
 import { Estimator } from "../arkfee";
@@ -33,6 +33,13 @@ interface SweepCapableWallet extends IReadonlyWallet {
     onchainProvider: OnchainProvider;
     arkProvider: ArkProvider;
     network: Network;
+    /**
+     * Descriptor-aware signer for on-chain boarding exit/sweep txs. Routes
+     * each input to the identity (baseline) or its per-index descriptor
+     * (rotated boarding), so a sweep that batches UTXOs across boarding
+     * addresses signs each with the correct key (plan §6-III.3).
+     */
+    signOnchainBoardingTx(tx: Transaction): Promise<Transaction>;
 }
 
 /**
@@ -46,7 +53,8 @@ function isSweepCapable(wallet: IWallet): wallet is IWallet & SweepCapableWallet
         "boardingTapscript" in wallet &&
         "onchainProvider" in wallet &&
         "arkProvider" in wallet &&
-        "network" in wallet
+        "network" in wallet &&
+        "signOnchainBoardingTx" in wallet
     );
 }
 
@@ -59,7 +67,7 @@ function isSweepCapable(wallet: IWallet): wallet is IWallet & SweepCapableWallet
 function assertSweepCapable(wallet: IWallet): asserts wallet is IWallet & SweepCapableWallet {
     if (!isSweepCapable(wallet)) {
         throw new Error(
-            "Boarding UTXO sweep requires a Wallet instance with boardingTapscript, onchainProvider, arkProvider, and network",
+            "Boarding UTXO sweep requires a Wallet instance with boardingTapscript, onchainProvider, arkProvider, network, and signOnchainBoardingTx",
         );
     }
 }
@@ -921,11 +929,11 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // Get fee rate from onchain provider
         const feeRate = (await this.getOnchainProvider().getFeeRate()) ?? 1;
 
-        // Get the exit tap leaf script for signing
+        // Representative exit leaf for fee estimation only. Every boarding
+        // exit leaf shares the same template (Alice + CSV) and so has an
+        // identical serialized size regardless of HD index — the actual
+        // per-UTXO leaf is resolved in the input loop below.
         const exitTapLeafScript = this.getBoardingExitLeaf();
-
-        // Estimate transaction size for fee calculation
-        const sequence = getSequence(exitTapLeafScript);
 
         // TapLeafScript: [{version, internalKey, merklePath}, scriptWithVersion]
         const leafScript = exitTapLeafScript[1];
@@ -956,22 +964,39 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         const tx = new Transaction();
 
         for (const utxo of expiredUtxos) {
+            // Resolve the exit (CSV) leaf and output script of the boarding
+            // address THIS UTXO actually sits on — not necessarily the current
+            // boarding address, since per-derivation rotation can leave unspent
+            // UTXOs at previous boarding addresses (plan §6-III.2). The per-UTXO
+            // boarding tapscript is carried on the ExtendedCoin's tapTree.
+            const utxoScript = VtxoScript.decode(utxo.tapTree);
+            const utxoExitLeaf = utxoScript.leaves.find((leaf) =>
+                CSVMultisigTapscript.isScriptValid(scriptFromTapLeafScript(leaf)),
+            );
+            if (!utxoExitLeaf) {
+                throw new Error(
+                    `Boarding sweep: no CSV exit leaf for UTXO ${utxo.txid}:${utxo.vout}`,
+                );
+            }
             tx.addInput({
                 txid: utxo.txid,
                 index: utxo.vout,
                 witnessUtxo: {
-                    script: this.getBoardingOutputScript(),
+                    script: utxoScript.pkScript,
                     amount: BigInt(utxo.value),
                 },
-                tapLeafScript: [exitTapLeafScript],
-                sequence,
+                tapLeafScript: [utxoExitLeaf],
+                sequence: getSequence(utxoExitLeaf),
             });
         }
 
         tx.addOutputAddress(boardingAddress, outputAmount, this.getNetwork());
 
-        // Sign and finalize
-        const signedTx = await this.getIdentity().sign(tx);
+        // Sign and finalize. Route each input to the correct key — the
+        // identity for index-0 / static boarding, the per-index descriptor for
+        // a rotated boarding UTXO (plan §6-III.3) — instead of signing every
+        // input with the index-0 identity key.
+        const signedTx = await this.getSweepWallet().signOnchainBoardingTx(tx);
         signedTx.finalize();
 
         // Broadcast
@@ -1011,11 +1036,6 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         return this.getSweepWallet().boardingTapscript.exit();
     }
 
-    /** Returns the pkScript (output script) of the boarding tapscript. */
-    private getBoardingOutputScript() {
-        return this.getSweepWallet().boardingTapscript.pkScript;
-    }
-
     /** Returns the onchain provider for fee estimation and broadcasting. */
     private getOnchainProvider() {
         return this.getSweepWallet().onchainProvider;
@@ -1029,11 +1049,6 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     /** Returns the Bitcoin network configuration from the wallet. */
     private getNetwork() {
         return this.getSweepWallet().network;
-    }
-
-    /** Returns the wallet's identity for transaction signing. */
-    private getIdentity() {
-        return this.wallet.identity;
     }
 
     private async initializeSubscription(): Promise<(() => void) | undefined> {

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -970,8 +970,9 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // UTXOs at previous boarding addresses (plan §6-III.2). The per-UTXO
             // boarding tapscript is carried on the ExtendedCoin's tapTree.
             const utxoScript = VtxoScript.decode(utxo.tapTree);
-            const utxoExitLeaf = utxoScript.leaves.find((leaf) =>
-                CSVMultisigTapscript.isScriptValid(scriptFromTapLeafScript(leaf)),
+            const utxoExitLeaf = utxoScript.leaves.find(
+                (leaf) =>
+                    CSVMultisigTapscript.isScriptValid(scriptFromTapLeafScript(leaf)) === true,
             );
             if (!utxoExitLeaf) {
                 throw new Error(

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -148,61 +148,19 @@ function dedupeTimelocks(timelocks: RelativeTimelock[]): RelativeTimelock[] {
 }
 
 /**
- * Whether two wallet baseline contract types may legitimately share a single
- * repository row when their scripts collide.
+ * Register a wallet baseline contract (`default` / `boarding`) idempotently.
  *
- * Contracts are keyed by their pkScript (`script` is the unique identity), so a
- * given script can own exactly one row. `default` and `boarding` are both built
- * from the same `DefaultVtxo.Script` shape and differ only by CSV timelock
- * value; when the offchain unilateral-exit delay and the boarding-exit delay
- * coincide, the two derive a byte-identical script and may share a single row
- * (the wallet coalesces such a collision onto `default` — see
- * {@link ensureWalletContract}). Same-type is trivially compatible. Every other
- * pairing (e.g. a `delegate` script, which carries an extra leaf and cannot
- * collide under normal semantics) is incompatible and signals a real
- * script/params mismatch.
- *
- * @internal Exported for unit tests; not part of the public API surface.
- */
-export function areSameScriptBaselineTypesCompatible(
-    existingType: string,
-    requestedType: string,
-): boolean {
-    if (existingType === requestedType) return true;
-    return (
-        (existingType === "default" && requestedType === "boarding") ||
-        (existingType === "boarding" && requestedType === "default")
-    );
-}
-
-/**
- * Register a wallet baseline contract (`default` / `boarding`) idempotently,
- * coalescing a same-script collision onto the `default` type.
- *
- * Contracts are keyed by script, so when `default` and `boarding` resolve to the
- * same pkScript the script can own only one row. This collision is degenerate: a
- * sound Ark server keeps `boardingExitDelay` strictly longer than the offchain
- * unilateral-exit delay (equal delays would expose the provider to a
- * double-spend), so in practice the two scripts differ and the boarding row
- * keeps its own identity. They can coincide only against a misconfigured /
- * malicious server — and even then the wallet must stay usable, so we coalesce
- * rather than throw.
- *
- * Resolution ("default wins" on a shared script):
- * - no existing row for the script → create it;
- * - existing row of the same type → {@link ContractManager.createContract} is a
- *   no-op (idempotent), so re-running initialization never duplicates;
- * - requested `default`, existing `boarding` (compatible) → promote the row to
- *   `default`. The shared script is also the wallet's live offchain baseline, so
- *   typing it `default` keeps it visible to the type-gated consumers
- *   (`notifyIncomingFunds`, `getWalletScripts`, `getScriptMap`);
- * - requested `boarding`, existing `default` (compatible) → accept as-is (the
- *   shared script is already canonical);
- * - existing row of an *incompatible* type → fall through to `createContract`,
- *   which throws its descriptive script/type mismatch error.
- *
- * Used only for the wallet's own `default` / `boarding` baseline contracts;
- * `delegate` creation stays strict (its script cannot collide with the others).
+ * Thin pass-through to {@link ContractManager.createContract}, which is now the
+ * single source of truth for the degenerate `default`/`boarding` same-script
+ * collision: contracts are keyed by pkScript, so when the two derive a
+ * byte-identical script (a misconfigured server whose `boardingExitDelay`
+ * coincides with the offchain unilateral-exit delay) only one row can exist for
+ * it, and `createContract` resolves the clash FIRST-WINS — it keeps the row
+ * already persisted for the shared script instead of throwing (see
+ * {@link areCoalescibleContractTypes}). The wallet-layer "default wins +
+ * promote" coalescing this helper used to carry has been consolidated into that
+ * one place so init and the restore scan share a single rule (see
+ * docs/hd-wallets_onchain_rotation_collision_fix.md §5.1, §5.3).
  *
  * @internal Exported for unit tests; not part of the public API surface.
  */
@@ -210,23 +168,6 @@ export async function ensureWalletContract(
     manager: ContractManager,
     params: CreateContractParams,
 ): Promise<void> {
-    const [existing] = await manager.getContracts({ script: params.script });
-    if (
-        existing &&
-        existing.type !== params.type &&
-        areSameScriptBaselineTypesCompatible(existing.type, params.type)
-    ) {
-        // Compatible collision (degenerate; sound servers keep the delays
-        // distinct). The script already persists and is watched, so the baseline
-        // purpose is served. Coalesce onto `default` ("default wins") so a shared
-        // script that is also the wallet's live offchain baseline stays
-        // discoverable through the type-gated consumers; otherwise the existing
-        // row is already `default`, so accept it as-is.
-        if (params.type === "default" && existing.type === "boarding") {
-            await manager.updateContract(params.script, { type: "default" });
-        }
-        return;
-    }
     await manager.createContract(params);
 }
 
@@ -1163,12 +1104,14 @@ export class ReadonlyWallet implements IReadonlyWallet {
             });
             const defaultScriptHex = hex.encode(defaultScript.pkScript);
 
-            // Use ensureWalletContract (not a strict createContract) so a
+            // ensureWalletContract (a thin pass-through to createContract) so a
             // default baseline whose script collides with an already-persisted
-            // `boarding` row promotes that row to `default` ("default wins")
-            // instead of throwing a type mismatch. Degenerate guard only: a
-            // sound server keeps the unilateral-exit and boarding-exit delays
-            // distinct, so these scripts never actually collide.
+            // `boarding` row is tolerated FIRST-WINS at the persistence layer
+            // instead of throwing a type mismatch. The default matrix is
+            // persisted before the boarding baseline below, so at index 0 the
+            // `default` row wins. Degenerate guard only: a sound server keeps
+            // the unilateral-exit and boarding-exit delays distinct, so these
+            // scripts never actually collide.
             await ensureWalletContract(manager, {
                 type: "default",
                 params: {
@@ -1229,9 +1172,10 @@ export class ReadonlyWallet implements IReadonlyWallet {
         // sound servers keep them distinct), the boarding script is
         // byte-identical to that default contract's script, so we cannot — and
         // need not — persist a second row: the shared script is already
-        // persisted and watched as a `default` contract ("default wins"), so
-        // funds landing on it stay visible/spendable. Re-running initialization
-        // is likewise a no-op once the row exists.
+        // persisted and watched as the `default` baseline (which was created
+        // first, so first-wins keeps it `default`), so funds landing on it stay
+        // visible/spendable. Re-running initialization is likewise a no-op once
+        // the row exists.
         const boardingCsvTimelock =
             this.boardingTapscript.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK;
         const baselineBoarding = new DefaultVtxo.Script({

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -216,7 +216,10 @@ export async function resolveBoardingBootTapscript(
     try {
         const pubKey = hex.decode(newest.params.pubKey);
         return new DefaultVtxo.Script({ ...baseline.options, pubKey });
-    } catch {
+    } catch (e) {
+        // Fall back to the baseline boarding tapscript rather than fail boot,
+        // but surface the corrupt row so repo corruption is detectable.
+        console.warn("Skipping malformed boarding contract at boot", newest.script, e);
         return baseline;
     }
 }
@@ -828,14 +831,23 @@ export class ReadonlyWallet implements IReadonlyWallet {
         // so fund discovery doesn't force contract-manager initialization as a
         // side effect; the boarding rows are persisted by init and the
         // allocator, which run earlier in the wallet lifecycle.
+        const serverPubKeyHex = hex.encode(this.boardingTapscript.options.serverPubKey);
         const boardingContracts = await this.contractRepository.getContracts({
             type: ["boarding"],
         });
         for (const c of boardingContracts) {
+            // Only this wallet's server. A row left by a previous ASP (e.g. a
+            // repo recovered against a different server) would otherwise emit a
+            // spurious onchain script — and a wasted getCoins/getTransactions
+            // call — on every boarding read. Mirrors the filter in
+            // resolveBoardingBootTapscript.
+            if (c.params.serverPubKey !== serverPubKeyHex) continue;
             try {
                 add(BoardingContractHandler.createScript(c.params));
-            } catch {
-                // Skip a malformed row rather than abort fund discovery.
+            } catch (e) {
+                // Skip a malformed row rather than abort fund discovery, but
+                // surface it so repo corruption is detectable.
+                console.warn("Skipping malformed boarding contract", c.script, e);
             }
         }
         return [...byScript.values()];
@@ -865,6 +877,13 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
     /**
      * Subscribe to onchain and offchain notifications for newly received funds.
+     *
+     * The boarding-address set is captured once, at call time. A boarding
+     * address allocated *after* subscribing (via {@link getNewBoardingAddress})
+     * is NOT added to the running watcher, so a deposit to it won't fire a
+     * notification until the subscription is torn down and re-created (e.g. the
+     * service worker's next init). Re-subscribe after rotating if the new
+     * address must be watched within the same session.
      *
      * @param eventCallback - Callback invoked when matching funds are detected
      * @returns A function that stops the subscriptions

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -357,6 +357,45 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }
 
     /**
+     * Listeners fired after the boarding tapscript rotates to a fresh index
+     * (see {@link Wallet.setBoardingTapscriptForRotation}). A live
+     * {@link notifyIncomingFunds} onchain watcher registers one so it can
+     * re-subscribe to include the newly allocated boarding address within the
+     * same session — without it, a deposit to the fresh address wouldn't fire
+     * a notification until the watcher's next re-init. Always empty for
+     * readonly / static / `auto` wallets, which never rotate boarding.
+     */
+    private readonly _boardingRotationListeners = new Set<() => void>();
+
+    /**
+     * Register a listener invoked synchronously after each boarding rotation.
+     * Returns an unsubscribe function. Protected: only internal subscribers
+     * (the incoming-funds watcher) participate.
+     */
+    protected onBoardingRotation(listener: () => void): () => void {
+        this._boardingRotationListeners.add(listener);
+        return () => {
+            this._boardingRotationListeners.delete(listener);
+        };
+    }
+
+    /**
+     * Notify boarding-rotation listeners. Called by the boarding-rotation
+     * write path ({@link Wallet.setBoardingTapscriptForRotation}) once the new
+     * tapscript is in place. A throwing listener is isolated so it can neither
+     * break the rotation nor starve sibling listeners.
+     */
+    protected notifyBoardingRotation(): void {
+        for (const listener of this._boardingRotationListeners) {
+            try {
+                listener();
+            } catch (e) {
+                console.warn("Boarding-rotation listener failed", e);
+            }
+        }
+    }
+
+    /**
      * Protected helper to set up shared wallet configuration.
      * Extracts common logic used by both ReadonlyWallet.create() and Wallet.create().
      */
@@ -878,55 +917,118 @@ export class ReadonlyWallet implements IReadonlyWallet {
     /**
      * Subscribe to onchain and offchain notifications for newly received funds.
      *
-     * The boarding-address set is captured once, at call time. A boarding
-     * address allocated *after* subscribing (via {@link getNewBoardingAddress})
-     * is NOT added to the running watcher, so a deposit to it won't fire a
-     * notification until the subscription is torn down and re-created (e.g. the
-     * service worker's next init). Re-subscribe after rotating if the new
-     * address must be watched within the same session.
+     * The onchain watcher tracks the full boarding-address set (current +
+     * historical rotated). When boarding rotates *after* subscribing — e.g.
+     * rotate-on-board allocates a fresh address via
+     * {@link getNewBoardingAddress} — the watcher automatically re-subscribes
+     * to widen its set, so a deposit to the new address fires a notification
+     * within the same session (no watcher re-init required). The re-subscribe
+     * is driven by {@link onBoardingRotation}; static / `auto` / readonly
+     * wallets never rotate boarding, so it never fires for them.
      *
      * @param eventCallback - Callback invoked when matching funds are detected
      * @returns A function that stops the subscriptions
      */
     async notifyIncomingFunds(eventCallback: (coins: IncomingFunds) => void): Promise<() => void> {
         const arkAddress = await this.getAddress();
-        // Watch the full boarding-address set (current + historical rotated),
-        // not just the current address, so a late deposit to a rotated-away
-        // address still fires a notification (plan §6-IV.2).
-        const boardingAddresses = await this.getBoardingAddresses();
-        const boardingAddressSet = new Set(boardingAddresses);
 
-        let onchainStopFunc: () => void;
-        let indexerStopFunc: () => void;
+        let onchainStopFunc: (() => void) | undefined;
+        let indexerStopFunc: (() => void) | undefined;
+        let boardingRotationStopFunc: (() => void) | undefined;
+        let stopped = false;
 
-        if (this.onchainProvider && boardingAddresses.length > 0) {
-            onchainStopFunc = await this.onchainProvider.watchAddresses(
-                boardingAddresses,
-                (txs) => {
-                    // Emit a coin for EVERY output that pays one of our boarding
-                    // addresses. A single tx can pay several (e.g. the current
-                    // and a rotated-away boarding address, now that boarding
-                    // fans out — plan §6-IV.2), so map per matching vout rather
-                    // than reporting only the first match per tx.
-                    const coins: Coin[] = txs.flatMap((tx) => {
-                        const { txid, status } = tx;
-                        const matched: Coin[] = [];
-                        tx.vout.forEach((v: any, vout: number) => {
-                            if (boardingAddressSet.has(v.scriptpubkey_address)) {
-                                matched.push({ txid, vout, value: Number(v.value), status });
-                            }
-                        });
-                        return matched;
-                    });
+        // (Re)subscribe the onchain watcher to the CURRENT boarding-address set.
+        // Serialized on a single chain so a burst of rotations can't interleave
+        // teardown/setup and leak a watcher. Re-reads `getBoardingAddresses()`
+        // each time: a rotation appends a new address, so the watcher must
+        // widen to include it while keeping the historical ones (plan §6-IV.2).
+        let onchainChain: Promise<void> = Promise.resolve();
+        const subscribeOnchain = (): Promise<void> => {
+            onchainChain = onchainChain
+                .then(async () => {
+                    if (stopped || !this.onchainProvider) return;
 
-                    // and notify via callback
-                    eventCallback({
-                        type: "utxo",
-                        coins,
-                    });
-                },
-            );
-        }
+                    const boardingAddresses = await this.getBoardingAddresses();
+                    if (boardingAddresses.length === 0) return;
+                    const boardingAddressSet = new Set(boardingAddresses);
+
+                    // Subscribe-then-swap: bring the NEW watcher up *before*
+                    // retiring the previous one. If `watchAddresses` throws, the
+                    // catch leaves `onchainStopFunc` (the old watcher) untouched,
+                    // so the subscription degrades to the stale set rather than
+                    // to no watcher at all; and there's no blind window where
+                    // neither is live (which would let a deposit be seeded as
+                    // "already known" history and never reported). The newly
+                    // allocated boarding address can't have received funds before
+                    // now — it was just derived — so the widened set needs no
+                    // separate reconciliation fetch.
+                    const previousStop = onchainStopFunc;
+                    const stop = await this.onchainProvider.watchAddresses(
+                        boardingAddresses,
+                        (txs) => {
+                            // Emit a coin for EVERY output that pays one of our
+                            // boarding addresses. A single tx can pay several
+                            // (e.g. the current and a rotated-away boarding
+                            // address, now that boarding fans out — plan
+                            // §6-IV.2), so map per matching vout rather than
+                            // reporting only the first match per tx.
+                            const coins: Coin[] = txs.flatMap((tx) => {
+                                const { txid, status } = tx;
+                                const matched: Coin[] = [];
+                                tx.vout.forEach((v: any, vout: number) => {
+                                    if (boardingAddressSet.has(v.scriptpubkey_address)) {
+                                        matched.push({
+                                            txid,
+                                            vout,
+                                            value: Number(v.value),
+                                            status,
+                                        });
+                                    }
+                                });
+                                return matched;
+                            });
+
+                            // and notify via callback
+                            eventCallback({
+                                type: "utxo",
+                                coins,
+                            });
+                        },
+                    );
+
+                    // `stopFunc` may have run while we awaited the subscribe. It
+                    // already stopped the previous watcher (then held in
+                    // `onchainStopFunc`), so only the fresh one needs tearing
+                    // down here — don't touch `previousStop` again.
+                    if (stopped) {
+                        stop();
+                        return;
+                    }
+
+                    // New watcher is live: promote it, then atomically retire
+                    // the old one. Brief overlap is fine — at worst a duplicate
+                    // notification, never a missed deposit.
+                    onchainStopFunc = stop;
+                    previousStop?.();
+                })
+                .catch((e) => {
+                    console.warn("Failed to (re)subscribe boarding-funds watcher", e);
+                });
+            return onchainChain;
+        };
+
+        // Widen the onchain watcher whenever boarding rotates (rotate-on-board
+        // / explicit allocation), so a deposit to the freshly allocated address
+        // is watched within this same session. Registered BEFORE the initial
+        // subscribe so a rotation that lands during initial setup still queues a
+        // re-subscribe on the chain (rather than being dropped, leaving the
+        // watcher stuck on the stale set). No-op for wallets that never rotate
+        // boarding.
+        boardingRotationStopFunc = this.onBoardingRotation(() => {
+            void subscribeOnchain();
+        });
+
+        await subscribeOnchain();
 
         if (this.indexerProvider && arkAddress) {
             // Share the ContractWatcher's single subscription instead of
@@ -968,7 +1070,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
         }
 
         const stopFunc = () => {
+            // Flag first so any in-flight (re)subscribe on `onchainChain` tears
+            // its fresh watcher down instead of leaking it.
+            stopped = true;
+            boardingRotationStopFunc?.();
             onchainStopFunc?.();
+            onchainStopFunc = undefined;
             indexerStopFunc?.();
         };
 
@@ -1319,6 +1426,10 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      */
     setBoardingTapscriptForRotation(tapscript: DefaultVtxo.Script): void {
         this._boardingTapscript = tapscript;
+        // Let live subscribers (the incoming-funds onchain watcher) widen to
+        // the freshly allocated boarding address. Harmless at boot — the
+        // boot-time restore runs before any subscription exists.
+        this.notifyBoardingRotation();
     }
 
     /**
@@ -2211,6 +2322,16 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
             await this.updateDbAfterSettle(params.inputs, commitmentTxid);
 
+            // Boarding rotation (rotate-on-board): if this settle swept any
+            // boarding (on-chain) UTXO into Arkade, advance the boarding
+            // address to a fresh HD index so the next deposit lands on a new
+            // address. This is the boarding analogue of the L2 receive
+            // rotation that runs on `vtxo_received` — boarding has no on-chain
+            // receival event (ContractWatcher watches only the L2 indexer), so
+            // the board itself is the trigger. Best-effort: it never fails an
+            // already-committed settle.
+            await this.maybeRotateBoardingAfterBoard(params.inputs);
+
             return commitmentTxid;
         } catch (error) {
             // delete the intent to not be stuck in the queue. If deletion fails
@@ -2235,6 +2356,42 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             // (e.g. safeRegisterIntent threw before Batch.join was called).
             abortController.abort();
             await stream?.return?.().catch(() => {});
+        }
+    }
+
+    /**
+     * Rotate the boarding address after a board (rotate-on-board trigger).
+     *
+     * Mirrors {@link WalletReceiveRotator}'s L2 rotation, but driven by a
+     * board instead of a `vtxo_received` event: when a settle consumes at
+     * least one boarding (on-chain) UTXO, the current boarding address has
+     * served its purpose, so we allocate a fresh one via
+     * {@link getNewBoardingAddress}. A settle that consumed only VTXOs (a
+     * renewal / offboard) is not a board and leaves the boarding address
+     * untouched.
+     *
+     * Boarding inputs are the non-VTXO coins (no `virtualStatus`), the same
+     * discriminator {@link handleSettlementFinalizationEvent} uses; the
+     * `typeof` guard skips arknote string inputs before the `in` test.
+     *
+     * No-ops for static / `auto` wallets (no descriptor provider — boarding
+     * stays on its fixed index-0 address). Best-effort and non-fatal: the
+     * settle has already committed and its txid must be returned, so a
+     * rotation failure is logged and swallowed rather than thrown. Funds at
+     * the retired boarding address remain discoverable — the old `boarding`
+     * contract stays active and {@link getBoardingUtxos} fans out over the
+     * full historical boarding set.
+     */
+    private async maybeRotateBoardingAfterBoard(inputs: SettleParams["inputs"]): Promise<void> {
+        if (!this._descriptorProvider) return;
+        const consumedBoarding = inputs.some(
+            (input) => typeof input !== "string" && !("virtualStatus" in input),
+        );
+        if (!consumedBoarding) return;
+        try {
+            await this.getNewBoardingAddress();
+        } catch (e) {
+            console.warn("Failed to rotate boarding address after board", e);
         }
     }
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -67,7 +67,7 @@ import { IndexerProvider, RestIndexerProvider } from "../providers/indexer";
 import { TxTree } from "../tree/txTree";
 import { WalletRepository } from "../repositories/walletRepository";
 import { ContractRepository } from "../repositories/contractRepository";
-import { extendCoin, validateRecipients } from "./utils";
+import { extendCoin, extendCoinWithTapscript, validateRecipients } from "./utils";
 import { ArkError } from "../providers/errors";
 import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
@@ -85,9 +85,11 @@ import { BoardingContractHandler } from "../contracts/handlers/boarding";
 import { timelockToSequence } from "../utils/timelock";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
 import { validateVtxosForScript, saveVtxosForContract } from "../contracts/vtxoOwnership";
-import { WalletReceiveRotator } from "./walletReceiveRotator";
+import { WalletReceiveRotator, signingDescriptorIndex } from "./walletReceiveRotator";
 import { HDDescriptorProvider } from "./hdDescriptorProvider";
 import { DescriptorProvider } from "../identity/descriptorProvider";
+import { deriveDescriptorLeafPubKey } from "../identity/descriptor";
+import { WALLET_RECEIVE_SOURCE } from "../contracts/metadata";
 import { DiscoveryDeps } from "../contracts/types";
 import { InputSignerRouter, InputSigningJob } from "./inputSignerRouter";
 import {
@@ -228,6 +230,56 @@ export async function ensureWalletContract(
     await manager.createContract(params);
 }
 
+/**
+ * Resolve the wallet's current boarding tapscript at boot.
+ *
+ * Mirrors {@link WalletReceiveRotator.resolveBoot} for the boarding domain:
+ * when the wallet rotates boarding (plan §6-II) the latest allocated boarding
+ * address is persisted as the newest `active` `boarding` contract tagged
+ * {@link WALLET_RECEIVE_SOURCE}. On restart this re-derives the boarding
+ * tapscript at that contract's pubkey so {@link Wallet.getBoardingAddress}
+ * keeps returning the most recently allocated boarding address.
+ *
+ * Returns the `baseline` boarding tapscript unchanged when no rotated boarding
+ * row exists (a fresh wallet, a never-rotated wallet, or — in the degenerate
+ * equal-delay case — an index-0 boarding row coalesced onto `default`). The
+ * boarding-exit CSV is index-independent, so the resolved tapscript reuses the
+ * baseline's options and swaps only the owner pubkey.
+ *
+ * @internal Exported for unit tests; not part of the public API surface.
+ */
+export async function resolveBoardingBootTapscript(
+    contractRepository: ContractRepository,
+    serverPubKey: Bytes,
+    baseline: DefaultVtxo.Script,
+): Promise<DefaultVtxo.Script> {
+    const serverPubKeyHex = hex.encode(serverPubKey);
+    const candidates = await contractRepository.getContracts({
+        type: ["boarding"],
+        state: "active",
+    });
+    const newest = candidates
+        .filter(
+            (c) =>
+                c.params.serverPubKey === serverPubKeyHex &&
+                c.metadata?.source === WALLET_RECEIVE_SOURCE,
+        )
+        .sort((a, b) => {
+            if (b.createdAt !== a.createdAt) return b.createdAt - a.createdAt;
+            return (
+                signingDescriptorIndex(b.metadata?.signingDescriptor) -
+                signingDescriptorIndex(a.metadata?.signingDescriptor)
+            );
+        })[0];
+    if (!newest?.params.pubKey) return baseline;
+    try {
+        const pubKey = hex.decode(newest.params.pubKey);
+        return new DefaultVtxo.Script({ ...baseline.options, pubKey });
+    } catch {
+        return baseline;
+    }
+}
+
 export type IncomingFunds =
     | {
           type: "utxo";
@@ -286,6 +338,18 @@ export class ReadonlyWallet implements IReadonlyWallet {
      */
     protected _offchainTapscript: DefaultVtxo.Script | DelegateVtxo.Script;
 
+    /**
+     * Backing field for the current boarding tapscript (the QR / onboarding
+     * target). Read via the public `boardingTapscript` getter; written only
+     * by {@link Wallet.setBoardingTapscriptForRotation}, the sanctioned
+     * boarding-rotation write path (analogue of `_offchainTapscript`). It is
+     * a *current value*, not a fixed setup constant, because per-derivation
+     * boarding rotation (plan §6-II) swaps it when a fresh boarding address
+     * is explicitly allocated. Static / `auto` wallets never rotate it, so
+     * it stays the index-0 baseline for their lifetime.
+     */
+    protected _boardingTapscript: DefaultVtxo.Script;
+
     protected constructor(
         readonly identity: ReadonlyIdentity,
         readonly network: Network,
@@ -293,7 +357,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         readonly indexerProvider: IndexerProvider,
         readonly arkServerPublicKey: Bytes,
         offchainTapscript: DefaultVtxo.Script | DelegateVtxo.Script,
-        readonly boardingTapscript: DefaultVtxo.Script,
+        boardingTapscript: DefaultVtxo.Script,
         readonly dustAmount: bigint,
         public readonly walletRepository: WalletRepository,
         public readonly contractRepository: ContractRepository,
@@ -317,6 +381,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             }
         }
         this._offchainTapscript = offchainTapscript;
+        this._boardingTapscript = boardingTapscript;
         this.watcherConfig = watcherConfig;
         this._assetManager = new ReadonlyAssetManager(this.indexerProvider);
         // Defensive for direct-construction callers; setupWalletConfig already
@@ -334,6 +399,17 @@ export class ReadonlyWallet implements IReadonlyWallet {
      */
     get offchainTapscript(): DefaultVtxo.Script | DelegateVtxo.Script {
         return this._offchainTapscript;
+    }
+
+    /**
+     * The wallet's current boarding tapscript (the on-chain onboarding
+     * target). Read-only from the outside; mutated only via
+     * {@link Wallet.setBoardingTapscriptForRotation} when a fresh boarding
+     * address is explicitly allocated. Single-valued for static / `auto`
+     * wallets.
+     */
+    get boardingTapscript(): DefaultVtxo.Script {
+        return this._boardingTapscript;
     }
 
     /**
@@ -674,7 +750,20 @@ export class ReadonlyWallet implements IReadonlyWallet {
         await clearSyncCursor(this.walletRepository);
     }
     /**
-     * Build a transaction history view for the wallet's boarding address.
+     * The on-chain (P2TR) addresses of every boarding tapscript this wallet
+     * uses — the current address plus any historical rotated boarding
+     * addresses. The aggregating boarding readers (history, notifications) fan
+     * out over this set so deposits at previous boarding addresses are still
+     * surfaced (plan §6-IV); {@link getBoardingAddress} stays single-valued.
+     */
+    async getBoardingAddresses(): Promise<string[]> {
+        const tapscripts = await this.getBoardingTapscripts();
+        return tapscripts.map((t) => t.onchainAddress(this.network));
+    }
+
+    /**
+     * Build a transaction history view across the wallet's boarding addresses
+     * (current + historical rotated; plan §6-IV.1).
      */
     async getBoardingTxs(): Promise<{
         boardingTxs: ArkTransaction[];
@@ -682,47 +771,54 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }> {
         const utxos: VirtualCoin[] = [];
         const commitmentsToIgnore = new Set<string>();
-        const boardingAddress = await this.getBoardingAddress();
-        const txs = await this.onchainProvider.getTransactions(boardingAddress);
+        const tapscripts = await this.getBoardingTapscripts();
 
         const outspendCache = new Map<
             string,
             Awaited<ReturnType<typeof this.onchainProvider.getTxOutspends>>
         >();
 
-        for (const tx of txs) {
-            for (let i = 0; i < tx.vout.length; i++) {
-                const vout = tx.vout[i];
-                if (vout.scriptpubkey_address === boardingAddress) {
-                    let spentStatuses = outspendCache.get(tx.txid);
-                    if (!spentStatuses) {
-                        spentStatuses = await this.onchainProvider.getTxOutspends(tx.txid);
-                        outspendCache.set(tx.txid, spentStatuses);
-                    }
-                    const spentStatus = spentStatuses[i];
+        for (const tapscript of tapscripts) {
+            const boardingAddress = tapscript.onchainAddress(this.network);
+            const scriptHex = hex.encode(tapscript.pkScript);
+            const txs = await this.onchainProvider.getTransactions(boardingAddress);
 
-                    if (spentStatus?.spent) {
-                        commitmentsToIgnore.add(spentStatus.txid);
-                    }
+            for (const tx of txs) {
+                for (let i = 0; i < tx.vout.length; i++) {
+                    const vout = tx.vout[i];
+                    if (vout.scriptpubkey_address === boardingAddress) {
+                        let spentStatuses = outspendCache.get(tx.txid);
+                        if (!spentStatuses) {
+                            spentStatuses = await this.onchainProvider.getTxOutspends(tx.txid);
+                            outspendCache.set(tx.txid, spentStatuses);
+                        }
+                        const spentStatus = spentStatuses[i];
 
-                    utxos.push({
-                        txid: tx.txid,
-                        vout: i,
-                        value: Number(vout.value),
-                        status: {
-                            confirmed: tx.status.confirmed,
-                            block_time: tx.status.block_time,
-                        },
-                        isUnrolled: true,
-                        virtualStatus: {
-                            state: spentStatus?.spent ? "spent" : "settled",
-                            commitmentTxIds: spentStatus?.spent ? [spentStatus.txid] : undefined,
-                        },
-                        createdAt: tx.status.confirmed
-                            ? new Date(tx.status.block_time * 1000)
-                            : new Date(0),
-                        script: hex.encode(this.boardingTapscript.pkScript),
-                    });
+                        if (spentStatus?.spent) {
+                            commitmentsToIgnore.add(spentStatus.txid);
+                        }
+
+                        utxos.push({
+                            txid: tx.txid,
+                            vout: i,
+                            value: Number(vout.value),
+                            status: {
+                                confirmed: tx.status.confirmed,
+                                block_time: tx.status.block_time,
+                            },
+                            isUnrolled: true,
+                            virtualStatus: {
+                                state: spentStatus?.spent ? "spent" : "settled",
+                                commitmentTxIds: spentStatus?.spent
+                                    ? [spentStatus.txid]
+                                    : undefined,
+                            },
+                            createdAt: tx.status.confirmed
+                                ? new Date(tx.status.block_time * 1000)
+                                : new Date(0),
+                            script: scriptHex,
+                        });
+                    }
                 }
             }
         }
@@ -759,20 +855,71 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }
 
     /**
-     * Fetch and cache onchain inputs (UTXOs) received at the boarding address.
+     * The set of boarding tapscripts whose on-chain UTXOs belong to this
+     * wallet — the current display tapscript plus every historical boarding
+     * address it has used. Under per-derivation rotation (plan §6-II) a wallet
+     * can hold unspent boarding UTXOs at several addresses at once, so fund
+     * discovery / spending must enumerate them all, not just the current one
+     * (plan §6-III.1). Deduplicated by scriptPubKey.
+     *
+     * Always includes the index-0 baseline (identity x-only key), which covers
+     * the degenerate equal-delay case where the index-0 boarding row is
+     * coalesced onto a `default` row and so isn't a `boarding`-typed contract.
+     */
+    protected async getBoardingTapscripts(): Promise<DefaultVtxo.Script[]> {
+        const byScript = new Map<string, DefaultVtxo.Script>();
+        const add = (s: DefaultVtxo.Script) => byScript.set(hex.encode(s.pkScript), s);
+
+        const boardingCsv =
+            this.boardingTapscript.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK;
+        // Index-0 baseline boarding (identity x-only key) — always in scope.
+        add(
+            new DefaultVtxo.Script({
+                pubKey: await this.identity.xOnlyPublicKey(),
+                serverPubKey: this.boardingTapscript.options.serverPubKey,
+                csvTimelock: boardingCsv,
+            }),
+        );
+        // Current display boarding tapscript (may be a rotated index).
+        add(this.boardingTapscript);
+        // Every persisted boarding contract — current + historical rotated.
+        // Read the contract repository directly (not via getContractManager)
+        // so fund discovery doesn't force contract-manager initialization as a
+        // side effect; the boarding rows are persisted by init and the
+        // allocator, which run earlier in the wallet lifecycle.
+        const boardingContracts = await this.contractRepository.getContracts({
+            type: ["boarding"],
+        });
+        for (const c of boardingContracts) {
+            try {
+                add(BoardingContractHandler.createScript(c.params));
+            } catch {
+                // Skip a malformed row rather than abort fund discovery.
+            }
+        }
+        return [...byScript.values()];
+    }
+
+    /**
+     * Fetch and cache onchain inputs (UTXOs) received at the wallet's boarding
+     * addresses — the current address plus any historical rotated boarding
+     * addresses that still hold unspent UTXOs (plan §6-III.1). Each UTXO is
+     * annotated with the tapscript of the address it actually sits on, so the
+     * spending path forfeits / exits it with the correct per-index leaves.
      */
     async getBoardingUtxos(): Promise<ExtendedCoin[]> {
-        const boardingAddress = await this.getBoardingAddress();
-        const boardingUtxos = await this.onchainProvider.getCoins(boardingAddress);
-
-        const utxos = boardingUtxos.map((utxo) => {
-            return extendCoin(this, utxo);
-        });
-
-        // Save boarding inputs using unified repository
-        await this.walletRepository.saveUtxos(boardingAddress, utxos);
-
-        return utxos;
+        const tapscripts = await this.getBoardingTapscripts();
+        const all: ExtendedCoin[] = [];
+        for (const tapscript of tapscripts) {
+            const address = tapscript.onchainAddress(this.network);
+            const coins = await this.onchainProvider.getCoins(address);
+            const utxos = coins.map((utxo) => extendCoinWithTapscript(tapscript, utxo));
+            // Save boarding inputs using unified repository, keyed by the
+            // address the UTXOs actually sit on.
+            await this.walletRepository.saveUtxos(address, utxos);
+            all.push(...utxos);
+        }
+        return all;
     }
 
     /**
@@ -783,29 +930,34 @@ export class ReadonlyWallet implements IReadonlyWallet {
      */
     async notifyIncomingFunds(eventCallback: (coins: IncomingFunds) => void): Promise<() => void> {
         const arkAddress = await this.getAddress();
-        const boardingAddress = await this.getBoardingAddress();
+        // Watch the full boarding-address set (current + historical rotated),
+        // not just the current address, so a late deposit to a rotated-away
+        // address still fires a notification (plan §6-IV.2).
+        const boardingAddresses = await this.getBoardingAddresses();
+        const boardingAddressSet = new Set(boardingAddresses);
 
         let onchainStopFunc: () => void;
         let indexerStopFunc: () => void;
 
-        if (this.onchainProvider && boardingAddress) {
-            const findVoutOnTx = (tx: any) => {
-                return tx.vout.findIndex((v: any) => v.scriptpubkey_address === boardingAddress);
-            };
+        if (this.onchainProvider && boardingAddresses.length > 0) {
             onchainStopFunc = await this.onchainProvider.watchAddresses(
-                [boardingAddress],
+                boardingAddresses,
                 (txs) => {
-                    // find all onchain outputs belonging to our boarding address
-                    const coins: Coin[] = txs
-                        // filter txs where address is in output
-                        .filter((tx) => findVoutOnTx(tx) !== -1)
-                        // return boarding input as Coin
-                        .map((tx) => {
-                            const { txid, status } = tx;
-                            const vout = findVoutOnTx(tx);
-                            const value = Number(tx.vout[vout].value);
-                            return { txid, vout, value, status };
+                    // Emit a coin for EVERY output that pays one of our boarding
+                    // addresses. A single tx can pay several (e.g. the current
+                    // and a rotated-away boarding address, now that boarding
+                    // fans out — plan §6-IV.2), so map per matching vout rather
+                    // than reporting only the first match per tx.
+                    const coins: Coin[] = txs.flatMap((tx) => {
+                        const { txid, status } = tx;
+                        const matched: Coin[] = [];
+                        tx.vout.forEach((v: any, vout: number) => {
+                            if (boardingAddressSet.has(v.scriptpubkey_address)) {
+                                matched.push({ txid, vout, value: Number(v.value), status });
+                            }
                         });
+                        return matched;
+                    });
 
                     // and notify via callback
                     eventCallback({
@@ -1055,15 +1207,21 @@ export class ReadonlyWallet implements IReadonlyWallet {
             }
         }
 
-        // Boarding contract: persisted from the same handler-produced boarding
-        // script the wallet uses (this.boardingTapscript). Created `active` so
-        // ContractWatcher monitors the boarding Arkade address and any VTXOs
-        // that land on the (valid) boarding script are visible and spendable
-        // through the normal contract paths — even though the SDK does not
-        // promote the boarding Arkade address as an L2 receive address.
-        // getBoardingAddress() does not depend on this contract (it derives from
-        // this.boardingTapscript directly), keeping the lazy contract-manager
-        // lifecycle intact.
+        // Boarding contract: the wallet's permanent INDEX-0 baseline boarding
+        // script. Bound to the identity's x-only pubkey (`baselinePubkey`) —
+        // NOT `this.boardingTapscript`, which is a *current value* that
+        // per-derivation rotation (plan §6-II) may have advanced to a higher
+        // index. Like the default/delegate matrix above, the baseline boarding
+        // row must stay anchored at index 0 so funds landing on the baseline
+        // address are always visible/spendable, independent of rotation.
+        // Rotated boarding rows are persisted separately (tagged) by the
+        // boarding allocator. The boarding-exit CSV is index-independent, so it
+        // is read from the current `boardingTapscript.options`.
+        //
+        // Created `active` so ContractWatcher monitors the boarding Arkade
+        // address. getBoardingAddress() does not depend on this contract (it
+        // derives from `this.boardingTapscript` directly), keeping the lazy
+        // contract-manager lifecycle intact.
         //
         // Create-if-missing via ensureWalletContract (idempotent): contracts
         // are keyed by script. In the degenerate case where boardingExitDelay
@@ -1074,20 +1232,22 @@ export class ReadonlyWallet implements IReadonlyWallet {
         // persisted and watched as a `default` contract ("default wins"), so
         // funds landing on it stay visible/spendable. Re-running initialization
         // is likewise a no-op once the row exists.
-        const boardingScriptHex = hex.encode(this.boardingTapscript.pkScript);
         const boardingCsvTimelock =
             this.boardingTapscript.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK;
+        const baselineBoarding = new DefaultVtxo.Script({
+            pubKey: baselinePubkey,
+            serverPubKey: this.boardingTapscript.options.serverPubKey,
+            csvTimelock: boardingCsvTimelock,
+        });
         await ensureWalletContract(manager, {
             type: "boarding",
             params: {
-                pubKey: hex.encode(this.boardingTapscript.options.pubKey),
-                serverPubKey: hex.encode(this.boardingTapscript.options.serverPubKey),
+                pubKey: hex.encode(baselineBoarding.options.pubKey),
+                serverPubKey: hex.encode(baselineBoarding.options.serverPubKey),
                 csvTimelock: timelockToSequence(boardingCsvTimelock).toString(),
             },
-            script: boardingScriptHex,
-            address: this.boardingTapscript
-                .address(this.network.hrp, this.arkServerPublicKey)
-                .encode(),
+            script: hex.encode(baselineBoarding.pkScript),
+            address: baselineBoarding.address(this.network.hrp, this.arkServerPublicKey).encode(),
             state: "active",
         });
 
@@ -1186,6 +1346,80 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      */
     setOffchainTapscriptForRotation(tapscript: DefaultVtxo.Script | DelegateVtxo.Script): void {
         this._offchainTapscript = tapscript;
+    }
+
+    /**
+     * @internal Sole write path for `boardingTapscript` after construction.
+     * Called by {@link Wallet.getNewBoardingAddress} once the rotated
+     * boarding contract has been persisted. External code must treat
+     * `boardingTapscript` as read-only.
+     */
+    setBoardingTapscriptForRotation(tapscript: DefaultVtxo.Script): void {
+        this._boardingTapscript = tapscript;
+    }
+
+    /**
+     * Allocate and return a *fresh* on-chain boarding address, rotating the
+     * wallet's current boarding tapscript to a new HD index.
+     *
+     * This is the explicit boarding allocator — the analogue of dotnet's
+     * `GetNextContract(NextContractPurpose.Boarding)`. Unlike
+     * {@link getBoardingAddress} (a stable read of the current display
+     * address that never burns an index), each call here:
+     *
+     * - allocates the next index from the shared HD stream (so boarding and
+     *   L2 receive interleave on one monotonic index);
+     * - builds the boarding tapscript at that index with the boarding-exit
+     *   CSV;
+     * - persists an `active` `boarding` contract tagged
+     *   {@link WALLET_RECEIVE_SOURCE} (with its `signingDescriptor`) so the
+     *   ContractWatcher monitors it, boot can restore it as the current
+     *   boarding address, and descriptor-aware signing can recover the
+     *   per-index key;
+     * - swaps the wallet's current `boardingTapscript`.
+     *
+     * Gated by `walletMode`: a static / `auto` wallet has no descriptor
+     * provider and keeps a single index-0 boarding address for its lifetime,
+     * so this returns the existing {@link getBoardingAddress} unchanged
+     * (no rotation, no index burned).
+     */
+    async getNewBoardingAddress(): Promise<string> {
+        const provider = this._descriptorProvider;
+        if (!provider) {
+            // Static / `auto`: single fixed boarding address, no rotation.
+            return this.getBoardingAddress();
+        }
+
+        const descriptor = await provider.getNextSigningDescriptor();
+        const pubKey = deriveDescriptorLeafPubKey(descriptor);
+        const newBoarding = new DefaultVtxo.Script({
+            ...this._boardingTapscript.options,
+            pubKey,
+        });
+        const csvTimelock = newBoarding.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK;
+
+        const manager = await this.getContractManager();
+        // Persist BEFORE swapping the visible tapscript: if registration
+        // throws, the wallet keeps displaying the previous (registered)
+        // boarding address — never an unwatched one (mirrors `rotate()`).
+        await manager.createContract({
+            type: "boarding",
+            params: {
+                pubKey: hex.encode(pubKey),
+                serverPubKey: hex.encode(newBoarding.options.serverPubKey),
+                csvTimelock: timelockToSequence(csvTimelock).toString(),
+            },
+            script: hex.encode(newBoarding.pkScript),
+            address: newBoarding.address(this.network.hrp, this.arkServerPublicKey).encode(),
+            state: "active",
+            metadata: {
+                source: WALLET_RECEIVE_SOURCE,
+                signingDescriptor: descriptor,
+            },
+        });
+
+        this.setBoardingTapscriptForRotation(newBoarding);
+        return newBoarding.onchainAddress(this.network);
     }
 
     /**
@@ -1305,8 +1539,16 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             indexerProvider: this.indexerProvider,
             onchainProvider: this.onchainProvider,
             network: { hrp: this.network.hrp },
+            // Full network for the boarding on-chain (P2TR) probe — the
+            // `{ hrp }` shape above lacks the `bech32` data
+            // `VtxoScript.onchainAddress` needs (plan §6-I.1).
+            onchainNetwork: this.network,
             serverPubKey: this.offchainTapscript.options.serverPubKey,
             csvTimelocks: this.walletContractTimelocks,
+            // Boarding-exit CSV so the boarding handler can build its
+            // candidate script (distinct from the unilateral-exit matrix).
+            boardingTimelock:
+                this.boardingTapscript.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK,
             delegatePubKey,
         };
 
@@ -1579,6 +1821,25 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             boot?.rotator,
             boot?.provider,
         );
+
+        // Boarding boot (plan §6-II.3): when HD/boarding rotation is active (a
+        // provider resolved), restore the most recently allocated boarding
+        // address from the repo so `getBoardingAddress()` survives restarts.
+        // The constructor was handed the index-0 baseline boarding tapscript
+        // (so `InputSignerRouter`'s boarding fallback and the init-time
+        // baseline boarding row both anchor to index 0); we swap the wallet's
+        // *current* boarding tapscript here. Static / `auto` wallets have no
+        // provider and keep the baseline.
+        if (boot?.provider) {
+            const resolvedBoarding = await resolveBoardingBootTapscript(
+                setup.contractRepository,
+                setup.serverPubKey,
+                setup.boardingTapscript,
+            );
+            if (resolvedBoarding !== setup.boardingTapscript) {
+                wallet.setBoardingTapscriptForRotation(resolvedBoarding);
+            }
+        }
 
         await wallet.getVtxoManager();
         return wallet;
@@ -2295,6 +2556,20 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             if (script) jobs.push({ index, lookupScript: script });
         }
         return jobs;
+    }
+
+    /**
+     * @internal Sign an on-chain boarding exit / sweep transaction, routing
+     * each input to the correct key by its `witnessUtxo.script`: the identity
+     * for index-0 / static boarding, the per-index descriptor for a rotated
+     * boarding UTXO (plan §6-III.3). Used by
+     * {@link VtxoManager.sweepExpiredBoardingUtxos}; without it, the
+     * unilateral exit of a rotated boarding UTXO would be signed with the
+     * wrong (index-0) key and rejected.
+     */
+    async signOnchainBoardingTx(tx: Transaction): Promise<Transaction> {
+        const signed = await this._signerRouter.sign(tx, this.inputSigningJobsFromWitnessUtxos(tx));
+        return signed as Transaction;
     }
 
     async safeRegisterIntent(
@@ -3071,11 +3346,14 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         commitmentTxid: string,
     ): Promise<void> {
         try {
-            const boardingAddress = await this.getBoardingAddress();
-
             const spentVtxos: ExtendedVirtualCoin[] = [];
             const inputArkTxIds = new Set<string>();
-            const boardingUtxoToRemove = new Set<string>();
+            // Boarding inputs to remove, grouped by the address they actually
+            // sit on. Under per-derivation rotation a settled boarding UTXO may
+            // have been received at a *previous* boarding address, so the
+            // cleanup must delete from the bucket the UTXO lives in — not just
+            // the current `getBoardingAddress()` bucket (plan §6-III.4).
+            const boardingRemovalsByAddress = new Map<string, Set<string>>();
 
             const isVtxo = (input: ExtendedCoin): input is ExtendedVirtualCoin =>
                 "virtualStatus" in input;
@@ -3101,8 +3379,28 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                         isSpent: true,
                     });
                 } else {
-                    // boarding input = remove it
-                    boardingUtxoToRemove.add(`${input.txid}:${input.vout}`);
+                    // boarding input = remove it from the bucket of the
+                    // address it actually sits on. The source boarding address
+                    // is recoverable from the input's tapTree (its leaves
+                    // determine the tweaked key → on-chain P2TR), so a UTXO
+                    // received at a rotated-away boarding address is cleaned up
+                    // in its own bucket rather than the current one. Fall back
+                    // to the current boarding address if the tapTree can't be
+                    // decoded (defensive — real inputs always carry it).
+                    let sourceAddress: string;
+                    try {
+                        sourceAddress = VtxoScript.decode(input.tapTree).onchainAddress(
+                            this.network,
+                        );
+                    } catch {
+                        sourceAddress = this.boardingTapscript.onchainAddress(this.network);
+                    }
+                    let set = boardingRemovalsByAddress.get(sourceAddress);
+                    if (!set) {
+                        set = new Set();
+                        boardingRemovalsByAddress.set(sourceAddress, set);
+                    }
+                    set.add(`${input.txid}:${input.vout}`);
                 }
             }
 
@@ -3145,15 +3443,13 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 }
             }
 
-            if (boardingUtxoToRemove.size > 0) {
-                const currentUtxos = await this.walletRepository.getUtxos(boardingAddress);
-                const filtered = currentUtxos.filter(
-                    (u) => !boardingUtxoToRemove.has(`${u.txid}:${u.vout}`),
-                );
-                // Clear and re-save the filtered list
-                await this.walletRepository.deleteUtxos(boardingAddress);
+            for (const [address, toRemove] of boardingRemovalsByAddress) {
+                const currentUtxos = await this.walletRepository.getUtxos(address);
+                const filtered = currentUtxos.filter((u) => !toRemove.has(`${u.txid}:${u.vout}`));
+                // Clear and re-save the filtered list for this address bucket.
+                await this.walletRepository.deleteUtxos(address);
                 if (filtered.length > 0) {
-                    await this.walletRepository.saveUtxos(boardingAddress, filtered);
+                    await this.walletRepository.saveUtxos(address, filtered);
                 }
             }
         } catch (e) {

--- a/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
+++ b/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
@@ -34,6 +34,17 @@ export interface ReceiveRotatorBootOpts {
      */
     expectedContractType?: "default" | "delegate";
     /**
+     * The wallet's baseline (index-0) receive pubkey — the x-only key the
+     * initial offchain tapscript is built from. Used by {@link
+     * WalletReceiveRotator.defaultBoot} as the no-tagged-row fallback:
+     * because boarding shares the single HD index stream, the raw watermark
+     * may have been advanced by a boarding-only allocation, so the boot must
+     * NOT derive the receive pubkey from it. A wallet with no tagged receive
+     * row has never rotated L2, so its correct current receive *is* the
+     * baseline index-0 key (plan §6-II.5).
+     */
+    baselineReceivePubKey?: Uint8Array;
+    /**
      * Logger to receive rotation-failure + backoff diagnostics. Defaults
      * to `console` when omitted. Any object implementing
      * {@link Logger.error} works (winston, pino, Sentry breadcrumbs,
@@ -295,6 +306,7 @@ export class WalletReceiveRotator {
             contractRepository: setup.contractRepository,
             serverPubKey: setup.serverPubKey,
             expectedContractType,
+            baselineReceivePubKey: setup.offchainTapscript.options.pubKey,
         };
 
         let boot: ReceiveRotatorBoot | undefined;
@@ -359,21 +371,36 @@ export class WalletReceiveRotator {
             };
         }
 
-        // No tagged display contract on this repo. Avoid burning a
-        // fresh HD index per restart: re-derive the descriptor at the
-        // most recently allocated index when the provider supports it
-        // (HD-style allocators do; static / one-shot providers don't
-        // and fall through to a regular allocation, which is a no-op
-        // for them anyway).
-        let descriptor: string | undefined;
-        if (hasPeekableDescriptor(provider)) {
-            descriptor = await provider.getCurrentSigningDescriptor();
+        // No tagged display contract on this repo. Two cases:
+        //
+        // 1. Fresh repo (no watermark yet, or a non-peekable provider) —
+        //    allocate the first index to establish the watermark so the
+        //    first rotation advances to the next index instead of landing
+        //    back on the baseline. For HD the allocated index-0 leaf IS the
+        //    baseline receive pubkey.
+        //
+        // 2. Watermark already set but no tagged receive row — the wallet
+        //    has never rotated L2 (a rotation would have left a tagged row),
+        //    so its correct current receive is the BASELINE index-0 key. We
+        //    must NOT derive from the raw watermark: boarding shares the one
+        //    HD index stream, so a boarding-only allocation may have advanced
+        //    it past index 0, and reading it here would drift the receive
+        //    address onto a boarding index (plan §6-II.5). A partial repo
+        //    that lost its tag self-heals on the next restore() scan, which
+        //    re-tags rotated receive rows.
+        const current = hasPeekableDescriptor(provider)
+            ? await provider.getCurrentSigningDescriptor()
+            : undefined;
+        if (current === undefined) {
+            const descriptor = await provider.getNextSigningDescriptor();
+            return {
+                rotator: new WalletReceiveRotator(provider, undefined, opts.logger),
+                receivePubkey: deriveLeafPubkey(descriptor),
+            };
         }
-        descriptor ??= await provider.getNextSigningDescriptor();
-
         return {
             rotator: new WalletReceiveRotator(provider, undefined, opts.logger),
-            receivePubkey: deriveLeafPubkey(descriptor),
+            receivePubkey: opts.baselineReceivePubKey ?? deriveLeafPubkey(current),
         };
     }
 

--- a/packages/ts-sdk/test/contracts/handlers/boarding.test.ts
+++ b/packages/ts-sdk/test/contracts/handlers/boarding.test.ts
@@ -312,11 +312,13 @@ describe("BoardingContractHandler.discoverAt", () => {
         expect(out[0].script).toBe(hex.encode(boarding.pkScript));
     });
 
-    it("equal-delay collision coalesces onto a `default` row (default wins)", async () => {
+    it("equal-delay collision still emits a `boarding` row (collision resolved at persistence)", async () => {
         // Degenerate server: boardingExitDelay === unilateralExitDelay → the
-        // boarding script is byte-identical to a default candidate, so the hit
-        // must be emitted as `default` to avoid a same-script/different-type
-        // clash aborting the restore scan.
+        // boarding script is byte-identical to a default candidate. discoverAt
+        // no longer pre-coalesces onto `default`; it always emits `boarding`,
+        // and the same-script collision is absorbed first-wins at the
+        // persistence layer (ContractManager.upsertContract). csvTimelocks is
+        // not read by the boarding handler anymore.
         const shared = UNILATERAL_EXIT_DELAY;
         const script = boardingScript(shared);
         const funded = new Set([script.onchainAddress(onchainNetwork)]);
@@ -326,7 +328,7 @@ describe("BoardingContractHandler.discoverAt", () => {
             deps(funded, { boardingTimelock: shared, csvTimelocks: [shared] }),
         );
         expect(out).toHaveLength(1);
-        expect(out[0].type).toBe("default");
+        expect(out[0].type).toBe("boarding");
         expect(out[0].script).toBe(hex.encode(script.pkScript));
     });
 });

--- a/packages/ts-sdk/test/contracts/handlers/boarding.test.ts
+++ b/packages/ts-sdk/test/contracts/handlers/boarding.test.ts
@@ -182,24 +182,152 @@ describe("BoardingContractHandler param serialize/deserialize", () => {
     });
 });
 
-describe("BoardingContractHandler is not discoverable", () => {
-    it("does not implement discoverAt", () => {
-        expect((BoardingContractHandler as { discoverAt?: unknown }).discoverAt).toBeUndefined();
+describe("BoardingContractHandler is discoverable", () => {
+    it("implements discoverAt", () => {
+        expect(typeof (BoardingContractHandler as { discoverAt?: unknown }).discoverAt).toBe(
+            "function",
+        );
     });
 
-    it("isDiscoverable(BoardingContractHandler) is false", () => {
-        expect(isDiscoverable(BoardingContractHandler)).toBe(false);
-        // sanity: the default handler IS discoverable, proving the guard works
+    it("isDiscoverable(BoardingContractHandler) is true", () => {
+        expect(isDiscoverable(BoardingContractHandler)).toBe(true);
+        // sanity: the default handler is also discoverable, proving the guard works
         expect(isDiscoverable(DefaultContractHandler)).toBe(true);
     });
 
-    it("is excluded from the scanner's discoverable handler set", () => {
+    it("is included in the scanner's discoverable handler set", () => {
         const discoverables = contractHandlers
             .getRegisteredTypes()
             .map((t) => contractHandlers.get(t))
             .filter(isDiscoverable)
             .map((h) => h!.type);
-        expect(discoverables).not.toContain("boarding");
+        expect(discoverables).toContain("boarding");
+    });
+});
+
+describe("BoardingContractHandler.discoverAt", () => {
+    // Valid secp256k1 x-only points — deriveDescriptorLeafPubKey parses the
+    // descriptor, so the pubkey must be a real curve point (mirrors restore.test.ts).
+    const PK_HEX = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const SERVER_HEX = "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+    const PK = hex.decode(PK_HEX);
+    const SERVER = hex.decode(SERVER_HEX);
+    const descriptor = `tr(${PK_HEX})`;
+    // onchainAddress only reads `bech32` for taproot — a partial network is enough.
+    const onchainNetwork = { bech32: "bcrt", hrp: "tark" } as any;
+
+    const boardingScript = (csvTimelock = BOARDING_EXIT_DELAY) =>
+        new DefaultVtxo.Script({ pubKey: PK, serverPubKey: SERVER, csvTimelock });
+
+    const makeOnchain = (funded: Set<string>) =>
+        ({
+            async getCoins(address: string) {
+                return funded.has(address)
+                    ? [
+                          {
+                              txid: "00".repeat(32),
+                              vout: 0,
+                              value: 10_000,
+                              status: { confirmed: true },
+                          },
+                      ]
+                    : [];
+            },
+        }) as any;
+
+    const deps = (funded: Set<string>, overrides: Record<string, unknown> = {}) =>
+        ({
+            indexerProvider: {} as any,
+            onchainProvider: makeOnchain(funded),
+            network: { hrp: "tark" },
+            onchainNetwork,
+            serverPubKey: SERVER,
+            csvTimelocks: [UNILATERAL_EXIT_DELAY],
+            boardingTimelock: BOARDING_EXIT_DELAY,
+            ...overrides,
+        }) as any;
+
+    it("no-ops when boardingTimelock is absent (scanner harness)", async () => {
+        const funded = new Set([boardingScript().onchainAddress(onchainNetwork)]);
+        const out = await BoardingContractHandler.discoverAt(
+            0,
+            descriptor,
+            deps(funded, { boardingTimelock: undefined }),
+        );
+        expect(out).toEqual([]);
+    });
+
+    it("no-ops when onchainNetwork is absent", async () => {
+        const funded = new Set([boardingScript().onchainAddress(onchainNetwork)]);
+        const out = await BoardingContractHandler.discoverAt(
+            0,
+            descriptor,
+            deps(funded, { onchainNetwork: undefined }),
+        );
+        expect(out).toEqual([]);
+    });
+
+    it("misses when the on-chain address has no coins", async () => {
+        const out = await BoardingContractHandler.discoverAt(0, descriptor, deps(new Set()));
+        expect(out).toEqual([]);
+    });
+
+    it("hits at index 0 (baseline): untagged boarding row, Ark-address bucket, boarding CSV", async () => {
+        const script = boardingScript();
+        const funded = new Set([script.onchainAddress(onchainNetwork)]);
+        const out = await BoardingContractHandler.discoverAt(0, descriptor, deps(funded));
+        expect(out).toHaveLength(1);
+        const c = out[0];
+        expect(c.type).toBe("boarding");
+        expect(c.script).toBe(hex.encode(script.pkScript));
+        // The row's address is the *Ark* address (repo bucket key), NOT the
+        // on-chain P2TR used only for the getCoins probe.
+        expect(c.address).toBe(script.address("tark", SERVER).encode());
+        expect(c.address).not.toBe(script.onchainAddress(onchainNetwork));
+        // CSV is sourced from boardingTimelock, not csvTimelocks.
+        expect(c.params.csvTimelock).toBe(timelockToSequence(BOARDING_EXIT_DELAY).toString());
+        expect(c.metadata).toBeUndefined();
+    });
+
+    it("hits at a rotated index (>0): tagged with source + signingDescriptor", async () => {
+        const script = boardingScript();
+        const funded = new Set([script.onchainAddress(onchainNetwork)]);
+        const out = await BoardingContractHandler.discoverAt(3, descriptor, deps(funded));
+        expect(out).toHaveLength(1);
+        expect(out[0].metadata).toEqual({
+            source: "wallet-receive",
+            signingDescriptor: descriptor,
+        });
+    });
+
+    it("builds the candidate from boardingTimelock, not csvTimelocks", async () => {
+        // Fund ONLY the boarding-delay script; the unilateral-delay script at
+        // the same index is a distinct address and must not be the one probed.
+        const boarding = boardingScript(BOARDING_EXIT_DELAY);
+        const unilateral = boardingScript(UNILATERAL_EXIT_DELAY);
+        expect(hex.encode(boarding.pkScript)).not.toBe(hex.encode(unilateral.pkScript));
+        const funded = new Set([boarding.onchainAddress(onchainNetwork)]);
+        const out = await BoardingContractHandler.discoverAt(0, descriptor, deps(funded));
+        expect(out).toHaveLength(1);
+        expect(out[0].script).toBe(hex.encode(boarding.pkScript));
+    });
+
+    it("equal-delay collision coalesces onto a `default` row (default wins)", async () => {
+        // Degenerate server: boardingExitDelay === unilateralExitDelay → the
+        // boarding script is byte-identical to a default candidate, so the hit
+        // must be emitted as `default` to avoid a same-script/different-type
+        // clash aborting the restore scan.
+        const shared = UNILATERAL_EXIT_DELAY;
+        const script = boardingScript(shared);
+        const funded = new Set([script.onchainAddress(onchainNetwork)]);
+        const out = await BoardingContractHandler.discoverAt(
+            0,
+            descriptor,
+            deps(funded, { boardingTimelock: shared, csvTimelocks: [shared] }),
+        );
+        expect(out).toHaveLength(1);
+        expect(out[0].type).toBe("default");
+        expect(out[0].script).toBe(hex.encode(script.pkScript));
     });
 });
 

--- a/packages/ts-sdk/test/e2e/boardingRotation.test.ts
+++ b/packages/ts-sdk/test/e2e/boardingRotation.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it, beforeEach } from "vitest";
 import { generateMnemonic } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
-import { Wallet, EsploraProvider, MnemonicIdentity, RelativeTimelock } from "../../src";
+import { Wallet, EsploraProvider, MnemonicIdentity, RelativeTimelock, Ramps } from "../../src";
 import {
     beforeEachFaucet,
     createSharedRepos,
@@ -155,6 +155,55 @@ describe("Boarding HD rotation - multi-address discovery & sweep", () => {
             expect(swept.every((u) => !initialTxids.has(u.txid))).toBe(true);
 
             await wallet.dispose();
+        },
+    );
+});
+
+describe("Boarding HD rotation - rotate-on-board", () => {
+    beforeEach(beforeEachFaucet, 60_000);
+
+    it(
+        "rotates the boarding address after a boarding UTXO is boarded into Arkade",
+        { timeout: 120_000 },
+        async () => {
+            const mnemonic = generateMnemonic(wordlist);
+            const repos = createSharedRepos();
+            // Settlement disabled so the only board is the explicit one below —
+            // no background poll races the rotation assertion.
+            const wallet = await createHdWallet({ mnemonic, repos, settlementConfig: false });
+            try {
+                const before = await wallet.getBoardingAddress();
+
+                // Fund the current boarding address and confirm it.
+                faucetOnchain(before, 100_000);
+                await waitFor(async () => (await wallet.getBoardingUtxos()).length >= 1, {
+                    timeout: 60_000,
+                    interval: 2_000,
+                });
+                execCommand("nigiri rpc --generate 1");
+                await waitFor(
+                    async () => {
+                        const u = await wallet.getBoardingUtxos();
+                        return u.length >= 1 && u.every((c) => (c.status.block_height ?? 0) > 0);
+                    },
+                    { timeout: 30_000, interval: 2_000 },
+                );
+
+                // Board the UTXO into Arkade. rotate-on-board fires inside
+                // settle, so by the time onboard resolves the boarding address
+                // has already advanced to a fresh HD index.
+                const { fees } = await wallet.arkProvider.getInfo();
+                const settleTxid = await new Ramps(wallet).onboard(fees);
+                expect(settleTxid).toBeDefined();
+
+                const after = await wallet.getBoardingAddress();
+                expect(after).not.toBe(before);
+                // The retired address stays in the historical set, so any later
+                // deposit to it is still discoverable / spendable.
+                expect(await wallet.getBoardingAddresses()).toContain(before);
+            } finally {
+                await wallet.dispose();
+            }
         },
     );
 });

--- a/packages/ts-sdk/test/e2e/boardingRotation.test.ts
+++ b/packages/ts-sdk/test/e2e/boardingRotation.test.ts
@@ -1,0 +1,225 @@
+import { expect, describe, it, beforeEach } from "vitest";
+import { generateMnemonic } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
+import { Wallet, EsploraProvider, MnemonicIdentity, RelativeTimelock } from "../../src";
+import {
+    beforeEachFaucet,
+    createSharedRepos,
+    execCommand,
+    faucetOnchain,
+    SharedRepos,
+    waitFor,
+} from "./utils";
+
+/**
+ * End-to-end coverage for per-derivation boarding rotation (plan §6) against
+ * the regtest stack. The unit suite (`walletBoardingRotation.test.ts`) covers
+ * allocation / boot / discovery filtering in isolation; these tests exercise
+ * the parts only real chain + signer can: multi-address on-chain discovery,
+ * per-index-key sweep signing, and on-chain boarding discovery during
+ * `restore()`.
+ */
+
+interface HdWalletOpts {
+    mnemonic: string;
+    repos: SharedRepos;
+    settlementConfig: false | { boardingUtxoSweep?: boolean; pollIntervalMs?: number };
+    boardingTimelock?: RelativeTimelock;
+}
+
+function createHdWallet(opts: HdWalletOpts): Promise<Wallet> {
+    return Wallet.create({
+        identity: MnemonicIdentity.fromMnemonic(opts.mnemonic, { isMainnet: false }),
+        walletMode: "hd",
+        arkServerUrl: "http://localhost:7070",
+        onchainProvider: new EsploraProvider("http://localhost:3000", {
+            forcePolling: true,
+            pollingInterval: 2000,
+        }),
+        storage: {
+            walletRepository: opts.repos.walletRepository,
+            contractRepository: opts.repos.contractRepository,
+        },
+        settlementConfig: opts.settlementConfig,
+        ...(opts.boardingTimelock ? { boardingTimelock: opts.boardingTimelock } : {}),
+    });
+}
+
+async function waitForChainTip(minHeight: number): Promise<void> {
+    const esplora = new EsploraProvider("http://localhost:3000", {
+        forcePolling: true,
+        pollingInterval: 2000,
+    });
+    await waitFor(async () => (await esplora.getChainTip()).height >= minHeight, {
+        timeout: 30_000,
+        interval: 1_000,
+    });
+}
+
+describe("Boarding HD rotation - multi-address discovery & sweep", () => {
+    beforeEach(beforeEachFaucet, 60_000);
+
+    it(
+        "discovers and sweeps boarding UTXOs across current + rotated addresses",
+        { timeout: 180_000 },
+        async () => {
+            const mnemonic = generateMnemonic(wordlist);
+            const repos = createSharedRepos();
+            // Short boarding-exit CSV so we can expire and sweep within the test.
+            const boardingTimelock: RelativeTimelock = { type: "blocks", value: 20n };
+
+            // ── Phase 1: rotate, fund two boarding addresses, expire them ──
+            // Settlement disabled so no poll loop settles the UTXOs before we
+            // can drive the sweep deterministically in phase 2.
+            const setup = await createHdWallet({
+                mnemonic,
+                repos,
+                settlementConfig: false,
+                boardingTimelock,
+            });
+
+            const addr0 = await setup.getBoardingAddress(); // index-0 baseline
+            const addr1 = await setup.getNewBoardingAddress(); // rotated index-1 (now current)
+            expect(addr1).not.toBe(addr0);
+
+            // Fund the current AND a rotated-away boarding address.
+            faucetOnchain(addr0, 100_000);
+            faucetOnchain(addr1, 100_000);
+
+            // Multi-address fan-out: discovery must surface UTXOs at BOTH the
+            // baseline (index-0) and the rotated (index-1) address, not just
+            // the current one (plan §6-III.1).
+            await waitFor(async () => (await setup.getBoardingUtxos()).length >= 2, {
+                timeout: 60_000,
+                interval: 2_000,
+            });
+            const funded = await setup.getBoardingUtxos();
+            expect(funded).toHaveLength(2);
+            const boardingAddresses = await setup.getBoardingAddresses();
+            expect(boardingAddresses).toContain(addr0);
+            expect(boardingAddresses).toContain(addr1);
+            const initialTxids = new Set(funded.map((u) => u.txid));
+            expect(initialTxids.size).toBe(2);
+
+            // Confirm the faucet txs and read their funding height — the CSV
+            // exit delay counts from confirmation, so we must mature both
+            // inputs relative to the block they actually land in.
+            execCommand("nigiri rpc --generate 1");
+            await waitFor(
+                async () => {
+                    const u = await setup.getBoardingUtxos();
+                    return u.length >= 2 && u.every((c) => (c.status.block_height ?? 0) > 0);
+                },
+                { timeout: 30_000, interval: 2_000 },
+            );
+            const confirmed = await setup.getBoardingUtxos();
+            const fundingHeight = Math.max(...confirmed.map((c) => c.status.block_height ?? 0));
+
+            // Expire both inputs (CSV = 20 blocks).
+            execCommand("nigiri rpc --generate 20");
+            await waitForChainTip(fundingHeight + 20);
+            await setup.dispose();
+
+            // ── Phase 2: sweep wallet on the SAME repos auto-sweeps both ──
+            const wallet = await createHdWallet({
+                mnemonic,
+                repos,
+                boardingTimelock,
+                settlementConfig: { boardingUtxoSweep: true, pollIntervalMs: 5_000 },
+            });
+
+            // Boot restored the rotated index-1 as the current boarding address.
+            // (Don't assert the pre-sweep UTXO count here: the poll loop runs
+            // once immediately on init and may already be mid-sweep.)
+            expect(await wallet.getBoardingAddress()).toBe(addr1);
+
+            // The poll loop sweeps BOTH inputs in a single tx: the index-0 input
+            // is signed with the identity key, the index-1 input with its
+            // per-index descriptor key (plan §6-III.3), consolidating to the
+            // current (addr1) boarding address. A mis-routed signing key would
+            // produce an invalid tx that never confirms — so a successful sweep
+            // is itself the per-index-signing assertion. Mine a block per poll
+            // so the sweep tx confirms and the new UTXO enters esplora's set.
+            await waitFor(
+                async () => {
+                    execCommand("nigiri rpc --generate 1");
+                    const utxos = await wallet.getBoardingUtxos();
+                    return utxos.length > 0 && utxos.every((u) => !initialTxids.has(u.txid));
+                },
+                { timeout: 90_000, interval: 5_000 },
+            );
+
+            const swept = await wallet.getBoardingUtxos();
+            expect(swept.length).toBeGreaterThan(0);
+            // Every UTXO now carries a fresh txid — both originals were consumed.
+            expect(swept.every((u) => !initialTxids.has(u.txid))).toBe(true);
+
+            await wallet.dispose();
+        },
+    );
+});
+
+describe("Boarding HD rotation - restore()", () => {
+    beforeEach(beforeEachFaucet, 60_000);
+
+    it(
+        "rediscovers boarding funds at a rotated index a fresh same-seed repo cannot see",
+        { timeout: 180_000 },
+        async () => {
+            const mnemonic = generateMnemonic(wordlist);
+
+            // ── Wallet A: rotate boarding and fund the rotated address ──
+            const a = await createHdWallet({
+                mnemonic,
+                repos: createSharedRepos(),
+                settlementConfig: false,
+            });
+            try {
+                const addr0 = await a.getBoardingAddress();
+                const addr1 = await a.getNewBoardingAddress(); // rotated index-1
+                expect(addr1).not.toBe(addr0);
+
+                // Fund ONLY the rotated address — its script is one a fresh
+                // same-seed wallet's index-0 baseline coverage cannot derive.
+                faucetOnchain(addr1, 100_000);
+                await waitFor(async () => (await a.getBoardingUtxos()).length >= 1, {
+                    timeout: 60_000,
+                    interval: 2_000,
+                });
+                // Confirm so the on-chain discovery probe (getCoins) sees it.
+                execCommand("nigiri rpc --generate 1");
+                const fundedA = await a.getBoardingUtxos();
+                await waitForChainTip((fundedA[0].status.block_height ?? 0) + 1);
+
+                // ── Wallet B: same seed, HD mode, FRESH separate repos ──
+                const freshRepos = createSharedRepos();
+                const b = await createHdWallet({
+                    mnemonic,
+                    repos: freshRepos,
+                    settlementConfig: false,
+                });
+                try {
+                    // B's baseline auto-registration covers only index-0, so it
+                    // cannot see the rotated index-1 boarding UTXO yet.
+                    const before = await b.getBoardingUtxos();
+                    expect(before).toHaveLength(0);
+
+                    // restore() scans the HD index range; the boarding probe
+                    // (plan §6-I) discovers and registers the index-1 boarding
+                    // contract the baseline missed.
+                    await b.restore();
+
+                    const after = await b.getBoardingUtxos();
+                    expect(after.length).toBeGreaterThan(before.length);
+                    expect(after.length).toBeGreaterThanOrEqual(1);
+                    // The recovered UTXO sits at the rotated address.
+                    expect(await b.getBoardingAddresses()).toContain(addr1);
+                } finally {
+                    await b.dispose();
+                }
+            } finally {
+                await a.dispose();
+            }
+        },
+    );
+});

--- a/packages/ts-sdk/test/helpers/restoreWallet.ts
+++ b/packages/ts-sdk/test/helpers/restoreWallet.ts
@@ -192,11 +192,25 @@ function makeMockIndexer(usedScripts: Set<string>): MockIndexer {
     return indexer;
 }
 
-/** Mock onchain provider — the wallet has no boarding funds in these tests. */
-function makeMockOnchain(): OnchainProvider {
+/**
+ * Mock onchain provider. `fundedOnchain` is the set of on-chain (P2TR)
+ * addresses the provider reports as holding an unspent coin — the single
+ * signal the boarding discovery probe (`OnchainProvider.getCoins`) reads.
+ * Empty by default (no boarding funds), so existing restore tests are
+ * unaffected.
+ */
+function makeMockOnchain(fundedOnchain: Set<string> = new Set()): OnchainProvider {
     return {
-        async getCoins() {
-            return [];
+        async getCoins(address: string) {
+            if (!fundedOnchain.has(address)) return [];
+            return [
+                {
+                    txid: uniqueTxid(address),
+                    vout: 0,
+                    value: 25_000,
+                    status: { confirmed: true },
+                },
+            ];
         },
         async getTxOutspends() {
             return [];
@@ -224,6 +238,8 @@ function makeMockOnchain(): OnchainProvider {
 export interface RestoreWalletHandle {
     wallet: Wallet;
     indexer: MockIndexer;
+    /** On-chain (P2TR) addresses the mock onchain provider reports as funded. */
+    fundedOnchain: Set<string>;
     walletRepository: InMemoryWalletRepository;
     contractRepository: InMemoryContractRepository;
 }
@@ -236,6 +252,7 @@ export interface RestoreWalletHandle {
  */
 export async function makeStaticWalletForTest(
     usedScripts: Set<string> = new Set(),
+    fundedOnchain: Set<string> = new Set(),
 ): Promise<RestoreWalletHandle> {
     const indexer = makeMockIndexer(usedScripts);
     const walletRepository = new InMemoryWalletRepository();
@@ -245,10 +262,10 @@ export async function makeStaticWalletForTest(
         walletMode: "static",
         arkServerUrl: "http://localhost:7070",
         indexerProvider: indexer,
-        onchainProvider: makeMockOnchain(),
+        onchainProvider: makeMockOnchain(fundedOnchain),
         storage: { walletRepository, contractRepository },
     });
-    return { wallet, indexer, walletRepository, contractRepository };
+    return { wallet, indexer, fundedOnchain, walletRepository, contractRepository };
 }
 
 export interface HdRestoreWalletHandle extends RestoreWalletHandle {
@@ -264,6 +281,7 @@ export interface HdRestoreWalletHandle extends RestoreWalletHandle {
  */
 export async function makeHdWalletForTest(
     usedScripts: Set<string> = new Set(),
+    fundedOnchain: Set<string> = new Set(),
 ): Promise<HdRestoreWalletHandle> {
     const indexer = makeMockIndexer(usedScripts);
     const walletRepository = new InMemoryWalletRepository();
@@ -275,7 +293,7 @@ export async function makeHdWalletForTest(
         walletMode: "hd",
         arkServerUrl: "http://localhost:7070",
         indexerProvider: indexer,
-        onchainProvider: makeMockOnchain(),
+        onchainProvider: makeMockOnchain(fundedOnchain),
         storage: { walletRepository, contractRepository },
     });
     const resolved = (wallet as unknown as { _descriptorProvider?: unknown })._descriptorProvider;
@@ -294,6 +312,7 @@ export async function makeHdWalletForTest(
     return {
         wallet,
         indexer,
+        fundedOnchain,
         walletRepository,
         contractRepository,
         hdProvider,

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -934,6 +934,143 @@ describe("Wallet.restore", () => {
         }
     });
 
+    it("notifyIncomingFunds re-subscribes the onchain watcher when boarding rotates within the session", async () => {
+        const { wallet } = await makeHdWalletForTest();
+        try {
+            const baseline = await wallet.getBoardingAddress();
+            const rotated1 = await wallet.getNewBoardingAddress();
+
+            // Record each subscription's address set + a per-call stop spy.
+            const calls: string[][] = [];
+            const stops: Array<ReturnType<typeof vi.fn>> = [];
+            vi.spyOn(wallet.onchainProvider, "watchAddresses").mockImplementation(
+                async (addrs: string[]) => {
+                    calls.push(addrs);
+                    const stop = vi.fn();
+                    stops.push(stop);
+                    return stop;
+                },
+            );
+
+            const stop = await wallet.notifyIncomingFunds(() => {});
+            expect(calls).toHaveLength(1);
+            expect(new Set(calls[0])).toEqual(new Set([baseline, rotated1]));
+
+            // Rotate boarding AFTER subscribing — rotate-on-board's situation.
+            const rotated2 = await wallet.getNewBoardingAddress();
+
+            // The watcher re-subscribes to the widened set without a re-init,
+            // then (subscribe-then-swap) retires the prior watcher only once
+            // the new one is live — so wait for that teardown to land.
+            await vi.waitFor(() => {
+                expect(calls).toHaveLength(2);
+                expect(stops[0]).toHaveBeenCalledTimes(1);
+            });
+            expect(calls[1]).toContain(rotated2);
+            expect(new Set(calls[1])).toEqual(new Set([baseline, rotated1, rotated2]));
+
+            // After stop(), the live watcher is torn down and the rotation
+            // listener is unregistered — a later rotation no longer re-subscribes.
+            stop();
+            expect(stops[1]).toHaveBeenCalledTimes(1);
+            await wallet.getNewBoardingAddress();
+            await new Promise((r) => setTimeout(r, 20));
+            expect(calls).toHaveLength(2);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("notifyIncomingFunds keeps the existing watcher live when a re-subscribe fails (no on-chain gap)", async () => {
+        const { wallet } = await makeHdWalletForTest();
+        try {
+            await wallet.getNewBoardingAddress();
+
+            const calls: string[][] = [];
+            const stops: Array<ReturnType<typeof vi.fn>> = [];
+            let failNext = false;
+            vi.spyOn(wallet.onchainProvider, "watchAddresses").mockImplementation(
+                async (addrs: string[]) => {
+                    if (failNext) throw new Error("watchAddresses failed");
+                    calls.push(addrs);
+                    const stop = vi.fn();
+                    stops.push(stop);
+                    return stop;
+                },
+            );
+            const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+            const stop = await wallet.notifyIncomingFunds(() => {});
+            expect(calls).toHaveLength(1); // initial watcher live
+
+            // A rotation whose re-subscribe throws must NOT tear down the
+            // existing watcher (subscribe-then-swap): degrade to the stale set,
+            // never to no watcher at all.
+            failNext = true;
+            await wallet.getNewBoardingAddress();
+            await vi.waitFor(() =>
+                expect(warn).toHaveBeenCalledWith(
+                    "Failed to (re)subscribe boarding-funds watcher",
+                    expect.anything(),
+                ),
+            );
+            expect(stops[0]).not.toHaveBeenCalled(); // old watcher still live
+
+            // It is still the live watcher: stop() tears exactly it down.
+            stop();
+            expect(stops[0]).toHaveBeenCalledTimes(1);
+
+            warn.mockRestore();
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("notifyIncomingFunds does not miss a rotation that lands during initial subscribe setup", async () => {
+        const { wallet } = await makeHdWalletForTest();
+        try {
+            const baseline = await wallet.getBoardingAddress();
+            const rotated1 = await wallet.getNewBoardingAddress();
+
+            const calls: string[][] = [];
+            let signalFirstCalled!: () => void;
+            const firstCalled = new Promise<void>((r) => (signalFirstCalled = r));
+            let releaseFirst!: () => void;
+            const firstGate = new Promise<void>((r) => (releaseFirst = r));
+            vi.spyOn(wallet.onchainProvider, "watchAddresses").mockImplementation(
+                async (addrs: string[]) => {
+                    calls.push(addrs);
+                    if (calls.length === 1) {
+                        // Block the INITIAL subscribe so we can rotate while it
+                        // is mid-setup — the race Finding 2 is about.
+                        signalFirstCalled();
+                        await firstGate;
+                    }
+                    return vi.fn();
+                },
+            );
+
+            const notifyPromise = wallet.notifyIncomingFunds(() => {});
+            // Initial subscribe is now blocked in watchAddresses; the rotation
+            // listener was registered BEFORE this await, so the rotation below
+            // is observed and queued behind the initial subscribe on the chain.
+            await firstCalled;
+            const rotated2 = await wallet.getNewBoardingAddress();
+            releaseFirst();
+            const stop = await notifyPromise;
+
+            // The serialized chain runs the queued re-subscribe after the
+            // initial one, so the watcher ends up on the widened set rather than
+            // stuck on the pre-rotation addresses.
+            await vi.waitFor(() => expect(calls).toHaveLength(2));
+            expect(new Set(calls[1])).toEqual(new Set([baseline, rotated1, rotated2]));
+
+            stop();
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
     it("notifyIncomingFunds emits one coin per matching output, even when a tx pays two boarding addresses (review Finding 4)", async () => {
         const { wallet } = await makeHdWalletForTest();
         try {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -10,6 +10,7 @@ import { isDiscoverable } from "../src/contracts/types";
 import { timelockToSequence } from "../src/utils/timelock";
 import { DefaultContractHandler } from "../src/contracts/handlers/default";
 import { DelegateContractHandler } from "../src/contracts/handlers/delegate";
+import { BoardingContractHandler } from "../src/contracts/handlers/boarding";
 import { DefaultVtxo } from "../src/script/default";
 import { DelegateVtxo } from "../src/script/delegate";
 import { VtxoScript } from "../src/script/base";
@@ -584,6 +585,40 @@ describe("ContractManager.scanContracts", () => {
             mgr.dispose();
         }
     });
+
+    it("probes boarding before default/delegate (load-bearing first-wins tie-break)", async () => {
+        // The iteration order IS the first-wins tie-break: each hit is
+        // persisted immediately, so a both-purpose equal-delay collision
+        // resolves to whichever handler is probed first. Boarding must be
+        // first so such a collision resolves to a `boarding` row (keeping the
+        // on-chain UTXO visible to the type-gated getBoardingUtxos). Guards
+        // against a future reorder of the registered handlers.
+        const order: string[] = [];
+        const spies = [
+            vi.spyOn(BoardingContractHandler, "discoverAt").mockImplementation(async () => {
+                order.push("boarding");
+                return [];
+            }),
+            vi.spyOn(DefaultContractHandler, "discoverAt").mockImplementation(async () => {
+                order.push("default");
+                return [];
+            }),
+            vi.spyOn(DelegateContractHandler, "discoverAt").mockImplementation(async () => {
+                order.push("delegate");
+                return [];
+            }),
+        ];
+        const mgr = await makeManagerForTest();
+        try {
+            await mgr.scanContracts({ gapLimit: 1, hd: false, materialize, deps: makeDeps() });
+            expect(order).toContain("boarding");
+            expect(order.indexOf("boarding")).toBeLessThan(order.indexOf("default"));
+            expect(order.indexOf("boarding")).toBeLessThan(order.indexOf("delegate"));
+        } finally {
+            for (const s of spies) s.mockRestore();
+            mgr.dispose();
+        }
+    });
 });
 
 describe("signingDescriptorIndex", () => {
@@ -704,16 +739,115 @@ describe("Wallet.restore", () => {
         }
     });
 
-    it("equal-delay server: a funded index-0 boarding UTXO restores without aborting (default wins)", async () => {
+    it("equal-delay server: a funded index-0 boarding UTXO restores without aborting (first-wins)", async () => {
         // mockArkInfo sets boardingExitDelay === unilateralExitDelay, so the
         // boarding script is byte-identical to the default candidate. A funded
-        // on-chain boarding UTXO must restore cleanly: the boarding hit
-        // coalesces onto the already-persisted `default` row (idempotent
-        // upsert) instead of aborting the scan with a same-script type clash.
+        // on-chain boarding UTXO must restore cleanly: the boarding hit is
+        // tolerated first-wins at the persistence layer (the init-persisted
+        // index-0 `default` baseline keeps the colliding row) instead of
+        // aborting the scan with a same-script type clash.
         const { wallet, fundedOnchain } = await makeHdWalletForTest();
         try {
             fundedOnchain.add(await wallet.getBoardingAddress());
             await expect(wallet.restore({ gapLimit: 5 })).resolves.toBeUndefined();
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("equal-delay: a funded ROTATED boarding index restores as a boarding UTXO (Finding #1)", async () => {
+        // The core regression. mockArkInfo is equal-delay, so the boarding
+        // script at a rotated index N (>0) is byte-identical to the default
+        // script at N. Fund index 2 ON-CHAIN ONLY (no L2 VTXO). The boarding
+        // probe is the sole hit, so the index is persisted as a `boarding`
+        // row — NOT mis-typed `default` (the old pre-coalescing bug, which hid
+        // the UTXO from the type-gated getBoardingUtxos).
+        const { wallet, hdProvider, fundedOnchain } = await makeHdWalletForTest();
+        try {
+            const serverPubKey = wallet.offchainTapscript.options.serverPubKey;
+            const boardingCsv = wallet.boardingTapscript.options.csvTimelock!;
+            const script = new DefaultVtxo.Script({
+                pubKey: deriveDescriptorLeafPubKey(hdProvider.materializeDescriptorAt(2)),
+                serverPubKey,
+                csvTimelock: boardingCsv,
+            });
+            const scriptHex = hex.encode(script.pkScript);
+            const onchainAddr = script.onchainAddress(wallet.network);
+            fundedOnchain.add(onchainAddr);
+
+            await wallet.restore({ gapLimit: 5 });
+
+            // Persisted as a boarding-typed contract at the rotated index.
+            const boardingRows = await wallet.contractRepository.getContracts({
+                type: ["boarding"],
+            });
+            expect(boardingRows.map((c) => c.script)).toContain(scriptHex);
+
+            // The on-chain UTXO is enumerated by getBoardingUtxos with the
+            // correct per-index boarding tapscript.
+            const utxos = await wallet.getBoardingUtxos();
+            const addrs = utxos.map((u) =>
+                VtxoScript.decode(u.tapTree).onchainAddress(wallet.network),
+            );
+            expect(addrs).toContain(onchainAddr);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("equal-delay: a both-hit rotated index recovers BOTH the on-chain UTXO and the L2 VTXO (reviewer's case)", async () => {
+        // The degenerate sub-case §6 calls out: a rotated index whose
+        // (byte-identical) script carries BOTH an on-chain boarding UTXO and an
+        // L2 VTXO. Boarding is probed first → the row resolves to `boarding`;
+        // the later default hit first-wins-no-ops. Both fund types must remain
+        // recoverable: the on-chain UTXO via the type-gated getBoardingUtxos,
+        // and the VTXO via the type-agnostic getVtxos.
+        const { wallet, indexer, hdProvider, fundedOnchain } = await makeHdWalletForTest();
+        try {
+            const serverPubKey = wallet.offchainTapscript.options.serverPubKey;
+            const boardingCsv = wallet.boardingTapscript.options.csvTimelock!;
+            const pubKey = deriveDescriptorLeafPubKey(hdProvider.materializeDescriptorAt(2));
+            const script = new DefaultVtxo.Script({
+                pubKey,
+                serverPubKey,
+                csvTimelock: boardingCsv,
+            });
+            const scriptHex = hex.encode(script.pkScript);
+            const onchainAddr = script.onchainAddress(wallet.network);
+
+            // Sanity: equal-delay → the index-2 default candidate is the SAME
+            // script as the boarding candidate.
+            const defaultScriptHex = hex.encode(
+                new DefaultVtxo.Script({
+                    pubKey,
+                    serverPubKey,
+                    csvTimelock: wallet.walletContractTimelocks[0],
+                }).pkScript,
+            );
+            expect(defaultScriptHex).toBe(scriptHex);
+
+            fundedOnchain.add(onchainAddr); // on-chain boarding UTXO
+            indexer.usedScripts.add(scriptHex); // L2 VTXO at the same script
+
+            await wallet.restore({ gapLimit: 5 });
+
+            // Resolved to a boarding row (boarding probed first, first-wins).
+            const boardingRows = await wallet.contractRepository.getContracts({
+                type: ["boarding"],
+            });
+            expect(boardingRows.map((c) => c.script)).toContain(scriptHex);
+
+            // On-chain UTXO recovered via the type-gated boarding reader.
+            const utxos = await wallet.getBoardingUtxos();
+            const addrs = utxos.map((u) =>
+                VtxoScript.decode(u.tapTree).onchainAddress(wallet.network),
+            );
+            expect(addrs).toContain(onchainAddr);
+
+            // L2 VTXO recovered via the type-agnostic getVtxos — proving a
+            // boarding-typed row's VTXOs stay visible/spendable.
+            const vtxos = await wallet.getVtxos();
+            expect(vtxos.some((v) => v.script === scriptHex)).toBe(true);
         } finally {
             await wallet.dispose();
         }

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { hex } from "@scure/base";
 import { signingDescriptorIndex } from "../src/wallet/walletReceiveRotator";
 import { mnemonicToSeedSync } from "@scure/bip39";
@@ -12,6 +12,7 @@ import { DefaultContractHandler } from "../src/contracts/handlers/default";
 import { DelegateContractHandler } from "../src/contracts/handlers/delegate";
 import { DefaultVtxo } from "../src/script/default";
 import { DelegateVtxo } from "../src/script/delegate";
+import { VtxoScript } from "../src/script/base";
 import type { RelativeTimelock } from "../src/script/tapscript";
 import { contractHandlers } from "../src/contracts/handlers";
 import { makeManagerForTest, makeDeps } from "./helpers/scanManager";
@@ -670,6 +671,172 @@ describe("Wallet.restore", () => {
             );
             const balance = await wallet.getBalance();
             expect(balance.total).toBeGreaterThan(0);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("HD: a funded boarding index is recovered via the on-chain probe (advances watermark)", async () => {
+        const { wallet, hdProvider, fundedOnchain } = await makeHdWalletForTest();
+        try {
+            // Boarding on-chain (P2TR) address at HD index 2, built the way
+            // BoardingContractHandler.discoverAt does. The index is funded
+            // ONLY on-chain (not in the indexer's usedScripts), so the index
+            // is recovered purely by the boarding on-chain probe — and the
+            // shared watermark advances to it.
+            const serverPubKey = wallet.offchainTapscript.options.serverPubKey;
+            const boardingCsv = wallet.boardingTapscript.options.csvTimelock!;
+            const boardingOnchainAt = (i: number) =>
+                new DefaultVtxo.Script({
+                    pubKey: deriveDescriptorLeafPubKey(hdProvider.materializeDescriptorAt(i)),
+                    serverPubKey,
+                    csvTimelock: boardingCsv,
+                }).onchainAddress(wallet.network);
+            fundedOnchain.add(boardingOnchainAt(2));
+
+            await wallet.restore({ gapLimit: 5 });
+
+            expect(await hdProvider.getCurrentSigningDescriptor()).toBe(
+                hdProvider.materializeDescriptorAt(2),
+            );
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("equal-delay server: a funded index-0 boarding UTXO restores without aborting (default wins)", async () => {
+        // mockArkInfo sets boardingExitDelay === unilateralExitDelay, so the
+        // boarding script is byte-identical to the default candidate. A funded
+        // on-chain boarding UTXO must restore cleanly: the boarding hit
+        // coalesces onto the already-persisted `default` row (idempotent
+        // upsert) instead of aborting the scan with a same-script type clash.
+        const { wallet, fundedOnchain } = await makeHdWalletForTest();
+        try {
+            fundedOnchain.add(await wallet.getBoardingAddress());
+            await expect(wallet.restore({ gapLimit: 5 })).resolves.toBeUndefined();
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("getBoardingUtxos unions funds across current + historical boarding addresses (plan §6-III.1)", async () => {
+        const { wallet, fundedOnchain } = await makeHdWalletForTest();
+        try {
+            const baselineBoarding = await wallet.getBoardingAddress();
+            const rotatedBoarding = await wallet.getNewBoardingAddress();
+            expect(rotatedBoarding).not.toBe(baselineBoarding);
+
+            // Fund BOTH the previous (index-0) and the current (rotated)
+            // boarding addresses on-chain.
+            fundedOnchain.add(baselineBoarding);
+            fundedOnchain.add(rotatedBoarding);
+
+            const utxos = await wallet.getBoardingUtxos();
+            expect(utxos).toHaveLength(2);
+            // Each coin is annotated with the tapscript of the address it sits
+            // on — so it can later be forfeited/exited with the right leaves.
+            const addrs = utxos.map((u) =>
+                VtxoScript.decode(u.tapTree).onchainAddress(wallet.network),
+            );
+            expect(new Set(addrs)).toEqual(new Set([baselineBoarding, rotatedBoarding]));
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("getBoardingTxs unions history across current + historical boarding addresses (plan §6-IV.1)", async () => {
+        const { wallet } = await makeHdWalletForTest();
+        try {
+            const baseline = await wallet.getBoardingAddress();
+            const rotated = await wallet.getNewBoardingAddress();
+            expect(rotated).not.toBe(baseline);
+
+            const txAt = (addr: string, txid: string) => ({
+                txid,
+                vout: [{ scriptpubkey_address: addr, value: 12_345 }],
+                status: { confirmed: true, block_time: 1_700_000_000 },
+            });
+            vi.spyOn(wallet.onchainProvider, "getTransactions").mockImplementation(
+                async (addr: string) => {
+                    if (addr === baseline) return [txAt(baseline, "aa".repeat(32))] as any;
+                    if (addr === rotated) return [txAt(rotated, "bb".repeat(32))] as any;
+                    return [];
+                },
+            );
+            vi.spyOn(wallet.onchainProvider, "getTxOutspends").mockResolvedValue([
+                { spent: false },
+            ] as any);
+
+            const { boardingTxs } = await wallet.getBoardingTxs();
+            const txids = boardingTxs.map((t) => t.key.boardingTxid);
+            expect(txids).toContain("aa".repeat(32));
+            expect(txids).toContain("bb".repeat(32));
+            // getBoardingAddress() stays single-valued (the QR / display target).
+            expect(await wallet.getBoardingAddress()).toBe(rotated);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("notifyIncomingFunds watches the full boarding-address set (plan §6-IV.2)", async () => {
+        const { wallet } = await makeHdWalletForTest();
+        try {
+            const baseline = await wallet.getBoardingAddress();
+            const rotated = await wallet.getNewBoardingAddress();
+
+            let watched: string[] = [];
+            vi.spyOn(wallet.onchainProvider, "watchAddresses").mockImplementation(
+                async (addrs: string[]) => {
+                    watched = addrs;
+                    return () => {};
+                },
+            );
+
+            const stop = await wallet.notifyIncomingFunds(() => {});
+            expect(new Set(watched)).toEqual(new Set([baseline, rotated]));
+            stop();
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("notifyIncomingFunds emits one coin per matching output, even when a tx pays two boarding addresses (review Finding 4)", async () => {
+        const { wallet } = await makeHdWalletForTest();
+        try {
+            const baseline = await wallet.getBoardingAddress();
+            const rotated = await wallet.getNewBoardingAddress();
+
+            let captured: ((txs: any[]) => void) | undefined;
+            vi.spyOn(wallet.onchainProvider, "watchAddresses").mockImplementation(
+                async (_addrs: string[], cb: (txs: any[]) => void) => {
+                    captured = cb;
+                    return () => {};
+                },
+            );
+
+            const received: any[] = [];
+            const stop = await wallet.notifyIncomingFunds((funds) => {
+                if (funds.type === "utxo") received.push(...funds.coins);
+            });
+
+            // One tx with outputs to BOTH boarding addresses (vout 0 and 2) plus
+            // an unrelated output (vout 1) that must be ignored.
+            captured!([
+                {
+                    txid: "ab".repeat(32),
+                    status: { confirmed: true },
+                    vout: [
+                        { scriptpubkey_address: baseline, value: 1000 },
+                        { scriptpubkey_address: "someone-else", value: 5 },
+                        { scriptpubkey_address: rotated, value: 2000 },
+                    ],
+                },
+            ]);
+
+            expect(received).toHaveLength(2);
+            expect(received.map((c) => c.vout).sort()).toEqual([0, 2]);
+            expect(received.map((c) => c.value).sort((a, b) => a - b)).toEqual([1000, 2000]);
+            stop();
         } finally {
             await wallet.dispose();
         }

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -1264,6 +1264,10 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
                 sign: vi.fn().mockImplementation((tx: any) => tx),
                 xOnlyPublicKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
             },
+            // Descriptor-aware on-chain boarding signer (plan §6-III.3). The
+            // mock mirrors the old identity-sign behaviour (returns the tx
+            // unchanged) so sweep tests still finalize a "signed" tx.
+            signOnchainBoardingTx: vi.fn().mockImplementation((tx: any) => tx),
         } as any;
     };
 
@@ -1491,6 +1495,7 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
                     sign: vi.fn().mockImplementation((tx: any) => tx),
                     xOnlyPublicKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
                 },
+                signOnchainBoardingTx: vi.fn().mockImplementation((tx: any) => tx),
             } as any;
         };
 
@@ -1796,6 +1801,10 @@ describe("VtxoManager - Periodic settle cooldown", () => {
                 sign: vi.fn().mockImplementation((tx: any) => tx),
                 xOnlyPublicKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
             },
+            // Descriptor-aware on-chain boarding signer (plan §6-III.3). The
+            // mock mirrors the old identity-sign behaviour (returns the tx
+            // unchanged) so sweep tests still finalize a "signed" tx.
+            signOnchainBoardingTx: vi.fn().mockImplementation((tx: any) => tx),
         } as any;
     };
 
@@ -2074,6 +2083,10 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
                 sign: vi.fn().mockImplementation((tx: any) => tx),
                 xOnlyPublicKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
             },
+            // Descriptor-aware on-chain boarding signer (plan §6-III.3). The
+            // mock mirrors the old identity-sign behaviour (returns the tx
+            // unchanged) so sweep tests still finalize a "signed" tx.
+            signOnchainBoardingTx: vi.fn().mockImplementation((tx: any) => tx),
         } as any;
     };
 
@@ -2334,6 +2347,10 @@ describe("VtxoManager - Cross-instance poll guard", () => {
                 sign: vi.fn().mockImplementation((tx: any) => tx),
                 xOnlyPublicKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
             },
+            // Descriptor-aware on-chain boarding signer (plan §6-III.3). The
+            // mock mirrors the old identity-sign behaviour (returns the tx
+            // unchanged) so sweep tests still finalize a "signed" tx.
+            signOnchainBoardingTx: vi.fn().mockImplementation((tx: any) => tx),
         } as any;
     };
 
@@ -2469,6 +2486,7 @@ describe("VtxoManager - VTXO_ALREADY_SPENT reconciliation", () => {
                     sign: vi.fn().mockImplementation((tx: any) => tx),
                     xOnlyPublicKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
                 },
+                signOnchainBoardingTx: vi.fn().mockImplementation((tx: any) => tx),
             } as any,
             contractManager,
         };

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -1063,6 +1063,8 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).readonlyWallet = {
             getAddress: vi.fn().mockResolvedValue(TEST_DEFAULT_ARK_ADDRESS),
             getBoardingAddress: vi.fn().mockResolvedValue("bc1-boarding"),
+            getBoardingAddresses: vi.fn().mockResolvedValue(["bc1-boarding"]),
+            getBoardingUtxos: vi.fn().mockResolvedValue([]),
             getBoardingTxs: vi.fn().mockResolvedValue({
                 boardingTxs: [],
                 commitmentsToIgnore: new Set(),
@@ -1099,6 +1101,8 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).readonlyWallet = {
             getAddress: vi.fn().mockResolvedValue(TEST_DEFAULT_ARK_ADDRESS),
             getBoardingAddress: vi.fn().mockResolvedValue("bc1-boarding"),
+            getBoardingAddresses: vi.fn().mockResolvedValue(["bc1-boarding"]),
+            getBoardingUtxos: vi.fn().mockResolvedValue([]),
             getBoardingTxs: vi.fn().mockResolvedValue({
                 boardingTxs: [],
                 commitmentsToIgnore: new Set(),
@@ -1238,6 +1242,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
         (updater as any).readonlyWallet = {
             getAddress: vi.fn().mockResolvedValue(TEST_DEFAULT_ARK_ADDRESS),
             getBoardingAddress: vi.fn().mockResolvedValue("boarding-address"),
+            getBoardingAddresses: vi.fn().mockResolvedValue(["boarding-address"]),
             getBoardingUtxos: vi.fn().mockResolvedValue([]),
             getBoardingTxs: vi.fn().mockResolvedValue({
                 boardingTxs: [],
@@ -1494,9 +1499,9 @@ describe("WalletMessageHandler repo-backed reads", () => {
         expect(vtxosArg[0].txid).toBe("aa".repeat(32));
     });
 
-    it("boarding UTXO fetch via onchainProvider is unaffected", async () => {
+    it("boarding cache refresh fans out over the boarding-address set (plan §6-IV.2)", async () => {
         setupHandler();
-        const getCoinsSpy = (updater as any).readonlyWallet.onchainProvider.getCoins;
+        const rw = (updater as any).readonlyWallet;
         (updater as any).wallet = {
             getVtxoManager: vi.fn().mockResolvedValue({}),
             finalizePendingTxs: vi.fn().mockResolvedValue({ pending: [], finalized: [] }),
@@ -1504,7 +1509,11 @@ describe("WalletMessageHandler repo-backed reads", () => {
 
         await (updater as any).onWalletInitialized();
 
-        expect(getCoinsSpy).toHaveBeenCalledWith("boarding-address");
+        // refreshCachedData now enumerates every boarding address and delegates
+        // the per-address fetch + cache to getBoardingUtxos, instead of fetching
+        // a single getBoardingAddress() via the onchain provider directly.
+        expect(rw.getBoardingAddresses).toHaveBeenCalled();
+        expect(rw.getBoardingUtxos).toHaveBeenCalled();
     });
 
     it("RELOAD_WALLET forces refreshVtxos before reading from repo", async () => {

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -1087,6 +1087,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).walletRepository = {
             getVtxos: vi.fn().mockResolvedValue([]),
             saveVtxos: vi.fn().mockResolvedValue(undefined),
+            getUtxos: vi.fn().mockResolvedValue([]),
             deleteUtxos: vi.fn().mockResolvedValue(undefined),
             saveUtxos: vi.fn().mockResolvedValue(undefined),
             saveTransactions: vi.fn().mockResolvedValue(undefined),
@@ -1122,6 +1123,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).walletRepository = {
             getVtxos: vi.fn().mockResolvedValue([]),
             saveVtxos: vi.fn().mockResolvedValue(undefined),
+            getUtxos: vi.fn().mockResolvedValue([]),
             deleteUtxos: vi.fn().mockResolvedValue(undefined),
             saveUtxos: vi.fn().mockResolvedValue(undefined),
             saveTransactions: vi.fn().mockResolvedValue(undefined),

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -2158,15 +2158,26 @@ describe("Wallet.updateDbAfterSettle", () => {
     const DELEGATE_ADDR = "ark1delegateaddress";
     const BOARDING_ADDR = "bc1boardingaddr";
 
+    // Per-address boarding-UTXO buckets keyed by address. `updateDbAfterSettle`
+    // resolves the source address of each boarding input from its tapTree, so
+    // the mock must return the right bucket per address (not a single global
+    // list) to exercise the address-aware cleanup (plan §6-III.4).
     const makeThisArg = (overrides: {
         annotateVtxos: ReturnType<typeof vi.fn>;
         contracts: { script: string; address: string }[];
         currentBoardingUtxos?: any[];
+        boardingUtxosByAddress?: Record<string, any[]>;
+        network?: any;
     }) => {
         const saveVtxos = vi.fn().mockResolvedValue(undefined);
         const saveUtxos = vi.fn().mockResolvedValue(undefined);
         const deleteUtxos = vi.fn().mockResolvedValue(undefined);
-        const getUtxos = vi.fn().mockResolvedValue(overrides.currentBoardingUtxos ?? []);
+        const byAddress = overrides.boardingUtxosByAddress;
+        const getUtxos = vi
+            .fn()
+            .mockImplementation(async (address: string) =>
+                byAddress ? (byAddress[address] ?? []) : (overrides.currentBoardingUtxos ?? []),
+            );
         const getContracts = vi.fn().mockResolvedValue(overrides.contracts);
         const getContractManager = vi.fn().mockResolvedValue({
             annotateVtxos: overrides.annotateVtxos,
@@ -2182,6 +2193,7 @@ describe("Wallet.updateDbAfterSettle", () => {
                 },
                 getContractManager,
                 getBoardingAddress: vi.fn().mockResolvedValue(BOARDING_ADDR),
+                network: overrides.network ?? { bech32: "bcrt", hrp: "tark" },
             } as any,
             saveVtxos,
             saveUtxos,
@@ -2189,6 +2201,23 @@ describe("Wallet.updateDbAfterSettle", () => {
             getUtxos,
         };
     };
+
+    // A boarding ExtendedCoin carrying a real per-UTXO tapTree, so
+    // `updateDbAfterSettle` can resolve its on-chain source address.
+    const makeBoardingCoin = (
+        tapscript: DefaultVtxo.Script,
+        txidChar: string,
+        value = 10_000,
+    ): ExtendedCoin =>
+        ({
+            txid: txidChar.repeat(64).slice(0, 64),
+            vout: 0,
+            value,
+            status: { confirmed: true },
+            forfeitTapLeafScript: tapscript.forfeit(),
+            intentTapLeafScript: tapscript.forfeit(),
+            tapTree: tapscript.encode(),
+        }) as ExtendedCoin;
 
     const makeVtxoInput = (script: string, suffix: string): ExtendedCoin =>
         ({
@@ -2204,14 +2233,6 @@ describe("Wallet.updateDbAfterSettle", () => {
             forfeitTapLeafScript: [new Uint8Array(32), new Uint8Array(33)],
             intentTapLeafScript: [new Uint8Array(32), new Uint8Array(34)],
             tapTree: new Uint8Array(64),
-        }) as ExtendedCoin;
-
-    const makeBoardingInput = (suffix: string): ExtendedCoin =>
-        ({
-            txid: suffix.repeat(64).slice(0, 64),
-            vout: 0,
-            value: 10_000,
-            status: { confirmed: true },
         }) as ExtendedCoin;
 
     it("saves single-contract settle rows under the primary bucket", async () => {
@@ -2259,8 +2280,15 @@ describe("Wallet.updateDbAfterSettle", () => {
         expect(calls.get(DELEGATE_ADDR)[0].script).toBe(DELEGATE_SCRIPT);
     });
 
-    it("removes settled boarding inputs even when no vtxo rows are settled", async () => {
-        const boardingInput = makeBoardingInput("b");
+    it("removes a settled boarding input from the bucket of the address it sits on", async () => {
+        const network = { bech32: "bcrt", hrp: "tark" } as any;
+        const boardingScript = new DefaultVtxo.Script({
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
+        });
+        const boardingAddr = boardingScript.onchainAddress(network);
+        const boardingInput = makeBoardingCoin(boardingScript, "b");
         const otherUtxo = {
             txid: "c".repeat(64),
             vout: 0,
@@ -2271,7 +2299,10 @@ describe("Wallet.updateDbAfterSettle", () => {
         const { thisArg, saveVtxos, deleteUtxos, saveUtxos, getUtxos } = makeThisArg({
             annotateVtxos,
             contracts: [{ script: PRIMARY_SCRIPT, address: PRIMARY_ADDR }],
-            currentBoardingUtxos: [{ txid: boardingInput.txid, vout: 0, value: 10_000 }, otherUtxo],
+            network,
+            boardingUtxosByAddress: {
+                [boardingAddr]: [{ txid: boardingInput.txid, vout: 0, value: 10_000 }, otherUtxo],
+            },
         });
 
         await (Wallet.prototype as any).updateDbAfterSettle.call(
@@ -2281,9 +2312,71 @@ describe("Wallet.updateDbAfterSettle", () => {
         );
 
         expect(saveVtxos).not.toHaveBeenCalled();
-        expect(getUtxos).toHaveBeenCalledWith(BOARDING_ADDR);
-        expect(deleteUtxos).toHaveBeenCalledWith(BOARDING_ADDR);
-        expect(saveUtxos).toHaveBeenCalledWith(BOARDING_ADDR, [otherUtxo]);
+        // Cleanup targets the bucket of the address the UTXO actually sits on.
+        expect(getUtxos).toHaveBeenCalledWith(boardingAddr);
+        expect(deleteUtxos).toHaveBeenCalledWith(boardingAddr);
+        expect(saveUtxos).toHaveBeenCalledWith(boardingAddr, [otherUtxo]);
+    });
+
+    it("settling a boarding UTXO from a PREVIOUS boarding address cleans up that historical bucket only (plan §6-III.4)", async () => {
+        const network = { bech32: "bcrt", hrp: "tark" } as any;
+        // Two distinct boarding addresses (different owner pubkeys) — a current
+        // and a rotated-away "previous" one.
+        const currentScript = new DefaultVtxo.Script({
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
+        });
+        const previousScript = new DefaultVtxo.Script({
+            pubKey: hex.decode("c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"),
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
+        });
+        const currentAddr = currentScript.onchainAddress(network);
+        const previousAddr = previousScript.onchainAddress(network);
+        expect(previousAddr).not.toBe(currentAddr);
+
+        // Settle a UTXO received at the PREVIOUS boarding address.
+        const previousInput = makeBoardingCoin(previousScript, "d");
+        const leftoverAtPrevious = {
+            txid: "e".repeat(64),
+            vout: 0,
+            value: 2000,
+            status: { confirmed: true },
+        };
+        const untouchedAtCurrent = {
+            txid: "f".repeat(64),
+            vout: 0,
+            value: 3000,
+            status: { confirmed: true },
+        };
+
+        const annotateVtxos = vi.fn().mockResolvedValue([]);
+        const { thisArg, deleteUtxos, saveUtxos, getUtxos } = makeThisArg({
+            annotateVtxos,
+            contracts: [{ script: PRIMARY_SCRIPT, address: PRIMARY_ADDR }],
+            network,
+            boardingUtxosByAddress: {
+                [previousAddr]: [
+                    { txid: previousInput.txid, vout: 0, value: 10_000 },
+                    leftoverAtPrevious,
+                ],
+                [currentAddr]: [untouchedAtCurrent],
+            },
+        });
+
+        await (Wallet.prototype as any).updateDbAfterSettle.call(
+            thisArg,
+            [previousInput],
+            "commitment-tx",
+        );
+
+        // Only the previous bucket is rewritten; the current bucket is untouched.
+        expect(getUtxos).toHaveBeenCalledWith(previousAddr);
+        expect(getUtxos).not.toHaveBeenCalledWith(currentAddr);
+        expect(deleteUtxos).toHaveBeenCalledWith(previousAddr);
+        expect(deleteUtxos).not.toHaveBeenCalledWith(currentAddr);
+        expect(saveUtxos).toHaveBeenCalledWith(previousAddr, [leftoverAtPrevious]);
     });
 
     it("rethrows when a settled VTXO has no script", async () => {

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -1711,6 +1711,7 @@ describe("Wallet._settleImpl", () => {
             safeRegisterIntent,
             createBatchHandler,
             updateDbAfterSettle,
+            maybeRotateBoardingAfterBoard: vi.fn().mockResolvedValue(undefined),
         };
 
         const result = await (Wallet.prototype as any)._settleImpl.call(thisArg, {
@@ -1730,6 +1731,9 @@ describe("Wallet._settleImpl", () => {
         expect(stream.return).toHaveBeenCalledTimes(1);
         expect(createBatchHandler).toHaveBeenCalledWith("intent-id", [input], [], undefined);
         expect(updateDbAfterSettle).toHaveBeenCalledWith([input], "commitment-txid");
+        // A successful settle feeds its resolved inputs to the rotate-on-board
+        // hook (which decides whether a boarding UTXO was consumed).
+        expect(thisArg.maybeRotateBoardingAfterBoard).toHaveBeenCalledWith([input]);
         batchJoinSpy.mockRestore();
     });
 

--- a/packages/ts-sdk/test/wallet/boarding-contract.test.ts
+++ b/packages/ts-sdk/test/wallet/boarding-contract.test.ts
@@ -1,14 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import {
-    Wallet,
-    areSameScriptBaselineTypesCompatible,
-    ensureWalletContract,
-} from "../../src/wallet/wallet";
+import { Wallet, ensureWalletContract } from "../../src/wallet/wallet";
 import { InMemoryWalletRepository } from "../../src/repositories/inMemory/walletRepository";
 import { InMemoryContractRepository } from "../../src/repositories/inMemory/contractRepository";
 import { SingleKey } from "../../src/identity/singleKey";
 import { DefaultVtxo } from "../../src/script/default";
-import { ContractManager } from "../../src/contracts/contractManager";
+import { ContractManager, areCoalescibleContractTypes } from "../../src/contracts/contractManager";
 import { contractHandlers } from "../../src/contracts/handlers";
 import { DefaultContractHandler } from "../../src/contracts/handlers/default";
 import { isDiscoverable } from "../../src/contracts/types";
@@ -332,29 +328,27 @@ describe("boarding contract: HD key selection stays wallet-owned", () => {
     });
 });
 
-describe("areSameScriptBaselineTypesCompatible", () => {
-    it("treats default <-> boarding as compatible (both directions)", () => {
-        expect(areSameScriptBaselineTypesCompatible("default", "boarding")).toBe(true);
-        expect(areSameScriptBaselineTypesCompatible("boarding", "default")).toBe(true);
+describe("areCoalescibleContractTypes", () => {
+    it("treats default <-> boarding as coalescible (both directions)", () => {
+        expect(areCoalescibleContractTypes("default", "boarding")).toBe(true);
+        expect(areCoalescibleContractTypes("boarding", "default")).toBe(true);
     });
 
-    it("treats same type as compatible", () => {
-        for (const t of ["default", "boarding", "delegate", "vhtlc"]) {
-            expect(areSameScriptBaselineTypesCompatible(t, t)).toBe(true);
-        }
-    });
-
-    it("treats every other pairing as incompatible", () => {
-        const incompatible: [string, string][] = [
+    it("treats every other distinct pairing as not coalescible", () => {
+        // Same-type is identity, not coalescing (handled separately as the
+        // idempotent no-op in upsertContract), so it is intentionally excluded
+        // from the coalescible pair set — this helper only governs which
+        // *different* types may share one script-keyed row.
+        const notCoalescible: [string, string][] = [
             ["default", "delegate"],
             ["boarding", "delegate"],
             ["default", "vhtlc"],
             ["boarding", "vhtlc"],
             ["delegate", "vhtlc"],
         ];
-        for (const [a, b] of incompatible) {
-            expect(areSameScriptBaselineTypesCompatible(a, b)).toBe(false);
-            expect(areSameScriptBaselineTypesCompatible(b, a)).toBe(false);
+        for (const [a, b] of notCoalescible) {
+            expect(areCoalescibleContractTypes(a, b)).toBe(false);
+            expect(areCoalescibleContractTypes(b, a)).toBe(false);
         }
     });
 });
@@ -435,7 +429,7 @@ describe("ensureWalletContract", () => {
         }
     });
 
-    it("collision direction B: existing boarding, then default promotes the row to default (default wins)", async () => {
+    it("collision direction B: existing boarding, then default keeps boarding (first-wins, no promote)", async () => {
         const { manager, indexerProvider } = await makeManager();
         try {
             // Stale `boarding` row persisted first (an earlier boot where the
@@ -446,13 +440,14 @@ describe("ensureWalletContract", () => {
 
             const rows = await manager.getContracts({ script: sharedScript });
             expect(rows).toHaveLength(1);
-            // Promoted to `default` so the shared script — also the wallet's
-            // live offchain baseline — stays visible to the type-gated
-            // consumers (notifyIncomingFunds, getWalletScripts, getScriptMap).
-            expect(rows[0].type).toBe("default");
+            // First-wins: the row keeps its original `boarding` type (no
+            // promotion). The shared script stays watched, and its VTXOs stay
+            // visible via the type-agnostic getVtxos path; this is the symmetric
+            // case that never occurs at init (default is persisted first there).
+            expect(rows[0].type).toBe("boarding");
             expect(rows[0].state).toBe("active");
-            // No boarding-typed row remains for the shared script.
-            expect(await manager.getContracts({ type: ["boarding"] })).toHaveLength(0);
+            // The boarding-typed row is the one that remains for the shared script.
+            expect(await manager.getContracts({ type: ["boarding"] })).toHaveLength(1);
             expect(subscribedScripts(indexerProvider)).toContain(sharedScript);
         } finally {
             manager.dispose();
@@ -508,5 +503,90 @@ describe("boarding contract: default/boarding script collision (boardingExitDela
         expect(await wallet.getBoardingAddress()).toEqual(
             wallet.boardingTapscript.onchainAddress(wallet.network),
         );
+    });
+});
+
+describe("ContractManager.createContract: default/boarding first-wins collision", () => {
+    // Same (params -> script) pair as the ensureWalletContract suite: boarding
+    // and default derive a byte-identical script from identical params, so the
+    // shared script can back either type. Exercises upsertContract's first-wins
+    // branch directly through the public createContract API (the same core that
+    // persistAndWatchContract — the restore scan's path — also runs).
+    const PK = "5b3a7b5e8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f";
+    const SPK = "9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b";
+    const sharedParams = {
+        pubKey: PK,
+        serverPubKey: SPK,
+        csvTimelock: timelockToSequence({ value: 86016n, type: "seconds" }).toString(),
+    };
+    const sharedScript = hex.encode(DefaultContractHandler.createScript(sharedParams).pkScript);
+
+    async function makeManager() {
+        const contractRepository = new InMemoryContractRepository();
+        const manager = await ContractManager.create({
+            indexerProvider: makeIdleIndexer(),
+            contractRepository,
+            walletRepository: new InMemoryWalletRepository(),
+            watcherConfig: { failsafePollIntervalMs: 1000, reconnectDelayMs: 500 },
+        });
+        return { manager, contractRepository };
+    }
+
+    const params = (type: string, label?: string) => ({
+        type,
+        params: sharedParams,
+        script: sharedScript,
+        address: "addr",
+        state: "active" as const,
+        ...(label ? { label } : {}),
+    });
+
+    it("keeps the existing row both directions (no throw, no overwrite, no promote)", async () => {
+        for (const [first, second] of [
+            ["default", "boarding"],
+            ["boarding", "default"],
+        ] as const) {
+            const { manager } = await makeManager();
+            try {
+                const created = await manager.createContract(params(first, "first"));
+                // The colliding second create is a no-op that returns the
+                // existing row untouched — same type, same label, same
+                // createdAt, no throw.
+                const result = await manager.createContract(params(second, "second"));
+                expect(result.type).toBe(first);
+                expect(result.label).toBe("first");
+                expect(result.createdAt).toBe(created.createdAt);
+
+                const rows = await manager.getContracts({ script: sharedScript });
+                expect(rows).toHaveLength(1);
+                expect(rows[0].type).toBe(first);
+                expect(rows[0].label).toBe("first");
+            } finally {
+                manager.dispose();
+            }
+        }
+    });
+
+    it("still throws on a genuinely incompatible collision (default <-> vhtlc)", async () => {
+        const { manager, contractRepository } = await makeManager();
+        try {
+            // Seed an incompatible (vhtlc) row directly at the shared script,
+            // bypassing createContract's params validation.
+            await contractRepository.saveContract({
+                type: "vhtlc",
+                params: sharedParams,
+                script: sharedScript,
+                address: "addr",
+                state: "active",
+                createdAt: 0,
+            });
+            await expect(manager.createContract(params("default"))).rejects.toThrow(
+                /already exists with type vhtlc/,
+            );
+            // No duplicate row was created.
+            expect(await manager.getContracts({ script: sharedScript })).toHaveLength(1);
+        } finally {
+            manager.dispose();
+        }
     });
 });

--- a/packages/ts-sdk/test/wallet/boarding-contract.test.ts
+++ b/packages/ts-sdk/test/wallet/boarding-contract.test.ts
@@ -250,10 +250,10 @@ describe("boarding contract: VTXO annotation and spend paths", () => {
     });
 });
 
-describe("boarding contract: not discoverable", () => {
-    it("is not part of the discoverable handler set", () => {
+describe("boarding contract: discoverable", () => {
+    it("is part of the discoverable handler set (boarding restore, plan §6-I)", () => {
         const handler = contractHandlers.get("boarding");
-        expect(isDiscoverable(handler)).toBe(false);
+        expect(isDiscoverable(handler)).toBe(true);
     });
 });
 

--- a/packages/ts-sdk/test/wallet/inputSignerRouter.test.ts
+++ b/packages/ts-sdk/test/wallet/inputSignerRouter.test.ts
@@ -309,6 +309,81 @@ describe("InputSignerRouter", async () => {
         expect(signSpy).toHaveBeenCalledWith(tx, [0]);
     });
 
+    it("routes baseline-owner boarding contract to identity (index-0 / static boarding unchanged)", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const script = taprootScript(BASELINE_REUSE_PUBKEY);
+        await contractRepo.saveContract(
+            makeContract({
+                script: hex.encode(script),
+                type: "boarding",
+                params: { pubKey: baselinePubKey },
+            }),
+        );
+
+        const signSpy = vi.fn().mockImplementation((tx) => tx);
+        const mockIdentity = {
+            xOnlyPublicKey: () => Promise.resolve(hex.decode(baselinePubKey)),
+            sign: signSpy,
+        };
+        const router = createRouter({
+            identity: mockIdentity,
+            contractRepository: contractRepo,
+        });
+
+        const tx = stubTxWithInputs(1);
+        await router.sign(tx, [{ index: 0, lookupScript: script }]);
+
+        expect(signSpy).toHaveBeenCalledWith(tx, [0]);
+    });
+
+    it("routes rotated boarding contract with descriptor to descriptor provider (plan §6-III.3)", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const script = taprootScript(ROTATED_A_PUBKEY);
+        const descriptor = "tr(rotated-boarding)";
+        await contractRepo.saveContract(
+            makeContract({
+                script: hex.encode(script),
+                type: "boarding",
+                params: { pubKey: ROTATED_A_PUBKEY },
+                metadata: { signingDescriptor: descriptor },
+            }),
+        );
+
+        const signWithDescriptor = vi.fn().mockImplementation((reqs) => [reqs[0].tx]);
+        const router = createRouter({
+            contractRepository: contractRepo,
+            descriptorProvider: { signWithDescriptor },
+        });
+
+        const tx = stubTxWithInputs(1);
+        await router.sign(tx, [{ index: 0, lookupScript: script }]);
+
+        expect(signWithDescriptor).toHaveBeenCalledWith([{ tx, descriptor, inputIndexes: [0] }]);
+    });
+
+    it("throws MissingSigningDescriptorError (contractType 'boarding') for a rotated boarding contract missing its descriptor", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const script = taprootScript(ROTATED_A_PUBKEY);
+        await contractRepo.saveContract(
+            makeContract({
+                script: hex.encode(script),
+                type: "boarding",
+                params: { pubKey: ROTATED_A_PUBKEY },
+                metadata: {},
+            }),
+        );
+
+        const router = createRouter({ contractRepository: contractRepo });
+        const tx = stubTxWithInputs(1);
+
+        const err = await router.sign(tx, [{ index: 0, lookupScript: script }]).then(
+            () => undefined,
+            (e) => e,
+        );
+        expect(err).toBeInstanceOf(MissingSigningDescriptorError);
+        expect((err as MissingSigningDescriptorError).contractType).toBe("boarding");
+    });
+
     it("threads identity and descriptor jobs through one accumulated transaction in sorted descriptor order", async () => {
         const contractRepo = new InMemoryContractRepository();
 

--- a/packages/ts-sdk/test/walletBoardingRotation.test.ts
+++ b/packages/ts-sdk/test/walletBoardingRotation.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+    Wallet,
+    MnemonicIdentity,
+    SingleKey,
+    InMemoryWalletRepository,
+    InMemoryContractRepository,
+} from "../src";
+
+/**
+ * Per-derivation boarding rotation (plan §6-II).
+ *
+ * Mirrors the harness in `test/walletHdRotation.test.ts`: mock the minimum
+ * `fetch` / `EventSource` surface so `Wallet.create` succeeds, then drive the
+ * explicit boarding allocator (`getNewBoardingAddress`) directly. Boarding
+ * coins are always reported empty by the onchain stub, so these tests exercise
+ * allocation / boot / receive-drift only — spending is covered elsewhere.
+ */
+
+const MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const SINGLEKEY_HEX = "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2";
+const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+const mockArkInfo = {
+    signerPubkey: SERVER_PUBKEY_HEX,
+    forfeitPubkey: SERVER_PUBKEY_HEX,
+    batchExpiry: BigInt(144),
+    unilateralExitDelay: BigInt(144),
+    boardingExitDelay: BigInt(144),
+    roundInterval: BigInt(144),
+    network: "mutinynet",
+    dust: BigInt(1000),
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    checkpointTapscript:
+        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+};
+
+const mockFetch = vi.fn();
+const MockEventSource = vi.fn().mockImplementation((url: string) => ({
+    url,
+    onmessage: null,
+    onerror: null,
+    close: vi.fn(),
+}));
+
+beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal("EventSource", MockEventSource);
+    mockFetch.mockReset();
+    mockFetch.mockImplementation((url: string) => {
+        const reply = (body: unknown) =>
+            Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+        if (url.includes("/info")) return reply(mockArkInfo);
+        if (url.includes("subscribe") || url.includes("subscriptions"))
+            return reply({ subscriptionId: "sub-1" });
+        if (url.includes("vtxo") || url.includes("scripts")) return reply({ vtxos: [] });
+        // Esplora onchain (boarding coins, txs, …) — empty.
+        return reply([]);
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function makeHdWallet(
+    walletRepo?: InMemoryWalletRepository,
+    contractRepo?: InMemoryContractRepository,
+) {
+    return Wallet.create({
+        identity: MnemonicIdentity.fromMnemonic(MNEMONIC, { isMainnet: false }),
+        walletMode: "hd",
+        arkServerUrl: "http://localhost:7070",
+        storage: {
+            walletRepository: walletRepo ?? new InMemoryWalletRepository(),
+            contractRepository: contractRepo ?? new InMemoryContractRepository(),
+        },
+    });
+}
+
+describe("Wallet boarding rotation", () => {
+    describe("static / auto (no rotation)", () => {
+        it("getNewBoardingAddress returns the fixed index-0 boarding address — no index burned", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const wallet = await Wallet.create({
+                identity: SingleKey.fromHex(SINGLEKEY_HEX),
+                walletMode: "static",
+                arkServerUrl: "http://localhost:7070",
+                storage: {
+                    walletRepository: walletRepo,
+                    contractRepository: new InMemoryContractRepository(),
+                },
+            });
+
+            const fixed = await wallet.getBoardingAddress();
+            const next = await wallet.getNewBoardingAddress();
+            expect(next).toBe(fixed);
+            // No HD watermark touched — static wallets never allocate.
+            const state = await walletRepo.getWalletState();
+            expect(state?.settings?.hd).toBeUndefined();
+
+            await wallet.dispose();
+        });
+    });
+
+    describe("HD rotation", () => {
+        it("getBoardingAddress is a stable read (does not burn an index)", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const wallet = await makeHdWallet(walletRepo);
+
+            const a1 = await wallet.getBoardingAddress();
+            const a2 = await wallet.getBoardingAddress();
+            expect(a2).toBe(a1);
+
+            const state = await walletRepo.getWalletState();
+            expect(state?.settings?.hd?.lastIndexUsed).toBe(0);
+
+            await wallet.dispose();
+        });
+
+        it("getNewBoardingAddress advances the index, persists a tagged boarding contract, and swaps the current tapscript", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const contractRepo = new InMemoryContractRepository();
+            const wallet = await makeHdWallet(walletRepo, contractRepo);
+
+            const before = await wallet.getBoardingAddress();
+            const rotated = await wallet.getNewBoardingAddress();
+
+            // A fresh boarding address (different HD index).
+            expect(rotated).not.toBe(before);
+            // The current display swapped to it.
+            expect(await wallet.getBoardingAddress()).toBe(rotated);
+            // Shared watermark advanced (boot allocated 0; boarding took 1).
+            const state = await walletRepo.getWalletState();
+            expect(state?.settings?.hd?.lastIndexUsed).toBe(1);
+
+            // The rotated boarding script is persisted as a tagged, active
+            // `boarding` contract.
+            const rotatedScript = hexEncode(wallet.boardingTapscript.pkScript);
+            const row = (await contractRepo.getContracts({})).find(
+                (c) => c.script === rotatedScript,
+            );
+            expect(row).toBeDefined();
+            expect(row!.type).toBe("boarding");
+            expect(row!.state).toBe("active");
+            expect(row!.metadata?.source).toBe("wallet-receive");
+            expect(typeof row!.metadata?.signingDescriptor).toBe("string");
+
+            await wallet.dispose();
+        });
+
+        it("boot restores the most recently allocated boarding address across restarts", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const contractRepo = new InMemoryContractRepository();
+
+            const first = await makeHdWallet(walletRepo, contractRepo);
+            const rotated = await first.getNewBoardingAddress();
+            await first.dispose();
+
+            // Restart on the same repos — boot picks the newest tagged
+            // `boarding` contract and re-derives the boarding tapscript there.
+            const second = await makeHdWallet(walletRepo, contractRepo);
+            expect(await second.getBoardingAddress()).toBe(rotated);
+            await second.dispose();
+        });
+
+        it("a boarding-only rotation does NOT drift the L2 receive address on reboot (receive-boot fix)", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const contractRepo = new InMemoryContractRepository();
+
+            const first = await makeHdWallet(walletRepo, contractRepo);
+            const receiveBefore = await first.getAddress();
+
+            // Boarding allocation advances the shared watermark with NO L2
+            // `vtxo_received`, so the L2 receive must stay at index 0.
+            await first.getNewBoardingAddress();
+            expect(await first.getAddress()).toBe(receiveBefore);
+            const stateAfter = await walletRepo.getWalletState();
+            expect(stateAfter?.settings?.hd?.lastIndexUsed).toBe(1);
+            await first.dispose();
+
+            // Reboot: the watermark is 1 (consumed by boarding) and there is no
+            // tagged L2 receive row. The boot must resolve receive to the
+            // baseline index-0 key, NOT the boarding-consumed index.
+            const second = await makeHdWallet(walletRepo, contractRepo);
+            expect(await second.getAddress()).toBe(receiveBefore);
+            await second.dispose();
+        });
+    });
+});
+
+// Local hex encoder to avoid importing @scure/base just for one call.
+function hexEncode(bytes: Uint8Array): string {
+    return Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+}

--- a/packages/ts-sdk/test/walletBoardingRotation.test.ts
+++ b/packages/ts-sdk/test/walletBoardingRotation.test.ts
@@ -21,6 +21,10 @@ const MNEMONIC =
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 const SINGLEKEY_HEX = "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2";
 const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+// A second, unrelated server key — stands in for a previous ASP. Valid hex so
+// `BoardingContractHandler.createScript` would succeed on it absent the filter.
+const FOREIGN_SERVER_PUBKEY_HEX =
+    "9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b";
 
 const mockArkInfo = {
     signerPubkey: SERVER_PUBKEY_HEX,
@@ -186,6 +190,80 @@ describe("Wallet boarding rotation", () => {
             const second = await makeHdWallet(walletRepo, contractRepo);
             expect(await second.getAddress()).toBe(receiveBefore);
             await second.dispose();
+        });
+    });
+
+    describe("boarding-address discovery (server-pubkey filter)", () => {
+        it("ignores boarding rows registered against a different ASP server", async () => {
+            const contractRepo = new InMemoryContractRepository();
+            const wallet = await makeHdWallet(new InMemoryWalletRepository(), contractRepo);
+
+            // Read the wallet's own server key in the exact form the filter
+            // compares against, so the test is independent of compressed vs
+            // x-only encoding.
+            const ownServerHex = hexEncode(wallet.boardingTapscript.options.serverPubKey);
+            expect(ownServerHex).not.toBe(FOREIGN_SERVER_PUBKEY_HEX);
+
+            const ownAddresses = new Set(await wallet.getBoardingAddresses());
+
+            // A boarding row this wallet owns but that was registered against a
+            // DIFFERENT server (e.g. a repo recovered while pointed at a
+            // previous ASP). Params are otherwise valid, so without the server
+            // filter `createScript` would succeed and surface a spurious
+            // boarding address — the assertion below would then fail.
+            await contractRepo.saveContract({
+                type: "boarding",
+                params: {
+                    pubKey: SINGLEKEY_HEX,
+                    serverPubKey: FOREIGN_SERVER_PUBKEY_HEX,
+                    csvTimelock: "144",
+                },
+                script: "ab".repeat(32), // not consulted by getBoardingTapscripts
+                address: "tb1pforeign-unused",
+                state: "active",
+                createdAt: 1,
+            });
+
+            const withForeign = new Set(await wallet.getBoardingAddresses());
+            // The foreign-server row contributed no boarding address: it was
+            // filtered out before its script was ever built.
+            expect(withForeign).toEqual(ownAddresses);
+
+            await wallet.dispose();
+        });
+
+        it("logs and skips a malformed boarding row without aborting discovery", async () => {
+            const contractRepo = new InMemoryContractRepository();
+            const wallet = await makeHdWallet(new InMemoryWalletRepository(), contractRepo);
+
+            const ownServerHex = hexEncode(wallet.boardingTapscript.options.serverPubKey);
+            const before = new Set(await wallet.getBoardingAddresses());
+
+            const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+            // Passes the server filter (right server) but the owner key is
+            // unparseable, so createScript throws inside discovery.
+            await contractRepo.saveContract({
+                type: "boarding",
+                params: { pubKey: "not-hex", serverPubKey: ownServerHex, csvTimelock: "144" },
+                script: "deadbeef",
+                address: "tb1pbad-unused",
+                state: "active",
+                createdAt: 1,
+            });
+
+            const after = new Set(await wallet.getBoardingAddresses());
+            // Discovery still returns the good addresses — the bad row didn't
+            // abort it…
+            expect(after).toEqual(before);
+            // …and the malformed row was surfaced, not silently swallowed.
+            expect(warn).toHaveBeenCalledWith(
+                "Skipping malformed boarding contract",
+                "deadbeef",
+                expect.anything(),
+            );
+
+            warn.mockRestore();
+            await wallet.dispose();
         });
     });
 });

--- a/packages/ts-sdk/test/walletBoardingRotation.test.ts
+++ b/packages/ts-sdk/test/walletBoardingRotation.test.ts
@@ -193,6 +193,91 @@ describe("Wallet boarding rotation", () => {
         });
     });
 
+    describe("rotate-on-board (settle trigger)", () => {
+        // Fake settle inputs: boarding coins are the non-VTXO coins (no
+        // `virtualStatus`); VTXOs carry one. The rotate-on-board helper keys
+        // off exactly this discriminator, so we don't need a full settle.
+        const boardingCoin = {
+            txid: "ab".repeat(32),
+            vout: 0,
+            value: 100_000,
+            status: { confirmed: true },
+        };
+        const vtxoCoin = {
+            txid: "cd".repeat(32),
+            vout: 0,
+            value: 100_000,
+            virtualStatus: { state: "settled" },
+        };
+
+        it("rotates the boarding address after a settle that consumed a boarding input", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const wallet = await makeHdWallet(walletRepo);
+
+            const before = await wallet.getBoardingAddress();
+            await (wallet as any).maybeRotateBoardingAfterBoard([boardingCoin]);
+            const after = await wallet.getBoardingAddress();
+
+            // The board burned an index and swapped the current boarding address.
+            expect(after).not.toBe(before);
+            const state = await walletRepo.getWalletState();
+            expect(state?.settings?.hd?.lastIndexUsed).toBe(1);
+
+            await wallet.dispose();
+        });
+
+        it("does NOT rotate after a settle that consumed only VTXOs (renewal / offboard)", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const wallet = await makeHdWallet(walletRepo);
+
+            const before = await wallet.getBoardingAddress();
+            await (wallet as any).maybeRotateBoardingAfterBoard([vtxoCoin]);
+
+            // No boarding input ⇒ no board ⇒ boarding address untouched.
+            expect(await wallet.getBoardingAddress()).toBe(before);
+            const state = await walletRepo.getWalletState();
+            expect(state?.settings?.hd?.lastIndexUsed).toBe(0);
+
+            await wallet.dispose();
+        });
+
+        it("ignores arknote string inputs without crashing, and still rotates on a mixed board", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const wallet = await makeHdWallet(walletRepo);
+
+            const before = await wallet.getBoardingAddress();
+            // A string input alongside a boarding coin: the `typeof` guard must
+            // skip the string before the `in` test (which throws on strings).
+            await (wallet as any).maybeRotateBoardingAfterBoard(["arknote-string", boardingCoin]);
+
+            expect(await wallet.getBoardingAddress()).not.toBe(before);
+
+            await wallet.dispose();
+        });
+
+        it("does NOT rotate for a static / auto wallet (no descriptor provider) even after a board", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const wallet = await Wallet.create({
+                identity: SingleKey.fromHex(SINGLEKEY_HEX),
+                walletMode: "static",
+                arkServerUrl: "http://localhost:7070",
+                storage: {
+                    walletRepository: walletRepo,
+                    contractRepository: new InMemoryContractRepository(),
+                },
+            });
+
+            const before = await wallet.getBoardingAddress();
+            await (wallet as any).maybeRotateBoardingAfterBoard([boardingCoin]);
+
+            expect(await wallet.getBoardingAddress()).toBe(before);
+            const state = await walletRepo.getWalletState();
+            expect(state?.settings?.hd).toBeUndefined();
+
+            await wallet.dispose();
+        });
+    });
+
     describe("boarding-address discovery (server-pubkey filter)", () => {
         it("ignores boarding rows registered against a different ASP server", async () => {
             const contractRepo = new InMemoryContractRepository();


### PR DESCRIPTION
Builds on the boarding-contract-type work: adds HD/per-derivation boarding address rotation, on-chain boarding discovery during `restore()`, and multi-address handling (history, notifications, UTXO/sweep fan-out across current + historical boarding addresses).

It also fixes the equal-delay `default`/`boarding` script collision (review Finding #1), aligning with the NArk reference: *tolerate, don't halt; dedupe, don't abort*.

## Collision fix

In the degenerate equal-delay case (`boardingExitDelay === unilateralExitDelay`) the boarding script at an HD index is byte-identical to the `default` script at that index. The old discovery-time coalescing mis-typed a **rotated** boarding index as `default`, making the on-chain UTXO invisible/unspendable.

- `upsertContract` resolves a same-script `default`/`boarding` collision **first-wins** (keeps the existing row; no overwrite, no promote, no throw). One source of truth for both init and the restore scan; any other type mismatch still throws.
- `boarding.discoverAt` always emits `type: "boarding"` — no more pre-coalescing.
- `scanContracts` probes `boarding` before `default`/`delegate` (load-bearing tie-break): a degenerate both-purpose rotated index resolves to a `boarding` row, keeping the on-chain UTXO visible via `getBoardingUtxos` and the L2 VTXO via the type-agnostic `getVtxos`.
- Wallet-layer coalescing consolidated into the persistence layer (`ensureWalletContract` → thin pass-through; helper moved/renamed to `areCoalescibleContractTypes`).

## Tests

New regressions for the rotated boarding-only index (core Finding #1) and the both-hit rotated index (both fund types recovered), a scan-ordering unit test, and `upsertContract` first-wins unit coverage. Full unit suite, lint, build, and smoke:dist all pass.

### Manual testing

- Receive funds to the onchain address
    - on settlement, the Boarding contract is rotated
    - also the Delegate contract is rotated (new VTXO received)
- Receive funds to an old Delegate address 
     -  funds are visibile, balance is updated    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-address boarding discovery, on-chain boarding probes, and automatic rotation-on-board
  * Descriptor-aware on-chain boarding sweep/signing that handles per-UTXO rotated addresses
  * Wallet APIs to expose/manage boarding tapscripts and enumerate boarding addresses

* **Bug Fixes**
  * Notifications and cache refresh now watch all boarding addresses and cleanup targets the correct source address

* **Documentation**
  * Added reference implementation & technical direction guidance

* **Tests**
  * New end-to-end and unit tests covering boarding rotation, discovery, restore, and sweep behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->