### PR TITLE
feat(wallet): pluggable activity history (getActivityHistory + resolver registry)

### DIFF
--- a/packages/boltz-swap/src/expo/background.ts
+++ b/packages/boltz-swap/src/expo/background.ts
@@ -62,6 +62,7 @@ function createBackgroundWalletShim(args: {
         getVtxos: async () => notImplemented("getVtxos"),
         getBoardingUtxos: async () => notImplemented("getBoardingUtxos"),
         getTransactionHistory: async () => notImplemented("getTransactionHistory"),
+        getActivityHistory: async () => notImplemented("getActivityHistory"),
         getContractManager: async () => notImplemented("getContractManager"),
         getDelegateManager: async () => notImplemented("getDelegateManager"),
         getDelegatorManager: async () => notImplemented("getDelegatorManager"),
@@ -70,6 +71,9 @@ function createBackgroundWalletShim(args: {
         settle: async () => notImplemented("settle"),
         assetManager: new Proxy({} as IWallet["assetManager"], {
             get: () => notImplemented("assetManager" as keyof IWallet),
+        }),
+        activity: new Proxy({} as IWallet["activity"], {
+            get: () => notImplemented("activity" as keyof IWallet),
         }),
     };
 }

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -363,8 +363,9 @@ const txid = await wallet.send({
 ### Activity history
 
 Group the wallet's transaction history into labelled, logical activities. Register an
-`ActivityResolver` — a pure `tx -> memberships` function — and `getActivityHistory()`
-buckets the transactions into `Activity` rows. The `boarding` built-in is pre-registered,
+`ActivityResolver` object; its optional `prepare()` can refresh correlation data, and
+its synchronous `resolve(tx)` returns memberships. `getActivityHistory()` buckets
+the transactions into `Activity` rows. The `boarding` built-in is pre-registered,
 and a transaction can belong to multiple groups (e.g. a batched settlement).
 
 ```typescript
@@ -379,6 +380,7 @@ wallet.activity.use({
 
 // Built-ins (boarding) + your resolver; txs grouped oldest-first per activity
 const activities = await wallet.getActivityHistory()
+// amount is signed sats: positive received, negative sent; same-key change rows are excluded
 // each Activity: { id, intent?, txs, amount, createdAt, settled }
 ```
 

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -360,6 +360,28 @@ const txid = await wallet.send({
 })
 ```
 
+### Activity history
+
+Group the wallet's transaction history into labelled, logical activities. Register an
+`ActivityResolver` — a pure `tx -> memberships` function — and `getActivityHistory()`
+buckets the transactions into `Activity` rows. The `boarding` built-in is pre-registered,
+and a transaction can belong to multiple groups (e.g. a batched settlement).
+
+```typescript
+// Tag your app's transactions (correlate by txid however you track them)
+wallet.activity.use({
+  id: 'my-app',
+  resolve: (tx) => {
+    const action = myActions.get(tx.key.arkTxid)
+    return action ? [{ groupId: action.id, label: action.label, kind: 'app' }] : undefined
+  },
+})
+
+// Built-ins (boarding) + your resolver; txs grouped oldest-first per activity
+const activities = await wallet.getActivityHistory()
+// each Activity: { id, intent?, txs, amount, createdAt, settled }
+```
+
 ### Assets (Issue, Reissue, Burn, Send)
 
 The wallet's `assetManager` lets you create and manage assets on Arkade. The `send` method supports sending assets.

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -72,6 +72,14 @@ import {
     IAssetManager,
     IReadonlyAssetManager,
 } from "./wallet";
+export {
+    ActivityRegistry,
+    boardingResolver,
+    createDefaultActivityRegistry,
+    type Activity,
+    type GroupMembership,
+    type ActivityResolver,
+} from "./wallet";
 import { Batch } from "./wallet/batch";
 import {
     Wallet,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -77,6 +77,7 @@ export {
     boardingResolver,
     createDefaultActivityRegistry,
     type Activity,
+    type ActivityIntent,
     type GroupMembership,
     type ActivityResolver,
 } from "./wallet";

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -123,3 +123,28 @@ export async function buildActivities(
         })
         .sort((a, c) => latest(c) - latest(a));
 }
+
+/** Holds activity resolvers keyed by id. Built-in resolvers are pre-registered on the wallet. */
+export class ActivityRegistry {
+    private readonly resolvers = new Map<string, ActivityResolver>();
+
+    /** Add a resolver, or override an existing one with the same id (kept in place). */
+    use(resolver: ActivityResolver): void {
+        this.resolvers.set(resolver.id, resolver);
+    }
+
+    /** Remove a resolver (built-in or custom) by id. */
+    remove(id: string): void {
+        this.resolvers.delete(id);
+    }
+
+    /** The registered resolver ids, in registration order. */
+    list(): string[] {
+        return [...this.resolvers.keys()];
+    }
+
+    /** All registered resolvers, in registration (priority) order. */
+    all(): ActivityResolver[] {
+        return [...this.resolvers.values()];
+    }
+}

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -148,3 +148,23 @@ export class ActivityRegistry {
         return [...this.resolvers.values()];
     }
 }
+
+/** Built-in resolver: labels on-chain boarding (deposit) transactions. */
+export function boardingResolver(): ActivityResolver {
+    return {
+        id: "boarding",
+        resolve(tx) {
+            if (!tx.key.boardingTxid) return undefined;
+            return [
+                { groupId: `boarding:${tx.key.boardingTxid}`, label: "Deposit", kind: "boarding" },
+            ];
+        },
+    };
+}
+
+/** A registry pre-populated with the SDK's built-in resolvers (currently `boarding`). */
+export function createDefaultActivityRegistry(): ActivityRegistry {
+    const registry = new ActivityRegistry();
+    registry.use(boardingResolver());
+    return registry;
+}

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -18,7 +18,10 @@ export interface GroupMembership {
 export interface ActivityResolver {
     /** Registry key — override or remove by it. */
     id: string;
-    /** Load fresh correlation data (swaps, games…) before `resolve` runs. */
+    /**
+     * Load fresh correlation data (swaps, games…) before `resolve` runs. A
+     * rejection is isolated — the resolver then contributes no memberships.
+     */
     prepare?(): Promise<void>;
     /** Pure and synchronous. The groups this tx belongs to, or undefined to leave it plain. */
     resolve(tx: ArkTransaction): GroupMembership[] | undefined;
@@ -50,13 +53,25 @@ export interface Activity {
  *   `label`/`kind` first-defined-wins (resolver order), `metadata` shallow-merged.
  * - A member's contribution defaults to the tx's full amount, or `membership.amount`
  *   when given (so a batched tx splits across the groups it touches).
- * - A resolver throwing on a tx is caught and treated as no membership.
+ * - A resolver that throws in resolve() or rejects in prepare() is isolated and
+ *   contributes no memberships, so one bad resolver never breaks the whole history.
  */
 export async function buildActivities(
     txs: ArkTransaction[],
     resolvers: ActivityResolver[],
 ): Promise<Activity[]> {
-    await Promise.all(resolvers.map((r) => r.prepare?.()));
+    // Isolate prepare() like resolve(): a resolver that fails to load its
+    // correlation data contributes no memberships, rather than throwing away
+    // the whole history.
+    await Promise.all(
+        resolvers.map(async (r) => {
+            try {
+                await r.prepare?.();
+            } catch {
+                // a failed prepare leaves this resolver with stale/empty data
+            }
+        }),
+    );
 
     const keyOf = (tx: ArkTransaction) =>
         tx.key.arkTxid || tx.key.commitmentTxid || tx.key.boardingTxid;

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -1,34 +1,32 @@
 import { TxType, type ArkTransaction } from "./index";
 
-/** One transaction's participation in one logical action. A tx may return several. */
+/** One transaction's participation in one logical action. */
 export interface GroupMembership {
     /**
      * Stable id of the action; txs sharing it group together. Third-party
      * resolvers should namespace it (`"vendor:thing"`) to avoid colliding with
-     * other resolvers' groups; the built-ins use `boarding:`/`exit:`/`mint:`.
+     * other resolvers' groups. SDK built-ins use namespaced ids such as `boarding:`.
      */
     groupId: string;
     /** Human label for the action, e.g. "Dice game". */
     label?: string;
-    /** App category for icon/filtering, e.g. "game". Namespace across vendors to avoid clashes. */
+    /** App category for icon/filtering, e.g. "game". */
     kind?: string;
     /**
-     * Free-form row data (renderer-defined). When several resolvers tag the same
-     * tx+group, this is shallow-merged with earlier-resolver-wins on key
-     * collision — namespace keys (e.g. `swap.status`) to avoid clobbering.
+     * Free-form row data. Same-group metadata is shallow-merged with
+     * earlier-resolver keys winning.
      */
     metadata?: Record<string, unknown>;
     /**
-     * This tx's contribution to THIS group, as an unsigned sat magnitude;
-     * defaults to the tx's full amount. The activity builder applies the tx
-     * direction (received positive, sent negative). Set it to split a batched
-     * tx across the groups it touches — omitting it on a multi-group tx
-     * attributes the full amount to each group.
+     * This tx's unsigned sat contribution to this group. Defaults to the tx's
+     * full amount; the builder applies direction. Use it to split a batched tx
+     * across groups. Same-key receive rows paired with a sent row are treated
+     * as change and excluded from `Activity.amount`.
      */
     amount?: number;
 }
 
-/** A pluggable resolver. Registered by id; `prepare()` refreshes correlation data. */
+/** A pluggable resolver keyed by `id`. */
 export interface ActivityResolver {
     /**
      * Registry key — override or remove by it. Namespace it (`"vendor:games"`)
@@ -37,15 +35,15 @@ export interface ActivityResolver {
      */
     id: string;
     /**
-     * Load fresh correlation data (swaps, games…) before `resolve` runs. A
-     * rejection is isolated — the resolver then contributes no memberships.
+     * Load correlation data before `resolve` runs. If it rejects, this resolver
+     * contributes no memberships.
      */
     prepare?(): Promise<void>;
     /** Pure and synchronous. The groups this tx belongs to, or undefined to leave it plain. */
     resolve(tx: ArkTransaction): GroupMembership[] | undefined;
 }
 
-/** The label/kind/metadata an activity carries — the non-id, non-amount part of a {@link GroupMembership}. */
+/** The non-id, non-amount part of a {@link GroupMembership}. */
 export interface ActivityIntent {
     /** Human label for the action, e.g. "Dice game". */
     label?: string;
@@ -55,15 +53,15 @@ export interface ActivityIntent {
     metadata?: Record<string, unknown>;
 }
 
-/** One logical activity: the projection of all txs sharing a groupId. */
+/** One logical activity. */
 export interface Activity {
-    /** The groupId, or the tx's own key when ungrouped. */
+    /** The groupId, or the natural tx key for untagged rows. */
     id: string;
     /** Merged intent for the group, if any resolver tagged it. */
     intent?: ActivityIntent;
     /** Member txs, oldest-first. */
     txs: ArkTransaction[];
-    /** Signed net amount across the group, in sats: positive received, negative sent. */
+    /** Signed net sats: positive received, negative sent; same-key change rows are excluded. */
     amount: number;
     /** Earliest member createdAt (ms since epoch). */
     createdAt: number;
@@ -72,27 +70,21 @@ export interface Activity {
 }
 
 /**
- * Pure grouping engine: project a flat tx list into activities via resolvers.
- * Mirrors `buildTransactionHistory` — no I/O beyond the resolvers' own `prepare()`.
+ * Project a flat tx list into activities via resolvers.
  *
- * - A tx with no memberships is bucketed by its own transaction key; rows that
- *   share a key stay together so send/change pairs remain one activity.
+ * - Untagged rows bucket by natural tx key, so send/change pairs stay together.
  * - Memberships are unioned across resolvers and bucketed by `groupId`; a tx may join
  *   several groups (Ark batching). Same-group memberships (across resolvers) merge:
  *   `label`/`kind` first-defined-wins (resolver order), `metadata` shallow-merged.
- * - A member's contribution defaults to the tx's signed amount (received positive,
- *   sent negative), or the signed form of `membership.amount` when given (so a
- *   batched tx splits across the groups it touches).
+ * - Contributions are signed by tx direction; same-key received rows paired with
+ *   a sent row are treated as change and excluded from the activity amount.
  * - A resolver that throws in resolve() or rejects in prepare() is isolated and
- *   contributes no memberships, so one bad resolver never breaks the whole history.
+ *   contributes no memberships.
  */
 export async function buildActivities(
     txs: ArkTransaction[],
     resolvers: ActivityResolver[],
 ): Promise<Activity[]> {
-    // Isolate prepare() like resolve(): a resolver that fails to load its
-    // correlation data contributes no memberships, rather than throwing away
-    // the whole history.
     const preparedResolvers = (
         await Promise.all(
             resolvers.map(async (r) => {
@@ -130,15 +122,14 @@ export async function buildActivities(
     const buckets = new Map<string, Bucket>();
 
     for (const tx of txs) {
-        // Collect this tx's memberships, deduping by groupId so two resolvers tagging
-        // the same tx+group merge into one membership (rather than counting the tx twice).
+        // Deduplicate resolver memberships by groupId for this tx.
         const perGroup = new Map<string, GroupMembership>();
         for (const r of preparedResolvers) {
             let ms: GroupMembership[] | undefined;
             try {
                 ms = r.resolve(tx);
             } catch {
-                ms = undefined; // one bad tag must not break the whole history
+                ms = undefined;
             }
             for (const m of ms ?? []) {
                 const existing = perGroup.get(m.groupId);
@@ -168,13 +159,12 @@ export async function buildActivities(
     const netAmount = (members: { tx: ArkTransaction; amount: number }[]) => {
         const sentKeys = new Set(members.filter((x) => isSent(x.tx)).map((x) => keyOf(x.tx)));
         return members.reduce((s, x) => {
-            // A sent row is already net of its own change; do not add the paired receive back.
+            // Same-key receives are change for sent rows.
             if (!isSent(x.tx) && sentKeys.has(keyOf(x.tx))) return s;
             return s + x.amount;
         }, 0);
     };
 
-    // Members are oldest-first, so the last one is the most recent.
     const latest = (a: Activity) => a.txs[a.txs.length - 1].createdAt;
     return [...buckets.entries()]
         .map(([id, b]): Activity => {
@@ -191,7 +181,7 @@ export async function buildActivities(
         .sort((a, c) => latest(c) - latest(a));
 }
 
-/** Holds activity resolvers keyed by id. Built-in resolvers are pre-registered on the wallet. */
+/** Resolver registry keyed by id. */
 export class ActivityRegistry {
     private readonly resolvers = new Map<string, ActivityResolver>();
 
@@ -229,7 +219,7 @@ export function boardingResolver(): ActivityResolver {
     };
 }
 
-/** A registry pre-populated with the SDK's built-in resolvers (currently `boarding`). */
+/** Default registry with SDK built-ins. */
 export function createDefaultActivityRegistry(): ActivityRegistry {
     const registry = new ActivityRegistry();
     registry.use(boardingResolver());

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -1,0 +1,125 @@
+import type { ArkTransaction } from "./index";
+
+/** One transaction's participation in one logical action. A tx may return several. */
+export interface GroupMembership {
+    /** Stable id of the action; txs sharing it group together. */
+    groupId: string;
+    /** Human label for the action, e.g. "Dice game". */
+    label?: string;
+    /** App category for icon/filtering, e.g. "game". */
+    kind?: string;
+    /** Free-form row data (renderer-defined). */
+    metadata?: Record<string, unknown>;
+    /** This tx's contribution to THIS group, in sats; defaults to the tx's full net amount. */
+    amount?: number;
+}
+
+/** A pluggable resolver. Registered by id; `prepare()` refreshes correlation data. */
+export interface ActivityResolver {
+    /** Registry key — override or remove by it. */
+    id: string;
+    /** Load fresh correlation data (swaps, games…) before `resolve` runs. */
+    prepare?(): Promise<void>;
+    /** Pure and synchronous. The groups this tx belongs to, or undefined to leave it plain. */
+    resolve(tx: ArkTransaction): GroupMembership[] | undefined;
+}
+
+/** One logical activity: the projection of all txs sharing a groupId. */
+export interface Activity {
+    /** The groupId, or the tx's own key when ungrouped. */
+    id: string;
+    /** Merged intent for the group, if any resolver tagged it. */
+    intent?: { label?: string; kind?: string; metadata?: Record<string, unknown> };
+    /** Member txs, oldest-first. */
+    txs: ArkTransaction[];
+    /** Net amount across the group, in sats (sum of members' attributed amounts). */
+    amount: number;
+    /** Earliest member createdAt (ms since epoch). */
+    createdAt: number;
+    /** True once every member tx is settled. */
+    settled: boolean;
+}
+
+/**
+ * Pure grouping engine: project a flat tx list into activities via resolvers.
+ * Mirrors `buildTransactionHistory` — no I/O beyond the resolvers' own `prepare()`.
+ *
+ * - A tx with no memberships becomes its own single-member activity (= the flat row).
+ * - Memberships are unioned across resolvers and bucketed by `groupId`; a tx may join
+ *   several groups (Ark batching). Same-group memberships (across resolvers) merge:
+ *   `label`/`kind` first-defined-wins (resolver order), `metadata` shallow-merged.
+ * - A member's contribution defaults to the tx's full amount, or `membership.amount`
+ *   when given (so a batched tx splits across the groups it touches).
+ * - A resolver throwing on a tx is caught and treated as no membership.
+ */
+export async function buildActivities(
+    txs: ArkTransaction[],
+    resolvers: ActivityResolver[],
+): Promise<Activity[]> {
+    await Promise.all(resolvers.map((r) => r.prepare?.()));
+
+    const keyOf = (tx: ArkTransaction) =>
+        tx.key.arkTxid || tx.key.commitmentTxid || tx.key.boardingTxid;
+
+    const merge = (a: GroupMembership, b: GroupMembership): GroupMembership => ({
+        groupId: a.groupId,
+        label: a.label ?? b.label,
+        kind: a.kind ?? b.kind,
+        metadata: { ...b.metadata, ...a.metadata },
+        amount: a.amount ?? b.amount,
+    });
+
+    type Bucket = {
+        intent?: Activity["intent"];
+        members: { tx: ArkTransaction; amount: number }[];
+    };
+    const buckets = new Map<string, Bucket>();
+
+    for (const tx of txs) {
+        // Collect this tx's memberships, deduping by groupId so two resolvers tagging
+        // the same tx+group merge into one membership (rather than counting the tx twice).
+        const perGroup = new Map<string, GroupMembership>();
+        for (const r of resolvers) {
+            let ms: GroupMembership[] | undefined;
+            try {
+                ms = r.resolve(tx);
+            } catch {
+                ms = undefined; // one bad tag must not break the whole history
+            }
+            for (const m of ms ?? []) {
+                const existing = perGroup.get(m.groupId);
+                perGroup.set(m.groupId, existing ? merge(existing, m) : { ...m });
+            }
+        }
+
+        if (perGroup.size === 0) {
+            buckets.set(keyOf(tx), { members: [{ tx, amount: tx.amount }] });
+            continue;
+        }
+        for (const m of perGroup.values()) {
+            const b = buckets.get(m.groupId) ?? { members: [] };
+            b.intent = {
+                label: b.intent?.label ?? m.label,
+                kind: b.intent?.kind ?? m.kind,
+                metadata: { ...m.metadata, ...b.intent?.metadata },
+            };
+            b.members.push({ tx, amount: m.amount ?? tx.amount });
+            buckets.set(m.groupId, b);
+        }
+    }
+
+    const latest = (a: Activity) => Math.max(...a.txs.map((t) => t.createdAt));
+    return [...buckets.entries()]
+        .map(([id, b]): Activity => {
+            const members = [...b.members].sort((x, y) => x.tx.createdAt - y.tx.createdAt);
+            return {
+                id,
+                intent: b.intent,
+                txs: members.map((x) => x.tx),
+                amount: members.reduce((s, x) => s + x.amount, 0),
+                createdAt: members[0].tx.createdAt,
+                settled: members.every((x) => x.tx.settled),
+            };
+        })
+        .sort((a, c) => latest(c) - latest(a));
+}

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -1,4 +1,4 @@
-import type { ArkTransaction } from "./index";
+import { TxType, type ArkTransaction } from "./index";
 
 /** One transaction's participation in one logical action. A tx may return several. */
 export interface GroupMembership {
@@ -117,8 +117,7 @@ export async function buildActivities(
         amount: a.amount ?? b.amount,
     });
 
-    const sentType = "SENT" as ArkTransaction["type"];
-    const isSent = (tx: ArkTransaction) => tx.type === sentType;
+    const isSent = (tx: ArkTransaction) => tx.type === TxType.TxSent;
     const signedAmount = (tx: ArkTransaction, amount = tx.amount) => {
         const magnitude = Math.abs(amount);
         return isSent(tx) ? -magnitude : magnitude;
@@ -175,7 +174,8 @@ export async function buildActivities(
         }, 0);
     };
 
-    const latest = (a: Activity) => Math.max(...a.txs.map((t) => t.createdAt));
+    // Members are oldest-first, so the last one is the most recent.
+    const latest = (a: Activity) => a.txs[a.txs.length - 1].createdAt;
     return [...buckets.entries()]
         .map(([id, b]): Activity => {
             const members = [...b.members].sort((x, y) => x.tx.createdAt - y.tx.createdAt);

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -19,9 +19,11 @@ export interface GroupMembership {
      */
     metadata?: Record<string, unknown>;
     /**
-     * This tx's contribution to THIS group, in sats; defaults to the tx's full
-     * net amount. Set it to split a batched tx across the groups it touches —
-     * omitting it on a multi-group tx attributes the full amount to each group.
+     * This tx's contribution to THIS group, as an unsigned sat magnitude;
+     * defaults to the tx's full amount. The activity builder applies the tx
+     * direction (received positive, sent negative). Set it to split a batched
+     * tx across the groups it touches — omitting it on a multi-group tx
+     * attributes the full amount to each group.
      */
     amount?: number;
 }
@@ -61,7 +63,7 @@ export interface Activity {
     intent?: ActivityIntent;
     /** Member txs, oldest-first. */
     txs: ArkTransaction[];
-    /** Net amount across the group, in sats — always sats, never asset units (sum of members' attributed amounts). */
+    /** Signed net amount across the group, in sats: positive received, negative sent. */
     amount: number;
     /** Earliest member createdAt (ms since epoch). */
     createdAt: number;
@@ -73,12 +75,14 @@ export interface Activity {
  * Pure grouping engine: project a flat tx list into activities via resolvers.
  * Mirrors `buildTransactionHistory` — no I/O beyond the resolvers' own `prepare()`.
  *
- * - A tx with no memberships becomes its own single-member activity (= the flat row).
+ * - A tx with no memberships is bucketed by its own transaction key; rows that
+ *   share a key stay together so send/change pairs remain one activity.
  * - Memberships are unioned across resolvers and bucketed by `groupId`; a tx may join
  *   several groups (Ark batching). Same-group memberships (across resolvers) merge:
  *   `label`/`kind` first-defined-wins (resolver order), `metadata` shallow-merged.
- * - A member's contribution defaults to the tx's full amount, or `membership.amount`
- *   when given (so a batched tx splits across the groups it touches).
+ * - A member's contribution defaults to the tx's signed amount (received positive,
+ *   sent negative), or the signed form of `membership.amount` when given (so a
+ *   batched tx splits across the groups it touches).
  * - A resolver that throws in resolve() or rejects in prepare() is isolated and
  *   contributes no memberships, so one bad resolver never breaks the whole history.
  */
@@ -110,9 +114,17 @@ export async function buildActivities(
         amount: a.amount ?? b.amount,
     });
 
+    const sentType = "SENT" as ArkTransaction["type"];
+    const isSent = (tx: ArkTransaction) => tx.type === sentType;
+    const signedAmount = (tx: ArkTransaction, amount = tx.amount) => {
+        const magnitude = Math.abs(amount);
+        return isSent(tx) ? -magnitude : magnitude;
+    };
+
     type Bucket = {
         intent?: Activity["intent"];
         members: { tx: ArkTransaction; amount: number }[];
+        ungrouped?: boolean;
     };
     const buckets = new Map<string, Bucket>();
 
@@ -134,7 +146,10 @@ export async function buildActivities(
         }
 
         if (perGroup.size === 0) {
-            buckets.set(keyOf(tx), { members: [{ tx, amount: tx.amount }] });
+            const id = keyOf(tx);
+            const b = buckets.get(id) ?? { members: [], ungrouped: true };
+            b.members.push({ tx, amount: signedAmount(tx) });
+            buckets.set(id, b);
             continue;
         }
         for (const m of perGroup.values()) {
@@ -144,10 +159,17 @@ export async function buildActivities(
                 kind: b.intent?.kind ?? m.kind,
                 metadata: { ...m.metadata, ...b.intent?.metadata },
             };
-            b.members.push({ tx, amount: m.amount ?? tx.amount });
+            b.members.push({ tx, amount: signedAmount(tx, m.amount ?? tx.amount) });
             buckets.set(m.groupId, b);
         }
     }
+
+    const netAmount = (b: Bucket, members: { tx: ArkTransaction; amount: number }[]) => {
+        if (b.ungrouped && members.some((x) => isSent(x.tx))) {
+            return members.filter((x) => isSent(x.tx)).reduce((s, x) => s + x.amount, 0);
+        }
+        return members.reduce((s, x) => s + x.amount, 0);
+    };
 
     const latest = (a: Activity) => Math.max(...a.txs.map((t) => t.createdAt));
     return [...buckets.entries()]
@@ -157,7 +179,7 @@ export async function buildActivities(
                 id,
                 intent: b.intent,
                 txs: members.map((x) => x.tx),
-                amount: members.reduce((s, x) => s + x.amount, 0),
+                amount: netAmount(b, members),
                 createdAt: members[0].tx.createdAt,
                 settled: members.every((x) => x.tx.settled),
             };

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -93,15 +93,18 @@ export async function buildActivities(
     // Isolate prepare() like resolve(): a resolver that fails to load its
     // correlation data contributes no memberships, rather than throwing away
     // the whole history.
-    await Promise.all(
-        resolvers.map(async (r) => {
-            try {
-                await r.prepare?.();
-            } catch {
-                // a failed prepare leaves this resolver with stale/empty data
-            }
-        }),
-    );
+    const preparedResolvers = (
+        await Promise.all(
+            resolvers.map(async (r) => {
+                try {
+                    await r.prepare?.();
+                    return r;
+                } catch {
+                    return undefined;
+                }
+            }),
+        )
+    ).filter((r): r is ActivityResolver => r !== undefined);
 
     const keyOf = (tx: ArkTransaction) =>
         tx.key.arkTxid || tx.key.commitmentTxid || tx.key.boardingTxid;
@@ -124,7 +127,6 @@ export async function buildActivities(
     type Bucket = {
         intent?: Activity["intent"];
         members: { tx: ArkTransaction; amount: number }[];
-        ungrouped?: boolean;
     };
     const buckets = new Map<string, Bucket>();
 
@@ -132,7 +134,7 @@ export async function buildActivities(
         // Collect this tx's memberships, deduping by groupId so two resolvers tagging
         // the same tx+group merge into one membership (rather than counting the tx twice).
         const perGroup = new Map<string, GroupMembership>();
-        for (const r of resolvers) {
+        for (const r of preparedResolvers) {
             let ms: GroupMembership[] | undefined;
             try {
                 ms = r.resolve(tx);
@@ -147,7 +149,7 @@ export async function buildActivities(
 
         if (perGroup.size === 0) {
             const id = keyOf(tx);
-            const b = buckets.get(id) ?? { members: [], ungrouped: true };
+            const b = buckets.get(id) ?? { members: [] };
             b.members.push({ tx, amount: signedAmount(tx) });
             buckets.set(id, b);
             continue;
@@ -164,11 +166,13 @@ export async function buildActivities(
         }
     }
 
-    const netAmount = (b: Bucket, members: { tx: ArkTransaction; amount: number }[]) => {
-        if (b.ungrouped && members.some((x) => isSent(x.tx))) {
-            return members.filter((x) => isSent(x.tx)).reduce((s, x) => s + x.amount, 0);
-        }
-        return members.reduce((s, x) => s + x.amount, 0);
+    const netAmount = (members: { tx: ArkTransaction; amount: number }[]) => {
+        const sentKeys = new Set(members.filter((x) => isSent(x.tx)).map((x) => keyOf(x.tx)));
+        return members.reduce((s, x) => {
+            // A sent row is already net of its own change; do not add the paired receive back.
+            if (!isSent(x.tx) && sentKeys.has(keyOf(x.tx))) return s;
+            return s + x.amount;
+        }, 0);
     };
 
     const latest = (a: Activity) => Math.max(...a.txs.map((t) => t.createdAt));
@@ -179,7 +183,7 @@ export async function buildActivities(
                 id,
                 intent: b.intent,
                 txs: members.map((x) => x.tx),
-                amount: netAmount(b, members),
+                amount: netAmount(members),
                 createdAt: members[0].tx.createdAt,
                 settled: members.every((x) => x.tx.settled),
             };

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -6,6 +6,7 @@ export interface GroupMembership {
      * Stable id of the action; txs sharing it group together. Third-party
      * resolvers should namespace it (`"vendor:thing"`) to avoid colliding with
      * other resolvers' groups. SDK built-ins use namespaced ids such as `boarding:`.
+     * A membership with an empty groupId is dropped.
      */
     groupId: string;
     /** Human label for the action, e.g. "Dice game". */
@@ -21,7 +22,8 @@ export interface GroupMembership {
      * This tx's unsigned sat contribution to this group. Defaults to the tx's
      * full amount; the builder applies direction. Use it to split a batched tx
      * across groups. Same-key receive rows paired with a sent row are treated
-     * as change and excluded from `Activity.amount`.
+     * as change and excluded from `Activity.amount`. A membership with a
+     * non-finite amount (NaN/Infinity) is dropped.
      */
     amount?: number;
 }
@@ -79,7 +81,8 @@ export interface Activity {
  * - Contributions are signed by tx direction; same-key received rows paired with
  *   a sent row are treated as change and excluded from the activity amount.
  * - A resolver that throws in resolve() or rejects in prepare() is isolated and
- *   contributes no memberships.
+ *   contributes no memberships. A membership with an empty `groupId` or a
+ *   non-finite `amount` is dropped the same way.
  */
 export async function buildActivities(
     txs: ArkTransaction[],
@@ -132,6 +135,8 @@ export async function buildActivities(
                 ms = undefined;
             }
             for (const m of ms ?? []) {
+                if (!m.groupId) continue;
+                if (m.amount !== undefined && !Number.isFinite(m.amount)) continue;
                 const existing = perGroup.get(m.groupId);
                 perGroup.set(m.groupId, existing ? merge(existing, m) : { ...m });
             }

--- a/packages/ts-sdk/src/wallet/activity.ts
+++ b/packages/ts-sdk/src/wallet/activity.ts
@@ -2,21 +2,37 @@ import type { ArkTransaction } from "./index";
 
 /** One transaction's participation in one logical action. A tx may return several. */
 export interface GroupMembership {
-    /** Stable id of the action; txs sharing it group together. */
+    /**
+     * Stable id of the action; txs sharing it group together. Third-party
+     * resolvers should namespace it (`"vendor:thing"`) to avoid colliding with
+     * other resolvers' groups; the built-ins use `boarding:`/`exit:`/`mint:`.
+     */
     groupId: string;
     /** Human label for the action, e.g. "Dice game". */
     label?: string;
-    /** App category for icon/filtering, e.g. "game". */
+    /** App category for icon/filtering, e.g. "game". Namespace across vendors to avoid clashes. */
     kind?: string;
-    /** Free-form row data (renderer-defined). */
+    /**
+     * Free-form row data (renderer-defined). When several resolvers tag the same
+     * tx+group, this is shallow-merged with earlier-resolver-wins on key
+     * collision — namespace keys (e.g. `swap.status`) to avoid clobbering.
+     */
     metadata?: Record<string, unknown>;
-    /** This tx's contribution to THIS group, in sats; defaults to the tx's full net amount. */
+    /**
+     * This tx's contribution to THIS group, in sats; defaults to the tx's full
+     * net amount. Set it to split a batched tx across the groups it touches —
+     * omitting it on a multi-group tx attributes the full amount to each group.
+     */
     amount?: number;
 }
 
 /** A pluggable resolver. Registered by id; `prepare()` refreshes correlation data. */
 export interface ActivityResolver {
-    /** Registry key — override or remove by it. */
+    /**
+     * Registry key — override or remove by it. Namespace it (`"vendor:games"`)
+     * so independent libraries don't clobber each other; `use()` overwrites
+     * silently on a duplicate id.
+     */
     id: string;
     /**
      * Load fresh correlation data (swaps, games…) before `resolve` runs. A
@@ -27,15 +43,25 @@ export interface ActivityResolver {
     resolve(tx: ArkTransaction): GroupMembership[] | undefined;
 }
 
+/** The label/kind/metadata an activity carries — the non-id, non-amount part of a {@link GroupMembership}. */
+export interface ActivityIntent {
+    /** Human label for the action, e.g. "Dice game". */
+    label?: string;
+    /** App category for icon/filtering, e.g. "game". */
+    kind?: string;
+    /** Free-form row data, shallow-merged across the group's resolvers (first-writer-wins). */
+    metadata?: Record<string, unknown>;
+}
+
 /** One logical activity: the projection of all txs sharing a groupId. */
 export interface Activity {
     /** The groupId, or the tx's own key when ungrouped. */
     id: string;
     /** Merged intent for the group, if any resolver tagged it. */
-    intent?: { label?: string; kind?: string; metadata?: Record<string, unknown> };
+    intent?: ActivityIntent;
     /** Member txs, oldest-first. */
     txs: ArkTransaction[];
-    /** Net amount across the group, in sats (sum of members' attributed amounts). */
+    /** Net amount across the group, in sats — always sats, never asset units (sum of members' attributed amounts). */
     amount: number;
     /** Earliest member createdAt (ms since epoch). */
     createdAt: number;

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -1,5 +1,6 @@
 import { hex } from "@scure/base";
 import { Wallet } from "../wallet";
+import type { Activity, ActivityRegistry } from "../activity";
 import { RestArkProvider } from "../../providers/ark";
 import type {
     IWallet,
@@ -280,6 +281,14 @@ export class ExpoWallet implements IWallet {
 
     getTransactionHistory(): Promise<ArkTransaction[]> {
         return this.wallet.getTransactionHistory();
+    }
+
+    get activity(): ActivityRegistry {
+        return this.wallet.activity;
+    }
+
+    getActivityHistory(): Promise<Activity[]> {
+        return this.wallet.getActivityHistory();
     }
 
     getContractManager(): Promise<IContractManager> {

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -11,6 +11,7 @@ import { ContractWatcherConfig } from "../contracts/contractWatcher";
 import { ContractRepository, WalletRepository } from "../repositories";
 import { IContractManager } from "../contracts/contractManager";
 import { IDelegateManager } from "./delegate";
+import type { Activity, ActivityRegistry } from "./activity";
 import { DelegateProvider } from "../providers/delegate";
 
 /**
@@ -883,6 +884,12 @@ export interface IReadonlyWallet {
 
     /** @returns Wallet transaction history derived from boarding and Arkade activity. */
     getTransactionHistory(): Promise<ArkTransaction[]>;
+
+    /** Registry of resolvers that group/label {@link getActivityHistory} rows. */
+    readonly activity: ActivityRegistry;
+
+    /** @returns Wallet history grouped into logical activities via the registered resolvers. */
+    getActivityHistory(): Promise<Activity[]>;
 
     /**
      * Get the contract manager associated with this wallet.

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -12,6 +12,14 @@ import { ContractRepository, WalletRepository } from "../repositories";
 import { IContractManager } from "../contracts/contractManager";
 import { IDelegateManager } from "./delegate";
 import type { Activity, ActivityRegistry } from "./activity";
+export {
+    ActivityRegistry,
+    boardingResolver,
+    createDefaultActivityRegistry,
+    type Activity,
+    type GroupMembership,
+    type ActivityResolver,
+} from "./activity";
 import { DelegateProvider } from "../providers/delegate";
 
 /**

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -894,10 +894,10 @@ export interface IReadonlyWallet {
     /** @returns Wallet transaction history derived from boarding and Arkade activity. */
     getTransactionHistory(): Promise<ArkTransaction[]>;
 
-    /** Registry of resolvers that group/label {@link getActivityHistory} rows. */
+    /** Resolvers that group/label {@link getActivityHistory} rows. */
     readonly activity: ActivityRegistry;
 
-    /** @returns Wallet history grouped into logical activities via the registered resolvers. */
+    /** @returns Wallet history grouped into logical activities with signed net amounts. */
     getActivityHistory(): Promise<Activity[]>;
 
     /**

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -17,6 +17,7 @@ export {
     boardingResolver,
     createDefaultActivityRegistry,
     type Activity,
+    type ActivityIntent,
     type GroupMembership,
     type ActivityResolver,
 } from "./activity";

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -19,6 +19,7 @@ import {
     Recipient,
 } from "..";
 import { SettlementEvent } from "../../providers/ark";
+import { ActivityRegistry, buildActivities, type Activity } from "../activity";
 import { hex } from "@scure/base";
 import {
     Identity,
@@ -486,6 +487,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
     public readonly walletRepository: WalletRepository;
     public readonly contractRepository: ContractRepository;
     public readonly identity: ReadonlyIdentity;
+    readonly activity = new ActivityRegistry();
     private readonly _readonlyAssetManager: IReadonlyAssetManager;
     protected initConfig: MessageBusInitConfig | null = null;
     protected initWalletPayload: RequestInitWallet["payload"] | null = null;
@@ -1023,6 +1025,10 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         } catch (error) {
             throw new Error(`Failed to get status: ${error}`);
         }
+    }
+
+    async getActivityHistory(): Promise<Activity[]> {
+        return buildActivities(await this.getTransactionHistory(), this.activity.all());
     }
 
     async getTransactionHistory(): Promise<ArkTransaction[]> {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -19,7 +19,7 @@ import {
     Recipient,
 } from "..";
 import { SettlementEvent } from "../../providers/ark";
-import { ActivityRegistry, buildActivities, type Activity } from "../activity";
+import { createDefaultActivityRegistry, buildActivities, type Activity } from "../activity";
 import { hex } from "@scure/base";
 import {
     Identity,
@@ -487,7 +487,7 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
     public readonly walletRepository: WalletRepository;
     public readonly contractRepository: ContractRepository;
     public readonly identity: ReadonlyIdentity;
-    readonly activity = new ActivityRegistry();
+    readonly activity = createDefaultActivityRegistry();
     private readonly _readonlyAssetManager: IReadonlyAssetManager;
     protected initConfig: MessageBusInitConfig | null = null;
     protected initWalletPayload: RequestInitWallet["payload"] | null = null;

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -871,7 +871,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
     /**
      * Wallet activity history: {@link getTransactionHistory} grouped into logical
      * {@link Activity} rows by the resolvers registered on {@link activity}. With no
-     * resolvers, every transaction is its own single-member activity.
+     * resolvers, rows are bucketed by their transaction key so send/change pairs stay together.
      */
     async getActivityHistory(): Promise<Activity[]> {
         return buildActivities(await this.getTransactionHistory(), this.activity.all());

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -303,7 +303,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
     // clears it, and a stale entry only hides a VTXO (never spends one).
     protected _pendingSpendOutpoints = new Set<string>();
 
-    /** Registry of activity resolvers consumed by {@link getActivityHistory}. */
+    /** Activity resolvers consumed by {@link getActivityHistory}. */
     readonly activity = createDefaultActivityRegistry();
 
     get assetManager(): IReadonlyAssetManager {
@@ -869,9 +869,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }
 
     /**
-     * Wallet activity history: {@link getTransactionHistory} grouped into logical
-     * {@link Activity} rows by the resolvers registered on {@link activity}. With no
-     * resolvers, rows are bucketed by their transaction key so send/change pairs stay together.
+     * Wallet history grouped by registered activity resolvers. With no resolver match,
+     * rows bucket by transaction key so send/change pairs stay together.
      */
     async getActivityHistory(): Promise<Activity[]> {
         return buildActivities(await this.getTransactionHistory(), this.activity.all());

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -77,6 +77,7 @@ import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
 import { DelegateProvider } from "../providers/delegate";
 import { buildTransactionHistory } from "../utils/transactionHistory";
+import { ActivityRegistry, buildActivities, type Activity } from "./activity";
 import { AssetManager, ReadonlyAssetManager } from "./asset-manager";
 import { Extension } from "../extension";
 import { DelegateVtxo } from "../script/delegate";
@@ -301,6 +302,9 @@ export class ReadonlyWallet implements IReadonlyWallet {
     // already on their way out. The set is in-memory only: a process crash
     // clears it, and a stale entry only hides a VTXO (never spends one).
     protected _pendingSpendOutpoints = new Set<string>();
+
+    /** Registry of activity resolvers consumed by {@link getActivityHistory}. */
+    readonly activity = new ActivityRegistry();
 
     get assetManager(): IReadonlyAssetManager {
         return this._assetManager;
@@ -862,6 +866,15 @@ export class ReadonlyWallet implements IReadonlyWallet {
                 .then((res) => res.vtxos[0]?.createdAt.getTime());
 
         return buildTransactionHistory(allVtxos, boardingTxs, commitmentsToIgnore, getTxCreatedAt);
+    }
+
+    /**
+     * Wallet activity history: {@link getTransactionHistory} grouped into logical
+     * {@link Activity} rows by the resolvers registered on {@link activity}. With no
+     * resolvers, every transaction is its own single-member activity.
+     */
+    async getActivityHistory(): Promise<Activity[]> {
+        return buildActivities(await this.getTransactionHistory(), this.activity.all());
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -77,7 +77,7 @@ import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
 import { DelegateProvider } from "../providers/delegate";
 import { buildTransactionHistory } from "../utils/transactionHistory";
-import { ActivityRegistry, buildActivities, type Activity } from "./activity";
+import { createDefaultActivityRegistry, buildActivities, type Activity } from "./activity";
 import { AssetManager, ReadonlyAssetManager } from "./asset-manager";
 import { Extension } from "../extension";
 import { DelegateVtxo } from "../script/delegate";
@@ -304,7 +304,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
     protected _pendingSpendOutpoints = new Set<string>();
 
     /** Registry of activity resolvers consumed by {@link getActivityHistory}. */
-    readonly activity = new ActivityRegistry();
+    readonly activity = createDefaultActivityRegistry();
 
     get assetManager(): IReadonlyAssetManager {
         return this._assetManager;

--- a/packages/ts-sdk/test/wallet/activity.test.ts
+++ b/packages/ts-sdk/test/wallet/activity.test.ts
@@ -97,6 +97,19 @@ describe("buildActivities", () => {
         expect(act.id).toBe("ok");
     });
 
+    it("isolates a resolver whose prepare() rejects (a bad prepare does not break history)", async () => {
+        const bad: ActivityResolver = {
+            id: "bad",
+            prepare: async () => {
+                throw new Error("prepare boom");
+            },
+            resolve: () => undefined, // prepare failed -> no correlation data -> plain
+        };
+        const good: ActivityResolver = { id: "good", resolve: () => [{ groupId: "ok" }] };
+        const [act] = await buildActivities([tx("t")], [bad, good]);
+        expect(act.id).toBe("ok");
+    });
+
     it("sorts activities by most-recent member, descending", async () => {
         const r: ActivityResolver = {
             id: "g",

--- a/packages/ts-sdk/test/wallet/activity.test.ts
+++ b/packages/ts-sdk/test/wallet/activity.test.ts
@@ -26,7 +26,7 @@ function tx(id: string, over: Partial<Omit<ArkTransaction, "key">> = {}): ArkTra
 }
 
 describe("buildActivities", () => {
-    it("with no resolvers, each tx is its own single-member activity (passthrough)", async () => {
+    it("with no resolvers, distinct txs are single-member activities (passthrough)", async () => {
         const txs = [tx("a", { amount: 10, createdAt: 1 }), tx("b", { amount: 20, createdAt: 2 })];
         const acts = await buildActivities(txs, []);
         expect(acts).toHaveLength(2);
@@ -43,6 +43,21 @@ describe("buildActivities", () => {
         ];
         const [act] = await buildActivities(txs, []);
         expect(act.id).toBe("same");
+        expect(act.amount).toBe(-300);
+        expect(act.txs).toEqual(txs);
+    });
+
+    it("nets grouped same-arkTxid send/change rows into one sent activity", async () => {
+        const r: ActivityResolver = {
+            id: "app",
+            resolve: (t) => [{ groupId: `app:${t.key.arkTxid}` }],
+        };
+        const txs = [
+            tx("same", { type: TxType.TxSent, amount: 300, createdAt: 2 }),
+            tx("same", { type: TxType.TxReceived, amount: 700, createdAt: 2 }),
+        ];
+        const [act] = await buildActivities(txs, [r]);
+        expect(act.id).toBe("app:same");
         expect(act.amount).toBe(-300);
         expect(act.txs).toEqual(txs);
     });
@@ -120,11 +135,11 @@ describe("buildActivities", () => {
             prepare: async () => {
                 throw new Error("prepare boom");
             },
-            resolve: () => undefined, // prepare failed -> no correlation data -> plain
+            resolve: () => [{ groupId: "stale" }],
         };
         const good: ActivityResolver = { id: "good", resolve: () => [{ groupId: "ok" }] };
-        const [act] = await buildActivities([tx("t")], [bad, good]);
-        expect(act.id).toBe("ok");
+        const acts = await buildActivities([tx("t")], [bad, good]);
+        expect(acts.map((act) => act.id)).toEqual(["ok"]);
     });
 
     it("sorts activities by most-recent member, descending", async () => {

--- a/packages/ts-sdk/test/wallet/activity.test.ts
+++ b/packages/ts-sdk/test/wallet/activity.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { buildActivities, type ActivityResolver } from "../../src/wallet/activity";
+import { TxType } from "../../src/wallet/index";
+import type { ArkTransaction } from "../../src/wallet/index";
+
+function tx(id: string, over: Partial<Omit<ArkTransaction, "key">> = {}): ArkTransaction {
+    return {
+        key: { arkTxid: id, commitmentTxid: "", boardingTxid: "" },
+        type: TxType.TxReceived,
+        amount: 100,
+        settled: true,
+        createdAt: 1000,
+        ...over,
+    };
+}
+
+describe("buildActivities", () => {
+    it("with no resolvers, each tx is its own single-member activity (passthrough)", async () => {
+        const txs = [tx("a", { amount: 10, createdAt: 1 }), tx("b", { amount: 20, createdAt: 2 })];
+        const acts = await buildActivities(txs, []);
+        expect(acts).toHaveLength(2);
+        const a = acts.find((x) => x.id === "a")!;
+        expect(a.txs).toHaveLength(1);
+        expect(a.amount).toBe(10);
+        expect(a.intent).toBeUndefined();
+    });
+
+    it("groups txs sharing a groupId, summing amounts, members oldest-first", async () => {
+        const r: ActivityResolver = {
+            id: "game",
+            resolve: () => [{ groupId: "game:1", label: "Dice game" }],
+        };
+        const txs = [tx("a", { amount: -50, createdAt: 2 }), tx("b", { amount: 80, createdAt: 5 })];
+        const [act] = await buildActivities(txs, [r]);
+        expect(act.id).toBe("game:1");
+        expect(act.intent?.label).toBe("Dice game");
+        expect(act.txs.map((t) => t.key.arkTxid)).toEqual(["a", "b"]);
+        expect(act.amount).toBe(30);
+    });
+
+    it("splits a batched tx across groups via per-membership amount", async () => {
+        const r: ActivityResolver = {
+            id: "batch",
+            resolve: (t) =>
+                t.key.arkTxid === "settle"
+                    ? [
+                          { groupId: "game:A", label: "Dice game", amount: 5 },
+                          { groupId: "game:B", label: "Dice game", amount: 3 },
+                      ]
+                    : undefined,
+        };
+        const acts = await buildActivities([tx("settle", { amount: 8 })], [r]);
+        expect(acts.find((x) => x.id === "game:A")!.amount).toBe(5);
+        expect(acts.find((x) => x.id === "game:B")!.amount).toBe(3);
+    });
+
+    it("defaults a membership's contribution to the tx's full amount", async () => {
+        const r: ActivityResolver = { id: "g", resolve: () => [{ groupId: "g:1" }] };
+        const [act] = await buildActivities([tx("a", { amount: 42 })], [r]);
+        expect(act.amount).toBe(42);
+    });
+
+    it("merges two resolvers on the same groupId: label first-wins, metadata additive", async () => {
+        const r1: ActivityResolver = {
+            id: "r1",
+            resolve: () => [{ groupId: "x", label: "First", metadata: { a: 1 } }],
+        };
+        const r2: ActivityResolver = {
+            id: "r2",
+            resolve: () => [{ groupId: "x", label: "Second", metadata: { b: 2 } }],
+        };
+        const [act] = await buildActivities([tx("t")], [r1, r2]);
+        expect(act.intent?.label).toBe("First");
+        expect(act.intent?.metadata).toEqual({ a: 1, b: 2 });
+    });
+
+    it("isolates a throwing resolver (one bad tag does not break history)", async () => {
+        const bad: ActivityResolver = {
+            id: "bad",
+            resolve: () => {
+                throw new Error("boom");
+            },
+        };
+        const good: ActivityResolver = { id: "good", resolve: () => [{ groupId: "ok" }] };
+        const [act] = await buildActivities([tx("t")], [bad, good]);
+        expect(act.id).toBe("ok");
+    });
+
+    it("sorts activities by most-recent member, descending", async () => {
+        const r: ActivityResolver = {
+            id: "g",
+            resolve: (t) => [{ groupId: `g:${t.key.arkTxid}` }],
+        };
+        const txs = [tx("old", { createdAt: 1 }), tx("new", { createdAt: 9 })];
+        const acts = await buildActivities(txs, [r]);
+        expect(acts.map((a) => a.id)).toEqual(["g:new", "g:old"]);
+    });
+
+    it("runs prepare() before resolve()", async () => {
+        let prepared = false;
+        const r: ActivityResolver = {
+            id: "g",
+            prepare: async () => {
+                prepared = true;
+            },
+            resolve: () => (prepared ? [{ groupId: "g:1" }] : undefined),
+        };
+        const [act] = await buildActivities([tx("t")], [r]);
+        expect(act.id).toBe("g:1");
+    });
+});

--- a/packages/ts-sdk/test/wallet/activity.test.ts
+++ b/packages/ts-sdk/test/wallet/activity.test.ts
@@ -36,12 +36,26 @@ describe("buildActivities", () => {
         expect(a.intent).toBeUndefined();
     });
 
-    it("groups txs sharing a groupId, summing amounts, members oldest-first", async () => {
+    it("nets ungrouped same-arkTxid send/change rows into one sent activity", async () => {
+        const txs = [
+            tx("same", { type: TxType.TxSent, amount: 300, createdAt: 2 }),
+            tx("same", { type: TxType.TxReceived, amount: 700, createdAt: 2 }),
+        ];
+        const [act] = await buildActivities(txs, []);
+        expect(act.id).toBe("same");
+        expect(act.amount).toBe(-300);
+        expect(act.txs).toEqual(txs);
+    });
+
+    it("groups txs sharing a groupId, netting sent and received amounts", async () => {
         const r: ActivityResolver = {
             id: "game",
             resolve: () => [{ groupId: "game:1", label: "Dice game" }],
         };
-        const txs = [tx("a", { amount: -50, createdAt: 2 }), tx("b", { amount: 80, createdAt: 5 })];
+        const txs = [
+            tx("a", { type: TxType.TxSent, amount: 50, createdAt: 2 }),
+            tx("b", { type: TxType.TxReceived, amount: 80, createdAt: 5 }),
+        ];
         const [act] = await buildActivities(txs, [r]);
         expect(act.id).toBe("game:1");
         expect(act.intent?.label).toBe("Dice game");
@@ -60,15 +74,18 @@ describe("buildActivities", () => {
                       ]
                     : undefined,
         };
-        const acts = await buildActivities([tx("settle", { amount: 8 })], [r]);
-        expect(acts.find((x) => x.id === "game:A")!.amount).toBe(5);
-        expect(acts.find((x) => x.id === "game:B")!.amount).toBe(3);
+        const acts = await buildActivities([tx("settle", { type: TxType.TxSent, amount: 8 })], [r]);
+        expect(acts.find((x) => x.id === "game:A")!.amount).toBe(-5);
+        expect(acts.find((x) => x.id === "game:B")!.amount).toBe(-3);
     });
 
-    it("defaults a membership's contribution to the tx's full amount", async () => {
+    it("defaults a membership's contribution to the tx's signed amount", async () => {
         const r: ActivityResolver = { id: "g", resolve: () => [{ groupId: "g:1" }] };
-        const [act] = await buildActivities([tx("a", { amount: 42 })], [r]);
-        expect(act.amount).toBe(42);
+        const [received] = await buildActivities([tx("a", { amount: 42 })], [r]);
+        expect(received.amount).toBe(42);
+
+        const [sent] = await buildActivities([tx("b", { type: TxType.TxSent, amount: 42 })], [r]);
+        expect(sent.amount).toBe(-42);
     });
 
     it("merges two resolvers on the same groupId: label first-wins, metadata additive", async () => {
@@ -169,6 +186,25 @@ describe("wallet.getActivityHistory", () => {
         expect(acts[0].id).toBe("g:1");
         expect(acts[0].intent?.label).toBe("Grouped");
         expect(acts[0].txs).toHaveLength(2);
+    });
+
+    it("preserves every getTransactionHistory row in the activity view", async () => {
+        const { wallet } = await makeStaticWalletForTest();
+        const history = [
+            tx("same", { type: TxType.TxSent, amount: 300, createdAt: 2 }),
+            tx("same", { type: TxType.TxReceived, amount: 700, createdAt: 2 }),
+            tx("other", { type: TxType.TxReceived, amount: 50, createdAt: 1 }),
+        ];
+        vi.spyOn(wallet, "getTransactionHistory").mockResolvedValue(history);
+
+        const acts = await wallet.getActivityHistory();
+        const flattened = acts.flatMap((a) => a.txs);
+
+        expect(flattened).toHaveLength(history.length);
+        for (const row of history) {
+            expect(flattened).toContain(row);
+        }
+        expect(acts.find((a) => a.id === "same")?.txs).toEqual([history[0], history[1]]);
     });
 });
 

--- a/packages/ts-sdk/test/wallet/activity.test.ts
+++ b/packages/ts-sdk/test/wallet/activity.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { buildActivities, type ActivityResolver } from "../../src/wallet/activity";
+import { describe, it, expect, vi } from "vitest";
+import {
+    buildActivities,
+    ActivityRegistry,
+    type ActivityResolver,
+} from "../../src/wallet/activity";
+import { makeStaticWalletForTest } from "../helpers/restoreWallet";
 import { TxType } from "../../src/wallet/index";
 import type { ArkTransaction } from "../../src/wallet/index";
 
@@ -107,5 +112,38 @@ describe("buildActivities", () => {
         };
         const [act] = await buildActivities([tx("t")], [r]);
         expect(act.id).toBe("g:1");
+    });
+});
+
+describe("ActivityRegistry", () => {
+    it("use/list/all in order, override in place, remove", () => {
+        const reg = new ActivityRegistry();
+        const a: ActivityResolver = { id: "a", resolve: () => undefined };
+        const b: ActivityResolver = { id: "b", resolve: () => undefined };
+        reg.use(a);
+        reg.use(b);
+        expect(reg.list()).toEqual(["a", "b"]);
+        const a2: ActivityResolver = { id: "a", resolve: () => [{ groupId: "x" }] };
+        reg.use(a2);
+        expect(reg.list()).toEqual(["a", "b"]);
+        expect(reg.all()[0]).toBe(a2);
+        reg.remove("b");
+        expect(reg.list()).toEqual(["a"]);
+    });
+});
+
+describe("wallet.getActivityHistory", () => {
+    it("groups getTransactionHistory via the registered resolvers", async () => {
+        const { wallet } = await makeStaticWalletForTest();
+        vi.spyOn(wallet, "getTransactionHistory").mockResolvedValue([
+            tx("a", { createdAt: 1 }),
+            tx("b", { createdAt: 2 }),
+        ]);
+        wallet.activity.use({ id: "g", resolve: () => [{ groupId: "g:1", label: "Grouped" }] });
+        const acts = await wallet.getActivityHistory();
+        expect(acts).toHaveLength(1);
+        expect(acts[0].id).toBe("g:1");
+        expect(acts[0].intent?.label).toBe("Grouped");
+        expect(acts[0].txs).toHaveLength(2);
     });
 });

--- a/packages/ts-sdk/test/wallet/activity.test.ts
+++ b/packages/ts-sdk/test/wallet/activity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
     buildActivities,
     ActivityRegistry,
@@ -6,7 +6,11 @@ import {
     createDefaultActivityRegistry,
     type ActivityResolver,
 } from "../../src/wallet/activity";
-import { makeStaticWalletForTest } from "../helpers/restoreWallet";
+import {
+    makeStaticWalletForTest,
+    installRestoreHarness,
+    teardownRestoreHarness,
+} from "../helpers/restoreWallet";
 import { TxType } from "../../src/wallet/index";
 import type { ArkTransaction } from "../../src/wallet/index";
 
@@ -135,6 +139,11 @@ describe("ActivityRegistry", () => {
 });
 
 describe("wallet.getActivityHistory", () => {
+    // Wallet.create resolves the ark /info over the global fetch; stub it
+    // (and EventSource) so the test never reaches a live :7070 ark server.
+    beforeEach(installRestoreHarness);
+    afterEach(teardownRestoreHarness);
+
     it("groups getTransactionHistory via the registered resolvers", async () => {
         const { wallet } = await makeStaticWalletForTest();
         vi.spyOn(wallet, "getTransactionHistory").mockResolvedValue([

--- a/packages/ts-sdk/test/wallet/activity.test.ts
+++ b/packages/ts-sdk/test/wallet/activity.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import {
     buildActivities,
     ActivityRegistry,
+    boardingResolver,
+    createDefaultActivityRegistry,
     type ActivityResolver,
 } from "../../src/wallet/activity";
 import { makeStaticWalletForTest } from "../helpers/restoreWallet";
@@ -145,5 +147,28 @@ describe("wallet.getActivityHistory", () => {
         expect(acts[0].id).toBe("g:1");
         expect(acts[0].intent?.label).toBe("Grouped");
         expect(acts[0].txs).toHaveLength(2);
+    });
+});
+
+describe("boardingResolver", () => {
+    it("tags a tx with a boardingTxid as a Deposit; ignores others", () => {
+        const r = boardingResolver();
+        const boarding: ArkTransaction = {
+            key: { arkTxid: "", commitmentTxid: "", boardingTxid: "bX" },
+            type: TxType.TxReceived,
+            amount: 1,
+            settled: true,
+            createdAt: 1,
+        };
+        expect(r.resolve(boarding)).toEqual([
+            { groupId: "boarding:bX", label: "Deposit", kind: "boarding" },
+        ]);
+        expect(r.resolve(tx("a"))).toBeUndefined();
+    });
+});
+
+describe("createDefaultActivityRegistry", () => {
+    it("pre-registers the boarding built-in", () => {
+        expect(createDefaultActivityRegistry().list()).toContain("boarding");
     });
 });


### PR DESCRIPTION
## Activity history — pluggable grouping over `getTransactionHistory()`

**Status: draft / WIP** — framework + `boarding` built-in here; `swap` and `collab-exit`/`asset-mint` built-ins stacked on top (#583, #584).

### What & why
Turn the flat `getTransactionHistory(): ArkTransaction[]` into a modular **activity history**: related transactions group into one logical action carrying an app- or SDK-supplied intent (e.g. "Dice game", "Lightning swap", "Deposit"). Every non-trivial wallet app re-implements this grouping today. Purely additive — `getTransactionHistory` is unchanged; `ArkTransaction` gains only an optional `tag` (in #584).

### Design
- **Read-time resolvers** (not write-time metadata) — covers txs the app didn't create (e.g. server-created settlements).
- **Membership model**: a tx maps to a *set* of `GroupMembership`s, because Ark batching puts one tx in multiple logical actions; an optional per-membership `amount` splits a batched tx's value across its groups.
- **Resolver = plugin** `{ id, prepare?, resolve }`: `prepare()` refreshes correlation data, `resolve()` is pure + sync. **Both are error-isolated** — a resolver that throws in `resolve()` or rejects in `prepare()` contributes no memberships rather than breaking the whole history.
- **Pluggable registry** on the wallet (`wallet.activity.use/remove`): built-ins pre-registered; apps add, override (by id), or remove.
- New API `wallet.getActivityHistory(): Promise<Activity[]>`, layered over `getTransactionHistory` via a pure `buildActivities(txs, resolvers)` engine (mirrors the existing `buildTransactionHistory`).

### This PR (#582)
- Types (`GroupMembership`, `ActivityResolver`, `Activity`) + the pure `buildActivities` engine, with per-resolver `prepare()`/`resolve()` isolation — 13 unit tests.
- `ActivityRegistry` + `getActivityHistory()` on `IReadonlyWallet`, implemented on `ReadonlyWallet`, `ServiceWorkerReadonlyWallet`, and `ExpoWallet` (delegating to its backing wallet).
- `boarding` built-in resolver, pre-registered via `createDefaultActivityRegistry()`.
- Public exports + README example. `tsc` clean; full unit suite green.

### Stacked built-ins
- **#583** — `swap` built-in (chain/reverse/submarine), persisting `claimTxid` to correlate.
- **#584** — `collab-exit` + `asset-mint` built-ins; exposes the history builder's `tag` on `ArkTransaction`.

### Reviewer note
Adding `getActivityHistory`/`activity` to the public `IReadonlyWallet`/`IWallet` obliges every implementer; this PR updates all in-tree (incl. the boltz-swap Expo background `IWallet` shim). Flagging in case of out-of-tree implementers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added activity history to the SDK, grouping transactions into labeled activities with computed net amounts and support for split/multi-group memberships.
  * Introduced an activity registry to customize how transactions are bucketed, including a built-in “boarding/Deposit” activity.
  * Exposed `activity` and `getActivityHistory()` APIs across supported wallet environments (including Expo and service worker).
* **Documentation**
  * Updated the SDK “Usage” guide with an Activity history section and examples using an `ActivityResolver`.
* **Tests**
  * Added test coverage for activity grouping, registry behavior, boarding detection, and activity history rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->