### PR TITLE
feat(boltz-swap): manage swap lifecycle through the ContractManager (VTXO-driven status)

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -486,8 +486,11 @@ export class ArkadeSwaps {
         // swap's terminal state can be derived from an on-chain signal even
         // when Boltz's own status feed goes silent — see
         // swap-status-reconciler.ts and SwapManager.resolveSwapFromVtxo.
-        // Exempt when contractManager is absent (Expo-background monitor
-        // path), same guard as the migration above.
+        // Also drives a swap's claim as soon as its lockup is observed
+        // FUNDED, ahead of Boltz's own status feed — see
+        // SwapManager.triggerClaimFromVtxo. Exempt when contractManager is
+        // absent (Expo-background monitor path), same guard as the
+        // migration above.
         if (this.contractManager) {
             const contractManager = this.contractManager;
             const swapManager = this.swapManager;
@@ -496,23 +499,37 @@ export class ArkadeSwaps {
             // would otherwise leak the previous subscription.
             this.reconcilerUnsubscribe?.();
 
-            const vhtlcContracts = await contractManager.getContracts({ type: "vhtlc" });
-            const reconciler = new SwapStatusReconciler({
-                getSwap: swapManager.getSwap.bind(swapManager),
-                getActionLog: swapManager.getActionLog.bind(swapManager),
-                onSwapResolved: swapManager.resolveSwapFromVtxo.bind(swapManager),
-            });
-            for (const contract of vhtlcContracts) {
-                const swapId = contract.metadata?.swapId;
-                if (typeof swapId === "string") {
-                    reconciler.addSwapScript(contract.script, swapId);
+            try {
+                const vhtlcContracts = await contractManager.getContracts({ type: "vhtlc" });
+                const reconciler = new SwapStatusReconciler({
+                    getSwap: swapManager.getSwap.bind(swapManager),
+                    getActionLog: swapManager.getActionLog.bind(swapManager),
+                    onSwapResolved: swapManager.resolveSwapFromVtxo.bind(swapManager),
+                    onSwapFunded: swapManager.triggerClaimFromVtxo.bind(swapManager),
+                });
+                for (const contract of vhtlcContracts) {
+                    const swapId = contract.metadata?.swapId;
+                    if (typeof swapId === "string") {
+                        reconciler.addSwapScript(contract.script, swapId);
+                    }
                 }
-            }
 
-            this.reconciler = reconciler;
-            this.reconcilerUnsubscribe = contractManager.onContractEvent((event) =>
-                reconciler.onContractEvent(event),
-            );
+                this.reconciler = reconciler;
+                this.reconcilerUnsubscribe = contractManager.onContractEvent((event) =>
+                    reconciler.onContractEvent(event),
+                );
+            } catch (error) {
+                // A transient contract-repo read (or wiring) failure must not
+                // take down swap monitoring — log and continue without
+                // VTXO-driven resolution/claims for this run; Boltz's own
+                // status feed remains the failsafe.
+                logger.error(
+                    "startSwapManager: failed to wire SwapStatusReconciler to ContractManager events:",
+                    error,
+                );
+                this.reconciler = undefined;
+                this.reconcilerUnsubscribe = undefined;
+            }
         }
 
         // Load all pending swaps from the swap repository

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -758,6 +758,13 @@ export class ArkadeSwaps {
             if (rawVtxos.length === 0) {
                 throw new Error(`Swap ${pendingSwap.id}: no spendable virtual coins found`);
             }
+            // The reconciler's VTXO-driven claim (or the Boltz-status-driven
+            // autonomous path) may have already claimed this VHTLC — both
+            // funnel through SwapManager's action log before we get here.
+            // Idempotent no-op instead of surfacing that race as a failure.
+            if (this.swapManager?.getActionLog().claimed.has(pendingSwap.id)) {
+                return;
+            }
             throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
         }
 
@@ -1267,6 +1274,12 @@ export class ArkadeSwaps {
                 );
             }
             if (diagnostic.allSpent) {
+                // Already refunded via SwapManager's autonomous (Boltz-status)
+                // path before our manual call got here — idempotent no-op
+                // rather than surfacing that race as a failure.
+                if (this.swapManager?.getActionLog().refunded.has(pendingSwap.id)) {
+                    return { swept: 0, skipped: 0 };
+                }
                 throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
             }
             throw new Error(`Swap ${pendingSwap.id}: VHTLC has no refundable VTXOs yet`);
@@ -2043,6 +2056,12 @@ export class ArkadeSwaps {
 
         const unspentVtxos = vtxos.filter((vtxo) => !vtxo.isSpent);
         if (unspentVtxos.length === 0) {
+            // Already refunded via SwapManager's autonomous (Boltz-status)
+            // path before our manual call got here — idempotent no-op rather
+            // than surfacing that race as a failure.
+            if (this.swapManager?.getActionLog().refunded.has(pendingSwap.id)) {
+                return { swept: 0, skipped: 0 };
+            }
             throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
         }
 

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -88,6 +88,7 @@ import { decodeInvoice, getInvoicePaymentHash } from "./utils/decoding";
 import { normalizeToXOnlyKey } from "./utils/signatures";
 import { extractInvoiceAmount, resolveVhtlcTimeouts } from "./utils/restoration";
 import { SwapManager, SwapManagerClient } from "./swap-manager";
+import { SwapStatusReconciler } from "./swap-status-reconciler";
 import {
     saveSwap,
     updateReverseSwapStatus,
@@ -247,6 +248,17 @@ export class ArkadeSwaps {
     private swapsMigrated = false;
 
     /**
+     * Bridges ContractManager VTXO events to swap-lifecycle resolution —
+     * see swap-status-reconciler.ts. Constructed in `startSwapManager`,
+     * alongside `contractManager` (Expo-background exemption: both are
+     * unset when `contractManager` is absent).
+     */
+    private reconciler: SwapStatusReconciler | undefined;
+
+    /** Unsubscribes `reconciler` from `contractManager.onContractEvent`. Called by `dispose`. */
+    private reconcilerUnsubscribe: (() => void) | undefined;
+
+    /**
      * Creates an ArkadeSwaps instance, auto-detecting the network from the wallet's Ark server.
      * If no `swapProvider` is given, one is created automatically using the detected network.
      *
@@ -381,11 +393,17 @@ export class ArkadeSwaps {
      * undefined (that path never calls create methods, so this is defensive).
      * Logs and rethrows on failure — do NOT swallow; a registration failure
      * surfaces to the caller so the create promise rejects.
+     *
+     * On success, routes the new contract's script to `reconciler` (if wired)
+     * so a swap created after `startSwapManager` — which only seeds the
+     * reconciler from contracts that already existed at that point — is
+     * still resolved by a later VTXO event.
      */
     private async registerSwapContractSafe(swap: BoltzSwap, arkInfo: ArkInfo): Promise<void> {
         if (!this.contractManager) return;
         try {
-            await registerSwapContract(this.contractManager, swap, arkInfo);
+            const contract = await registerSwapContract(this.contractManager, swap, arkInfo);
+            this.reconciler?.addSwapScript(contract.script, swap.id);
         } catch (err) {
             logger.error(`Failed to register contract for swap ${swap.id}:`, err);
             throw err;
@@ -464,6 +482,39 @@ export class ArkadeSwaps {
             }
         }
 
+        // Wire a SwapStatusReconciler to ContractManager VTXO events, so a
+        // swap's terminal state can be derived from an on-chain signal even
+        // when Boltz's own status feed goes silent — see
+        // swap-status-reconciler.ts and SwapManager.resolveSwapFromVtxo.
+        // Exempt when contractManager is absent (Expo-background monitor
+        // path), same guard as the migration above.
+        if (this.contractManager) {
+            const contractManager = this.contractManager;
+            const swapManager = this.swapManager;
+
+            // A restart (startSwapManager called again after stopSwapManager)
+            // would otherwise leak the previous subscription.
+            this.reconcilerUnsubscribe?.();
+
+            const vhtlcContracts = await contractManager.getContracts({ type: "vhtlc" });
+            const reconciler = new SwapStatusReconciler({
+                getSwap: swapManager.getSwap.bind(swapManager),
+                getActionLog: swapManager.getActionLog.bind(swapManager),
+                onSwapResolved: swapManager.resolveSwapFromVtxo.bind(swapManager),
+            });
+            for (const contract of vhtlcContracts) {
+                const swapId = contract.metadata?.swapId;
+                if (typeof swapId === "string") {
+                    reconciler.addSwapScript(contract.script, swapId);
+                }
+            }
+
+            this.reconciler = reconciler;
+            this.reconcilerUnsubscribe = contractManager.onContractEvent((event) =>
+                reconciler.onContractEvent(event),
+            );
+        }
+
         // Load all pending swaps from the swap repository
         const allSwaps = await this.swapRepository.getAllSwaps();
 
@@ -503,6 +554,7 @@ export class ArkadeSwaps {
     }
 
     async dispose(): Promise<void> {
+        this.reconcilerUnsubscribe?.();
         if (this.swapManager) {
             await this.stopSwapManager();
         }

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -98,7 +98,9 @@ import {
 import { logger } from "./logger";
 import { IndexedDbSwapRepository } from "./repositories/IndexedDb/swap-repository";
 import { SwapRepository } from "./repositories/swap-repository";
+import { migrateSwapsToContracts } from "./repositories/migrateSwapsToContracts";
 import { claimVHTLCIdentity } from "./utils/identity";
+import { registerSwapContract } from "./utils/swap-contract";
 import {
     candidateServerPubkeys,
     claimVHTLCwithOffchainTx,
@@ -228,6 +230,23 @@ export class ArkadeSwaps {
     readonly swapRepository: SwapRepository;
 
     /**
+     * ContractManager for registering VHTLC scripts as tracked contracts.
+     *
+     * Optional internally: the background swapsPollProcessor constructs
+     * ArkadeSwaps without one (monitor-only, never creates swaps, never
+     * registers contracts). All registration code must guard `if
+     * (!this.contractManager) return;` before using it.
+     */
+    private readonly contractManager: import("@arkade-os/sdk").IContractManager | undefined;
+
+    /**
+     * Guards against running the one-shot swap→contract migration more than
+     * once per process. Set to true after the first successful call to
+     * `startSwapManager`.
+     */
+    private swapsMigrated = false;
+
+    /**
      * Creates an ArkadeSwaps instance, auto-detecting the network from the wallet's Ark server.
      * If no `swapProvider` is given, one is created automatically using the detected network.
      *
@@ -262,8 +281,14 @@ export class ArkadeSwaps {
     constructor(config: ArkadeSwapsConfig) {
         if (!config.wallet) throw new Error("Wallet is required.");
         if (!config.swapProvider) throw new Error("Swap provider is required.");
+        if (!config.contractManager)
+            throw new Error(
+                "ArkadeSwaps requires a contractManager. " +
+                    "Pass the ContractManager from your SDK wallet instance.",
+            );
 
         this.wallet = config.wallet;
+        this.contractManager = config.contractManager;
         // Prioritize wallet providers, fallback to config providers for backward compatibility
         const arkProvider = config.arkProvider ?? (config.wallet as any).arkProvider;
         if (!arkProvider) throw new Error("Ark provider is required either in wallet or config.");
@@ -332,6 +357,42 @@ export class ArkadeSwaps {
     }
 
     // =========================================================================
+    // ContractManager accessor
+    // =========================================================================
+
+    /**
+     * Returns the ContractManager if present, or undefined for the background
+     * poll path (which is exempt from contract registration).
+     *
+     * All callers that register contracts must guard: `if (!cm) return;`
+     *
+     * @internal Used by contract-registration helpers added in later phases.
+     */
+    protected getContractManager(): import("@arkade-os/sdk").IContractManager | undefined {
+        return this.contractManager;
+    }
+
+    /**
+     * Registers a swap's VHTLC as a tracked contract in ContractManager.
+     * Called by all three create paths (createReverseSwap, createSubmarineSwap,
+     * createChainSwap) immediately after persisting the swap to the repository.
+     *
+     * Guards against the Expo-background monitor path where contractManager is
+     * undefined (that path never calls create methods, so this is defensive).
+     * Logs and rethrows on failure — do NOT swallow; a registration failure
+     * surfaces to the caller so the create promise rejects.
+     */
+    private async registerSwapContractSafe(swap: BoltzSwap, arkInfo: ArkInfo): Promise<void> {
+        if (!this.contractManager) return;
+        try {
+            await registerSwapContract(this.contractManager, swap, arkInfo);
+        } catch (err) {
+            logger.error(`Failed to register contract for swap ${swap.id}:`, err);
+            throw err;
+        }
+    }
+
+    // =========================================================================
     // Storage helpers
     // =========================================================================
 
@@ -379,6 +440,28 @@ export class ArkadeSwaps {
             throw new Error(
                 "SwapManager is not enabled. Provide 'swapManager' config in ArkadeSwapsConfig.",
             );
+        }
+
+        // Run the one-shot swap→contract migration once per process.
+        // Exempt when contractManager is absent (Expo-background monitor path).
+        if (this.contractManager && !this.swapsMigrated) {
+            this.swapsMigrated = true;
+            const arkInfo = await this.arkProvider.getInfo();
+            const isTerminal = (swap: BoltzSwap): boolean => {
+                if (swap.type === "reverse") return isReverseFinalStatus(swap.status);
+                if (swap.type === "submarine") return isSubmarineFinalStatus(swap.status);
+                if (swap.type === "chain") return isChainFinalStatus(swap.status);
+                return false;
+            };
+            const { migrated, failed } = await migrateSwapsToContracts({
+                swapRepository: this.swapRepository,
+                contractManager: this.contractManager,
+                arkInfo,
+                isTerminal,
+            });
+            if (migrated > 0 || failed > 0) {
+                logger.log(`migrateSwapsToContracts: migrated=${migrated}, failed=${failed}`);
+            }
         }
 
         // Load all pending swaps from the swap repository
@@ -518,6 +601,12 @@ export class ArkadeSwaps {
 
         // save pending swap to storage
         await this.savePendingReverseSwap(pendingSwap);
+
+        // Register the VHTLC as a tracked contract so the SDK can watch it.
+        // Fetched here (not before the save) so a registration failure doesn't
+        // orphan an unregistered swap — the init migration backfills on next run.
+        const arkInfo = await this.arkProvider.getInfo();
+        await this.registerSwapContractSafe(pendingSwap, arkInfo);
 
         // Add to swap manager if enabled
         if (this.swapManager) {
@@ -874,11 +963,17 @@ export class ArkadeSwaps {
         // make submarine swap request
         const swapResponse = await this.swapProvider.createSubmarineSwap(swapRequest);
 
+        // Extract the preimage hash from the invoice so it's durably stored on
+        // the swap object — required by extractSwapVhtlcInputs (submarine branch)
+        // for VHTLC construction and contract registration.
+        const preimageHash = getInvoicePaymentHash(invoice);
+
         // create pending swap object
         const pendingSwap: BoltzSubmarineSwap = {
             id: swapResponse.id,
             type: "submarine",
             createdAt: Math.floor(Date.now() / 1000),
+            preimageHash,
             request: swapRequest,
             response: swapResponse,
             status: "invoice.set",
@@ -886,6 +981,10 @@ export class ArkadeSwaps {
 
         // save pending swap to storage
         await this.savePendingSubmarineSwap(pendingSwap);
+
+        // Register the VHTLC as a tracked contract so the SDK can watch it.
+        const arkInfo = await this.arkProvider.getInfo();
+        await this.registerSwapContractSafe(pendingSwap, arkInfo);
 
         // Add to swap manager if enabled
         if (this.swapManager) {
@@ -2361,6 +2460,10 @@ export class ArkadeSwaps {
         };
 
         await this.savePendingChainSwap(pendingSwap);
+
+        // Register the VHTLC as a tracked contract so the SDK can watch it.
+        const arkInfo = await this.arkProvider.getInfo();
+        await this.registerSwapContractSafe(pendingSwap, arkInfo);
 
         this.swapManager?.addSwap(pendingSwap);
 

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -242,8 +242,9 @@ export class ArkadeSwaps {
 
     /**
      * Guards against running the one-shot swap→contract migration more than
-     * once per process. Set to true after the first successful call to
-     * `startSwapManager`.
+     * once per instance. Set to true up front (so concurrent
+     * `startSwapManager` calls don't double-run it) and reset to false if the
+     * migration throws, so a transient failure stays retryable.
      */
     private swapsMigrated = false;
 
@@ -463,22 +464,30 @@ export class ArkadeSwaps {
         // Run the one-shot swap→contract migration once per process.
         // Exempt when contractManager is absent (Expo-background monitor path).
         if (this.contractManager && !this.swapsMigrated) {
+            // Set the re-entrancy guard up front so concurrent startSwapManager
+            // calls don't double-run migration, but reset it on failure below
+            // so a transient error (e.g. a getInfo network blip) stays retryable.
             this.swapsMigrated = true;
-            const arkInfo = await this.arkProvider.getInfo();
-            const isTerminal = (swap: BoltzSwap): boolean => {
-                if (swap.type === "reverse") return isReverseFinalStatus(swap.status);
-                if (swap.type === "submarine") return isSubmarineFinalStatus(swap.status);
-                if (swap.type === "chain") return isChainFinalStatus(swap.status);
-                return false;
-            };
-            const { migrated, failed } = await migrateSwapsToContracts({
-                swapRepository: this.swapRepository,
-                contractManager: this.contractManager,
-                arkInfo,
-                isTerminal,
-            });
-            if (migrated > 0 || failed > 0) {
-                logger.log(`migrateSwapsToContracts: migrated=${migrated}, failed=${failed}`);
+            try {
+                const arkInfo = await this.arkProvider.getInfo();
+                const isTerminal = (swap: BoltzSwap): boolean => {
+                    if (swap.type === "reverse") return isReverseFinalStatus(swap.status);
+                    if (swap.type === "submarine") return isSubmarineFinalStatus(swap.status);
+                    if (swap.type === "chain") return isChainFinalStatus(swap.status);
+                    return false;
+                };
+                const { migrated, failed } = await migrateSwapsToContracts({
+                    swapRepository: this.swapRepository,
+                    contractManager: this.contractManager,
+                    arkInfo,
+                    isTerminal,
+                });
+                if (migrated > 0 || failed > 0) {
+                    logger.log(`migrateSwapsToContracts: migrated=${migrated}, failed=${failed}`);
+                }
+            } catch (err) {
+                this.swapsMigrated = false;
+                throw err;
             }
         }
 

--- a/packages/boltz-swap/src/expo/swapsPollProcessor.ts
+++ b/packages/boltz-swap/src/expo/swapsPollProcessor.ts
@@ -55,7 +55,11 @@ export const swapsPollProcessor: TaskProcessor<SwapTaskDependencies> = {
         let refunded = 0;
         let errors = 0;
 
-        // Create a temporary ArkadeSwaps without SwapManager for claim/refund logic
+        // Create a temporary ArkadeSwaps without SwapManager for claim/refund logic.
+        // contractManager is intentionally omitted: the background poll processor only
+        // monitors and claims existing swaps — it never creates new ones, so it never
+        // needs to register contracts. The cast bypasses the required-field check;
+        // all registration code in ArkadeSwaps guards `if (!this.contractManager) return`.
         const tempSwaps = new ArkadeSwaps({
             wallet,
             arkProvider,
@@ -63,7 +67,7 @@ export const swapsPollProcessor: TaskProcessor<SwapTaskDependencies> = {
             swapProvider,
             swapManager: false,
             swapRepository,
-        });
+        } as any);
 
         try {
             for (const swap of pendingSwaps) {

--- a/packages/boltz-swap/src/repositories/migrateSwapsToContracts.ts
+++ b/packages/boltz-swap/src/repositories/migrateSwapsToContracts.ts
@@ -1,0 +1,59 @@
+import { ArkInfo, IContractManager } from "@arkade-os/sdk";
+import { logger } from "../logger";
+import { BoltzSwap } from "../types";
+import { registerSwapContract } from "../utils/swap-contract";
+import { SwapRepository } from "./swap-repository";
+
+export type MigrateSwapsToContractsDeps = {
+    swapRepository: SwapRepository;
+    contractManager: IContractManager;
+    arkInfo: ArkInfo;
+    isTerminal: (swap: BoltzSwap) => boolean;
+};
+
+export type MigrateSwapsToContractsResult = {
+    migrated: number;
+    failed: number;
+};
+
+/**
+ * One-shot migration: registers all in-flight (non-terminal) swaps as tracked
+ * contracts in the SDK's ContractManager.
+ *
+ * Idempotent: ContractManager.createContract deduplicates on script, so running
+ * this multiple times for the same swap is safe.
+ *
+ * Per-swap errors are caught and counted rather than aborting the whole run.
+ * A swap whose VHTLC cannot be reconstructed (e.g. resolveSwapVhtlc throws
+ * because the lockup predates a pruned deprecated signer) is logged and skipped
+ * so the remaining swaps still get registered.
+ *
+ * Processing is sequential to avoid a thundering-herd on the indexer at startup
+ * (createContract fetches VTXOs per contract).
+ */
+export const migrateSwapsToContracts = async (
+    deps: MigrateSwapsToContractsDeps,
+): Promise<MigrateSwapsToContractsResult> => {
+    const { swapRepository, contractManager, arkInfo, isTerminal } = deps;
+
+    const allSwaps = await swapRepository.getAllSwaps();
+    const inFlight = allSwaps.filter((swap) => !isTerminal(swap));
+
+    let migrated = 0;
+    let failed = 0;
+
+    for (const swap of inFlight) {
+        try {
+            await registerSwapContract(contractManager, swap, arkInfo);
+            migrated++;
+        } catch (err) {
+            logger.error(
+                `migrateSwapsToContracts: failed to register contract for swap ${swap.id}:`,
+                err,
+            );
+            failed++;
+        }
+    }
+
+    return { migrated, failed };
+};

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -65,7 +65,10 @@ export type RequestInitArkSwaps = RequestEnvelope & {
     type: "INIT_ARKADE_SWAPS";
     payload: Omit<
         ArkadeSwapsConfig,
-        "wallet" | "swapRepository" | "swapProvider" | "indexerProvider"
+        // contractManager is not postMessage-serializable; the service-worker
+        // handler reconstructs ArkadeSwaps in its own worker context without
+        // one (monitor-only, same exemption as swapsPollProcessor).
+        "wallet" | "swapRepository" | "swapProvider" | "indexerProvider" | "contractManager"
     > & {
         network: Network;
         arkServerUrl: string;
@@ -1223,6 +1226,11 @@ export class ArkadeSwapsMessageHandler
             referralId: payload.referralId,
         });
 
+        // contractManager is intentionally omitted: the service-worker handler
+        // runs in a separate JS context and cannot receive the main-thread
+        // ContractManager across postMessage. It monitors/claims existing swaps
+        // and never creates new ones, so it is exempt from contract registration.
+        // All registration code in ArkadeSwaps guards `if (!this.contractManager) return`.
         const handler = new ArkadeSwaps({
             wallet: this.wallet,
             arkProvider: this.arkProvider,
@@ -1230,7 +1238,7 @@ export class ArkadeSwapsMessageHandler
             indexerProvider: this.indexerProvider,
             swapRepository: this.swapRepository,
             swapManager: payload.swapManager,
-        });
+        } as any);
         this.handler = handler;
 
         const sm = handler.getSwapManager();

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -83,6 +83,7 @@ import {
     enrichSubmarineSwapInvoice as _enrichSubmarineSwapInvoice,
 } from "../utils/swap-helpers";
 import type { Actions, SwapManagerClient } from "../swap-manager";
+import type { SwapActionLog } from "../swap-status-reconciler";
 
 // Check by error message content instead of instanceof because postMessage uses the
 // structured clone algorithm which strips the prototype chain — the page
@@ -333,6 +334,15 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
                         };
                     }
                 ).payload;
+            },
+            // `getActionLog` is synchronous by contract (SwapStatusReconciler
+            // calls it inline from a sync ContractEventCallback), which a
+            // postMessage round trip to the service worker cannot honor —
+            // same constraint as createVHTLCScript/joinBatch below. The
+            // reconciler is wired in-process alongside the real SwapManager
+            // instance, never through this proxy.
+            getActionLog: (): SwapActionLog => {
+                throw new Error("getActionLog is not supported via service worker");
             },
             waitForSwapCompletion: async (swapId: string) => {
                 const res = await send({

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -335,14 +335,18 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
                     }
                 ).payload;
             },
-            // `getActionLog` is synchronous by contract (SwapStatusReconciler
-            // calls it inline from a sync ContractEventCallback), which a
-            // postMessage round trip to the service worker cannot honor —
-            // same constraint as createVHTLCScript/joinBatch below. The
-            // reconciler is wired in-process alongside the real SwapManager
-            // instance, never through this proxy.
+            // `getActionLog`/`getSwap` are synchronous by contract
+            // (SwapStatusReconciler calls them inline from a sync
+            // ContractEventCallback), which a postMessage round trip to the
+            // service worker cannot honor — same constraint as
+            // createVHTLCScript/joinBatch below. The reconciler is wired
+            // in-process alongside the real SwapManager instance, never
+            // through this proxy.
             getActionLog: (): SwapActionLog => {
                 throw new Error("getActionLog is not supported via service worker");
+            },
+            getSwap: (): BoltzReverseSwap | BoltzSubmarineSwap | BoltzChainSwap | undefined => {
+                throw new Error("getSwap is not supported via service worker");
             },
             waitForSwapCompletion: async (swapId: string) => {
                 const res = await send({

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -1157,6 +1157,97 @@ export class SwapManager implements SwapManagerClient {
     }
 
     /**
+     * Trigger the claim action for a swap whose tracked VHTLC lockup was
+     * observed FUNDED via a `vtxo_received` `ContractManager` event — ahead
+     * of Boltz's own status feed reporting the swap claimable (
+     * `isReverseClaimableStatus`/`isChainClaimableStatus`). Intended to be
+     * wired as `SwapStatusReconciler`'s `onSwapFunded` dependency (see
+     * swap-status-reconciler.ts and `ArkadeSwaps.startSwapManager`).
+     *
+     * Boltz's own status-driven path ({@link executeAutonomousAction}, via
+     * WS push or poll) remains the failsafe and is untouched by this method.
+     * Both share the same `swapsInProgress` lock (via {@link
+     * runFundedClaim}), so whichever fires first wins the claim and the
+     * other becomes a no-op — this method never fakes `swap.status` to force
+     * `executeAutonomousAction`'s own dispatch to run early.
+     *
+     * Reuses the same per-type claim helpers `executeAutonomousAction` calls
+     * (`executeClaimAction`/`executeClaimArkAction`) — only the *trigger
+     * condition* differs (VTXO signal vs. Boltz status), not the claim
+     * itself.
+     *
+     * Only claims where the wallet is the VHTLC *receiver* on the tracked
+     * contract are reachable this way — mirrors the role table in
+     * `extractSwapVhtlcInputs` (swap-contract.ts):
+     * - reverse: wallet is always receiver -> {@link executeClaimAction}.
+     * - chain, `request.to === "ARK"` (BTC→ARK): wallet is receiver on the
+     *   tracked ARK-side VHTLC -> {@link executeClaimArkAction}.
+     * - submarine, and chain `request.to === "BTC"` (ARK→BTC): wallet is the
+     *   *sender* on the tracked VHTLC — a `vtxo_received` there is our own
+     *   funding transaction, not Boltz's, so there is nothing to claim. For
+     *   ARK→BTC specifically, the actual claim (`claimBtc`) spends a BTC-side
+     *   HTLC that isn't an Ark contract at all and so never emits a VTXO
+     *   event — it remains reachable only via Boltz's own status. Both are
+     *   no-ops here; these swaps complete via the spent-driven resolver
+     *   instead (see {@link resolveSwapFromVtxo}).
+     *
+     * No-op if the swap is already in the action log (claimed or refunded —
+     * already resolved by an earlier funded event or the Boltz-triggered
+     * path) or already being processed (`swapsInProgress`).
+     */
+    async triggerClaimFromVtxo(swap: BoltzSwap): Promise<void> {
+        if (this.claimedSwapIds.has(swap.id) || this.refundedSwapIds.has(swap.id)) return;
+
+        if (isPendingReverseSwap(swap)) {
+            // Mirrors executeAutonomousAction's restored-swap guard: cannot
+            // claim without the preimage.
+            if (!swap.preimage || swap.preimage.length === 0) {
+                logger.log(
+                    `Skipping VTXO-triggered claim for swap ${swap.id}: missing preimage (restored swap)`,
+                );
+                return;
+            }
+            await this.runFundedClaim(swap, () => this.executeClaimAction(swap), "claim");
+            return;
+        }
+
+        if (isPendingChainSwap(swap) && swap.request.to === "ARK") {
+            await this.runFundedClaim(swap, () => this.executeClaimArkAction(swap), "claimArk");
+            return;
+        }
+
+        // submarine, and chain request.to === "BTC": no VTXO-driven claim
+        // applies here — see docstring.
+    }
+
+    /**
+     * Lock/execute/emit wrapper shared by both {@link triggerClaimFromVtxo}
+     * branches. Mirrors the `swapsInProgress` locking and
+     * actionExecuted/swapFailed emission shape of {@link
+     * executeAutonomousAction} — the SAME guard `Set`, so a claim already
+     * running via the Boltz-status path (or a previous funded event) makes
+     * this a no-op.
+     */
+    private async runFundedClaim(
+        swap: BoltzSwap,
+        claim: () => Promise<void>,
+        action: Actions,
+    ): Promise<void> {
+        if (this.swapsInProgress.has(swap.id)) return;
+        this.swapsInProgress.add(swap.id);
+        try {
+            logger.log(`Swap ${swap.id}: VTXO funded — claiming ahead of Boltz status`);
+            await claim();
+            this.actionExecutedListeners.forEach((listener) => listener(swap, action));
+        } catch (error) {
+            logger.error(`Failed to execute VTXO-triggered claim for swap ${swap.id}:`, error);
+            this.swapFailedListeners.forEach((listener) => listener(swap, error as Error));
+        } finally {
+            this.swapsInProgress.delete(swap.id);
+        }
+    }
+
+    /**
      * Schedule another `executeAutonomousAction` run for a chain swap whose
      * refund left VTXOs deferred. After the retry completes, if no further
      * deferral was reported, finalize monitoring cleanup.

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -22,7 +22,7 @@ import {
 } from "./types";
 import { NetworkError, SwapError, SwapNotFoundError } from "./errors";
 import { logger } from "./logger";
-import { SwapActionLog } from "./swap-status-reconciler";
+import { SwapActionLog, SwapState } from "./swap-status-reconciler";
 
 /**
  * Swap action types emitted by SwapManager.
@@ -124,6 +124,13 @@ export interface SwapManagerClient {
         currentReconnectDelay: number;
         currentPollRetryDelay: number;
     }>;
+    /**
+     * Returns the local action log: swap IDs whose claim/refund this manager
+     * has personally completed. Used by `SwapStatusReconciler` (see
+     * swap-status-reconciler.ts) to disambiguate a VTXO observed spent when
+     * Boltz hasn't (yet) reported a terminal status.
+     */
+    getActionLog(): SwapActionLog;
     onSwapUpdate(listener: SwapUpdateListener): Promise<() => void>;
     onSwapCompleted(listener: SwapCompletedListener): Promise<() => void>;
     onSwapFailed(listener: SwapFailedListener): Promise<() => void>;
@@ -977,13 +984,19 @@ export class SwapManager implements SwapManagerClient {
     }
 
     /**
-     * Drop a swap from monitoring and emit the terminal completion event.
-     * Shared between the on-status-update finalization path and the
-     * refund-retry finalization path (used when a previously-deferred
-     * chain refund has finished its remaining work).
+     * Idempotent cleanup core shared by every finalization path: removes the
+     * swap from `monitoredSwaps` and clears its per-swap bookkeeping
+     * (subscriptions, in-flight chain-claim promise, poll/refund retry
+     * timers). Returns `false` (no-op) if the swap was already finalized.
+     *
+     * Deliberately does NOT touch `swapUpdateListeners`/per-swap
+     * `swapSubscriptions` callbacks — those report a `BoltzSwapStatus`
+     * transition, which callers of this helper (see
+     * {@link finalizeMonitoredSwap}, {@link resolveSwapFromVtxo}) may not
+     * have (a VTXO-derived finalize never mutates `swap.status`).
      */
-    private finalizeMonitoredSwap(swap: BoltzSwap): void {
-        if (!this.monitoredSwaps.has(swap.id)) return;
+    private stopMonitoring(swap: BoltzSwap): boolean {
+        if (!this.monitoredSwaps.has(swap.id)) return false;
         this.monitoredSwaps.delete(swap.id);
         this.swapSubscriptions.delete(swap.id);
         this.chainClaimPromises.delete(swap.id);
@@ -997,7 +1010,65 @@ export class SwapManager implements SwapManagerClient {
             clearTimeout(refundRetry);
             this.refundRetryTimers.delete(swap.id);
         }
+        return true;
+    }
+
+    /**
+     * Drop a swap from monitoring and emit the terminal completion event.
+     * Shared between the on-status-update finalization path and the
+     * refund-retry finalization path (used when a previously-deferred
+     * chain refund has finished its remaining work).
+     */
+    private finalizeMonitoredSwap(swap: BoltzSwap): void {
+        if (!this.stopMonitoring(swap)) return;
         this.swapCompletedListeners.forEach((listener) => listener(swap));
+    }
+
+    /**
+     * Finalize a swap whose terminal lifecycle state was derived from an
+     * on-chain VTXO signal rather than a Boltz-reported status — see
+     * `SwapStatusReconciler`/`deriveSwapState` in swap-status-reconciler.ts.
+     * Designed to be wired as the reconciler's `onSwapResolved` callback.
+     *
+     * Reuses the same cleanup and terminal-event emission as
+     * {@link finalizeMonitoredSwap}: `"Settled"`/`"Refunded"` route to the
+     * `onSwapCompleted` listeners (matching how the Boltz-status-driven path
+     * treats any terminal outcome reached without an autonomous-action
+     * exception), `"Failed"` routes to `onSwapFailed` with a `SwapError`
+     * describing the VTXO-derived outcome.
+     *
+     * Idempotent: a swap no longer in `monitoredSwaps` (e.g. already
+     * finalized by a Boltz status update that raced this VTXO event) is a
+     * no-op. Also a no-op while {@link executeAutonomousAction} is mid-flight
+     * for this swap (`swapsInProgress`), so this method can never pull a
+     * swap out from under an in-progress claim/refund — that action will
+     * reach its own terminal status shortly and finalize through the normal
+     * path instead.
+     *
+     * Does NOT mutate `swap.status` or persist anything (this task adds no
+     * persisted derived-state field). Consequently, `waitForSwapCompletion`
+     * and per-swap `subscribeToSwapUpdates` subscribers — which gate on
+     * `isFinalStatus(swap)`, itself keyed entirely off `BoltzSwapStatus` —
+     * do not observe a resolution reached only through this path; they keep
+     * waiting for Boltz's own status feed, exactly as before this method
+     * existed. Known limitation, flagged for whoever wires this into a live
+     * ContractManager subscription.
+     */
+    resolveSwapFromVtxo(swap: BoltzSwap, state: SwapState): void {
+        if (state !== "Settled" && state !== "Refunded" && state !== "Failed") return;
+        if (this.swapsInProgress.has(swap.id)) return;
+
+        if (state === "Failed") {
+            if (!this.stopMonitoring(swap)) return;
+            const error = new SwapError({
+                message: `Swap ${swap.id} resolved as failed from an on-chain VTXO signal`,
+                pendingSwap: swap,
+            });
+            this.swapFailedListeners.forEach((listener) => listener(swap, error));
+            return;
+        }
+
+        this.finalizeMonitoredSwap(swap);
     }
 
     /**

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -22,6 +22,7 @@ import {
 } from "./types";
 import { NetworkError, SwapError, SwapNotFoundError } from "./errors";
 import { logger } from "./logger";
+import { SwapActionLog } from "./swap-status-reconciler";
 
 /**
  * Swap action types emitted by SwapManager.
@@ -228,6 +229,14 @@ export class SwapManager implements SwapManagerClient {
     // Race condition prevention
     private swapsInProgress = new Set<string>();
 
+    // Action log: swap IDs whose claim/refund WE personally completed via
+    // the callbacks below (populated at the end of the execute*Action
+    // helpers, success only). Consumed by deriveSwapState
+    // (swap-status-reconciler.ts) to disambiguate "spent, but by whom" when
+    // reconciling swap status from VTXO events.
+    private claimedSwapIds = new Set<string>();
+    private refundedSwapIds = new Set<string>();
+
     // Per-swap subscriptions for UI hooks
     private swapSubscriptions = new Map<string, Set<SwapUpdateCallback>>();
 
@@ -299,6 +308,16 @@ export class SwapManager implements SwapManagerClient {
         this.refundArkCallback = callbacks.refundArk;
         this.signServerClaimCallback = callbacks.signServerClaim ?? null;
         this.saveSwapCallback = callbacks.saveSwap;
+    }
+
+    /**
+     * Returns the local action log: swap IDs whose claim/refund this manager
+     * has personally completed (see the execute*Action methods). Used by
+     * deriveSwapState (swap-status-reconciler.ts) to disambiguate a VTXO
+     * observed spent when Boltz hasn't (yet) reported a terminal status.
+     */
+    getActionLog(): SwapActionLog {
+        return { claimed: this.claimedSwapIds, refunded: this.refundedSwapIds };
     }
 
     /**
@@ -1160,6 +1179,7 @@ export class SwapManager implements SwapManagerClient {
         }
 
         await this.claimCallback(swap);
+        this.claimedSwapIds.add(swap.id);
     }
 
     /**
@@ -1172,6 +1192,7 @@ export class SwapManager implements SwapManagerClient {
         }
 
         await this.refundCallback(swap);
+        this.refundedSwapIds.add(swap.id);
     }
 
     /**
@@ -1186,6 +1207,7 @@ export class SwapManager implements SwapManagerClient {
         const claimPromise = this.claimArkCallback(swap);
         this.rememberChainClaim(swap.id, claimPromise);
         await claimPromise;
+        this.claimedSwapIds.add(swap.id);
     }
 
     /**
@@ -1200,6 +1222,7 @@ export class SwapManager implements SwapManagerClient {
         const claimPromise = this.claimBtcCallback(swap);
         this.rememberChainClaim(swap.id, claimPromise);
         await claimPromise;
+        this.claimedSwapIds.add(swap.id);
     }
 
     /**
@@ -1231,7 +1254,16 @@ export class SwapManager implements SwapManagerClient {
             return;
         }
 
-        return this.refundArkCallback(swap);
+        const outcome = await this.refundArkCallback(swap);
+        // Only record when nothing was left outstanding (mirrors the
+        // `outcome.skipped > 0` retry gate above in executeAutonomousAction):
+        // a partial sweep means the refund is not actually complete yet, so
+        // recording it here would let a later "already refunded" check skip
+        // the still-pending retry and strand the remaining VTXOs.
+        if (outcome.skipped === 0) {
+            this.refundedSwapIds.add(swap.id);
+        }
+        return outcome;
     }
 
     /**

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -131,6 +131,13 @@ export interface SwapManagerClient {
      * Boltz hasn't (yet) reported a terminal status.
      */
     getActionLog(): SwapActionLog;
+    /**
+     * Synchronous lookup of a currently-monitored swap by id, or `undefined`
+     * if unknown. Used by `SwapStatusReconciler.deriveSwapState`, which must
+     * resolve a swap's derived state synchronously inside `onContractEvent`
+     * (see swap-status-reconciler.ts).
+     */
+    getSwap(id: string): BoltzSwap | undefined;
     onSwapUpdate(listener: SwapUpdateListener): Promise<() => void>;
     onSwapCompleted(listener: SwapCompletedListener): Promise<() => void>;
     onSwapFailed(listener: SwapFailedListener): Promise<() => void>;
@@ -325,6 +332,14 @@ export class SwapManager implements SwapManagerClient {
      */
     getActionLog(): SwapActionLog {
         return { claimed: this.claimedSwapIds, refunded: this.refundedSwapIds };
+    }
+
+    /**
+     * Synchronous lookup of a currently-monitored swap by id. See
+     * {@link SwapManagerClient.getSwap}.
+     */
+    getSwap(id: string): BoltzSwap | undefined {
+        return this.monitoredSwaps.get(id);
     }
 
     /**
@@ -989,11 +1004,14 @@ export class SwapManager implements SwapManagerClient {
      * (subscriptions, in-flight chain-claim promise, poll/refund retry
      * timers). Returns `false` (no-op) if the swap was already finalized.
      *
-     * Deliberately does NOT touch `swapUpdateListeners`/per-swap
-     * `swapSubscriptions` callbacks — those report a `BoltzSwapStatus`
-     * transition, which callers of this helper (see
-     * {@link finalizeMonitoredSwap}, {@link resolveSwapFromVtxo}) may not
-     * have (a VTXO-derived finalize never mutates `swap.status`).
+     * Deliberately does NOT fire `swapUpdateListeners`/per-swap
+     * `swapSubscriptions` callbacks itself — those report a `BoltzSwapStatus`
+     * transition and must fire with the swap's `oldStatus`, which only the
+     * caller has (see {@link finalizeMonitoredSwap}, {@link
+     * resolveSwapFromVtxo}). A caller that needs subscribers notified must
+     * capture `swapSubscriptions.get(swap.id)` BEFORE calling this method —
+     * the captured `Set` reference stays valid after its map entry is
+     * deleted here, so it can still be iterated afterwards.
      */
     private stopMonitoring(swap: BoltzSwap): boolean {
         if (!this.monitoredSwaps.has(swap.id)) return false;
@@ -1025,41 +1043,108 @@ export class SwapManager implements SwapManagerClient {
     }
 
     /**
+     * Maps a terminal `SwapState` derived from an on-chain VTXO signal (see
+     * `deriveSwapState` in swap-status-reconciler.ts) to a concrete
+     * `BoltzSwapStatus` for `swap.status`. Every branch is chosen so the
+     * corresponding `is*FinalStatus` predicate accepts it — that's what
+     * {@link isFinalStatus} gates `waitForSwapCompletion`/
+     * `subscribeToSwapUpdates` on, so an unrecognized status here would
+     * silently defeat the whole point of {@link resolveSwapFromVtxo}.
+     *
+     * Submarine has no first-class "refunded" Boltz status: unlike
+     * reverse/chain, `isSubmarineFinalStatus` never includes
+     * `"transaction.refunded"` — this mirrors `deriveTerminalState`'s
+     * submarine branch in swap-status-reconciler.ts, which likewise only
+     * ever derives `"Failed"`/`"Settled"` from Boltz's own reported
+     * statuses, never `"Refunded"`. `"swap.expired"` is used instead: it's
+     * already the status `isSubmarineRefundableStatus` associates with the
+     * one non-final refundable status this case arises from
+     * (`"transaction.lockupFailed"` — the swap sat refundable-but-pending
+     * until our own refund tx spent the VHTLC), and it satisfies both
+     * `isSubmarineFinalStatus` and `isSubmarineFailedStatus`.
+     */
+    private terminalStatusForVtxoState(
+        swap: BoltzSwap,
+        state: "Settled" | "Refunded" | "Failed",
+    ): BoltzSwapStatus {
+        switch (swap.type) {
+            case "reverse":
+                if (state === "Settled") return "invoice.settled"; // isReverseFinalStatus ✓
+                if (state === "Refunded") return "transaction.refunded"; // isReverseFinalStatus ✓
+                return "transaction.failed"; // Failed; isReverseFinalStatus ✓
+            case "submarine":
+                if (state === "Settled") return "transaction.claimed"; // isSubmarineFinalStatus ✓
+                if (state === "Refunded") return "swap.expired"; // isSubmarineFinalStatus ✓ (see docstring)
+                return "invoice.failedToPay"; // Failed; isSubmarineFinalStatus ✓
+            case "chain":
+                if (state === "Settled") return "transaction.claimed"; // isChainFinalStatus ✓
+                if (state === "Refunded") return "transaction.refunded"; // isChainFinalStatus ✓
+                return "transaction.failed"; // Failed; isChainFinalStatus ✓
+        }
+    }
+
+    /**
      * Finalize a swap whose terminal lifecycle state was derived from an
      * on-chain VTXO signal rather than a Boltz-reported status — see
      * `SwapStatusReconciler`/`deriveSwapState` in swap-status-reconciler.ts.
      * Designed to be wired as the reconciler's `onSwapResolved` callback.
      *
-     * Reuses the same cleanup and terminal-event emission as
-     * {@link finalizeMonitoredSwap}: `"Settled"`/`"Refunded"` route to the
-     * `onSwapCompleted` listeners (matching how the Boltz-status-driven path
-     * treats any terminal outcome reached without an autonomous-action
-     * exception), `"Failed"` routes to `onSwapFailed` with a `SwapError`
-     * describing the VTXO-derived outcome.
+     * Sets `swap.status` to a concrete terminal `BoltzSwapStatus` (see
+     * {@link terminalStatusForVtxoState}) and fires the same update
+     * listeners and per-swap subscriptions a Boltz-status-driven transition
+     * would (see {@link handleSwapStatusUpdate}/{@link
+     * markSwapAsUnknownToProvider}) — this is what wakes a pending
+     * `waitForSwapCompletion`/`subscribeToSwapUpdates` waiter, which
+     * otherwise gates purely on `isFinalStatus(swap)` (itself keyed
+     * entirely off `BoltzSwapStatus`) and would hang forever on a swap only
+     * ever resolved through this VTXO-driven path.
      *
-     * Idempotent: a swap no longer in `monitoredSwaps` (e.g. already
-     * finalized by a Boltz status update that raced this VTXO event) is a
-     * no-op. Also a no-op while {@link executeAutonomousAction} is mid-flight
-     * for this swap (`swapsInProgress`), so this method can never pull a
-     * swap out from under an in-progress claim/refund — that action will
-     * reach its own terminal status shortly and finalize through the normal
-     * path instead.
+     * `"Settled"`/`"Refunded"` route to the `onSwapCompleted` listeners
+     * (matching how the Boltz-status-driven path treats any terminal
+     * outcome reached without an autonomous-action exception), `"Failed"`
+     * routes to `onSwapFailed` with a `SwapError` describing the
+     * VTXO-derived outcome.
      *
-     * Does NOT mutate `swap.status` or persist anything (this task adds no
-     * persisted derived-state field). Consequently, `waitForSwapCompletion`
-     * and per-swap `subscribeToSwapUpdates` subscribers — which gate on
-     * `isFinalStatus(swap)`, itself keyed entirely off `BoltzSwapStatus` —
-     * do not observe a resolution reached only through this path; they keep
-     * waiting for Boltz's own status feed, exactly as before this method
-     * existed. Known limitation, flagged for whoever wires this into a live
-     * ContractManager subscription.
+     * Idempotent: removal from `monitoredSwaps` happens synchronously, up
+     * front (via `stopMonitoring`, mirroring `markSwapAsUnknownToProvider`),
+     * so a duplicate or overlapping call for the same swap — including one
+     * that arrives while an earlier call is still awaiting `saveSwap` — is
+     * a no-op. Also a no-op while {@link executeAutonomousAction} is
+     * mid-flight for this swap (`swapsInProgress`), so this method can
+     * never pull a swap out from under an in-progress claim/refund — that
+     * action will reach its own terminal status shortly and finalize
+     * through the normal path instead.
      */
-    resolveSwapFromVtxo(swap: BoltzSwap, state: SwapState): void {
+    async resolveSwapFromVtxo(swap: BoltzSwap, state: SwapState): Promise<void> {
         if (state !== "Settled" && state !== "Refunded" && state !== "Failed") return;
         if (this.swapsInProgress.has(swap.id)) return;
 
+        // Capture the per-swap subscriber set (if any) before stopMonitoring
+        // deletes its map entry — see stopMonitoring's docstring.
+        const subscribers = this.swapSubscriptions.get(swap.id);
+        if (!this.stopMonitoring(swap)) return;
+
+        const oldStatus = swap.status;
+        swap.status = this.terminalStatusForVtxoState(swap, state);
+
+        this.swapUpdateListeners.forEach((listener) => listener(swap, oldStatus));
+        if (subscribers) {
+            subscribers.forEach((callback) => {
+                try {
+                    callback(swap, oldStatus);
+                } catch (error) {
+                    logger.error(`Error in swap subscription callback for ${swap.id}:`, error);
+                }
+            });
+        }
+
+        try {
+            await this.saveSwap(swap);
+        } catch (saveError) {
+            logger.error(`Failed to persist VTXO-derived status for swap ${swap.id}:`, saveError);
+        }
+
         if (state === "Failed") {
-            if (!this.stopMonitoring(swap)) return;
             const error = new SwapError({
                 message: `Swap ${swap.id} resolved as failed from an on-chain VTXO signal`,
                 pendingSwap: swap,
@@ -1068,7 +1153,7 @@ export class SwapManager implements SwapManagerClient {
             return;
         }
 
-        this.finalizeMonitoredSwap(swap);
+        this.swapCompletedListeners.forEach((listener) => listener(swap));
     }
 
     /**

--- a/packages/boltz-swap/src/swap-status-reconciler.ts
+++ b/packages/boltz-swap/src/swap-status-reconciler.ts
@@ -15,12 +15,14 @@
  * sender (refund path, after timeout) — so if it wasn't us, it must have
  * been the other one.
  */
+import type { ContractEvent } from "@arkade-os/sdk";
 import {
     isChainFinalStatus,
     isReverseFinalStatus,
     isSubmarineFailedStatus,
     isSubmarineFinalStatus,
 } from "./boltz-swap-provider";
+import { logger } from "./logger";
 import { BoltzSwap } from "./types";
 
 /** Domain swap lifecycle state, derived from Boltz status + VTXO signal + action log. */
@@ -144,5 +146,84 @@ function deriveSpentByOthersState(swap: BoltzSwap): SwapState {
             if (swap.request.from === "ARK") return "Settled";
             if (swap.request.to === "ARK") return "Failed";
             return "Pending"; // genuinely ambiguous / malformed direction
+    }
+}
+
+/** Dependencies injected into {@link SwapStatusReconciler}. */
+export interface SwapStatusReconcilerDeps {
+    /** Looks up a currently-monitored swap by id, or `undefined` if unknown. */
+    getSwap(id: string): BoltzSwap | undefined;
+    /** Returns the current action log — see {@link SwapManager.getActionLog}. */
+    getActionLog(): SwapActionLog;
+    /**
+     * Invoked when a `ContractEvent` resolves a swap to a terminal
+     * {@link SwapState} (`"Settled"`, `"Refunded"`, or `"Failed"`).
+     */
+    onSwapResolved(swap: BoltzSwap, state: SwapState): void;
+}
+
+/**
+ * Bridges `ContractManager` VTXO events to swap-lifecycle resolution.
+ *
+ * Maintains a `contractScript -> swapId` index — populated by whoever
+ * registers a swap's tracked `vhtlc` contract (see `swap-contract.ts`) — and,
+ * on each `vtxo_received`/`vtxo_spent` event for a known script, derives the
+ * swap's current {@link SwapState} via {@link deriveSwapState} and reports it
+ * through {@link SwapStatusReconcilerDeps.onSwapResolved} whenever that state
+ * is terminal.
+ *
+ * `connection_reset` events are intentionally ignored here: they carry no
+ * `contractScript`, and `ContractManager` re-establishes VTXO state on
+ * reconnect by re-emitting `vtxo_received`/`vtxo_spent` for anything that
+ * changed, so a dropped-and-restored connection still converges without
+ * special-casing it in this class.
+ */
+export class SwapStatusReconciler {
+    private readonly scriptToSwapId = new Map<string, string>();
+
+    constructor(private readonly deps: SwapStatusReconcilerDeps) {}
+
+    /** Start resolving VTXO events on `contractScript` against `swapId`. */
+    addSwapScript(contractScript: string, swapId: string): void {
+        this.scriptToSwapId.set(contractScript, swapId);
+    }
+
+    /** Stop resolving VTXO events on `contractScript` (e.g. swap finalized). */
+    removeSwapScript(contractScript: string): void {
+        this.scriptToSwapId.delete(contractScript);
+    }
+
+    /**
+     * Handles a single `ContractManager` event. Intended to be wired as the
+     * `ContractEventCallback` passed to `contractManager.onContractEvent`,
+     * e.g. `contractManager.onContractEvent((event) =>
+     * reconciler.onContractEvent(event))`.
+     *
+     * Never throws: a malformed event, an unregistered script, or an error
+     * thrown while deriving state is logged and swallowed so one bad event
+     * can never tear down the caller's event subscription.
+     */
+    onContractEvent(event: ContractEvent): void {
+        try {
+            if (event.type !== "vtxo_received" && event.type !== "vtxo_spent") {
+                // "connection_reset" — ignored, see class docstring.
+                return;
+            }
+
+            const swapId = this.scriptToSwapId.get(event.contractScript);
+            if (!swapId) return;
+
+            const swap = this.deps.getSwap(swapId);
+            if (!swap) return;
+
+            const signal: VtxoSignal = event.type === "vtxo_received" ? "funded" : "spent";
+            const state = deriveSwapState(swap, signal, this.deps.getActionLog());
+
+            if (state === "Settled" || state === "Refunded" || state === "Failed") {
+                this.deps.onSwapResolved(swap, state);
+            }
+        } catch (error) {
+            logger.error("SwapStatusReconciler: error handling contract event:", error);
+        }
     }
 }

--- a/packages/boltz-swap/src/swap-status-reconciler.ts
+++ b/packages/boltz-swap/src/swap-status-reconciler.ts
@@ -160,6 +160,17 @@ export interface SwapStatusReconcilerDeps {
      * {@link SwapState} (`"Settled"`, `"Refunded"`, or `"Failed"`).
      */
     onSwapResolved(swap: BoltzSwap, state: SwapState): void;
+    /**
+     * Invoked when a `vtxo_received` event funds a known swap's tracked
+     * VHTLC and the derived state is not (yet) terminal — i.e. the lockup is
+     * merely funded, not finalized. Lets a swap's claim action run as soon
+     * as the lockup is observed on-chain, without waiting for Boltz's own
+     * status feed to report the swap claimable — see
+     * `SwapManager.triggerClaimFromVtxo`. A no-op there for swap
+     * types/directions where the wallet isn't the VHTLC claimer (e.g.
+     * submarine) is expected, not an error.
+     */
+    onSwapFunded(swap: BoltzSwap): void;
 }
 
 /**
@@ -171,6 +182,16 @@ export interface SwapStatusReconcilerDeps {
  * swap's current {@link SwapState} via {@link deriveSwapState} and reports it
  * through {@link SwapStatusReconcilerDeps.onSwapResolved} whenever that state
  * is terminal.
+ *
+ * A `vtxo_received` event that does NOT resolve to a terminal state (the
+ * common case — the lockup is merely funded, not yet finalized) is reported
+ * through {@link SwapStatusReconcilerDeps.onSwapFunded} instead, so a claim
+ * can run ahead of Boltz's own status feed for swap types/directions where
+ * the wallet is the VHTLC claimer.
+ *
+ * Once a script's swap resolves to a terminal state, its `scriptToSwapId`
+ * entry is pruned (via {@link removeSwapScript}) — left unpruned, the
+ * mapping would otherwise grow for the lifetime of the process.
  *
  * `connection_reset` events are intentionally ignored here: they carry no
  * `contractScript`, and `ContractManager` re-establishes VTXO state on
@@ -221,6 +242,22 @@ export class SwapStatusReconciler {
 
             if (state === "Settled" || state === "Refunded" || state === "Failed") {
                 this.deps.onSwapResolved(swap, state);
+                // Finalized — this script has no further use; leaving it
+                // mapped would grow scriptToSwapId unboundedly (see class
+                // docstring).
+                this.removeSwapScript(event.contractScript);
+                return;
+            }
+
+            // Not (yet) terminal. A funded lockup is worth acting on
+            // immediately for swap types/directions where the wallet is the
+            // VHTLC claimer — see SwapManager.triggerClaimFromVtxo. There is
+            // no equivalent action for a non-terminal "spent" signal (the
+            // only way deriveSwapState returns non-terminal for "spent" is
+            // the genuinely-ambiguous malformed-direction fallback), so this
+            // is gated to the funded signal only.
+            if (signal === "funded") {
+                this.deps.onSwapFunded(swap);
             }
         } catch (error) {
             logger.error("SwapStatusReconciler: error handling contract event:", error);

--- a/packages/boltz-swap/src/swap-status-reconciler.ts
+++ b/packages/boltz-swap/src/swap-status-reconciler.ts
@@ -1,0 +1,148 @@
+/**
+ * Pure swap-status reconciliation: derives a domain `SwapState` from Boltz's
+ * reported status, an on-chain VTXO signal (from `ContractManager` watching
+ * the swap's registered `vhtlc` contract — see `swap-contract.ts`), and a
+ * local action-log of claims/refunds WE completed (see
+ * `SwapManager.getActionLog`).
+ *
+ * Disambiguation is ACTION-LOG-PRIMARY: Boltz's own status feed is trusted
+ * directly only for the small set of genuinely terminal statuses (a
+ * failsafe). Everything else — including a VTXO we've observed spent while
+ * Boltz hasn't (yet) reported a terminal status — is derived from (a) our
+ * own action log ("did WE complete the claim/refund?") and, failing that,
+ * (b) the VHTLC role structure of the swap type: only two parties can ever
+ * spend a VHTLC — its receiver (claim path, needs the preimage) or its
+ * sender (refund path, after timeout) — so if it wasn't us, it must have
+ * been the other one.
+ */
+import {
+    isChainFinalStatus,
+    isReverseFinalStatus,
+    isSubmarineFailedStatus,
+    isSubmarineFinalStatus,
+} from "./boltz-swap-provider";
+import { BoltzSwap } from "./types";
+
+/** Domain swap lifecycle state, derived from Boltz status + VTXO signal + action log. */
+export type SwapState = "Pending" | "Settled" | "Refunded" | "Failed" | "Unknown";
+
+/**
+ * Local record of swap IDs whose claim/refund WE (this wallet) completed.
+ * Populated by {@link SwapManager.getActionLog} — see swap-manager.ts.
+ */
+export interface SwapActionLog {
+    /** Swap IDs we successfully claimed. */
+    claimed: ReadonlySet<string>;
+    /** Swap IDs we successfully refunded. */
+    refunded: ReadonlySet<string>;
+}
+
+/**
+ * On-chain state of the swap's tracked VHTLC, from ContractManager/VTXO
+ * events:
+ * - `"none"` — never observed funded.
+ * - `"funded"` — lockup VTXO present and unspent.
+ * - `"spent"` — the lockup VTXO has been spent, by either party.
+ */
+export type VtxoSignal = "none" | "funded" | "spent";
+
+/**
+ * Derives a swap's domain lifecycle state from its Boltz status, the current
+ * VTXO signal for its tracked VHTLC, and the local action log.
+ *
+ * Precedence:
+ * 1. A genuinely terminal Boltz status is a failsafe truth, returned
+ *    regardless of signal or action log (reuses the `is*FinalStatus`
+ *    predicates from `boltz-swap-provider.ts`).
+ * 2. Otherwise, if the VHTLC is `"spent"`: the action log first (did we
+ *    complete the claim/refund?), then the VHTLC role for this swap
+ *    type/direction (see {@link deriveSpentByOthersState}).
+ * 3. Otherwise (`"funded"` or `"none"`, no terminal status yet): `"Pending"`.
+ *
+ * Pure function — no I/O, no mutation.
+ */
+export function deriveSwapState(
+    swap: BoltzSwap,
+    signal: VtxoSignal,
+    log: SwapActionLog,
+): SwapState {
+    const terminal = deriveTerminalState(swap);
+    if (terminal) return terminal;
+
+    if (signal === "spent") {
+        if (log.claimed.has(swap.id)) return "Settled";
+        if (log.refunded.has(swap.id)) return "Refunded";
+        return deriveSpentByOthersState(swap);
+    }
+
+    // "funded" or "none", with no Boltz-terminal status yet: still in flight.
+    return "Pending";
+}
+
+/**
+ * Boltz-terminal arm: trusted directly regardless of VTXO signal (failsafe).
+ * Returns `undefined` when the swap's current status is not (yet) terminal.
+ *
+ * Note: `isReverseFailedStatus` is intentionally NOT used here — unlike
+ * `isSubmarineFailedStatus`/`isChainFailedStatus`, it classifies
+ * `"transaction.refunded"` as a failure, which would collide with the
+ * separate `"Refunded"` state below. Reverse's terminal 3-way split is
+ * therefore spelled out explicitly instead.
+ */
+function deriveTerminalState(swap: BoltzSwap): SwapState | undefined {
+    switch (swap.type) {
+        case "reverse":
+            if (!isReverseFinalStatus(swap.status)) return undefined;
+            if (swap.status === "invoice.settled") return "Settled";
+            if (swap.status === "transaction.refunded") return "Refunded";
+            return "Failed"; // invoice.expired | transaction.failed | swap.expired
+
+        case "submarine":
+            if (!isSubmarineFinalStatus(swap.status)) return undefined;
+            // Safe to use directly here: isSubmarineFinalStatus already
+            // excludes "transaction.lockupFailed" (negotiable, not
+            // terminal), so within the final set isSubmarineFailedStatus
+            // correctly separates invoice.failedToPay/swap.expired (Failed)
+            // from transaction.claimed (Settled).
+            return isSubmarineFailedStatus(swap.status) ? "Failed" : "Settled";
+
+        case "chain":
+            if (!isChainFinalStatus(swap.status)) return undefined;
+            if (swap.status === "transaction.claimed") return "Settled";
+            if (swap.status === "transaction.refunded") return "Refunded";
+            return "Failed"; // transaction.failed | swap.expired
+    }
+}
+
+/**
+ * Operational arm: the VHTLC was observed spent, but not via an action we
+ * recorded ourselves. Only two parties can ever spend a VHTLC — its receiver
+ * (claim path) or its sender (refund path) — so the outcome follows from
+ * which role WE hold for this swap type/direction (role table mirrored from
+ * `extractSwapVhtlcInputs` in `swap-contract.ts`):
+ *
+ * - reverse: wallet is the VHTLC receiver (only the wallet can claim).
+ *   Spent-without-us means Boltz (sender) refunded its own lockup — we never
+ *   got paid — `"Failed"`.
+ * - submarine: wallet is the VHTLC sender (only the wallet can refund).
+ *   Spent-without-us means Boltz (receiver) claimed our lockup after paying
+ *   the invoice — `"Settled"`.
+ * - chain ARK→BTC (`request.from === "ARK"`): same role shape as submarine
+ *   (wallet is sender, Boltz is receiver on the ARK-side lockup) —
+ *   `"Settled"`.
+ * - chain BTC→ARK (`request.to === "ARK"`): same role shape as reverse
+ *   (wallet is receiver, Boltz is sender on the ARK-side lockup) —
+ *   `"Failed"`.
+ */
+function deriveSpentByOthersState(swap: BoltzSwap): SwapState {
+    switch (swap.type) {
+        case "reverse":
+            return "Failed";
+        case "submarine":
+            return "Settled";
+        case "chain":
+            if (swap.request.from === "ARK") return "Settled";
+            if (swap.request.to === "ARK") return "Failed";
+            return "Pending"; // genuinely ambiguous / malformed direction
+    }
+}

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -1,4 +1,5 @@
 import { ArkProvider, IndexerProvider, IWallet, NetworkName } from "@arkade-os/sdk";
+import type { IContractManager } from "@arkade-os/sdk";
 import {
     CreateReverseSwapResponse,
     CreateSubmarineSwapResponse,
@@ -311,6 +312,16 @@ export interface ArkadeSwapsConfig {
     swapProvider: BoltzSwapProvider;
     /** Explicit IndexerProvider. Falls back to wallet.indexerProvider if omitted. */
     indexerProvider?: IndexerProvider;
+    /**
+     * ContractManager from @arkade-os/sdk used to register VHTLC scripts as
+     * tracked contracts so the wallet monitors and annotates swap virtual outputs.
+     *
+     * Required for all public construction paths. The background swap-poll
+     * processor (swapsPollProcessor) is exempt: it only monitors/claims existing
+     * swaps and never creates them, so it never registers contracts. It
+     * constructs ArkadeSwaps without this field via an internal cast.
+     */
+    contractManager: IContractManager;
     /**
      * Background swap monitoring and autonomous actions (enabled by default).
      * - `undefined` or `true`: SwapManager enabled with default configuration

--- a/packages/boltz-swap/src/utils/swap-contract.ts
+++ b/packages/boltz-swap/src/utils/swap-contract.ts
@@ -99,9 +99,9 @@ const extractSwapVhtlcInputs = (swap: BoltzSwap): SwapVhtlcInputs => {
             if (isFromArk) {
                 // ARK → BTC: user sends ARK, Boltz claims; user is sender, Boltz server is receiver.
                 const { lockupDetails } = swap.response;
-                if (!lockupDetails.timeouts) {
+                if (!lockupDetails?.timeouts) {
                     throw new Error(
-                        `Swap ${swap.id}: missing timeouts in lockupDetails for ARK→BTC chain swap`,
+                        `Swap ${swap.id}: missing lockupDetails or timeouts for ARK→BTC chain swap`,
                     );
                 }
                 return {
@@ -114,9 +114,9 @@ const extractSwapVhtlcInputs = (swap: BoltzSwap): SwapVhtlcInputs => {
             } else {
                 // BTC → ARK: Boltz locks on BTC side; user claims on ARK side (claimDetails).
                 const { claimDetails } = swap.response;
-                if (!claimDetails.timeouts) {
+                if (!claimDetails?.timeouts) {
                     throw new Error(
-                        `Swap ${swap.id}: missing timeouts in claimDetails for BTC→ARK chain swap`,
+                        `Swap ${swap.id}: missing claimDetails or timeouts for BTC→ARK chain swap`,
                     );
                 }
                 return {

--- a/packages/boltz-swap/src/utils/swap-contract.ts
+++ b/packages/boltz-swap/src/utils/swap-contract.ts
@@ -1,0 +1,276 @@
+/**
+ * Pure mapper: converts a persisted BoltzSwap into the CreateContractParams
+ * shape that ContractManager.createContract() accepts.
+ *
+ * This module is intentionally dependency-free from ArkadeSwaps — it takes
+ * only the swap object and ArkInfo (both already available at call sites) and
+ * produces a value object, making it straightforwardly testable.
+ *
+ * The resolver loop mirrors the private `ArkadeSwaps.resolveVHTLCForLockup`
+ * method, extracted here as a shared free function (`resolveSwapVhtlc`) so
+ * the mapper and the class can stay in sync without duplicating the logic.
+ */
+import { hex } from "@scure/base";
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { ArkInfo, CreateContractParams, VHTLCContractHandler, VHTLC } from "@arkade-os/sdk";
+import type { VHTLCContractParams, IContractManager, Contract } from "@arkade-os/sdk";
+import { BoltzSwap } from "../types";
+import { candidateServerPubkeys, createVHTLCScript } from "./vhtlc";
+import { normalizeToXOnlyKey } from "./signatures";
+
+/**
+ * Per-swap-type field extraction result.
+ *
+ * These are the inputs that vary between swap types before the common VHTLC
+ * construction step.
+ */
+interface SwapVhtlcInputs {
+    /** SHA256 preimage hash bytes (the raw 32-byte digest, NOT yet RIPEMD160'd). */
+    preimageHashBytes: Uint8Array;
+    /** X-only or compressed receiver public key hex (normalised internally). */
+    receiverPubkey: string;
+    /** X-only or compressed sender public key hex (normalised internally). */
+    senderPubkey: string;
+    timeoutBlockHeights: {
+        refund: number;
+        unilateralClaim: number;
+        unilateralRefund: number;
+        unilateralRefundWithoutReceiver: number;
+    };
+    lockupAddress: string;
+}
+
+/**
+ * Extracts the VHTLC construction inputs for each swap type.
+ *
+ * Role assignments mirror the private `ArkadeSwaps.resolveVHTLCForLockup`
+ * call sites:
+ *
+ * | Swap type        | receiver              | sender                             | lockupAddress                      |
+ * |------------------|-----------------------|------------------------------------|------------------------------------|
+ * | reverse          | wallet (claimPubkey)  | Boltz (response.refundPublicKey)   | response.lockupAddress             |
+ * | submarine        | Boltz (claimPubkey)   | wallet (request.refundPublicKey)   | response.address                   |
+ * | chain (BTC→ARK)  | wallet (claimPubkey)  | Boltz (claimDetails.serverPubkey)  | claimDetails.lockupAddress         |
+ * | chain (ARK→BTC)  | Boltz (claimDetails.serverPubkey) | wallet (refundPublicKey) | lockupDetails.lockupAddress    |
+ */
+const extractSwapVhtlcInputs = (swap: BoltzSwap): SwapVhtlcInputs => {
+    switch (swap.type) {
+        case "reverse": {
+            const { refundPublicKey, lockupAddress, timeoutBlockHeights } = swap.response;
+            if (!refundPublicKey || !lockupAddress || !timeoutBlockHeights) {
+                throw new Error(
+                    `Swap ${swap.id}: incomplete reverse swap response (missing refundPublicKey, lockupAddress, or timeoutBlockHeights)`,
+                );
+            }
+            return {
+                preimageHashBytes: hex.decode(swap.request.preimageHash),
+                receiverPubkey: swap.request.claimPublicKey,
+                senderPubkey: refundPublicKey,
+                timeoutBlockHeights,
+                lockupAddress,
+            };
+        }
+
+        case "submarine": {
+            const { claimPublicKey, address, timeoutBlockHeights } = swap.response;
+            const preimageHash = swap.preimageHash;
+            if (!claimPublicKey || !address || !timeoutBlockHeights) {
+                throw new Error(
+                    `Swap ${swap.id}: incomplete submarine swap response (missing claimPublicKey, address, or timeoutBlockHeights)`,
+                );
+            }
+            if (!preimageHash) {
+                throw new Error(
+                    `Swap ${swap.id}: preimage hash is required for submarine swap contract registration`,
+                );
+            }
+            return {
+                preimageHashBytes: hex.decode(preimageHash),
+                receiverPubkey: claimPublicKey,
+                senderPubkey: swap.request.refundPublicKey,
+                timeoutBlockHeights,
+                lockupAddress: address,
+            };
+        }
+
+        case "chain": {
+            // Determine which side is ARK to identify the VHTLC lockup address.
+            const isFromArk = swap.request.from === "ARK";
+            if (isFromArk) {
+                // ARK → BTC: user sends ARK, Boltz claims; user is sender, Boltz server is receiver.
+                const { lockupDetails } = swap.response;
+                if (!lockupDetails.timeouts) {
+                    throw new Error(
+                        `Swap ${swap.id}: missing timeouts in lockupDetails for ARK→BTC chain swap`,
+                    );
+                }
+                return {
+                    preimageHashBytes: hex.decode(swap.request.preimageHash),
+                    receiverPubkey: lockupDetails.serverPublicKey,
+                    senderPubkey: swap.request.refundPublicKey,
+                    timeoutBlockHeights: lockupDetails.timeouts,
+                    lockupAddress: lockupDetails.lockupAddress,
+                };
+            } else {
+                // BTC → ARK: Boltz locks on BTC side; user claims on ARK side (claimDetails).
+                const { claimDetails } = swap.response;
+                if (!claimDetails.timeouts) {
+                    throw new Error(
+                        `Swap ${swap.id}: missing timeouts in claimDetails for BTC→ARK chain swap`,
+                    );
+                }
+                return {
+                    preimageHashBytes: hex.decode(swap.request.preimageHash),
+                    receiverPubkey: swap.request.claimPublicKey,
+                    senderPubkey: claimDetails.serverPublicKey,
+                    timeoutBlockHeights: claimDetails.timeouts,
+                    lockupAddress: claimDetails.lockupAddress,
+                };
+            }
+        }
+    }
+};
+
+/**
+ * Reconstruct a swap's VHTLC by matching the stored lockup address across the
+ * current and deprecated server signers in `arkInfo`.
+ *
+ * Extracted from the private `ArkadeSwaps.resolveVHTLCForLockup` method so
+ * the mapper can use it without going through the class, keeping this module
+ * pure (no `this` / provider calls).
+ *
+ * @returns The matched VHTLC script, its address, and the server x-only pubkey
+ *   it was built under (which may be a deprecated signer).
+ * @throws if no candidate matches the stored lockup address.
+ */
+export const resolveSwapVhtlc = (args: {
+    arkInfo: ArkInfo;
+    preimageHashBytes: Uint8Array;
+    receiverPubkey: string;
+    senderPubkey: string;
+    timeoutBlockHeights: SwapVhtlcInputs["timeoutBlockHeights"];
+    lockupAddress: string;
+    swapId: string;
+}): { vhtlcScript: VHTLC.Script; vhtlcAddress: string; serverXOnlyPublicKey: Uint8Array } => {
+    const candidates = candidateServerPubkeys(args.arkInfo);
+    for (const serverPubkey of candidates) {
+        const { vhtlcScript, vhtlcAddress } = createVHTLCScript({
+            network: args.arkInfo.network,
+            preimageHash: args.preimageHashBytes,
+            receiverPubkey: args.receiverPubkey,
+            senderPubkey: args.senderPubkey,
+            serverPubkey,
+            timeoutBlockHeights: args.timeoutBlockHeights,
+        });
+        if (vhtlcAddress !== args.lockupAddress) continue;
+        // Note: createVHTLCScript (vhtlc.ts:110) already throws if claimScript is
+        // absent, so no redundant guard is needed here.
+        return {
+            vhtlcScript,
+            vhtlcAddress,
+            serverXOnlyPublicKey: normalizeToXOnlyKey(hex.decode(serverPubkey), "server"),
+        };
+    }
+    throw new Error(
+        `Swap ${args.swapId}: VHTLC address mismatch. Expected ${args.lockupAddress}; ` +
+            `no current or deprecated server signer (${candidates.length} candidate(s) tried) ` +
+            `reproduced it`,
+    );
+};
+
+/**
+ * Maps a persisted BoltzSwap to a `CreateContractParams` for the SDK's
+ * ContractManager.
+ *
+ * The returned value is a pure data object — no side effects, no network
+ * calls.  Callers are responsible for passing it to
+ * `contractManager.createContract()`.
+ *
+ * @param swap - The swap whose ARK-side VHTLC should be registered.
+ * @param arkInfo - Current ArkInfo (with `deprecatedSigners`) so that swaps
+ *   created under a now-rotated signer are still resolved correctly.
+ * @returns A `CreateContractParams` with `type: "vhtlc"`, serialized params,
+ *   script, address, state, and metadata.
+ * @throws if the swap response is incomplete or no server signer matches the
+ *   stored lockup address.
+ */
+export const swapToContractParams = (swap: BoltzSwap, arkInfo: ArkInfo): CreateContractParams => {
+    const inputs = extractSwapVhtlcInputs(swap);
+
+    const { vhtlcScript, vhtlcAddress, serverXOnlyPublicKey } = resolveSwapVhtlc({
+        arkInfo,
+        preimageHashBytes: inputs.preimageHashBytes,
+        receiverPubkey: inputs.receiverPubkey,
+        senderPubkey: inputs.senderPubkey,
+        timeoutBlockHeights: inputs.timeoutBlockHeights,
+        lockupAddress: inputs.lockupAddress,
+        swapId: swap.id,
+    });
+
+    // Build the typed VHTLCContractParams.
+    // createVHTLCScript applies ripemd160 internally, so `params.hash` must
+    // be the RIPEMD160 digest of the SHA256 preimage hash — not the raw SHA256.
+    const receiverXOnly = normalizeToXOnlyKey(hex.decode(inputs.receiverPubkey), "receiver");
+    const senderXOnly = normalizeToXOnlyKey(hex.decode(inputs.senderPubkey), "sender");
+    // serverXOnlyPublicKey is the key that matched the lockup address (may be deprecated).
+
+    const { timeoutBlockHeights: t } = inputs;
+    const typedParams: VHTLCContractParams = {
+        sender: senderXOnly,
+        receiver: receiverXOnly,
+        server: serverXOnlyPublicKey,
+        // CRITICAL: createVHTLCScript applies ripemd160 internally.
+        // serializeParams stores this as `params.hash`, and deserializeParams
+        // reads it back without re-hashing. So we must store the RIPEMD160
+        // digest here, not the raw SHA256.
+        preimageHash: ripemd160(inputs.preimageHashBytes),
+        refundLocktime: BigInt(t.refund),
+        unilateralClaimDelay: {
+            type: t.unilateralClaim < 512 ? ("blocks" as const) : ("seconds" as const),
+            value: BigInt(t.unilateralClaim),
+        },
+        unilateralRefundDelay: {
+            type: t.unilateralRefund < 512 ? ("blocks" as const) : ("seconds" as const),
+            value: BigInt(t.unilateralRefund),
+        },
+        unilateralRefundWithoutReceiverDelay: {
+            type:
+                t.unilateralRefundWithoutReceiver < 512
+                    ? ("blocks" as const)
+                    : ("seconds" as const),
+            value: BigInt(t.unilateralRefundWithoutReceiver),
+        },
+    };
+
+    const serializedParams = VHTLCContractHandler.serializeParams(typedParams);
+
+    return {
+        type: "vhtlc",
+        params: serializedParams,
+        script: hex.encode(vhtlcScript.pkScript),
+        address: vhtlcAddress,
+        state: "active",
+        metadata: {
+            swapId: swap.id,
+            swapType: swap.type,
+            source: `swap:${swap.id}`,
+        },
+    };
+};
+
+/**
+ * Registers a swap's VHTLC as a tracked contract in the SDK's ContractManager.
+ *
+ * Idempotent: ContractManager.createContract deduplicates on script, so calling
+ * this multiple times for the same swap is safe.
+ *
+ * @param contractManager - The SDK ContractManager that owns contract state.
+ * @param swap - The swap whose ARK-side VHTLC should be registered.
+ * @param arkInfo - Current ArkInfo (with `deprecatedSigners`) for signer resolution.
+ * @returns The created (or existing) Contract.
+ */
+export const registerSwapContract = (
+    contractManager: IContractManager,
+    swap: BoltzSwap,
+    arkInfo: ArkInfo,
+): Promise<Contract> => contractManager.createContract(swapToContractParams(swap, arkInfo));

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -61,6 +61,31 @@ vi.mock("@arkade-os/sdk", async () => {
     };
 });
 
+// Mock swap-contract: let registerSwapContract forward to contractManager.createContract
+// with a minimal valid shape so existing tests don't need real VHTLC addresses,
+// while still verifying that createContract is called with the right metadata.
+vi.mock("../src/utils/swap-contract", () => ({
+    registerSwapContract: vi.fn(
+        async (
+            contractManager: import("@arkade-os/sdk").IContractManager,
+            swap: import("../src/types").BoltzSwap,
+        ) => {
+            await contractManager.createContract({
+                type: "vhtlc",
+                script: "aa",
+                address: "mock-vhtlc-address",
+                state: "active",
+                params: {},
+                metadata: {
+                    swapId: swap.id,
+                    swapType: swap.type,
+                    source: `swap:${swap.id}`,
+                },
+            });
+        },
+    ),
+}));
+
 // Mock vhtlc utils — passthrough except the offchain-tx helpers, which
 // touch real Ark protocol APIs we can't reach in unit tests.
 vi.mock("../src/utils/vhtlc", async () => {
@@ -198,6 +223,7 @@ describe("ArkadeSwaps", () => {
     let identity: Identity;
     let wallet: Wallet;
     let mockSwapRepository: any;
+    let mockContractManager: any;
 
     const seckeys = {
         alice: schnorr.utils.randomSecretKey(),
@@ -584,7 +610,9 @@ describe("ArkadeSwaps", () => {
 
         // Create mock providers first
         arkProvider = {
-            getInfo: vi.fn(),
+            // Default: resolve with mockArkInfo so contract registration in create
+            // paths doesn't throw (individual tests override with mockResolvedValueOnce).
+            getInfo: vi.fn().mockResolvedValue(mockArkInfo),
             submitTx: vi.fn(),
             finalizeTx: vi.fn(),
         } as any;
@@ -600,6 +628,11 @@ describe("ArkadeSwaps", () => {
             getAllSwaps: vi.fn(),
             clear: vi.fn(),
             [Symbol.asyncDispose]: vi.fn(),
+        };
+
+        // Create fake ContractManager (captures createContract calls; dedup is done by the real impl)
+        mockContractManager = {
+            createContract: vi.fn().mockResolvedValue({ state: "active", createdAt: 0 }),
         };
 
         // Mock wallet with necessary methods and providers
@@ -623,6 +656,7 @@ describe("ArkadeSwaps", () => {
             indexerProvider,
             swapRepository: mockSwapRepository,
             swapManager: false,
+            contractManager: mockContractManager,
         });
     });
 
@@ -642,6 +676,7 @@ describe("ArkadeSwaps", () => {
                 swapProvider,
                 arkProvider,
                 indexerProvider,
+                contractManager: mockContractManager,
             };
             expect(
                 () =>
@@ -652,12 +687,20 @@ describe("ArkadeSwaps", () => {
             ).toThrow("Swap provider is required.");
         });
 
+        it("requires a contractManager", () => {
+            expect(
+                // @ts-expect-error contractManager is required
+                () => new ArkadeSwaps({ wallet, swapProvider, arkProvider, indexerProvider }),
+            ).toThrow(/contractManager/i);
+        });
+
         it("should default to wallet instances without required config", async () => {
             const params: ArkadeSwapsConfig = {
                 wallet,
                 swapProvider,
                 arkProvider,
                 indexerProvider,
+                contractManager: mockContractManager,
             };
             expect(() => new ArkadeSwaps({ ...params })).not.toThrow();
             expect(() => new ArkadeSwaps({ ...params, arkProvider: null as any })).not.toThrow();
@@ -766,6 +809,16 @@ describe("ArkadeSwaps", () => {
                     reverseSwapResponseFor(createReverseSwapResponse),
                 );
 
+                // I1: track save-before-register ordering
+                const order: string[] = [];
+                mockSwapRepository.saveSwap.mockImplementation(async () => {
+                    order.push("save");
+                });
+                mockContractManager.createContract.mockImplementation(async () => {
+                    order.push("register");
+                    return { state: "active", createdAt: 0 };
+                });
+
                 // act
                 const pendingSwap = await swaps.createReverseSwap({
                     amount: mock.invoice.amount,
@@ -779,6 +832,22 @@ describe("ArkadeSwaps", () => {
                 expect(pendingSwap.response.onchainAmount).toBe(mock.invoice.amount);
                 expect(pendingSwap.response.refundPublicKey).toBe(compressedPubkeys.boltz);
                 expect(pendingSwap.status).toEqual("swap.created");
+                // I1: save must precede register
+                expect(order.indexOf("save")).toBeLessThan(order.indexOf("register"));
+            });
+
+            it("should propagate registration failure to caller (reverse)", async () => {
+                // I2: if createContract rejects, createReverseSwap must reject (not swallow)
+                // and saveSwap must have been called first (save-then-register ordering)
+                vi.spyOn(swapProvider, "createReverseSwap").mockImplementationOnce(
+                    reverseSwapResponseFor(createReverseSwapResponse),
+                );
+                mockContractManager.createContract.mockRejectedValue(new Error("boom"));
+
+                await expect(
+                    swaps.createReverseSwap({ amount: mock.invoice.amount }),
+                ).rejects.toThrow("boom");
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledOnce();
             });
 
             it("should get correct swap status", async () => {
@@ -1042,9 +1111,11 @@ describe("ArkadeSwaps", () => {
                 });
 
                 // Mock monitorSwap to directly trigger the invoice.settled case
-                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(async (swapId, update) => {
-                    setTimeout(() => update("invoice.settled"), 10);
-                });
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        setTimeout(() => update("invoice.settled"), 10);
+                    },
+                );
 
                 // act
                 const result = await swaps.waitAndClaim(pendingSwap);
@@ -1074,9 +1145,11 @@ describe("ArkadeSwaps", () => {
                 });
 
                 // Mock monitorSwap to directly trigger the invoice.settled case
-                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(async (swapId, update) => {
-                    setTimeout(() => update("invoice.settled"), 10);
-                });
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(
+                    async (_swapId, update) => {
+                        setTimeout(() => update("invoice.settled"), 10);
+                    },
+                );
 
                 // act & assert
                 await expect(swaps.waitAndClaim(pendingSwap)).rejects.toThrow(
@@ -1094,6 +1167,16 @@ describe("ArkadeSwaps", () => {
                     createSubmarineSwapResponse,
                 );
 
+                // I1: track save-before-register ordering
+                const order: string[] = [];
+                mockSwapRepository.saveSwap.mockImplementation(async () => {
+                    order.push("save");
+                });
+                mockContractManager.createContract.mockImplementation(async () => {
+                    order.push("register");
+                    return { state: "active", createdAt: 0 };
+                });
+
                 // act
                 const pendingSwap = await swaps.createSubmarineSwap({
                     invoice: mock.invoice.address,
@@ -1103,6 +1186,22 @@ describe("ArkadeSwaps", () => {
                 expect(pendingSwap.status).toEqual("invoice.set");
                 expect(pendingSwap.request).toEqual(createSubmarineSwapRequest);
                 expect(pendingSwap.response).toEqual(createSubmarineSwapResponse);
+                // I1: save must precede register
+                expect(order.indexOf("save")).toBeLessThan(order.indexOf("register"));
+            });
+
+            it("should propagate registration failure to caller (submarine)", async () => {
+                // I2: if createContract rejects, createSubmarineSwap must reject (not swallow)
+                // and saveSwap must have been called first (save-then-register ordering)
+                vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
+                    createSubmarineSwapResponse,
+                );
+                mockContractManager.createContract.mockRejectedValue(new Error("boom"));
+
+                await expect(
+                    swaps.createSubmarineSwap({ invoice: mock.invoice.address }),
+                ).rejects.toThrow("boom");
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledOnce();
             });
 
             it("should get correct swap status", async () => {
@@ -1586,6 +1685,16 @@ describe("ArkadeSwaps", () => {
                     createArkBtcChainSwapResponse,
                 );
 
+                // I1: track save-before-register ordering
+                const order: string[] = [];
+                mockSwapRepository.saveSwap.mockImplementation(async () => {
+                    order.push("save");
+                });
+                mockContractManager.createContract.mockImplementation(async () => {
+                    order.push("register");
+                    return { state: "active", createdAt: 0 };
+                });
+
                 // act
                 const pendingSwap = await swaps.createChainSwap({
                     to: "BTC",
@@ -1604,6 +1713,28 @@ describe("ArkadeSwaps", () => {
                 expect(pendingSwap.response.lockupDetails.lockupAddress).toBe(mock.address.ark);
                 expect(pendingSwap.status).toEqual("swap.created");
                 expect(pendingSwap.toAddress).toBe(mock.address.btc);
+                // I1: save must precede register
+                expect(order.indexOf("save")).toBeLessThan(order.indexOf("register"));
+            });
+
+            it("should propagate registration failure to caller (chain)", async () => {
+                // I2: if createContract rejects, createChainSwap must reject (not swallow)
+                // and saveSwap must have been called first (save-then-register ordering)
+                vi.spyOn(swapProvider, "createChainSwap").mockResolvedValueOnce(
+                    createArkBtcChainSwapResponse,
+                );
+                mockContractManager.createContract.mockRejectedValue(new Error("boom"));
+
+                await expect(
+                    swaps.createChainSwap({
+                        to: "BTC",
+                        from: "ARK",
+                        feeSatsPerByte: 1,
+                        senderLockAmount: mock.amount,
+                        toAddress: mock.address.btc,
+                    }),
+                ).rejects.toThrow("boom");
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledOnce();
             });
         });
 
@@ -5113,6 +5244,176 @@ describe("ArkadeSwaps", () => {
             await expect(
                 swaps.verifyChainSwap({ to: "ARK", from: "BTC", swap: bad, arkInfo: mockArkInfo }),
             ).rejects.toThrow(/invalid BTC address/);
+        });
+    });
+
+    // =========================================================================
+    // Contract registration on swap create
+    // =========================================================================
+    //
+    // registerSwapContract is mocked at module level (vi.mock above) to call
+    // contractManager.createContract directly with a typed shape, bypassing
+    // the real VHTLC address-matching in swapToContractParams. This keeps
+    // existing fixtures working while still verifying the wiring: that each
+    // create path calls registerSwapContract (and thus createContract) once
+    // with the correct type and swap-type metadata.
+
+    describe("startSwapManager migration", () => {
+        it("registers a pre-existing non-terminal swap as a contract on init", async () => {
+            // Arrange: build an ArkadeSwaps instance with autoStart:false so we
+            // control when startSwapManager is called.
+            const swapsWithManager = new ArkadeSwaps({
+                wallet,
+                arkProvider,
+                swapProvider,
+                indexerProvider,
+                swapRepository: mockSwapRepository,
+                swapManager: { autoStart: false },
+                contractManager: mockContractManager,
+            });
+
+            // Stub the internal SwapManager.start to avoid real network calls.
+            const internalManager = (swapsWithManager as any).swapManager;
+            const startSpy = vi.spyOn(internalManager, "start").mockResolvedValue(undefined);
+
+            // A non-terminal reverse swap already in the repository.
+            const preExistingSwap: BoltzReverseSwap = {
+                ...mockReverseSwap,
+                id: "pre-existing-reverse-swap",
+            };
+
+            // getAllSwaps is called twice by startSwapManager: once for migration
+            // (no filter) and once for loading all swaps (no filter).
+            mockSwapRepository.getAllSwaps.mockResolvedValue([preExistingSwap]);
+
+            // Act
+            await swapsWithManager.startSwapManager();
+
+            // Assert: the pre-existing swap's contract was registered.
+            expect(mockContractManager.createContract).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "vhtlc",
+                    metadata: expect.objectContaining({
+                        swapId: "pre-existing-reverse-swap",
+                        swapType: "reverse",
+                    }),
+                }),
+            );
+
+            // SwapManager.start was still called (swap loading is unaffected).
+            expect(startSpy).toHaveBeenCalledOnce();
+        });
+
+        it("does not run migration when contractManager is absent (Expo-background exemption)", async () => {
+            // Build a swaps instance without contractManager — mirroring the
+            // Expo-background monitor path. startSwapManager should not attempt
+            // migration (would throw on undefined.createContract).
+            //
+            // Note: the ArkadeSwaps constructor enforces contractManager, so we
+            // bypass that guard via `as any` to simulate the background path.
+            const swapsNoContract = new ArkadeSwaps({
+                wallet,
+                arkProvider,
+                swapProvider,
+                indexerProvider,
+                swapRepository: mockSwapRepository,
+                swapManager: { autoStart: false },
+                contractManager: mockContractManager, // provide to pass constructor
+            });
+            // Overwrite with undefined post-construction to simulate the exempt path.
+            (swapsNoContract as any).contractManager = undefined;
+
+            const internalManager = (swapsNoContract as any).swapManager;
+            vi.spyOn(internalManager, "start").mockResolvedValue(undefined);
+
+            mockSwapRepository.getAllSwaps.mockResolvedValue([mockReverseSwap]);
+
+            await swapsNoContract.startSwapManager();
+
+            // With contractManager undefined the migration is skipped entirely.
+            expect(mockContractManager.createContract).not.toHaveBeenCalled();
+        });
+
+        it("does not run migration twice if startSwapManager is called again", async () => {
+            const swapsWithManager = new ArkadeSwaps({
+                wallet,
+                arkProvider,
+                swapProvider,
+                indexerProvider,
+                swapRepository: mockSwapRepository,
+                swapManager: { autoStart: false },
+                contractManager: mockContractManager,
+            });
+
+            const internalManager = (swapsWithManager as any).swapManager;
+            vi.spyOn(internalManager, "start").mockResolvedValue(undefined);
+
+            mockSwapRepository.getAllSwaps.mockResolvedValue([mockReverseSwap]);
+
+            await swapsWithManager.startSwapManager();
+            await swapsWithManager.startSwapManager();
+
+            // createContract is called once per run (the migration ran only on
+            // the first startSwapManager call), but SwapManager.start ran twice.
+            // The first call registered the swap; the second skipped migration.
+            const migrateCallCount = mockContractManager.createContract.mock.calls.length;
+            // Only 1 migration run (from the first startSwapManager) × 1 swap
+            expect(migrateCallCount).toBe(1);
+        });
+    });
+
+    describe("contract registration on swap create", () => {
+        it("createReverseSwap calls contractManager.createContract with type:vhtlc and swapType:reverse", async () => {
+            vi.spyOn(swapProvider, "createReverseSwap").mockImplementationOnce(
+                reverseSwapResponseFor(createReverseSwapResponse),
+            );
+
+            await swaps.createReverseSwap({ amount: mock.invoice.amount });
+
+            expect(mockContractManager.createContract).toHaveBeenCalledOnce();
+            expect(mockContractManager.createContract).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "vhtlc",
+                    metadata: expect.objectContaining({ swapType: "reverse" }),
+                }),
+            );
+        });
+
+        it("createSubmarineSwap calls contractManager.createContract with type:vhtlc and swapType:submarine", async () => {
+            vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
+                createSubmarineSwapResponse,
+            );
+
+            await swaps.createSubmarineSwap({ invoice: mock.invoice.address });
+
+            expect(mockContractManager.createContract).toHaveBeenCalledOnce();
+            expect(mockContractManager.createContract).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "vhtlc",
+                    metadata: expect.objectContaining({ swapType: "submarine" }),
+                }),
+            );
+        });
+
+        it("createChainSwap (ARK→BTC) calls contractManager.createContract with type:vhtlc and swapType:chain", async () => {
+            vi.spyOn(swapProvider, "createChainSwap").mockResolvedValueOnce(
+                createArkBtcChainSwapResponse,
+            );
+
+            await swaps.createChainSwap({
+                to: "BTC",
+                from: "ARK",
+                senderLockAmount: mock.amount,
+                toAddress: mock.address.btc,
+            });
+
+            expect(mockContractManager.createContract).toHaveBeenCalledOnce();
+            expect(mockContractManager.createContract).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "vhtlc",
+                    metadata: expect.objectContaining({ swapType: "chain" }),
+                }),
+            );
         });
     });
 });

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -77,7 +77,7 @@ vi.mock("../src/utils/swap-contract", () => ({
                 type: "vhtlc",
                 script: `mock-vhtlc-script:${swap.id}`,
                 address: "mock-vhtlc-address",
-                state: "active",
+                state: "active" as const,
                 params: {},
                 metadata: {
                     swapId: swap.id,

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -5567,6 +5567,148 @@ describe("ArkadeSwaps", () => {
             await expect(completion).rejects.toThrow();
         });
 
+        it("offline proof: Boltz mocked DOWN — a funded VTXO drives the claim, and a subsequent spent VTXO resolves Settled from VTXO events alone", async () => {
+            const swap: BoltzReverseSwap = {
+                ...mockReverseSwap,
+                status: "swap.created", // well before Boltz's own "transaction.mempool"
+            };
+            const swapContractScript = `offline-proof-script:${swap.id}`;
+
+            // Boltz mocked DOWN: getSwapStatus (polling) always rejects; the
+            // only Boltz call the flow ever makes is the post-hoc txid
+            // lookup waitForSwapCompletion needs once the swap is already
+            // known (from VTXO events alone) to be settled — never a status
+            // call.
+            vi.spyOn(swapProvider, "getSwapStatus").mockRejectedValue(
+                new Error("Boltz is unreachable (offline proof)"),
+            );
+            vi.spyOn(swapProvider, "getReverseSwapTxId").mockResolvedValue({
+                id: "vtxo-derived-txid",
+                timeoutBlockHeight: 10,
+            });
+
+            mockContractManager.getContracts.mockResolvedValue([
+                {
+                    type: "vhtlc",
+                    script: swapContractScript,
+                    address: "mock-vhtlc-address",
+                    state: "active",
+                    params: {},
+                    createdAt: 0,
+                    metadata: { swapId: swap.id, swapType: swap.type, source: `swap:${swap.id}` },
+                },
+            ]);
+
+            const swapsWithManager = new ArkadeSwaps({
+                wallet,
+                arkProvider,
+                swapProvider,
+                indexerProvider,
+                swapRepository: mockSwapRepository,
+                swapManager: { autoStart: false },
+                contractManager: mockContractManager,
+            });
+            const internalManager = (swapsWithManager as any).swapManager;
+            // Boltz mocked DOWN, continued: start() is stubbed exactly as in
+            // the other reconciler-wiring tests above, so the real WebSocket
+            // never connects and polling never begins — start() is never
+            // meaningfully invoked for the rest of this test.
+            vi.spyOn(internalManager, "start").mockResolvedValue(undefined);
+            mockSwapRepository.getAllSwaps.mockResolvedValue([]);
+
+            // Isolate the wiring under test from the real claim
+            // implementation (claimVHTLC's on-chain mechanics are covered by
+            // dedicated tests elsewhere in this file).
+            const claimSpy = vi.spyOn(swapsWithManager, "claimVHTLC").mockResolvedValue(undefined);
+
+            await swapsWithManager.startSwapManager();
+            await internalManager.addSwap(swap);
+
+            const completion = internalManager.waitForSwapCompletion(swap.id);
+
+            const eventCallback = mockContractManager.onContractEvent.mock.calls[0][0];
+
+            // 1) FUNDED — the claim runs immediately, off the VTXO signal
+            // alone. isReverseClaimableStatus's claimable set is
+            // {transaction.mempool, transaction.confirmed}; swap.status is
+            // still "swap.created", nowhere near it — proving Boltz status
+            // was never consulted to trigger this claim.
+            eventCallback({
+                type: "vtxo_received",
+                contractScript: swapContractScript,
+                vtxos: [],
+                contract: {},
+                timestamp: Date.now(),
+            });
+            // onSwapFunded -> triggerClaimFromVtxo is fire-and-forget from
+            // the reconciler's synchronous event callback (same shape as
+            // onSwapResolved -> resolveSwapFromVtxo elsewhere in this
+            // describe block); flush the microtask queue so the awaited
+            // claim() resolves before asserting on it.
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(claimSpy).toHaveBeenCalledTimes(1);
+            expect(claimSpy).toHaveBeenCalledWith(swap);
+            expect(internalManager.getActionLog().claimed.has(swap.id)).toBe(true);
+            expect(swap.status).toBe("swap.created"); // untouched by the VTXO-driven claim
+
+            // Duplicate FUNDED event for the same swap — must NOT re-claim.
+            eventCallback({
+                type: "vtxo_received",
+                contractScript: swapContractScript,
+                vtxos: [],
+                contract: {},
+                timestamp: Date.now(),
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(claimSpy).toHaveBeenCalledTimes(1);
+
+            // 2) SPENT (our own claim spent the lockup) — resolves the swap
+            // to Settled from the VTXO signal + action log alone; Boltz
+            // still never reported a terminal status.
+            eventCallback({
+                type: "vtxo_spent",
+                contractScript: swapContractScript,
+                vtxos: [],
+                contract: {},
+                timestamp: Date.now(),
+            });
+
+            expect(swap.status).toBe("invoice.settled");
+            expect(await internalManager.hasSwap(swap.id)).toBe(false);
+            await expect(completion).resolves.toEqual({ txid: "vtxo-derived-txid" });
+        });
+
+        it("a transient contract-repo read failure is logged and does not prevent swap monitoring from starting", async () => {
+            const readError = new Error("contract repo unavailable");
+            mockContractManager.getContracts.mockRejectedValue(readError);
+            const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+            const swapsWithManager = new ArkadeSwaps({
+                wallet,
+                arkProvider,
+                swapProvider,
+                indexerProvider,
+                swapRepository: mockSwapRepository,
+                swapManager: { autoStart: false },
+                contractManager: mockContractManager,
+            });
+            const internalManager = (swapsWithManager as any).swapManager;
+            const startSpy = vi.spyOn(internalManager, "start").mockResolvedValue(undefined);
+            mockSwapRepository.getAllSwaps.mockResolvedValue([]);
+
+            await expect(swapsWithManager.startSwapManager()).resolves.toBeUndefined();
+
+            expect(startSpy).toHaveBeenCalledTimes(1);
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining("SwapStatusReconciler"),
+                readError,
+            );
+
+            errorSpy.mockRestore();
+        });
+
         it("dispose() calls the ContractManager unsubscribe", async () => {
             const unsubscribe = vi.fn();
             mockContractManager.onContractEvent.mockReturnValue(unsubscribe);

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -64,15 +64,18 @@ vi.mock("@arkade-os/sdk", async () => {
 // Mock swap-contract: let registerSwapContract forward to contractManager.createContract
 // with a minimal valid shape so existing tests don't need real VHTLC addresses,
 // while still verifying that createContract is called with the right metadata.
+// Returns the built contract (matching the real function's Promise<Contract>
+// signature) with a script keyed on swap.id, so tests can address a specific
+// swap's contract script unambiguously via the SwapStatusReconciler wiring.
 vi.mock("../src/utils/swap-contract", () => ({
     registerSwapContract: vi.fn(
         async (
             contractManager: import("@arkade-os/sdk").IContractManager,
             swap: import("../src/types").BoltzSwap,
         ) => {
-            await contractManager.createContract({
+            const contract = {
                 type: "vhtlc",
-                script: "aa",
+                script: `mock-vhtlc-script:${swap.id}`,
                 address: "mock-vhtlc-address",
                 state: "active",
                 params: {},
@@ -81,7 +84,9 @@ vi.mock("../src/utils/swap-contract", () => ({
                     swapType: swap.type,
                     source: `swap:${swap.id}`,
                 },
-            });
+            };
+            await contractManager.createContract(contract);
+            return contract;
         },
     ),
 }));
@@ -633,6 +638,11 @@ describe("ArkadeSwaps", () => {
         // Create fake ContractManager (captures createContract calls; dedup is done by the real impl)
         mockContractManager = {
             createContract: vi.fn().mockResolvedValue({ state: "active", createdAt: 0 }),
+            // Defaults for the SwapStatusReconciler wiring (see
+            // "SwapStatusReconciler wiring" describe below): no pre-existing
+            // vhtlc contracts, and a fresh mock unsubscribe per subscription.
+            getContracts: vi.fn().mockResolvedValue([]),
+            onContractEvent: vi.fn().mockReturnValue(vi.fn()),
         };
 
         // Mock wallet with necessary methods and providers
@@ -5332,6 +5342,9 @@ describe("ArkadeSwaps", () => {
 
             // With contractManager undefined the migration is skipped entirely.
             expect(mockContractManager.createContract).not.toHaveBeenCalled();
+            // The SwapStatusReconciler wiring shares the same guard.
+            expect(mockContractManager.getContracts).not.toHaveBeenCalled();
+            expect(mockContractManager.onContractEvent).not.toHaveBeenCalled();
         });
 
         it("does not run migration twice if startSwapManager is called again", async () => {
@@ -5414,6 +5427,170 @@ describe("ArkadeSwaps", () => {
                     metadata: expect.objectContaining({ swapType: "chain" }),
                 }),
             );
+        });
+    });
+
+    // =========================================================================
+    // SwapStatusReconciler wiring (phase 2)
+    // =========================================================================
+    //
+    // startSwapManager wires a SwapStatusReconciler to
+    // contractManager.onContractEvent so a swap's terminal state can be
+    // derived from an on-chain VTXO signal even when Boltz's own status feed
+    // goes silent (see swap-status-reconciler.ts / swap-manager.ts's
+    // resolveSwapFromVtxo). These tests drive that wiring end-to-end: they
+    // capture the real callback passed to the mocked
+    // contractManager.onContractEvent and fire fake ContractEvents through
+    // it, against a REAL SwapManager instance (only start()/stop() and the
+    // network-facing swapProvider/contractManager/repository are stubbed).
+    describe("SwapStatusReconciler wiring", () => {
+        it("subscribes to contractManager.onContractEvent when starting with a contractManager present", async () => {
+            const swapsWithManager = new ArkadeSwaps({
+                wallet,
+                arkProvider,
+                swapProvider,
+                indexerProvider,
+                swapRepository: mockSwapRepository,
+                swapManager: { autoStart: false },
+                contractManager: mockContractManager,
+            });
+            const internalManager = (swapsWithManager as any).swapManager;
+            vi.spyOn(internalManager, "start").mockResolvedValue(undefined);
+            mockSwapRepository.getAllSwaps.mockResolvedValue([]);
+
+            await swapsWithManager.startSwapManager();
+
+            expect(mockContractManager.getContracts).toHaveBeenCalledWith(
+                expect.objectContaining({ type: "vhtlc" }),
+            );
+            expect(mockContractManager.onContractEvent).toHaveBeenCalledTimes(1);
+            expect(mockContractManager.onContractEvent).toHaveBeenCalledWith(expect.any(Function));
+        });
+
+        it("seeds the reconciler from existing vhtlc contracts; a matching vtxo_spent event drives resolveSwapFromVtxo and wakes a pending waitForSwapCompletion", async () => {
+            const swap: BoltzReverseSwap = { ...mockReverseSwap, status: "transaction.confirmed" };
+            const swapContractScript = "vhtlc-script-for-reconciler-test";
+
+            mockContractManager.getContracts.mockResolvedValue([
+                {
+                    type: "vhtlc",
+                    script: swapContractScript,
+                    address: "mock-vhtlc-address",
+                    state: "active",
+                    params: {},
+                    createdAt: 0,
+                    metadata: { swapId: swap.id, swapType: swap.type, source: `swap:${swap.id}` },
+                },
+            ]);
+
+            const swapsWithManager = new ArkadeSwaps({
+                wallet,
+                arkProvider,
+                swapProvider,
+                indexerProvider,
+                swapRepository: mockSwapRepository,
+                swapManager: { autoStart: false },
+                contractManager: mockContractManager,
+            });
+            const internalManager = (swapsWithManager as any).swapManager;
+            vi.spyOn(internalManager, "start").mockResolvedValue(undefined);
+            mockSwapRepository.getAllSwaps.mockResolvedValue([]);
+
+            await swapsWithManager.startSwapManager();
+            // start() is stubbed (no real WebSocket/polling), so populate
+            // monitoredSwaps directly via the real addSwap.
+            await internalManager.addSwap(swap);
+
+            const completion = internalManager.waitForSwapCompletion(swap.id);
+
+            // Fire a fake vtxo_spent event through the callback the
+            // reconciler wired via contractManager.onContractEvent.
+            const eventCallback = mockContractManager.onContractEvent.mock.calls[0][0];
+            eventCallback({
+                type: "vtxo_spent",
+                contractScript: swapContractScript,
+                vtxos: [],
+                contract: {},
+                timestamp: Date.now(),
+            });
+
+            // reverse + vtxo_spent + empty action log -> "Failed" (Boltz's
+            // own lockup was refunded without us ever claiming it) — see
+            // deriveSpentByOthersState in swap-status-reconciler.ts. The
+            // status mutation, monitoredSwaps removal, and
+            // waitForSwapCompletion wakeup all happen synchronously inside
+            // resolveSwapFromVtxo, before its internal `await saveSwap`.
+            expect(swap.status).toBe("transaction.failed");
+            expect(await internalManager.hasSwap(swap.id)).toBe(false);
+            await expect(completion).rejects.toThrow();
+        });
+
+        it("registerSwapContractSafe routes a swap created after startup to the reconciler", async () => {
+            const swapsWithManager = new ArkadeSwaps({
+                wallet,
+                arkProvider,
+                swapProvider,
+                indexerProvider,
+                swapRepository: mockSwapRepository,
+                swapManager: { autoStart: false },
+                contractManager: mockContractManager,
+            });
+            const internalManager = (swapsWithManager as any).swapManager;
+            vi.spyOn(internalManager, "start").mockResolvedValue(undefined);
+            mockSwapRepository.getAllSwaps.mockResolvedValue([]);
+
+            await swapsWithManager.startSwapManager();
+
+            vi.spyOn(swapProvider, "createReverseSwap").mockImplementationOnce(
+                reverseSwapResponseFor(createReverseSwapResponse),
+            );
+            const created = await swapsWithManager.createReverseSwap({
+                amount: mock.invoice.amount,
+            });
+            // Give the swap a non-final status so it stays monitored/routable
+            // (createReverseSwap's own addSwap call already put it in
+            // monitoredSwaps with this same object reference).
+            created.status = "transaction.confirmed";
+
+            const completion = internalManager.waitForSwapCompletion(created.id);
+
+            const eventCallback = mockContractManager.onContractEvent.mock.calls[0][0];
+            eventCallback({
+                type: "vtxo_spent",
+                contractScript: `mock-vhtlc-script:${created.id}`,
+                vtxos: [],
+                contract: {},
+                timestamp: Date.now(),
+            });
+
+            expect(created.status).toBe("transaction.failed");
+            await expect(completion).rejects.toThrow();
+        });
+
+        it("dispose() calls the ContractManager unsubscribe", async () => {
+            const unsubscribe = vi.fn();
+            mockContractManager.onContractEvent.mockReturnValue(unsubscribe);
+
+            const swapsWithManager = new ArkadeSwaps({
+                wallet,
+                arkProvider,
+                swapProvider,
+                indexerProvider,
+                swapRepository: mockSwapRepository,
+                swapManager: { autoStart: false },
+                contractManager: mockContractManager,
+            });
+            const internalManager = (swapsWithManager as any).swapManager;
+            vi.spyOn(internalManager, "start").mockResolvedValue(undefined);
+            vi.spyOn(internalManager, "stop").mockResolvedValue(undefined);
+            mockSwapRepository.getAllSwaps.mockResolvedValue([]);
+
+            await swapsWithManager.startSwapManager();
+            expect(unsubscribe).not.toHaveBeenCalled();
+
+            await swapsWithManager.dispose();
+
+            expect(unsubscribe).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/boltz-swap/test/boltz-swap-provider.test.ts
+++ b/packages/boltz-swap/test/boltz-swap-provider.test.ts
@@ -17,7 +17,7 @@ function createFetchResponse(mockData: any) {
             return { ...this };
         },
         headers: {
-            get: (arg: string) => "mock-header-value",
+            get: (_arg: string) => "mock-header-value",
         },
     });
 }
@@ -866,10 +866,8 @@ describe("BoltzSwapProvider", () => {
 
     describe("monitorSwap", () => {
         let mockWebSocket: any;
-        let webSocketCallbacks: any;
 
         beforeEach(() => {
-            webSocketCallbacks = {};
             mockWebSocket = {
                 send: vi.fn(),
                 close: vi.fn(),

--- a/packages/boltz-swap/test/e2e/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/e2e/arkade-swaps.test.ts
@@ -17,6 +17,7 @@ import {
     ArkNote,
     InMemoryWalletRepository,
     InMemoryContractRepository,
+    type IContractManager,
 } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
 import { schnorr } from "@noble/curves/secp256k1.js";
@@ -183,6 +184,7 @@ describe("ArkadeSwaps", () => {
     let aliceSecKey: Uint8Array;
     let aliceCompressedPubKey: string;
     let fundedWallet: Wallet;
+    let contractManager: IContractManager;
 
     const arkUrl = "http://localhost:7070";
 
@@ -261,6 +263,8 @@ describe("ArkadeSwaps", () => {
             }),
         });
 
+        contractManager = await wallet.getContractManager();
+
         // Create ArkadeSwaps instance (disable SwapManager for manual swap tests).
         // Use a fresh in-memory swap repo per test so state doesn't leak across
         // describes via the shared fake-indexeddb (the default backend).
@@ -269,6 +273,7 @@ describe("ArkadeSwaps", () => {
             swapProvider,
             arkProvider,
             indexerProvider,
+            contractManager,
             swapRepository: new InMemorySwapRepository(),
             swapManager: false,
         });
@@ -286,6 +291,7 @@ describe("ArkadeSwaps", () => {
                         arkProvider,
                         swapProvider,
                         indexerProvider,
+                        contractManager,
                     }),
             ).not.toThrow();
         });
@@ -296,6 +302,7 @@ describe("ArkadeSwaps", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
             };
 
             expect(
@@ -313,6 +320,14 @@ describe("ArkadeSwaps", () => {
                         swapProvider: null as any,
                     }),
             ).toThrow("Swap provider is required.");
+
+            expect(
+                () =>
+                    new ArkadeSwaps({
+                        ...config,
+                        contractManager: null as any,
+                    }),
+            ).toThrow("ArkadeSwaps requires a contractManager");
         });
 
         it("should default to wallet instances without required config", async () => {
@@ -322,6 +337,7 @@ describe("ArkadeSwaps", () => {
                         wallet,
                         swapProvider,
                         indexerProvider,
+                        contractManager,
                         arkProvider: null as any,
                     }),
             ).not.toThrow();
@@ -331,6 +347,7 @@ describe("ArkadeSwaps", () => {
                         wallet,
                         arkProvider,
                         swapProvider,
+                        contractManager,
                         indexerProvider: null as any,
                     }),
             ).not.toThrow();
@@ -1438,6 +1455,7 @@ describe("ArkadeSwaps", () => {
                         swapProvider,
                         arkProvider: new RestArkProvider(arkUrl),
                         indexerProvider: new RestIndexerProvider(arkUrl),
+                        contractManager: await defaultWallet.getContractManager(),
                         swapManager: false,
                     });
 
@@ -1512,6 +1530,7 @@ describe("ArkadeSwaps", () => {
                         swapProvider,
                         arkProvider: new RestArkProvider(arkUrl),
                         indexerProvider: new RestIndexerProvider(arkUrl),
+                        contractManager: await defaultWallet.getContractManager(),
                         swapManager: false,
                     });
 

--- a/packages/boltz-swap/test/e2e/swap-manager.test.ts
+++ b/packages/boltz-swap/test/e2e/swap-manager.test.ts
@@ -7,10 +7,9 @@ import {
     Wallet,
     SingleKey,
     EsploraProvider,
+    type IContractManager,
 } from "@arkade-os/sdk";
 import { schnorr } from "@noble/curves/secp256k1.js";
-import { hex } from "@scure/base";
-import { pubECDSA } from "@scure/btc-signer/utils.js";
 import { BoltzSwapProvider } from "../../src";
 
 describe("SwapManager", () => {
@@ -21,16 +20,15 @@ describe("SwapManager", () => {
     let swaps: ArkadeSwaps;
     let identity: Identity;
     let wallet: Wallet;
+    let contractManager: IContractManager;
 
     let aliceSecKey: Uint8Array;
-    let aliceCompressedPubKey: string;
 
     beforeEach(async () => {
         const arkUrl = "http://localhost:7070";
 
         // Create identity
         aliceSecKey = schnorr.utils.randomSecretKey();
-        aliceCompressedPubKey = hex.encode(pubECDSA(aliceSecKey, true));
         identity = SingleKey.fromPrivateKey(aliceSecKey);
 
         // Create providers
@@ -48,12 +46,15 @@ describe("SwapManager", () => {
             }),
         });
 
+        contractManager = await wallet.getContractManager();
+
         // Create ArkadeSwaps instance without SwapManager (for baseline tests)
         swaps = new ArkadeSwaps({
             wallet,
             swapProvider,
             arkProvider,
             indexerProvider,
+            contractManager,
             swapManager: false,
         });
 
@@ -76,6 +77,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: true,
             });
 
@@ -90,6 +92,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     enableAutoActions: false,
                     pollInterval: 60000,
@@ -107,6 +110,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: false,
             });
 
@@ -126,6 +130,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: true,
             });
 
@@ -161,6 +166,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     autoStart: false,
                 },
@@ -203,6 +209,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     autoStart: false,
                 },
@@ -229,6 +236,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     autoStart: false,
                 },
@@ -254,6 +262,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     autoStart: false,
                 },
@@ -279,6 +288,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     autoStart: false,
                 },
@@ -304,6 +314,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     autoStart: false,
                 },
@@ -325,6 +336,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     autoStart: false,
                 },
@@ -346,6 +358,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     autoStart: false,
                 },
@@ -367,6 +380,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     autoStart: false,
                 },
@@ -390,6 +404,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: true,
             });
 
@@ -409,6 +424,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     reconnectDelayMs: 2000,
                 },
@@ -428,6 +444,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     pollRetryDelayMs: 10000,
                 },
@@ -452,6 +469,7 @@ describe("SwapManager", () => {
                 arkProvider,
                 swapProvider,
                 indexerProvider,
+                contractManager,
                 swapManager: {
                     events: {
                         onSwapUpdate,

--- a/packages/boltz-swap/test/fixtures/swaps.ts
+++ b/packages/boltz-swap/test/fixtures/swaps.ts
@@ -1,0 +1,239 @@
+/**
+ * Test fixtures for swap-contract mapper tests.
+ *
+ * The fixture keys are all set to the same x-only key (`signerPubkey`) so
+ * that `createVHTLCScript` can derive the lockup address without a real wallet
+ * identity.  Real production swaps use distinct keys — the mapper logic under
+ * test is the same regardless of which keys occupy each role.
+ */
+import { ArkInfo } from "@arkade-os/sdk";
+import { hex } from "@scure/base";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { pubECDSA } from "@scure/btc-signer/utils.js";
+import { BoltzReverseSwap, BoltzSubmarineSwap, BoltzChainSwap } from "../../src/types";
+import {
+    CreateReverseSwapRequest,
+    CreateSubmarineSwapResponse,
+} from "../../src/boltz-swap-provider";
+import { createVHTLCScript } from "../../src/utils/vhtlc";
+
+// Deterministic test key (32-byte x-only)
+const FIXTURE_SECKEY = new Uint8Array(32).fill(0x42);
+const FIXTURE_XONLY_HEX = hex.encode(schnorr.getPublicKey(FIXTURE_SECKEY));
+// Compressed (33-byte) form of the same key
+const FIXTURE_COMPRESSED_HEX = hex.encode(pubECDSA(FIXTURE_SECKEY, true));
+
+const FIXTURE_PREIMAGE = new Uint8Array(32).fill(0xab);
+const FIXTURE_PREIMAGE_HASH = sha256(FIXTURE_PREIMAGE);
+
+const FIXTURE_TIMEOUTS = {
+    refund: 1700000000,
+    unilateralClaim: 266752,
+    unilateralRefund: 432128,
+    unilateralRefundWithoutReceiver: 518656,
+};
+
+export const makeArkInfoFixture = (): ArkInfo =>
+    ({
+        signerPubkey: FIXTURE_XONLY_HEX,
+        deprecatedSigners: [],
+        network: "regtest",
+    }) as unknown as ArkInfo;
+
+/**
+ * Reverse swap fixture (Lightning → Ark).
+ *
+ * Roles (mirroring ArkadeSwaps.claimVHTLC):
+ *   receiver = wallet key  (= signerPubkey in fixture)
+ *   sender   = Boltz key   (= signerPubkey in fixture — same for test simplicity)
+ */
+export const makeReverseSwapFixture = (arkInfo: ArkInfo): BoltzReverseSwap => {
+    // Derive the real lockup address so the mapper can reconstruct it.
+    const { vhtlcAddress } = createVHTLCScript({
+        network: arkInfo.network,
+        preimageHash: FIXTURE_PREIMAGE_HASH,
+        receiverPubkey: FIXTURE_XONLY_HEX, // wallet key
+        senderPubkey: FIXTURE_XONLY_HEX, // Boltz refund key
+        serverPubkey: FIXTURE_XONLY_HEX, // ark server
+        timeoutBlockHeights: FIXTURE_TIMEOUTS,
+    });
+
+    const request: CreateReverseSwapRequest = {
+        claimPublicKey: FIXTURE_COMPRESSED_HEX,
+        invoiceAmount: 50000,
+        preimageHash: hex.encode(FIXTURE_PREIMAGE_HASH),
+    };
+
+    return {
+        id: "fixture-reverse-swap-id",
+        type: "reverse",
+        createdAt: 1700000000,
+        preimage: hex.encode(FIXTURE_PREIMAGE),
+        status: "swap.created",
+        request,
+        response: {
+            id: "fixture-reverse-swap-id",
+            invoice: "lntb...",
+            onchainAmount: 50000,
+            lockupAddress: vhtlcAddress,
+            refundPublicKey: FIXTURE_COMPRESSED_HEX,
+            timeoutBlockHeights: FIXTURE_TIMEOUTS,
+        },
+    };
+};
+
+/**
+ * Submarine swap fixture (Ark → Lightning).
+ *
+ * Roles (mirroring ArkadeSwaps.buildSubmarineVHTLCContext):
+ *   receiver = Boltz claim key  (= signerPubkey in fixture)
+ *   sender   = wallet key       (= signerPubkey in fixture — same for test simplicity)
+ */
+export const makeSubmarineSwapFixture = (arkInfo: ArkInfo): BoltzSubmarineSwap => {
+    const { vhtlcAddress } = createVHTLCScript({
+        network: arkInfo.network,
+        preimageHash: FIXTURE_PREIMAGE_HASH,
+        receiverPubkey: FIXTURE_XONLY_HEX, // Boltz claim key
+        senderPubkey: FIXTURE_XONLY_HEX, // wallet refund key
+        serverPubkey: FIXTURE_XONLY_HEX, // ark server
+        timeoutBlockHeights: FIXTURE_TIMEOUTS,
+    });
+
+    const response: CreateSubmarineSwapResponse = {
+        id: "fixture-submarine-swap-id",
+        expectedAmount: 50000,
+        address: vhtlcAddress,
+        claimPublicKey: FIXTURE_COMPRESSED_HEX,
+        acceptZeroConf: true,
+        timeoutBlockHeights: FIXTURE_TIMEOUTS,
+    };
+
+    return {
+        id: "fixture-submarine-swap-id",
+        type: "submarine",
+        createdAt: 1700000000,
+        preimageHash: hex.encode(FIXTURE_PREIMAGE_HASH),
+        status: "swap.created",
+        request: {
+            invoice: "lntb...",
+            refundPublicKey: FIXTURE_COMPRESSED_HEX,
+        },
+        response,
+    };
+};
+
+/**
+ * Chain swap fixture (BTC → Ark).
+ *
+ * Roles (mirroring ArkadeSwaps.claimArk for BTC→ARK direction):
+ *   receiver = wallet claim key           (= signerPubkey in fixture)
+ *   sender   = Boltz claimDetails server  (= signerPubkey in fixture)
+ *
+ * The ARK-side VHTLC lives at claimDetails.lockupAddress.
+ */
+export const makeChainSwapFixture = (arkInfo: ArkInfo): BoltzChainSwap => {
+    const { vhtlcAddress } = createVHTLCScript({
+        network: arkInfo.network,
+        preimageHash: FIXTURE_PREIMAGE_HASH,
+        receiverPubkey: FIXTURE_XONLY_HEX, // wallet claim key
+        senderPubkey: FIXTURE_XONLY_HEX, // Boltz server public key
+        serverPubkey: FIXTURE_XONLY_HEX, // ark server
+        timeoutBlockHeights: FIXTURE_TIMEOUTS,
+    });
+
+    return {
+        id: "fixture-chain-swap-id",
+        type: "chain",
+        preimage: hex.encode(FIXTURE_PREIMAGE),
+        createdAt: 1700000000,
+        ephemeralKey: "ef".repeat(32),
+        feeSatsPerByte: 1,
+        status: "swap.created",
+        amount: 50000,
+        toAddress: "tark1q...",
+        request: {
+            to: "ARK",
+            from: "BTC",
+            preimageHash: hex.encode(FIXTURE_PREIMAGE_HASH),
+            claimPublicKey: FIXTURE_COMPRESSED_HEX,
+            refundPublicKey: FIXTURE_COMPRESSED_HEX,
+            feeSatsPerByte: 1,
+        },
+        response: {
+            id: "fixture-chain-swap-id",
+            claimDetails: {
+                lockupAddress: vhtlcAddress,
+                amount: 50000,
+                serverPublicKey: FIXTURE_COMPRESSED_HEX,
+                timeoutBlockHeight: 100,
+                timeouts: FIXTURE_TIMEOUTS,
+            },
+            lockupDetails: {
+                lockupAddress: "bcrt1p...",
+                amount: 50000,
+                serverPublicKey: FIXTURE_COMPRESSED_HEX,
+                timeoutBlockHeight: 100,
+            },
+        },
+    };
+};
+
+/**
+ * Chain swap fixture (Ark → BTC).
+ *
+ * Roles (mirroring the `isFromArk === true` branch in `extractSwapVhtlcInputs`):
+ *   receiver = Boltz server key  (= lockupDetails.serverPublicKey in fixture)
+ *   sender   = wallet refund key (= request.refundPublicKey in fixture)
+ *
+ * The ARK-side VHTLC lives at lockupDetails.lockupAddress (user locks ARK here,
+ * Boltz claims it once it sees the BTC payment to the user's address).
+ */
+export const makeChainSwapFromArkFixture = (arkInfo: ArkInfo): BoltzChainSwap => {
+    const { vhtlcAddress } = createVHTLCScript({
+        network: arkInfo.network,
+        preimageHash: FIXTURE_PREIMAGE_HASH,
+        receiverPubkey: FIXTURE_XONLY_HEX, // Boltz server key (receiver on ARK side)
+        senderPubkey: FIXTURE_XONLY_HEX, // wallet refund key (sender)
+        serverPubkey: FIXTURE_XONLY_HEX, // ark server
+        timeoutBlockHeights: FIXTURE_TIMEOUTS,
+    });
+
+    return {
+        id: "fixture-chain-from-ark-swap-id",
+        type: "chain",
+        preimage: hex.encode(FIXTURE_PREIMAGE),
+        createdAt: 1700000000,
+        ephemeralKey: "ef".repeat(32),
+        feeSatsPerByte: 1,
+        status: "swap.created",
+        amount: 50000,
+        toAddress: "bcrt1q...",
+        request: {
+            to: "BTC",
+            from: "ARK",
+            preimageHash: hex.encode(FIXTURE_PREIMAGE_HASH),
+            claimPublicKey: FIXTURE_COMPRESSED_HEX,
+            refundPublicKey: FIXTURE_COMPRESSED_HEX,
+            feeSatsPerByte: 1,
+        },
+        response: {
+            id: "fixture-chain-from-ark-swap-id",
+            claimDetails: {
+                // BTC-side claim details — not the ARK VHTLC
+                lockupAddress: "bcrt1p...",
+                amount: 50000,
+                serverPublicKey: FIXTURE_COMPRESSED_HEX,
+                timeoutBlockHeight: 100,
+            },
+            lockupDetails: {
+                // ARK-side lockup: user locks funds here, Boltz claims
+                lockupAddress: vhtlcAddress,
+                amount: 50000,
+                serverPublicKey: FIXTURE_COMPRESSED_HEX,
+                timeoutBlockHeight: 100,
+                timeouts: FIXTURE_TIMEOUTS,
+            },
+        },
+    };
+};

--- a/packages/boltz-swap/test/migrateSwapsToContracts.test.ts
+++ b/packages/boltz-swap/test/migrateSwapsToContracts.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from "vitest";
+import { migrateSwapsToContracts } from "../src/repositories/migrateSwapsToContracts";
+import { InMemorySwapRepository } from "../src/repositories/inMemory/swap-repository";
+import {
+    makeArkInfoFixture,
+    makeReverseSwapFixture,
+    makeSubmarineSwapFixture,
+} from "./fixtures/swaps";
+import {
+    isReverseFinalStatus,
+    isSubmarineFinalStatus,
+    isChainFinalStatus,
+} from "../src/boltz-swap-provider";
+import type { BoltzSwap } from "../src/types";
+import type { IContractManager } from "@arkade-os/sdk";
+
+// Mirror SwapManager.isFinalStatus — dispatch on type to the correct predicate.
+const isTerminal = (swap: BoltzSwap): boolean => {
+    if (swap.type === "reverse") return isReverseFinalStatus(swap.status);
+    if (swap.type === "submarine") return isSubmarineFinalStatus(swap.status);
+    if (swap.type === "chain") return isChainFinalStatus(swap.status);
+    return false;
+};
+
+const makeFakeContractManager = (): {
+    cm: IContractManager;
+    calls: unknown[];
+} => {
+    const calls: unknown[] = [];
+    const cm = {
+        createContract: vi.fn(async (p: unknown) => {
+            calls.push(p);
+            return { ...((p as any) ?? {}), state: "active", createdAt: 0 };
+        }),
+    } as unknown as IContractManager;
+    return { cm, calls };
+};
+
+describe("migrateSwapsToContracts", () => {
+    it("registers non-terminal swaps and skips terminal ones", async () => {
+        const arkInfo = makeArkInfoFixture();
+        const repo = new InMemorySwapRepository();
+
+        // Non-terminal (swap.created is active for both reverse and submarine)
+        const reverseSwap = makeReverseSwapFixture(arkInfo);
+        const submarineSwap = {
+            ...makeSubmarineSwapFixture(arkInfo),
+            id: "fixture-submarine-swap-id-2",
+        };
+
+        // Terminal: submarine swap that has settled
+        const terminalSwap = {
+            ...makeSubmarineSwapFixture(arkInfo),
+            id: "fixture-submarine-terminal-id",
+            status: "transaction.claimed" as const,
+        };
+
+        await repo.saveSwap(reverseSwap);
+        await repo.saveSwap(submarineSwap);
+        await repo.saveSwap(terminalSwap);
+
+        const { cm, calls } = makeFakeContractManager();
+
+        const result = await migrateSwapsToContracts({
+            swapRepository: repo,
+            contractManager: cm,
+            arkInfo,
+            isTerminal,
+        });
+
+        // Only the 2 non-terminal swaps should be registered
+        expect(result.migrated).toBe(2);
+        expect(result.failed).toBe(0);
+        expect(calls).toHaveLength(2);
+    });
+
+    it("is idempotent: running twice still registers the non-terminal swaps both times", async () => {
+        const arkInfo = makeArkInfoFixture();
+        const repo = new InMemorySwapRepository();
+        await repo.saveSwap(makeReverseSwapFixture(arkInfo));
+
+        const { cm } = makeFakeContractManager();
+
+        const r1 = await migrateSwapsToContracts({
+            swapRepository: repo,
+            contractManager: cm,
+            arkInfo,
+            isTerminal,
+        });
+        expect(r1.migrated).toBe(1);
+        expect(r1.failed).toBe(0);
+
+        // Second run — createContract deduplicates internally; count still increments
+        const r2 = await migrateSwapsToContracts({
+            swapRepository: repo,
+            contractManager: cm,
+            arkInfo,
+            isTerminal,
+        });
+        expect(r2.migrated).toBe(1);
+        expect(r2.failed).toBe(0);
+    });
+
+    it("continues after a per-swap error and counts it as failed", async () => {
+        const arkInfo = makeArkInfoFixture();
+        const repo = new InMemorySwapRepository();
+
+        const goodSwap = makeReverseSwapFixture(arkInfo);
+        // A swap with a bad id that will cause registerSwapContract to throw — we
+        // simulate this by making createContract reject for that specific swap id.
+        const badSwap = { ...makeSubmarineSwapFixture(arkInfo), id: "bad-swap-id" };
+
+        await repo.saveSwap(goodSwap);
+        await repo.saveSwap(badSwap);
+
+        const calls: unknown[] = [];
+        const cm = {
+            createContract: vi.fn(async (p: any) => {
+                calls.push(p);
+                if (p?.metadata?.swapId === "bad-swap-id") {
+                    throw new Error("simulated registration failure");
+                }
+                return { ...p, state: "active", createdAt: 0 };
+            }),
+        } as unknown as IContractManager;
+
+        const result = await migrateSwapsToContracts({
+            swapRepository: repo,
+            contractManager: cm,
+            arkInfo,
+            isTerminal,
+        });
+
+        // One succeeded, one failed — but neither aborted the other
+        expect(result.migrated).toBe(1);
+        expect(result.failed).toBe(1);
+        // createContract was called for both (the error only came from inside)
+        expect(calls).toHaveLength(2);
+    });
+});

--- a/packages/boltz-swap/test/realm-swap-repository.test.ts
+++ b/packages/boltz-swap/test/realm-swap-repository.test.ts
@@ -106,7 +106,7 @@ function createMockRealm() {
         delete(obj: Record<string, unknown> | Record<string, unknown>[]): void {
             // Handle both single objects and collections (arrays)
             const items = Array.isArray(obj) ? obj : [obj];
-            for (const [schemaName, table] of store.entries()) {
+            for (const [, table] of store.entries()) {
                 for (const item of items) {
                     const pk = item.id as string;
                     if (pk !== undefined) {

--- a/packages/boltz-swap/test/swap-contract.test.ts
+++ b/packages/boltz-swap/test/swap-contract.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { createVHTLCScript } from "../src/utils/vhtlc";
+import { swapToContractParams, registerSwapContract } from "../src/utils/swap-contract";
+import {
+    makeReverseSwapFixture,
+    makeSubmarineSwapFixture,
+    makeChainSwapFixture,
+    makeChainSwapFromArkFixture,
+    makeArkInfoFixture,
+} from "./fixtures/swaps";
+
+describe("swapToContractParams", () => {
+    it("maps a reverse swap to a vhtlc CreateContractParams whose script matches the real VHTLC", () => {
+        const arkInfo = makeArkInfoFixture();
+        const swap = makeReverseSwapFixture(arkInfo); // lockupAddress derived from current signer
+        const params = swapToContractParams(swap, arkInfo);
+
+        // Rebuild the script the canonical way and compare.
+        const { vhtlcScript, vhtlcAddress } = createVHTLCScript({
+            network: arkInfo.network,
+            preimageHash: hex.decode(swap.request.preimageHash),
+            receiverPubkey: swap.request.claimPublicKey, // fixture wires the counterparty key
+            senderPubkey: arkInfo.signerPubkey, // fixture wires the counterparty key
+            serverPubkey: arkInfo.signerPubkey,
+            timeoutBlockHeights: swap.response.timeoutBlockHeights!,
+        });
+
+        expect(params.type).toBe("vhtlc");
+        expect(params.script).toBe(hex.encode(vhtlcScript.pkScript));
+        expect(params.address).toBe(vhtlcAddress);
+        // critical: HASH160 commitment, not raw sha256
+        expect(params.params.hash).toBe(
+            hex.encode(ripemd160(hex.decode(swap.request.preimageHash))),
+        );
+        expect(params.metadata).toMatchObject({
+            swapId: swap.id,
+            swapType: "reverse",
+            source: `swap:${swap.id}`,
+        });
+        expect(params.state).toBe("active");
+    });
+
+    it("maps a submarine swap to a vhtlc CreateContractParams whose script matches the real VHTLC", () => {
+        const arkInfo = makeArkInfoFixture();
+        const swap = makeSubmarineSwapFixture(arkInfo);
+        const params = swapToContractParams(swap, arkInfo);
+
+        // Submarine: receiver = Boltz claimPublicKey, sender = wallet refundPublicKey.
+        const { vhtlcScript, vhtlcAddress } = createVHTLCScript({
+            network: arkInfo.network,
+            preimageHash: hex.decode(swap.preimageHash!),
+            receiverPubkey: swap.response.claimPublicKey!,
+            senderPubkey: swap.request.refundPublicKey,
+            serverPubkey: arkInfo.signerPubkey,
+            timeoutBlockHeights: swap.response.timeoutBlockHeights!,
+        });
+
+        expect(params.type).toBe("vhtlc");
+        expect(params.script).toBe(hex.encode(vhtlcScript.pkScript));
+        expect(params.address).toBe(vhtlcAddress);
+        expect(params.params.hash).toBe(hex.encode(ripemd160(hex.decode(swap.preimageHash!))));
+        expect(params.metadata).toMatchObject({
+            swapId: swap.id,
+            swapType: "submarine",
+            source: `swap:${swap.id}`,
+        });
+        expect(params.state).toBe("active");
+    });
+
+    it("maps a chain swap (BTC→ARK) to a vhtlc CreateContractParams whose script matches the real VHTLC", () => {
+        const arkInfo = makeArkInfoFixture();
+        const swap = makeChainSwapFixture(arkInfo);
+        const params = swapToContractParams(swap, arkInfo);
+
+        // Chain BTC→ARK: receiver = wallet claimPublicKey, sender = claimDetails.serverPublicKey.
+        const { vhtlcScript, vhtlcAddress } = createVHTLCScript({
+            network: arkInfo.network,
+            preimageHash: hex.decode(swap.request.preimageHash),
+            receiverPubkey: swap.request.claimPublicKey,
+            senderPubkey: swap.response.claimDetails.serverPublicKey,
+            serverPubkey: arkInfo.signerPubkey,
+            timeoutBlockHeights: swap.response.claimDetails.timeouts!,
+        });
+
+        expect(params.type).toBe("vhtlc");
+        expect(params.script).toBe(hex.encode(vhtlcScript.pkScript));
+        expect(params.address).toBe(vhtlcAddress);
+        expect(params.params.hash).toBe(
+            hex.encode(ripemd160(hex.decode(swap.request.preimageHash))),
+        );
+        expect(params.metadata).toMatchObject({
+            swapId: swap.id,
+            swapType: "chain",
+            source: `swap:${swap.id}`,
+        });
+        expect(params.state).toBe("active");
+    });
+
+    it("maps a chain swap (ARK→BTC) to a vhtlc CreateContractParams whose script matches the real VHTLC", () => {
+        const arkInfo = makeArkInfoFixture();
+        const swap = makeChainSwapFromArkFixture(arkInfo);
+        const params = swapToContractParams(swap, arkInfo);
+
+        // Chain ARK→BTC: receiver = lockupDetails.serverPublicKey (Boltz), sender = wallet refundPublicKey.
+        const { vhtlcScript, vhtlcAddress } = createVHTLCScript({
+            network: arkInfo.network,
+            preimageHash: hex.decode(swap.request.preimageHash),
+            receiverPubkey: swap.response.lockupDetails.serverPublicKey,
+            senderPubkey: swap.request.refundPublicKey,
+            serverPubkey: arkInfo.signerPubkey,
+            timeoutBlockHeights: swap.response.lockupDetails.timeouts!,
+        });
+
+        expect(params.type).toBe("vhtlc");
+        expect(params.script).toBe(hex.encode(vhtlcScript.pkScript));
+        expect(params.address).toBe(vhtlcAddress);
+        expect(params.params.hash).toBe(
+            hex.encode(ripemd160(hex.decode(swap.request.preimageHash))),
+        );
+        expect(params.metadata).toMatchObject({
+            swapId: swap.id,
+            swapType: "chain",
+            source: `swap:${swap.id}`,
+        });
+        expect(params.state).toBe("active");
+    });
+});
+
+describe("registerSwapContract", () => {
+    it("registers the swap's vhtlc contract idempotently", async () => {
+        const arkInfo = makeArkInfoFixture();
+        const swap = makeReverseSwapFixture(arkInfo);
+        const calls: any[] = [];
+        const fakeManager = {
+            createContract: async (p: any) => {
+                calls.push(p);
+                return { ...p, state: "active", createdAt: 0 };
+            },
+        } as any;
+
+        await registerSwapContract(fakeManager, swap, arkInfo);
+        await registerSwapContract(fakeManager, swap, arkInfo);
+
+        expect(calls).toHaveLength(2); // createContract itself is idempotent on script; helper always calls
+        expect(calls[0].script).toBe(swapToContractParams(swap, arkInfo).script);
+        expect(calls[0].metadata.swapId).toBe(swap.id);
+    });
+});

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -1900,4 +1900,189 @@ describe("SwapManager", () => {
             }
         });
     });
+
+    describe("Action Log", () => {
+        beforeEach(() => {
+            // Mock fetch for polling (needed once the WebSocket connects).
+            global.fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ status: "swap.created" }),
+                    headers: new Headers({ "content-length": "100" }),
+                } as Response),
+            );
+        });
+
+        it("records the swapId in claimed after a successful reverse claim", async () => {
+            const claimCallback = vi.fn();
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ claim: claimCallback }));
+
+            await swapManager.start([{ ...mockReverseSwap, status: "swap.created" }]);
+            mockWebSocket.onopen();
+
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: "reverse-swap-1", status: "transaction.confirmed" }],
+                }),
+            });
+
+            expect(claimCallback).toHaveBeenCalled();
+            const log = swapManager.getActionLog();
+            expect(log.claimed.has("reverse-swap-1")).toBe(true);
+            expect(log.refunded.has("reverse-swap-1")).toBe(false);
+        });
+
+        it("records the swapId in refunded after a successful submarine refund", async () => {
+            const refundCallback = vi.fn();
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ refund: refundCallback }));
+
+            const refundableSwap: BoltzSubmarineSwap = {
+                ...mockSubmarineSwap,
+                status: "invoice.set",
+            };
+            await swapManager.start([refundableSwap]);
+            mockWebSocket.onopen();
+
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: "submarine-swap-1", status: "invoice.failedToPay" }],
+                }),
+            });
+
+            expect(refundCallback).toHaveBeenCalled();
+            const log = swapManager.getActionLog();
+            expect(log.refunded.has("submarine-swap-1")).toBe(true);
+            expect(log.claimed.has("submarine-swap-1")).toBe(false);
+        });
+
+        it("records the swapId in claimed after a successful chain ARK claim (BTC->ARK)", async () => {
+            const claimArk = vi.fn();
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ claimArk }));
+
+            const btcToArkSwap: BoltzChainSwap = {
+                ...mockChainSwap,
+                status: "swap.created",
+                request: { ...mockChainSwap.request, from: "BTC", to: "ARK" },
+            };
+            await swapManager.start([btcToArkSwap]);
+            mockWebSocket.onopen();
+
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: btcToArkSwap.id, status: "transaction.server.mempool" }],
+                }),
+            });
+
+            expect(claimArk).toHaveBeenCalled();
+            expect(swapManager.getActionLog().claimed.has(btcToArkSwap.id)).toBe(true);
+        });
+
+        it("records the swapId in claimed after a successful chain BTC claim (ARK->BTC)", async () => {
+            const claimBtc = vi.fn();
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ claimBtc }));
+
+            // mockChainSwap.request is already {from: "ARK", to: "BTC"}.
+            const arkToBtcSwap: BoltzChainSwap = { ...mockChainSwap, status: "swap.created" };
+            await swapManager.start([arkToBtcSwap]);
+            mockWebSocket.onopen();
+
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: arkToBtcSwap.id, status: "transaction.server.mempool" }],
+                }),
+            });
+
+            expect(claimBtc).toHaveBeenCalled();
+            expect(swapManager.getActionLog().claimed.has(arkToBtcSwap.id)).toBe(true);
+        });
+
+        it("records the swapId in refunded when refundArk fully sweeps (skipped: 0)", async () => {
+            const refundArk = vi.fn().mockResolvedValue({ swept: 1, skipped: 0 });
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ refundArk, saveSwap: vi.fn() }));
+
+            const arkToBtcSwap: BoltzChainSwap = { ...mockChainSwap, status: "swap.created" };
+            await swapManager.start([arkToBtcSwap]);
+            mockWebSocket.onopen();
+
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: arkToBtcSwap.id, status: "swap.expired" }],
+                }),
+            });
+
+            expect(refundArk).toHaveBeenCalled();
+            expect(swapManager.getActionLog().refunded.has(arkToBtcSwap.id)).toBe(true);
+        });
+
+        it("does NOT record when refundArk reports a partial sweep (skipped > 0)", async () => {
+            const refundArk = vi.fn().mockResolvedValue({ swept: 0, skipped: 2 });
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ refundArk, saveSwap: vi.fn() }));
+
+            const arkToBtcSwap: BoltzChainSwap = { ...mockChainSwap, status: "swap.created" };
+            await swapManager.start([arkToBtcSwap]);
+            mockWebSocket.onopen();
+
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: arkToBtcSwap.id, status: "swap.expired" }],
+                }),
+            });
+
+            expect(refundArk).toHaveBeenCalled();
+            expect(swapManager.getActionLog().refunded.has(arkToBtcSwap.id)).toBe(false);
+        });
+
+        it("does not record when the claim callback is not set (skipped)", async () => {
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            // setCallbacks() intentionally never called — claimCallback stays null.
+
+            await swapManager.start([{ ...mockReverseSwap, status: "swap.created" }]);
+            mockWebSocket.onopen();
+
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: "reverse-swap-1", status: "transaction.confirmed" }],
+                }),
+            });
+
+            expect(swapManager.getActionLog().claimed.has("reverse-swap-1")).toBe(false);
+        });
+
+        it("does not record when the claim callback throws", async () => {
+            const claimCallback = vi.fn().mockRejectedValue(new Error("claim failed"));
+            const onSwapFailed = vi.fn();
+            swapManager = new SwapManager(swapProvider, {
+                ...swapManagerConfig,
+                events: { onSwapFailed },
+            });
+            swapManager.setCallbacks(makeCallbacks({ claim: claimCallback }));
+
+            await swapManager.start([{ ...mockReverseSwap, status: "swap.created" }]);
+            mockWebSocket.onopen();
+
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: "reverse-swap-1", status: "transaction.confirmed" }],
+                }),
+            });
+
+            expect(claimCallback).toHaveBeenCalled();
+            expect(onSwapFailed).toHaveBeenCalled();
+            expect(swapManager.getActionLog().claimed.has("reverse-swap-1")).toBe(false);
+        });
+    });
 });

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { SwapManager, SwapManagerConfig } from "../src/swap-manager";
+import { SwapManager, SwapManagerClient, SwapManagerConfig } from "../src/swap-manager";
 import { BoltzSwapProvider } from "../src/boltz-swap-provider";
 import { BoltzChainSwap, BoltzReverseSwap, BoltzSubmarineSwap } from "../src/types";
+import { SwapError } from "../src/errors";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -2083,6 +2084,130 @@ describe("SwapManager", () => {
             expect(claimCallback).toHaveBeenCalled();
             expect(onSwapFailed).toHaveBeenCalled();
             expect(swapManager.getActionLog().claimed.has("reverse-swap-1")).toBe(false);
+        });
+    });
+
+    /**
+     * `resolveSwapFromVtxo` is the SwapManager-side hook a `SwapStatusReconciler`
+     * calls (as `onSwapResolved`) once a VTXO event derives a swap's terminal
+     * `SwapState` — see swap-status-reconciler.ts. Unlike the Boltz-status-driven
+     * finalize path, it never touches `swap.status`.
+     */
+    describe("resolveSwapFromVtxo (VTXO-driven finalize)", () => {
+        beforeEach(() => {
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks());
+        });
+
+        it("exposes getActionLog on the SwapManagerClient interface (M2)", () => {
+            const client: SwapManagerClient = swapManager;
+            const log = client.getActionLog();
+            expect(log.claimed).toBeInstanceOf(Set);
+            expect(log.refunded).toBeInstanceOf(Set);
+        });
+
+        it("finalizes on Settled: removes from monitoring and fires onSwapCompleted", async () => {
+            const onSwapCompleted = vi.fn();
+            await swapManager.onSwapCompleted(onSwapCompleted);
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+            expect(await swapManager.hasSwap(swap.id)).toBe(true);
+
+            swapManager.resolveSwapFromVtxo(swap, "Settled");
+
+            expect(await swapManager.hasSwap(swap.id)).toBe(false);
+            expect(onSwapCompleted).toHaveBeenCalledWith(swap);
+        });
+
+        it("finalizes on Refunded: removes from monitoring and fires onSwapCompleted", async () => {
+            const onSwapCompleted = vi.fn();
+            await swapManager.onSwapCompleted(onSwapCompleted);
+
+            const swap = { ...mockSubmarineSwap, status: "invoice.set" as const };
+            await swapManager.start([swap]);
+
+            swapManager.resolveSwapFromVtxo(swap, "Refunded");
+
+            expect(await swapManager.hasSwap(swap.id)).toBe(false);
+            expect(onSwapCompleted).toHaveBeenCalledWith(swap);
+        });
+
+        it("finalizes on Failed: removes from monitoring and fires onSwapFailed with a SwapError", async () => {
+            const onSwapFailed = vi.fn();
+            await swapManager.onSwapFailed(onSwapFailed);
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            swapManager.resolveSwapFromVtxo(swap, "Failed");
+
+            expect(await swapManager.hasSwap(swap.id)).toBe(false);
+            expect(onSwapFailed).toHaveBeenCalledTimes(1);
+            const [failedSwap, error] = onSwapFailed.mock.calls[0];
+            expect(failedSwap).toBe(swap);
+            expect(error).toBeInstanceOf(SwapError);
+            expect((error as Error).message).toContain(swap.id);
+        });
+
+        it("is idempotent: a second call after finalization is a no-op", async () => {
+            const onSwapCompleted = vi.fn();
+            await swapManager.onSwapCompleted(onSwapCompleted);
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            swapManager.resolveSwapFromVtxo(swap, "Settled");
+            swapManager.resolveSwapFromVtxo(swap, "Settled");
+
+            expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not act on a swap the manager never monitored", async () => {
+            const onSwapCompleted = vi.fn();
+            const onSwapFailed = vi.fn();
+            await swapManager.onSwapCompleted(onSwapCompleted);
+            await swapManager.onSwapFailed(onSwapFailed);
+
+            // Note: swap is never passed to start(), so it's not in monitoredSwaps.
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+
+            swapManager.resolveSwapFromVtxo(swap, "Settled");
+
+            expect(onSwapCompleted).not.toHaveBeenCalled();
+            expect(onSwapFailed).not.toHaveBeenCalled();
+        });
+
+        it("does not finalize while executeAutonomousAction is mid-flight (swapsInProgress guard)", async () => {
+            const onSwapCompleted = vi.fn();
+            await swapManager.onSwapCompleted(onSwapCompleted);
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            // Simulate an in-progress autonomous action without actually running one.
+            (swapManager as any).swapsInProgress.add(swap.id);
+
+            swapManager.resolveSwapFromVtxo(swap, "Settled");
+
+            expect(await swapManager.hasSwap(swap.id)).toBe(true);
+            expect(onSwapCompleted).not.toHaveBeenCalled();
+        });
+
+        it("ignores a non-terminal derived state", async () => {
+            const onSwapCompleted = vi.fn();
+            const onSwapFailed = vi.fn();
+            await swapManager.onSwapCompleted(onSwapCompleted);
+            await swapManager.onSwapFailed(onSwapFailed);
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            swapManager.resolveSwapFromVtxo(swap, "Pending");
+
+            expect(await swapManager.hasSwap(swap.id)).toBe(true);
+            expect(onSwapCompleted).not.toHaveBeenCalled();
+            expect(onSwapFailed).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -2114,10 +2114,12 @@ describe("SwapManager", () => {
             await swapManager.start([swap]);
             expect(await swapManager.hasSwap(swap.id)).toBe(true);
 
-            swapManager.resolveSwapFromVtxo(swap, "Settled");
+            await swapManager.resolveSwapFromVtxo(swap, "Settled");
 
             expect(await swapManager.hasSwap(swap.id)).toBe(false);
             expect(onSwapCompleted).toHaveBeenCalledWith(swap);
+            // reverse + Settled -> "invoice.settled" (isReverseFinalStatus ✓).
+            expect(swap.status).toBe("invoice.settled");
         });
 
         it("finalizes on Refunded: removes from monitoring and fires onSwapCompleted", async () => {
@@ -2127,10 +2129,15 @@ describe("SwapManager", () => {
             const swap = { ...mockSubmarineSwap, status: "invoice.set" as const };
             await swapManager.start([swap]);
 
-            swapManager.resolveSwapFromVtxo(swap, "Refunded");
+            await swapManager.resolveSwapFromVtxo(swap, "Refunded");
 
             expect(await swapManager.hasSwap(swap.id)).toBe(false);
             expect(onSwapCompleted).toHaveBeenCalledWith(swap);
+            // Submarine has no first-class "refunded" Boltz status
+            // (isSubmarineFinalStatus never includes "transaction.refunded"),
+            // so "swap.expired" is used instead — see
+            // terminalStatusForVtxoState in swap-manager.ts.
+            expect(swap.status).toBe("swap.expired");
         });
 
         it("finalizes on Failed: removes from monitoring and fires onSwapFailed with a SwapError", async () => {
@@ -2140,7 +2147,7 @@ describe("SwapManager", () => {
             const swap = { ...mockReverseSwap, status: "swap.created" as const };
             await swapManager.start([swap]);
 
-            swapManager.resolveSwapFromVtxo(swap, "Failed");
+            await swapManager.resolveSwapFromVtxo(swap, "Failed");
 
             expect(await swapManager.hasSwap(swap.id)).toBe(false);
             expect(onSwapFailed).toHaveBeenCalledTimes(1);
@@ -2148,6 +2155,64 @@ describe("SwapManager", () => {
             expect(failedSwap).toBe(swap);
             expect(error).toBeInstanceOf(SwapError);
             expect((error as Error).message).toContain(swap.id);
+            expect(swap.status).toBe("transaction.failed");
+        });
+
+        it("maps a chain swap's Settled/Refunded/Failed states to the matching terminal BoltzSwapStatus", async () => {
+            const settledSwap = {
+                ...mockChainSwap,
+                id: "chain-settled",
+                status: "swap.created" as const,
+            };
+            const refundedSwap = {
+                ...mockChainSwap,
+                id: "chain-refunded",
+                status: "swap.created" as const,
+            };
+            const failedSwap = {
+                ...mockChainSwap,
+                id: "chain-failed",
+                status: "swap.created" as const,
+            };
+            await swapManager.start([settledSwap, refundedSwap, failedSwap]);
+
+            await swapManager.resolveSwapFromVtxo(settledSwap, "Settled");
+            await swapManager.resolveSwapFromVtxo(refundedSwap, "Refunded");
+            await swapManager.resolveSwapFromVtxo(failedSwap, "Failed");
+
+            expect(settledSwap.status).toBe("transaction.claimed");
+            expect(refundedSwap.status).toBe("transaction.refunded");
+            expect(failedSwap.status).toBe("transaction.failed");
+        });
+
+        it("maps submarine Failed to invoice.failedToPay (distinct from the Refunded mapping)", async () => {
+            const swap = { ...mockSubmarineSwap, status: "invoice.set" as const };
+            await swapManager.start([swap]);
+
+            await swapManager.resolveSwapFromVtxo(swap, "Failed");
+
+            expect(swap.status).toBe("invoice.failedToPay");
+        });
+
+        it("resolves a pending waitForSwapCompletion when the VTXO signal settles the swap", async () => {
+            // Regression: resolveSwapFromVtxo used to drop the swap from
+            // monitoredSwaps without touching swap.status or firing the
+            // update listeners/per-swap subscriptions waitForSwapCompletion
+            // depends on — a waiter would hang forever. Mirrors the
+            // markSwapAsUnknownToProvider regression test above (~line 1545).
+            vi.spyOn(swapProvider, "getReverseSwapTxId").mockResolvedValue({
+                id: "vtxo-derived-txid",
+                timeoutBlockHeight: 10,
+            });
+
+            const swap = { ...mockReverseSwap, status: "transaction.confirmed" as const };
+            await swapManager.start([swap]);
+
+            const completion = swapManager.waitForSwapCompletion(swap.id);
+
+            await swapManager.resolveSwapFromVtxo(swap, "Settled");
+
+            await expect(completion).resolves.toEqual({ txid: "vtxo-derived-txid" });
         });
 
         it("is idempotent: a second call after finalization is a no-op", async () => {
@@ -2157,10 +2222,25 @@ describe("SwapManager", () => {
             const swap = { ...mockReverseSwap, status: "swap.created" as const };
             await swapManager.start([swap]);
 
-            swapManager.resolveSwapFromVtxo(swap, "Settled");
-            swapManager.resolveSwapFromVtxo(swap, "Settled");
+            const first = swapManager.resolveSwapFromVtxo(swap, "Settled");
+            const second = swapManager.resolveSwapFromVtxo(swap, "Settled");
+            await Promise.all([first, second]);
 
             expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+        });
+
+        it("is idempotent: a second call after Failed finalization is a no-op", async () => {
+            const onSwapFailed = vi.fn();
+            await swapManager.onSwapFailed(onSwapFailed);
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            const first = swapManager.resolveSwapFromVtxo(swap, "Failed");
+            const second = swapManager.resolveSwapFromVtxo(swap, "Failed");
+            await Promise.all([first, second]);
+
+            expect(onSwapFailed).toHaveBeenCalledTimes(1);
         });
 
         it("does not act on a swap the manager never monitored", async () => {
@@ -2172,7 +2252,7 @@ describe("SwapManager", () => {
             // Note: swap is never passed to start(), so it's not in monitoredSwaps.
             const swap = { ...mockReverseSwap, status: "swap.created" as const };
 
-            swapManager.resolveSwapFromVtxo(swap, "Settled");
+            await swapManager.resolveSwapFromVtxo(swap, "Settled");
 
             expect(onSwapCompleted).not.toHaveBeenCalled();
             expect(onSwapFailed).not.toHaveBeenCalled();
@@ -2188,7 +2268,7 @@ describe("SwapManager", () => {
             // Simulate an in-progress autonomous action without actually running one.
             (swapManager as any).swapsInProgress.add(swap.id);
 
-            swapManager.resolveSwapFromVtxo(swap, "Settled");
+            await swapManager.resolveSwapFromVtxo(swap, "Settled");
 
             expect(await swapManager.hasSwap(swap.id)).toBe(true);
             expect(onSwapCompleted).not.toHaveBeenCalled();
@@ -2203,7 +2283,7 @@ describe("SwapManager", () => {
             const swap = { ...mockReverseSwap, status: "swap.created" as const };
             await swapManager.start([swap]);
 
-            swapManager.resolveSwapFromVtxo(swap, "Pending");
+            await swapManager.resolveSwapFromVtxo(swap, "Pending");
 
             expect(await swapManager.hasSwap(swap.id)).toBe(true);
             expect(onSwapCompleted).not.toHaveBeenCalled();

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -2290,4 +2290,163 @@ describe("SwapManager", () => {
             expect(onSwapFailed).not.toHaveBeenCalled();
         });
     });
+
+    /**
+     * `triggerClaimFromVtxo` is the SwapManager-side hook a
+     * `SwapStatusReconciler` calls (as `onSwapFunded`) when a swap's tracked
+     * VHTLC lockup is observed FUNDED (`vtxo_received`) — see
+     * swap-status-reconciler.ts. Unlike the Boltz-status-driven claim path
+     * (`executeAutonomousAction`, gated on `isReverseClaimableStatus`/
+     * `isChainClaimableStatus`), it acts purely on the VTXO signal and never
+     * touches `swap.status`.
+     */
+    describe("triggerClaimFromVtxo (VTXO-funded claim, ahead of Boltz status)", () => {
+        beforeEach(() => {
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+        });
+
+        it("reverse: claims immediately even though Boltz status is not yet claimable", async () => {
+            const claimCallback = vi.fn();
+            swapManager.setCallbacks(makeCallbacks({ claim: claimCallback }));
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(claimCallback).toHaveBeenCalledWith(swap);
+            expect(swapManager.getActionLog().claimed.has(swap.id)).toBe(true);
+            // The claim ran off the VTXO signal, not because Boltz's status
+            // became claimable — status is untouched by this path.
+            expect(swap.status).toBe("swap.created");
+        });
+
+        it("reverse: skips a restored swap without a preimage (mirrors executeAutonomousAction's guard)", async () => {
+            const claimCallback = vi.fn();
+            swapManager.setCallbacks(makeCallbacks({ claim: claimCallback }));
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const, preimage: "" };
+            await swapManager.start([swap]);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(claimCallback).not.toHaveBeenCalled();
+            expect(swapManager.getActionLog().claimed.has(swap.id)).toBe(false);
+        });
+
+        it('chain BTC->ARK (request.to === "ARK"): claims the ARK side immediately', async () => {
+            const claimArk = vi.fn();
+            swapManager.setCallbacks(makeCallbacks({ claimArk }));
+
+            const swap: BoltzChainSwap = {
+                ...mockChainSwap,
+                status: "swap.created",
+                request: { ...mockChainSwap.request, from: "BTC", to: "ARK" },
+            };
+            await swapManager.start([swap]);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(claimArk).toHaveBeenCalledWith(swap);
+            expect(swapManager.getActionLog().claimed.has(swap.id)).toBe(true);
+        });
+
+        it('chain ARK->BTC (request.to === "BTC"): no-op — wallet is sender on the tracked VHTLC', async () => {
+            const claimBtc = vi.fn();
+            swapManager.setCallbacks(makeCallbacks({ claimBtc }));
+
+            // mockChainSwap.request is already {from: "ARK", to: "BTC"}.
+            const swap: BoltzChainSwap = { ...mockChainSwap, status: "swap.created" };
+            await swapManager.start([swap]);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(claimBtc).not.toHaveBeenCalled();
+            expect(swapManager.getActionLog().claimed.has(swap.id)).toBe(false);
+        });
+
+        it("submarine: no-op — wallet is sender on the tracked VHTLC (Boltz is the claimer)", async () => {
+            const refundCallback = vi.fn();
+            swapManager.setCallbacks(makeCallbacks({ refund: refundCallback }));
+
+            const swap = { ...mockSubmarineSwap, status: "invoice.set" as const };
+            await swapManager.start([swap]);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(refundCallback).not.toHaveBeenCalled();
+            expect(swapManager.getActionLog().claimed.has(swap.id)).toBe(false);
+            expect(swapManager.getActionLog().refunded.has(swap.id)).toBe(false);
+        });
+
+        it("does not re-claim a swap already recorded as claimed (duplicate funded event)", async () => {
+            const claimCallback = vi.fn();
+            swapManager.setCallbacks(makeCallbacks({ claim: claimCallback }));
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+            (swapManager as any).claimedSwapIds.add(swap.id);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(claimCallback).not.toHaveBeenCalled();
+        });
+
+        it("does not claim a swap already recorded as refunded", async () => {
+            const claimCallback = vi.fn();
+            swapManager.setCallbacks(makeCallbacks({ claim: claimCallback }));
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+            (swapManager as any).refundedSwapIds.add(swap.id);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(claimCallback).not.toHaveBeenCalled();
+        });
+
+        it("does not claim while a claim/refund is already in progress (swapsInProgress guard shared with executeAutonomousAction)", async () => {
+            const claimCallback = vi.fn();
+            swapManager.setCallbacks(makeCallbacks({ claim: claimCallback }));
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+            // Simulate a concurrent Boltz-triggered executeAutonomousAction
+            // (or an earlier funded event) already holding the lock.
+            (swapManager as any).swapsInProgress.add(swap.id);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(claimCallback).not.toHaveBeenCalled();
+        });
+
+        it('fires actionExecuted(swap, "claim") on success', async () => {
+            const onActionExecuted = vi.fn();
+            await swapManager.onActionExecuted(onActionExecuted);
+            swapManager.setCallbacks(makeCallbacks({ claim: vi.fn() }));
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(onActionExecuted).toHaveBeenCalledWith(swap, "claim");
+        });
+
+        it("releases the lock and fires onSwapFailed when the claim callback throws, without recording the claim", async () => {
+            const claimCallback = vi.fn().mockRejectedValue(new Error("claim failed"));
+            const onSwapFailed = vi.fn();
+            await swapManager.onSwapFailed(onSwapFailed);
+            swapManager.setCallbacks(makeCallbacks({ claim: claimCallback }));
+
+            const swap = { ...mockReverseSwap, status: "swap.created" as const };
+            await swapManager.start([swap]);
+
+            await swapManager.triggerClaimFromVtxo(swap);
+
+            expect(onSwapFailed).toHaveBeenCalledWith(swap, expect.any(Error));
+            expect(swapManager.getActionLog().claimed.has(swap.id)).toBe(false);
+            expect(await swapManager.isProcessing(swap.id)).toBe(false);
+        });
+    });
 });

--- a/packages/boltz-swap/test/swap-status-reconciler.test.ts
+++ b/packages/boltz-swap/test/swap-status-reconciler.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { deriveSwapState, SwapActionLog } from "../src/swap-status-reconciler";
+import { describe, it, expect, vi } from "vitest";
+import type { ContractEvent } from "@arkade-os/sdk";
+import {
+    deriveSwapState,
+    SwapActionLog,
+    SwapState,
+    SwapStatusReconciler,
+} from "../src/swap-status-reconciler";
 import { BoltzSwap } from "../src/types";
 import {
     makeArkInfoFixture,
@@ -212,5 +218,138 @@ describe("deriveSwapState", () => {
             };
             expect(deriveSwapState(malformed, "spent", EMPTY_LOG)).toBe("Pending");
         });
+    });
+});
+
+/** Minimal, well-typed `ContractEvent` fixture — only `type`/`contractScript` matter to the reconciler. */
+const makeVtxoEvent = (
+    type: "vtxo_received" | "vtxo_spent",
+    contractScript: string,
+): ContractEvent => ({
+    type,
+    contractScript,
+    vtxos: [],
+    contract: {
+        type: "vhtlc",
+        params: {},
+        script: contractScript,
+        address: "ark1test",
+        state: "active",
+        createdAt: 0,
+    },
+    timestamp: Date.now(),
+});
+
+const CONNECTION_RESET_EVENT: ContractEvent = { type: "connection_reset", timestamp: Date.now() };
+
+describe("SwapStatusReconciler", () => {
+    const arkInfo = makeArkInfoFixture();
+    const EMPTY_LOG: SwapActionLog = { claimed: new Set(), refunded: new Set() };
+    const claimedLog = (id: string): SwapActionLog => ({
+        claimed: new Set([id]),
+        refunded: new Set(),
+    });
+
+    /** Builds a reconciler wired to a single swap, with mockable deps. */
+    function makeReconciler(swap: BoltzSwap, actionLog: SwapActionLog = EMPTY_LOG) {
+        const getSwap = vi.fn((id: string) => (id === swap.id ? swap : undefined));
+        const getActionLog = vi.fn(() => actionLog);
+        const onSwapResolved = vi.fn();
+        const reconciler = new SwapStatusReconciler({ getSwap, getActionLog, onSwapResolved });
+        return { reconciler, getSwap, getActionLog, onSwapResolved };
+    }
+
+    it("addSwapScript + vtxo_spent for a swap we claimed -> onSwapResolved(swap, Settled)", () => {
+        const swap: BoltzSwap = {
+            ...makeReverseSwapFixture(arkInfo),
+            status: "transaction.confirmed",
+        };
+        const { reconciler, onSwapResolved } = makeReconciler(swap, claimedLog(swap.id));
+
+        reconciler.addSwapScript("script-claimed", swap.id);
+        reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "script-claimed"));
+
+        expect(onSwapResolved).toHaveBeenCalledTimes(1);
+        expect(onSwapResolved).toHaveBeenCalledWith(swap, "Settled" satisfies SwapState);
+    });
+
+    it("submarine vtxo_spent we did NOT refund -> onSwapResolved(swap, Settled) (Boltz claimed after paying invoice)", () => {
+        const swap: BoltzSwap = { ...makeSubmarineSwapFixture(arkInfo), status: "invoice.pending" };
+        const { reconciler, onSwapResolved } = makeReconciler(swap, EMPTY_LOG);
+
+        reconciler.addSwapScript("script-submarine", swap.id);
+        reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "script-submarine"));
+
+        expect(onSwapResolved).toHaveBeenCalledWith(swap, "Settled" satisfies SwapState);
+    });
+
+    it("unknown contractScript -> no-op, does not throw, does not resolve", () => {
+        const swap = makeReverseSwapFixture(arkInfo);
+        const { reconciler, onSwapResolved, getSwap } = makeReconciler(swap);
+
+        expect(() =>
+            reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "never-registered")),
+        ).not.toThrow();
+        expect(getSwap).not.toHaveBeenCalled();
+        expect(onSwapResolved).not.toHaveBeenCalled();
+    });
+
+    it("swallows and logs an internal error instead of throwing", () => {
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        const swap = makeReverseSwapFixture(arkInfo);
+        const onSwapResolved = vi.fn();
+        const reconciler = new SwapStatusReconciler({
+            getSwap: () => {
+                throw new Error("boom");
+            },
+            getActionLog: () => EMPTY_LOG,
+            onSwapResolved,
+        });
+        reconciler.addSwapScript("script-throws", swap.id);
+
+        expect(() =>
+            reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "script-throws")),
+        ).not.toThrow();
+        expect(onSwapResolved).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+
+        errorSpy.mockRestore();
+    });
+
+    it("vtxo_received (funded) with no terminal Boltz status -> Pending, onSwapResolved not called", () => {
+        const swap: BoltzSwap = {
+            ...makeReverseSwapFixture(arkInfo),
+            status: "transaction.mempool",
+        };
+        const { reconciler, onSwapResolved } = makeReconciler(swap);
+
+        reconciler.addSwapScript("script-funded", swap.id);
+        reconciler.onContractEvent(makeVtxoEvent("vtxo_received", "script-funded"));
+
+        expect(onSwapResolved).not.toHaveBeenCalled();
+    });
+
+    it("ignores connection_reset events", () => {
+        const swap = makeReverseSwapFixture(arkInfo);
+        const { reconciler, onSwapResolved, getSwap } = makeReconciler(swap);
+        reconciler.addSwapScript("script-reset", swap.id);
+
+        expect(() => reconciler.onContractEvent(CONNECTION_RESET_EVENT)).not.toThrow();
+        expect(getSwap).not.toHaveBeenCalled();
+        expect(onSwapResolved).not.toHaveBeenCalled();
+    });
+
+    it("removeSwapScript stops resolving further events for that script", () => {
+        const swap: BoltzSwap = {
+            ...makeReverseSwapFixture(arkInfo),
+            status: "transaction.confirmed",
+        };
+        const { reconciler, onSwapResolved } = makeReconciler(swap, claimedLog(swap.id));
+        reconciler.addSwapScript("script-removed", swap.id);
+        reconciler.removeSwapScript("script-removed");
+
+        reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "script-removed"));
+
+        expect(onSwapResolved).not.toHaveBeenCalled();
     });
 });

--- a/packages/boltz-swap/test/swap-status-reconciler.test.ts
+++ b/packages/boltz-swap/test/swap-status-reconciler.test.ts
@@ -294,15 +294,23 @@ describe("SwapStatusReconciler", () => {
         expect(onSwapResolved).not.toHaveBeenCalled();
     });
 
-    it("swallows and logs an internal error instead of throwing", () => {
+    it("swallows and logs an internal error instead of throwing, and keeps handling later events", () => {
         const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-        const swap = makeReverseSwapFixture(arkInfo);
+        const swap: BoltzSwap = {
+            ...makeReverseSwapFixture(arkInfo),
+            status: "transaction.confirmed",
+        };
         const onSwapResolved = vi.fn();
+        // First call throws (simulating an internal error); later calls
+        // resolve normally, so the second onContractEvent below exercises a
+        // genuinely well-formed lookup rather than another swallowed error.
+        const getSwap = vi.fn((id: string) => (id === swap.id ? swap : undefined));
+        getSwap.mockImplementationOnce(() => {
+            throw new Error("boom");
+        });
         const reconciler = new SwapStatusReconciler({
-            getSwap: () => {
-                throw new Error("boom");
-            },
-            getActionLog: () => EMPTY_LOG,
+            getSwap,
+            getActionLog: () => claimedLog(swap.id),
             onSwapResolved,
         });
         reconciler.addSwapScript("script-throws", swap.id);
@@ -312,6 +320,15 @@ describe("SwapStatusReconciler", () => {
         ).not.toThrow();
         expect(onSwapResolved).not.toHaveBeenCalled();
         expect(errorSpy).toHaveBeenCalledTimes(1);
+
+        // Regression/depth: a thrown error inside one event's handling must
+        // not leave the reconciler's subscription broken for later events —
+        // fire a second, well-formed event on the SAME instance and confirm
+        // it's still handled (not just "didn't throw once").
+        reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "script-throws"));
+
+        expect(onSwapResolved).toHaveBeenCalledTimes(1);
+        expect(onSwapResolved).toHaveBeenCalledWith(swap, "Settled" satisfies SwapState);
 
         errorSpy.mockRestore();
     });

--- a/packages/boltz-swap/test/swap-status-reconciler.test.ts
+++ b/packages/boltz-swap/test/swap-status-reconciler.test.ts
@@ -255,8 +255,14 @@ describe("SwapStatusReconciler", () => {
         const getSwap = vi.fn((id: string) => (id === swap.id ? swap : undefined));
         const getActionLog = vi.fn(() => actionLog);
         const onSwapResolved = vi.fn();
-        const reconciler = new SwapStatusReconciler({ getSwap, getActionLog, onSwapResolved });
-        return { reconciler, getSwap, getActionLog, onSwapResolved };
+        const onSwapFunded = vi.fn();
+        const reconciler = new SwapStatusReconciler({
+            getSwap,
+            getActionLog,
+            onSwapResolved,
+            onSwapFunded,
+        });
+        return { reconciler, getSwap, getActionLog, onSwapResolved, onSwapFunded };
     }
 
     it("addSwapScript + vtxo_spent for a swap we claimed -> onSwapResolved(swap, Settled)", () => {
@@ -312,6 +318,7 @@ describe("SwapStatusReconciler", () => {
             getSwap,
             getActionLog: () => claimedLog(swap.id),
             onSwapResolved,
+            onSwapFunded: vi.fn(),
         });
         reconciler.addSwapScript("script-throws", swap.id);
 
@@ -333,17 +340,46 @@ describe("SwapStatusReconciler", () => {
         errorSpy.mockRestore();
     });
 
-    it("vtxo_received (funded) with no terminal Boltz status -> Pending, onSwapResolved not called", () => {
+    it("vtxo_received (funded) with no terminal Boltz status -> onSwapFunded called, onSwapResolved not called", () => {
         const swap: BoltzSwap = {
             ...makeReverseSwapFixture(arkInfo),
             status: "transaction.mempool",
         };
-        const { reconciler, onSwapResolved } = makeReconciler(swap);
+        const { reconciler, onSwapResolved, onSwapFunded } = makeReconciler(swap);
 
         reconciler.addSwapScript("script-funded", swap.id);
         reconciler.onContractEvent(makeVtxoEvent("vtxo_received", "script-funded"));
 
         expect(onSwapResolved).not.toHaveBeenCalled();
+        expect(onSwapFunded).toHaveBeenCalledTimes(1);
+        expect(onSwapFunded).toHaveBeenCalledWith(swap);
+    });
+
+    it("vtxo_received where Boltz status is already terminal -> onSwapResolved called (failsafe), onSwapFunded NOT called", () => {
+        const swap: BoltzSwap = {
+            ...makeReverseSwapFixture(arkInfo),
+            status: "invoice.settled",
+        };
+        const { reconciler, onSwapResolved, onSwapFunded } = makeReconciler(swap);
+
+        reconciler.addSwapScript("script-already-terminal", swap.id);
+        reconciler.onContractEvent(makeVtxoEvent("vtxo_received", "script-already-terminal"));
+
+        expect(onSwapResolved).toHaveBeenCalledWith(swap, "Settled" satisfies SwapState);
+        expect(onSwapFunded).not.toHaveBeenCalled();
+    });
+
+    it("vtxo_spent -> never calls onSwapFunded (only a funded signal can)", () => {
+        const swap: BoltzSwap = {
+            ...makeSubmarineSwapFixture(arkInfo),
+            status: "invoice.pending",
+        };
+        const { reconciler, onSwapFunded } = makeReconciler(swap, EMPTY_LOG);
+
+        reconciler.addSwapScript("script-spent-only", swap.id);
+        reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "script-spent-only"));
+
+        expect(onSwapFunded).not.toHaveBeenCalled();
     });
 
     it("ignores connection_reset events", () => {
@@ -367,6 +403,29 @@ describe("SwapStatusReconciler", () => {
 
         reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "script-removed"));
 
+        expect(onSwapResolved).not.toHaveBeenCalled();
+    });
+
+    it("resolving to a terminal state auto-prunes the script mapping (map does not grow unboundedly)", () => {
+        const swap: BoltzSwap = {
+            ...makeReverseSwapFixture(arkInfo),
+            status: "transaction.confirmed",
+        };
+        const { reconciler, onSwapResolved, getSwap } = makeReconciler(swap, claimedLog(swap.id));
+        reconciler.addSwapScript("script-auto-pruned", swap.id);
+
+        reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "script-auto-pruned"));
+        expect(onSwapResolved).toHaveBeenCalledTimes(1);
+
+        // A second event for the same script, after resolution, must be a
+        // no-op — the script's swapId mapping was pruned as part of
+        // resolving, so the lookup fails before getSwap/onSwapResolved run
+        // again (same observable shape as the "unknown contractScript" test).
+        getSwap.mockClear();
+        onSwapResolved.mockClear();
+        reconciler.onContractEvent(makeVtxoEvent("vtxo_spent", "script-auto-pruned"));
+
+        expect(getSwap).not.toHaveBeenCalled();
         expect(onSwapResolved).not.toHaveBeenCalled();
     });
 });

--- a/packages/boltz-swap/test/swap-status-reconciler.test.ts
+++ b/packages/boltz-swap/test/swap-status-reconciler.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import { deriveSwapState, SwapActionLog } from "../src/swap-status-reconciler";
+import { BoltzSwap } from "../src/types";
+import {
+    makeArkInfoFixture,
+    makeReverseSwapFixture,
+    makeSubmarineSwapFixture,
+    makeChainSwapFixture,
+    makeChainSwapFromArkFixture,
+} from "./fixtures/swaps";
+
+const EMPTY_LOG: SwapActionLog = { claimed: new Set(), refunded: new Set() };
+const claimedLog = (id: string): SwapActionLog => ({ claimed: new Set([id]), refunded: new Set() });
+const refundedLog = (id: string): SwapActionLog => ({
+    claimed: new Set(),
+    refunded: new Set([id]),
+});
+
+describe("deriveSwapState", () => {
+    const arkInfo = makeArkInfoFixture();
+
+    describe("reverse swap (wallet is VHTLC receiver — only the wallet can claim)", () => {
+        const swap = makeReverseSwapFixture(arkInfo);
+
+        it.each([
+            ["invoice.settled", "Settled"],
+            ["transaction.refunded", "Refunded"],
+            ["invoice.expired", "Failed"],
+            ["transaction.failed", "Failed"],
+            ["swap.expired", "Failed"],
+        ] as const)(
+            "terminal status %s -> %s (failsafe, regardless of signal/log)",
+            (status, expected) => {
+                const terminalSwap: BoltzSwap = { ...swap, status };
+                // A contradicting signal/log must not override a terminal Boltz status.
+                expect(deriveSwapState(terminalSwap, "none", EMPTY_LOG)).toBe(expected);
+                expect(deriveSwapState(terminalSwap, "spent", claimedLog("other-id"))).toBe(
+                    expected,
+                );
+            },
+        );
+
+        it("spent + we claimed -> Settled", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.confirmed" };
+            expect(deriveSwapState(pending, "spent", claimedLog(swap.id))).toBe("Settled");
+        });
+
+        it("spent + we refunded -> Refunded", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.confirmed" };
+            expect(deriveSwapState(pending, "spent", refundedLog(swap.id))).toBe("Refunded");
+        });
+
+        it("spent + neither -> Failed (only we can claim; spent-without-us = Boltz refunded its lockup)", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.confirmed" };
+            expect(deriveSwapState(pending, "spent", EMPTY_LOG)).toBe("Failed");
+        });
+
+        it("funded, no terminal status -> Pending", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.mempool" };
+            expect(deriveSwapState(pending, "funded", EMPTY_LOG)).toBe("Pending");
+        });
+
+        it("none, no terminal status -> Pending", () => {
+            const pending: BoltzSwap = { ...swap, status: "swap.created" };
+            expect(deriveSwapState(pending, "none", EMPTY_LOG)).toBe("Pending");
+        });
+    });
+
+    describe("submarine swap (wallet is VHTLC sender — only the wallet can refund)", () => {
+        const swap = makeSubmarineSwapFixture(arkInfo);
+
+        it.each([
+            ["transaction.claimed", "Settled"],
+            ["invoice.failedToPay", "Failed"],
+            ["swap.expired", "Failed"],
+        ] as const)(
+            "terminal status %s -> %s (failsafe, regardless of signal/log)",
+            (status, expected) => {
+                const terminalSwap: BoltzSwap = { ...swap, status };
+                expect(deriveSwapState(terminalSwap, "none", EMPTY_LOG)).toBe(expected);
+                expect(deriveSwapState(terminalSwap, "spent", claimedLog("other-id"))).toBe(
+                    expected,
+                );
+            },
+        );
+
+        it("transaction.lockupFailed is NOT terminal (negotiable) -> falls through to operational Pending", () => {
+            const negotiable: BoltzSwap = { ...swap, status: "transaction.lockupFailed" };
+            expect(deriveSwapState(negotiable, "none", EMPTY_LOG)).toBe("Pending");
+        });
+
+        it("spent + we claimed -> Settled", () => {
+            const pending: BoltzSwap = { ...swap, status: "invoice.pending" };
+            expect(deriveSwapState(pending, "spent", claimedLog(swap.id))).toBe("Settled");
+        });
+
+        it("spent + we refunded -> Refunded", () => {
+            const pending: BoltzSwap = { ...swap, status: "invoice.pending" };
+            expect(deriveSwapState(pending, "spent", refundedLog(swap.id))).toBe("Refunded");
+        });
+
+        it("spent + neither -> Settled (Boltz claimed our lockup after paying the invoice)", () => {
+            const pending: BoltzSwap = { ...swap, status: "invoice.pending" };
+            expect(deriveSwapState(pending, "spent", EMPTY_LOG)).toBe("Settled");
+        });
+
+        it("funded, no terminal status -> Pending", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.mempool" };
+            expect(deriveSwapState(pending, "funded", EMPTY_LOG)).toBe("Pending");
+        });
+
+        it("none, no terminal status -> Pending", () => {
+            const pending: BoltzSwap = { ...swap, status: "swap.created" };
+            expect(deriveSwapState(pending, "none", EMPTY_LOG)).toBe("Pending");
+        });
+    });
+
+    describe("chain swap BTC->ARK (wallet is VHTLC receiver on the ARK lockup — same role shape as reverse)", () => {
+        const swap = makeChainSwapFixture(arkInfo); // request: {from: "BTC", to: "ARK"}
+
+        it.each([
+            ["transaction.claimed", "Settled"],
+            ["transaction.refunded", "Refunded"],
+            ["transaction.failed", "Failed"],
+            ["swap.expired", "Failed"],
+        ] as const)(
+            "terminal status %s -> %s (failsafe, regardless of signal/log)",
+            (status, expected) => {
+                const terminalSwap: BoltzSwap = { ...swap, status };
+                expect(deriveSwapState(terminalSwap, "none", EMPTY_LOG)).toBe(expected);
+                expect(deriveSwapState(terminalSwap, "spent", claimedLog("other-id"))).toBe(
+                    expected,
+                );
+            },
+        );
+
+        it("spent + we claimed -> Settled", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.server.mempool" };
+            expect(deriveSwapState(pending, "spent", claimedLog(swap.id))).toBe("Settled");
+        });
+
+        it("spent + we refunded -> Refunded", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.server.mempool" };
+            expect(deriveSwapState(pending, "spent", refundedLog(swap.id))).toBe("Refunded");
+        });
+
+        it("spent + neither -> Failed (wallet is receiver; spent-without-us = Boltz refunded its lockup)", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.server.mempool" };
+            expect(deriveSwapState(pending, "spent", EMPTY_LOG)).toBe("Failed");
+        });
+
+        it("funded, no terminal status -> Pending", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.mempool" };
+            expect(deriveSwapState(pending, "funded", EMPTY_LOG)).toBe("Pending");
+        });
+
+        it("none, no terminal status -> Pending", () => {
+            const pending: BoltzSwap = { ...swap, status: "swap.created" };
+            expect(deriveSwapState(pending, "none", EMPTY_LOG)).toBe("Pending");
+        });
+    });
+
+    describe("chain swap ARK->BTC (wallet is VHTLC sender on the ARK lockup — same role shape as submarine)", () => {
+        const swap = makeChainSwapFromArkFixture(arkInfo); // request: {from: "ARK", to: "BTC"}
+
+        it.each([
+            ["transaction.claimed", "Settled"],
+            ["transaction.refunded", "Refunded"],
+            ["transaction.failed", "Failed"],
+            ["swap.expired", "Failed"],
+        ] as const)(
+            "terminal status %s -> %s (failsafe, regardless of signal/log)",
+            (status, expected) => {
+                const terminalSwap: BoltzSwap = { ...swap, status };
+                expect(deriveSwapState(terminalSwap, "none", EMPTY_LOG)).toBe(expected);
+                expect(deriveSwapState(terminalSwap, "spent", claimedLog("other-id"))).toBe(
+                    expected,
+                );
+            },
+        );
+
+        it("spent + we claimed -> Settled", () => {
+            const pending: BoltzSwap = { ...swap, status: "swap.created" };
+            expect(deriveSwapState(pending, "spent", claimedLog(swap.id))).toBe("Settled");
+        });
+
+        it("spent + we refunded -> Refunded", () => {
+            const pending: BoltzSwap = { ...swap, status: "swap.created" };
+            expect(deriveSwapState(pending, "spent", refundedLog(swap.id))).toBe("Refunded");
+        });
+
+        it("spent + neither -> Settled (wallet is sender; spent-without-us = Boltz claimed our lockup)", () => {
+            const pending: BoltzSwap = { ...swap, status: "swap.created" };
+            expect(deriveSwapState(pending, "spent", EMPTY_LOG)).toBe("Settled");
+        });
+
+        it("funded, no terminal status -> Pending", () => {
+            const pending: BoltzSwap = { ...swap, status: "transaction.mempool" };
+            expect(deriveSwapState(pending, "funded", EMPTY_LOG)).toBe("Pending");
+        });
+
+        it("none, no terminal status -> Pending", () => {
+            const pending: BoltzSwap = { ...swap, status: "swap.created" };
+            expect(deriveSwapState(pending, "none", EMPTY_LOG)).toBe("Pending");
+        });
+
+        it("spent + neither, malformed non-ARK/non-ARK direction -> Pending (genuinely ambiguous fallback)", () => {
+            const malformed: BoltzSwap = {
+                ...swap,
+                status: "swap.created",
+                request: { ...swap.request, from: "BTC", to: "BTC" },
+            };
+            expect(deriveSwapState(malformed, "spent", EMPTY_LOG)).toBe("Pending");
+        });
+    });
+});

--- a/packages/ts-sdk/src/contracts/handlers/boarding.ts
+++ b/packages/ts-sdk/src/contracts/handlers/boarding.ts
@@ -6,6 +6,7 @@ import { DefaultContractHandler, DefaultContractParams } from "./default";
 import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
 import { timelockToSequence } from "../../utils/timelock";
 import { WALLET_RECEIVE_SOURCE } from "../metadata";
+import type { ContractTapscripts } from "../../wallet/utils";
 
 /**
  * Typed parameters for boarding contracts.
@@ -80,6 +81,10 @@ export const BoardingContractHandler: ContractHandler<BoardingContractParams, De
 
     deserializeParams(params: Record<string, string>): BoardingContractParams {
         return DefaultContractHandler.deserializeParams(params);
+    },
+
+    getContractTapscripts(params: Record<string, string>): ContractTapscripts {
+        return DefaultContractHandler.getContractTapscripts(params);
     },
 
     selectPath(

--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -11,6 +11,7 @@ import {
     deriveDescriptorLeafPubKey,
 } from "../../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../metadata";
+import type { ContractTapscripts } from "../../wallet/utils";
 
 /**
  * Typed parameters for DefaultVtxo contracts.
@@ -65,6 +66,15 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
             pubKey: extractPubKeyBytes(params.pubKey),
             serverPubKey: extractPubKeyBytes(params.serverPubKey),
             csvTimelock,
+        };
+    },
+
+    getContractTapscripts(params: Record<string, string>): ContractTapscripts {
+        const script = this.createScript(params);
+        return {
+            forfeitTapLeafScript: script.forfeit(),
+            intentTapLeafScript: script.forfeit(),
+            tapTree: script.encode(),
         };
     },
 

--- a/packages/ts-sdk/src/contracts/handlers/delegate.ts
+++ b/packages/ts-sdk/src/contracts/handlers/delegate.ts
@@ -7,6 +7,7 @@ import { isCsvSpendable, detectUsedScripts } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../metadata";
+import type { ContractTapscripts } from "../../wallet/utils";
 
 /**
  * Typed parameters for DelegateVtxo contracts.
@@ -51,6 +52,15 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
             serverPubKey: hex.decode(params.serverPubKey),
             delegatePubKey: hex.decode(params.delegatePubKey),
             csvTimelock,
+        };
+    },
+
+    getContractTapscripts(params: Record<string, string>): ContractTapscripts {
+        const script = this.createScript(params);
+        return {
+            forfeitTapLeafScript: script.forfeit(),
+            intentTapLeafScript: script.forfeit(),
+            tapTree: script.encode(),
         };
     },
 

--- a/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
@@ -4,6 +4,7 @@ import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, PathContext, PathSelection } from "../types";
 import { isCltvSatisfied, isCsvSpendable, resolveRole } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
+import type { ContractTapscripts } from "../../wallet/utils";
 
 /**
  * Typed parameters for VHTLC contracts.
@@ -69,6 +70,54 @@ export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Sc
             unilateralRefundWithoutReceiverDelay: sequenceToTimelock(
                 Number(params.refundNoReceiverDelay),
             ),
+        };
+    },
+
+    /**
+     * VHTLC has no single (owner + server) "forfeit" leaf like
+     * `default`/`delegate`/`boarding` — it exposes 6 role- and
+     * condition-gated paths (claim / refund / refundWithoutReceiver, each
+     * with a unilateral variant), and which one applies depends on
+     * `contract.params` (role, preimage) and timing, not just the script.
+     *
+     * Swap VHTLC VTXOs are NOT spent through this generic forfeit/intent
+     * path: the swap layer resolves its own role-specific leaf and signs it
+     * directly — see `packages/boltz-swap/src/utils/vhtlc.ts` (`joinBatch`,
+     * `claimVHTLCwithOffchainTx`, `refundVHTLCwithOffchainTx`), which builds
+     * `ArkTxInput.tapLeafScript` from `vhtlcScript.claim()` /
+     * `.refund()` / `.refundWithoutReceiver()` directly and never reads
+     * `ExtendedVirtualCoin.forfeitTapLeafScript`/`intentTapLeafScript`. These
+     * fields exist here only so `ContractWatcher`/`ContractManager.annotateVtxos`
+     * don't crash on a registered `vhtlc` contract and so a valid `tapTree` is
+     * available for encoding/inspection.
+     *
+     * We return `claim()` — the receiver+server path gated on a HASH160
+     * preimage — specifically because it CANNOT be completed by the wallet's
+     * *other* generic forfeit-signing path,
+     * `Wallet.handleSettlementFinalizationEvent` (`wallet/wallet.ts`), which
+     * never supplies the required preimage witness element. That path is
+     * reachable from `wallet.settle()` (called with no params) and
+     * `VtxoManager.recoverVtxos()`, and — unlike `getWalletScripts()` /
+     * `getScriptMap()`, which deliberately scope to
+     * `type: ["default", "delegate"]` — `Wallet.getVtxos()` /
+     * `ContractManager.getContractsWithVtxos()` do NOT filter by contract
+     * type, so a live `vhtlc` contract's VTXO is a candidate input there
+     * today. Picking `claim()` makes any such accidental inclusion fail
+     * closed (invalid/incomplete witness) instead of risking a leaf that
+     * could be fully signed (e.g. `refundWithoutReceiver()`, if the wallet
+     * happens to hold the "sender" role's key for a submarine swap).
+     *
+     * This is a mitigation, not a fix — see the task report
+     * (task-core-annotation-report.md) for the recommended follow-up
+     * (excluding non-wallet-owned contract types from the generic
+     * settle/recovery input set).
+     */
+    getContractTapscripts(params: Record<string, string>): ContractTapscripts {
+        const script = this.createScript(params);
+        return {
+            forfeitTapLeafScript: script.claim(),
+            intentTapLeafScript: script.claim(),
+            tapTree: script.encode(),
         };
     },
 

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -6,6 +6,11 @@ import type { RelativeTimelock } from "../script/tapscript";
 import type { IndexerProvider } from "../providers/indexer";
 import type { OnchainProvider } from "../providers/onchain";
 import type { Network } from "../networks";
+// `import type` only — `wallet/utils.ts` imports `contractHandlers` (this
+// module's handler registry) as a value, so a value-level import here would
+// create a runtime cycle. The type-only import is erased by `isolatedModules`
+// and carries no such risk.
+import type { ContractTapscripts } from "../wallet/utils";
 
 /**
  * Contract state indicating whether it should be actively monitored.
@@ -198,6 +203,24 @@ export interface ContractHandler<P = Record<string, unknown>, S extends VtxoScri
      * @returns Contract script instance
      */
     createScript(params: Record<string, string>): S;
+
+    /**
+     * Derive the contract's forfeit/intent tapscripts and tap tree, purely
+     * from its serialized params (no VTXO-specific data — every VTXO locked
+     * to the same contract shares this data).
+     *
+     * Replaces the old pattern of casting `createScript(params)`'s result to
+     * a concrete `VtxoScript` subclass and calling `.forfeit()` on it
+     * directly: that assumed every contract type's script exposes a single
+     * `.forfeit()` leaf, which is only true for `default`/`delegate`/
+     * `boarding` — `VHTLC.Script` has no `.forfeit()` at all (see the
+     * `vhtlc` handler for what it returns instead and why). Handlers own
+     * the mapping from their own script shape to these fields.
+     *
+     * @param params - Serialized contract parameters
+     * @returns The contract's forfeit/intent tapscripts and tap tree
+     */
+    getContractTapscripts(params: Record<string, string>): ContractTapscripts;
 
     /**
      * Serialize typed parameters to string key-value pairs.

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -769,6 +769,13 @@ export type GetVtxosFilter = {
 
     /** Include virtual outputs that have been unrolled onchain. */
     withUnrolled?: boolean;
+
+    /**
+     * Restrict to virtual outputs owned by contract(s) of the given type(s)
+     * (e.g. "default", "delegate", "vhtlc"). Defaults to every contract type
+     * when omitted.
+     */
+    type?: string | string[];
 };
 
 /**

--- a/packages/ts-sdk/src/wallet/utils.ts
+++ b/packages/ts-sdk/src/wallet/utils.ts
@@ -9,7 +9,6 @@ import {
 import type { Contract } from "../contracts/types";
 import { contractHandlers } from "../contracts/handlers";
 import { DefaultVtxo } from "../script/default";
-import { DelegateVtxo } from "../script/delegate";
 import type { ReadonlyWallet } from "./wallet";
 import { hex } from "@scure/base";
 import { Bytes } from "@scure/btc-signer/utils.js";
@@ -83,14 +82,7 @@ function deriveContractTapscripts(contract: Contract): ContractTapscripts {
     if (!handler) {
         throw new Error(`No handler for contract type '${contract.type}'`);
     }
-    const script = handler.createScript(contract.params) as
-        | DefaultVtxo.Script
-        | DelegateVtxo.Script;
-    return {
-        forfeitTapLeafScript: script.forfeit(),
-        intentTapLeafScript: script.forfeit(),
-        tapTree: script.encode(),
-    };
+    return handler.getContractTapscripts(contract.params);
 }
 
 function cloneTapLeafScript([

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -797,7 +797,16 @@ export class ReadonlyWallet implements IReadonlyWallet {
     async getBalance(): Promise<WalletBalance> {
         const [boardingUtxos, vtxos, pendingOutpoints] = await Promise.all([
             this.getBoardingUtxos(),
-            this.getVtxos(),
+            // Scoped to the wallet's own receiving contracts (default +
+            // delegate), same as getWalletScripts(). Excludes external
+            // contract types such as "vhtlc": an in-flight swap's escrow
+            // is not spendable wallet balance until it's claimed (or
+            // refunded back) into a wallet-owned contract.
+            this.getVtxos({
+                withRecoverable: true,
+                withUnrolled: false,
+                type: ["default", "delegate"],
+            }),
             this.pendingRecoveryOutpoints(),
         ]);
         const isPendingRecovery = (coin: ExtendedVirtualCoin) =>
@@ -890,12 +899,14 @@ export class ReadonlyWallet implements IReadonlyWallet {
     /**
      * Return virtual outputs tracked by the wallet.
      *
-     * @param filter - Optional flags controlling whether recoverable or unrolled VTXOs are included
+     * @param filter - Optional flags controlling whether recoverable or unrolled VTXOs are included, and which contract type(s) to scope to
      */
     async getVtxos(filter?: GetVtxosFilter): Promise<ExtendedVirtualCoin[]> {
         const f = filter ?? { withRecoverable: true, withUnrolled: false };
         const contractManager = await this.getContractManager();
-        const vtxos = await contractManager.getContractsWithVtxos();
+        const vtxos = await contractManager.getContractsWithVtxos(
+            f.type ? { type: f.type } : undefined,
+        );
 
         return vtxos
             .flatMap((_) => _.vtxos)

--- a/packages/ts-sdk/test/wallet/utils.test.ts
+++ b/packages/ts-sdk/test/wallet/utils.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { hex } from "@scure/base";
 
 import type { Contract } from "../../src/contracts/types";
 import { contractHandlers } from "../../src/contracts/handlers";
+import { VHTLCContractHandler } from "../../src/contracts/handlers/vhtlc";
 import { extendVirtualCoinForContract, type ContractTapscriptCache } from "../../src/wallet/utils";
+import { timelockToSequence } from "../../src/utils/timelock";
 import {
     createDefaultContractParams,
     createDelegateContractParams,
     createMockVtxo,
+    testDefaultScript,
+    testDelegateScript,
     TEST_DEFAULT_SCRIPT,
     TEST_DELEGATE_SCRIPT,
 } from "../contracts/helpers";
@@ -25,6 +30,30 @@ const delegateContract: Contract = {
     params: createDelegateContractParams(),
     script: TEST_DELEGATE_SCRIPT,
     address: "ark1delegate",
+    state: "active",
+    createdAt: Date.now(),
+};
+
+// Same test keys/params shape used by test/contracts/handlers.test.ts's
+// VHTLCContractHandler suite.
+const vhtlcParams = {
+    sender: "0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+    receiver: "1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+    server: "aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+    hash: "4d487dd3753a89bc9fe98401d1196523058251fc",
+    refundLocktime: "800000",
+    claimDelay: timelockToSequence({ type: "blocks", value: 17n }).toString(),
+    refundDelay: timelockToSequence({ type: "blocks", value: 144n }).toString(),
+    refundNoReceiverDelay: timelockToSequence({ type: "blocks", value: 144n }).toString(),
+};
+const vhtlcScript = VHTLCContractHandler.createScript(vhtlcParams);
+const TEST_VHTLC_SCRIPT = hex.encode(vhtlcScript.pkScript);
+
+const vhtlcContract: Contract = {
+    type: "vhtlc",
+    params: vhtlcParams,
+    script: TEST_VHTLC_SCRIPT,
+    address: "ark1vhtlc",
     state: "active",
     createdAt: Date.now(),
 };
@@ -102,6 +131,83 @@ describe("extendVirtualCoinForContract", () => {
         const map = new Map<string, Contract>([[bogus.script, bogus]]);
 
         expect(() => extendVirtualCoinForContract(vtxo, map)).toThrow(/handler/);
+    });
+});
+
+describe("extendVirtualCoinForContract - vhtlc contracts (regression: VHTLC has no forfeit())", () => {
+    it("annotates a vhtlc-contract vtxo without throwing", () => {
+        // Before the fix, deriveContractTapscripts cast every contract's
+        // script to `DefaultVtxo.Script | DelegateVtxo.Script` and called
+        // `.forfeit()` on it unconditionally. VHTLC.Script has no `.forfeit()`,
+        // so this crashed with "script.forfeit is not a function" the moment a
+        // Boltz swap's VHTLC VTXO was registered as a contract and annotated
+        // by ContractWatcher.emitVtxoEvent / ContractManager.annotateVtxos —
+        // this is that exact crash path.
+        const vtxo = createMockVtxo({ script: TEST_VHTLC_SCRIPT });
+
+        expect(() => extendVirtualCoinForContract(vtxo, vhtlcContract)).not.toThrow();
+    });
+
+    it("returns a valid tapTree and structurally-valid forfeit/intent leaves", () => {
+        const vtxo = createMockVtxo({ script: TEST_VHTLC_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(vtxo, vhtlcContract);
+
+        expect(extended.tapTree).toEqual(vhtlcScript.encode());
+        expect(extended.forfeitTapLeafScript).toBeDefined();
+        expect(extended.intentTapLeafScript).toBeDefined();
+        // Structurally valid: one of the VHTLC script's own registered
+        // leaves (findLeaf would throw on a fabricated/unregistered script),
+        // not an empty or made-up placeholder.
+        expect(extended.forfeitTapLeafScript[1]).toEqual(vhtlcScript.claim()[1]);
+        expect(extended.intentTapLeafScript[1]).toEqual(vhtlcScript.claim()[1]);
+    });
+
+    it("resolves via map the same way as a direct Contract", () => {
+        const vtxo = createMockVtxo({ script: TEST_VHTLC_SCRIPT });
+        const map = new Map<string, Contract>([[vhtlcContract.script, vhtlcContract]]);
+
+        expect(() => extendVirtualCoinForContract(vtxo, map)).not.toThrow();
+    });
+});
+
+describe("extendVirtualCoinForContract - default/delegate/boarding stay forfeit-based (no regression)", () => {
+    it("default contract still returns the forfeit leaf", () => {
+        const vtxo = createMockVtxo({ script: TEST_DEFAULT_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(vtxo, defaultContract);
+
+        expect(extended.forfeitTapLeafScript).toEqual(testDefaultScript.forfeit());
+        expect(extended.intentTapLeafScript).toEqual(testDefaultScript.forfeit());
+        expect(extended.tapTree).toEqual(testDefaultScript.encode());
+    });
+
+    it("delegate contract still returns the forfeit leaf", () => {
+        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(vtxo, delegateContract);
+
+        expect(extended.forfeitTapLeafScript).toEqual(testDelegateScript.forfeit());
+        expect(extended.intentTapLeafScript).toEqual(testDelegateScript.forfeit());
+        expect(extended.tapTree).toEqual(testDelegateScript.encode());
+    });
+
+    it("boarding contract still returns the forfeit leaf (shares DefaultVtxo.Script)", () => {
+        const boardingContract: Contract = {
+            type: "boarding",
+            params: createDefaultContractParams(),
+            script: TEST_DEFAULT_SCRIPT,
+            address: "ark1boarding",
+            state: "active",
+            createdAt: Date.now(),
+        };
+        const vtxo = createMockVtxo({ script: TEST_DEFAULT_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(vtxo, boardingContract);
+
+        expect(extended.forfeitTapLeafScript).toEqual(testDefaultScript.forfeit());
+        expect(extended.intentTapLeafScript).toEqual(testDefaultScript.forfeit());
+        expect(extended.tapTree).toEqual(testDefaultScript.encode());
     });
 });
 


### PR DESCRIPTION
## Summary

Manage Boltz swap lifecycle through the SDK's `ContractManager`: register each swap's VHTLC as a first-class `"vhtlc"` contract, and derive swap status from VTXO/contract state instead of relying **exclusively** on the Boltz API. Mirrors the .NET SDK (NArk) architecture.

> **Status: DRAFT / work in progress.** Landing in phases; progressed incrementally as each phase clears review + the full pre-commit gate.

## Motivation

Swaps were managed entirely out of band from the `ContractManager`, with status coming 100% from the Boltz API. This brings the TS SDK to parity with NArk: a swap's lockup VHTLC becomes a watched contract, and status is reconciled from `vtxo_received`/`vtxo_spent` events — so a swap can reach a terminal state (and even be *claimed*) from on-chain/VTXO state with Boltz offline.

## Phases

- **Phase 1 — ✅ landed:** register each swap's VHTLC as a `vhtlc` contract on create (reverse / submarine / chain) + one-shot migration of existing in-flight swaps on init. `ArkadeSwaps` requires a `ContractManager` (the Expo-background monitor path is exempt).
- **Phase 2 — ✅ landed:** VTXO-driven status reconciliation. A pure `deriveSwapState` truth table; an action-log of claims/refunds we complete; a `SwapStatusReconciler` consuming `ContractManager.onContractEvent`; a VTXO-driven finalize that sets a terminal status and wakes `waitForSwapCompletion`; and **claims driven off the VTXO-funded signal** (Boltz demoted to a failsafe). Proven by a Boltz-offline test: a reverse swap goes funded → claimed → settled purely from VTXO events.
- **Phase 3 — planned:** unified recovery — a swap-agnostic recovery/sweep-policy seam in `@arkade-os/sdk` core + a VHTLC sweep policy in boltz-swap.
- **Phase 4 — planned:** restore/discovery — make the `vhtlc` handler `Discoverable` so `wallet.restore()` rediscovers in-flight swaps.

## Test status (at current tip)

- boltz-swap unit: **531/531**; `@arkade-os/sdk` unit: **1679/1679**; monorepo lint clean; test-inclusive typecheck clean; build clean.
- Every commit goes through the full pre-commit hook (monorepo lint + both packages' `test:unit`).
- Integration (regtest) suites run in CI.

## Scope / compatibility

- boltz-swap-only through Phase 2 (no `@arkade-os/sdk` core changes); Phase 3 introduces a small **swap-agnostic** core seam.
- Breaking (pre-1.0): `ArkadeSwaps` requires a `ContractManager`. Existing in-flight swaps are migrated to contracts on first init.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event-driven on-chain swap monitoring and status reconciliation, including automatic registration of in-flight swaps and migration support.
  * VTXO activity can now resolve swaps and trigger eligible claim/refund flows.
  * Expanded SDK contract tap-script support across contract types, and improved virtual-UTXO filtering by contract type.
* **Bug Fixes**
  * Made VHTLC claim/refund operations idempotent to prevent race-condition errors during concurrent reconciliation and manual calls.
  * Improved reliability when swap-provider status updates are temporarily unavailable, while continuing monitoring.
  * Fixed virtual-output balance scoping and filtering so non-relevant contract VTXOs no longer affect wallet balance calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->