### PR TITLE
fix: keep watching boarding addresses across operator signer rotation

### DIFF
--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -306,6 +306,18 @@ export class ReadonlyWallet implements IReadonlyWallet {
      */
     protected _boardingTapscript: DefaultVtxo.Script;
 
+    /**
+     * x-only hex of the operator's deprecated signer keys (from
+     * {@link ArkInfo.deprecatedSigners}). {@link getBoardingTapscripts} keeps a
+     * persisted boarding row whose `serverPubKey` is the current signer OR a
+     * member of this set, so funds at a boarding address derived under a
+     * now-rotated operator signer stay watched — while a row from a genuinely
+     * different operator is still excluded. Captured once at setup from the
+     * server-info snapshot so the hot boarding read path stays repo-only
+     * (offline-first).
+     */
+    protected readonly _deprecatedSignerHexes: ReadonlySet<string>;
+
     protected constructor(
         readonly identity: ReadonlyIdentity,
         readonly network: Network,
@@ -320,6 +332,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         readonly delegateProvider?: DelegateProvider,
         watcherConfig?: ReadonlyWalletConfig["watcherConfig"],
         walletContractTimelocks?: RelativeTimelock[],
+        deprecatedSignerPubKeys: Bytes[] = [],
     ) {
         // Guard: detect identity/server network mismatch for descriptor-based identities.
         // This duplicates the check in setupWalletConfig() so that subclasses
@@ -338,6 +351,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         }
         this._offchainTapscript = offchainTapscript;
         this._boardingTapscript = boardingTapscript;
+        this._deprecatedSignerHexes = new Set(deprecatedSignerPubKeys.map((k) => hex.encode(k)));
         this.watcherConfig = watcherConfig;
         this._assetManager = new ReadonlyAssetManager(this.indexerProvider);
         // Defensive for direct-construction callers; setupWalletConfig already
@@ -552,6 +566,22 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const contractRepository =
             config.storage?.contractRepository ?? new IndexedDBContractRepository();
 
+        // The operator's previous signer keys (x-only). A boarding address
+        // derived while one of these was the current signer can still hold coins
+        // after the operator rotates its signer, so the runtime boarding monitor
+        // ({@link getBoardingTapscripts}) treats such rows as this wallet's own —
+        // mirroring how restore() consults deprecatedSigners. Parsed leniently
+        // from the info snapshot already fetched above (no extra round-trip); a
+        // malformed entry is skipped rather than aborting wallet creation.
+        const deprecatedSignerPubKeys: Bytes[] = [];
+        for (const s of info.deprecatedSigners ?? []) {
+            try {
+                deprecatedSignerPubKeys.push(toXOnlyPubKey(hex.decode(s.pubkey)));
+            } catch (e) {
+                console.warn("Skipping malformed deprecated signer pubkey", s.pubkey, e);
+            }
+        }
+
         return {
             arkProvider,
             indexerProvider,
@@ -565,6 +595,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             walletRepository,
             contractRepository,
             info,
+            deprecatedSignerPubKeys,
             delegateProvider: config.delegateProvider || config.delegatorProvider,
             /** @deprecated alias for `delegateProvider` */
             delegatorProvider: config.delegateProvider || config.delegatorProvider,
@@ -600,6 +631,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             setup.delegateProvider || setup.delegatorProvider,
             config.watcherConfig,
             setup.walletContractTimelocks,
+            setup.deprecatedSignerPubKeys,
         );
     }
 
@@ -887,12 +919,22 @@ export class ReadonlyWallet implements IReadonlyWallet {
             type: ["boarding"],
         });
         for (const c of boardingContracts) {
-            // Only this wallet's server. A row left by a previous ASP (e.g. a
-            // repo recovered against a different server) would otherwise emit a
-            // spurious onchain script — and a wasted getCoins/getTransactions
-            // call — on every boarding read. Mirrors the filter in
-            // resolveBoardingBootTapscript.
-            if (c.params.serverPubKey !== serverPubKeyHex) continue;
+            // Keep a row when its server key is the operator's CURRENT signer or
+            // one of its DEPRECATED signers (server-key rotation): a boarding
+            // address funded under a previous signer still holds coins, so it
+            // must stay watched/spendable across the rotation. A row from a
+            // genuinely different operator — neither current nor deprecated — is
+            // still excluded, so a repo recovered against another server emits no
+            // spurious onchain script or wasted getCoins/getTransactions call.
+            // Unlike resolveBoardingBootTapscript (which resolves the single
+            // DISPLAY address and so stays pinned to the current signer), this is
+            // the fan-out monitoring set and must include deprecated signers.
+            if (
+                c.params.serverPubKey !== serverPubKeyHex &&
+                !this._deprecatedSignerHexes.has(c.params.serverPubKey)
+            ) {
+                continue;
+            }
             try {
                 add(BoardingContractHandler.createScript(c.params));
             } catch (e) {
@@ -1707,6 +1749,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         walletContractTimelocks?: RelativeTimelock[],
         receiveRotator?: WalletReceiveRotator,
         descriptorProvider?: DescriptorProvider,
+        deprecatedSignerPubKeys: Bytes[] = [],
     ) {
         super(
             identity,
@@ -1722,6 +1765,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             delegateProvider,
             watcherConfig,
             walletContractTimelocks,
+            deprecatedSignerPubKeys,
         );
         this.identity = identity;
 
@@ -1918,6 +1962,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             setup.walletContractTimelocks,
             boot?.rotator,
             boot?.provider,
+            setup.deprecatedSignerPubKeys,
         );
 
         // Boarding boot (plan §6-II.3): when HD/boarding rotation is active (a
@@ -1980,6 +2025,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             this.delegateProvider,
             this.watcherConfig,
             this.walletContractTimelocks,
+            Array.from(this._deprecatedSignerHexes, (h) => hex.decode(h)),
         );
     }
 

--- a/packages/ts-sdk/test/walletBoardingRotation.test.ts
+++ b/packages/ts-sdk/test/walletBoardingRotation.test.ts
@@ -25,6 +25,11 @@ const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f
 // `BoardingContractHandler.createScript` would succeed on it absent the filter.
 const FOREIGN_SERVER_PUBKEY_HEX =
     "9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b";
+// The operator's PREVIOUS signer key (compressed, as arkd advertises it in
+// `deprecatedSigners`). Its x-only form is what a boarding row registered while
+// this key was current would carry in `params.serverPubKey`.
+const PREV_SERVER_PUBKEY_HEX = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+const PREV_SERVER_PUBKEY_XONLY = PREV_SERVER_PUBKEY_HEX.slice(2);
 
 const mockArkInfo = {
     signerPubkey: SERVER_PUBKEY_HEX,
@@ -354,6 +359,60 @@ describe("Wallet boarding rotation", () => {
             );
 
             warn.mockRestore();
+            await wallet.dispose();
+        });
+    });
+
+    describe("boarding-address discovery (deprecated signer rotation)", () => {
+        it("keeps watching a boarding row registered under a now-deprecated operator signer", async () => {
+            // The operator has rotated its signer key: the current key is
+            // SERVER_PUBKEY_HEX and the previous one is advertised in
+            // `deprecatedSigners`. A boarding address funded while the previous
+            // key was current still holds coins, so it MUST stay monitored.
+            mockFetch.mockImplementation((url: string) => {
+                const reply = (body: unknown) =>
+                    Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+                if (url.includes("/info"))
+                    return reply({
+                        ...mockArkInfo,
+                        deprecatedSigners: [
+                            { pubkey: PREV_SERVER_PUBKEY_HEX, cutoffDate: 9999999999 },
+                        ],
+                    });
+                if (url.includes("subscribe") || url.includes("subscriptions"))
+                    return reply({ subscriptionId: "sub-1" });
+                if (url.includes("vtxo") || url.includes("scripts")) return reply({ vtxos: [] });
+                return reply([]);
+            });
+
+            const contractRepo = new InMemoryContractRepository();
+            const wallet = await makeHdWallet(new InMemoryWalletRepository(), contractRepo);
+
+            const ownAddresses = new Set(await wallet.getBoardingAddresses());
+
+            // A boarding row this wallet derived while the operator's signer was
+            // the now-deprecated PREV key. Params are valid, so its on-chain
+            // address is real and still potentially funded.
+            await contractRepo.saveContract({
+                type: "boarding",
+                params: {
+                    pubKey: SINGLEKEY_HEX,
+                    serverPubKey: PREV_SERVER_PUBKEY_XONLY,
+                    csvTimelock: "144",
+                },
+                script: "cd".repeat(32), // not consulted by getBoardingTapscripts
+                address: "tb1pdeprecated-unused",
+                state: "active",
+                createdAt: 1,
+            });
+
+            const withDeprecated = new Set(await wallet.getBoardingAddresses());
+            // The deprecated-signer row contributes exactly one new boarding
+            // address (PREV is in the operator's deprecatedSigners, so it is
+            // recognized as ours), and no previously-watched address is dropped.
+            expect(withDeprecated.size).toBe(ownAddresses.size + 1);
+            for (const a of ownAddresses) expect(withDeprecated.has(a)).toBe(true);
+
             await wallet.dispose();
         });
     });


### PR DESCRIPTION
## Problem

`getBoardingTapscripts()` is the single enumerator every boarding monitoring / fund-discovery path funnels through — `getBoardingAddresses`, `getBoardingUtxos`, `getBoardingTxs`, `notifyIncomingFunds` (the on-chain `watchAddresses` set), the `VtxoManager` boarding poll, balance, and sweep.

It filtered persisted `boarding` rows on the **current** signer key only:

```ts
if (c.params.serverPubKey !== serverPubKeyHex) continue;
```

When the operator rotates its signer key (`arkd` `ArkInfo.signerPubkey` changes; the old key moves into `ArkInfo.deprecatedSigners`), the wallet rebuilds its boarding tapscript with the new key. Every previously-persisted boarding row carries the **old** key, so all of them were skipped — a boarding address funded under the previous signer silently dropped out of the watch set, balance, history, and sweep, even though it still holds coins and still needs either a cooperative board before its `cutoffDate` or a unilateral CSV exit afterward.

In practice this shows up as two `active` boarding contracts in the repo where only one is monitored:

| address | created | csvTimelock |
|---|---|---|
| `ark1qrxn43a…` | 1h ago | 4194338 |
| `ark1qra883h…` | 2h ago | 4194338 |

## Fix

Keep a boarding row when its `serverPubKey` is the operator's **current** signer **or one of its deprecated signers** (`current ∪ deprecated`) — mirroring how VTXO discovery (`default`/`delegate` handlers, and `NArk`'s `IndexerVtxoDiscoveryProvider`) already scopes signers. A genuinely different operator's key is still excluded, preserving the guard against a repo recovered against another server.

The deprecated-signer set is parsed from `ArkInfo.deprecatedSigners` and cached at wallet construction from the info snapshot setup already fetches, so the hot boarding read path stays repo-only (offline-first) — no new network round-trip.

### Deliberately out of scope
- **`resolveBoardingBootTapscript`** (the display/receive address) stays pinned to the current signer: new deposits must not be advertised to a deprecated-key address.
- **Boarding discovery** (`BoardingContractHandler.discoverAt`) is unchanged — current-signer-only on a fresh-repo restore, consistent with `NArk`'s `BoardingUtxoDiscoveryProvider`. A continuous repo already has the row persisted, which this PR now keeps monitoring.

## Test plan
- New unit test in `walletBoardingRotation.test.ts`: a boarding row under a now-deprecated signer is watched (`getBoardingAddresses` returns it). Red→green verified.
- Existing "different ASP server" test still passes (foreign key still excluded).
- Full ts-sdk unit suite: **1416 passed, 1 skipped, 0 failed**.
- `tsc --noEmit` clean; prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended boarding address monitoring to include UTXOs funded under deprecated operator signer keys, enabling proper wallet recovery during operator key rotation.

* **Tests**
  * Added test coverage for deprecated signer key rotation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->