### PR TITLE
fix: Improve MissingSigningDescriptorError message

### DIFF
--- a/packages/ts-sdk/src/wallet/inputSignerRouter.ts
+++ b/packages/ts-sdk/src/wallet/inputSignerRouter.ts
@@ -71,9 +71,8 @@ export class InputSignerRouter {
      * here) so the routing rules never live in two places.
      *
      * Throws {@link MissingSigningDescriptorError} for a non-baseline
-     * default/delegate contract whose `metadata.signingDescriptor` is
-     * missing — the same condition that would later abort signing. Failing
-     * here moves the failure earlier, before any PSBT is mutated.
+     * default/delegate/boarding contract whose `metadata.signingDescriptor` is
+     * missing.
      */
     async classify(jobs: InputSigningJob[]): Promise<InputRoutingPlan> {
         const identityIndexes: number[] = [];
@@ -114,11 +113,8 @@ export class InputSignerRouter {
                 continue;
             }
 
-            // `baselinePubKeyHex` is freshly produced by `hex.encode`,
-            // so it is already lowercase. `contract.params.pubKey` is
-            // persisted data: a migration or custom repository adapter
-            // could legitimately store it uppercase, so canonicalize
-            // before comparing to match the legacy router behaviour.
+            // this is persisted data: a migration or custom repository adapter
+            // could legitimately store it uppercase
             const ownerPubKeyHex = contract.params.pubKey?.toLowerCase();
             if (ownerPubKeyHex && ownerPubKeyHex === baselinePubKeyHex) {
                 identityIndexes.push(job.index);

--- a/packages/ts-sdk/src/wallet/signingErrors.ts
+++ b/packages/ts-sdk/src/wallet/signingErrors.ts
@@ -1,7 +1,10 @@
 /**
- * Thrown when a rotated contract (default, delegate, or boarding) is missing
- * the metadata.signingDescriptor required to route it to a descriptor-aware
- * signer.
+ * Thrown when a descriptor-capable contract (default, delegate, or boarding)
+ * cannot be routed to any signer: its owner key (`params.pubKey`) is not this
+ * wallet's baseline signing key, and the record carries no
+ * `metadata.signingDescriptor` to send it to a descriptor-aware signer.
+ *
+ * Note that this can arise also when a contract belongs to a different identity (storage reuse).
  */
 export class MissingSigningDescriptorError extends Error {
     readonly name = "MissingSigningDescriptorError";
@@ -12,10 +15,11 @@ export class MissingSigningDescriptorError extends Error {
     ) {
         super(
             `Cannot sign input for ${contractType} contract ${contractScript}: ` +
-                `metadata.signingDescriptor is missing. This wallet was rotated ` +
-                `on an earlier build that did not persist signing descriptors. ` +
+                `metadata.signingDescriptor is missing. Possible causes: this wallet was rotated ` +
+                `on an earlier build that did not persist signing descriptors, or the contract ` +
+                `belongs to a different identity. ` +
                 `Manually set metadata.signingDescriptor on the contract record, ` +
-                `or restore from a pre-rotation snapshot.`,
+                `or restore from a pre-rotation snapshot or delete the contract.`,
         );
     }
 }


### PR DESCRIPTION
- simplify verbose docs
- improve error message to include _foreign contract_ possibility, not just rotation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced error messages in wallet signing operations to clarify failure causes and provide expanded recovery guidance options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->