### PR TITLE
restore: scan deprecated server signers for L2 vtxos

### DIFF
--- a/packages/ts-sdk/src/contracts/constants.ts
+++ b/packages/ts-sdk/src/contracts/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Default indexer pagination size for batched VTXO queries (`getVtxos`).
+ *
+ * Shared by {@link ContractManager}'s bulk history sync and the discovery
+ * handlers' batched `detectUsedScripts` probe so the two can't drift. It lives
+ * in its own leaf module (importing nothing) so both the manager and the
+ * handler layer can use it without a `handlers → contractManager` import cycle —
+ * contractManager imports the handler registry, so the handlers must not import
+ * back from contractManager.
+ *
+ * Large enough that a single wallet index's candidate scripts resolve in one
+ * page in the common case.
+ */
+export const DEFAULT_PAGE_SIZE = 500;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -8,7 +8,6 @@ import {
     ContractState,
     ContractVtxo,
     ContractWithVtxos,
-    DiscoveredContract,
     DiscoveryDeps,
     GetContractsFilter,
     PathContext,
@@ -33,8 +32,7 @@ import {
     saveVtxosForContract,
     warnAndFilterVtxosForScript,
 } from "./vtxoOwnership";
-
-const DEFAULT_PAGE_SIZE = 500;
+import { DEFAULT_PAGE_SIZE } from "./constants";
 
 /**
  * Whether two *different* contract types may legitimately share a single
@@ -585,6 +583,9 @@ export class ContractManager implements IContractManager {
      *   other handler hit it).
      * - `persistAndWatchContract` rejecting is operational/fatal and
      *   propagates (only `discoverAt` is guarded).
+     * - Within an index the handler probes run concurrently (independent
+     *   network reads); their hits are persisted sequentially in
+     *   `discoverables` order to preserve the first-wins collision tie-break.
      */
     async scanContracts(opts: ScanContractsOptions): Promise<ScanResult> {
         const gapLimit = opts.gapLimit ?? 20;
@@ -599,9 +600,10 @@ export class ContractManager implements IContractManager {
             .filter(isDiscoverable);
 
         // Probe `boarding` before `default`/`delegate`. This ordering is
-        // LOAD-BEARING, not cosmetic: each hit is persisted immediately and
-        // `upsertContract` resolves a same-script collision FIRST-WINS, so the
-        // iteration order IS the tie-break. In the degenerate equal-delay case
+        // LOAD-BEARING, not cosmetic: within each index the probes run
+        // concurrently, but their hits are persisted in THIS order and
+        // `upsertContract` resolves a same-script collision FIRST-WINS, so this
+        // order IS the persistence tie-break. In the degenerate equal-delay case
         // a rotated index can carry BOTH an on-chain boarding UTXO and an L2
         // VTXO at the same (byte-identical) script; probing boarding first
         // resolves that collision to a `boarding` row, which keeps the on-chain
@@ -625,20 +627,50 @@ export class ContractManager implements IContractManager {
         while (i <= maxIdx && unused < gapLimit) {
             // Materialization failure is fatal/structural — let it propagate.
             const descriptor = opts.materialize(i);
+
+            // Probe every discoverable handler for this index CONCURRENTLY:
+            // they are independent network reads (indexer / on-chain explorer),
+            // so overlapping them cuts per-index latency. The outer index loop
+            // stays sequential — the gap-limit stop condition needs index i
+            // fully evaluated before deciding whether to scan i+1. Each probe's
+            // try/catch mirrors the former serial guard, capturing a discoverAt
+            // rejection (or synchronous throw) instead of propagating it, so one
+            // failing handler never aborts the others.
+            const probes = await Promise.all(
+                discoverables.map(async (h) => {
+                    try {
+                        return {
+                            ok: true as const,
+                            found: await h.discoverAt(i, descriptor, opts.deps),
+                        };
+                    } catch (error) {
+                        return { ok: false as const, error };
+                    }
+                }),
+            );
+
+            // Persist SEQUENTIALLY in the original `discoverables` order — only
+            // the I/O above overlapped. That order is the FIRST-WINS collision
+            // tie-break (boarding before default/delegate), so it must not be
+            // reordered. A persistAndWatchContract rejection stays
+            // operational/fatal (unguarded), matching the materialize contract.
             let hitAtThisIndex = false;
-            for (const h of discoverables) {
-                let found: DiscoveredContract[];
-                try {
-                    found = await h.discoverAt(i, descriptor, opts.deps);
-                } catch (error) {
-                    handlerErrors.push({ handler: h.type, index: i, error });
+            for (let h = 0; h < discoverables.length; h++) {
+                const probe = probes[h];
+                if (!probe.ok) {
+                    handlerErrors.push({
+                        handler: discoverables[h].type,
+                        index: i,
+                        error: probe.error,
+                    });
                     continue;
                 }
-                for (const c of found) {
+                for (const c of probe.found) {
                     await this.persistAndWatchContract(c); // idempotent (script-keyed)
                     hitAtThisIndex = true;
                 }
             }
+
             if (hitAtThisIndex) {
                 lastIndexUsed = i;
                 unused = 0;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -72,6 +72,17 @@ export function areCoalescibleContractTypes(a: string, b: string): boolean {
  */
 const SCAN_MAX_INDEX = 10_000;
 
+/**
+ * Default number of HD indices probed concurrently per {@link scanContracts}
+ * window. The gap loop is still gap-limit bounded and its discovered set is
+ * identical to a one-index-at-a-time scan (see the over-scan-discard rule in
+ * `scanContracts`); the window only overlaps the per-index network round-trips
+ * so an empty wallet closes its `gapLimit` window in `ceil(gapLimit / batch)`
+ * rounds instead of `gapLimit` serial ones. 10 keeps the worst-case over-scan
+ * (indices probed but discarded past the gap-close point) under one window.
+ */
+const DEFAULT_SCAN_BATCH = 10;
+
 export type RefreshVtxosOptions = {
     scripts?: string[];
     after?: number;
@@ -124,6 +135,14 @@ export interface ScanResult {
 export interface ScanContractsOptions {
     /** Default 20. A non-positive / non-integer value throws. */
     gapLimit?: number;
+    /**
+     * Number of HD indices probed concurrently per window (default
+     * {@link DEFAULT_SCAN_BATCH}). Pure latency knob: the gap loop stays
+     * gap-limit bounded and the discovered set is identical regardless of
+     * batch size. A non-positive / non-integer value throws. Ignored when
+     * `hd` is false (the static pass probes only index 0).
+     */
+    batchSize?: number;
     /** HD mode → unbounded gap loop guided by the gap counter; false → probe only index 0 (single static pass). */
     hd: boolean;
     /**
@@ -586,12 +605,28 @@ export class ContractManager implements IContractManager {
      * - Within an index the handler probes run concurrently (independent
      *   network reads); their hits are persisted sequentially in
      *   `discoverables` order to preserve the first-wins collision tie-break.
+     * - Indices are probed `batchSize` at a time (a second concurrency layer
+     *   over the per-index probes), but each window is CAPPED to
+     *   `gapLimit - unused` indices — the most a serial scan could still reach
+     *   before the gap window is guaranteed to close. So every index probed in
+     *   a window is one a one-index-at-a-time scan would also reach: nothing is
+     *   over-scanned, nothing is discarded, and `materialize`/`discoverAt` are
+     *   invoked on exactly the same index set. The window's hits are still
+     *   processed strictly in ascending index order, so the discovered set,
+     *   persisted rows, `lastIndexUsed`, and `handlerErrors` are byte-for-byte
+     *   identical to the serial path — only the wall-clock differs.
      */
     async scanContracts(opts: ScanContractsOptions): Promise<ScanResult> {
         const gapLimit = opts.gapLimit ?? 20;
         if (!Number.isInteger(gapLimit) || gapLimit <= 0) {
             throw new Error(
                 `scanContracts: gapLimit must be a positive integer (got ${String(opts.gapLimit)})`,
+            );
+        }
+        const batchSize = opts.batchSize ?? DEFAULT_SCAN_BATCH;
+        if (!Number.isInteger(batchSize) || batchSize <= 0) {
+            throw new Error(
+                `scanContracts: batchSize must be a positive integer (got ${String(opts.batchSize)})`,
             );
         }
         const registered = contractHandlers
@@ -624,60 +659,76 @@ export class ContractManager implements IContractManager {
         let unused = 0;
         let i = 0;
 
-        while (i <= maxIdx && unused < gapLimit) {
-            // Materialization failure is fatal/structural — let it propagate.
-            const descriptor = opts.materialize(i);
-
-            // Probe every discoverable handler for this index CONCURRENTLY:
-            // they are independent network reads (indexer / on-chain explorer),
-            // so overlapping them cuts per-index latency. The outer index loop
-            // stays sequential — the gap-limit stop condition needs index i
-            // fully evaluated before deciding whether to scan i+1. Each probe's
-            // try/catch mirrors the former serial guard, capturing a discoverAt
-            // rejection (or synchronous throw) instead of propagating it, so one
-            // failing handler never aborts the others.
-            const probes = await Promise.all(
+        // Probe one index's discoverable handlers CONCURRENTLY: they are
+        // independent network reads (indexer / on-chain explorer), so
+        // overlapping them cuts per-index latency. Each probe's try/catch
+        // mirrors the former serial guard, capturing a discoverAt rejection
+        // (or synchronous throw) instead of propagating it, so one failing
+        // handler never aborts the others. Materialization failure is
+        // fatal/structural — it is NOT guarded and propagates.
+        const probeIndex = async (index: number) => {
+            const descriptor = opts.materialize(index);
+            return Promise.all(
                 discoverables.map(async (h) => {
                     try {
                         return {
                             ok: true as const,
-                            found: await h.discoverAt(i, descriptor, opts.deps),
+                            found: await h.discoverAt(index, descriptor, opts.deps),
                         };
                     } catch (error) {
                         return { ok: false as const, error };
                     }
                 }),
             );
+        };
 
-            // Persist SEQUENTIALLY in the original `discoverables` order — only
-            // the I/O above overlapped. That order is the FIRST-WINS collision
-            // tie-break (boarding before default/delegate), so it must not be
-            // reordered. A persistAndWatchContract rejection stays
+        while (i <= maxIdx && unused < gapLimit) {
+            // Probe a WINDOW of indices concurrently (a second concurrency
+            // layer over the per-index probes). The window is capped to
+            // `gapLimit - unused` indices: the most a serial scan could still
+            // reach before the gap window is guaranteed to close. So every
+            // index probed here is one a one-index-at-a-time scan would also
+            // reach — nothing is over-scanned or discarded, and the discovered
+            // set stays byte-for-byte identical to the serial path.
+            const windowEnd = Math.min(maxIdx, i + Math.min(batchSize, gapLimit - unused) - 1);
+            const windowIndices: number[] = [];
+            for (let idx = i; idx <= windowEnd; idx++) windowIndices.push(idx);
+            const windowProbes = await Promise.all(windowIndices.map(probeIndex));
+
+            // Process the window strictly in ASCENDING index order, and within
+            // each index persist in the original `discoverables` order — that
+            // order is the FIRST-WINS collision tie-break (boarding before
+            // default/delegate), so it must not be reordered. Only the I/O
+            // above overlapped. A persistAndWatchContract rejection stays
             // operational/fatal (unguarded), matching the materialize contract.
-            let hitAtThisIndex = false;
-            for (let h = 0; h < discoverables.length; h++) {
-                const probe = probes[h];
-                if (!probe.ok) {
-                    handlerErrors.push({
-                        handler: discoverables[h].type,
-                        index: i,
-                        error: probe.error,
-                    });
-                    continue;
+            for (let w = 0; w < windowIndices.length; w++) {
+                const index = windowIndices[w];
+                const probes = windowProbes[w];
+                let hitAtThisIndex = false;
+                for (let h = 0; h < discoverables.length; h++) {
+                    const probe = probes[h];
+                    if (!probe.ok) {
+                        handlerErrors.push({
+                            handler: discoverables[h].type,
+                            index,
+                            error: probe.error,
+                        });
+                        continue;
+                    }
+                    for (const c of probe.found) {
+                        await this.persistAndWatchContract(c); // idempotent (script-keyed)
+                        hitAtThisIndex = true;
+                    }
                 }
-                for (const c of probe.found) {
-                    await this.persistAndWatchContract(c); // idempotent (script-keyed)
-                    hitAtThisIndex = true;
-                }
-            }
 
-            if (hitAtThisIndex) {
-                lastIndexUsed = i;
-                unused = 0;
-            } else {
-                unused += 1;
+                if (hitAtThisIndex) {
+                    lastIndexUsed = index;
+                    unused = 0;
+                } else {
+                    unused += 1;
+                }
             }
-            i += 1;
+            i = windowEnd + 1;
         }
 
         // Hit the safety ceiling without the gap window closing — the

--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -146,35 +146,47 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
     ): Promise<DiscoveredContract[]> {
         const pubKey = deriveDescriptorLeafPubKey(descriptor);
         const out: DiscoveredContract[] = [];
-        for (const csvTimelock of deps.csvTimelocks) {
-            const script = new DefaultVtxo.Script({
-                pubKey,
-                serverPubKey: deps.serverPubKey,
-                csvTimelock,
-            });
-            const scriptHex = hex.encode(script.pkScript);
-            const { vtxos } = await deps.indexerProvider.getVtxos({
-                scripts: [scriptHex],
-            });
-            if (vtxos.length === 0) continue;
-            out.push({
-                type: "default",
-                params: {
-                    pubKey: hex.encode(pubKey),
-                    serverPubKey: hex.encode(deps.serverPubKey),
-                    csvTimelock: timelockToSequence(csvTimelock).toString(),
-                },
-                script: scriptHex,
-                address: script.address(deps.network.hrp, deps.serverPubKey).encode(),
-                ...(index > 0
-                    ? {
-                          metadata: {
-                              source: WALLET_RECEIVE_SOURCE,
-                              signingDescriptor: descriptor,
-                          },
-                      }
-                    : {}),
-            });
+        // Scan the current signer first, then any deprecated signers, so a VTXO
+        // minted under a now-rotated server key is still discovered. The matched
+        // signer is threaded through the script, persisted params, and encoded
+        // address so signing/forfeit later resolves the right key. Dedup by
+        // scriptHex: a deprecated signer that produced no rotation yields the
+        // same scripts as the current key and must not emit a duplicate.
+        const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
+        const seen = new Set<string>();
+        for (const serverPubKey of signers) {
+            for (const csvTimelock of deps.csvTimelocks) {
+                const script = new DefaultVtxo.Script({
+                    pubKey,
+                    serverPubKey,
+                    csvTimelock,
+                });
+                const scriptHex = hex.encode(script.pkScript);
+                if (seen.has(scriptHex)) continue;
+                seen.add(scriptHex);
+                const { vtxos } = await deps.indexerProvider.getVtxos({
+                    scripts: [scriptHex],
+                });
+                if (vtxos.length === 0) continue;
+                out.push({
+                    type: "default",
+                    params: {
+                        pubKey: hex.encode(pubKey),
+                        serverPubKey: hex.encode(serverPubKey),
+                        csvTimelock: timelockToSequence(csvTimelock).toString(),
+                    },
+                    script: scriptHex,
+                    address: script.address(deps.network.hrp, serverPubKey).encode(),
+                    ...(index > 0
+                        ? {
+                              metadata: {
+                                  source: WALLET_RECEIVE_SOURCE,
+                                  signingDescriptor: descriptor,
+                              },
+                          }
+                        : {}),
+                });
+            }
         }
         return out;
     },

--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -3,7 +3,7 @@ import { DefaultVtxo } from "../../script/default";
 import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
-import { isCsvSpendable } from "./helpers";
+import { isCsvSpendable, detectUsedScripts } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 import {
     normalizeToDescriptor,
@@ -145,15 +145,21 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
         deps: DiscoveryDeps,
     ): Promise<DiscoveredContract[]> {
         const pubKey = deriveDescriptorLeafPubKey(descriptor);
-        const out: DiscoveredContract[] = [];
-        // Scan the current signer first, then any deprecated signers, so a VTXO
-        // minted under a now-rotated server key is still discovered. The matched
-        // signer is threaded through the script, persisted params, and encoded
-        // address so signing/forfeit later resolves the right key. Dedup by
-        // scriptHex: a deprecated signer that produced no rotation yields the
-        // same scripts as the current key and must not emit a duplicate.
+        // Build the candidate set for this wallet index: the current signer
+        // first, then any deprecated signers (so a VTXO minted under a
+        // now-rotated server key is still discovered), each crossed with the
+        // CSV-timelock matrix. Dedup by scriptHex — a deprecated signer that
+        // produced no rotation yields the same scripts as the current key, so
+        // it must neither be probed nor emitted twice; the current signer wins
+        // the attribution.
         const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
         const seen = new Set<string>();
+        const candidates: {
+            serverPubKey: Uint8Array;
+            csvTimelock: RelativeTimelock;
+            script: DefaultVtxo.Script;
+            scriptHex: string;
+        }[] = [];
         for (const serverPubKey of signers) {
             for (const csvTimelock of deps.csvTimelocks) {
                 const script = new DefaultVtxo.Script({
@@ -164,29 +170,41 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
                 const scriptHex = hex.encode(script.pkScript);
                 if (seen.has(scriptHex)) continue;
                 seen.add(scriptHex);
-                const { vtxos } = await deps.indexerProvider.getVtxos({
-                    scripts: [scriptHex],
-                });
-                if (vtxos.length === 0) continue;
-                out.push({
-                    type: "default",
-                    params: {
-                        pubKey: hex.encode(pubKey),
-                        serverPubKey: hex.encode(serverPubKey),
-                        csvTimelock: timelockToSequence(csvTimelock).toString(),
-                    },
-                    script: scriptHex,
-                    address: script.address(deps.network.hrp, serverPubKey).encode(),
-                    ...(index > 0
-                        ? {
-                              metadata: {
-                                  source: WALLET_RECEIVE_SOURCE,
-                                  signingDescriptor: descriptor,
-                              },
-                          }
-                        : {}),
-                });
+                candidates.push({ serverPubKey, csvTimelock, script, scriptHex });
             }
+        }
+
+        // One batched indexer query over every candidate, instead of one call
+        // per (signer × CSV) variant.
+        const used = await detectUsedScripts(
+            deps.indexerProvider,
+            candidates.map((c) => c.scriptHex),
+        );
+
+        const out: DiscoveredContract[] = [];
+        for (const c of candidates) {
+            if (!used.has(c.scriptHex)) continue;
+            // The matched signer is threaded through the script (already built),
+            // the persisted params, and the encoded address so signing/forfeit
+            // later resolves the right key.
+            out.push({
+                type: "default",
+                params: {
+                    pubKey: hex.encode(pubKey),
+                    serverPubKey: hex.encode(c.serverPubKey),
+                    csvTimelock: timelockToSequence(c.csvTimelock).toString(),
+                },
+                script: c.scriptHex,
+                address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
+                ...(index > 0
+                    ? {
+                          metadata: {
+                              source: WALLET_RECEIVE_SOURCE,
+                              signingDescriptor: descriptor,
+                          },
+                      }
+                    : {}),
+            });
         }
         return out;
     },

--- a/packages/ts-sdk/src/contracts/handlers/delegate.ts
+++ b/packages/ts-sdk/src/contracts/handlers/delegate.ts
@@ -134,37 +134,47 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
         if (!deps.delegatePubKey) return [];
         const pubKey = deriveDescriptorLeafPubKey(descriptor);
         const out: DiscoveredContract[] = [];
-        for (const csvTimelock of deps.csvTimelocks) {
-            const script = new DelegateVtxo.Script({
-                pubKey,
-                serverPubKey: deps.serverPubKey,
-                delegatePubKey: deps.delegatePubKey,
-                csvTimelock,
-            });
-            const scriptHex = hex.encode(script.pkScript);
-            const { vtxos } = await deps.indexerProvider.getVtxos({
-                scripts: [scriptHex],
-            });
-            if (vtxos.length === 0) continue;
-            out.push({
-                type: "delegate",
-                params: {
-                    pubKey: hex.encode(pubKey),
-                    serverPubKey: hex.encode(deps.serverPubKey),
-                    delegatePubKey: hex.encode(deps.delegatePubKey),
-                    csvTimelock: timelockToSequence(csvTimelock).toString(),
-                },
-                script: scriptHex,
-                address: script.address(deps.network.hrp, deps.serverPubKey).encode(),
-                ...(index > 0
-                    ? {
-                          metadata: {
-                              source: WALLET_RECEIVE_SOURCE,
-                              signingDescriptor: descriptor,
-                          },
-                      }
-                    : {}),
-            });
+        // Scan the current signer first, then any deprecated signers (see
+        // DefaultContractHandler.discoverAt for the rationale). The matched
+        // signer is threaded through script, params, and address; scriptHex
+        // dedup suppresses duplicate emissions from a non-rotating signer.
+        const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
+        const seen = new Set<string>();
+        for (const serverPubKey of signers) {
+            for (const csvTimelock of deps.csvTimelocks) {
+                const script = new DelegateVtxo.Script({
+                    pubKey,
+                    serverPubKey,
+                    delegatePubKey: deps.delegatePubKey,
+                    csvTimelock,
+                });
+                const scriptHex = hex.encode(script.pkScript);
+                if (seen.has(scriptHex)) continue;
+                seen.add(scriptHex);
+                const { vtxos } = await deps.indexerProvider.getVtxos({
+                    scripts: [scriptHex],
+                });
+                if (vtxos.length === 0) continue;
+                out.push({
+                    type: "delegate",
+                    params: {
+                        pubKey: hex.encode(pubKey),
+                        serverPubKey: hex.encode(serverPubKey),
+                        delegatePubKey: hex.encode(deps.delegatePubKey),
+                        csvTimelock: timelockToSequence(csvTimelock).toString(),
+                    },
+                    script: scriptHex,
+                    address: script.address(deps.network.hrp, serverPubKey).encode(),
+                    ...(index > 0
+                        ? {
+                              metadata: {
+                                  source: WALLET_RECEIVE_SOURCE,
+                                  signingDescriptor: descriptor,
+                              },
+                          }
+                        : {}),
+                });
+            }
         }
         return out;
     },

--- a/packages/ts-sdk/src/contracts/handlers/delegate.ts
+++ b/packages/ts-sdk/src/contracts/handlers/delegate.ts
@@ -3,7 +3,7 @@ import { DelegateVtxo } from "../../script/delegate";
 import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
-import { isCsvSpendable } from "./helpers";
+import { isCsvSpendable, detectUsedScripts } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../metadata";
@@ -133,13 +133,19 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
     ): Promise<DiscoveredContract[]> {
         if (!deps.delegatePubKey) return [];
         const pubKey = deriveDescriptorLeafPubKey(descriptor);
-        const out: DiscoveredContract[] = [];
-        // Scan the current signer first, then any deprecated signers (see
-        // DefaultContractHandler.discoverAt for the rationale). The matched
-        // signer is threaded through script, params, and address; scriptHex
-        // dedup suppresses duplicate emissions from a non-rotating signer.
+        // Build the candidate set: current signer first, then any deprecated
+        // signers, each crossed with the CSV-timelock matrix (see
+        // DefaultContractHandler.discoverAt for the rationale). Dedup by
+        // scriptHex so a non-rotating signer is neither probed nor emitted
+        // twice; the current signer wins the attribution.
         const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
         const seen = new Set<string>();
+        const candidates: {
+            serverPubKey: Uint8Array;
+            csvTimelock: RelativeTimelock;
+            script: DelegateVtxo.Script;
+            scriptHex: string;
+        }[] = [];
         for (const serverPubKey of signers) {
             for (const csvTimelock of deps.csvTimelocks) {
                 const script = new DelegateVtxo.Script({
@@ -151,30 +157,41 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
                 const scriptHex = hex.encode(script.pkScript);
                 if (seen.has(scriptHex)) continue;
                 seen.add(scriptHex);
-                const { vtxos } = await deps.indexerProvider.getVtxos({
-                    scripts: [scriptHex],
-                });
-                if (vtxos.length === 0) continue;
-                out.push({
-                    type: "delegate",
-                    params: {
-                        pubKey: hex.encode(pubKey),
-                        serverPubKey: hex.encode(serverPubKey),
-                        delegatePubKey: hex.encode(deps.delegatePubKey),
-                        csvTimelock: timelockToSequence(csvTimelock).toString(),
-                    },
-                    script: scriptHex,
-                    address: script.address(deps.network.hrp, serverPubKey).encode(),
-                    ...(index > 0
-                        ? {
-                              metadata: {
-                                  source: WALLET_RECEIVE_SOURCE,
-                                  signingDescriptor: descriptor,
-                              },
-                          }
-                        : {}),
-                });
+                candidates.push({ serverPubKey, csvTimelock, script, scriptHex });
             }
+        }
+
+        // One batched indexer query over every candidate, instead of one call
+        // per (signer × CSV) variant.
+        const used = await detectUsedScripts(
+            deps.indexerProvider,
+            candidates.map((c) => c.scriptHex),
+        );
+
+        const out: DiscoveredContract[] = [];
+        for (const c of candidates) {
+            if (!used.has(c.scriptHex)) continue;
+            // The matched signer is threaded through script, params, and
+            // address so signing/forfeit later resolves the right key.
+            out.push({
+                type: "delegate",
+                params: {
+                    pubKey: hex.encode(pubKey),
+                    serverPubKey: hex.encode(c.serverPubKey),
+                    delegatePubKey: hex.encode(deps.delegatePubKey),
+                    csvTimelock: timelockToSequence(c.csvTimelock).toString(),
+                },
+                script: c.scriptHex,
+                address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
+                ...(index > 0
+                    ? {
+                          metadata: {
+                              source: WALLET_RECEIVE_SOURCE,
+                              signingDescriptor: descriptor,
+                          },
+                      }
+                    : {}),
+            });
         }
         return out;
     },

--- a/packages/ts-sdk/src/contracts/handlers/helpers.ts
+++ b/packages/ts-sdk/src/contracts/handlers/helpers.ts
@@ -1,6 +1,8 @@
 import { sequenceToTimelock } from "../../utils/timelock";
 import { Contract, PathContext } from "../types";
 import { isDescriptor, extractPubKey } from "../../identity/descriptor";
+import type { IndexerProvider } from "../../providers/indexer";
+import { DEFAULT_PAGE_SIZE } from "../constants";
 
 /**
  * Extract raw hex pubkey from a value that may be a descriptor or raw hex.
@@ -115,4 +117,48 @@ export function isCsvSpendable(context: PathContext, sequence?: number): boolean
     }
 
     return false;
+}
+
+/**
+ * Batched discovery probe for a single wallet index: given the candidate
+ * pkScripts a `discoverAt` built (the signer × CSV-timelock cross-product,
+ * already deduped), return the subset the indexer has at least one VTXO for —
+ * in any state, since restore counts a spent-but-used script as activity.
+ *
+ * Collapses what used to be one `getVtxos` call per candidate script into a
+ * single call per page, the same batching shape as
+ * {@link ContractManager.fetchContractVtxosBulk}: the indexer reports each
+ * returned VTXO's `script`, which is matched back to the candidate set. It
+ * pages only as far as needed to observe every candidate (stopping early once
+ * all are seen), and otherwise to the end of history, so the discovered set is
+ * identical to the prior per-script path — a heavily-reused candidate cannot
+ * starve another candidate off the first page.
+ */
+export async function detectUsedScripts(
+    indexerProvider: IndexerProvider,
+    scriptHexes: string[],
+): Promise<Set<string>> {
+    const used = new Set<string>();
+    if (scriptHexes.length === 0) return used;
+
+    // `scripts` stays the full candidate set across pages so the indexer's
+    // pagination is consistent; `remaining` only drives the early stop.
+    const remaining = new Set(scriptHexes);
+    let pageIndex = 0;
+    let hasMore = true;
+    while (hasMore && remaining.size > 0) {
+        const { vtxos, page } = await indexerProvider.getVtxos({
+            scripts: scriptHexes,
+            pageIndex,
+            pageSize: DEFAULT_PAGE_SIZE,
+        });
+        for (const vtxo of vtxos) {
+            if (remaining.delete(vtxo.script)) used.add(vtxo.script);
+        }
+        // Same end-of-history heuristic as fetchContractVtxosBulk: a short page
+        // (or absent page metadata) means there is nothing left to fetch.
+        hasMore = page ? vtxos.length === DEFAULT_PAGE_SIZE : false;
+        pageIndex++;
+    }
+    return used;
 }

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -272,7 +272,21 @@ export interface DiscoveryDeps {
      * the scanner unit harness), in which case boarding `discoverAt` no-ops.
      */
     onchainNetwork?: Network;
+    /**
+     * The server's **current** signer key (x-only, 32 bytes), taken from a
+     * fresh server-info snapshot at restore time. L2 (`default`/`delegate`)
+     * discovery probes this key first.
+     */
     serverPubKey: Uint8Array;
+    /**
+     * The server's **deprecated** signer keys (x-only, 32 bytes) from the same
+     * snapshot. A VTXO minted under a now-rotated signer is anchored to a
+     * different script; L2 discovery scans these keys alongside
+     * {@link DiscoveryDeps.serverPubKey} so signer rotation does not strand
+     * funds. Empty/absent when the server advertises no deprecated signers.
+     * Boarding discovery does not consult this set (current UTXO set only).
+     */
+    deprecatedSignerPubKeys?: Uint8Array[];
     /** Relative timelocks the wallet treats as its baseline matrix. */
     csvTimelocks: RelativeTimelock[];
     /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -126,6 +126,16 @@ function extractArkProviderUrl(provider: ArkProvider): string | undefined {
 // legacy address after arkd starts advertising a different delay.
 const MAINNET_UNILATERAL_EXIT_DELAY = 605184n;
 
+// Normalize a server signer pubkey to the x-only (32-byte) form script
+// encoding requires (CSVMultisigTapscript.encode throws on anything else).
+// A 33-byte compressed key drops its parity prefix; a 32-byte key is already
+// x-only. Mirrors the setup path's `hex.decode(info.signerPubkey).slice(1)`.
+function toXOnlyPubKey(pubkey: Uint8Array): Uint8Array {
+    if (pubkey.length === 33) return pubkey.slice(1);
+    if (pubkey.length === 32) return pubkey;
+    throw new Error(`invalid signer pubkey length: expected 32 or 33, got ${pubkey.length}`);
+}
+
 function delayToTimelock(delay: bigint): RelativeTimelock {
     return {
         value: delay,
@@ -1609,6 +1619,17 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 ? this.offchainTapscript.options.delegatePubKey
                 : undefined;
 
+        // Source the signer axis from a single fresh server-info snapshot so
+        // the current and deprecated signers are mutually consistent (mirrors
+        // NArk's recovery-time snapshot). Deriving the current signer from this
+        // snapshot rather than `this.offchainTapscript.options.serverPubKey`
+        // avoids mixing a stale instance signer with fresh history.
+        const arkInfo = await this.arkProvider.getInfo();
+        const currentSignerPubKey = toXOnlyPubKey(hex.decode(arkInfo.signerPubkey));
+        const deprecatedSignerPubKeys = arkInfo.deprecatedSigners.map((s) =>
+            toXOnlyPubKey(hex.decode(s.pubkey)),
+        );
+
         const deps: DiscoveryDeps = {
             indexerProvider: this.indexerProvider,
             onchainProvider: this.onchainProvider,
@@ -1617,7 +1638,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             // `{ hrp }` shape above lacks the `bech32` data
             // `VtxoScript.onchainAddress` needs (plan §6-I.1).
             onchainNetwork: this.network,
-            serverPubKey: this.offchainTapscript.options.serverPubKey,
+            serverPubKey: currentSignerPubKey,
+            deprecatedSignerPubKeys,
             csvTimelocks: this.walletContractTimelocks,
             // Boarding-exit CSV so the boarding handler can build its
             // candidate script (distinct from the unilateral-exit matrix).

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -1100,6 +1100,10 @@ describe("Wallet.restore", () => {
             return reply([]);
         });
         vi.stubGlobal("fetch", mockFetch);
+        return () => {
+            vi.unstubAllGlobals();
+            installRestoreHarness();
+        };
     };
 
     it("discovers a VTXO minted under a deprecated signer and persists the deprecated key in BOTH params and address (plan §3/§4)", async () => {
@@ -1112,10 +1116,13 @@ describe("Wallet.restore", () => {
         const deprecatedKey = hex.decode(deprecatedXOnly);
 
         const { wallet, indexer, hdProvider, contractRepository } = await makeHdWalletForTest();
+        let unstub: (() => void) | undefined;
         try {
             const currentXOnly = hex.encode(wallet.offchainTapscript.options.serverPubKey);
             // Keep the current signer unchanged; advertise one deprecated key.
-            stubInfoWithDeprecated(currentXOnly, [{ cutoffDate: 0, pubkey: deprecatedCompressed }]);
+            unstub = stubInfoWithDeprecated(currentXOnly, [
+                { cutoffDate: 0, pubkey: deprecatedCompressed },
+            ]);
 
             // Mint an L2 VTXO at receive index 2 anchored to the DEPRECATED
             // signer's script (one csvTimelock on this network).
@@ -1146,6 +1153,7 @@ describe("Wallet.restore", () => {
                 hdProvider.materializeDescriptorAt(2),
             );
         } finally {
+            unstub?.();
             await wallet.dispose();
         }
     });

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -242,6 +242,69 @@ describe("DefaultContractHandler.discoverAt", () => {
         expect(out[0].script).toBe(script1);
         expect(out[0].params.csvTimelock).toBe(timelockToSequence(tl1).toString());
     });
+
+    it("scans deprecated signers and stamps the matched key into params AND address", async () => {
+        // A distinct valid x-only point standing in for a now-rotated signer.
+        const deprecatedHex = "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
+        const deprecated = hex.decode(deprecatedHex);
+        const deprecatedScript = hex.encode(
+            new DefaultVtxo.Script({
+                pubKey: hex.decode(pkHex),
+                serverPubKey: deprecated,
+                csvTimelock: tl,
+            }).pkScript,
+        );
+        // Only the deprecated-key script is funded — the current key has none.
+        const out = await DefaultContractHandler.discoverAt(2, descriptor, {
+            indexerProvider: mockIndexer(new Set([deprecatedScript])),
+            onchainProvider: {} as any,
+            network: { hrp: "ark" },
+            serverPubKey: server,
+            deprecatedSignerPubKeys: [deprecated],
+            csvTimelocks: [tl],
+        });
+        expect(out).toHaveLength(1);
+        expect(out[0].script).toBe(deprecatedScript);
+        // The matched deprecated key is threaded through BOTH the persisted
+        // params and the encoded address — not the current serverPubKey.
+        expect(out[0].params.serverPubKey).toBe(deprecatedHex);
+        expect(out[0].address).toBe(
+            new DefaultVtxo.Script({
+                pubKey: hex.decode(pkHex),
+                serverPubKey: deprecated,
+                csvTimelock: tl,
+            })
+                .address("ark", deprecated)
+                .encode(),
+        );
+    });
+
+    it("dedups by scriptHex: a deprecated signer reproducing the current script yields one entry and one probe", async () => {
+        // Degenerate deprecated set: the same key as the current signer, so it
+        // rebuilds a byte-identical script. The `seen` guard must collapse the
+        // two passes into a single probe and a single emitted contract.
+        const calls: string[][] = [];
+        const indexer = {
+            async getVtxos(opts: any) {
+                const scripts = (opts.scripts ?? []) as string[];
+                calls.push(scripts);
+                const vtxos = scripts
+                    .filter((s) => s === script)
+                    .map((s) => ({ value: 1, script: s }) as any);
+                return { vtxos };
+            },
+        } as any;
+        const out = await DefaultContractHandler.discoverAt(2, descriptor, {
+            indexerProvider: indexer,
+            onchainProvider: {} as any,
+            network: { hrp: "ark" },
+            serverPubKey: server,
+            deprecatedSignerPubKeys: [server],
+            csvTimelocks: [tl],
+        });
+        expect(out).toHaveLength(1);
+        expect(calls.flat().filter((s) => s === script)).toHaveLength(1);
+    });
 });
 
 describe("DelegateContractHandler.discoverAt", () => {
@@ -354,6 +417,42 @@ describe("DelegateContractHandler.discoverAt", () => {
 
         expect(entry1.params.csvTimelock).toBe(timelockToSequence(tl1).toString());
         expect(entry2.params.csvTimelock).toBe(timelockToSequence(tl2).toString());
+    });
+
+    it("scans deprecated signers and stamps the matched key into params AND address", async () => {
+        // A distinct valid x-only point standing in for a now-rotated signer.
+        const deprecatedHex = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        const deprecated = hex.decode(deprecatedHex);
+        const deprecatedScript = hex.encode(
+            new DelegateVtxo.Script({
+                pubKey,
+                serverPubKey: deprecated,
+                delegatePubKey: del,
+                csvTimelock: tl,
+            }).pkScript,
+        );
+        const out = await DelegateContractHandler.discoverAt(2, descriptor, {
+            indexerProvider: mockIndexer(new Set([deprecatedScript])),
+            onchainProvider: {} as any,
+            network: { hrp: "ark" },
+            serverPubKey: server,
+            delegatePubKey: del,
+            deprecatedSignerPubKeys: [deprecated],
+            csvTimelocks: [tl],
+        });
+        expect(out).toHaveLength(1);
+        expect(out[0].script).toBe(deprecatedScript);
+        expect(out[0].params.serverPubKey).toBe(deprecatedHex);
+        expect(out[0].address).toBe(
+            new DelegateVtxo.Script({
+                pubKey,
+                serverPubKey: deprecated,
+                delegatePubKey: del,
+                csvTimelock: tl,
+            })
+                .address("ark", deprecated)
+                .encode(),
+        );
     });
 });
 
@@ -967,6 +1066,85 @@ describe("Wallet.restore", () => {
                 }).pkScript,
             );
             expect(boardingRows.map((c) => c.script)).toContain(boardingScript4);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    // Re-point the global fetch's `/info` reply at a fresh server-info
+    // snapshot carrying `deprecatedSigners`. `_runRestore` re-reads
+    // `getInfo()` live, so a stub installed AFTER wallet creation but BEFORE
+    // restore() drives the signer axis without disturbing the build-time key.
+    const stubInfoWithDeprecated = (
+        signerPubkey: string,
+        deprecatedSigners: { cutoffDate: number; pubkey: string }[],
+    ) => {
+        const mockFetch = vi.fn().mockImplementation((url: string) => {
+            const reply = (body: unknown) =>
+                Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+            if (url.includes("/info"))
+                return reply({
+                    signerPubkey,
+                    forfeitPubkey: signerPubkey,
+                    boardingExitDelay: 144,
+                    unilateralExitDelay: 144,
+                    network: "mutinynet",
+                    dust: 1000,
+                    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+                    checkpointTapscript:
+                        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                    deprecatedSigners,
+                });
+            if (url.includes("subscribe") || url.includes("subscriptions"))
+                return reply({ subscriptionId: "sub-1" });
+            return reply([]);
+        });
+        vi.stubGlobal("fetch", mockFetch);
+    };
+
+    it("discovers a VTXO minted under a deprecated signer and persists the deprecated key in BOTH params and address (plan §3/§4)", async () => {
+        // A COMPRESSED (33-byte) deprecated signer key, distinct from the
+        // current one. Restore must x-only-normalize it (33→32 slice, plan
+        // step 2) before building candidate scripts; using the compressed
+        // form keeps that normalization under test.
+        const deprecatedCompressed = "03" + "ab".repeat(32);
+        const deprecatedXOnly = deprecatedCompressed.slice(2);
+        const deprecatedKey = hex.decode(deprecatedXOnly);
+
+        const { wallet, indexer, hdProvider, contractRepository } = await makeHdWalletForTest();
+        try {
+            const currentXOnly = hex.encode(wallet.offchainTapscript.options.serverPubKey);
+            // Keep the current signer unchanged; advertise one deprecated key.
+            stubInfoWithDeprecated(currentXOnly, [{ cutoffDate: 0, pubkey: deprecatedCompressed }]);
+
+            // Mint an L2 VTXO at receive index 2 anchored to the DEPRECATED
+            // signer's script (one csvTimelock on this network).
+            const pubKey2 = deriveDescriptorLeafPubKey(hdProvider.materializeDescriptorAt(2));
+            const deprecatedScript = new DefaultVtxo.Script({
+                pubKey: pubKey2,
+                serverPubKey: deprecatedKey,
+                csvTimelock: wallet.walletContractTimelocks[0],
+            });
+            const deprecatedScriptHex = hex.encode(deprecatedScript.pkScript);
+            indexer.usedScripts.add(deprecatedScriptHex);
+
+            await wallet.restore({ gapLimit: 5 });
+
+            // The contract is recovered and carries the deprecated signer in
+            // BOTH the persisted params and the encoded Ark address — so later
+            // signing/forfeit resolves the key the VTXO was actually minted
+            // under, not the current one.
+            const rows = await contractRepository.getContracts({ type: ["default"] });
+            const match = rows.find((c) => c.script === deprecatedScriptHex);
+            expect(match).toBeDefined();
+            expect(match!.params.serverPubKey).toBe(deprecatedXOnly);
+            expect(match!.address).toBe(
+                deprecatedScript.address(wallet.network.hrp, deprecatedKey).encode(),
+            );
+            // The watermark advances to the recovered index.
+            expect(await hdProvider.getCurrentSigningDescriptor()).toBe(
+                hdProvider.materializeDescriptorAt(2),
+            );
         } finally {
             await wallet.dispose();
         }

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -811,6 +811,116 @@ describe("ContractManager.scanContracts", () => {
             mgr.dispose();
         }
     });
+
+    it("rejects a non-positive / non-integer batchSize", async () => {
+        const mgr = await makeManagerForTest();
+        try {
+            for (const bad of [0, -1, 2.5]) {
+                await expect(
+                    mgr.scanContracts({
+                        batchSize: bad,
+                        hd: true,
+                        materialize,
+                        deps: makeDeps(),
+                    }),
+                ).rejects.toThrow(/batchSize/);
+            }
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("probes a WINDOW of indices concurrently, not one index at a time", async () => {
+        // Cross-index concurrency proof (the point of batching). A SINGLE
+        // handler is registered so the only overlap possible is between
+        // DIFFERENT indices. The handler's probe at the first index waits for a
+        // later index to ALSO enter before returning; a one-index-at-a-time
+        // loop would never launch index 1 until index 0 returned, so index 0
+        // would only ever observe itself and time out. gapLimit 3 → the first
+        // window caps to indices 0,1,2 (all probed concurrently). The handler
+        // always misses so the gap window still closes.
+        let entered = 0;
+        let releaseBoth!: () => void;
+        const bothInFlight = new Promise<void>((r) => (releaseBoth = r));
+        let firstSawBoth = false;
+        const fake = {
+            type: "windowfake",
+            createScript: (p: Record<string, string>) =>
+                ({ pkScript: hex.decode(p.script) }) as any,
+            serializeParams: (p: any) => p,
+            deserializeParams: (p: any) => p,
+            selectPath: () => null,
+            getAllSpendingPaths: () => [],
+            getSpendablePaths: () => [],
+            async discoverAt(index: number) {
+                entered += 1;
+                if (entered === 2) releaseBoth();
+                let timer: ReturnType<typeof setTimeout>;
+                const sawBoth = await Promise.race([
+                    bothInFlight.then(() => true),
+                    new Promise<boolean>((r) => {
+                        timer = setTimeout(() => r(false), 1000);
+                    }),
+                ]);
+                clearTimeout(timer!);
+                if (index === 0) firstSawBoth = sawBoth;
+                return [];
+            },
+        };
+        register("windowfake", fake);
+        const mgr = await makeManagerForTest();
+        try {
+            await mgr.scanContracts({ gapLimit: 3, hd: true, materialize, deps: makeDeps() });
+            expect(entered).toBeGreaterThanOrEqual(2);
+            // Index 0's probe observed a later index in-flight before
+            // returning — only possible if the window overlapped distinct
+            // indices. A serial regression makes this time out (false).
+            expect(firstSawBoth).toBe(true);
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("batchSize is a pure latency knob: the probe sequence and result are batch-invariant", async () => {
+        // The swap-hit-at-4 scenario probes EXACTLY 0..9 under the serial path
+        // (see the core test above). Re-run it under several batch sizes — the
+        // window cap (`gapLimit - unused`) must keep the probed set, its order,
+        // and lastIndexUsed byte-identical regardless of how indices are
+        // grouped. A batch that over-scanned past the gap-close point would
+        // probe index 10+ and break this.
+        for (const batchSize of [1, 2, 3, 7, 100]) {
+            const { handler, calls } = makeFakeHandler("swapbatch", (i) =>
+                i === 4
+                    ? [
+                          {
+                              type: "swapbatch",
+                              params: { script: "aabb" },
+                              script: "aabb",
+                              address: "ark1qswap",
+                          },
+                      ]
+                    : [],
+            );
+            register("swapbatch", handler);
+            const mgr = await makeManagerForTest();
+            try {
+                const res = await mgr.scanContracts({
+                    gapLimit: 5,
+                    batchSize,
+                    hd: true,
+                    materialize,
+                    deps: makeDeps(),
+                });
+                expect(res.lastIndexUsed).toBe(4);
+                expect(res.handlerErrors).toEqual([]);
+                expect([...calls].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            } finally {
+                mgr.dispose();
+                contractHandlers.unregister("swapbatch");
+                registered.splice(registered.indexOf("swapbatch"), 1);
+            }
+        }
+    });
 });
 
 describe("signingDescriptorIndex", () => {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -853,6 +853,125 @@ describe("Wallet.restore", () => {
         }
     });
 
+    it("spent-boarding blind spot: a fully-boarded index is invisible; the receive-destination index holds the line (plan §2/§4/§5)", async () => {
+        // Models a completed board. `Ramps.onboard` pays the boarded VTXO to
+        // `wallet.getAddress()` (the current L2 RECEIVE index), NOT back to the
+        // boarding index, so a boarding index that is funded and then fully
+        // boarded goes cold in BOTH restore signals: no current on-chain UTXO
+        // (not in fundedOnchain) and no L2 VTXO at its own index (not in
+        // usedScripts). The single-branch / current-UTXO model accepts this —
+        // the gap window is instead held open by the receive-destination index.
+        const { wallet, indexer, hdProvider, fundedOnchain } = await makeHdWalletForTest();
+        try {
+            const serverPubKey = wallet.offchainTapscript.options.serverPubKey;
+            const boardingCsv = wallet.boardingTapscript.options.csvTimelock!;
+
+            // L2 receive scripts at an HD index, built like DefaultContractHandler.discoverAt.
+            const receiveScriptsAt = (i: number) =>
+                wallet.walletContractTimelocks.map((csvTimelock) =>
+                    hex.encode(
+                        new DefaultVtxo.Script({
+                            pubKey: deriveDescriptorLeafPubKey(
+                                hdProvider.materializeDescriptorAt(i),
+                            ),
+                            serverPubKey,
+                            csvTimelock,
+                        }).pkScript,
+                    ),
+                );
+            // Boarding pkScript at an HD index, built like BoardingContractHandler.discoverAt.
+            const boardingScriptHexAt = (i: number) =>
+                hex.encode(
+                    new DefaultVtxo.Script({
+                        pubKey: deriveDescriptorLeafPubKey(hdProvider.materializeDescriptorAt(i)),
+                        serverPubKey,
+                        csvTimelock: boardingCsv,
+                    }).pkScript,
+                );
+
+            // The board came from boarding index 2 (now fully spent → left cold),
+            // and paid its VTXO to receive index 1.
+            for (const s of receiveScriptsAt(1)) indexer.usedScripts.add(s);
+            // index 2 deliberately funded in NEITHER signal.
+
+            await wallet.restore({ gapLimit: 5 });
+
+            // The spent boarding index 2 is NOT recovered: no boarding row for
+            // its script (the documented blind spot).
+            const boardingRows = await wallet.contractRepository.getContracts({
+                type: ["boarding"],
+            });
+            expect(boardingRows.map((c) => c.script)).not.toContain(boardingScriptHexAt(2));
+
+            // The watermark sits at the receive-destination index (1) — the
+            // index that actually held the gap window open — NOT the cold
+            // boarding index (2).
+            expect(await hdProvider.getCurrentSigningDescriptor()).toBe(
+                hdProvider.materializeDescriptorAt(1),
+            );
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("a cold (spent) boarding index between used indices does not close the gap window early (plan §4)", async () => {
+        // The reason the spent-boarding blind spot is tolerable: a used
+        // receive-destination index resets the gap counter, so a cold boarding
+        // index in between does not strand a later funded boarding index. Here
+        // gapLimit=3 with the only earlier hit at receive index 1; without that
+        // reset the window would close before reaching the funded boarding UTXO
+        // at index 4 (idx 0,1,2,3 = 4 consecutive misses > 3).
+        const { wallet, indexer, hdProvider, fundedOnchain } = await makeHdWalletForTest();
+        try {
+            const serverPubKey = wallet.offchainTapscript.options.serverPubKey;
+            const boardingCsv = wallet.boardingTapscript.options.csvTimelock!;
+            const receiveScriptsAt = (i: number) =>
+                wallet.walletContractTimelocks.map((csvTimelock) =>
+                    hex.encode(
+                        new DefaultVtxo.Script({
+                            pubKey: deriveDescriptorLeafPubKey(
+                                hdProvider.materializeDescriptorAt(i),
+                            ),
+                            serverPubKey,
+                            csvTimelock,
+                        }).pkScript,
+                    ),
+                );
+            const boardingOnchainAt = (i: number) =>
+                new DefaultVtxo.Script({
+                    pubKey: deriveDescriptorLeafPubKey(hdProvider.materializeDescriptorAt(i)),
+                    serverPubKey,
+                    csvTimelock: boardingCsv,
+                }).onchainAddress(wallet.network);
+
+            // Receive hit at index 1 (board destination); index 2 cold (spent
+            // boarding); a still-unspent funded boarding UTXO at index 4.
+            for (const s of receiveScriptsAt(1)) indexer.usedScripts.add(s);
+            fundedOnchain.add(boardingOnchainAt(4));
+
+            await wallet.restore({ gapLimit: 3 });
+
+            // The funded boarding index 4 is recovered because index 1 reset the
+            // gap counter — the watermark advances all the way to 4.
+            expect(await hdProvider.getCurrentSigningDescriptor()).toBe(
+                hdProvider.materializeDescriptorAt(4),
+            );
+            const boardingRows = await wallet.contractRepository.getContracts({
+                type: ["boarding"],
+            });
+            const boardingScript4 = hex.encode(
+                new DefaultVtxo.Script({
+                    pubKey: deriveDescriptorLeafPubKey(hdProvider.materializeDescriptorAt(4)),
+                    serverPubKey,
+                    csvTimelock: boardingCsv,
+                }).pkScript,
+            );
+            expect(boardingRows.map((c) => c.script)).toContain(boardingScript4);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
     it("getBoardingUtxos unions funds across current + historical boarding addresses (plan §6-III.1)", async () => {
         const { wallet, fundedOnchain } = await makeHdWalletForTest();
         try {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -305,6 +305,48 @@ describe("DefaultContractHandler.discoverAt", () => {
         expect(out).toHaveLength(1);
         expect(calls.flat().filter((s) => s === script)).toHaveLength(1);
     });
+
+    it("batches all csvTimelock variants into a single indexer query (one probe)", async () => {
+        // Win: instead of one getVtxos per csvTimelock, discoverAt issues a
+        // single batched probe over the whole candidate set and maps the
+        // returned vtxos back by script. Both funded timelock scripts are
+        // still discovered, with no over-discovery of the unfunded ones.
+        const tl1: RelativeTimelock = DefaultVtxo.Script.DEFAULT_TIMELOCK;
+        const tl2: RelativeTimelock = { value: 288n, type: "blocks" };
+        const pubKey = hex.decode(pkHex);
+        const mk = (csvTimelock: RelativeTimelock) =>
+            hex.encode(
+                new DefaultVtxo.Script({ pubKey, serverPubKey: server, csvTimelock }).pkScript,
+            );
+        const s1 = mk(tl1);
+        const s2 = mk(tl2);
+
+        const calls: string[][] = [];
+        const indexer = {
+            async getVtxos(opts: any) {
+                const scripts = (opts.scripts ?? []) as string[];
+                calls.push(scripts);
+                const vtxos = scripts
+                    .filter((s) => s === s1 || s === s2)
+                    .map((s) => ({ value: 1, script: s }) as any);
+                return { vtxos };
+            },
+        } as any;
+
+        const out = await DefaultContractHandler.discoverAt(2, descriptor, {
+            indexerProvider: indexer,
+            onchainProvider: {} as any,
+            network: { hrp: "ark" },
+            serverPubKey: server,
+            csvTimelocks: [tl1, tl2],
+        });
+
+        // Exactly ONE batched probe, covering BOTH candidate scripts.
+        expect(calls).toHaveLength(1);
+        expect(new Set(calls[0])).toEqual(new Set([s1, s2]));
+        // Both funded timelock scripts discovered.
+        expect(new Set(out.map((e) => e.script))).toEqual(new Set([s1, s2]));
+    });
 });
 
 describe("DelegateContractHandler.discoverAt", () => {
@@ -718,6 +760,57 @@ describe("ContractManager.scanContracts", () => {
             mgr.dispose();
         }
     });
+
+    it("probes the index's handlers concurrently, not serially", async () => {
+        // Concurrency proof: handler A, once inside discoverAt, waits for
+        // handler B to ALSO enter before returning. Serial probing would never
+        // start B until A returned (A would observe only itself); concurrent
+        // probing lets B enter while A waits, so A resolves via the shared
+        // barrier. A bounded fallback turns a serial regression into a fast
+        // assertion failure instead of a hang.
+        let entered = 0;
+        let releaseBoth!: () => void;
+        const bothInFlight = new Promise<void>((r) => (releaseBoth = r));
+        let seq = 0;
+        let firstSawBoth = false;
+        const makeConcurrentFake = (type: string) => ({
+            type,
+            createScript: (p: Record<string, string>) =>
+                ({ pkScript: hex.decode(p.script) }) as any,
+            serializeParams: (p: any) => p,
+            deserializeParams: (p: any) => p,
+            selectPath: () => null,
+            getAllSpendingPaths: () => [],
+            getSpendablePaths: () => [],
+            async discoverAt() {
+                const mine = ++seq; // 1 = first handler launched, 2 = second
+                entered += 1;
+                if (entered === 2) releaseBoth();
+                let timer: ReturnType<typeof setTimeout>;
+                const sawBoth = await Promise.race([
+                    bothInFlight.then(() => true),
+                    new Promise<boolean>((r) => {
+                        timer = setTimeout(() => r(false), 1000);
+                    }),
+                ]);
+                clearTimeout(timer!);
+                if (mine === 1) firstSawBoth = sawBoth;
+                return [];
+            },
+        });
+        register("concA", makeConcurrentFake("concA"));
+        register("concB", makeConcurrentFake("concB"));
+        const mgr = await makeManagerForTest();
+        try {
+            await mgr.scanContracts({ gapLimit: 1, hd: false, materialize, deps: makeDeps() });
+            expect(entered).toBe(2);
+            // The first-launched handler observed the second in-flight before
+            // returning — only possible if the probes overlapped.
+            expect(firstSawBoth).toBe(true);
+        } finally {
+            mgr.dispose();
+        }
+    });
 });
 
 describe("signingDescriptorIndex", () => {
@@ -763,10 +856,9 @@ describe("Wallet.restore", () => {
             const balance = await wallet.getBalance();
             expect(balance.total).toBeGreaterThan(0);
 
-            // Static mode is a single pass at index 0: the default
-            // handler probes each csvTimelock at index 0 exactly once.
-            // Every probed scripts-array should be index-0 derived; the
-            // scan must not have walked an HD range.
+            // Static mode is a single pass at index 0: the default handler
+            // probes its index-0 candidate scripts in one batched query, so
+            // a discovery probe ran. The scan must not have walked an HD range.
             expect(indexer.getVtxosCalls.length).toBeGreaterThan(0);
         } finally {
             await wallet.dispose();
@@ -1427,10 +1519,10 @@ describe("Wallet.restore", () => {
             expect(a).toBeUndefined();
             expect(b).toBeUndefined();
 
-            // Both awaited the same in-flight promise: the static scan
-            // is a single index-0 pass, so the number of probes equals
-            // exactly one run (one getVtxos per csvTimelock) plus the
-            // single inline refreshVtxos pull — NOT doubled.
+            // Both awaited the same in-flight promise: the static scan is a
+            // single index-0 pass, so the probe count reflects exactly one run
+            // (a batched discovery query plus the single inline refreshVtxos
+            // pull) — NOT doubled.
             const singleRunCalls = indexer.getVtxosCalls.length;
             expect(singleRunCalls).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

Closes the signer-rotation restore gap: `wallet.restore()` discovered L2 (`default`/`delegate`) VTXOs only under the server's **current** signer key, so VTXOs minted under a now-deprecated signer were anchored to a different script and silently missed — a fund-loss path on signer rotation. This mirrors how the reference NArk SDK already scans `{ current ∪ deprecated signers }`.

Implements `docs/hd-wallets-deprecated-signers.md`.

## Changes

- **`DiscoveryDeps`** gains `deprecatedSignerPubKeys?: Uint8Array[]`; `serverPubKey` is now documented as the snapshot's *current* signer.
- **`_runRestore`** fetches a single fresh `getInfo()` snapshot and derives **both** the current signer (used as `deps.serverPubKey`) and the deprecated set from it — no longer mixing a stale instance signer with fresh history. A new `toXOnlyPubKey` normalizer handles 33-byte compressed → x-only (32-byte) keys.
- **`default.ts` / `delegate.ts`** `discoverAt` wraps the `csvTimelocks` loop in a signer loop over `[serverPubKey, ...deprecatedSignerPubKeys]`, dedupes candidates by `scriptHex`, and threads the matched signer through the script, persisted `params.serverPubKey`, **and** the encoded `address` so signing/forfeit later resolves the correct key.
- Boarding discovery stays current-key only (documented out-of-scope blind spot).

Also includes a separate commit covering the spent-boarding restore blind spot in tests.

## Tests

- Handler-level: deprecated-signer discovery stamps the matched key into params + address (default & delegate); scriptHex dedup yields one entry / one probe.
- Restore-level: a VTXO minted under a **compressed (33-byte)** deprecated key is discovered and persisted under the deprecated x-only key in both `params.serverPubKey` and the encoded `address` (exercises the normalization).
- `tsc --noEmit` clean; full unit suite passes (1333 passed, 1 skipped) excluding e2e and the pre-existing `migrations.test.ts` failure (missing `better-sqlite3` native bindings locally — fails on `master` too).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster, batched contract discovery with concurrent probing and a configurable scan batch size for quicker restores and syncs.
  * Improved detection that scans historical signer variants to recover addresses minted under rotated keys.

* **Bug Fixes**
  * Wallet restore now recovers funds created under deprecated signer keys, deduplicates duplicate discoveries, and records the actual signer for restored addresses.

* **Tests**
  * Expanded regression tests for deprecated-signer discovery, deduplication, batching, concurrency, and nuanced restore edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->