### PR TITLE
fix(transactionHistory): drop ghost zero-amount sent for signer-rotation migration

### DIFF
--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -171,15 +171,24 @@ export async function buildTransactionHistory(
                 }
 
                 const assets = subtractAssets(allSpent, changes);
-                sent.push({
-                    key: { ...txKey, arkTxid: vtxo.arkTxId },
-                    tag: "offchain",
-                    type: TxType.TxSent,
-                    amount: txAmount,
-                    settled: true,
-                    createdAt: txTime,
-                    ...(assets && { assets }),
-                });
+
+                // A pure self-transfer returns the full spent amount as change and moves
+                // no assets, so nothing actually leaves the wallet. This happens when all
+                // VTXOs are spent to a self address (e.g. migrating to a new signer after a
+                // server key rotation). Don't record a ghost zero-amount sent transaction.
+                // Note: zero-amount sends that do move assets (issuance/reissuance/burn)
+                // are kept because `assets` is set in those cases.
+                if (txAmount !== 0 || assets) {
+                    sent.push({
+                        key: { ...txKey, arkTxid: vtxo.arkTxId },
+                        tag: "offchain",
+                        type: TxType.TxSent,
+                        amount: txAmount,
+                        settled: true,
+                        createdAt: txTime,
+                        ...(assets && { assets }),
+                    });
+                }
             }
 
             // If the virtual output is forfeited in a batch and the total sum of forfeited virtual outputs is bigger than the sum of new virtual outputs,

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -162,6 +162,50 @@ describe("buildTransactionHistory", () => {
             // The result vtxos should not show as received either (they're change from our own spend)
             expect(receivedTxs).toHaveLength(0);
         });
+
+        it("should not record a ghost zero-amount sent for a signer-rotation migration", async () => {
+            // Migrating all VTXOs to a new signer spends old-signer VTXOs to a single
+            // self output of the full amount. spentAmount === changeAmount, so the net
+            // sent amount is 0 and no assets move: it must not appear in the history.
+            const arkTxId = "migration-ark-tx";
+            const baseDate = new Date("2026-06-15T07:45:58Z");
+
+            const oldSignerVtxos: VirtualCoin[] = [1000, 2471, 173875, 7529].map((value, i) => ({
+                txid: `old-signer-vtxo-${i}`,
+                vout: 0,
+                value,
+                status: { confirmed: false },
+                virtualStatus: { state: "preconfirmed" },
+                createdAt: new Date(baseDate.getTime() - 1000),
+                isUnrolled: false,
+                isSpent: true,
+                arkTxId,
+            }));
+
+            // Single new-signer output holding the full migrated amount (self change).
+            const newSignerOutput: VirtualCoin = {
+                txid: arkTxId,
+                vout: 0,
+                value: 184875,
+                status: { confirmed: false },
+                virtualStatus: { state: "preconfirmed" },
+                createdAt: baseDate,
+                isUnrolled: false,
+                isSpent: false,
+            };
+
+            const txs = await buildTransactionHistory(
+                [...oldSignerVtxos, newSignerOutput],
+                [],
+                new Set<string>(),
+            );
+
+            // No sent tx at all, and nothing keyed by the migration tx (the ghost).
+            expect(txs.filter((t) => t.type === TxType.TxSent)).toHaveLength(0);
+            expect(txs.some((t) => t.key.arkTxid === arkTxId)).toBe(false);
+            // The new-signer self output is change, not a receive.
+            expect(txs.some((t) => t.amount === 184875)).toBe(false);
+        });
     });
 
     describe("Receive transactions", () => {


### PR DESCRIPTION
## Summary

Migrating all VTXOs to a new signer spends them to a single self output of the full amount, so `spentAmount` equals `changeAmount` and the net sent amount is 0. This produced a "ghost" zero-amount offchain *sent* entry in the transaction history.

This change skips recording the offchain sent entry when the amount is 0 and no assets move, while keeping zero-amount asset sends (issuance/reissuance/burn).

## Changes

- `packages/ts-sdk/src/utils/transactionHistory.ts` — suppress zero-amount, no-asset offchain sent entries
- `packages/ts-sdk/test/transactionHistory.test.ts` — coverage for the ghost-entry case and for preserved zero-amount asset sends

## Test plan

- [x] `pnpm -C packages/ts-sdk vitest run test/transactionHistory.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where zero-amount self-transfer transactions were incorrectly recorded in transaction history during account operations.

* **Tests**
  * Added test coverage for signer rotation migrations to ensure transaction history accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->