### PR TITLE
feat: align indexer/provider layer with arkd 0.9.14

### DIFF
--- a/packages/ts-sdk/.env.regtest
+++ b/packages/ts-sdk/.env.regtest
@@ -1,7 +1,7 @@
 # ts-sdk arkade-regtest overrides
 
-ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.11
-ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.11
+ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.14
+ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.14
 
 # Match old ts-sdk docker-compose arkd config (block scheduler needs CSV block type)
 ARKD_SCHEDULER_TYPE=block

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -250,7 +250,13 @@ import type {
     ExitChainResolver,
     ExitDataSource,
 } from "./wallet/exit";
-import { ArkError, maybeArkError, ProviderUnavailableError } from "./providers/errors";
+import {
+    ArkError,
+    ArkErrorName,
+    isArkError,
+    maybeArkError,
+    ProviderUnavailableError,
+} from "./providers/errors";
 import type { ProviderKind } from "./providers/errors";
 import { isRetryableProviderError } from "./providers/availability";
 import type { ServerInfoSource } from "./wallet/arkInfoSnapshot";
@@ -524,6 +530,8 @@ export {
 
     // Errors
     ArkError,
+    ArkErrorName,
+    isArkError,
     maybeArkError,
     ProviderUnavailableError,
     isRetryableProviderError,

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -3,7 +3,13 @@ import { TreeNonces, TreePartialSigs } from "../tree/signingSession";
 import { hex } from "@scure/base";
 import { Vtxo } from "./indexer";
 import { eventSourceIterator, isEventSourceError } from "./utils";
-import { maybeArkError, throwIfHttpUnavailable, toProviderUnavailable } from "./errors";
+import {
+    ArkErrorName,
+    isArkError,
+    maybeArkError,
+    throwIfHttpUnavailable,
+    toProviderUnavailable,
+} from "./errors";
 import type { IntentFeeConfig } from "../arkfee";
 import { Intent } from "../intent";
 import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
@@ -369,7 +375,7 @@ export class RestArkProvider implements ArkProvider {
         // 5xx. Only a non-structured 429/5xx (a bare proxy/gateway failure) is a
         // retryable availability condition.
         if (!arkError) throwIfHttpUnavailable(response, "arkade");
-        if (arkError?.name !== "DIGEST_MISMATCH") return response;
+        if (!isArkError(arkError, ArkErrorName.DIGEST_MISMATCH)) return response;
         // arkd rejected this request because our cached server info is stale
         // (e.g. the operator rotated its signer). Mirror NArk's BuildVersionHandler
         // (dotnet-sdk #131): clear the digest, refetch info, fire onServerInfoChanged

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -29,10 +29,14 @@ export type ArkErrorName = (typeof ArkErrorName)[keyof typeof ArkErrorName];
  * Type guard for a structured {@link ArkError}, optionally narrowing to a specific
  * `name`. Prefer it over comparing `err.name` literals.
  *
+ * `name` accepts only cataloged {@link ArkErrorName} values; to branch on a name the
+ * catalog does not cover, either add it there or compare `err.name` after guarding
+ * with the one-argument form.
+ *
  * @example
  * if (isArkError(maybeArkError(err), ArkErrorName.DIGEST_MISMATCH)) { ... }
  */
-export function isArkError(error: unknown, name?: string): error is ArkError {
+export function isArkError(error: unknown, name?: ArkErrorName): error is ArkError {
     return error instanceof ArkError && (name === undefined || error.name === name);
 }
 

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -12,6 +12,31 @@ export class ArkError extends Error {
 }
 
 /**
+ * Structured arkd error `name`s the SDK branches on, centralized so call sites don't
+ * hardcode string literals. Not an exhaustive mirror of the server's codes — only the
+ * ones the SDK acts on.
+ */
+export const ArkErrorName = {
+    DIGEST_MISMATCH: "DIGEST_MISMATCH",
+    VTXO_ALREADY_SPENT: "VTXO_ALREADY_SPENT",
+    INVALID_TX_FILTER: "INVALID_TX_FILTER",
+    TX_FILTERS_LIMIT_EXCEEDED: "TX_FILTERS_LIMIT_EXCEEDED",
+} as const;
+
+export type ArkErrorName = (typeof ArkErrorName)[keyof typeof ArkErrorName];
+
+/**
+ * Type guard for a structured {@link ArkError}, optionally narrowing to a specific
+ * `name`. Prefer it over comparing `err.name` literals.
+ *
+ * @example
+ * if (isArkError(maybeArkError(err), ArkErrorName.DIGEST_MISMATCH)) { ... }
+ */
+export function isArkError(error: unknown, name?: string): error is ArkError {
+    return error instanceof ArkError && (name === undefined || error.name === name);
+}
+
+/**
  * Which remote dependency an availability failure refers to. Used to label the
  * {@link ProviderUnavailableError} message and the wallet's
  * `ProviderConnectionState`; it is deliberately *not* carried as a structured

--- a/packages/ts-sdk/src/providers/indexer.ts
+++ b/packages/ts-sdk/src/providers/indexer.ts
@@ -171,6 +171,8 @@ export type GetVtxosOptions = PaginationOptions & {
     recoverableOnly?: boolean;
     /** Only return pending/preconfirmed virtual outputs. */
     pendingOnly?: boolean;
+    /** Only return renewable virtual outputs (the union of the spendable and recoverable sets). */
+    renewableOnly?: boolean;
     /** Only return virtual outputs created after this timestamp. */
     after?: number;
     /** Only return virtual outputs created before this timestamp. */
@@ -610,12 +612,17 @@ export class RestIndexerProvider implements IndexerProvider {
             throw new Error("Either scripts or outpoints must be provided");
         }
 
-        const filterCount = [opts?.spendableOnly, opts?.spentOnly, opts?.recoverableOnly].filter(
-            Boolean,
-        ).length;
+        // The server treats these state filters as mutually exclusive.
+        const filterCount = [
+            opts?.spendableOnly,
+            opts?.spentOnly,
+            opts?.recoverableOnly,
+            opts?.pendingOnly,
+            opts?.renewableOnly,
+        ].filter(Boolean).length;
         if (filterCount > 1) {
             throw new Error(
-                "spendableOnly, spentOnly, and recoverableOnly are mutually exclusive options",
+                "spendableOnly, spentOnly, recoverableOnly, pendingOnly, and renewableOnly are mutually exclusive options",
             );
         }
 
@@ -654,6 +661,8 @@ export class RestIndexerProvider implements IndexerProvider {
                 params.append("recoverableOnly", opts.recoverableOnly.toString());
             if (opts.pendingOnly !== undefined)
                 params.append("pendingOnly", opts.pendingOnly.toString());
+            if (opts.renewableOnly !== undefined)
+                params.append("renewableOnly", opts.renewableOnly.toString());
             if (opts.after !== undefined) params.append("after", opts.after.toString());
             if (opts.before !== undefined) params.append("before", opts.before.toString());
             if (opts.pageIndex !== undefined)

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -11,7 +11,7 @@ import {
     VirtualCoin,
 } from ".";
 import { ArkInfo, ArkProvider, SettlementEvent } from "../providers/ark";
-import { maybeArkError } from "../providers/errors";
+import { ArkErrorName, isArkError, maybeArkError } from "../providers/errors";
 import type { BoardingUtxoGroup } from "./wallet";
 import type { ExtendedContractVtxo } from "../contracts/types";
 import {
@@ -2394,7 +2394,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      */
     private extractSpentOutpoint(error: unknown): Outpoint | undefined {
         const ark = maybeArkError(error);
-        if (!ark || ark.name !== "VTXO_ALREADY_SPENT") return undefined;
+        if (!isArkError(ark, ArkErrorName.VTXO_ALREADY_SPENT)) return undefined;
         const raw = ark.metadata?.vtxo_outpoint;
         if (typeof raw !== "string") return undefined;
         const [txid, voutStr] = raw.split(":");

--- a/packages/ts-sdk/test/e2e/indexer.test.ts
+++ b/packages/ts-sdk/test/e2e/indexer.test.ts
@@ -60,6 +60,39 @@ describe("Indexer provider", () => {
         expect(leaves.leaves).toHaveLength(0);
     });
 
+    it("filters vtxos by renewableOnly", { timeout: 60000 }, async () => {
+        const alice = await createTestArkWallet();
+        const aliceOffchainAddress = await alice.wallet.getAddress();
+        expect(aliceOffchainAddress).toBeDefined();
+
+        const fundAmount = 1000;
+        faucetOffchain(aliceOffchainAddress!, fundAmount);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        const indexerProvider = new RestIndexerProvider("http://localhost:7070");
+        const scripts = [hex.encode(ArkAddress.decode(aliceOffchainAddress!).pkScript)];
+
+        // renewableOnly is the union of the spendable and recoverable sets. A freshly
+        // funded wallet has one spendable and zero recoverable vtxos, so renewableOnly
+        // matches spendableOnly here (the union-with-recoverable case needs a swept /
+        // subdust vtxo, which this fixture does not create).
+        const renewable = await indexerProvider.getVtxos({ scripts, renewableOnly: true });
+        const spendable = await indexerProvider.getVtxos({ scripts, spendableOnly: true });
+
+        expect(renewable.vtxos).toHaveLength(1);
+        expect(renewable.vtxos.map((v) => `${v.txid}:${v.vout}`).sort()).toEqual(
+            spendable.vtxos.map((v) => `${v.txid}:${v.vout}`).sort(),
+        );
+
+        // State filters are applied only when querying by scripts; the server ignores
+        // them for outpoint queries, so the vtxo still comes back.
+        const byOutpoint = await indexerProvider.getVtxos({
+            outpoints: [{ txid: renewable.vtxos[0].txid, vout: renewable.vtxos[0].vout }],
+            renewableOnly: true,
+        });
+        expect(byOutpoint.vtxos).toHaveLength(1);
+    });
+
     it("should inspect a commitment tx", { timeout: 60000 }, async () => {
         // Create fresh wallet instance for this test
         const alice = await createTestArkWallet();

--- a/packages/ts-sdk/test/errors.test.ts
+++ b/packages/ts-sdk/test/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ArkError, maybeArkError } from "../src/providers/errors";
+import { ArkError, ArkErrorName, isArkError, maybeArkError } from "../src/providers/errors";
 
 describe("maybeArkError", () => {
     it("parses a structured ark.v1.ErrorDetails in details[]", () => {
@@ -55,5 +55,16 @@ describe("maybeArkError", () => {
     it("returns undefined for non-JSON / non-Error input", () => {
         expect(maybeArkError(new Error("not json"))).toBeUndefined();
         expect(maybeArkError("nope" as unknown as Error)).toBeUndefined();
+    });
+});
+
+describe("isArkError", () => {
+    it("matches an ArkError, optionally narrowing by name", () => {
+        const err = new ArkError(6, "already spent", ArkErrorName.VTXO_ALREADY_SPENT);
+        expect(isArkError(err)).toBe(true);
+        expect(isArkError(err, ArkErrorName.VTXO_ALREADY_SPENT)).toBe(true);
+        expect(isArkError(err, ArkErrorName.DIGEST_MISMATCH)).toBe(false);
+        expect(isArkError(new Error("plain"))).toBe(false);
+        expect(isArkError(undefined)).toBe(false);
     });
 });

--- a/packages/ts-sdk/test/indexer-provider.test.ts
+++ b/packages/ts-sdk/test/indexer-provider.test.ts
@@ -53,6 +53,19 @@ describe("RestIndexerProvider", () => {
             expect(requestUrl.searchParams.get("page.size")).toBe("50");
         });
 
+        it("serializes the renewableOnly filter", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ vtxos: [] }),
+            });
+
+            const provider = new RestIndexerProvider("http://localhost:7070");
+            await provider.getVtxos({ scripts: ["script-a"], renewableOnly: true });
+
+            const requestUrl = new URL(mockFetch.mock.calls[0][0]);
+            expect(requestUrl.searchParams.get("renewableOnly")).toBe("true");
+        });
+
         it("serializes outpoints and legacy filters alongside the new bounds", async () => {
             mockFetch.mockResolvedValueOnce({
                 ok: true,
@@ -112,8 +125,29 @@ describe("RestIndexerProvider", () => {
                     spentOnly: true,
                 }),
             ).rejects.toThrow(
-                "spendableOnly, spentOnly, and recoverableOnly are mutually exclusive options",
+                "spendableOnly, spentOnly, recoverableOnly, pendingOnly, and renewableOnly are mutually exclusive options",
             );
+
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it("treats renewableOnly and pendingOnly as part of the exclusive filter set", async () => {
+            const provider = new RestIndexerProvider("http://localhost:7070");
+
+            await expect(
+                provider.getVtxos({
+                    scripts: ["script-a"],
+                    renewableOnly: true,
+                    spendableOnly: true,
+                }),
+            ).rejects.toThrow("mutually exclusive");
+            await expect(
+                provider.getVtxos({
+                    scripts: ["script-a"],
+                    pendingOnly: true,
+                    recoverableOnly: true,
+                }),
+            ).rejects.toThrow("mutually exclusive");
 
             expect(mockFetch).not.toHaveBeenCalled();
         });


### PR DESCRIPTION
- Add `renewableOnly` filter to indexer `GetVtxos`, and align the mutually-exclusive filter validation with the server.
- Add `ArkErrorName` constants + `isArkError` helper covering the new `TX_FILTERS_LIMIT_EXCEEDED` / `INVALID_TX_FILTER` codes; refactor existing name-branch call sites onto them.
- Bump the ts-sdk regtest arkd override to v0.9.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `renewableOnly` VTXO filter (covers spendable or recoverable outputs).
  * Exposed structured Arkade error names and an `isArkError` helper for safer, name-specific error handling.
* **Bug Fixes**
  * Improved digest-mismatch handling during authenticated requests.
  * Updated already-spent VTXO detection to rely on structured error identification.
* **Tests**
  * Added e2e and unit test coverage for `renewableOnly` behavior and `isArkError`.
* **Chores**
  * Updated regtest Arkade Docker image tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->