### PR TITLE
feat(intent): set BIP-322 PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE (0x09)

### DIFF
--- a/packages/ts-sdk/src/intent/index.ts
+++ b/packages/ts-sdk/src/intent/index.ts
@@ -67,7 +67,7 @@ export namespace Intent {
         const toSpend = craftToSpendTx(message, inputs[0].witnessUtxo.script);
 
         // Create the transaction to sign.
-        return craftToSignTx(toSpend, inputs, outputs);
+        return craftToSignTx(toSpend, inputs, outputs, message);
     }
 
     /**
@@ -154,6 +154,10 @@ export const OP_RETURN_EMPTY_PKSCRIPT = new Uint8Array([OP.RETURN]);
 const ZERO_32 = new Uint8Array(32).fill(0);
 const MAX_INDEX = 0xffffffff;
 export const TAG_INTENT_PROOF = "ark-intent-proof-message";
+// BIP-322 v2 global field: the UTF-8 message being signed. Lets a co-signer
+// recognise a message-signing PSBT and recompute the to_spend commitment from
+// PSBT-internal data alone.
+const PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09;
 
 type ValidatedTxInput = TransactionInput & {
     witnessUtxo: { script: Uint8Array; amount: bigint };
@@ -235,6 +239,7 @@ function craftToSignTx(
     toSpend: Transaction,
     inputs: ValidatedTxInput[],
     outputs: ValidatedTxOutput[],
+    message: string,
 ): Transaction {
     const firstInput = inputs[0];
 
@@ -291,6 +296,24 @@ function craftToSignTx(
             script: output.script,
         });
     }
+
+    // Set BIP-322's PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE (0x09) to the signed
+    // message. @scure/btc-signer exposes no public setter for PSBT global
+    // fields, so write the unknown global entry directly. 0x09 is unused in the
+    // global keymap, so it round-trips as an unknown field that toPSBT()/
+    // fromPSBT() preserve.
+    const global = (
+        tx as unknown as {
+            global: { unknown?: [{ type: number; key: Uint8Array }, Uint8Array][] };
+        }
+    ).global;
+    global.unknown = [
+        ...(global.unknown ?? []),
+        [
+            { type: PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE, key: new Uint8Array() },
+            new TextEncoder().encode(message),
+        ],
+    ];
 
     return tx;
 }

--- a/packages/ts-sdk/src/intent/index.ts
+++ b/packages/ts-sdk/src/intent/index.ts
@@ -234,7 +234,21 @@ export function craftToSpendTx(
     return tx;
 }
 
-// craftToSignTx creates the transaction that will be signed for the proof
+/**
+ * Creates the "to_sign" transaction that is signed to produce the proof.
+ *
+ * The first input references the `toSpend` transaction; the remaining inputs are
+ * the ownership inputs being proven. When no outputs are provided a single
+ * value-0 OP_RETURN output is added. The BIP-322 `PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE`
+ * (`0x09`) global field is set to the UTF-8 message so a verifier can recompute
+ * the `toSpend` commitment from PSBT-internal data alone.
+ *
+ * @param toSpend - The "to_spend" transaction whose id the first input references
+ * @param inputs - Validated ownership inputs (input[0] is the toSpend reference)
+ * @param outputs - Proof outputs; an OP_RETURN placeholder is used when empty
+ * @param message - The canonical message the proof commits to
+ * @returns The unsigned "to_sign" proof transaction
+ */
 function craftToSignTx(
     toSpend: Transaction,
     inputs: ValidatedTxInput[],

--- a/packages/ts-sdk/test/intent.test.ts
+++ b/packages/ts-sdk/test/intent.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { Intent } from "../src/intent";
+import { Transaction } from "../src/utils/transaction";
+
+const PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09;
+
+function globalSignedMessage(tx: unknown): Uint8Array | undefined {
+    const unknown =
+        (tx as { global?: { unknown?: [{ type: number; key: Uint8Array }, Uint8Array][] } }).global
+            ?.unknown ?? [];
+    return unknown.find(([k]) => k.type === PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE)?.[1];
+}
 
 describe("Intent", () => {
     // Minimal P2TR-shaped pkscript (OP_1 <32-byte x-only key>). The Intent
@@ -75,6 +85,40 @@ describe("Intent", () => {
             const proof = Intent.create("msg", inputs);
 
             expect(proof.lockTime).toBe(0);
+        });
+    });
+
+    describe("BIP-322 generic signed message (0x09)", () => {
+        it("sets the 0x09 global field to the signed message", () => {
+            const input = { txid: zeroTxid, index: 0, witnessUtxo };
+
+            const proof = Intent.create("hello", [input]);
+
+            const value = globalSignedMessage(proof);
+            expect(value).toBeDefined();
+            expect(new TextDecoder().decode(value)).toBe("hello");
+        });
+
+        it("sets the 0x09 global field to the canonical encoded message for object messages", () => {
+            const input = { txid: zeroTxid, index: 0, witnessUtxo };
+            const message: Intent.Message = { type: "delete", expire_at: 42 };
+
+            const proof = Intent.create(message, [input]);
+
+            const value = globalSignedMessage(proof);
+            expect(value).toBeDefined();
+            expect(new TextDecoder().decode(value)).toBe(Intent.encodeMessage(message));
+        });
+
+        it("survives a PSBT round-trip so a co-signer recovers the message from wire bytes", () => {
+            const input = { txid: zeroTxid, index: 0, witnessUtxo };
+
+            const proof = Intent.create("round-trip", [input]);
+            const parsed = Transaction.fromPSBT(proof.toPSBT());
+
+            const value = globalSignedMessage(parsed);
+            expect(value).toBeDefined();
+            expect(new TextDecoder().decode(value)).toBe("round-trip");
         });
     });
 });

--- a/packages/ts-sdk/test/intent.test.ts
+++ b/packages/ts-sdk/test/intent.test.ts
@@ -8,7 +8,9 @@ function globalSignedMessage(tx: unknown): Uint8Array | undefined {
     const unknown =
         (tx as { global?: { unknown?: [{ type: number; key: Uint8Array }, Uint8Array][] } }).global
             ?.unknown ?? [];
-    return unknown.find(([k]) => k.type === PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE)?.[1];
+    return unknown.find(
+        ([k]) => k.type === PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE && k.key.length === 0,
+    )?.[1];
 }
 
 describe("Intent", () => {


### PR DESCRIPTION
Currently intent-proof PSBTs never set BIP-322's global 0x09 field (key=PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE, value=the UTF-8 message being signed). Without this field a co-signer cannot recompute the to_spend commitment from PSBT-internal data, so it cannot reliably distinguish a genuine ownership proof from an ordinary fund-moving spend before contributing a partial signature.

In this PR we thread the (already canonical) message into craftToSignTx() and set the 0x09 global field to its UTF-8 encoding, which is the same value the proof already commits to via the to_spend tagged hash.

@scure/btc-signer exposes no public setter for PSBT global fields, so the unknown global entry is written directly; 0x09 is unused in the global keymap and round-trips as an unknown field that toPSBT()/ fromPSBT() preserves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced signing process to store message data within PSBT format for verifier and co-signer access

* **Tests**
  * Added comprehensive test coverage for message preservation in PSBT signing and round-trip conversion validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->