### PR TITLE
feat(wallet): reset persisted local data + unblock IndexedDB deletion

### DIFF
--- a/packages/boltz-swap/src/expo/background.ts
+++ b/packages/boltz-swap/src/expo/background.ts
@@ -68,7 +68,7 @@ function createBackgroundWalletShim(args: {
         sendBitcoin: async () => notImplemented("sendBitcoin"),
         send: async () => notImplemented("send"),
         settle: async () => notImplemented("settle"),
-        clearLocalData: async () => notImplemented("clearLocalData"),
+        clear: async () => notImplemented("clear"),
         assetManager: new Proxy({} as IWallet["assetManager"], {
             get: () => notImplemented("assetManager" as keyof IWallet),
         }),

--- a/packages/boltz-swap/src/expo/background.ts
+++ b/packages/boltz-swap/src/expo/background.ts
@@ -68,6 +68,7 @@ function createBackgroundWalletShim(args: {
         sendBitcoin: async () => notImplemented("sendBitcoin"),
         send: async () => notImplemented("send"),
         settle: async () => notImplemented("settle"),
+        clearLocalData: async () => notImplemented("clearLocalData"),
         assetManager: new Proxy({} as IWallet["assetManager"], {
             get: () => notImplemented("assetManager" as keyof IWallet),
         }),

--- a/packages/ts-sdk/src/repositories/indexedDB/manager.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/manager.ts
@@ -67,7 +67,15 @@ export async function openDatabase(
             reject(request.error);
         };
         request.onsuccess = () => {
-            resolve(request.result);
+            const db = request.result;
+            // Close on versionchange so an external indexedDB.deleteDatabase()
+            // (or a version upgrade in another tab) isn't blocked by this connection.
+            db.onversionchange = () => {
+                db.close();
+                dbCache.delete(dbName);
+                refCounts.delete(dbName);
+            };
+            resolve(db);
         };
         request.onupgradeneeded = (event) => {
             const db = request.result;

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -260,13 +260,13 @@ export class ExpoWallet implements IWallet {
      * Stop foreground polling and wipe all locally persisted wallet data.
      * Does not unregister the OS background task or persisted queue config.
      */
-    async clearLocalData(): Promise<void> {
+    async clear(): Promise<void> {
         if (this.foregroundIntervalId) {
             clearInterval(this.foregroundIntervalId);
             this.foregroundIntervalId = undefined;
         }
 
-        await this.wallet.clearLocalData();
+        await this.wallet.clear();
     }
 
     // ── IWallet delegation ───────────────────────────────────────────

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -118,6 +118,8 @@ export class ExpoWallet implements IWallet {
     readonly indexerProvider: Wallet["indexerProvider"];
 
     private foregroundIntervalId?: ReturnType<typeof setInterval>;
+    private foregroundPollChain: Promise<void> = Promise.resolve();
+    private cleared = false;
 
     private constructor(
         private readonly wallet: Wallet,
@@ -207,11 +209,16 @@ export class ExpoWallet implements IWallet {
 
     private startForegroundPolling(intervalMs: number): void {
         this.foregroundIntervalId = setInterval(() => {
-            this.runForegroundPoll().catch(console.error);
+            // Serialize polls so clear() can await the in-flight one before wiping.
+            this.foregroundPollChain = this.foregroundPollChain
+                .then(() => this.runForegroundPoll())
+                .catch(console.error);
         }, intervalMs);
     }
 
     private async runForegroundPoll(): Promise<void> {
+        if (this.cleared) return;
+
         await runTasks(this.taskQueue, this.processors, this.deps);
 
         // Consume results immediately (no background handoff needed)
@@ -219,6 +226,8 @@ export class ExpoWallet implements IWallet {
         if (results.length > 0) {
             await this.taskQueue.acknowledgeResults(results.map((r) => r.id));
         }
+
+        if (this.cleared) return;
 
         // Re-seed for the next tick
         await this.seedContractPollTask();
@@ -235,6 +244,13 @@ export class ExpoWallet implements IWallet {
             createdAt: Date.now(),
         };
         await this.taskQueue.addTask(task);
+    }
+
+    private async removeContractPollTasks(): Promise<void> {
+        const tasks = await this.taskQueue.getTasks(CONTRACT_POLL_TASK_TYPE);
+        for (const task of tasks) {
+            await this.taskQueue.removeTask(task.id);
+        }
     }
 
     // ── Lifecycle ────────────────────────────────────────────────────
@@ -261,12 +277,16 @@ export class ExpoWallet implements IWallet {
      * Does not unregister the OS background task or persisted queue config.
      */
     async clear(): Promise<void> {
+        this.cleared = true;
+
         if (this.foregroundIntervalId) {
             clearInterval(this.foregroundIntervalId);
             this.foregroundIntervalId = undefined;
         }
 
+        await this.foregroundPollChain;
         await this.wallet.clear();
+        await this.removeContractPollTasks();
     }
 
     // ── IWallet delegation ───────────────────────────────────────────

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -256,6 +256,19 @@ export class ExpoWallet implements IWallet {
         await this.wallet.dispose();
     }
 
+    /**
+     * Stop foreground polling and wipe all locally persisted wallet data.
+     * Does not unregister the OS background task or persisted queue config.
+     */
+    async clearLocalData(): Promise<void> {
+        if (this.foregroundIntervalId) {
+            clearInterval(this.foregroundIntervalId);
+            this.foregroundIntervalId = undefined;
+        }
+
+        await this.wallet.clearLocalData();
+    }
+
     // ── IWallet delegation ───────────────────────────────────────────
 
     getAddress(): Promise<string> {

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -897,7 +897,7 @@ export interface IReadonlyWallet {
 
     /**
      * Wipe all locally persisted wallet data (VTXOs, UTXOs, history, sync
-     * cursor, contracts). Create a fresh wallet instance afterward.
+     * cursor, contracts).
      */
     clear(): Promise<void>;
 }

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -894,4 +894,10 @@ export interface IReadonlyWallet {
 
     /** Readonly asset manager bound to this wallet instance. */
     assetManager: IReadonlyAssetManager;
+
+    /**
+     * Wipe all locally persisted wallet data (VTXOs, UTXOs, history, sync
+     * cursor, contracts). Create a fresh wallet instance afterward.
+     */
+    clearLocalData(): Promise<void>;
 }

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -899,5 +899,5 @@ export interface IReadonlyWallet {
      * Wipe all locally persisted wallet data (VTXOs, UTXOs, history, sync
      * cursor, contracts). Create a fresh wallet instance afterward.
      */
-    clearLocalData(): Promise<void>;
+    clear(): Promise<void>;
 }

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1708,37 +1708,28 @@ export class WalletMessageHandler
         return filteredVtxos;
     }
 
+    /** Tear down handler subscriptions, then delegate the full wipe to the wallet. */
     private async clear() {
-        if (!this.readonlyWallet) return;
-        if (this.incomingFundsSubscription) this.incomingFundsSubscription();
+        const wallet = this.wallet ?? this.readonlyWallet;
+        if (!wallet) return;
+
+        if (this.incomingFundsSubscription) {
+            this.incomingFundsSubscription();
+            this.incomingFundsSubscription = undefined;
+        }
         if (this.contractEventsSubscription) {
             this.contractEventsSubscription();
             this.contractEventsSubscription = undefined;
         }
 
-        // Dispose the wallet to stop the ContractWatcher (and its polling
-        // intervals) before clearing the repositories, otherwise the poller
-        // will hit a closing IndexedDB connection.
         try {
-            if (this.wallet) {
-                await this.wallet.dispose();
-            } else {
-                await this.readonlyWallet.dispose();
-            }
-        } catch (_) {
-            // best-effort teardown
+            await wallet.clear();
+        } finally {
+            this.wallet = undefined;
+            this.readonlyWallet = undefined;
+            this.arkProvider = undefined;
+            this.indexerProvider = undefined;
         }
-
-        try {
-            await this.walletRepository?.clear();
-        } catch (_) {
-            console.warn("Failed to clear vtxos from wallet repository");
-        }
-
-        this.wallet = undefined;
-        this.readonlyWallet = undefined;
-        this.arkProvider = undefined;
-        this.indexerProvider = undefined;
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1722,14 +1722,12 @@ export class WalletMessageHandler
             this.contractEventsSubscription = undefined;
         }
 
-        try {
-            await wallet.clear();
-        } finally {
-            this.wallet = undefined;
-            this.readonlyWallet = undefined;
-            this.arkProvider = undefined;
-            this.indexerProvider = undefined;
-        }
+        await wallet.clear();
+
+        this.wallet = undefined;
+        this.readonlyWallet = undefined;
+        this.arkProvider = undefined;
+        this.indexerProvider = undefined;
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -966,10 +966,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         }
     }
 
-    /**
-     * Wipe all locally persisted wallet data on the page and service worker
-     * (VTXOs, UTXOs, history, sync cursor, contracts). Re-init the wallet after.
-     */
+    /** This tells the service worker to wipe all locally persisted wallet data. */
     async clear(): Promise<void> {
         const message: RequestClear = {
             id: getRandomId(),
@@ -977,7 +974,6 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             type: "CLEAR",
         };
         await this.sendMessage(message);
-        await Promise.all([this.walletRepository.clear(), this.contractRepository.clear()]);
     }
 
     async getAddress(): Promise<string> {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -935,20 +935,6 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
     }
 
     /**
-     * Wipe all locally persisted wallet data on the page and service worker
-     * (VTXOs, UTXOs, history, sync cursor, contracts). Re-init the wallet after.
-     */
-    async clearLocalData(): Promise<void> {
-        const message: RequestClear = {
-            id: getRandomId(),
-            tag: this.messageTag,
-            type: "CLEAR",
-        };
-        await this.sendMessage(message);
-        await Promise.all([this.walletRepository.clear(), this.contractRepository.clear()]);
-    }
-
-    /**
      * Verify the worker is bound to this wallet's identity before the SDK hands
      * back (or recovers) a usable wallet object.
      *
@@ -980,22 +966,18 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         }
     }
 
-    /** @deprecated Use {@link clearLocalData} for a full reset; clear() leaves contract rows. */
-    async clear() {
+    /**
+     * Wipe all locally persisted wallet data on the page and service worker
+     * (VTXOs, UTXOs, history, sync cursor, contracts). Re-init the wallet after.
+     */
+    async clear(): Promise<void> {
         const message: RequestClear = {
             id: getRandomId(),
             tag: this.messageTag,
             type: "CLEAR",
         };
-        // Clear page-side storage to maintain parity with SW
-        try {
-            const address = await this.getAddress();
-            await this.walletRepository.deleteVtxos(address);
-        } catch (_) {
-            console.warn("Failed to clear vtxos from wallet repository");
-        }
-
         await this.sendMessage(message);
+        await Promise.all([this.walletRepository.clear(), this.contractRepository.clear()]);
     }
 
     async getAddress(): Promise<string> {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -928,7 +928,25 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         return this.reinitPromise;
     }
 
-    /** Clear cached wallet state from both the page and service worker storage. */
+    /**
+     * Wipe all locally persisted wallet data on the page and service worker
+     * (VTXOs, UTXOs, history, sync cursor, contracts). Re-init the wallet after.
+     */
+    async clearLocalData(): Promise<void> {
+        const message: RequestClear = {
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "CLEAR",
+        };
+        await this.sendMessage(message);
+        try {
+            await Promise.all([this.walletRepository.clear(), this.contractRepository.clear()]);
+        } catch (_) {
+            console.warn("Failed to clear page-side wallet storage");
+        }
+    }
+
+    /** @deprecated Use {@link clearLocalData} for a full reset; clear() leaves contract rows. */
     async clear() {
         const message: RequestClear = {
             id: getRandomId(),

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -945,11 +945,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             type: "CLEAR",
         };
         await this.sendMessage(message);
-        try {
-            await Promise.all([this.walletRepository.clear(), this.contractRepository.clear()]);
-        } catch (_) {
-            console.warn("Failed to clear page-side wallet storage");
-        }
+        await Promise.all([this.walletRepository.clear(), this.contractRepository.clear()]);
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -876,7 +876,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * Wipe all locally persisted wallet data (VTXOs, UTXOs, history, sync
      * cursor, contracts). Create a fresh wallet instance afterward.
      */
-    async clearLocalData(): Promise<void> {
+    async clear(): Promise<void> {
         try {
             await this.dispose();
         } finally {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -871,6 +871,18 @@ export class ReadonlyWallet implements IReadonlyWallet {
     async clearSyncCursor(): Promise<void> {
         await clearSyncCursor(this.walletRepository);
     }
+
+    /**
+     * Wipe all locally persisted wallet data (VTXOs, UTXOs, history, sync
+     * cursor, contracts). Create a fresh wallet instance afterward.
+     */
+    async clearLocalData(): Promise<void> {
+        try {
+            await this.dispose();
+        } finally {
+            await Promise.all([this.walletRepository.clear(), this.contractRepository.clear()]);
+        }
+    }
     /**
      * The on-chain (P2TR) addresses of every boarding tapscript this wallet
      * uses — the current address plus any historical rotated boarding

--- a/packages/ts-sdk/test/db.test.ts
+++ b/packages/ts-sdk/test/db.test.ts
@@ -24,6 +24,25 @@ describe("db manager", () => {
         expect(closedTwice).toBe(true);
     });
 
+    it("closes on versionchange so an external deleteDatabase is not blocked", async () => {
+        const dbName = getUniqueDbName("db-manager-delete");
+        const initDb = vi.fn();
+
+        await openDatabase(dbName, 1, initDb);
+
+        let blocked = false;
+        await new Promise<void>((resolve, reject) => {
+            const request = indexedDB.deleteDatabase(dbName);
+            request.onsuccess = () => resolve();
+            request.onerror = () => reject(request.error);
+            request.onblocked = () => {
+                blocked = true;
+            };
+        });
+
+        expect(blocked).toBe(false);
+    });
+
     it("rejects opening a different version for the same DB name", async () => {
         const dbName = getUniqueDbName("db-manager-version");
         const initDb = vi.fn();

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -877,6 +877,91 @@ describe("Wallet", () => {
         });
     });
 
+    describe("clearLocalData", () => {
+        const mockArkInfo = {
+            signerPubkey: mockServerKeyHex,
+            forfeitPubkey: mockServerKeyHex,
+            batchExpiry: BigInt(144),
+            unilateralExitDelay: BigInt(144),
+            boardingExitDelay: BigInt(144),
+            roundInterval: BigInt(144),
+            network: "mutinynet",
+            dust: BigInt(1000),
+            forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+            checkpointTapscript:
+                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        };
+
+        function createMockVtxo(script: string): VirtualCoin {
+            return {
+                txid: "11".repeat(32),
+                vout: 0,
+                value: 50_000,
+                status: { confirmed: false, isLeaf: false },
+                virtualStatus: {
+                    state: "preconfirmed",
+                    commitmentTxIds: ["22".repeat(32)],
+                    batchExpiry: 1767225600000,
+                },
+                spentBy: "",
+                settledBy: undefined,
+                arkTxId: "",
+                createdAt: new Date("2026-01-01T00:00:00.000Z"),
+                isUnrolled: false,
+                isSpent: false,
+                script,
+            };
+        }
+
+        async function createReadonlyTestWallet() {
+            let walletScript = "";
+            const getVtxos = vi
+                .fn<IndexerProvider["getVtxos"]>()
+                .mockImplementation(async (opts) => {
+                    if (!walletScript && opts?.scripts?.[0]) walletScript = opts.scripts[0];
+                    return { vtxos: [createMockVtxo(walletScript)] };
+                });
+
+            const compressedPubKey = await mockIdentity.compressedPublicKey();
+            const readonlyIdentity = ReadonlySingleKey.fromPublicKey(compressedPubKey);
+            const walletRepository = new InMemoryWalletRepository();
+            const contractRepository = new InMemoryContractRepository();
+
+            const wallet = await ReadonlyWallet.create({
+                identity: readonlyIdentity,
+                arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: vi.fn().mockResolvedValue(mockArkInfo),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider: {
+                    getVtxos,
+                    subscribeForScripts: vi.fn().mockResolvedValue("sub-1"),
+                    unsubscribeForScripts: vi.fn().mockResolvedValue(undefined),
+                    getSubscription: async function* () {},
+                } as Partial<IndexerProvider> as IndexerProvider,
+                onchainProvider: {} as OnchainProvider,
+                storage: { walletRepository, contractRepository },
+            });
+
+            return { wallet, walletRepository, contractRepository };
+        }
+
+        it("wipes stored VTXOs and contracts from both repositories", async () => {
+            const { wallet, walletRepository, contractRepository } =
+                await createReadonlyTestWallet();
+            const address = await wallet.getAddress();
+
+            expect(await wallet.getVtxos()).toHaveLength(1);
+            expect(await walletRepository.getVtxos(address)).toHaveLength(1);
+            expect((await contractRepository.getContracts()).length).toBeGreaterThan(0);
+
+            await wallet.clearLocalData();
+
+            expect(await walletRepository.getVtxos(address)).toEqual([]);
+            expect(await contractRepository.getContracts()).toEqual([]);
+        });
+    });
+
     describe("notifyIncomingFunds — single SSE stream", () => {
         const mockArkInfo = {
             signerPubkey: mockServerKeyHex,

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -877,7 +877,7 @@ describe("Wallet", () => {
         });
     });
 
-    describe("clearLocalData", () => {
+    describe("clear", () => {
         const mockArkInfo = {
             signerPubkey: mockServerKeyHex,
             forfeitPubkey: mockServerKeyHex,
@@ -955,7 +955,7 @@ describe("Wallet", () => {
             expect(await walletRepository.getVtxos(address)).toHaveLength(1);
             expect((await contractRepository.getContracts()).length).toBeGreaterThan(0);
 
-            await wallet.clearLocalData();
+            await wallet.clear();
 
             expect(await walletRepository.getVtxos(address)).toEqual([]);
             expect(await contractRepository.getContracts()).toEqual([]);


### PR DESCRIPTION
part of #522

ffter a chain reset, network switch, or logout, the wallet shows a stale balance from coins that no longer exist, with no supported way to clear it.

**What this does**
- Makes `clear()` a full reset on every wallet type + the shared interface: wipes cached coins, history, sync cursor, and contracts in one call.
- Stops the background sync first so nothing re-saves stale data mid-wipe.
- Unblocks `indexedDB.deleteDatabase()` (it used to hang because the wallet never released the DB connection).
- Folds the full reset into the existing service-worker `clear()` (it previously deleted only the current address's VTXOs).

**Scope**
- Covers requests 1 and 3 of #522.
- Follow-up (separate PR): sync auto-drops coins the server stops reporting, so the stale balance self-heals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/extended a public `clear()` wallet action to fully wipe locally persisted wallet data (including cached VTXOs and stored contracts) across read-only, service worker, and Expo wallet flows.
* **Bug Fixes**
  * Improved IndexedDB behavior on `versionchange` to avoid stale open connections blocking database deletion.
  * Expo background shim `clear` now consistently follows the expected “not implemented” behavior.
* **Tests**
  * Added coverage for IndexedDB deletion unblocking and for `clear()` removing cached VTXOs and stored contracts.
* **Chores**
  * Updated the `regtest` subproject pointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
