### PR TITLE
feat: defer boltz refunds rejected as CLTV-immature

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -2701,20 +2701,14 @@ export class ArkadeSwaps {
     }
 
     /**
-     * {@link settleRefundWithoutReceiver}, treating the server's "CLTV not mature yet"
-     * rejection as a deferral rather than a failure.
+     * {@link settleRefundWithoutReceiver}, deferring instead of failing when the server
+     * rejects the spend as CLTV-immature ({@link ArkErrorName.FORFEIT_CLOSURE_LOCKED}):
+     * we gate on the local wall clock, the server on the chain tip's, which lags. The
+     * server-authoritative sibling of the wall-clock deferral the pre-CLTV branches
+     * already implement. Anything else propagates.
      *
-     * Our callers gate on the local wall clock, but the server does not: arkd validates
-     * a seconds-CLTV against the **chain tip block's timestamp**, which advances only
-     * when a block is mined. Tip time therefore lags wall clock by however long since
-     * the last block (~10 min on average, routinely more), so a refund attempted
-     * promptly at maturity is *expected* to be rejected until a block lands bearing a
-     * timestamp past the locktime. That is self-healing — the caller retries later — so
-     * it must not surface as a swap failure. This is the server-authoritative sibling of
-     * the wall-clock deferral the pre-CLTV branches already implement.
-     *
-     * Only `submitTx` can raise it; the batch-round path never does, making this a
-     * pass-through for recoverable VTXOs. Anything else propagates.
+     * Only `submitTx` can raise it, so this is a pass-through for recoverable VTXOs,
+     * which settle via a batch round.
      *
      * @returns `true` if settled, `false` if the server deferred it.
      */
@@ -2745,11 +2739,10 @@ export class ArkadeSwaps {
      * Refund every VTXO at a swap's VHTLC address back to the wallet, shared by
      * {@link ArkadeSwaps.refundVHTLC} (submarine) and {@link ArkadeSwaps.refundArk}
      * (chain). Path selection per VTXO:
-     * - CLTV elapsed → `refundWithoutReceiver` (offchain for a live VTXO, via a
-     *   batch round for a swept one — see {@link settleRefundWithoutReceiver}).
-     *   "Elapsed" here is a local wall-clock judgement, so the server may still
-     *   defer the spend as immature — also skipped, see
-     *   {@link trySettleRefundWithoutReceiver}.
+     * - CLTV elapsed by our wall clock → `refundWithoutReceiver` (offchain for a
+     *   live VTXO, via a batch round for a swept one — see
+     *   {@link settleRefundWithoutReceiver}), or skipped if the server defers it as
+     *   still immature (see {@link trySettleRefundWithoutReceiver}).
      * - Pre-CLTV recoverable → skipped (Boltz can't co-sign a swept-batch refund).
      * - Pre-CLTV non-recoverable → cooperative 3-of-3 refund via Boltz, falling
      *   back to `refundWithoutReceiver` offchain if Boltz rejects after the

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -11,8 +11,10 @@ import {
 } from "./errors";
 import {
     ArkAddress,
+    ArkErrorName,
     ArkProvider,
     IndexerProvider,
+    isArkError,
     IWallet,
     VHTLC,
     ArkInfo,
@@ -2699,11 +2701,55 @@ export class ArkadeSwaps {
     }
 
     /**
+     * {@link settleRefundWithoutReceiver}, treating the server's "CLTV not mature yet"
+     * rejection as a deferral rather than a failure.
+     *
+     * Our callers gate on the local wall clock, but the server does not: arkd validates
+     * a seconds-CLTV against the **chain tip block's timestamp**, which advances only
+     * when a block is mined. Tip time therefore lags wall clock by however long since
+     * the last block (~10 min on average, routinely more), so a refund attempted
+     * promptly at maturity is *expected* to be rejected until a block lands bearing a
+     * timestamp past the locktime. That is self-healing — the caller retries later — so
+     * it must not surface as a swap failure. This is the server-authoritative sibling of
+     * the wall-clock deferral the pre-CLTV branches already implement.
+     *
+     * Only `submitTx` can raise it; the batch-round path never does, making this a
+     * pass-through for recoverable VTXOs. Anything else propagates.
+     *
+     * @returns `true` if settled, `false` if the server deferred it.
+     */
+    private async trySettleRefundWithoutReceiver(
+        swapId: string,
+        ctx: RefundWithoutReceiverContext,
+        vtxo: VirtualCoin,
+    ): Promise<boolean> {
+        try {
+            await this.settleRefundWithoutReceiver(ctx, vtxo);
+            return true;
+        } catch (error) {
+            if (!isArkError(error, ArkErrorName.FORFEIT_CLOSURE_LOCKED)) throw error;
+
+            logger.warn(
+                `Swap ${swapId}: server deferred refundWithoutReceiver for VTXO ` +
+                    `${vtxo.txid}:${vtxo.vout} — refund locktime has not matured against ` +
+                    `the chain tip (locktime=${error.metadata?.locktime}, ` +
+                    `currentLocktime=${error.metadata?.current_locktime}, ` +
+                    `type=${error.metadata?.type}). ` +
+                    `Refund will be retried once a later block carries the locktime.`,
+            );
+            return false;
+        }
+    }
+
+    /**
      * Refund every VTXO at a swap's VHTLC address back to the wallet, shared by
      * {@link ArkadeSwaps.refundVHTLC} (submarine) and {@link ArkadeSwaps.refundArk}
      * (chain). Path selection per VTXO:
      * - CLTV elapsed → `refundWithoutReceiver` (offchain for a live VTXO, via a
      *   batch round for a swept one — see {@link settleRefundWithoutReceiver}).
+     *   "Elapsed" here is a local wall-clock judgement, so the server may still
+     *   defer the spend as immature — also skipped, see
+     *   {@link trySettleRefundWithoutReceiver}.
      * - Pre-CLTV recoverable → skipped (Boltz can't co-sign a swept-batch refund).
      * - Pre-CLTV non-recoverable → cooperative 3-of-3 refund via Boltz, falling
      *   back to `refundWithoutReceiver` offchain if Boltz rejects after the
@@ -2745,8 +2791,11 @@ export class ArkadeSwaps {
             // refundWithoutReceiver leaf is spendable — settle it offchain for a
             // live VTXO, or via a batch round for a swept one.
             if (isSubmarineRefundLocktimeReached(refundLocktime)) {
-                await this.settleRefundWithoutReceiver(refundContext, vtxo);
-                sweptCount++;
+                if (await this.trySettleRefundWithoutReceiver(swapId, refundContext, vtxo)) {
+                    sweptCount++;
+                } else {
+                    skippedCount++;
+                }
                 continue;
             }
 
@@ -2818,8 +2867,11 @@ export class ArkadeSwaps {
                 );
                 // Past CLTV and non-recoverable (recoverable VTXOs are skipped
                 // pre-CLTV) → settle offchain, same as the primary post-CLTV path.
-                await this.settleRefundWithoutReceiver(refundContext, vtxo);
-                sweptCount++;
+                if (await this.trySettleRefundWithoutReceiver(swapId, refundContext, vtxo)) {
+                    sweptCount++;
+                } else {
+                    skippedCount++;
+                }
             }
         }
 

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -1140,6 +1140,8 @@ export class ArkadeSwaps {
         // failure-refund statuses still update normally.
         if (!isSubmarineSuccessStatus(pendingSwap.status)) {
             const fullyRefunded = outcome.skipped === 0;
+            pendingSwap.refundable = true;
+            pendingSwap.refunded = fullyRefunded;
             await updateSubmarineSwapStatus(
                 pendingSwap,
                 pendingSwap.status, // Keep current status
@@ -1909,10 +1911,8 @@ export class ArkadeSwaps {
 
         // update the pending swap on storage
         const finalStatus = await this.getSwapStatus(pendingSwap.id);
-        await this.savePendingChainSwap({
-            ...pendingSwap,
-            status: finalStatus.status,
-        });
+        pendingSwap.status = finalStatus.status;
+        await this.savePendingChainSwap(pendingSwap);
 
         return outcome;
     }

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -192,6 +192,14 @@ const canRecoverViaBoltz3of3 = (
 const isSubmarineRefundLocktimeReached = (refundTimestamp: number): boolean =>
     Math.floor(Date.now() / 1000) >= refundTimestamp;
 
+/**
+ * How long to wait before re-attempting a spend the server rejected as
+ * CLTV-immature. It matures the locktime against the chain tip block's
+ * timestamp rather than its wall clock, so the rejection clears once a later
+ * block lands — on the order of one block interval, not of the locktime itself.
+ */
+const CLTV_IMMATURE_RETRY_SEC = 60;
+
 // Retry policy for fetching the lockup VTXO when claiming a swap: the indexer
 // may lag behind the on-chain lockup tx, so retry a few times before giving up.
 const CLAIM_VTXO_RETRY_ATTEMPTS = 3;
@@ -303,9 +311,7 @@ export class ArkadeSwaps {
                 claim: async (swap: BoltzReverseSwap) => {
                     await this.claimVHTLC(swap);
                 },
-                refund: async (swap: BoltzSubmarineSwap) => {
-                    await this.refundVHTLC(swap);
-                },
+                refund: (swap: BoltzSubmarineSwap) => this.refundVHTLC(swap),
                 claimArk: (swap: BoltzChainSwap) => this.claimArk(swap),
                 claimBtc: (swap: BoltzChainSwap) => this.claimBtc(swap),
                 refundArk: async (swap: BoltzChainSwap) => {
@@ -1117,7 +1123,7 @@ export class ArkadeSwaps {
         };
 
         // Refund every unspent VTXO at the contract address.
-        const { swept: sweptCount, skipped: skippedCount } = await this.refundVtxos({
+        const outcome = await this.refundVtxos({
             swapId: pendingSwap.id,
             vtxos: refundableVtxos,
             refundLocktime: vhtlcTimeouts.refund,
@@ -1133,7 +1139,7 @@ export class ArkadeSwaps {
         // transaction.claimed swap would muddle its history. Legitimate
         // failure-refund statuses still update normally.
         if (!isSubmarineSuccessStatus(pendingSwap.status)) {
-            const fullyRefunded = skippedCount === 0;
+            const fullyRefunded = outcome.skipped === 0;
             await updateSubmarineSwapStatus(
                 pendingSwap,
                 pendingSwap.status, // Keep current status
@@ -1142,7 +1148,7 @@ export class ArkadeSwaps {
             );
         }
 
-        return { swept: sweptCount, skipped: skippedCount };
+        return outcome;
     }
 
     /**
@@ -1891,7 +1897,7 @@ export class ArkadeSwaps {
             outputScript,
         };
 
-        const { swept: sweptCount, skipped: skippedCount } = await this.refundVtxos({
+        const outcome = await this.refundVtxos({
             swapId: pendingSwap.id,
             vtxos: unspentVtxos,
             refundLocktime,
@@ -1908,7 +1914,7 @@ export class ArkadeSwaps {
             status: finalStatus.status,
         });
 
-        return { swept: sweptCount, skipped: skippedCount };
+        return outcome;
     }
 
     // =========================================================================
@@ -2748,7 +2754,7 @@ export class ArkadeSwaps {
      *   back to `refundWithoutReceiver` offchain if Boltz rejects after the
      *   locktime has since elapsed.
      *
-     * @returns Counts of VTXOs swept vs. deferred.
+     * @returns Counts of VTXOs swept vs. deferred, and when to retry the latter.
      */
     private async refundVtxos(params: {
         swapId: string;
@@ -2758,7 +2764,7 @@ export class ArkadeSwaps {
         boltzXOnlyPublicKey: Uint8Array;
         ourXOnlyPublicKey: Uint8Array;
         refundViaBoltz: Parameters<typeof refundVHTLCwithOffchainTx>[9];
-    }): Promise<{ swept: number; skipped: number }> {
+    }): Promise<{ swept: number; skipped: number; retryAt?: number }> {
         const {
             swapId,
             vtxos,
@@ -2774,6 +2780,17 @@ export class ArkadeSwaps {
         let boltzCallCount = 0;
         let sweptCount = 0;
         let skippedCount = 0;
+        let retryAt: number | undefined;
+
+        // Record a deferral alongside the earliest moment it could clear. The
+        // two causes resolve on very different timescales — a block interval for
+        // a server-side CLTV rejection, the full locktime for a pre-CLTV VTXO —
+        // so keep the soonest, otherwise one long wait would hold back a VTXO
+        // that is ready sooner.
+        const defer = (candidate: number) => {
+            skippedCount++;
+            retryAt = retryAt === undefined ? candidate : Math.min(retryAt, candidate);
+        };
 
         for (const vtxo of vtxos) {
             const isRecoverableVtxo = isRecoverable(vtxo);
@@ -2787,7 +2804,7 @@ export class ArkadeSwaps {
                 if (await this.trySettleRefundWithoutReceiver(swapId, refundContext, vtxo)) {
                     sweptCount++;
                 } else {
-                    skippedCount++;
+                    defer(Math.floor(Date.now() / 1000) + CLTV_IMMATURE_RETRY_SEC);
                 }
                 continue;
             }
@@ -2802,7 +2819,7 @@ export class ArkadeSwaps {
                         `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
                         `Refund will be retried after locktime.`,
                 );
-                skippedCount++;
+                defer(refundLocktime);
                 continue;
             }
 
@@ -2850,7 +2867,7 @@ export class ArkadeSwaps {
                             `locktime=${refundLocktime}). ` +
                             `Refund will be retried after locktime.`,
                     );
-                    skippedCount++;
+                    defer(refundLocktime);
                     continue;
                 }
 
@@ -2863,12 +2880,12 @@ export class ArkadeSwaps {
                 if (await this.trySettleRefundWithoutReceiver(swapId, refundContext, vtxo)) {
                     sweptCount++;
                 } else {
-                    skippedCount++;
+                    defer(Math.floor(Date.now() / 1000) + CLTV_IMMATURE_RETRY_SEC);
                 }
             }
         }
 
-        return { swept: sweptCount, skipped: skippedCount };
+        return { swept: sweptCount, skipped: skippedCount, retryAt };
     }
 
     /**

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -19,6 +19,7 @@ import {
     BoltzSubmarineSwap,
     BoltzSwap,
     ChainArkRefundOutcome,
+    SubmarineRefundOutcome,
 } from "./types";
 import { NetworkError, SwapError, SwapNotFoundError } from "./errors";
 import { logger } from "./logger";
@@ -140,7 +141,14 @@ export interface SwapManagerClient {
 /** Internal callbacks wired by ArkadeSwaps to perform claim/refund/save operations. */
 export interface SwapManagerCallbacks {
     claim: (swap: BoltzReverseSwap) => Promise<void>;
-    refund: (swap: BoltzSubmarineSwap) => Promise<void>;
+    /**
+     * Refund a submarine swap's VHTLC.
+     *
+     * Returns the outcome so the manager can re-arm a deferred refund: every
+     * refundable submarine status except `transaction.lockupFailed` is also
+     * final, so Boltz sends no further update to re-trigger one.
+     */
+    refund: (swap: BoltzSubmarineSwap) => Promise<SubmarineRefundOutcome>;
     /**
      * Claim the ARK side of a BTC→ARK chain swap.
      *
@@ -180,12 +188,21 @@ export class SwapManager implements SwapManagerClient {
     private static readonly NOT_FOUND_THRESHOLD = 10;
 
     /**
-     * Delay between re-attempts of a chain refund that left VTXOs deferred
-     * (e.g. pre-CLTV recoverable VTXO, or Boltz 3-of-3 rejected before CLTV
-     * has elapsed). Boltz won't send another status update once the swap
-     * is `swap.expired`, so the manager owns the local retry cadence.
+     * Floor on the delay between re-attempts of a refund that left VTXOs
+     * deferred, and the delay used when the outcome names no retry time. Boltz
+     * won't send another status update once the swap is refundable-and-final,
+     * so the manager owns the local retry cadence.
      */
     private static readonly REFUND_RETRY_DELAY_MS = 60_000;
+
+    /**
+     * Ceiling on that delay. A deferral can be hours out (a pre-CLTV VTXO waits
+     * out the whole refund locktime), and `setTimeout` fires *immediately* past
+     * its 32-bit millisecond range, so long waits are broken into re-armed
+     * hops. Re-attempting costs an indexer lookup and re-defers, which also lets
+     * the cadence recover from a suspended device or a clock jump.
+     */
+    private static readonly MAX_REFUND_RETRY_DELAY_MS = 60 * 60_000;
 
     private readonly swapProvider: BoltzSwapProvider;
     private readonly config: SwapManagerConfig;
@@ -241,7 +258,8 @@ export class SwapManager implements SwapManagerClient {
 
     // Action callbacks (injected via setCallbacks)
     private claimCallback: ((swap: BoltzReverseSwap) => Promise<void>) | null = null;
-    private refundCallback: ((swap: BoltzSubmarineSwap) => Promise<void>) | null = null;
+    private refundCallback: ((swap: BoltzSubmarineSwap) => Promise<SubmarineRefundOutcome>) | null =
+        null;
     private claimArkCallback: ((swap: BoltzChainSwap) => Promise<{ txid: string }>) | null = null;
     private claimBtcCallback: ((swap: BoltzChainSwap) => Promise<{ txid: string }>) | null = null;
     private refundArkCallback: ((swap: BoltzChainSwap) => Promise<ChainArkRefundOutcome>) | null =
@@ -982,11 +1000,25 @@ export class SwapManager implements SwapManagerClient {
     }
 
     /**
-     * Schedule another `executeAutonomousAction` run for a chain swap whose
-     * refund left VTXOs deferred. After the retry completes, if no further
-     * deferral was reported, finalize monitoring cleanup.
+     * How long to wait before re-attempting a refund, given the `retryAt`
+     * (Unix seconds) the outcome reported. Clamped at both ends: see
+     * {@link SwapManager.REFUND_RETRY_DELAY_MS} and
+     * {@link SwapManager.MAX_REFUND_RETRY_DELAY_MS}.
      */
-    private scheduleRefundRetry(swap: BoltzChainSwap, delayMs: number): void {
+    private static refundRetryDelayMs(retryAt?: number): number {
+        if (retryAt === undefined) return SwapManager.REFUND_RETRY_DELAY_MS;
+        return Math.min(
+            Math.max(retryAt * 1000 - Date.now(), SwapManager.REFUND_RETRY_DELAY_MS),
+            SwapManager.MAX_REFUND_RETRY_DELAY_MS,
+        );
+    }
+
+    /**
+     * Schedule another `executeAutonomousAction` run for a swap whose refund
+     * left VTXOs deferred. After the retry completes, if no further deferral
+     * was reported, finalize monitoring cleanup.
+     */
+    private scheduleRefundRetry(swap: BoltzSwap, delayMs: number): void {
         const existing = this.refundRetryTimers.get(swap.id);
         if (existing) clearTimeout(existing);
         this.refundRetryTimers.set(
@@ -994,20 +1026,29 @@ export class SwapManager implements SwapManagerClient {
             setTimeout(async () => {
                 this.refundRetryTimers.delete(swap.id);
                 if (!this.isRunning) return;
-                if (!this.monitoredSwaps.has(swap.id)) return;
+                // Re-read rather than reuse the swap captured at scheduling
+                // time: a submarine swap can advance invoice.failedToPay →
+                // swap.expired while the retry is pending, and finalization
+                // below must report the status it actually ended on.
+                const current = this.monitoredSwaps.get(swap.id);
+                if (!current) return;
+                let ran = false;
                 try {
-                    // `swap` is captured at scheduling time; its fields
-                    // are stable for chain refunds because swap.expired
-                    // is terminal and Boltz won't transition it again,
-                    // so the snapshot remains accurate across retries.
-                    await this.executeAutonomousAction(swap);
+                    ran = await this.executeAutonomousAction(current);
                 } finally {
-                    // The retry callback either re-scheduled itself (still
-                    // deferred) or finished the work; in the latter case
-                    // we owe the terminal-status finalization that
-                    // handleSwapStatusUpdate skipped.
-                    if (!this.refundRetryTimers.has(swap.id) && this.isFinalStatus(swap)) {
-                        this.finalizeMonitoredSwap(swap);
+                    // The retry either re-scheduled itself (still deferred) or
+                    // finished the work; in the latter case we owe the
+                    // terminal-status finalization that handleSwapStatusUpdate
+                    // skipped. Only when it actually ran, though: this timer
+                    // has already removed itself, so finalizing on a call that
+                    // was skipped for a concurrent action would drop the swap
+                    // mid-refund and strand whatever that action defers.
+                    if (
+                        ran &&
+                        !this.refundRetryTimers.has(current.id) &&
+                        this.isFinalStatus(current)
+                    ) {
+                        this.finalizeMonitoredSwap(current);
                     }
                 }
             }, delayMs),
@@ -1017,12 +1058,17 @@ export class SwapManager implements SwapManagerClient {
     /**
      * Execute autonomous action based on swap status
      * Uses locking to prevent race conditions with manual operations
+     *
+     * @returns `false` when another action for this swap already held the lock
+     * and this call did nothing, `true` when it ran. Callers that finalize on
+     * the result must not act on `false`: the in-flight action owns the swap's
+     * outcome and will re-arm or finalize from its own result.
      */
-    private async executeAutonomousAction(swap: BoltzSwap): Promise<void> {
+    private async executeAutonomousAction(swap: BoltzSwap): Promise<boolean> {
         // Skip if already processing this swap
         if (this.swapsInProgress.has(swap.id)) {
             logger.log(`Swap ${swap.id} is already being processed, skipping autonomous action`);
-            return;
+            return false;
         }
 
         try {
@@ -1035,7 +1081,7 @@ export class SwapManager implements SwapManagerClient {
                     logger.log(
                         `Skipping claim for swap ${swap.id}: missing preimage (restored swap)`,
                     );
-                    return;
+                    return true;
                 }
                 // Claim reverse swap if status is claimable
                 if (isReverseClaimableStatus(swap.status)) {
@@ -1050,12 +1096,27 @@ export class SwapManager implements SwapManagerClient {
                     logger.log(
                         `Skipping refund for swap ${swap.id}: missing invoice (restored swap)`,
                     );
-                    return;
+                    return true;
                 }
                 // Refund submarine swap if status is refundable
                 if (isSubmarineRefundableStatus(swap.status)) {
                     logger.log(`Auto-refunding submarine swap ${swap.id}`);
-                    await this.executeRefundAction(swap);
+                    // invoice.failedToPay and swap.expired are refundable *and*
+                    // final, so a deferred refund left alone would be dropped
+                    // from monitoring with funds still locked and no further
+                    // Boltz update to re-trigger it. Only a partial outcome
+                    // schedules a retry: a throw is a genuine failure (already
+                    // spent, VHTLC not found) that retrying can't clear, so it
+                    // propagates to the catch below and stays loud.
+                    const outcome = await this.executeRefundAction(swap);
+                    if (outcome && outcome.skipped > 0) {
+                        const delayMs = SwapManager.refundRetryDelayMs(outcome.retryAt);
+                        logger.log(
+                            `Submarine swap ${swap.id}: ${outcome.skipped} VTXO(s) deferred — ` +
+                                `scheduling refund retry in ${Math.round(delayMs / 1000)}s`,
+                        );
+                        this.scheduleRefundRetry(swap, delayMs);
+                    }
                     // Emit action executed event to all listeners
                     this.actionExecutedListeners.forEach((listener) => listener(swap, "refund"));
                 }
@@ -1093,10 +1154,12 @@ export class SwapManager implements SwapManagerClient {
                         try {
                             const outcome = await this.executeRefundArkAction(swap);
                             if (outcome && outcome.skipped > 0) {
+                                const delayMs = SwapManager.refundRetryDelayMs(outcome.retryAt);
                                 logger.log(
-                                    `Chain swap ${swap.id}: ${outcome.skipped} VTXO(s) deferred — scheduling refund retry`,
+                                    `Chain swap ${swap.id}: ${outcome.skipped} VTXO(s) deferred — ` +
+                                        `scheduling refund retry in ${Math.round(delayMs / 1000)}s`,
                                 );
-                                this.scheduleRefundRetry(swap, SwapManager.REFUND_RETRY_DELAY_MS);
+                                this.scheduleRefundRetry(swap, delayMs);
                             }
                             this.actionExecutedListeners.forEach((listener) =>
                                 listener(swap, "refundArk"),
@@ -1148,6 +1211,7 @@ export class SwapManager implements SwapManagerClient {
             // Always release the lock
             this.swapsInProgress.delete(swap.id);
         }
+        return true;
     }
 
     /**
@@ -1164,14 +1228,18 @@ export class SwapManager implements SwapManagerClient {
 
     /**
      * Execute refund action for submarine swap
+     *
+     * @returns The refund outcome, or `undefined` if no callback is wired.
      */
-    private async executeRefundAction(swap: BoltzSubmarineSwap): Promise<void> {
+    private async executeRefundAction(
+        swap: BoltzSubmarineSwap,
+    ): Promise<SubmarineRefundOutcome | undefined> {
         if (!this.refundCallback) {
             logger.error("Refund callback not set");
             return;
         }
 
-        await this.refundCallback(swap);
+        return this.refundCallback(swap);
     }
 
     /**

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -167,6 +167,11 @@ export interface SwapManagerCallbacks {
     saveSwap: (swap: BoltzSwap) => Promise<void>;
 }
 
+type RefundRetryableSwap = BoltzSubmarineSwap | BoltzChainSwap;
+type RefundRetryableSwapWithRetry = RefundRetryableSwap & {
+    refundRetry: NonNullable<RefundRetryableSwap["refundRetry"]>;
+};
+
 /**
  * Background swap monitor with WebSocket + polling fallback.
  *
@@ -223,10 +228,9 @@ export class SwapManager implements SwapManagerClient {
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     private initialPollTimer: ReturnType<typeof setTimeout> | null = null;
     private pollRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
-    // Per-swap retry timers for chain refunds that left work undone
-    // (refundArk returned `skipped > 0`). The swap is held in
-    // `monitoredSwaps` past its terminal Boltz status until the local
-    // refund completes or the manager stops.
+    // Per-swap retry timers for deferred refunds that left local work undone.
+    // The swap is held in `monitoredSwaps` past its terminal Boltz status
+    // until the local refund completes or the manager stops.
     private refundRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
     // Per-swap counter of consecutive `SwapNotFoundError` responses from
     // `getSwapStatus`. Reset on any successful poll. Once a swap reaches
@@ -426,15 +430,19 @@ export class SwapManager implements SwapManagerClient {
             this.initialSwaps.set(swap.id, swap);
         }
 
-        // Load pending swaps into monitoring map (only non-final swaps)
+        // Load active swaps plus terminal swaps with persisted deferred refunds.
         for (const swap of pendingSwaps) {
-            if (!this.isFinalStatus(swap)) {
+            if (this.shouldMonitorOnStart(swap)) {
                 this.monitoredSwaps.set(swap.id, swap);
             }
         }
 
         // Try to connect WebSocket; method handles runtime detection + fallback.
         await this.tryConnectWebSocket();
+
+        // Re-arm persisted deferred refund retries before normal action resume,
+        // so restart honors the saved next retry time instead of retrying early.
+        this.resumePersistedRefundRetries();
 
         // Resume any actionable swaps immediately
         await this.resumeActionableSwaps();
@@ -541,6 +549,7 @@ export class SwapManager implements SwapManagerClient {
      * Remove a swap from monitoring
      */
     async removeSwap(swapId: string): Promise<void> {
+        const swap = this.monitoredSwaps.get(swapId);
         this.monitoredSwaps.delete(swapId);
         this.swapSubscriptions.delete(swapId);
         this.chainClaimPromises.delete(swapId);
@@ -553,6 +562,9 @@ export class SwapManager implements SwapManagerClient {
         if (refundRetryTimer) {
             clearTimeout(refundRetryTimer);
             this.refundRetryTimers.delete(swapId);
+        }
+        if (swap) {
+            await this.clearRefundRetry(swap);
         }
         this.notFoundCounts.delete(swapId);
         logger.log(`Removed swap ${swapId} from monitoring`);
@@ -999,6 +1011,20 @@ export class SwapManager implements SwapManagerClient {
         this.swapCompletedListeners.forEach((listener) => listener(swap));
     }
 
+    private static isRefundRetryableSwap(swap: BoltzSwap): swap is RefundRetryableSwap {
+        return isPendingSubmarineSwap(swap) || isPendingChainSwap(swap);
+    }
+
+    private static hasPendingRefundRetry(swap: BoltzSwap): swap is RefundRetryableSwapWithRetry {
+        if (!SwapManager.isRefundRetryableSwap(swap)) return false;
+        return swap.refundRetry?.pending === true && Number.isFinite(swap.refundRetry.nextRetryAt);
+    }
+
+    private shouldMonitorOnStart(swap: BoltzSwap): boolean {
+        if (!this.isFinalStatus(swap)) return true;
+        return this.config.enableAutoActions === true && SwapManager.hasPendingRefundRetry(swap);
+    }
+
     /**
      * How long to wait before re-attempting a refund, given the `retryAt`
      * (Unix seconds) the outcome reported. Clamped at both ends: see
@@ -1013,12 +1039,50 @@ export class SwapManager implements SwapManagerClient {
         );
     }
 
+    private static persistedRefundRetryDelayMs(nextRetryAt: number): number {
+        return Math.min(
+            Math.max(nextRetryAt * 1000 - Date.now(), 0),
+            SwapManager.MAX_REFUND_RETRY_DELAY_MS,
+        );
+    }
+
+    private static nextRefundRetryAt(delayMs: number): number {
+        return Math.ceil((Date.now() + delayMs) / 1000);
+    }
+
+    private async clearRefundRetry(swap: BoltzSwap): Promise<void> {
+        if (!SwapManager.isRefundRetryableSwap(swap) || swap.refundRetry === undefined) return;
+        delete swap.refundRetry;
+        await this.saveSwap(swap);
+    }
+
+    private resumePersistedRefundRetries(): void {
+        if (!this.config.enableAutoActions) return;
+        for (const swap of this.monitoredSwaps.values()) {
+            if (!SwapManager.hasPendingRefundRetry(swap)) continue;
+            const delayMs = SwapManager.persistedRefundRetryDelayMs(swap.refundRetry.nextRetryAt);
+            logger.log(
+                `Swap ${swap.id}: resuming deferred refund retry in ${Math.round(delayMs / 1000)}s`,
+            );
+            this.armRefundRetryTimer(swap, delayMs);
+        }
+    }
+
     /**
      * Schedule another `executeAutonomousAction` run for a swap whose refund
-     * left VTXOs deferred. After the retry completes, if no further deferral
-     * was reported, finalize monitoring cleanup.
+     * left VTXOs deferred. The pending retry and its next attempt time are saved
+     * with the swap so stop/start and application restart can re-arm it.
      */
-    private scheduleRefundRetry(swap: BoltzSwap, delayMs: number): void {
+    private async scheduleRefundRetry(swap: RefundRetryableSwap, delayMs: number): Promise<void> {
+        swap.refundRetry = {
+            pending: true,
+            nextRetryAt: SwapManager.nextRefundRetryAt(delayMs),
+        };
+        await this.saveSwap(swap);
+        this.armRefundRetryTimer(swap, delayMs);
+    }
+
+    private armRefundRetryTimer(swap: RefundRetryableSwap, delayMs: number): void {
         const existing = this.refundRetryTimers.get(swap.id);
         if (existing) clearTimeout(existing);
         this.refundRetryTimers.set(
@@ -1027,7 +1091,7 @@ export class SwapManager implements SwapManagerClient {
                 this.refundRetryTimers.delete(swap.id);
                 if (!this.isRunning) return;
                 // Re-read rather than reuse the swap captured at scheduling
-                // time: a submarine swap can advance invoice.failedToPay →
+                // time: a submarine swap can advance invoice.failedToPay ->
                 // swap.expired while the retry is pending, and finalization
                 // below must report the status it actually ended on.
                 const current = this.monitoredSwaps.get(swap.id);
@@ -1108,14 +1172,22 @@ export class SwapManager implements SwapManagerClient {
                     // schedules a retry: a throw is a genuine failure (already
                     // spent, VHTLC not found) that retrying can't clear, so it
                     // propagates to the catch below and stays loud.
-                    const outcome = await this.executeRefundAction(swap);
+                    let outcome: SubmarineRefundOutcome | undefined;
+                    try {
+                        outcome = await this.executeRefundAction(swap);
+                    } catch (error) {
+                        await this.clearRefundRetry(swap);
+                        throw error;
+                    }
                     if (outcome && outcome.skipped > 0) {
                         const delayMs = SwapManager.refundRetryDelayMs(outcome.retryAt);
                         logger.log(
                             `Submarine swap ${swap.id}: ${outcome.skipped} VTXO(s) deferred — ` +
                                 `scheduling refund retry in ${Math.round(delayMs / 1000)}s`,
                         );
-                        this.scheduleRefundRetry(swap, delayMs);
+                        await this.scheduleRefundRetry(swap, delayMs);
+                    } else if (outcome) {
+                        await this.clearRefundRetry(swap);
                     }
                     // Emit action executed event to all listeners
                     this.actionExecutedListeners.forEach((listener) => listener(swap, "refund"));
@@ -1159,7 +1231,9 @@ export class SwapManager implements SwapManagerClient {
                                     `Chain swap ${swap.id}: ${outcome.skipped} VTXO(s) deferred — ` +
                                         `scheduling refund retry in ${Math.round(delayMs / 1000)}s`,
                                 );
-                                this.scheduleRefundRetry(swap, delayMs);
+                                await this.scheduleRefundRetry(swap, delayMs);
+                            } else if (outcome) {
+                                await this.clearRefundRetry(swap);
                             }
                             this.actionExecutedListeners.forEach((listener) =>
                                 listener(swap, "refundArk"),
@@ -1172,7 +1246,7 @@ export class SwapManager implements SwapManagerClient {
                             this.swapFailedListeners.forEach((listener) =>
                                 listener(swap, error as Error),
                             );
-                            this.scheduleRefundRetry(swap, SwapManager.REFUND_RETRY_DELAY_MS);
+                            await this.scheduleRefundRetry(swap, SwapManager.REFUND_RETRY_DELAY_MS);
                         }
                     }
                     if (swap.request.from === "BTC") {
@@ -1340,6 +1414,7 @@ export class SwapManager implements SwapManagerClient {
         }
 
         for (const swap of this.monitoredSwaps.values()) {
+            if (this.refundRetryTimers.has(swap.id)) continue;
             try {
                 // Check if swap needs action based on current status
                 if (isPendingReverseSwap(swap) && isReverseClaimableStatus(swap.status)) {

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -226,6 +226,16 @@ export interface SubmarineRecoveryInfo {
     error?: string;
 }
 
+/**
+ * Earliest Unix timestamp (seconds) at which retrying the deferred VTXOs could
+ * make progress, or `undefined` when nothing was deferred. Deferrals do not all
+ * last the same time — a server-side CLTV rejection clears as soon as a later
+ * block carries the locktime, whereas a pre-CLTV VTXO must wait out the whole
+ * refund locktime — so callers schedule from this instead of polling at a fixed
+ * interval. It is a lower bound, not a promise: a retry may defer again.
+ */
+type RefundRetryAt = number | undefined;
+
 /** Outcome of a single `refundVHTLC` call: how many VTXOs were swept vs. deferred. */
 export interface SubmarineRefundOutcome {
     /** Number of VTXOs successfully refunded (joined a batch or via Boltz co-sign). */
@@ -236,6 +246,8 @@ export interface SubmarineRefundOutcome {
      * is expected to retry these later.
      */
     skipped: number;
+    /** When a retry could first succeed; see {@link RefundRetryAt}. */
+    retryAt?: RefundRetryAt;
 }
 
 /** Outcome of a single `refundArk` call: how many VTXOs were swept vs. deferred. */
@@ -248,6 +260,8 @@ export interface ChainArkRefundOutcome {
      * is expected to retry these later.
      */
     skipped: number;
+    /** When a retry could first succeed; see {@link RefundRetryAt}. */
+    retryAt?: RefundRetryAt;
 }
 
 /** Per-swap outcome of a bulk recovery call. */

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -141,6 +141,14 @@ export interface OptimisticSendLightningPaymentResponse {
     txid: string;
 }
 
+/** Persisted state for a locally deferred refund retry. */
+export interface RefundRetryState {
+    /** True while SwapManager still needs to retry the local refund path. */
+    pending: true;
+    /** Unix timestamp (seconds) for the next retry attempt. */
+    nextRetryAt: number;
+}
+
 /** Tracks an in-progress reverse swap (Lightning → Arkade). */
 export interface BoltzReverseSwap {
     /** Unique swap ID from Boltz. */
@@ -175,6 +183,8 @@ export interface BoltzSubmarineSwap {
     refunded?: boolean;
     /** Whether the swap is eligible for refund. */
     refundable?: boolean;
+    /** Deferred local refund retry state, if any. */
+    refundRetry?: RefundRetryState;
     /** Current Boltz swap status. */
     status: BoltzSwapStatus;
     /** The original request sent to Boltz. */
@@ -296,6 +306,8 @@ export interface BoltzChainSwap {
     feeSatsPerByte: number;
     /** Current Boltz swap status. */
     status: BoltzSwapStatus;
+    /** Deferred local ARK refund retry state, if any. */
+    refundRetry?: RefundRetryState;
     /** The original chain swap request sent to Boltz. */
     request: CreateChainSwapRequest;
     /** Boltz API response with lockup and claim details. */

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3761,9 +3761,16 @@ describe("ArkadeSwaps", () => {
                         forfeitClosureLocked(refundableSwap.response.timeoutBlockHeights!.refund),
                     );
 
+                    const nowSec = Math.floor(Date.now() / 1000);
                     const outcome = await swaps.refundVHTLC(refundableSwap);
 
-                    expect(outcome).toEqual({ swept: 0, skipped: 1 });
+                    expect(outcome.swept).toBe(0);
+                    expect(outcome.skipped).toBe(1);
+                    // A server-side rejection clears once a later block carries
+                    // the locktime, so the retry is a block interval away — not
+                    // the locktime itself, which has already passed here.
+                    expect(outcome.retryAt).toBeGreaterThanOrEqual(nowSec);
+                    expect(outcome.retryAt).toBeLessThanOrEqual(nowSec + 60);
                     // The throw used to escape past this write, so the swap was never
                     // marked refundable for a later retry to pick up.
                     expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
@@ -3786,13 +3793,19 @@ describe("ArkadeSwaps", () => {
                     // Boltz rejection falls through to refundWithoutReceiver. This
                     // site sits inside a catch block — an inline try/catch here would
                     // throw straight past the enclosing handler.
+                    const nowSec = Math.floor(Date.now() / 1000);
                     const dateSpy = vi.spyOn(Date, "now");
                     dateSpy.mockReturnValueOnce((futureRefundTimestamp - 60) * 1000);
                     dateSpy.mockReturnValueOnce((futureRefundTimestamp + 60) * 1000);
 
                     const outcome = await swaps.refundVHTLC(refundableSwapPreCltv);
 
-                    expect(outcome).toEqual({ swept: 0, skipped: 1 });
+                    expect(outcome.swept).toBe(0);
+                    expect(outcome.skipped).toBe(1);
+                    // Deferred by the server, not by the locktime, so the retry
+                    // is a block interval out rather than at futureRefundTimestamp.
+                    expect(outcome.retryAt).toBeGreaterThanOrEqual(nowSec);
+                    expect(outcome.retryAt).toBeLessThanOrEqual(nowSec + 60);
                     expect(refundWithoutReceiverVHTLCwithOffchainTx).toHaveBeenCalledOnce();
                 });
 
@@ -4927,11 +4940,14 @@ describe("ArkadeSwaps", () => {
                 vtxos: vtxos as any,
             });
 
-            const outcome = await swaps.refundArk(buildSwap(futureRefund()));
+            const refundLocktime = futureRefund();
+            const outcome = await swaps.refundArk(buildSwap(refundLocktime));
 
             expect(refundVHTLCwithOffchainTx).not.toHaveBeenCalled();
             expect((swaps as any).joinBatch).not.toHaveBeenCalled();
-            expect(outcome).toEqual({ swept: 0, skipped: 2 });
+            // Both VTXOs must wait out the whole locktime, so retrying any
+            // sooner cannot make progress.
+            expect(outcome).toEqual({ swept: 0, skipped: 2, retryAt: refundLocktime });
         });
 
         it("still throttles the next Boltz call by 2s after a BoltzRefundError on the previous VTXO", async () => {
@@ -4951,7 +4967,8 @@ describe("ArkadeSwaps", () => {
                     .mockRejectedValueOnce(new BoltzRefundError("outpoint mismatch"))
                     .mockResolvedValueOnce(undefined);
 
-                const promise = swaps.refundArk(buildSwap(futureRefund()));
+                const refundLocktime = futureRefund();
+                const promise = swaps.refundArk(buildSwap(refundLocktime));
                 promise.catch(() => {});
 
                 // Drain microtasks so the first call lands.
@@ -4967,7 +4984,7 @@ describe("ArkadeSwaps", () => {
                 expect(mockRefund).toHaveBeenCalledTimes(2);
 
                 const outcome = await promise;
-                expect(outcome).toEqual({ swept: 1, skipped: 1 });
+                expect(outcome).toEqual({ swept: 1, skipped: 1, retryAt: refundLocktime });
             } finally {
                 vi.useRealTimers();
             }
@@ -5009,10 +5026,11 @@ describe("ArkadeSwaps", () => {
                 new BoltzRefundError("outpoint mismatch"),
             );
 
-            const outcome = await swaps.refundArk(buildSwap(futureRefund()));
+            const refundLocktime = futureRefund();
+            const outcome = await swaps.refundArk(buildSwap(refundLocktime));
 
             expect((swaps as any).joinBatch).not.toHaveBeenCalled();
-            expect(outcome).toEqual({ swept: 0, skipped: 1 });
+            expect(outcome).toEqual({ swept: 0, skipped: 1, retryAt: refundLocktime });
         });
 
         it("re-throws non-Boltz errors from the refund offchain tx", async () => {

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -26,6 +26,7 @@ import {
     SingleKey,
     ArkInfo,
     getNetwork,
+    maybeArkError,
 } from "@arkade-os/sdk";
 import { VHTLC } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
@@ -3697,6 +3698,121 @@ describe("ArkadeSwaps", () => {
                 await expect(swaps.refundVHTLC(refundableSwapPreCltv)).rejects.toThrow(
                     /local signing failure/,
                 );
+            });
+
+            describe("server-side CLTV deferral (FORFEIT_CLOSURE_LOCKED)", () => {
+                // Our locktime gate reads the wall clock, but arkd validates a
+                // seconds-CLTV against the chain tip *block's* timestamp, which only
+                // advances when a block is mined. So the server routinely rejects a
+                // refund we consider mature, until a block lands carrying a timestamp
+                // past the locktime. That is self-healing — it must be recorded as a
+                // deferral the caller retries, never as a swap failure.
+
+                /**
+                 * Build the error as the wire delivers it: arkd attaches
+                 * `ark.v1.ErrorDetails` to the gRPC status, grpc-gateway renders it
+                 * into the HTTP body, and `RestArkProvider.submitTx` feeds that body
+                 * through `maybeArkError`. Going through the real parser pins the wire
+                 * contract, which a hand-rolled `ArkError` would let drift.
+                 */
+                const wireArkError = (args: {
+                    name: string;
+                    code: number;
+                    metadata?: Record<string, string>;
+                }) => {
+                    const message = `${args.name} (${args.code}): rejected by the server`;
+                    const parsed = maybeArkError(
+                        new Error(
+                            JSON.stringify({
+                                code: 9, // gRPC FailedPrecondition -> HTTP 400
+                                message,
+                                details: [
+                                    {
+                                        "@type": "type.googleapis.com/ark.v1.ErrorDetails",
+                                        code: args.code,
+                                        name: args.name,
+                                        message,
+                                        ...(args.metadata ? { metadata: args.metadata } : {}),
+                                    },
+                                ],
+                            }),
+                        ),
+                    );
+                    if (!parsed) {
+                        throw new Error(`fixture: ${args.name} did not parse as an ArkError`);
+                    }
+                    return parsed;
+                };
+
+                // `type: "time"` matches the boltz VHTLC's seconds-based CLTV.
+                // `current_locktime` is the tip block's timestamp — behind the
+                // locktime, which is exactly why this fires despite our clock.
+                const forfeitClosureLocked = (locktime: number) =>
+                    wireArkError({
+                        name: "FORFEIT_CLOSURE_LOCKED",
+                        code: 11,
+                        metadata: {
+                            locktime: String(locktime),
+                            current_locktime: String(locktime - 600),
+                            type: "time",
+                        },
+                    });
+
+                it("defers rather than throwing when the server rejects the primary post-CLTV settle", async () => {
+                    const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
+                    mockRefundSelection({ spendable: [vtxo] });
+
+                    vi.mocked(refundWithoutReceiverVHTLCwithOffchainTx).mockRejectedValueOnce(
+                        forfeitClosureLocked(refundableSwap.response.timeoutBlockHeights!.refund),
+                    );
+
+                    const outcome = await swaps.refundVHTLC(refundableSwap);
+
+                    expect(outcome).toEqual({ swept: 0, skipped: 1 });
+                    // The throw used to escape past this write, so the swap was never
+                    // marked refundable for a later retry to pick up.
+                    expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                        expect.objectContaining({ refundable: true, refunded: false }),
+                    );
+                });
+
+                it("defers when the server rejects the Boltz-rejection fallback settle", async () => {
+                    const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
+                    mockRefundSelection({ spendable: [vtxo] });
+
+                    vi.mocked(refundVHTLCwithOffchainTx).mockRejectedValueOnce(
+                        new BoltzRefundError("outpoint mismatch"),
+                    );
+                    vi.mocked(refundWithoutReceiverVHTLCwithOffchainTx).mockRejectedValueOnce(
+                        forfeitClosureLocked(futureRefundTimestamp),
+                    );
+
+                    // Pre-CLTV on the first check, post-CLTV on the re-check, so the
+                    // Boltz rejection falls through to refundWithoutReceiver. This
+                    // site sits inside a catch block — an inline try/catch here would
+                    // throw straight past the enclosing handler.
+                    const dateSpy = vi.spyOn(Date, "now");
+                    dateSpy.mockReturnValueOnce((futureRefundTimestamp - 60) * 1000);
+                    dateSpy.mockReturnValueOnce((futureRefundTimestamp + 60) * 1000);
+
+                    const outcome = await swaps.refundVHTLC(refundableSwapPreCltv);
+
+                    expect(outcome).toEqual({ swept: 0, skipped: 1 });
+                    expect(refundWithoutReceiverVHTLCwithOffchainTx).toHaveBeenCalledOnce();
+                });
+
+                it("propagates an Ark error that is not FORFEIT_CLOSURE_LOCKED", async () => {
+                    const vtxo = makeNonRecoverableVtxo(lockupTxid, 0);
+                    mockRefundSelection({ spendable: [vtxo] });
+
+                    vi.mocked(refundWithoutReceiverVHTLCwithOffchainTx).mockRejectedValueOnce(
+                        wireArkError({ name: "VTXO_ALREADY_SPENT", code: 24 }),
+                    );
+
+                    await expect(swaps.refundVHTLC(refundableSwap)).rejects.toThrow(
+                        /VTXO_ALREADY_SPENT/,
+                    );
+                });
             });
         });
 

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3701,18 +3701,14 @@ describe("ArkadeSwaps", () => {
             });
 
             describe("server-side CLTV deferral (FORFEIT_CLOSURE_LOCKED)", () => {
-                // Our locktime gate reads the wall clock, but arkd validates a
-                // seconds-CLTV against the chain tip *block's* timestamp, which only
-                // advances when a block is mined. So the server routinely rejects a
-                // refund we consider mature, until a block lands carrying a timestamp
-                // past the locktime. That is self-healing — it must be recorded as a
-                // deferral the caller retries, never as a swap failure.
+                // Our locktime gate reads the wall clock, arkd's reads the lagging
+                // chain tip, so it routinely rejects a refund we consider mature. That
+                // is self-healing: a deferral the caller retries, never a swap failure.
 
                 /**
-                 * Build the error as the wire delivers it: arkd attaches
-                 * `ark.v1.ErrorDetails` to the gRPC status, grpc-gateway renders it
-                 * into the HTTP body, and `RestArkProvider.submitTx` feeds that body
-                 * through `maybeArkError`. Going through the real parser pins the wire
+                 * Build the error as the wire delivers it — through the same
+                 * `maybeArkError` parse of arkd's `ark.v1.ErrorDetails` that
+                 * `RestArkProvider.submitTx` performs — so the fixture pins the wire
                  * contract, which a hand-rolled `ArkError` would let drift.
                  */
                 const wireArkError = (args: {
@@ -3744,9 +3740,8 @@ describe("ArkadeSwaps", () => {
                     return parsed;
                 };
 
-                // `type: "time"` matches the boltz VHTLC's seconds-based CLTV.
-                // `current_locktime` is the tip block's timestamp — behind the
-                // locktime, which is exactly why this fires despite our clock.
+                // `type: "time"` matches the boltz VHTLC's seconds CLTV;
+                // `current_locktime` is the lagging tip timestamp.
                 const forfeitClosureLocked = (locktime: number) =>
                     wireArkError({
                         name: "FORFEIT_CLOSURE_LOCKED",

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -1900,4 +1900,227 @@ describe("SwapManager", () => {
             }
         });
     });
+
+    describe("Submarine refund partial-outcome retry", () => {
+        const refundableSubmarineSwap: BoltzSubmarineSwap = {
+            ...mockSubmarineSwap,
+            status: "swap.expired",
+        };
+
+        const triggerStatus = async (status: string) => {
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: refundableSubmarineSwap.id, status }],
+                }),
+            });
+        };
+
+        beforeEach(() => {
+            global.fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ status: "swap.expired" }),
+                    headers: new Headers({ "content-length": "100" }),
+                } as Response),
+            );
+        });
+
+        afterEach(() => {
+            delete (global as { fetch?: unknown }).fetch;
+        });
+
+        const startWith = async (refund: ReturnType<typeof vi.fn>, events = {}) => {
+            swapManager = new SwapManager(swapProvider, { ...swapManagerConfig, events });
+            swapManager.setCallbacks(makeCallbacks({ refund, saveSwap: vi.fn() }));
+            await swapManager.start([{ ...refundableSubmarineSwap, status: "invoice.set" }]);
+            mockWebSocket.onopen();
+        };
+
+        it("keeps the swap monitored and schedules a retry when refund reports skipped > 0", async () => {
+            vi.useFakeTimers();
+            try {
+                // swap.expired is refundable *and* final: without a local retry
+                // the swap would be dropped here with funds still locked.
+                const refund = vi.fn().mockResolvedValueOnce({ swept: 0, skipped: 1 });
+                const onSwapCompleted = vi.fn();
+                await startWith(refund, { onSwapCompleted });
+                await triggerStatus("swap.expired");
+
+                expect(refund).toHaveBeenCalledTimes(1);
+                const stats = await swapManager.getStats();
+                expect(stats.monitoredSwaps).toBe(1);
+                expect(onSwapCompleted).not.toHaveBeenCalled();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("re-invokes refund after the retry delay until it sweeps the remaining VTXOs", async () => {
+            vi.useFakeTimers();
+            try {
+                const refund = vi
+                    .fn()
+                    .mockResolvedValueOnce({ swept: 0, skipped: 1 })
+                    .mockResolvedValueOnce({ swept: 1, skipped: 0 });
+                const onSwapCompleted = vi.fn();
+                await startWith(refund, { onSwapCompleted });
+                await triggerStatus("swap.expired");
+
+                await vi.advanceTimersByTimeAsync(60_001);
+
+                expect(refund).toHaveBeenCalledTimes(2);
+                const stats = await swapManager.getStats();
+                expect(stats.monitoredSwaps).toBe(0);
+                expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("waits until the reported retryAt instead of polling every minute", async () => {
+            vi.useFakeTimers();
+            try {
+                // A pre-CLTV VTXO cannot clear until its locktime, so retrying
+                // at the 60s floor would spin for hours to no purpose.
+                const retryAt = Math.floor(Date.now() / 1000) + 30 * 60;
+                const refund = vi
+                    .fn()
+                    .mockResolvedValueOnce({ swept: 0, skipped: 1, retryAt })
+                    .mockResolvedValueOnce({ swept: 1, skipped: 0 });
+                await startWith(refund);
+                await triggerStatus("swap.expired");
+
+                await vi.advanceTimersByTimeAsync(60_001);
+                expect(refund).toHaveBeenCalledTimes(1);
+
+                // Only once the locktime lands does the retry fire.
+                await vi.advanceTimersByTimeAsync(30 * 60_000);
+                expect(refund).toHaveBeenCalledTimes(2);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("caps the wait so a far-future retryAt cannot overflow setTimeout", async () => {
+            vi.useFakeTimers();
+            try {
+                // Past setTimeout's 32-bit range a timer fires immediately;
+                // the cap must re-arm in hops instead.
+                const retryAt = Math.floor(Date.now() / 1000) + 90 * 24 * 60 * 60;
+                const refund = vi.fn().mockResolvedValue({ swept: 0, skipped: 1, retryAt });
+                await startWith(refund);
+                await triggerStatus("swap.expired");
+                expect(refund).toHaveBeenCalledTimes(1);
+
+                // Not fired early despite the 90-day target...
+                await vi.advanceTimersByTimeAsync(59 * 60_000);
+                expect(refund).toHaveBeenCalledTimes(1);
+
+                // ...and re-attempted at the 1h ceiling.
+                await vi.advanceTimersByTimeAsync(60_001);
+                expect(refund).toHaveBeenCalledTimes(2);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("drops the swap and emits completed when refund sweeps everything", async () => {
+            const refund = vi.fn().mockResolvedValue({ swept: 1, skipped: 0 });
+            const onSwapCompleted = vi.fn();
+            await startWith(refund, { onSwapCompleted });
+            await triggerStatus("swap.expired");
+
+            expect(refund).toHaveBeenCalledTimes(1);
+            const stats = await swapManager.getStats();
+            expect(stats.monitoredSwaps).toBe(0);
+            expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not retry when refund throws — a hard failure stays loud", async () => {
+            vi.useFakeTimers();
+            try {
+                // Unlike a deferral, "already spent" / "VHTLC not found" cannot
+                // clear by waiting, so retrying would spin forever.
+                const refund = vi.fn().mockRejectedValue(new Error("VHTLC is already spent"));
+                const onSwapFailed = vi.fn();
+                await startWith(refund, { onSwapFailed });
+                await triggerStatus("swap.expired");
+
+                expect(refund).toHaveBeenCalledTimes(1);
+                expect(onSwapFailed).toHaveBeenCalledTimes(1);
+
+                await vi.advanceTimersByTimeAsync(120_000);
+                expect(refund).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("clears the pending retry on stop()", async () => {
+            vi.useFakeTimers();
+            try {
+                const refund = vi.fn().mockResolvedValueOnce({ swept: 0, skipped: 1 });
+                await startWith(refund);
+                await triggerStatus("swap.expired");
+                expect(refund).toHaveBeenCalledTimes(1);
+
+                await swapManager.stop();
+                await vi.advanceTimersByTimeAsync(120_000);
+                expect(refund).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("does not finalize when the retry fires while another refund is in flight", async () => {
+            vi.useFakeTimers();
+            try {
+                // transaction.lockupFailed is refundable but *not* final, so a
+                // deferral there arms a retry that is still pending when
+                // swap.expired arrives — the one refundable→refundable
+                // transition submarine swaps have, and chain swaps don't.
+                // The retry must not finalize on a call the lock made a no-op:
+                // the in-flight refund is still holding deferred VTXOs.
+                let releaseInFlight: (v: unknown) => void = () => {};
+                const inFlight = new Promise((resolve) => {
+                    releaseInFlight = resolve;
+                });
+                const refund = vi
+                    .fn()
+                    .mockResolvedValueOnce({ swept: 0, skipped: 1 })
+                    .mockImplementationOnce(() => inFlight.then(() => ({ swept: 0, skipped: 1 })))
+                    .mockResolvedValue({ swept: 1, skipped: 0 });
+                const onSwapCompleted = vi.fn();
+                await startWith(refund, { onSwapCompleted });
+
+                await triggerStatus("transaction.lockupFailed");
+                expect(refund).toHaveBeenCalledTimes(1);
+
+                // swap.expired lands and its refund hangs, holding the lock.
+                const expired = triggerStatus("swap.expired");
+                await vi.advanceTimersByTimeAsync(0);
+                expect(refund).toHaveBeenCalledTimes(2);
+
+                // The pending retry fires into the held lock and must no-op.
+                await vi.advanceTimersByTimeAsync(60_001);
+                expect(onSwapCompleted).not.toHaveBeenCalled();
+                expect((await swapManager.getStats()).monitoredSwaps).toBe(1);
+
+                // The in-flight refund resolves still-deferred and re-arms.
+                releaseInFlight(undefined);
+                await expired;
+                expect((await swapManager.getStats()).monitoredSwaps).toBe(1);
+                expect(onSwapCompleted).not.toHaveBeenCalled();
+
+                // That retry lands, sweeps the rest, and only then completes.
+                await vi.advanceTimersByTimeAsync(60_001);
+                expect(refund).toHaveBeenCalledTimes(3);
+                expect((await swapManager.getStats()).monitoredSwaps).toBe(0);
+                expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
 });

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -4,6 +4,7 @@ import { BoltzSwapProvider } from "../src/boltz-swap-provider";
 import { BoltzChainSwap, BoltzReverseSwap, BoltzSubmarineSwap } from "../src/types";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
 
 describe("SwapManager", () => {
     let swapProvider: BoltzSwapProvider;
@@ -1731,6 +1732,50 @@ describe("SwapManager", () => {
             }
         });
 
+        it("re-arms a persisted deferred refund after restart", async () => {
+            vi.useFakeTimers();
+            try {
+                let persisted: BoltzChainSwap | undefined;
+                const saveSwap = vi.fn(async (swap: BoltzChainSwap) => {
+                    persisted = clone(swap);
+                });
+                const refundArk = vi
+                    .fn()
+                    .mockResolvedValueOnce({ swept: 0, skipped: 1 })
+                    .mockResolvedValueOnce({ swept: 1, skipped: 0 });
+
+                swapManager = new SwapManager(swapProvider, swapManagerConfig);
+                swapManager.setCallbacks(makeCallbacks({ refundArk, saveSwap }));
+
+                await swapManager.start([{ ...refundableChainSwap, status: "swap.created" }]);
+                mockWebSocket.onopen();
+                await triggerSwapExpired();
+
+                expect(refundArk).toHaveBeenCalledTimes(1);
+                expect(persisted?.refundRetry).toEqual(
+                    expect.objectContaining({ pending: true, nextRetryAt: expect.any(Number) }),
+                );
+
+                await swapManager.stop();
+
+                const restarted = new SwapManager(swapProvider, swapManagerConfig);
+                restarted.setCallbacks(makeCallbacks({ refundArk, saveSwap }));
+                swapManager = restarted;
+                await swapManager.start([clone(persisted!)]);
+
+                expect(refundArk).toHaveBeenCalledTimes(1);
+                expect((await swapManager.getStats()).monitoredSwaps).toBe(1);
+
+                await vi.advanceTimersByTimeAsync(61_000);
+
+                expect(refundArk).toHaveBeenCalledTimes(2);
+                expect((await swapManager.getStats()).monitoredSwaps).toBe(0);
+                expect(persisted?.refundRetry).toBeUndefined();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
         it("removes the swap immediately and emits completed when refundArk reports no skipped VTXOs", async () => {
             const refundArk = vi.fn().mockResolvedValue({
                 swept: 1,
@@ -1973,6 +2018,50 @@ describe("SwapManager", () => {
                 const stats = await swapManager.getStats();
                 expect(stats.monitoredSwaps).toBe(0);
                 expect(onSwapCompleted).toHaveBeenCalledTimes(1);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("re-arms a persisted deferred refund after restart", async () => {
+            vi.useFakeTimers();
+            try {
+                let persisted: BoltzSubmarineSwap | undefined;
+                const saveSwap = vi.fn(async (swap: BoltzSubmarineSwap) => {
+                    persisted = clone(swap);
+                });
+                const refund = vi
+                    .fn()
+                    .mockResolvedValueOnce({ swept: 0, skipped: 1 })
+                    .mockResolvedValueOnce({ swept: 1, skipped: 0 });
+
+                swapManager = new SwapManager(swapProvider, swapManagerConfig);
+                swapManager.setCallbacks(makeCallbacks({ refund, saveSwap }));
+
+                await swapManager.start([{ ...refundableSubmarineSwap, status: "invoice.set" }]);
+                mockWebSocket.onopen();
+                await triggerStatus("swap.expired");
+
+                expect(refund).toHaveBeenCalledTimes(1);
+                expect(persisted?.refundRetry).toEqual(
+                    expect.objectContaining({ pending: true, nextRetryAt: expect.any(Number) }),
+                );
+
+                await swapManager.stop();
+
+                const restarted = new SwapManager(swapProvider, swapManagerConfig);
+                restarted.setCallbacks(makeCallbacks({ refund, saveSwap }));
+                swapManager = restarted;
+                await swapManager.start([clone(persisted!)]);
+
+                expect(refund).toHaveBeenCalledTimes(1);
+                expect((await swapManager.getStats()).monitoredSwaps).toBe(1);
+
+                await vi.advanceTimersByTimeAsync(61_000);
+
+                expect(refund).toHaveBeenCalledTimes(2);
+                expect((await swapManager.getStats()).monitoredSwaps).toBe(0);
+                expect(persisted?.refundRetry).toBeUndefined();
             } finally {
                 vi.useRealTimers();
             }

--- a/packages/ts-sdk/.env.regtest
+++ b/packages/ts-sdk/.env.regtest
@@ -12,6 +12,11 @@ ARKD_UNILATERAL_EXIT_DELAY=20
 ARKD_PUBLIC_UNILATERAL_EXIT_DELAY=20
 ARKD_VTXO_MIN_AMOUNT=1
 
+# Block-denominated locktimes above require this per regtest/.env.defaults: the
+# background auto-miner would otherwise advance the tip and fire sweeps/expiry
+# (or mature a test's CLTV) at an uncontrolled point mid-suite.
+AUTOMINE_INTERVAL=0
+
 # Zero fees — ts-sdk tests manage fees individually via setFees()/clearFees()
 ARK_OFFCHAIN_INPUT_FEE="0.0"
 ARK_ONCHAIN_INPUT_FEE="0.0"

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -26,10 +26,9 @@ export const ArkErrorName = {
      * `submitTx` (never `finalizeTx`), with metadata
      * `{ locktime, current_locktime, type: "height" | "time" }`.
      *
-     * Self-healing, so callers should defer and retry rather than fail: the server
-     * compares a seconds-locktime against the **chain tip block's timestamp**, not its
-     * wall clock, so a spend attempted promptly at maturity is rejected until a block
-     * lands carrying a timestamp past the locktime.
+     * Self-healing, so defer and retry rather than fail: the server matures a
+     * seconds-locktime against the **chain tip block's timestamp**, not its wall clock,
+     * so a spend attempted promptly at maturity is rejected until a later block lands.
      */
     FORFEIT_CLOSURE_LOCKED: "FORFEIT_CLOSURE_LOCKED",
 } as const;

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -21,6 +21,17 @@ export const ArkErrorName = {
     VTXO_ALREADY_SPENT: "VTXO_ALREADY_SPENT",
     INVALID_TX_FILTER: "INVALID_TX_FILTER",
     TX_FILTERS_LIMIT_EXCEEDED: "TX_FILTERS_LIMIT_EXCEEDED",
+    /**
+     * A CLTV closure was spent before its absolute locktime matured. Raised only by
+     * `submitTx` (never `finalizeTx`), with metadata
+     * `{ locktime, current_locktime, type: "height" | "time" }`.
+     *
+     * Self-healing, so callers should defer and retry rather than fail: the server
+     * compares a seconds-locktime against the **chain tip block's timestamp**, not its
+     * wall clock, so a spend attempted promptly at maturity is rejected until a block
+     * lands carrying a timestamp past the locktime.
+     */
+    FORFEIT_CLOSURE_LOCKED: "FORFEIT_CLOSURE_LOCKED",
 } as const;
 
 export type ArkErrorName = (typeof ArkErrorName)[keyof typeof ArkErrorName];

--- a/packages/ts-sdk/test/e2e/vhtlc.test.ts
+++ b/packages/ts-sdk/test/e2e/vhtlc.test.ts
@@ -3,10 +3,14 @@ import * as bip68 from "bip68";
 import { base64, hex } from "@scure/base";
 import { hash160 } from "@scure/btc-signer/utils.js";
 import {
+    ArkError,
+    ArkErrorName,
     buildOffchainTx,
     ConditionWitness,
     CSVMultisigTapscript,
+    EsploraProvider,
     Identity,
+    isArkError,
     networks,
     OnchainWallet,
     RestArkProvider,
@@ -23,6 +27,8 @@ import {
     createTestIdentity,
     execCommand,
     faucetOffchain,
+    mineBlocks,
+    waitFor,
 } from "./utils";
 import { execSync } from "child_process";
 import { beforeAll } from "vitest";
@@ -250,4 +256,160 @@ describe("vhtlc", () => {
         const txid = await onchainBob.provider.broadcastTransaction(signedTx.hex);
         expect(txid).toBeDefined();
     });
+
+    // Regression for arkd #1146 (fixed in 0.9.14 by PR #1147). A CLTV tx refused
+    // before its locktime used to poison its own txid: the offchain-tx aggregate
+    // treated `Failed` as sticky, so the post-maturity retry — byte-identical, hence
+    // the same txid — got a *success* response while event replay skipped the
+    // projections. The input stayed spendable and no output was created: a silent
+    // double-spend hazard.
+    it(
+        "should refund without receiver on a post-maturity retry of a rejected CLTV tx",
+        { timeout: 120_000 },
+        async () => {
+            const alice = createTestIdentity();
+            const bob = createTestIdentity();
+
+            const arkProvider = new RestArkProvider("http://localhost:7070");
+            const indexerProvider = new RestIndexerProvider("http://localhost:7070");
+            const onchainProvider = new EsploraProvider("http://localhost:3000/api");
+
+            // A block-height CLTV matures deterministically under mineBlocks(). A
+            // seconds-CLTV could not: arkd matures it against the chain tip block's
+            // *timestamp*, needing both wall-clock passage and a later block to carry
+            // that time forward — mining alone can't do it, waiting alone can't either.
+            const { height } = await onchainProvider.getChainTip();
+            const refundLocktime = BigInt(height + 5);
+
+            const preimageHash = hash160(new TextEncoder().encode("preimage"));
+            const vhtlcScript = new VHTLC.Script({
+                preimageHash,
+                sender: await alice.xOnlyPublicKey(),
+                receiver: await bob.xOnlyPublicKey(),
+                server: X_ONLY_PUBLIC_KEY,
+                refundLocktime,
+                unilateralClaimDelay: { type: "blocks", value: 100n },
+                unilateralRefundDelay: { type: "blocks", value: 50n },
+                unilateralRefundWithoutReceiverDelay: { type: "blocks", value: 50n },
+            });
+
+            const address = vhtlcScript.address(networks.regtest.hrp, X_ONLY_PUBLIC_KEY).encode();
+            const fundAmount = 1000;
+            faucetOffchain(address, fundAmount);
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            const spendable = await indexerProvider.getVtxos({
+                scripts: [hex.encode(vhtlcScript.pkScript)],
+                spendableOnly: true,
+            });
+            expect(spendable.vtxos).toHaveLength(1);
+            const vtxo = spendable.vtxos[0];
+
+            const info = await arkProvider.getInfo();
+            const checkpointUnrollClosure = CSVMultisigTapscript.decode(
+                hex.decode(info.checkpointTapscript),
+            );
+
+            // refundWithoutReceiver is the VHTLC's CLTV leaf (sender + server). The
+            // output goes back to the same script, as the claim test above does —
+            // where the funds land is irrelevant to this regression.
+            const buildRefund = () =>
+                buildOffchainTx(
+                    [
+                        {
+                            ...vtxo,
+                            tapLeafScript: vhtlcScript.refundWithoutReceiver(),
+                            tapTree: vhtlcScript.encode(),
+                        },
+                    ],
+                    [{ script: vhtlcScript.pkScript, amount: BigInt(fundAmount) }],
+                    checkpointUnrollClosure,
+                );
+
+            // Capture the txid client-side — a rejected submitTx throws, so there is
+            // no response body to read it from.
+            const first = buildRefund();
+            const txid1 = first.arkTx.id;
+            const signedFirst = await alice.sign(first.arkTx);
+
+            const rejection = await arkProvider
+                .submitTx(
+                    base64.encode(signedFirst.toPSBT()),
+                    first.checkpoints.map((c) => base64.encode(c.toPSBT())),
+                )
+                .then(
+                    () => {
+                        throw new Error(
+                            "submitTx accepted a CLTV spend before its locktime matured",
+                        );
+                    },
+                    (e: unknown) => e,
+                );
+            expect(isArkError(rejection, ArkErrorName.FORFEIT_CLOSURE_LOCKED)).toBe(true);
+            expect((rejection as ArkError).metadata?.type).toBe("height");
+
+            mineBlocks(6);
+            await waitFor(
+                async () => (await onchainProvider.getChainTip()).height >= Number(refundLocktime),
+            );
+
+            // Rebuild from the same VTXO, as a real client retrying later would —
+            // don't stash and replay the signed payload.
+            const second = buildRefund();
+
+            // Test-validity guard, not a nicety: the identical txid *is* #1146. A
+            // retry carrying a different txid never touches the sticky-`Failed`
+            // aggregate, so it would pass vacuously against a broken server. The txid
+            // is stable by construction — a taproot txid is computed pre-witness, and
+            // everything it commits to here (version, the CLTV leaf's locktime,
+            // sequence, the input outpoint, one full-value output plus the anchor) is
+            // fixed, with no nonce anywhere.
+            expect(second.arkTx.id).toBe(txid1);
+
+            const signedSecond = await alice.sign(second.arkTx);
+
+            // arkd reads the tip through nbxplorer, which lags the mined block by a
+            // moment. Retry only while it still reports the CLTV immature — this is
+            // exactly the retry-after-maturity behaviour under test; anything else
+            // fails the test.
+            const deadline = Date.now() + 30_000;
+            let submitted: Awaited<ReturnType<typeof arkProvider.submitTx>> | undefined;
+            while (!submitted) {
+                try {
+                    submitted = await arkProvider.submitTx(
+                        base64.encode(signedSecond.toPSBT()),
+                        second.checkpoints.map((c) => base64.encode(c.toPSBT())),
+                    );
+                } catch (e) {
+                    if (!isArkError(e, ArkErrorName.FORFEIT_CLOSURE_LOCKED)) throw e;
+                    if (Date.now() > deadline) throw e;
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                }
+            }
+
+            expect(submitted.arkTxid).toBe(txid1);
+
+            const finalCheckpoints = await Promise.all(
+                submitted.signedCheckpointTxs.map(async (c) => {
+                    const signed = await alice.sign(Transaction.fromPSBT(base64.decode(c)), [0]);
+                    return base64.encode(signed.toPSBT());
+                }),
+            );
+            await arkProvider.finalizeTx(submitted.arkTxid, finalCheckpoints);
+
+            // The actual regression: the old server reported success above while
+            // dropping the projections, leaving the input spendable and no output.
+            await waitFor(async () => {
+                const { vtxos } = await indexerProvider.getVtxos({
+                    outpoints: [{ txid: vtxo.txid, vout: vtxo.vout }],
+                });
+                return vtxos[0]?.isSpent === true;
+            });
+
+            const { vtxos: created } = await indexerProvider.getVtxos({
+                scripts: [hex.encode(vhtlcScript.pkScript)],
+            });
+            expect(created.some((v) => v.txid === txid1 && !v.isSpent)).toBe(true);
+        },
+    );
 });

--- a/packages/ts-sdk/test/e2e/vhtlc.test.ts
+++ b/packages/ts-sdk/test/e2e/vhtlc.test.ts
@@ -261,8 +261,7 @@ describe("vhtlc", () => {
     // before its locktime used to poison its own txid: the offchain-tx aggregate
     // treated `Failed` as sticky, so the post-maturity retry — byte-identical, hence
     // the same txid — got a *success* response while event replay skipped the
-    // projections. The input stayed spendable and no output was created: a silent
-    // double-spend hazard.
+    // projections, leaving the input spendable and no output created.
     it(
         "should refund without receiver on a post-maturity retry of a rejected CLTV tx",
         { timeout: 120_000 },
@@ -274,10 +273,9 @@ describe("vhtlc", () => {
             const indexerProvider = new RestIndexerProvider("http://localhost:7070");
             const onchainProvider = new EsploraProvider("http://localhost:3000/api");
 
-            // A block-height CLTV matures deterministically under mineBlocks(). A
-            // seconds-CLTV could not: arkd matures it against the chain tip block's
-            // *timestamp*, needing both wall-clock passage and a later block to carry
-            // that time forward — mining alone can't do it, waiting alone can't either.
+            // A block-height CLTV matures deterministically under mineBlocks(); a
+            // seconds-CLTV would need both wall-clock passage and a later block to
+            // carry that time forward, so neither mining nor waiting alone gets there.
             const { height } = await onchainProvider.getChainTip();
             const refundLocktime = BigInt(height + 5);
 
@@ -310,8 +308,7 @@ describe("vhtlc", () => {
                 hex.decode(info.checkpointTapscript),
             );
 
-            // refundWithoutReceiver is the VHTLC's CLTV leaf (sender + server). The
-            // output goes back to the same script, as the claim test above does —
+            // Output goes back to the same script, as the claim test above does —
             // where the funds land is irrelevant to this regression.
             const buildRefund = () =>
                 buildOffchainTx(
@@ -359,19 +356,16 @@ describe("vhtlc", () => {
 
             // Test-validity guard, not a nicety: the identical txid *is* #1146. A
             // retry carrying a different txid never touches the sticky-`Failed`
-            // aggregate, so it would pass vacuously against a broken server. The txid
-            // is stable by construction — a taproot txid is computed pre-witness, and
-            // everything it commits to here (version, the CLTV leaf's locktime,
-            // sequence, the input outpoint, one full-value output plus the anchor) is
-            // fixed, with no nonce anywhere.
+            // aggregate, so it would pass vacuously against a broken server. Stable by
+            // construction — a taproot txid is computed pre-witness, and everything it
+            // commits to here is fixed, with no nonce anywhere.
             expect(second.arkTx.id).toBe(txid1);
 
             const signedSecond = await alice.sign(second.arkTx);
 
             // arkd reads the tip through nbxplorer, which lags the mined block by a
-            // moment. Retry only while it still reports the CLTV immature — this is
-            // exactly the retry-after-maturity behaviour under test; anything else
-            // fails the test.
+            // moment. Retry only while it still reports the CLTV immature — the
+            // retry-after-maturity behaviour under test; anything else fails.
             const deadline = Date.now() + 30_000;
             let submitted: Awaited<ReturnType<typeof arkProvider.submitTx>> | undefined;
             while (!submitted) {
@@ -397,8 +391,8 @@ describe("vhtlc", () => {
             );
             await arkProvider.finalizeTx(submitted.arkTxid, finalCheckpoints);
 
-            // The actual regression: the old server reported success above while
-            // dropping the projections, leaving the input spendable and no output.
+            // The regression itself: the old server reported success above while
+            // dropping these projections.
             await waitFor(async () => {
                 const { vtxos } = await indexerProvider.getVtxos({
                     outpoints: [{ txid: vtxo.txid, vout: vtxo.vout }],

--- a/packages/ts-sdk/test/e2e/vhtlc.test.ts
+++ b/packages/ts-sdk/test/e2e/vhtlc.test.ts
@@ -276,8 +276,15 @@ describe("vhtlc", () => {
             // A block-height CLTV matures deterministically under mineBlocks(); a
             // seconds-CLTV would need both wall-clock passage and a later block to
             // carry that time forward, so neither mining nor waiting alone gets there.
+            //
+            // The buffer is wide (not a tight +1) because `height` comes from
+            // EsploraProvider (mempool, polling Fulcrum every 2s), while arkd matures
+            // the CLTV against its own nbxplorer-derived tip — a separate indexing
+            // pipeline with no sync guarantee against mempool's. A thin margin here
+            // previously let indexer lag alone satisfy the locktime before the first
+            // submitTx below, failing this test's premature-rejection assertion.
             const { height } = await onchainProvider.getChainTip();
-            const refundLocktime = BigInt(height + 5);
+            const refundLocktime = BigInt(height + 30);
 
             const preimageHash = hash160(new TextEncoder().encode("preimage"));
             const vhtlcScript = new VHTLC.Script({
@@ -345,7 +352,7 @@ describe("vhtlc", () => {
             expect(isArkError(rejection, ArkErrorName.FORFEIT_CLOSURE_LOCKED)).toBe(true);
             expect((rejection as ArkError).metadata?.type).toBe("height");
 
-            mineBlocks(6);
+            mineBlocks(31);
             await waitFor(
                 async () => (await onchainProvider.getChainTip()).height >= Number(refundLocktime),
             );


### PR DESCRIPTION
arkd matures a seconds-CLTV against the chain tip block's timestamp, not its wall
clock, so a refund attempted promptly at maturity is routinely rejected until the
next block lands. That error bubbled out of `refundVtxos`, stranding submarine
swaps before the refundable status write and emitting a false failure on the chain
path.

- `FORFEIT_CLOSURE_LOCKED` added to `ArkErrorName`.
- `trySettleRefundWithoutReceiver` counts it as `skipped` at both `refundVtxos`
  settle call sites (primary post-CLTV + Boltz-rejection fallback), so callers
  retry instead of failing. Anything else propagates.
- Mocked boltz deferral tests: both call sites + non-FORFEIT propagation.
- Block-height-CLTV regression e2e for arkd #1146.

Lint, typecheck and unit suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary (Release Notes)

* **Bug Fixes**
  * Improved swap refund handling to recognize “closure locked” deferrals and automatically return a deferred result with a recommended retry time instead of failing.
  * Refund retries are now scheduled using the provided timing, capped to safe limits, and won’t mark swaps as complete until the deferred retry actually runs.
  * Added persisted support for pending refund retries across restarts.
* **New Features**
  * Enhanced callback/refund outcomes to support deferred retry metadata.
* **Tests**
  * Added unit and e2e coverage for CLTV deferral “self-heal” behavior and verified non-deferral errors still fail normally.
* **Chores**
  * Stabilized regtest timing to prevent unpredictable chain-tip advancement during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->