### PR TITLE
fix(wallet): fail fast on unsignable boarding input during settle

### DIFF
--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -3036,18 +3036,9 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                     settlementPsbt = await this._signerRouter.sign(settlementPsbt, [
                         { index: i, lookupScript: script },
                     ]);
-                    // Defense-in-depth: the signer router silently skips any
-                    // input whose script it cannot resolve (no matching contract
-                    // row and not the recognized boarding script). For a
-                    // boarding input the wallet itself selected, a skip means we
-                    // would submit an unsigned, leaf-less-looking input that arkd
-                    // rejects far downstream with the opaque "script ... is not a
-                    // wallet script" — after every signature already "succeeded".
-                    // Fail here instead, naming the exact outpoint and the
-                    // boarding addresses the wallet actually recognizes, so an
-                    // unsignable boarding address (e.g. a rotated boarding script
-                    // whose contract row is missing from the repo) is immediately
-                    // diagnosable rather than a server-side mystery.
+                    // The signer router silently skips inputs it can't resolve,
+                    // which would leave this boarding input unsigned and cause
+                    // arkd to reject it as "not a wallet script". Fail early.
                     if (!settlementPsbt.getInput(i).tapScriptSig?.length) {
                         throw new Error(await this.unsignableBoardingInputError(input, script));
                     }
@@ -3130,17 +3121,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         }
     }
 
-    /**
-     * Build the diagnostic thrown when a selected boarding input could not be
-     * signed (the signer router resolved no contract row and no recognized
-     * boarding script for it). Without this, the unsigned input flows to arkd
-     * and surfaces as the opaque "script ... is not a wallet script" two RPCs
-     * later. The message names the exact outpoint, the unresolved boarding
-     * address, and the boarding addresses the wallet *does* recognize — enough
-     * to classify the offender (rotated vs baseline, missing contract row)
-     * without introspecting wallet internals. Best-effort: every enrichment is
-     * guarded so building the error can never itself throw and mask the cause.
-     */
+    // Best-effort: every enrichment is guarded so a secondary failure can't
+    // mask the original signing error.
     private async unsignableBoardingInputError(
         input: { txid: string; vout: number },
         script: Bytes,
@@ -3149,25 +3131,19 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         let unresolvedAddress = "<undecodable>";
         try {
             unresolvedAddress = Address(this.network).encode(OutScript.decode(script));
-        } catch {
-            // leave placeholder — a non-standard script is itself a signal
-        }
+        } catch {}
         let recognized = "<unavailable>";
         try {
             const current = await this.getBoardingAddress();
             const all = await this.getBoardingAddresses();
             recognized = `current=${current}; all=[${all.join(", ")}]`;
-        } catch {
-            // never let address discovery failure mask the signing error
-        }
+        } catch {}
         return (
             `failed to sign boarding input ${input.txid}:${input.vout}: ` +
-            `no signer recognized its script ${scriptHex} (${unresolvedAddress}). ` +
-            `This boarding address is not in the signer's recognized set, so its ` +
-            `commitment-tx input would reach the operator unsigned and be rejected ` +
-            `as "not a wallet script". Recognized boarding addresses: ${recognized}. ` +
-            `Likely a rotated boarding address whose contract row is missing from the ` +
-            `repository; onboarding this UTXO cannot proceed until that row is restored.`
+            `signer did not recognize script ${scriptHex} (${unresolvedAddress}); ` +
+            `would have reached arkd unsigned and been rejected as "not a wallet script". ` +
+            `Recognized boarding addresses: ${recognized}. ` +
+            `Likely a rotated boarding address with a missing contract row.`
         );
     }
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -3016,6 +3016,21 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                     settlementPsbt = await this._signerRouter.sign(settlementPsbt, [
                         { index: i, lookupScript: script },
                     ]);
+                    // Defense-in-depth: the signer router silently skips any
+                    // input whose script it cannot resolve (no matching contract
+                    // row and not the recognized boarding script). For a
+                    // boarding input the wallet itself selected, a skip means we
+                    // would submit an unsigned, leaf-less-looking input that arkd
+                    // rejects far downstream with the opaque "script ... is not a
+                    // wallet script" — after every signature already "succeeded".
+                    // Fail here instead, naming the exact outpoint and the
+                    // boarding addresses the wallet actually recognizes, so an
+                    // unsignable boarding address (e.g. a rotated boarding script
+                    // whose contract row is missing from the repo) is immediately
+                    // diagnosable rather than a server-side mystery.
+                    if (!settlementPsbt.getInput(i).tapScriptSig?.length) {
+                        throw new Error(await this.unsignableBoardingInputError(input, script));
+                    }
                     hasBoardingUtxos = true;
                     break;
                 }
@@ -3093,6 +3108,47 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 hasBoardingUtxos ? base64.encode(settlementPsbt.toPSBT()) : undefined,
             );
         }
+    }
+
+    /**
+     * Build the diagnostic thrown when a selected boarding input could not be
+     * signed (the signer router resolved no contract row and no recognized
+     * boarding script for it). Without this, the unsigned input flows to arkd
+     * and surfaces as the opaque "script ... is not a wallet script" two RPCs
+     * later. The message names the exact outpoint, the unresolved boarding
+     * address, and the boarding addresses the wallet *does* recognize — enough
+     * to classify the offender (rotated vs baseline, missing contract row)
+     * without introspecting wallet internals. Best-effort: every enrichment is
+     * guarded so building the error can never itself throw and mask the cause.
+     */
+    private async unsignableBoardingInputError(
+        input: { txid: string; vout: number },
+        script: Bytes,
+    ): Promise<string> {
+        const scriptHex = hex.encode(script);
+        let unresolvedAddress = "<undecodable>";
+        try {
+            unresolvedAddress = Address(this.network).encode(OutScript.decode(script));
+        } catch {
+            // leave placeholder — a non-standard script is itself a signal
+        }
+        let recognized = "<unavailable>";
+        try {
+            const current = await this.getBoardingAddress();
+            const all = await this.getBoardingAddresses();
+            recognized = `current=${current}; all=[${all.join(", ")}]`;
+        } catch {
+            // never let address discovery failure mask the signing error
+        }
+        return (
+            `failed to sign boarding input ${input.txid}:${input.vout}: ` +
+            `no signer recognized its script ${scriptHex} (${unresolvedAddress}). ` +
+            `This boarding address is not in the signer's recognized set, so its ` +
+            `commitment-tx input would reach the operator unsigned and be rejected ` +
+            `as "not a wallet script". Recognized boarding addresses: ${recognized}. ` +
+            `Likely a rotated boarding address whose contract row is missing from the ` +
+            `repository; onboarding this UTXO cannot proceed until that row is restored.`
+        );
     }
 
     /**

--- a/packages/ts-sdk/test/wallet/unsignableBoardingInput.test.ts
+++ b/packages/ts-sdk/test/wallet/unsignableBoardingInput.test.ts
@@ -7,18 +7,6 @@ import {
     InMemoryContractRepository,
 } from "../../src";
 
-/**
- * Regression for the boarding onboard failure that surfaced server-side as the
- * opaque arkd error "script ... is not a wallet script" (arkd-wallet
- * SignTransaction key-path branch): a boarding UTXO the wallet selected but
- * whose script the signer router could not resolve was *silently skipped*, so
- * its commitment-tx input reached the operator unsigned/leaf-less.
- *
- * The wallet now fails fast with a diagnostic naming the exact outpoint, the
- * unresolved boarding address, and the boarding addresses it *does* recognize.
- * This test pins that diagnostic (the harness mirrors walletBoardingRotation).
- */
-
 const MNEMONIC =
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
@@ -69,9 +57,7 @@ afterEach(() => {
     vi.unstubAllGlobals();
 });
 
-// A taproot scriptPubKey (OP_1 <32-byte key>) for a boarding address the wallet
-// does NOT own — stands in for the unresolved boarding script (e.g. a rotated
-// boarding address whose contract row is missing from the repo).
+// Taproot scriptPubKey the wallet does not own — simulates an unresolved boarding script.
 const FOREIGN_BOARDING_SCRIPT = new Uint8Array([
     0x51,
     0x20,
@@ -97,13 +83,9 @@ describe("unsignable boarding input diagnostic", () => {
             FOREIGN_BOARDING_SCRIPT,
         );
 
-        // Exact outpoint and script the operator would have rejected.
         expect(msg).toContain("0c2a677ca31a50d1745b9f49d43756b8a274e751e957d9cb7271960f87649243:2");
         expect(msg).toContain(hex.encode(FOREIGN_BOARDING_SCRIPT));
-        // Maps the cryptic server error to its client-side cause.
         expect(msg).toContain("not a wallet script");
-        // Surfaces what the wallet *can* sign, so the offender is classifiable
-        // without introspecting wallet internals.
         expect(msg).toContain(recognized);
 
         await wallet.dispose();
@@ -120,8 +102,6 @@ describe("unsignable boarding input diagnostic", () => {
             },
         });
 
-        // A non-taproot / undecodable script must degrade to a placeholder, not
-        // throw — the signing error must never be masked by error-building.
         const garbage = new Uint8Array([0x00, 0x01, 0x02]);
         const msg = await (wallet as any).unsignableBoardingInputError(
             { txid: "deadbeef", vout: 0 },

--- a/packages/ts-sdk/test/wallet/unsignableBoardingInput.test.ts
+++ b/packages/ts-sdk/test/wallet/unsignableBoardingInput.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { hex } from "@scure/base";
+import {
+    Wallet,
+    MnemonicIdentity,
+    InMemoryWalletRepository,
+    InMemoryContractRepository,
+} from "../../src";
+
+/**
+ * Regression for the boarding onboard failure that surfaced server-side as the
+ * opaque arkd error "script ... is not a wallet script" (arkd-wallet
+ * SignTransaction key-path branch): a boarding UTXO the wallet selected but
+ * whose script the signer router could not resolve was *silently skipped*, so
+ * its commitment-tx input reached the operator unsigned/leaf-less.
+ *
+ * The wallet now fails fast with a diagnostic naming the exact outpoint, the
+ * unresolved boarding address, and the boarding addresses it *does* recognize.
+ * This test pins that diagnostic (the harness mirrors walletBoardingRotation).
+ */
+
+const MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+const mockArkInfo = {
+    signerPubkey: SERVER_PUBKEY_HEX,
+    forfeitPubkey: SERVER_PUBKEY_HEX,
+    batchExpiry: BigInt(144),
+    unilateralExitDelay: BigInt(144),
+    boardingExitDelay: BigInt(144),
+    roundInterval: BigInt(144),
+    network: "mutinynet",
+    dust: BigInt(1000),
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    checkpointTapscript:
+        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+};
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
+
+vi.mock("../../src/utils/fetch", () => ({
+    fetch: mockFetch,
+    baseFetch: mockFetch,
+}));
+
+const MockEventSource = vi.fn().mockImplementation((url: string) => ({
+    url,
+    onmessage: null,
+    onerror: null,
+    close: vi.fn(),
+}));
+
+beforeEach(() => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    mockFetch.mockReset();
+    mockFetch.mockImplementation((url: string) => {
+        const reply = (body: unknown) =>
+            Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+        if (url.includes("/info")) return reply(mockArkInfo);
+        if (url.includes("subscribe") || url.includes("subscriptions"))
+            return reply({ subscriptionId: "sub-1" });
+        if (url.includes("vtxo") || url.includes("scripts")) return reply({ vtxos: [] });
+        return reply([]);
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+// A taproot scriptPubKey (OP_1 <32-byte key>) for a boarding address the wallet
+// does NOT own — stands in for the unresolved boarding script (e.g. a rotated
+// boarding address whose contract row is missing from the repo).
+const FOREIGN_BOARDING_SCRIPT = new Uint8Array([
+    0x51,
+    0x20,
+    ...hex.decode("4b19fd86e7e906094334b7f683aad231d472979a6109fba34b3a49fe0ea80df9"),
+]);
+
+describe("unsignable boarding input diagnostic", () => {
+    it("names the outpoint, the unresolved boarding address, and the recognized boarding set", async () => {
+        const wallet = await Wallet.create({
+            identity: MnemonicIdentity.fromMnemonic(MNEMONIC, { isMainnet: false }),
+            walletMode: "hd",
+            arkServerUrl: "http://localhost:7070",
+            storage: {
+                walletRepository: new InMemoryWalletRepository(),
+                contractRepository: new InMemoryContractRepository(),
+            },
+        });
+
+        const recognized = await wallet.getBoardingAddress();
+
+        const msg = await (wallet as any).unsignableBoardingInputError(
+            { txid: "0c2a677ca31a50d1745b9f49d43756b8a274e751e957d9cb7271960f87649243", vout: 2 },
+            FOREIGN_BOARDING_SCRIPT,
+        );
+
+        // Exact outpoint and script the operator would have rejected.
+        expect(msg).toContain("0c2a677ca31a50d1745b9f49d43756b8a274e751e957d9cb7271960f87649243:2");
+        expect(msg).toContain(hex.encode(FOREIGN_BOARDING_SCRIPT));
+        // Maps the cryptic server error to its client-side cause.
+        expect(msg).toContain("not a wallet script");
+        // Surfaces what the wallet *can* sign, so the offender is classifiable
+        // without introspecting wallet internals.
+        expect(msg).toContain(recognized);
+
+        await wallet.dispose();
+    });
+
+    it("never throws while building the error, even on an undecodable script", async () => {
+        const wallet = await Wallet.create({
+            identity: MnemonicIdentity.fromMnemonic(MNEMONIC, { isMainnet: false }),
+            walletMode: "hd",
+            arkServerUrl: "http://localhost:7070",
+            storage: {
+                walletRepository: new InMemoryWalletRepository(),
+                contractRepository: new InMemoryContractRepository(),
+            },
+        });
+
+        // A non-taproot / undecodable script must degrade to a placeholder, not
+        // throw — the signing error must never be masked by error-building.
+        const garbage = new Uint8Array([0x00, 0x01, 0x02]);
+        const msg = await (wallet as any).unsignableBoardingInputError(
+            { txid: "deadbeef", vout: 0 },
+            garbage,
+        );
+        expect(msg).toContain("deadbeef:0");
+        expect(msg).toContain("<undecodable>");
+
+        await wallet.dispose();
+    });
+});


### PR DESCRIPTION
## Summary

Onboarding certain boarding UTXOs fails — after every client signature and approval *succeeds* — with the opaque operator error:

> `failed to sign commitment tx: script <x> is not a wallet script`

Root cause is a **discovery↔signing asymmetry**, not batching:

- `Wallet.getBoardingTapscripts` (fund discovery) recognizes **three** boarding-script sources: the synthetic index‑0 baseline, the current display tapscript, and every persisted `boarding` contract row. So `getBoardingUtxos` will *select* a UTXO at any of them.
- `InputSignerRouter` (signing) resolves a boarding input only via a matching contract row **or** the single static `boardingPkScript` it was constructed with. Anything else is **silently skipped** — no signature, no error (intended for connector/cosigner inputs).

A selected-but-unresolved boarding input (e.g. a rotated boarding address whose contract row is missing/unresolvable in the repo) is therefore skipped → left unsigned. On the operator: `VerifyBoardingTapscriptSigs` drops unsigned inputs (`WithSkipUnsignedInputs`), so the leaf never merges into `round.CommitmentTx`; final `SignTransaction` then hits the key‑path branch the operator doesn't own → `"is not a wallet script"`. The trigger is **which boarding address** (its script's resolvability), **not** the number of inputs batched.

## What this PR does

This is a **defensive guard / diagnostic**, not the full routing fix. `handleSettlementFinalizationEvent` now verifies each boarding input received a tapscript spend signature after routing and, if not, throws **before submission** — naming the exact outpoint, the unresolved boarding address, and the boarding addresses the wallet *does* recognize. This converts a server-side mystery (and a confusing "all signatures succeeded, yet it failed") into an actionable client-side error.

It does **not** make an unresolvable boarding address signable. The full routing fix (make the signer resolve the same boarding-script set discovery spends, and/or restore the missing contract row / re-derive its descriptor) is tracked separately — it needs a repo-state classification of the offending address to choose the correct path safely.

## Test plan

- [x] New `test/wallet/unsignableBoardingInput.test.ts` pins the diagnostic message (outpoint, unresolved address, recognized set) and that error-building never throws on an undecodable script.
- [x] The silent-skip premise is already covered by `test/wallet/inputSignerRouter.test.ts` ("skips unknown script with no contract and no boarding match").
- [x] ts-sdk full unit suite: 1505 passed, 1 skipped, 0 failed.
- [x] boltz-swap unit suite: 389 passed (pre-commit hook).
- [x] `tsc --noEmit` clean; Prettier clean.

## Notes for reviewers

- The leaf-less rejection path does **not** trigger the operator's boarding-input ban (that's the leaf-present-but-unsigned branch), so affected UTXOs are not convicted.
- No change to signing behavior on the success path: the guard only fires for an input that received no signature — which would have failed at the operator anyway.