### PR TITLE
fix(worker): guard service-worker init against stale identity binding

### DIFF
--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -310,7 +310,9 @@ import {
     DelegatorNotConfiguredError,
 } from "./wallet/serviceWorker/wallet-message-handler";
 import {
+    MESSAGE_BUS_INITIALIZING,
     MESSAGE_BUS_NOT_INITIALIZED,
+    MessageBusInitializingError,
     MessageBusNotInitializedError,
     ServiceWorkerTimeoutError,
 } from "./worker/errors";
@@ -374,7 +376,9 @@ export {
     ReadonlyWalletError,
     DelegateNotConfiguredError,
     DelegatorNotConfiguredError,
+    MESSAGE_BUS_INITIALIZING,
     MESSAGE_BUS_NOT_INITIALIZED,
+    MessageBusInitializingError,
     MessageBusNotInitializedError,
     ServiceWorkerTimeoutError,
     ServiceWorkerWallet,

--- a/packages/ts-sdk/src/providers/electrum.ts
+++ b/packages/ts-sdk/src/providers/electrum.ts
@@ -1024,6 +1024,16 @@ function errorText(err: unknown): string {
 }
 
 /**
+ * Lowercased, whitespace-stripped error text for substring matching.
+ * `ws-electrumx-client`'s frame parser drops the spaces inside server error
+ * messages, so we strip whitespace from both sides (matching against the
+ * whitespace-free needles below) to classify regardless of the mangling.
+ */
+function normalizedErrorText(err: unknown): string {
+    return errorText(err).toLowerCase().replace(/\s+/g, "");
+}
+
+/**
  * Recognise the "block header not yet indexable" failure shape returned by
  * electrum servers (electrs in particular) when `block.header(N)` runs
  * against a height that's already in `listunspent`/`get_merkle` but hasn't
@@ -1032,7 +1042,7 @@ function errorText(err: unknown): string {
  * failures (auth/network) propagate.
  */
 function isMissingHeightError(err: unknown): boolean {
-    return errorText(err).toLowerCase().includes("missingheight");
+    return normalizedErrorText(err).includes("missingheight");
 }
 
 /**
@@ -1043,12 +1053,15 @@ function isMissingHeightError(err: unknown): boolean {
  * malformed response) still propagate.
  */
 function isTxNotInBlockError(err: unknown): boolean {
-    const normalized = errorText(err).toLowerCase();
+    // Needles are whitespace-free because normalizedErrorText() strips spaces
+    // from the haystack (see its doc); they still match servers that send the
+    // wording with spaces intact.
+    const normalized = normalizedErrorText(err);
     return (
-        normalized.includes("not yet in a block") ||
-        normalized.includes("not in a block") ||
-        normalized.includes("not in block") ||
-        normalized.includes("no confirmed transaction")
+        normalized.includes("notyetinablock") ||
+        normalized.includes("notinablock") ||
+        normalized.includes("notinblock") ||
+        normalized.includes("noconfirmedtransaction")
     );
 }
 

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -154,18 +154,10 @@ import {
 } from "../../worker/errors";
 import { getArkadeServerUrl } from "../wallet";
 
-// Check by error message content instead of instanceof because postMessage uses the
-// structured clone algorithm which strips the prototype chain — the page
-// receives a plain Error, not the original MessageBusNotInitializedError.
 function isMessageBusNotInitializedError(error: unknown): boolean {
     return error instanceof Error && error.message.includes(MESSAGE_BUS_NOT_INITIALIZED);
 }
 
-// The "initializing" message is a superset of MESSAGE_BUS_NOT_INITIALIZED, so
-// isMessageBusNotInitializedError is also true for it — callers must check this
-// more specific predicate FIRST. It signals an init is already in flight in the
-// worker; the right reaction is to wait and retry the same message rather than
-// enqueue a redundant re-init.
 function isMessageBusInitializingError(error: unknown): boolean {
     return error instanceof Error && error.message.includes(MESSAGE_BUS_INITIALIZING);
 }
@@ -818,11 +810,13 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
 
     // send a message, retrying up to 2 times if the service worker was
     // killed and restarted by the OS (mobile browsers do this aggressively)
-    private async sendMessageWithRetry(
+    protected async sendMessageWithRetry(
         request: WalletUpdaterRequest,
+        withEvents?: {
+            onEvent: (response: WalletUpdaterResponse) => void;
+            isComplete: (response: WalletUpdaterResponse) => boolean;
+        },
     ): Promise<WalletUpdaterResponse> {
-        // Skip the preflight ping during the initial INIT_WALLET call:
-        // create() hasn't set initConfig yet, so reinitialize() would throw.
         if (this.initConfig) {
             try {
                 await this.pingServiceWorker();
@@ -835,49 +829,16 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         const maxRetries = 2;
         for (let attempt = 0, initWaits = 0; ; attempt++) {
             try {
+                if (withEvents) {
+                    return await this.sendMessageStreaming(
+                        request,
+                        withEvents.onEvent,
+                        withEvents.isComplete,
+                    );
+                }
                 return await this.sendMessageDirect(request, timeoutMs);
             } catch (error: any) {
-                // An init is already in flight in the worker. Wait for it to
-                // settle and retry the same message; do not enqueue a redundant
-                // re-init behind it. A wait does not consume the re-init budget.
-                if (isMessageBusInitializingError(error)) {
-                    if (initWaits >= MAX_INIT_WAITS) throw error;
-                    await sleep(initWaitBackoffMs(initWaits++));
-                    attempt--;
-                    continue;
-                }
-                if (!isMessageBusNotInitializedError(error) || attempt >= maxRetries) {
-                    throw error;
-                }
-
-                await this.reinitialize();
-            }
-        }
-    }
-
-    // Like sendMessage but for streaming responses — retries with
-    // reinitialize when the service worker has been killed/restarted.
-    protected async sendMessageWithEvents(
-        request: WalletUpdaterRequest,
-        onEvent: (response: WalletUpdaterResponse) => void,
-        isComplete: (response: WalletUpdaterResponse) => boolean,
-    ): Promise<WalletUpdaterResponse> {
-        if (this.initConfig) {
-            try {
-                await this.pingServiceWorker();
-            } catch {
-                await this.reinitialize();
-            }
-        }
-
-        const maxRetries = 2;
-        for (let attempt = 0, initWaits = 0; ; attempt++) {
-            try {
-                return await this.sendMessageStreaming(request, onEvent, isComplete);
-            } catch (error: any) {
-                // An init is already in flight in the worker. Wait for it to
-                // settle and retry the same message; do not enqueue a redundant
-                // re-init behind it. A wait does not consume the re-init budget.
+                // If init is already in flight in the worker, wait for it
                 if (isMessageBusInitializingError(error)) {
                     if (initWaits >= MAX_INIT_WAITS) throw error;
                     await sleep(initWaitBackoffMs(initWaits++));
@@ -977,17 +938,8 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
      * Verify the worker is bound to this wallet's identity before the SDK hands
      * back (or recovers) a usable wallet object.
      *
-     * A completed `INITIALIZE_MESSAGE_BUS` only proves that *an* init ran; with
-     * FIFO-serialized inits a later or stale/retried init can still rebind the
-     * worker to a different identity. `GET_STATUS` reports the worker's live
-     * x-only pubkey, so comparing it against this identity catches a
-     * wrong-identity binding before `getAddress()` / `getBoardingAddress()` can
-     * return another wallet's address — a loss-of-funds path.
-     *
-     * Compares the stable baseline identity key (`identity.xOnlyPublicKey()`),
-     * not the current rotated receive/boarding key, so HD wallets keep matching
-     * after rotation. Sent via `sendMessageDirect` (no ping/retry/reinit) so it
-     * cannot recurse into `reinitialize()` when called from within it.
+     * Compares the stable baseline identity key (`identity.xOnlyPublicKey()`) to the one reported
+     * by the worker via GET_STATUS.
      */
     protected async assertWorkerIdentityMatches(): Promise<void> {
         const expected = hex.encode(await this.identity.xOnlyPublicKey());
@@ -1003,8 +955,6 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         )) as ResponseGetStatus;
 
         const workerKey = response.payload.xOnlyPublicKey;
-        // A worker that cannot prove its identity must not be trusted to serve
-        // addresses.
         if (!workerKey) {
             throw new Error("Service worker identity mismatch: worker did not report an identity");
         }
@@ -1590,11 +1540,10 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
         };
 
         try {
-            const response = await this.sendMessageWithEvents(
-                message,
-                (resp) => callback?.((resp as ResponseSettleEvent).payload),
-                (resp) => resp.type === "SETTLE_SUCCESS",
-            );
+            const response = await this.sendMessageWithRetry(message, {
+                onEvent: (resp) => callback?.((resp as ResponseSettleEvent).payload),
+                isComplete: (resp) => resp.type === "SETTLE_SUCCESS",
+            });
             return (response as ResponseSettle).payload.txid;
         } catch (error) {
             throw new Error(`Settlement failed: ${error}`);
@@ -1621,11 +1570,10 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
         };
 
         try {
-            await this.sendMessageWithEvents(
-                message,
-                () => {},
-                (resp) => resp.type === "RESTORE_WALLET_SUCCESS",
-            );
+            await this.sendMessageWithRetry(message, {
+                onEvent: () => {},
+                isComplete: (resp) => resp.type === "RESTORE_WALLET_SUCCESS",
+            });
         } catch (error: unknown) {
             if (isSerializedAggregateError(error)) {
                 throw deserializeAggregateError(error);
@@ -1724,11 +1672,11 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
                     id: getRandomId(),
                 };
                 try {
-                    const response = await wallet.sendMessageWithEvents(
-                        message,
-                        (resp) => eventCallback?.((resp as ResponseRecoverVtxosEvent).payload),
-                        (resp) => resp.type === "RECOVER_VTXOS_SUCCESS",
-                    );
+                    const response = await wallet.sendMessageWithRetry(message, {
+                        onEvent: (resp) =>
+                            eventCallback?.((resp as ResponseRecoverVtxosEvent).payload),
+                        isComplete: (resp) => resp.type === "RECOVER_VTXOS_SUCCESS",
+                    });
                     return (response as ResponseRecoverVtxos).payload.txid;
                 } catch (e) {
                     throw new Error(`Failed to recover vtxos: ${e}`);
@@ -1781,11 +1729,11 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
                     payload: options,
                 };
                 try {
-                    const response = await wallet.sendMessageWithEvents(
-                        message,
-                        (resp) => eventCallback?.((resp as ResponseRenewVtxosEvent).payload),
-                        (resp) => resp.type === "RENEW_VTXOS_SUCCESS",
-                    );
+                    const response = await wallet.sendMessageWithRetry(message, {
+                        onEvent: (resp) =>
+                            eventCallback?.((resp as ResponseRenewVtxosEvent).payload),
+                        isComplete: (resp) => resp.type === "RENEW_VTXOS_SUCCESS",
+                    });
                     return (response as ResponseRenewVtxos).payload.txid;
                 } catch (e) {
                     throw new Error(`Failed to renew vtxos: ${e}`);
@@ -1829,14 +1777,14 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
                     id: getRandomId(),
                 };
                 try {
-                    const response = await wallet.sendMessageWithEvents(
-                        message,
-                        (resp) =>
+                    const response = await wallet.sendMessageWithRetry(message, {
+                        onEvent: (resp) =>
                             options?.eventCallback?.(
                                 (resp as ResponseMigrateDeprecatedSignerVtxosEvent).payload,
                             ),
-                        (resp) => resp.type === "MIGRATE_DEPRECATED_SIGNER_VTXOS_SUCCESS",
-                    );
+                        isComplete: (resp) =>
+                            resp.type === "MIGRATE_DEPRECATED_SIGNER_VTXOS_SUCCESS",
+                    });
                     return deserializeMigrationReport(
                         (response as ResponseMigrateDeprecatedSignerVtxos).payload.report,
                     );

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -147,7 +147,11 @@ import type { ContractWatcherConfig } from "../../contracts/contractWatcher";
 import type { DelegateInfo } from "../../providers/delegate";
 import { getRandomId } from "../utils";
 import type { VirtualCoin } from "..";
-import { MESSAGE_BUS_NOT_INITIALIZED, ServiceWorkerTimeoutError } from "../../worker/errors";
+import {
+    MESSAGE_BUS_INITIALIZING,
+    MESSAGE_BUS_NOT_INITIALIZED,
+    ServiceWorkerTimeoutError,
+} from "../../worker/errors";
 import { getArkadeServerUrl } from "../wallet";
 
 // Check by error message content instead of instanceof because postMessage uses the
@@ -156,6 +160,24 @@ import { getArkadeServerUrl } from "../wallet";
 function isMessageBusNotInitializedError(error: unknown): boolean {
     return error instanceof Error && error.message.includes(MESSAGE_BUS_NOT_INITIALIZED);
 }
+
+// The "initializing" message is a superset of MESSAGE_BUS_NOT_INITIALIZED, so
+// isMessageBusNotInitializedError is also true for it — callers must check this
+// more specific predicate FIRST. It signals an init is already in flight in the
+// worker; the right reaction is to wait and retry the same message rather than
+// enqueue a redundant re-init.
+function isMessageBusInitializingError(error: unknown): boolean {
+    return error instanceof Error && error.message.includes(MESSAGE_BUS_INITIALIZING);
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// Bounded backoff for waiting out an in-flight init: ~100ms, 200ms, … capped at
+// 2s, so a stuck init still surfaces an error instead of hanging the caller.
+const INIT_WAIT_BACKOFF_CAP_MS = 2_000;
+const MAX_INIT_WAITS = 8;
+const initWaitBackoffMs = (attempt: number) =>
+    Math.min(100 * 2 ** attempt, INIT_WAIT_BACKOFF_CAP_MS);
 
 type RequestType = WalletUpdaterRequest["type"];
 
@@ -627,6 +649,10 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         wallet.messageBusTimeoutMs = options.messageBusTimeoutMs;
         wallet.messageTimeouts = messageTimeouts;
 
+        // Refuse to return a wallet bound to a different identity than the
+        // worker ended up with (e.g. a stale/queued init rebinding it).
+        await wallet.assertWorkerIdentityMatches();
+
         return wallet;
     }
 
@@ -807,10 +833,19 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
 
         const timeoutMs = this.getTimeoutForRequest(request);
         const maxRetries = 2;
-        for (let attempt = 0; ; attempt++) {
+        for (let attempt = 0, initWaits = 0; ; attempt++) {
             try {
                 return await this.sendMessageDirect(request, timeoutMs);
             } catch (error: any) {
+                // An init is already in flight in the worker. Wait for it to
+                // settle and retry the same message; do not enqueue a redundant
+                // re-init behind it. A wait does not consume the re-init budget.
+                if (isMessageBusInitializingError(error)) {
+                    if (initWaits >= MAX_INIT_WAITS) throw error;
+                    await sleep(initWaitBackoffMs(initWaits++));
+                    attempt--;
+                    continue;
+                }
                 if (!isMessageBusNotInitializedError(error) || attempt >= maxRetries) {
                     throw error;
                 }
@@ -836,10 +871,19 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         }
 
         const maxRetries = 2;
-        for (let attempt = 0; ; attempt++) {
+        for (let attempt = 0, initWaits = 0; ; attempt++) {
             try {
                 return await this.sendMessageStreaming(request, onEvent, isComplete);
             } catch (error: any) {
+                // An init is already in flight in the worker. Wait for it to
+                // settle and retry the same message; do not enqueue a redundant
+                // re-init behind it. A wait does not consume the re-init budget.
+                if (isMessageBusInitializingError(error)) {
+                    if (initWaits >= MAX_INIT_WAITS) throw error;
+                    await sleep(initWaitBackoffMs(initWaits++));
+                    attempt--;
+                    continue;
+                }
                 if (!isMessageBusNotInitializedError(error) || attempt >= maxRetries) {
                     throw error;
                 }
@@ -921,11 +965,55 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             };
 
             await this.sendMessageDirect(initMessage, this.getTimeoutForRequest(initMessage));
+            await this.assertWorkerIdentityMatches();
         })().finally(() => {
             this.reinitPromise = null;
         });
 
         return this.reinitPromise;
+    }
+
+    /**
+     * Verify the worker is bound to this wallet's identity before the SDK hands
+     * back (or recovers) a usable wallet object.
+     *
+     * A completed `INITIALIZE_MESSAGE_BUS` only proves that *an* init ran; with
+     * FIFO-serialized inits a later or stale/retried init can still rebind the
+     * worker to a different identity. `GET_STATUS` reports the worker's live
+     * x-only pubkey, so comparing it against this identity catches a
+     * wrong-identity binding before `getAddress()` / `getBoardingAddress()` can
+     * return another wallet's address — a loss-of-funds path.
+     *
+     * Compares the stable baseline identity key (`identity.xOnlyPublicKey()`),
+     * not the current rotated receive/boarding key, so HD wallets keep matching
+     * after rotation. Sent via `sendMessageDirect` (no ping/retry/reinit) so it
+     * cannot recurse into `reinitialize()` when called from within it.
+     */
+    protected async assertWorkerIdentityMatches(): Promise<void> {
+        const expected = hex.encode(await this.identity.xOnlyPublicKey());
+
+        const message: RequestGetStatus = {
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "GET_STATUS",
+        };
+        const response = (await this.sendMessageDirect(
+            message,
+            this.getTimeoutForRequest(message),
+        )) as ResponseGetStatus;
+
+        const workerKey = response.payload.xOnlyPublicKey;
+        // A worker that cannot prove its identity must not be trusted to serve
+        // addresses.
+        if (!workerKey) {
+            throw new Error("Service worker identity mismatch: worker did not report an identity");
+        }
+        const actual = hex.encode(workerKey);
+        if (actual !== expected) {
+            throw new Error(
+                `Service worker identity mismatch: expected ${expected}, got ${actual}`,
+            );
+        }
     }
 
     /** Clear cached wallet state from both the page and service worker storage. */
@@ -1439,6 +1527,10 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
         wallet.initWalletPayload = initWalletPayload;
         wallet.messageBusTimeoutMs = options.messageBusTimeoutMs;
         wallet.messageTimeouts = messageTimeouts;
+
+        // Refuse to return a wallet bound to a different identity than the
+        // worker ended up with (e.g. a stale/queued init rebinding it).
+        await wallet.assertWorkerIdentityMatches();
 
         return wallet;
     }

--- a/packages/ts-sdk/src/worker/errors.ts
+++ b/packages/ts-sdk/src/worker/errors.ts
@@ -1,28 +1,18 @@
 export const MESSAGE_BUS_NOT_INITIALIZED = "MessageBus not initialized";
 
 /**
- * Message for the "an init is in flight" variant. It is a superset of
- * MESSAGE_BUS_NOT_INITIALIZED so the existing substring detector keeps
- * classifying it as "not initialized" — older callers (and third-party
- * embedders) treat it as retryable exactly as before, while updated callers
- * can match the more specific marker to wait instead of forcing a re-init.
+ * Message for the "an init is in flight" variant.
+ * It is a superset of MESSAGE_BUS_NOT_INITIALIZED so the existing consumers
+ * keeps classifying it as "not initialized".
  */
 export const MESSAGE_BUS_INITIALIZING = `${MESSAGE_BUS_NOT_INITIALIZED}: initializing`;
 
 export class MessageBusNotInitializedError extends Error {
-    // Default keeps existing no-arg call sites unchanged.
     constructor(message: string = MESSAGE_BUS_NOT_INITIALIZED) {
         super(message);
     }
 }
 
-/**
- * Thrown when a wallet message arrives while an `INITIALIZE_MESSAGE_BUS` is
- * still queued or running. Distinct from {@link MessageBusNotInitializedError}
- * (worker never initialized / was killed) so the caller can wait for the
- * in-flight init rather than enqueuing a redundant one. Subclasses
- * `MessageBusNotInitializedError` so `instanceof` checks stay true.
- */
 export class MessageBusInitializingError extends MessageBusNotInitializedError {
     constructor() {
         super(MESSAGE_BUS_INITIALIZING);

--- a/packages/ts-sdk/src/worker/errors.ts
+++ b/packages/ts-sdk/src/worker/errors.ts
@@ -1,8 +1,31 @@
 export const MESSAGE_BUS_NOT_INITIALIZED = "MessageBus not initialized";
 
+/**
+ * Message for the "an init is in flight" variant. It is a superset of
+ * MESSAGE_BUS_NOT_INITIALIZED so the existing substring detector keeps
+ * classifying it as "not initialized" — older callers (and third-party
+ * embedders) treat it as retryable exactly as before, while updated callers
+ * can match the more specific marker to wait instead of forcing a re-init.
+ */
+export const MESSAGE_BUS_INITIALIZING = `${MESSAGE_BUS_NOT_INITIALIZED}: initializing`;
+
 export class MessageBusNotInitializedError extends Error {
+    // Default keeps existing no-arg call sites unchanged.
+    constructor(message: string = MESSAGE_BUS_NOT_INITIALIZED) {
+        super(message);
+    }
+}
+
+/**
+ * Thrown when a wallet message arrives while an `INITIALIZE_MESSAGE_BUS` is
+ * still queued or running. Distinct from {@link MessageBusNotInitializedError}
+ * (worker never initialized / was killed) so the caller can wait for the
+ * in-flight init rather than enqueuing a redundant one. Subclasses
+ * `MessageBusNotInitializedError` so `instanceof` checks stay true.
+ */
+export class MessageBusInitializingError extends MessageBusNotInitializedError {
     constructor() {
-        super(MESSAGE_BUS_NOT_INITIALIZED);
+        super(MESSAGE_BUS_INITIALIZING);
     }
 }
 

--- a/packages/ts-sdk/src/worker/messageBus.ts
+++ b/packages/ts-sdk/src/worker/messageBus.ts
@@ -16,7 +16,11 @@ import { ReadonlyWallet, Wallet } from "../wallet/wallet";
 import type { SettlementConfig } from "../wallet/vtxo-manager";
 import type { ContractWatcherConfig } from "../contracts/contractWatcher";
 import { ContractRepository, WalletRepository } from "../repositories";
-import { MessageBusNotInitializedError, ServiceWorkerTimeoutError } from "./errors";
+import {
+    MessageBusInitializingError,
+    MessageBusNotInitializedError,
+    ServiceWorkerTimeoutError,
+} from "./errors";
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -164,6 +168,21 @@ export class MessageBus {
     private tickInProgress = false;
     private debug = false;
     private initialized = false;
+    /**
+     * FIFO chain that serializes `INITIALIZE_MESSAGE_BUS` handling. Each init
+     * runs to completion in enqueue order so a later init can never interleave
+     * with — or finish before — an earlier one and bind the bus to a stale
+     * identity. The stored promise is kept healed (`.catch`) so a rejected
+     * init never blocks the next request.
+     */
+    private initChain: Promise<void> = Promise.resolve();
+    /**
+     * Number of inits accepted but not yet settled (queued or running). The
+     * bus refuses ordinary wallet messages while this is > 0 so the previous
+     * wallet is no longer served the moment a new init is accepted, even
+     * before that init begins running.
+     */
+    private pendingInitCount = 0;
     private readonly buildServicesFn: (config: Initialize["config"]) => Promise<{
         arkProvider: ArkProvider;
         wallet?: Wallet;
@@ -292,7 +311,39 @@ export class MessageBus {
         }
     }
 
-    private async waitForInit(config: Initialize["config"]) {
+    /**
+     * Serialize init requests on {@link initChain}. The bus stops serving the
+     * old wallet as soon as a new init is accepted (via `pendingInitCount`),
+     * even while this request is still queued behind an older one. Returns
+     * this init's own result, but heals the stored chain so a rejected init
+     * never blocks the next request.
+     */
+    private waitForInit(config: Initialize["config"]): Promise<void> {
+        this.pendingInitCount += 1;
+
+        const run = this.initChain
+            .then(
+                () => this.doInit(config),
+                () => this.doInit(config),
+            )
+            .finally(() => {
+                this.pendingInitCount -= 1;
+            });
+        this.initChain = run.catch(() => undefined);
+        return run;
+    }
+
+    /**
+     * The bus serves ordinary wallet messages only when it is initialized and
+     * no init is in flight. A pending init (queued or running) makes the bus
+     * unavailable even though the currently bound handlers may still point at
+     * a previously initialized wallet.
+     */
+    private acceptsWalletMessages(): boolean {
+        return this.initialized && this.pendingInitCount === 0;
+    }
+
+    private async doInit(config: Initialize["config"]) {
         if (this.initialized) {
             // Stop existing handlers before re-initializing.
             // This handles the case where CLEAR was called, which nullifies
@@ -316,12 +367,22 @@ export class MessageBus {
         };
 
         const services = await this.buildServicesFn(config);
-        // Start all handlers
-        for (const updater of this.handlers.values()) {
-            if (this.debug) console.log(`Starting updater: ${updater.messageTag}`);
-            await updater.start(services, {
-                walletRepository: this.walletRepository,
-            });
+        // Start all handlers. Track the ones that started so a later failure
+        // can roll them back — a partial service set must not survive a
+        // failed init.
+        const started: MessageHandler[] = [];
+        try {
+            for (const updater of this.handlers.values()) {
+                if (this.debug) console.log(`Starting updater: ${updater.messageTag}`);
+                await updater.start(services, {
+                    walletRepository: this.walletRepository,
+                });
+                started.push(updater);
+            }
+        } catch (err) {
+            await Promise.all(started.map((h) => h.stop().catch(() => {})));
+            this.initialized = false;
+            throw err;
         }
 
         // Kick off scheduler
@@ -404,28 +465,45 @@ export class MessageBus {
             // Intentionally not wrapped with withTimeout: initialization
             // performs network calls (buildServices) and handler startup
             // that may legitimately exceed the message timeout.
-            await this.waitForInit(event.data.config);
-            this.deliverResponse(event.source, { id, tag }, { id, tag });
-            if (this.debug) {
-                console.log("MessageBus initialized");
+            try {
+                await this.waitForInit(event.data.config);
+                this.deliverResponse(event.source, { id, tag }, { id, tag });
+                if (this.debug) {
+                    console.log("MessageBus initialized");
+                }
+            } catch (error) {
+                // Deliver the failure so the page fails fast instead of
+                // waiting for its own timeout, and a failed init does not
+                // poison the next queued one. Do not rethrow: event.waitUntil
+                // must observe a handled init message, not turn an
+                // already-reported failure into an unhandled worker error.
+                if (this.debug) console.error("MessageBus init failed", error);
+                this.deliverResponse(event.source, { id, tag, error: toError(error) }, { id, tag });
             }
             return;
         }
 
-        if (!this.initialized) {
+        if (!this.acceptsWalletMessages()) {
             if (this.debug)
-                console.warn("Event received before initialization, dropping", event.data);
+                console.warn("Event received while bus unavailable, dropping", event.data);
             // Send error response so the caller's promise rejects instead of
-            // hanging forever. This happens when the browser kills and restarts
-            // the service worker — the new instance has initialized=false and
-            // messages arrive before INITIALIZE_MESSAGE_BUS is re-sent.
+            // hanging forever. Distinguish the two unavailable states so the
+            // page can react correctly:
+            //  - an init is in flight (queued or running) → the caller should
+            //    wait for it and retry the same message, NOT force a re-init;
+            //  - otherwise the worker was never initialized / was killed and
+            //    restarted → the caller should (re)initialize.
             const fallbackTag = tag ?? "unknown";
+            const error =
+                this.pendingInitCount > 0
+                    ? new MessageBusInitializingError()
+                    : new MessageBusNotInitializedError();
             this.deliverResponse(
                 event.source,
                 {
                     id,
                     tag: fallbackTag,
-                    error: new MessageBusNotInitializedError(),
+                    error,
                 },
                 { id, tag: fallbackTag },
             );

--- a/packages/ts-sdk/src/worker/messageBus.ts
+++ b/packages/ts-sdk/src/worker/messageBus.ts
@@ -170,17 +170,12 @@ export class MessageBus {
     private initialized = false;
     /**
      * FIFO chain that serializes `INITIALIZE_MESSAGE_BUS` handling. Each init
-     * runs to completion in enqueue order so a later init can never interleave
-     * with — or finish before — an earlier one and bind the bus to a stale
-     * identity. The stored promise is kept healed (`.catch`) so a rejected
-     * init never blocks the next request.
+     * runs to completion in enqueue order.
      */
     private initChain: Promise<void> = Promise.resolve();
     /**
      * Number of inits accepted but not yet settled (queued or running). The
-     * bus refuses ordinary wallet messages while this is > 0 so the previous
-     * wallet is no longer served the moment a new init is accepted, even
-     * before that init begins running.
+     * bus refuses ordinary wallet messages while this is > 0.
      */
     private pendingInitCount = 0;
     private readonly buildServicesFn: (config: Initialize["config"]) => Promise<{
@@ -269,16 +264,13 @@ export class MessageBus {
         if (!this.running) return;
         if (this.tickInProgress) return;
 
-        // The fired timer has elapsed; drop its handle first so an early
-        // return below cannot leave a stale handle that wedges scheduleNextTick().
         if (this.tickTimeout !== null) {
+            // The fired timer has elapsed: clear its handle.
             self.clearTimeout(this.tickTimeout);
             this.tickTimeout = null;
         }
 
-        // Never tick while an init is queued or running: doInit() stops and
-        // rebuilds handlers, so ticking them would touch stale/half-reset
-        // state. doInit() re-arms the scheduler once it completes.
+        // Never tick while an init is queued or running
         if (this.pendingInitCount > 0) return;
 
         this.tickInProgress = true;
@@ -321,11 +313,8 @@ export class MessageBus {
     }
 
     /**
-     * Serialize init requests on {@link initChain}. The bus stops serving the
-     * old wallet as soon as a new init is accepted (via `pendingInitCount`),
-     * even while this request is still queued behind an older one. Returns
-     * this init's own result, but heals the stored chain so a rejected init
-     * never blocks the next request.
+     * Serialize init requests on {@link initChain}.
+     * Returns this init's own result.
      */
     private waitForInit(config: Initialize["config"]): Promise<void> {
         this.pendingInitCount += 1;
@@ -333,6 +322,7 @@ export class MessageBus {
         const run = this.initChain
             .then(
                 () => this.doInit(config),
+                // A rejected init never blocks the next request.
                 () => this.doInit(config),
             )
             .finally(() => {
@@ -343,10 +333,8 @@ export class MessageBus {
     }
 
     /**
-     * The bus serves ordinary wallet messages only when it is initialized and
-     * no init is in flight. A pending init (queued or running) makes the bus
-     * unavailable even though the currently bound handlers may still point at
-     * a previously initialized wallet.
+     * The bus serves ordinary wallet messages only when it is initialized AND
+     * no init is in flight.
      */
     private acceptsWalletMessages(): boolean {
         return this.initialized && this.pendingInitCount === 0;
@@ -354,39 +342,26 @@ export class MessageBus {
 
     private async doInit(config: Initialize["config"]) {
         // Cancel any tick scheduled by a previous init so it cannot fire while
-        // handlers are stopped or rebuilt below (the awaits in this method
-        // yield to the event loop). scheduleNextTick() re-arms after a
-        // successful start.
+        // handlers are stopped or rebuilt.
         if (this.tickTimeout !== null) {
             self.clearTimeout(this.tickTimeout);
             this.tickTimeout = null;
         }
         if (this.initialized) {
-            // Stop existing handlers before re-initializing.
-            // This handles the case where CLEAR was called, which nullifies
-            // handler state (readonlyWallet, etc.) without resetting the
-            // initialized flag. Without this, handlers never get start()
-            // called again and all messages fail with "not initialized".
-            //
             // Clear the flag first so onMessage() rejects incoming messages
-            // during the stop/start window instead of routing them to
-            // half-reset handlers. Restored to true after start() completes.
             this.initialized = false;
+            // Stop existing handlers before re-initializing.
             await Promise.all(
                 Array.from(this.handlers.values()).map((h) => h.stop().catch(() => {})),
             );
         }
-        // Recompute the active timeout map from scratch so a prior init's
-        // keys cannot linger after re-init with a smaller map.
         this.messageTimeoutOverrides = {
             ...this.constructorTimeoutOverrides,
             ...(config.messageTimeouts ?? {}),
         };
 
         const services = await this.buildServicesFn(config);
-        // Start all handlers. Track the ones that started so a later failure
-        // can roll them back — a partial service set must not survive a
-        // failed init.
+
         const started: MessageHandler[] = [];
         try {
             for (const updater of this.handlers.values()) {
@@ -489,11 +464,7 @@ export class MessageBus {
                     console.log("MessageBus initialized");
                 }
             } catch (error) {
-                // Deliver the failure so the page fails fast instead of
-                // waiting for its own timeout, and a failed init does not
-                // poison the next queued one. Do not rethrow: event.waitUntil
-                // must observe a handled init message, not turn an
-                // already-reported failure into an unhandled worker error.
+                // Deliver the failure so the page fails fast
                 if (this.debug) console.error("MessageBus init failed", error);
                 this.deliverResponse(event.source, { id, tag, error: toError(error) }, { id, tag });
             }
@@ -503,13 +474,7 @@ export class MessageBus {
         if (!this.acceptsWalletMessages()) {
             if (this.debug)
                 console.warn("Event received while bus unavailable, dropping", event.data);
-            // Send error response so the caller's promise rejects instead of
-            // hanging forever. Distinguish the two unavailable states so the
-            // page can react correctly:
-            //  - an init is in flight (queued or running) → the caller should
-            //    wait for it and retry the same message, NOT force a re-init;
-            //  - otherwise the worker was never initialized / was killed and
-            //    restarted → the caller should (re)initialize.
+
             const fallbackTag = tag ?? "unknown";
             const error =
                 this.pendingInitCount > 0

--- a/packages/ts-sdk/src/worker/messageBus.ts
+++ b/packages/ts-sdk/src/worker/messageBus.ts
@@ -268,11 +268,20 @@ export class MessageBus {
     private async runTick() {
         if (!this.running) return;
         if (this.tickInProgress) return;
-        this.tickInProgress = true;
+
+        // The fired timer has elapsed; drop its handle first so an early
+        // return below cannot leave a stale handle that wedges scheduleNextTick().
         if (this.tickTimeout !== null) {
             self.clearTimeout(this.tickTimeout);
             this.tickTimeout = null;
         }
+
+        // Never tick while an init is queued or running: doInit() stops and
+        // rebuilds handlers, so ticking them would touch stale/half-reset
+        // state. doInit() re-arms the scheduler once it completes.
+        if (this.pendingInitCount > 0) return;
+
+        this.tickInProgress = true;
 
         try {
             const now = Date.now();
@@ -344,6 +353,14 @@ export class MessageBus {
     }
 
     private async doInit(config: Initialize["config"]) {
+        // Cancel any tick scheduled by a previous init so it cannot fire while
+        // handlers are stopped or rebuilt below (the awaits in this method
+        // yield to the event loop). scheduleNextTick() re-arms after a
+        // successful start.
+        if (this.tickTimeout !== null) {
+            self.clearTimeout(this.tickTimeout);
+            this.tickTimeout = null;
+        }
         if (this.initialized) {
             // Stop existing handlers before re-initializing.
             // This handles the case where CLEAR was called, which nullifies

--- a/packages/ts-sdk/test/electrum.test.ts
+++ b/packages/ts-sdk/test/electrum.test.ts
@@ -414,6 +414,20 @@ describe("ElectrumOnchainProvider", () => {
             });
         });
 
+        it("returns confirmed=false when the not-in-block error arrives space-stripped", async () => {
+            // ws-electrumx-client's frame parser splits incoming frames on
+            // spaces (and CR/LF) and reassembles the pieces without re-adding
+            // the delimiters, so multi-word server errors reach us with their
+            // internal spaces removed. The classifier must match the collapsed
+            // wording — this is the actual shape behind the recurring CI flake.
+            wsMock.request.mockRejectedValueOnce(
+                new Error("Noconfirmedtransactionmatchingtherequestedhashwasfound"),
+            );
+            expect(await provider.getTxStatus("abc")).toEqual({
+                confirmed: false,
+            });
+        });
+
         it("returns confirmed=false when transaction.get_merkle reports block_height <= 0", async () => {
             wsMock.request.mockResolvedValueOnce({ block_height: 0 });
             expect(await provider.getTxStatus("abc")).toEqual({

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -22,6 +22,12 @@ import { DEFAULT_ARKADE_SERVER_URL } from "../../src/networks";
 
 type MessageHandler = (event: { data: any }) => void;
 
+// Stub identity key reported by the harness for GET_STATUS and produced by the
+// stub identities below, so the create()/reinitialize() identity assertion
+// passes by default. Tests that need a mismatch override the GET_STATUS
+// response explicitly.
+const STUB_XONLY_PUBLIC_KEY = new Uint8Array(32).fill(0xab);
+
 // Simulate the structured clone algorithm that postMessage uses: Error
 // subclasses lose their prototype chain and arrive as plain Error objects,
 // but name and message are preserved as own properties. Plain objects in
@@ -47,9 +53,15 @@ function structuredCloneResponse(response: any): any {
 
 const createServiceWorkerHarness = (
     responder?: (message: any) => any,
-    options?: { handlePing?: boolean },
+    options?: { handlePing?: boolean; getStatusKey?: Uint8Array | null },
 ) => {
     const handlePing = options?.handlePing ?? true;
+    // Auto-answer GET_STATUS with this x-only key when the responder does not
+    // handle it, so the create()/reinitialize() identity assertion can pass.
+    // Pass `null` to disable the auto-answer (e.g. to exercise a worker that
+    // reports no identity).
+    const getStatusKey =
+        options && "getStatusKey" in options ? options.getStatusKey : STUB_XONLY_PUBLIC_KEY;
     const listeners = new Set<MessageHandler>();
 
     const navigatorServiceWorker = {
@@ -71,11 +83,27 @@ const createServiceWorkerHarness = (
                 );
                 return;
             }
-            if (!responder) return;
-            const response = responder(message);
-            if (!response) return;
-            const cloned = structuredCloneResponse(response);
-            listeners.forEach((handler) => handler({ data: cloned }));
+            const response = responder ? responder(message) : null;
+            if (response) {
+                const cloned = structuredCloneResponse(response);
+                listeners.forEach((handler) => handler({ data: cloned }));
+                return;
+            }
+            if (message.type === "GET_STATUS" && getStatusKey !== null) {
+                listeners.forEach((handler) =>
+                    handler({
+                        data: {
+                            id: message.id,
+                            tag: message.tag,
+                            type: "WALLET_STATUS",
+                            payload: {
+                                walletInitialized: true,
+                                xOnlyPublicKey: getStatusKey,
+                            },
+                        },
+                    }),
+                );
+            }
         }),
     };
 
@@ -90,7 +118,7 @@ const createServiceWorkerHarness = (
 const createWallet = (serviceWorker: ServiceWorker, messageTag: string = DEFAULT_MESSAGE_TAG) =>
     new (ServiceWorkerReadonlyWallet as any)(
         serviceWorker,
-        {} as any,
+        { xOnlyPublicKey: async () => STUB_XONLY_PUBLIC_KEY } as any,
         new InMemoryWalletRepository(),
         new InMemoryContractRepository(),
         messageTag,
@@ -321,7 +349,7 @@ const createSWWallet = (
 ) =>
     new (ServiceWorkerWallet as any)(
         serviceWorker,
-        { toHex: () => "deadbeef" } as any,
+        { toHex: () => "deadbeef", xOnlyPublicKey: async () => STUB_XONLY_PUBLIC_KEY } as any,
         new InMemoryWalletRepository(),
         new InMemoryContractRepository(),
         messageTag,
@@ -612,6 +640,19 @@ describe("sendMessage reinitialize on SW restart", () => {
                     id: message.id,
                     tag: messageTag,
                     type: "WALLET_INITIALIZED",
+                };
+            }
+            // Let the post-init identity assertion pass so reinitialize()
+            // succeeds and GET_ADDRESS exhausts its own retry budget.
+            if (message.type === "GET_STATUS") {
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    type: "WALLET_STATUS",
+                    payload: {
+                        walletInitialized: true,
+                        xOnlyPublicKey: STUB_XONLY_PUBLIC_KEY,
+                    },
                 };
             }
             // Always return not-initialized (simulates persistent failure)
@@ -1186,8 +1227,12 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
         return null;
     };
 
-    const setup = () => {
-        const harness = createServiceWorkerHarness(initResponder);
+    // Answer the post-init identity assertion's GET_STATUS with the identity's
+    // own x-only key so create() resolves. Tests that omit the identity fall
+    // back to the stub key (only used by paths that reject before GET_STATUS).
+    const setup = async (identity?: { xOnlyPublicKey(): Promise<Uint8Array> }) => {
+        const getStatusKey = identity ? await identity.xOnlyPublicKey() : STUB_XONLY_PUBLIC_KEY;
+        const harness = createServiceWorkerHarness(initResponder, { getStatusKey });
         vi.stubGlobal("navigator", {
             serviceWorker: harness.navigatorServiceWorker,
         } as any);
@@ -1234,8 +1279,8 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("SingleKey emits a tagged single-key envelope", async () => {
-        const { serviceWorker } = setup();
         const identity = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1252,8 +1297,8 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("ServiceWorkerWallet.create uses the default Arkade server URL when omitted", async () => {
-        const { serviceWorker } = setup();
         const identity = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1270,10 +1315,10 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("ServiceWorkerWallet.create forwards walletMode to the worker init config", async () => {
-        const { serviceWorker } = setup();
         const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
             isMainnet: true,
         });
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1287,9 +1332,9 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("ServiceWorkerReadonlyWallet.create uses the default Arkade server URL when omitted", async () => {
-        const { serviceWorker } = setup();
         const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
         const identity = await signing.toReadonly();
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerReadonlyWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1306,10 +1351,10 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("ReadonlySingleKey emits a tagged readonly-single-key envelope", async () => {
-        const { serviceWorker } = setup();
         const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
         const identity = await signing.toReadonly();
         const expectedPubKey = hex.encode(await identity.compressedPublicKey());
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerReadonlyWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1326,10 +1371,10 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("MnemonicIdentity emits a tagged mnemonic envelope", async () => {
-        const { serviceWorker } = setup();
         const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
             isMainnet: true,
         });
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1347,11 +1392,11 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("MnemonicIdentity with passphrase includes it in the envelope", async () => {
-        const { serviceWorker } = setup();
         const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
             isMainnet: true,
             passphrase: "extra secret",
         });
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1369,9 +1414,9 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("SeedIdentity emits a tagged seed envelope", async () => {
-        const { serviceWorker } = setup();
         const seed = mnemonicToSeedSync(TEST_MNEMONIC);
         const identity = SeedIdentity.fromSeed(seed, { isMainnet: true });
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1389,11 +1434,11 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("ReadonlyDescriptorIdentity emits a tagged readonly-descriptor envelope", async () => {
-        const { serviceWorker } = setup();
         const reference = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
             isMainnet: true,
         });
         const identity = ReadonlyDescriptorIdentity.fromDescriptor(reference.descriptor);
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerReadonlyWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1410,11 +1455,11 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("ServiceWorkerReadonlyWallet downgrades a signing mnemonic identity to readonly-descriptor", async () => {
-        const { serviceWorker } = setup();
         const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
             isMainnet: true,
             passphrase: "extra secret",
         });
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerReadonlyWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1434,9 +1479,9 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("ServiceWorkerReadonlyWallet with a signing SingleKey downgrades to readonly-single-key", async () => {
-        const { serviceWorker } = setup();
         const identity = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
         const expectedPubKey = hex.encode(await identity.compressedPublicKey());
+        const { serviceWorker } = await setup(identity);
 
         await ServiceWorkerReadonlyWallet.create({
             serviceWorker: serviceWorker as any,
@@ -1454,7 +1499,7 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 
     it("ServiceWorkerWallet.create rejects a ReadonlyIdentity input", async () => {
-        const { serviceWorker } = setup();
+        const { serviceWorker } = await setup();
         const readonly = ReadonlySingleKey.fromPublicKey(
             await SingleKey.fromHex(TEST_PRIVATE_KEY_HEX).compressedPublicKey(),
         );
@@ -1467,5 +1512,165 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
                 storage: storage(),
             }),
         ).rejects.toThrow(/requires a signing Identity/);
+    });
+});
+
+describe("ServiceWorker identity boundary assertion (Iteration 2)", () => {
+    const messageTag = DEFAULT_MESSAGE_TAG;
+    const KEY_A = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const KEY_B = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+    const storage = () => ({
+        walletRepository: new InMemoryWalletRepository(),
+        contractRepository: new InMemoryContractRepository(),
+    });
+
+    // Drives the init handshake and answers GET_STATUS with `statusKey` (or
+    // omits the key when `statusKey === "omit"`), so each test controls exactly
+    // what identity the worker claims.
+    const initResponder = (statusKey: Uint8Array | "omit") => (message: any) => {
+        if (message.tag === "INITIALIZE_MESSAGE_BUS") {
+            return { id: message.id, tag: "INITIALIZE_MESSAGE_BUS" };
+        }
+        if (message.type === "INIT_WALLET") {
+            return { id: message.id, tag: messageTag, type: "WALLET_INITIALIZED" };
+        }
+        if (message.type === "GET_STATUS") {
+            return {
+                id: message.id,
+                tag: messageTag,
+                type: "WALLET_STATUS",
+                payload: {
+                    walletInitialized: true,
+                    xOnlyPublicKey: statusKey === "omit" ? undefined : statusKey,
+                },
+            };
+        }
+        return null;
+    };
+
+    // Disable the harness auto-status so the responder fully controls GET_STATUS.
+    const stub = (responder: (m: any) => any) => {
+        const harness = createServiceWorkerHarness(responder, { getStatusKey: null });
+        vi.stubGlobal("navigator", { serviceWorker: harness.navigatorServiceWorker } as any);
+        return harness;
+    };
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("readonly create() resolves when the worker reports the matching identity", async () => {
+        const identity = await SingleKey.fromHex(KEY_A).toReadonly();
+        const key = await identity.xOnlyPublicKey();
+        const { serviceWorker } = stub(initResponder(key));
+
+        await expect(
+            ServiceWorkerReadonlyWallet.create({
+                serviceWorker: serviceWorker as any,
+                arkServerUrl: "https://ark.test",
+                identity,
+                storage: storage(),
+            }),
+        ).resolves.toBeDefined();
+    });
+
+    it("readonly create() rejects when the worker reports a different identity", async () => {
+        const identity = await SingleKey.fromHex(KEY_A).toReadonly();
+        const otherKey = await SingleKey.fromHex(KEY_B).xOnlyPublicKey();
+        const { serviceWorker } = stub(initResponder(otherKey));
+
+        await expect(
+            ServiceWorkerReadonlyWallet.create({
+                serviceWorker: serviceWorker as any,
+                arkServerUrl: "https://ark.test",
+                identity,
+                storage: storage(),
+            }),
+        ).rejects.toThrow(/identity mismatch/i);
+    });
+
+    it("signing create() rejects when the worker reports a different identity", async () => {
+        const identity = SingleKey.fromHex(KEY_A);
+        const otherKey = await SingleKey.fromHex(KEY_B).xOnlyPublicKey();
+        const { serviceWorker } = stub(initResponder(otherKey));
+
+        await expect(
+            ServiceWorkerWallet.create({
+                serviceWorker: serviceWorker as any,
+                arkServerUrl: "https://ark.test",
+                identity,
+                storage: storage(),
+            }),
+        ).rejects.toThrow(/identity mismatch/i);
+    });
+
+    it("create() rejects when the worker cannot prove any identity", async () => {
+        const identity = SingleKey.fromHex(KEY_A);
+        const { serviceWorker } = stub(initResponder("omit"));
+
+        await expect(
+            ServiceWorkerWallet.create({
+                serviceWorker: serviceWorker as any,
+                arkServerUrl: "https://ark.test",
+                identity,
+                storage: storage(),
+            }),
+        ).rejects.toThrow(/identity mismatch/i);
+    });
+
+    it("reinitialize() rejects on mismatch before retrying the original wallet message", async () => {
+        const identity = SingleKey.fromHex(KEY_A);
+        const expectedKey = await identity.xOnlyPublicKey();
+        const otherKey = await SingleKey.fromHex(KEY_B).xOnlyPublicKey();
+
+        // The first init (inside create) matches; a later re-init reports a
+        // different identity, so recovery must reject rather than rebind.
+        let initCount = 0;
+        const { serviceWorker } = stub((message: any) => {
+            if (message.tag === "INITIALIZE_MESSAGE_BUS") {
+                initCount += 1;
+                return { id: message.id, tag: "INITIALIZE_MESSAGE_BUS" };
+            }
+            if (message.type === "INIT_WALLET") {
+                return { id: message.id, tag: messageTag, type: "WALLET_INITIALIZED" };
+            }
+            if (message.type === "GET_STATUS") {
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    type: "WALLET_STATUS",
+                    payload: {
+                        walletInitialized: true,
+                        xOnlyPublicKey: initCount >= 2 ? otherKey : expectedKey,
+                    },
+                };
+            }
+            // Force the wallet down the not-initialized → reinitialize path.
+            if (message.type === "GET_ADDRESS") {
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    error: new Error(MESSAGE_BUS_NOT_INITIALIZED),
+                };
+            }
+            return null;
+        });
+
+        const wallet = await ServiceWorkerWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        await expect(wallet.getAddress()).rejects.toThrow(/identity mismatch/i);
+
+        // The mismatch is detected inside reinitialize(), so the original
+        // GET_ADDRESS is never retried against the wrong identity.
+        const addressCalls = serviceWorker.postMessage.mock.calls.filter(
+            ([msg]: any) => msg.type === "GET_ADDRESS",
+        );
+        expect(addressCalls).toHaveLength(1);
     });
 });

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -22,18 +22,9 @@ import { DEFAULT_ARKADE_SERVER_URL } from "../../src/networks";
 
 type MessageHandler = (event: { data: any }) => void;
 
-// Stub identity key reported by the harness for GET_STATUS and produced by the
-// stub identities below, so the create()/reinitialize() identity assertion
-// passes by default. Tests that need a mismatch override the GET_STATUS
-// response explicitly.
 const STUB_XONLY_PUBLIC_KEY = new Uint8Array(32).fill(0xab);
 
-// Simulate the structured clone algorithm that postMessage uses: Error
-// subclasses lose their prototype chain and arrive as plain Error objects,
-// but name and message are preserved as own properties. Plain objects in
-// the error envelope (e.g., the RESTORE_WALLET path's serialized
-// AggregateError) survive structured clone with all enumerable own
-// properties intact, so we deep-clone them via JSON to preserve fidelity.
+// Simulate the structured clone algorithm that postMessage uses
 function structuredCloneError(error: any): any {
     if (error instanceof Error) {
         const cloned = new Error(error.message);
@@ -1515,7 +1506,7 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
     });
 });
 
-describe("ServiceWorker identity boundary assertion (Iteration 2)", () => {
+describe("ServiceWorker identity boundary assertion", () => {
     const messageTag = DEFAULT_MESSAGE_TAG;
     const KEY_A = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const KEY_B = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
@@ -1525,9 +1516,8 @@ describe("ServiceWorker identity boundary assertion (Iteration 2)", () => {
         contractRepository: new InMemoryContractRepository(),
     });
 
-    // Drives the init handshake and answers GET_STATUS with `statusKey` (or
-    // omits the key when `statusKey === "omit"`), so each test controls exactly
-    // what identity the worker claims.
+    // Drives the init handshake and answers GET_STATUS with `statusKey` so each test controls
+    // exactly what identity the worker claims.
     const initResponder = (statusKey: Uint8Array | "omit") => (message: any) => {
         if (message.tag === "INITIALIZE_MESSAGE_BUS") {
             return { id: message.id, tag: "INITIALIZE_MESSAGE_BUS" };
@@ -1560,13 +1550,13 @@ describe("ServiceWorker identity boundary assertion (Iteration 2)", () => {
         vi.unstubAllGlobals();
     });
 
-    it("readonly create() resolves when the worker reports the matching identity", async () => {
+    it("create() resolves when the worker reports the matching identity", async () => {
         const identity = await SingleKey.fromHex(KEY_A).toReadonly();
         const key = await identity.xOnlyPublicKey();
         const { serviceWorker } = stub(initResponder(key));
 
         await expect(
-            ServiceWorkerReadonlyWallet.create({
+            ServiceWorkerWallet.create({
                 serviceWorker: serviceWorker as any,
                 arkServerUrl: "https://ark.test",
                 identity,
@@ -1575,22 +1565,7 @@ describe("ServiceWorker identity boundary assertion (Iteration 2)", () => {
         ).resolves.toBeDefined();
     });
 
-    it("readonly create() rejects when the worker reports a different identity", async () => {
-        const identity = await SingleKey.fromHex(KEY_A).toReadonly();
-        const otherKey = await SingleKey.fromHex(KEY_B).xOnlyPublicKey();
-        const { serviceWorker } = stub(initResponder(otherKey));
-
-        await expect(
-            ServiceWorkerReadonlyWallet.create({
-                serviceWorker: serviceWorker as any,
-                arkServerUrl: "https://ark.test",
-                identity,
-                storage: storage(),
-            }),
-        ).rejects.toThrow(/identity mismatch/i);
-    });
-
-    it("signing create() rejects when the worker reports a different identity", async () => {
+    it("create() rejects when the worker reports a different identity", async () => {
         const identity = SingleKey.fromHex(KEY_A);
         const otherKey = await SingleKey.fromHex(KEY_B).xOnlyPublicKey();
         const { serviceWorker } = stub(initResponder(otherKey));
@@ -1603,74 +1578,5 @@ describe("ServiceWorker identity boundary assertion (Iteration 2)", () => {
                 storage: storage(),
             }),
         ).rejects.toThrow(/identity mismatch/i);
-    });
-
-    it("create() rejects when the worker cannot prove any identity", async () => {
-        const identity = SingleKey.fromHex(KEY_A);
-        const { serviceWorker } = stub(initResponder("omit"));
-
-        await expect(
-            ServiceWorkerWallet.create({
-                serviceWorker: serviceWorker as any,
-                arkServerUrl: "https://ark.test",
-                identity,
-                storage: storage(),
-            }),
-        ).rejects.toThrow(/identity mismatch/i);
-    });
-
-    it("reinitialize() rejects on mismatch before retrying the original wallet message", async () => {
-        const identity = SingleKey.fromHex(KEY_A);
-        const expectedKey = await identity.xOnlyPublicKey();
-        const otherKey = await SingleKey.fromHex(KEY_B).xOnlyPublicKey();
-
-        // The first init (inside create) matches; a later re-init reports a
-        // different identity, so recovery must reject rather than rebind.
-        let initCount = 0;
-        const { serviceWorker } = stub((message: any) => {
-            if (message.tag === "INITIALIZE_MESSAGE_BUS") {
-                initCount += 1;
-                return { id: message.id, tag: "INITIALIZE_MESSAGE_BUS" };
-            }
-            if (message.type === "INIT_WALLET") {
-                return { id: message.id, tag: messageTag, type: "WALLET_INITIALIZED" };
-            }
-            if (message.type === "GET_STATUS") {
-                return {
-                    id: message.id,
-                    tag: messageTag,
-                    type: "WALLET_STATUS",
-                    payload: {
-                        walletInitialized: true,
-                        xOnlyPublicKey: initCount >= 2 ? otherKey : expectedKey,
-                    },
-                };
-            }
-            // Force the wallet down the not-initialized → reinitialize path.
-            if (message.type === "GET_ADDRESS") {
-                return {
-                    id: message.id,
-                    tag: messageTag,
-                    error: new Error(MESSAGE_BUS_NOT_INITIALIZED),
-                };
-            }
-            return null;
-        });
-
-        const wallet = await ServiceWorkerWallet.create({
-            serviceWorker: serviceWorker as any,
-            arkServerUrl: "https://ark.test",
-            identity,
-            storage: storage(),
-        });
-
-        await expect(wallet.getAddress()).rejects.toThrow(/identity mismatch/i);
-
-        // The mismatch is detected inside reinitialize(), so the original
-        // GET_ADDRESS is never retried against the wrong identity.
-        const addressCalls = serviceWorker.postMessage.mock.calls.filter(
-            ([msg]: any) => msg.type === "GET_ADDRESS",
-        );
-        expect(addressCalls).toHaveLength(1);
     });
 });

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -1551,7 +1551,7 @@ describe("ServiceWorker identity boundary assertion", () => {
     });
 
     it("create() resolves when the worker reports the matching identity", async () => {
-        const identity = await SingleKey.fromHex(KEY_A).toReadonly();
+        const identity = await SingleKey.fromHex(KEY_A);
         const key = await identity.xOnlyPublicKey();
         const { serviceWorker } = stub(initResponder(key));
 
@@ -1578,5 +1578,60 @@ describe("ServiceWorker identity boundary assertion", () => {
                 storage: storage(),
             }),
         ).rejects.toThrow(/identity mismatch/i);
+    });
+
+    it("reinitialize() rejects on mismatch before retrying the original wallet message", async () => {
+        const identity = SingleKey.fromHex(KEY_A);
+        const expectedKey = await identity.xOnlyPublicKey();
+        const otherKey = await SingleKey.fromHex(KEY_B).xOnlyPublicKey();
+
+        // The first init (inside create) matches; a later re-init reports a
+        // different identity, so recovery must reject rather than rebind.
+        let initCount = 0;
+        const { serviceWorker } = stub((message: any) => {
+            if (message.tag === "INITIALIZE_MESSAGE_BUS") {
+                initCount += 1;
+                return { id: message.id, tag: "INITIALIZE_MESSAGE_BUS" };
+            }
+            if (message.type === "INIT_WALLET") {
+                return { id: message.id, tag: messageTag, type: "WALLET_INITIALIZED" };
+            }
+            if (message.type === "GET_STATUS") {
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    type: "WALLET_STATUS",
+                    payload: {
+                        walletInitialized: true,
+                        xOnlyPublicKey: initCount >= 2 ? otherKey : expectedKey,
+                    },
+                };
+            }
+            // Force the wallet down the not-initialized → reinitialize path.
+            if (message.type === "GET_ADDRESS") {
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    error: new Error(MESSAGE_BUS_NOT_INITIALIZED),
+                };
+            }
+            return null;
+        });
+
+        const wallet = await ServiceWorkerWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        await expect(wallet.getAddress()).rejects.toThrow(/identity mismatch/i);
+
+        // The mismatch is detected inside reinitialize(), so the original
+        // GET_ADDRESS is never retried against the wrong identity.
+        const addressCalls = serviceWorker.postMessage.mock.calls.filter(
+            ([msg]: any) => msg.type === "GET_ADDRESS",
+        );
+        expect(addressCalls).toHaveLength(1);
     });
 });

--- a/packages/ts-sdk/test/worker/messageBus.test.ts
+++ b/packages/ts-sdk/test/worker/messageBus.test.ts
@@ -6,7 +6,13 @@ import {
     RequestEnvelope,
     ResponseEnvelope,
 } from "../../src/worker/messageBus";
-import { ServiceWorkerTimeoutError } from "../../src/worker/errors";
+import {
+    MESSAGE_BUS_INITIALIZING,
+    MESSAGE_BUS_NOT_INITIALIZED,
+    MessageBusInitializingError,
+    MessageBusNotInitializedError,
+    ServiceWorkerTimeoutError,
+} from "../../src/worker/errors";
 
 type StubbedSelf = {
     addEventListener: ReturnType<typeof vi.fn>;
@@ -869,5 +875,268 @@ describe("MessageBus delivery guarantees (issue #448)", () => {
         expect(bResponse.payload).toEqual({ ok: true });
 
         await bus.stop();
+    });
+});
+
+describe("MessageBus init serialization (Iteration 1)", () => {
+    beforeEach(() => {
+        installSelfStub();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    function deferred<T>() {
+        let resolve!: (value: T) => void;
+        let reject!: (reason?: unknown) => void;
+        const promise = new Promise<T>((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return { promise, resolve, reject };
+    }
+
+    // Drain the microtask queue (and any chained continuations) by crossing a
+    // macrotask boundary. These tests use real timers.
+    const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+    const initConfig = {
+        wallet: { publicKey: "00".repeat(33) },
+        arkServer: { url: "http://localhost" },
+    };
+
+    function sendInit(id: string, source: { postMessage: (m: unknown) => void }) {
+        return messageHandler({
+            data: {
+                type: "INITIALIZE_MESSAGE_BUS",
+                id,
+                tag: "INITIALIZE_MESSAGE_BUS",
+                config: initConfig,
+            } as never,
+            source: source as never,
+            waitUntil: (p: Promise<unknown>) => p,
+        });
+    }
+
+    function sendMessage(id: string, tag: string, source: { postMessage: (m: unknown) => void }) {
+        return messageHandler({
+            data: { id, tag },
+            source: source as never,
+            waitUntil: (p: Promise<unknown>) => p,
+        });
+    }
+
+    function makeBus(
+        handlers: MessageHandler[],
+        buildServices: () => Promise<unknown>,
+    ): MessageBus {
+        return new MessageBus(new InMemoryWalletRepository(), new InMemoryContractRepository(), {
+            messageHandlers: handlers,
+            buildServices: buildServices as never,
+        });
+    }
+
+    it("runs concurrent inits FIFO: B does not build until A settles, and acks only after its handlers start", async () => {
+        const handler = new TestHandler();
+        const buildCalls: string[] = [];
+        const gates = [deferred<unknown>(), deferred<unknown>()];
+        let n = 0;
+        const bus = makeBus([handler], () => {
+            const i = n++;
+            buildCalls.push(`build${i}`);
+            return gates[i].promise;
+        });
+        await bus.start();
+
+        const srcA = { postMessage: vi.fn() };
+        const srcB = { postMessage: vi.fn() };
+        const pA = sendInit("A", srcA);
+        const pB = sendInit("B", srcB);
+
+        // Only A's buildServices is running; B is queued behind it.
+        await flush();
+        expect(buildCalls).toEqual(["build0"]);
+        expect(handler.start).not.toHaveBeenCalled();
+
+        // A's build completes → A starts handlers and acks; only now B builds.
+        gates[0].resolve({});
+        await pA;
+        await flush();
+        expect(srcA.postMessage).toHaveBeenCalledWith({ id: "A", tag: "INITIALIZE_MESSAGE_BUS" });
+        expect(buildCalls).toEqual(["build0", "build1"]);
+        // B has not acked while its build is still pending.
+        expect(srcB.postMessage).not.toHaveBeenCalled();
+
+        gates[1].resolve({});
+        await pB;
+        expect(srcB.postMessage).toHaveBeenCalledWith({ id: "B", tag: "INITIALIZE_MESSAGE_BUS" });
+        // B's handlers were started (re-init stop + start) before its ack.
+        expect(handler.start).toHaveBeenCalledTimes(2);
+
+        await bus.stop();
+    });
+
+    it("rejects ordinary wallet messages with MessageBusInitializingError while an init is pending", async () => {
+        const handler = new TestHandler();
+        const gates = [deferred<unknown>(), deferred<unknown>()];
+        let n = 0;
+        const bus = makeBus([handler], () => gates[n++].promise);
+        await bus.start();
+
+        const pA = sendInit("A", { postMessage: vi.fn() });
+        gates[0].resolve({});
+        await pA;
+
+        // Begin B but leave its build pending: the bus is now unavailable.
+        const pB = sendInit("B", { postMessage: vi.fn() });
+        await flush();
+
+        const srcM = { postMessage: vi.fn() };
+        await sendMessage("m1", handler.messageTag, srcM);
+
+        expect(handler.handleMessage).not.toHaveBeenCalled();
+        const sent = srcM.postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.id).toBe("m1");
+        expect(sent.error).toBeInstanceOf(MessageBusInitializingError);
+
+        gates[1].resolve({});
+        await pB;
+        await bus.stop();
+    });
+
+    it("stops existing handlers before starting new ones on re-init", async () => {
+        const order: string[] = [];
+        const handler = new TestHandler();
+        handler.start.mockImplementation(async () => {
+            order.push("start");
+        });
+        handler.stop.mockImplementation(async () => {
+            order.push("stop");
+        });
+        const bus = makeBus([handler], async () => ({}));
+        await bus.start();
+
+        await sendInit("A", { postMessage: vi.fn() });
+        await sendInit("B", { postMessage: vi.fn() });
+
+        expect(order).toEqual(["start", "stop", "start"]);
+        await bus.stop();
+    });
+
+    it("a failed init delivers an error and does not poison the next queued init", async () => {
+        const handler = new TestHandler();
+        let call = 0;
+        const bus = makeBus([handler], async () => {
+            if (call++ === 0) throw new Error("build boom");
+            return {};
+        });
+        await bus.start();
+
+        const srcA = { postMessage: vi.fn() };
+        await sendInit("A", srcA);
+        const aResp = srcA.postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(aResp.id).toBe("A");
+        expect(aResp.error?.message).toBe("build boom");
+
+        const srcB = { postMessage: vi.fn() };
+        await sendInit("B", srcB);
+        expect(srcB.postMessage).toHaveBeenCalledWith({ id: "B", tag: "INITIALIZE_MESSAGE_BUS" });
+
+        // The bus is usable after the recovered init.
+        handler.handleMessage.mockResolvedValueOnce({
+            id: "m",
+            tag: handler.messageTag,
+            payload: { ok: true },
+        } as ResponseEnvelope);
+        const srcM = { postMessage: vi.fn() };
+        await sendMessage("m", handler.messageTag, srcM);
+        expect(srcM.postMessage.mock.calls[0][0]).toMatchObject({ payload: { ok: true } });
+
+        await bus.stop();
+    });
+
+    it("after a successful init, a failed re-init rejects and wallet messages then report not-initialized", async () => {
+        const handler = new TestHandler();
+        let call = 0;
+        const bus = makeBus([handler], async () => {
+            if (call++ === 1) throw new Error("reinit boom");
+            return {};
+        });
+        await bus.start();
+
+        await sendInit("A", { postMessage: vi.fn() });
+        const srcB = { postMessage: vi.fn() };
+        await sendInit("B", srcB);
+        expect((srcB.postMessage.mock.calls[0][0] as ResponseEnvelope).error?.message).toBe(
+            "reinit boom",
+        );
+
+        const srcM = { postMessage: vi.fn() };
+        await sendMessage("m", handler.messageTag, srcM);
+        const sent = srcM.postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent.error).toBeInstanceOf(MessageBusNotInitializedError);
+        expect(sent.error).not.toBeInstanceOf(MessageBusInitializingError);
+
+        await bus.stop();
+    });
+
+    it("rolls back started handlers and stays unavailable when a later handler fails to start", async () => {
+        const h1 = new TestHandler("H1");
+        const h2 = new TestHandler("H2");
+        h2.start.mockRejectedValueOnce(new Error("start boom"));
+        const bus = makeBus([h1, h2], async () => ({}));
+        await bus.start();
+
+        const srcA = { postMessage: vi.fn() };
+        await sendInit("A", srcA);
+
+        // h1 started, h2 failed → h1 rolled back, init reported as failed.
+        expect(h1.start).toHaveBeenCalledTimes(1);
+        expect(h1.stop).toHaveBeenCalledTimes(1);
+        expect((srcA.postMessage.mock.calls[0][0] as ResponseEnvelope).error?.message).toBe(
+            "start boom",
+        );
+
+        // pendingInitCount returned to 0, so the bus reports not-initialized.
+        const srcM = { postMessage: vi.fn() };
+        await sendMessage("m", "H1", srcM);
+        expect((srcM.postMessage.mock.calls[0][0] as ResponseEnvelope).error).toBeInstanceOf(
+            MessageBusNotInitializedError,
+        );
+
+        await bus.stop();
+    });
+
+    it("delivers an init failure exactly once and resolves the init message (no unhandled throw)", async () => {
+        const handler = new TestHandler();
+        const bus = makeBus([handler], async () => {
+            throw new Error("boom");
+        });
+        await bus.start();
+
+        const src = { postMessage: vi.fn() };
+        await expect(sendInit("X", src)).resolves.toBeUndefined();
+
+        expect(src.postMessage).toHaveBeenCalledTimes(1);
+        const sent = src.postMessage.mock.calls[0][0] as ResponseEnvelope;
+        expect(sent).toMatchObject({ id: "X", tag: "INITIALIZE_MESSAGE_BUS" });
+        expect(sent.error?.message).toBe("boom");
+
+        await bus.stop();
+    });
+
+    it("MessageBusInitializingError is a not-initialized error with a superset message", () => {
+        const e = new MessageBusInitializingError();
+        // Backward compatibility: instanceof and the substring detector both
+        // still classify the pending variant as not-initialized.
+        expect(e).toBeInstanceOf(MessageBusNotInitializedError);
+        expect(e.message.includes(MESSAGE_BUS_NOT_INITIALIZED)).toBe(true);
+        // The more specific marker distinguishes it for opt-in callers.
+        expect(e.message.includes(MESSAGE_BUS_INITIALIZING)).toBe(true);
+        expect(new MessageBusNotInitializedError().message.includes(MESSAGE_BUS_INITIALIZING)).toBe(
+            false,
+        );
     });
 });

--- a/packages/ts-sdk/test/worker/messageBus.test.ts
+++ b/packages/ts-sdk/test/worker/messageBus.test.ts
@@ -1127,6 +1127,41 @@ describe("MessageBus init serialization (Iteration 1)", () => {
         await bus.stop();
     });
 
+    it("does not tick handlers while a re-init is in flight (stale-tick guard)", async () => {
+        const handler = new TestHandler();
+        const gates = [deferred<unknown>(), deferred<unknown>()];
+        let n = 0;
+        const bus = makeBus([handler], () => gates[n++].promise);
+        await bus.start();
+
+        // Init A completes and schedules a tick.
+        const pA = sendInit("A", { postMessage: vi.fn() });
+        gates[0].resolve({});
+        await pA;
+        expect((bus as any).tickTimeout).not.toBeNull();
+
+        // Begin a re-init (B) but leave its buildServices pending.
+        const pB = sendInit("B", { postMessage: vi.fn() });
+        await flush();
+
+        // doInit cancelled the tick scheduled by the previous init (part 1) ...
+        expect((bus as any).tickTimeout).toBeNull();
+
+        // ... and a tick firing during the in-flight init is a no-op (part 2):
+        // handlers are stopped / mid-rebuild and must not be ticked.
+        handler.tick.mockClear();
+        await (bus as any).runTick();
+        expect(handler.tick).not.toHaveBeenCalled();
+
+        // Once the re-init settles, ticking resumes against the new handlers.
+        gates[1].resolve({});
+        await pB;
+        await (bus as any).runTick();
+        expect(handler.tick).toHaveBeenCalled();
+
+        await bus.stop();
+    });
+
     it("MessageBusInitializingError is a not-initialized error with a superset message", () => {
         const e = new MessageBusInitializingError();
         // Backward compatibility: instanceof and the substring detector both


### PR DESCRIPTION
## Summary

Closes the service-worker identity-init race where the `MessageBus` could end up bound to a different identity than the page last asked for, causing `getBoardingAddress()` / `getAddress()` to return a previous identity's address — a potential loss-of-funds path. 

### FIFO-serialize bus initialization
- `INITIALIZE_MESSAGE_BUS` now runs on a FIFO `initChain`, so concurrent inits can no longer interleave or finish out of order and bind the bus to a stale identity.
- A `pendingInitCount` gate makes the bus refuse ordinary wallet messages while any init is queued or running, so the previous wallet stops being served the moment a new init is accepted.
- Failed inits deliver an error response (page fails fast) without poisoning the next queued init; partially-started handlers are rolled back on failure.
- New `MessageBusInitializingError`  distinguishes "an init is in flight" from "never initialized". Legacy substring/`instanceof` detection stays backward-compatible.

### page-side identity boundary assertion
- `create()` and `reinitialize()` verify the worker reports the expected x-only pubkey via `GET_STATUS` before returning a usable wallet, refusing to hand back a wallet that would serve another identity's addresses.
- Compares the stable baseline identity key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit “message bus initializing” reporting, including new exported marker/error for init-in-flight vs not-initialized.
  * Added an identity boundary check so service-worker operations verify the worker matches the expected wallet public identity.

* **Bug Fixes**
  * Improved message-bus initialization by serializing concurrent init requests and preventing redundant re-initialization.
  * Updated wallet request retry to wait for initialization to settle, with safer handling of partial handler startup.

* **Tests**
  * Expanded service-worker and message-bus coverage for identity matching, init concurrency, and error/backoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->