### PR TITLE
chore: bump regtest arkd to v0.9.14

### DIFF
--- a/packages/ts-sdk/.env.regtest
+++ b/packages/ts-sdk/.env.regtest
@@ -1,7 +1,7 @@
 # ts-sdk arkade-regtest overrides
 
-ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.11
-ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.11
+ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.14
+ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.14
 
 # Match old ts-sdk docker-compose arkd config (block scheduler needs CSV block type)
 ARKD_SCHEDULER_TYPE=block


### PR DESCRIPTION
Bumps the regtest stack to arkd/arkd-wallet **v0.9.14**, unblocking e2e validation of the 0.9.14 server changes we're aligning to (`renewableOnly` GetVtxos filter, `TX_FILTERS_LIMIT_EXCEEDED` / `INVALID_TX_FILTER`, CLTV submit/finalize retry fix).

### Changes
- **`regtest` submodule:** `772d224` → `963c55b` (arkd/arkd-wallet default images → v0.9.14). This also advances past two intervening upstream commits: `Show local time` (#40) and `add covclaimd` (#41). `covclaimd` is behind an opt-in `covclaimd` compose profile and is **not** started by the ts-sdk `ark` tier.
- **`packages/ts-sdk/.env.regtest`:** override → v0.9.14.

### Deliberately out of scope
- **`packages/boltz-swap/.env.regtest`** is left at `v0.9.9-rc.0`. It's a separate, tuned stack (gocron scheduler, own `FULMINE_IMAGE`) and a jump to v0.9.14 is 5 versions — that bump belongs with the Change 3 PR, where boltz VHTLC-refund e2e actually exercises it.

### Dependency / follow-up
- Depends on `ArkLabsHQ/arkade-regtest#42`. The submodule currently points at that PR's branch commit (`963c55b`); once #42 merges, **re-point the submodule to the resulting `master` commit** (required if arkade-regtest squash-merges, since `963c55b` would no longer be reachable from `master`).

Both `arkd:v0.9.14` and `arkd-wallet:v0.9.14` are published on ghcr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the regtest environment to use the newer Arkade Regtest image version.
  * Advanced the regtest subproject reference to the latest revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->