### PR TITLE
add digest header to http request

### DIFF
--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -7,6 +7,7 @@ import { maybeArkError } from "./errors";
 import type { IntentFeeConfig } from "../arkfee";
 import { Intent } from "../intent";
 import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
+import { fetch } from "../utils/fetch";
 
 /** Output requested during settlement or transaction submission. */
 export type Output = {

--- a/packages/ts-sdk/src/providers/delegate.ts
+++ b/packages/ts-sdk/src/providers/delegate.ts
@@ -1,5 +1,6 @@
 import { Intent } from "../intent";
 import { SignedIntent } from "./ark";
+import { fetch } from "../utils/fetch";
 
 /**
  * Delegate identity and fee information returned by `getDelegateInfo`.

--- a/packages/ts-sdk/src/providers/expoUtils.ts
+++ b/packages/ts-sdk/src/providers/expoUtils.ts
@@ -1,3 +1,5 @@
+import { fetch, buildVersion } from "../utils/fetch";
+
 /**
  * Dynamically imports expo/fetch with fallback to standard fetch.
  * @returns A fetch function suitable for SSE streaming
@@ -8,7 +10,12 @@ export async function getExpoFetch(options?: { requireExpo?: boolean }): Promise
     try {
         const expoFetchModule = await import("expo/fetch");
         console.debug("Using expo/fetch for streaming");
-        return expoFetchModule.fetch as unknown as typeof fetch;
+        const expoFetchWithHeader = (input: RequestInfo, init?: RequestInit) => {
+            const headers = new Headers(init?.headers);
+            headers.set("X-Build-Version", buildVersion);
+            return expoFetchModule.fetch(input, { ...init, headers });
+        };
+        return expoFetchWithHeader as unknown as typeof fetch;
     } catch (error) {
         if (requireExpo) {
             throw new Error(

--- a/packages/ts-sdk/src/providers/indexer.ts
+++ b/packages/ts-sdk/src/providers/indexer.ts
@@ -4,6 +4,7 @@ import { isFetchTimeoutError } from "./ark";
 import { eventSourceIterator, isEventSourceError } from "./utils";
 import { MetadataList } from "../extension/asset";
 import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
+import { fetch } from "../utils/fetch";
 
 export type PaginationOptions = {
     pageIndex?: number;

--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_NETWORK_NAME, type NetworkName } from "../networks";
 import { Coin } from "../wallet";
+import { fetch } from "../utils/fetch";
 
 /**
  * The default base URLs for esplora API providers.

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -1,4 +1,4 @@
-const digest = "83e847f06e157c8da464824a556098452323158cc34f65d40a72ffd8ff1b90e3";
+const version = "0.9.7";
 
 export function fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
     if (typeof globalThis.fetch !== "function") {
@@ -7,7 +7,7 @@ export function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>
     if (init) {
         init.headers = {
             ...init.headers,
-            "X-Server-Digest": digest,
+            "X-Build-Version": version,
         };
     }
     return globalThis.fetch(input, init);

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -1,0 +1,14 @@
+const digest = "83e847f06e157c8da464824a556098452323158cc34f65d40a72ffd8ff1b90e3";
+
+export function fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+    if (typeof globalThis.fetch !== "function") {
+        throw new Error("Fetch API is not available in this environment.");
+    }
+    if (init) {
+        init.headers = {
+            ...init.headers,
+            "X-Server-Digest": digest,
+        };
+    }
+    return globalThis.fetch(input, init);
+}

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -4,11 +4,7 @@ export function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>
     if (typeof globalThis.fetch !== "function") {
         throw new Error("Fetch API is not available in this environment.");
     }
-    if (init) {
-        init.headers = {
-            ...init.headers,
-            "X-Build-Version": version,
-        };
-    }
-    return globalThis.fetch(input, init);
+    const headers = new Headers(init?.headers);
+    headers.set("X-Build-Version", version);
+    return globalThis.fetch(input, { ...init, headers });
 }

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -1,10 +1,10 @@
-const version = "0.9.7";
+export const buildVersion = "0.9.7";
 
 export function fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
     if (typeof globalThis.fetch !== "function") {
         throw new Error("Fetch API is not available in this environment.");
     }
     const headers = new Headers(init?.headers);
-    headers.set("X-Build-Version", version);
+    headers.set("X-Build-Version", buildVersion);
     return globalThis.fetch(input, { ...init, headers });
 }

--- a/packages/ts-sdk/test/delegate-provider.test.ts
+++ b/packages/ts-sdk/test/delegate-provider.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RestDelegateProvider } from "../src";
 
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+const { mockFetch } = vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+}));
+
+vi.mock("../src/utils/fetch", () => ({
+    fetch: mockFetch,
+}));
 
 describe("RestDelegateProvider.getDelegateInfo", () => {
     beforeEach(() => {

--- a/packages/ts-sdk/test/esplora.test.ts
+++ b/packages/ts-sdk/test/esplora.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EsploraProvider, Coin } from "../src";
-// Mock fetch
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+
+const { mockFetch } = vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+}));
+
+vi.mock("../src/utils/fetch", () => ({
+    fetch: mockFetch,
+}));
 
 describe("EsploraProvider", () => {
     beforeEach(() => {

--- a/packages/ts-sdk/test/indexer-provider.test.ts
+++ b/packages/ts-sdk/test/indexer-provider.test.ts
@@ -2,8 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RestIndexerProvider } from "../src";
 import { MockEventSource } from "./mocks/eventSource";
 
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+const { mockFetch } = vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+}));
+
+vi.mock("../src/utils/fetch", () => ({
+    fetch: mockFetch,
+}));
 
 describe("RestIndexerProvider", () => {
     beforeEach(() => {

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -28,8 +28,13 @@ import { timelockToSequence } from "../src/utils/timelock";
 import { DEFAULT_ARKADE_SERVER_URL } from "../src/networks";
 
 // Mock fetch
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+const { mockFetch } = vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+}));
+
+vi.mock("../src/utils/fetch", () => ({
+    fetch: mockFetch,
+}));
 
 vi.stubGlobal("EventSource", MockEventSource);
 

--- a/packages/ts-sdk/test/walletBoardingRotation.test.ts
+++ b/packages/ts-sdk/test/walletBoardingRotation.test.ts
@@ -40,7 +40,14 @@ const mockArkInfo = {
         "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
 };
 
-const mockFetch = vi.fn();
+const { mockFetch } = vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+}));
+
+vi.mock("../src/utils/fetch", () => ({
+    fetch: mockFetch,
+}));
+
 const MockEventSource = vi.fn().mockImplementation((url: string) => ({
     url,
     onmessage: null,
@@ -49,7 +56,6 @@ const MockEventSource = vi.fn().mockImplementation((url: string) => ({
 }));
 
 beforeEach(() => {
-    vi.stubGlobal("fetch", mockFetch);
     vi.stubGlobal("EventSource", MockEventSource);
     mockFetch.mockReset();
     mockFetch.mockImplementation((url: string) => {

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -45,8 +45,15 @@ const mockArkInfo = {
         "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
 };
 
-// Shared mocks - reset between each test
-const mockFetch = vi.fn();
+// Mock fetch
+const { mockFetch } = vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+}));
+
+vi.mock("../src/utils/fetch", () => ({
+    fetch: mockFetch,
+}));
+
 const MockEventSource = vi.fn().mockImplementation((url: string) => ({
     url,
     onmessage: null,
@@ -55,7 +62,6 @@ const MockEventSource = vi.fn().mockImplementation((url: string) => ({
 }));
 
 beforeEach(() => {
-    vi.stubGlobal("fetch", mockFetch);
     vi.stubGlobal("EventSource", MockEventSource);
     mockFetch.mockReset();
     // Route by URL so test ordering doesn't depend on exact fetch counts.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized fetch utility that includes build-version metadata on requests and verifies Fetch API availability.
* **Chores**
  * Switched SDK providers to use the centralized fetch utility for HTTP calls.
* **Tests**
  * Updated test suites to mock the new fetch utility instead of stubbing the global fetch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->