### PR TITLE
fix(electrum): de-flake getTxStatus by classifying RPCError-wrapped not-in-block errors

### DIFF
--- a/packages/ts-sdk/src/providers/electrum.ts
+++ b/packages/ts-sdk/src/providers/electrum.ts
@@ -1006,6 +1006,24 @@ function isHeaderSubscribeResult(v: unknown): v is HeaderSubscribeResult {
 }
 
 /**
+ * Best-effort text extraction from a thrown value. `ws-electrumx-client` wraps a
+ * JSON-RPC error whose payload carries a numeric `code` as an `RPCError`: the
+ * human-readable server text moves to a non-standard `.str` field while
+ * `.message` becomes a generic "<code-name> (code: N)". A classifier that reads
+ * only `.message` therefore misses the real reason, so pull from both (plus the
+ * raw string form) — the matchers below must see the server wording regardless
+ * of how the transport wrapped the error.
+ */
+function errorText(err: unknown): string {
+    if (typeof err === "string") return err;
+    if (err && typeof err === "object") {
+        const e = err as { message?: unknown; str?: unknown };
+        return [e.message, e.str].filter((v): v is string => typeof v === "string").join(" ");
+    }
+    return "";
+}
+
+/**
  * Recognise the "block header not yet indexable" failure shape returned by
  * electrum servers (electrs in particular) when `block.header(N)` runs
  * against a height that's already in `listunspent`/`get_merkle` but hasn't
@@ -1014,8 +1032,7 @@ function isHeaderSubscribeResult(v: unknown): v is HeaderSubscribeResult {
  * failures (auth/network) propagate.
  */
 function isMissingHeightError(err: unknown): boolean {
-    const msg = err instanceof Error ? err.message : typeof err === "string" ? err : "";
-    return msg.toLowerCase().includes("missingheight");
+    return errorText(err).toLowerCase().includes("missingheight");
 }
 
 /**
@@ -1026,8 +1043,7 @@ function isMissingHeightError(err: unknown): boolean {
  * malformed response) still propagate.
  */
 function isTxNotInBlockError(err: unknown): boolean {
-    const msg = err instanceof Error ? err.message : typeof err === "string" ? err : "";
-    const normalized = msg.toLowerCase();
+    const normalized = errorText(err).toLowerCase();
     return (
         normalized.includes("not yet in a block") ||
         normalized.includes("not in a block") ||

--- a/packages/ts-sdk/test/electrum.test.ts
+++ b/packages/ts-sdk/test/electrum.test.ts
@@ -398,6 +398,22 @@ describe("ElectrumOnchainProvider", () => {
             });
         });
 
+        it("returns confirmed=false when the not-in-block error is RPCError-wrapped (text in .str)", async () => {
+            // ws-electrumx-client wraps JSON-RPC errors whose payload carries a
+            // numeric "code" as an RPCError: the human-readable server text moves
+            // to a non-standard `.str` field while `.message` becomes a generic
+            // "<code-name> (code: N)". The not-in-block classifier must still
+            // recognize it — otherwise get_merkle's index-lag race escapes
+            // getTxStatus intermittently (the CI flake this fixes).
+            const wrapped = Object.assign(new Error("server error (code: 2)"), {
+                str: "No confirmed transaction matching the requested hash was found",
+            });
+            wsMock.request.mockRejectedValueOnce(wrapped);
+            expect(await provider.getTxStatus("abc")).toEqual({
+                confirmed: false,
+            });
+        });
+
         it("returns confirmed=false when transaction.get_merkle reports block_height <= 0", async () => {
             wsMock.request.mockResolvedValueOnce({ block_height: 0 });
             expect(await provider.getTxStatus("abc")).toEqual({


### PR DESCRIPTION
## Problem

`electrum.test.ts > getTxStatus > tracks a freshly-funded address …` flakes intermittently in CI with:

```
Error: No confirmed transaction matching the requested hash was found
```

It's the only e2e test that calls `blockchain.transaction.get_merkle`, which needs the funding tx *mined and merkle-indexed*. Right after a fresh block, electrs exposes the height via `listunspent` before `get_merkle` can answer, so `get_merkle` rejects — the index-lag race.

`getTxStatus` → `fetchTxMerkle` is *designed* to swallow that and return `{ confirmed: false }` (via `isTxNotInBlockError` / `isMissingHeightError`). **The classifiers only inspected `err.message`.** But `ws-electrumx-client` wraps a JSON-RPC error whose payload carries a numeric `code` as an `RPCError`: the human-readable server text moves to a non-standard **`.str`** field while `.message` becomes a generic `"<code-name> (code: N)"`. When the rejection arrives in that shape, the matcher misses it, the error escapes `getTxStatus`, and the test fails. The `"code"`-or-not variance under CI load is the intermittency.

This has recurred across multiple PRs' CI runs.

## Fix

Extract text from **both `.message` and `.str`** (plus the raw string form) via a shared `errorText(err)` helper, and use it in `isTxNotInBlockError` and `isMissingHeightError`. The not-in-block / missing-height races are now recognized regardless of how the transport wrapped the error, so `getTxStatus` reliably returns `{ confirmed: false }` — for every caller, not just the test. Genuine errors (auth/network/malformed) still propagate.

## Test plan

- New unit test reproducing the `RPCError`-wrapped variant (`.message` generic, text in `.str`) — red before the fix, green after.
- Existing `getTxStatus` swallow/propagate cases unchanged and passing.
- Full ts-sdk unit suite: 1416 passed / 0 failed; `tsc --noEmit` clean; prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection in transaction status checks to handle server responses more reliably across different error formats.

* **Tests**
  * Added test coverage for transaction status checking with edge case error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->