### PR TITLE
fix(sdk): bump @marcbachmann/cel-js to 8.0.0 for MetaMask Snap (SES) compatibility

### DIFF
--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -163,7 +163,7 @@
     },
     "dependencies": {
         "@bitcoinerlab/descriptors-scure": "3.1.7",
-        "@marcbachmann/cel-js": "7.3.1",
+        "@marcbachmann/cel-js": "8.0.0",
         "@noble/curves": "2.0.1",
         "@noble/secp256k1": "3.0.0",
         "@scure/base": "2.0.0",

--- a/packages/ts-sdk/test/fee.test.ts
+++ b/packages/ts-sdk/test/fee.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { readFileSync, readdirSync } from "fs";
+import { createRequire } from "module";
+import { dirname, join } from "path";
 import {
     Estimator,
     type IntentFeeConfig,
@@ -256,6 +257,23 @@ describe("Estimator", () => {
                     });
                 }
             });
+        }
+    });
+});
+
+// Regression guard for issue #580: the SES bundler used by MetaMask Snaps rejects
+// any bare `eval(` token. cel-js < 8 shipped an interpreter method literally named
+// `eval`, which the Estimator pulls into every consumer bundle. The pin must stay on
+// a cel-js version whose shipped sources contain no bare `eval(` token.
+describe("@marcbachmann/cel-js SES/Snap compatibility (issue #580)", () => {
+    it("resolved cel-js ships no bare eval( token", () => {
+        const require = createRequire(import.meta.url);
+        const libDir = dirname(require.resolve("@marcbachmann/cel-js"));
+        const jsFiles = readdirSync(libDir).filter((f) => f.endsWith(".js"));
+        expect(jsFiles.length).toBeGreaterThan(0);
+        for (const file of jsFiles) {
+            const src = readFileSync(join(libDir, file), "utf-8");
+            expect(/\beval\s*\(/.test(src), `bare eval( token found in ${file}`).toBe(false);
         }
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: 3.1.7
         version: 3.1.7
       '@marcbachmann/cel-js':
-        specifier: 7.3.1
-        version: 7.3.1
+        specifier: 8.0.0
+        version: 8.0.0
       '@noble/curves':
         specifier: 2.0.1
         version: 2.0.1
@@ -1182,8 +1182,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@marcbachmann/cel-js@7.3.1':
-    resolution: {integrity: sha512-P6o26TvjStT8V8+8EF+yq9Pp7ZFV00bpiUMbssr76XbIZGxaB+NNWeBp6WNxOrR9gp0JPzvJueCKHpOs5LE9PQ==}
+  '@marcbachmann/cel-js@8.0.0':
+    resolution: {integrity: sha512-oaTrAziGr3zDLFiMt/yLU3nZuRMawyWQB5X1a0I7s9eGy3JYzX9l8ZXXHyMd64nzbeVFZTewuUShwsZQdK6UCA==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -5118,7 +5118,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@marcbachmann/cel-js@7.3.1': {}
+  '@marcbachmann/cel-js@8.0.0': {}
 
   '@noble/curves@2.0.1':
     dependencies:


### PR DESCRIPTION
## Problem
`@arkade-os/sdk` cannot be bundled inside a MetaMask Snap: `mm-snap build` runs the bundle through SES, whose direct-eval detector rejects any bare `eval(` token (`SES_EVAL_REJECTED`). Renaming the SDK's own `Estimator.eval()` (#581) was necessary but **not sufficient** — the fee `Estimator` also pulls in `@marcbachmann/cel-js`, whose interpreter had a method literally named `eval`, so the token still landed in every consumer bundle.

Closes #580.

## Change
Bump `@marcbachmann/cel-js` `7.3.1` → `8.0.0`. The upstream rename of cel-js's `eval` method is **8.x-only** — I unpacked the published tarballs and confirmed the latest 7.x (`7.6.1`) *still* ships `eval(ast, ctx)` in `lib/evaluator.js`, while `8.0.0` has **zero** `eval` tokens anywhere in the package. So 8.0.0 is the lowest version that clears it.

- **No `estimator.ts` changes needed.** The API the `Estimator` uses (`Environment`, `ParseResult`, `parseProgram`, `registerVariable`/`registerFunction`) is unchanged across the major bump (verified against the shipped `.d.ts`). 8.0.0's `node >=20.19.0` engine is already satisfied by the SDK's `>=22` requirement.
- **Regression guard:** a new test in `test/fee.test.ts` resolves the installed cel-js and asserts none of its shipped `lib/*.js` contains a bare `eval(` token, so #580 can't silently regress on a future bump.

## Test plan
- `test/fee.test.ts`: 40 passed (the 39 existing fixture-driven parse/check/evaluate/error tests all green **unmodified** against 8.0.0, + the guard).
- Typecheck clean; full ts-sdk unit suite + pre-commit hook (both packages) green.

## Not covered here
I verified the SES-triggering `eval(` token is gone from the resolved dependency (the documented cause), but did not run an actual `mm-snap`/SES `lockdown` build — only the snap toolchain in [arkade-os/packages](https://github.com/arkade-os/packages) can exercise that end to end.