### PR TITLE
feat(providers): send X-SDK-VERSION header to arkd

### DIFF
--- a/packages/ts-sdk/src/providers/expoUtils.ts
+++ b/packages/ts-sdk/src/providers/expoUtils.ts
@@ -1,4 +1,4 @@
-import { fetch, buildVersion } from "../utils/fetch";
+import { fetch, buildVersion, sdkVersion } from "../utils/fetch";
 
 /**
  * Dynamically imports expo/fetch with fallback to standard fetch.
@@ -13,6 +13,7 @@ export async function getExpoFetch(options?: { requireExpo?: boolean }): Promise
         const expoFetchWithHeader = (input: RequestInfo, init?: RequestInit) => {
             const headers = new Headers(init?.headers);
             headers.set("X-Build-Version", buildVersion);
+            headers.set("X-SDK-VERSION", sdkVersion);
             return expoFetchModule.fetch(input, { ...init, headers });
         };
         return expoFetchWithHeader as unknown as typeof fetch;

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -1,4 +1,15 @@
+import { version } from "../../package.json";
+
 export const buildVersion = "0.9.9";
+
+/**
+ * The SDK's own version string, sent to arkd as `X-SDK-VERSION` so the operator
+ * can distinguish client builds. Formatted `ts-sdk/{version}` to namespace it by
+ * client. The version is sourced from package.json so it stays in sync with every
+ * release bump — unlike {@link buildVersion}, which tracks arkd's compatibility
+ * guard rather than this package's version.
+ */
+export const sdkVersion = `ts-sdk/${version}`;
 
 /**
  * Guarded passthrough to the platform `fetch` with no Arkade-specific headers.
@@ -15,11 +26,13 @@ export function baseFetch(input: RequestInfo, init?: RequestInit): Promise<Respo
 
 /**
  * `fetch` for the Ark server only: adds the `X-Build-Version` compatibility
- * header that arkd's version guard reads. Do NOT use it for other origins —
- * they reject the header in CORS preflight.
+ * header that arkd's version guard reads, plus the `X-SDK-VERSION` header
+ * carrying this package's own version. Do NOT use it for other origins — they
+ * reject these custom headers in CORS preflight.
  */
 export function fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
     const headers = new Headers(init?.headers);
     headers.set("X-Build-Version", buildVersion);
+    headers.set("X-SDK-VERSION", sdkVersion);
     return baseFetch(input, { ...init, headers });
 }

--- a/packages/ts-sdk/test/provider-build-version-header.test.ts
+++ b/packages/ts-sdk/test/provider-build-version-header.test.ts
@@ -1,38 +1,52 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { EsploraProvider, RestIndexerProvider } from "../src";
+import { EsploraProvider, RestArkProvider, RestIndexerProvider } from "../src";
+import { version as sdkVersion } from "../package.json";
 
 afterEach(() => vi.unstubAllGlobals());
 
-// X-Build-Version is an arkd-only compatibility header. The Esplora and indexer
-// services run on different origins whose CORS preflight rejects unknown request
-// headers, so these providers must use the header-less baseFetch (not the
-// X-Build-Version-adding fetch wrapper).
-describe("non-ark providers omit X-Build-Version (CORS)", () => {
-    function captureHeaders(): Headers[] {
-        const seen: Headers[] = [];
-        vi.stubGlobal(
-            "fetch",
-            vi.fn(async (_url: string, init?: RequestInit) => {
-                seen.push(new Headers(init?.headers));
-                return { ok: true, json: async () => [], text: async () => "[]" };
-            }),
-        );
-        return seen;
-    }
+function captureHeaders(json: () => any = async () => []): Headers[] {
+    const seen: Headers[] = [];
+    vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string, init?: RequestInit) => {
+            seen.push(new Headers(init?.headers));
+            return { ok: true, json, text: async () => "[]" };
+        }),
+    );
+    return seen;
+}
 
-    it("EsploraProvider does not send X-Build-Version", async () => {
+// X-Build-Version and X-SDK-VERSION are arkd-only custom headers. The Esplora
+// and indexer services run on different origins whose CORS preflight rejects
+// unknown request headers, so these providers must use the header-less baseFetch
+// (not the header-adding fetch wrapper).
+describe("non-ark providers omit arkd-only headers (CORS)", () => {
+    it("EsploraProvider does not send X-Build-Version or X-SDK-VERSION", async () => {
         const seen = captureHeaders();
         await new EsploraProvider("https://esplora.test").getCoins("addr").catch(() => undefined);
         expect(seen.length).toBeGreaterThan(0);
         expect(seen[0].has("X-Build-Version")).toBe(false);
+        expect(seen[0].has("X-SDK-VERSION")).toBe(false);
     });
 
-    it("RestIndexerProvider does not send X-Build-Version", async () => {
+    it("RestIndexerProvider does not send X-Build-Version or X-SDK-VERSION", async () => {
         const seen = captureHeaders();
         await new RestIndexerProvider("https://indexer.test")
             .getVtxoTree({ txid: "aa".repeat(32), vout: 0 })
             .catch(() => undefined);
         expect(seen.length).toBeGreaterThan(0);
         expect(seen[0].has("X-Build-Version")).toBe(false);
+        expect(seen[0].has("X-SDK-VERSION")).toBe(false);
+    });
+});
+
+// The Ark server is the one origin that accepts (and reads) these headers.
+describe("RestArkProvider sends arkd compatibility headers", () => {
+    it("sends X-SDK-VERSION carrying the package version", async () => {
+        const seen = captureHeaders(async () => ({}));
+        await new RestArkProvider("https://ark.test").getInfo().catch(() => undefined);
+        expect(seen.length).toBeGreaterThan(0);
+        expect(seen[0].get("X-Build-Version")).toBe("0.9.9");
+        expect(seen[0].get("X-SDK-VERSION")).toBe(`ts-sdk/${sdkVersion}`);
     });
 });


### PR DESCRIPTION
## Summary

Adds an `X-SDK-VERSION` request header alongside the existing `X-Build-Version` on the **arkd-only** fetch path, so the operator can identify which client (and version) is talking to it.

- Value format: `ts-sdk/{version}` (e.g. `ts-sdk/0.4.34`).
- The version is sourced from `package.json` (`import { version }`), so it stays in sync with every `release.mjs` bump automatically. This differs from `buildVersion = "0.9.9"`, which tracks arkd's *compatibility* guard rather than this package's own version.
- Set in both header-adding sites: the shared `fetch` wrapper (`src/utils/fetch.ts`) and the `expo/fetch` wrapper (`src/providers/expoUtils.ts`).
- Kept **off** non-ark origins (Esplora, indexer, delegate): `X-SDK-VERSION` is a custom header, and those origins reject unknown headers in the CORS preflight — same constraint that already applies to `X-Build-Version`.

The bundler tree-shakes the JSON import down to just the version literal; the full `package.json` does not end up in `dist`.

## Test plan

- New positive test: `RestArkProvider.getInfo()` sends `X-Build-Version: 0.9.9` and `X-SDK-VERSION: ts-sdk/<pkg version>`.
- Extended the non-ark CORS tests: `EsploraProvider` and `RestIndexerProvider` assert they send **neither** `X-Build-Version` nor `X-SDK-VERSION`.
- Full ts-sdk unit suite green (76 files, 1504 passed, 1 pre-existing skip); `tsc --noEmit` clean; `tsup` build clean (DTS generated).

## Note for reviewers

The exact header **name** `X-SDK-VERSION` and the `ts-sdk/{version}` value format should be confirmed against what arkd / the NArk reference implementation actually reads — I could not verify against a local dotnet-sdk checkout.