### PR TITLE
Add optimistic Lightning payment settlement with waitFor option

### DIFF
--- a/packages/boltz-swap/README.md
+++ b/packages/boltz-swap/README.md
@@ -72,8 +72,10 @@ const result = await swaps.sendLightningPayment(
 );
 // Resolves as soon as the status is observed (or any later status in the
 // lifecycle — intermediate statuses can be skipped). result.preimage is
-// undefined when the swap hasn't settled yet; keep the SwapManager enabled
-// so settlement tracking and auto-refunds continue in the background.
+// undefined when the swap hasn't settled yet. Monitoring continues in the
+// background and keeps the stored swap up to date until a terminal status,
+// but a late failure no longer rejects — keep the SwapManager enabled so
+// auto-refunds are handled for you.
 ```
 
 The same option is accepted by `waitForSwapSettlement(pendingSwap, options)`.

--- a/packages/boltz-swap/README.md
+++ b/packages/boltz-swap/README.md
@@ -81,6 +81,12 @@ const result = await swaps.sendLightningPayment({
 The same milestone is exposed for a swap you already hold as
 `waitForSwapFunded(pendingSwap)`, alongside `waitForSwapSettlement(pendingSwap)`.
 
+If the app restarts before the swap settles, the in-process monitoring is gone — call
+`refreshSwapsStatus()` on startup to reconcile: it polls every pending swap and persists
+the latest status, including the preimage for swaps that settled while the app was
+closed. Read the swap back from the repository (e.g. `getSwapHistory()`) to flip a
+pending UI row to "completed".
+
 ### ARK to BTC
 
 ```typescript

--- a/packages/boltz-swap/README.md
+++ b/packages/boltz-swap/README.md
@@ -61,6 +61,23 @@ console.log('Paid:', result.txid);
 // SwapManager auto-refunds if payment fails
 ```
 
+By default the call resolves only once the swap fully settles (`transaction.claimed`),
+i.e. after Boltz has swept the HTLC. To show an optimistic "sent" state as soon as the
+payment is in flight — like most Lightning wallets — pass `optimisticResolveAt`:
+
+```typescript
+const result = await swaps.sendLightningPayment(
+  { invoice: 'lnbc500u1pj...' },
+  { optimisticResolveAt: 'invoice.pending' },
+);
+// Resolves as soon as the status is observed (or any later status in the
+// lifecycle — intermediate statuses can be skipped). result.preimage is
+// undefined when the swap hasn't settled yet; keep the SwapManager enabled
+// so settlement tracking and auto-refunds continue in the background.
+```
+
+The same option is accepted by `waitForSwapSettlement(pendingSwap, options)`.
+
 ### ARK to BTC
 
 ```typescript

--- a/packages/boltz-swap/README.md
+++ b/packages/boltz-swap/README.md
@@ -63,22 +63,23 @@ console.log('Paid:', result.txid);
 
 By default the call resolves only once the swap fully settles (`transaction.claimed`),
 i.e. after Boltz has swept the HTLC. To show an optimistic "sent" state as soon as the
-payment is in flight — like most Lightning wallets — pass `optimisticResolveAt`:
+payment is in flight — like most Lightning wallets — pass `waitFor: 'funded'`:
 
 ```typescript
-const result = await swaps.sendLightningPayment(
-  { invoice: 'lnbc500u1pj...' },
-  { optimisticResolveAt: 'invoice.pending' },
-);
-// Resolves as soon as the status is observed (or any later status in the
-// lifecycle — intermediate statuses can be skipped). result.preimage is
-// undefined when the swap hasn't settled yet. Monitoring continues in the
+const result = await swaps.sendLightningPayment({
+  invoice: 'lnbc500u1pj...',
+  waitFor: 'funded',
+});
+// Resolves as soon as the lockup transaction is observed: the funds are
+// committed and the swap is refundable from here. result.preimage is
+// undefined since the swap hasn't settled yet. Monitoring continues in the
 // background and keeps the stored swap up to date until a terminal status,
 // but a late failure no longer rejects — keep the SwapManager enabled so
 // auto-refunds are handled for you.
 ```
 
-The same option is accepted by `waitForSwapSettlement(pendingSwap, options)`.
+The same milestone is exposed for a swap you already hold as
+`waitForSwapFunded(pendingSwap)`, alongside `waitForSwapSettlement(pendingSwap)`.
 
 ### ARK to BTC
 

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -2841,13 +2841,33 @@ export class ArkadeSwaps {
             if (isSubmarineFinalStatus(swap.status)) continue;
             promises.push(
                 this.getSwapStatus(swap.id)
-                    .then(({ status }) =>
-                        updateSubmarineSwapStatus(
+                    .then(async ({ status }) => {
+                        // A swap that settled while no monitor was attached
+                        // (e.g. a "funded" optimistic send followed by an app
+                        // restart) has no stored preimage yet — fetch it so
+                        // the repository carries the proof of payment. Never
+                        // fail the status update over a missing preimage.
+                        let additionalFields: Partial<BoltzSubmarineSwap> | undefined;
+                        if (isSubmarineSuccessStatus(status) && !swap.preimage) {
+                            try {
+                                const { preimage } = await this.swapProvider.getSwapPreimage(
+                                    swap.id,
+                                );
+                                additionalFields = { preimage };
+                            } catch (error) {
+                                logger.warn(
+                                    `Failed to fetch preimage for settled swap ${swap.id}:`,
+                                    error,
+                                );
+                            }
+                        }
+                        await updateSubmarineSwapStatus(
                             swap,
                             status,
                             this.savePendingSubmarineSwap.bind(this),
-                        ),
-                    )
+                            additionalFields,
+                        );
+                    })
                     .catch((error) => {
                         logger.error(`Failed to refresh swap status for ${swap.id}:`, error);
                     }),

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -1416,8 +1416,10 @@ export class ArkadeSwaps {
      * @param options.optimisticResolveAt - Resolve as soon as this status (or a
      * later one in the lifecycle) is observed, instead of waiting for
      * "transaction.claimed". The preimage is undefined when resolving before
-     * settlement; the caller is then responsible for tracking the final
-     * outcome (e.g. via the SwapManager or getSwapStatus).
+     * settlement. Monitoring continues in the background until a terminal
+     * status, persisting updates to the repository, but the settled promise
+     * no longer rejects — acting on a late failure is the caller's
+     * responsibility (e.g. via the SwapManager or getSwapStatus).
      * @returns The preimage from the settled Lightning payment (proof of payment),
      * or no preimage when resolved optimistically before settlement.
      * @throws {SwapExpiredError} If the swap expires.
@@ -1435,10 +1437,17 @@ export class ArkadeSwaps {
     ): Promise<{ preimage?: string }> {
         const optimisticResolveAt = options?.optimisticResolveAt;
         return new Promise<{ preimage?: string }>((resolve, reject) => {
-            let isResolved = false;
+            // A terminal status was processed — stop handling updates. An
+            // optimistic resolution deliberately does NOT set this: the
+            // monitor keeps persisting subsequent statuses (refundable flag
+            // on failure, preimage on claim) so the stored swap doesn't go
+            // stale for SwapManager / restoreSwaps.
+            let isFinal = false;
+            // The promise was resolved or rejected, possibly optimistically.
+            let isSettled = false;
 
             const onStatusUpdate = async (status: BoltzSwapStatus) => {
-                if (isResolved) return;
+                if (isFinal) return;
 
                 const saveStatus = (additionalFields?: Partial<BoltzSubmarineSwap>) =>
                     updateSubmarineSwapStatus(
@@ -1448,9 +1457,13 @@ export class ArkadeSwaps {
                         additionalFields,
                     );
 
+                // After an optimistic resolution, reject/resolve below are
+                // no-ops on the already-settled promise; only persistence
+                // still takes effect.
                 switch (status) {
                     case "swap.expired":
-                        isResolved = true;
+                        isFinal = true;
+                        isSettled = true;
                         await saveStatus({ refundable: true });
                         reject(
                             new SwapExpiredError({
@@ -1460,7 +1473,8 @@ export class ArkadeSwaps {
                         );
                         break;
                     case "invoice.failedToPay":
-                        isResolved = true;
+                        isFinal = true;
+                        isSettled = true;
                         await saveStatus({ refundable: true });
                         reject(
                             new InvoiceFailedToPayError({
@@ -1470,7 +1484,8 @@ export class ArkadeSwaps {
                         );
                         break;
                     case "transaction.lockupFailed":
-                        isResolved = true;
+                        isFinal = true;
+                        isSettled = true;
                         await saveStatus({ refundable: true });
                         reject(
                             new TransactionLockupFailedError({
@@ -1480,7 +1495,8 @@ export class ArkadeSwaps {
                         );
                         break;
                     case "transaction.claimed": {
-                        isResolved = true;
+                        isFinal = true;
+                        isSettled = true;
                         const { preimage } = await this.swapProvider.getSwapPreimage(
                             pendingSwap.id,
                         );
@@ -1499,19 +1515,31 @@ export class ArkadeSwaps {
                             optimisticResolveAt &&
                             hasSubmarineStatusReached(status, optimisticResolveAt)
                         ) {
-                            isResolved = true;
+                            isSettled = true;
                             resolve({ preimage: undefined });
                         }
                         break;
                 }
             };
 
-            this.swapProvider.monitorSwap(pendingSwap.id, onStatusUpdate).catch((error) => {
-                if (!isResolved) {
-                    isResolved = true;
-                    reject(error);
-                }
-            });
+            this.swapProvider
+                .monitorSwap(pendingSwap.id, (status) => {
+                    // monitorSwap doesn't await the callback, so a persistence
+                    // failure here (e.g. after the promise already settled
+                    // optimistically) must not become an unhandled rejection.
+                    onStatusUpdate(status).catch((error) =>
+                        logger.error(
+                            `Swap ${pendingSwap.id}: error handling status "${status}": ${error}`,
+                        ),
+                    );
+                })
+                .catch((error) => {
+                    if (!isSettled) {
+                        isFinal = true;
+                        isSettled = true;
+                        reject(error);
+                    }
+                });
         });
     }
 

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -38,6 +38,8 @@ import type {
     CreateLightningInvoiceResponse,
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
+    OptimisticSendLightningPaymentResponse,
+    SwapSettlementOptions,
     ArkToBtcResponse,
     BtcToArkResponse,
     SubmarineRecoveryInfo,
@@ -54,6 +56,7 @@ import {
     isSubmarineFinalStatus,
     isSubmarineSuccessStatus,
     isSubmarineRefundableStatus,
+    hasSubmarineStatusReached,
     isReverseFinalStatus,
     isChainFinalStatus,
     isRestoredReverseSwap,
@@ -746,12 +749,25 @@ export class ArkadeSwaps {
      * Sends a Lightning payment via a submarine swap (Arkade → Lightning).
      * Creates the swap, sends funds, and waits for settlement. Auto-refunds on failure.
      * @param args.invoice - BOLT11 Lightning invoice to pay.
+     * @param options.optimisticResolveAt - Resolve once this status (or a later
+     * one) is observed instead of waiting for "transaction.claimed". When the
+     * call resolves optimistically the preimage is not yet available and
+     * failures past that point are not auto-refunded here — enable the
+     * SwapManager to track settlement and refund in the background.
      * @returns The amount paid, preimage (proof of payment), and transaction ID.
      * @throws {TransactionFailedError} If the payment fails (auto-refunds if possible).
      */
     async sendLightningPayment(
         args: SendLightningPaymentRequest,
-    ): Promise<SendLightningPaymentResponse> {
+    ): Promise<SendLightningPaymentResponse>;
+    async sendLightningPayment(
+        args: SendLightningPaymentRequest,
+        options?: SwapSettlementOptions,
+    ): Promise<OptimisticSendLightningPaymentResponse>;
+    async sendLightningPayment(
+        args: SendLightningPaymentRequest,
+        options?: SwapSettlementOptions,
+    ): Promise<OptimisticSendLightningPaymentResponse> {
         const pendingSwap = await this.createSubmarineSwap(args);
         if (!pendingSwap.response.address)
             throw new Error(`Swap ${pendingSwap.id}: missing address in submarine swap response`);
@@ -765,7 +781,7 @@ export class ArkadeSwaps {
         });
 
         try {
-            const { preimage } = await this.waitForSwapSettlement(pendingSwap);
+            const { preimage } = await this.waitForSwapSettlement(pendingSwap, options);
             return {
                 amount: pendingSwap.response.expectedAmount,
                 preimage,
@@ -1395,14 +1411,30 @@ export class ArkadeSwaps {
 
     /**
      * Waits for a submarine swap's Lightning payment to settle.
+     * By default resolves only at the terminal "transaction.claimed" status.
      * @param pendingSwap - The submarine swap to monitor.
-     * @returns The preimage from the settled Lightning payment (proof of payment).
+     * @param options.optimisticResolveAt - Resolve as soon as this status (or a
+     * later one in the lifecycle) is observed, instead of waiting for
+     * "transaction.claimed". The preimage is undefined when resolving before
+     * settlement; the caller is then responsible for tracking the final
+     * outcome (e.g. via the SwapManager or getSwapStatus).
+     * @returns The preimage from the settled Lightning payment (proof of payment),
+     * or no preimage when resolved optimistically before settlement.
      * @throws {SwapExpiredError} If the swap expires.
      * @throws {InvoiceFailedToPayError} If Boltz fails to route the payment.
      * @throws {TransactionLockupFailedError} If the lockup transaction fails.
      */
-    async waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }> {
-        return new Promise<{ preimage: string }>((resolve, reject) => {
+    async waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }>;
+    async waitForSwapSettlement(
+        pendingSwap: BoltzSubmarineSwap,
+        options?: SwapSettlementOptions,
+    ): Promise<{ preimage?: string }>;
+    async waitForSwapSettlement(
+        pendingSwap: BoltzSubmarineSwap,
+        options?: SwapSettlementOptions,
+    ): Promise<{ preimage?: string }> {
+        const optimisticResolveAt = options?.optimisticResolveAt;
+        return new Promise<{ preimage?: string }>((resolve, reject) => {
             let isResolved = false;
 
             const onStatusUpdate = async (status: BoltzSwapStatus) => {
@@ -1458,6 +1490,18 @@ export class ArkadeSwaps {
                     }
                     default:
                         await saveStatus();
+                        // Optimistic resolution: the swap is not settled yet, but
+                        // the caller opted in to resolve at this point of the
+                        // lifecycle. "At or beyond" because the subscription only
+                        // reports the current status — intermediate statuses can
+                        // be skipped and would otherwise never be observed.
+                        if (
+                            optimisticResolveAt &&
+                            hasSubmarineStatusReached(status, optimisticResolveAt)
+                        ) {
+                            isResolved = true;
+                            resolve({ preimage: undefined });
+                        }
                         break;
                 }
             };
@@ -2959,6 +3003,10 @@ export interface IArkadeSwaps extends AsyncDisposable {
         args: CreateLightningInvoiceRequest,
     ): Promise<CreateLightningInvoiceResponse>;
     sendLightningPayment(args: SendLightningPaymentRequest): Promise<SendLightningPaymentResponse>;
+    sendLightningPayment(
+        args: SendLightningPaymentRequest,
+        options?: SwapSettlementOptions,
+    ): Promise<OptimisticSendLightningPaymentResponse>;
     createSubmarineSwap(args: SendLightningPaymentRequest): Promise<BoltzSubmarineSwap>;
     createReverseSwap(args: CreateLightningInvoiceRequest): Promise<BoltzReverseSwap>;
     claimVHTLC(pendingSwap: BoltzReverseSwap): Promise<void>;
@@ -2969,6 +3017,10 @@ export interface IArkadeSwaps extends AsyncDisposable {
     recoverAllSubmarineFunds(swaps: BoltzSubmarineSwap[]): Promise<SubmarineRecoveryResult[]>;
     waitAndClaim(pendingSwap: BoltzReverseSwap): Promise<{ txid: string }>;
     waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }>;
+    waitForSwapSettlement(
+        pendingSwap: BoltzSubmarineSwap,
+        options?: SwapSettlementOptions,
+    ): Promise<{ preimage?: string }>;
     restoreSwaps(boltzFees?: FeesResponse): Promise<{
         chainSwaps: BoltzChainSwap[];
         reverseSwaps: BoltzReverseSwap[];

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -39,7 +39,6 @@ import type {
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
     OptimisticSendLightningPaymentResponse,
-    SwapSettlementOptions,
     ArkToBtcResponse,
     BtcToArkResponse,
     SubmarineRecoveryInfo,
@@ -57,6 +56,7 @@ import {
     isSubmarineSuccessStatus,
     isSubmarineRefundableStatus,
     hasSubmarineStatusReached,
+    type SubmarineProgressionStatus,
     isReverseFinalStatus,
     isChainFinalStatus,
     isRestoredReverseSwap,
@@ -747,26 +747,26 @@ export class ArkadeSwaps {
 
     /**
      * Sends a Lightning payment via a submarine swap (Arkade → Lightning).
-     * Creates the swap, sends funds, and waits for settlement. Auto-refunds on failure.
+     * Creates the swap, sends funds, and waits for settlement (or, with
+     * `waitFor: "funded"`, only until the lockup transaction is observed —
+     * see {@link SendLightningPaymentRequest.waitFor}). Auto-refunds on
+     * failures observed before the promise resolves.
      * @param args.invoice - BOLT11 Lightning invoice to pay.
-     * @param options.optimisticResolveAt - Resolve once this status (or a later
-     * one) is observed instead of waiting for "transaction.claimed". When the
-     * call resolves optimistically the preimage is not yet available and
-     * failures past that point are not auto-refunded here — enable the
-     * SwapManager to track settlement and refund in the background.
-     * @returns The amount paid, preimage (proof of payment), and transaction ID.
+     * @param args.waitFor - "settled" (default) resolves with the preimage at
+     * "transaction.claimed"; "funded" resolves without a preimage as soon as
+     * the payment is in flight.
+     * @returns The amount paid, preimage (proof of payment, unless resolved
+     * at "funded"), and transaction ID.
      * @throws {TransactionFailedError} If the payment fails (auto-refunds if possible).
      */
     async sendLightningPayment(
-        args: SendLightningPaymentRequest,
+        args: SendLightningPaymentRequest & { waitFor?: "settled" },
     ): Promise<SendLightningPaymentResponse>;
     async sendLightningPayment(
         args: SendLightningPaymentRequest,
-        options?: SwapSettlementOptions,
     ): Promise<OptimisticSendLightningPaymentResponse>;
     async sendLightningPayment(
         args: SendLightningPaymentRequest,
-        options?: SwapSettlementOptions,
     ): Promise<OptimisticSendLightningPaymentResponse> {
         const pendingSwap = await this.createSubmarineSwap(args);
         if (!pendingSwap.response.address)
@@ -781,7 +781,14 @@ export class ArkadeSwaps {
         });
 
         try {
-            const { preimage } = await this.waitForSwapSettlement(pendingSwap, options);
+            if (args.waitFor === "funded") {
+                await this.waitForSwapFunded(pendingSwap);
+                return {
+                    amount: pendingSwap.response.expectedAmount,
+                    txid,
+                };
+            }
+            const { preimage } = await this.waitForSwapSettlement(pendingSwap);
             return {
                 amount: pendingSwap.response.expectedAmount,
                 preimage,
@@ -1411,31 +1418,53 @@ export class ArkadeSwaps {
 
     /**
      * Waits for a submarine swap's Lightning payment to settle.
-     * By default resolves only at the terminal "transaction.claimed" status.
+     * Resolves only at the terminal "transaction.claimed" status, once Boltz
+     * has swept the HTLC. To resolve as soon as the payment is in flight, use
+     * {@link waitForSwapFunded} instead.
      * @param pendingSwap - The submarine swap to monitor.
-     * @param options.optimisticResolveAt - Resolve as soon as this status (or a
-     * later one in the lifecycle) is observed, instead of waiting for
-     * "transaction.claimed". The preimage is undefined when resolving before
-     * settlement. Monitoring continues in the background until a terminal
-     * status, persisting updates to the repository, but the settled promise
-     * no longer rejects — acting on a late failure is the caller's
-     * responsibility (e.g. via the SwapManager or getSwapStatus).
-     * @returns The preimage from the settled Lightning payment (proof of payment),
-     * or no preimage when resolved optimistically before settlement.
+     * @returns The preimage from the settled Lightning payment (proof of payment).
      * @throws {SwapExpiredError} If the swap expires.
      * @throws {InvoiceFailedToPayError} If Boltz fails to route the payment.
      * @throws {TransactionLockupFailedError} If the lockup transaction fails.
      */
-    async waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }>;
-    async waitForSwapSettlement(
+    async waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }> {
+        // Without a funded-target the internal wait only resolves at
+        // "transaction.claimed", where the preimage is always present.
+        return this.waitForSubmarineSwap(pendingSwap) as Promise<{ preimage: string }>;
+    }
+
+    /**
+     * Waits until a submarine swap is funded: resolves as soon as the lockup
+     * transaction is observed ("transaction.mempool" or any later status in
+     * the lifecycle — statuses can be skipped since subscriptions report only
+     * the current one). The sender's funds are committed and the swap is
+     * refundable from this point, which is when most Lightning wallets show
+     * a payment as "sent".
+     *
+     * Monitoring continues in the background until the swap reaches a
+     * terminal status, persisting updates to the repository (the preimage on
+     * claim, the refundable flag on failure), but this promise no longer
+     * rejects once resolved — acting on a late failure is the caller's
+     * responsibility (the SwapManager handles it automatically when enabled).
+     * @param pendingSwap - The submarine swap to monitor.
+     * @throws {SwapExpiredError} If the swap expires before funding.
+     * @throws {InvoiceFailedToPayError} If Boltz fails to route the payment.
+     * @throws {TransactionLockupFailedError} If the lockup transaction fails.
+     */
+    async waitForSwapFunded(pendingSwap: BoltzSubmarineSwap): Promise<void> {
+        await this.waitForSubmarineSwap(pendingSwap, "transaction.mempool");
+    }
+
+    /**
+     * Shared wait machinery: monitors the swap and resolves at the terminal
+     * "transaction.claimed" status (with the preimage) or, when `resolveAt`
+     * is given, as soon as that status — or any later one in the successful
+     * progression — is observed (without a preimage).
+     */
+    private async waitForSubmarineSwap(
         pendingSwap: BoltzSubmarineSwap,
-        options?: SwapSettlementOptions,
-    ): Promise<{ preimage?: string }>;
-    async waitForSwapSettlement(
-        pendingSwap: BoltzSubmarineSwap,
-        options?: SwapSettlementOptions,
+        resolveAt?: SubmarineProgressionStatus,
     ): Promise<{ preimage?: string }> {
-        const optimisticResolveAt = options?.optimisticResolveAt;
         return new Promise<{ preimage?: string }>((resolve, reject) => {
             // A terminal status was processed — stop handling updates. An
             // optimistic resolution deliberately does NOT set this: the
@@ -1511,10 +1540,7 @@ export class ArkadeSwaps {
                         // lifecycle. "At or beyond" because the subscription only
                         // reports the current status — intermediate statuses can
                         // be skipped and would otherwise never be observed.
-                        if (
-                            optimisticResolveAt &&
-                            hasSubmarineStatusReached(status, optimisticResolveAt)
-                        ) {
+                        if (resolveAt && hasSubmarineStatusReached(status, resolveAt)) {
                             isSettled = true;
                             resolve({ preimage: undefined });
                         }
@@ -3030,10 +3056,11 @@ export interface IArkadeSwaps extends AsyncDisposable {
     createLightningInvoice(
         args: CreateLightningInvoiceRequest,
     ): Promise<CreateLightningInvoiceResponse>;
-    sendLightningPayment(args: SendLightningPaymentRequest): Promise<SendLightningPaymentResponse>;
+    sendLightningPayment(
+        args: SendLightningPaymentRequest & { waitFor?: "settled" },
+    ): Promise<SendLightningPaymentResponse>;
     sendLightningPayment(
         args: SendLightningPaymentRequest,
-        options?: SwapSettlementOptions,
     ): Promise<OptimisticSendLightningPaymentResponse>;
     createSubmarineSwap(args: SendLightningPaymentRequest): Promise<BoltzSubmarineSwap>;
     createReverseSwap(args: CreateLightningInvoiceRequest): Promise<BoltzReverseSwap>;
@@ -3045,10 +3072,7 @@ export interface IArkadeSwaps extends AsyncDisposable {
     recoverAllSubmarineFunds(swaps: BoltzSubmarineSwap[]): Promise<SubmarineRecoveryResult[]>;
     waitAndClaim(pendingSwap: BoltzReverseSwap): Promise<{ txid: string }>;
     waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }>;
-    waitForSwapSettlement(
-        pendingSwap: BoltzSubmarineSwap,
-        options?: SwapSettlementOptions,
-    ): Promise<{ preimage?: string }>;
+    waitForSwapFunded(pendingSwap: BoltzSubmarineSwap): Promise<void>;
     restoreSwaps(boltzFees?: FeesResponse): Promise<{
         chainSwaps: BoltzChainSwap[];
         reverseSwaps: BoltzReverseSwap[];

--- a/packages/boltz-swap/src/boltz-swap-provider.ts
+++ b/packages/boltz-swap/src/boltz-swap-provider.ts
@@ -77,6 +77,36 @@ export const isSubmarineRefundableStatus = (status: BoltzSwapStatus): boolean =>
     return ["invoice.failedToPay", "transaction.lockupFailed", "swap.expired"].includes(status);
 };
 
+/**
+ * Canonical progression of a successful submarine swap, in order. Failure
+ * statuses are intentionally absent. Used to decide whether an observed
+ * status is at or beyond another status in the lifecycle.
+ */
+const SUBMARINE_STATUS_PROGRESSION: BoltzSwapStatus[] = [
+    "swap.created",
+    "invoice.set",
+    "transaction.mempool",
+    "transaction.confirmed",
+    "invoice.pending",
+    "invoice.paid",
+    "transaction.claim.pending",
+    "transaction.claimed",
+];
+
+/**
+ * Returns true if `status` is at or beyond `target` in the successful
+ * submarine swap progression. Returns false when either status is not part
+ * of the progression (e.g. failure statuses like "swap.expired").
+ */
+export const hasSubmarineStatusReached = (
+    status: BoltzSwapStatus,
+    target: BoltzSwapStatus,
+): boolean => {
+    const statusIndex = SUBMARINE_STATUS_PROGRESSION.indexOf(status);
+    const targetIndex = SUBMARINE_STATUS_PROGRESSION.indexOf(target);
+    return statusIndex >= 0 && targetIndex >= 0 && statusIndex >= targetIndex;
+};
+
 /** Returns true if the submarine swap completed successfully. */
 export const isSubmarineSuccessStatus = (status: BoltzSwapStatus): boolean => {
     return status === "transaction.claimed";

--- a/packages/boltz-swap/src/boltz-swap-provider.ts
+++ b/packages/boltz-swap/src/boltz-swap-provider.ts
@@ -79,10 +79,14 @@ export const isSubmarineRefundableStatus = (status: BoltzSwapStatus): boolean =>
 
 /**
  * Canonical progression of a successful submarine swap, in order. Failure
- * statuses are intentionally absent. Used to decide whether an observed
- * status is at or beyond another status in the lifecycle.
+ * statuses are intentionally absent. This defines relative ordering, NOT a
+ * guaranteed sequence: statuses can be skipped (e.g. "transaction.mempool"
+ * jumps straight to "invoice.pending" when Boltz accepts 0-conf, and a
+ * subscription only ever reports the current status). Consumers must treat
+ * any later status as implying the earlier ones — which is exactly what
+ * hasSubmarineStatusReached does.
  */
-const SUBMARINE_STATUS_PROGRESSION: BoltzSwapStatus[] = [
+const SUBMARINE_STATUS_PROGRESSION = [
     "swap.created",
     "invoice.set",
     "transaction.mempool",
@@ -91,19 +95,26 @@ const SUBMARINE_STATUS_PROGRESSION: BoltzSwapStatus[] = [
     "invoice.paid",
     "transaction.claim.pending",
     "transaction.claimed",
-];
+] as const satisfies readonly BoltzSwapStatus[];
+
+/**
+ * A status in the successful submarine swap progression — the only valid
+ * targets for optimistic settlement resolution.
+ */
+export type SubmarineProgressionStatus = (typeof SUBMARINE_STATUS_PROGRESSION)[number];
 
 /**
  * Returns true if `status` is at or beyond `target` in the successful
- * submarine swap progression. Returns false when either status is not part
- * of the progression (e.g. failure statuses like "swap.expired").
+ * submarine swap progression. Returns false when the observed status is not
+ * part of the progression (e.g. failure statuses like "swap.expired").
  */
 export const hasSubmarineStatusReached = (
     status: BoltzSwapStatus,
-    target: BoltzSwapStatus,
+    target: SubmarineProgressionStatus,
 ): boolean => {
-    const statusIndex = SUBMARINE_STATUS_PROGRESSION.indexOf(status);
-    const targetIndex = SUBMARINE_STATUS_PROGRESSION.indexOf(target);
+    const progression: readonly BoltzSwapStatus[] = SUBMARINE_STATUS_PROGRESSION;
+    const statusIndex = progression.indexOf(status);
+    const targetIndex = progression.indexOf(target);
     return statusIndex >= 0 && targetIndex >= 0 && statusIndex >= targetIndex;
 };
 

--- a/packages/boltz-swap/src/expo/arkade-lightning.ts
+++ b/packages/boltz-swap/src/expo/arkade-lightning.ts
@@ -19,7 +19,6 @@ import type {
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
     OptimisticSendLightningPaymentResponse,
-    SwapSettlementOptions,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
     SubmarineRefundOutcome,
@@ -249,16 +248,16 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.createLightningInvoice(args);
     }
 
-    sendLightningPayment(args: SendLightningPaymentRequest): Promise<SendLightningPaymentResponse>;
+    sendLightningPayment(
+        args: SendLightningPaymentRequest & { waitFor?: "settled" },
+    ): Promise<SendLightningPaymentResponse>;
     sendLightningPayment(
         args: SendLightningPaymentRequest,
-        options?: SwapSettlementOptions,
     ): Promise<OptimisticSendLightningPaymentResponse>;
     sendLightningPayment(
         args: SendLightningPaymentRequest,
-        options?: SwapSettlementOptions,
     ): Promise<OptimisticSendLightningPaymentResponse> {
-        return this.inner.sendLightningPayment(args, options);
+        return this.inner.sendLightningPayment(args);
     }
 
     createSubmarineSwap(args: SendLightningPaymentRequest): Promise<BoltzSubmarineSwap> {
@@ -297,16 +296,12 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.waitAndClaim(pendingSwap);
     }
 
-    waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }>;
-    waitForSwapSettlement(
-        pendingSwap: BoltzSubmarineSwap,
-        options?: SwapSettlementOptions,
-    ): Promise<{ preimage?: string }>;
-    waitForSwapSettlement(
-        pendingSwap: BoltzSubmarineSwap,
-        options?: SwapSettlementOptions,
-    ): Promise<{ preimage?: string }> {
-        return this.inner.waitForSwapSettlement(pendingSwap, options);
+    waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }> {
+        return this.inner.waitForSwapSettlement(pendingSwap);
+    }
+
+    waitForSwapFunded(pendingSwap: BoltzSubmarineSwap): Promise<void> {
+        return this.inner.waitForSwapFunded(pendingSwap);
     }
 
     restoreSwaps(boltzFees?: FeesResponse): Promise<{

--- a/packages/boltz-swap/src/expo/arkade-lightning.ts
+++ b/packages/boltz-swap/src/expo/arkade-lightning.ts
@@ -18,6 +18,8 @@ import type {
     BoltzSwap,
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
+    OptimisticSendLightningPaymentResponse,
+    SwapSettlementOptions,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
     SubmarineRefundOutcome,
@@ -247,8 +249,16 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.createLightningInvoice(args);
     }
 
-    sendLightningPayment(args: SendLightningPaymentRequest): Promise<SendLightningPaymentResponse> {
-        return this.inner.sendLightningPayment(args);
+    sendLightningPayment(args: SendLightningPaymentRequest): Promise<SendLightningPaymentResponse>;
+    sendLightningPayment(
+        args: SendLightningPaymentRequest,
+        options?: SwapSettlementOptions,
+    ): Promise<OptimisticSendLightningPaymentResponse>;
+    sendLightningPayment(
+        args: SendLightningPaymentRequest,
+        options?: SwapSettlementOptions,
+    ): Promise<OptimisticSendLightningPaymentResponse> {
+        return this.inner.sendLightningPayment(args, options);
     }
 
     createSubmarineSwap(args: SendLightningPaymentRequest): Promise<BoltzSubmarineSwap> {
@@ -287,8 +297,16 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         return this.inner.waitAndClaim(pendingSwap);
     }
 
-    waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }> {
-        return this.inner.waitForSwapSettlement(pendingSwap);
+    waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }>;
+    waitForSwapSettlement(
+        pendingSwap: BoltzSubmarineSwap,
+        options?: SwapSettlementOptions,
+    ): Promise<{ preimage?: string }>;
+    waitForSwapSettlement(
+        pendingSwap: BoltzSubmarineSwap,
+        options?: SwapSettlementOptions,
+    ): Promise<{ preimage?: string }> {
+        return this.inner.waitForSwapSettlement(pendingSwap, options);
     }
 
     restoreSwaps(boltzFees?: FeesResponse): Promise<{

--- a/packages/boltz-swap/src/index.ts
+++ b/packages/boltz-swap/src/index.ts
@@ -1,6 +1,6 @@
 export { ArkadeSwaps } from "./arkade-swaps";
 export type { QuoteSwapOptions } from "./arkade-swaps";
-export type { BoltzSwapStatus } from "./boltz-swap-provider";
+export type { BoltzSwapStatus, SubmarineProgressionStatus } from "./boltz-swap-provider";
 export {
     BoltzSwapProvider,
     isChainClaimableStatus,

--- a/packages/boltz-swap/src/index.ts
+++ b/packages/boltz-swap/src/index.ts
@@ -27,6 +27,7 @@ export {
     isSubmarineSuccessStatus,
     isSubmarineRefundableStatus,
     isSubmarineSwapRefundable,
+    hasSubmarineStatusReached,
 } from "./boltz-swap-provider";
 export {
     SwapError,
@@ -72,6 +73,8 @@ export type {
     CreateLightningInvoiceRequest,
     SendLightningPaymentResponse,
     SendLightningPaymentRequest,
+    OptimisticSendLightningPaymentResponse,
+    SwapSettlementOptions,
     IncomingPaymentSubscription,
     ArkadeSwapsConfig,
     ArkadeSwapsCreateConfig,

--- a/packages/boltz-swap/src/index.ts
+++ b/packages/boltz-swap/src/index.ts
@@ -74,7 +74,6 @@ export type {
     SendLightningPaymentResponse,
     SendLightningPaymentRequest,
     OptimisticSendLightningPaymentResponse,
-    SwapSettlementOptions,
     IncomingPaymentSubscription,
     ArkadeSwapsConfig,
     ArkadeSwapsCreateConfig,

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -28,9 +28,7 @@ import {
     BoltzReverseSwap,
     BoltzSubmarineSwap,
     type SendLightningPaymentRequest,
-    SendLightningPaymentResponse,
     type OptimisticSendLightningPaymentResponse,
-    type SwapSettlementOptions,
     type SubmarineRecoveryInfo,
     type SubmarineRecoveryResult,
     type SubmarineRefundOutcome,
@@ -94,12 +92,11 @@ export type ResponseCreateLightningInvoice = ResponseEnvelope & {
 export type RequestSendLightningPayment = RequestEnvelope & {
     type: "SEND_LIGHTNING_PAYMENT";
     payload: SendLightningPaymentRequest;
-    /** Settlement options; absent for clients that predate optimistic resolution. */
-    options?: SwapSettlementOptions;
 };
 export type ResponseSendLightningPayment = ResponseEnvelope & {
     type: "LIGHTNING_PAYMENT_SENT";
-    payload: SendLightningPaymentResponse | OptimisticSendLightningPaymentResponse;
+    /** Strict SendLightningPaymentResponse unless the request used waitFor: "funded". */
+    payload: OptimisticSendLightningPaymentResponse;
 };
 
 export type RequestCreateSubmarineSwap = RequestEnvelope & {
@@ -187,12 +184,18 @@ export type ResponseWaitAndClaim = ResponseEnvelope & {
 export type RequestWaitForSwapSettlement = RequestEnvelope & {
     type: "WAIT_FOR_SWAP_SETTLEMENT";
     payload: BoltzSubmarineSwap;
-    /** Settlement options; absent for clients that predate optimistic resolution. */
-    options?: SwapSettlementOptions;
 };
 export type ResponseWaitForSwapSettlement = ResponseEnvelope & {
     type: "SWAP_SETTLED";
-    payload: { preimage?: string };
+    payload: { preimage: string };
+};
+
+export type RequestWaitForSwapFunded = RequestEnvelope & {
+    type: "WAIT_FOR_SWAP_FUNDED";
+    payload: BoltzSubmarineSwap;
+};
+export type ResponseWaitForSwapFunded = ResponseEnvelope & {
+    type: "SWAP_FUNDED";
 };
 
 export type RequestRestoreSwaps = RequestEnvelope & {
@@ -534,6 +537,7 @@ export type ArkadeSwapsUpdaterRequest =
     | RequestRecoverAllSubmarineFunds
     | RequestWaitAndClaim
     | RequestWaitForSwapSettlement
+    | RequestWaitForSwapFunded
     | RequestRestoreSwaps
     | RequestEnrichReverseSwapPreimage
     | RequestEnrichSubmarineSwapInvoice
@@ -583,6 +587,7 @@ export type ArkadeSwapsUpdaterResponse =
     | ResponseRecoverAllSubmarineFunds
     | ResponseWaitAndClaim
     | ResponseWaitForSwapSettlement
+    | ResponseWaitForSwapFunded
     | ResponseRestoreSwaps
     | ResponseEnrichReverseSwapPreimage
     | ResponseEnrichSubmarineSwapInvoice
@@ -630,6 +635,7 @@ export const LONG_RUNNING_ARKADE_SWAPS_REQUEST_TYPES: ReadonlySet<
     "RECOVER_ALL_SUBMARINE_FUNDS",
     "WAIT_AND_CLAIM",
     "WAIT_FOR_SWAP_SETTLEMENT",
+    "WAIT_FOR_SWAP_FUNDED",
     "RESTORE_SWAPS",
     "WAIT_AND_CLAIM_CHAIN",
     "WAIT_AND_CLAIM_ARK",
@@ -797,10 +803,7 @@ export class ArkadeSwapsMessageHandler
                 }
 
                 case "SEND_LIGHTNING_PAYMENT": {
-                    const res = await this.handler.sendLightningPayment(
-                        message.payload,
-                        message.options,
-                    );
+                    const res = await this.handler.sendLightningPayment(message.payload);
                     return this.tagged({
                         id,
                         type: "LIGHTNING_PAYMENT_SENT",
@@ -885,15 +888,17 @@ export class ArkadeSwapsMessageHandler
                 }
 
                 case "WAIT_FOR_SWAP_SETTLEMENT": {
-                    const res = await this.handler.waitForSwapSettlement(
-                        message.payload,
-                        message.options,
-                    );
+                    const res = await this.handler.waitForSwapSettlement(message.payload);
                     return this.tagged({
                         id,
                         type: "SWAP_SETTLED",
                         payload: res,
                     });
+                }
+
+                case "WAIT_FOR_SWAP_FUNDED": {
+                    await this.handler.waitForSwapFunded(message.payload);
+                    return this.tagged({ id, type: "SWAP_FUNDED" });
                 }
 
                 case "RESTORE_SWAPS": {

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -29,6 +29,8 @@ import {
     BoltzSubmarineSwap,
     type SendLightningPaymentRequest,
     SendLightningPaymentResponse,
+    type OptimisticSendLightningPaymentResponse,
+    type SwapSettlementOptions,
     type SubmarineRecoveryInfo,
     type SubmarineRecoveryResult,
     type SubmarineRefundOutcome,
@@ -92,10 +94,12 @@ export type ResponseCreateLightningInvoice = ResponseEnvelope & {
 export type RequestSendLightningPayment = RequestEnvelope & {
     type: "SEND_LIGHTNING_PAYMENT";
     payload: SendLightningPaymentRequest;
+    /** Settlement options; absent for clients that predate optimistic resolution. */
+    options?: SwapSettlementOptions;
 };
 export type ResponseSendLightningPayment = ResponseEnvelope & {
     type: "LIGHTNING_PAYMENT_SENT";
-    payload: SendLightningPaymentResponse;
+    payload: SendLightningPaymentResponse | OptimisticSendLightningPaymentResponse;
 };
 
 export type RequestCreateSubmarineSwap = RequestEnvelope & {
@@ -183,10 +187,12 @@ export type ResponseWaitAndClaim = ResponseEnvelope & {
 export type RequestWaitForSwapSettlement = RequestEnvelope & {
     type: "WAIT_FOR_SWAP_SETTLEMENT";
     payload: BoltzSubmarineSwap;
+    /** Settlement options; absent for clients that predate optimistic resolution. */
+    options?: SwapSettlementOptions;
 };
 export type ResponseWaitForSwapSettlement = ResponseEnvelope & {
     type: "SWAP_SETTLED";
-    payload: { preimage: string };
+    payload: { preimage?: string };
 };
 
 export type RequestRestoreSwaps = RequestEnvelope & {
@@ -791,7 +797,10 @@ export class ArkadeSwapsMessageHandler
                 }
 
                 case "SEND_LIGHTNING_PAYMENT": {
-                    const res = await this.handler.sendLightningPayment(message.payload);
+                    const res = await this.handler.sendLightningPayment(
+                        message.payload,
+                        message.options,
+                    );
                     return this.tagged({
                         id,
                         type: "LIGHTNING_PAYMENT_SENT",
@@ -876,7 +885,10 @@ export class ArkadeSwapsMessageHandler
                 }
 
                 case "WAIT_FOR_SWAP_SETTLEMENT": {
-                    const res = await this.handler.waitForSwapSettlement(message.payload);
+                    const res = await this.handler.waitForSwapSettlement(
+                        message.payload,
+                        message.options,
+                    );
                     return this.tagged({
                         id,
                         type: "SWAP_SETTLED",

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -16,6 +16,8 @@ import {
     BoltzSubmarineSwap,
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
+    OptimisticSendLightningPaymentResponse,
+    SwapSettlementOptions,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
     SubmarineRefundOutcome,
@@ -463,13 +465,22 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
 
     async sendLightningPayment(
         args: SendLightningPaymentRequest,
-    ): Promise<SendLightningPaymentResponse> {
+    ): Promise<SendLightningPaymentResponse>;
+    async sendLightningPayment(
+        args: SendLightningPaymentRequest,
+        options?: SwapSettlementOptions,
+    ): Promise<OptimisticSendLightningPaymentResponse>;
+    async sendLightningPayment(
+        args: SendLightningPaymentRequest,
+        options?: SwapSettlementOptions,
+    ): Promise<OptimisticSendLightningPaymentResponse> {
         try {
             const res = await this.sendMessage({
                 id: getRandomId(),
                 tag: this.messageTag,
                 type: "SEND_LIGHTNING_PAYMENT",
                 payload: args,
+                options,
             });
             return (res as ResponseSendLightningPayment).payload;
         } catch (e) {
@@ -581,13 +592,22 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         }
     }
 
-    async waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }> {
+    async waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }>;
+    async waitForSwapSettlement(
+        pendingSwap: BoltzSubmarineSwap,
+        options?: SwapSettlementOptions,
+    ): Promise<{ preimage?: string }>;
+    async waitForSwapSettlement(
+        pendingSwap: BoltzSubmarineSwap,
+        options?: SwapSettlementOptions,
+    ): Promise<{ preimage?: string }> {
         try {
             const res = await this.sendMessage({
                 id: getRandomId(),
                 tag: this.messageTag,
                 type: "WAIT_FOR_SWAP_SETTLEMENT",
                 payload: pendingSwap,
+                options,
             });
             return (res as ResponseWaitForSwapSettlement).payload;
         } catch (e) {

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -17,7 +17,6 @@ import {
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
     OptimisticSendLightningPaymentResponse,
-    SwapSettlementOptions,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
     SubmarineRefundOutcome,
@@ -464,15 +463,13 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
     }
 
     async sendLightningPayment(
-        args: SendLightningPaymentRequest,
+        args: SendLightningPaymentRequest & { waitFor?: "settled" },
     ): Promise<SendLightningPaymentResponse>;
     async sendLightningPayment(
         args: SendLightningPaymentRequest,
-        options?: SwapSettlementOptions,
     ): Promise<OptimisticSendLightningPaymentResponse>;
     async sendLightningPayment(
         args: SendLightningPaymentRequest,
-        options?: SwapSettlementOptions,
     ): Promise<OptimisticSendLightningPaymentResponse> {
         try {
             const res = await this.sendMessage({
@@ -480,7 +477,6 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
                 tag: this.messageTag,
                 type: "SEND_LIGHTNING_PAYMENT",
                 payload: args,
-                options,
             });
             return (res as ResponseSendLightningPayment).payload;
         } catch (e) {
@@ -592,26 +588,30 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         }
     }
 
-    async waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }>;
-    async waitForSwapSettlement(
-        pendingSwap: BoltzSubmarineSwap,
-        options?: SwapSettlementOptions,
-    ): Promise<{ preimage?: string }>;
-    async waitForSwapSettlement(
-        pendingSwap: BoltzSubmarineSwap,
-        options?: SwapSettlementOptions,
-    ): Promise<{ preimage?: string }> {
+    async waitForSwapSettlement(pendingSwap: BoltzSubmarineSwap): Promise<{ preimage: string }> {
         try {
             const res = await this.sendMessage({
                 id: getRandomId(),
                 tag: this.messageTag,
                 type: "WAIT_FOR_SWAP_SETTLEMENT",
                 payload: pendingSwap,
-                options,
             });
             return (res as ResponseWaitForSwapSettlement).payload;
         } catch (e) {
             throw new Error("Cannot wait for swap settlement", { cause: e });
+        }
+    }
+
+    async waitForSwapFunded(pendingSwap: BoltzSubmarineSwap): Promise<void> {
+        try {
+            await this.sendMessage({
+                id: getRandomId(),
+                tag: this.messageTag,
+                type: "WAIT_FOR_SWAP_FUNDED",
+                payload: pendingSwap,
+            });
+        } catch (e) {
+            throw new Error("Cannot wait for swap funding", { cause: e });
         }
     }
 

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -6,6 +6,7 @@ import {
     CreateReverseSwapRequest,
     CreateSubmarineSwapRequest,
     BoltzSwapStatus,
+    SubmarineProgressionStatus,
     CreateChainSwapRequest,
     CreateChainSwapResponse,
 } from "./boltz-swap-provider";
@@ -125,11 +126,13 @@ export interface SwapSettlementOptions {
      *
      * Failure statuses (e.g. "swap.expired", "invoice.failedToPay") observed
      * before the optimistic status still reject as usual. After an optimistic
-     * resolution the SDK stops monitoring the swap: tracking final settlement
-     * (and refunding on late failure) is the caller's responsibility — enable
-     * the SwapManager to handle this automatically in the background.
+     * resolution the monitor stays open until the swap reaches a terminal
+     * status and keeps persisting updates (the preimage on claim, the
+     * refundable flag on failure), but the settled promise no longer rejects:
+     * acting on a late failure (refunding) is the caller's responsibility —
+     * enable the SwapManager to handle this automatically in the background.
      */
-    optimisticResolveAt?: BoltzSwapStatus;
+    optimisticResolveAt?: SubmarineProgressionStatus;
 }
 
 /** Tracks an in-progress reverse swap (Lightning → Arkade). */

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -100,6 +100,38 @@ export interface SendLightningPaymentResponse {
     txid: string;
 }
 
+/**
+ * Response after a Lightning payment that may have resolved optimistically
+ * (see {@link SwapSettlementOptions.optimisticResolveAt}). The swap may not
+ * be settled yet, so the preimage may not be available.
+ */
+export interface OptimisticSendLightningPaymentResponse {
+    /** Amount paid in satoshis. */
+    amount: number;
+    /** Payment preimage (hex-encoded). Undefined when the call resolved optimistically before the swap settled. */
+    preimage?: string;
+    /** Transaction ID of the Arkade payment. */
+    txid: string;
+}
+
+/** Options controlling when waiting for a submarine swap settlement resolves. */
+export interface SwapSettlementOptions {
+    /**
+     * Resolve optimistically once this status — or any later status in the
+     * successful submarine swap lifecycle — is observed, instead of waiting
+     * for the terminal "transaction.claimed" status. Statuses can be skipped
+     * (WebSocket subscriptions report only the current status), so "at or
+     * beyond" semantics avoid waiting forever on a status that was missed.
+     *
+     * Failure statuses (e.g. "swap.expired", "invoice.failedToPay") observed
+     * before the optimistic status still reject as usual. After an optimistic
+     * resolution the SDK stops monitoring the swap: tracking final settlement
+     * (and refunding on late failure) is the caller's responsibility — enable
+     * the SwapManager to handle this automatically in the background.
+     */
+    optimisticResolveAt?: BoltzSwapStatus;
+}
+
 /** Tracks an in-progress reverse swap (Lightning → Arkade). */
 export interface BoltzReverseSwap {
     /** Unique swap ID from Boltz. */

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -6,7 +6,6 @@ import {
     CreateReverseSwapRequest,
     CreateSubmarineSwapRequest,
     BoltzSwapStatus,
-    SubmarineProgressionStatus,
     CreateChainSwapRequest,
     CreateChainSwapResponse,
 } from "./boltz-swap-provider";
@@ -89,6 +88,22 @@ export interface CreateLightningInvoiceResponse {
 export interface SendLightningPaymentRequest {
     /** BOLT11-encoded Lightning invoice to pay. */
     invoice: string;
+    /**
+     * When the returned promise resolves (default "settled").
+     *
+     * - "settled": at the terminal "transaction.claimed" status, once Boltz
+     *   has swept the HTLC. The preimage is included in the response.
+     * - "funded": optimistically, as soon as the lockup transaction is
+     *   observed ("transaction.mempool" or any later status — statuses can be
+     *   skipped since subscriptions report only the current one). The sender's
+     *   funds are committed and the swap is refundable from this point, so
+     *   most wallets show the payment as "sent" here. No preimage is available
+     *   yet; monitoring continues in the background and keeps persisting
+     *   status updates until a terminal status, but a late failure no longer
+     *   rejects — keep the SwapManager enabled so refunds are handled
+     *   automatically.
+     */
+    waitFor?: "settled" | "funded";
 }
 
 /** Response after a successful Lightning payment. */
@@ -102,37 +117,17 @@ export interface SendLightningPaymentResponse {
 }
 
 /**
- * Response after a Lightning payment that may have resolved optimistically
- * (see {@link SwapSettlementOptions.optimisticResolveAt}). The swap may not
- * be settled yet, so the preimage may not be available.
+ * Response after a Lightning payment sent with `waitFor: "funded"` — the
+ * payment is in flight but may not be settled yet, so the preimage may not
+ * be available.
  */
 export interface OptimisticSendLightningPaymentResponse {
     /** Amount paid in satoshis. */
     amount: number;
-    /** Payment preimage (hex-encoded). Undefined when the call resolved optimistically before the swap settled. */
+    /** Payment preimage (hex-encoded). Undefined when the call resolved before the swap settled. */
     preimage?: string;
     /** Transaction ID of the Arkade payment. */
     txid: string;
-}
-
-/** Options controlling when waiting for a submarine swap settlement resolves. */
-export interface SwapSettlementOptions {
-    /**
-     * Resolve optimistically once this status — or any later status in the
-     * successful submarine swap lifecycle — is observed, instead of waiting
-     * for the terminal "transaction.claimed" status. Statuses can be skipped
-     * (WebSocket subscriptions report only the current status), so "at or
-     * beyond" semantics avoid waiting forever on a status that was missed.
-     *
-     * Failure statuses (e.g. "swap.expired", "invoice.failedToPay") observed
-     * before the optimistic status still reject as usual. After an optimistic
-     * resolution the monitor stays open until the swap reaches a terminal
-     * status and keeps persisting updates (the preimage on claim, the
-     * refundable flag on failure), but the settled promise no longer rejects:
-     * acting on a late failure (refunding) is the caller's responsibility —
-     * enable the SwapManager to handle this automatically in the background.
-     */
-    optimisticResolveAt?: SubmarineProgressionStatus;
 }
 
 /** Tracks an in-progress reverse swap (Lightning → Arkade). */

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -1101,6 +1101,87 @@ describe("ArkadeSwaps", () => {
                     }),
                 ).rejects.toBeInstanceOf(InvoiceFailedToPayError);
             });
+
+            it("should keep persisting a failure that arrives after optimistic resolution", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        setTimeout(() => update("invoice.pending"), 5);
+                        setTimeout(() => update("invoice.failedToPay"), 10);
+                    },
+                );
+
+                // act
+                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
+                    optimisticResolveAt: "invoice.pending",
+                });
+
+                // assert: resolved optimistically...
+                expect(result.preimage).toBeUndefined();
+                // ...and the late failure is still written to the repository
+                // (marked refundable) so SwapManager / restoreSwaps can act on it
+                await vi.waitFor(() => {
+                    expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            id: mockSubmarineSwap.id,
+                            status: "invoice.failedToPay",
+                            refundable: true,
+                        }),
+                    );
+                });
+            });
+
+            it("should persist the preimage when the swap settles after optimistic resolution", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "getSwapPreimage").mockResolvedValueOnce({
+                    preimage: mock.preimage,
+                });
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        setTimeout(() => update("invoice.pending"), 5);
+                        setTimeout(() => update("transaction.claimed"), 10);
+                    },
+                );
+
+                // act
+                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
+                    optimisticResolveAt: "invoice.pending",
+                });
+
+                // assert: resolved optimistically without a preimage...
+                expect(result.preimage).toBeUndefined();
+                // ...but the final settlement is still persisted with it
+                await vi.waitFor(() => {
+                    expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            id: mockSubmarineSwap.id,
+                            status: "transaction.claimed",
+                            preimage: mock.preimage,
+                        }),
+                    );
+                });
+            });
+
+            it("should not be affected by monitor errors after optimistic resolution", async () => {
+                // arrange: the monitor fails (e.g. WebSocket drop) after the
+                // optimistic status was already observed
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        update("invoice.pending");
+                        await new Promise((r) => setTimeout(r, 10));
+                        throw new Error("websocket dropped");
+                    },
+                );
+
+                // act
+                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
+                    optimisticResolveAt: "invoice.pending",
+                });
+
+                // assert: resolves, and the late monitor error is swallowed
+                expect(result.preimage).toBeUndefined();
+                await new Promise((r) => setTimeout(r, 20));
+            });
         });
 
         describe("Decoding lightning invoices", () => {

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -38,7 +38,7 @@ import {
     createVHTLCScript as createVHTLCScriptReal,
     refundVHTLCwithOffchainTx,
 } from "../src/utils/vhtlc";
-import { BoltzRefundError, SwapError } from "../src/errors";
+import { BoltzRefundError, InvoiceFailedToPayError, SwapError } from "../src/errors";
 
 // Mock the @arkade-os/sdk modules
 vi.mock("@arkade-os/sdk", async () => {
@@ -975,6 +975,131 @@ describe("ArkadeSwaps", () => {
                 expect(result.amount).toBe(mock.invoice.amount);
                 expect(result.preimage).toBe(mock.preimage);
                 expect(result.txid).toBe(mock.txid);
+            });
+
+            it("should send a Lightning payment optimistically without waiting for settlement", async () => {
+                // arrange
+                const pendingSwap = mockSubmarineSwap;
+                vi.spyOn(wallet, "send").mockResolvedValueOnce(mock.txid);
+                vi.spyOn(swaps, "createSubmarineSwap").mockResolvedValueOnce(pendingSwap);
+                const waitSpy = vi
+                    .spyOn(swaps, "waitForSwapSettlement")
+                    .mockResolvedValueOnce({ preimage: undefined });
+                // act
+                const result = await swaps.sendLightningPayment(
+                    { invoice: mock.invoice.address },
+                    { optimisticResolveAt: "invoice.pending" },
+                );
+                // assert
+                expect(waitSpy).toHaveBeenCalledWith(pendingSwap, {
+                    optimisticResolveAt: "invoice.pending",
+                });
+                expect(result.amount).toBe(mock.invoice.amount);
+                expect(result.preimage).toBeUndefined();
+                expect(result.txid).toBe(mock.txid);
+            });
+        });
+
+        describe("waitForSwapSettlement", () => {
+            it("should resolve with the preimage at transaction.claimed by default", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "getSwapPreimage").mockResolvedValueOnce({
+                    preimage: mock.preimage,
+                });
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        setTimeout(() => update("invoice.pending"), 5);
+                        setTimeout(() => update("transaction.claimed"), 10);
+                    },
+                );
+
+                // act
+                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap);
+
+                // assert
+                expect(result.preimage).toBe(mock.preimage);
+            });
+
+            it("should resolve optimistically when the optimisticResolveAt status is observed", async () => {
+                // arrange
+                const getPreimageSpy = vi.spyOn(swapProvider, "getSwapPreimage");
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        setTimeout(() => update("invoice.pending"), 5);
+                    },
+                );
+
+                // act
+                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
+                    optimisticResolveAt: "invoice.pending",
+                });
+
+                // assert
+                expect(result.preimage).toBeUndefined();
+                expect(getPreimageSpy).not.toHaveBeenCalled();
+                // the observed status is persisted before resolving
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        id: mockSubmarineSwap.id,
+                        status: "invoice.pending",
+                    }),
+                );
+            });
+
+            it("should resolve optimistically when a status beyond optimisticResolveAt is observed", async () => {
+                // arrange: "invoice.set" is never reported — the monitor only
+                // sees the current status, which has already moved on
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        setTimeout(() => update("invoice.paid"), 5);
+                    },
+                );
+
+                // act
+                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
+                    optimisticResolveAt: "invoice.set",
+                });
+
+                // assert
+                expect(result.preimage).toBeUndefined();
+            });
+
+            it("should not resolve optimistically on statuses earlier than optimisticResolveAt", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "getSwapPreimage").mockResolvedValueOnce({
+                    preimage: mock.preimage,
+                });
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        setTimeout(() => update("invoice.set"), 5);
+                        setTimeout(() => update("transaction.claimed"), 10);
+                    },
+                );
+
+                // act: invoice.set is earlier than invoice.paid, so the wait
+                // continues until the swap settles
+                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
+                    optimisticResolveAt: "invoice.paid",
+                });
+
+                // assert
+                expect(result.preimage).toBe(mock.preimage);
+            });
+
+            it("should still reject on failure statuses when optimisticResolveAt is set", async () => {
+                // arrange
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        setTimeout(() => update("invoice.failedToPay"), 5);
+                    },
+                );
+
+                // act & assert
+                await expect(
+                    swaps.waitForSwapSettlement(mockSubmarineSwap, {
+                        optimisticResolveAt: "invoice.paid",
+                    }),
+                ).rejects.toBeInstanceOf(InvoiceFailedToPayError);
             });
         });
 

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -977,23 +977,21 @@ describe("ArkadeSwaps", () => {
                 expect(result.txid).toBe(mock.txid);
             });
 
-            it("should send a Lightning payment optimistically without waiting for settlement", async () => {
+            it("should send a Lightning payment without waiting for settlement when waitFor is funded", async () => {
                 // arrange
                 const pendingSwap = mockSubmarineSwap;
                 vi.spyOn(wallet, "send").mockResolvedValueOnce(mock.txid);
                 vi.spyOn(swaps, "createSubmarineSwap").mockResolvedValueOnce(pendingSwap);
                 const waitSpy = vi
-                    .spyOn(swaps, "waitForSwapSettlement")
-                    .mockResolvedValueOnce({ preimage: undefined });
+                    .spyOn(swaps, "waitForSwapFunded")
+                    .mockResolvedValueOnce(undefined);
                 // act
-                const result = await swaps.sendLightningPayment(
-                    { invoice: mock.invoice.address },
-                    { optimisticResolveAt: "invoice.pending" },
-                );
-                // assert
-                expect(waitSpy).toHaveBeenCalledWith(pendingSwap, {
-                    optimisticResolveAt: "invoice.pending",
+                const result = await swaps.sendLightningPayment({
+                    invoice: mock.invoice.address,
+                    waitFor: "funded",
                 });
+                // assert
+                expect(waitSpy).toHaveBeenCalledWith(pendingSwap);
                 expect(result.amount).toBe(mock.invoice.amount);
                 expect(result.preimage).toBeUndefined();
                 expect(result.txid).toBe(mock.txid);
@@ -1001,15 +999,16 @@ describe("ArkadeSwaps", () => {
         });
 
         describe("waitForSwapSettlement", () => {
-            it("should resolve with the preimage at transaction.claimed by default", async () => {
+            it("should resolve with the preimage only at transaction.claimed", async () => {
                 // arrange
                 vi.spyOn(swapProvider, "getSwapPreimage").mockResolvedValueOnce({
                     preimage: mock.preimage,
                 });
                 vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
                     async (_swapId, update) => {
-                        setTimeout(() => update("invoice.pending"), 5);
-                        setTimeout(() => update("transaction.claimed"), 10);
+                        setTimeout(() => update("transaction.mempool"), 5);
+                        setTimeout(() => update("invoice.pending"), 10);
+                        setTimeout(() => update("transaction.claimed"), 15);
                     },
                 );
 
@@ -1019,56 +1018,51 @@ describe("ArkadeSwaps", () => {
                 // assert
                 expect(result.preimage).toBe(mock.preimage);
             });
+        });
 
-            it("should resolve optimistically when the optimisticResolveAt status is observed", async () => {
+        describe("waitForSwapFunded", () => {
+            it("should resolve when the lockup transaction is observed", async () => {
                 // arrange
                 const getPreimageSpy = vi.spyOn(swapProvider, "getSwapPreimage");
                 vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
                     async (_swapId, update) => {
-                        setTimeout(() => update("invoice.pending"), 5);
+                        setTimeout(() => update("transaction.mempool"), 5);
                     },
                 );
 
                 // act
-                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
-                    optimisticResolveAt: "invoice.pending",
-                });
+                await swaps.waitForSwapFunded(mockSubmarineSwap);
 
                 // assert
-                expect(result.preimage).toBeUndefined();
                 expect(getPreimageSpy).not.toHaveBeenCalled();
                 // the observed status is persisted before resolving
                 expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
                     expect.objectContaining({
                         id: mockSubmarineSwap.id,
-                        status: "invoice.pending",
+                        status: "transaction.mempool",
                     }),
                 );
             });
 
-            it("should resolve optimistically when a status beyond optimisticResolveAt is observed", async () => {
-                // arrange: "invoice.set" is never reported — the monitor only
-                // sees the current status, which has already moved on
+            it("should resolve when a status beyond transaction.mempool is observed", async () => {
+                // arrange: "transaction.mempool" is never reported — the
+                // monitor only sees the current status, which has already
+                // moved on (e.g. 0-conf accepted, invoice being paid)
                 vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
                     async (_swapId, update) => {
                         setTimeout(() => update("invoice.paid"), 5);
                     },
                 );
 
-                // act
-                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
-                    optimisticResolveAt: "invoice.set",
-                });
-
-                // assert
-                expect(result.preimage).toBeUndefined();
+                // act & assert: resolves instead of hanging
+                await swaps.waitForSwapFunded(mockSubmarineSwap);
             });
 
-            it("should not resolve optimistically on statuses earlier than optimisticResolveAt", async () => {
+            it("should not resolve on statuses earlier than transaction.mempool", async () => {
                 // arrange
-                vi.spyOn(swapProvider, "getSwapPreimage").mockResolvedValueOnce({
-                    preimage: mock.preimage,
-                });
+                const getPreimageSpy = vi
+                    .spyOn(swapProvider, "getSwapPreimage")
+                    .mockResolvedValueOnce({ preimage: mock.preimage });
                 vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
                     async (_swapId, update) => {
                         setTimeout(() => update("invoice.set"), 5);
@@ -1076,17 +1070,15 @@ describe("ArkadeSwaps", () => {
                     },
                 );
 
-                // act: invoice.set is earlier than invoice.paid, so the wait
-                // continues until the swap settles
-                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
-                    optimisticResolveAt: "invoice.paid",
-                });
+                // act: invoice.set precedes funding, so the wait continues
+                // until the swap settles
+                await swaps.waitForSwapFunded(mockSubmarineSwap);
 
-                // assert
-                expect(result.preimage).toBe(mock.preimage);
+                // assert: it resolved via the terminal claimed handler
+                expect(getPreimageSpy).toHaveBeenCalled();
             });
 
-            it("should still reject on failure statuses when optimisticResolveAt is set", async () => {
+            it("should reject on failure statuses observed before funding", async () => {
                 // arrange
                 vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
                     async (_swapId, update) => {
@@ -1095,30 +1087,24 @@ describe("ArkadeSwaps", () => {
                 );
 
                 // act & assert
-                await expect(
-                    swaps.waitForSwapSettlement(mockSubmarineSwap, {
-                        optimisticResolveAt: "invoice.paid",
-                    }),
-                ).rejects.toBeInstanceOf(InvoiceFailedToPayError);
+                await expect(swaps.waitForSwapFunded(mockSubmarineSwap)).rejects.toBeInstanceOf(
+                    InvoiceFailedToPayError,
+                );
             });
 
-            it("should keep persisting a failure that arrives after optimistic resolution", async () => {
+            it("should keep persisting a failure that arrives after funding resolved", async () => {
                 // arrange
                 vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
                     async (_swapId, update) => {
-                        setTimeout(() => update("invoice.pending"), 5);
+                        setTimeout(() => update("transaction.mempool"), 5);
                         setTimeout(() => update("invoice.failedToPay"), 10);
                     },
                 );
 
                 // act
-                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
-                    optimisticResolveAt: "invoice.pending",
-                });
+                await swaps.waitForSwapFunded(mockSubmarineSwap);
 
-                // assert: resolved optimistically...
-                expect(result.preimage).toBeUndefined();
-                // ...and the late failure is still written to the repository
+                // assert: the late failure is still written to the repository
                 // (marked refundable) so SwapManager / restoreSwaps can act on it
                 await vi.waitFor(() => {
                     expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
@@ -1131,26 +1117,22 @@ describe("ArkadeSwaps", () => {
                 });
             });
 
-            it("should persist the preimage when the swap settles after optimistic resolution", async () => {
+            it("should persist the preimage when the swap settles after funding resolved", async () => {
                 // arrange
                 vi.spyOn(swapProvider, "getSwapPreimage").mockResolvedValueOnce({
                     preimage: mock.preimage,
                 });
                 vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
                     async (_swapId, update) => {
-                        setTimeout(() => update("invoice.pending"), 5);
+                        setTimeout(() => update("transaction.mempool"), 5);
                         setTimeout(() => update("transaction.claimed"), 10);
                     },
                 );
 
                 // act
-                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
-                    optimisticResolveAt: "invoice.pending",
-                });
+                await swaps.waitForSwapFunded(mockSubmarineSwap);
 
-                // assert: resolved optimistically without a preimage...
-                expect(result.preimage).toBeUndefined();
-                // ...but the final settlement is still persisted with it
+                // assert: the final settlement is still persisted with the preimage
                 await vi.waitFor(() => {
                     expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
                         expect.objectContaining({
@@ -1162,24 +1144,19 @@ describe("ArkadeSwaps", () => {
                 });
             });
 
-            it("should not be affected by monitor errors after optimistic resolution", async () => {
+            it("should not be affected by monitor errors after funding resolved", async () => {
                 // arrange: the monitor fails (e.g. WebSocket drop) after the
-                // optimistic status was already observed
+                // funding status was already observed
                 vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
                     async (_swapId, update) => {
-                        update("invoice.pending");
+                        update("transaction.mempool");
                         await new Promise((r) => setTimeout(r, 10));
                         throw new Error("websocket dropped");
                     },
                 );
 
-                // act
-                const result = await swaps.waitForSwapSettlement(mockSubmarineSwap, {
-                    optimisticResolveAt: "invoice.pending",
-                });
-
-                // assert: resolves, and the late monitor error is swallowed
-                expect(result.preimage).toBeUndefined();
+                // act & assert: resolves, and the late monitor error is swallowed
+                await swaps.waitForSwapFunded(mockSubmarineSwap);
                 await new Promise((r) => setTimeout(r, 20));
             });
         });

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -1161,6 +1161,92 @@ describe("ArkadeSwaps", () => {
             });
         });
 
+        describe("refreshSwapsStatus", () => {
+            it("should fetch and persist the preimage when a pending submarine swap has settled", async () => {
+                // arrange: a swap left pending (e.g. after a "funded" optimistic
+                // send and an app restart) that has settled on Boltz since
+                const pendingSwap: BoltzSubmarineSwap = {
+                    ...mockSubmarineSwap,
+                    status: "invoice.pending",
+                };
+                mockSwapRepository.getAllSwaps.mockImplementation(async (filter: any) =>
+                    filter?.type === "submarine" ? [pendingSwap] : [],
+                );
+                vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                    status: "transaction.claimed",
+                });
+                const getPreimageSpy = vi
+                    .spyOn(swapProvider, "getSwapPreimage")
+                    .mockResolvedValueOnce({ preimage: mock.preimage });
+
+                // act
+                await swaps.refreshSwapsStatus();
+
+                // assert
+                expect(getPreimageSpy).toHaveBeenCalledWith(pendingSwap.id);
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        id: pendingSwap.id,
+                        status: "transaction.claimed",
+                        preimage: mock.preimage,
+                    }),
+                );
+            });
+
+            it("should still persist the settled status when the preimage fetch fails", async () => {
+                // arrange
+                const pendingSwap: BoltzSubmarineSwap = {
+                    ...mockSubmarineSwap,
+                    status: "invoice.pending",
+                };
+                mockSwapRepository.getAllSwaps.mockImplementation(async (filter: any) =>
+                    filter?.type === "submarine" ? [pendingSwap] : [],
+                );
+                vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                    status: "transaction.claimed",
+                });
+                vi.spyOn(swapProvider, "getSwapPreimage").mockRejectedValueOnce(new Error("boom"));
+
+                // act
+                await swaps.refreshSwapsStatus();
+
+                // assert
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        id: pendingSwap.id,
+                        status: "transaction.claimed",
+                    }),
+                );
+            });
+
+            it("should not fetch the preimage for swaps that have not settled", async () => {
+                // arrange
+                const pendingSwap: BoltzSubmarineSwap = {
+                    ...mockSubmarineSwap,
+                    status: "invoice.set",
+                };
+                mockSwapRepository.getAllSwaps.mockImplementation(async (filter: any) =>
+                    filter?.type === "submarine" ? [pendingSwap] : [],
+                );
+                vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                    status: "invoice.pending",
+                });
+                const getPreimageSpy = vi.spyOn(swapProvider, "getSwapPreimage");
+
+                // act
+                await swaps.refreshSwapsStatus();
+
+                // assert
+                expect(getPreimageSpy).not.toHaveBeenCalled();
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        id: pendingSwap.id,
+                        status: "invoice.pending",
+                    }),
+                );
+            });
+        });
+
         describe("Decoding lightning invoices", () => {
             it("should decode a lightning invoice", async () => {
                 // act


### PR DESCRIPTION
## Summary
Adds support for optimistic Lightning payment settlement in submarine swaps, allowing callers to resolve as soon as the payment is in flight rather than waiting for full settlement. This enables UIs to show an optimistic "sent" state immediately while monitoring continues in the background.

## Key Changes

- **New `waitFor` parameter** on `sendLightningPayment()`: accepts `"settled"` (default, waits for `transaction.claimed`) or `"funded"` (resolves at `transaction.mempool` or later)
- **New `waitForSwapFunded()` method**: public API to wait until a submarine swap's lockup transaction is observed, without requiring the preimage
- **Refactored settlement monitoring**: unified `waitForSubmarineSwap()` internal method handles both optimistic and full settlement paths
- **Background persistence**: after optimistic resolution, monitoring continues persisting status updates (preimage on claim, refundable flag on failure) so the stored swap stays current for SwapManager
- **New `refreshSwapsStatus()` logic**: fetches and persists preimages for swaps that settled while the app was closed (e.g., after a "funded" optimistic send and restart)
- **New `SubmarineProgressionStatus` type**: defines the canonical successful swap progression for validating optimistic resolution targets
- **Updated response types**: `OptimisticSendLightningPaymentResponse` (with optional preimage) for `waitFor: "funded"` calls
- **Service worker and Expo wrapper updates**: propagate new method and overloaded signatures through abstraction layers

## Notable Implementation Details

- Optimistic resolution deliberately does NOT set the "final" flag, allowing background monitoring to persist subsequent statuses
- Monitor errors after optimistic resolution are logged but don't reject the already-settled promise
- Persistence failures in the status update callback are caught to prevent unhandled rejections
- The progression-based status checking (`hasSubmarineStatusReached`) handles skipped statuses since subscriptions only report the current one
- Documentation updated with examples and guidance on using SwapManager for automatic refund handling

https://claude.ai/code/session_01GC1cY1ZkPiEncsMxyWuisN