### PR TITLE
feat(sdk): VTXO exit-data availability — local-first resolver + capture/prune

### DIFF
--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -862,6 +862,41 @@ Key properties:
 - `validUntil` carries the earliest batch expiry: execute before it, or the operator may
   sweep the expired batch first.
 
+### Exit data available offline
+
+The exit above resolves a VTXO's transaction chain from the Ark **indexer** at
+exit time. To make a unilateral exit work even when the indexer is unreachable,
+configure a `virtualTxRepository` (SQLite / Realm / IndexedDB / InMemory): the
+wallet then captures each received VTXO's exit branch locally and prunes it on
+spend, and `estimate` / `prepare` read that data **local-first**, falling back to
+the indexer only on a miss.
+
+```typescript
+import { Wallet, InMemoryVirtualTxRepository } from '@arkade-os/sdk'
+
+const wallet = await Wallet.create({
+  identity,
+  storage: {
+    walletRepository,
+    contractRepository,
+    virtualTxRepository: new InMemoryVirtualTxRepository(),
+    // Optional. `mode` defaults to "lite" (structure only, cheap — most VTXOs
+    // never exit). Use "full" to also store the pre-signed PSBTs, so an exit
+    // needs no Ark indexer (only an Esplora endpoint to broadcast).
+    exitDataCapture: { mode: 'full' },
+  },
+})
+```
+
+- **Lite (default)** stores only the chain structure; an exit still fetches PSBTs
+  from the indexer. **Full** stores the PSBTs too, so the exit is fully
+  indexer-independent. `minExitWorthSats` (default 1000) skips dust VTXOs.
+- Capture and prune are best-effort — a persistence failure never blocks sync or
+  the exit. Pruning is ref-counted, so tree ancestors shared by other VTXOs survive.
+- **Provider tier:** pass extra sources via `exitDataCapture.sources` to resolve
+  exit data from your own service before the indexer — implement the
+  `ExitDataSource` interface (`getVtxoChain` / `getVirtualTxs`).
+
 ### Running the wallet in a service worker
 
 The SDK provides a `MessageBus` orchestrator that runs inside a service worker

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -344,6 +344,20 @@ export interface ContractManagerConfig {
      */
     intentRepository?: IntentRepository;
 
+    /**
+     * Optional exit-data capture hook. Fired best-effort after VTXOs are
+     * persisted so a configured virtualTxRepository can store each one's
+     * unilateral-exit branch. Absent ⇒ no-op.
+     */
+    onVtxosPersisted?: (contract: Contract, vtxos: ExtendedVirtualCoin[]) => Promise<void>;
+
+    /**
+     * Optional exit-data prune hook. Fired best-effort with the spent outpoints
+     * on `vtxo_spent` so a configured virtualTxRepository can drop their branch.
+     * Absent ⇒ no-op.
+     */
+    onVtxosSpent?: (vtxos: Outpoint[]) => Promise<void>;
+
     /** Watcher configuration */
     watcherConfig?: Partial<ContractWatcherConfig>;
 }
@@ -1094,8 +1108,19 @@ export class ContractManager implements IContractManager {
         switch (event.type) {
             // Delta-sync only the changed virtual outputs for this contract.
             case "vtxo_received":
+                await this.syncContracts({ contracts: [event.contract] });
+                break;
             case "vtxo_spent":
                 await this.syncContracts({ contracts: [event.contract] });
+                if (this.config.onVtxosSpent) {
+                    try {
+                        await this.config.onVtxosSpent(
+                            event.vtxos.map((v) => ({ txid: v.txid, vout: v.vout })),
+                        );
+                    } catch {
+                        // prune is best-effort; never block the spend event
+                    }
+                }
                 break;
             case "connection_reset":
                 // Same recovery path as boot: delta-sync the watched set
@@ -1253,6 +1278,16 @@ export class ContractManager implements IContractManager {
                     contract,
                     filtered as ExtendedVirtualCoin[],
                 );
+                if (this.config.onVtxosPersisted) {
+                    try {
+                        await this.config.onVtxosPersisted(
+                            contract,
+                            filtered as ExtendedVirtualCoin[],
+                        );
+                    } catch {
+                        // capture is best-effort; never block sync
+                    }
+                }
             }
         }
         return result;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -1253,6 +1253,13 @@ export class ContractManager implements IContractManager {
                 contract,
                 filtered as ExtendedVirtualCoin[],
             );
+            if (this.config.onVtxosPersisted) {
+                try {
+                    await this.config.onVtxosPersisted(contract, filtered as ExtendedVirtualCoin[]);
+                } catch {
+                    // capture is best-effort; never block reconciliation
+                }
+            }
         }
     }
 

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -229,7 +229,12 @@ import { PartialSig } from "./musig2/sign";
 import { AnchorBumper, P2A } from "./utils/anchor";
 import { TxWeightEstimator, type VSize } from "./utils/txSizeEstimator";
 import { Unroll } from "./wallet/unroll";
-import { UnilateralExit, deserializeExitPackage, serializeExitPackage } from "./wallet/exit";
+import {
+    UnilateralExit,
+    createExitChainResolver,
+    deserializeExitPackage,
+    serializeExitPackage,
+} from "./wallet/exit";
 import type {
     ExitDelay,
     ExitMode,
@@ -241,6 +246,9 @@ import type {
     ExitOptions,
     ExecutorEvent,
     ExitFeeWallet,
+    ExitCaptureMode,
+    ExitChainResolver,
+    ExitDataSource,
 } from "./wallet/exit";
 import { ArkError, maybeArkError } from "./providers/errors";
 import { validateVtxoTxGraph, validateConnectorsTxGraph } from "./tree/validation";
@@ -501,6 +509,7 @@ export {
     P2A,
     Unroll,
     UnilateralExit,
+    createExitChainResolver,
     serializeExitPackage,
     deserializeExitPackage,
     Transaction,
@@ -682,6 +691,9 @@ export type {
     VSize,
 
     // Unilateral exit packages
+    ExitCaptureMode,
+    ExitChainResolver,
+    ExitDataSource,
     ExitDelay,
     ExitMode,
     ExitPackage,

--- a/packages/ts-sdk/src/wallet/exit/capture.ts
+++ b/packages/ts-sdk/src/wallet/exit/capture.ts
@@ -16,6 +16,10 @@ export type ExitCaptureMode = "lite" | "full";
 /** BTC-value floor for capture; below it, exit fees would exceed the VTXO (NArk parity). */
 export const DEFAULT_MIN_EXIT_WORTH_SATS = 1000;
 
+/** Default capture mode: Lite (structure only). Full (store PSBTs) is opt-in for
+ *  wallets that want indexer-independent exit — most VTXOs never exit (NArk parity). */
+export const DEFAULT_EXIT_CAPTURE_MODE: ExitCaptureMode = "lite";
+
 /** ChainTxType (indexer string enum) → ChainedTxType (repo numeric enum).
  *  Duplicated from unroll.ts:27 to keep the exit path free of a cross-module dep. */
 function chainTxTypeToChainedExit(t: ChainTxType): ChainedTxType {

--- a/packages/ts-sdk/src/wallet/exit/capture.ts
+++ b/packages/ts-sdk/src/wallet/exit/capture.ts
@@ -1,0 +1,111 @@
+import { base64 } from "@scure/base";
+import { ChainTx, ChainTxType } from "../../providers/indexer";
+import {
+    ChainedTxType,
+    VirtualTx,
+    VirtualTxRepository,
+    VtxoBranch,
+} from "../../repositories/virtualTxRepository";
+import { Transaction } from "../../utils/transaction";
+import { Outpoint } from "../index";
+import { topoSortByDeps } from "./chain";
+import { ExitChainResolver } from "./resolver";
+
+export type ExitCaptureMode = "lite" | "full";
+
+/** BTC-value floor for capture; below it, exit fees would exceed the VTXO (NArk parity). */
+export const DEFAULT_MIN_EXIT_WORTH_SATS = 1000;
+
+/** ChainTxType (indexer string enum) → ChainedTxType (repo numeric enum).
+ *  Duplicated from unroll.ts:27 to keep the exit path free of a cross-module dep. */
+function chainTxTypeToChainedExit(t: ChainTxType): ChainedTxType {
+    switch (t) {
+        case ChainTxType.COMMITMENT:
+            return ChainedTxType.Commitment;
+        case ChainTxType.ARK:
+            return ChainedTxType.Ark;
+        case ChainTxType.TREE:
+            return ChainedTxType.Tree;
+        case ChainTxType.CHECKPOINT:
+            return ChainedTxType.Checkpoint;
+        default:
+            return ChainedTxType.Unspecified;
+    }
+}
+
+/** Order a chain ancestors-first so position 0 is the root/commitment. */
+function orderAncestryFirst(chain: ChainTx[]): ChainTx[] {
+    const ids = new Set(chain.map((c) => c.txid));
+    return topoSortByDeps(
+        chain,
+        (c) => c.txid,
+        (c) => c.spends.filter((s) => ids.has(s)),
+    );
+}
+
+/**
+ * Fetch and persist a received VTXO's unilateral-exit branch. Idempotent (skips
+ * if a branch is already stored) and dust-gated. Full mode stores PSBTs so the
+ * exit needs no indexer; Lite stores structure only. Throws on failure — callers
+ * wrap best-effort so capture never blocks receive.
+ */
+export async function captureExitBranch(params: {
+    resolver: ExitChainResolver;
+    repository: VirtualTxRepository;
+    vtxo: Outpoint;
+    value: number;
+    mode: ExitCaptureMode;
+    minExitWorthSats: number;
+}): Promise<void> {
+    const { resolver, repository, vtxo, value, mode, minExitWorthSats } = params;
+    if (value < minExitWorthSats) return;
+    if (await repository.hasBranch(vtxo)) return;
+
+    const ordered = orderAncestryFirst(await resolver.getVtxoChain(vtxo));
+
+    const psbtByTxid = new Map<string, string>();
+    if (mode === "full") {
+        const nonCommitment = ordered
+            .filter((c) => chainTxTypeToChainedExit(c.type) !== ChainedTxType.Commitment)
+            .map((c) => c.txid);
+        if (nonCommitment.length > 0) {
+            for (const psbt of await resolver.getVirtualTxs(nonCommitment)) {
+                psbtByTxid.set(Transaction.fromPSBT(base64.decode(psbt)).id, psbt);
+            }
+        }
+    }
+
+    const virtualTxs: VirtualTx[] = ordered.map((c) => {
+        const expires = Number(c.expiresAt);
+        return {
+            txid: c.txid,
+            psbt: psbtByTxid.get(c.txid) ?? null,
+            expiresAt: Number.isFinite(expires) && expires > 0 ? expires : null,
+            type: chainTxTypeToChainedExit(c.type),
+        };
+    });
+    const branch: VtxoBranch[] = ordered.map((c, i) => ({
+        vtxoTxid: vtxo.txid,
+        vtxoVout: vtxo.vout,
+        virtualTxid: c.txid,
+        position: i,
+    }));
+
+    await repository.upsertVirtualTxs(virtualTxs);
+    await repository.setBranch(vtxo, branch);
+}
+
+/** Prune stored exit data for spent VTXOs (the repo ref-counts shared ancestors).
+ *  Best-effort per outpoint — one failure never blocks the others. */
+export async function pruneExitBranches(
+    repository: VirtualTxRepository,
+    outpoints: Outpoint[],
+): Promise<void> {
+    for (const outpoint of outpoints) {
+        try {
+            await repository.pruneForSpentVtxo(outpoint);
+        } catch {
+            // best-effort: a prune failure must not block the spend path
+        }
+    }
+}

--- a/packages/ts-sdk/src/wallet/exit/chain.ts
+++ b/packages/ts-sdk/src/wallet/exit/chain.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_PAGE_SIZE } from "../../contracts/constants";
-import { ChainTx, ChainTxType, IndexerProvider } from "../../providers/indexer";
+import { ChainTx, ChainTxType } from "../../providers/indexer";
 import { OnchainProvider } from "../../providers/onchain";
+import { ExitChainResolver } from "./resolver";
 
 export type DagNode = {
     txid: string;
@@ -25,32 +25,22 @@ const isCommitment = (t: ChainTxType) =>
  */
 export async function buildExitDag(params: {
     vtxos: { txid: string; vout: number }[];
-    indexer: IndexerProvider;
+    chain: Pick<ExitChainResolver, "getVtxoChain">;
     onchain: OnchainProvider;
 }): Promise<DagNode[]> {
     const byTxid = new Map<string, ChainTx & { forVtxos: Set<string> }>();
 
     for (const vtxo of params.vtxos) {
         const outpoint = `${vtxo.txid}:${vtxo.vout}`;
-        // The chain endpoint is paginated; a deep chain can span pages, so walk
-        // them all — a short page (or absent page metadata) means end of history.
-        let pageIndex = 0;
-        let hasMore = true;
-        while (hasMore) {
-            const { chain, page } = await params.indexer.getVtxoChain(
-                { txid: vtxo.txid, vout: vtxo.vout },
-                { pageIndex, pageSize: DEFAULT_PAGE_SIZE },
-            );
-            for (const chainTx of chain) {
-                const existing = byTxid.get(chainTx.txid);
-                if (existing) {
-                    existing.forVtxos.add(outpoint);
-                } else {
-                    byTxid.set(chainTx.txid, { ...chainTx, forVtxos: new Set([outpoint]) });
-                }
+        // The resolver returns the full chain (all pages merged, local-first).
+        const chain = await params.chain.getVtxoChain({ txid: vtxo.txid, vout: vtxo.vout });
+        for (const chainTx of chain) {
+            const existing = byTxid.get(chainTx.txid);
+            if (existing) {
+                existing.forVtxos.add(outpoint);
+            } else {
+                byTxid.set(chainTx.txid, { ...chainTx, forVtxos: new Set([outpoint]) });
             }
-            hasMore = page ? chain.length === DEFAULT_PAGE_SIZE : false;
-            pageIndex++;
         }
     }
 

--- a/packages/ts-sdk/src/wallet/exit/estimate.ts
+++ b/packages/ts-sdk/src/wallet/exit/estimate.ts
@@ -145,6 +145,7 @@ export async function computeExitLayout(opts: ExitOptions, feeRate: number): Pro
     const resolver = createExitChainResolver({
         indexer: wallet.indexerProvider,
         repository: wallet.virtualTxRepository,
+        extraSources: wallet.exitDataCapture?.sources,
     });
     const dag = await buildExitDag({
         vtxos,

--- a/packages/ts-sdk/src/wallet/exit/estimate.ts
+++ b/packages/ts-sdk/src/wallet/exit/estimate.ts
@@ -1,6 +1,5 @@
 import { base64, hex } from "@scure/base";
 import type { Outpoint, VirtualCoin } from "..";
-import { DEFAULT_PAGE_SIZE } from "../../contracts/constants";
 import { contractHandlers } from "../../contracts/handlers";
 import { NetworkName } from "../../networks";
 import { VtxoScript } from "../../script/base";
@@ -10,6 +9,7 @@ import { TxWeightEstimator } from "../../utils/txSizeEstimator";
 import { OnchainWallet } from "../onchain";
 import type { Wallet } from "../wallet";
 import { buildExitDag, DagNode, topoSortByDeps } from "./chain";
+import { createExitChainResolver } from "./resolver";
 import { finalizeVirtualTx } from "./finalizeVirtualTx";
 import { ExitPathError, ResolvedExitPath, resolveUnilateralPath } from "./path";
 import { sweepFeeFor } from "./sweep";
@@ -140,9 +140,15 @@ export async function computeExitLayout(opts: ExitOptions, feeRate: number): Pro
     const vtxos = await selectExitVtxos(opts);
     if (vtxos.length === 0) throw new Error("no vtxos to exit");
 
+    // Resolve exit chain data local-first (repo → indexer), read-through cached.
+    // With no virtualTxRepository this is exactly the indexer-only path.
+    const resolver = createExitChainResolver({
+        indexer: wallet.indexerProvider,
+        repository: wallet.virtualTxRepository,
+    });
     const dag = await buildExitDag({
         vtxos,
-        indexer: wallet.indexerProvider,
+        chain: resolver,
         onchain: wallet.onchainProvider,
     });
 
@@ -151,22 +157,9 @@ export async function computeExitLayout(opts: ExitOptions, feeRate: number): Pro
     const pendingNodes = dag.filter((n) => !n.confirmed);
     const psbts = new Map<string, string>();
     if (pendingNodes.length > 0) {
-        // getVirtualTxs is paginated; a deep chain can exceed one page, so fetch
-        // every page or a later psbt lookup throws "indexer did not return virtual
-        // tx". A short page (or absent page metadata) means end of history.
-        const txids = pendingNodes.map((n) => n.txid);
-        let pageIndex = 0;
-        let hasMore = true;
-        while (hasMore) {
-            const { txs, page } = await wallet.indexerProvider.getVirtualTxs(txids, {
-                pageIndex,
-                pageSize: DEFAULT_PAGE_SIZE,
-            });
-            for (const psbt of txs) {
-                psbts.set(Transaction.fromPSBT(base64.decode(psbt)).id, psbt);
-            }
-            hasMore = page ? txs.length === DEFAULT_PAGE_SIZE : false;
-            pageIndex++;
+        const txs = await resolver.getVirtualTxs(pendingNodes.map((n) => n.txid));
+        for (const psbt of txs) {
+            psbts.set(Transaction.fromPSBT(base64.decode(psbt)).id, psbt);
         }
     }
 

--- a/packages/ts-sdk/src/wallet/exit/index.ts
+++ b/packages/ts-sdk/src/wallet/exit/index.ts
@@ -8,6 +8,9 @@ export { ExitPathError, resolveUnilateralPath } from "./path";
 export type { ResolvedExitPath } from "./path";
 export type { ExecutorEvent, ExitFeeWallet } from "./executor";
 export type { ExitOptions } from "./estimate";
+export type { ExitCaptureMode } from "./capture";
+export type { ExitChainResolver, ExitDataSource } from "./resolver";
+export { createExitChainResolver } from "./resolver";
 
 /**
  * Pre-signed unilateral exit.

--- a/packages/ts-sdk/src/wallet/exit/indexerSource.ts
+++ b/packages/ts-sdk/src/wallet/exit/indexerSource.ts
@@ -1,0 +1,50 @@
+import { base64 } from "@scure/base";
+import { DEFAULT_PAGE_SIZE } from "../../contracts/constants";
+import { ChainTx, IndexerProvider } from "../../providers/indexer";
+import { Transaction } from "../../utils/transaction";
+import { Outpoint } from "../index";
+import { ExitDataSource } from "./resolver";
+
+/**
+ * Exit-data source backed by the Ark indexer. Behavior-preserving vs. the
+ * pre-resolver code: the same paginated getVtxoChain / getVirtualTxs walks.
+ */
+export class IndexerExitDataSource implements ExitDataSource {
+    readonly name = "indexer";
+
+    constructor(private readonly indexer: IndexerProvider) {}
+
+    async getVtxoChain(vtxo: Outpoint): Promise<ChainTx[]> {
+        const chain: ChainTx[] = [];
+        let pageIndex = 0;
+        let hasMore = true;
+        while (hasMore) {
+            const { chain: page, page: meta } = await this.indexer.getVtxoChain(
+                { txid: vtxo.txid, vout: vtxo.vout },
+                { pageIndex, pageSize: DEFAULT_PAGE_SIZE },
+            );
+            chain.push(...page);
+            hasMore = meta ? page.length === DEFAULT_PAGE_SIZE : false;
+            pageIndex++;
+        }
+        return chain;
+    }
+
+    async getVirtualTxs(txids: string[]): Promise<Map<string, string>> {
+        const out = new Map<string, string>();
+        let pageIndex = 0;
+        let hasMore = true;
+        while (hasMore) {
+            const { txs, page } = await this.indexer.getVirtualTxs(txids, {
+                pageIndex,
+                pageSize: DEFAULT_PAGE_SIZE,
+            });
+            for (const psbt of txs) {
+                out.set(Transaction.fromPSBT(base64.decode(psbt)).id, psbt);
+            }
+            hasMore = page ? txs.length === DEFAULT_PAGE_SIZE : false;
+            pageIndex++;
+        }
+        return out;
+    }
+}

--- a/packages/ts-sdk/src/wallet/exit/repositorySource.ts
+++ b/packages/ts-sdk/src/wallet/exit/repositorySource.ts
@@ -1,0 +1,74 @@
+import { base64, hex } from "@scure/base";
+import { ChainTx, ChainTxType } from "../../providers/indexer";
+import { ChainedTxType, VirtualTxRepository } from "../../repositories/virtualTxRepository";
+import { Transaction } from "../../utils/transaction";
+import { Outpoint } from "../index";
+import { ExitDataSource } from "./resolver";
+
+/** Reverse of `chainTxTypeToChainedExit` (unroll.ts:27): numeric repo enum → indexer string enum. */
+export function chainedTxTypeToChainTxType(t: ChainedTxType): ChainTxType {
+    switch (t) {
+        case ChainedTxType.Commitment:
+            return ChainTxType.COMMITMENT;
+        case ChainedTxType.Ark:
+            return ChainTxType.ARK;
+        case ChainedTxType.Tree:
+            return ChainTxType.TREE;
+        case ChainedTxType.Checkpoint:
+            return ChainTxType.CHECKPOINT;
+        default:
+            return ChainTxType.UNSPECIFIED;
+    }
+}
+
+/** Prevout txids (display order) of every input of a base64 PSBT — the physical `spends`. */
+export function psbtInputTxids(psbtBase64: string): string[] {
+    const tx = Transaction.fromPSBT(base64.decode(psbtBase64));
+    const ids: string[] = [];
+    for (let i = 0; i < tx.inputsLength; i++) {
+        const txid = tx.getInput(i).txid;
+        if (txid) ids.push(hex.encode(txid));
+    }
+    return ids;
+}
+
+/**
+ * Exit-data source backed by the local `VirtualTxRepository`. Full data (PSBTs
+ * present) yields a full chain with physical `spends`; Lite (a non-commitment
+ * tx lacking a PSBT) is a structure miss, so the resolver falls to the indexer.
+ */
+export class RepositoryExitDataSource implements ExitDataSource {
+    readonly name = "repository";
+
+    constructor(private readonly repo: VirtualTxRepository) {}
+
+    async getVtxoChain(vtxo: Outpoint): Promise<ChainTx[] | null> {
+        const branch = await this.repo.getBranch(vtxo);
+        if (branch.length === 0) return null;
+        const chain: ChainTx[] = [];
+        for (const v of branch) {
+            const type = chainedTxTypeToChainTxType(v.type);
+            let spends: string[] = [];
+            if (v.type !== ChainedTxType.Commitment) {
+                if (!v.psbt) return null; // Lite / structure unavailable
+                spends = psbtInputTxids(v.psbt);
+            }
+            chain.push({
+                txid: v.txid,
+                type,
+                expiresAt: v.expiresAt != null ? String(v.expiresAt) : "",
+                spends,
+            });
+        }
+        return chain;
+    }
+
+    async getVirtualTxs(txids: string[]): Promise<Map<string, string>> {
+        const out = new Map<string, string>();
+        for (const txid of txids) {
+            const stored = await this.repo.getVirtualTx(txid);
+            if (stored?.psbt) out.set(txid, stored.psbt);
+        }
+        return out;
+    }
+}

--- a/packages/ts-sdk/src/wallet/exit/resolver.ts
+++ b/packages/ts-sdk/src/wallet/exit/resolver.ts
@@ -1,0 +1,84 @@
+import { ChainTx } from "../../providers/indexer";
+import {
+    ChainedTxType,
+    VirtualTx,
+    VirtualTxRepository,
+} from "../../repositories/virtualTxRepository";
+import { Outpoint } from "../index";
+
+/**
+ * A source of unilateral-exit chain data for a set of VTXOs. Sources are tried
+ * in order by the resolver; a source returns `null` (chain) or omits keys (psbts)
+ * for data it cannot supply — a "miss" — and the resolver falls through.
+ */
+export interface ExitDataSource {
+    readonly name: string;
+    /** Full ancestry chain for a vtxo (all pages merged), or null on a miss. */
+    getVtxoChain(vtxo: Outpoint): Promise<ChainTx[] | null>;
+    /** Base64 PSBTs this source has, keyed by (unsigned) txid. Absent key = miss. */
+    getVirtualTxs(txids: string[]): Promise<Map<string, string>>;
+}
+
+/** Reads exit chain data through an ordered chain of sources. */
+export interface ExitChainResolver {
+    getVtxoChain(vtxo: Outpoint): Promise<ChainTx[]>;
+    getVirtualTxs(txids: string[]): Promise<string[]>;
+}
+
+/**
+ * Tries sources in order (local repo → [provider] → indexer). PSBT hits from a
+ * non-first source are persisted back to `persist` best-effort so the local
+ * store self-heals — never throwing from that write, per the exit-correctness
+ * rule (mirrors `Unroll.Session.resolveVirtualTxBase64`).
+ */
+export class OrderedExitChainResolver implements ExitChainResolver {
+    constructor(
+        private readonly sources: ExitDataSource[],
+        private readonly persist?: VirtualTxRepository,
+    ) {}
+
+    async getVtxoChain(vtxo: Outpoint): Promise<ChainTx[]> {
+        let lastErr: unknown;
+        for (const source of this.sources) {
+            try {
+                const chain = await source.getVtxoChain(vtxo);
+                if (chain) return chain;
+            } catch (e) {
+                lastErr = e;
+            }
+        }
+        if (lastErr) throw lastErr;
+        throw new Error(`no exit-data source resolved the chain for ${vtxo.txid}:${vtxo.vout}`);
+    }
+
+    async getVirtualTxs(txids: string[]): Promise<string[]> {
+        const found = new Map<string, string>();
+        let remaining = txids;
+        for (const [i, source] of this.sources.entries()) {
+            if (remaining.length === 0) break;
+            let got: Map<string, string>;
+            try {
+                got = await source.getVirtualTxs(remaining);
+            } catch {
+                continue; // miss; try the next source
+            }
+            const fresh: VirtualTx[] = [];
+            for (const [txid, psbt] of got) {
+                if (found.has(txid)) continue;
+                found.set(txid, psbt);
+                fresh.push({ txid, psbt, expiresAt: null, type: ChainedTxType.Unspecified });
+            }
+            // Read-through persist: only for non-local sources (i > 0). An
+            // Unspecified type never downgrades a stored type (mergeChainedTxType).
+            if (i > 0 && this.persist && fresh.length > 0) {
+                try {
+                    await this.persist.upsertVirtualTxs(fresh);
+                } catch {
+                    // best-effort cache only
+                }
+            }
+            remaining = txids.filter((t) => !found.has(t));
+        }
+        return [...found.values()];
+    }
+}

--- a/packages/ts-sdk/src/wallet/exit/resolver.ts
+++ b/packages/ts-sdk/src/wallet/exit/resolver.ts
@@ -1,10 +1,12 @@
-import { ChainTx } from "../../providers/indexer";
+import { ChainTx, IndexerProvider } from "../../providers/indexer";
 import {
     ChainedTxType,
     VirtualTx,
     VirtualTxRepository,
 } from "../../repositories/virtualTxRepository";
 import { Outpoint } from "../index";
+import { IndexerExitDataSource } from "./indexerSource";
+import { RepositoryExitDataSource } from "./repositorySource";
 
 /**
  * A source of unilateral-exit chain data for a set of VTXOs. Sources are tried
@@ -81,4 +83,21 @@ export class OrderedExitChainResolver implements ExitChainResolver {
         }
         return [...found.values()];
     }
+}
+
+/**
+ * Assemble the standard exit-data resolver: local repo (if configured) → any
+ * extra sources (e.g. a future provider) → indexer. Read-through persists to the
+ * repository. With no repository this is exactly the indexer path (a no-op seam).
+ */
+export function createExitChainResolver(params: {
+    indexer: IndexerProvider;
+    repository?: VirtualTxRepository;
+    extraSources?: ExitDataSource[];
+}): ExitChainResolver {
+    const sources: ExitDataSource[] = [];
+    if (params.repository) sources.push(new RepositoryExitDataSource(params.repository));
+    if (params.extraSources) sources.push(...params.extraSources);
+    sources.push(new IndexerExitDataSource(params.indexer));
+    return new OrderedExitChainResolver(sources, params.repository);
 }

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -251,8 +251,8 @@ export type StorageConfig = {
     virtualTxRepository?: VirtualTxRepository;
     /**
      * Optional exit-data capture settings (only in effect when
-     * `virtualTxRepository` is set). `mode` "full" (default) stores PSBTs so a
-     * unilateral exit needs no Ark indexer; "lite" stores structure only.
+     * `virtualTxRepository` is set). `mode` "lite" (default) stores structure
+     * only; "full" stores PSBTs so a unilateral exit needs no Ark indexer.
      * `minExitWorthSats` (default 1000) skips dust. `sources` are extra
      * `ExitDataSource`s (e.g. a wallet-provider) tried before the indexer for
      * both capture and exit reads.

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -17,6 +17,8 @@ import {
 import { IContractManager } from "../contracts/contractManager";
 import { IDelegateManager } from "./delegate";
 import type { Activity, ActivityRegistry } from "./activity";
+import type { ExitCaptureMode } from "./exit/capture";
+import type { ExitDataSource } from "./exit/resolver";
 export {
     ActivityRegistry,
     boardingResolver,
@@ -247,6 +249,19 @@ export type StorageConfig = {
      * option as experimental until those paths land. Absent ⇒ no-op.
      */
     virtualTxRepository?: VirtualTxRepository;
+    /**
+     * Optional exit-data capture settings (only in effect when
+     * `virtualTxRepository` is set). `mode` "full" (default) stores PSBTs so a
+     * unilateral exit needs no Ark indexer; "lite" stores structure only.
+     * `minExitWorthSats` (default 1000) skips dust. `sources` are extra
+     * `ExitDataSource`s (e.g. a wallet-provider) tried before the indexer for
+     * both capture and exit reads.
+     */
+    exitDataCapture?: {
+        mode?: ExitCaptureMode;
+        minExitWorthSats?: number;
+        sources?: ExitDataSource[];
+    };
 };
 
 /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -77,8 +77,13 @@ import { isTerminalIntentState } from "../repositories/intentRepository";
 import type { VirtualTxRepository } from "../repositories/virtualTxRepository";
 import { wrapHandlerWithIntentPersistence } from "./intentPersistenceHandler";
 import { extendCoinWithTapscript, validateRecipients } from "./utils";
-import { captureExitBranch, DEFAULT_MIN_EXIT_WORTH_SATS, pruneExitBranches } from "./exit/capture";
-import { createExitChainResolver } from "./exit/resolver";
+import {
+    captureExitBranch,
+    DEFAULT_MIN_EXIT_WORTH_SATS,
+    ExitCaptureMode,
+    pruneExitBranches,
+} from "./exit/capture";
+import { createExitChainResolver, ExitDataSource } from "./exit/resolver";
 import { ArkError } from "../providers/errors";
 import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
@@ -355,6 +360,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * (ContractManager isn't given it); `undefined` ⇒ no-op.
      */
     public virtualTxRepository?: VirtualTxRepository;
+    /** Opt-in exit-data capture settings; see {@link StorageConfig.exitDataCapture}. */
+    public exitDataCapture?: {
+        mode?: ExitCaptureMode;
+        minExitWorthSats?: number;
+        sources?: ExitDataSource[];
+    };
     private readonly _assetManager: IReadonlyAssetManager;
     readonly walletContractTimelocks: RelativeTimelock[];
     // Outpoints ("txid:vout") committed to an in-flight settle/send. Filtered
@@ -767,6 +778,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         );
         wallet.intentRepository = config.storage?.intentRepository;
         wallet.virtualTxRepository = config.storage?.virtualTxRepository;
+        wallet.exitDataCapture = config.storage?.exitDataCapture;
         wallet.refreshDeprecatedSigners(setup.info);
         return wallet;
     }
@@ -1525,9 +1537,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
         let onVtxosPersisted: ContractManagerConfig["onVtxosPersisted"];
         let onVtxosSpent: ContractManagerConfig["onVtxosSpent"];
         if (virtualTxRepository) {
+            const capture = this.exitDataCapture;
             const resolver = createExitChainResolver({
                 indexer: this.indexerProvider,
                 repository: virtualTxRepository,
+                extraSources: capture?.sources,
             });
             onVtxosPersisted = async (_contract, vtxos) => {
                 for (const v of vtxos) {
@@ -1537,8 +1551,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
                         repository: virtualTxRepository,
                         vtxo: { txid: v.txid, vout: v.vout },
                         value: v.value,
-                        mode: "full",
-                        minExitWorthSats: DEFAULT_MIN_EXIT_WORTH_SATS,
+                        mode: capture?.mode ?? "full",
+                        minExitWorthSats: capture?.minExitWorthSats ?? DEFAULT_MIN_EXIT_WORTH_SATS,
                     }).catch(() => {
                         // capture is best-effort
                     });
@@ -2611,6 +2625,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
         wallet.intentRepository = config.storage?.intentRepository;
         wallet.virtualTxRepository = config.storage?.virtualTxRepository;
+        wallet.exitDataCapture = config.storage?.exitDataCapture;
 
         await wallet.getVtxoManager();
         return wallet;

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -79,6 +79,7 @@ import { wrapHandlerWithIntentPersistence } from "./intentPersistenceHandler";
 import { extendCoinWithTapscript, validateRecipients } from "./utils";
 import {
     captureExitBranch,
+    DEFAULT_EXIT_CAPTURE_MODE,
     DEFAULT_MIN_EXIT_WORTH_SATS,
     ExitCaptureMode,
     pruneExitBranches,
@@ -1551,7 +1552,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
                         repository: virtualTxRepository,
                         vtxo: { txid: v.txid, vout: v.vout },
                         value: v.value,
-                        mode: capture?.mode ?? "full",
+                        mode: capture?.mode ?? DEFAULT_EXIT_CAPTURE_MODE,
                         minExitWorthSats: capture?.minExitWorthSats ?? DEFAULT_MIN_EXIT_WORTH_SATS,
                     }).catch(() => {
                         // capture is best-effort

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -77,6 +77,8 @@ import { isTerminalIntentState } from "../repositories/intentRepository";
 import type { VirtualTxRepository } from "../repositories/virtualTxRepository";
 import { wrapHandlerWithIntentPersistence } from "./intentPersistenceHandler";
 import { extendCoinWithTapscript, validateRecipients } from "./utils";
+import { captureExitBranch, DEFAULT_MIN_EXIT_WORTH_SATS, pruneExitBranches } from "./exit/capture";
+import { createExitChainResolver } from "./exit/resolver";
 import { ArkError } from "../providers/errors";
 import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
@@ -89,7 +91,7 @@ import { DelegateVtxo } from "../script/delegate";
 import { DelegateManagerImpl, findDestinationOutputIndex, IDelegateManager } from "./delegate";
 import { IndexedDBContractRepository, IndexedDBWalletRepository } from "../repositories";
 import { ContractManager } from "../contracts/contractManager";
-import type { CreateContractParams } from "../contracts/contractManager";
+import type { ContractManagerConfig, CreateContractParams } from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
 import { BoardingContractHandler } from "../contracts/handlers/boarding";
 import { timelockToSequence } from "../utils/timelock";
@@ -1517,11 +1519,40 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }
 
     private async initializeContractManager(): Promise<ContractManager> {
+        // When a virtualTxRepository is configured, capture each received VTXO's
+        // unilateral-exit branch and prune it on spend (both best-effort).
+        const virtualTxRepository = this.virtualTxRepository;
+        let onVtxosPersisted: ContractManagerConfig["onVtxosPersisted"];
+        let onVtxosSpent: ContractManagerConfig["onVtxosSpent"];
+        if (virtualTxRepository) {
+            const resolver = createExitChainResolver({
+                indexer: this.indexerProvider,
+                repository: virtualTxRepository,
+            });
+            onVtxosPersisted = async (_contract, vtxos) => {
+                for (const v of vtxos) {
+                    if (v.virtualStatus.state === "spent") continue;
+                    await captureExitBranch({
+                        resolver,
+                        repository: virtualTxRepository,
+                        vtxo: { txid: v.txid, vout: v.vout },
+                        value: v.value,
+                        mode: "full",
+                        minExitWorthSats: DEFAULT_MIN_EXIT_WORTH_SATS,
+                    }).catch(() => {
+                        // capture is best-effort
+                    });
+                }
+            };
+            onVtxosSpent = (vtxos) => pruneExitBranches(virtualTxRepository, vtxos);
+        }
         const manager = await ContractManager.create({
             indexerProvider: this.indexerProvider,
             contractRepository: this.contractRepository,
             walletRepository: this.walletRepository,
             intentRepository: this.intentRepository,
+            onVtxosPersisted,
+            onVtxosSpent,
             watcherConfig: this.watcherConfig,
         });
 

--- a/packages/ts-sdk/test/e2e/exitDataCapture.test.ts
+++ b/packages/ts-sdk/test/e2e/exitDataCapture.test.ts
@@ -11,7 +11,10 @@ describe("exit-data capture (e2e)", () => {
         { timeout: 180_000 },
         async () => {
             const repo = new InMemoryVirtualTxRepository();
-            const alice = await createTestArkWallet({ virtualTxRepository: repo });
+            const alice = await createTestArkWallet({
+                virtualTxRepository: repo,
+                exitDataCapture: { mode: "full" },
+            });
             const address = await alice.wallet.getAddress();
 
             // A settled VTXO, then an off-chain self-send so the surviving VTXO has

--- a/packages/ts-sdk/test/e2e/exitDataCapture.test.ts
+++ b/packages/ts-sdk/test/e2e/exitDataCapture.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { InMemoryVirtualTxRepository } from "../../src/repositories/inMemory/virtualTxRepository";
+import { createExitChainResolver } from "../../src/wallet/exit/resolver";
+import { beforeEachFaucet, createTestArkWallet, createVtxo, mineBlocks, waitFor } from "./utils";
+
+describe("exit-data capture (e2e)", () => {
+    beforeEach(beforeEachFaucet, 20000);
+
+    it(
+        "captures a branch on receive, exits from the repo offline, and prunes on spend",
+        { timeout: 180_000 },
+        async () => {
+            const repo = new InMemoryVirtualTxRepository();
+            const alice = await createTestArkWallet({ virtualTxRepository: repo });
+            const address = await alice.wallet.getAddress();
+
+            // A settled VTXO, then an off-chain self-send so the surviving VTXO has
+            // a real off-chain chain (ARK + checkpoint) worth capturing PSBTs for.
+            await createVtxo(alice, 200_000);
+            await alice.wallet.send({ address, amount: 150_000 });
+            await waitFor(async () => (await alice.wallet.getVtxos()).length >= 1, {
+                timeout: 30_000,
+            });
+            mineBlocks(1);
+            const spine = (await alice.wallet.getVtxos()).reduce((a, b) =>
+                a.value > b.value ? a : b,
+            );
+            const vtxo = { txid: spine.txid, vout: spine.vout };
+
+            // Capture wiring: ContractManager persisted the branch on receive.
+            await waitFor(async () => await repo.hasBranch(vtxo), { timeout: 30_000 });
+            expect((await repo.getBranch(vtxo)).length).toBeGreaterThan(0);
+
+            // Offline exit read: a repo-only resolver (indexer throws) still resolves
+            // the chain — Full-mode PSBTs let it reconstruct structure locally.
+            const dead = {
+                getVtxoChain: async () => {
+                    throw new Error("indexer offline");
+                },
+                getVirtualTxs: async () => {
+                    throw new Error("indexer offline");
+                },
+            } as never;
+            const repoOnly = createExitChainResolver({ indexer: dead, repository: repo });
+            expect((await repoOnly.getVtxoChain(vtxo)).length).toBeGreaterThan(0);
+
+            // Prune wiring: spending the VTXO drops its branch.
+            await alice.wallet.send({ address, amount: 20_000 });
+            await waitFor(async () => !(await repo.hasBranch(vtxo)), { timeout: 30_000 });
+        },
+    );
+});

--- a/packages/ts-sdk/test/e2e/utils.ts
+++ b/packages/ts-sdk/test/e2e/utils.ts
@@ -16,6 +16,8 @@ import {
     WalletMode,
     RestDelegateProvider,
     VirtualTxRepository,
+    ExitCaptureMode,
+    ExitDataSource,
 } from "../../src";
 import { execSync } from "child_process";
 import { hex } from "@scure/base";
@@ -83,6 +85,11 @@ export async function createTestOnchainWallet(): Promise<TestOnchainWallet> {
 
 export async function createTestArkWallet(opts?: {
     virtualTxRepository?: VirtualTxRepository;
+    exitDataCapture?: {
+        mode?: ExitCaptureMode;
+        minExitWorthSats?: number;
+        sources?: ExitDataSource[];
+    };
 }): Promise<TestArkWallet> {
     const identity = createTestIdentity();
 
@@ -97,6 +104,7 @@ export async function createTestArkWallet(opts?: {
             walletRepository: new InMemoryWalletRepository(),
             contractRepository: new InMemoryContractRepository(),
             virtualTxRepository: opts?.virtualTxRepository,
+            exitDataCapture: opts?.exitDataCapture,
         },
         settlementConfig: false,
     });

--- a/packages/ts-sdk/test/e2e/utils.ts
+++ b/packages/ts-sdk/test/e2e/utils.ts
@@ -15,6 +15,7 @@ import {
     ContractRepository,
     WalletMode,
     RestDelegateProvider,
+    VirtualTxRepository,
 } from "../../src";
 import { execSync } from "child_process";
 import { hex } from "@scure/base";
@@ -80,7 +81,9 @@ export async function createTestOnchainWallet(): Promise<TestOnchainWallet> {
     };
 }
 
-export async function createTestArkWallet(): Promise<TestArkWallet> {
+export async function createTestArkWallet(opts?: {
+    virtualTxRepository?: VirtualTxRepository;
+}): Promise<TestArkWallet> {
     const identity = createTestIdentity();
 
     const wallet = await Wallet.create({
@@ -93,6 +96,7 @@ export async function createTestArkWallet(): Promise<TestArkWallet> {
         storage: {
             walletRepository: new InMemoryWalletRepository(),
             contractRepository: new InMemoryContractRepository(),
+            virtualTxRepository: opts?.virtualTxRepository,
         },
         settlementConfig: false,
     });

--- a/packages/ts-sdk/test/exit-capture.test.ts
+++ b/packages/ts-sdk/test/exit-capture.test.ts
@@ -1,0 +1,138 @@
+import { base64, hex } from "@scure/base";
+import { describe, expect, it, vi } from "vitest";
+import { ChainTx, ChainTxType } from "../src/providers/indexer";
+import { InMemoryVirtualTxRepository } from "../src/repositories/inMemory/virtualTxRepository";
+import { ChainedTxType } from "../src/repositories/virtualTxRepository";
+import { Transaction } from "../src/utils/transaction";
+import { captureExitBranch, pruneExitBranches } from "../src/wallet/exit/capture";
+import { ExitChainResolver } from "../src/wallet/exit/resolver";
+
+const ROOT = "c0".repeat(32);
+
+// A PSBT spending `parent:0`; its own id becomes the leaf txid the chain uses.
+function leaf(parent: string): { psbt: string; txid: string } {
+    const t = new Transaction({ version: 2 });
+    t.addInput({
+        txid: hex.decode(parent),
+        index: 0,
+        witnessUtxo: { script: hex.decode("0014" + "00".repeat(20)), amount: 1000n },
+    });
+    const psbt = base64.encode(t.toPSBT());
+    return { psbt, txid: t.id };
+}
+
+function fakeResolver(
+    chains: Record<string, ChainTx[]>,
+    psbts: Record<string, string>,
+): ExitChainResolver {
+    return {
+        getVtxoChain: async (vtxo) => chains[`${vtxo.txid}:${vtxo.vout}`] ?? [],
+        getVirtualTxs: async (txids) => txids.map((t) => psbts[t]).filter(Boolean),
+    };
+}
+
+describe("captureExitBranch", () => {
+    it("Full: stores the branch with PSBTs, ordered root-first", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        const l = leaf(ROOT);
+        const chain: ChainTx[] = [
+            { txid: l.txid, type: ChainTxType.ARK, expiresAt: "5", spends: [ROOT] },
+            { txid: ROOT, type: ChainTxType.COMMITMENT, expiresAt: "", spends: [] },
+        ];
+        const resolver = fakeResolver({ "bb:0": chain }, { [l.txid]: l.psbt });
+        await captureExitBranch({
+            resolver,
+            repository: repo,
+            vtxo: { txid: "bb", vout: 0 },
+            value: 50000,
+            mode: "full",
+            minExitWorthSats: 1000,
+        });
+        const stored = await repo.getBranch({ txid: "bb", vout: 0 });
+        expect(stored.map((v) => v.txid)).toEqual([ROOT, l.txid]); // position 0 = root
+        expect(stored.find((v) => v.txid === l.txid)!.psbt).toBe(l.psbt);
+        expect(stored.find((v) => v.txid === ROOT)!.psbt).toBeNull();
+    });
+
+    it("Lite: stores structure only (null PSBTs)", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        const l = leaf(ROOT);
+        const chain: ChainTx[] = [
+            { txid: l.txid, type: ChainTxType.ARK, expiresAt: "5", spends: [ROOT] },
+            { txid: ROOT, type: ChainTxType.COMMITMENT, expiresAt: "", spends: [] },
+        ];
+        const getVirtualTxs = vi.fn(async () => [] as string[]);
+        const resolver = { getVtxoChain: async () => chain, getVirtualTxs } as ExitChainResolver;
+        await captureExitBranch({
+            resolver,
+            repository: repo,
+            vtxo: { txid: "bb", vout: 0 },
+            value: 50000,
+            mode: "lite",
+            minExitWorthSats: 1000,
+        });
+        expect(getVirtualTxs).not.toHaveBeenCalled(); // Lite never fetches PSBTs
+        const stored = await repo.getBranch({ txid: "bb", vout: 0 });
+        expect(stored.every((v) => v.psbt === null)).toBe(true);
+    });
+
+    it("skips dust below minExitWorthSats", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        await captureExitBranch({
+            resolver: fakeResolver({}, {}),
+            repository: repo,
+            vtxo: { txid: "bb", vout: 0 },
+            value: 500,
+            mode: "full",
+            minExitWorthSats: 1000,
+        });
+        expect(await repo.hasBranch({ txid: "bb", vout: 0 })).toBe(false);
+    });
+
+    it("is idempotent: skips fetching when a branch already exists", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        await repo.setBranch({ txid: "bb", vout: 0 }, [
+            { vtxoTxid: "bb", vtxoVout: 0, virtualTxid: ROOT, position: 0 },
+        ]);
+        const getVtxoChain = vi.fn(async () => [] as ChainTx[]);
+        const resolver = { getVtxoChain, getVirtualTxs: async () => [] } as ExitChainResolver;
+        await captureExitBranch({
+            resolver,
+            repository: repo,
+            vtxo: { txid: "bb", vout: 0 },
+            value: 50000,
+            mode: "full",
+            minExitWorthSats: 1000,
+        });
+        expect(getVtxoChain).not.toHaveBeenCalled();
+    });
+});
+
+describe("pruneExitBranches", () => {
+    it("drops the spent VTXO's branch and ref-counted orphans, keeping shared ancestors", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        const shared = "a1".repeat(32);
+        const uniqueA = "a2".repeat(32);
+        const uniqueB = "b2".repeat(32);
+        await repo.upsertVirtualTxs([
+            { txid: shared, psbt: "s", expiresAt: null, type: ChainedTxType.Tree },
+            { txid: uniqueA, psbt: "a", expiresAt: null, type: ChainedTxType.Ark },
+            { txid: uniqueB, psbt: "b", expiresAt: null, type: ChainedTxType.Ark },
+        ]);
+        await repo.setBranch({ txid: "aa", vout: 0 }, [
+            { vtxoTxid: "aa", vtxoVout: 0, virtualTxid: shared, position: 0 },
+            { vtxoTxid: "aa", vtxoVout: 0, virtualTxid: uniqueA, position: 1 },
+        ]);
+        await repo.setBranch({ txid: "bb", vout: 0 }, [
+            { vtxoTxid: "bb", vtxoVout: 0, virtualTxid: shared, position: 0 },
+            { vtxoTxid: "bb", vtxoVout: 0, virtualTxid: uniqueB, position: 1 },
+        ]);
+
+        await pruneExitBranches(repo, [{ txid: "aa", vout: 0 }]);
+
+        expect(await repo.hasBranch({ txid: "aa", vout: 0 })).toBe(false);
+        expect(await repo.getVirtualTx(uniqueA)).toBeNull(); // orphan collected
+        expect((await repo.getVirtualTx(shared))?.txid).toBe(shared); // still referenced by bb
+        expect((await repo.getVirtualTx(uniqueB))?.txid).toBe(uniqueB);
+    });
+});

--- a/packages/ts-sdk/test/exit-estimate.test.ts
+++ b/packages/ts-sdk/test/exit-estimate.test.ts
@@ -11,6 +11,7 @@ import { CSVMultisigTapscript } from "../src/script/tapscript";
 import { P2A } from "../src/utils/anchor";
 import { Transaction } from "../src/utils/transaction";
 import { buildExitDag } from "../src/wallet/exit/chain";
+import { IndexerExitDataSource } from "../src/wallet/exit/indexerSource";
 import { CHILD_OUTPUT_DUST, estimate } from "../src/wallet/exit/estimate";
 import type { ExitOptions } from "../src/wallet/exit/estimate";
 
@@ -51,7 +52,9 @@ describe("buildExitDag", () => {
                 { txid: LEAF_A, vout: 0 },
                 { txid: LEAF_B, vout: 0 },
             ],
-            indexer: fakeIndexer({ [LEAF_A]: chainOf(LEAF_A), [LEAF_B]: chainOf(LEAF_B) }),
+            chain: new IndexerExitDataSource(
+                fakeIndexer({ [LEAF_A]: chainOf(LEAF_A), [LEAF_B]: chainOf(LEAF_B) }),
+            ),
             onchain: fakeOnchain(new Set([COMMIT])),
         });
         expect(dag.map((n) => n.txid)).toEqual([SHARED, LEAF_A, LEAF_B]);
@@ -62,7 +65,7 @@ describe("buildExitDag", () => {
     it("marks already-confirmed nodes", async () => {
         const dag = await buildExitDag({
             vtxos: [{ txid: LEAF_A, vout: 0 }],
-            indexer: fakeIndexer({ [LEAF_A]: chainOf(LEAF_A) }),
+            chain: new IndexerExitDataSource(fakeIndexer({ [LEAF_A]: chainOf(LEAF_A) })),
             onchain: fakeOnchain(new Set([COMMIT, SHARED])),
         });
         expect(dag.find((n) => n.txid === SHARED)!.confirmed).toBe(true);
@@ -77,7 +80,7 @@ describe("buildExitDag", () => {
         await expect(
             buildExitDag({
                 vtxos: [{ txid: LEAF_A, vout: 0 }],
-                indexer: fakeIndexer({ [LEAF_A]: cyclic }),
+                chain: new IndexerExitDataSource(fakeIndexer({ [LEAF_A]: cyclic })),
                 onchain: fakeOnchain(new Set()),
             }),
         ).rejects.toThrow(/inconsistent/i);

--- a/packages/ts-sdk/test/exit-indexer-source.test.ts
+++ b/packages/ts-sdk/test/exit-indexer-source.test.ts
@@ -1,0 +1,65 @@
+import { base64 } from "@scure/base";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PAGE_SIZE } from "../src/contracts/constants";
+import { ChainTx, ChainTxType } from "../src/providers/indexer";
+import { Transaction } from "../src/utils/transaction";
+import { IndexerExitDataSource } from "../src/wallet/exit/indexerSource";
+
+const tx = (txid: string): ChainTx => ({
+    txid,
+    expiresAt: "0",
+    type: ChainTxType.ARK,
+    spends: [],
+});
+
+// A tiny valid PSBT so getVirtualTxs can derive an id from it.
+function emptyPsbtBase64(): { psbt: string; id: string } {
+    const t = new Transaction({ version: 2 });
+    return { psbt: base64.encode(t.toPSBT()), id: t.id };
+}
+
+function fakeIndexer(
+    pages: { chain: ChainTx[]; page?: any }[],
+    psbtsByTxid: Record<string, string>,
+) {
+    return {
+        getVtxoChain: async (_o: any, opts: any) => pages[opts.pageIndex] ?? { chain: [] },
+        getVirtualTxs: async (txids: string[]) => ({
+            txs: txids.map((t) => psbtsByTxid[t]).filter(Boolean),
+        }),
+    } as any;
+}
+
+describe("IndexerExitDataSource", () => {
+    it("returns a single-page chain", async () => {
+        const source = new IndexerExitDataSource(fakeIndexer([{ chain: [tx("a"), tx("b")] }], {}));
+        const chain = await source.getVtxoChain({ txid: "aa", vout: 0 });
+        expect(chain!.map((c) => c.txid)).toEqual(["a", "b"]);
+    });
+
+    it("walks and merges all pages until a short page", async () => {
+        // A full page (== DEFAULT_PAGE_SIZE) signals "there may be more" → fetch page 1;
+        // the short page 1 ends it.
+        const full = Array.from({ length: DEFAULT_PAGE_SIZE }, (_, i) => tx(`p0_${i}`));
+        const indexer = fakeIndexer(
+            [
+                { chain: full, page: { current: 0, next: 1, total: 2 } },
+                { chain: [tx("leaf")], page: { current: 1, next: 1, total: 2 } },
+            ],
+            {},
+        );
+        const chain = await new IndexerExitDataSource(indexer).getVtxoChain({
+            txid: "aa",
+            vout: 0,
+        });
+        expect(chain!.length).toBe(DEFAULT_PAGE_SIZE + 1);
+        expect(chain![chain!.length - 1].txid).toBe("leaf");
+    });
+
+    it("keys PSBTs by their derived (unsigned) txid", async () => {
+        const { psbt, id } = emptyPsbtBase64();
+        const source = new IndexerExitDataSource(fakeIndexer([], { [id]: psbt }));
+        const got = await source.getVirtualTxs([id]);
+        expect(got.get(id)).toBe(psbt);
+    });
+});

--- a/packages/ts-sdk/test/exit-repo-source.test.ts
+++ b/packages/ts-sdk/test/exit-repo-source.test.ts
@@ -1,0 +1,69 @@
+import { base64, hex } from "@scure/base";
+import { describe, expect, it } from "vitest";
+import { InMemoryVirtualTxRepository } from "../src/repositories/inMemory/virtualTxRepository";
+import { ChainedTxType } from "../src/repositories/virtualTxRepository";
+import { Transaction } from "../src/utils/transaction";
+import { RepositoryExitDataSource } from "../src/wallet/exit/repositorySource";
+
+// A PSBT spending `parentTxid:0`, so `spends` can be derived from its inputs.
+function psbtSpending(parentTxid: string): string {
+    const t = new Transaction({ version: 2 });
+    t.addInput({
+        txid: hex.decode(parentTxid),
+        index: 0,
+        witnessUtxo: { script: hex.decode("0014" + "00".repeat(20)), amount: 1000n },
+    });
+    return base64.encode(t.toPSBT());
+}
+
+describe("RepositoryExitDataSource", () => {
+    it("Full: reconstructs the chain with spends derived from stored PSBTs", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        const root = "aa".repeat(32);
+        const leafPsbt = psbtSpending(root);
+        const leafTxid = Transaction.fromPSBT(base64.decode(leafPsbt)).id;
+        await repo.upsertVirtualTxs([
+            { txid: root, psbt: null, expiresAt: null, type: ChainedTxType.Commitment },
+            { txid: leafTxid, psbt: leafPsbt, expiresAt: 1234, type: ChainedTxType.Ark },
+        ]);
+        await repo.setBranch({ txid: "bb".repeat(32), vout: 0 }, [
+            { vtxoTxid: "bb".repeat(32), vtxoVout: 0, virtualTxid: root, position: 0 },
+            { vtxoTxid: "bb".repeat(32), vtxoVout: 0, virtualTxid: leafTxid, position: 1 },
+        ]);
+
+        const source = new RepositoryExitDataSource(repo);
+        const chain = await source.getVtxoChain({ txid: "bb".repeat(32), vout: 0 });
+        expect(chain).not.toBeNull();
+        const leaf = chain!.find((c) => c.txid === leafTxid)!;
+        expect(leaf.spends).toEqual([root]); // derived from the PSBT input
+        expect(leaf.type).toBe("INDEXER_CHAINED_TX_TYPE_ARK");
+    });
+
+    it("Lite: returns null when a non-commitment tx has no PSBT (structure miss)", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        await repo.upsertVirtualTxs([
+            { txid: "cc".repeat(32), psbt: null, expiresAt: null, type: ChainedTxType.Ark },
+        ]);
+        await repo.setBranch({ txid: "dd".repeat(32), vout: 0 }, [
+            { vtxoTxid: "dd".repeat(32), vtxoVout: 0, virtualTxid: "cc".repeat(32), position: 0 },
+        ]);
+        const source = new RepositoryExitDataSource(repo);
+        expect(await source.getVtxoChain({ txid: "dd".repeat(32), vout: 0 })).toBeNull();
+    });
+
+    it("returns null for an unknown vtxo (empty branch)", async () => {
+        const source = new RepositoryExitDataSource(new InMemoryVirtualTxRepository());
+        expect(await source.getVtxoChain({ txid: "ee".repeat(32), vout: 0 })).toBeNull();
+    });
+
+    it("getVirtualTxs returns only stored PSBTs, keyed by txid", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        await repo.upsertVirtualTxs([
+            { txid: "ff".repeat(32), psbt: "storedpsbt", expiresAt: null, type: ChainedTxType.Ark },
+        ]);
+        const source = new RepositoryExitDataSource(repo);
+        const got = await source.getVirtualTxs(["ff".repeat(32), "99".repeat(32)]);
+        expect(got.get("ff".repeat(32))).toBe("storedpsbt");
+        expect(got.has("99".repeat(32))).toBe(false);
+    });
+});

--- a/packages/ts-sdk/test/exit-resolver.test.ts
+++ b/packages/ts-sdk/test/exit-resolver.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { ExitDataSource, OrderedExitChainResolver } from "../src/wallet/exit/resolver";
+import { ChainTx, ChainTxType } from "../src/providers/indexer";
+
+const chainTx = (txid: string): ChainTx => ({
+    txid,
+    expiresAt: "0",
+    type: ChainTxType.ARK,
+    spends: [],
+});
+
+// A fake source that answers only the keys it was seeded with.
+function fakeSource(
+    name: string,
+    chains: Record<string, ChainTx[]>,
+    psbts: Record<string, string>,
+): ExitDataSource {
+    return {
+        name,
+        getVtxoChain: async (vtxo) => chains[`${vtxo.txid}:${vtxo.vout}`] ?? null,
+        getVirtualTxs: async (txids) => {
+            const out = new Map<string, string>();
+            for (const t of txids) if (psbts[t]) out.set(t, psbts[t]);
+            return out;
+        },
+    };
+}
+
+describe("OrderedExitChainResolver", () => {
+    it("returns the first source that resolves the chain", async () => {
+        const local = fakeSource("local", {}, {});
+        const indexer = fakeSource("indexer", { "aa:0": [chainTx("t1")] }, {});
+        const r = new OrderedExitChainResolver([local, indexer]);
+        expect((await r.getVtxoChain({ txid: "aa", vout: 0 })).map((c) => c.txid)).toEqual(["t1"]);
+    });
+
+    it("merges partial PSBT hits across sources, local first", async () => {
+        const local = fakeSource("local", {}, { t1: "psbt1" });
+        const indexer = fakeSource("indexer", {}, { t1: "IGNORED", t2: "psbt2" });
+        const r = new OrderedExitChainResolver([local, indexer]);
+        const txs = await r.getVirtualTxs(["t1", "t2"]);
+        expect(new Set(txs)).toEqual(new Set(["psbt1", "psbt2"]));
+    });
+
+    it("read-through persists non-local PSBT hits, best-effort", async () => {
+        const persist = { upsertVirtualTxs: vi.fn(async () => {}) } as any;
+        const local = fakeSource("local", {}, {});
+        const indexer = fakeSource("indexer", {}, { t2: "psbt2" });
+        const r = new OrderedExitChainResolver([local, indexer], persist);
+        await r.getVirtualTxs(["t2"]);
+        expect(persist.upsertVirtualTxs).toHaveBeenCalledOnce();
+        expect(persist.upsertVirtualTxs.mock.calls[0][0]).toEqual([
+            { txid: "t2", psbt: "psbt2", expiresAt: null, type: 0 },
+        ]);
+    });
+
+    it("rethrows the last source error when nothing resolves the chain", async () => {
+        const throwing: ExitDataSource = {
+            name: "indexer",
+            getVtxoChain: async () => {
+                throw new Error("indexer down");
+            },
+            getVirtualTxs: async () => new Map(),
+        };
+        const r = new OrderedExitChainResolver([throwing]);
+        await expect(r.getVtxoChain({ txid: "aa", vout: 0 })).rejects.toThrow(/indexer down/);
+    });
+});

--- a/packages/ts-sdk/test/exit-resolver.test.ts
+++ b/packages/ts-sdk/test/exit-resolver.test.ts
@@ -85,4 +85,39 @@ describe("OrderedExitChainResolver", () => {
         const resolver = createExitChainResolver({ indexer, repository: repo });
         expect(await resolver.getVirtualTxs(["z1"])).toEqual(["P"]);
     });
+
+    it("createExitChainResolver orders sources repo -> extraSources -> indexer", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        await repo.upsertVirtualTxs([{ txid: "r1", psbt: "R", expiresAt: null, type: 2 }]);
+        const calls: string[] = [];
+        const extra: ExitDataSource = {
+            name: "provider",
+            getVtxoChain: async () => {
+                calls.push("extra");
+                return null;
+            },
+            getVirtualTxs: async () => {
+                calls.push("extra");
+                return new Map();
+            },
+        };
+        const indexer = {
+            getVtxoChain: async () => ({ chain: [] }),
+            getVirtualTxs: async () => {
+                calls.push("indexer");
+                return { txs: [] };
+            },
+        } as any;
+        const resolver = createExitChainResolver({
+            indexer,
+            repository: repo,
+            extraSources: [extra],
+        });
+        // repo answers first — extra + indexer are not consulted
+        expect(await resolver.getVirtualTxs(["r1"])).toEqual(["R"]);
+        expect(calls).toEqual([]);
+        // a miss falls through repo -> extra -> indexer, in that order
+        await resolver.getVirtualTxs(["miss"]);
+        expect(calls).toEqual(["extra", "indexer"]);
+    });
 });

--- a/packages/ts-sdk/test/exit-resolver.test.ts
+++ b/packages/ts-sdk/test/exit-resolver.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { ExitDataSource, OrderedExitChainResolver } from "../src/wallet/exit/resolver";
+import {
+    createExitChainResolver,
+    ExitDataSource,
+    OrderedExitChainResolver,
+} from "../src/wallet/exit/resolver";
+import { InMemoryVirtualTxRepository } from "../src/repositories/inMemory/virtualTxRepository";
 import { ChainTx, ChainTxType } from "../src/providers/indexer";
 
 const chainTx = (txid: string): ChainTx => ({
@@ -64,5 +69,20 @@ describe("OrderedExitChainResolver", () => {
         };
         const r = new OrderedExitChainResolver([throwing]);
         await expect(r.getVtxoChain({ txid: "aa", vout: 0 })).rejects.toThrow(/indexer down/);
+    });
+
+    it("createExitChainResolver serves a pre-seeded repo without hitting the indexer", async () => {
+        const repo = new InMemoryVirtualTxRepository();
+        await repo.upsertVirtualTxs([{ txid: "z1", psbt: "P", expiresAt: null, type: 2 }]);
+        const indexer = {
+            getVirtualTxs: async () => {
+                throw new Error("indexer must not be called");
+            },
+            getVtxoChain: async () => {
+                throw new Error("indexer must not be called");
+            },
+        } as any;
+        const resolver = createExitChainResolver({ indexer, repository: repo });
+        expect(await resolver.getVirtualTxs(["z1"])).toEqual(["P"]);
     });
 });


### PR DESCRIPTION
## Summary

Makes unilateral exit work without the Ark indexer: capture each VTXO's exit chain data locally on receive, and read it local-first at exit time. This activates `VirtualTxRepository` (the declared follow-up of #494) and adds a modular resolver, ported from NArk's design.

**Stacked on #606** (base `worktree-unilateral-exit-package`) — merge after #606 lands, or rebase onto `master` once it does.

### Resolver seam (local-first reads)
- `ExitDataSource` + `ExitChainResolver` (`src/wallet/exit/resolver.ts`): an ordered source chain — local repo → provider slot → indexer — with best-effort read-through persist.
- `IndexerExitDataSource` (paginated, behavior-preserving) and `RepositoryExitDataSource` (Full derives physical `spends` from stored PSBTs; Lite reports a structure miss so the resolver falls through).
- Threaded into `buildExitDag` and `computeExitLayout`. With no `virtualTxRepository` configured it is a pure no-op that falls through to the indexer.

### Capture + prune
- `captureExitBranch` / `pruneExitBranches` (`src/wallet/exit/capture.ts`): idempotent, dust-gated (`minExitWorthSats`), Lite/Full modes (**default Lite**).
- Wired into `ContractManager` via best-effort `onVtxosPersisted` / `onVtxosSpent` callbacks bound by the wallet — keeping `contracts/` independent of `wallet/exit/`. Capture fires after the sync write path and at `reconcilePendingFrontier`; prune fires on `vtxo_spent`.
- Prune is ref-counted (via the repo): ancestors shared with surviving VTXOs are kept, so change / self-spend "keep + extend" falls out of the normalized `VirtualTx` + `VtxoBranch` storage — no special-casing.

### Configurability & extensibility
- **Lite/Full + dust:** `storage.exitDataCapture.mode` — **default "lite"** (structure only, cheap; most VTXOs never exit); set `"full"` to store PSBTs for indexer-independent exit. `minExitWorthSats` (default 1000) skips dust.
- **Provider source slot:** `storage.exitDataCapture.sources?: ExitDataSource[]` — extra sources tried before the indexer for both capture and exit reads. `ExitDataSource` / `ExitChainResolver` / `createExitChainResolver` / `ExitCaptureMode` are exported so an integration can implement a provider-backed source.

## Test plan
- Unit: resolver composition + read-through + source ordering, indexer/repository sources, capture/prune helpers (Full, Lite, dust, idempotent re-receive, ref-counted prune).
- Full ts-sdk unit suite: **1742 passed / 1 skipped**; tsc clean; behavior-preserving with no repo configured.
- e2e (regtest): capture on receive (Full) → chain resolves from the repo with the indexer offline → prune on spend.

## Still deferred
- A concrete provider *implementation* (wire protocol + client) — the slot and interface are in place; the protocol needs a target service to define.