### PR TITLE
fix(boltz-swap): refund live VTXOs offchain past CLTV instead of always joining a batch

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -140,6 +140,19 @@ type SubmarineScanPrepared =
           error: string;
       };
 
+/**
+ * Loop-invariant inputs shared by every `refundWithoutReceiver` settlement in a
+ * single refund pass. Bundled so {@link ArkadeSwaps.settleRefundWithoutReceiver}
+ * needs only the per-VTXO coin alongside it.
+ */
+type RefundWithoutReceiverContext = {
+    arkInfo: ArkInfo;
+    vhtlcScript: VHTLC.Script;
+    serverXOnlyPublicKey: Uint8Array;
+    refundWithoutReceiverLeaf: ArkTxInput["tapLeafScript"];
+    outputScript: Uint8Array;
+};
+
 const dedupeVtxos = (vtxos: VirtualCoin[]): VirtualCoin[] => [
     ...new Map(vtxos.map((vtxo) => [`${vtxo.txid}:${vtxo.vout}`, vtxo] as const)).values(),
 ];
@@ -1080,6 +1093,13 @@ export class ArkadeSwaps {
         const outputScript = ArkAddress.decode(address).pkScript;
         const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
         const cltvSatisfied = isSubmarineRefundLocktimeReached(vhtlcTimeouts.refund);
+        const refundContext: RefundWithoutReceiverContext = {
+            arkInfo,
+            vhtlcScript,
+            serverXOnlyPublicKey,
+            refundWithoutReceiverLeaf,
+            outputScript,
+        };
 
         // Refund every unspent VTXO at the contract address.
         // Throttle between Boltz API calls to avoid 429 rate-limiting.
@@ -1099,15 +1119,7 @@ export class ArkadeSwaps {
             // leaf is spendable — settle it offchain for a live VTXO, or via a
             // batch round for a swept one (see settleRefundWithoutReceiver).
             if (cltvSatisfied) {
-                await this.settleRefundWithoutReceiver({
-                    vtxo,
-                    isRecoverable: isRecoverableVtxo,
-                    output,
-                    refundWithoutReceiverLeaf,
-                    vhtlcScript,
-                    serverXOnlyPublicKey,
-                    arkInfo,
-                });
+                await this.settleRefundWithoutReceiver(refundContext, vtxo);
                 sweptCount++;
                 continue;
             }
@@ -1181,15 +1193,7 @@ export class ArkadeSwaps {
                 );
                 // Past CLTV and non-recoverable (recoverable VTXOs are skipped
                 // pre-CLTV) → settle offchain, same as the primary post-CLTV path.
-                await this.settleRefundWithoutReceiver({
-                    vtxo,
-                    isRecoverable: isRecoverableVtxo,
-                    output,
-                    refundWithoutReceiverLeaf,
-                    vhtlcScript,
-                    serverXOnlyPublicKey,
-                    arkInfo,
-                });
+                await this.settleRefundWithoutReceiver(refundContext, vtxo);
                 sweptCount++;
             }
         }
@@ -1952,6 +1956,13 @@ export class ArkadeSwaps {
         const outputScript = ArkAddress.decode(address).pkScript;
         const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
         const refundLocktime = pendingSwap.response.lockupDetails.timeouts!.refund;
+        const refundContext: RefundWithoutReceiverContext = {
+            arkInfo,
+            vhtlcScript,
+            serverXOnlyPublicKey,
+            refundWithoutReceiverLeaf,
+            outputScript,
+        };
 
         let boltzCallCount = 0;
         let sweptCount = 0;
@@ -1970,15 +1981,7 @@ export class ArkadeSwaps {
             // and could needlessly defer a recoverable VTXO whose
             // locktime had just passed.
             if (isSubmarineRefundLocktimeReached(refundLocktime)) {
-                await this.settleRefundWithoutReceiver({
-                    vtxo,
-                    isRecoverable: isRecoverableVtxo,
-                    output,
-                    refundWithoutReceiverLeaf,
-                    vhtlcScript,
-                    serverXOnlyPublicKey,
-                    arkInfo,
-                });
+                await this.settleRefundWithoutReceiver(refundContext, vtxo);
                 sweptCount++;
                 continue;
             }
@@ -2045,15 +2048,7 @@ export class ArkadeSwaps {
                 );
                 // Past CLTV and non-recoverable (recoverable VTXOs are skipped
                 // pre-CLTV) → settle offchain, same as the primary post-CLTV path.
-                await this.settleRefundWithoutReceiver({
-                    vtxo,
-                    isRecoverable: isRecoverableVtxo,
-                    output,
-                    refundWithoutReceiverLeaf,
-                    vhtlcScript,
-                    serverXOnlyPublicKey,
-                    arkInfo,
-                });
+                await this.settleRefundWithoutReceiver(refundContext, vtxo);
                 sweptCount++;
             }
         }
@@ -2770,30 +2765,26 @@ export class ArkadeSwaps {
      * swept (recoverable) VTXO is no longer a live leaf, so it can only be
      * reclaimed by re-registering it into a batch.
      */
-    private async settleRefundWithoutReceiver(args: {
-        vtxo: VirtualCoin;
-        isRecoverable: boolean;
-        output: TransactionOutput;
-        refundWithoutReceiverLeaf: ArkTxInput["tapLeafScript"];
-        vhtlcScript: VHTLC.Script;
-        serverXOnlyPublicKey: Uint8Array;
-        arkInfo: ArkInfo;
-    }): Promise<void> {
+    private async settleRefundWithoutReceiver(
+        ctx: RefundWithoutReceiverContext,
+        vtxo: VirtualCoin,
+    ): Promise<void> {
         const input = {
-            ...args.vtxo,
-            tapLeafScript: args.refundWithoutReceiverLeaf,
-            tapTree: args.vhtlcScript.encode(),
+            ...vtxo,
+            tapLeafScript: ctx.refundWithoutReceiverLeaf,
+            tapTree: ctx.vhtlcScript.encode(),
         };
-        if (args.isRecoverable) {
-            await this.joinBatch(this.wallet.identity, input, args.output, args.arkInfo, true);
+        const output = { amount: BigInt(vtxo.value), script: ctx.outputScript };
+        if (isRecoverable(vtxo)) {
+            await this.joinBatch(this.wallet.identity, input, output, ctx.arkInfo, true);
         } else {
             await refundWithoutReceiverVHTLCwithOffchainTx(
                 this.wallet.identity,
-                args.vhtlcScript,
-                args.serverXOnlyPublicKey,
+                ctx.vhtlcScript,
+                ctx.serverXOnlyPublicKey,
                 input,
-                args.output,
-                args.arkInfo,
+                output,
+                ctx.arkInfo,
                 this.arkProvider,
             );
         }

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -101,6 +101,7 @@ import {
     createVHTLCScript,
     joinBatch,
     refundVHTLCwithOffchainTx,
+    refundWithoutReceiverVHTLCwithOffchainTx,
     type VhtlcTimeouts,
 } from "./utils/vhtlc";
 
@@ -1094,22 +1095,30 @@ export class ArkadeSwaps {
                 script: outputScript,
             };
 
-            // Prefer refundWithoutReceiver (sender + server, no Boltz) when
-            // the CLTV locktime has passed — works for both recoverable and
-            // non-recoverable VTXOs.
+            // Once the CLTV locktime has passed, the refundWithoutReceiver
+            // leaf (sender + server, no Boltz) is spendable. A live VTXO can
+            // settle it offchain — no batch round needed. A swept
+            // (recoverable) VTXO is no longer a spendable leaf, so it must be
+            // reclaimed by re-registering it into a batch.
             if (cltvSatisfied) {
                 const input = {
                     ...vtxo,
                     tapLeafScript: refundWithoutReceiverLeaf,
                     tapTree: vhtlcScript.encode(),
                 };
-                await this.joinBatch(
-                    this.wallet.identity,
-                    input,
-                    output,
-                    arkInfo,
-                    isRecoverableVtxo,
-                );
+                if (isRecoverableVtxo) {
+                    await this.joinBatch(this.wallet.identity, input, output, arkInfo, true);
+                } else {
+                    await refundWithoutReceiverVHTLCwithOffchainTx(
+                        this.wallet.identity,
+                        vhtlcScript,
+                        serverXOnlyPublicKey,
+                        input,
+                        output,
+                        arkInfo,
+                        this.arkProvider,
+                    );
+                }
                 sweptCount++;
                 continue;
             }
@@ -1179,14 +1188,24 @@ export class ArkadeSwaps {
 
                 logger.warn(
                     `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint, ` +
-                        `falling back to refundWithoutReceiver via joinBatch`,
+                        `falling back to refundWithoutReceiver offchain`,
                 );
                 const fallbackInput = {
                     ...vtxo,
                     tapLeafScript: refundWithoutReceiverLeaf,
                     tapTree: vhtlcScript.encode(),
                 };
-                await this.joinBatch(this.wallet.identity, fallbackInput, output, arkInfo, false);
+                // Non-recoverable VTXO past CLTV → settle refundWithoutReceiver
+                // offchain (sender + server), same as the primary post-CLTV path.
+                await refundWithoutReceiverVHTLCwithOffchainTx(
+                    this.wallet.identity,
+                    vhtlcScript,
+                    serverXOnlyPublicKey,
+                    fallbackInput,
+                    output,
+                    arkInfo,
+                    this.arkProvider,
+                );
                 sweptCount++;
             }
         }
@@ -1873,7 +1892,10 @@ export class ArkadeSwaps {
      * swap's ARK lockup address.
      *
      * Path selection per VTXO:
-     * - CLTV has elapsed → `refundWithoutReceiver` via `joinBatch` (no Boltz).
+     * - CLTV elapsed, live VTXO → `refundWithoutReceiver` offchain (sender +
+     *   server, no Boltz, no batch round).
+     * - CLTV elapsed, swept VTXO → `refundWithoutReceiver` via `joinBatch`
+     *   (a swept VTXO is no longer a live leaf).
      * - Pre-CLTV recoverable → skipped (Boltz can't co-sign swept-batch refund).
      * - Pre-CLTV non-recoverable → cooperative 3-of-3 refund via Boltz.
      *
@@ -1969,13 +1991,21 @@ export class ArkadeSwaps {
                     tapLeafScript: refundWithoutReceiverLeaf,
                     tapTree: vhtlcScript.encode(),
                 };
-                await this.joinBatch(
-                    this.wallet.identity,
-                    input,
-                    output,
-                    arkInfo,
-                    isRecoverableVtxo,
-                );
+                // Live VTXO → settle refundWithoutReceiver offchain; swept
+                // VTXO → reclaim via a batch round (no longer a live leaf).
+                if (isRecoverableVtxo) {
+                    await this.joinBatch(this.wallet.identity, input, output, arkInfo, true);
+                } else {
+                    await refundWithoutReceiverVHTLCwithOffchainTx(
+                        this.wallet.identity,
+                        vhtlcScript,
+                        serverXOnlyPublicKey,
+                        input,
+                        output,
+                        arkInfo,
+                        this.arkProvider,
+                    );
+                }
                 sweptCount++;
                 continue;
             }
@@ -2038,14 +2068,24 @@ export class ArkadeSwaps {
 
                 logger.warn(
                     `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint, ` +
-                        `falling back to refundWithoutReceiver via joinBatch`,
+                        `falling back to refundWithoutReceiver offchain`,
                 );
                 const fallbackInput = {
                     ...vtxo,
                     tapLeafScript: refundWithoutReceiverLeaf,
                     tapTree: vhtlcScript.encode(),
                 };
-                await this.joinBatch(this.wallet.identity, fallbackInput, output, arkInfo, false);
+                // Non-recoverable VTXO past CLTV → settle refundWithoutReceiver
+                // offchain (sender + server), same as the primary post-CLTV path.
+                await refundWithoutReceiverVHTLCwithOffchainTx(
+                    this.wallet.identity,
+                    vhtlcScript,
+                    serverXOnlyPublicKey,
+                    fallbackInput,
+                    output,
+                    arkInfo,
+                    this.arkProvider,
+                );
                 sweptCount++;
             }
         }

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -1092,7 +1092,6 @@ export class ArkadeSwaps {
 
         const outputScript = ArkAddress.decode(address).pkScript;
         const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
-        const cltvSatisfied = isSubmarineRefundLocktimeReached(vhtlcTimeouts.refund);
         const refundContext: RefundWithoutReceiverContext = {
             arkInfo,
             vhtlcScript,
@@ -1102,101 +1101,15 @@ export class ArkadeSwaps {
         };
 
         // Refund every unspent VTXO at the contract address.
-        // Throttle between Boltz API calls to avoid 429 rate-limiting.
-        let boltzCallCount = 0;
-        let sweptCount = 0;
-        let skippedCount = 0;
-
-        for (const vtxo of refundableVtxos) {
-            const isRecoverableVtxo = isRecoverable(vtxo);
-
-            const output = {
-                amount: BigInt(vtxo.value),
-                script: outputScript,
-            };
-
-            // Once the CLTV locktime has passed, the refundWithoutReceiver
-            // leaf is spendable — settle it offchain for a live VTXO, or via a
-            // batch round for a swept one (see settleRefundWithoutReceiver).
-            if (cltvSatisfied) {
-                await this.settleRefundWithoutReceiver(refundContext, vtxo);
-                sweptCount++;
-                continue;
-            }
-
-            // Pre-CLTV: recoverable VTXOs can't use the Boltz 3-of-3 path
-            // (Boltz can't co-sign a swept-batch refund), so we must wait.
-            if (isRecoverableVtxo) {
-                logger.error(
-                    `Swap ${pendingSwap.id}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
-                        `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
-                        `(refundLocktime=${vhtlcTimeouts.refund}, ` +
-                        `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
-                        `Refund will be retried after locktime.`,
-                );
-                skippedCount++;
-                continue;
-            }
-
-            // Pre-CLTV, non-recoverable: try the 3-of-3 refund via Boltz.
-            const input = {
-                ...vtxo,
-                tapLeafScript: vhtlcScript.refund(),
-                tapTree: vhtlcScript.encode(),
-            };
-            try {
-                if (boltzCallCount > 0) {
-                    await new Promise((r) => setTimeout(r, 2000));
-                }
-                // Count attempts, not successes — a thrown call still
-                // consumed Boltz's rate-limit slot, so the next attempt
-                // must observe the throttle even when the previous one
-                // failed.
-                boltzCallCount++;
-                await refundVHTLCwithOffchainTx(
-                    pendingSwap.id,
-                    this.wallet.identity,
-                    this.arkProvider,
-                    boltzXOnlyPublicKey,
-                    ourXOnlyPublicKey,
-                    serverXOnlyPublicKey,
-                    input,
-                    output,
-                    arkInfo,
-                    this.swapProvider.refundSubmarineSwap.bind(this.swapProvider),
-                );
-                sweptCount++;
-            } catch (error) {
-                // Only fall back for Boltz-side rejections (e.g. outpoint
-                // mismatch after an Ark round). Re-throw anything else.
-                if (!(error instanceof BoltzRefundError)) {
-                    throw error;
-                }
-
-                // Re-check the locktime — wall clock may have advanced while
-                // talking to Boltz.
-                if (!isSubmarineRefundLocktimeReached(vhtlcTimeouts.refund)) {
-                    logger.error(
-                        `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint and ` +
-                            `refundWithoutReceiver locktime has not passed yet ` +
-                            `(currentTimestamp=${Math.floor(Date.now() / 1000)}, ` +
-                            `locktime=${vhtlcTimeouts.refund}). ` +
-                            `Refund will be retried after locktime.`,
-                    );
-                    skippedCount++;
-                    continue;
-                }
-
-                logger.warn(
-                    `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint, ` +
-                        `falling back to refundWithoutReceiver offchain`,
-                );
-                // Past CLTV and non-recoverable (recoverable VTXOs are skipped
-                // pre-CLTV) → settle offchain, same as the primary post-CLTV path.
-                await this.settleRefundWithoutReceiver(refundContext, vtxo);
-                sweptCount++;
-            }
-        }
+        const { swept: sweptCount, skipped: skippedCount } = await this.refundVtxos({
+            swapId: pendingSwap.id,
+            vtxos: refundableVtxos,
+            refundLocktime: vhtlcTimeouts.refund,
+            refundContext,
+            boltzXOnlyPublicKey,
+            ourXOnlyPublicKey,
+            refundViaBoltz: this.swapProvider.refundSubmarineSwap.bind(this.swapProvider),
+        });
 
         // Skip the flag update when this is a manual recovery on a
         // successfully-claimed swap (e.g. user accidentally double-funded
@@ -1964,94 +1877,15 @@ export class ArkadeSwaps {
             outputScript,
         };
 
-        let boltzCallCount = 0;
-        let sweptCount = 0;
-        let skippedCount = 0;
-
-        for (const vtxo of unspentVtxos) {
-            const isRecoverableVtxo = isRecoverable(vtxo);
-            const output = {
-                amount: BigInt(vtxo.value),
-                script: outputScript,
-            };
-
-            // Re-evaluate per iteration so a CLTV that elapses mid-loop
-            // is observed by every branch (recoverable + non-recoverable).
-            // `Date.now()` is cheap; the snapshot saved nothing material
-            // and could needlessly defer a recoverable VTXO whose
-            // locktime had just passed.
-            if (isSubmarineRefundLocktimeReached(refundLocktime)) {
-                await this.settleRefundWithoutReceiver(refundContext, vtxo);
-                sweptCount++;
-                continue;
-            }
-
-            if (isRecoverableVtxo) {
-                logger.error(
-                    `Swap ${pendingSwap.id}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
-                        `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
-                        `(refundLocktime=${refundLocktime}, ` +
-                        `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
-                        `Refund will be retried after locktime.`,
-                );
-                skippedCount++;
-                continue;
-            }
-
-            const input = {
-                ...vtxo,
-                tapLeafScript: vhtlcScript.refund(),
-                tapTree: vhtlcScript.encode(),
-            };
-            try {
-                if (boltzCallCount > 0) {
-                    await new Promise((r) => setTimeout(r, 2000));
-                }
-                // Count attempts, not successes — a thrown call still
-                // consumed Boltz's rate-limit slot, so the next attempt
-                // must observe the throttle even when the previous one
-                // failed.
-                boltzCallCount++;
-                await refundVHTLCwithOffchainTx(
-                    pendingSwap.id,
-                    this.wallet.identity,
-                    this.arkProvider,
-                    boltzXOnlyPublicKey,
-                    ourXOnlyPublicKey,
-                    serverXOnlyPublicKey,
-                    input,
-                    output,
-                    arkInfo,
-                    this.swapProvider.refundChainSwap.bind(this.swapProvider),
-                );
-                sweptCount++;
-            } catch (error) {
-                if (!(error instanceof BoltzRefundError)) {
-                    throw error;
-                }
-
-                if (!isSubmarineRefundLocktimeReached(refundLocktime)) {
-                    logger.error(
-                        `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint and ` +
-                            `refundWithoutReceiver locktime has not passed yet ` +
-                            `(currentTimestamp=${Math.floor(Date.now() / 1000)}, ` +
-                            `locktime=${refundLocktime}). ` +
-                            `Refund will be retried after locktime.`,
-                    );
-                    skippedCount++;
-                    continue;
-                }
-
-                logger.warn(
-                    `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint, ` +
-                        `falling back to refundWithoutReceiver offchain`,
-                );
-                // Past CLTV and non-recoverable (recoverable VTXOs are skipped
-                // pre-CLTV) → settle offchain, same as the primary post-CLTV path.
-                await this.settleRefundWithoutReceiver(refundContext, vtxo);
-                sweptCount++;
-            }
-        }
+        const { swept: sweptCount, skipped: skippedCount } = await this.refundVtxos({
+            swapId: pendingSwap.id,
+            vtxos: unspentVtxos,
+            refundLocktime,
+            refundContext,
+            boltzXOnlyPublicKey,
+            ourXOnlyPublicKey,
+            refundViaBoltz: this.swapProvider.refundChainSwap.bind(this.swapProvider),
+        });
 
         // update the pending swap on storage
         const finalStatus = await this.getSwapStatus(pendingSwap.id);
@@ -2788,6 +2622,134 @@ export class ArkadeSwaps {
                 this.arkProvider,
             );
         }
+    }
+
+    /**
+     * Refund every VTXO at a swap's VHTLC address back to the wallet, shared by
+     * {@link ArkadeSwaps.refundVHTLC} (submarine) and {@link ArkadeSwaps.refundArk}
+     * (chain). Path selection per VTXO:
+     * - CLTV elapsed → `refundWithoutReceiver` (offchain for a live VTXO, via a
+     *   batch round for a swept one — see {@link settleRefundWithoutReceiver}).
+     * - Pre-CLTV recoverable → skipped (Boltz can't co-sign a swept-batch refund).
+     * - Pre-CLTV non-recoverable → cooperative 3-of-3 refund via Boltz, falling
+     *   back to `refundWithoutReceiver` offchain if Boltz rejects after the
+     *   locktime has since elapsed.
+     *
+     * @returns Counts of VTXOs swept vs. deferred.
+     */
+    private async refundVtxos(params: {
+        swapId: string;
+        vtxos: VirtualCoin[];
+        refundLocktime: number;
+        refundContext: RefundWithoutReceiverContext;
+        boltzXOnlyPublicKey: Uint8Array;
+        ourXOnlyPublicKey: Uint8Array;
+        refundViaBoltz: Parameters<typeof refundVHTLCwithOffchainTx>[9];
+    }): Promise<{ swept: number; skipped: number }> {
+        const {
+            swapId,
+            vtxos,
+            refundLocktime,
+            refundContext,
+            boltzXOnlyPublicKey,
+            ourXOnlyPublicKey,
+            refundViaBoltz,
+        } = params;
+        const { vhtlcScript, serverXOnlyPublicKey, arkInfo, outputScript } = refundContext;
+
+        // Throttle between Boltz API calls to avoid 429 rate-limiting.
+        let boltzCallCount = 0;
+        let sweptCount = 0;
+        let skippedCount = 0;
+
+        for (const vtxo of vtxos) {
+            const isRecoverableVtxo = isRecoverable(vtxo);
+            const output = { amount: BigInt(vtxo.value), script: outputScript };
+
+            // Re-evaluate the locktime per iteration so a CLTV that elapses
+            // mid-loop is observed by every branch. Once it has passed, the
+            // refundWithoutReceiver leaf is spendable — settle it offchain for a
+            // live VTXO, or via a batch round for a swept one.
+            if (isSubmarineRefundLocktimeReached(refundLocktime)) {
+                await this.settleRefundWithoutReceiver(refundContext, vtxo);
+                sweptCount++;
+                continue;
+            }
+
+            // Pre-CLTV: recoverable VTXOs can't use the Boltz 3-of-3 path
+            // (Boltz can't co-sign a swept-batch refund), so we must wait.
+            if (isRecoverableVtxo) {
+                logger.error(
+                    `Swap ${swapId}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
+                        `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
+                        `(refundLocktime=${refundLocktime}, ` +
+                        `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
+                        `Refund will be retried after locktime.`,
+                );
+                skippedCount++;
+                continue;
+            }
+
+            // Pre-CLTV, non-recoverable: try the 3-of-3 refund via Boltz.
+            const input = {
+                ...vtxo,
+                tapLeafScript: vhtlcScript.refund(),
+                tapTree: vhtlcScript.encode(),
+            };
+            try {
+                if (boltzCallCount > 0) {
+                    await new Promise((r) => setTimeout(r, 2000));
+                }
+                // Count attempts, not successes — a thrown call still consumed
+                // Boltz's rate-limit slot, so the next attempt must observe the
+                // throttle even when the previous one failed.
+                boltzCallCount++;
+                await refundVHTLCwithOffchainTx(
+                    swapId,
+                    this.wallet.identity,
+                    this.arkProvider,
+                    boltzXOnlyPublicKey,
+                    ourXOnlyPublicKey,
+                    serverXOnlyPublicKey,
+                    input,
+                    output,
+                    arkInfo,
+                    refundViaBoltz,
+                );
+                sweptCount++;
+            } catch (error) {
+                // Only fall back for Boltz-side rejections (e.g. outpoint
+                // mismatch after an Ark round). Re-throw anything else.
+                if (!(error instanceof BoltzRefundError)) {
+                    throw error;
+                }
+
+                // Re-check the locktime — wall clock may have advanced while
+                // talking to Boltz.
+                if (!isSubmarineRefundLocktimeReached(refundLocktime)) {
+                    logger.error(
+                        `Swap ${swapId}: Boltz rejected VTXO outpoint and ` +
+                            `refundWithoutReceiver locktime has not passed yet ` +
+                            `(currentTimestamp=${Math.floor(Date.now() / 1000)}, ` +
+                            `locktime=${refundLocktime}). ` +
+                            `Refund will be retried after locktime.`,
+                    );
+                    skippedCount++;
+                    continue;
+                }
+
+                logger.warn(
+                    `Swap ${swapId}: Boltz rejected VTXO outpoint, ` +
+                        `falling back to refundWithoutReceiver offchain`,
+                );
+                // Past CLTV and non-recoverable (recoverable VTXOs are skipped
+                // pre-CLTV) → settle offchain, same as the primary post-CLTV path.
+                await this.settleRefundWithoutReceiver(refundContext, vtxo);
+                sweptCount++;
+            }
+        }
+
+        return { swept: sweptCount, skipped: skippedCount };
     }
 
     /**

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -1096,29 +1096,18 @@ export class ArkadeSwaps {
             };
 
             // Once the CLTV locktime has passed, the refundWithoutReceiver
-            // leaf (sender + server, no Boltz) is spendable. A live VTXO can
-            // settle it offchain — no batch round needed. A swept
-            // (recoverable) VTXO is no longer a spendable leaf, so it must be
-            // reclaimed by re-registering it into a batch.
+            // leaf is spendable — settle it offchain for a live VTXO, or via a
+            // batch round for a swept one (see settleRefundWithoutReceiver).
             if (cltvSatisfied) {
-                const input = {
-                    ...vtxo,
-                    tapLeafScript: refundWithoutReceiverLeaf,
-                    tapTree: vhtlcScript.encode(),
-                };
-                if (isRecoverableVtxo) {
-                    await this.joinBatch(this.wallet.identity, input, output, arkInfo, true);
-                } else {
-                    await refundWithoutReceiverVHTLCwithOffchainTx(
-                        this.wallet.identity,
-                        vhtlcScript,
-                        serverXOnlyPublicKey,
-                        input,
-                        output,
-                        arkInfo,
-                        this.arkProvider,
-                    );
-                }
+                await this.settleRefundWithoutReceiver({
+                    vtxo,
+                    isRecoverable: isRecoverableVtxo,
+                    output,
+                    refundWithoutReceiverLeaf,
+                    vhtlcScript,
+                    serverXOnlyPublicKey,
+                    arkInfo,
+                });
                 sweptCount++;
                 continue;
             }
@@ -1190,22 +1179,17 @@ export class ArkadeSwaps {
                     `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint, ` +
                         `falling back to refundWithoutReceiver offchain`,
                 );
-                const fallbackInput = {
-                    ...vtxo,
-                    tapLeafScript: refundWithoutReceiverLeaf,
-                    tapTree: vhtlcScript.encode(),
-                };
-                // Non-recoverable VTXO past CLTV → settle refundWithoutReceiver
-                // offchain (sender + server), same as the primary post-CLTV path.
-                await refundWithoutReceiverVHTLCwithOffchainTx(
-                    this.wallet.identity,
+                // Past CLTV and non-recoverable (recoverable VTXOs are skipped
+                // pre-CLTV) → settle offchain, same as the primary post-CLTV path.
+                await this.settleRefundWithoutReceiver({
+                    vtxo,
+                    isRecoverable: isRecoverableVtxo,
+                    output,
+                    refundWithoutReceiverLeaf,
                     vhtlcScript,
                     serverXOnlyPublicKey,
-                    fallbackInput,
-                    output,
                     arkInfo,
-                    this.arkProvider,
-                );
+                });
                 sweptCount++;
             }
         }
@@ -1986,26 +1970,15 @@ export class ArkadeSwaps {
             // and could needlessly defer a recoverable VTXO whose
             // locktime had just passed.
             if (isSubmarineRefundLocktimeReached(refundLocktime)) {
-                const input = {
-                    ...vtxo,
-                    tapLeafScript: refundWithoutReceiverLeaf,
-                    tapTree: vhtlcScript.encode(),
-                };
-                // Live VTXO → settle refundWithoutReceiver offchain; swept
-                // VTXO → reclaim via a batch round (no longer a live leaf).
-                if (isRecoverableVtxo) {
-                    await this.joinBatch(this.wallet.identity, input, output, arkInfo, true);
-                } else {
-                    await refundWithoutReceiverVHTLCwithOffchainTx(
-                        this.wallet.identity,
-                        vhtlcScript,
-                        serverXOnlyPublicKey,
-                        input,
-                        output,
-                        arkInfo,
-                        this.arkProvider,
-                    );
-                }
+                await this.settleRefundWithoutReceiver({
+                    vtxo,
+                    isRecoverable: isRecoverableVtxo,
+                    output,
+                    refundWithoutReceiverLeaf,
+                    vhtlcScript,
+                    serverXOnlyPublicKey,
+                    arkInfo,
+                });
                 sweptCount++;
                 continue;
             }
@@ -2070,22 +2043,17 @@ export class ArkadeSwaps {
                     `Swap ${pendingSwap.id}: Boltz rejected VTXO outpoint, ` +
                         `falling back to refundWithoutReceiver offchain`,
                 );
-                const fallbackInput = {
-                    ...vtxo,
-                    tapLeafScript: refundWithoutReceiverLeaf,
-                    tapTree: vhtlcScript.encode(),
-                };
-                // Non-recoverable VTXO past CLTV → settle refundWithoutReceiver
-                // offchain (sender + server), same as the primary post-CLTV path.
-                await refundWithoutReceiverVHTLCwithOffchainTx(
-                    this.wallet.identity,
+                // Past CLTV and non-recoverable (recoverable VTXOs are skipped
+                // pre-CLTV) → settle offchain, same as the primary post-CLTV path.
+                await this.settleRefundWithoutReceiver({
+                    vtxo,
+                    isRecoverable: isRecoverableVtxo,
+                    output,
+                    refundWithoutReceiverLeaf,
                     vhtlcScript,
                     serverXOnlyPublicKey,
-                    fallbackInput,
-                    output,
                     arkInfo,
-                    this.arkProvider,
-                );
+                });
                 sweptCount++;
             }
         }
@@ -2792,6 +2760,43 @@ export class ArkadeSwaps {
         isRecoverable = true,
     ): Promise<string> {
         return joinBatch(this.arkProvider, identity, input, output, arkInfo, isRecoverable);
+    }
+
+    /**
+     * Settle a `refundWithoutReceiver` (sender + server, no Boltz) refund for a
+     * single VTXO whose CLTV refund locktime has elapsed.
+     *
+     * A live VTXO settles the leaf with an offchain Ark tx — no batch round. A
+     * swept (recoverable) VTXO is no longer a live leaf, so it can only be
+     * reclaimed by re-registering it into a batch.
+     */
+    private async settleRefundWithoutReceiver(args: {
+        vtxo: VirtualCoin;
+        isRecoverable: boolean;
+        output: TransactionOutput;
+        refundWithoutReceiverLeaf: ArkTxInput["tapLeafScript"];
+        vhtlcScript: VHTLC.Script;
+        serverXOnlyPublicKey: Uint8Array;
+        arkInfo: ArkInfo;
+    }): Promise<void> {
+        const input = {
+            ...args.vtxo,
+            tapLeafScript: args.refundWithoutReceiverLeaf,
+            tapTree: args.vhtlcScript.encode(),
+        };
+        if (args.isRecoverable) {
+            await this.joinBatch(this.wallet.identity, input, args.output, args.arkInfo, true);
+        } else {
+            await refundWithoutReceiverVHTLCwithOffchainTx(
+                this.wallet.identity,
+                args.vhtlcScript,
+                args.serverXOnlyPublicKey,
+                input,
+                args.output,
+                args.arkInfo,
+                this.arkProvider,
+            );
+        }
     }
 
     /**

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -308,6 +308,82 @@ export const claimVHTLCwithOffchainTx = async (
 };
 
 /**
+ * Refunds a VHTLC offchain via the `refundWithoutReceiver` leaf (sender +
+ * server, no Boltz).
+ *
+ * Mirrors {@link claimVHTLCwithOffchainTx} — both spend a 2-of-2-with-server
+ * leaf offchain; the only difference is which leaf the server co-signs. Use
+ * this once the VHTLC's CLTV refund locktime has elapsed: `buildOffchainTx`
+ * reads the absolute timelock off the `refundWithoutReceiver` (CLTV) leaf and
+ * sets the Ark tx's nLockTime, so the server will co-sign without a batch
+ * round. Only valid for live (non-recoverable) VTXOs — a swept VTXO is no
+ * longer a spendable leaf and must be reclaimed via {@link joinBatch}.
+ *
+ * @param identity - The sender identity; one of the two signers on the leaf.
+ * @param vhtlcScript
+ * @param serverXOnlyPublicKey
+ * @param input - `input.tapLeafScript` must be the refundWithoutReceiver leaf.
+ * @param output
+ * @param arkInfo
+ * @param arkProvider
+ * @returns The Ark transaction ID of the refund.
+ */
+export const refundWithoutReceiverVHTLCwithOffchainTx = async (
+    identity: Identity,
+    vhtlcScript: VHTLC.Script,
+    serverXOnlyPublicKey: Uint8Array,
+    input: ArkTxInput,
+    output: TransactionOutput,
+    arkInfo: ArkInfo,
+    arkProvider: ArkProvider,
+): Promise<string> => {
+    // create the server unroll script for checkpoint transactions
+    const rawCheckpointTapscript = hex.decode(arkInfo.checkpointTapscript);
+    const serverUnrollScript = CSVMultisigTapscript.decode(rawCheckpointTapscript);
+
+    // create the offchain transaction to refund the VHTLC
+    const { arkTx, checkpoints } = buildOffchainTx([input], [output], serverUnrollScript);
+
+    // sign and submit the virtual transaction
+    const signedArkTx = await identity.sign(arkTx);
+    const { arkTxid, finalArkTx, signedCheckpointTxs } = await arkProvider.submitTx(
+        base64.encode(signedArkTx.toPSBT()),
+        checkpoints.map((c) => base64.encode(c.toPSBT())),
+    );
+
+    // verify the server signed the transaction with correct key on the refundWithoutReceiver leaf
+    const finalTx = Transaction.fromPSBT(base64.decode(finalArkTx));
+    const serverPubkeyHex = hex.encode(serverXOnlyPublicKey);
+    const refundLeafHash = tapLeafHash(
+        scriptFromTapLeafScript(vhtlcScript.refundWithoutReceiver()),
+    );
+    for (let i = 0; i < finalTx.inputsLength; i++) {
+        if (!verifySignatures(finalTx, i, [serverPubkeyHex], refundLeafHash)) {
+            throw new Error("Invalid final Ark transaction");
+        }
+    }
+
+    // verify and sign the checkpoint transactions pre signed by the server
+    const finalCheckpoints = await Promise.all(
+        signedCheckpointTxs.map(async (c, idx) => {
+            const tx = Transaction.fromPSBT(base64.decode(c));
+            const checkpointLeaf = checkpoints[idx].getInput(0).tapLeafScript![0];
+            const cpLeafHash = tapLeafHash(scriptFromTapLeafScript(checkpointLeaf));
+            if (!verifySignatures(tx, 0, [serverPubkeyHex], cpLeafHash)) {
+                throw new Error("Invalid server signature in checkpoint transaction");
+            }
+            const signedCheckpoint = await identity.sign(tx, [0]);
+            return base64.encode(signedCheckpoint.toPSBT());
+        }),
+    );
+
+    // submit the final transaction to the Ark provider
+    await arkProvider.finalizeTx(arkTxid, finalCheckpoints);
+
+    return arkTxid;
+};
+
+/**
  * Refunds a VHTLC using an offchain transaction.
  * @param swapId
  * @param identity

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -38,6 +38,7 @@ import {
     claimVHTLCwithOffchainTx,
     createVHTLCScript as createVHTLCScriptReal,
     refundVHTLCwithOffchainTx,
+    refundWithoutReceiverVHTLCwithOffchainTx,
 } from "../src/utils/vhtlc";
 import { BoltzRefundError, InvoiceFailedToPayError, SwapError } from "../src/errors";
 
@@ -64,6 +65,9 @@ vi.mock("../src/utils/vhtlc", async () => {
             "a".repeat(64), // claim ark txid returned to claimArk
         ),
         refundVHTLCwithOffchainTx: vi.fn().mockResolvedValue(undefined),
+        refundWithoutReceiverVHTLCwithOffchainTx: vi.fn().mockResolvedValue(
+            "b".repeat(64), // refundWithoutReceiver ark txid
+        ),
     };
 });
 
@@ -257,7 +261,7 @@ describe("ArkadeSwaps", () => {
         claimPublicKey: compressedPubkeys.boltz,
         // Prod-shaped Boltz Ark VHTLC timeouts:
         //   refund — absolute Unix timestamp; 2023-11-14 in the past so the
-        //     default test case has CLTV satisfied (joinBatch path).
+        //     default test case has CLTV satisfied (refundWithoutReceiver path).
         //   unilateral* — BIP68 relative delays (seconds, ≥ 512 type-flag).
         timeoutBlockHeights: {
             refund: 1700000000,
@@ -3349,10 +3353,15 @@ describe("ArkadeSwaps", () => {
 
             await swaps.refundVHTLC(refundableSwap);
 
+            // Swept (recoverable) VTXO must join a batch; the live (settled)
+            // VTXO settles its refundWithoutReceiver leaf offchain.
             const joinBatch = vi.mocked((swaps as any).joinBatch);
-            expect(joinBatch).toHaveBeenCalledTimes(2);
-            expect(joinBatch.mock.calls[0][1].txid).toBe(otherTxid);
-            expect(joinBatch.mock.calls[1][1].txid).toBe(lockupTxid);
+            expect(joinBatch).toHaveBeenCalledOnce();
+            expect(joinBatch.mock.calls[0][1].txid).toBe(lockupTxid);
+
+            const offchain = vi.mocked(refundWithoutReceiverVHTLCwithOffchainTx);
+            expect(offchain).toHaveBeenCalledOnce();
+            expect((offchain.mock.calls[0][3] as any).txid).toBe(otherTxid);
         });
 
         it("should throw when all VTXOs are spent", async () => {
@@ -3462,9 +3471,11 @@ describe("ArkadeSwaps", () => {
                 expect((mockRefund.mock.calls[0][6] as any).txid).toBe(lockupTxid);
             });
 
-            it("should skip Boltz and use joinBatch when CLTV has passed", async () => {
+            it("should refund a non-recoverable VTXO offchain (refundWithoutReceiver) when CLTV has passed", async () => {
                 // Default refundableSwap has past refund timestamp; CLTV
-                // satisfied via wall-clock check → refundWithoutReceiver.
+                // satisfied via wall-clock check. A non-recoverable (live)
+                // VTXO can settle the refundWithoutReceiver leaf (sender +
+                // server) via an offchain Ark tx — no batch round needed.
                 const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
 
                 mockRefundSelection({
@@ -3473,14 +3484,20 @@ describe("ArkadeSwaps", () => {
 
                 await swaps.refundVHTLC(refundableSwap);
 
+                // Neither the Boltz 3-of-3 path nor a batch round.
                 expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
-                const joinBatch = vi.mocked((swaps as any).joinBatch);
-                expect(joinBatch).toHaveBeenCalledOnce();
-                // isRecoverable arg must be false for non-recoverable VTXOs
-                expect(joinBatch.mock.calls[0][4]).toBe(false);
+                expect((swaps as any).joinBatch).not.toHaveBeenCalled();
+
+                const offchain = vi.mocked(refundWithoutReceiverVHTLCwithOffchainTx);
+                expect(offchain).toHaveBeenCalledOnce();
+                // input (4th positional arg) carries the refundWithoutReceiver leaf
+                expect((offchain.mock.calls[0][3] as any).txid).toBe(lockupTxid);
+                expect((offchain.mock.calls[0][3] as any).tapLeafScript[1]).toEqual(
+                    new Uint8Array([4]),
+                );
             });
 
-            it("should fall back to joinBatch when Boltz rejects and CLTV has since passed", async () => {
+            it("should fall back to refundWithoutReceiver offchain when Boltz rejects and CLTV has since passed", async () => {
                 const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
 
                 mockRefundSelection({
@@ -3500,9 +3517,14 @@ describe("ArkadeSwaps", () => {
 
                 await swaps.refundVHTLC(refundableSwapPreCltv);
 
-                const joinBatch = vi.mocked((swaps as any).joinBatch);
-                expect(joinBatch).toHaveBeenCalledOnce();
-                expect(joinBatch.mock.calls[0][4]).toBe(false);
+                // Non-recoverable VTXO past CLTV → offchain, not a batch round.
+                expect((swaps as any).joinBatch).not.toHaveBeenCalled();
+                const offchain = vi.mocked(refundWithoutReceiverVHTLCwithOffchainTx);
+                expect(offchain).toHaveBeenCalledOnce();
+                expect((offchain.mock.calls[0][3] as any).txid).toBe(lockupTxid);
+                expect((offchain.mock.calls[0][3] as any).tapLeafScript[1]).toEqual(
+                    new Uint8Array([4]),
+                );
             });
 
             it("should skip when Boltz rejects and CLTV still not passed", async () => {
@@ -4182,7 +4204,7 @@ describe("ArkadeSwaps", () => {
             const swap = swapWithRefund(refundTs);
             const outcome = await swaps.refundVHTLC(swap);
 
-            // CLTV satisfied → joinBatch path; no Boltz 3-of-3 attempt.
+            // CLTV satisfied → live VTXO refunds offchain; no Boltz 3-of-3 attempt.
             expect(outcome.swept).toBe(1);
             expect(outcome.skipped).toBe(0);
             expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
@@ -4577,7 +4599,7 @@ describe("ArkadeSwaps", () => {
             });
         });
 
-        it("refunds two unspent VTXOs via joinBatch when CLTV is satisfied", async () => {
+        it("refunds two unspent non-recoverable VTXOs offchain (refundWithoutReceiver) when CLTV is satisfied", async () => {
             const vtxos = [nonRecoverableVtxo(txidA, 0), nonRecoverableVtxo(txidB, 1)];
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: vtxos as any,
@@ -4585,13 +4607,40 @@ describe("ArkadeSwaps", () => {
 
             const outcome = await swaps.refundArk(buildSwap(pastRefund()));
 
+            // Live VTXOs settle the refundWithoutReceiver leaf offchain;
+            // no batch round, no Boltz.
+            const offchain = vi.mocked(refundWithoutReceiverVHTLCwithOffchainTx);
+            expect(offchain).toHaveBeenCalledTimes(2);
+            expect((offchain.mock.calls[0][3] as any).txid).toBe(txidA);
+            expect((offchain.mock.calls[1][3] as any).txid).toBe(txidB);
+            // refundWithoutReceiver leaf (script byte 4) was used
+            expect((offchain.mock.calls[0][3] as any).tapLeafScript[1]).toEqual(
+                new Uint8Array([4]),
+            );
+            expect((swaps as any).joinBatch).not.toHaveBeenCalled();
+            expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
+            expect(outcome).toEqual({ swept: 2, skipped: 0 });
+        });
+
+        it("refunds swept (recoverable) VTXOs via joinBatch when CLTV is satisfied", async () => {
+            const vtxos = [recoverableVtxo(txidA, 0), recoverableVtxo(txidB, 1)];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+
+            const outcome = await swaps.refundArk(buildSwap(pastRefund()));
+
+            // Swept VTXOs are no longer live leaves — only a batch round
+            // can reclaim them.
             const joinBatchSpy = vi.mocked((swaps as any).joinBatch);
             expect(joinBatchSpy).toHaveBeenCalledTimes(2);
             expect(joinBatchSpy.mock.calls[0][1].txid).toBe(txidA);
             expect(joinBatchSpy.mock.calls[1][1].txid).toBe(txidB);
             // refundWithoutReceiver leaf (script byte 4) was used
             expect(joinBatchSpy.mock.calls[0][1].tapLeafScript[1]).toEqual(new Uint8Array([4]));
-            expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
+            // isRecoverable arg must be true for swept VTXOs
+            expect(joinBatchSpy.mock.calls[0][4]).toBe(true);
+            expect(refundWithoutReceiverVHTLCwithOffchainTx).not.toHaveBeenCalled();
             expect(outcome).toEqual({ swept: 2, skipped: 0 });
         });
 
@@ -4673,7 +4722,7 @@ describe("ArkadeSwaps", () => {
             }
         });
 
-        it("falls back to joinBatch when Boltz rejects and CLTV passes during the catch", async () => {
+        it("falls back to refundWithoutReceiver offchain when Boltz rejects and CLTV passes during the catch", async () => {
             const futureTs = Math.floor(Date.now() / 1000) + 86400;
             vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
                 vtxos: [nonRecoverableVtxo(txidA, 0)] as any,
@@ -4689,11 +4738,14 @@ describe("ArkadeSwaps", () => {
 
             const outcome = await swaps.refundArk(buildSwap(futureTs));
 
-            const joinBatchSpy = vi.mocked((swaps as any).joinBatch);
-            expect(joinBatchSpy).toHaveBeenCalledTimes(1);
+            // Non-recoverable VTXO past CLTV → offchain, not a batch round.
+            expect((swaps as any).joinBatch).not.toHaveBeenCalled();
+            const offchain = vi.mocked(refundWithoutReceiverVHTLCwithOffchainTx);
+            expect(offchain).toHaveBeenCalledOnce();
             // fallback uses refundWithoutReceiver leaf (script byte 4)
-            expect(joinBatchSpy.mock.calls[0][1].tapLeafScript[1]).toEqual(new Uint8Array([4]));
-            expect(joinBatchSpy.mock.calls[0][4]).toBe(false);
+            expect((offchain.mock.calls[0][3] as any).tapLeafScript[1]).toEqual(
+                new Uint8Array([4]),
+            );
             expect(outcome).toEqual({ swept: 1, skipped: 0 });
         });
 


### PR DESCRIPTION
## Summary

Once a VHTLC's CLTV refund locktime has elapsed, the `refundWithoutReceiver` leaf (sender + server, no Boltz) becomes spendable. A **live** VTXO can settle that leaf with an offchain Ark tx — no batch round required. But the post-CLTV refund path **always** called `joinBatch`, forcing every refund through a batch round even when a cheaper, faster offchain settlement was possible.

This was a genuine bug: a batch round is only actually required for **swept** (recoverable) VTXOs, which are no longer live leaves and can only be reclaimed by re-registering into a batch.

## Fix

Branch on `isRecoverableVtxo` in the post-CLTV path:

| VTXO state | Before | After |
|---|---|---|
| live (non-recoverable) | `joinBatch` | **`refundWithoutReceiver` offchain** |
| swept (recoverable) | `joinBatch` | `joinBatch` (unchanged) |

Applied **symmetrically in both `refundVHTLC` and `refundArk`**, including their Boltz-rejection fallback paths (where a non-recoverable VTXO past CLTV now also settles offchain rather than joining a batch).

Adds `refundWithoutReceiverVHTLCwithOffchainTx` to `utils/vhtlc.ts`, mirroring the existing `claimVHTLCwithOffchainTx` — both spend a 2-of-2-with-server leaf offchain; the only difference is which leaf the server co-signs. It verifies the server co-signed the `refundWithoutReceiver` leaf on the Ark tx and the checkpoint txs.

## Code structure (de-duplication)

`refundVHTLC` (submarine) and `refundArk` (chain) ran near-identical per-VTXO refund loops. This PR collapses the duplication into two private helpers on `ArkadeSwaps`:

- **`settleRefundWithoutReceiver(ctx, vtxo)`** — the post-CLTV settlement (offchain for a live VTXO, `joinBatch` for a swept one). Loop-invariant inputs are bundled into a `RefundWithoutReceiverContext` built once per pass, so every call site is a single line.
- **`refundVtxos({...})`** — the whole per-VTXO loop (skip-if-recoverable, the throttled Boltz 3-of-3 try/catch, and the `refundWithoutReceiver` fallback), parameterized by what differs between the two callers: the VTXO set, the refund locktime, and the Boltz refund callback (`refundSubmarineSwap` vs `refundChainSwap`). Each method now builds the context, delegates to `refundVtxos`, and runs its own teardown.

### One intentional behavior change

Unifying the loop standardizes `refundVHTLC` on `refundArk`'s **per-iteration** CLTV check; `refundVHTLC` previously snapshotted the locktime once before the loop. The check is a cheap `Date.now()` comparison, and re-evaluating it per VTXO lets a locktime that elapses mid-loop be observed by every VTXO instead of deferring some to a later refund pass. This is the behavior `refundArk` already had.

## Test plan

- `pnpm -C packages/boltz-swap test:unit` — **405 passed**, unmodified across all three refactor commits (the helpers call the same `joinBatch` / offchain / Boltz functions with identical arguments). Coverage asserts:
  - live VTXO past CLTV → `refundWithoutReceiverVHTLCwithOffchainTx`, no `joinBatch`
  - swept VTXO past CLTV → `joinBatch` with `isRecoverable=true`, no offchain call
  - both Boltz-rejection fallback paths now go offchain for non-recoverable VTXOs
  - mixed-VTXO case: one swept (joinBatch) + one live (offchain) in a single refund
  - the Boltz-rejects-then-CLTV-elapses path (call-count-mocked `Date.now()`) still falls back offchain under the per-iteration check
- `pnpm -C packages/boltz-swap build` — passes (incl. DTS type-check)
- `prettier --check` — clean

The offchain `refundWithoutReceiver` path was additionally validated end-to-end against a real arkd regtest node (the server co-signs the leaf and the VTXO is spent offchain).