### PR TITLE
feat: expose boltz-swap version

### DIFF
--- a/packages/boltz-swap/src/index.ts
+++ b/packages/boltz-swap/src/index.ts
@@ -1,3 +1,11 @@
+import { version } from "../package.json";
+
+/**
+ * This SDK plugin's own version string, sourced from package.json, and scoped
+ * by plugin name.
+ */
+export const sdkVersion = `boltz-swap/${version}`;
+
 export { ArkadeSwaps } from "./arkade-swaps";
 export type { QuoteSwapOptions } from "./arkade-swaps";
 export type { BoltzSwapStatus, SubmarineProgressionStatus } from "./boltz-swap-provider";

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -3,11 +3,7 @@ import { version } from "../../package.json";
 export const buildVersion = "0.9.9";
 
 /**
- * The SDK's own version string, sent to arkd as `X-SDK-VERSION` so the operator
- * can distinguish client builds. Formatted `ts-sdk/{version}` to namespace it by
- * client. The version is sourced from package.json so it stays in sync with every
- * release bump — unlike {@link buildVersion}, which tracks arkd's compatibility
- * guard rather than this package's version.
+ * The SDK's own version string, sourced from package.json
  */
 export const sdkVersion = `ts-sdk/${version}`;
 


### PR DESCRIPTION
Export `sdkVersion`  from `@arkade-os/boltz-swap` scoped by plugin name `boltz-swap/$version` for debugging purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SDK now exposes version information in a standardized format, enabling applications to easily track and verify the SDK version in use for improved debugging and compatibility verification

* **Documentation**
  * Updated documentation describing version information accessibility and handling for SDK integrations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->