### PR TITLE
restore: parallelize per-index probes and batch candidate queries

### DIFF
--- a/packages/ts-sdk/src/contracts/constants.ts
+++ b/packages/ts-sdk/src/contracts/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Default indexer pagination size for batched VTXO queries (`getVtxos`).
+ *
+ * Shared by {@link ContractManager}'s bulk history sync and the discovery
+ * handlers' batched `detectUsedScripts` probe so the two can't drift. It lives
+ * in its own leaf module (importing nothing) so both the manager and the
+ * handler layer can use it without a `handlers → contractManager` import cycle —
+ * contractManager imports the handler registry, so the handlers must not import
+ * back from contractManager.
+ *
+ * Large enough that a single wallet index's candidate scripts resolve in one
+ * page in the common case.
+ */
+export const DEFAULT_PAGE_SIZE = 500;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -8,7 +8,6 @@ import {
     ContractState,
     ContractVtxo,
     ContractWithVtxos,
-    DiscoveredContract,
     DiscoveryDeps,
     GetContractsFilter,
     PathContext,
@@ -33,8 +32,7 @@ import {
     saveVtxosForContract,
     warnAndFilterVtxosForScript,
 } from "./vtxoOwnership";
-
-const DEFAULT_PAGE_SIZE = 500;
+import { DEFAULT_PAGE_SIZE } from "./constants";
 
 /**
  * Whether two *different* contract types may legitimately share a single
@@ -585,6 +583,9 @@ export class ContractManager implements IContractManager {
      *   other handler hit it).
      * - `persistAndWatchContract` rejecting is operational/fatal and
      *   propagates (only `discoverAt` is guarded).
+     * - Within an index the handler probes run concurrently (independent
+     *   network reads); their hits are persisted sequentially in
+     *   `discoverables` order to preserve the first-wins collision tie-break.
      */
     async scanContracts(opts: ScanContractsOptions): Promise<ScanResult> {
         const gapLimit = opts.gapLimit ?? 20;
@@ -599,9 +600,10 @@ export class ContractManager implements IContractManager {
             .filter(isDiscoverable);
 
         // Probe `boarding` before `default`/`delegate`. This ordering is
-        // LOAD-BEARING, not cosmetic: each hit is persisted immediately and
-        // `upsertContract` resolves a same-script collision FIRST-WINS, so the
-        // iteration order IS the tie-break. In the degenerate equal-delay case
+        // LOAD-BEARING, not cosmetic: within each index the probes run
+        // concurrently, but their hits are persisted in THIS order and
+        // `upsertContract` resolves a same-script collision FIRST-WINS, so this
+        // order IS the persistence tie-break. In the degenerate equal-delay case
         // a rotated index can carry BOTH an on-chain boarding UTXO and an L2
         // VTXO at the same (byte-identical) script; probing boarding first
         // resolves that collision to a `boarding` row, which keeps the on-chain
@@ -625,20 +627,50 @@ export class ContractManager implements IContractManager {
         while (i <= maxIdx && unused < gapLimit) {
             // Materialization failure is fatal/structural — let it propagate.
             const descriptor = opts.materialize(i);
+
+            // Probe every discoverable handler for this index CONCURRENTLY:
+            // they are independent network reads (indexer / on-chain explorer),
+            // so overlapping them cuts per-index latency. The outer index loop
+            // stays sequential — the gap-limit stop condition needs index i
+            // fully evaluated before deciding whether to scan i+1. Each probe's
+            // try/catch mirrors the former serial guard, capturing a discoverAt
+            // rejection (or synchronous throw) instead of propagating it, so one
+            // failing handler never aborts the others.
+            const probes = await Promise.all(
+                discoverables.map(async (h) => {
+                    try {
+                        return {
+                            ok: true as const,
+                            found: await h.discoverAt(i, descriptor, opts.deps),
+                        };
+                    } catch (error) {
+                        return { ok: false as const, error };
+                    }
+                }),
+            );
+
+            // Persist SEQUENTIALLY in the original `discoverables` order — only
+            // the I/O above overlapped. That order is the FIRST-WINS collision
+            // tie-break (boarding before default/delegate), so it must not be
+            // reordered. A persistAndWatchContract rejection stays
+            // operational/fatal (unguarded), matching the materialize contract.
             let hitAtThisIndex = false;
-            for (const h of discoverables) {
-                let found: DiscoveredContract[];
-                try {
-                    found = await h.discoverAt(i, descriptor, opts.deps);
-                } catch (error) {
-                    handlerErrors.push({ handler: h.type, index: i, error });
+            for (let h = 0; h < discoverables.length; h++) {
+                const probe = probes[h];
+                if (!probe.ok) {
+                    handlerErrors.push({
+                        handler: discoverables[h].type,
+                        index: i,
+                        error: probe.error,
+                    });
                     continue;
                 }
-                for (const c of found) {
+                for (const c of probe.found) {
                     await this.persistAndWatchContract(c); // idempotent (script-keyed)
                     hitAtThisIndex = true;
                 }
             }
+
             if (hitAtThisIndex) {
                 lastIndexUsed = i;
                 unused = 0;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -72,6 +72,17 @@ export function areCoalescibleContractTypes(a: string, b: string): boolean {
  */
 const SCAN_MAX_INDEX = 10_000;
 
+/**
+ * Default number of HD indices probed concurrently per {@link scanContracts}
+ * window. The gap loop is still gap-limit bounded and its discovered set is
+ * identical to a one-index-at-a-time scan (see the over-scan-discard rule in
+ * `scanContracts`); the window only overlaps the per-index network round-trips
+ * so an empty wallet closes its `gapLimit` window in `ceil(gapLimit / batch)`
+ * rounds instead of `gapLimit` serial ones. 10 keeps the worst-case over-scan
+ * (indices probed but discarded past the gap-close point) under one window.
+ */
+const DEFAULT_SCAN_BATCH = 10;
+
 export type RefreshVtxosOptions = {
     scripts?: string[];
     after?: number;
@@ -124,6 +135,14 @@ export interface ScanResult {
 export interface ScanContractsOptions {
     /** Default 20. A non-positive / non-integer value throws. */
     gapLimit?: number;
+    /**
+     * Number of HD indices probed concurrently per window (default
+     * {@link DEFAULT_SCAN_BATCH}). Pure latency knob: the gap loop stays
+     * gap-limit bounded and the discovered set is identical regardless of
+     * batch size. A non-positive / non-integer value throws. Ignored when
+     * `hd` is false (the static pass probes only index 0).
+     */
+    batchSize?: number;
     /** HD mode → unbounded gap loop guided by the gap counter; false → probe only index 0 (single static pass). */
     hd: boolean;
     /**
@@ -586,12 +605,28 @@ export class ContractManager implements IContractManager {
      * - Within an index the handler probes run concurrently (independent
      *   network reads); their hits are persisted sequentially in
      *   `discoverables` order to preserve the first-wins collision tie-break.
+     * - Indices are probed `batchSize` at a time (a second concurrency layer
+     *   over the per-index probes), but each window is CAPPED to
+     *   `gapLimit - unused` indices — the most a serial scan could still reach
+     *   before the gap window is guaranteed to close. So every index probed in
+     *   a window is one a one-index-at-a-time scan would also reach: nothing is
+     *   over-scanned, nothing is discarded, and `materialize`/`discoverAt` are
+     *   invoked on exactly the same index set. The window's hits are still
+     *   processed strictly in ascending index order, so the discovered set,
+     *   persisted rows, `lastIndexUsed`, and `handlerErrors` are byte-for-byte
+     *   identical to the serial path — only the wall-clock differs.
      */
     async scanContracts(opts: ScanContractsOptions): Promise<ScanResult> {
         const gapLimit = opts.gapLimit ?? 20;
         if (!Number.isInteger(gapLimit) || gapLimit <= 0) {
             throw new Error(
                 `scanContracts: gapLimit must be a positive integer (got ${String(opts.gapLimit)})`,
+            );
+        }
+        const batchSize = opts.batchSize ?? DEFAULT_SCAN_BATCH;
+        if (!Number.isInteger(batchSize) || batchSize <= 0) {
+            throw new Error(
+                `scanContracts: batchSize must be a positive integer (got ${String(opts.batchSize)})`,
             );
         }
         const registered = contractHandlers
@@ -624,60 +659,76 @@ export class ContractManager implements IContractManager {
         let unused = 0;
         let i = 0;
 
-        while (i <= maxIdx && unused < gapLimit) {
-            // Materialization failure is fatal/structural — let it propagate.
-            const descriptor = opts.materialize(i);
-
-            // Probe every discoverable handler for this index CONCURRENTLY:
-            // they are independent network reads (indexer / on-chain explorer),
-            // so overlapping them cuts per-index latency. The outer index loop
-            // stays sequential — the gap-limit stop condition needs index i
-            // fully evaluated before deciding whether to scan i+1. Each probe's
-            // try/catch mirrors the former serial guard, capturing a discoverAt
-            // rejection (or synchronous throw) instead of propagating it, so one
-            // failing handler never aborts the others.
-            const probes = await Promise.all(
+        // Probe one index's discoverable handlers CONCURRENTLY: they are
+        // independent network reads (indexer / on-chain explorer), so
+        // overlapping them cuts per-index latency. Each probe's try/catch
+        // mirrors the former serial guard, capturing a discoverAt rejection
+        // (or synchronous throw) instead of propagating it, so one failing
+        // handler never aborts the others. Materialization failure is
+        // fatal/structural — it is NOT guarded and propagates.
+        const probeIndex = async (index: number) => {
+            const descriptor = opts.materialize(index);
+            return Promise.all(
                 discoverables.map(async (h) => {
                     try {
                         return {
                             ok: true as const,
-                            found: await h.discoverAt(i, descriptor, opts.deps),
+                            found: await h.discoverAt(index, descriptor, opts.deps),
                         };
                     } catch (error) {
                         return { ok: false as const, error };
                     }
                 }),
             );
+        };
 
-            // Persist SEQUENTIALLY in the original `discoverables` order — only
-            // the I/O above overlapped. That order is the FIRST-WINS collision
-            // tie-break (boarding before default/delegate), so it must not be
-            // reordered. A persistAndWatchContract rejection stays
+        while (i <= maxIdx && unused < gapLimit) {
+            // Probe a WINDOW of indices concurrently (a second concurrency
+            // layer over the per-index probes). The window is capped to
+            // `gapLimit - unused` indices: the most a serial scan could still
+            // reach before the gap window is guaranteed to close. So every
+            // index probed here is one a one-index-at-a-time scan would also
+            // reach — nothing is over-scanned or discarded, and the discovered
+            // set stays byte-for-byte identical to the serial path.
+            const windowEnd = Math.min(maxIdx, i + Math.min(batchSize, gapLimit - unused) - 1);
+            const windowIndices: number[] = [];
+            for (let idx = i; idx <= windowEnd; idx++) windowIndices.push(idx);
+            const windowProbes = await Promise.all(windowIndices.map(probeIndex));
+
+            // Process the window strictly in ASCENDING index order, and within
+            // each index persist in the original `discoverables` order — that
+            // order is the FIRST-WINS collision tie-break (boarding before
+            // default/delegate), so it must not be reordered. Only the I/O
+            // above overlapped. A persistAndWatchContract rejection stays
             // operational/fatal (unguarded), matching the materialize contract.
-            let hitAtThisIndex = false;
-            for (let h = 0; h < discoverables.length; h++) {
-                const probe = probes[h];
-                if (!probe.ok) {
-                    handlerErrors.push({
-                        handler: discoverables[h].type,
-                        index: i,
-                        error: probe.error,
-                    });
-                    continue;
+            for (let w = 0; w < windowIndices.length; w++) {
+                const index = windowIndices[w];
+                const probes = windowProbes[w];
+                let hitAtThisIndex = false;
+                for (let h = 0; h < discoverables.length; h++) {
+                    const probe = probes[h];
+                    if (!probe.ok) {
+                        handlerErrors.push({
+                            handler: discoverables[h].type,
+                            index,
+                            error: probe.error,
+                        });
+                        continue;
+                    }
+                    for (const c of probe.found) {
+                        await this.persistAndWatchContract(c); // idempotent (script-keyed)
+                        hitAtThisIndex = true;
+                    }
                 }
-                for (const c of probe.found) {
-                    await this.persistAndWatchContract(c); // idempotent (script-keyed)
-                    hitAtThisIndex = true;
-                }
-            }
 
-            if (hitAtThisIndex) {
-                lastIndexUsed = i;
-                unused = 0;
-            } else {
-                unused += 1;
+                if (hitAtThisIndex) {
+                    lastIndexUsed = index;
+                    unused = 0;
+                } else {
+                    unused += 1;
+                }
             }
-            i += 1;
+            i = windowEnd + 1;
         }
 
         // Hit the safety ceiling without the gap window closing — the

--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -3,7 +3,7 @@ import { DefaultVtxo } from "../../script/default";
 import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
-import { isCsvSpendable } from "./helpers";
+import { isCsvSpendable, detectUsedScripts } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 import {
     normalizeToDescriptor,
@@ -145,15 +145,21 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
         deps: DiscoveryDeps,
     ): Promise<DiscoveredContract[]> {
         const pubKey = deriveDescriptorLeafPubKey(descriptor);
-        const out: DiscoveredContract[] = [];
-        // Scan the current signer first, then any deprecated signers, so a VTXO
-        // minted under a now-rotated server key is still discovered. The matched
-        // signer is threaded through the script, persisted params, and encoded
-        // address so signing/forfeit later resolves the right key. Dedup by
-        // scriptHex: a deprecated signer that produced no rotation yields the
-        // same scripts as the current key and must not emit a duplicate.
+        // Build the candidate set for this wallet index: the current signer
+        // first, then any deprecated signers (so a VTXO minted under a
+        // now-rotated server key is still discovered), each crossed with the
+        // CSV-timelock matrix. Dedup by scriptHex — a deprecated signer that
+        // produced no rotation yields the same scripts as the current key, so
+        // it must neither be probed nor emitted twice; the current signer wins
+        // the attribution.
         const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
         const seen = new Set<string>();
+        const candidates: {
+            serverPubKey: Uint8Array;
+            csvTimelock: RelativeTimelock;
+            script: DefaultVtxo.Script;
+            scriptHex: string;
+        }[] = [];
         for (const serverPubKey of signers) {
             for (const csvTimelock of deps.csvTimelocks) {
                 const script = new DefaultVtxo.Script({
@@ -164,29 +170,41 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
                 const scriptHex = hex.encode(script.pkScript);
                 if (seen.has(scriptHex)) continue;
                 seen.add(scriptHex);
-                const { vtxos } = await deps.indexerProvider.getVtxos({
-                    scripts: [scriptHex],
-                });
-                if (vtxos.length === 0) continue;
-                out.push({
-                    type: "default",
-                    params: {
-                        pubKey: hex.encode(pubKey),
-                        serverPubKey: hex.encode(serverPubKey),
-                        csvTimelock: timelockToSequence(csvTimelock).toString(),
-                    },
-                    script: scriptHex,
-                    address: script.address(deps.network.hrp, serverPubKey).encode(),
-                    ...(index > 0
-                        ? {
-                              metadata: {
-                                  source: WALLET_RECEIVE_SOURCE,
-                                  signingDescriptor: descriptor,
-                              },
-                          }
-                        : {}),
-                });
+                candidates.push({ serverPubKey, csvTimelock, script, scriptHex });
             }
+        }
+
+        // One batched indexer query over every candidate, instead of one call
+        // per (signer × CSV) variant.
+        const used = await detectUsedScripts(
+            deps.indexerProvider,
+            candidates.map((c) => c.scriptHex),
+        );
+
+        const out: DiscoveredContract[] = [];
+        for (const c of candidates) {
+            if (!used.has(c.scriptHex)) continue;
+            // The matched signer is threaded through the script (already built),
+            // the persisted params, and the encoded address so signing/forfeit
+            // later resolves the right key.
+            out.push({
+                type: "default",
+                params: {
+                    pubKey: hex.encode(pubKey),
+                    serverPubKey: hex.encode(c.serverPubKey),
+                    csvTimelock: timelockToSequence(c.csvTimelock).toString(),
+                },
+                script: c.scriptHex,
+                address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
+                ...(index > 0
+                    ? {
+                          metadata: {
+                              source: WALLET_RECEIVE_SOURCE,
+                              signingDescriptor: descriptor,
+                          },
+                      }
+                    : {}),
+            });
         }
         return out;
     },

--- a/packages/ts-sdk/src/contracts/handlers/delegate.ts
+++ b/packages/ts-sdk/src/contracts/handlers/delegate.ts
@@ -3,7 +3,7 @@ import { DelegateVtxo } from "../../script/delegate";
 import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
-import { isCsvSpendable } from "./helpers";
+import { isCsvSpendable, detectUsedScripts } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../metadata";
@@ -133,13 +133,19 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
     ): Promise<DiscoveredContract[]> {
         if (!deps.delegatePubKey) return [];
         const pubKey = deriveDescriptorLeafPubKey(descriptor);
-        const out: DiscoveredContract[] = [];
-        // Scan the current signer first, then any deprecated signers (see
-        // DefaultContractHandler.discoverAt for the rationale). The matched
-        // signer is threaded through script, params, and address; scriptHex
-        // dedup suppresses duplicate emissions from a non-rotating signer.
+        // Build the candidate set: current signer first, then any deprecated
+        // signers, each crossed with the CSV-timelock matrix (see
+        // DefaultContractHandler.discoverAt for the rationale). Dedup by
+        // scriptHex so a non-rotating signer is neither probed nor emitted
+        // twice; the current signer wins the attribution.
         const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
         const seen = new Set<string>();
+        const candidates: {
+            serverPubKey: Uint8Array;
+            csvTimelock: RelativeTimelock;
+            script: DelegateVtxo.Script;
+            scriptHex: string;
+        }[] = [];
         for (const serverPubKey of signers) {
             for (const csvTimelock of deps.csvTimelocks) {
                 const script = new DelegateVtxo.Script({
@@ -151,30 +157,41 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
                 const scriptHex = hex.encode(script.pkScript);
                 if (seen.has(scriptHex)) continue;
                 seen.add(scriptHex);
-                const { vtxos } = await deps.indexerProvider.getVtxos({
-                    scripts: [scriptHex],
-                });
-                if (vtxos.length === 0) continue;
-                out.push({
-                    type: "delegate",
-                    params: {
-                        pubKey: hex.encode(pubKey),
-                        serverPubKey: hex.encode(serverPubKey),
-                        delegatePubKey: hex.encode(deps.delegatePubKey),
-                        csvTimelock: timelockToSequence(csvTimelock).toString(),
-                    },
-                    script: scriptHex,
-                    address: script.address(deps.network.hrp, serverPubKey).encode(),
-                    ...(index > 0
-                        ? {
-                              metadata: {
-                                  source: WALLET_RECEIVE_SOURCE,
-                                  signingDescriptor: descriptor,
-                              },
-                          }
-                        : {}),
-                });
+                candidates.push({ serverPubKey, csvTimelock, script, scriptHex });
             }
+        }
+
+        // One batched indexer query over every candidate, instead of one call
+        // per (signer × CSV) variant.
+        const used = await detectUsedScripts(
+            deps.indexerProvider,
+            candidates.map((c) => c.scriptHex),
+        );
+
+        const out: DiscoveredContract[] = [];
+        for (const c of candidates) {
+            if (!used.has(c.scriptHex)) continue;
+            // The matched signer is threaded through script, params, and
+            // address so signing/forfeit later resolves the right key.
+            out.push({
+                type: "delegate",
+                params: {
+                    pubKey: hex.encode(pubKey),
+                    serverPubKey: hex.encode(c.serverPubKey),
+                    delegatePubKey: hex.encode(deps.delegatePubKey),
+                    csvTimelock: timelockToSequence(c.csvTimelock).toString(),
+                },
+                script: c.scriptHex,
+                address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
+                ...(index > 0
+                    ? {
+                          metadata: {
+                              source: WALLET_RECEIVE_SOURCE,
+                              signingDescriptor: descriptor,
+                          },
+                      }
+                    : {}),
+            });
         }
         return out;
     },

--- a/packages/ts-sdk/src/contracts/handlers/helpers.ts
+++ b/packages/ts-sdk/src/contracts/handlers/helpers.ts
@@ -1,6 +1,8 @@
 import { sequenceToTimelock } from "../../utils/timelock";
 import { Contract, PathContext } from "../types";
 import { isDescriptor, extractPubKey } from "../../identity/descriptor";
+import type { IndexerProvider } from "../../providers/indexer";
+import { DEFAULT_PAGE_SIZE } from "../constants";
 
 /**
  * Extract raw hex pubkey from a value that may be a descriptor or raw hex.
@@ -115,4 +117,48 @@ export function isCsvSpendable(context: PathContext, sequence?: number): boolean
     }
 
     return false;
+}
+
+/**
+ * Batched discovery probe for a single wallet index: given the candidate
+ * pkScripts a `discoverAt` built (the signer × CSV-timelock cross-product,
+ * already deduped), return the subset the indexer has at least one VTXO for —
+ * in any state, since restore counts a spent-but-used script as activity.
+ *
+ * Collapses what used to be one `getVtxos` call per candidate script into a
+ * single call per page, the same batching shape as
+ * {@link ContractManager.fetchContractVtxosBulk}: the indexer reports each
+ * returned VTXO's `script`, which is matched back to the candidate set. It
+ * pages only as far as needed to observe every candidate (stopping early once
+ * all are seen), and otherwise to the end of history, so the discovered set is
+ * identical to the prior per-script path — a heavily-reused candidate cannot
+ * starve another candidate off the first page.
+ */
+export async function detectUsedScripts(
+    indexerProvider: IndexerProvider,
+    scriptHexes: string[],
+): Promise<Set<string>> {
+    const used = new Set<string>();
+    if (scriptHexes.length === 0) return used;
+
+    // `scripts` stays the full candidate set across pages so the indexer's
+    // pagination is consistent; `remaining` only drives the early stop.
+    const remaining = new Set(scriptHexes);
+    let pageIndex = 0;
+    let hasMore = true;
+    while (hasMore && remaining.size > 0) {
+        const { vtxos, page } = await indexerProvider.getVtxos({
+            scripts: scriptHexes,
+            pageIndex,
+            pageSize: DEFAULT_PAGE_SIZE,
+        });
+        for (const vtxo of vtxos) {
+            if (remaining.delete(vtxo.script)) used.add(vtxo.script);
+        }
+        // Same end-of-history heuristic as fetchContractVtxosBulk: a short page
+        // (or absent page metadata) means there is nothing left to fetch.
+        hasMore = page ? vtxos.length === DEFAULT_PAGE_SIZE : false;
+        pageIndex++;
+    }
+    return used;
 }

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -811,6 +811,116 @@ describe("ContractManager.scanContracts", () => {
             mgr.dispose();
         }
     });
+
+    it("rejects a non-positive / non-integer batchSize", async () => {
+        const mgr = await makeManagerForTest();
+        try {
+            for (const bad of [0, -1, 2.5]) {
+                await expect(
+                    mgr.scanContracts({
+                        batchSize: bad,
+                        hd: true,
+                        materialize,
+                        deps: makeDeps(),
+                    }),
+                ).rejects.toThrow(/batchSize/);
+            }
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("probes a WINDOW of indices concurrently, not one index at a time", async () => {
+        // Cross-index concurrency proof (the point of batching). A SINGLE
+        // handler is registered so the only overlap possible is between
+        // DIFFERENT indices. The handler's probe at the first index waits for a
+        // later index to ALSO enter before returning; a one-index-at-a-time
+        // loop would never launch index 1 until index 0 returned, so index 0
+        // would only ever observe itself and time out. gapLimit 3 → the first
+        // window caps to indices 0,1,2 (all probed concurrently). The handler
+        // always misses so the gap window still closes.
+        let entered = 0;
+        let releaseBoth!: () => void;
+        const bothInFlight = new Promise<void>((r) => (releaseBoth = r));
+        let firstSawBoth = false;
+        const fake = {
+            type: "windowfake",
+            createScript: (p: Record<string, string>) =>
+                ({ pkScript: hex.decode(p.script) }) as any,
+            serializeParams: (p: any) => p,
+            deserializeParams: (p: any) => p,
+            selectPath: () => null,
+            getAllSpendingPaths: () => [],
+            getSpendablePaths: () => [],
+            async discoverAt(index: number) {
+                entered += 1;
+                if (entered === 2) releaseBoth();
+                let timer: ReturnType<typeof setTimeout>;
+                const sawBoth = await Promise.race([
+                    bothInFlight.then(() => true),
+                    new Promise<boolean>((r) => {
+                        timer = setTimeout(() => r(false), 1000);
+                    }),
+                ]);
+                clearTimeout(timer!);
+                if (index === 0) firstSawBoth = sawBoth;
+                return [];
+            },
+        };
+        register("windowfake", fake);
+        const mgr = await makeManagerForTest();
+        try {
+            await mgr.scanContracts({ gapLimit: 3, hd: true, materialize, deps: makeDeps() });
+            expect(entered).toBeGreaterThanOrEqual(2);
+            // Index 0's probe observed a later index in-flight before
+            // returning — only possible if the window overlapped distinct
+            // indices. A serial regression makes this time out (false).
+            expect(firstSawBoth).toBe(true);
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("batchSize is a pure latency knob: the probe sequence and result are batch-invariant", async () => {
+        // The swap-hit-at-4 scenario probes EXACTLY 0..9 under the serial path
+        // (see the core test above). Re-run it under several batch sizes — the
+        // window cap (`gapLimit - unused`) must keep the probed set, its order,
+        // and lastIndexUsed byte-identical regardless of how indices are
+        // grouped. A batch that over-scanned past the gap-close point would
+        // probe index 10+ and break this.
+        for (const batchSize of [1, 2, 3, 7, 100]) {
+            const { handler, calls } = makeFakeHandler("swapbatch", (i) =>
+                i === 4
+                    ? [
+                          {
+                              type: "swapbatch",
+                              params: { script: "aabb" },
+                              script: "aabb",
+                              address: "ark1qswap",
+                          },
+                      ]
+                    : [],
+            );
+            register("swapbatch", handler);
+            const mgr = await makeManagerForTest();
+            try {
+                const res = await mgr.scanContracts({
+                    gapLimit: 5,
+                    batchSize,
+                    hd: true,
+                    materialize,
+                    deps: makeDeps(),
+                });
+                expect(res.lastIndexUsed).toBe(4);
+                expect(res.handlerErrors).toEqual([]);
+                expect([...calls].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            } finally {
+                mgr.dispose();
+                contractHandlers.unregister("swapbatch");
+                registered.splice(registered.indexOf("swapbatch"), 1);
+            }
+        }
+    });
 });
 
 describe("signingDescriptorIndex", () => {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -305,6 +305,48 @@ describe("DefaultContractHandler.discoverAt", () => {
         expect(out).toHaveLength(1);
         expect(calls.flat().filter((s) => s === script)).toHaveLength(1);
     });
+
+    it("batches all csvTimelock variants into a single indexer query (one probe)", async () => {
+        // Win: instead of one getVtxos per csvTimelock, discoverAt issues a
+        // single batched probe over the whole candidate set and maps the
+        // returned vtxos back by script. Both funded timelock scripts are
+        // still discovered, with no over-discovery of the unfunded ones.
+        const tl1: RelativeTimelock = DefaultVtxo.Script.DEFAULT_TIMELOCK;
+        const tl2: RelativeTimelock = { value: 288n, type: "blocks" };
+        const pubKey = hex.decode(pkHex);
+        const mk = (csvTimelock: RelativeTimelock) =>
+            hex.encode(
+                new DefaultVtxo.Script({ pubKey, serverPubKey: server, csvTimelock }).pkScript,
+            );
+        const s1 = mk(tl1);
+        const s2 = mk(tl2);
+
+        const calls: string[][] = [];
+        const indexer = {
+            async getVtxos(opts: any) {
+                const scripts = (opts.scripts ?? []) as string[];
+                calls.push(scripts);
+                const vtxos = scripts
+                    .filter((s) => s === s1 || s === s2)
+                    .map((s) => ({ value: 1, script: s }) as any);
+                return { vtxos };
+            },
+        } as any;
+
+        const out = await DefaultContractHandler.discoverAt(2, descriptor, {
+            indexerProvider: indexer,
+            onchainProvider: {} as any,
+            network: { hrp: "ark" },
+            serverPubKey: server,
+            csvTimelocks: [tl1, tl2],
+        });
+
+        // Exactly ONE batched probe, covering BOTH candidate scripts.
+        expect(calls).toHaveLength(1);
+        expect(new Set(calls[0])).toEqual(new Set([s1, s2]));
+        // Both funded timelock scripts discovered.
+        expect(new Set(out.map((e) => e.script))).toEqual(new Set([s1, s2]));
+    });
 });
 
 describe("DelegateContractHandler.discoverAt", () => {
@@ -718,6 +760,57 @@ describe("ContractManager.scanContracts", () => {
             mgr.dispose();
         }
     });
+
+    it("probes the index's handlers concurrently, not serially", async () => {
+        // Concurrency proof: handler A, once inside discoverAt, waits for
+        // handler B to ALSO enter before returning. Serial probing would never
+        // start B until A returned (A would observe only itself); concurrent
+        // probing lets B enter while A waits, so A resolves via the shared
+        // barrier. A bounded fallback turns a serial regression into a fast
+        // assertion failure instead of a hang.
+        let entered = 0;
+        let releaseBoth!: () => void;
+        const bothInFlight = new Promise<void>((r) => (releaseBoth = r));
+        let seq = 0;
+        let firstSawBoth = false;
+        const makeConcurrentFake = (type: string) => ({
+            type,
+            createScript: (p: Record<string, string>) =>
+                ({ pkScript: hex.decode(p.script) }) as any,
+            serializeParams: (p: any) => p,
+            deserializeParams: (p: any) => p,
+            selectPath: () => null,
+            getAllSpendingPaths: () => [],
+            getSpendablePaths: () => [],
+            async discoverAt() {
+                const mine = ++seq; // 1 = first handler launched, 2 = second
+                entered += 1;
+                if (entered === 2) releaseBoth();
+                let timer: ReturnType<typeof setTimeout>;
+                const sawBoth = await Promise.race([
+                    bothInFlight.then(() => true),
+                    new Promise<boolean>((r) => {
+                        timer = setTimeout(() => r(false), 1000);
+                    }),
+                ]);
+                clearTimeout(timer!);
+                if (mine === 1) firstSawBoth = sawBoth;
+                return [];
+            },
+        });
+        register("concA", makeConcurrentFake("concA"));
+        register("concB", makeConcurrentFake("concB"));
+        const mgr = await makeManagerForTest();
+        try {
+            await mgr.scanContracts({ gapLimit: 1, hd: false, materialize, deps: makeDeps() });
+            expect(entered).toBe(2);
+            // The first-launched handler observed the second in-flight before
+            // returning — only possible if the probes overlapped.
+            expect(firstSawBoth).toBe(true);
+        } finally {
+            mgr.dispose();
+        }
+    });
 });
 
 describe("signingDescriptorIndex", () => {
@@ -763,10 +856,9 @@ describe("Wallet.restore", () => {
             const balance = await wallet.getBalance();
             expect(balance.total).toBeGreaterThan(0);
 
-            // Static mode is a single pass at index 0: the default
-            // handler probes each csvTimelock at index 0 exactly once.
-            // Every probed scripts-array should be index-0 derived; the
-            // scan must not have walked an HD range.
+            // Static mode is a single pass at index 0: the default handler
+            // probes its index-0 candidate scripts in one batched query, so
+            // a discovery probe ran. The scan must not have walked an HD range.
             expect(indexer.getVtxosCalls.length).toBeGreaterThan(0);
         } finally {
             await wallet.dispose();
@@ -1427,10 +1519,10 @@ describe("Wallet.restore", () => {
             expect(a).toBeUndefined();
             expect(b).toBeUndefined();
 
-            // Both awaited the same in-flight promise: the static scan
-            // is a single index-0 pass, so the number of probes equals
-            // exactly one run (one getVtxos per csvTimelock) plus the
-            // single inline refreshVtxos pull — NOT doubled.
+            // Both awaited the same in-flight promise: the static scan is a
+            // single index-0 pass, so the probe count reflects exactly one run
+            // (a batched discovery query plus the single inline refreshVtxos
+            // pull) — NOT doubled.
             const singleRunCalls = indexer.getVtxosCalls.length;
             expect(singleRunCalls).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

Performance/robustness follow-up to the HD-wallet restore work. `wallet.restore()`'s gap-limit scan had **two** serial bottlenecks: (1) within each index it awaited each discovery handler one at a time, and `default`/`delegate` additionally issued one `getVtxos` per CSV/signer variant; (2) the outer index loop walked indices strictly one at a time, so an empty wallet paid `gapLimit` sequential round-trips just to close the gap window.

This PR parallelizes on **three** axes — per-index handler probes, per-index candidate queries (batched into one `getVtxos`), and now the **index dimension itself** (windowed batches) — cutting restore latency without changing the discovered result. Mirrors how the reference NArk SDK probes providers in parallel and batches its candidate set per index, and extends it with index batching.

Stacked on #545 (base `deprecated-signer-restore`).

## Changes

- **`ContractManager.scanContracts`** probes all discoverable handlers for an index concurrently via `Promise.all`, then persists their hits **sequentially in `discoverables` order**. The boarding-before-`default`/`delegate` order is the load-bearing first-wins collision tie-break, so only the I/O overlaps — persistence order is unchanged. Each probe keeps its own try/catch, so one handler's failure is still collected into `handlerErrors` rather than aborting the others; `materialize` throws stay fatal.
- **Index batching (new):** the outer gap loop now probes **`batchSize` indices per window concurrently** (default 10), a second concurrency layer over the per-index probes. Each window is **capped to `gapLimit - unused` indices** — the most a serial scan could still reach before the gap window is guaranteed to close. So every index probed in a window is one a one-index-at-a-time scan would also reach: nothing is over-scanned, nothing is discarded, `materialize`/`discoverAt` run on exactly the same index set, and hits are still processed strictly in ascending index order. The discovered set, persisted rows, `lastIndexUsed`, and `handlerErrors` stay **byte-for-byte identical** to the serial path — an empty wallet just closes its gap window in `ceil(gapLimit / batchSize)` rounds instead of `gapLimit` serial ones. Exposed as an optional `batchSize` on `ScanContractsOptions` (validated like `gapLimit`; ignored when `hd` is false).
- **`default.ts` / `delegate.ts`** `discoverAt` build their full deduped (signer × CSV) candidate set, then issue a **single batched probe** via a new `detectUsedScripts` helper instead of one `getVtxos` per variant. The matched signer/CSV is still threaded through script, params, and address.
- **`detectUsedScripts`** (`handlers/helpers.ts`) mirrors `fetchContractVtxosBulk`'s page loop but stops early once every candidate is observed — so the common case is one round-trip, yet a heavily-reused candidate can never starve another off the first page (parity with the old per-script path). Matched back to candidates via the indexer's per-VTXO `script`.

No public API or `Discoverable` interface change; behavior is identical to the serial path (same discovered set, persisted rows, and `lastIndexUsed`) — only faster.

## Tests

- Added: `default` `discoverAt` issues exactly one batched probe covering all candidate scripts (Win 2); `scanContracts` probes handlers concurrently, not serially (Win 1 — fails fast if reverted to serial).
- Added for index batching: rejects a non-positive / non-integer `batchSize`; **cross-index window concurrency** (a single handler's index-0 probe observes a later index in-flight — a serial loop would time out); **batch-invariance** (the swap-hit-at-4 scenario run at `batchSize ∈ {1,2,3,7,100}` yields the identical probed set `0..9` and `lastIndexUsed=4`, proving `batchSize` is a pure latency knob with no effect on the result).
- The load-bearing first-wins ordering test and the equal-delay / deprecated-signer / spent-boarding restore tests remain green. The existing `[0..9]` exact-probe-sequence test (gap-limit window) also stays green, pinning identical behavior under batching.
- `tsc --noEmit` clean; prettier clean (both packages). Full unit suite passes excluding the pre-existing `migrations.test.ts` failures (missing `better-sqlite3` native bindings locally — fail on the base branch too).
