### PR TITLE
feat(sdk): explicit-outpoint exit falls back to local VTXOs when the indexer is down

### DIFF
--- a/packages/ts-sdk/src/utils/operatorReachability.ts
+++ b/packages/ts-sdk/src/utils/operatorReachability.ts
@@ -1,0 +1,37 @@
+import { FetchError } from "./fetch";
+import { ArkError } from "../providers/errors";
+
+/**
+ * gRPC status codes that mean "the operator is up but not servicing the
+ * request right now" — treated as unreachable so the wallet can serve cached
+ * state instead of throwing.
+ */
+const UNAVAILABLE = 14;
+const DEADLINE_EXCEEDED = 4;
+
+/**
+ * Classify an error as a network-level operator failure (degrade to cached
+ * state) vs. a logic/malformed error (propagate).
+ *
+ * Returns `true` only for signals that definitively mean "could not reach /
+ * be serviced by the operator":
+ *   - {@link FetchError} — a transport-level reject (DNS failure, connection
+ *     refused, TLS/CORS error, timeout) from the base-fetch layer.
+ *   - {@link ArkError} with a grpc `UNAVAILABLE` (14) or `DEADLINE_EXCEEDED`
+ *     (4) code — the server explicitly reported unavailability.
+ *
+ * Everything else — a well-formed logic `ArkError` (e.g. `DIGEST_MISMATCH`,
+ * bad request), a parse/validation `Error`, or a non-`ArkError` 5xx that
+ * arrived as a plain `Error` (its status code is not recoverable) — returns
+ * `false` and MUST propagate, so a corrupt response is never silently masked
+ * as stale cache.
+ */
+export function isOperatorUnreachable(err: unknown): boolean {
+    if (err instanceof FetchError) {
+        return true;
+    }
+    if (err instanceof ArkError) {
+        return err.code === UNAVAILABLE || err.code === DEADLINE_EXCEEDED;
+    }
+    return false;
+}

--- a/packages/ts-sdk/src/wallet/exit/estimate.ts
+++ b/packages/ts-sdk/src/wallet/exit/estimate.ts
@@ -6,6 +6,7 @@ import { VtxoScript } from "../../script/base";
 import { sequenceToTimelock } from "../../utils/timelock";
 import { Transaction } from "../../utils/transaction";
 import { TxWeightEstimator } from "../../utils/txSizeEstimator";
+import { isOperatorUnreachable } from "../../utils/operatorReachability";
 import { OnchainWallet } from "../onchain";
 import type { Wallet } from "../wallet";
 import { buildExitDag, DagNode, topoSortByDeps } from "./chain";
@@ -73,17 +74,49 @@ export async function resolveFeeRate(opts: ExitOptions): Promise<number> {
 /** The VTXO shape the exit flow needs — a coin plus its taproot tree. */
 export type ExitVtxo = Pick<VirtualCoin, "txid" | "vout" | "value"> & { tapTree: Uint8Array };
 
+/**
+ * Resolve the raw VTXO rows for an explicit set of exit outpoints.
+ *
+ * Tries the indexer first (authoritative, and reaches contract VTXOs the wallet
+ * does not itself track). On a network-level operator failure it degrades to the
+ * wallet's offline-first `getVtxos()` (backed by the local repository — see the
+ * operator-offline resilience work), filtered to the requested outpoints, so an
+ * explicit-outpoint exit can be built with the indexer down. Non-network errors
+ * (e.g. a malformed response) propagate.
+ *
+ * Offline caveat: only VTXOs present in the local cache are returned — an
+ * untracked contract VTXO cannot be exited via this path while the indexer is
+ * unreachable.
+ */
+export async function resolveExplicitOutpointVtxos(
+    wallet: Wallet,
+    outpoints: Outpoint[],
+): Promise<Pick<VirtualCoin, "txid" | "vout" | "value" | "script" | "isSpent">[]> {
+    try {
+        const res = await wallet.indexerProvider.getVtxos({ outpoints });
+        return res.vtxos;
+    } catch (err) {
+        if (!isOperatorUnreachable(err)) {
+            throw err;
+        }
+        const wanted = new Set(outpoints.map((o) => `${o.txid}:${o.vout}`));
+        const cached = await wallet.getVtxos();
+        return cached.filter((v) => wanted.has(`${v.txid}:${v.vout}`));
+    }
+}
+
 export async function selectExitVtxos(opts: ExitOptions): Promise<ExitVtxo[]> {
     if (!opts.vtxos) return opts.wallet.getVtxos();
 
     // Explicit outpoints are resolved from the indexer plus the registered
     // contract row (tap tree derived via the contract handler). This
     // deliberately bypasses the wallet's own VTXO listing, so contract
-    // VTXOs the wallet does not track are exitable too.
-    const res = await opts.wallet.indexerProvider.getVtxos({ outpoints: opts.vtxos });
+    // VTXOs the wallet does not track are exitable too. With the indexer
+    // unreachable, resolveExplicitOutpointVtxos degrades to the local cache.
+    const resolved = await resolveExplicitOutpointVtxos(opts.wallet, opts.vtxos);
     const tapTrees = new Map<string, Uint8Array>();
     const out: ExitVtxo[] = [];
-    for (const vtxo of res.vtxos) {
+    for (const vtxo of resolved) {
         if (vtxo.isSpent) continue;
         let tapTree = tapTrees.get(vtxo.script);
         if (!tapTree) {

--- a/packages/ts-sdk/test/exit-offline-fallback.test.ts
+++ b/packages/ts-sdk/test/exit-offline-fallback.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveExplicitOutpointVtxos } from "../src/wallet/exit/estimate";
+import { FetchError } from "../src/utils/fetch";
+import type { Wallet } from "../src/wallet/wallet";
+
+const OP_A = { txid: "aa".repeat(32), vout: 0 };
+const OP_B = { txid: "bb".repeat(32), vout: 1 };
+
+// Minimal VTXO row shape the resolver returns / the caller reads.
+function vtxo(op: { txid: string; vout: number }, over: Record<string, unknown> = {}) {
+    return {
+        txid: op.txid,
+        vout: op.vout,
+        value: 50_000,
+        script: "5120aa",
+        isSpent: false,
+        ...over,
+    };
+}
+
+function mockWallet(over: Partial<{ indexerGetVtxos: any; getVtxos: any }> = {}): Wallet {
+    return {
+        indexerProvider: {
+            getVtxos: over.indexerGetVtxos ?? vi.fn().mockResolvedValue({ vtxos: [] }),
+        },
+        getVtxos: over.getVtxos ?? vi.fn().mockResolvedValue([]),
+    } as unknown as Wallet;
+}
+
+describe("resolveExplicitOutpointVtxos", () => {
+    it("returns the indexer result when online", async () => {
+        const wallet = mockWallet({
+            indexerGetVtxos: vi.fn().mockResolvedValue({ vtxos: [vtxo(OP_A)] }),
+        });
+        const out = await resolveExplicitOutpointVtxos(wallet, [OP_A]);
+        expect(out.map((v) => `${v.txid}:${v.vout}`)).toEqual([`${OP_A.txid}:0`]);
+    });
+
+    it("falls back to cached VTXOs (filtered to the outpoints) on a FetchError", async () => {
+        const wallet = mockWallet({
+            indexerGetVtxos: vi
+                .fn()
+                .mockRejectedValue(new FetchError("down", { url: "u", method: "GET" })),
+            // repo cache holds A (wanted) and B (not wanted)
+            getVtxos: vi.fn().mockResolvedValue([vtxo(OP_A), vtxo(OP_B)]),
+        });
+        const out = await resolveExplicitOutpointVtxos(wallet, [OP_A]);
+        expect(out.map((v) => `${v.txid}:${v.vout}`)).toEqual([`${OP_A.txid}:0`]);
+    });
+
+    it("propagates a non-network error", async () => {
+        const wallet = mockWallet({
+            indexerGetVtxos: vi.fn().mockRejectedValue(new Error("malformed response")),
+        });
+        await expect(resolveExplicitOutpointVtxos(wallet, [OP_A])).rejects.toThrow(
+            "malformed response",
+        );
+    });
+});

--- a/packages/ts-sdk/test/operator-reachability.test.ts
+++ b/packages/ts-sdk/test/operator-reachability.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { isOperatorUnreachable } from "../src/utils/operatorReachability";
+import { FetchError } from "../src/utils/fetch";
+import { ArkError } from "../src/providers/errors";
+
+describe("isOperatorUnreachable", () => {
+    it("returns true for a transport-level FetchError", () => {
+        const err = new FetchError("Network request failed: GET http://op/v1/info", {
+            url: "http://op/v1/info",
+            method: "GET",
+            cause: new TypeError("fetch failed"),
+        });
+        expect(isOperatorUnreachable(err)).toBe(true);
+    });
+
+    it("returns true for an UNAVAILABLE ArkError (grpc code 14)", () => {
+        expect(isOperatorUnreachable(new ArkError(14, "unavailable", "UNAVAILABLE"))).toBe(true);
+    });
+
+    it("returns true for a DEADLINE_EXCEEDED ArkError (grpc code 4)", () => {
+        expect(isOperatorUnreachable(new ArkError(4, "deadline", "DEADLINE_EXCEEDED"))).toBe(true);
+    });
+
+    it("returns false for a logic ArkError (e.g. DIGEST_MISMATCH)", () => {
+        expect(
+            isOperatorUnreachable(new ArkError(1101, "digest mismatch", "DIGEST_MISMATCH")),
+        ).toBe(false);
+    });
+
+    it("returns false for a plain Error (propagates)", () => {
+        expect(isOperatorUnreachable(new Error("Invalid checkpointTapscript from server"))).toBe(
+            false,
+        );
+    });
+
+    it("returns false for non-Error values", () => {
+        expect(isOperatorUnreachable(undefined)).toBe(false);
+        expect(isOperatorUnreachable("offline")).toBe(false);
+        expect(isOperatorUnreachable(null)).toBe(false);
+    });
+});


### PR DESCRIPTION
Stacks on #608. Completes the offline story for **explicit-outpoint unilateral exit**.

`selectExitVtxos`' explicit-outpoint branch (`estimate.ts`) calls `indexerProvider.getVtxos({ outpoints })` directly, so `prepare({ vtxos })` throws when the indexer is unreachable — even though the VTXOs are already cached locally. This wraps that call in `resolveExplicitOutpointVtxos(wallet, outpoints)`: try the indexer, and on a network-level failure fall back to the wallet's local VTXO set filtered to the requested outpoints. The default (non-explicit) branch is unchanged — it already reads through the wallet.

### Relationship to #609
#609 ("Offline-first wallet: survive an offline/uncooperative operator") makes `create`/reads survive an unreachable operator but intentionally leaves the experimental exit path untouched. This is that missing exit-side piece; the fallback relies on #609's offline-first `getVtxos` to serve repository state.

**Convergence with #609:** to build standalone on #608, this PR ships a minimal `isOperatorUnreachable` classifier. Once #609 lands, it swaps to #609's exported `isRetryableProviderError` (one-line change) and the local helper is dropped. This was verified end to end: merging #608 + #609 + this change is a clean 2-file / 4-hunk union (no semantic clash), `tsc`/`build` are clean, the full unit suite is green, and an offline `prepare({ vtxos })` e2e builds the exit package from Full-mode local data with the indexer pointed at a dead port.

### Changes
- `resolveExplicitOutpointVtxos(wallet, outpoints)` in `estimate.ts` — indexer first; on a retryable failure, the local repo filtered to the requested outpoints. Non-network errors propagate.
- `selectExitVtxos` routes its explicit-outpoint branch through it (the tap-tree derivation loop is unchanged).

### Test plan
- Unit (`test/exit-offline-fallback.test.ts`): returns the indexer result online; falls back to cached VTXOs on a `FetchError`; propagates a non-network error.
- Existing exit unit + e2e suites unaffected (online behavior is byte-for-byte preserved).
- Offline `prepare({ vtxos })` e2e validated against the #608 + #609 integration (see Convergence).