### PR TITLE
Limit settlement VTXO batches to 50

### DIFF
--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -108,13 +108,49 @@ async function runWithCrossInstanceLock(name: string, fn: () => Promise<void>): 
 /**
  * Maximum number of VTXOs included in a single settlement intent.
  *
- * arkd rejects intents carrying more than 91 VTXOs with a `TX_TOO_LARGE`
- * error. We cap well below that so the remaining headroom absorbs any
- * boarding inputs (which are added uncapped) plus transaction-size overhead.
- * When more VTXOs are eligible, the overflow is left for the next
- * settlement cycle. Mirrors the go-sdk `maxVtxosPerBatch`.
+ * arkd has no fixed per-intent VTXO count limit; it rejects an intent with
+ * `TX_TOO_LARGE` once the resulting ark transaction exceeds its weight budget
+ * (`maxTxWeight`, ~40k weight units by default). 50 is a conservative count
+ * that stays well under that weight, leaving headroom for boarding inputs
+ * (added uncapped) plus transaction-size overhead. When more VTXOs are
+ * eligible, the overflow is left for the next settlement cycle.
+ *
+ * This cap is a ts-sdk-specific safeguard: neither go-sdk nor NArk caps the
+ * settlement batch — go-sdk submits every spendable VTXO in a single intent.
+ * Because the reference SDKs impose no selection order (go-sdk's query has no
+ * `ORDER BY`), we are free to order the candidates before capping so the most
+ * important VTXOs survive the cut — see {@link byValueDescending} and
+ * {@link byExpiryAscending}.
  */
 export const MAX_VTXOS_PER_SETTLEMENT = 50;
+
+/**
+ * Order VTXOs so the highest-value ones come first. New array; input untouched.
+ *
+ * Used by the value-driven paths (recovery, manual full settle): when the
+ * {@link MAX_VTXOS_PER_SETTLEMENT} cap defers the overflow to a later cycle,
+ * the batch should carry the most value. For recovery this also gives the
+ * capped subset the best chance of clearing the dust threshold.
+ */
+export function byValueDescending<T extends { value: number }>(vtxos: T[]): T[] {
+    return [...vtxos].sort((a, b) => b.value - a.value);
+}
+
+/**
+ * Order VTXOs so the soonest-expiring ones come first. New array; input
+ * untouched. VTXOs without a batch expiry never expire, so they sort last.
+ *
+ * Used by the expiry-driven paths (renewal, periodic settle): when the
+ * {@link MAX_VTXOS_PER_SETTLEMENT} cap defers the overflow to a later cycle,
+ * the most urgent VTXOs must make the cut so none miss their renewal window
+ * and get forced into a unilateral exit.
+ */
+export function byExpiryAscending(vtxos: ExtendedVirtualCoin[]): ExtendedVirtualCoin[] {
+    return [...vtxos].sort(
+        (a, b) =>
+            (a.virtualStatus.batchExpiry ?? Infinity) - (b.virtualStatus.batchExpiry ?? Infinity),
+    );
+}
 
 /** Default renewal threshold in seconds (3 days). */
 export const DEFAULT_THRESHOLD_SECONDS = 259_200;
@@ -601,15 +637,16 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         }
 
         // Cap the number of VTXOs per settlement to stay under the server's
-        // intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). The subdust
-        // inclusion decision above was made on the full set's combined total,
-        // so a naive slice can drop the batch below dust — which the server
-        // rejects, and the next cycle would re-pick the same prefix forever.
-        // Preserve selection order for go-sdk parity, but re-run the
-        // subdust/dust eligibility on that exact capped subset. The overflow
-        // is recovered next cycle.
+        // intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). Recover the
+        // highest-value VTXOs first: the subdust inclusion decision above was
+        // made on the full set's combined total, so a naive prefix can drop the
+        // capped batch below dust — which the server rejects, leaving the next
+        // cycle to re-pick the same prefix forever. Ordering by value maximizes
+        // the recovered amount and gives the capped subset the best chance of
+        // clearing dust. We re-run the subdust/dust eligibility on that exact
+        // capped subset; the overflow is recovered next cycle.
         if (vtxosToRecover.length > MAX_VTXOS_PER_SETTLEMENT) {
-            const capped = vtxosToRecover.slice(0, MAX_VTXOS_PER_SETTLEMENT);
+            const capped = byValueDescending(vtxosToRecover).slice(0, MAX_VTXOS_PER_SETTLEMENT);
             ({ vtxosToRecover, totalAmount } = getRecoverableWithSubdust(capped, dustAmount));
             if (vtxosToRecover.length === 0) {
                 // The capped batch stays below dust, so submitting it would be
@@ -827,11 +864,14 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             }
 
             // Cap the number of VTXOs per settlement to stay under the
-            // server's intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). The
-            // output amount is summed from the capped set below, so it stays
-            // consistent; the overflow is renewed on the next cycle.
+            // server's intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). Renew
+            // the soonest-expiring VTXOs first so the most urgent ones make the
+            // cut — otherwise a viable VTXO past the cap could miss its renewal
+            // window and be forced into a unilateral exit. The output amount is
+            // summed from the capped set below, so it stays consistent; the
+            // overflow is renewed on the next cycle.
             if (vtxos.length > MAX_VTXOS_PER_SETTLEMENT) {
-                vtxos = vtxos.slice(0, MAX_VTXOS_PER_SETTLEMENT);
+                vtxos = byExpiryAscending(vtxos).slice(0, MAX_VTXOS_PER_SETTLEMENT);
             }
 
             const totalAmount = vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
@@ -1476,13 +1516,15 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         }
 
         // Cap the VTXOs per settlement to stay under the server's intent-size
-        // limit (see MAX_VTXOS_PER_SETTLEMENT). Apply the cap to economically
-        // viable VTXOs only: skipping uneconomic inputs and continuing past the
-        // cap avoids an uneconomic prefix permanently starving valid VTXOs
-        // behind it. Boarding inputs are added uncapped above; the headroom
-        // absorbs them. Any overflow is settled on the next cycle.
+        // limit (see MAX_VTXOS_PER_SETTLEMENT). Settle the soonest-expiring
+        // VTXOs first so the most urgent ones make the cut. Apply the cap to
+        // economically viable VTXOs only: skipping uneconomic inputs and
+        // continuing past the cap avoids an uneconomic prefix permanently
+        // starving valid VTXOs behind it. Boarding inputs are added uncapped
+        // above; the headroom absorbs them. Any overflow is settled on the next
+        // cycle.
         const filteredVtxos: ExtendedVirtualCoin[] = [];
-        for (const v of expiringVtxos) {
+        for (const v of byExpiryAscending(expiringVtxos)) {
             if (filteredVtxos.length >= MAX_VTXOS_PER_SETTLEMENT) {
                 break;
             }

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -105,6 +105,17 @@ async function runWithCrossInstanceLock(name: string, fn: () => Promise<void>): 
     });
 }
 
+/**
+ * Maximum number of VTXOs included in a single settlement intent.
+ *
+ * arkd rejects intents carrying more than 91 VTXOs with a `TX_TOO_LARGE`
+ * error. We cap well below that so the remaining headroom absorbs any
+ * boarding inputs (which are added uncapped) plus transaction-size overhead.
+ * When more VTXOs are eligible, the overflow is left for the next
+ * settlement cycle. Mirrors the go-sdk `maxVtxosPerBatch`.
+ */
+export const MAX_VTXOS_PER_SETTLEMENT = 50;
+
 /** Default renewal threshold in seconds (3 days). */
 export const DEFAULT_THRESHOLD_SECONDS = 259_200;
 
@@ -583,10 +594,28 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         const dustAmount = getDustAmount(this.wallet);
 
         // Filter recoverable virtual outputs and handle subdust logic
-        const { vtxosToRecover, totalAmount } = getRecoverableWithSubdust(allVtxos, dustAmount);
+        let { vtxosToRecover, totalAmount } = getRecoverableWithSubdust(allVtxos, dustAmount);
 
         if (vtxosToRecover.length === 0) {
             throw new Error("No recoverable VTXOs found");
+        }
+
+        // Cap the number of VTXOs per settlement to stay under the server's
+        // intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). The subdust
+        // inclusion decision above was made on the full set's combined total,
+        // so a naive slice can drop the batch below dust — which the server
+        // rejects, and the next cycle would re-pick the same prefix forever.
+        // Preserve selection order for go-sdk parity, but re-run the
+        // subdust/dust eligibility on that exact capped subset. The overflow
+        // is recovered next cycle.
+        if (vtxosToRecover.length > MAX_VTXOS_PER_SETTLEMENT) {
+            const capped = vtxosToRecover.slice(0, MAX_VTXOS_PER_SETTLEMENT);
+            ({ vtxosToRecover, totalAmount } = getRecoverableWithSubdust(capped, dustAmount));
+            if (vtxosToRecover.length === 0) {
+                // The capped batch stays below dust, so submitting it would be
+                // rejected and the next cycle would pick the same prefix.
+                throw new Error("No recoverable VTXOs found");
+            }
         }
 
         const arkAddress = await this.wallet.getAddress();
@@ -795,6 +824,14 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             vtxos = await this.revalidateBeforeSettle(vtxos, threshold);
             if (vtxos.length === 0) {
                 throw new Error("No VTXOs available to renew");
+            }
+
+            // Cap the number of VTXOs per settlement to stay under the
+            // server's intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). The
+            // output amount is summed from the capped set below, so it stays
+            // consistent; the overflow is renewed on the next cycle.
+            if (vtxos.length > MAX_VTXOS_PER_SETTLEMENT) {
+                vtxos = vtxos.slice(0, MAX_VTXOS_PER_SETTLEMENT);
             }
 
             const totalAmount = vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
@@ -1438,8 +1475,17 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             totalAmount += BigInt(u.value) - BigInt(inputFee.satoshis);
         }
 
+        // Cap the VTXOs per settlement to stay under the server's intent-size
+        // limit (see MAX_VTXOS_PER_SETTLEMENT). Apply the cap to economically
+        // viable VTXOs only: skipping uneconomic inputs and continuing past the
+        // cap avoids an uneconomic prefix permanently starving valid VTXOs
+        // behind it. Boarding inputs are added uncapped above; the headroom
+        // absorbs them. Any overflow is settled on the next cycle.
         const filteredVtxos: ExtendedVirtualCoin[] = [];
         for (const v of expiringVtxos) {
+            if (filteredVtxos.length >= MAX_VTXOS_PER_SETTLEMENT) {
+                break;
+            }
             const inputFee = estimator.evalOffchainInput({
                 amount: BigInt(v.value),
                 type: v.virtualStatus.state === "swept" ? "recoverable" : "vtxo",

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -646,12 +646,21 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // clearing dust. We re-run the subdust/dust eligibility on that exact
         // capped subset; the overflow is recovered next cycle.
         if (vtxosToRecover.length > MAX_VTXOS_PER_SETTLEMENT) {
+            const recoverableCount = vtxosToRecover.length;
             const capped = byValueDescending(vtxosToRecover).slice(0, MAX_VTXOS_PER_SETTLEMENT);
             ({ vtxosToRecover, totalAmount } = getRecoverableWithSubdust(capped, dustAmount));
             if (vtxosToRecover.length === 0) {
-                // The capped batch stays below dust, so submitting it would be
-                // rejected and the next cycle would pick the same prefix.
-                throw new Error("No recoverable VTXOs found");
+                // Recoverable VTXOs exist, but the highest-value subset that
+                // fits in one settlement stays below dust, so submitting it
+                // would be rejected and the next cycle would pick the same
+                // prefix. Distinct from the "none recoverable" case above so
+                // operators can tell a stuck-but-funded wallet from an empty
+                // one. Recovery resumes once the prefix accumulates dust.
+                throw new Error(
+                    `Capped recovery batch (highest-value ${MAX_VTXOS_PER_SETTLEMENT} of ` +
+                        `${recoverableCount} recoverable VTXOs) is below the dust threshold ` +
+                        `${dustAmount}`,
+                );
             }
         }
 

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -138,7 +138,9 @@ export function byValueDescending<T extends { value: number }>(vtxos: T[]): T[] 
 
 /**
  * Order VTXOs so the soonest-expiring ones come first. New array; input
- * untouched. VTXOs without a batch expiry never expire, so they sort last.
+ * untouched. Already recoverable/expired VTXOs sort first. VTXOs without a
+ * batch expiry, or with a block-height-looking expiry value, sort last because
+ * they do not have a usable wall-clock expiry.
  *
  * Used by the expiry-driven paths (renewal, periodic settle): when the
  * {@link MAX_VTXOS_PER_SETTLEMENT} cap defers the overflow to a later cycle,
@@ -146,10 +148,23 @@ export function byValueDescending<T extends { value: number }>(vtxos: T[]): T[] 
  * and get forced into a unilateral exit.
  */
 export function byExpiryAscending(vtxos: ExtendedVirtualCoin[]): ExtendedVirtualCoin[] {
-    return [...vtxos].sort(
-        (a, b) =>
-            (a.virtualStatus.batchExpiry ?? Infinity) - (b.virtualStatus.batchExpiry ?? Infinity),
-    );
+    const expiryKey = (vtxo: ExtendedVirtualCoin) => {
+        if (isRecoverable(vtxo)) return -Infinity;
+
+        const batchExpiry = vtxo.virtualStatus.batchExpiry;
+
+        if (isExpired(vtxo)) return batchExpiry ?? -Infinity;
+        if (!batchExpiry) return Infinity;
+
+        // Some regtest-like indexers return a block height here instead of a
+        // timestamp. Match isVtxoExpiringSoon/isExpired and avoid treating that
+        // as the most urgent wall-clock expiry.
+        if (new Date(batchExpiry).getFullYear() < 2025) return Infinity;
+
+        return batchExpiry;
+    };
+
+    return [...vtxos].sort((a, b) => expiryKey(a) - expiryKey(b));
 }
 
 /** Default renewal threshold in seconds (3 days). */

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -56,6 +56,7 @@ import {
     isValidArkAddress,
 } from "../utils/arkTransaction";
 import {
+    byValueDescending,
     DEFAULT_RENEWAL_CONFIG,
     DEFAULT_SETTLEMENT_CONFIG,
     MAX_VTXOS_PER_SETTLEMENT,
@@ -2143,14 +2144,15 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             const vtxos = await this.getVtxos({ withRecoverable: true });
 
             // Cap the VTXOs per settlement to stay under the server's
-            // intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). Apply the cap to
-            // economically viable VTXOs only: skipping uneconomic inputs and
-            // continuing past the cap avoids an uneconomic prefix permanently
-            // starving valid VTXOs behind it. The boarding inputs above are
-            // added uncapped; the headroom absorbs them. Any overflow is
-            // settled on the next call.
+            // intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). Settle the
+            // highest-value VTXOs first so the capped batch carries the most
+            // value. Apply the cap to economically viable VTXOs only: skipping
+            // uneconomic inputs and continuing past the cap avoids an uneconomic
+            // prefix permanently starving valid VTXOs behind it. The boarding
+            // inputs above are added uncapped; the headroom absorbs them. Any
+            // overflow is settled on the next call.
             const filteredVtxos = [];
-            for (const vtxo of vtxos) {
+            for (const vtxo of byValueDescending(vtxos)) {
                 if (filteredVtxos.length >= MAX_VTXOS_PER_SETTLEMENT) {
                     break;
                 }

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -58,6 +58,7 @@ import {
 import {
     DEFAULT_RENEWAL_CONFIG,
     DEFAULT_SETTLEMENT_CONFIG,
+    MAX_VTXOS_PER_SETTLEMENT,
     SettlementConfig,
     VtxoManager,
 } from "./vtxo-manager";
@@ -2141,8 +2142,18 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
             const vtxos = await this.getVtxos({ withRecoverable: true });
 
+            // Cap the VTXOs per settlement to stay under the server's
+            // intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). Apply the cap to
+            // economically viable VTXOs only: skipping uneconomic inputs and
+            // continuing past the cap avoids an uneconomic prefix permanently
+            // starving valid VTXOs behind it. The boarding inputs above are
+            // added uncapped; the headroom absorbs them. Any overflow is
+            // settled on the next call.
             const filteredVtxos = [];
             for (const vtxo of vtxos) {
+                if (filteredVtxos.length >= MAX_VTXOS_PER_SETTLEMENT) {
+                    break;
+                }
                 const inputFee = estimator.evalOffchainInput({
                     amount: BigInt(vtxo.value),
                     type: vtxo.virtualStatus.state === "swept" ? "recoverable" : "vtxo",

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -969,6 +969,48 @@ describe("VtxoManager - Renewal", () => {
             }
         });
 
+        it("should prioritize swept recoverable VTXOs without batch expiry when capping", async () => {
+            const now = Date.now();
+            const createdAt = new Date(now - 100_000);
+            const value = 5000;
+            const makeVtxo = (
+                count: number,
+                prefix: string,
+                state: "settled" | "swept",
+                batchExpiry?: number,
+            ) =>
+                Array.from(
+                    { length: count },
+                    (_, i) =>
+                        ({
+                            txid: `${prefix}-${i}`,
+                            vout: 0,
+                            value,
+                            createdAt,
+                            virtualStatus:
+                                batchExpiry === undefined ? { state } : { state, batchExpiry },
+                            status: { confirmed: true },
+                            isUnrolled: false,
+                            isSpent: false,
+                        }) as any,
+                );
+
+            const future = makeVtxo(MAX_VTXOS_PER_SETTLEMENT, "future", "settled", now + 200_000);
+            const swept = makeVtxo(10, "swept", "swept");
+            const wallet = createMockWallet([...future, ...swept], "arkade1myaddress");
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            const txid = await manager.renewVtxos();
+
+            expect(txid).toBe("mock-txid");
+            const settleArgs = (wallet.settle as any).mock.calls[0][0];
+            expect(settleArgs.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+            const inputTxids = settleArgs.inputs.map((v: any) => v.txid);
+            for (let i = 0; i < 10; i++) {
+                expect(inputTxids).toContain(`swept-${i}`);
+            }
+        });
+
         it("should throw error when total amount is below dust threshold", async () => {
             const vtxos = [
                 {
@@ -2250,14 +2292,18 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
         }) as ExtendedCoin;
 
     // VTXO expiring within 1 hour (well inside the default 3-day threshold).
-    const makeExpiringVtxo = (value: number, vout = 0): ExtendedVirtualCoin =>
+    const makeExpiringVtxo = (
+        value: number,
+        vout = 0,
+        batchExpiry = Date.now() + 60 * 60 * 1000,
+    ): ExtendedVirtualCoin =>
         ({
             txid: `vtxo-txid-${value}-${vout}`,
             vout,
             value,
             virtualStatus: {
                 state: "settled",
-                batchExpiry: Date.now() + 60 * 60 * 1000,
+                batchExpiry,
             },
             isSpent: false,
             status: { confirmed: true },
@@ -2410,6 +2456,57 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
         const call = (wallet.settle as any).mock.calls[0][0];
         expect(call.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
         expect(call.outputs[0].amount).toBe(BigInt(MAX_VTXOS_PER_SETTLEMENT * value));
+    });
+
+    it("settles the soonest-expiring VTXOs first during periodic cap", async () => {
+        const now = Date.now();
+        const value = 5_000;
+        const lessUrgent = Array.from({ length: MAX_VTXOS_PER_SETTLEMENT }, (_, i) =>
+            makeExpiringVtxo(value, i, now + 200_000),
+        );
+        const urgent = Array.from({ length: 10 }, (_, i) =>
+            makeExpiringVtxo(value, 1_000 + i, now + 1_000),
+        );
+        const wallet = buildWallet([], [...lessUrgent, ...urgent]);
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle([]);
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+        const call = (wallet.settle as any).mock.calls[0][0];
+        expect(call.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+        const inputTxids = call.inputs.map((v: any) => v.txid);
+        for (let i = 0; i < 10; i++) {
+            expect(inputTxids).toContain(`vtxo-txid-${value}-${1_000 + i}`);
+        }
+    });
+
+    it("caps periodic VTXOs without capping boarding inputs", async () => {
+        const boarding = [makeUnexpiredUtxo(10_000), makeUnexpiredUtxo(12_000, 1)];
+        const value = 5_000;
+        const vtxos = Array.from({ length: MAX_VTXOS_PER_SETTLEMENT + 5 }, (_, i) =>
+            makeExpiringVtxo(value, i),
+        );
+        const wallet = buildWallet(boarding, vtxos);
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle(boarding);
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+        const call = (wallet.settle as any).mock.calls[0][0];
+        expect(call.inputs).toHaveLength(boarding.length + MAX_VTXOS_PER_SETTLEMENT);
+        expect(call.inputs.slice(0, boarding.length)).toEqual(boarding);
+        expect(call.inputs.slice(boarding.length)).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
     });
 
     it("skips VTXO collection while an event-driven renewal is in flight", async () => {

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -306,7 +306,11 @@ describe("VtxoManager - Recovery", () => {
             const wallet = createMockWallet(subdust, "arkade1myaddress");
             const manager = new VtxoManager(wallet);
 
-            await expect(manager.recoverVtxos()).rejects.toThrow("No recoverable VTXOs found");
+            // Distinct from the genuine "no recoverable VTXOs" message: this
+            // wallet IS funded, the capped batch just can't reach dust yet.
+            await expect(manager.recoverVtxos()).rejects.toThrow(
+                /Capped recovery batch .* is below the dust threshold/,
+            );
             expect((wallet.settle as any).mock.calls).toHaveLength(0);
         });
 

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -7,6 +7,7 @@ import {
     DEFAULT_THRESHOLD_SECONDS,
     getExpiringAndRecoverableVtxos,
     DEFAULT_THRESHOLD_MS,
+    MAX_VTXOS_PER_SETTLEMENT,
     SettlementConfig,
 } from "../src/wallet/vtxo-manager";
 import { IWallet, ExtendedCoin, ExtendedVirtualCoin } from "../src/wallet";
@@ -236,6 +237,66 @@ describe("VtxoManager - Recovery", () => {
                 },
                 undefined,
             );
+        });
+
+        const makeRecoverable = (count: number, value: number, prefix: string) =>
+            Array.from(
+                { length: count },
+                (_, i) =>
+                    ({
+                        txid: `${prefix}-${i}`,
+                        vout: 0,
+                        value,
+                        virtualStatus: { state: "swept" },
+                        isSpent: false,
+                        status: { confirmed: true },
+                        createdAt: new Date(),
+                        isUnrolled: false,
+                        forfeitTapLeafScript: [new Uint8Array(), new Uint8Array()],
+                        intentTapLeafScript: [new Uint8Array(), new Uint8Array()],
+                        tapTree: new Uint8Array(),
+                    }) as any,
+            );
+
+        it("should cap the number of recovered VTXOs per settlement", async () => {
+            const value = 5000;
+            const vtxos = makeRecoverable(MAX_VTXOS_PER_SETTLEMENT + 10, value, "swept");
+            const wallet = createMockWallet(vtxos, "arkade1myaddress");
+            const manager = new VtxoManager(wallet);
+
+            const txid = await manager.recoverVtxos();
+
+            expect(txid).toBe("mock-txid");
+            const settleArgs = (wallet.settle as any).mock.calls[0][0];
+            expect(settleArgs.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+            // Output amount is recomputed from the capped set, not the full list.
+            expect(settleArgs.outputs[0].amount).toBe(BigInt(MAX_VTXOS_PER_SETTLEMENT * value));
+        });
+
+        it("should preserve selection order and not submit a below-dust capped prefix", async () => {
+            // Subdust (below dust) listed before regular VTXOs. For go-sdk
+            // parity, the cap keeps the first N VTXOs rather than sorting to
+            // rescue later regulars; the below-dust capped prefix is rejected
+            // client-side instead of being submitted to the server.
+            const subdust = makeRecoverable(MAX_VTXOS_PER_SETTLEMENT, 18, "subdust");
+            const regular = makeRecoverable(10, 5000, "regular");
+            const wallet = createMockWallet([...subdust, ...regular], "arkade1myaddress");
+            const manager = new VtxoManager(wallet);
+
+            await expect(manager.recoverVtxos()).rejects.toThrow("No recoverable VTXOs found");
+            expect((wallet.settle as any).mock.calls).toHaveLength(0);
+        });
+
+        it("should not submit a below-dust batch when no valid capped subset exists", async () => {
+            // 60 subdust VTXOs are viable as a full set (1080 >= dust) but no
+            // <=50 subset reaches dust (50 * 18 = 900). Rather than submit a
+            // doomed batch that the server rejects every cycle, recovery throws.
+            const subdust = makeRecoverable(60, 18, "subdust");
+            const wallet = createMockWallet(subdust, "arkade1myaddress");
+            const manager = new VtxoManager(wallet);
+
+            await expect(manager.recoverVtxos()).rejects.toThrow("No recoverable VTXOs found");
+            expect((wallet.settle as any).mock.calls).toHaveLength(0);
         });
 
         it("should include subdust when combined value exceeds dust threshold", async () => {
@@ -819,6 +880,40 @@ describe("VtxoManager - Renewal", () => {
             const txid = await manager.renewVtxos();
 
             expect(txid).toBe("mock-txid");
+        });
+
+        it("should cap the number of renewed VTXOs per settlement", async () => {
+            const now = Date.now();
+            const createdAt = new Date(now - 100_000);
+            const count = MAX_VTXOS_PER_SETTLEMENT + 10;
+            const value = 5000;
+            const vtxos = Array.from(
+                { length: count },
+                (_, i) =>
+                    ({
+                        txid: `tx-${i}`,
+                        vout: 0,
+                        value,
+                        createdAt,
+                        virtualStatus: {
+                            state: "settled",
+                            batchExpiry: now + 5000, // expiring soon
+                        },
+                        status: { confirmed: true },
+                        isUnrolled: false,
+                        isSpent: false,
+                    }) as any,
+            );
+            const wallet = createMockWallet(vtxos, "arkade1myaddress");
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            const txid = await manager.renewVtxos();
+
+            expect(txid).toBe("mock-txid");
+            const settleArgs = (wallet.settle as any).mock.calls[0][0];
+            expect(settleArgs.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+            // Output amount is summed from the capped set, not the full list.
+            expect(settleArgs.outputs[0].amount).toBe(BigInt(MAX_VTXOS_PER_SETTLEMENT * value));
         });
 
         it("should throw error when total amount is below dust threshold", async () => {
@@ -2212,6 +2307,56 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
         const call = (wallet.settle as any).mock.calls[0][0];
         expect(call.inputs).toEqual([vtxo]);
         expect(call.outputs[0].amount).toBe(5_000n);
+    });
+
+    it("caps viable VTXOs, not an uneconomic prefix", async () => {
+        // 50 uneconomic VTXOs ahead of 3 viable ones. The cap must apply to
+        // economically viable inputs only — otherwise the uneconomic prefix
+        // fills the cap and the viable VTXOs behind it are starved every cycle.
+        const tiny = Array.from({ length: MAX_VTXOS_PER_SETTLEMENT }, (_, i) =>
+            makeExpiringVtxo(100, i),
+        );
+        const normal = Array.from({ length: 3 }, (_, i) => makeExpiringVtxo(10_000, 100 + i));
+        const wallet = buildWallet([], [...tiny, ...normal]);
+        // Flat 200-sat fee per offchain input makes the 100-sat VTXOs uneconomic.
+        (wallet.arkProvider.getInfo as any).mockResolvedValue({
+            fees: { intentFee: { offchainInput: "200.0" } },
+        });
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle([]);
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+        const call = (wallet.settle as any).mock.calls[0][0];
+        expect(call.inputs).toHaveLength(3);
+        expect(call.inputs.every((v: any) => v.value === 10_000)).toBe(true);
+        expect(call.outputs[0].amount).toBe(BigInt(3 * (10_000 - 200)));
+    });
+
+    it("caps the number of VTXOs per periodic settle", async () => {
+        const value = 5_000;
+        const vtxos = Array.from({ length: MAX_VTXOS_PER_SETTLEMENT + 5 }, (_, i) =>
+            makeExpiringVtxo(value, i),
+        );
+        const wallet = buildWallet([], vtxos);
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle([]);
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+        const call = (wallet.settle as any).mock.calls[0][0];
+        expect(call.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+        expect(call.outputs[0].amount).toBe(BigInt(MAX_VTXOS_PER_SETTLEMENT * value));
     });
 
     it("skips VTXO collection while an event-driven renewal is in flight", async () => {

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -273,23 +273,34 @@ describe("VtxoManager - Recovery", () => {
             expect(settleArgs.outputs[0].amount).toBe(BigInt(MAX_VTXOS_PER_SETTLEMENT * value));
         });
 
-        it("should preserve selection order and not submit a below-dust capped prefix", async () => {
-            // Subdust (below dust) listed before regular VTXOs. For go-sdk
-            // parity, the cap keeps the first N VTXOs rather than sorting to
-            // rescue later regulars; the below-dust capped prefix is rejected
-            // client-side instead of being submitted to the server.
+        it("should recover by value so a subdust prefix doesn't starve regulars", async () => {
+            // Subdust (below dust) listed before regular VTXOs. The reference
+            // SDKs impose no selection order, so we sort by value before
+            // capping: the 10 regulars are rescued ahead of the subdust prefix
+            // and the capped batch clears dust instead of being rejected.
             const subdust = makeRecoverable(MAX_VTXOS_PER_SETTLEMENT, 18, "subdust");
             const regular = makeRecoverable(10, 5000, "regular");
             const wallet = createMockWallet([...subdust, ...regular], "arkade1myaddress");
             const manager = new VtxoManager(wallet);
 
-            await expect(manager.recoverVtxos()).rejects.toThrow("No recoverable VTXOs found");
-            expect((wallet.settle as any).mock.calls).toHaveLength(0);
+            const txid = await manager.recoverVtxos();
+
+            expect(txid).toBe("mock-txid");
+            const settleArgs = (wallet.settle as any).mock.calls[0][0];
+            // Capped to 50: 10 regulars (value first) + 40 subdust filling the rest.
+            expect(settleArgs.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+            const inputTxids = settleArgs.inputs.map((v: any) => v.txid);
+            for (let i = 0; i < 10; i++) {
+                expect(inputTxids).toContain(`regular-${i}`);
+            }
+            // Output amount = 10 * 5000 + 40 * 18, recomputed from the capped set.
+            expect(settleArgs.outputs[0].amount).toBe(BigInt(10 * 5000 + 40 * 18));
         });
 
         it("should not submit a below-dust batch when no valid capped subset exists", async () => {
             // 60 subdust VTXOs are viable as a full set (1080 >= dust) but no
-            // <=50 subset reaches dust (50 * 18 = 900). Rather than submit a
+            // <=50 subset reaches dust (50 * 18 = 900) — and since they are all
+            // equal value, sorting can't rescue it either. Rather than submit a
             // doomed batch that the server rejects every cycle, recovery throws.
             const subdust = makeRecoverable(60, 18, "subdust");
             const wallet = createMockWallet(subdust, "arkade1myaddress");
@@ -914,6 +925,44 @@ describe("VtxoManager - Renewal", () => {
             expect(settleArgs.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
             // Output amount is summed from the capped set, not the full list.
             expect(settleArgs.outputs[0].amount).toBe(BigInt(MAX_VTXOS_PER_SETTLEMENT * value));
+        });
+
+        it("should renew the soonest-expiring VTXOs first when capping", async () => {
+            // The 10 most urgent VTXOs are listed AFTER 50 less-urgent ones.
+            // Sorting by expiry before the cap must rescue them so they don't
+            // miss their renewal window and get forced into a unilateral exit.
+            const now = Date.now();
+            const createdAt = new Date(now - 100_000);
+            const value = 5000;
+            const makeExpiring = (count: number, expiry: number, prefix: string) =>
+                Array.from(
+                    { length: count },
+                    (_, i) =>
+                        ({
+                            txid: `${prefix}-${i}`,
+                            vout: 0,
+                            value,
+                            createdAt,
+                            virtualStatus: { state: "settled", batchExpiry: expiry },
+                            status: { confirmed: true },
+                            isUnrolled: false,
+                            isSpent: false,
+                        }) as any,
+                );
+            const lessUrgent = makeExpiring(MAX_VTXOS_PER_SETTLEMENT, now + 200_000, "far");
+            const urgent = makeExpiring(10, now + 1_000, "urgent");
+            const wallet = createMockWallet([...lessUrgent, ...urgent], "arkade1myaddress");
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            const txid = await manager.renewVtxos();
+
+            expect(txid).toBe("mock-txid");
+            const settleArgs = (wallet.settle as any).mock.calls[0][0];
+            expect(settleArgs.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+            const inputTxids = settleArgs.inputs.map((v: any) => v.txid);
+            for (let i = 0; i < 10; i++) {
+                expect(inputTxids).toContain(`urgent-${i}`);
+            }
         });
 
         it("should throw error when total amount is below dust threshold", async () => {

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -17,7 +17,9 @@ import {
     DelegateProvider,
 } from "../src";
 import { TEST_PUB_KEY, TEST_DELEGATE_PUB_KEY, TEST_SERVER_PUB_KEY } from "./contracts/helpers";
-import type { ExtendedCoin } from "../src/wallet";
+import type { ExtendedCoin, ExtendedVirtualCoin } from "../src/wallet";
+import { CSVMultisigTapscript } from "../src/script/tapscript";
+import { MAX_VTXOS_PER_SETTLEMENT } from "../src/wallet/vtxo-manager";
 import { ReadonlySingleKey } from "../src/identity/singleKey";
 import { IndexedDBWalletRepository, IndexedDBContractRepository } from "../src/repositories";
 import type { Coin, VirtualCoin } from "../src/wallet";
@@ -1798,6 +1800,107 @@ describe("Wallet._settleImpl", () => {
         expect(deleteIntent).toHaveBeenCalledTimes(1);
         expect(batchJoinSpy).not.toHaveBeenCalled();
         batchJoinSpy.mockRestore();
+    });
+
+    // Regression coverage for the no-params (auto-select) settle branch, which
+    // selects all spendable inputs itself and applies MAX_VTXOS_PER_SETTLEMENT.
+    describe("no-params auto-select cap", () => {
+        const exitScriptHex = hex.encode(
+            CSVMultisigTapscript.encode({
+                timelock: { type: "seconds", value: 604_672n },
+                pubkeys: [new Uint8Array(32).fill(0x01)],
+            }).script,
+        );
+
+        const makeVtxo = (value: number, i: number): ExtendedVirtualCoin =>
+            ({
+                txid: `vtxo-${value}-${i}`,
+                vout: 0,
+                value,
+                virtualStatus: {
+                    state: "settled",
+                    batchExpiry: Date.now() + 60 * 60 * 1000,
+                },
+                isSpent: false,
+                status: { confirmed: true },
+                createdAt: new Date(),
+                isUnrolled: false,
+                forfeitTapLeafScript: [new Uint8Array(), new Uint8Array()],
+                intentTapLeafScript: [new Uint8Array(), new Uint8Array()],
+                tapTree: new Uint8Array(),
+            }) as any;
+
+        // Build a `this` for _settleImpl that runs the auto-select branch and
+        // short-circuits at makeRegisterIntentSignature, capturing the final
+        // selected inputs (which is what gets registered with the server).
+        const buildThisArg = (vtxos: ExtendedVirtualCoin[], intentFee: Record<string, string>) => {
+            let capturedInputs: ExtendedCoin[] | undefined;
+            const sentinel = new Error("stop-after-selection");
+            const thisArg: any = {
+                network: "mutinynet",
+                dustAmount: 330n,
+                arkProvider: {
+                    getInfo: vi.fn().mockResolvedValue({ fees: { intentFee } }),
+                },
+                onchainProvider: {
+                    getChainTip: vi.fn().mockResolvedValue({ height: 1000 }),
+                },
+                boardingTapscript: { exitScript: exitScriptHex },
+                getBoardingUtxos: vi.fn().mockResolvedValue([]),
+                getVtxos: vi.fn().mockResolvedValue(vtxos),
+                getAddress: vi.fn().mockResolvedValue(walletAddress),
+                identity: {
+                    signerSession: () => ({
+                        getPublicKey: async () => new Uint8Array(32),
+                    }),
+                },
+                makeRegisterIntentSignature: vi.fn(async (coins: ExtendedCoin[]) => {
+                    capturedInputs = coins;
+                    throw sentinel;
+                }),
+                makeDeleteIntentSignature: vi.fn().mockResolvedValue({
+                    proof: "delete-proof",
+                    message: { type: "delete", expire_at: 0 },
+                }),
+                _addPendingSpends: vi.fn(),
+            };
+            return { thisArg, sentinel, getCaptured: () => capturedInputs };
+        };
+
+        it("caps the number of auto-selected VTXOs at MAX_VTXOS_PER_SETTLEMENT", async () => {
+            const value = 5_000;
+            const vtxos = Array.from({ length: MAX_VTXOS_PER_SETTLEMENT + 5 }, (_, i) =>
+                makeVtxo(value, i),
+            );
+            const { thisArg, sentinel, getCaptured } = buildThisArg(vtxos, {});
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            expect(getCaptured()).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+        });
+
+        it("caps viable VTXOs, not an uneconomic prefix", async () => {
+            // 50 uneconomic VTXOs ahead of 3 viable ones, with a flat 200-sat
+            // offchain input fee. The cap must count viable inputs only, so the
+            // 3 VTXOs behind the uneconomic prefix are still selected.
+            const tiny = Array.from({ length: MAX_VTXOS_PER_SETTLEMENT }, (_, i) =>
+                makeVtxo(100, i),
+            );
+            const normal = Array.from({ length: 3 }, (_, i) => makeVtxo(10_000, 1_000 + i));
+            const { thisArg, sentinel, getCaptured } = buildThisArg([...tiny, ...normal], {
+                offchainInput: "200.0",
+            });
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            const captured = getCaptured()!;
+            expect(captured).toHaveLength(3);
+            expect(captured.every((v: any) => v.value === 10_000)).toBe(true);
+        });
     });
 });
 

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -1830,10 +1830,25 @@ describe("Wallet._settleImpl", () => {
                 tapTree: new Uint8Array(),
             }) as any;
 
+        const makeBoardingUtxo = (value: number, vout = 0): ExtendedCoin =>
+            ({
+                txid: `boarding-${value}-${vout}`,
+                vout,
+                value,
+                status: {
+                    confirmed: true,
+                    block_time: Math.floor(Date.now() / 1000) - 60,
+                },
+            }) as ExtendedCoin;
+
         // Build a `this` for _settleImpl that runs the auto-select branch and
         // short-circuits at makeRegisterIntentSignature, capturing the final
         // selected inputs (which is what gets registered with the server).
-        const buildThisArg = (vtxos: ExtendedVirtualCoin[], intentFee: Record<string, string>) => {
+        const buildThisArg = (
+            vtxos: ExtendedVirtualCoin[],
+            intentFee: Record<string, string>,
+            boardingUtxos: ExtendedCoin[] = [],
+        ) => {
             let capturedInputs: ExtendedCoin[] | undefined;
             const sentinel = new Error("stop-after-selection");
             const thisArg: any = {
@@ -1846,7 +1861,7 @@ describe("Wallet._settleImpl", () => {
                     getChainTip: vi.fn().mockResolvedValue({ height: 1000 }),
                 },
                 boardingTapscript: { exitScript: exitScriptHex },
-                getBoardingUtxos: vi.fn().mockResolvedValue([]),
+                getBoardingUtxos: vi.fn().mockResolvedValue(boardingUtxos),
                 getVtxos: vi.fn().mockResolvedValue(vtxos),
                 getAddress: vi.fn().mockResolvedValue(walletAddress),
                 identity: {
@@ -1879,6 +1894,24 @@ describe("Wallet._settleImpl", () => {
             ).rejects.toBe(sentinel);
 
             expect(getCaptured()).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+        });
+
+        it("keeps boarding inputs in addition to capped auto-selected VTXOs", async () => {
+            const boarding = [makeBoardingUtxo(10_000), makeBoardingUtxo(12_000, 1)];
+            const value = 5_000;
+            const vtxos = Array.from({ length: MAX_VTXOS_PER_SETTLEMENT + 5 }, (_, i) =>
+                makeVtxo(value, i),
+            );
+            const { thisArg, sentinel, getCaptured } = buildThisArg(vtxos, {}, boarding);
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            const captured = getCaptured()!;
+            expect(captured).toHaveLength(boarding.length + MAX_VTXOS_PER_SETTLEMENT);
+            expect(captured.slice(0, boarding.length)).toEqual(boarding);
+            expect(captured.slice(boarding.length)).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
         });
 
         it("settles the highest-value VTXOs first when capping", async () => {

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -1881,6 +1881,25 @@ describe("Wallet._settleImpl", () => {
             expect(getCaptured()).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
         });
 
+        it("settles the highest-value VTXOs first when capping", async () => {
+            // 10 large VTXOs listed AFTER 50 small ones. Sorting by value
+            // before the cap must rescue the large ones so the capped batch
+            // carries the most value (overflow settles on the next call).
+            const small = Array.from({ length: MAX_VTXOS_PER_SETTLEMENT }, (_, i) =>
+                makeVtxo(1_000, i),
+            );
+            const large = Array.from({ length: 10 }, (_, i) => makeVtxo(10_000, 1_000 + i));
+            const { thisArg, sentinel, getCaptured } = buildThisArg([...small, ...large], {});
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            const captured = getCaptured()!;
+            expect(captured).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+            expect(captured.filter((v: any) => v.value === 10_000)).toHaveLength(10);
+        });
+
         it("caps viable VTXOs, not an uneconomic prefix", async () => {
             // 50 uneconomic VTXOs ahead of 3 viable ones, with a flat 200-sat
             // offchain input fee. The cap must count viable inputs only, so the


### PR DESCRIPTION
## Summary

Limit automatically selected settlement VTXO batches to `MAX_VTXOS_PER_SETTLEMENT = 50` so wallet renewal and settlement paths avoid arkd `TX_TOO_LARGE` failures when a wallet has many VTXOs.

## Details

- Add a shared `MAX_VTXOS_PER_SETTLEMENT` constant in `VtxoManager`.
- Cap automatically selected VTXOs in:
  - `VtxoManager.recoverVtxos`
  - `VtxoManager.renewVtxos`
  - `VtxoManager.runPeriodicSettle`
  - no-params `Wallet.settle()`
- Preserve selection order for recovery to stay aligned with go-sdk behavior.
- Re-run recovery subdust/dust eligibility on the capped recovery batch so a below-dust prefix is not submitted to the server.
- Leave caller-provided `wallet.settle({ inputs })` uncapped.
- Add regression coverage for recovery, renewal, periodic settle, and no-params wallet settle caps.

## Validation

- `pnpm exec vitest run test/vtxo-manager.test.ts test/wallet.test.ts -t "cap|auto-select|subdust"`
- `pnpm exec prettier --check src/wallet/vtxo-manager.ts src/wallet/wallet.ts test/vtxo-manager.test.ts test/wallet.test.ts`
- `pnpm exec tsc --noEmit`
- Commit hook: `pnpm -r lint` and `pnpm -r test:unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents large-settlement rejections by capping the number of offchain virtual outputs per settlement (50), and ensuring periodic settlements stop once the cap is reached.

* **New Features**
  * Deterministic selection: settles prioritize highest-value and soonest-expiring outputs, skip uneconomic inputs so viable outputs aren’t starved, and defer overflow to later settlements.

* **Tests**
  * Added coverage validating capping, ordering, viability checks, and recomputation of outputs when capping applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->