### PR TITLE
fix: preserve invoice millisat precision

### DIFF
--- a/packages/boltz-swap/src/utils/decoding.ts
+++ b/packages/boltz-swap/src/utils/decoding.ts
@@ -9,10 +9,10 @@ import { ArkAddress } from "@arkade-os/sdk";
  */
 export const decodeInvoice = (invoice: string): DecodedInvoice => {
     const decoded = bolt11.decode(invoice);
-    const millisats = Number(decoded.sections.find((s) => s.name === "amount")?.value ?? "0");
+    const millisats = BigInt(decoded.sections.find((s) => s.name === "amount")?.value ?? "0");
     return {
         expiry: decoded.expiry ?? 3600,
-        amountSats: Math.floor(millisats / 1000),
+        amountSats: Number(millisats / 1000n),
         description: decoded.sections.find((s) => s.name === "description")?.value ?? "",
         paymentHash: decoded.sections.find((s) => s.name === "payment_hash")?.value ?? "",
     };

--- a/packages/boltz-swap/test/decoding.test.ts
+++ b/packages/boltz-swap/test/decoding.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("light-bolt11-decoder", () => ({
+    default: {
+        decode: () => ({
+            expiry: 3600,
+            sections: [
+                { name: "amount", value: "9007199254741999" },
+                { name: "description", value: "large invoice" },
+                { name: "payment_hash", value: "hash" },
+            ],
+        }),
+    },
+}));
+
+const { decodeInvoice } = await import("../src/utils/decoding");
+
+describe("decodeInvoice", () => {
+    it("converts millisats to sats without Number precision loss", () => {
+        expect(decodeInvoice("lnbc1mock").amountSats).toBe(9007199254741);
+    });
+});


### PR DESCRIPTION
Lightning invoice amounts were converted from millisats with `Number(...)` before dividing by 1000.

That can lose precision for large millisat values. This keeps the conversion in bigint arithmetic until the sats value is derived.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision in invoice amount parsing to prevent rounding errors when handling large values.

* **Tests**
  * Added test coverage for invoice amount decoding to ensure accurate precision handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->