### PR TITLE
fix(contracts): restore DEFAULT_TIMELOCK fallback for params without csvTimelock

### DIFF
--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -53,7 +53,14 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
     },
 
     deserializeParams(params: Record<string, string>): DefaultContractParams {
-        const csvTimelock = sequenceToTimelock(Number(params.csvTimelock));
+        // csvTimelock may be absent on legacy/minimal params (e.g. hex pubkeys
+        // with no timelock). DefaultVtxo.Script no longer applies its own
+        // fallback, so restore it here rather than feeding sequenceToTimelock
+        // a NaN (which silently decodes to a zero timelock).
+        const csvTimelock =
+            params.csvTimelock !== undefined && params.csvTimelock !== ""
+                ? sequenceToTimelock(Number(params.csvTimelock))
+                : DefaultVtxo.Script.DEFAULT_TIMELOCK;
         return {
             pubKey: extractPubKeyBytes(params.pubKey),
             serverPubKey: extractPubKeyBytes(params.serverPubKey),


### PR DESCRIPTION
PR #533 (`feat/boarding-contract-type`) made `DefaultVtxo.Script.Options.csvTimelock` required and removed the constructor-level `= DEFAULT_TIMELOCK` fallback, but never moved that fallback into the contract handler. As a result `DefaultContractHandler.deserializeParams` runs `sequenceToTimelock(Number(params.csvTimelock))` when `csvTimelock` is absent, i.e. `sequenceToTimelock(NaN)` → `bip68.decode(0)` → a zero timelock instead of `DEFAULT_TIMELOCK`, producing the wrong pkScript.

This surfaced as a failing unit test that #533 itself added:

```
test/contracts/handlers/boarding.test.ts > "falls back to the default timelock when csvTimelock is missing"
  AssertionError: expected `51200ffce6c9…` to deeply equal `5120cb829bac…`
```

(The analogous `default.test.ts` legacy-hex-param tests only assert the script is defined, so they pass even with the zero-timelock bug — which is why only the boarding test caught it.)

## Fix

Restore the fallback at the deserialize boundary: when `csvTimelock` is absent (legacy/minimal params), use `DefaultVtxo.Script.DEFAULT_TIMELOCK` instead of decoding `NaN`. This keeps the `Script` type strict (explicit timelock required) while preserving the lenient legacy-params behavior the handler tests expect. Real callers (`wallet.ts` boarding/default/delegate) always pass an explicit `csvTimelock`, so this only affects the defensive legacy path.

## Validation

- `boarding.test.ts` now passes; full ts-sdk unit suite green (1305 passed, 1 skipped).
- `default.test.ts` legacy-hex tests still pass (hex and descriptor params both fall back identically).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where contract parameters with missing timelock values could result in invalid data. The system now properly defaults to a standard timelock value in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->