### PR TITLE
Offline-first wallet: survive an offline/uncooperative operator

### DIFF
--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -1,5 +1,6 @@
 import { hex } from "@scure/base";
 import { IndexerProvider } from "../providers/indexer";
+import { isRetryableProviderError } from "../providers/availability";
 import { WalletRepository } from "../repositories/walletRepository";
 import {
     Contract,
@@ -153,6 +154,17 @@ export interface ScanContractsOptions {
     deps: DiscoveryDeps;
 }
 
+/**
+ * Freshness of the ContractManager's provider-backed sync. `degraded` means the
+ * most recent sync (boot, best-effort read, or contract hydration) hit a
+ * retryable indexer/operator failure and the manager is serving repository
+ * state; it returns to `online` on the next successful sync. This only
+ * describes sync freshness — never wallet data itself.
+ */
+export type ContractSyncState =
+    | { mode: "online"; lastSyncedAt?: number }
+    | { mode: "degraded"; reason: string; lastSyncedAt?: number };
+
 export interface IContractManager extends Disposable {
     /**
      * Create and register a new contract.
@@ -182,6 +194,12 @@ export interface IContractManager extends Disposable {
      * If no filter is provided, returns all contracts with their virtual outputs.
      */
     getContractsWithVtxos(filter?: GetContractsFilter): Promise<ContractWithVtxos[]>;
+
+    /**
+     * Latest provider-sync health (online vs. degraded to repository data).
+     * See {@link ContractSyncState}.
+     */
+    getSyncState(): ContractSyncState;
 
     /**
      * Stamp raw virtual outputs with the correct per-contract tapscripts
@@ -423,6 +441,10 @@ export class ContractManager implements IContractManager {
     private initialized = false;
     private eventCallbacks: Set<ContractEventCallback> = new Set();
     private stopWatcherFn?: () => void;
+    /** `undefined` while online; the failure reason once a sync degrades. */
+    private syncDegradedReason?: string;
+    /** Epoch-ms of the last successful provider sync, if any. */
+    private lastSyncedAt?: number;
 
     private constructor(config: ContractManagerConfig) {
         this.config = config;
@@ -450,6 +472,31 @@ export class ContractManager implements IContractManager {
         return cm;
     }
 
+    /**
+     * Latest provider-sync health. See {@link ContractSyncState}. Degradation is
+     * recorded by {@link initialize}, {@link getContractsWithVtxos}, and
+     * {@link createContract}; it flips back to `online` on the next successful
+     * sync. Purely a freshness signal — not a source of truth for wallet data.
+     */
+    getSyncState(): ContractSyncState {
+        return this.syncDegradedReason === undefined
+            ? { mode: "online", lastSyncedAt: this.lastSyncedAt }
+            : {
+                  mode: "degraded",
+                  reason: this.syncDegradedReason,
+                  lastSyncedAt: this.lastSyncedAt,
+              };
+    }
+
+    private markSyncOnline(): void {
+        this.syncDegradedReason = undefined;
+        this.lastSyncedAt = Date.now();
+    }
+
+    private markSyncDegraded(err: unknown): void {
+        this.syncDegradedReason = err instanceof Error ? err.message : String(err);
+    }
+
     private async initialize(): Promise<void> {
         if (this.initialized) {
             return;
@@ -465,7 +512,17 @@ export class ContractManager implements IContractManager {
             await this.watcher.addContract(contract);
         }
 
-        await this.reconcileWatched();
+        // Best-effort boot sync: a retryable indexer/operator failure must not
+        // fail construction. Record degraded state and continue with repository
+        // data — the watcher still starts below and reconciles when the operator
+        // returns. Terminal failures still propagate.
+        try {
+            await this.reconcileWatched();
+            this.markSyncOnline();
+        } catch (err) {
+            if (!isRetryableProviderError(err)) throw err;
+            this.markSyncDegraded(err);
+        }
 
         this.initialized = true;
 
@@ -525,8 +582,17 @@ export class ContractManager implements IContractManager {
     async createContract(params: CreateContractParams): Promise<Contract> {
         const { contract, persisted } = await this.upsertContract(params);
         if (persisted) {
-            // fetch all virtual outputs (including spent/swept) for this contract
-            await this.fetchContractVxosFromIndexer([contract]);
+            // Best-effort VTXO hydration (including spent/swept): on a retryable
+            // indexer failure the contract stays persisted and is still watched,
+            // so it hydrates on the next reconcile — wallet construction (which
+            // registers baseline contracts) survives an offline operator.
+            try {
+                await this.fetchContractVxosFromIndexer([contract]);
+                this.markSyncOnline();
+            } catch (err) {
+                if (!isRetryableProviderError(err)) throw err;
+                this.markSyncDegraded(err);
+            }
             await this.watcher.addContract(contract);
         }
         return contract;
@@ -814,7 +880,17 @@ export class ContractManager implements IContractManager {
         pageSize?: number,
     ): Promise<ContractWithVtxos[]> {
         const contracts = await this.getContracts(filter);
-        await this.syncContracts({ contracts, pageSize });
+        // Best-effort opportunistic sync: on a retryable indexer/operator
+        // failure, serve repository state rather than failing the read. The
+        // failed sync writes no partial state and does not advance the cursor
+        // (targeted subset queries never do). Terminal failures still propagate.
+        try {
+            await this.syncContracts({ contracts, pageSize });
+            this.markSyncOnline();
+        } catch (err) {
+            if (!isRetryableProviderError(err)) throw err;
+            this.markSyncDegraded(err);
+        }
         const vtxos = await this.getVtxosForContracts(contracts);
         return contracts.map((contract) => ({
             contract,

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -1181,29 +1181,44 @@ export class ContractManager implements IContractManager {
      * Handle events from the watcher.
      */
     private async handleContractEvent(event: ContractEvent) {
-        switch (event.type) {
-            // Delta-sync only the changed virtual outputs for this contract.
-            case "vtxo_received":
-                await this.syncContracts({ contracts: [event.contract] });
-                break;
-            case "vtxo_spent":
-                await this.syncContracts({ contracts: [event.contract] });
-                if (this.config.onVtxosSpent) {
-                    try {
-                        await this.config.onVtxosSpent(
-                            event.vtxos.map((v) => ({ txid: v.txid, vout: v.vout })),
-                        );
-                    } catch {
-                        // prune is best-effort; never block the spend event
+        // Watcher-driven syncs update provider-sync health the same way the boot
+        // and read paths do (initialize / getContractsWithVtxos): a retryable
+        // indexer/operator failure here — notably the post-boot connection_reset
+        // recovery — must record degraded state rather than being swallowed by
+        // the startWatching callback's `.catch`, or diagnostics would keep
+        // reporting online after a real degradation. Terminal failures still
+        // propagate. The event is forwarded to subscribers either way.
+        try {
+            switch (event.type) {
+                // Delta-sync only the changed virtual outputs for this contract.
+                case "vtxo_received":
+                    await this.syncContracts({ contracts: [event.contract] });
+                    this.markSyncOnline();
+                    break;
+                case "vtxo_spent":
+                    await this.syncContracts({ contracts: [event.contract] });
+                    this.markSyncOnline();
+                    if (this.config.onVtxosSpent) {
+                        try {
+                            await this.config.onVtxosSpent(
+                                event.vtxos.map((v) => ({ txid: v.txid, vout: v.vout })),
+                            );
+                        } catch {
+                            // prune is best-effort; never block the spend event
+                        }
                     }
-                }
-                break;
-            case "connection_reset":
-                // Same recovery path as boot: delta-sync the watched set
-                // and reconcile the pending frontier. `advanceSyncCursor`
-                // is monotonic so this never rewinds the cursor.
-                await this.reconcileWatched();
-                break;
+                    break;
+                case "connection_reset":
+                    // Same recovery path as boot: delta-sync the watched set
+                    // and reconcile the pending frontier. `advanceSyncCursor`
+                    // is monotonic so this never rewinds the cursor.
+                    await this.reconcileWatched();
+                    this.markSyncOnline();
+                    break;
+            }
+        } catch (err) {
+            if (!isRetryableProviderError(err)) throw err;
+            this.markSyncDegraded(err);
         }
 
         // Forward to all callbacks

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -250,7 +250,10 @@ import type {
     ExitChainResolver,
     ExitDataSource,
 } from "./wallet/exit";
-import { ArkError, maybeArkError } from "./providers/errors";
+import { ArkError, maybeArkError, ProviderUnavailableError } from "./providers/errors";
+import type { ProviderKind } from "./providers/errors";
+import { isRetryableProviderError } from "./providers/availability";
+import type { ServerInfoSource } from "./wallet/arkInfoSnapshot";
 import { validateVtxoTxGraph, validateConnectorsTxGraph } from "./tree/validation";
 import { buildForfeitTx } from "./forfeit";
 import { IndexedDBWalletRepository } from "./repositories/indexedDB/walletRepository";
@@ -520,6 +523,8 @@ export {
     // Errors
     ArkError,
     maybeArkError,
+    ProviderUnavailableError,
+    isRetryableProviderError,
     DescriptorSigningProviderMissingError,
     MissingSigningDescriptorError,
 
@@ -662,6 +667,10 @@ export type {
     SignerStatus,
     SignerClassification,
     SignerSet,
+
+    // Provider availability
+    ProviderKind,
+    ServerInfoSource,
 
     // Asset types
     IReadonlyAssetManager,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -254,6 +254,8 @@ import { ArkError, maybeArkError, ProviderUnavailableError } from "./providers/e
 import type { ProviderKind } from "./providers/errors";
 import { isRetryableProviderError } from "./providers/availability";
 import type { ServerInfoSource } from "./wallet/arkInfoSnapshot";
+import type { ProviderConnectionState } from "./wallet/wallet";
+import type { ContractSyncState } from "./contracts/contractManager";
 import { validateVtxoTxGraph, validateConnectorsTxGraph } from "./tree/validation";
 import { buildForfeitTx } from "./forfeit";
 import { IndexedDBWalletRepository } from "./repositories/indexedDB/walletRepository";
@@ -671,6 +673,8 @@ export type {
     // Provider availability
     ProviderKind,
     ServerInfoSource,
+    ProviderConnectionState,
+    ContractSyncState,
 
     // Asset types
     IReadonlyAssetManager,

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -3,7 +3,7 @@ import { TreeNonces, TreePartialSigs } from "../tree/signingSession";
 import { hex } from "@scure/base";
 import { Vtxo } from "./indexer";
 import { eventSourceIterator, isEventSourceError } from "./utils";
-import { maybeArkError, ProviderUnavailableError } from "./errors";
+import { maybeArkError, throwIfHttpUnavailable, toProviderUnavailable } from "./errors";
 import type { IntentFeeConfig } from "../arkfee";
 import { Intent } from "../intent";
 import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
@@ -332,8 +332,19 @@ export class RestArkProvider implements ArkProvider {
             ...(init.headers as Record<string, string> | undefined),
         };
         if (digest) headers["X-Digest"] = digest;
-        const response = await fetch(url, { ...init, headers });
+        let response: Response;
+        try {
+            response = await fetch(url, { ...init, headers });
+        } catch (err) {
+            // Server unreachable: surface a typed retryable unavailable error so
+            // cooperative flows fail with it rather than leaking a raw FetchError.
+            throw toProviderUnavailable(err, "arkade");
+        }
         if (response.ok) return response;
+        // A 429/5xx means the operator is temporarily unable to serve; classify
+        // it as retryable before the digest-mismatch check (which is a 4xx-class
+        // rejection, so the two never overlap).
+        throwIfHttpUnavailable(response, "arkade");
         let body: string;
         try {
             body = await response.clone().text();
@@ -375,12 +386,7 @@ export class RestArkProvider implements ArkProvider {
             // Surface it as a typed unavailable error so wallet boot can fall
             // back to a cached server-info snapshot. `fetch` transport failures
             // (server unreachable) are already surfaced as FetchError upstream.
-            if (response.status === 429 || response.status >= 500) {
-                throw new ProviderUnavailableError(
-                    "arkade",
-                    `Arkade server info unavailable: ${response.status} ${response.statusText}`,
-                );
-            }
+            throwIfHttpUnavailable(response, "arkade");
             const errorText = await response.text();
             handleError(errorText, `Failed to get server info: ${response.statusText}`);
         }

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -3,7 +3,7 @@ import { TreeNonces, TreePartialSigs } from "../tree/signingSession";
 import { hex } from "@scure/base";
 import { Vtxo } from "./indexer";
 import { eventSourceIterator, isEventSourceError } from "./utils";
-import { maybeArkError } from "./errors";
+import { maybeArkError, ProviderUnavailableError } from "./errors";
 import type { IntentFeeConfig } from "../arkfee";
 import { Intent } from "../intent";
 import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
@@ -370,6 +370,17 @@ export class RestArkProvider implements ArkProvider {
         const url = `${this.serverUrl}/v1/info`;
         const response = await fetch(url);
         if (!response.ok) {
+            // A 429 or 5xx means the operator is up but temporarily unable to
+            // serve — a retryable availability failure, not a config/auth error.
+            // Surface it as a typed unavailable error so wallet boot can fall
+            // back to a cached server-info snapshot. `fetch` transport failures
+            // (server unreachable) are already surfaced as FetchError upstream.
+            if (response.status === 429 || response.status >= 500) {
+                throw new ProviderUnavailableError(
+                    "arkade",
+                    `Arkade server info unavailable: ${response.status} ${response.statusText}`,
+                );
+            }
             const errorText = await response.text();
             handleError(errorText, `Failed to get server info: ${response.statusText}`);
         }

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -341,19 +341,21 @@ export class RestArkProvider implements ArkProvider {
             throw toProviderUnavailable(err, "arkade");
         }
         if (response.ok) return response;
-        // A 429/5xx means the operator is temporarily unable to serve; classify
-        // it as retryable before the digest-mismatch check (which is a 4xx-class
-        // rejection, so the two never overlap).
-        throwIfHttpUnavailable(response, "arkade");
+        // Read the body first: error classification must branch on its content,
+        // not just the HTTP status. arkd is behind grpc-gateway, which renders
+        // application-level errors across the 4xx AND 5xx range (gRPC INTERNAL ->
+        // HTTP 500), so status alone can't tell a terminal rejection apart from a
+        // genuine availability failure.
         let body: string;
         try {
             body = await response.clone().text();
         } catch (e) {
             // Couldn't read the body to classify it (e.g. the connection dropped
-            // mid-body). Detection is only deferred to the next getInfo(), not
-            // lost — but surface it rather than swallowing silently. Return the
-            // original response so the caller still sees the underlying error.
+            // mid-body). Fall back to status-only classification so a genuine
+            // 429/5xx still surfaces as retryable; digest detection is only
+            // deferred to the next getInfo(), not lost.
             console.warn("authedFetch could not read response body for digest check", e);
+            throwIfHttpUnavailable(response, "arkade");
             return response;
         }
         // Only arkd's *structured* digest error counts: a grpc-gateway
@@ -361,7 +363,13 @@ export class RestArkProvider implements ArkProvider {
         // v0.9.9-rc.1 #1104), parsed via the shared maybeArkError. A raw
         // substring match would let an unrelated error body that merely mentions
         // the token trigger a spurious refresh + signer rotation.
-        if (maybeArkError(new Error(body))?.name !== "DIGEST_MISMATCH") return response;
+        const arkError = maybeArkError(new Error(body));
+        // A structured arkd error means the operator is up and deliberately
+        // rejecting the request — terminal, even when grpc-gateway renders it as a
+        // 5xx. Only a non-structured 429/5xx (a bare proxy/gateway failure) is a
+        // retryable availability condition.
+        if (!arkError) throwIfHttpUnavailable(response, "arkade");
+        if (arkError?.name !== "DIGEST_MISMATCH") return response;
         // arkd rejected this request because our cached server info is stale
         // (e.g. the operator rotated its signer). Mirror NArk's BuildVersionHandler
         // (dotnet-sdk #131): clear the digest, refetch info, fire onServerInfoChanged
@@ -381,13 +389,16 @@ export class RestArkProvider implements ArkProvider {
         const url = `${this.serverUrl}/v1/info`;
         const response = await fetch(url);
         if (!response.ok) {
+            const errorText = await response.text();
             // A 429 or 5xx means the operator is up but temporarily unable to
             // serve — a retryable availability failure, not a config/auth error.
             // Surface it as a typed unavailable error so wallet boot can fall
-            // back to a cached server-info snapshot. `fetch` transport failures
-            // (server unreachable) are already surfaced as FetchError upstream.
-            throwIfHttpUnavailable(response, "arkade");
-            const errorText = await response.text();
+            // back to a cached server-info snapshot. Pass the body so a 5xx that
+            // actually carries a structured arkd error (grpc-gateway maps gRPC
+            // INTERNAL -> HTTP 500) stays terminal instead. `fetch` transport
+            // failures (server unreachable) are already surfaced as FetchError
+            // upstream.
+            throwIfHttpUnavailable(response, "arkade", errorText);
             handleError(errorText, `Failed to get server info: ${response.statusText}`);
         }
         const fromServer = await response.json();

--- a/packages/ts-sdk/src/providers/availability.ts
+++ b/packages/ts-sdk/src/providers/availability.ts
@@ -1,0 +1,31 @@
+import { FetchError } from "../utils/fetch";
+import { isFetchTimeoutError } from "./ark";
+import { ProviderUnavailableError } from "./errors";
+
+/**
+ * Whether a provider error is a *retryable* availability failure (operator or
+ * indexer temporarily unreachable) rather than a terminal one.
+ *
+ * Retryable:
+ *  - {@link ProviderUnavailableError} — already-classified 5xx/429/unavailable
+ *    (see e.g. {@link https | RestArkProvider.getInfo}'s non-2xx branch);
+ *  - {@link FetchError} — transport-level `fetch` rejection (DNS failure,
+ *    connection refused, TLS/CORS), which also carries undici timeouts as its
+ *    `cause`;
+ *  - {@link isFetchTimeoutError} — header/body timeouts that surface directly.
+ *
+ * Everything else (4xx, invalid JSON, schema violations, network mismatch,
+ * unsupported network) is terminal and returns `false`.
+ *
+ * NOTE (Step 2, Scope 2): this classifies the errors currently produced by the
+ * boot-critical `getInfo` path. Normalizing the indexer's per-branch
+ * `!res.ok` throws and the remaining Ark RPC methods into
+ * {@link ProviderUnavailableError} is the broader Scope-2 work still pending.
+ */
+export function isRetryableProviderError(error: unknown): boolean {
+    return (
+        error instanceof ProviderUnavailableError ||
+        error instanceof FetchError ||
+        isFetchTimeoutError(error)
+    );
+}

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -1,3 +1,5 @@
+import { FetchError } from "../utils/fetch";
+
 export class ArkError extends Error {
     constructor(
         readonly code: number,
@@ -32,6 +34,35 @@ export class ProviderUnavailableError extends Error {
         super(message, { cause: options?.cause });
         this.name = "ProviderUnavailableError";
     }
+}
+
+/**
+ * Throw a typed {@link ProviderUnavailableError} for a temporary HTTP response
+ * (429 rate-limit or any 5xx), otherwise return. `fetch()` resolves — rather
+ * than rejects — on HTTP error status, so status-code classification has to live
+ * at each provider's non-2xx branch, not in the transport wrapper. 4xx and other
+ * responses are left to the caller to treat as terminal.
+ */
+export function throwIfHttpUnavailable(response: Response, kind: ProviderKind): void {
+    if (response.status === 429 || response.status >= 500) {
+        throw new ProviderUnavailableError(
+            kind,
+            `${kind} unavailable: ${response.status} ${response.statusText}`,
+        );
+    }
+}
+
+/**
+ * Map a transport-level {@link FetchError} (server unreachable) to a typed
+ * {@link ProviderUnavailableError}, preserving the original as `cause`; return
+ * any other error unchanged. Returns the error to `throw` rather than throwing,
+ * so a `catch` block can `throw toProviderUnavailable(err, kind)`.
+ */
+export function toProviderUnavailable(err: unknown, kind: ProviderKind): unknown {
+    if (err instanceof FetchError) {
+        return new ProviderUnavailableError(kind, `${kind} request failed`, { cause: err });
+    }
+    return err;
 }
 
 /**

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -42,8 +42,25 @@ export class ProviderUnavailableError extends Error {
  * than rejects — on HTTP error status, so status-code classification has to live
  * at each provider's non-2xx branch, not in the transport wrapper. 4xx and other
  * responses are left to the caller to treat as terminal.
+ *
+ * Status alone is not enough to classify an arkd response, though: arkd sits
+ * behind grpc-gateway, which maps application-level gRPC errors onto HTTP status
+ * codes across the whole range — gRPC INTERNAL becomes HTTP 500, for instance. So
+ * a 5xx does not by itself mean the operator is unavailable: a 500 whose body
+ * carries a structured arkd error (e.g. `INTERNAL_ERROR (0): ...already registered
+ * by another intent`) is a deliberate, terminal rejection that must reach the
+ * caller as an {@link ArkError}, never be retried. When `body` is provided and
+ * decodes to a structured arkd error, this returns without throwing; classify by
+ * status only for a bodyless call or a non-structured body (a bare proxy/gateway
+ * failure). Mirrors NArk's BuildVersionHandler, which branches on body content,
+ * not status.
  */
-export function throwIfHttpUnavailable(response: Response, kind: ProviderKind): void {
+export function throwIfHttpUnavailable(
+    response: Response,
+    kind: ProviderKind,
+    body?: string,
+): void {
+    if (body !== undefined && maybeArkError(new Error(body))) return;
     if (response.status === 429 || response.status >= 500) {
         throw new ProviderUnavailableError(
             kind,

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -9,6 +9,31 @@ export class ArkError extends Error {
     }
 }
 
+/** Which remote dependency a {@link ProviderUnavailableError} refers to. */
+export type ProviderKind = "arkade" | "indexer";
+
+/**
+ * A remote provider (Arkade operator or its indexer) is temporarily
+ * unreachable. This is a *retryable* condition — transport failure, request
+ * timeout, or a 5xx/429-style temporary HTTP response — as opposed to a
+ * terminal configuration/authorization/schema error, which stays a plain
+ * `Error`/{@link ArkError}. The original low-level error is preserved as
+ * {@link Error.cause}.
+ */
+export class ProviderUnavailableError extends Error {
+    /** Always `true`: this error type only ever wraps retryable conditions. */
+    readonly retryable = true;
+
+    constructor(
+        readonly kind: ProviderKind,
+        message: string,
+        options?: { cause?: unknown },
+    ) {
+        super(message, { cause: options?.cause });
+        this.name = "ProviderUnavailableError";
+    }
+}
+
 /**
  * Try to convert an error to an ArkError class, returning undefined if the error is not an ArkError
  * @param error - The error to parse

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -11,7 +11,13 @@ export class ArkError extends Error {
     }
 }
 
-/** Which remote dependency a {@link ProviderUnavailableError} refers to. */
+/**
+ * Which remote dependency an availability failure refers to. Used to label the
+ * {@link ProviderUnavailableError} message and the wallet's
+ * `ProviderConnectionState`; it is deliberately *not* carried as a structured
+ * field on the error, since custom `Error` own-properties do not survive the
+ * service-worker `postMessage` boundary (only `name`/`message`/`cause` do).
+ */
 export type ProviderKind = "arkade" | "indexer";
 
 /**
@@ -26,11 +32,7 @@ export class ProviderUnavailableError extends Error {
     /** Always `true`: this error type only ever wraps retryable conditions. */
     readonly retryable = true;
 
-    constructor(
-        readonly kind: ProviderKind,
-        message: string,
-        options?: { cause?: unknown },
-    ) {
+    constructor(message: string, options?: { cause?: unknown }) {
         super(message, { cause: options?.cause });
         this.name = "ProviderUnavailableError";
     }
@@ -63,7 +65,6 @@ export function throwIfHttpUnavailable(
     if (body !== undefined && maybeArkError(new Error(body))) return;
     if (response.status === 429 || response.status >= 500) {
         throw new ProviderUnavailableError(
-            kind,
             `${kind} unavailable: ${response.status} ${response.statusText}`,
         );
     }
@@ -77,7 +78,7 @@ export function throwIfHttpUnavailable(
  */
 export function toProviderUnavailable(err: unknown, kind: ProviderKind): unknown {
     if (err instanceof FetchError) {
-        return new ProviderUnavailableError(kind, `${kind} request failed`, { cause: err });
+        return new ProviderUnavailableError(`${kind} request failed`, { cause: err });
     }
     return err;
 }

--- a/packages/ts-sdk/src/providers/indexer.ts
+++ b/packages/ts-sdk/src/providers/indexer.ts
@@ -5,6 +5,26 @@ import { eventSourceIterator, isEventSourceError } from "./utils";
 import { MetadataList } from "../extension/asset";
 import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
 import { baseFetch } from "../utils/fetch";
+import { throwIfHttpUnavailable, toProviderUnavailable } from "./errors";
+
+/**
+ * `baseFetch` for indexer requests with availability classification: a transport
+ * failure (server unreachable) or a 429/5xx response becomes a typed
+ * {@link ProviderUnavailableError} of kind `"indexer"`, so offline-first read
+ * paths can catch it and fall back to repository state. Other non-2xx responses
+ * are returned unchanged for each method to reject with its descriptive
+ * (terminal) error.
+ */
+async function indexerFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    let res: Response;
+    try {
+        res = await baseFetch(input, init);
+    } catch (err) {
+        throw toProviderUnavailable(err, "indexer");
+    }
+    throwIfHttpUnavailable(res, "indexer");
+    return res;
+}
 
 export type PaginationOptions = {
     pageIndex?: number;
@@ -314,7 +334,7 @@ export class RestIndexerProvider implements IndexerProvider {
         if (params.toString()) {
             url += "?" + params.toString();
         }
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch vtxo tree: ${res.statusText}`);
         }
@@ -345,7 +365,7 @@ export class RestIndexerProvider implements IndexerProvider {
         if (params.toString()) {
             url += "?" + params.toString();
         }
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch vtxo tree leaves: ${res.statusText}`);
         }
@@ -358,7 +378,7 @@ export class RestIndexerProvider implements IndexerProvider {
 
     async getBatchSweepTransactions(batchOutpoint: Outpoint): Promise<{ sweptBy: string[] }> {
         const url = `${this.serverUrl}/v1/indexer/batch/${batchOutpoint.txid}/${batchOutpoint.vout}/sweepTxs`;
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch batch sweep transactions: ${res.statusText}`);
         }
@@ -371,7 +391,7 @@ export class RestIndexerProvider implements IndexerProvider {
 
     async getCommitmentTx(txid: string): Promise<CommitmentTx> {
         const url = `${this.serverUrl}/v1/indexer/commitmentTx/${txid}`;
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch commitment tx: ${res.statusText}`);
         }
@@ -397,7 +417,7 @@ export class RestIndexerProvider implements IndexerProvider {
         if (params.toString()) {
             url += "?" + params.toString();
         }
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch commitment tx connectors: ${res.statusText}`);
         }
@@ -428,7 +448,7 @@ export class RestIndexerProvider implements IndexerProvider {
         if (params.toString()) {
             url += "?" + params.toString();
         }
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch commitment tx forfeitTxs: ${res.statusText}`);
         }
@@ -532,7 +552,7 @@ export class RestIndexerProvider implements IndexerProvider {
         if (params.toString()) {
             url += "?" + params.toString();
         }
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch virtual txs: ${res.statusText}`);
         }
@@ -554,7 +574,7 @@ export class RestIndexerProvider implements IndexerProvider {
         if (params.toString()) {
             url += "?" + params.toString();
         }
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch vtxo chain: ${res.statusText}`);
         }
@@ -631,7 +651,7 @@ export class RestIndexerProvider implements IndexerProvider {
         if (params.toString()) {
             url += "?" + params.toString();
         }
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch vtxos: ${res.statusText}`);
         }
@@ -647,7 +667,7 @@ export class RestIndexerProvider implements IndexerProvider {
 
     async getAssetDetails(assetId: string): Promise<AssetDetails> {
         const url = `${this.serverUrl}/v1/indexer/asset/${encodeURIComponent(assetId)}`;
-        const res = await baseFetch(url);
+        const res = await indexerFetch(url);
         if (!res.ok) {
             throw new Error(`Failed to fetch asset details: ${res.statusText}`);
         }
@@ -666,7 +686,7 @@ export class RestIndexerProvider implements IndexerProvider {
 
     async subscribeForScripts(scripts: string[], subscriptionId?: string): Promise<string> {
         const url = `${this.serverUrl}/v1/indexer/script/subscribe`;
-        const res = await baseFetch(url, {
+        const res = await indexerFetch(url, {
             headers: {
                 "Content-Type": "application/json",
             },
@@ -684,7 +704,7 @@ export class RestIndexerProvider implements IndexerProvider {
 
     async unsubscribeForScripts(subscriptionId: string, scripts?: string[]): Promise<void> {
         const url = `${this.serverUrl}/v1/indexer/script/unsubscribe`;
-        const res = await baseFetch(url, {
+        const res = await indexerFetch(url, {
             headers: {
                 "Content-Type": "application/json",
             },

--- a/packages/ts-sdk/src/providers/indexer.ts
+++ b/packages/ts-sdk/src/providers/indexer.ts
@@ -22,7 +22,19 @@ async function indexerFetch(input: RequestInfo | URL, init?: RequestInit): Promi
     } catch (err) {
         throw toProviderUnavailable(err, "indexer");
     }
-    throwIfHttpUnavailable(res, "indexer");
+    if (!res.ok) {
+        // Pass the body so a 5xx carrying a structured arkd error (grpc-gateway
+        // maps gRPC INTERNAL -> HTTP 500) stays terminal instead of being
+        // misclassified as a retryable availability failure. If the body can't be
+        // read, fall back to status-only classification.
+        let body: string | undefined;
+        try {
+            body = await res.clone().text();
+        } catch {
+            body = undefined;
+        }
+        throwIfHttpUnavailable(res, "indexer", body);
+    }
     return res;
 }
 

--- a/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
+++ b/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
@@ -338,7 +338,6 @@ export async function resolveArkInfo(
         const snapshot = await loadArkInfoSnapshot(walletRepository);
         if (!snapshot) {
             throw new ProviderUnavailableError(
-                "arkade",
                 "Arkade server info is unavailable and no cached snapshot exists",
                 { cause: err },
             );

--- a/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
+++ b/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
@@ -299,6 +299,12 @@ export interface ResolvedArkInfo {
     info: ArkInfo;
     /** `live` when fetched from the operator, `cache` when hydrated offline. */
     source: ServerInfoSource;
+    /**
+     * Epoch-ms of the last known live operator contact: the cached snapshot's
+     * `savedAt` on the `cache` path, `undefined` on the `live` path (the caller
+     * stamps "now" after it persists the validated snapshot).
+     */
+    lastOnlineAt?: number;
 }
 
 /**
@@ -337,7 +343,7 @@ export async function resolveArkInfo(
                 { cause: err },
             );
         }
-        return { info: hydrateArkInfo(snapshot), source: "cache" };
+        return { info: hydrateArkInfo(snapshot), source: "cache", lastOnlineAt: snapshot.savedAt };
     }
     return { info, source: "live" };
 }

--- a/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
+++ b/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
@@ -1,0 +1,362 @@
+import type { ArkInfo, ArkProvider, FeeInfo } from "../providers/ark";
+import { isRetryableProviderError } from "../providers/availability";
+import { ProviderUnavailableError } from "../providers/errors";
+import type { WalletRepository } from "../repositories/walletRepository";
+import { updateWalletState } from "../utils/syncCursors";
+
+/**
+ * Key under {@link WalletState.settings} holding the cached server-info
+ * snapshot. Namespaced so it coexists with unrelated settings keys
+ * (`hasPendingTx`, `vtxoCursorMigrated`, …).
+ */
+export const ARK_INFO_SNAPSHOT_KEY = "arkInfoSnapshot";
+
+/**
+ * A JSON-safe, versioned cache of the operator's {@link ArkInfo} metadata,
+ * persisted so a previously synced wallet can still construct — derive its
+ * network, signer-dependent scripts, address parameters, dust/fee policy, and
+ * delays — while the operator's live `getInfo` is unreachable.
+ *
+ * This is NOT proof the operator is live: it is only enough to build the wallet
+ * and interpret locally persisted state. Cooperative operations that need the
+ * operator must revalidate live metadata or fail with a typed unavailable error.
+ *
+ * `bigint` fields are stored as decimal strings; `ArkInfo.serviceStatus` is
+ * deliberately not cached (it is live operator-health state, not static
+ * construction metadata) and is rehydrated as `{}`.
+ */
+export type StoredArkInfoSnapshot = {
+    version: 1;
+    savedAt: number;
+    source: "arkade.getInfo";
+    arkInfo: {
+        network: string;
+        signerPubkey: string;
+        checkpointTapscript: string;
+        forfeitAddress: string;
+        forfeitPubkey: string;
+        unilateralExitDelay: string;
+        boardingExitDelay: string;
+        sessionDuration: string;
+        dust: string;
+        fees: FeeInfo;
+        digest: string;
+        version: string;
+        vtxoMinAmount: string;
+        vtxoMaxAmount: string;
+        utxoMinAmount: string;
+        utxoMaxAmount: string;
+        deprecatedSigners: Array<{ pubkey: string; cutoffDate: string }>;
+        scheduledSession?: {
+            duration: string;
+            fees: FeeInfo;
+            nextEndTime: string;
+            nextStartTime: string;
+            period: string;
+        };
+    };
+};
+
+/**
+ * A stored snapshot exists but is structurally invalid (wrong version, missing
+ * or wrong-typed fields, non-decimal bigint strings). This is a *terminal*
+ * failure: a corrupt cache must fail the same way malformed live server-info
+ * does, never silently fall through as if no cache were present.
+ */
+export class MalformedArkInfoSnapshotError extends Error {
+    constructor(message: string, options?: { cause?: unknown }) {
+        super(message, { cause: options?.cause });
+        this.name = "MalformedArkInfoSnapshotError";
+    }
+}
+
+const CURRENT_VERSION = 1 as const;
+
+/** Convert a live {@link ArkInfo} into its JSON-safe snapshot form. */
+export function serializeArkInfoSnapshot(info: ArkInfo, savedAt: number): StoredArkInfoSnapshot {
+    return {
+        version: CURRENT_VERSION,
+        savedAt,
+        source: "arkade.getInfo",
+        arkInfo: {
+            network: info.network,
+            signerPubkey: info.signerPubkey,
+            checkpointTapscript: info.checkpointTapscript,
+            forfeitAddress: info.forfeitAddress,
+            forfeitPubkey: info.forfeitPubkey,
+            unilateralExitDelay: info.unilateralExitDelay.toString(),
+            boardingExitDelay: info.boardingExitDelay.toString(),
+            sessionDuration: info.sessionDuration.toString(),
+            dust: info.dust.toString(),
+            fees: info.fees,
+            digest: info.digest,
+            version: info.version,
+            vtxoMinAmount: info.vtxoMinAmount.toString(),
+            vtxoMaxAmount: info.vtxoMaxAmount.toString(),
+            utxoMinAmount: info.utxoMinAmount.toString(),
+            utxoMaxAmount: info.utxoMaxAmount.toString(),
+            deprecatedSigners: info.deprecatedSigners.map((s) => ({
+                pubkey: s.pubkey,
+                cutoffDate: s.cutoffDate.toString(),
+            })),
+            scheduledSession: info.scheduledSession
+                ? {
+                      duration: info.scheduledSession.duration.toString(),
+                      fees: info.scheduledSession.fees,
+                      nextEndTime: info.scheduledSession.nextEndTime.toString(),
+                      nextStartTime: info.scheduledSession.nextStartTime.toString(),
+                      period: info.scheduledSession.period.toString(),
+                  }
+                : undefined,
+        },
+    };
+}
+
+/**
+ * Rehydrate an {@link ArkInfo} from a validated snapshot. Decimal strings
+ * become `bigint`; `serviceStatus` is reset to `{}` (never cached — see
+ * {@link StoredArkInfoSnapshot}).
+ */
+export function hydrateArkInfo(snapshot: StoredArkInfoSnapshot): ArkInfo {
+    const a = snapshot.arkInfo;
+    return {
+        boardingExitDelay: BigInt(a.boardingExitDelay),
+        checkpointTapscript: a.checkpointTapscript,
+        deprecatedSigners: a.deprecatedSigners.map((s) => ({
+            cutoffDate: BigInt(s.cutoffDate),
+            pubkey: s.pubkey,
+        })),
+        digest: a.digest,
+        dust: BigInt(a.dust),
+        fees: a.fees,
+        forfeitAddress: a.forfeitAddress,
+        forfeitPubkey: a.forfeitPubkey,
+        network: a.network,
+        scheduledSession: a.scheduledSession
+            ? {
+                  duration: BigInt(a.scheduledSession.duration),
+                  fees: a.scheduledSession.fees,
+                  nextEndTime: BigInt(a.scheduledSession.nextEndTime),
+                  nextStartTime: BigInt(a.scheduledSession.nextStartTime),
+                  period: BigInt(a.scheduledSession.period),
+              }
+            : undefined,
+        serviceStatus: {},
+        sessionDuration: BigInt(a.sessionDuration),
+        signerPubkey: a.signerPubkey,
+        unilateralExitDelay: BigInt(a.unilateralExitDelay),
+        utxoMaxAmount: BigInt(a.utxoMaxAmount),
+        utxoMinAmount: BigInt(a.utxoMinAmount),
+        version: a.version,
+        vtxoMaxAmount: BigInt(a.vtxoMaxAmount),
+        vtxoMinAmount: BigInt(a.vtxoMinAmount),
+    };
+}
+
+const DECIMAL_STRING = /^-?\d+$/;
+
+function assertString(value: unknown, path: string): asserts value is string {
+    if (typeof value !== "string") {
+        throw new MalformedArkInfoSnapshotError(`${path} must be a string`);
+    }
+}
+
+function assertDecimalString(value: unknown, path: string): asserts value is string {
+    assertString(value, path);
+    if (!DECIMAL_STRING.test(value)) {
+        throw new MalformedArkInfoSnapshotError(`${path} must be a decimal integer string`);
+    }
+}
+
+function assertFeeInfo(value: unknown, path: string): asserts value is FeeInfo {
+    if (typeof value !== "object" || value === null) {
+        throw new MalformedArkInfoSnapshotError(`${path} must be an object`);
+    }
+    const fees = value as Record<string, unknown>;
+    assertString(fees.txFeeRate, `${path}.txFeeRate`);
+    if (typeof fees.intentFee !== "object" || fees.intentFee === null) {
+        throw new MalformedArkInfoSnapshotError(`${path}.intentFee must be an object`);
+    }
+}
+
+/**
+ * Validate an untrusted stored value into a {@link StoredArkInfoSnapshot},
+ * throwing {@link MalformedArkInfoSnapshotError} on any structural problem.
+ */
+export function parseStoredArkInfoSnapshot(raw: unknown): StoredArkInfoSnapshot {
+    if (typeof raw !== "object" || raw === null) {
+        throw new MalformedArkInfoSnapshotError("snapshot must be an object");
+    }
+    const snap = raw as Record<string, unknown>;
+    if (snap.version !== CURRENT_VERSION) {
+        throw new MalformedArkInfoSnapshotError(
+            `unsupported snapshot version: ${String(snap.version)}`,
+        );
+    }
+    if (typeof snap.savedAt !== "number") {
+        throw new MalformedArkInfoSnapshotError("savedAt must be a number");
+    }
+    if (snap.source !== "arkade.getInfo") {
+        throw new MalformedArkInfoSnapshotError(`unexpected source: ${String(snap.source)}`);
+    }
+    if (typeof snap.arkInfo !== "object" || snap.arkInfo === null) {
+        throw new MalformedArkInfoSnapshotError("arkInfo must be an object");
+    }
+    const a = snap.arkInfo as Record<string, unknown>;
+
+    for (const field of [
+        "network",
+        "signerPubkey",
+        "checkpointTapscript",
+        "forfeitAddress",
+        "forfeitPubkey",
+        "digest",
+        "version",
+    ]) {
+        assertString(a[field], `arkInfo.${field}`);
+    }
+    for (const field of [
+        "unilateralExitDelay",
+        "boardingExitDelay",
+        "sessionDuration",
+        "dust",
+        "vtxoMinAmount",
+        "vtxoMaxAmount",
+        "utxoMinAmount",
+        "utxoMaxAmount",
+    ]) {
+        assertDecimalString(a[field], `arkInfo.${field}`);
+    }
+    assertFeeInfo(a.fees, "arkInfo.fees");
+
+    if (!Array.isArray(a.deprecatedSigners)) {
+        throw new MalformedArkInfoSnapshotError("arkInfo.deprecatedSigners must be an array");
+    }
+    a.deprecatedSigners.forEach((s: unknown, i: number) => {
+        if (typeof s !== "object" || s === null) {
+            throw new MalformedArkInfoSnapshotError(
+                `arkInfo.deprecatedSigners[${i}] must be an object`,
+            );
+        }
+        const signer = s as Record<string, unknown>;
+        assertString(signer.pubkey, `arkInfo.deprecatedSigners[${i}].pubkey`);
+        assertDecimalString(signer.cutoffDate, `arkInfo.deprecatedSigners[${i}].cutoffDate`);
+    });
+
+    if (a.scheduledSession !== undefined) {
+        if (typeof a.scheduledSession !== "object" || a.scheduledSession === null) {
+            throw new MalformedArkInfoSnapshotError("arkInfo.scheduledSession must be an object");
+        }
+        const s = a.scheduledSession as Record<string, unknown>;
+        for (const field of ["duration", "nextEndTime", "nextStartTime", "period"]) {
+            assertDecimalString(s[field], `arkInfo.scheduledSession.${field}`);
+        }
+        assertFeeInfo(s.fees, "arkInfo.scheduledSession.fees");
+    }
+
+    return raw as StoredArkInfoSnapshot;
+}
+
+/**
+ * Read and validate the cached snapshot from the wallet repository.
+ * Returns `null` when no snapshot has been persisted; throws
+ * {@link MalformedArkInfoSnapshotError} when a stored snapshot is corrupt.
+ */
+export async function loadArkInfoSnapshot(
+    repo: WalletRepository,
+): Promise<StoredArkInfoSnapshot | null> {
+    const state = await repo.getWalletState();
+    const raw = state?.settings?.[ARK_INFO_SNAPSHOT_KEY];
+    if (raw === undefined || raw === null) return null;
+    return parseStoredArkInfoSnapshot(raw);
+}
+
+/**
+ * Persist a fresh snapshot from live server-info, preserving all other
+ * {@link WalletState.settings} keys. Serialized through the shared
+ * {@link updateWalletState} mutex so it can't lose-update a concurrent
+ * settings write.
+ */
+export async function saveArkInfoSnapshot(
+    repo: WalletRepository,
+    info: ArkInfo,
+    savedAt: number,
+): Promise<void> {
+    const snapshot = serializeArkInfoSnapshot(info, savedAt);
+    await updateWalletState(repo, (state) => ({
+        ...state,
+        settings: {
+            ...(state.settings ?? {}),
+            [ARK_INFO_SNAPSHOT_KEY]: snapshot,
+        },
+    }));
+}
+
+/** Where the {@link ArkInfo} used to construct a wallet came from. */
+export type ServerInfoSource = "live" | "cache";
+
+export interface ResolvedArkInfo {
+    info: ArkInfo;
+    /** `live` when fetched from the operator, `cache` when hydrated offline. */
+    source: ServerInfoSource;
+}
+
+/**
+ * Resolve the server-info needed to construct a wallet, with cache fallback.
+ * **This never writes the cache** — persistence is deferred to
+ * {@link saveValidatedArkInfoSnapshot}, called only once construction has
+ * validated the response, so a terminal live response can't poison the cache.
+ *
+ *  - Live `getInfo` succeeds → return it as `source: "live"`. **Live wins.**
+ *  - Live `getInfo` fails with a *retryable* provider error → hydrate the cached
+ *    snapshot if present (`source: "cache"`); otherwise throw a typed
+ *    {@link ProviderUnavailableError}.
+ *  - Live `getInfo` fails *terminally* (4xx/config/schema), or a stored snapshot
+ *    is malformed → propagate the terminal error; never silently fall back.
+ *
+ * Network validation is left to the caller and runs identically on either
+ * source, so a cached snapshot for the wrong network fails the same way a live
+ * wrong-network response does.
+ */
+export async function resolveArkInfo(
+    arkProvider: Pick<ArkProvider, "getInfo">,
+    walletRepository: WalletRepository,
+): Promise<ResolvedArkInfo> {
+    let info: ArkInfo;
+    try {
+        info = await arkProvider.getInfo();
+    } catch (err) {
+        if (!isRetryableProviderError(err)) throw err;
+        // Retryable: fall back to cache. A malformed stored snapshot throws
+        // (terminal) out of loadArkInfoSnapshot rather than being swallowed.
+        const snapshot = await loadArkInfoSnapshot(walletRepository);
+        if (!snapshot) {
+            throw new ProviderUnavailableError(
+                "arkade",
+                "Arkade server info is unavailable and no cached snapshot exists",
+                { cause: err },
+            );
+        }
+        return { info: hydrateArkInfo(snapshot), source: "cache" };
+    }
+    return { info, source: "live" };
+}
+
+/**
+ * Persist a snapshot of *validated* live server-info. Call this only after
+ * wallet construction has accepted the response — network, signer, and (for a
+ * full wallet) checkpoint/forfeit parsing — so a terminal live response can
+ * never overwrite a good cache before failing. Best-effort: a storage hiccup
+ * must not fail an otherwise-online construction.
+ */
+export async function saveValidatedArkInfoSnapshot(
+    repo: WalletRepository,
+    info: ArkInfo,
+    savedAt: number,
+): Promise<void> {
+    try {
+        await saveArkInfoSnapshot(repo, info, savedAt);
+    } catch (err) {
+        console.warn("Failed to persist Ark info snapshot", err);
+    }
+}

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -1,5 +1,5 @@
 import { hex } from "@scure/base";
-import { Wallet } from "../wallet";
+import { Wallet, type ProviderConnectionState } from "../wallet";
 import type { Activity, ActivityRegistry } from "../activity";
 import { RestArkProvider } from "../../providers/ark";
 import type {
@@ -326,6 +326,16 @@ export class ExpoWallet implements IWallet {
 
     getContractManager(): Promise<IContractManager> {
         return this.wallet.getContractManager();
+    }
+
+    /**
+     * Wallet-level provider-connection freshness, delegated to the wrapped
+     * in-process wallet. Synchronous because the Expo foreground wallet is
+     * in-process (no worker boundary). Foreground-only: it does not imply any
+     * background task can read live foreground state.
+     */
+    getProviderConnectionState(): ProviderConnectionState {
+        return this.wallet.getProviderConnectionState();
     }
 
     getDelegateManager(): Promise<IDelegateManager | undefined> {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -9,6 +9,7 @@ import type {
     PathSelection,
 } from "../../contracts";
 import type {
+    ContractSyncState,
     CreateContractParams,
     GetAllSpendingPathsOptions,
     GetSpendablePathsOptions,
@@ -35,7 +36,7 @@ import {
     WalletBalance,
 } from "../index";
 import { DelegateInfo } from "../../providers/delegate";
-import { ReadonlyWallet, Wallet } from "../wallet";
+import { ReadonlyWallet, Wallet, type ProviderConnectionState } from "../wallet";
 import type {
     DeprecatedSignerMigrationReport,
     DeprecatedSignerReport,
@@ -216,7 +217,20 @@ export type ResponseGetStatus = ResponseEnvelope & {
     payload: {
         walletInitialized: boolean;
         xOnlyPublicKey: Uint8Array | undefined;
+        // Wallet-level provider-connection freshness (boot server-info source
+        // composed with contract-manager sync health). Optional so a status
+        // response can predate a fully wired worker; always set for an
+        // initialized wallet.
+        providerConnectionState?: ProviderConnectionState;
     };
+};
+
+export type RequestGetContractSyncState = RequestEnvelope & {
+    type: "GET_CONTRACT_SYNC_STATE";
+};
+export type ResponseGetContractSyncState = ResponseEnvelope & {
+    type: "CONTRACT_SYNC_STATE";
+    payload: { syncState: ContractSyncState };
 };
 
 export type RequestClear = RequestEnvelope & { type: "CLEAR" };
@@ -686,6 +700,7 @@ export type WalletUpdaterRequest =
     | RequestGetBoardingUtxos
     | RequestGetTransactionHistory
     | RequestGetStatus
+    | RequestGetContractSyncState
     | RequestClear
     | RequestReloadWallet
     | RequestSignTransaction
@@ -730,6 +745,7 @@ export type WalletUpdaterResponse = ResponseEnvelope &
         | ResponseGetBoardingUtxos
         | ResponseGetTransactionHistory
         | ResponseGetStatus
+        | ResponseGetContractSyncState
         | ResponseClear
         | ResponseReloadWallet
         | ResponseUtxoUpdate
@@ -975,7 +991,18 @@ export class WalletMessageHandler
                         payload: {
                             walletInitialized: true,
                             xOnlyPublicKey: pubKey,
+                            providerConnectionState:
+                                this.readonlyWallet.getProviderConnectionState(),
                         },
+                    });
+                }
+                case "GET_CONTRACT_SYNC_STATE": {
+                    // Pure diagnostics read: report the manager's already-known
+                    // state without forcing initialization or a remote sync.
+                    return this.tagged({
+                        id,
+                        type: "CONTRACT_SYNC_STATE",
+                        payload: { syncState: this.readonlyWallet.getContractSyncState() },
                     });
                 }
                 case "CLEAR": {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -127,6 +127,7 @@ import type {
     PathSelection,
 } from "../../contracts";
 import type {
+    ContractSyncState,
     CreateContractParams,
     GetAllSpendingPathsOptions,
     GetSpendablePathsOptions,
@@ -1166,6 +1167,13 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 } catch (e) {
                     throw new Error("Failed to get contracts with vtxos");
                 }
+            },
+
+            getSyncState(): ContractSyncState {
+                // The worker owns the authoritative sync state; the proxy reports
+                // online by default (degradation is not surfaced across the
+                // worker message boundary yet).
+                return { mode: "online" };
             },
 
             async annotateVtxos(vtxos: VirtualCoin[]): Promise<ExtendedVirtualCoin[]> {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -44,6 +44,7 @@ import {
     RequestAnnotateVtxos,
     RequestGetContracts,
     RequestGetContractsWithVtxos,
+    RequestGetContractSyncState,
     RequestGetStatus,
     RequestGetSpendablePaths,
     RequestGetTransactionHistory,
@@ -65,6 +66,7 @@ import {
     ResponseGetBoardingUtxos,
     ResponseGetContracts,
     ResponseGetContractsWithVtxos,
+    ResponseGetContractSyncState,
     ResponseGetStatus,
     ResponseGetSpendablePaths,
     ResponseGetTransactionHistory,
@@ -154,7 +156,7 @@ import {
     MESSAGE_BUS_NOT_INITIALIZED,
     ServiceWorkerTimeoutError,
 } from "../../worker/errors";
-import { getArkadeServerUrl } from "../wallet";
+import { getArkadeServerUrl, type ProviderConnectionState } from "../wallet";
 
 function isMessageBusNotInitializedError(error: unknown): boolean {
     return error instanceof Error && error.message.includes(MESSAGE_BUS_NOT_INITIALIZED);
@@ -185,6 +187,7 @@ export const DEFAULT_MESSAGE_TIMEOUTS: Readonly<Record<RequestType, number>> = {
     GET_BALANCE: 10_000,
     GET_BOARDING_ADDRESS: 10_000,
     GET_STATUS: 10_000,
+    GET_CONTRACT_SYNC_STATE: 10_000,
     GET_DELEGATE_INFO: 10_000,
     IS_CONTRACT_MANAGER_WATCHING: 10_000,
 
@@ -1058,6 +1061,20 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
         }
     }
 
+    /**
+     * Wallet-level provider-connection freshness, delegated to the worker via
+     * `GET_STATUS`. Async by necessity (the worker boundary is asynchronous); no
+     * synchronous variant is offered because it would have the same transport
+     * mismatch as the contract-manager proxy's cached `getSyncState()`.
+     */
+    async getProviderConnectionState(): Promise<ProviderConnectionState> {
+        const { providerConnectionState } = await this.getStatus();
+        if (!providerConnectionState) {
+            throw new Error("Worker did not report provider connection state");
+        }
+        return providerConnectionState;
+    }
+
     async getActivityHistory(): Promise<Activity[]> {
         return buildActivities(await this.getTransactionHistory(), this.activity.all());
     }
@@ -1123,6 +1140,35 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
 
         const messageTag = this.messageTag;
 
+        // Page-side cache of the worker-owned ContractManager's sync health. The
+        // worker remains the authoritative owner (see the file-level ownership
+        // rules); this proxy is a cached VIEW refreshed at call boundaries, never
+        // a second source of truth. Synchronous IContractManager.getSyncState()
+        // reads this cache; async operations refresh it.
+        const fetchSyncState = async (): Promise<ContractSyncState> => {
+            const message: RequestGetContractSyncState = {
+                type: "GET_CONTRACT_SYNC_STATE",
+                id: getRandomId(),
+                tag: messageTag,
+            };
+            const response = await sendContractMessage(message);
+            return (response as ResponseGetContractSyncState).payload.syncState;
+        };
+        let syncState: ContractSyncState = { mode: "online" };
+        const refreshSyncState = async (): Promise<void> => {
+            // Best-effort: a failed diagnostics refresh must never mask the
+            // caller's operation result/error, and must leave the last known
+            // state in place rather than throwing.
+            try {
+                syncState = await fetchSyncState();
+            } catch {
+                // keep the previous cached value
+            }
+        };
+        // Seed the cache before returning the proxy (best-effort — never blocks
+        // or fails construction on a diagnostics hiccup).
+        await refreshSyncState();
+
         const manager: IContractManager = {
             async createContract(params: CreateContractParams): Promise<Contract> {
                 const message: RequestCreateContract = {
@@ -1133,6 +1179,9 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 };
                 try {
                     const response = await sendContractMessage(message);
+                    // Hydration may have degraded the worker manager (or cleared
+                    // a prior degradation) — refresh the cached view.
+                    await refreshSyncState();
                     return (response as ResponseCreateContract).payload.contract;
                 } catch (e) {
                     throw new Error("Failed to create contract");
@@ -1163,6 +1212,9 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 };
                 try {
                     const response = await sendContractMessage(message);
+                    // A best-effort sync ran on the worker; it may have degraded
+                    // to repository data or recovered — refresh the cached view.
+                    await refreshSyncState();
                     return (response as ResponseGetContractsWithVtxos).payload.contracts;
                 } catch (e) {
                     throw new Error("Failed to get contracts with vtxos");
@@ -1170,10 +1222,10 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             },
 
             getSyncState(): ContractSyncState {
-                // The worker owns the authoritative sync state; the proxy reports
-                // online by default (degradation is not surfaced across the
-                // worker message boundary yet).
-                return { mode: "online" };
+                // Synchronous read of the page-side cache, seeded at proxy
+                // construction and refreshed after operations that can move the
+                // worker manager between online and degraded.
+                return syncState;
             },
 
             async annotateVtxos(vtxos: VirtualCoin[]): Promise<ExtendedVirtualCoin[]> {
@@ -1298,7 +1350,14 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                     tag: messageTag,
                     payload: opts,
                 };
-                await sendContractMessage(message);
+                // Explicit remote refresh: it surfaces its own retryable error to
+                // the caller, but the proxy cache is refreshed either way so it
+                // doesn't stay stale after a thrown provider failure.
+                try {
+                    await sendContractMessage(message);
+                } finally {
+                    await refreshSyncState();
+                }
             },
 
             async refreshOutpoints(outpoints: { txid: string; vout: number }[]): Promise<void> {
@@ -1308,7 +1367,11 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                     tag: messageTag,
                     payload: { outpoints },
                 };
-                await sendContractMessage(message);
+                try {
+                    await sendContractMessage(message);
+                } finally {
+                    await refreshSyncState();
+                }
             },
 
             scanContracts(): Promise<ScanResult> {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -1154,15 +1154,28 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             const response = await sendContractMessage(message);
             return (response as ResponseGetContractSyncState).payload.syncState;
         };
-        let syncState: ContractSyncState = { mode: "online" };
+        // Start degraded/unknown — NOT online — so a probe that times out, hits
+        // an old worker, or errors is never reported as fresh. Only a successful
+        // probe establishes a real state; after that, a failed probe preserves
+        // the last known good value (best-effort) rather than fabricating one.
+        const UNKNOWN_STATE: ContractSyncState = {
+            mode: "degraded",
+            reason: "contract sync state unavailable from the worker",
+        };
+        let syncState: ContractSyncState = UNKNOWN_STATE;
+        let everProbed = false;
         const refreshSyncState = async (): Promise<void> => {
             // Best-effort: a failed diagnostics refresh must never mask the
-            // caller's operation result/error, and must leave the last known
-            // state in place rather than throwing.
+            // caller's operation result/error, and must never throw.
             try {
                 syncState = await fetchSyncState();
+                everProbed = true;
             } catch {
-                // keep the previous cached value
+                // Keep the last known good state only once we've had one; before
+                // any successful probe, stay degraded/unknown instead of online.
+                if (!everProbed) {
+                    syncState = UNKNOWN_STATE;
+                }
             }
         };
         // Seed the cache before returning the proxy (best-effort — never blocks

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -86,6 +86,11 @@ import {
 } from "./exit/capture";
 import { createExitChainResolver, ExitDataSource } from "./exit/resolver";
 import { ArkError } from "../providers/errors";
+import {
+    resolveArkInfo,
+    saveValidatedArkInfoSnapshot,
+    type ServerInfoSource,
+} from "./arkInfoSnapshot";
 import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
 import { DelegateProvider } from "../providers/delegate";
@@ -415,6 +420,19 @@ export class ReadonlyWallet implements IReadonlyWallet {
      */
     protected _arkServerPublicKey: Bytes;
 
+    /**
+     * Whether this wallet was constructed from live operator server-info
+     * (`"live"`) or from a cached snapshot because the operator was unreachable
+     * (`"cache"`). Minimal internal freshness signal for offline-degradation
+     * diagnostics; the composed provider-connection state lands in Scope 5.
+     */
+    protected _serverInfoSource: ServerInfoSource = "live";
+
+    /** @see {@link _serverInfoSource} */
+    get serverInfoSource(): ServerInfoSource {
+        return this._serverInfoSource;
+    }
+
     protected constructor(
         readonly identity: ReadonlyIdentity,
         readonly network: Network,
@@ -616,7 +634,25 @@ export class ReadonlyWallet implements IReadonlyWallet {
             indexerProvider = new RestIndexerProvider(indexerUrl);
         }
 
-        const info = await arkProvider.getInfo();
+        // Instantiate the repositories BEFORE the first required server-info
+        // fetch so boot can read a cached snapshot and fall back to it when the
+        // operator is unreachable, instead of failing construction outright.
+        const walletRepository =
+            config.storage?.walletRepository ?? new IndexedDBWalletRepository();
+
+        const contractRepository =
+            config.storage?.contractRepository ?? new IndexedDBContractRepository();
+
+        // Live server-info wins; a retryable failure falls back to the cached
+        // snapshot (or throws a typed unavailable error when none exists), and
+        // terminal failures propagate unchanged. The cache is NOT written here:
+        // persistence is deferred to after construction validates the response
+        // (see saveValidatedArkInfoSnapshot in the create() paths) so a terminal
+        // live response can't poison the cache before construction fails.
+        const { info, source: serverInfoSource } = await resolveArkInfo(
+            arkProvider,
+            walletRepository,
+        );
 
         const network = getNetwork(info.network as NetworkName);
 
@@ -722,12 +758,6 @@ export class ReadonlyWallet implements IReadonlyWallet {
             csvTimelock: timelockToSequence(boardingTimelock).toString(),
         });
 
-        const walletRepository =
-            config.storage?.walletRepository ?? new IndexedDBWalletRepository();
-
-        const contractRepository =
-            config.storage?.contractRepository ?? new IndexedDBContractRepository();
-
         return {
             arkProvider,
             indexerProvider,
@@ -741,6 +771,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             walletRepository,
             contractRepository,
             info,
+            serverInfoSource,
             delegateProvider: config.delegateProvider || config.delegatorProvider,
             /** @deprecated alias for `delegateProvider` */
             delegatorProvider: config.delegateProvider || config.delegatorProvider,
@@ -780,7 +811,13 @@ export class ReadonlyWallet implements IReadonlyWallet {
         wallet.intentRepository = config.storage?.intentRepository;
         wallet.virtualTxRepository = config.storage?.virtualTxRepository;
         wallet.exitDataCapture = config.storage?.exitDataCapture;
+        wallet._serverInfoSource = setup.serverInfoSource;
         wallet.refreshDeprecatedSigners(setup.info);
+        // Construction validated the live response (network, signer, address
+        // params); only now is it safe to refresh the cached snapshot.
+        if (setup.serverInfoSource === "live") {
+            await saveValidatedArkInfoSnapshot(setup.walletRepository, setup.info, Date.now());
+        }
         return wallet;
     }
 
@@ -2580,7 +2617,14 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             boot?.rotator,
             boot?.provider,
         );
+        wallet._serverInfoSource = setup.serverInfoSource;
         wallet.refreshDeprecatedSigners(setup.info);
+        // The response cleared construction validation — network/signer in
+        // setupWalletConfig plus the checkpoint/forfeit parsing above — so it is
+        // now safe to refresh the cached snapshot from live server-info.
+        if (setup.serverInfoSource === "live") {
+            await saveValidatedArkInfoSnapshot(setup.walletRepository, setup.info, Date.now());
+        }
         // Mid-session signer-rotation detection: when the arkProvider detects a
         // stale-info DIGEST_MISMATCH and refetches info, re-derive the wallet's
         // signer-dependent state. Duck-typed: only RestArkProvider implements it.

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -85,7 +85,8 @@ import {
     pruneExitBranches,
 } from "./exit/capture";
 import { createExitChainResolver, ExitDataSource } from "./exit/resolver";
-import { ArkError } from "../providers/errors";
+import { ArkError, type ProviderKind } from "../providers/errors";
+import { isRetryableProviderError } from "../providers/availability";
 import {
     resolveArkInfo,
     saveValidatedArkInfoSnapshot,
@@ -347,6 +348,22 @@ export interface BoardingUtxoGroup {
     coins: ExtendedCoin[];
 }
 
+/**
+ * Freshness of the wallet's provider-backed sync, composed from the boot
+ * server-info source and the contract-manager's indexer-sync health. It
+ * describes only how fresh provider data is — never the wallet balances/VTXOs
+ * themselves, which are always served from the repository (system of record).
+ */
+export type ProviderConnectionState =
+    | { mode: "online"; source: "live"; lastOnlineAt: number }
+    | {
+          mode: "degraded";
+          source: "cache" | "repository";
+          provider: ProviderKind;
+          reason: string;
+          lastOnlineAt?: number;
+      };
+
 export class ReadonlyWallet implements IReadonlyWallet {
     private _contractManager?: ContractManager;
     private _contractManagerInitializing?: Promise<ContractManager>;
@@ -423,14 +440,61 @@ export class ReadonlyWallet implements IReadonlyWallet {
     /**
      * Whether this wallet was constructed from live operator server-info
      * (`"live"`) or from a cached snapshot because the operator was unreachable
-     * (`"cache"`). Minimal internal freshness signal for offline-degradation
-     * diagnostics; the composed provider-connection state lands in Scope 5.
+     * (`"cache"`). Freshness signal for {@link getProviderConnectionState}.
      */
     protected _serverInfoSource: ServerInfoSource = "live";
+
+    /**
+     * Epoch-ms of the last known live operator contact: construction time on the
+     * `live` boot path, the cached snapshot's `savedAt` on the `cache` path.
+     */
+    protected _serverInfoLastOnlineAt?: number;
 
     /** @see {@link _serverInfoSource} */
     get serverInfoSource(): ServerInfoSource {
         return this._serverInfoSource;
+    }
+
+    /**
+     * Composed provider-connection freshness: the boot server-info source
+     * (Arkade) combined with the contract-manager's indexer-sync health, if the
+     * manager has been initialized. Reads no live provider state — it never
+     * forces a `ContractManager` to construct — so it is safe for readonly
+     * callers that only use address/balance APIs.
+     *
+     *  - Boot fell back to a cached snapshot → degraded on `arkade` (`cache`).
+     *  - Otherwise, if the contract manager has degraded to repository data →
+     *    degraded on `indexer` (`repository`).
+     *  - Otherwise online.
+     *
+     * This only describes sync freshness; wallet balances/VTXOs are always read
+     * from the repository regardless of this state.
+     */
+    getProviderConnectionState(): ProviderConnectionState {
+        if (this._serverInfoSource === "cache") {
+            return {
+                mode: "degraded",
+                source: "cache",
+                provider: "arkade",
+                reason: "constructed from cached server-info; operator was unreachable at boot",
+                lastOnlineAt: this._serverInfoLastOnlineAt,
+            };
+        }
+        const sync = this._contractManager?.getSyncState();
+        if (sync?.mode === "degraded") {
+            return {
+                mode: "degraded",
+                source: "repository",
+                provider: "indexer",
+                reason: sync.reason,
+                lastOnlineAt: sync.lastSyncedAt ?? this._serverInfoLastOnlineAt,
+            };
+        }
+        return {
+            mode: "online",
+            source: "live",
+            lastOnlineAt: sync?.lastSyncedAt ?? this._serverInfoLastOnlineAt ?? 0,
+        };
     }
 
     protected constructor(
@@ -649,10 +713,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
         // persistence is deferred to after construction validates the response
         // (see saveValidatedArkInfoSnapshot in the create() paths) so a terminal
         // live response can't poison the cache before construction fails.
-        const { info, source: serverInfoSource } = await resolveArkInfo(
-            arkProvider,
-            walletRepository,
-        );
+        const {
+            info,
+            source: serverInfoSource,
+            lastOnlineAt: serverInfoLastOnlineAt,
+        } = await resolveArkInfo(arkProvider, walletRepository);
 
         const network = getNetwork(info.network as NetworkName);
 
@@ -772,6 +837,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             contractRepository,
             info,
             serverInfoSource,
+            serverInfoLastOnlineAt,
             delegateProvider: config.delegateProvider || config.delegatorProvider,
             /** @deprecated alias for `delegateProvider` */
             delegatorProvider: config.delegateProvider || config.delegatorProvider,
@@ -812,12 +878,16 @@ export class ReadonlyWallet implements IReadonlyWallet {
         wallet.virtualTxRepository = config.storage?.virtualTxRepository;
         wallet.exitDataCapture = config.storage?.exitDataCapture;
         wallet._serverInfoSource = setup.serverInfoSource;
-        wallet.refreshDeprecatedSigners(setup.info);
         // Construction validated the live response (network, signer, address
         // params); only now is it safe to refresh the cached snapshot.
         if (setup.serverInfoSource === "live") {
-            await saveValidatedArkInfoSnapshot(setup.walletRepository, setup.info, Date.now());
+            const now = Date.now();
+            await saveValidatedArkInfoSnapshot(setup.walletRepository, setup.info, now);
+            wallet._serverInfoLastOnlineAt = now;
+        } else {
+            wallet._serverInfoLastOnlineAt = setup.serverInfoLastOnlineAt;
         }
+        wallet.refreshDeprecatedSigners(setup.info);
         return wallet;
     }
 
@@ -996,7 +1066,15 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const getTxCreatedAt = (txid: string) =>
             this.indexerProvider
                 .getVtxos({ outpoints: [{ txid, vout: 0 }] })
-                .then((res) => res.vtxos[0]?.createdAt.getTime());
+                .then((res) => res.vtxos[0]?.createdAt.getTime())
+                // Best-effort createdAt enrichment: when the indexer is
+                // unavailable, leave it undefined (history still builds from
+                // repository VTXOs) rather than failing the whole read. Terminal
+                // failures still propagate.
+                .catch((err) => {
+                    if (isRetryableProviderError(err)) return undefined;
+                    throw err;
+                });
 
         return buildTransactionHistory(allVtxos, boardingTxs, commitmentsToIgnore, getTxCreatedAt);
     }
@@ -2618,13 +2696,17 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             boot?.provider,
         );
         wallet._serverInfoSource = setup.serverInfoSource;
-        wallet.refreshDeprecatedSigners(setup.info);
         // The response cleared construction validation — network/signer in
         // setupWalletConfig plus the checkpoint/forfeit parsing above — so it is
         // now safe to refresh the cached snapshot from live server-info.
         if (setup.serverInfoSource === "live") {
-            await saveValidatedArkInfoSnapshot(setup.walletRepository, setup.info, Date.now());
+            const now = Date.now();
+            await saveValidatedArkInfoSnapshot(setup.walletRepository, setup.info, now);
+            wallet._serverInfoLastOnlineAt = now;
+        } else {
+            wallet._serverInfoLastOnlineAt = setup.serverInfoLastOnlineAt;
         }
+        wallet.refreshDeprecatedSigners(setup.info);
         // Mid-session signer-rotation detection: when the arkProvider detects a
         // stale-info DIGEST_MISMATCH and refetches info, re-derive the wallet's
         // signer-dependent state. Duck-typed: only RestArkProvider implements it.

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -103,7 +103,11 @@ import { DelegateVtxo } from "../script/delegate";
 import { DelegateManagerImpl, findDestinationOutputIndex, IDelegateManager } from "./delegate";
 import { IndexedDBContractRepository, IndexedDBWalletRepository } from "../repositories";
 import { ContractManager } from "../contracts/contractManager";
-import type { ContractManagerConfig, CreateContractParams } from "../contracts/contractManager";
+import type {
+    ContractManagerConfig,
+    ContractSyncState,
+    CreateContractParams,
+} from "../contracts/contractManager";
 import { contractHandlers } from "../contracts/handlers";
 import { BoardingContractHandler } from "../contracts/handlers/boarding";
 import { timelockToSequence } from "../utils/timelock";
@@ -495,6 +499,17 @@ export class ReadonlyWallet implements IReadonlyWallet {
             source: "live",
             lastOnlineAt: sync?.lastSyncedAt ?? this._serverInfoLastOnlineAt ?? 0,
         };
+    }
+
+    /**
+     * The contract-manager's current provider-sync health **without forcing it
+     * to initialize** — reads the already-constructed manager, or reports
+     * `online` when none exists yet. Unlike {@link getContractManager}, this
+     * never triggers a remote sync, so it is safe on a pure diagnostics path
+     * (e.g. the service-worker sync-state message).
+     */
+    getContractSyncState(): ContractSyncState {
+        return this._contractManager?.getSyncState() ?? { mode: "online" };
     }
 
     protected constructor(

--- a/packages/ts-sdk/test/ark-info-snapshot.test.ts
+++ b/packages/ts-sdk/test/ark-info-snapshot.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect } from "vitest";
+import {
+    Wallet,
+    ReadonlyWallet,
+    InMemoryWalletRepository,
+    InMemoryContractRepository,
+    ProviderUnavailableError,
+    isRetryableProviderError,
+    type ArkProvider,
+    type IndexerProvider,
+    type OnchainProvider,
+} from "../src";
+import type { ArkInfo } from "../src/providers/ark";
+import { FetchError } from "../src/utils/fetch";
+import { ReadonlySingleKey } from "../src/identity/singleKey";
+import { SingleKey } from "../src/identity/singleKey";
+import {
+    ARK_INFO_SNAPSHOT_KEY,
+    MalformedArkInfoSnapshotError,
+    hydrateArkInfo,
+    loadArkInfoSnapshot,
+    parseStoredArkInfoSnapshot,
+    resolveArkInfo,
+    saveArkInfoSnapshot,
+    saveValidatedArkInfoSnapshot,
+    serializeArkInfoSnapshot,
+} from "../src/wallet/arkInfoSnapshot";
+
+// 33-byte compressed key (setupWalletConfig slices the parity byte off).
+const serverKeyHex = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const privKeyHex = "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2";
+
+function makeArkInfo(overrides: Partial<ArkInfo> = {}): ArkInfo {
+    return {
+        boardingExitDelay: 144n,
+        checkpointTapscript:
+            "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        deprecatedSigners: [{ cutoffDate: 1_700_000_000n, pubkey: "02" + "ab".repeat(32) }],
+        digest: "digest-abc",
+        dust: 1000n,
+        fees: { intentFee: { offchainInput: "1", onchainOutput: "2" }, txFeeRate: "3" },
+        forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+        forfeitPubkey: serverKeyHex,
+        network: "mutinynet",
+        scheduledSession: {
+            duration: 10n,
+            fees: { intentFee: {}, txFeeRate: "0" },
+            nextEndTime: 20n,
+            nextStartTime: 15n,
+            period: 30n,
+        },
+        serviceStatus: { round: "ok" },
+        sessionDuration: 3600n,
+        signerPubkey: serverKeyHex,
+        unilateralExitDelay: 144n,
+        utxoMaxAmount: -1n,
+        utxoMinAmount: 0n,
+        version: "1.2.3",
+        vtxoMaxAmount: -1n,
+        vtxoMinAmount: 0n,
+        ...overrides,
+    };
+}
+
+describe("serializeArkInfoSnapshot / hydrateArkInfo", () => {
+    it("round-trips every field except serviceStatus (reset to {})", () => {
+        const info = makeArkInfo();
+        const snapshot = serializeArkInfoSnapshot(info, 111);
+        const hydrated = hydrateArkInfo(snapshot);
+        expect(hydrated).toEqual({ ...info, serviceStatus: {} });
+    });
+
+    it("produces a JSON-safe snapshot (no bigints survive)", () => {
+        const snapshot = serializeArkInfoSnapshot(makeArkInfo(), 111);
+        expect(() => JSON.stringify(snapshot)).not.toThrow();
+        // bigints are stringified
+        expect(snapshot.arkInfo.unilateralExitDelay).toBe("144");
+        expect(snapshot.arkInfo.utxoMaxAmount).toBe("-1");
+        expect(snapshot.arkInfo.deprecatedSigners[0].cutoffDate).toBe("1700000000");
+        expect(snapshot.arkInfo.scheduledSession?.period).toBe("30");
+        expect(snapshot.version).toBe(1);
+        expect(snapshot.savedAt).toBe(111);
+        expect(snapshot.source).toBe("arkade.getInfo");
+    });
+
+    it("round-trips when scheduledSession is absent", () => {
+        const info = makeArkInfo({ scheduledSession: undefined });
+        const hydrated = hydrateArkInfo(serializeArkInfoSnapshot(info, 1));
+        expect(hydrated.scheduledSession).toBeUndefined();
+        expect(hydrated).toEqual({ ...info, serviceStatus: {} });
+    });
+});
+
+describe("parseStoredArkInfoSnapshot", () => {
+    it("accepts a well-formed snapshot", () => {
+        const snapshot = serializeArkInfoSnapshot(makeArkInfo(), 1);
+        expect(parseStoredArkInfoSnapshot(JSON.parse(JSON.stringify(snapshot)))).toEqual(snapshot);
+    });
+
+    it.each([
+        ["non-object", 42],
+        ["wrong version", { version: 2 }],
+        ["missing savedAt", { version: 1, source: "arkade.getInfo", arkInfo: {} }],
+        ["wrong source", { version: 1, savedAt: 1, source: "x", arkInfo: {} }],
+    ])("rejects %s", (_label, raw) => {
+        expect(() => parseStoredArkInfoSnapshot(raw)).toThrow(MalformedArkInfoSnapshotError);
+    });
+
+    it("rejects a non-decimal bigint field", () => {
+        const snapshot = serializeArkInfoSnapshot(makeArkInfo(), 1);
+        (snapshot.arkInfo as any).dust = "not-a-number";
+        expect(() => parseStoredArkInfoSnapshot(snapshot)).toThrow(MalformedArkInfoSnapshotError);
+    });
+
+    it("rejects a missing string field", () => {
+        const snapshot = serializeArkInfoSnapshot(makeArkInfo(), 1);
+        delete (snapshot.arkInfo as any).signerPubkey;
+        expect(() => parseStoredArkInfoSnapshot(snapshot)).toThrow(MalformedArkInfoSnapshotError);
+    });
+
+    it("rejects a malformed deprecatedSigners entry", () => {
+        const snapshot = serializeArkInfoSnapshot(makeArkInfo(), 1);
+        (snapshot.arkInfo as any).deprecatedSigners = [{ pubkey: "02ab" }];
+        expect(() => parseStoredArkInfoSnapshot(snapshot)).toThrow(MalformedArkInfoSnapshotError);
+    });
+
+    it("rejects a malformed scheduledSession", () => {
+        const snapshot = serializeArkInfoSnapshot(makeArkInfo(), 1);
+        (snapshot.arkInfo.scheduledSession as any).period = 30; // number, not decimal string
+        expect(() => parseStoredArkInfoSnapshot(snapshot)).toThrow(MalformedArkInfoSnapshotError);
+    });
+});
+
+describe("loadArkInfoSnapshot / saveArkInfoSnapshot", () => {
+    it("returns null when nothing has been persisted", async () => {
+        const repo = new InMemoryWalletRepository();
+        expect(await loadArkInfoSnapshot(repo)).toBeNull();
+    });
+
+    it("round-trips through the repository", async () => {
+        const repo = new InMemoryWalletRepository();
+        const info = makeArkInfo();
+        await saveArkInfoSnapshot(repo, info, 999);
+        const loaded = await loadArkInfoSnapshot(repo);
+        expect(loaded).toEqual(serializeArkInfoSnapshot(info, 999));
+    });
+
+    it("preserves unrelated settings keys", async () => {
+        const repo = new InMemoryWalletRepository();
+        await repo.saveWalletState({ settings: { hasPendingTx: true }, lastSyncTime: 42 });
+        await saveArkInfoSnapshot(repo, makeArkInfo(), 1);
+        const state = await repo.getWalletState();
+        expect(state?.settings?.hasPendingTx).toBe(true);
+        expect(state?.lastSyncTime).toBe(42);
+        expect(state?.settings?.[ARK_INFO_SNAPSHOT_KEY]).toBeDefined();
+    });
+
+    it("throws terminally when the stored snapshot is malformed", async () => {
+        const repo = new InMemoryWalletRepository();
+        await repo.saveWalletState({ settings: { [ARK_INFO_SNAPSHOT_KEY]: { version: 2 } } });
+        await expect(loadArkInfoSnapshot(repo)).rejects.toThrow(MalformedArkInfoSnapshotError);
+    });
+});
+
+describe("resolveArkInfo", () => {
+    const live = (info: ArkInfo) => ({ getInfo: async () => info });
+    const failing = (err: unknown) => ({
+        getInfo: async () => {
+            throw err;
+        },
+    });
+
+    it("returns live info WITHOUT writing the cache (persistence is deferred)", async () => {
+        const repo = new InMemoryWalletRepository();
+        const info = makeArkInfo();
+        const resolved = await resolveArkInfo(live(info), repo);
+        expect(resolved.source).toBe("live");
+        expect(resolved.info).toEqual(info);
+        // resolve must not persist — that only happens post-validation.
+        expect(await loadArkInfoSnapshot(repo)).toBeNull();
+    });
+
+    it("falls back to the cached snapshot on a retryable failure", async () => {
+        const repo = new InMemoryWalletRepository();
+        const info = makeArkInfo();
+        await saveArkInfoSnapshot(repo, info, 700);
+        const resolved = await resolveArkInfo(
+            failing(new ProviderUnavailableError("arkade", "503")),
+            repo,
+        );
+        expect(resolved.source).toBe("cache");
+        expect(resolved.info).toEqual({ ...info, serviceStatus: {} });
+    });
+
+    it("treats a transport FetchError as retryable", async () => {
+        const repo = new InMemoryWalletRepository();
+        await saveArkInfoSnapshot(repo, makeArkInfo(), 1);
+        const resolved = await resolveArkInfo(
+            failing(new FetchError("Network request failed", { url: "x" })),
+            repo,
+        );
+        expect(resolved.source).toBe("cache");
+    });
+
+    it("throws a typed unavailable error on retryable failure with no cache", async () => {
+        const repo = new InMemoryWalletRepository();
+        await expect(
+            resolveArkInfo(failing(new ProviderUnavailableError("arkade", "503")), repo),
+        ).rejects.toBeInstanceOf(ProviderUnavailableError);
+    });
+
+    it("propagates a terminal failure unchanged (no cache fallback)", async () => {
+        const repo = new InMemoryWalletRepository();
+        await saveArkInfoSnapshot(repo, makeArkInfo(), 1); // cache present, but must be ignored
+        const terminal = new Error("400 bad request");
+        await expect(resolveArkInfo(failing(terminal), repo)).rejects.toBe(terminal);
+    });
+
+    it("surfaces a malformed cache as terminal on retryable failure", async () => {
+        const repo = new InMemoryWalletRepository();
+        await repo.saveWalletState({ settings: { [ARK_INFO_SNAPSHOT_KEY]: { version: 9 } } });
+        await expect(
+            resolveArkInfo(failing(new ProviderUnavailableError("arkade", "503")), repo),
+        ).rejects.toThrow(MalformedArkInfoSnapshotError);
+    });
+});
+
+describe("saveValidatedArkInfoSnapshot", () => {
+    it("persists the snapshot", async () => {
+        const repo = new InMemoryWalletRepository();
+        const info = makeArkInfo();
+        await saveValidatedArkInfoSnapshot(repo, info, 321);
+        expect(await loadArkInfoSnapshot(repo)).toEqual(serializeArkInfoSnapshot(info, 321));
+    });
+
+    it("swallows storage failures (best-effort — must not fail boot)", async () => {
+        const repo = new InMemoryWalletRepository();
+        repo.saveWalletState = async () => {
+            throw new Error("disk full");
+        };
+        await expect(saveValidatedArkInfoSnapshot(repo, makeArkInfo(), 1)).resolves.toBeUndefined();
+    });
+});
+
+describe("isRetryableProviderError", () => {
+    it("classifies unavailable + transport errors as retryable, others terminal", () => {
+        expect(isRetryableProviderError(new ProviderUnavailableError("indexer", "x"))).toBe(true);
+        expect(isRetryableProviderError(new FetchError("x", { url: "y" }))).toBe(true);
+        expect(isRetryableProviderError(new Error("400"))).toBe(false);
+        expect(isRetryableProviderError(new MalformedArkInfoSnapshotError("x"))).toBe(false);
+    });
+});
+
+describe("wallet boot: cache fallback derives identical construction metadata", () => {
+    const readonlyIdentity = async () =>
+        ReadonlySingleKey.fromPublicKey(await SingleKey.fromHex(privKeyHex).compressedPublicKey());
+
+    const indexerStub = () =>
+        ({
+            subscribeForScripts: async () => "sub-1",
+            unsubscribeForScripts: async () => undefined,
+            getSubscription: async function* () {},
+        }) as Partial<IndexerProvider> as IndexerProvider;
+
+    async function createWallet(
+        getInfo: ArkProvider["getInfo"],
+        repos: {
+            walletRepository: InMemoryWalletRepository;
+            contractRepository: InMemoryContractRepository;
+        },
+    ) {
+        return ReadonlyWallet.create({
+            identity: await readonlyIdentity(),
+            arkServerUrl: "http://localhost:7070",
+            arkProvider: { getInfo } as Partial<ArkProvider> as ArkProvider,
+            indexerProvider: indexerStub(),
+            onchainProvider: {} as OnchainProvider,
+            storage: repos,
+        });
+    }
+
+    it("online boot marks source=live and persists a snapshot; offline boot reuses it", async () => {
+        const repos = {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        };
+        const info = makeArkInfo();
+
+        const online = await createWallet(async () => info, repos);
+        expect(online.serverInfoSource).toBe("live");
+        const onlineAddress = online.arkAddress.encode();
+
+        // Operator now unreachable → construct from the snapshot written above.
+        const offline = await createWallet(async () => {
+            throw new ProviderUnavailableError("arkade", "operator down");
+        }, repos);
+        expect(offline.serverInfoSource).toBe("cache");
+        expect(offline.arkAddress.encode()).toBe(onlineAddress);
+        expect(offline.network).toEqual(online.network);
+        expect(offline.dustAmount).toBe(online.dustAmount);
+    });
+
+    it("fails with the typed unavailable error when offline with no cache", async () => {
+        const repos = {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        };
+        await expect(
+            createWallet(async () => {
+                throw new ProviderUnavailableError("arkade", "operator down");
+            }, repos),
+        ).rejects.toBeInstanceOf(ProviderUnavailableError);
+    });
+
+    it("keeps network validation terminal even on the cached path", async () => {
+        const repos = {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        };
+        // Seed a cached snapshot for an unsupported network.
+        await saveArkInfoSnapshot(repos.walletRepository, makeArkInfo({ network: "bogusnet" }), 1);
+        await expect(
+            createWallet(async () => {
+                throw new ProviderUnavailableError("arkade", "operator down");
+            }, repos),
+        ).rejects.toThrow(/Unsupported network/);
+    });
+
+    it("does NOT cache a live response that fails construction validation", async () => {
+        const repos = {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        };
+        // Live getInfo succeeds but returns an unsupported network, so
+        // construction throws after resolveArkInfo returned. The cache must
+        // stay empty — a terminal live response must never poison it.
+        await expect(
+            createWallet(async () => makeArkInfo({ network: "bogusnet" }), repos),
+        ).rejects.toThrow(/Unsupported network/);
+        expect(await loadArkInfoSnapshot(repos.walletRepository)).toBeNull();
+    });
+
+    it("full Wallet.create does not cache a live response with invalid checkpoint metadata", async () => {
+        const walletRepository = new InMemoryWalletRepository();
+        const contractRepository = new InMemoryContractRepository();
+        // Network/signer pass in setupWalletConfig, but Wallet.create parses
+        // checkpointTapscript later and throws — the cache must stay empty.
+        await expect(
+            Wallet.create({
+                identity: SingleKey.fromHex(privKeyHex),
+                arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: async () => makeArkInfo({ checkpointTapscript: "zz" }),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider: indexerStub(),
+                onchainProvider: {} as OnchainProvider,
+                storage: { walletRepository, contractRepository },
+            }),
+        ).rejects.toThrow(/checkpointTapscript/);
+        expect(await loadArkInfoSnapshot(walletRepository)).toBeNull();
+    });
+});

--- a/packages/ts-sdk/test/ark-info-snapshot.test.ts
+++ b/packages/ts-sdk/test/ark-info-snapshot.test.ts
@@ -184,10 +184,7 @@ describe("resolveArkInfo", () => {
         const repo = new InMemoryWalletRepository();
         const info = makeArkInfo();
         await saveArkInfoSnapshot(repo, info, 700);
-        const resolved = await resolveArkInfo(
-            failing(new ProviderUnavailableError("arkade", "503")),
-            repo,
-        );
+        const resolved = await resolveArkInfo(failing(new ProviderUnavailableError("503")), repo);
         expect(resolved.source).toBe("cache");
         expect(resolved.info).toEqual({ ...info, serviceStatus: {} });
     });
@@ -205,7 +202,7 @@ describe("resolveArkInfo", () => {
     it("throws a typed unavailable error on retryable failure with no cache", async () => {
         const repo = new InMemoryWalletRepository();
         await expect(
-            resolveArkInfo(failing(new ProviderUnavailableError("arkade", "503")), repo),
+            resolveArkInfo(failing(new ProviderUnavailableError("503")), repo),
         ).rejects.toBeInstanceOf(ProviderUnavailableError);
     });
 
@@ -220,7 +217,7 @@ describe("resolveArkInfo", () => {
         const repo = new InMemoryWalletRepository();
         await repo.saveWalletState({ settings: { [ARK_INFO_SNAPSHOT_KEY]: { version: 9 } } });
         await expect(
-            resolveArkInfo(failing(new ProviderUnavailableError("arkade", "503")), repo),
+            resolveArkInfo(failing(new ProviderUnavailableError("503")), repo),
         ).rejects.toThrow(MalformedArkInfoSnapshotError);
     });
 });
@@ -244,7 +241,7 @@ describe("saveValidatedArkInfoSnapshot", () => {
 
 describe("isRetryableProviderError", () => {
     it("classifies unavailable + transport errors as retryable, others terminal", () => {
-        expect(isRetryableProviderError(new ProviderUnavailableError("indexer", "x"))).toBe(true);
+        expect(isRetryableProviderError(new ProviderUnavailableError("x"))).toBe(true);
         expect(isRetryableProviderError(new FetchError("x", { url: "y" }))).toBe(true);
         expect(isRetryableProviderError(new Error("400"))).toBe(false);
         expect(isRetryableProviderError(new MalformedArkInfoSnapshotError("x"))).toBe(false);
@@ -292,7 +289,7 @@ describe("wallet boot: cache fallback derives identical construction metadata", 
 
         // Operator now unreachable → construct from the snapshot written above.
         const offline = await createWallet(async () => {
-            throw new ProviderUnavailableError("arkade", "operator down");
+            throw new ProviderUnavailableError("operator down");
         }, repos);
         expect(offline.serverInfoSource).toBe("cache");
         expect(offline.arkAddress.encode()).toBe(onlineAddress);
@@ -307,7 +304,7 @@ describe("wallet boot: cache fallback derives identical construction metadata", 
         };
         await expect(
             createWallet(async () => {
-                throw new ProviderUnavailableError("arkade", "operator down");
+                throw new ProviderUnavailableError("operator down");
             }, repos),
         ).rejects.toBeInstanceOf(ProviderUnavailableError);
     });
@@ -321,7 +318,7 @@ describe("wallet boot: cache fallback derives identical construction metadata", 
         await saveArkInfoSnapshot(repos.walletRepository, makeArkInfo({ network: "bogusnet" }), 1);
         await expect(
             createWallet(async () => {
-                throw new ProviderUnavailableError("arkade", "operator down");
+                throw new ProviderUnavailableError("operator down");
             }, repos),
         ).rejects.toThrow(/Unsupported network/);
     });

--- a/packages/ts-sdk/test/contract-manager-offline.test.ts
+++ b/packages/ts-sdk/test/contract-manager-offline.test.ts
@@ -151,4 +151,51 @@ describe("ContractManager offline-first reads (Scope 3)", () => {
         await m.getContractsWithVtxos();
         expect(m.getSyncState().mode).toBe("online");
     });
+
+    it("marks degraded when a connection_reset recovery hits a retryable failure", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const walletRepo = new InMemoryWalletRepository();
+        await contractRepo.saveContract(seededContract());
+        const indexer = createMockIndexerProvider(); // boot online (getVtxos → [])
+        const m = await create(indexer, contractRepo, walletRepo);
+        expect(m.getSyncState().mode).toBe("online");
+
+        // Operator degrades post-boot; the watcher fires connection_reset and the
+        // recovery sync fails retryably. This must flip sync state to degraded
+        // even though the watcher callback swallows the rejection.
+        (indexer.getVtxos as any).mockRejectedValue(
+            new ProviderUnavailableError("indexer", "down"),
+        );
+        await (m as any).handleContractEvent({ type: "connection_reset", timestamp: 1 });
+
+        expect(m.getSyncState().mode).toBe("degraded");
+    });
+
+    it("clears degraded when a later connection_reset recovery succeeds", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const walletRepo = new InMemoryWalletRepository();
+        await contractRepo.saveContract(seededContract());
+        const indexer = createMockIndexerProvider();
+        (indexer.getVtxos as any).mockRejectedValueOnce(
+            new ProviderUnavailableError("indexer", "down"),
+        );
+        const m = await create(indexer, contractRepo, walletRepo);
+        expect(m.getSyncState().mode).toBe("degraded");
+
+        // Operator recovers; the next connection_reset recovery succeeds.
+        await (m as any).handleContractEvent({ type: "connection_reset", timestamp: 2 });
+        expect(m.getSyncState().mode).toBe("online");
+    });
+
+    it("rethrows a terminal connection_reset recovery failure", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        await contractRepo.saveContract(seededContract());
+        const indexer = createMockIndexerProvider();
+        const m = await create(indexer, contractRepo, new InMemoryWalletRepository());
+
+        (indexer.getVtxos as any).mockRejectedValue(new Error("schema violation"));
+        await expect(
+            (m as any).handleContractEvent({ type: "connection_reset", timestamp: 3 }),
+        ).rejects.toThrow("schema violation");
+    });
 });

--- a/packages/ts-sdk/test/contract-manager-offline.test.ts
+++ b/packages/ts-sdk/test/contract-manager-offline.test.ts
@@ -62,9 +62,7 @@ describe("ContractManager offline-first reads (Scope 3)", () => {
         const walletRepo = new InMemoryWalletRepository();
         await contractRepo.saveContract(seededContract());
         const indexer = createMockIndexerProvider();
-        (indexer.getVtxos as any).mockRejectedValue(
-            new ProviderUnavailableError("indexer", "down"),
-        );
+        (indexer.getVtxos as any).mockRejectedValue(new ProviderUnavailableError("down"));
 
         const m = await create(indexer, contractRepo, walletRepo);
 
@@ -99,9 +97,7 @@ describe("ContractManager offline-first reads (Scope 3)", () => {
         await m.createContract(params());
         expect(m.getSyncState().mode).toBe("online");
 
-        (indexer.getVtxos as any).mockRejectedValue(
-            new ProviderUnavailableError("indexer", "down"),
-        );
+        (indexer.getVtxos as any).mockRejectedValue(new ProviderUnavailableError("down"));
         const result = await m.getContractsWithVtxos(); // must NOT throw
 
         expect(result).toHaveLength(1);
@@ -125,9 +121,7 @@ describe("ContractManager offline-first reads (Scope 3)", () => {
         const indexer = createMockIndexerProvider();
         const m = await create(indexer, contractRepo, walletRepo);
 
-        (indexer.getVtxos as any).mockRejectedValue(
-            new ProviderUnavailableError("indexer", "down"),
-        );
+        (indexer.getVtxos as any).mockRejectedValue(new ProviderUnavailableError("down"));
         const c = await m.createContract(params());
 
         expect(c.script).toBe(TEST_DEFAULT_SCRIPT);
@@ -140,9 +134,7 @@ describe("ContractManager offline-first reads (Scope 3)", () => {
         const walletRepo = new InMemoryWalletRepository();
         await contractRepo.saveContract(seededContract());
         const indexer = createMockIndexerProvider();
-        (indexer.getVtxos as any).mockRejectedValueOnce(
-            new ProviderUnavailableError("indexer", "down"),
-        );
+        (indexer.getVtxos as any).mockRejectedValueOnce(new ProviderUnavailableError("down"));
 
         const m = await create(indexer, contractRepo, walletRepo);
         expect(m.getSyncState().mode).toBe("degraded");
@@ -163,9 +155,7 @@ describe("ContractManager offline-first reads (Scope 3)", () => {
         // Operator degrades post-boot; the watcher fires connection_reset and the
         // recovery sync fails retryably. This must flip sync state to degraded
         // even though the watcher callback swallows the rejection.
-        (indexer.getVtxos as any).mockRejectedValue(
-            new ProviderUnavailableError("indexer", "down"),
-        );
+        (indexer.getVtxos as any).mockRejectedValue(new ProviderUnavailableError("down"));
         await (m as any).handleContractEvent({ type: "connection_reset", timestamp: 1 });
 
         expect(m.getSyncState().mode).toBe("degraded");
@@ -176,9 +166,7 @@ describe("ContractManager offline-first reads (Scope 3)", () => {
         const walletRepo = new InMemoryWalletRepository();
         await contractRepo.saveContract(seededContract());
         const indexer = createMockIndexerProvider();
-        (indexer.getVtxos as any).mockRejectedValueOnce(
-            new ProviderUnavailableError("indexer", "down"),
-        );
+        (indexer.getVtxos as any).mockRejectedValueOnce(new ProviderUnavailableError("down"));
         const m = await create(indexer, contractRepo, walletRepo);
         expect(m.getSyncState().mode).toBe("degraded");
 

--- a/packages/ts-sdk/test/contract-manager-offline.test.ts
+++ b/packages/ts-sdk/test/contract-manager-offline.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+    ContractManager,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    ProviderUnavailableError,
+    type IndexerProvider,
+} from "../src";
+import type { Contract } from "../src/contracts";
+import {
+    createMockIndexerProvider,
+    createDefaultContractParams,
+    TEST_DEFAULT_SCRIPT,
+} from "./contracts/helpers";
+import { getSyncCursor } from "../src/utils/syncCursors";
+
+// Long timers so the watcher's failsafe poll / reconnect never fire mid-test;
+// every manager is disposed in afterEach to stop them.
+const watcherConfig = { failsafePollIntervalMs: 1_000_000, reconnectDelayMs: 1_000_000 };
+
+describe("ContractManager offline-first reads (Scope 3)", () => {
+    const managers: ContractManager[] = [];
+    const track = (m: ContractManager) => {
+        managers.push(m);
+        return m;
+    };
+
+    afterEach(async () => {
+        while (managers.length) await managers.pop()!.dispose();
+    });
+
+    const create = (
+        indexer: IndexerProvider,
+        contractRepository: InMemoryContractRepository,
+        walletRepository: InMemoryWalletRepository,
+    ) =>
+        ContractManager.create({
+            indexerProvider: indexer,
+            contractRepository,
+            walletRepository,
+            watcherConfig,
+        }).then(track);
+
+    const seededContract = (): Contract => ({
+        type: "default",
+        params: createDefaultContractParams(),
+        script: TEST_DEFAULT_SCRIPT,
+        address: "addr",
+        state: "active",
+        createdAt: 1,
+    });
+
+    const params = () => ({
+        type: "default" as const,
+        params: createDefaultContractParams(),
+        script: TEST_DEFAULT_SCRIPT,
+        address: "addr",
+    });
+
+    it("boot survives a retryable indexer failure and reports degraded", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const walletRepo = new InMemoryWalletRepository();
+        await contractRepo.saveContract(seededContract());
+        const indexer = createMockIndexerProvider();
+        (indexer.getVtxos as any).mockRejectedValue(
+            new ProviderUnavailableError("indexer", "down"),
+        );
+
+        const m = await create(indexer, contractRepo, walletRepo);
+
+        expect(m.getSyncState().mode).toBe("degraded");
+        // Repository rows are intact — a failed boot sync must not clear them.
+        expect(await m.getContracts()).toHaveLength(1);
+        // ...and it must not advance the sync cursor.
+        expect(await getSyncCursor(walletRepo)).toBe(0);
+    });
+
+    it("boot rethrows a terminal (non-retryable) indexer failure", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        await contractRepo.saveContract(seededContract());
+        const indexer = createMockIndexerProvider();
+        (indexer.getVtxos as any).mockRejectedValue(new Error("schema violation"));
+
+        await expect(
+            ContractManager.create({
+                indexerProvider: indexer,
+                contractRepository: contractRepo,
+                walletRepository: new InMemoryWalletRepository(),
+                watcherConfig,
+            }),
+        ).rejects.toThrow("schema violation");
+    });
+
+    it("getContractsWithVtxos serves repository state on a retryable sync failure", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const walletRepo = new InMemoryWalletRepository();
+        const indexer = createMockIndexerProvider(); // getVtxos resolves [] initially
+        const m = await create(indexer, contractRepo, walletRepo);
+        await m.createContract(params());
+        expect(m.getSyncState().mode).toBe("online");
+
+        (indexer.getVtxos as any).mockRejectedValue(
+            new ProviderUnavailableError("indexer", "down"),
+        );
+        const result = await m.getContractsWithVtxos(); // must NOT throw
+
+        expect(result).toHaveLength(1);
+        expect(m.getSyncState().mode).toBe("degraded");
+    });
+
+    it("getContractsWithVtxos rethrows a terminal sync failure", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const walletRepo = new InMemoryWalletRepository();
+        const indexer = createMockIndexerProvider();
+        const m = await create(indexer, contractRepo, walletRepo);
+        await m.createContract(params());
+
+        (indexer.getVtxos as any).mockRejectedValue(new Error("schema violation"));
+        await expect(m.getContractsWithVtxos()).rejects.toThrow("schema violation");
+    });
+
+    it("createContract persists and watches even when hydration is retryable-unavailable", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const walletRepo = new InMemoryWalletRepository();
+        const indexer = createMockIndexerProvider();
+        const m = await create(indexer, contractRepo, walletRepo);
+
+        (indexer.getVtxos as any).mockRejectedValue(
+            new ProviderUnavailableError("indexer", "down"),
+        );
+        const c = await m.createContract(params());
+
+        expect(c.script).toBe(TEST_DEFAULT_SCRIPT);
+        expect(await m.getContracts()).toHaveLength(1);
+        expect(m.getSyncState().mode).toBe("degraded");
+    });
+
+    it("a later successful sync clears a prior degraded state", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const walletRepo = new InMemoryWalletRepository();
+        await contractRepo.saveContract(seededContract());
+        const indexer = createMockIndexerProvider();
+        (indexer.getVtxos as any).mockRejectedValueOnce(
+            new ProviderUnavailableError("indexer", "down"),
+        );
+
+        const m = await create(indexer, contractRepo, walletRepo);
+        expect(m.getSyncState().mode).toBe("degraded");
+
+        // Operator recovers (base mock resolves { vtxos: [] }).
+        await m.getContractsWithVtxos();
+        expect(m.getSyncState().mode).toBe("online");
+    });
+});

--- a/packages/ts-sdk/test/e2e/deprecatedSignerMigration.test.ts
+++ b/packages/ts-sdk/test/e2e/deprecatedSignerMigration.test.ts
@@ -218,7 +218,16 @@ describe("deprecated-signer migration (real rotation)", () => {
 
                     // Wallet re-derived onto the active (B) signer; nothing left under A.
                     expect(hex.encode(wallet.arkServerPublicKey)).toBe(toX);
-                    const postStatus = await vtxoManager.getDeprecatedSignerStatus();
+                    // The migration's spend reaches the repository via a fresh
+                    // indexer sync that lags the just-submitted ark tx (the sync
+                    // re-writes VTXO rows indexer-wins), so poll until no
+                    // spendable VTXO remains under the deprecated signer.
+                    const postStatus = await poll(async () => {
+                        const s = await vtxoManager.getDeprecatedSignerStatus();
+                        return s.some((x) => x.signerPubKey === fromX && x.vtxoCount > 0)
+                            ? null
+                            : s;
+                    });
                     expect(
                         postStatus.some((s) => s.signerPubKey === fromX && s.vtxoCount > 0),
                     ).toBe(false);
@@ -295,7 +304,16 @@ describe("deprecated-signer migration (real rotation)", () => {
                     expect(report.vtxos?.migrated[0].cutoffDate).toBe(BigInt(cutoff));
 
                     expect(hex.encode(wallet.arkServerPublicKey)).toBe(toX);
-                    const postStatus = await vtxoManager.getDeprecatedSignerStatus();
+                    // The migration's spend reaches the repository via a fresh
+                    // indexer sync that lags the just-submitted ark tx (the sync
+                    // re-writes VTXO rows indexer-wins), so poll until no
+                    // spendable VTXO remains under the deprecated signer.
+                    const postStatus = await poll(async () => {
+                        const s = await vtxoManager.getDeprecatedSignerStatus();
+                        return s.some((x) => x.signerPubKey === fromX && x.vtxoCount > 0)
+                            ? null
+                            : s;
+                    });
                     expect(
                         postStatus.some((s) => s.signerPubKey === fromX && s.vtxoCount > 0),
                     ).toBe(false);

--- a/packages/ts-sdk/test/e2e/operatorOffline.test.ts
+++ b/packages/ts-sdk/test/e2e/operatorOffline.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Wallet, EsploraProvider } from "../../src";
+import {
+    beforeEachFaucet,
+    createSharedRepos,
+    createTestIdentity,
+    createVtxo,
+    waitFor,
+} from "./utils";
+
+// End-to-end coverage for the offline-first wallet: a previously-synced wallet
+// must open and serve cached reads when the operator is unreachable, and report
+// its degraded provider-connection state.
+describe("operator offline (e2e)", () => {
+    beforeEach(beforeEachFaucet, 20000);
+
+    it(
+        "creates offline from the cached snapshot and serves cached reads",
+        { timeout: 120_000 },
+        async () => {
+            const repos = createSharedRepos();
+            const identity = createTestIdentity();
+            const onchain = () =>
+                new EsploraProvider("http://localhost:3000/api", {
+                    forcePolling: true,
+                    pollingInterval: 2000,
+                });
+
+            // 1) Create online against the live operator: persists the ArkInfo
+            //    snapshot and (after funding) the VTXO set into the shared repos.
+            const online = await Wallet.create({
+                identity,
+                arkServerUrl: "http://localhost:7070",
+                onchainProvider: onchain(),
+                storage: {
+                    walletRepository: repos.walletRepository,
+                    contractRepository: repos.contractRepository,
+                },
+                settlementConfig: false,
+            });
+            let onlineDisposed = false;
+            let offline: Wallet | undefined;
+            try {
+                expect(online.getProviderConnectionState().mode).toBe("online");
+
+                await createVtxo({ wallet: online, identity }, 100_000);
+                await waitFor(async () => (await online.getVtxos()).length >= 1, {
+                    timeout: 30_000,
+                });
+                const cachedVtxos = await online.getVtxos();
+                expect(cachedVtxos.length).toBeGreaterThan(0);
+
+                // Dispose the online wallet before re-creating offline: its live
+                // ContractManager/subscriptions would otherwise keep writing to
+                // the shared repos while the offline wallet reads them. InMemory
+                // repos survive dispose(), so the cached snapshot + VTXO set
+                // persist for the offline boot below.
+                await online.dispose();
+                onlineDisposed = true;
+
+                // 2) Re-create the SAME wallet (same identity + repos) pointed at
+                //    an unreachable operator. Port 9 is on the Fetch bad-ports
+                //    blocklist, so `fetch` rejects before dialing; the rejection is
+                //    classified as a retryable provider error, so create must
+                //    SUCCEED from the cached snapshot.
+                offline = await Wallet.create({
+                    identity,
+                    arkServerUrl: "http://127.0.0.1:9",
+                    onchainProvider: onchain(),
+                    storage: {
+                        walletRepository: repos.walletRepository,
+                        contractRepository: repos.contractRepository,
+                    },
+                    settlementConfig: false,
+                });
+
+                // 3) Reads serve cached state; the connection state reports degraded.
+                const offlineVtxos = await offline.getVtxos();
+                expect(offlineVtxos.map((v) => `${v.txid}:${v.vout}`).sort()).toEqual(
+                    cachedVtxos.map((v) => `${v.txid}:${v.vout}`).sort(),
+                );
+                expect(offline.getProviderConnectionState().mode).toBe("degraded");
+                expect(offline.serverInfoSource).toBe("cache");
+            } finally {
+                if (!onlineDisposed) await online.dispose().catch(() => undefined);
+                await offline?.dispose().catch(() => undefined);
+            }
+        },
+    );
+});

--- a/packages/ts-sdk/test/provider-availability.test.ts
+++ b/packages/ts-sdk/test/provider-availability.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { RestIndexerProvider, RestArkProvider, ProviderUnavailableError } from "../src";
+import { RestIndexerProvider, RestArkProvider, ProviderUnavailableError, ArkError } from "../src";
 import { throwIfHttpUnavailable, toProviderUnavailable } from "../src/providers/errors";
 import { FetchError } from "../src/utils/fetch";
 
@@ -27,6 +27,38 @@ describe("throwIfHttpUnavailable", () => {
                 throwIfHttpUnavailable({ status, statusText: "x" } as Response, "arkade"),
             ).not.toThrow();
         }
+    });
+
+    it("keeps a 5xx that carries a structured arkd error terminal (grpc-gateway maps gRPC INTERNAL -> 500)", () => {
+        // arkd rejects a duplicate intent with INTERNAL_ERROR, which grpc-gateway
+        // renders as HTTP 500 with a structured ErrorDetails body. That is a
+        // deliberate application rejection, not an availability failure, so it must
+        // NOT be reclassified as ProviderUnavailableError.
+        const body = JSON.stringify({
+            message: "INTERNAL_ERROR (0): input already registered by another intent",
+            details: [
+                {
+                    "@type": "type.googleapis.com/ark.v1.ErrorDetails",
+                    code: 0,
+                    name: "INTERNAL_ERROR",
+                    message: "input already registered by another intent",
+                },
+            ],
+        });
+        expect(() =>
+            throwIfHttpUnavailable({ status: 500, statusText: "x" } as Response, "arkade", body),
+        ).not.toThrow();
+    });
+
+    it("still classifies a 5xx with a non-structured body as unavailable", () => {
+        // A bare proxy/gateway 5xx (no structured arkd error) stays retryable.
+        expect(() =>
+            throwIfHttpUnavailable(
+                { status: 503, statusText: "Service Unavailable" } as Response,
+                "arkade",
+                "<html>502 Bad Gateway</html>",
+            ),
+        ).toThrow(ProviderUnavailableError);
     });
 });
 
@@ -108,10 +140,45 @@ describe("RestArkProvider availability classification", () => {
             ok: false,
             status: 503,
             statusText: "Service Unavailable",
+            clone: () => ({ text: async () => "" }),
+            text: async () => "",
         });
         await expect(provider().submitTx("tx", [])).rejects.toMatchObject({
             name: "ProviderUnavailableError",
             kind: "arkade",
         });
+    });
+
+    it("cooperative submitTx keeps a structured 500 (gRPC INTERNAL) terminal, not unavailable", async () => {
+        // Regression: arkd rejects e.g. a duplicate intent with INTERNAL_ERROR,
+        // which grpc-gateway renders as HTTP 500 with a structured ErrorDetails
+        // body. authedFetch must NOT reclassify that as ProviderUnavailableError —
+        // it is a deliberate application rejection and must reach the caller as an
+        // ArkError.
+        const body = JSON.stringify({
+            message: "INTERNAL_ERROR (0): input already registered by another intent",
+            details: [
+                {
+                    "@type": "type.googleapis.com/ark.v1.ErrorDetails",
+                    code: 0,
+                    name: "INTERNAL_ERROR",
+                    message: "input already registered by another intent",
+                },
+            ],
+        });
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            statusText: "Internal Server Error",
+            clone: () => ({ text: async () => body }),
+            text: async () => body,
+        });
+        const err = await provider()
+            .submitTx("tx", [])
+            .catch((e) => e);
+        expect(err).not.toBeInstanceOf(ProviderUnavailableError);
+        expect(err).toBeInstanceOf(ArkError);
+        expect(err.name).toBe("INTERNAL_ERROR");
+        expect(err.code).toBe(0);
     });
 });

--- a/packages/ts-sdk/test/provider-availability.test.ts
+++ b/packages/ts-sdk/test/provider-availability.test.ts
@@ -63,11 +63,10 @@ describe("throwIfHttpUnavailable", () => {
 });
 
 describe("toProviderUnavailable", () => {
-    it("maps a transport FetchError to a typed unavailable error with kind + cause", () => {
+    it("maps a transport FetchError to a typed unavailable error with cause", () => {
         const fe = new FetchError("net", { url: "u" });
         const mapped = toProviderUnavailable(fe, "indexer");
         expect(mapped).toBeInstanceOf(ProviderUnavailableError);
-        expect((mapped as ProviderUnavailableError).kind).toBe("indexer");
         expect((mapped as ProviderUnavailableError).cause).toBe(fe);
     });
 
@@ -89,7 +88,7 @@ describe("RestIndexerProvider availability classification", () => {
         });
         await expect(provider().getVtxos({ scripts: ["s"] })).rejects.toMatchObject({
             name: "ProviderUnavailableError",
-            kind: "indexer",
+            message: expect.stringContaining("indexer unavailable"),
         });
     });
 
@@ -124,7 +123,7 @@ describe("RestArkProvider availability classification", () => {
         });
         await expect(provider().getInfo()).rejects.toMatchObject({
             name: "ProviderUnavailableError",
-            kind: "arkade",
+            message: expect.stringContaining("arkade unavailable"),
         });
     });
 
@@ -145,7 +144,7 @@ describe("RestArkProvider availability classification", () => {
         });
         await expect(provider().submitTx("tx", [])).rejects.toMatchObject({
             name: "ProviderUnavailableError",
-            kind: "arkade",
+            message: expect.stringContaining("arkade unavailable"),
         });
     });
 

--- a/packages/ts-sdk/test/provider-availability.test.ts
+++ b/packages/ts-sdk/test/provider-availability.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RestIndexerProvider, RestArkProvider, ProviderUnavailableError } from "../src";
+import { throwIfHttpUnavailable, toProviderUnavailable } from "../src/providers/errors";
+import { FetchError } from "../src/utils/fetch";
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
+
+// Preserve the real FetchError (and other exports); only override the two
+// fetch entry points so transport failures / HTTP statuses are controllable.
+vi.mock("../src/utils/fetch", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../src/utils/fetch")>();
+    return { ...actual, fetch: mockFetch, baseFetch: mockFetch };
+});
+
+describe("throwIfHttpUnavailable", () => {
+    it("throws a typed unavailable error for 429 and any 5xx", () => {
+        for (const status of [429, 500, 502, 503]) {
+            expect(() =>
+                throwIfHttpUnavailable({ status, statusText: "x" } as Response, "indexer"),
+            ).toThrow(ProviderUnavailableError);
+        }
+    });
+
+    it("does not throw for 2xx / 4xx", () => {
+        for (const status of [200, 400, 404, 409]) {
+            expect(() =>
+                throwIfHttpUnavailable({ status, statusText: "x" } as Response, "arkade"),
+            ).not.toThrow();
+        }
+    });
+});
+
+describe("toProviderUnavailable", () => {
+    it("maps a transport FetchError to a typed unavailable error with kind + cause", () => {
+        const fe = new FetchError("net", { url: "u" });
+        const mapped = toProviderUnavailable(fe, "indexer");
+        expect(mapped).toBeInstanceOf(ProviderUnavailableError);
+        expect((mapped as ProviderUnavailableError).kind).toBe("indexer");
+        expect((mapped as ProviderUnavailableError).cause).toBe(fe);
+    });
+
+    it("returns non-transport (terminal) errors unchanged", () => {
+        const terminal = new Error("bad request");
+        expect(toProviderUnavailable(terminal, "arkade")).toBe(terminal);
+    });
+});
+
+describe("RestIndexerProvider availability classification", () => {
+    beforeEach(() => mockFetch.mockReset());
+    const provider = () => new RestIndexerProvider("http://localhost:7070");
+
+    it("maps a 503 response to ProviderUnavailableError(indexer)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 503,
+            statusText: "Service Unavailable",
+        });
+        await expect(provider().getVtxos({ scripts: ["s"] })).rejects.toMatchObject({
+            name: "ProviderUnavailableError",
+            kind: "indexer",
+        });
+    });
+
+    it("maps a transport failure to ProviderUnavailableError(indexer)", async () => {
+        mockFetch.mockRejectedValueOnce(new FetchError("down", { url: "u" }));
+        await expect(provider().getVtxos({ scripts: ["s"] })).rejects.toBeInstanceOf(
+            ProviderUnavailableError,
+        );
+    });
+
+    it("leaves a 404 as a terminal plain Error (not unavailable)", async () => {
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: "Not Found" });
+        const err = await provider()
+            .getVtxos({ scripts: ["s"] })
+            .catch((e) => e);
+        expect(err).toBeInstanceOf(Error);
+        expect(err).not.toBeInstanceOf(ProviderUnavailableError);
+        expect(err.message).toMatch(/Failed to fetch vtxos/);
+    });
+});
+
+describe("RestArkProvider availability classification", () => {
+    beforeEach(() => mockFetch.mockReset());
+    const provider = () => new RestArkProvider("http://localhost:7070");
+
+    it("getInfo maps a 503 to ProviderUnavailableError(arkade)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 503,
+            statusText: "Service Unavailable",
+            text: async () => "",
+        });
+        await expect(provider().getInfo()).rejects.toMatchObject({
+            name: "ProviderUnavailableError",
+            kind: "arkade",
+        });
+    });
+
+    it("cooperative submitTx maps a transport failure to ProviderUnavailableError(arkade)", async () => {
+        mockFetch.mockRejectedValueOnce(new FetchError("down", { url: "u" }));
+        await expect(provider().submitTx("tx", [])).rejects.toBeInstanceOf(
+            ProviderUnavailableError,
+        );
+    });
+
+    it("cooperative submitTx maps a 503 to ProviderUnavailableError(arkade)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 503,
+            statusText: "Service Unavailable",
+        });
+        await expect(provider().submitTx("tx", [])).rejects.toMatchObject({
+            name: "ProviderUnavailableError",
+            kind: "arkade",
+        });
+    });
+});

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -407,6 +407,95 @@ describe("ServiceWorkerReadonlyWallet", () => {
         await manager.getContractsWithVtxos({} as any); // worker degraded → probe #2
         expect(manager.getSyncState()).toMatchObject({ mode: "degraded", reason: "indexer down" });
     });
+
+    it("reports degraded (never a fabricated online) when the initial sync-state probe fails", async () => {
+        // Probe fails (error response) — models a timeout / old worker / error.
+        const responder = (message: any) => {
+            if (message.type === "GET_CONTRACT_SYNC_STATE") {
+                return { id: message.id, tag: messageTag, error: new Error("probe failed") };
+            }
+            return null;
+        };
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness(responder);
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createWallet(serviceWorker as any, messageTag);
+        const manager = await wallet.getContractManager();
+
+        expect(manager.getSyncState().mode).toBe("degraded");
+    });
+
+    it("recovers from a failed initial probe once an operation refresh succeeds", async () => {
+        let probe = 0;
+        const responder = (message: any) => {
+            if (message.type === "GET_CONTRACTS_WITH_VTXOS") {
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    type: "CONTRACTS_WITH_VTXOS",
+                    payload: { contracts: [] },
+                };
+            }
+            if (message.type === "GET_CONTRACT_SYNC_STATE") {
+                probe += 1;
+                // Construction probe fails; the post-operation probe succeeds.
+                return probe === 1
+                    ? { id: message.id, tag: messageTag, error: new Error("probe failed") }
+                    : {
+                          id: message.id,
+                          tag: messageTag,
+                          type: "CONTRACT_SYNC_STATE",
+                          payload: { syncState: { mode: "online" } },
+                      };
+            }
+            return null;
+        };
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness(responder);
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createWallet(serviceWorker as any, messageTag);
+        const manager = await wallet.getContractManager();
+        expect(manager.getSyncState().mode).toBe("degraded"); // initial probe failed
+
+        await manager.getContractsWithVtxos({} as any); // refresh succeeds
+        expect(manager.getSyncState()).toEqual({ mode: "online" });
+    });
+
+    it("preserves the last known state when a refresh fails after a prior success", async () => {
+        let probe = 0;
+        const responder = (message: any) => {
+            if (message.type === "GET_CONTRACTS_WITH_VTXOS") {
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    type: "CONTRACTS_WITH_VTXOS",
+                    payload: { contracts: [] },
+                };
+            }
+            if (message.type === "GET_CONTRACT_SYNC_STATE") {
+                probe += 1;
+                // Construction probe succeeds (online); the post-operation probe fails.
+                return probe === 1
+                    ? {
+                          id: message.id,
+                          tag: messageTag,
+                          type: "CONTRACT_SYNC_STATE",
+                          payload: { syncState: { mode: "online" } },
+                      }
+                    : { id: message.id, tag: messageTag, error: new Error("probe failed") };
+            }
+            return null;
+        };
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness(responder);
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createWallet(serviceWorker as any, messageTag);
+        const manager = await wallet.getContractManager();
+        expect(manager.getSyncState()).toEqual({ mode: "online" });
+
+        await manager.getContractsWithVtxos({} as any); // refresh fails → keep last known
+        expect(manager.getSyncState()).toEqual({ mode: "online" });
+    });
 });
 
 const createSWWallet = (

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -9,6 +9,7 @@ import {
     MnemonicIdentity,
     SeedIdentity,
     ReadonlyDescriptorIdentity,
+    type ContractSyncState,
 } from "../../src";
 import { ServiceWorkerWallet } from "../../src/wallet/serviceWorker/wallet";
 import { mnemonicToSeedSync } from "@scure/bip39";
@@ -44,9 +45,14 @@ function structuredCloneResponse(response: any): any {
 
 const createServiceWorkerHarness = (
     responder?: (message: any) => any,
-    options?: { handlePing?: boolean; getStatusKey?: Uint8Array | null },
+    options?: {
+        handlePing?: boolean;
+        getStatusKey?: Uint8Array | null;
+        contractSyncState?: ContractSyncState;
+    },
 ) => {
     const handlePing = options?.handlePing ?? true;
+    const contractSyncState: ContractSyncState = options?.contractSyncState ?? { mode: "online" };
     // Auto-answer GET_STATUS with this x-only key when the responder does not
     // handle it, so the create()/reinitialize() identity assertion can pass.
     // Pass `null` to disable the auto-answer (e.g. to exercise a worker that
@@ -91,6 +97,21 @@ const createServiceWorkerHarness = (
                                 walletInitialized: true,
                                 xOnlyPublicKey: getStatusKey,
                             },
+                        },
+                    }),
+                );
+            }
+            // Auto-answer the contract-manager proxy's construction-time /
+            // refresh sync-state probe so tests that don't care about sync state
+            // don't hang. Tests that assert degraded state pass a `responder`.
+            if (message.type === "GET_CONTRACT_SYNC_STATE") {
+                listeners.forEach((handler) =>
+                    handler({
+                        data: {
+                            id: message.id,
+                            tag: message.tag,
+                            type: "CONTRACT_SYNC_STATE",
+                            payload: { syncState: contractSyncState },
                         },
                     }),
                 );
@@ -330,6 +351,61 @@ describe("ServiceWorkerReadonlyWallet", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(listeners.size).toBe(0);
+    });
+
+    it("seeds the contract-manager proxy sync cache from the worker (degraded, not the online stub)", async () => {
+        const degraded: ContractSyncState = {
+            mode: "degraded",
+            reason: "indexer down",
+            lastSyncedAt: 7,
+        };
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness(undefined, {
+            contractSyncState: degraded,
+        });
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createWallet(serviceWorker as any, messageTag);
+        const manager = await wallet.getContractManager();
+
+        expect(manager.getSyncState()).toEqual(degraded);
+    });
+
+    it("refreshes the proxy sync cache after getContractsWithVtxos", async () => {
+        let syncProbe = 0;
+        const responder = (message: any) => {
+            if (message.type === "GET_CONTRACTS_WITH_VTXOS") {
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    type: "CONTRACTS_WITH_VTXOS",
+                    payload: { contracts: [] },
+                };
+            }
+            if (message.type === "GET_CONTRACT_SYNC_STATE") {
+                syncProbe += 1;
+                return {
+                    id: message.id,
+                    tag: messageTag,
+                    type: "CONTRACT_SYNC_STATE",
+                    payload: {
+                        syncState:
+                            syncProbe === 1
+                                ? { mode: "online" }
+                                : { mode: "degraded", reason: "indexer down" },
+                    },
+                };
+            }
+            return null;
+        };
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness(responder);
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createWallet(serviceWorker as any, messageTag);
+        const manager = await wallet.getContractManager(); // probe #1 → online
+        expect(manager.getSyncState()).toEqual({ mode: "online" });
+
+        await manager.getContractsWithVtxos({} as any); // worker degraded → probe #2
+        expect(manager.getSyncState()).toMatchObject({ mode: "degraded", reason: "indexer down" });
     });
 });
 

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -255,10 +255,16 @@ describe("WalletMessageHandler handleMessage", () => {
 
     it("handles GET_STATUS messages", async () => {
         const pubkey = new Uint8Array([1, 2, 3]);
+        const providerConnectionState = {
+            mode: "online",
+            source: "live",
+            lastOnlineAt: 123,
+        };
         (updater as any).readonlyWallet = {
             identity: {
                 xOnlyPublicKey: vi.fn().mockResolvedValue(pubkey),
             },
+            getProviderConnectionState: vi.fn().mockReturnValue(providerConnectionState),
         };
 
         const response = await updater.handleMessage({
@@ -272,8 +278,29 @@ describe("WalletMessageHandler handleMessage", () => {
             payload: {
                 walletInitialized: true,
                 xOnlyPublicKey: pubkey,
+                providerConnectionState,
             },
         });
+    });
+
+    it("handles GET_CONTRACT_SYNC_STATE by reading the manager state without forcing init", async () => {
+        const syncState = { mode: "degraded", reason: "indexer down", lastSyncedAt: 5 };
+        const getContractSyncState = vi.fn().mockReturnValue(syncState);
+        (updater as any).readonlyWallet = { getContractSyncState };
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "GET_CONTRACT_SYNC_STATE",
+        } as any);
+
+        expect(response).toMatchObject({
+            tag: updater.messageTag,
+            type: "CONTRACT_SYNC_STATE",
+            payload: { syncState },
+        });
+        // Diagnostics path must not go through getContractManager() (which would
+        // initialize the manager and trigger a remote sync).
+        expect(getContractSyncState).toHaveBeenCalledTimes(1);
     });
 
     it("handles CLEAR messages", async () => {
@@ -472,6 +499,9 @@ describe("WalletMessageHandler handleMessage", () => {
             getContractManager: vi.fn().mockResolvedValue({
                 getContracts: vi.fn().mockResolvedValue([]),
             }),
+            getProviderConnectionState: vi
+                .fn()
+                .mockReturnValue({ mode: "online", source: "live", lastOnlineAt: 0 }),
             identity: {
                 xOnlyPublicKey: vi.fn().mockResolvedValue(new Uint8Array([1])),
             },

--- a/packages/ts-sdk/test/wallet-offline-reads.test.ts
+++ b/packages/ts-sdk/test/wallet-offline-reads.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+    ReadonlyWallet,
+    InMemoryWalletRepository,
+    InMemoryContractRepository,
+    ProviderUnavailableError,
+    type ArkProvider,
+    type IndexerProvider,
+    type OnchainProvider,
+} from "../src";
+import type { ArkInfo } from "../src/providers/ark";
+import { ReadonlySingleKey, SingleKey } from "../src/identity/singleKey";
+
+const serverKeyHex = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const privKeyHex = "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2";
+
+const arkInfo = (): ArkInfo => ({
+    boardingExitDelay: 144n,
+    checkpointTapscript:
+        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+    deprecatedSigners: [],
+    digest: "d",
+    dust: 1000n,
+    fees: { intentFee: {}, txFeeRate: "0" },
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    forfeitPubkey: serverKeyHex,
+    network: "mutinynet",
+    serviceStatus: {},
+    sessionDuration: 3600n,
+    signerPubkey: serverKeyHex,
+    unilateralExitDelay: 144n,
+    utxoMaxAmount: -1n,
+    utxoMinAmount: 0n,
+    version: "1",
+    vtxoMaxAmount: -1n,
+    vtxoMinAmount: 0n,
+});
+
+// Indexer with every offchain read failing as a retryable unavailable error,
+// plus the watcher subscription stubs the ContractManager needs to start.
+const downIndexer = () =>
+    ({
+        getVtxos: async () => {
+            throw new ProviderUnavailableError("indexer", "operator down");
+        },
+        subscribeForScripts: async () => "sub-1",
+        unsubscribeForScripts: async () => undefined,
+        getSubscription: async function* () {},
+    }) as Partial<IndexerProvider> as IndexerProvider;
+
+type Storage = {
+    walletRepository: InMemoryWalletRepository;
+    contractRepository: InMemoryContractRepository;
+};
+
+const freshStorage = (): Storage => ({
+    walletRepository: new InMemoryWalletRepository(),
+    contractRepository: new InMemoryContractRepository(),
+});
+
+const healthyIndexer = () =>
+    ({
+        getVtxos: async () => ({ vtxos: [] }),
+        subscribeForScripts: async () => "sub-1",
+        unsubscribeForScripts: async () => undefined,
+        getSubscription: async function* () {},
+    }) as Partial<IndexerProvider> as IndexerProvider;
+
+async function createWallet(
+    indexerProvider: IndexerProvider,
+    opts?: { getInfo?: ArkProvider["getInfo"]; storage?: Storage },
+) {
+    const identity = ReadonlySingleKey.fromPublicKey(
+        await SingleKey.fromHex(privKeyHex).compressedPublicKey(),
+    );
+    return ReadonlyWallet.create({
+        identity,
+        arkServerUrl: "http://localhost:7070",
+        arkProvider: {
+            getInfo: opts?.getInfo ?? (async () => arkInfo()),
+        } as Partial<ArkProvider> as ArkProvider,
+        indexerProvider,
+        onchainProvider: {} as OnchainProvider,
+        storage: opts?.storage ?? freshStorage(),
+    });
+}
+
+describe("wallet offline-first reads (Scope 4)", () => {
+    it("getVtxos returns repository state instead of throwing when the indexer is down", async () => {
+        const wallet = await createWallet(downIndexer());
+        await expect(wallet.getVtxos()).resolves.toEqual([]);
+    });
+
+    it("getVtxos still rethrows a terminal (non-retryable) indexer failure", async () => {
+        const indexer = {
+            getVtxos: async () => {
+                throw new Error("schema violation");
+            },
+            subscribeForScripts: async () => "sub-1",
+            unsubscribeForScripts: async () => undefined,
+            getSubscription: async function* () {},
+        } as Partial<IndexerProvider> as IndexerProvider;
+        const wallet = await createWallet(indexer);
+        await expect(wallet.getVtxos()).rejects.toThrow("schema violation");
+    });
+});
+
+describe("provider connection state (Scope 5)", () => {
+    it("reports online when booted live with a healthy indexer", async () => {
+        const wallet = await createWallet(healthyIndexer());
+        const state = wallet.getProviderConnectionState();
+        expect(state).toMatchObject({ mode: "online", source: "live" });
+        expect(typeof state.lastOnlineAt).toBe("number");
+    });
+
+    it("reports degraded on arkade/cache when booted from a cached snapshot", async () => {
+        const storage = freshStorage();
+        // An online boot persists the snapshot...
+        await createWallet(healthyIndexer(), { storage });
+        // ...then the operator is unreachable, so the next boot falls back to it.
+        const offline = await createWallet(healthyIndexer(), {
+            storage,
+            getInfo: async () => {
+                throw new ProviderUnavailableError("arkade", "operator down");
+            },
+        });
+        expect(offline.getProviderConnectionState()).toMatchObject({
+            mode: "degraded",
+            source: "cache",
+            provider: "arkade",
+        });
+    });
+
+    it("reports degraded on indexer/repository after a read hits a down indexer", async () => {
+        const wallet = await createWallet(downIndexer());
+        // The contract manager isn't initialized until the first read.
+        expect(wallet.getProviderConnectionState().mode).toBe("online");
+
+        await wallet.getVtxos();
+        expect(wallet.getProviderConnectionState()).toMatchObject({
+            mode: "degraded",
+            source: "repository",
+            provider: "indexer",
+        });
+    });
+});

--- a/packages/ts-sdk/test/wallet-offline-reads.test.ts
+++ b/packages/ts-sdk/test/wallet-offline-reads.test.ts
@@ -41,7 +41,7 @@ const arkInfo = (): ArkInfo => ({
 const downIndexer = () =>
     ({
         getVtxos: async () => {
-            throw new ProviderUnavailableError("indexer", "operator down");
+            throw new ProviderUnavailableError("operator down");
         },
         subscribeForScripts: async () => "sub-1",
         unsubscribeForScripts: async () => undefined,
@@ -121,7 +121,7 @@ describe("provider connection state (Scope 5)", () => {
         const offline = await createWallet(healthyIndexer(), {
             storage,
             getInfo: async () => {
-                throw new ProviderUnavailableError("arkade", "operator down");
+                throw new ProviderUnavailableError("operator down");
             },
         });
         expect(offline.getProviderConnectionState()).toMatchObject({

--- a/packages/ts-sdk/test/wallet/expo/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet/expo/wallet.test.ts
@@ -41,6 +41,9 @@ const createWalletStub = () => ({
     getBoardingUtxos: vi.fn().mockResolvedValue([{ txid: "u1" }]),
     getTransactionHistory: vi.fn().mockResolvedValue([{ txid: "h1" }]),
     getContractManager: vi.fn().mockResolvedValue({ id: "manager" }),
+    getProviderConnectionState: vi
+        .fn()
+        .mockReturnValue({ mode: "degraded", source: "cache", provider: "arkade", reason: "down" }),
     getDelegateManager: vi.fn().mockResolvedValue({ id: "delegate" }),
     sendBitcoin: vi.fn().mockResolvedValue("send-txid"),
     settle: vi.fn().mockResolvedValue("settle-txid"),
@@ -171,6 +174,12 @@ describe("ExpoWallet", () => {
         await expect(wallet.getContractManager()).resolves.toEqual({
             id: "manager",
         });
+        expect(wallet.getProviderConnectionState()).toEqual({
+            mode: "degraded",
+            source: "cache",
+            provider: "arkade",
+            reason: "down",
+        });
         await expect(wallet.getDelegateManager()).resolves.toEqual({
             id: "delegate",
         });
@@ -184,6 +193,7 @@ describe("ExpoWallet", () => {
         expect(walletStub.getBoardingUtxos).toHaveBeenCalledTimes(1);
         expect(walletStub.getTransactionHistory).toHaveBeenCalledTimes(1);
         expect(walletStub.getContractManager).toHaveBeenCalledTimes(1);
+        expect(walletStub.getProviderConnectionState).toHaveBeenCalledTimes(1);
         expect(walletStub.getDelegateManager).toHaveBeenCalledTimes(1);
         expect(walletStub.sendBitcoin).toHaveBeenCalledWith({ amount: 1 });
         expect(walletStub.settle).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Makes the wallet degrade gracefully instead of crashing when the Arkade operator/indexer is unreachable.

- **Cached server-info fallback** — a previously synced wallet boots from a persisted `ArkInfo` snapshot when live `getInfo` is down; a no-cache boot fails with a typed retryable error. The snapshot is written only after construction validates the response, so a terminal response can't poison the cache.
- **Typed provider errors** — indexer/ark transport and 429/5xx failures normalize to a retryable `ProviderUnavailableError`; 4xx/schema/network-mismatch stay terminal.
- **Offline-first reads** — `ContractManager` boot/reads/hydration and `getBalance`/`getVtxos`/history serve repository state on retryable failure (no partial mutation, no cursor advance); cooperative send/settle/refresh still fail with the typed error.
- **Degradation diagnostics** — `ProviderConnectionState` composes boot (cache) and indexer-sync (repository) degradation, surfaced across in-process, service-worker (`GET_STATUS` / `GET_CONTRACT_SYNC_STATE`), and Expo foreground wallets.

Implements Step 2 of `plans/unilateral-exit-sdk-readiness-v2.md`. Experimental exit APIs stay experimental.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider connection and contract sync diagnostics across wallet, Expo, and service-worker APIs.
  * Added offline-first server-info snapshot caching (live vs cache reporting) for temporary provider outages.
  * Added typed provider-unavailable errors plus a retryability classifier, and exposed additional provider status helpers.
* **Bug Fixes**
  * Retryable provider/indexer/operator sync failures now degrade health and continue serving repository-backed data instead of failing operations.
  * Improved Arkade/indexer HTTP unavailability detection and made transaction-history enrichment best-effort.
* **Tests**
  * Expanded coverage for snapshot caching, offline reads, degraded/online transitions, provider availability classification, and related e2e timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->