### PR TITLE
fix(wallet): phantom receive inflation from boarding sweeps (Esplora outspends without txid)

### DIFF
--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -21,6 +21,17 @@ export const ESPLORA_URL: Record<NetworkName, string> = {
 
 export type ExplorerTransaction = {
     txid: string;
+    /**
+     * Inputs as returned by Esplora's `/address/:addr/txs`, each carrying the
+     * outpoint it spends (`txid:vout`). Optional: not every provider populates
+     * it (the electrum provider omits inputs), so consumers that correlate
+     * spenders must tolerate its absence. Used to recover a boarding output's
+     * spending (commitment) tx when `/outspends` omits the spender txid.
+     */
+    vin?: {
+        txid: string;
+        vout: number;
+    }[];
     vout: {
         scriptpubkey_address: string;
         value: string;

--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -75,10 +75,12 @@ export interface OnchainProvider {
      * Fetch outspend information for every output in a transaction.
      *
      * @param txid - Transaction id to inspect
-     * @returns Per-output spend status information
+     * @returns Per-output spend status information. `txid` (the spender) may be
+     *   absent even when `spent` is true: some Esplora deployments
+     *   (e.g. mempool.arkade.sh) omit it from `/outspends`.
      * @see getTxStatus
      */
-    getTxOutspends(txid: string): Promise<{ spent: boolean; txid: string }[]>;
+    getTxOutspends(txid: string): Promise<{ spent: boolean; txid?: string }[]>;
 
     /**
      * Fetch transactions associated with an address.
@@ -190,7 +192,7 @@ export class EsploraProvider implements OnchainProvider {
         }
     }
 
-    async getTxOutspends(txid: string): Promise<{ spent: boolean; txid: string }[]> {
+    async getTxOutspends(txid: string): Promise<{ spent: boolean; txid?: string }[]> {
         const response = await baseFetch(`${this.baseUrl}/tx/${txid}/outspends`);
         if (!response.ok) {
             const error = await response.text();
@@ -436,6 +438,11 @@ function isValidBlocksTip(tip: any): tip is { id: string; height: number; median
 const isExplorerTransaction = (tx: any): tx is ExplorerTransaction => {
     return (
         typeof tx.txid === "string" &&
+        (tx.vin === undefined ||
+            (Array.isArray(tx.vin) &&
+                tx.vin.every(
+                    (vin: any) => typeof vin.txid === "string" && typeof vin.vout === "number",
+                ))) &&
         Array.isArray(tx.vout) &&
         tx.vout.every(
             (vout: any) =>

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -905,6 +905,19 @@ export class ReadonlyWallet implements IReadonlyWallet {
             const scriptHex = hex.encode(tapscript.pkScript);
             const txs = await this.onchainProvider.getTransactions(boardingAddress);
 
+            // A boarding output's spending (commitment) tx is the tx in this same
+            // address history whose vin spends it. We index that here as a fallback
+            // for the spender txid: some Esplora deployments (e.g. mempool.arkade.sh)
+            // return `/outspends` as `{spent:true}` WITHOUT the spender txid, which
+            // would leave the boarding sweep uncorrelated and double-count the
+            // resulting VTXO as a phantom receive in the history.
+            const commitmentByOutpoint = new Map<string, string>();
+            for (const tx of txs) {
+                for (const input of tx.vin ?? []) {
+                    commitmentByOutpoint.set(`${input.txid}:${input.vout}`, tx.txid);
+                }
+            }
+
             for (const tx of txs) {
                 for (let i = 0; i < tx.vout.length; i++) {
                     const vout = tx.vout[i];
@@ -916,8 +929,16 @@ export class ReadonlyWallet implements IReadonlyWallet {
                         }
                         const spentStatus = spentStatuses[i];
 
-                        if (spentStatus?.spent) {
-                            commitmentsToIgnore.add(spentStatus.txid);
+                        // Prefer the outspends spender txid; fall back to the
+                        // vin-derived commitment when the provider omits it. `||`
+                        // (not `??`) so the electrum provider's `txid: ""` sentinel
+                        // for unspent outputs falls through to the vin lookup.
+                        const commitmentTxid =
+                            spentStatus?.txid || commitmentByOutpoint.get(`${tx.txid}:${i}`);
+                        const spent = Boolean(spentStatus?.spent) || commitmentTxid !== undefined;
+
+                        if (spent && commitmentTxid) {
+                            commitmentsToIgnore.add(commitmentTxid);
                         }
 
                         utxos.push({
@@ -930,10 +951,9 @@ export class ReadonlyWallet implements IReadonlyWallet {
                             },
                             isUnrolled: true,
                             virtualStatus: {
-                                state: spentStatus?.spent ? "spent" : "settled",
-                                commitmentTxIds: spentStatus?.spent
-                                    ? [spentStatus.txid]
-                                    : undefined,
+                                state: spent ? "spent" : "settled",
+                                commitmentTxIds:
+                                    spent && commitmentTxid ? [commitmentTxid] : undefined,
                             },
                             createdAt: tx.status.confirmed
                                 ? new Date(tx.status.block_time * 1000)

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -436,6 +436,98 @@ describe("buildTransactionHistory", () => {
             ).toBe(true);
         });
 
+        it("does not double-count when several boardings are swept into one combined VTXO (arkade.money N->1 regression)", async () => {
+            // Feb 2026 mainnet incident: two boarding deposits (76,186 + 152,346)
+            // were swept into a single 228,532 VTXO in commitment 58b3d35a. With
+            // the commitment ignored, the swept VTXO must be suppressed, leaving
+            // only the two boarding receives — net 228,532, NOT 457,064. The
+            // amount-fallback dedup cannot catch this (no single boarding equals
+            // the combined value), so it relies on the commitment-id match that
+            // getBoardingTxs() now populates reliably.
+            const sweepTxid = "58b3d35a7f0fb5f0a67294d28c409a8acaf56fd95b3aedcfbfa74b96e918ff11";
+
+            const boarding1: ArkTransaction = {
+                key: { boardingTxid: "1aece24a", commitmentTxid: sweepTxid, arkTxid: "" },
+                amount: 76186,
+                type: TxType.TxReceived,
+                settled: true,
+                createdAt: new Date("2026-02-23T17:06:18Z").getTime(),
+            };
+            const boarding2: ArkTransaction = {
+                key: { boardingTxid: "a4f9f575", commitmentTxid: sweepTxid, arkTxid: "" },
+                amount: 152346,
+                type: TxType.TxReceived,
+                settled: true,
+                createdAt: new Date("2026-02-23T18:37:36Z").getTime(),
+            };
+            const combinedVtxo: VirtualCoin = {
+                txid: "34592d08e0a22d91d58a9e80afdc87073831e5bea856e985daf52fadee62063c",
+                vout: 0,
+                value: 228532,
+                status: { confirmed: true, isLeaf: true },
+                virtualStatus: { state: "settled", commitmentTxIds: [sweepTxid] },
+                settledBy: "",
+                createdAt: new Date("2026-02-23T19:59:12Z"),
+                isUnrolled: false,
+                isSpent: false,
+            };
+
+            const transactions = await buildTransactionHistory(
+                [combinedVtxo],
+                [boarding1, boarding2],
+                new Set([sweepTxid]),
+            );
+
+            const received = transactions.filter((tx) => tx.type === TxType.TxReceived);
+            const net = received.reduce((acc, tx) => acc + tx.amount, 0);
+
+            // Net inflow equals the deposited amount; no phantom VTXO receive.
+            expect(net).toBe(228532);
+            // The combined VTXO must NOT surface as its own receive (would inflate).
+            expect(received.some((tx) => tx.amount === 228532)).toBe(false);
+            // Both boarding deposits are present.
+            expect(received.filter((tx) => tx.key.boardingTxid !== "")).toHaveLength(2);
+        });
+
+        it("suppresses a boarding sweep whose VTXO batches in refreshed funds (Dec refill regression)", async () => {
+            // Dec 2025 mainnet incident: a 28,469 boarding deposit settled into an
+            // 82,147 VTXO because the same commitment refreshed 53,678 of existing
+            // VTXOs. Showing the 82,147 VTXO would double-count the refreshed part,
+            // so the swept VTXO is suppressed and only the boarding deposit shows.
+            const sweepTxid = "d5e1c7cf6387ed6725a9a7af3eb9e46f2991275c4685c4701389ce0e8455d7d3";
+
+            const boarding: ArkTransaction = {
+                key: { boardingTxid: "f53e56e8", commitmentTxid: sweepTxid, arkTxid: "" },
+                amount: 28469,
+                type: TxType.TxReceived,
+                settled: true,
+                createdAt: new Date("2025-12-06T12:13:48Z").getTime(),
+            };
+            // The combined leaf created by the sweep (boarding + refreshed funds).
+            const combinedVtxo: VirtualCoin = {
+                txid: "d46e8991f8bc534f63cd05cf673791d024a440fde9e80891eb5698fb53dff7ec",
+                vout: 0,
+                value: 82147,
+                status: { confirmed: true, isLeaf: true },
+                virtualStatus: { state: "settled", commitmentTxIds: [sweepTxid] },
+                settledBy: "",
+                createdAt: new Date("2025-12-10T13:47:08Z"),
+                isUnrolled: false,
+                isSpent: false,
+            };
+
+            const transactions = await buildTransactionHistory(
+                [combinedVtxo],
+                [boarding],
+                new Set([sweepTxid]),
+            );
+
+            const received = transactions.filter((tx) => tx.type === TxType.TxReceived);
+            // Only the boarding deposit is counted; the 82,147 combined leaf is hidden.
+            expect(received.reduce((acc, tx) => acc + tx.amount, 0)).toBe(28469);
+            expect(received.some((tx) => tx.amount === 82147)).toBe(false);
+        });
+
         it("should create a receive transaction for a new vtxo", async () => {
             const arkTxId = "receive-ark-tx-id";
             const baseDate = new Date("2025-10-31T20:00:00Z");

--- a/packages/ts-sdk/test/walletBoardingTxs.test.ts
+++ b/packages/ts-sdk/test/walletBoardingTxs.test.ts
@@ -97,21 +97,23 @@ describe("getBoardingTxs — sweep correlation without outspend txid", () => {
             },
         });
 
-        boardingAddr = await wallet.getBoardingAddress();
-        fundingTx.vout[0].scriptpubkey_address = boardingAddr;
+        try {
+            boardingAddr = await wallet.getBoardingAddress();
+            fundingTx.vout[0].scriptpubkey_address = boardingAddr;
 
-        const { boardingTxs, commitmentsToIgnore } = await wallet.getBoardingTxs();
+            const { boardingTxs, commitmentsToIgnore } = await wallet.getBoardingTxs();
 
-        // The sweep must be ignorable so the resulting VTXO is suppressed.
-        expect(commitmentsToIgnore.has(SWEEP_TXID)).toBe(true);
-        // And we must never pollute the set with `undefined`.
-        expect(commitmentsToIgnore.has(undefined as unknown as string)).toBe(false);
+            // The sweep must be ignorable so the resulting VTXO is suppressed.
+            expect(commitmentsToIgnore.has(SWEEP_TXID)).toBe(true);
+            // And we must never pollute the set with `undefined`.
+            expect(commitmentsToIgnore.has(undefined as unknown as string)).toBe(false);
 
-        const boarding = boardingTxs.find((t) => t.key.boardingTxid === FUNDING_TXID);
-        expect(boarding).toBeDefined();
-        expect(boarding!.settled).toBe(true);
-        expect(boarding!.key.commitmentTxid).toBe(SWEEP_TXID);
-
-        await wallet.dispose();
+            const boarding = boardingTxs.find((t) => t.key.boardingTxid === FUNDING_TXID);
+            expect(boarding).toBeDefined();
+            expect(boarding!.settled).toBe(true);
+            expect(boarding!.key.commitmentTxid).toBe(SWEEP_TXID);
+        } finally {
+            await wallet.dispose();
+        }
     });
 });

--- a/packages/ts-sdk/test/walletBoardingTxs.test.ts
+++ b/packages/ts-sdk/test/walletBoardingTxs.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Wallet, SingleKey, InMemoryWalletRepository, InMemoryContractRepository } from "../src";
+
+/**
+ * Regression for the arkade.money phantom-receive inflation (boarding sweeps).
+ *
+ * The mainnet Esplora (mempool.arkade.sh) returns `/outspends` as
+ * `[{"spent":true}]` WITHOUT the spender txid. getBoardingTxs() must still
+ * recover the sweep (commitment) txid — by scanning the boarding address's own
+ * transactions for the one whose vin spends the boarding output — so the swept
+ * VTXO is correctly suppressed by buildTransactionHistory instead of being
+ * double-counted on top of the boarding deposit.
+ */
+
+const SINGLEKEY_HEX = "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2";
+const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+const mockArkInfo = {
+    signerPubkey: SERVER_PUBKEY_HEX,
+    forfeitPubkey: SERVER_PUBKEY_HEX,
+    batchExpiry: BigInt(144),
+    unilateralExitDelay: BigInt(144),
+    boardingExitDelay: BigInt(144),
+    roundInterval: BigInt(144),
+    network: "mutinynet",
+    dust: BigInt(1000),
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    checkpointTapscript:
+        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+};
+
+const FUNDING_TXID = "aa".repeat(32);
+const SWEEP_TXID = "bb".repeat(32);
+const BOARDING_VALUE = 48955;
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
+vi.mock("../src/utils/fetch", () => ({ fetch: mockFetch, baseFetch: mockFetch }));
+
+const MockEventSource = vi.fn().mockImplementation((url: string) => ({
+    url,
+    onmessage: null,
+    onerror: null,
+    close: vi.fn(),
+}));
+
+beforeEach(() => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    mockFetch.mockReset();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("getBoardingTxs — sweep correlation without outspend txid", () => {
+    it("recovers the sweep commitment txid from address-tx vins (arkade Esplora omits it)", async () => {
+        // Resolved after wallet.create(); the mock closure reads it lazily so
+        // the /info fetch during create() is served before we know the address.
+        let boardingAddr = "";
+
+        // The boarding address's on-chain history: a funding deposit, then a
+        // sweep tx that spends that deposit (boarding output appears in its vin).
+        const fundingTx = {
+            txid: FUNDING_TXID,
+            vin: [{ txid: "ee".repeat(32), vout: 7 }],
+            vout: [{ scriptpubkey_address: "", value: BOARDING_VALUE }],
+            status: { confirmed: true, block_time: 1_763_000_000 },
+        };
+        const sweepTx = {
+            txid: SWEEP_TXID,
+            vin: [{ txid: FUNDING_TXID, vout: 0 }], // spends the boarding output
+            vout: [{ scriptpubkey_address: "tb1pelsewhere", value: 40000 }],
+            status: { confirmed: true, block_time: 1_763_000_500 },
+        };
+
+        mockFetch.mockImplementation((url: string) => {
+            const reply = (body: unknown) =>
+                Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+            if (url.includes("/info")) return reply(mockArkInfo);
+            if (url.includes("subscribe") || url.includes("subscriptions"))
+                return reply({ subscriptionId: "sub-1" });
+            if (url.includes("vtxo") || url.includes("scripts")) return reply({ vtxos: [] });
+            if (boardingAddr && url.includes(`/address/${boardingAddr}/txs`))
+                return reply([fundingTx, sweepTx]);
+            // arkade Esplora: spent flag present, spender txid OMITTED.
+            if (url.includes(`/tx/${FUNDING_TXID}/outspends`)) return reply([{ spent: true }]);
+            return reply([]);
+        });
+
+        const wallet = await Wallet.create({
+            identity: SingleKey.fromHex(SINGLEKEY_HEX),
+            walletMode: "static",
+            arkServerUrl: "http://localhost:7070",
+            storage: {
+                walletRepository: new InMemoryWalletRepository(),
+                contractRepository: new InMemoryContractRepository(),
+            },
+        });
+
+        boardingAddr = await wallet.getBoardingAddress();
+        fundingTx.vout[0].scriptpubkey_address = boardingAddr;
+
+        const { boardingTxs, commitmentsToIgnore } = await wallet.getBoardingTxs();
+
+        // The sweep must be ignorable so the resulting VTXO is suppressed.
+        expect(commitmentsToIgnore.has(SWEEP_TXID)).toBe(true);
+        // And we must never pollute the set with `undefined`.
+        expect(commitmentsToIgnore.has(undefined as unknown as string)).toBe(false);
+
+        const boarding = boardingTxs.find((t) => t.key.boardingTxid === FUNDING_TXID);
+        expect(boarding).toBeDefined();
+        expect(boarding!.settled).toBe(true);
+        expect(boarding!.key.commitmentTxid).toBe(SWEEP_TXID);
+
+        await wallet.dispose();
+    });
+});


### PR DESCRIPTION
## Summary

Wallet TX history showed **phantom "Received" inflation** for onboards: a boarding deposit swept into a batch appeared *both* as the on-chain deposit(s) *and* as the resulting VTXO, double-counting the inflow. Reproduced on arkade.money mainnet — a 228,532-sat onboard (two deposits, 76,186 + 152,346) displayed as **+457,064**.

## Root cause

`getBoardingTxs()` builds `commitmentsToIgnore` (the batch txids whose swept VTXOs must be suppressed) from `OnchainProvider.getTxOutspends()`. The default mainnet Esplora (`mempool.arkade.sh`) returns `/outspends` as `[{"spent":true}]` — **without** the spender `txid` (mempool.space includes it; the singular `/outspend/:vout` endpoint 404s there). So `commitmentsToIgnore.add(spentStatus.txid)` added `undefined`, the swept VTXO's real `commitmentTxIds[0]` (from the indexer) never matched the ignore set, and `buildTransactionHistory` emitted it as an extra receive on top of the boarding deposits.

The existing amount-based dedup fallback can't catch this when several deposits combine into one VTXO (no single deposit equals the combined value) or when a sweep also refreshes existing VTXOs.

## Fix

Recover the spending (commitment) tx from the boarding address's **own transaction list** — the sweep tx is there, with the boarding output in its `vin`. Prefer `outspends.txid`, fall back to the vin-derived commitment, and never add `undefined` to the ignore set.

- `providers/onchain`: add optional `vin` to `ExplorerTransaction` (the electrum provider omits inputs, so it's optional and backward-compatible).
- `wallet`: derive the commitment txid via a vin scan in `getBoardingTxs`.

## Test plan

- New `test/walletBoardingTxs.test.ts`: drives `getBoardingTxs` against a mocked Esplora that returns `{spent:true}` with no txid → the sweep is correctly placed in `commitmentsToIgnore` (fails before the fix, passes after).
- New `buildTransactionHistory` regressions from the real arkade.money cycles: N→1 combined boarding (nets 228,532, not 457,064) and the Dec refill (28,469 deposit → 82,147 combined leaf; no double-count of the refreshed funds).
- Full unit suite green (77 files, 1521 passed, 1 skipped); prettier clean.

Verified end-to-end against mainnet read-only data: the vin scan derives the correct sweep txids, and a full history reconstruction nets to the wallet's actual balance with zero inflation.

## Note (infra, separate)

`mempool.arkade.sh` omitting the outspend spender txid is a server-side deviation from standard Esplora. This PR makes the SDK resilient to it, but the deployment is worth fixing too — other outspends-dependent tooling may be affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction history handling so boarding-related received amounts are not double-counted when multiple deposits are swept together or refreshed.
  * Made boarding transaction tracking more reliable when spent-output details are incomplete, ensuring swept outputs are still recognized correctly.
  * Enhanced support for transaction input data when available, while safely handling providers that do not return it.

* **Tests**
  * Added regression coverage for boarding sweep aggregation and spent-output fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->