### PR TITLE
fix(arkfee)!: rename Estimator.eval() to evaluate() for SES/Snap compatibility

### DIFF
--- a/packages/ts-sdk/src/arkfee/estimator.ts
+++ b/packages/ts-sdk/src/arkfee/estimator.ts
@@ -103,7 +103,7 @@ export class Estimator {
      * @param onchainOutputs - Array of onchain outputs to evaluate
      * @returns The total fee amount
      */
-    eval(
+    evaluate(
         offchainInputs: OffchainInput[],
         onchainInputs: OnchainInput[],
         offchainOutputs: FeeOutput[],

--- a/packages/ts-sdk/test/fee.test.ts
+++ b/packages/ts-sdk/test/fee.test.ts
@@ -246,7 +246,7 @@ describe("Estimator", () => {
                             convertJsonOutput,
                         );
 
-                        const result = estimator.eval(
+                        const result = estimator.evaluate(
                             offchainInputs,
                             onchainInputs,
                             offchainOutputs,


### PR DESCRIPTION
## What

Renames the fee `Estimator`'s aggregate method `eval()` → `evaluate()`.

## Why

MetaMask Snaps bundle the SDK and run the bundle through SES, whose static "direct eval" detector (`rejectSomeDirectEvalExpressions`) rejects any bare `eval(` token. `Estimator` exposed a method literally named `eval`, so SES rejected the whole snap bundle (`SES_EVAL_REJECTED`), making the SDK impossible to bundle inside a snap. See #580.

The per-input helpers (`evalOffchainInput`, `evalOnchainInput`, `evalOffchainOutput`, `evalOnchainOutput`) are unaffected — SES only flags the exact `eval` identifier.

## Verification

- Behaviour is identical; `test/fee.test.ts` passes (39/39).
- `tsc --noEmit` clean; `tsup` build clean; full unit suite green (pre-commit hook).
- The built SDK dist now contains **0** bare `eval(` tokens.

## ⚠️ Necessary, but not sufficient, to unblock the snap

This removes the SDK's *own* `eval` token. It does **not** fully fix the snap on its own: the `Estimator` depends on [`@marcbachmann/cel-js`](https://www.npmjs.com/package/@marcbachmann/cel-js), whose interpreter also defines an `eval(ast, ctx)` method (`lib/evaluator.js`). Because `Estimator` is used by core (`wallet`, `ramps`, `vtxo-manager`, `delegate`), cel-js is bundled into every SDK consumer — so the snap bundle still carries cel-js's `eval` token and SES will keep rejecting it until that's resolved upstream (filing an issue on cel-js). Tracked in #580.

## BREAKING CHANGE

`Estimator.eval()` is renamed to `Estimator.evaluate()`. Callers of the public `Estimator` must update `.eval(...)` → `.evaluate(...)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed a fee estimation method to a clearer, more descriptive name.
  * Updated related usage so fee calculations continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->