### PR TITLE
fix(sdk): wrap transport-level fetch failures in a typed FetchError

### DIFF
--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -310,7 +310,7 @@ import type {
 } from "./contracts/types";
 import type { ScanResult, ScanContractsOptions, HandlerError } from "./contracts/contractManager";
 import { timelockToSequence, sequenceToTimelock } from "./utils/timelock";
-import { buildVersion, sdkVersion } from "./utils/fetch";
+import { buildVersion, sdkVersion, FetchError } from "./utils/fetch";
 import { closeDatabase, openDatabase } from "./repositories/indexedDB/manager";
 import {
     WalletMessageHandler,
@@ -362,6 +362,7 @@ export {
     WsElectrumChainSource,
     RestArkProvider,
     DigestMismatchError,
+    FetchError,
     RestIndexerProvider,
 
     // Script-related

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -8,16 +8,48 @@ export const buildVersion = "0.9.9";
 export const sdkVersion = `ts-sdk/${version}`;
 
 /**
+ * Thrown by {@link baseFetch} — and therefore by the Ark-server {@link fetch}
+ * wrapper, which delegates to it — when the underlying platform `fetch` rejects
+ * at the transport layer: DNS failure, connection refused, TLS or CORS error,
+ * etc. The raw platform rejection (`TypeError: Failed to fetch` in browsers, the
+ * opaque `TypeError: fetch failed` in Node) says nothing about which request
+ * failed; this wraps it with the request method and URL and preserves the
+ * original as {@link Error.cause}. It does NOT retry — retrying is the caller's
+ * responsibility.
+ */
+export class FetchError extends Error {
+    /** The request URL that failed, when derivable from the `fetch` input. */
+    readonly url?: string;
+    /** The HTTP method of the failed request (defaults to `"GET"`). */
+    readonly method?: string;
+
+    constructor(message: string, options: { url?: string; method?: string; cause?: unknown }) {
+        super(message, { cause: options.cause });
+        this.name = "FetchError";
+        this.url = options.url;
+        this.method = options.method;
+    }
+}
+
+/**
  * Guarded passthrough to the platform `fetch` with no Arkade-specific headers.
  * Use for any service that is NOT the Ark server (delegate, Esplora, …): those
  * origins reject unknown request headers such as `X-Build-Version` in the CORS
  * preflight.
+ *
+ * A transport-level rejection from the platform `fetch` is re-thrown as a
+ * {@link FetchError} that names the request and keeps the original error as
+ * `cause`, so callers can tell *which* request failed instead of receiving an
+ * opaque `TypeError: Failed to fetch`.
  */
-export function baseFetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+export function baseFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     if (typeof globalThis.fetch !== "function") {
         throw new Error("Fetch API is not available in this environment.");
     }
-    return globalThis.fetch(input, init);
+    return globalThis.fetch(input, init).catch((cause) => {
+        const { url, method } = describeRequest(input, init);
+        throw new FetchError(`Network request failed: ${method} ${url}`, { url, method, cause });
+    });
 }
 
 /**
@@ -26,9 +58,39 @@ export function baseFetch(input: RequestInfo, init?: RequestInit): Promise<Respo
  * carrying this package's own version. Do NOT use it for other origins — they
  * reject these custom headers in CORS preflight.
  */
-export function fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+export function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     const headers = new Headers(init?.headers);
     headers.set("X-Build-Version", buildVersion);
     headers.set("X-SDK-VERSION", sdkVersion);
     return baseFetch(input, { ...init, headers });
+}
+
+/**
+ * Derive a human-readable `{ url, method }` for a failed request from the
+ * `fetch` arguments, handling the `string | URL | Request` input shapes. The
+ * `init.method` wins, then a `Request`'s own method, defaulting to `"GET"`.
+ */
+function describeRequest(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+): { url: string; method: string } {
+    let url: string;
+    if (typeof input === "string") {
+        url = input;
+    } else if (input instanceof URL) {
+        url = input.href;
+    } else {
+        url = input.url;
+    }
+
+    let method: string;
+    if (init?.method !== undefined) {
+        method = init.method;
+    } else if (input instanceof Request) {
+        method = input.method;
+    } else {
+        method = "GET";
+    }
+
+    return { url, method };
 }

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -8,14 +8,9 @@ export const buildVersion = "0.9.9";
 export const sdkVersion = `ts-sdk/${version}`;
 
 /**
- * Thrown by {@link baseFetch} — and therefore by the Ark-server {@link fetch}
- * wrapper, which delegates to it — when the underlying platform `fetch` rejects
- * at the transport layer: DNS failure, connection refused, TLS or CORS error,
- * etc. The raw platform rejection (`TypeError: Failed to fetch` in browsers, the
- * opaque `TypeError: fetch failed` in Node) says nothing about which request
- * failed; this wraps it with the request method and URL and preserves the
- * original as {@link Error.cause}. It does NOT retry — retrying is the caller's
- * responsibility.
+ * Wraps a transport-level `fetch` rejection (DNS failure, connection refused,
+ * TLS or CORS error) with the request method and URL, preserving the original
+ * as {@link Error.cause}.
  */
 export class FetchError extends Error {
     /** The request URL that failed, when derivable from the `fetch` input. */
@@ -37,10 +32,7 @@ export class FetchError extends Error {
  * origins reject unknown request headers such as `X-Build-Version` in the CORS
  * preflight.
  *
- * A transport-level rejection from the platform `fetch` is re-thrown as a
- * {@link FetchError} that names the request and keeps the original error as
- * `cause`, so callers can tell *which* request failed instead of receiving an
- * opaque `TypeError: Failed to fetch`.
+ * Transport-level rejections are re-thrown as a {@link FetchError}.
  */
 export function baseFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     if (typeof globalThis.fetch !== "function") {

--- a/packages/ts-sdk/test/fetch.test.ts
+++ b/packages/ts-sdk/test/fetch.test.ts
@@ -22,7 +22,7 @@ describe("FetchError", () => {
 });
 
 describe("baseFetch", () => {
-    it("wraps a transport-level rejection in FetchError with context and cause", async () => {
+    it("wraps a transport-level rejection in FetchError, defaulting method to GET and honoring init.method", async () => {
         const cause = new TypeError("Failed to fetch");
         vi.stubGlobal(
             "fetch",
@@ -31,29 +31,17 @@ describe("baseFetch", () => {
             }),
         );
 
-        const err = await baseFetch("https://esplora.test/address/abc/utxo").catch((e) => e);
-        expect(err).toBeInstanceOf(FetchError);
-        expect(err.name).toBe("FetchError");
-        expect(err.message).toContain("https://esplora.test/address/abc/utxo");
-        expect(err.message).toContain("GET");
-        expect(err.url).toBe("https://esplora.test/address/abc/utxo");
-        expect(err.method).toBe("GET");
-        expect(err.cause).toBe(cause);
-    });
+        const getErr = await baseFetch("https://esplora.test/address/abc/utxo").catch((e) => e);
+        expect(getErr).toBeInstanceOf(FetchError);
+        expect(getErr.name).toBe("FetchError");
+        expect(getErr.message).toContain("GET https://esplora.test/address/abc/utxo");
+        expect(getErr.url).toBe("https://esplora.test/address/abc/utxo");
+        expect(getErr.method).toBe("GET");
+        expect(getErr.cause).toBe(cause);
 
-    it("reflects the request method from init in the wrapped error", async () => {
-        vi.stubGlobal(
-            "fetch",
-            vi.fn(async () => {
-                throw new TypeError("Failed to fetch");
-            }),
-        );
-
-        const err = await baseFetch("https://x.test/tx", { method: "POST" }).catch((e) => e);
-        expect(err).toBeInstanceOf(FetchError);
-        expect(err.method).toBe("POST");
-        expect(err.message).toContain("POST");
-        expect(err.message).toContain("https://x.test/tx");
+        const postErr = await baseFetch("https://x.test/tx", { method: "POST" }).catch((e) => e);
+        expect(postErr.method).toBe("POST");
+        expect(postErr.message).toContain("POST https://x.test/tx");
     });
 
     it("derives the request URL from a URL instance", async () => {

--- a/packages/ts-sdk/test/fetch.test.ts
+++ b/packages/ts-sdk/test/fetch.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { baseFetch, fetch, FetchError } from "../src/utils/fetch";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("FetchError", () => {
+    it("is a named Error subclass carrying url, method and cause", () => {
+        const cause = new TypeError("Failed to fetch");
+        const err = new FetchError("boom", {
+            url: "https://x.test/a",
+            method: "POST",
+            cause,
+        });
+        expect(err).toBeInstanceOf(Error);
+        expect(err).toBeInstanceOf(FetchError);
+        expect(err.name).toBe("FetchError");
+        expect(err.message).toBe("boom");
+        expect(err.url).toBe("https://x.test/a");
+        expect(err.method).toBe("POST");
+        expect(err.cause).toBe(cause);
+    });
+});
+
+describe("baseFetch", () => {
+    it("wraps a transport-level rejection in FetchError with context and cause", async () => {
+        const cause = new TypeError("Failed to fetch");
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                throw cause;
+            }),
+        );
+
+        const err = await baseFetch("https://esplora.test/address/abc/utxo").catch((e) => e);
+        expect(err).toBeInstanceOf(FetchError);
+        expect(err.name).toBe("FetchError");
+        expect(err.message).toContain("https://esplora.test/address/abc/utxo");
+        expect(err.message).toContain("GET");
+        expect(err.url).toBe("https://esplora.test/address/abc/utxo");
+        expect(err.method).toBe("GET");
+        expect(err.cause).toBe(cause);
+    });
+
+    it("reflects the request method from init in the wrapped error", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                throw new TypeError("Failed to fetch");
+            }),
+        );
+
+        const err = await baseFetch("https://x.test/tx", { method: "POST" }).catch((e) => e);
+        expect(err).toBeInstanceOf(FetchError);
+        expect(err.method).toBe("POST");
+        expect(err.message).toContain("POST");
+        expect(err.message).toContain("https://x.test/tx");
+    });
+
+    it("derives the request URL from a URL instance", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                throw new TypeError("Failed to fetch");
+            }),
+        );
+
+        const err = await baseFetch(new URL("https://x.test/path")).catch((e) => e);
+        expect(err).toBeInstanceOf(FetchError);
+        expect(err.url).toBe("https://x.test/path");
+    });
+
+    it("derives URL and method from a Request instance", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                throw new TypeError("Failed to fetch");
+            }),
+        );
+
+        const request = new Request("https://x.test/req", { method: "PUT" });
+        const err = await baseFetch(request).catch((e) => e);
+        expect(err).toBeInstanceOf(FetchError);
+        expect(err.url).toBe("https://x.test/req");
+        expect(err.method).toBe("PUT");
+    });
+
+    it("passes a resolving Response through unchanged", async () => {
+        const response = { ok: true, status: 200 } as unknown as Response;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => response),
+        );
+
+        const result = await baseFetch("https://x.test/ok");
+        expect(result).toBe(response);
+    });
+
+    it("still throws synchronously when the Fetch API is unavailable", () => {
+        vi.stubGlobal("fetch", undefined);
+        expect(() => baseFetch("https://x.test/none")).toThrow(
+            "Fetch API is not available in this environment.",
+        );
+    });
+
+    it("does not wrap the unavailable-fetch guard error as a FetchError", () => {
+        vi.stubGlobal("fetch", undefined);
+        try {
+            baseFetch("https://x.test/none");
+            expect.unreachable("baseFetch should have thrown");
+        } catch (e) {
+            expect(e).toBeInstanceOf(Error);
+            expect(e).not.toBeInstanceOf(FetchError);
+        }
+    });
+});
+
+describe("Ark-server fetch wrapper", () => {
+    it("surfaces the wrapped FetchError on transport failure (delegates to baseFetch)", async () => {
+        const cause = new TypeError("Failed to fetch");
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                throw cause;
+            }),
+        );
+
+        const err = await fetch("https://ark.test/v1/info").catch((e) => e);
+        expect(err).toBeInstanceOf(FetchError);
+        expect(err.name).toBe("FetchError");
+        expect(err.url).toBe("https://ark.test/v1/info");
+        expect(err.cause).toBe(cause);
+    });
+
+    it("passes a resolving Response through unchanged", async () => {
+        const response = { ok: true } as unknown as Response;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => response),
+        );
+
+        const result = await fetch("https://ark.test/v1/info");
+        expect(result).toBe(response);
+    });
+});


### PR DESCRIPTION
## Problem
`baseFetch` (`packages/ts-sdk/src/utils/fetch.ts`) — and the Ark-server `fetch` wrapper that delegates to it — returned `globalThis.fetch(...)` directly, so a transport-level rejection (DNS failure, connection refused, TLS/CORS) propagated as the raw, contextless platform error: `TypeError: Failed to fetch` in browsers, the opaque `TypeError: fetch failed` in Node. Callers can't tell *which* request failed, nor cleanly discriminate a network failure from other errors.

Closes #593.

## Change
- Add `FetchError extends Error` (colocated in `utils/fetch.ts`, matching the repo's single-module error convention — `DigestMismatchError`, `DustChangeError`, etc.). It carries `readonly url` / `readonly method` and forwards the original error as `cause`.
- `baseFetch` now `.catch()`es the platform `fetch` rejection and re-throws a `FetchError` naming the request (`method URL`). The Ark-server `fetch` wrapper inherits this for free (it delegates).
- Re-export `FetchError` from `src/index.ts` (next to `DigestMismatchError`) so consumers can `instanceof`-discriminate it.
- The "Fetch API is not available" guard keeps its **synchronous** throw (programmer/environment error, not transport) — the `.catch` approach is deliberate so that semantic is preserved.
- No retry — retrying stays the caller's responsibility.
- Widened `input` from `RequestInfo` to `RequestInfo | URL` (matches the platform `fetch` signature; backward-compatible).

## Test plan
- 10 new unit tests in `test/fetch.test.ts` (written red-first): transport rejection → `FetchError` with correct `name`/message/`cause`; method/URL derivation from `string | URL | Request`; happy-path passthrough; the unavailable-fetch guard still throws synchronously and is **not** wrapped; the Ark-server `fetch` wrapper surfaces the wrapped error too.
- Full ts-sdk unit suite green (1555 passed); pre-commit hook (both packages' `test:unit` + lint) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public fetch error type that includes the request URL, HTTP method, and original failure details.

* **Bug Fixes**
  * Network request failures are now reported more consistently with clearer error messages.
  * Fetch helpers now support both string/URL inputs and preserve successful responses unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->