### PR TITLE
fix(sdk): match new arkd stale-subscription error format

### DIFF
--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -607,11 +607,11 @@ export class ContractWatcher {
         } catch (error) {
             // If we sent a stale subscription ID that the server no longer
             // recognises, clear it and retry to create a fresh subscription.
-            // The server currently returns HTTP 500 with a JSON body whose
-            // message field looks like "subscription <uuid> not found".
+            // Match both server phrasings: "subscription <uuid> not found" and
+            // "subscription not found: <uuid>".
             // All other errors (network failures, parse errors, etc.) are rethrown.
             const isStale =
-                error instanceof Error && /subscription\s+\S+\s+not\s+found/i.test(error.message);
+                error instanceof Error && /subscription\b.*\bnot\s+found/i.test(error.message);
             if (this.subscriptionId && isStale) {
                 this.subscriptionId = undefined;
                 this.subscriptionId =

--- a/packages/ts-sdk/test/contracts/watcher.test.ts
+++ b/packages/ts-sdk/test/contracts/watcher.test.ts
@@ -132,85 +132,91 @@ describe("ContractWatcher", () => {
         });
     });
 
-    it("should clear stale subscription ID and create a fresh subscription on reconnect", async () => {
-        vi.useFakeTimers();
+    it.each([
+        { label: "old format", message: (id: string) => `subscription ${id} not found` },
+        { label: "new format", message: (id: string) => `subscription not found: ${id}` },
+    ])(
+        "should clear stale subscription ID and create a fresh subscription on reconnect ($label)",
+        async ({ message }) => {
+            vi.useFakeTimers();
 
-        try {
-            const contract: Contract = {
-                type: "default",
-                params: createDefaultContractParams(),
-                script: TEST_DEFAULT_SCRIPT,
-                address: "address",
-                state: "active",
-                createdAt: Date.now(),
-            };
-            await watcher.addContract(contract);
+            try {
+                const contract: Contract = {
+                    type: "default",
+                    params: createDefaultContractParams(),
+                    script: TEST_DEFAULT_SCRIPT,
+                    address: "address",
+                    state: "active",
+                    createdAt: Date.now(),
+                };
+                await watcher.addContract(contract);
 
-            // getSubscription returns an async iterator that immediately
-            // rejects, simulating the SSE stream dying after the server
-            // drops the subscription due to inactivity
-            (mockIndexer.getSubscription as any).mockImplementation(() => ({
-                [Symbol.asyncIterator]: () => ({
-                    next: () => Promise.reject(new Error("stream died")),
-                }),
-            }));
+                // getSubscription returns an async iterator that immediately
+                // rejects, simulating the SSE stream dying after the server
+                // drops the subscription due to inactivity
+                (mockIndexer.getSubscription as any).mockImplementation(() => ({
+                    [Symbol.asyncIterator]: () => ({
+                        next: () => Promise.reject(new Error("stream died")),
+                    }),
+                }));
 
-            const callback = vi.fn();
-            await watcher.startWatching(callback);
-            // connect() succeeded: subscriptionId = "mock-subscription-id"
-            // listenLoop() started in background (will fail immediately)
+                const callback = vi.fn();
+                await watcher.startWatching(callback);
+                // connect() succeeded: subscriptionId = "mock-subscription-id"
+                // listenLoop() started in background (will fail immediately)
 
-            // Reset subscribe mock to track only reconnection calls.
-            // Reject when called with the stale ID (server cleaned it up),
-            // succeed when called without an ID (fresh subscription).
-            const subscribeMock = mockIndexer.subscribeForScripts as ReturnType<typeof vi.fn>;
-            subscribeMock.mockReset();
-            subscribeMock.mockImplementation((scripts: string[], existingId?: string) => {
-                if (existingId) {
-                    return Promise.reject(new Error(`subscription ${existingId} not found`));
-                }
-                return Promise.resolve("fresh-subscription-id");
-            });
+                // Reset subscribe mock to track only reconnection calls.
+                // Reject when called with the stale ID (server cleaned it up),
+                // succeed when called without an ID (fresh subscription).
+                const subscribeMock = mockIndexer.subscribeForScripts as ReturnType<typeof vi.fn>;
+                subscribeMock.mockReset();
+                subscribeMock.mockImplementation((scripts: string[], existingId?: string) => {
+                    if (existingId) {
+                        return Promise.reject(new Error(message(existingId)));
+                    }
+                    return Promise.resolve("fresh-subscription-id");
+                });
 
-            // After successful reconnection, make getSubscription hang
-            // so we don't trigger another reconnect cycle
-            (mockIndexer.getSubscription as any).mockImplementation(() => ({
-                [Symbol.asyncIterator]: () => ({
-                    next: () => new Promise(() => {}),
-                }),
-            }));
+                // After successful reconnection, make getSubscription hang
+                // so we don't trigger another reconnect cycle
+                (mockIndexer.getSubscription as any).mockImplementation(() => ({
+                    [Symbol.asyncIterator]: () => ({
+                        next: () => new Promise(() => {}),
+                    }),
+                }));
 
-            // Flush microtasks: listenLoop rejects → scheduleReconnect()
-            await vi.advanceTimersByTimeAsync(0);
+                // Flush microtasks: listenLoop rejects → scheduleReconnect()
+                await vi.advanceTimersByTimeAsync(0);
 
-            // Advance past the reconnect delay (1s default)
-            await vi.advanceTimersByTimeAsync(1000);
-            // Flush microtasks so connect() resolves
-            await vi.advanceTimersByTimeAsync(0);
+                // Advance past the reconnect delay (1s default)
+                await vi.advanceTimersByTimeAsync(1000);
+                // Flush microtasks so connect() resolves
+                await vi.advanceTimersByTimeAsync(0);
 
-            // subscribeForScripts should have been called twice:
-            // 1st: with the stale ID → server rejects "not found"
-            // 2nd: without ID → fresh subscription created
-            //
-            // Without the fix the 2nd call never happens — the error
-            // propagates, connect() catches it, and it retries forever
-            // with the same stale ID.
-            expect(subscribeMock).toHaveBeenCalledTimes(2);
-            expect(subscribeMock).toHaveBeenNthCalledWith(
-                1,
-                [contract.script],
-                "mock-subscription-id",
-            );
-            expect(subscribeMock).toHaveBeenNthCalledWith(2, [contract.script]);
+                // subscribeForScripts should have been called twice:
+                // 1st: with the stale ID → server rejects "not found"
+                // 2nd: without ID → fresh subscription created
+                //
+                // Without the fix the 2nd call never happens — the error
+                // propagates, connect() catches it, and it retries forever
+                // with the same stale ID.
+                expect(subscribeMock).toHaveBeenCalledTimes(2);
+                expect(subscribeMock).toHaveBeenNthCalledWith(
+                    1,
+                    [contract.script],
+                    "mock-subscription-id",
+                );
+                expect(subscribeMock).toHaveBeenNthCalledWith(2, [contract.script]);
 
-            // Watcher recovered — not stuck in a reconnect loop
-            expect(watcher.getConnectionState()).toBe("connected");
+                // Watcher recovered — not stuck in a reconnect loop
+                expect(watcher.getConnectionState()).toBe("connected");
 
-            await watcher.stopWatching();
-        } finally {
-            vi.useRealTimers();
-        }
-    });
+                await watcher.stopWatching();
+            } finally {
+                vi.useRealTimers();
+            }
+        },
+    );
 
     it("opens listenLoop immediately when the first contract is added after a zero-script startWatching", async () => {
         // Without the cold-start kick, the listener parks behind the


### PR DESCRIPTION
`ContractWatcher.updateSubscription` detects a stale subscription ID via a regex that only matched arkd's old wording `subscription <uuid> not found`. arkd changed it to `subscription not found: <uuid>` in [`c4f16324`](https://github.com/arkade-os/arkd/commit/c4f16324) (#1074), so the stale ID was never cleared and the watcher looped on reconnect (`ContractWatcher connection failed: ... subscription not found: <uuid>`).

Broaden the regex to match both phrasings; parameterize the reconnect test over both formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription recovery when the backend reports a stale subscription ID, handling multiple error-message formats.
  * Watchers now clear the old subscription ID and reconnect more reliably after a dropped stream.
  * Updated tests to cover both error-message variants and confirm the connection returns to a connected state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->