### PR TITLE
Cap settlement batches by vtxoMaxAmount

### DIFF
--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -167,6 +167,43 @@ export function byExpiryAscending(vtxos: ExtendedVirtualCoin[]): ExtendedVirtual
     return [...vtxos].sort((a, b) => expiryKey(a) - expiryKey(b));
 }
 
+/**
+ * Select inputs from `sorted` that fit in a single settlement: at most
+ * {@link MAX_VTXOS_PER_SETTLEMENT} inputs AND a cumulative `value` no greater
+ * than `maxAmount`. `maxAmount < 0` disables the amount bound — it is the
+ * server's `-1` "no limit" sentinel for `ArkInfo.vtxoMaxAmount`.
+ *
+ * Each settlement path builds a single output equal to the (fee-adjusted) sum
+ * of its inputs, and the server rejects any virtual output above `vtxoMaxAmount`
+ * with `AMOUNT_TOO_HIGH`. Capping the input total therefore keeps that output
+ * within bounds; the overflow is settled on the next cycle, mirroring the
+ * count-cap behaviour.
+ *
+ * `sorted` must already be ordered by the caller's priority (value-descending
+ * for recovery / manual full settle, expiry-ascending for renewal) so the
+ * inputs that matter most are tried first. An input that would breach the
+ * amount cap is skipped — not a stopping point — so a smaller input behind an
+ * oversized or awkwardly-sized one still gets in (a break would strand it and
+ * could leave the batch below dust). The count cap is a hard stop. Uses
+ * `> maxAmount` to mirror the server's strict check, so a batch whose total
+ * equals the limit still fits.
+ */
+export function capSettlementBatch<T extends { value: number }>(
+    sorted: T[],
+    maxAmount: bigint,
+): T[] {
+    const batch: T[] = [];
+    let total = 0n;
+    for (const vtxo of sorted) {
+        if (batch.length >= MAX_VTXOS_PER_SETTLEMENT) break;
+        const next = total + BigInt(vtxo.value);
+        if (maxAmount >= 0n && next > maxAmount) continue;
+        batch.push(vtxo);
+        total = next;
+    }
+    return batch;
+}
+
 /** Default renewal threshold in seconds (3 days). */
 export const DEFAULT_THRESHOLD_SECONDS = 259_200;
 
@@ -651,18 +688,20 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             throw new Error("No recoverable VTXOs found");
         }
 
-        // Cap the number of VTXOs per settlement to stay under the server's
-        // intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). Recover the
-        // highest-value VTXOs first: the subdust inclusion decision above was
-        // made on the full set's combined total, so a naive prefix can drop the
-        // capped batch below dust — which the server rejects, leaving the next
-        // cycle to re-pick the same prefix forever. Ordering by value maximizes
-        // the recovered amount and gives the capped subset the best chance of
-        // clearing dust. We re-run the subdust/dust eligibility on that exact
-        // capped subset; the overflow is recovered next cycle.
-        if (vtxosToRecover.length > MAX_VTXOS_PER_SETTLEMENT) {
+        // Cap the recovery batch to stay under both the server's intent-size
+        // limit (MAX_VTXOS_PER_SETTLEMENT inputs) and its per-output ceiling
+        // (vtxoMaxAmount; -1 means no limit). Recover the highest-value VTXOs
+        // first: the subdust inclusion decision above was made on the full set's
+        // combined total, so a naive prefix can drop the capped batch below
+        // dust — which the server rejects, leaving the next cycle to re-pick the
+        // same prefix forever. Ordering by value maximizes the recovered amount
+        // and gives the capped subset the best chance of clearing dust. We
+        // re-run the subdust/dust eligibility on that exact capped subset; the
+        // overflow is recovered next cycle.
+        const vtxoMaxAmount = (await this.getInfoProvider()?.getInfo())?.vtxoMaxAmount ?? -1n;
+        const capped = capSettlementBatch(byValueDescending(vtxosToRecover), vtxoMaxAmount);
+        if (capped.length < vtxosToRecover.length) {
             const recoverableCount = vtxosToRecover.length;
-            const capped = byValueDescending(vtxosToRecover).slice(0, MAX_VTXOS_PER_SETTLEMENT);
             ({ vtxosToRecover, totalAmount } = getRecoverableWithSubdust(capped, dustAmount));
             if (vtxosToRecover.length === 0) {
                 // Recoverable VTXOs exist, but the highest-value subset that
@@ -672,9 +711,9 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 // operators can tell a stuck-but-funded wallet from an empty
                 // one. Recovery resumes once the prefix accumulates dust.
                 throw new Error(
-                    `Capped recovery batch (highest-value ${MAX_VTXOS_PER_SETTLEMENT} of ` +
-                        `${recoverableCount} recoverable VTXOs) is below the dust threshold ` +
-                        `${dustAmount}`,
+                    `Capped recovery batch (highest-value subset of ${recoverableCount} ` +
+                        `recoverable VTXOs within the ${MAX_VTXOS_PER_SETTLEMENT}-input and ` +
+                        `${vtxoMaxAmount}-sat limits) is below the dust threshold ${dustAmount}`,
                 );
             }
         }
@@ -887,15 +926,29 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 throw new Error("No VTXOs available to renew");
             }
 
-            // Cap the number of VTXOs per settlement to stay under the
-            // server's intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). Renew
-            // the soonest-expiring VTXOs first so the most urgent ones make the
-            // cut — otherwise a viable VTXO past the cap could miss its renewal
-            // window and be forced into a unilateral exit. The output amount is
-            // summed from the capped set below, so it stays consistent; the
-            // overflow is renewed on the next cycle.
-            if (vtxos.length > MAX_VTXOS_PER_SETTLEMENT) {
-                vtxos = byExpiryAscending(vtxos).slice(0, MAX_VTXOS_PER_SETTLEMENT);
+            // Cap the renewal batch to stay under both the server's intent-size
+            // limit (MAX_VTXOS_PER_SETTLEMENT inputs) and its per-output ceiling
+            // (vtxoMaxAmount; -1 means no limit). Renew the soonest-expiring
+            // VTXOs first so the most urgent ones make the cut — otherwise a
+            // viable VTXO past the cap could miss its renewal window and be
+            // forced into a unilateral exit. The output amount is summed from
+            // the capped set below, so it stays consistent; the overflow is
+            // renewed on the next cycle.
+            const vtxoMaxAmount = (await this.getInfoProvider()?.getInfo())?.vtxoMaxAmount ?? -1n;
+            const capped = capSettlementBatch(byExpiryAscending(vtxos), vtxoMaxAmount);
+            if (capped.length < vtxos.length) {
+                // A cap dropped inputs: settle the soonest-expiring subset now
+                // and renew the overflow next cycle. When neither cap bites we
+                // keep the original selection (and order) untouched.
+                vtxos = capped;
+                if (vtxos.length === 0) {
+                    // The soonest-expiring VTXO alone exceeds vtxoMaxAmount, so
+                    // no batch fits. Only reachable if the server lowered the
+                    // ceiling below an existing VTXO; it would reject it anyway.
+                    throw new Error(
+                        `No VTXOs available to renew within the per-output limit ${vtxoMaxAmount}`,
+                    );
+                }
             }
 
             const totalAmount = vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
@@ -1146,6 +1199,17 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     /** Returns the Ark provider for intent fee and server info lookups. */
     private getArkProvider() {
         return this.getSweepWallet().arkProvider;
+    }
+
+    /**
+     * Read-only access to the ark provider for fetching server limits. Unlike
+     * {@link getArkProvider}, this does not require full boarding-sweep
+     * capability — recovery and renewal only need it to read `vtxoMaxAmount`.
+     * Returns undefined when no provider is wired, which callers treat as
+     * "no limit".
+     */
+    private getInfoProvider(): ArkProvider | undefined {
+        return (this.wallet as Partial<SweepCapableWallet>).arkProvider;
     }
 
     /** Returns the Bitcoin network configuration from the wallet. */
@@ -1521,7 +1585,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // Without this, settle sends `outputAmount = sum(inputs)` and the
         // server rejects with INTENT_INSUFFICIENT_FEE whenever the operator
         // charges non-zero intent fees.
-        const { fees } = await this.getArkProvider().getInfo();
+        const { fees, vtxoMaxAmount } = await this.getArkProvider().getInfo();
         const estimator = new Estimator(fees.intentFee);
 
         let totalAmount = 0n;
@@ -1540,13 +1604,17 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         }
 
         // Cap the VTXOs per settlement to stay under the server's intent-size
-        // limit (see MAX_VTXOS_PER_SETTLEMENT). Settle the soonest-expiring
-        // VTXOs first so the most urgent ones make the cut. Apply the cap to
+        // limit (MAX_VTXOS_PER_SETTLEMENT inputs) and its per-output ceiling
+        // (vtxoMaxAmount; -1 means no limit). Settle the soonest-expiring VTXOs
+        // first so the most urgent ones make the cut. Apply the cap to
         // economically viable VTXOs only: skipping uneconomic inputs and
         // continuing past the cap avoids an uneconomic prefix permanently
         // starving valid VTXOs behind it. Boarding inputs are added uncapped
-        // above; the headroom absorbs them. Any overflow is settled on the next
-        // cycle.
+        // above; the amount cap accounts for them via the running total (so if
+        // boarding alone already exceeds vtxoMaxAmount no VTXO fits and the
+        // server rejects the over-limit output — a multi-output split would be
+        // needed to settle that, which is out of scope here). Any overflow is
+        // settled on the next cycle.
         const filteredVtxos: ExtendedVirtualCoin[] = [];
         for (const v of byExpiryAscending(expiringVtxos)) {
             if (filteredVtxos.length >= MAX_VTXOS_PER_SETTLEMENT) {
@@ -1564,8 +1632,14 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             if (inputFee.satoshis >= v.value) {
                 continue;
             }
+            const net = BigInt(v.value) - BigInt(inputFee.satoshis);
+            // Skip (don't stop at) a VTXO that would push the output past the
+            // ceiling; a smaller VTXO behind it can still fit.
+            if (vtxoMaxAmount >= 0n && totalAmount + net > vtxoMaxAmount) {
+                continue;
+            }
             filteredVtxos.push(v);
-            totalAmount += BigInt(v.value) - BigInt(inputFee.satoshis);
+            totalAmount += net;
         }
 
         if (filteredBoarding.length === 0 && filteredVtxos.length === 0) {

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -179,6 +179,14 @@ export function byExpiryAscending(vtxos: ExtendedVirtualCoin[]): ExtendedVirtual
  * within bounds; the overflow is settled on the next cycle, mirroring the
  * count-cap behaviour.
  *
+ * The bound is applied to each input's gross `value`, not its fee-adjusted net
+ * contribution. This is intentional and strictly conservative: the real output
+ * is smaller once the offchain output fee is removed, so a batch that fits on
+ * gross value always fits post-fee. The helper has no fee context, and erring
+ * toward fewer inputs per cycle is safe. Do not "tighten" this by subtracting
+ * fees here. (The periodic-settle / manual-settle paths, which do have a fee
+ * estimator on hand, cap on net instead — a deliberate, harmless asymmetry.)
+ *
  * `sorted` must already be ordered by the caller's priority (value-descending
  * for recovery / manual full settle, expiry-ascending for renewal) so the
  * inputs that matter most are tried first. An input that would breach the
@@ -196,6 +204,7 @@ export function capSettlementBatch<T extends { value: number }>(
     let total = 0n;
     for (const vtxo of sorted) {
         if (batch.length >= MAX_VTXOS_PER_SETTLEMENT) break;
+        // Gross value, intentionally not fee-adjusted — see the note above.
         const next = total + BigInt(vtxo.value);
         if (maxAmount >= 0n && next > maxAmount) continue;
         batch.push(vtxo);
@@ -936,6 +945,20 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // renewed on the next cycle.
             const vtxoMaxAmount = (await this.getInfoProvider()?.getInfo())?.vtxoMaxAmount ?? -1n;
             const capped = capSettlementBatch(byExpiryAscending(vtxos), vtxoMaxAmount);
+            if (vtxoMaxAmount >= 0n) {
+                // A VTXO whose value alone exceeds the per-output ceiling can
+                // never be renewed by this path (the server would reject it) and
+                // will drift toward a unilateral exit as it nears expiry. The
+                // routine count-cap overflow is benign (deferred next cycle), but
+                // this is not — surface it so operators can act (e.g. split it).
+                const oversized = vtxos.filter((vtxo) => BigInt(vtxo.value) > vtxoMaxAmount);
+                if (oversized.length > 0) {
+                    console.warn(
+                        `Renewal: ${oversized.length} VTXO(s) exceed the per-output limit ` +
+                            `${vtxoMaxAmount} and cannot be renewed; they risk unilateral exit`,
+                    );
+                }
+            }
             if (capped.length < vtxos.length) {
                 // A cap dropped inputs: settle the soonest-expiring subset now
                 // and renew the overflow next cycle. When neither cap bites we
@@ -1209,7 +1232,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * "no limit".
      */
     private getInfoProvider(): ArkProvider | undefined {
-        return (this.wallet as Partial<SweepCapableWallet>).arkProvider;
+        // Narrow cast: reach only for an optional arkProvider rather than the
+        // full sweep-capable shape, so an incompatible future IWallet.arkProvider
+        // surfaces here as a type error instead of being silently absorbed.
+        return (this.wallet as { arkProvider?: ArkProvider }).arkProvider;
     }
 
     /** Returns the Bitcoin network configuration from the wallet. */

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2165,6 +2165,9 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
             const vtxos = await this.getVtxos({ withRecoverable: true });
 
+            const offchainAddress = await this.getAddress();
+            const offchainOutputScript = hex.encode(ArkAddress.decode(offchainAddress).pkScript);
+
             // Cap the VTXOs per settlement to stay under the server's
             // intent-size limit (MAX_VTXOS_PER_SETTLEMENT inputs) and its
             // per-output ceiling (vtxoMaxAmount; -1 means no limit). Settle the
@@ -2197,9 +2200,20 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
                 const net = vtxo.value - inputFee.satoshis;
                 // Skip (don't stop at) a VTXO that would push the output past
-                // the ceiling; a smaller VTXO behind it can still fit.
-                if (vtxoMaxAmount >= 0n && BigInt(amount + net) > vtxoMaxAmount) {
-                    continue;
+                // the ceiling; a smaller VTXO behind it can still fit. Compare
+                // against the projected post-fee output (what the server
+                // actually receives) rather than the pre-fee subtotal, so a
+                // VTXO whose output would fit once the output fee is deducted
+                // isn't dropped.
+                if (vtxoMaxAmount >= 0n) {
+                    const projectedAmount = BigInt(amount + net);
+                    const projectedOutputFee = estimator.evalOffchainOutput({
+                        amount: projectedAmount,
+                        script: offchainOutputScript,
+                    });
+                    if (projectedAmount - BigInt(projectedOutputFee.satoshis) > vtxoMaxAmount) {
+                        continue;
+                    }
                 }
 
                 filteredVtxos.push(vtxo);
@@ -2212,13 +2226,13 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             }
 
             const output = {
-                address: await this.getAddress(),
+                address: offchainAddress,
                 amount: BigInt(amount),
             };
 
             const outputFee = estimator.evalOffchainOutput({
                 amount: output.amount,
-                script: hex.encode(ArkAddress.decode(output.address).pkScript),
+                script: offchainOutputScript,
             });
 
             output.amount -= BigInt(outputFee.satoshis);

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2122,6 +2122,17 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             }
         }
 
+        // Resolve the wallet's receive address once and reuse it for every read
+        // below. `WalletReceiveRotator.rotate` mutates `this.offchainTapscript`
+        // without acquiring `_txLock`, so re-calling `getAddress()` later could
+        // observe a rotated script — building the output from one and matching
+        // `findDestinationOutputIndex` against the other, which fails with a
+        // spurious "no output matches". A single read pins the no-params output
+        // below and the asset-routing destination script later to one address.
+        const offchainAddress = await this.getAddress();
+        const offchainPkScript = ArkAddress.decode(offchainAddress).pkScript;
+        const offchainOutputScript = hex.encode(offchainPkScript);
+
         // if no params are provided, use all non-expired boarding inputs and offchain virtual outputs as inputs
         // and send all to the offchain address
         if (!params) {
@@ -2164,9 +2175,6 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             }
 
             const vtxos = await this.getVtxos({ withRecoverable: true });
-
-            const offchainAddress = await this.getAddress();
-            const offchainOutputScript = hex.encode(ArkAddress.decode(offchainAddress).pkScript);
 
             // Cap the VTXOs per settlement to stay under the server's
             // intent-size limit (MAX_VTXOS_PER_SETTLEMENT inputs) and its
@@ -2286,8 +2294,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
         let outputAssets: Asset[] | undefined;
 
-        const destinationScript = ArkAddress.decode(await this.getAddress()).pkScript;
-        const assetOutputIndex = findDestinationOutputIndex(outputs, destinationScript);
+        const assetOutputIndex = findDestinationOutputIndex(outputs, offchainPkScript);
 
         if (assetInputs.size > 0) {
             if (assetOutputIndex === -1) {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2125,7 +2125,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         // if no params are provided, use all non-expired boarding inputs and offchain virtual outputs as inputs
         // and send all to the offchain address
         if (!params) {
-            const { fees } = await this.arkProvider.getInfo();
+            const { fees, vtxoMaxAmount } = await this.arkProvider.getInfo();
             const estimator = new Estimator(fees.intentFee);
 
             let amount = 0;
@@ -2166,12 +2166,15 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             const vtxos = await this.getVtxos({ withRecoverable: true });
 
             // Cap the VTXOs per settlement to stay under the server's
-            // intent-size limit (see MAX_VTXOS_PER_SETTLEMENT). Settle the
+            // intent-size limit (MAX_VTXOS_PER_SETTLEMENT inputs) and its
+            // per-output ceiling (vtxoMaxAmount; -1 means no limit). Settle the
             // highest-value VTXOs first so the capped batch carries the most
             // value. Apply the cap to economically viable VTXOs only: skipping
             // uneconomic inputs and continuing past the cap avoids an uneconomic
             // prefix permanently starving valid VTXOs behind it. The boarding
-            // inputs above are added uncapped; the headroom absorbs them. Any
+            // inputs above are added uncapped; the amount cap accounts for them
+            // via the running total (if boarding alone exceeds vtxoMaxAmount no
+            // VTXO fits and the server rejects the over-limit output). Any
             // overflow is settled on the next call.
             const filteredVtxos = [];
             for (const vtxo of byValueDescending(vtxos)) {
@@ -2192,8 +2195,15 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                     continue;
                 }
 
+                const net = vtxo.value - inputFee.satoshis;
+                // Skip (don't stop at) a VTXO that would push the output past
+                // the ceiling; a smaller VTXO behind it can still fit.
+                if (vtxoMaxAmount >= 0n && BigInt(amount + net) > vtxoMaxAmount) {
+                    continue;
+                }
+
                 filteredVtxos.push(vtxo);
-                amount += vtxo.value - inputFee.satoshis;
+                amount += net;
             }
 
             const inputs = [...filteredBoardingUtxos, ...filteredVtxos];

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -1077,6 +1077,55 @@ describe("VtxoManager - Renewal", () => {
             expect(settleArgs.outputs[0].amount).toBeLessThanOrEqual(12000n);
         });
 
+        it("warns when an oversized VTXO cannot be renewed within vtxoMaxAmount", async () => {
+            const now = Date.now();
+            const createdAt = new Date(now - 100_000);
+            // The soonest-expiring VTXO (12000) alone exceeds the 10000 ceiling,
+            // so it is skipped and drifts toward a unilateral exit while the
+            // smaller 5000 one renews. The skip must be surfaced, not silent.
+            const vtxos = [
+                {
+                    txid: "oversized",
+                    vout: 0,
+                    value: 12_000,
+                    createdAt,
+                    virtualStatus: { state: "settled", batchExpiry: now + 1_000 },
+                    status: { confirmed: true },
+                    isUnrolled: false,
+                    isSpent: false,
+                } as any,
+                {
+                    txid: "fits",
+                    vout: 0,
+                    value: 5_000,
+                    createdAt,
+                    virtualStatus: { state: "settled", batchExpiry: now + 5_000 },
+                    status: { confirmed: true },
+                    isUnrolled: false,
+                    isSpent: false,
+                } as any,
+            ];
+            const wallet = createMockWallet(vtxos, "arkade1myaddress", {
+                vtxoMaxAmount: 10_000n,
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+            try {
+                const txid = await manager.renewVtxos();
+
+                expect(txid).toBe("mock-txid");
+                const settleArgs = (wallet.settle as any).mock.calls[0][0];
+                expect(settleArgs.inputs).toHaveLength(1);
+                expect(settleArgs.inputs[0].txid).toBe("fits");
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining("exceed the per-output limit 10000"),
+                );
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
         it("should renew the soonest-expiring VTXOs first when capping", async () => {
             // The 10 most urgent VTXOs are listed AFTER 50 less-urgent ones.
             // Sorting by expiry before the cap must rescue them so they don't

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -8,6 +8,7 @@ import {
     getExpiringAndRecoverableVtxos,
     DEFAULT_THRESHOLD_MS,
     MAX_VTXOS_PER_SETTLEMENT,
+    capSettlementBatch,
     SettlementConfig,
 } from "../src/wallet/vtxo-manager";
 import { IWallet, ExtendedCoin, ExtendedVirtualCoin } from "../src/wallet";
@@ -23,6 +24,11 @@ type MockWalletOptions = {
     delegateManager?: {
         delegate: ReturnType<typeof vi.fn>;
     };
+    /**
+     * Server per-output ceiling surfaced via `arkProvider.getInfo()`. Defaults
+     * to `-1n` ("no limit") so existing recovery/renewal tests are unaffected.
+     */
+    vtxoMaxAmount?: bigint;
 };
 
 // Mock wallet implementation
@@ -51,6 +57,15 @@ const createMockWallet = (
         getContractManager: vi.fn().mockResolvedValue(contractManager),
         settle: vi.fn().mockResolvedValue("mock-txid"),
         dustAmount: 1000n,
+        // Recovery/renewal read `vtxoMaxAmount` from here (without requiring full
+        // sweep capability). Only `arkProvider` is set, so the wallet stays
+        // non-sweep-capable and the boarding-poll paths are untouched.
+        arkProvider: {
+            getInfo: vi.fn().mockResolvedValue({
+                fees: { intentFee: {} },
+                vtxoMaxAmount: options.vtxoMaxAmount ?? -1n,
+            }),
+        },
     } as any;
 };
 
@@ -85,6 +100,67 @@ const createMockVtxo = (
         tapTree: new Uint8Array(),
     } as any;
 };
+
+describe("capSettlementBatch", () => {
+    const make = (values: number[]) => values.map((value, i) => ({ value, id: i }));
+
+    it("caps by count, keeping the sorted prefix", () => {
+        const sorted = make(Array.from({ length: MAX_VTXOS_PER_SETTLEMENT + 10 }, () => 100));
+        const batch = capSettlementBatch(sorted, -1n);
+        expect(batch).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+        expect(batch).toEqual(sorted.slice(0, MAX_VTXOS_PER_SETTLEMENT));
+    });
+
+    it("caps by cumulative amount, stopping before the limit is breached", () => {
+        // 5000 + 5000 = 10000 (ok), + 5000 = 15000 (> 12000) → stop at 2.
+        const batch = capSettlementBatch(make([5000, 5000, 5000, 5000]), 12000n);
+        expect(batch).toHaveLength(2);
+        expect(batch.reduce((s, v) => s + BigInt(v.value), 0n)).toBe(10000n);
+    });
+
+    it("includes a batch whose total equals the limit (server rejects only > max)", () => {
+        const batch = capSettlementBatch(make([6000, 6000, 6000]), 12000n);
+        expect(batch).toHaveLength(2);
+        expect(batch.reduce((s, v) => s + BigInt(v.value), 0n)).toBe(12000n);
+    });
+
+    it("applies whichever cap binds first (count and amount together)", () => {
+        const sorted = make(Array.from({ length: MAX_VTXOS_PER_SETTLEMENT + 10 }, () => 100));
+        // Amount cap (250) bites at 3 inputs (300 > 250) before the count cap.
+        const batch = capSettlementBatch(sorted, 250n);
+        expect(batch).toHaveLength(2);
+    });
+
+    it("treats a negative limit as no amount bound", () => {
+        const sorted = make([10_000, 10_000, 10_000]);
+        expect(capSettlementBatch(sorted, -1n)).toHaveLength(3);
+    });
+
+    it("returns an empty batch for empty input", () => {
+        expect(capSettlementBatch(make([]), 5000n)).toEqual([]);
+    });
+
+    it("skips an oversized leading candidate and still takes a smaller one that fits", () => {
+        // max 10000, [12000, 5000] → [5000]: a leading VTXO above the limit must
+        // not strand the smaller ones behind it.
+        const batch = capSettlementBatch(make([12_000, 5_000]), 10_000n);
+        expect(batch.map((v) => v.value)).toEqual([5_000]);
+    });
+
+    it("skips an awkwardly-sized candidate to pack a smaller one within budget", () => {
+        // max 10000, [9000, 4000, 1000] → [9000, 1000] = 10000, not [9000]:
+        // 4000 would overflow but 1000 still fits the remaining budget.
+        const batch = capSettlementBatch(make([9_000, 4_000, 1_000]), 10_000n);
+        expect(batch.map((v) => v.value)).toEqual([9_000, 1_000]);
+        expect(batch.reduce((s, v) => s + BigInt(v.value), 0n)).toBe(10_000n);
+    });
+
+    it("returns an empty batch only when no candidate fits the limit", () => {
+        // Every candidate alone exceeds the ceiling — only reachable if the
+        // server lowered it below all existing VTXOs.
+        expect(capSettlementBatch(make([9000, 8000]), 5000n)).toEqual([]);
+    });
+});
 
 describe("VtxoManager - Recovery", () => {
     describe("getRecoverableBalance", () => {
@@ -271,6 +347,41 @@ describe("VtxoManager - Recovery", () => {
             expect(settleArgs.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
             // Output amount is recomputed from the capped set, not the full list.
             expect(settleArgs.outputs[0].amount).toBe(BigInt(MAX_VTXOS_PER_SETTLEMENT * value));
+        });
+
+        it("should cap the recovery batch to the server's vtxoMaxAmount", async () => {
+            const value = 5000;
+            // 10 recoverable VTXOs = 50000 total, but the server caps a single
+            // virtual output at 12000: only the highest-value subset that stays
+            // within the limit (2 * 5000 = 10000) is recovered this cycle.
+            const vtxos = makeRecoverable(10, value, "swept");
+            const wallet = createMockWallet(vtxos, "arkade1myaddress", {
+                vtxoMaxAmount: 12000n,
+            });
+            const manager = new VtxoManager(wallet);
+
+            const txid = await manager.recoverVtxos();
+
+            expect(txid).toBe("mock-txid");
+            const settleArgs = (wallet.settle as any).mock.calls[0][0];
+            expect(settleArgs.inputs).toHaveLength(2);
+            expect(settleArgs.outputs[0].amount).toBe(10000n);
+            expect(settleArgs.outputs[0].amount).toBeLessThanOrEqual(12000n);
+        });
+
+        it("should not cap the recovery batch when vtxoMaxAmount is -1 (no limit)", async () => {
+            const value = 5000;
+            const vtxos = makeRecoverable(10, value, "swept");
+            const wallet = createMockWallet(vtxos, "arkade1myaddress", {
+                vtxoMaxAmount: -1n,
+            });
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            const settleArgs = (wallet.settle as any).mock.calls[0][0];
+            expect(settleArgs.inputs).toHaveLength(10);
+            expect(settleArgs.outputs[0].amount).toBe(BigInt(10 * value));
         });
 
         it("should recover by value so a subdust prefix doesn't starve regulars", async () => {
@@ -929,6 +1040,41 @@ describe("VtxoManager - Renewal", () => {
             expect(settleArgs.inputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
             // Output amount is summed from the capped set, not the full list.
             expect(settleArgs.outputs[0].amount).toBe(BigInt(MAX_VTXOS_PER_SETTLEMENT * value));
+        });
+
+        it("should cap the renewal batch to the server's vtxoMaxAmount", async () => {
+            const now = Date.now();
+            const createdAt = new Date(now - 100_000);
+            const value = 5000;
+            // 10 expiring VTXOs = 50000 total, but the server caps a single
+            // virtual output at 12000: only 2 * 5000 = 10000 is renewed now, the
+            // rest on the next cycle.
+            const vtxos = Array.from(
+                { length: 10 },
+                (_, i) =>
+                    ({
+                        txid: `tx-${i}`,
+                        vout: 0,
+                        value,
+                        createdAt,
+                        virtualStatus: { state: "settled", batchExpiry: now + 5000 },
+                        status: { confirmed: true },
+                        isUnrolled: false,
+                        isSpent: false,
+                    }) as any,
+            );
+            const wallet = createMockWallet(vtxos, "arkade1myaddress", {
+                vtxoMaxAmount: 12000n,
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            const txid = await manager.renewVtxos();
+
+            expect(txid).toBe("mock-txid");
+            const settleArgs = (wallet.settle as any).mock.calls[0][0];
+            expect(settleArgs.inputs).toHaveLength(2);
+            expect(settleArgs.outputs[0].amount).toBe(10000n);
+            expect(settleArgs.outputs[0].amount).toBeLessThanOrEqual(12000n);
         });
 
         it("should renew the soonest-expiring VTXOs first when capping", async () => {
@@ -2507,6 +2653,57 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
         expect(call.inputs).toHaveLength(boarding.length + MAX_VTXOS_PER_SETTLEMENT);
         expect(call.inputs.slice(0, boarding.length)).toEqual(boarding);
         expect(call.inputs.slice(boarding.length)).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+    });
+
+    it("caps periodic VTXOs to the server's vtxoMaxAmount", async () => {
+        const value = 5_000;
+        const vtxos = Array.from({ length: 10 }, (_, i) => makeExpiringVtxo(value, i));
+        const wallet = buildWallet([], vtxos);
+        // No intent fees, so net == value; the 12000 ceiling fits only 2 VTXOs.
+        (wallet.arkProvider.getInfo as any).mockResolvedValue({
+            fees: { intentFee: {} },
+            vtxoMaxAmount: 12000n,
+        });
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle([]);
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+        const call = (wallet.settle as any).mock.calls[0][0];
+        expect(call.inputs).toHaveLength(2);
+        expect(call.outputs[0].amount).toBe(10000n);
+        expect(call.outputs[0].amount).toBeLessThanOrEqual(12000n);
+    });
+
+    it("skips an oversized VTXO during periodic settle and takes a smaller one", async () => {
+        const expiry = Date.now() + 60 * 60 * 1000;
+        // Soonest-expiring 12000 exceeds the 10000 ceiling and is skipped; the
+        // 5000 behind it still settles. A break would settle nothing.
+        const vtxos = [makeExpiringVtxo(12_000, 0, expiry), makeExpiringVtxo(5_000, 1, expiry)];
+        const wallet = buildWallet([], vtxos);
+        (wallet.arkProvider.getInfo as any).mockResolvedValue({
+            fees: { intentFee: {} },
+            vtxoMaxAmount: 10_000n,
+        });
+
+        const manager = new VtxoManager(wallet, undefined, {
+            boardingUtxoSweep: false,
+            pollIntervalMs: 60_000,
+        });
+        manager.dispose();
+
+        await (manager as any).runPeriodicSettle([]);
+
+        expect(wallet.settle).toHaveBeenCalledTimes(1);
+        const call = (wallet.settle as any).mock.calls[0][0];
+        expect(call.inputs).toHaveLength(1);
+        expect(call.inputs[0].value).toBe(5_000);
+        expect(call.outputs[0].amount).toBe(5000n);
     });
 
     it("skips VTXO collection while an event-driven renewal is in flight", async () => {

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -2005,6 +2005,28 @@ describe("Wallet._settleImpl", () => {
             expect(captured).toHaveLength(1);
             expect(captured[0].value).toBe(5_000);
         });
+
+        it("compares vtxoMaxAmount against the projected post-fee output", async () => {
+            // Pre-fee subtotal (10_500) exceeds the 10_000 ceiling, but the
+            // flat 1000-sat output fee brings the registered output down to
+            // 9_500, which fits. The VTXO must be selected, not dropped.
+            const vtxos = [makeVtxo(10_500, 0)];
+            const { thisArg, sentinel, getCaptured } = buildThisArg(vtxos, {
+                offchainOutput: "1000.0",
+            });
+            thisArg.arkProvider.getInfo.mockResolvedValue({
+                fees: { intentFee: { offchainOutput: "1000.0" } },
+                vtxoMaxAmount: 10_000n,
+            });
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            const captured = getCaptured()!;
+            expect(captured).toHaveLength(1);
+            expect(captured[0].value).toBe(10_500);
+        });
     });
 });
 

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -1953,6 +1953,58 @@ describe("Wallet._settleImpl", () => {
             expect(captured).toHaveLength(3);
             expect(captured.every((v: any) => v.value === 10_000)).toBe(true);
         });
+
+        it("caps the auto-selected total at the server's vtxoMaxAmount", async () => {
+            const value = 5_000;
+            const vtxos = Array.from({ length: 10 }, (_, i) => makeVtxo(value, i));
+            const { thisArg, sentinel, getCaptured } = buildThisArg(vtxos, {});
+            // No intent fees, so net == value; the 12000 ceiling fits only 2.
+            thisArg.arkProvider.getInfo.mockResolvedValue({
+                fees: { intentFee: {} },
+                vtxoMaxAmount: 12000n,
+            });
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            expect(getCaptured()).toHaveLength(2);
+        });
+
+        it("does not cap the auto-selected total when vtxoMaxAmount is -1", async () => {
+            const value = 5_000;
+            const vtxos = Array.from({ length: 10 }, (_, i) => makeVtxo(value, i));
+            const { thisArg, sentinel, getCaptured } = buildThisArg(vtxos, {});
+            thisArg.arkProvider.getInfo.mockResolvedValue({
+                fees: { intentFee: {} },
+                vtxoMaxAmount: -1n,
+            });
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            expect(getCaptured()).toHaveLength(10);
+        });
+
+        it("skips an oversized VTXO and selects a smaller one within vtxoMaxAmount", async () => {
+            // byValueDescending tries 12000 first (> 10000 ceiling, skipped),
+            // then 5000 fits. A break here would settle nothing.
+            const vtxos = [makeVtxo(12_000, 0), makeVtxo(5_000, 1)];
+            const { thisArg, sentinel, getCaptured } = buildThisArg(vtxos, {});
+            thisArg.arkProvider.getInfo.mockResolvedValue({
+                fees: { intentFee: {} },
+                vtxoMaxAmount: 10_000n,
+            });
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            const captured = getCaptured()!;
+            expect(captured).toHaveLength(1);
+            expect(captured[0].value).toBe(5_000);
+        });
     });
 });
 

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -2027,6 +2027,21 @@ describe("Wallet._settleImpl", () => {
             expect(captured).toHaveLength(1);
             expect(captured[0].value).toBe(10_500);
         });
+
+        it("reads the receive address once so a mid-settle rotation can't desync the output script", async () => {
+            // The output and the asset-routing destination script must come
+            // from one address read; re-reading could observe a
+            // WalletReceiveRotator.rotate() swap (it mutates offchainTapscript
+            // without _txLock) and make findDestinationOutputIndex miss.
+            const vtxos = [makeVtxo(5_000, 0)];
+            const { thisArg, sentinel } = buildThisArg(vtxos, {});
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            expect(thisArg.getAddress).toHaveBeenCalledTimes(1);
+        });
     });
 });
 


### PR DESCRIPTION
## What

Adds a per-settlement **amount** cap so a settlement's single VTXO output never exceeds the server's `vtxoMaxAmount`. Complements the input-**count** cap from #549 (`MAX_VTXOS_PER_SETTLEMENT`).

## Why

Every auto-selection settlement path builds one output equal to the fee-adjusted sum of its inputs. `arkd` rejects any virtual output above `vtxoMaxAmount` with `AMOUNT_TOO_HIGH` (the check is skipped when the limit is `-1` / no-limit). Consolidating more than the limit in one settlement — recovery of many subdust VTXOs, renewal, full settle — was therefore guaranteed to be rejected by the server.

## How

"Cap & defer", mirroring #549: select inputs until the cumulative output would exceed `vtxoMaxAmount`, settle that subset, and leave the overflow for the next cycle. `-1` disables the cap.

- New `capSettlementBatch(sorted, maxAmount)` helper applies both the count and amount caps to an already-sorted candidate list (value-descending for recovery / full settle, expiry-ascending for renewal). Used by `recoverVtxos` and `renewVtxos`.
- Periodic auto-settle and `Wallet.settle()` no-params get an inline amount check alongside their existing count cap.
- An over-budget candidate is **skipped** (not a stop), so a smaller VTXO behind an oversized or awkwardly-sized one still gets in — e.g. `max 10_000, [12_000, 5_000] → [5_000]` and `[9_000, 4_000, 1_000] → [9_000, 1_000]`. The count cap stays a hard stop.
- Boundary matches the server's strict check: an output exactly equal to `vtxoMaxAmount` is allowed.

## Known limitation

Periodic-settle and `Wallet.settle()` add boarding inputs uncapped, so if boarding alone exceeds `vtxoMaxAmount` the output is still over-limit and the server rejects it. Fully solving that needs multi-output splitting, which this change (like #549) deliberately does not do.

## Testing

- `capSettlementBatch` unit tests: count cap, amount cap, both, `-1`, skip-and-fill, all-oversized → empty
- amount-cap + skip-and-fill coverage for recovery, renewal, periodic settle, and `Wallet.settle()` no-params
- Full ts-sdk unit suite, `tsc --noEmit`, and prettier all pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-driven per-output amount ceiling enforced for VTXO recovery, renewal, and periodic settlement (can be disabled by server).
  * Oversized VTXOs are skipped while later smaller qualifying VTXOs remain eligible; selection evaluates projected post-fee output when applicable.
  * Wallet caches the receive address/script during auto-settle to prevent mid-settle desync; new user-facing error/warning when no VTXOs fit the server limit.

* **Tests**
  * Expanded tests covering capping behavior, edge cases, uncapped mode, warnings/errors, and packing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->