### PR TITLE
Fix/invoice expiry timestamp docs

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -451,6 +451,7 @@ export class ArkadeSwaps {
         return {
             amount: pendingSwap.response.onchainAmount,
             expiry: decodedInvoice.expiry,
+            timestamp: decodedInvoice.timestamp,
             invoice: pendingSwap.response.invoice,
             paymentHash: decodedInvoice.paymentHash,
             pendingSwap,

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -81,7 +81,7 @@ export interface CreateLightningInvoiceRequest {
 export interface CreateLightningInvoiceResponse {
     /** The on-chain amount in satoshis (after Boltz fees). */
     amount: number;
-    /** Invoice expiry timestamp (Unix seconds). */
+    /** Invoice expiry: seconds from invoice creation (timestamp) until it expires. */
     expiry: number;
     /** The BOLT11-encoded Lightning invoice string. */
     invoice: string;

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -83,7 +83,7 @@ export interface CreateLightningInvoiceResponse {
     amount: number;
     /** Invoice expiry: seconds from invoice creation (timestamp) until it expires. */
     expiry: number;
-    /** Invoice creation timestamp (Unix seconds). */
+    /** Invoice creation timestamp (Unix seconds). Always present in a valid BOLT11 invoice; `0` should not occur in practice. */
     timestamp: number;
     /** The BOLT11-encoded Lightning invoice string. */
     invoice: string;
@@ -338,7 +338,7 @@ export type ArkadeSwapsCreateConfig = Omit<ArkadeSwapsConfig, "swapProvider"> & 
 export interface DecodedInvoice {
     /** Invoice expiry timestamp (Unix seconds). */
     expiry: number;
-    /** Invoice creation timestamp (Unix seconds). */
+    /** Invoice creation timestamp (Unix seconds). Always present in a valid BOLT11 invoice; `0` should not occur in practice. */
     timestamp: number;
     /** Invoice amount in satoshis. */
     amountSats: number;

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -83,6 +83,8 @@ export interface CreateLightningInvoiceResponse {
     amount: number;
     /** Invoice expiry: seconds from invoice creation (timestamp) until it expires. */
     expiry: number;
+    /** Invoice creation timestamp (Unix seconds). */
+    timestamp: number;
     /** The BOLT11-encoded Lightning invoice string. */
     invoice: string;
     /** The payment hash (hex-encoded). */
@@ -336,6 +338,8 @@ export type ArkadeSwapsCreateConfig = Omit<ArkadeSwapsConfig, "swapProvider"> & 
 export interface DecodedInvoice {
     /** Invoice expiry timestamp (Unix seconds). */
     expiry: number;
+    /** Invoice creation timestamp (Unix seconds). */
+    timestamp: number;
     /** Invoice amount in satoshis. */
     amountSats: number;
     /** Invoice description string (BOLT11 `d` field; "" if none). */

--- a/packages/boltz-swap/src/utils/decoding.ts
+++ b/packages/boltz-swap/src/utils/decoding.ts
@@ -12,6 +12,8 @@ export const decodeInvoice = (invoice: string): DecodedInvoice => {
     const millisats = BigInt(decoded.sections.find((s) => s.name === "amount")?.value ?? "0");
     return {
         expiry: decoded.expiry ?? 3600,
+        // The timestamp fallback to 0 is just to satisfy the type checker.
+        // In practice, the timestamp is always present in well-formatted BOLT11 invoices.
         timestamp: decoded.sections.find((s) => s.name === "timestamp")?.value ?? 0,
         amountSats: Number(millisats / 1000n),
         description: decoded.sections.find((s) => s.name === "description")?.value ?? "",

--- a/packages/boltz-swap/src/utils/decoding.ts
+++ b/packages/boltz-swap/src/utils/decoding.ts
@@ -12,6 +12,7 @@ export const decodeInvoice = (invoice: string): DecodedInvoice => {
     const millisats = BigInt(decoded.sections.find((s) => s.name === "amount")?.value ?? "0");
     return {
         expiry: decoded.expiry ?? 3600,
+        timestamp: decoded.sections.find((s) => s.name === "timestamp")?.value ?? 0,
         amountSats: Number(millisats / 1000n),
         description: decoded.sections.find((s) => s.name === "description")?.value ?? "",
         // description_hash (BOLT11 `h`) is missing from light-bolt11-decoder's

--- a/packages/boltz-swap/test/decoding.test.ts
+++ b/packages/boltz-swap/test/decoding.test.ts
@@ -6,6 +6,7 @@ vi.mock("light-bolt11-decoder", () => ({
             expiry: 3600,
             sections: [
                 { name: "amount", value: "9007199254741999" },
+                { name: "timestamp", value: 1700000000 },
                 { name: "description", value: "large invoice" },
                 { name: "description_hash", value: "a".repeat(64) },
                 { name: "payment_hash", value: "hash" },
@@ -23,5 +24,9 @@ describe("decodeInvoice", () => {
 
     it("surfaces the description_hash (BOLT11 h) section", () => {
         expect(decodeInvoice("lnbc1mock").descriptionHash).toBe("a".repeat(64));
+    });
+
+    it("surfaces the timestamp (invoice creation) section", () => {
+        expect(decodeInvoice("lnbc1mock").timestamp).toBe(1700000000);
     });
 });


### PR DESCRIPTION
`CreateLightningInvoiceResponse.expiry` (and `DecodedInvoice.expiry`) were documented as an absolute Unix-seconds timestamp, but the value is actually a relative delta: seconds from invoice creation until it expires. This mismatch caused a real bug as code that trusted the docstring multiplied `expiry` by 1000, as if it were an absolute timestamp and ended up treating every invoice as expired already.

This fixes the docstring to describe the value correctly, and adds a `timestamp` field (the invoice's own creation time, Unix seconds) to both types so callers can compute an absolute deadline (`timestamp + expiry`) using the invoice's own embedded time rather than their local clock. `decodeInvoice()` and `createLightningInvoice()` are updated to populate it, with a test covering the new field.

Both changes are additive/non-breaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lightning invoice details now include the invoice creation timestamp, and decoded invoices now expose it as well.
* **Bug Fixes**
  * Invoice decoding now returns a timestamp consistently, defaulting to `0` when the BOLT11 timestamp section is missing.
* **Documentation**
  * Updated expiry documentation to clarify it represents seconds remaining from invoice creation until expiration.
* **Tests**
  * Extended invoice decoding tests to verify timestamp extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->