### PR TITLE
feat(boltz-swap): support descriptionHash on reverse swaps

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -479,11 +479,14 @@ export class ArkadeSwaps {
         // build request object for reverse swap. A BOLT11 invoice carries
         // either a description or a description hash, never both, so prefer
         // descriptionHash when present and drop the plaintext description.
+        // Gate on `!== undefined` (not truthiness) so a present-but-invalid
+        // hash like "" is forwarded and rejected by the provider's hex check,
+        // rather than silently falling back to the description.
         const swapRequest: CreateReverseSwapRequest = {
             invoiceAmount: args.amount,
             claimPublicKey,
             preimageHash,
-            ...(args.descriptionHash
+            ...(args.descriptionHash !== undefined
                 ? { descriptionHash: args.descriptionHash }
                 : args.description?.trim()
                   ? { description: args.description.trim() }

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -476,12 +476,18 @@ export class ArkadeSwaps {
         const preimageHash = hex.encode(sha256(preimage));
         if (!preimageHash) throw new SwapError({ message: "Failed to get preimage hash" });
 
-        // build request object for reverse swap
+        // build request object for reverse swap. A BOLT11 invoice carries
+        // either a description or a description hash, never both, so prefer
+        // descriptionHash when present and drop the plaintext description.
         const swapRequest: CreateReverseSwapRequest = {
             invoiceAmount: args.amount,
             claimPublicKey,
             preimageHash,
-            ...(args.description?.trim() ? { description: args.description.trim() } : {}),
+            ...(args.descriptionHash
+                ? { descriptionHash: args.descriptionHash }
+                : args.description?.trim()
+                  ? { description: args.description.trim() }
+                  : {}),
         };
 
         // make reverse swap request

--- a/packages/boltz-swap/src/boltz-swap-provider.ts
+++ b/packages/boltz-swap/src/boltz-swap-provider.ts
@@ -1147,7 +1147,7 @@ export class BoltzSwapProvider {
             });
         }
         // descriptionHash, when given, must be a 32-byte SHA256 (64 hex chars)
-        if (descriptionHash !== undefined && descriptionHash.length != 64) {
+        if (descriptionHash !== undefined && !/^[0-9a-fA-F]{64}$/.test(descriptionHash)) {
             throw new SwapError({
                 message: "descriptionHash must be a 32-byte SHA256 (64 hex chars)",
             });

--- a/packages/boltz-swap/src/boltz-swap-provider.ts
+++ b/packages/boltz-swap/src/boltz-swap-provider.ts
@@ -457,6 +457,12 @@ export type CreateReverseSwapRequest = {
     preimageHash: string;
     /** Optional description for the BOLT11 invoice. */
     description?: string;
+    /**
+     * Optional SHA256 description hash (hex, 32 bytes / 64 chars) to commit
+     * into the invoice instead of a plaintext description. BOLT11 carries one
+     * or the other, never both; when set, `description` is omitted.
+     */
+    descriptionHash?: string;
 };
 
 /** Response from creating a reverse swap. */
@@ -1132,6 +1138,7 @@ export class BoltzSwapProvider {
         claimPublicKey,
         preimageHash,
         description,
+        descriptionHash,
     }: CreateReverseSwapRequest): Promise<CreateReverseSwapResponse> {
         // claimPublicKey must be in compressed version (33 bytes / 66 hex chars)
         if (claimPublicKey.length != 66) {
@@ -1139,14 +1146,23 @@ export class BoltzSwapProvider {
                 message: "claimPublicKey must be a compressed public key",
             });
         }
-        // make reverse swap request
+        // descriptionHash, when given, must be a 32-byte SHA256 (64 hex chars)
+        if (descriptionHash !== undefined && descriptionHash.length != 64) {
+            throw new SwapError({
+                message: "descriptionHash must be a 32-byte SHA256 (64 hex chars)",
+            });
+        }
+        // make reverse swap request. BOLT11 carries a description OR a
+        // description hash, never both — prefer the hash when present.
         const requestBody = {
             from: "BTC",
             to: "ARK",
             invoiceAmount,
             claimPublicKey,
             preimageHash,
-            description: description?.trim() || "Send to Arkade address",
+            ...(descriptionHash
+                ? { descriptionHash }
+                : { description: description?.trim() || "Send to Arkade address" }),
             ...(this.referralId ? { referralId: this.referralId } : {}),
         };
 

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -338,8 +338,10 @@ export interface DecodedInvoice {
     expiry: number;
     /** Invoice amount in satoshis. */
     amountSats: number;
-    /** Invoice description string. */
+    /** Invoice description string (BOLT11 `d` field; "" if none). */
     description: string;
+    /** Invoice description hash (BOLT11 `h` field, hex; "" if none). */
+    descriptionHash: string;
     /** Payment hash (hex-encoded). */
     paymentHash: string;
 }

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -66,6 +66,15 @@ export interface CreateLightningInvoiceRequest {
     amount: number;
     /** Optional description embedded in the BOLT11 invoice. */
     description?: string;
+    /**
+     * Optional SHA256 description hash (hex, 32 bytes) to commit into the
+     * BOLT11 invoice instead of a plaintext description. A BOLT11 invoice
+     * carries either a description or a description hash, never both, so when
+     * this is set `description` is ignored. Use this for flows that must bind
+     * the invoice to an external document — e.g. NIP-57 zaps, where the hash
+     * is SHA256 of the zap request and the receipt later proves the match.
+     */
+    descriptionHash?: string;
 }
 
 /** Response containing the created Lightning invoice and swap details. */

--- a/packages/boltz-swap/src/utils/decoding.ts
+++ b/packages/boltz-swap/src/utils/decoding.ts
@@ -14,6 +14,13 @@ export const decodeInvoice = (invoice: string): DecodedInvoice => {
         expiry: decoded.expiry ?? 3600,
         amountSats: Number(millisats / 1000n),
         description: decoded.sections.find((s) => s.name === "description")?.value ?? "",
+        // description_hash (BOLT11 `h`) is missing from light-bolt11-decoder's
+        // Section union even though the decoder emits it. Widen just this lookup
+        // rather than patch the library's types (separate repo, out of scope).
+        descriptionHash:
+            (decoded.sections as Array<{ name: string; value?: string }>).find(
+                (s) => s.name === "description_hash",
+            )?.value ?? "",
         paymentHash: decoded.sections.find((s) => s.name === "payment_hash")?.value ?? "",
     };
 };

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -730,6 +730,52 @@ describe("ArkadeSwaps", () => {
                     description: testDescription,
                 });
             });
+
+            it("should forward descriptionHash and omit description", async () => {
+                // arrange
+                const descriptionHash = "a".repeat(64);
+                const spy = vi
+                    .spyOn(swapProvider, "createReverseSwap")
+                    .mockImplementationOnce(reverseSwapResponseFor(createReverseSwapResponse));
+
+                // act — both supplied: hash wins, description dropped
+                await swaps.createReverseSwap({
+                    amount: mock.invoice.amount,
+                    description: "ignored when hash present",
+                    descriptionHash,
+                });
+
+                // assert
+                expect(spy).toHaveBeenCalledWith({
+                    invoiceAmount: mock.invoice.amount,
+                    claimPublicKey: expect.any(String),
+                    preimageHash: expect.any(String),
+                    descriptionHash,
+                });
+                expect(spy.mock.calls[0]![0]).not.toHaveProperty("description");
+            });
+
+            it("should forward a present-but-empty descriptionHash, not silently drop it", async () => {
+                // A present descriptionHash (even "") must reach the provider so
+                // its hex check rejects it, rather than falling back to the
+                // description. Guards the `!== undefined` gating.
+                const spy = vi
+                    .spyOn(swapProvider, "createReverseSwap")
+                    .mockImplementationOnce(reverseSwapResponseFor(createReverseSwapResponse));
+
+                await swaps.createReverseSwap({
+                    amount: mock.invoice.amount,
+                    descriptionHash: "",
+                });
+
+                expect(spy).toHaveBeenCalledWith({
+                    invoiceAmount: mock.invoice.amount,
+                    claimPublicKey: expect.any(String),
+                    preimageHash: expect.any(String),
+                    descriptionHash: "",
+                });
+                expect(spy.mock.calls[0]![0]).not.toHaveProperty("description");
+            });
         });
 
         describe("VHTLC Operations", () => {

--- a/packages/boltz-swap/test/boltz-swap-provider.test.ts
+++ b/packages/boltz-swap/test/boltz-swap-provider.test.ts
@@ -623,6 +623,17 @@ describe("BoltzSwapProvider", () => {
             ).rejects.toThrow("descriptionHash must be a 32-byte SHA256");
         });
 
+        it("should throw when descriptionHash is not valid hex", async () => {
+            await expect(
+                provider.createReverseSwap({
+                    invoiceAmount: 21000,
+                    claimPublicKey: mockHexCompressedPubKey,
+                    preimageHash: "mock-preimage-hash",
+                    descriptionHash: "g".repeat(64), // right length, non-hex
+                }),
+            ).rejects.toThrow("descriptionHash must be a 32-byte SHA256");
+        });
+
         it("should throw on invalid reverse swap response", async () => {
             // arrange
             vi.stubGlobal(

--- a/packages/boltz-swap/test/boltz-swap-provider.test.ts
+++ b/packages/boltz-swap/test/boltz-swap-provider.test.ts
@@ -564,6 +564,65 @@ describe("BoltzSwapProvider", () => {
             expect(response).toEqual(mockResponse);
         });
 
+        it("should send descriptionHash and omit description when provided", async () => {
+            // arrange
+            const mockResponse = {
+                id: "mock-swap-id",
+                invoice: invoice,
+                onchainAmount: 21000,
+                lockupAddress: "mock-lockup-address",
+                refundPublicKey: "mock-refund-public-key",
+                timeoutBlockHeight: 21,
+                timeoutBlockHeights: {
+                    refund: 800000,
+                    unilateralClaim: 800050,
+                    unilateralRefund: 800100,
+                    unilateralRefundWithoutReceiver: 800150,
+                },
+            };
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(() => createFetchResponse(mockResponse)),
+            );
+            const descriptionHash = "a".repeat(64); // 32-byte SHA256 in hex
+            // act
+            const response = await provider.createReverseSwap({
+                invoiceAmount: 21000,
+                claimPublicKey: mockHexCompressedPubKey,
+                preimageHash: "mock-preimage-hash",
+                // both supplied: BOLT11 carries one or the other, hash wins
+                description: "ignored when hash present",
+                descriptionHash,
+            });
+            // assert
+            expect(fetch).toHaveBeenCalledWith("http://localhost:9090/v2/swap/reverse", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    from: "BTC",
+                    to: "ARK",
+                    invoiceAmount: 21000,
+                    claimPublicKey: mockHexCompressedPubKey,
+                    preimageHash: "mock-preimage-hash",
+                    descriptionHash,
+                    referralId: "arkade-ts-sdk",
+                    // description is dropped in favor of descriptionHash
+                }),
+            });
+            expect(response).toEqual(mockResponse);
+        });
+
+        it("should throw when descriptionHash is not 32 bytes", async () => {
+            await expect(
+                provider.createReverseSwap({
+                    invoiceAmount: 21000,
+                    claimPublicKey: mockHexCompressedPubKey,
+                    preimageHash: "mock-preimage-hash",
+                    descriptionHash: "deadbeef", // too short
+                }),
+            ).rejects.toThrow("descriptionHash must be a 32-byte SHA256");
+        });
+
         it("should throw on invalid reverse swap response", async () => {
             // arrange
             vi.stubGlobal(

--- a/packages/boltz-swap/test/decoding.test.ts
+++ b/packages/boltz-swap/test/decoding.test.ts
@@ -7,6 +7,7 @@ vi.mock("light-bolt11-decoder", () => ({
             sections: [
                 { name: "amount", value: "9007199254741999" },
                 { name: "description", value: "large invoice" },
+                { name: "description_hash", value: "a".repeat(64) },
                 { name: "payment_hash", value: "hash" },
             ],
         }),
@@ -18,5 +19,9 @@ const { decodeInvoice } = await import("../src/utils/decoding");
 describe("decodeInvoice", () => {
     it("converts millisats to sats without Number precision loss", () => {
         expect(decodeInvoice("lnbc1mock").amountSats).toBe(9007199254741);
+    });
+
+    it("surfaces the description_hash (BOLT11 h) section", () => {
+        expect(decodeInvoice("lnbc1mock").descriptionHash).toBe("a".repeat(64));
     });
 });

--- a/packages/boltz-swap/test/e2e/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/e2e/arkade-swaps.test.ts
@@ -418,6 +418,35 @@ describe("ArkadeSwaps", () => {
                 const decodeInvoiceResult = decodeInvoice(result.invoice);
                 expect(decodeInvoiceResult.amountSats).toBe(amount);
                 expect(decodeInvoiceResult.description).toBe(description);
+                // description only → no description hash
+                expect(decodeInvoiceResult.descriptionHash).toBe("");
+            });
+
+            it("should create a Lightning invoice with descriptionHash", async () => {
+                const amount = 1000;
+                const descriptionHash = "a".repeat(64);
+                const result = await swaps.createLightningInvoice({
+                    amount,
+                    descriptionHash,
+                });
+                const decoded = decodeInvoice(result.invoice);
+                expect(decoded.amountSats).toBe(amount);
+                expect(decoded.descriptionHash).toBe(descriptionHash);
+                // BOLT11 carries one or the other → no plaintext description
+                expect(decoded.description).toBe("");
+            });
+
+            it("should put only descriptionHash on the invoice when both are given", async () => {
+                const amount = 1000;
+                const descriptionHash = "b".repeat(64);
+                const result = await swaps.createLightningInvoice({
+                    amount,
+                    description: "ignored when hash present",
+                    descriptionHash,
+                });
+                const decoded = decodeInvoice(result.invoice);
+                expect(decoded.descriptionHash).toBe(descriptionHash);
+                expect(decoded.description).toBe("");
             });
 
             it("should return a valid response object", async () => {


### PR DESCRIPTION
## Summary

Let callers commit a SHA256 description hash into a reverse-swap BOLT11 invoice instead of a plaintext description, by adding an optional `descriptionHash` to `createLightningInvoice` / `createReverseSwap`.

Motivation: a wallet built on this SDK that wants to support NIP-57 zaps must produce an invoice whose `description_hash` equals `SHA256(zap request)`, so the kind-9735 zap receipt verifies. The Boltz backend already accepts `descriptionHash` on `POST /v2/swap/reverse` (hex, optional) and forwards it to the node's hold invoice — the SDK was the only layer dropping it, so today every reverse-swap invoice can only carry a plaintext description. This adds the missing passthrough; nothing else is needed on the Boltz/node side.

## What changed

- `CreateLightningInvoiceRequest` and the low-level `CreateReverseSwapRequest` gain an optional `descriptionHash?: string` (hex, 32 bytes).
- `BoltzSwapProvider.createReverseSwap` sends it in the request body.
- A BOLT11 invoice carries a description or a description hash, never both, so when `descriptionHash` is set the plaintext `description` (including the default `"Send to Arkade address"`) is omitted.
- Minimal validation: `descriptionHash`, when present, must be 64 hex chars.

## Not changed (scope / safety)

- No change to the preimage, payment hash, VHTLC, claim, or settlement paths — this only affects the invoice's description field.
- Behavior is identical for existing callers: when `descriptionHash` is unset, the request is byte-for-byte what it was before (default description preserved).

## Test plan

- New `BoltzSwapProvider` unit tests: (1) `descriptionHash` is sent and the plaintext description is dropped when both are supplied; (2) a non-32-byte `descriptionHash` throws.
- `boltz-swap` unit suite green (405 passed); `tsc --noEmit` clean for both packages; `tsup` build clean (JS + DTS); prettier clean.

## Note for reviewers

- I could not run the regtest integration suite locally (Docker), so the end-to-end `descriptionHash` to invoice `h` field round-trip against a live LND/CLN node is unverified here. The backend wiring is confirmed by reading `boltz-backend` (`/v2/swap/reverse` accepts `descriptionHash`; LND `addinvoice` and the CLN hold plugin embed a precomputed hash, preferring it over memo).
- When both `description` and `descriptionHash` are passed, `descriptionHash` wins and `description` is silently dropped (mirrors LND/CLN-hold behavior) rather than throwing. Flag if you'd prefer a hard error instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reverse swaps now support an optional SHA256 description hash. When provided, it’s sent in place of the plaintext description (including when the hash is an empty string).
  * Lightning invoice creation can also commit an optional description hash, and decoded invoices now expose `descriptionHash`.
  * Input validation ensures the description hash is a valid 32-byte / 64-hex-character SHA256.
* **Tests**
  * Added unit and end-to-end coverage for description vs. descriptionHash prioritization and for validation error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->