### PR TITLE
Fix BIP21 amount validation

### DIFF
--- a/packages/ts-sdk/src/utils/bip21.ts
+++ b/packages/ts-sdk/src/utils/bip21.ts
@@ -113,7 +113,9 @@ export class BIP21 {
                 if (!value) continue;
 
                 if (key === "amount") {
-                    if (!/^\d+(?:\.\d+)?$/.test(value)) {
+                    // BIP21 ABNF: amount = *digit [ "." *digit ], so digits are
+                    // optional on either side of the decimal point (".5", "5.").
+                    if (!/^(?:\d+\.?\d*|\.\d+)$/.test(value)) {
                         continue;
                     }
                     const amount = Number(value);

--- a/packages/ts-sdk/src/utils/bip21.ts
+++ b/packages/ts-sdk/src/utils/bip21.ts
@@ -112,8 +112,11 @@ export class BIP21 {
                 if (!value) continue;
 
                 if (key === "amount") {
+                    if (!/^\d+(?:\.\d+)?$/.test(value)) {
+                        continue;
+                    }
                     const amount = Number(value);
-                    if (!isFinite(amount)) {
+                    if (!isFinite(amount) || !Number.isSafeInteger(Math.trunc(amount))) {
                         continue;
                     }
                     if (amount < 0) {

--- a/packages/ts-sdk/src/utils/bip21.ts
+++ b/packages/ts-sdk/src/utils/bip21.ts
@@ -41,11 +41,12 @@ export class BIP21 {
             if (value === undefined) continue;
 
             if (key === "amount") {
-                if (!isFinite(value as number)) {
+                const amount = value as number;
+                if (!isFinite(amount) || !Number.isSafeInteger(Math.trunc(amount))) {
                     console.warn("Invalid amount");
                     continue;
                 }
-                if ((value as number) < 0) {
+                if (amount < 0) {
                     continue;
                 }
                 queryParams[key] = value;
@@ -117,9 +118,6 @@ export class BIP21 {
                     }
                     const amount = Number(value);
                     if (!isFinite(amount) || !Number.isSafeInteger(Math.trunc(amount))) {
-                        continue;
-                    }
-                    if (amount < 0) {
                         continue;
                     }
                     params[key] = amount;

--- a/packages/ts-sdk/test/bip21.test.ts
+++ b/packages/ts-sdk/test/bip21.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { BIP21 } from "../src/utils/bip21";
+
+describe("BIP21", () => {
+    it("parses valid amount values", () => {
+        const result = BIP21.parse("bitcoin:bc1qexample?amount=1.25");
+
+        expect(result.params.amount).toBe(1.25);
+    });
+
+    it("ignores malformed amount values", () => {
+        const result = BIP21.parse("bitcoin:bc1qexample?amount=1abc");
+
+        expect(result.params.amount).toBeUndefined();
+    });
+
+    it("ignores unsafe amount values", () => {
+        const result = BIP21.parse("bitcoin:bc1qexample?amount=9007199254740992");
+
+        expect(result.params.amount).toBeUndefined();
+    });
+});

--- a/packages/ts-sdk/test/bip21.test.ts
+++ b/packages/ts-sdk/test/bip21.test.ts
@@ -20,4 +20,10 @@ describe("BIP21", () => {
 
         expect(result.params.amount).toBeUndefined();
     });
+
+    it("omits unsafe amount values when creating a URI", () => {
+        const uri = BIP21.create({ address: "bc1qexample", amount: Number.MAX_SAFE_INTEGER + 1 });
+
+        expect(uri).toBe("bitcoin:bc1qexample");
+    });
 });

--- a/packages/ts-sdk/test/bip21.test.ts
+++ b/packages/ts-sdk/test/bip21.test.ts
@@ -9,6 +9,11 @@ describe("BIP21", () => {
         expect(result.params.amount).toBe(1.25);
     });
 
+    it("parses amounts with digits omitted on either side of the decimal", () => {
+        expect(BIP21.parse("bitcoin:bc1qexample?amount=.5").params.amount).toBe(0.5);
+        expect(BIP21.parse("bitcoin:bc1qexample?amount=5.").params.amount).toBe(5);
+    });
+
     it("ignores malformed amount values", () => {
         const result = BIP21.parse("bitcoin:bc1qexample?amount=1abc");
 


### PR DESCRIPTION
Replacing https://github.com/arkade-os/ts-sdk/pull/537 with the requested updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of amount parameters in Bitcoin payment URIs to reject non-numeric, unsafe, and negative values, ensuring only valid numeric amounts are accepted.

* **Tests**
  * Added test coverage to verify proper handling of valid and invalid amount parameters in payment URI parsing and creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->