### PR TITLE
refactor: extract the offchain submit/finalize core

### DIFF
--- a/packages/ts-sdk/src/utils/arkTransaction.ts
+++ b/packages/ts-sdk/src/utils/arkTransaction.ts
@@ -1,5 +1,5 @@
 import { schnorr } from "@noble/curves/secp256k1.js";
-import { hex } from "@scure/base";
+import { base64, hex } from "@scure/base";
 import { DEFAULT_SEQUENCE, Script, SigHash } from "@scure/btc-signer";
 import { tapLeafHash } from "@scure/btc-signer/payment.js";
 import { TransactionOutput } from "@scure/btc-signer/psbt.js";
@@ -375,4 +375,146 @@ export function isValidArkAddress(address: string): boolean {
     } catch (e) {
         return false;
     }
+}
+
+/**
+ * Minimal Ark provider surface required to submit and finalize an offchain
+ * transaction. Both {@link ArkProvider} implementations satisfy it
+ * structurally, so declaring it here keeps this module free of a provider
+ * import (and of the dependency cycle that would create).
+ */
+export interface OffchainTxSubmitProvider {
+    submitTx(
+        signedArkTx: string,
+        checkpointTxs: string[],
+    ): Promise<{ arkTxid: string; signedCheckpointTxs: string[] }>;
+    finalizeTx(arkTxid: string, finalCheckpointTxs: string[]): Promise<void>;
+}
+
+/**
+ * Signing strategy for an offchain transaction, abstracting the two ways the
+ * owner's signatures are produced:
+ *
+ * - The wallet path routes each input to its owning contract's key
+ *   (`InputSignerRouter`) and, when every input resolves to the baseline key,
+ *   batch-signs the arkTx and all checkpoints in one popup — returning the
+ *   user-signed checkpoints from {@link signArkTx} so they are merged onto the
+ *   server's signatures.
+ * - A single-key spend (e.g. an ArkCash sweep) signs every input with one
+ *   identity and lets each server-returned checkpoint be signed afterwards via
+ *   {@link signCheckpoint}.
+ */
+export interface OffchainTxSigner {
+    /**
+     * Sign the ark (virtual) transaction. May optionally also return
+     * user-signed checkpoint transactions (batch path); when present, they are
+     * merged onto the server-signed checkpoints instead of calling
+     * {@link signCheckpoint}.
+     */
+    signArkTx(
+        arkTx: Transaction,
+        checkpoints: Transaction[],
+    ): Promise<{ arkTx: Transaction; userSignedCheckpoints?: Transaction[] }>;
+    /**
+     * Add the owner's signature to a single server-returned checkpoint
+     * transaction. Only invoked when {@link signArkTx} returned no
+     * `userSignedCheckpoints` (the non-batch path).
+     */
+    signCheckpoint(checkpoint: Transaction): Promise<Transaction>;
+}
+
+/**
+ * Submit a pre-built offchain transaction to the Ark server and finalize it.
+ *
+ * Owns the submit → checkpoint-sign → finalize sequence shared by every Ark
+ * spend path (the wallet send/migration path and the single-key ArkCash
+ * sweep). The signing strategy is injected via {@link OffchainTxSigner} so a
+ * caller holding a single key does not pull in the wallet's router/batch
+ * machinery. Optional {@link hooks} let the wallet mark/clear its pending-tx
+ * recovery flag around the network round-trip; a stateless caller omits them.
+ *
+ * @returns The Ark transaction id and the server-signed checkpoint PSBTs
+ * (the raw server response, for the wallet's bookkeeping).
+ */
+export async function submitOffchainTx(
+    provider: OffchainTxSubmitProvider,
+    offchainTx: OffchainTx,
+    signer: OffchainTxSigner,
+    hooks?: { beforeSubmit?: () => Promise<void>; afterFinalize?: () => Promise<void> },
+): Promise<{ arkTxid: string; signedCheckpointTxs: string[] }> {
+    const { arkTx: signedArkTx, userSignedCheckpoints } = await signer.signArkTx(
+        offchainTx.arkTx,
+        offchainTx.checkpoints,
+    );
+
+    // Mark pending before submitting — if the caller crashes between submit and
+    // finalize, its recovery hook can retry from persisted state.
+    await hooks?.beforeSubmit?.();
+
+    const { arkTxid, signedCheckpointTxs } = await provider.submitTx(
+        base64.encode(signedArkTx.toPSBT()),
+        offchainTx.checkpoints.map((c) => base64.encode(c.toPSBT())),
+    );
+
+    let finalCheckpoints: string[];
+    if (userSignedCheckpoints) {
+        // The server must return exactly one checkpoint per user-signed
+        // checkpoint: the merge pairs them by index, so a short response would
+        // silently drop the tail (→ incomplete finalizeTx) and a long one would
+        // throw a cryptic undefined access. Guard explicitly.
+        if (signedCheckpointTxs.length !== userSignedCheckpoints.length) {
+            throw new Error(
+                `submitTx returned ${signedCheckpointTxs.length} checkpoints, expected ${userSignedCheckpoints.length}`,
+            );
+        }
+        finalCheckpoints = signedCheckpointTxs.map((c, i) => {
+            const serverSigned = Transaction.fromPSBT(base64.decode(c));
+            combineTapscriptSigs(userSignedCheckpoints[i], serverSigned);
+            return base64.encode(serverSigned.toPSBT());
+        });
+    } else {
+        finalCheckpoints = await Promise.all(
+            signedCheckpointTxs.map(async (c) => {
+                const tx = Transaction.fromPSBT(base64.decode(c));
+                const signed = await signer.signCheckpoint(tx);
+                return base64.encode(signed.toPSBT());
+            }),
+        );
+    }
+
+    await provider.finalizeTx(arkTxid, finalCheckpoints);
+    await hooks?.afterFinalize?.();
+
+    return { arkTxid, signedCheckpointTxs };
+}
+
+/**
+ * Build, sign, submit, and finalize an offchain transaction whose every input
+ * is controlled by a single key — the "thin signer" path.
+ *
+ * Needs no wallet, repository, or contract state: just an identity that can
+ * sign, an Ark provider, the inputs (already carrying their spend leaf and tap
+ * tree), the outputs, and the server unroll script. Used by the ArkCash sweep
+ * to move bearer coins to the receiver's address without spinning up a full
+ * background-managed wallet on shared repositories.
+ *
+ * @returns The Ark transaction id.
+ */
+export async function signAndSubmitOffchainTx(params: {
+    identity: { sign(tx: Transaction, inputIndexes?: number[]): Promise<Transaction> };
+    provider: OffchainTxSubmitProvider;
+    inputs: ArkTxInput[];
+    outputs: TransactionOutput[];
+    serverUnrollScript: CSVMultisigTapscript.Type;
+}): Promise<string> {
+    const offchainTx = buildOffchainTx(params.inputs, params.outputs, params.serverUnrollScript);
+    // Single key: every input is signed by the same identity (all indexes), and
+    // each server-returned checkpoint is signed the same way. No router, no
+    // batch popup — signing is in-process and free.
+    const signer: OffchainTxSigner = {
+        signArkTx: async (arkTx) => ({ arkTx: await params.identity.sign(arkTx) }),
+        signCheckpoint: (checkpoint) => params.identity.sign(checkpoint),
+    };
+    const { arkTxid } = await submitOffchainTx(params.provider, offchainTx, signer);
+    return arkTxid;
 }

--- a/packages/ts-sdk/src/utils/arkTransaction.ts
+++ b/packages/ts-sdk/src/utils/arkTransaction.ts
@@ -447,6 +447,18 @@ export async function submitOffchainTx(
         offchainTx.checkpoints,
     );
 
+    // The checkpoint set built here is the source of truth: every one of them
+    // must reach finalizeTx signed. Both the signer's array and the server's are
+    // therefore checked against it rather than against each other — two equally
+    // truncated arrays agree with each other while still dropping a checkpoint.
+    // A miscounting signer is caught before submitTx, so it fails outright
+    // instead of stranding a registered-but-unfinalizable tx on the server.
+    if (userSignedCheckpoints && userSignedCheckpoints.length !== offchainTx.checkpoints.length) {
+        throw new Error(
+            `signer returned ${userSignedCheckpoints.length} signed checkpoints, expected ${offchainTx.checkpoints.length}`,
+        );
+    }
+
     // Mark pending before submitting — if the caller crashes between submit and
     // finalize, its recovery hook can retry from persisted state.
     await hooks?.beforeSubmit?.();
@@ -456,17 +468,18 @@ export async function submitOffchainTx(
         offchainTx.checkpoints.map((c) => base64.encode(c.toPSBT())),
     );
 
+    // The server returns one signed checkpoint per submitted checkpoint; both
+    // branches below pair them positionally. A short response would silently
+    // drop the tail (→ incomplete finalizeTx), a long one would carry
+    // checkpoints that were never built.
+    if (signedCheckpointTxs.length !== offchainTx.checkpoints.length) {
+        throw new Error(
+            `submitTx returned ${signedCheckpointTxs.length} checkpoints, expected ${offchainTx.checkpoints.length}`,
+        );
+    }
+
     let finalCheckpoints: string[];
     if (userSignedCheckpoints) {
-        // The server must return exactly one checkpoint per user-signed
-        // checkpoint: the merge pairs them by index, so a short response would
-        // silently drop the tail (→ incomplete finalizeTx) and a long one would
-        // throw a cryptic undefined access. Guard explicitly.
-        if (signedCheckpointTxs.length !== userSignedCheckpoints.length) {
-            throw new Error(
-                `submitTx returned ${signedCheckpointTxs.length} checkpoints, expected ${userSignedCheckpoints.length}`,
-            );
-        }
         finalCheckpoints = signedCheckpointTxs.map((c, i) => {
             const serverSigned = Transaction.fromPSBT(base64.decode(c));
             combineTapscriptSigs(userSignedCheckpoints[i], serverSigned);

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -53,9 +53,10 @@ import { CSVMultisigTapscript, RelativeTimelock } from "../script/tapscript";
 import { toXOnlySignerHex } from "./signerRotation";
 import {
     buildOffchainTx,
-    combineTapscriptSigs,
     hasBoardingTxExpired,
     isValidArkAddress,
+    submitOffchainTx,
+    type OffchainTxSigner,
 } from "../utils/arkTransaction";
 import {
     byValueDescending,
@@ -4381,98 +4382,70 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             index,
             lookupScript: VtxoScript.decode(input.tapTree).pkScript,
         }));
-        const checkpointJobs = offchainTx.checkpoints.map((c) =>
-            this.inputSigningJobsFromWitnessUtxos(c),
-        );
-
-        // Batch path: when every signable input across arkTx + checkpoints
-        // resolves to the baseline identity key, a `BatchSignableIdentity`
-        // can sign all N+1 PSBTs in a single wallet popup. Stash the
-        // user-signed checkpoints, submit the unsigned ones to the server
-        // for its share, then merge server + user tapscript sigs.
-        let signedVirtualTx: Transaction;
-        let userSignedCheckpoints: Transaction[] | undefined;
+        // Wallet signer: routes each input to its owning contract's key and,
+        // when eligible, batch-signs the arkTx + all checkpoints in one popup.
+        // The shared `submitOffchainTx` owns the submit → finalize sequence.
         const identity = this.identity;
-        const batchEligible =
-            isBatchSignable(identity) &&
-            (await this._signerRouter.canBatch(arkTxJobs, ...checkpointJobs));
-
-        if (batchEligible) {
-            // Clone so a misbehaving provider can't mutate the originals
-            // before submitTx. The contract on `signMultiple` is "one
-            // result per request, in input order" — validated below.
-            const requests = [
-                {
-                    tx: offchainTx.arkTx.clone(),
-                    inputIndexes: arkTxJobs.map((j) => j.index),
-                },
-                ...offchainTx.checkpoints.map((c, i) => ({
-                    tx: c.clone(),
-                    inputIndexes: checkpointJobs[i].map((j) => j.index),
-                })),
-            ];
-            const signed = await identity.signMultiple(requests);
-            if (signed.length !== requests.length) {
-                throw new Error(
-                    `signMultiple returned ${signed.length} transactions, expected ${requests.length}`,
+        const signer: OffchainTxSigner = {
+            signArkTx: async (arkTx, checkpoints) => {
+                const checkpointJobs = checkpoints.map((c) =>
+                    this.inputSigningJobsFromWitnessUtxos(c),
                 );
-            }
-            const [firstSignedTx, ...signedCheckpoints] = signed;
-            signedVirtualTx = firstSignedTx;
-            userSignedCheckpoints = signedCheckpoints;
-        } else {
-            signedVirtualTx = await this._signerRouter.sign(offchainTx.arkTx, arkTxJobs);
-        }
 
-        // Mark pending before submitting — if we crash between submit and
-        // finalize, the next init will recover via finalizePendingTxs.
-        await this.setPendingTxFlag(true);
+                // Batch path: when every signable input across arkTx +
+                // checkpoints resolves to the baseline identity key, a
+                // `BatchSignableIdentity` can sign all N+1 PSBTs in a single
+                // wallet popup. Return the user-signed checkpoints so
+                // `submitOffchainTx` merges them onto the server's shares.
+                const batchEligible =
+                    isBatchSignable(identity) &&
+                    (await this._signerRouter.canBatch(arkTxJobs, ...checkpointJobs));
 
-        const { arkTxid, signedCheckpointTxs } = await this.arkProvider.submitTx(
-            base64.encode(signedVirtualTx.toPSBT()),
-            offchainTx.checkpoints.map((c) => base64.encode(c.toPSBT())),
-        );
+                if (batchEligible) {
+                    // Clone so a misbehaving provider can't mutate the originals
+                    // before submitTx. The contract on `signMultiple` is "one
+                    // result per request, in input order" — validated below.
+                    const requests = [
+                        {
+                            tx: arkTx.clone(),
+                            inputIndexes: arkTxJobs.map((j) => j.index),
+                        },
+                        ...checkpoints.map((c, i) => ({
+                            tx: c.clone(),
+                            inputIndexes: checkpointJobs[i].map((j) => j.index),
+                        })),
+                    ];
+                    const signed = await identity.signMultiple(requests);
+                    if (signed.length !== requests.length) {
+                        throw new Error(
+                            `signMultiple returned ${signed.length} transactions, expected ${requests.length}`,
+                        );
+                    }
+                    const [firstSignedTx, ...signedCheckpoints] = signed;
+                    return { arkTx: firstSignedTx, userSignedCheckpoints: signedCheckpoints };
+                }
 
-        let finalCheckpoints: string[];
-        if (userSignedCheckpoints) {
-            // The server must return exactly one checkpoint per user-signed
-            // checkpoint: the merge below pairs them by index, so a short
-            // response would silently drop the tail (→ incomplete finalizeTx)
-            // and a long one would throw a cryptic undefined access. Guard
-            // explicitly, mirroring the signMultiple length check above.
-            if (signedCheckpointTxs.length !== userSignedCheckpoints.length) {
-                throw new Error(
-                    `submitTx returned ${signedCheckpointTxs.length} checkpoints, expected ${userSignedCheckpoints.length}`,
-                );
-            }
-            // Merge stashed user sigs onto the server-signed checkpoints.
-            finalCheckpoints = signedCheckpointTxs.map((c, i) => {
-                const serverSigned = Transaction.fromPSBT(base64.decode(c));
-                combineTapscriptSigs(userSignedCheckpoints![i], serverSigned);
-                return base64.encode(serverSigned.toPSBT());
-            });
-        } else {
-            finalCheckpoints = await Promise.all(
-                signedCheckpointTxs.map(async (c) => {
-                    const tx = Transaction.fromPSBT(base64.decode(c));
-                    const signedCheckpoint = await this._signerRouter.sign(
-                        tx,
-                        this.inputSigningJobsFromWitnessUtxos(tx),
-                    );
-                    return base64.encode(signedCheckpoint.toPSBT());
-                }),
-            );
-        }
+                return { arkTx: await this._signerRouter.sign(arkTx, arkTxJobs) };
+            },
+            signCheckpoint: (checkpoint) =>
+                this._signerRouter.sign(
+                    checkpoint,
+                    this.inputSigningJobsFromWitnessUtxos(checkpoint),
+                ),
+        };
 
-        await this.arkProvider.finalizeTx(arkTxid, finalCheckpoints);
-
-        try {
-            await this.setPendingTxFlag(false);
-        } catch (error) {
-            console.error("Failed to clear pending tx flag:", error);
-        }
-
-        return { arkTxid, signedCheckpointTxs };
+        return submitOffchainTx(this.arkProvider, offchainTx, signer, {
+            // Mark pending before submitting — if we crash between submit and
+            // finalize, the next init recovers via finalizePendingTxs.
+            beforeSubmit: () => this.setPendingTxFlag(true),
+            afterFinalize: async () => {
+                try {
+                    await this.setPendingTxFlag(false);
+                } catch (error) {
+                    console.error("Failed to clear pending tx flag:", error);
+                }
+            },
+        });
     }
 
     // mark virtual outputs as spent, save change outputs if any.

--- a/packages/ts-sdk/test/arkTransactionSubmit.test.ts
+++ b/packages/ts-sdk/test/arkTransactionSubmit.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { base64 } from "@scure/base";
+import { Transaction } from "@scure/btc-signer";
+import {
+    submitOffchainTx,
+    type OffchainTx,
+    type OffchainTxSigner,
+    type OffchainTxSubmitProvider,
+} from "../src/utils/arkTransaction";
+
+// The checkpoint contents are irrelevant here: these tests pin the count
+// invariants around submit/finalize, which are enforced before any signature is
+// inspected. Empty PSBTs keep the fixtures honest about that.
+function offchainTx(checkpointCount: number): OffchainTx {
+    return {
+        arkTx: new Transaction({ allowUnknown: true, allowUnknownOutputs: true }),
+        checkpoints: Array.from(
+            { length: checkpointCount },
+            () => new Transaction({ allowUnknown: true, allowUnknownOutputs: true }),
+        ),
+    };
+}
+
+function encoded(count: number): string[] {
+    return Array.from({ length: count }, () =>
+        base64.encode(new Transaction({ allowUnknown: true }).toPSBT()),
+    );
+}
+
+// Signs nothing; `userSignedCheckpoints` selects the batch (merge) branch vs the
+// sign-after branch, which is all these tests need to steer.
+function signer(userSignedCheckpointCount?: number): OffchainTxSigner {
+    return {
+        signArkTx: async (arkTx) => ({
+            arkTx,
+            userSignedCheckpoints:
+                userSignedCheckpointCount === undefined
+                    ? undefined
+                    : Array.from(
+                          { length: userSignedCheckpointCount },
+                          () => new Transaction({ allowUnknown: true }),
+                      ),
+        }),
+        signCheckpoint: async (checkpoint) => checkpoint,
+    };
+}
+
+function provider(signedCheckpointCount: number): OffchainTxSubmitProvider & {
+    submitTx: ReturnType<typeof vi.fn>;
+    finalizeTx: ReturnType<typeof vi.fn>;
+} {
+    return {
+        submitTx: vi.fn(async () => ({
+            arkTxid: "txid",
+            signedCheckpointTxs: encoded(signedCheckpointCount),
+        })),
+        finalizeTx: vi.fn(async () => {}),
+    };
+}
+
+describe("submitOffchainTx checkpoint count guards", () => {
+    it("rejects a truncated submitTx response on the sign-after path", async () => {
+        const p = provider(1);
+
+        await expect(submitOffchainTx(p, offchainTx(2), signer())).rejects.toThrow(
+            /submitTx returned 1 checkpoints, expected 2/,
+        );
+        expect(p.finalizeTx).not.toHaveBeenCalled();
+    });
+
+    it("rejects an overlong submitTx response on the sign-after path", async () => {
+        const p = provider(3);
+
+        await expect(submitOffchainTx(p, offchainTx(2), signer())).rejects.toThrow(
+            /submitTx returned 3 checkpoints, expected 2/,
+        );
+        expect(p.finalizeTx).not.toHaveBeenCalled();
+    });
+
+    // The pre-existing guard compared the two arrays to each other, so a signer
+    // and a server that were truncated by the same amount agreed with each other
+    // while still dropping a checkpoint. Both are checked against the built set.
+    it("rejects equally truncated signer and server arrays", async () => {
+        const p = provider(1);
+
+        await expect(submitOffchainTx(p, offchainTx(2), signer(1))).rejects.toThrow(
+            /signer returned 1 signed checkpoints, expected 2/,
+        );
+    });
+
+    it("rejects a miscounting signer before submitting", async () => {
+        const p = provider(2);
+
+        await expect(submitOffchainTx(p, offchainTx(2), signer(1))).rejects.toThrow(
+            /signer returned 1 signed checkpoints, expected 2/,
+        );
+        // Failing before submitTx is the point: a tx registered server-side but
+        // never finalized would be left pending with no local recovery path.
+        expect(p.submitTx).not.toHaveBeenCalled();
+        expect(p.finalizeTx).not.toHaveBeenCalled();
+    });
+
+    it("finalizes every checkpoint when the counts line up", async () => {
+        const p = provider(2);
+
+        const { arkTxid } = await submitOffchainTx(p, offchainTx(2), signer());
+
+        expect(arkTxid).toBe("txid");
+        expect(p.finalizeTx).toHaveBeenCalledTimes(1);
+        expect(p.finalizeTx.mock.calls[0][1]).toHaveLength(2);
+    });
+});


### PR DESCRIPTION
`Wallet.buildAndSubmitOffchainTx` owned the submit → checkpoint-sign → finalize sequence inline. Any other spend path wanting that sequence therefore had to either duplicate the protocol logic or spin up a whole background-managed `Wallet` just to reach it.

This moves the sequence into a shared `submitOffchainTx` in `utils/arkTransaction.ts` (next to the already-pure `buildOffchainTx`), with the signing strategy injected via an `OffchainTxSigner` interface. The wallet's router + batch-popup logic becomes one implementation of that interface, so there is one implementation of the protocol sequence and two callers rather than two copies.

Details:

- **`submitOffchainTx`** — owns submit → checkpoint-sign → finalize, including the checkpoint-count guard and the batch-merge vs. sign-after branches. The wallet's pending-tx recovery flag rides along as optional `beforeSubmit`/`afterFinalize` hooks, which a stateless caller simply omits.
- **`signAndSubmitOffchainTx`** — the thin single-key path: `buildOffchainTx` + a signer that signs every input with one identity (no router, no batch popup) + `submitOffchainTx`. **No caller in this PR** — it lands here so the dependent PR touches no `arkTransaction.ts`.
- **Provider dependency** is a minimal structural `OffchainTxSubmitProvider` (just `submitTx` / `finalizeTx`), keeping the module free of a provider import and the dependency cycle that would create.
- **`Wallet.buildAndSubmitOffchainTx`** rewired to delegate. Same batch-eligibility check, same `signMultiple`/count guards, same pending-flag timing — behaviour preserving.

## Why

Groundwork for #337 (ArkCash bearer instruments). That PR's `claimCash` sweep currently builds a **full** `Wallet` with a foreign identity on the main wallet's **shared** repositories, and never disposes it — leaking a second live wallet with its own `VtxoManager`, SSE subscription, and renewal loop racing the real one over the same repo. A bearer sweep is a pure protocol operation, so it needs a *signer*, not a wallet; `signAndSubmitOffchainTx` is what lets #337 drop `Wallet.create` from that path without copy-pasting the submit sequence.

It ships separately because a regression in this sequence hits **every** offchain send/settle, not just ArkCash — so it deserves isolated review and its own e2e run, rather than riding in on a feature PR.

## Testing

- `typecheck` — clean
- `test:unit` — 1808 passed / 1 skipped
- `prettier --check` — clean

> [!IMPORTANT]
> The offchain send path is covered by the regtest e2e suite (Docker), **not** by unit tests — the extraction is faithful but untested here. The wallet send/settle e2e suite should be green before this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public utilities to sign, submit, and finalize offchain transactions, including support for custom submission providers, signing strategies, and lifecycle hooks.
  * Added a streamlined helper to sign-and-submit with a single identity.
* **Improvements**
  * Refined the wallet’s offchain spend submission flow, including batch-sign behavior and checkpoint signature merging.
* **Bug Fixes**
  * Added stricter validation around expected checkpoint counts during submission.
* **Tests**
  * Added coverage for checkpoint count guardrails and finalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->