### PR TITLE
feat(boltz-swap): verify BTC HTLC in chain swaps

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -20,6 +20,8 @@ import {
     ArkTxInput,
     Identity,
     VirtualCoin,
+    getNetwork,
+    type NetworkName,
 } from "@arkade-os/sdk";
 import type {
     Chain,
@@ -80,7 +82,6 @@ import {
     targetFee,
     p2trScript,
     toXOnly,
-    arkNetworkToBtc,
     assertChainHtlcLeaves,
 } from "./utils/boltz-swap-tx";
 import { decodeInvoice, getInvoicePaymentHash } from "./utils/decoding";
@@ -1714,7 +1715,7 @@ export class ArkadeSwaps {
 
         const arkInfo = await this.arkProvider.getInfo();
 
-        const network = arkNetworkToBtc(arkInfo.network);
+        const network = getNetwork(arkInfo.network as NetworkName);
 
         const swapTree = deserializeSwapTree(pendingSwap.response.claimDetails.swapTree);
 
@@ -2458,7 +2459,7 @@ export class ArkadeSwaps {
                 message: `Swap ${swap.id}: missing timeout block height in BTC details`,
             });
 
-        const network = arkNetworkToBtc(arkNetwork);
+        const network = getNetwork(arkNetwork as NetworkName);
         const swapTree = deserializeSwapTree(btcDetails.swapTree);
         const ephemeralPub = secp256k1.getPublicKey(hex.decode(swap.ephemeralKey));
 

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -64,12 +64,13 @@ import {
     isRestoredChainSwap,
 } from "./boltz-swap-provider";
 import { sha256 } from "@noble/hashes/sha2.js";
+import { ripemd160 } from "@noble/hashes/legacy.js";
 import { hex } from "@scure/base";
 import { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { randomBytes } from "@noble/hashes/utils.js";
 import { Address, OutScript, SigHash, Transaction } from "@scure/btc-signer";
-import { NETWORK } from "@scure/btc-signer/utils.js";
+import { equalBytes } from "@scure/btc-signer/utils.js";
 import { create as createMusig } from "./utils/musig";
 import {
     deserializeSwapTree,
@@ -77,8 +78,10 @@ import {
     detectSwapOutput,
     constructClaimTransaction,
     targetFee,
-    REGTEST_NETWORK,
-    MUTINYNET_NETWORK,
+    p2trScript,
+    toXOnly,
+    arkNetworkToBtc,
+    assertChainHtlcLeaves,
 } from "./utils/boltz-swap-tx";
 import { decodeInvoice, getInvoicePaymentHash } from "./utils/decoding";
 import { normalizeToXOnlyKey } from "./utils/signatures";
@@ -1711,12 +1714,7 @@ export class ArkadeSwaps {
 
         const arkInfo = await this.arkProvider.getInfo();
 
-        const network =
-            arkInfo.network === "bitcoin"
-                ? NETWORK
-                : arkInfo.network === "mutinynet"
-                  ? MUTINYNET_NETWORK
-                  : REGTEST_NETWORK;
+        const network = arkNetworkToBtc(arkInfo.network);
 
         const swapTree = deserializeSwapTree(pendingSwap.response.claimDetails.swapTree);
 
@@ -2428,7 +2426,69 @@ export class ArkadeSwaps {
             });
         }
 
+        this.verifyBtcChainHtlc({ to, swap, arkNetwork: arkInfo.network });
+
         return true;
+    }
+
+    /**
+     * Verifies the BTC-side Taproot HTLC of a chain swap before funds are
+     * committed: the lockup address must bind to MuSig2(boltz, user) over
+     * Boltz's leaves, and those leaves must enforce the agreed preimage hash,
+     * direction-specific keys, leaf version, and absolute refund CLTV.
+     */
+    private verifyBtcChainHtlc(args: {
+        to: Chain;
+        swap: BoltzChainSwap;
+        arkNetwork: string;
+    }): void {
+        const { to, swap, arkNetwork } = args;
+
+        // The BTC side is the details object opposite the verified ARK side.
+        const btcDetails = to === "ARK" ? swap.response.lockupDetails : swap.response.claimDetails;
+
+        if (!btcDetails.swapTree)
+            throw new SwapError({ message: `Swap ${swap.id}: missing swap tree in BTC details` });
+        if (!btcDetails.serverPublicKey)
+            throw new SwapError({
+                message: `Swap ${swap.id}: missing server public key in BTC details`,
+            });
+        if (typeof btcDetails.timeoutBlockHeight !== "number")
+            throw new SwapError({
+                message: `Swap ${swap.id}: missing timeout block height in BTC details`,
+            });
+
+        const network = arkNetworkToBtc(arkNetwork);
+        const swapTree = deserializeSwapTree(btcDetails.swapTree);
+        const ephemeralPub = secp256k1.getPublicKey(hex.decode(swap.ephemeralKey));
+
+        // boltz first, no sorting — matches claimBtc and NArk ComputeAggregateKey.
+        const musig = tweakMusig(
+            createMusig(hex.decode(swap.ephemeralKey), [
+                hex.decode(btcDetails.serverPublicKey),
+                ephemeralPub,
+            ]),
+            swapTree.tree,
+        );
+
+        const expectedScript = OutScript.encode(Address(network).decode(btcDetails.lockupAddress));
+        if (!equalBytes(p2trScript(musig.aggPubkey), expectedScript))
+            throw new SwapError({ message: "Boltz is trying to scam us (invalid BTC address)" });
+
+        const boltzXOnly = toXOnly(hex.decode(btcDetails.serverPublicKey));
+        const userXOnly = toXOnly(ephemeralPub);
+        try {
+            assertChainHtlcLeaves(swapTree, {
+                preimageHash160: ripemd160(hex.decode(swap.request.preimageHash)),
+                claimXOnly: to === "ARK" ? boltzXOnly : userXOnly,
+                refundXOnly: to === "ARK" ? userXOnly : boltzXOnly,
+                timeoutBlockHeight: btcDetails.timeoutBlockHeight,
+            });
+        } catch (err) {
+            throw new SwapError({
+                message: `Boltz is trying to scam us (invalid BTC HTLC: ${(err as Error).message})`,
+            });
+        }
     }
 
     /**

--- a/packages/boltz-swap/src/expo/background.ts
+++ b/packages/boltz-swap/src/expo/background.ts
@@ -22,7 +22,7 @@ import * as BackgroundTask from "expo-background-task";
 import type { TaskItem } from "@arkade-os/sdk/worker/expo";
 import { runTasks } from "@arkade-os/sdk/worker/expo";
 import { ExpoArkProvider, ExpoIndexerProvider } from "@arkade-os/sdk/adapters/expo";
-import { getRandomId, type IWallet } from "@arkade-os/sdk";
+import { getRandomId, type IWallet, type NetworkName } from "@arkade-os/sdk";
 import { BoltzSwapProvider } from "../boltz-swap-provider";
 import { swapsPollProcessor, SWAP_POLL_TASK_TYPE } from "./swapsPollProcessor";
 import type {
@@ -130,14 +130,14 @@ export function defineExpoSwapBackgroundTask(
             const wallet = createBackgroundWalletShim({
                 identity,
                 getAddress: async () => {
-                    const { ArkAddress } = await import("@arkade-os/sdk");
+                    const { ArkAddress, getNetwork } = await import("@arkade-os/sdk");
                     const { hex } = await import("@scure/base");
                     const info = await arkProvider.getInfo();
                     const pubkey = await identity.xOnlyPublicKey();
                     const serverPubKey = hex.decode(info.signerPubkey);
                     const xOnlyServerPubKey =
                         serverPubKey.length === 33 ? serverPubKey.slice(1) : serverPubKey;
-                    const hrp = info.network === "bitcoin" ? "ark" : "tark";
+                    const hrp = getNetwork(info.network as NetworkName).hrp;
                     return new ArkAddress(xOnlyServerPubKey, pubkey, hrp).encode();
                 },
             });

--- a/packages/boltz-swap/src/utils/boltz-swap-tx.ts
+++ b/packages/boltz-swap/src/utils/boltz-swap-tx.ts
@@ -6,7 +6,7 @@ import { schnorr } from "@noble/curves/secp256k1.js";
 import { hex } from "@scure/base";
 import { Script, Transaction } from "@scure/btc-signer";
 import { tapLeafHash } from "@scure/btc-signer/payment.js";
-import { compareBytes, equalBytes } from "@scure/btc-signer/utils.js";
+import { compareBytes, equalBytes, NETWORK } from "@scure/btc-signer/utils.js";
 import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import type { MusigKeyAgg } from "./musig";
 
@@ -48,6 +48,13 @@ export const MUTINYNET_NETWORK = {
     wif: 0xef,
 };
 
+export const arkNetworkToBtc = (arkNetwork: string): typeof NETWORK =>
+    arkNetwork === "bitcoin"
+        ? NETWORK
+        : arkNetwork === "mutinynet"
+          ? MUTINYNET_NETWORK
+          : REGTEST_NETWORK;
+
 // ---------------------------------------------------------------------------
 // Swap tree serialization
 // ---------------------------------------------------------------------------
@@ -88,6 +95,67 @@ export const deserializeSwapTree = (tree: string | SerializedTree): SwapTree => 
             { probability: 49, value: refundLeaf },
         ]),
     };
+};
+
+// ---------------------------------------------------------------------------
+// BTC chain HTLC leaf assertions
+// ---------------------------------------------------------------------------
+
+// Boltz uses tapscript v1 leaves only; see NArk BtcHtlcScripts.
+const TAPLEAF_V1 = 0xc0;
+const PUSH_32 = Uint8Array.of(0x20);
+
+const scriptNumToInt = (data: unknown): number | undefined => {
+    if (!(data instanceof Uint8Array) || data.length === 0) return undefined;
+    return parseInt(hex.encode(Uint8Array.from(data).reverse()), 16);
+};
+
+/**
+ * Asserts a BTC chain-swap HTLC's leaves match the canonical Boltz shape and
+ * carry the agreed preimage hash, keys, and CLTV. Throws on any deviation.
+ *
+ * claim:  OP_SIZE 32 OP_EQUALVERIFY OP_HASH160 <h160> OP_EQUALVERIFY <claim> OP_CHECKSIG
+ * refund: <refund> OP_CHECKSIGVERIFY <timeout> OP_CHECKLOCKTIMEVERIFY
+ */
+export const assertChainHtlcLeaves = (
+    tree: SwapTree,
+    expected: {
+        preimageHash160: Uint8Array;
+        claimXOnly: Uint8Array;
+        refundXOnly: Uint8Array;
+        timeoutBlockHeight: number;
+    },
+): void => {
+    if (tree.claimLeaf.version !== TAPLEAF_V1 || tree.refundLeaf.version !== TAPLEAF_V1)
+        throw new Error("unexpected leaf version");
+
+    const claim = Script.decode(tree.claimLeaf.output);
+    if (
+        claim.length !== 8 ||
+        claim[0] !== "SIZE" ||
+        !(claim[1] instanceof Uint8Array) ||
+        !equalBytes(claim[1], PUSH_32) ||
+        claim[2] !== "EQUALVERIFY" ||
+        claim[3] !== "HASH160" ||
+        !(claim[4] instanceof Uint8Array) ||
+        !equalBytes(claim[4], expected.preimageHash160) ||
+        claim[5] !== "EQUALVERIFY" ||
+        !(claim[6] instanceof Uint8Array) ||
+        !equalBytes(claim[6], expected.claimXOnly) ||
+        claim[7] !== "CHECKSIG"
+    )
+        throw new Error("unexpected claim leaf");
+
+    const refund = Script.decode(tree.refundLeaf.output);
+    if (
+        refund.length !== 4 ||
+        !(refund[0] instanceof Uint8Array) ||
+        !equalBytes(refund[0], expected.refundXOnly) ||
+        refund[1] !== "CHECKSIGVERIFY" ||
+        scriptNumToInt(refund[2]) !== expected.timeoutBlockHeight ||
+        refund[3] !== "CHECKLOCKTIMEVERIFY"
+    )
+        throw new Error("unexpected refund leaf");
 };
 
 // ---------------------------------------------------------------------------
@@ -144,7 +212,7 @@ export const tweakMusig = (musig: MusigKeyAgg, tree: TapTree): MusigKeyAgg => {
 // Swap output detection
 // ---------------------------------------------------------------------------
 
-const toXOnly = (pubKey: Uint8Array): Uint8Array => {
+export const toXOnly = (pubKey: Uint8Array): Uint8Array => {
     if (pubKey.length === 32) return pubKey;
     if (pubKey.length === 33) {
         if (pubKey[0] !== 0x02 && pubKey[0] !== 0x03) {
@@ -157,7 +225,7 @@ const toXOnly = (pubKey: Uint8Array): Uint8Array => {
     throw new Error(`Invalid public key length: expected 32 or 33 bytes, got ${pubKey.length}`);
 };
 
-const p2trScript = (publicKey: Uint8Array): Uint8Array =>
+export const p2trScript = (publicKey: Uint8Array): Uint8Array =>
     Script.encode(["OP_1", toXOnly(publicKey)]);
 
 export const detectSwapOutput = (

--- a/packages/boltz-swap/src/utils/boltz-swap-tx.ts
+++ b/packages/boltz-swap/src/utils/boltz-swap-tx.ts
@@ -80,9 +80,12 @@ export const deserializeSwapTree = (tree: string | SerializedTree): SwapTree => 
 const TAPLEAF_V1 = 0xc0;
 const PUSH_32 = Uint8Array.of(0x20);
 
-// CLTV timeout is a minimally-encoded script number; reuse scure's decoder.
+// CLTV timeout is a canonical ScriptNum: at most 5 bytes (BIP65) and minimally
+// encoded. Enforce both so only the exact Boltz refund-leaf shape is accepted.
 const decodeScriptNum = (data: unknown): number | undefined =>
-    data instanceof Uint8Array && data.length > 0 ? Number(ScriptNum().decode(data)) : undefined;
+    data instanceof Uint8Array && data.length > 0
+        ? Number(ScriptNum(5, true).decode(data))
+        : undefined;
 
 /**
  * Asserts a BTC chain-swap HTLC's leaves match the canonical Boltz shape and

--- a/packages/boltz-swap/src/utils/boltz-swap-tx.ts
+++ b/packages/boltz-swap/src/utils/boltz-swap-tx.ts
@@ -48,12 +48,20 @@ export const MUTINYNET_NETWORK = {
     wif: 0xef,
 };
 
-export const arkNetworkToBtc = (arkNetwork: string): typeof NETWORK =>
-    arkNetwork === "bitcoin"
-        ? NETWORK
-        : arkNetwork === "mutinynet"
-          ? MUTINYNET_NETWORK
-          : REGTEST_NETWORK;
+// Fail closed on unrecognized networks: validating a BTC address against the
+// wrong network params would silently weaken the check.
+export const arkNetworkToBtc = (arkNetwork: string): typeof NETWORK => {
+    switch (arkNetwork) {
+        case "bitcoin":
+            return NETWORK;
+        case "mutinynet":
+            return MUTINYNET_NETWORK;
+        case "regtest":
+            return REGTEST_NETWORK;
+        default:
+            throw new Error(`Unsupported network: ${arkNetwork}`);
+    }
+};
 
 // ---------------------------------------------------------------------------
 // Swap tree serialization

--- a/packages/boltz-swap/src/utils/boltz-swap-tx.ts
+++ b/packages/boltz-swap/src/utils/boltz-swap-tx.ts
@@ -4,9 +4,9 @@
  */
 import { schnorr } from "@noble/curves/secp256k1.js";
 import { hex } from "@scure/base";
-import { Script, Transaction } from "@scure/btc-signer";
+import { Script, ScriptNum, Transaction } from "@scure/btc-signer";
 import { tapLeafHash } from "@scure/btc-signer/payment.js";
-import { compareBytes, equalBytes, NETWORK } from "@scure/btc-signer/utils.js";
+import { compareBytes, equalBytes } from "@scure/btc-signer/utils.js";
 import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import type { MusigKeyAgg } from "./musig";
 
@@ -29,39 +29,6 @@ type SerializedTree = {
 };
 
 export type DetectedSwapOutput = TransactionOutput & { vout: number };
-
-// ---------------------------------------------------------------------------
-// Network constants
-// ---------------------------------------------------------------------------
-
-export const REGTEST_NETWORK = {
-    bech32: "bcrt",
-    pubKeyHash: 0x6f,
-    scriptHash: 0xc4,
-    wif: 0xef,
-};
-
-export const MUTINYNET_NETWORK = {
-    bech32: "tb",
-    pubKeyHash: 0x6f,
-    scriptHash: 0xc4,
-    wif: 0xef,
-};
-
-// Fail closed on unrecognized networks: validating a BTC address against the
-// wrong network params would silently weaken the check.
-export const arkNetworkToBtc = (arkNetwork: string): typeof NETWORK => {
-    switch (arkNetwork) {
-        case "bitcoin":
-            return NETWORK;
-        case "mutinynet":
-            return MUTINYNET_NETWORK;
-        case "regtest":
-            return REGTEST_NETWORK;
-        default:
-            throw new Error(`Unsupported network: ${arkNetwork}`);
-    }
-};
 
 // ---------------------------------------------------------------------------
 // Swap tree serialization
@@ -113,10 +80,9 @@ export const deserializeSwapTree = (tree: string | SerializedTree): SwapTree => 
 const TAPLEAF_V1 = 0xc0;
 const PUSH_32 = Uint8Array.of(0x20);
 
-const scriptNumToInt = (data: unknown): number | undefined => {
-    if (!(data instanceof Uint8Array) || data.length === 0) return undefined;
-    return parseInt(hex.encode(Uint8Array.from(data).reverse()), 16);
-};
+// CLTV timeout is a minimally-encoded script number; reuse scure's decoder.
+const decodeScriptNum = (data: unknown): number | undefined =>
+    data instanceof Uint8Array && data.length > 0 ? Number(ScriptNum().decode(data)) : undefined;
 
 /**
  * Asserts a BTC chain-swap HTLC's leaves match the canonical Boltz shape and
@@ -160,7 +126,7 @@ export const assertChainHtlcLeaves = (
         !(refund[0] instanceof Uint8Array) ||
         !equalBytes(refund[0], expected.refundXOnly) ||
         refund[1] !== "CHECKSIGVERIFY" ||
-        scriptNumToInt(refund[2]) !== expected.timeoutBlockHeight ||
+        decodeScriptNum(refund[2]) !== expected.timeoutBlockHeight ||
         refund[3] !== "CHECKLOCKTIMEVERIFY"
     )
         throw new Error("unexpected refund leaf");

--- a/packages/boltz-swap/src/utils/scripts.ts
+++ b/packages/boltz-swap/src/utils/scripts.ts
@@ -1,6 +1,6 @@
 import { hex } from "@scure/base";
 import { normalizeToXOnlyPublicKey } from "./keys";
-import { VHTLC } from "@arkade-os/sdk";
+import { getNetwork, VHTLC, type NetworkName } from "@arkade-os/sdk";
 import { ripemd160 } from "@noble/hashes/legacy.js";
 
 /**
@@ -77,7 +77,7 @@ export function createVHTLCScript({
     if (!vhtlcScript) throw new Error("Failed to create VHTLC script");
 
     // validate vhtlc script
-    const hrp = network === "bitcoin" ? "ark" : "tark";
+    const hrp = getNetwork(network as NetworkName).hrp;
     const vhtlcAddress = vhtlcScript.address(hrp, serverXOnlyPublicKey).encode();
 
     return { vhtlcScript, vhtlcAddress };

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -7,7 +7,9 @@ import {
     getSequence,
     Identity,
     Intent,
+    getNetwork,
     networks,
+    NetworkName,
     VHTLC,
     VtxoScript,
     VtxoTaprootTree,
@@ -110,7 +112,7 @@ export const createVHTLCScript = (args: {
     if (!vhtlcScript.claimScript) throw new Error("Failed to create VHTLC script");
 
     // validate vhtlc script
-    const hrp = network === "bitcoin" ? "ark" : "tark";
+    const hrp = getNetwork(network as NetworkName).hrp;
     const vhtlcAddress = vhtlcScript.address(hrp, serverXOnlyPublicKey).encode();
 
     return { vhtlcScript, vhtlcAddress };

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -25,6 +25,7 @@ import {
     Wallet,
     SingleKey,
     ArkInfo,
+    getNetwork,
 } from "@arkade-os/sdk";
 import { VHTLC } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
@@ -38,12 +39,7 @@ import { decodeInvoice } from "../src/utils/decoding";
 import { logger } from "../src/logger";
 import { pubECDSA } from "@scure/btc-signer/utils.js";
 import { create as createMusig } from "../src/utils/musig";
-import {
-    deserializeSwapTree,
-    tweakMusig,
-    p2trScript,
-    REGTEST_NETWORK,
-} from "../src/utils/boltz-swap-tx";
+import { deserializeSwapTree, tweakMusig, p2trScript } from "../src/utils/boltz-swap-tx";
 import {
     claimVHTLCwithOffchainTx,
     createVHTLCScript as createVHTLCScriptReal,
@@ -536,7 +532,7 @@ describe("ArkadeSwaps", () => {
             createMusig(btcEphemeralPriv, [btcBoltzPub, btcEphemeralPub]),
             tree,
         );
-        return Address(REGTEST_NETWORK).encode(OutScript.decode(p2trScript(musig.aggPubkey)));
+        return Address(getNetwork("regtest")).encode(OutScript.decode(p2trScript(musig.aggPubkey)));
     };
 
     // Builds a chain swap with a real, self-consistent BTC HTLC on the side the

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -32,9 +32,18 @@ import { randomBytes } from "@noble/hashes/utils.js";
 import { schnorr } from "@noble/curves/secp256k1.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { ripemd160 } from "@noble/hashes/legacy.js";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { Address, OutScript, Script, ScriptNum } from "@scure/btc-signer";
 import { decodeInvoice } from "../src/utils/decoding";
 import { logger } from "../src/logger";
 import { pubECDSA } from "@scure/btc-signer/utils.js";
+import { create as createMusig } from "../src/utils/musig";
+import {
+    deserializeSwapTree,
+    tweakMusig,
+    p2trScript,
+    REGTEST_NETWORK,
+} from "../src/utils/boltz-swap-tx";
 import {
     claimVHTLCwithOffchainTx,
     createVHTLCScript as createVHTLCScriptReal,
@@ -483,6 +492,92 @@ describe("ArkadeSwaps", () => {
             },
         }),
         vhtlcAddress: mock.address.ark,
+    };
+
+    // --- BTC chain HTLC fixtures (canonical Boltz / NArk BtcHtlcScripts shape) ---
+    const BTC_HTLC_TIMEOUT = 500000;
+    const btcEphemeralPriv = seckeys.ephemeral;
+    const btcEphemeralPub = secp256k1.getPublicKey(btcEphemeralPriv);
+    const btcBoltzPub = hex.decode(compressedPubkeys.boltz);
+    const xonly = (k: Uint8Array) => k.subarray(1, 33);
+
+    const buildBtcLeaves = (opts: {
+        claimKey: Uint8Array;
+        refundKey: Uint8Array;
+        preimageHash?: Uint8Array;
+        timeout?: number;
+        version?: number;
+        omitSize?: boolean;
+    }) => {
+        const version = opts.version ?? 0xc0;
+        const claim = Script.encode([
+            ...(opts.omitSize ? [] : (["SIZE", Uint8Array.of(0x20), "EQUALVERIFY"] as const)),
+            "HASH160",
+            ripemd160(opts.preimageHash ?? mockPreimageHash),
+            "EQUALVERIFY",
+            xonly(opts.claimKey),
+            "CHECKSIG",
+        ]);
+        const refund = Script.encode([
+            xonly(opts.refundKey),
+            "CHECKSIGVERIFY",
+            ScriptNum().encode(BigInt(opts.timeout ?? BTC_HTLC_TIMEOUT)),
+            "CHECKLOCKTIMEVERIFY",
+        ]);
+        return {
+            claimLeaf: { version, output: hex.encode(claim) },
+            refundLeaf: { version, output: hex.encode(refund) },
+        };
+    };
+
+    const btcLockupAddress = (swapTree: any) => {
+        const { tree } = deserializeSwapTree(swapTree);
+        const musig = tweakMusig(
+            createMusig(btcEphemeralPriv, [btcBoltzPub, btcEphemeralPub]),
+            tree,
+        );
+        return Address(REGTEST_NETWORK).encode(OutScript.decode(p2trScript(musig.aggPubkey)));
+    };
+
+    // Builds a chain swap with a real, self-consistent BTC HTLC on the side the
+    // user funds (lockupDetails for btcToArk, claimDetails for arkToBtc) and a
+    // placeholder ARK side (callers mock createVHTLCScript to its lockupAddress).
+    const makeBtcChainSwap = (to: "ARK" | "BTC", treeOverride?: any, timeoutOverride?: number) => {
+        const swapTree =
+            treeOverride ??
+            buildBtcLeaves({
+                claimKey: to === "ARK" ? btcBoltzPub : btcEphemeralPub,
+                refundKey: to === "ARK" ? btcEphemeralPub : btcBoltzPub,
+            });
+        const btcDetails = {
+            serverPublicKey: compressedPubkeys.boltz,
+            lockupAddress: btcLockupAddress(swapTree),
+            amount: mock.amount,
+            swapTree,
+            timeoutBlockHeight: timeoutOverride ?? BTC_HTLC_TIMEOUT,
+        };
+        const arkDetails = {
+            serverPublicKey: compressedPubkeys.fulmine,
+            lockupAddress: mock.address.ark,
+            amount: mock.amount,
+            timeoutBlockHeight: 21,
+            timeouts: {
+                refund: 17,
+                unilateralClaim: 21,
+                unilateralRefund: 42,
+                unilateralRefundWithoutReceiver: 63,
+            },
+        };
+        return {
+            ...mockBtcArkChainSwap,
+            ephemeralKey: hex.encode(btcEphemeralPriv),
+            request: { ...mockBtcArkChainSwap.request, preimageHash: hex.encode(mockPreimageHash) },
+            response: {
+                id: mock.id,
+                claimDetails: to === "ARK" ? arkDetails : btcDetails,
+                lockupDetails: to === "ARK" ? btcDetails : arkDetails,
+            },
+        } as unknown as BoltzChainSwap;
     };
 
     beforeEach(async () => {
@@ -1922,10 +2017,7 @@ describe("ArkadeSwaps", () => {
                     vhtlcAddress: mock.address.ark,
                 });
 
-                const pendingSwap: BoltzChainSwap = {
-                    ...mockArkBtcChainSwap,
-                    response: createArkBtcChainSwapResponse,
-                };
+                const pendingSwap = makeBtcChainSwap("BTC");
 
                 // act & assert
                 await expect(
@@ -2380,10 +2472,7 @@ describe("ArkadeSwaps", () => {
                     vhtlcAddress: mock.address.ark,
                 });
 
-                const pendingSwap: BoltzChainSwap = {
-                    ...mockBtcArkChainSwap,
-                    response: createBtcArkChainSwapResponse,
-                };
+                const pendingSwap = makeBtcChainSwap("ARK");
 
                 // act & assert
                 await expect(
@@ -4921,6 +5010,113 @@ describe("ArkadeSwaps", () => {
         it("throws an address mismatch when no candidate signer matches", () => {
             const unrelated = buildAddress(mock.pubkeys.alice);
             expect(() => resolve(unrelated.vhtlcAddress)).toThrow(/VHTLC address mismatch/);
+        });
+    });
+
+    describe("BTC chain HTLC verification", () => {
+        const verify = (to: "ARK" | "BTC", swap: BoltzChainSwap) =>
+            (swaps as any).verifyBtcChainHtlc({ to, swap, arkNetwork: "regtest" });
+
+        it("accepts a valid btcToArk BTC HTLC", () => {
+            expect(() => verify("ARK", makeBtcChainSwap("ARK"))).not.toThrow();
+        });
+
+        it("accepts a valid arkToBtc BTC HTLC", () => {
+            expect(() => verify("BTC", makeBtcChainSwap("BTC"))).not.toThrow();
+        });
+
+        it("rejects a tampered lockup address", () => {
+            const swap = makeBtcChainSwap("ARK");
+            swap.response.lockupDetails.lockupAddress = mock.address.btc;
+            expect(() => verify("ARK", swap)).toThrow(/invalid BTC address/);
+        });
+
+        it("rejects an internal key not bound to MuSig2(boltz, user)", () => {
+            const swap = makeBtcChainSwap("ARK");
+            swap.response.lockupDetails.serverPublicKey = compressedPubkeys.alice;
+            expect(() => verify("ARK", swap)).toThrow(/invalid BTC address/);
+        });
+
+        // The leaves below still bind to the address (they drive its derivation);
+        // only the content assertions reject them.
+        it("rejects a claim leaf with the wrong preimage hash", () => {
+            const tree = buildBtcLeaves({
+                claimKey: btcBoltzPub,
+                refundKey: btcEphemeralPub,
+                preimageHash: randomBytes(32),
+            });
+            expect(() => verify("ARK", makeBtcChainSwap("ARK", tree))).toThrow(/invalid BTC HTLC/);
+        });
+
+        it("rejects a claim leaf with the wrong claim key", () => {
+            const tree = buildBtcLeaves({
+                claimKey: hex.decode(compressedPubkeys.alice),
+                refundKey: btcEphemeralPub,
+            });
+            expect(() => verify("ARK", makeBtcChainSwap("ARK", tree))).toThrow(/invalid BTC HTLC/);
+        });
+
+        it("rejects a refund leaf with the wrong refund key", () => {
+            const tree = buildBtcLeaves({
+                claimKey: btcBoltzPub,
+                refundKey: hex.decode(compressedPubkeys.alice),
+            });
+            expect(() => verify("ARK", makeBtcChainSwap("ARK", tree))).toThrow(/invalid BTC HTLC/);
+        });
+
+        it("rejects a non-0xc0 leaf version", () => {
+            const tree = buildBtcLeaves({
+                claimKey: btcBoltzPub,
+                refundKey: btcEphemeralPub,
+                version: 0xc1,
+            });
+            expect(() => verify("ARK", makeBtcChainSwap("ARK", tree))).toThrow(/invalid BTC HTLC/);
+        });
+
+        it("rejects a CLTV that does not equal timeoutBlockHeight", () => {
+            expect(() =>
+                verify("ARK", makeBtcChainSwap("ARK", undefined, BTC_HTLC_TIMEOUT + 1)),
+            ).toThrow(/invalid BTC HTLC/);
+        });
+
+        it("rejects a malformed claim leaf missing OP_SIZE 32", () => {
+            const tree = buildBtcLeaves({
+                claimKey: btcBoltzPub,
+                refundKey: btcEphemeralPub,
+                omitSize: true,
+            });
+            expect(() => verify("ARK", makeBtcChainSwap("ARK", tree))).toThrow(/invalid BTC HTLC/);
+        });
+
+        it("fails closed when the BTC side lacks swapTree, serverPublicKey, or timeout", () => {
+            const noTree = makeBtcChainSwap("ARK");
+            noTree.response.lockupDetails.swapTree = undefined;
+            expect(() => verify("ARK", noTree)).toThrow(/missing swap tree/);
+
+            const noKey = makeBtcChainSwap("ARK");
+            noKey.response.lockupDetails.serverPublicKey = "";
+            expect(() => verify("ARK", noKey)).toThrow(/missing server public key/);
+
+            const noTimeout = makeBtcChainSwap("ARK");
+            noTimeout.response.lockupDetails.timeoutBlockHeight = undefined as any;
+            expect(() => verify("ARK", noTimeout)).toThrow(/missing timeout block height/);
+        });
+
+        it("verifyChainSwap invokes the BTC check after the ARK side", async () => {
+            const swap = makeBtcChainSwap("ARK");
+            vi.spyOn(swaps, "createVHTLCScript").mockReturnValue({
+                vhtlcAddress: swap.response.claimDetails.lockupAddress,
+            } as any);
+
+            await expect(
+                swaps.verifyChainSwap({ to: "ARK", from: "BTC", swap, arkInfo: mockArkInfo }),
+            ).resolves.toBe(true);
+
+            const bad = makeBtcChainSwap("ARK");
+            bad.response.lockupDetails.lockupAddress = mock.address.btc;
+            await expect(
+                swaps.verifyChainSwap({ to: "ARK", from: "BTC", swap: bad, arkInfo: mockArkInfo }),
+            ).rejects.toThrow(/invalid BTC address/);
         });
     });
 });

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -196,7 +196,7 @@ import {
 import { Intent } from "./intent";
 import { BIP322 } from "./bip322";
 import { ArkNote } from "./arknote";
-import { networks, Network, NetworkName } from "./networks";
+import { getNetwork, networks, Network, NetworkName } from "./networks";
 import {
     RestIndexerProvider,
     IndexerProvider,
@@ -421,6 +421,7 @@ export {
     ArkNote,
 
     // Network
+    getNetwork,
     networks,
 
     // DB

--- a/packages/ts-sdk/src/networks.ts
+++ b/packages/ts-sdk/src/networks.ts
@@ -10,7 +10,11 @@ export interface Network {
     wif: number;
 }
 export const getNetwork = (network: NetworkName): Network => {
-    return networks[network];
+    const found = networks[network];
+    // Fail closed: an unknown network must never silently fall through to
+    // mainnet params (e.g. via Address()'s default) when validating addresses.
+    if (!found) throw new Error(`Unsupported network: ${network}`);
+    return found;
 };
 
 export const networks = {


### PR DESCRIPTION
## Summary

`verifyChainSwap()` is the trust boundary for chain swaps (ARK ↔ BTC), proving that the addresses Boltz returned actually encode the agreed HTLC. Until now it only verified the **ARK-side VHTLC**; the **BTC-side Taproot HTLC was never checked**. For a `btcToArk` swap that BTC side is the address the user funds with real on-chain BTC, so it was asserted on Boltz's word alone.

## What it does

`verifyChainSwap()` now also reconstructs and validates the BTC-side HTLC:

- Selects the BTC-side details by direction (`lockupDetails` for `btcToArk`, `claimDetails` for `arkToBtc`).
- Rebuilds the Taproot internal key as `MuSig2([boltz, user])` — boltz-first, no sorting (matches `claimBtc` and NArk `ComputeAggregateKey`).
- Asserts the lockup address binds to that key over Boltz's leaves, compared at the **script** level (sidesteps bech32m/HRP edge cases).
- Asserts the leaf **contents**: claim leaf enforces `OP_SIZE 32 … OP_HASH160 <ripemd160(preimageHash)> … <claimXOnly> OP_CHECKSIG`; refund leaf enforces `<refundXOnly> OP_CHECKSIGVERIFY <timeout> OP_CHECKLOCKTIMEVERIFY`; both leaves must be tapscript version `0xc0`; the CLTV must equal `timeoutBlockHeight` exactly.
- **Fails closed** when a fresh create response's BTC side lacks `swapTree`, `serverPublicKey`, or `timeoutBlockHeight`.

## Changes

- `src/utils/boltz-swap-tx.ts` — export `p2trScript`/`toXOnly`; add `arkNetworkToBtc` (dedup'd from `claimBtc`'s inline network map); add `assertChainHtlcLeaves` for exact leaf-shape assertions.
- `src/arkade-swaps.ts` — add private `verifyBtcChainHtlc`, invoked from `verifyChainSwap` after the ARK check; refactor `claimBtc` to reuse `arkNetworkToBtc`.
- `test/arkade-swaps.test.ts` — 13 focused tests (happy paths both directions, address/internal-key tampering, wrong preimage hash, wrong claim/refund key, non-`0xc0` version, CLTV mismatch, malformed claim, fail-closed guards, `verifyChainSwap` wiring). The two pre-existing `verifyChainSwap` happy-path tests now use a real BTC HTLC fixture instead of empty-`swapTree` stubs, exercising the BTC branch end-to-end.

## Verification

- `tsc --noEmit` clean, full build clean, prettier clean.
- All 423 boltz-swap unit tests pass (210 in `arkade-swaps.test.ts`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added stronger BTC-side chain-swap verification, including Taproot lockup address binding and strict HTLC claim/refund leaf validation.
  * Standardized network HRP selection across swap scripting and Expo background wallet address derivation.
  * Expanded end-to-end and unit test coverage for both valid and tampered BTC HTLC scenarios.

* **Bug Fixes**
  * Reduced the likelihood of accepting malformed or mismatched BTC swap details (keys, preimage hash, leaf version/structure, and CLTV timeout).
  * Unsupported network names now fail fast instead of continuing with ambiguous defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->