### PR TITLE
fix: don't fail on delegate errors

### DIFF
--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -616,10 +616,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
             ? await config.delegateProvider
                   .getDelegateInfo()
                   .then((info) => hex.decode(info.pubkey).slice(1))
+                  .catch(() => undefined)
             : config.delegatorProvider
               ? await config.delegatorProvider
                     .getDelegateInfo()
                     .then((info) => hex.decode(info.pubkey).slice(1))
+                    .catch(() => undefined)
               : undefined;
 
         const offchainOptions = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet setup so it continues gracefully if delegate information can’t be decoded.
  * In cases where delegate or delegator info is unavailable or invalid, the wallet now falls back to an undefined delegate key instead of failing the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->