### PR TITLE
feat(sdk): refresh deprecated-signer cache on migration so custom renewal loops survive rotation

### DIFF
--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -734,13 +734,7 @@ interface MigrationCapableWallet {
     arkServerPublicKey: Uint8Array;
     onchainProvider: OnchainProvider;
     rotateServerSigner(newServerPubKey: Uint8Array, checkpointTapscript: string): Promise<void>;
-    /**
-     * Refresh the wallet's cached deprecated-signer set from a fresh
-     * {@link ArkInfo} snapshot. The migration pass calls this so the wallet's
-     * spendability filter — which keeps EXPIRED deprecated-signer inputs out of
-     * `settle()` — reflects the same server info the pass classified against.
-     * Inherited by the concrete `Wallet` from `ReadonlyWallet`.
-     */
+    /** Refresh the wallet's cached deprecated-signer set from a fresh {@link ArkInfo} snapshot. */
     refreshDeprecatedSigners(info: ArkInfo): void;
     /**
      * Spend an explicit set of the wallet's own deprecated-signer VTXOs into a
@@ -925,10 +919,7 @@ export interface IVtxoManager {
      *
      * As a side effect, refreshes the wallet's cached deprecated-signer set from
      * fresh server info, so a subsequent `settle()` correctly excludes EXPIRED
-     * deprecated-signer inputs. A consumer that disables the poll loop
-     * (`settlementConfig: false`) and drives its own renewal can therefore call
-     * this before `settle()` to keep ticking across an arkd signer rotation. To
-     * only refresh that filter without migrating, call
+     * deprecated-signer inputs. To refresh that filter without migrating, call
      * `wallet.refreshDeprecatedSigners(await wallet.arkProvider.getInfo())` instead.
      *
      * @returns A report of what was migrated, skipped, expired, or failed.
@@ -1633,12 +1624,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         const wallet = this.requireMigrationCapableWallet();
         const info = await wallet.arkProvider.getInfo();
         // Refresh the wallet's cached deprecated-signer set from this fresh
-        // snapshot BEFORE any classification or early-exit, so the wallet's
-        // spendability filter — which keeps EXPIRED deprecated-signer inputs out
-        // of settle() — is consistent for the rest of this pass and, crucially,
-        // for a consumer running its own renewal loop who calls settle() after a
-        // migrate pass (#589). Placed ahead of the cheap no-deprecated exit so a
-        // pass that finds nothing deprecated still clears any now-stale cache.
+        // snapshot before any classification or early-exit, so the spendability
+        // filter that excludes EXPIRED deprecated-signer inputs from settle() is
+        // consistent for the rest of this pass. Placed ahead of the no-deprecated
+        // exit so a pass that finds nothing deprecated still clears a stale cache.
         wallet.refreshDeprecatedSigners(info);
         const signerSet = signerSetFromInfo(info);
         const nowSeconds = Math.floor(Date.now() / 1000);

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -735,6 +735,14 @@ interface MigrationCapableWallet {
     onchainProvider: OnchainProvider;
     rotateServerSigner(newServerPubKey: Uint8Array, checkpointTapscript: string): Promise<void>;
     /**
+     * Refresh the wallet's cached deprecated-signer set from a fresh
+     * {@link ArkInfo} snapshot. The migration pass calls this so the wallet's
+     * spendability filter — which keeps EXPIRED deprecated-signer inputs out of
+     * `settle()` — reflects the same server info the pass classified against.
+     * Inherited by the concrete `Wallet` from `ReadonlyWallet`.
+     */
+    refreshDeprecatedSigners(info: ArkInfo): void;
+    /**
      * Spend an explicit set of the wallet's own deprecated-signer VTXOs into a
      * single full-value active-signer output through the Ark send path (not
      * `settle`), preserving input assets. The pre-cutoff VTXO migration primitive
@@ -757,6 +765,8 @@ function isMigrationCapable(wallet: IWallet): wallet is IWallet & MigrationCapab
         "arkServerPublicKey" in wallet &&
         "onchainProvider" in wallet &&
         typeof (wallet as Partial<MigrationCapableWallet>).rotateServerSigner === "function" &&
+        typeof (wallet as Partial<MigrationCapableWallet>).refreshDeprecatedSigners ===
+            "function" &&
         typeof (wallet as Partial<MigrationCapableWallet>).sendSelectedVtxosToSelf === "function" &&
         typeof (wallet as Partial<MigrationCapableWallet>).getBoardingUtxosForSigners === "function"
     );
@@ -912,6 +922,14 @@ export interface IVtxoManager {
      *
      * Available regardless of the `deprecatedSignerMigration` config flag (that
      * flag only gates the automatic poll-loop pass).
+     *
+     * As a side effect, refreshes the wallet's cached deprecated-signer set from
+     * fresh server info, so a subsequent `settle()` correctly excludes EXPIRED
+     * deprecated-signer inputs. A consumer that disables the poll loop
+     * (`settlementConfig: false`) and drives its own renewal can therefore call
+     * this before `settle()` to keep ticking across an arkd signer rotation. To
+     * only refresh that filter without migrating, call
+     * `wallet.refreshDeprecatedSigners(await wallet.arkProvider.getInfo())` instead.
      *
      * @returns A report of what was migrated, skipped, expired, or failed.
      */
@@ -1614,6 +1632,14 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     ): Promise<DeprecatedSignerMigrationReport> {
         const wallet = this.requireMigrationCapableWallet();
         const info = await wallet.arkProvider.getInfo();
+        // Refresh the wallet's cached deprecated-signer set from this fresh
+        // snapshot BEFORE any classification or early-exit, so the wallet's
+        // spendability filter — which keeps EXPIRED deprecated-signer inputs out
+        // of settle() — is consistent for the rest of this pass and, crucially,
+        // for a consumer running its own renewal loop who calls settle() after a
+        // migrate pass (#589). Placed ahead of the cheap no-deprecated exit so a
+        // pass that finds nothing deprecated still clears any now-stale cache.
+        wallet.refreshDeprecatedSigners(info);
         const signerSet = signerSetFromInfo(info);
         const nowSeconds = Math.floor(Date.now() / 1000);
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -401,9 +401,16 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
     /**
      * Refresh the cached deprecated-signer set from a fresh server-info
-     * snapshot. Called by the create() factories at construction and by the
-     * server-info-change handler mid-session. Lenient: a malformed deprecated
-     * entry is skipped, never fatal to wallet creation.
+     * snapshot. Called by the create() factories at construction, by the
+     * server-info-change handler mid-session, and by the deprecated-signer
+     * migration pass (`VtxoManager.migrateDeprecatedSignerVtxos`). This set feeds
+     * {@link pendingRecoveryOutpoints}, which drops EXPIRED (past-cutoff)
+     * deprecated-signer VTXOs from the wallet's own coin selection — so a
+     * consumer that disables the poll loop (`settlementConfig: false`) and drives
+     * its own renewal can call
+     * `wallet.refreshDeprecatedSigners(await wallet.arkProvider.getInfo())` before
+     * `settle(undefined)` to keep ticking across an arkd signer rotation. Lenient:
+     * a malformed deprecated entry is skipped, never fatal to wallet creation.
      */
     refreshDeprecatedSigners(info: {
         deprecatedSigners?: readonly { pubkey?: string; cutoffDate?: bigint }[];

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -405,12 +405,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * server-info-change handler mid-session, and by the deprecated-signer
      * migration pass (`VtxoManager.migrateDeprecatedSignerVtxos`). This set feeds
      * {@link pendingRecoveryOutpoints}, which drops EXPIRED (past-cutoff)
-     * deprecated-signer VTXOs from the wallet's own coin selection — so a
-     * consumer that disables the poll loop (`settlementConfig: false`) and drives
-     * its own renewal can call
-     * `wallet.refreshDeprecatedSigners(await wallet.arkProvider.getInfo())` before
-     * `settle(undefined)` to keep ticking across an arkd signer rotation. Lenient:
-     * a malformed deprecated entry is skipped, never fatal to wallet creation.
+     * deprecated-signer VTXOs from the wallet's own coin selection. Lenient: a
+     * malformed deprecated entry is skipped, never fatal to wallet creation.
      */
     refreshDeprecatedSigners(info: {
         deprecatedSigners?: readonly { pubkey?: string; cutoffDate?: bigint }[];

--- a/packages/ts-sdk/test/deprecatedSignerMigration.test.ts
+++ b/packages/ts-sdk/test/deprecatedSignerMigration.test.ts
@@ -155,12 +155,16 @@ function createMigrationMockWallet(opts: MigrationMockOptions) {
         (opts.boardingGroups ?? []).filter((g) => allowed.has(g.serverPubKey)),
     );
     const getInfo = vi.fn().mockResolvedValue(opts.info);
+    // The migration pass refreshes the wallet's deprecated-signer cache from the
+    // fresh info snapshot (the real Wallet inherits this from ReadonlyWallet).
+    const refreshDeprecatedSigners = vi.fn();
 
     const wallet = {
         get arkServerPublicKey() {
             return arkServerPublicKey;
         },
         arkProvider: { getInfo },
+        refreshDeprecatedSigners,
         rotateServerSigner,
         getContractManager: vi.fn().mockResolvedValue({
             getContractsWithVtxos,
@@ -191,6 +195,7 @@ function createMigrationMockWallet(opts: MigrationMockOptions) {
         getContractsWithVtxos,
         getBoardingUtxosForSigners,
         getInfo,
+        refreshDeprecatedSigners,
     };
 }
 
@@ -426,6 +431,61 @@ describe("VtxoManager - deprecated-signer migration", () => {
         expect(byKey.get(DEP_A)?.vtxoCount).toBe(2);
         expect(byKey.get(DEP_A)?.totalValue).toBe(5000);
         expect(byKey.get(DEP_EXPIRED)?.status).toBe("EXPIRED");
+    });
+
+    it("refreshes the wallet's deprecated-signer cache from the fresh info snapshot", async () => {
+        // Bug #589: a consumer running its own renewal loop needs a migrate pass
+        // to also update the wallet's deprecated-signer filter, so a subsequent
+        // settle() excludes EXPIRED deprecated-signer inputs instead of jamming.
+        // migrateCore proves this by pushing the fresh info into
+        // refreshDeprecatedSigners (which drives that filter) before classifying.
+        const info = makeInfo(ACTIVE, [
+            { pubkey: DEP_DUE },
+            { pubkey: DEP_EXPIRED, cutoffDate: BigInt(NOW_S - 100) },
+        ]);
+        const { wallet, refreshDeprecatedSigners, sendSelectedVtxosToSelf } =
+            createMigrationMockWallet({
+                info,
+                contractsWithVtxos: [
+                    cwv(DEP_DUE, [makeVtxo("default-" + DEP_DUE, 5000)]),
+                    cwv(DEP_EXPIRED, [makeVtxo("default-" + DEP_EXPIRED, 9000)]),
+                ],
+            });
+        const manager = newManager(wallet);
+
+        await manager.migrateDeprecatedSignerVtxos();
+
+        // Refreshed exactly once, from the SAME fresh snapshot the pass fetched…
+        expect(refreshDeprecatedSigners).toHaveBeenCalledTimes(1);
+        expect(refreshDeprecatedSigners.mock.calls[0][0]).toBe(info);
+        // …which carries the now-EXPIRED signer that the settle() filter excludes.
+        const refreshed = refreshDeprecatedSigners.mock.calls[0][0] as ArkInfo;
+        expect(refreshed.deprecatedSigners.map((s) => s.pubkey)).toContain(DEP_EXPIRED);
+        // The refresh lands before the migration leg builds inputs, so the whole
+        // pass sees a consistent cache.
+        expect(refreshDeprecatedSigners.mock.invocationCallOrder[0]).toBeLessThan(
+            sendSelectedVtxosToSelf.mock.invocationCallOrder[0],
+        );
+    });
+
+    it("refreshes (and empties) the cache even on the cheap no-deprecated early-exit", async () => {
+        // The refresh sits before the nothing-deprecated early-exit, so a pass
+        // that finds nothing deprecated still clears any stale cached signers
+        // rather than leaving the settle() filter out of date.
+        const info = makeInfo(ACTIVE, []);
+        const { wallet, refreshDeprecatedSigners, getContractsWithVtxos } =
+            createMigrationMockWallet({ info, contractsWithVtxos: [] });
+        const manager = newManager(wallet);
+
+        const report = await manager.migrateDeprecatedSignerVtxos();
+
+        // Cheap exit still taken — no indexer sweep, nothing to migrate…
+        expect(getContractsWithVtxos).not.toHaveBeenCalled();
+        expect(report.signers).toHaveLength(0);
+        // …but the cache was refreshed from fresh (now empty) info.
+        expect(refreshDeprecatedSigners).toHaveBeenCalledWith(info);
+        const refreshed = refreshDeprecatedSigners.mock.calls[0][0] as ArkInfo;
+        expect(refreshed.deprecatedSigners).toHaveLength(0);
     });
 });
 
@@ -754,6 +814,7 @@ function createPollableWallet() {
     const wallet = {
         arkServerPublicKey: hex.decode(ACTIVE),
         arkProvider: { getInfo },
+        refreshDeprecatedSigners: vi.fn(),
         rotateServerSigner: vi.fn().mockResolvedValue(undefined),
         getVtxos: vi.fn().mockResolvedValue([]),
         getAddress: vi.fn().mockResolvedValue(ARK_ADDRESS),
@@ -871,6 +932,7 @@ function createRecoveryMockWallet(opts: RecoveryMockOptions) {
             return arkServerPublicKey;
         },
         arkProvider: { getInfo: vi.fn().mockResolvedValue(opts.info) },
+        refreshDeprecatedSigners: vi.fn(),
         rotateServerSigner,
         getVtxos,
         getAddress,


### PR DESCRIPTION
## Problem
A consumer that disables the VtxoManager poll loop (`settlementConfig: false`) and runs its own renewal — e.g. a server calling `wallet.settle(undefined)` on a timer — had no clean way to survive an arkd **signer rotation**. When the operator rotates the signer, the wallet's old-signer VTXOs get pulled into `settle()` and arkd rejects the whole intent with `INVALID_VTXO_SCRIPT (10): ... deprecated key`, jamming every tick.

Closes #589.

## Root cause
`refreshDeprecatedSigners(info)` populates the wallet's `_deprecatedSigners` map, which gates the EXPIRED-exclusion that keeps deprecated inputs out of `settle()` coin selection. `migrateDeprecatedSignerVtxos()` fetched fresh `ArkInfo` (`migrateCore`) and classified against it, but **never called `refreshDeprecatedSigners`** — so the wallet's cache, and thus the `settle()` filter, stayed stale. Calling migrate did not unjam a self-driven renewal.

Notably, both primitives the issue asked to "expose" were **already public** — `refreshDeprecatedSigners` (no access modifier) and `wallet.arkProvider.getInfo()`. They just weren't wired together.

## Change
- Wire `wallet.refreshDeprecatedSigners(info)` into `migrateCore`, immediately after the `getInfo()` fetch and **before** the cheap no-deprecated early-exit — so a migrate pass refreshes the spendability filter, and a no-op pass still clears a now-stale set (covered by a dedicated test).
- Add `refreshDeprecatedSigners(info: ArkInfo)` to the `MigrationCapableWallet` interface, and the matching `isMigrationCapable` runtime-guard check to keep the type predicate sound.
- Document, via JSDoc on `migrateDeprecatedSignerVtxos` and `refreshDeprecatedSigners`, both the new side effect and the standalone path — a consumer can call `wallet.refreshDeprecatedSigners(await wallet.arkProvider.getInfo())` before `settle()` to refresh the filter without migrating.

## Test plan
- 2 new unit tests (red-first) in `deprecatedSignerMigration.test.ts`: after `migrateDeprecatedSignerVtxos()`, `refreshDeprecatedSigners` is called exactly once with the **same** fresh `info` object (which carries the EXPIRED signer), ordered before the migration leg; and the refresh still runs on the no-deprecated early-exit.
- Full ts-sdk unit suite green (1547 passed); pre-commit hook (both packages) passes.

## Not covered here
The unit tests use mock wallets, so they prove the *wiring*. The full `refreshDeprecatedSigners → _deprecatedSigners → settle() exclusion` chain on a concrete `Wallet` is exercised by existing e2e (rotation) coverage rather than a single unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deprecated-signer migration so the wallet refreshes its cached signer status before each pass, helping keep settlement and recovery behavior consistent.
  * The cache is now refreshed even when migration exits early, reducing stale results from older wallet state.

* **Documentation**
  * Updated wallet API guidance to explain the refreshed cache behavior and how to refresh signer status without running a migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->