### PR TITLE
fix(contractWatcher): recover promptly after subscription disruption

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "trailingComma": "all",
   "printWidth": 100,
   "tabWidth": 4,
-  "semi": true
+  "semi": true,
+  "endOfLine": "auto"
 }

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -7,6 +7,30 @@ import { isEventSourceError } from "../providers/utils";
 import { filterVtxosForScript, getVtxosForContract } from "./vtxoOwnership";
 
 /**
+ * Exponential reconnect backoff: `baseMs * 2^(attempt-1)`, capped at `maxMs`.
+ * The cap is kept low (see {@link DEFAULT_CONTRACT_WATCHER_CONFIG}) so the
+ * wallet re-tracks state promptly after a brief server restart — e.g. an
+ * operator signer rotation momentarily drops the SSE subscription.
+ */
+export function computeReconnectDelay(attempt: number, baseMs: number, maxMs: number): number {
+    return Math.min(baseMs * Math.pow(2, attempt - 1), maxMs);
+}
+
+/**
+ * Default tunables for {@link ContractWatcher}. Recovery-oriented: the reconnect
+ * backoff caps at 5s and the failsafe re-poll runs every 20s, so a wallet
+ * re-syncs quickly after its subscription is disrupted (a server restart),
+ * rather than sitting idle for the tens of seconds the previous 30s/60s
+ * defaults allowed.
+ */
+export const DEFAULT_CONTRACT_WATCHER_CONFIG = {
+    failsafePollIntervalMs: 20_000,
+    reconnectDelayMs: 1_000,
+    maxReconnectDelayMs: 5_000,
+    maxReconnectAttempts: 0, // unlimited
+};
+
+/**
  * Configuration for the ContractWatcher.
  *
  * @see ContractWatcher
@@ -124,10 +148,7 @@ export class ContractWatcher {
      */
     constructor(config: ContractWatcherConfig) {
         this.config = {
-            failsafePollIntervalMs: 60_000, // 1 minute
-            reconnectDelayMs: 1000, // 1 second
-            maxReconnectDelayMs: 30_000, // 30 seconds
-            maxReconnectAttempts: 0, // unlimited
+            ...DEFAULT_CONTRACT_WATCHER_CONFIG,
             ...config,
         };
     }
@@ -436,9 +457,10 @@ export class ContractWatcher {
         this.connectionState = "reconnecting";
         this.reconnectAttempts++;
 
-        // Calculate delay with exponential backoff
-        const delay = Math.min(
-            this.config.reconnectDelayMs * Math.pow(2, this.reconnectAttempts - 1),
+        // Calculate delay with exponential backoff (capped low for prompt recovery)
+        const delay = computeReconnectDelay(
+            this.reconnectAttempts,
+            this.config.reconnectDelayMs,
             this.config.maxReconnectDelayMs,
         );
 

--- a/packages/ts-sdk/test/contractWatcher-reconnect.test.ts
+++ b/packages/ts-sdk/test/contractWatcher-reconnect.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import {
+    computeReconnectDelay,
+    DEFAULT_CONTRACT_WATCHER_CONFIG,
+} from "../src/contracts/contractWatcher";
+
+describe("computeReconnectDelay", () => {
+    it("grows exponentially from the base delay", () => {
+        expect(computeReconnectDelay(1, 1000, 5000)).toBe(1000); // 1000 * 2^0
+        expect(computeReconnectDelay(2, 1000, 5000)).toBe(2000); // 1000 * 2^1
+        expect(computeReconnectDelay(3, 1000, 5000)).toBe(4000); // 1000 * 2^2
+    });
+
+    it("caps at maxMs so recovery after a server restart stays prompt", () => {
+        expect(computeReconnectDelay(4, 1000, 5000)).toBe(5000); // 8000 -> capped
+        expect(computeReconnectDelay(20, 1000, 5000)).toBe(5000); // far past the cap
+    });
+});
+
+describe("ContractWatcher reconnect defaults", () => {
+    it("recovers promptly: backoff cap and failsafe poll are bounded", () => {
+        // Regression guard: a server restart (e.g. an operator signer rotation)
+        // briefly drops the SSE subscription. The wallet must re-track state
+        // quickly afterwards, so neither the reconnect backoff nor the failsafe
+        // poll may sit in the tens of seconds.
+        expect(DEFAULT_CONTRACT_WATCHER_CONFIG.maxReconnectDelayMs).toBeLessThanOrEqual(5_000);
+        expect(DEFAULT_CONTRACT_WATCHER_CONFIG.failsafePollIntervalMs).toBeLessThanOrEqual(20_000);
+    });
+});


### PR DESCRIPTION
## Problem

The wallet's SSE subscription (`ContractWatcher`) drops briefly whenever the server restarts — e.g. an operator signer-key rotation, or any arkd restart. Recovery was slow:
- reconnect backoff capped at **30s**,
- failsafe re-poll only every **60s**.

So after the server came back, a wallet could sit idle for tens of seconds before re-tracking VTXO/contract state. This surfaced as flakiness in the deprecated-signer-migration e2e (the rotation restarts arkd mid-test).

## Fix

- Lower the recovery-oriented defaults: backoff cap **5s**, failsafe poll **20s** (`DEFAULT_CONTRACT_WATCHER_CONFIG`).
- Extract the backoff into a tested pure helper `computeReconnectDelay(attempt, base, max)`.

Behaviour is otherwise unchanged: unlimited reconnect attempts, exponential backoff, and the existing stale-subscription re-subscribe.

## Tests

New `test/contractWatcher-reconnect.test.ts` covers the backoff growth + cap and guards the recovery-oriented defaults. Full unit suite green (1419 passed).

Also includes a one-line chore — `endOfLine: "auto"` in `.prettierrc` — so the lint/pre-commit hook passes on Windows checkouts as well as on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnect behavior for contract watching, with faster recovery and a capped retry delay.
  * Updated default timing settings to reduce wait times during polling and reconnect attempts.

* **Chores**
  * Adjusted formatting settings to handle line endings more consistently across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->