### PR TITLE
feat: ArkCash bearer instruments

### DIFF
--- a/packages/ts-sdk/examples/node/arkcash.ts
+++ b/packages/ts-sdk/examples/node/arkcash.ts
@@ -1,0 +1,128 @@
+/**
+ * This example shows how Alice can send money to Bob using ArkCash.
+ *
+ * ArkCash is a bearer instrument: Alice creates a cash string and sends that
+ * string to Bob. Bob does not need to share an address with Alice.
+ *
+ * To run it:
+ * ```
+ * $ npx tsx examples/node/arkcash.ts
+ * ```
+ *
+ * Requires the local regtest stack to be running.
+ */
+
+import { execFileSync } from "child_process";
+import { EventSource } from "eventsource";
+
+// EventSource is used internally by the SDK for settlement events (SSE).
+// It is not available in Node.js by default, so we need to polyfill it.
+(globalThis as any).EventSource = EventSource;
+
+const { InMemoryContractRepository, InMemoryWalletRepository, Ramps, SingleKey, Wallet } =
+    await import("../../src");
+
+type WalletInstance = Awaited<ReturnType<typeof Wallet.create>>;
+
+const ARK_SERVER_URL = "http://localhost:7070";
+const ESPLORA_URL = "http://localhost:3000/api";
+const CASH_AMOUNT_SATS = 5000;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+    description: string,
+    predicate: () => Promise<boolean>,
+    timeoutMs = 60_000,
+    intervalMs = 2_000,
+): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (!(await predicate())) {
+        if (Date.now() > deadline) {
+            throw new Error(`Timed out waiting for ${description}`);
+        }
+
+        await sleep(intervalMs);
+    }
+}
+
+async function createWallet(name: string): Promise<WalletInstance> {
+    const wallet = await Wallet.create({
+        identity: SingleKey.fromRandomBytes(),
+        arkServerUrl: ARK_SERVER_URL,
+        esploraUrl: ESPLORA_URL,
+        storage: {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        },
+    });
+
+    console.log(`[${name}]\tWallet created successfully!`);
+    console.log(`[${name}]\tArk Address:`, wallet.arkAddress.encode());
+
+    return wallet;
+}
+
+async function printBalance(name: string, wallet: WalletInstance): Promise<void> {
+    console.log(`[${name}]\tBalance:`, await wallet.getBalance());
+}
+
+async function main() {
+    console.log("Starting ArkCash NodeJS Example...");
+
+    const aliceWallet = await createWallet("Alice");
+    const bobWallet = await createWallet("Bob");
+
+    const boardingAddress = await aliceWallet.getBoardingAddress();
+    console.log("[Alice]\tBoarding Address:", boardingAddress);
+
+    console.log("[Alice]\tFunding boarding address via regtest faucet...");
+    execFileSync("node", ["regtest/regtest.mjs", "faucet", boardingAddress, "0.001", "--confirm"], {
+        stdio: "inherit",
+    });
+
+    console.log("[Alice]\tWaiting for boarding UTXOs...");
+    await waitFor(
+        "Alice's boarding UTXOs",
+        async () => (await aliceWallet.getBoardingUtxos()).length > 0,
+    );
+
+    console.log("[Alice]\tOnboarding into Ark...");
+    const info = await aliceWallet.arkProvider.getInfo();
+    const ramps = new Ramps(aliceWallet);
+    const settlementTxid = await ramps.onboard(info.fees);
+    console.log("[Alice]\tSettlement txid:", settlementTxid);
+
+    console.log("[Alice]\tWaiting for spendable VTXOs...");
+    await waitFor("Alice's spendable VTXOs", async () => (await aliceWallet.getVtxos()).length > 0);
+
+    await printBalance("Alice", aliceWallet);
+    await printBalance("Bob", bobWallet);
+
+    console.log(`[Alice]\tCreating ${CASH_AMOUNT_SATS} sats of ArkCash for Bob...`);
+    const cash = await aliceWallet.createCash(CASH_AMOUNT_SATS);
+    console.log("[Alice]\tArkCash string sent to Bob:", cash);
+
+    console.log("[Bob]\tClaiming ArkCash...");
+    const claim = await bobWallet.claimCash(cash);
+    console.log("[Bob]\tSwept:", claim.swept, "sats");
+    if (claim.unclaimed.vtxos.length > 0) {
+        console.log("[Bob]\tUnclaimed:", claim.unclaimed.amount, "sats", claim.unclaimed.vtxos);
+    }
+
+    await waitFor("Bob's claimed balance", async () => {
+        const balance = await bobWallet.getBalance();
+        return balance.total > 0;
+    });
+
+    await printBalance("Alice", aliceWallet);
+    await printBalance("Bob", bobWallet);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/packages/ts-sdk/src/arkcash/index.ts
+++ b/packages/ts-sdk/src/arkcash/index.ts
@@ -19,11 +19,16 @@ export class ArkCash {
     static readonly Version = 0;
     static readonly PayloadLength = 1 + 32 + 32 + 4; // 69 bytes
 
-    readonly publicKey: Uint8Array;
+    // Keys are held as private copies so a caller mutating the array it passed
+    // in — or one it reads back from a getter — cannot alter this note's
+    // identity or the outputs derived from it.
+    private readonly _privateKey: Uint8Array;
+    private readonly _serverPubKey: Uint8Array;
+    private readonly _publicKey: Uint8Array;
 
     constructor(
-        readonly privateKey: Uint8Array,
-        readonly serverPubKey: Uint8Array,
+        privateKey: Uint8Array,
+        serverPubKey: Uint8Array,
         readonly csvTimelock: RelativeTimelock,
         readonly hrp: string = ArkCash.DefaultHRP,
     ) {
@@ -37,7 +42,24 @@ export class ArkCash {
                 `Invalid server public key length: expected 32 bytes, got ${serverPubKey.length}`,
             );
         }
-        this.publicKey = pubSchnorr(privateKey);
+        this._privateKey = privateKey.slice();
+        this._serverPubKey = serverPubKey.slice();
+        this._publicKey = pubSchnorr(this._privateKey);
+    }
+
+    /** The note's private key. Returns a fresh copy; mutating it is a no-op. */
+    get privateKey(): Uint8Array {
+        return this._privateKey.slice();
+    }
+
+    /** The server's public key. Returns a fresh copy; mutating it is a no-op. */
+    get serverPubKey(): Uint8Array {
+        return this._serverPubKey.slice();
+    }
+
+    /** The note's public key. Returns a fresh copy; mutating it is a no-op. */
+    get publicKey(): Uint8Array {
+        return this._publicKey.slice();
     }
 
     static generate(
@@ -77,8 +99,8 @@ export class ArkCash {
     toString(): string {
         const data = new Uint8Array(ArkCash.PayloadLength);
         data[0] = ArkCash.Version;
-        data.set(this.privateKey, 1);
-        data.set(this.serverPubKey, 33);
+        data.set(this._privateKey, 1);
+        data.set(this._serverPubKey, 33);
         const sequence = timelockToSequence(this.csvTimelock);
         new DataView(data.buffer, data.byteOffset + 65, 4).setUint32(0, sequence, false);
         const words = bech32m.toWords(data);
@@ -86,18 +108,18 @@ export class ArkCash {
     }
 
     get identity(): SingleKey {
-        return SingleKey.fromPrivateKey(this.privateKey);
+        return SingleKey.fromPrivateKey(this._privateKey);
     }
 
     get vtxoScript(): DefaultVtxo.Script {
         return new DefaultVtxo.Script({
-            pubKey: this.publicKey,
-            serverPubKey: this.serverPubKey,
+            pubKey: this._publicKey,
+            serverPubKey: this._serverPubKey,
             csvTimelock: this.csvTimelock,
         });
     }
 
     address(addressHrp: string): ArkAddress {
-        return this.vtxoScript.address(addressHrp, this.serverPubKey);
+        return this.vtxoScript.address(addressHrp, this._serverPubKey);
     }
 }

--- a/packages/ts-sdk/src/arkcash/index.ts
+++ b/packages/ts-sdk/src/arkcash/index.ts
@@ -1,0 +1,103 @@
+import { bech32m } from "@scure/base";
+import { pubSchnorr, randomPrivateKeyBytes } from "@scure/btc-signer/utils.js";
+import { SingleKey } from "../identity/singleKey";
+import { DefaultVtxo } from "../script/default";
+import { ArkAddress } from "../script/address";
+import { RelativeTimelock } from "../script/tapscript";
+import { sequenceToTimelock, timelockToSequence } from "../utils/timelock";
+
+/**
+ * ArkCash is a bearer instrument for the Ark protocol.
+ * It encodes a private key and contract parameters as a bech32m string,
+ * enabling wallet-to-wallet transfers without address exchange.
+ *
+ * Format: arkcash1... (bech32m encoded)
+ * Payload: version (1 byte) + private key (32 bytes) + server pubkey (32 bytes) + csv timelock sequence (4 bytes)
+ */
+export class ArkCash {
+    static readonly DefaultHRP = "arkcash";
+    static readonly Version = 0;
+    static readonly PayloadLength = 1 + 32 + 32 + 4; // 69 bytes
+
+    readonly publicKey: Uint8Array;
+
+    constructor(
+        readonly privateKey: Uint8Array,
+        readonly serverPubKey: Uint8Array,
+        readonly csvTimelock: RelativeTimelock,
+        readonly hrp: string = ArkCash.DefaultHRP,
+    ) {
+        if (privateKey.length !== 32) {
+            throw new Error(
+                `Invalid private key length: expected 32 bytes, got ${privateKey.length}`,
+            );
+        }
+        if (serverPubKey.length !== 32) {
+            throw new Error(
+                `Invalid server public key length: expected 32 bytes, got ${serverPubKey.length}`,
+            );
+        }
+        this.publicKey = pubSchnorr(privateKey);
+    }
+
+    static generate(
+        serverPubKey: Uint8Array,
+        csvTimelock: RelativeTimelock,
+        hrp?: string,
+    ): ArkCash {
+        return new ArkCash(randomPrivateKeyBytes(), serverPubKey, csvTimelock, hrp);
+    }
+
+    static fromString(encoded: string): ArkCash {
+        const decoded = bech32m.decodeUnsafe(encoded.trim().toLowerCase(), 1023);
+        if (!decoded) {
+            throw new Error("Invalid arkcash string: failed to decode bech32m");
+        }
+
+        const data = new Uint8Array(bech32m.fromWords(decoded.words));
+        if (data.length !== ArkCash.PayloadLength) {
+            throw new Error(
+                `Invalid arkcash data length: expected ${ArkCash.PayloadLength} bytes, got ${data.length}`,
+            );
+        }
+
+        const version = data[0];
+        if (version !== ArkCash.Version) {
+            throw new Error(`Unsupported arkcash version: ${version}`);
+        }
+
+        const privateKey = data.slice(1, 33);
+        const serverPubKey = data.slice(33, 65);
+        const sequence = new DataView(data.buffer, data.byteOffset + 65, 4).getUint32(0, false);
+        const csvTimelock = sequenceToTimelock(sequence);
+
+        return new ArkCash(privateKey, serverPubKey, csvTimelock, decoded.prefix);
+    }
+
+    toString(): string {
+        const data = new Uint8Array(ArkCash.PayloadLength);
+        data[0] = ArkCash.Version;
+        data.set(this.privateKey, 1);
+        data.set(this.serverPubKey, 33);
+        const sequence = timelockToSequence(this.csvTimelock);
+        new DataView(data.buffer, data.byteOffset + 65, 4).setUint32(0, sequence, false);
+        const words = bech32m.toWords(data);
+        return bech32m.encode(this.hrp, words, 1023);
+    }
+
+    get identity(): SingleKey {
+        return SingleKey.fromPrivateKey(this.privateKey);
+    }
+
+    get vtxoScript(): DefaultVtxo.Script {
+        return new DefaultVtxo.Script({
+            pubKey: this.publicKey,
+            serverPubKey: this.serverPubKey,
+            csvTimelock: this.csvTimelock,
+        });
+    }
+
+    address(addressHrp: string): ArkAddress {
+        return this.vtxoScript.address(addressHrp, this.serverPubKey);
+    }
+}

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -91,6 +91,7 @@ import {
     type ArkCashClaimResult,
     type ArkCashUnclaimedReason,
     type ArkCashUnclaimedVtxo,
+    ArkCashCreateError,
     DescriptorSigningProviderMissingError,
     MissingSigningDescriptorError,
 } from "./wallet/wallet";
@@ -485,6 +486,7 @@ export {
 
     // Arkcash
     ArkCash,
+    ArkCashCreateError,
 
     // Network
     getNetwork,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -88,6 +88,9 @@ import {
     waitForIncomingFunds,
     IncomingFunds,
     BoardingUtxoGroup,
+    type ArkCashClaimResult,
+    type ArkCashUnclaimedReason,
+    type ArkCashUnclaimedVtxo,
     DescriptorSigningProviderMissingError,
     MissingSigningDescriptorError,
 } from "./wallet/wallet";
@@ -205,6 +208,7 @@ import {
 import { Intent } from "./intent";
 import { BIP322 } from "./bip322";
 import { ArkNote } from "./arknote";
+import { ArkCash } from "./arkcash";
 import { getNetwork, networks, Network, NetworkName } from "./networks";
 import {
     RestIndexerProvider,
@@ -479,6 +483,9 @@ export {
     // Arknote
     ArkNote,
 
+    // Arkcash
+    ArkCash,
+
     // Network
     getNetwork,
     networks,
@@ -664,6 +671,9 @@ export type {
     // Wallet types
     GetVtxosFilter,
     BoardingUtxoGroup,
+    ArkCashClaimResult,
+    ArkCashUnclaimedReason,
+    ArkCashUnclaimedVtxo,
     SettlementConfig,
     IVtxoManager,
     RenewVtxosOptions,

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -171,6 +171,12 @@ async function runWithCrossInstanceLock(name: string, fn: () => Promise<void>): 
 export const MAX_VTXOS_PER_SETTLEMENT = 50;
 
 /**
+ * Maximum number of inputs the server accepts in a single intent proof
+ * (get-pending-tx and friends). Larger input sets must be split into batches.
+ */
+export const MAX_INPUTS_PER_INTENT = 20;
+
+/**
  * Order VTXOs so the highest-value ones come first. New array; input untouched.
  *
  * Used by the value-driven paths (recovery, manual full settle): when the

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -4116,7 +4116,9 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             throw new Error("No VTXOs found for this arkcash");
         }
 
+        const myPkScript = ArkAddress.decode(await this.getAddress()).pkScript;
         let { spendable, unclaimed } = this.classifyCashVtxos(vtxos, cashSubdustPkScript);
+        let swept = 0;
 
         // Drain first: a previous claim may have registered a sweep it never
         // finalized. That pending tx is keyed to the arkcash key, so this
@@ -4132,31 +4134,44 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         // server reject the whole proof.
         const drainable = vtxos.filter((vtxo) => vtxo.script === cashPkScript);
         if (drainable.length > 0) {
-            let finalized = 0;
+            let drained = { count: 0, swept: 0, claimed: new Set<string>() };
             try {
-                finalized = await this.finalizePendingCashTxs(cash, drainable, cashScript);
+                drained = await this.finalizePendingCashTxs(
+                    cash,
+                    drainable,
+                    cashScript,
+                    myPkScript,
+                );
             } catch (error) {
                 // A drain that cannot run must not sink a claim that can still
                 // sweep: any VTXO still held by a pending tx simply fails its
                 // own sweep below and is reported.
                 console.error("Failed to drain pending arkcash txs:", error);
             }
-            if (finalized > 0) {
+            if (drained.count > 0) {
                 // A completed sweep spends its input, so the snapshot above is
                 // now stale: re-read it, or we would re-sweep an outpoint we
                 // just spent and report the rejection as a failure.
                 vtxos = await this.fetchAllVtxos(scripts);
                 ({ spendable, unclaimed } = this.classifyCashVtxos(vtxos, cashSubdustPkScript));
+
+                // The drain moved these to this wallet, so they are swept by
+                // this call — the re-read above sees them spent and would
+                // otherwise report the funds as left behind while they were in
+                // fact just claimed. Outpoints a drained tx paid to someone
+                // else stay reported: for this claimer they really are gone.
+                swept += drained.swept;
+                unclaimed = unclaimed.filter(
+                    (vtxo) => !drained.claimed.has(`${vtxo.txid}:${vtxo.vout}`),
+                );
             }
         }
 
-        let swept = 0;
         if (spendable.length > 0) {
             const info = await this.arkProvider.getInfo();
             const serverUnrollScript = CSVMultisigTapscript.decode(
                 hex.decode(info.checkpointTapscript),
             );
-            const myPkScript = ArkAddress.decode(await this.getAddress()).pkScript;
 
             // One tx per VTXO: a stale or rejected input then dents only its own
             // sweep instead of blocking the whole claim, and each output is one
@@ -4260,24 +4275,34 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      * A thin variant of {@link finalizePendingTxs}, scoped to the arkcash key:
      * the intent is signed with it, and so are the returned checkpoints.
      *
+     * A drained sweep is not automatically *ours*. Whoever registered it chose
+     * the destination, so a tx a different claimer left half-finished pays that
+     * claimer — finalizing it is still right (the input is spent either way, and
+     * completing it unsticks the funds), but only the value it actually pays to
+     * `myPkScript` may be counted as claimed here.
+     *
      * @param vtxos - VTXOs at the arkcash contract's own pkScript, spent ones
      * included (a registered sweep marks its input spent). Any other outpoint —
      * subdust above all — would make the proof invalid, since it describes every
      * input by that pkScript.
-     * @returns How many pending transactions were finalized.
+     * @returns The number of pending txs finalized, the sats among them paid to
+     * this wallet, and the outpoints those txs consumed to pay it.
      */
     private async finalizePendingCashTxs(
         cash: ArkCash,
         vtxos: VirtualCoin[],
         cashScript: DefaultVtxo.Script,
-    ): Promise<number> {
+        myPkScript: Bytes,
+    ): Promise<{ count: number; swept: number; claimed: Set<string> }> {
+        const result = { count: 0, swept: 0, claimed: new Set<string>() };
+
         const inputs = vtxos.map((vtxo) => ({
             ...vtxo,
             forfeitTapLeafScript: cashScript.forfeit(),
             intentTapLeafScript: cashScript.forfeit(),
             tapTree: cashScript.encode(),
         }));
-        if (inputs.length === 0) return 0;
+        if (inputs.length === 0) return result;
 
         const identity = cash.identity;
         const message: Intent.GetPendingTxMessage = { type: "get-pending-tx", expire_at: 0 };
@@ -4296,27 +4321,55 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             message,
         });
 
-        let finalized = 0;
+        const myPkScriptHex = hex.encode(myPkScript);
+
         for (const pendingTx of pendingTxs) {
             try {
                 // These checkpoints already carry the server's signature; the
                 // arkcash key adds its own share in place.
+                const checkpointTxs = pendingTx.signedCheckpointTxs.map((checkpoint) =>
+                    Transaction.fromPSBT(base64.decode(checkpoint)),
+                );
                 const finalCheckpoints = await Promise.all(
-                    pendingTx.signedCheckpointTxs.map(async (checkpoint) => {
-                        const signed = await identity.sign(
-                            Transaction.fromPSBT(base64.decode(checkpoint)),
-                        );
-                        return base64.encode(signed.toPSBT());
-                    }),
+                    checkpointTxs.map(async (checkpoint) =>
+                        base64.encode((await identity.sign(checkpoint)).toPSBT()),
+                    ),
                 );
                 await this.arkProvider.finalizeTx(pendingTx.arkTxid, finalCheckpoints);
-                finalized++;
+                result.count++;
+
+                const paidToMe = this.arkTxAmountPaidTo(pendingTx.finalArkTx, myPkScriptHex);
+                if (paidToMe === 0) continue;
+
+                // The ark tx spends the checkpoints, not the arkcash VTXOs —
+                // the VTXOs are the checkpoints' own inputs, so that is where
+                // the outpoints this claim just consumed are read from.
+                result.swept += paidToMe;
+                for (const checkpoint of checkpointTxs) {
+                    for (let i = 0; i < checkpoint.inputsLength; i++) {
+                        const input = checkpoint.getInput(i);
+                        if (!input.txid) continue;
+                        result.claimed.add(`${hex.encode(input.txid)}:${input.index}`);
+                    }
+                }
             } catch (error) {
                 console.error(`Failed to finalize pending arkcash tx ${pendingTx.arkTxid}:`, error);
             }
         }
 
-        return finalized;
+        return result;
+    }
+
+    /** Sum the outputs of an ark tx PSBT that pay the given scriptPubKey. */
+    private arkTxAmountPaidTo(arkTxPsbt: string, pkScriptHex: string): number {
+        const arkTx = Transaction.fromPSBT(base64.decode(arkTxPsbt));
+        let total = 0;
+        for (let i = 0; i < arkTx.outputsLength; i++) {
+            const output = arkTx.getOutput(i);
+            if (!output.script || output.amount === undefined) continue;
+            if (hex.encode(output.script) === pkScriptHex) total += Number(output.amount);
+        }
+        return total;
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -55,6 +55,7 @@ import {
     buildOffchainTx,
     hasBoardingTxExpired,
     isValidArkAddress,
+    signAndSubmitOffchainTx,
     submitOffchainTx,
     type OffchainTxSigner,
 } from "../utils/arkTransaction";
@@ -68,6 +69,7 @@ import {
     selectPendingRecoveryOutpoints,
 } from "./vtxo-manager";
 import { ArkNote } from "../arknote";
+import { ArkCash } from "../arkcash";
 import { Intent } from "../intent";
 import { IndexerProvider, RestIndexerProvider } from "../providers/indexer";
 import { TxTree } from "../tree/txTree";
@@ -351,6 +353,56 @@ export interface BoardingUtxoGroup {
     /** CSV exit timelock decoded from THIS tapscript's exit leaf. */
     csvTimelock: RelativeTimelock;
     coins: ExtendedCoin[];
+}
+
+/**
+ * Why a VTXO at an arkcash address could not be swept by {@link Wallet.claimCash}.
+ *
+ * - `swept` — the server swept the batch at expiry. Recoverable in principle,
+ *   but only through a settlement, which the thin sweep cannot do.
+ * - `subdust` — below dust, so it sits at an OP_RETURN script with no spendable
+ *   leaf. Unspendable as cash; `createCash` prevents minting these.
+ * - `already-spent` — someone else claimed it first.
+ * - `has-assets` — asset-bearing; the BTC-only sweep would burn the assets.
+ * - `sweep-failed` — spendable, but its own sweep was rejected.
+ */
+export type ArkCashUnclaimedReason =
+    | "swept"
+    | "subdust"
+    | "already-spent"
+    | "has-assets"
+    | "sweep-failed";
+
+const cashReport = (vtxo: VirtualCoin, reason: ArkCashUnclaimedReason): ArkCashUnclaimedVtxo => ({
+    txid: vtxo.txid,
+    vout: vtxo.vout,
+    value: vtxo.value,
+    reason,
+});
+
+/** A VTXO {@link Wallet.claimCash} left behind, with the reason why. */
+export interface ArkCashUnclaimedVtxo {
+    txid: string;
+    vout: number;
+    /** Value in satoshis. */
+    value: number;
+    reason: ArkCashUnclaimedReason;
+}
+
+/**
+ * Outcome of {@link Wallet.claimCash}: what was swept, and what was not.
+ *
+ * The shape is open — further buckets may be added alongside `unclaimed` as
+ * more of the non-sweepable states become claimable.
+ */
+export interface ArkCashClaimResult {
+    /** Satoshis swept to this wallet. */
+    swept: number;
+    unclaimed: {
+        /** Satoshis left behind. */
+        amount: number;
+        vtxos: ArkCashUnclaimedVtxo[];
+    };
 }
 
 /**
@@ -3982,6 +4034,289 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             ...state,
             settings: { ...state.settings, hasPendingTx: value },
         }));
+    }
+
+    /**
+     * Create an ArkCash bearer instrument.
+     *
+     * Generates a fresh keypair, sends the specified amount to a DefaultVtxo
+     * controlled by the new key, and returns the encoded arkcash string.
+     * The receiver can claim the funds using `claimCash()` without ever
+     * sharing their address.
+     *
+     * ArkCash is a short-lived instrument: it carries a private key, so it is
+     * meant to be handed over and claimed promptly, not held. A note left
+     * unclaimed past its batch expiry is swept by the server and `claimCash`
+     * can only report it, not move it.
+     *
+     * @param amount - Amount in satoshis to send. Must be a whole number of
+     * sats at or above the dust threshold — a below-dust amount would mint an
+     * OP_RETURN output that is unspendable as cash.
+     * @returns The encoded arkcash string (e.g., "arkcash1...")
+     */
+    async createCash(amount: number): Promise<string> {
+        // A bare `amount < dust` guard would let NaN, Infinity and fractional
+        // amounts through (all compare false), and `send` itself defaults every
+        // falsy amount to a dust send rather than rejecting it.
+        if (!Number.isSafeInteger(amount) || amount < Number(this.dustAmount)) {
+            throw new Error(
+                `Invalid ArkCash amount ${amount}: must be a whole number of sats >= dust (${this.dustAmount})`,
+            );
+        }
+
+        // Derive HRP: ark→arkcash, tark→tarkcash, nark→narkcash
+        const cashHrp = this.network.hrp.replace(/ark$/, "arkcash");
+
+        const cash = ArkCash.generate(
+            this.arkServerPublicKey,
+            this.offchainTapscript.options.csvTimelock,
+            cashHrp,
+        );
+        const address = cash.address(this.network.hrp).encode();
+
+        await this.send({ address, amount });
+
+        return cash.toString();
+    }
+
+    /**
+     * Claim an ArkCash bearer instrument: sweep what can be swept, report the
+     * rest.
+     *
+     * Every spendable VTXO at the arkcash address is swept to this wallet in
+     * its own offchain transaction, signed with the key carried by the arkcash
+     * string. Nothing is ever persisted: no contract is imported, and the
+     * arkcash key is not stored. Anything that cannot be swept — server-swept,
+     * subdust, already claimed, or asset-bearing — is returned in `unclaimed`
+     * with a per-VTXO reason and otherwise ignored.
+     *
+     * The arkcash string is the recovery token: a claim interrupted between
+     * submit and finalize is completed by simply re-running `claimCash`, which
+     * drains any pending arkcash transaction on the server before sweeping.
+     *
+     * @param cashStr - The encoded arkcash string (e.g., "arkcash1...")
+     * @returns The swept total and the report of what was left behind. The
+     * shape is open: further buckets may be added alongside `unclaimed`.
+     */
+    async claimCash(cashStr: string): Promise<ArkCashClaimResult> {
+        const cash = ArkCash.fromString(cashStr);
+        const cashScript = cash.vtxoScript;
+        const cashAddress = cash.address(this.network.hrp);
+        const cashPkScript = hex.encode(cashScript.pkScript);
+        const cashSubdustPkScript = hex.encode(cashAddress.subdustPkScript);
+
+        // One unfiltered query: the server's state filters are mutually
+        // exclusive, so any filter here would hide the very states this method
+        // reports. Both scripts are queried in the same call — subdust arkcash
+        // lives at the OP_RETURN script and would otherwise vanish silently.
+        const scripts = [cashPkScript, cashSubdustPkScript];
+        let vtxos = await this.fetchAllVtxos(scripts);
+
+        if (vtxos.length === 0) {
+            throw new Error("No VTXOs found for this arkcash");
+        }
+
+        let { spendable, unclaimed } = this.classifyCashVtxos(vtxos, cashSubdustPkScript);
+
+        // Drain first: a previous claim may have registered a sweep it never
+        // finalized. That pending tx is keyed to the arkcash key, so this
+        // wallet's own finalizePendingTxs can never reach it — but we hold the
+        // key right now, so we run the same server-side recovery scoped to it.
+        //
+        // The candidate set is neither `spendable` nor everything. Registering
+        // a sweep marks its input spent, so the very inputs needing a drain are
+        // the ones classified `already-spent` — gating on `spendable` would
+        // skip the drain exactly when it is needed. Subdust must stay out
+        // regardless: the proof describes every input by the contract's own
+        // pkScript, which is a lie for an OP_RETURN outpoint and would have the
+        // server reject the whole proof.
+        const drainable = vtxos.filter((vtxo) => vtxo.script === cashPkScript);
+        if (drainable.length > 0) {
+            let finalized = 0;
+            try {
+                finalized = await this.finalizePendingCashTxs(cash, drainable, cashScript);
+            } catch (error) {
+                // A drain that cannot run must not sink a claim that can still
+                // sweep: any VTXO still held by a pending tx simply fails its
+                // own sweep below and is reported.
+                console.error("Failed to drain pending arkcash txs:", error);
+            }
+            if (finalized > 0) {
+                // A completed sweep spends its input, so the snapshot above is
+                // now stale: re-read it, or we would re-sweep an outpoint we
+                // just spent and report the rejection as a failure.
+                vtxos = await this.fetchAllVtxos(scripts);
+                ({ spendable, unclaimed } = this.classifyCashVtxos(vtxos, cashSubdustPkScript));
+            }
+        }
+
+        let swept = 0;
+        if (spendable.length > 0) {
+            const info = await this.arkProvider.getInfo();
+            const serverUnrollScript = CSVMultisigTapscript.decode(
+                hex.decode(info.checkpointTapscript),
+            );
+            const myPkScript = ArkAddress.decode(await this.getAddress()).pkScript;
+
+            // One tx per VTXO: a stale or rejected input then dents only its own
+            // sweep instead of blocking the whole claim, and each output is one
+            // VTXO's value — already within the server's per-output ceiling, so
+            // no consolidation can breach it.
+            for (const vtxo of spendable) {
+                try {
+                    await signAndSubmitOffchainTx({
+                        identity: cash.identity,
+                        provider: this.arkProvider,
+                        inputs: [
+                            {
+                                txid: vtxo.txid,
+                                vout: vtxo.vout,
+                                value: vtxo.value,
+                                tapLeafScript: cashScript.forfeit(),
+                                tapTree: cashScript.encode(),
+                            },
+                        ],
+                        outputs: [{ script: myPkScript, amount: BigInt(vtxo.value) }],
+                        serverUnrollScript,
+                    });
+                    swept += vtxo.value;
+                } catch (error) {
+                    console.error(`Failed to sweep arkcash VTXO ${vtxo.txid}:${vtxo.vout}:`, error);
+                    unclaimed.push(cashReport(vtxo, "sweep-failed"));
+                }
+            }
+        }
+
+        return {
+            swept,
+            unclaimed: {
+                amount: unclaimed.reduce((total, vtxo) => total + vtxo.value, 0),
+                vtxos: unclaimed,
+            },
+        };
+    }
+
+    /**
+     * Split the VTXOs at an arkcash address into the ones the thin sweep can
+     * move and the ones it can only report.
+     */
+    private classifyCashVtxos(
+        vtxos: VirtualCoin[],
+        cashSubdustPkScript: string,
+    ): { spendable: VirtualCoin[]; unclaimed: ArkCashUnclaimedVtxo[] } {
+        const spendable: VirtualCoin[] = [];
+        const unclaimed: ArkCashUnclaimedVtxo[] = [];
+
+        for (const vtxo of vtxos) {
+            if (!isSpendable(vtxo)) {
+                unclaimed.push(cashReport(vtxo, "already-spent"));
+            } else if (vtxo.script === cashSubdustPkScript || isSubdust(vtxo, this.dustAmount)) {
+                // Subdust sits at an OP_RETURN script: no forfeit leaf, nothing
+                // to spend, and no settlement can lift it out on its own.
+                // Checked before the swept case, which would otherwise claim
+                // these are recoverable. createCash now prevents minting them.
+                unclaimed.push(cashReport(vtxo, "subdust"));
+            } else if (isRecoverable(vtxo)) {
+                // The server swept the batch at expiry. The funds are still
+                // owed, but only a settlement can move them — no sweep can.
+                unclaimed.push(cashReport(vtxo, "swept"));
+            } else if (vtxo.assets && vtxo.assets.length > 0) {
+                // The thin sweep builds a BTC-only output; sweeping an
+                // asset-bearing VTXO with it would burn the assets. Detected up
+                // front rather than left to a server rejection.
+                unclaimed.push(cashReport(vtxo, "has-assets"));
+            } else {
+                spendable.push(vtxo);
+            }
+        }
+
+        return { spendable, unclaimed };
+    }
+
+    /** Read every page of an unfiltered VTXO query for the given scripts. */
+    private async fetchAllVtxos(scripts: string[]): Promise<VirtualCoin[]> {
+        const pageSize = 100;
+        const all: VirtualCoin[] = [];
+        const seen = new Set<string>();
+
+        for (let pageIndex = 0; ; pageIndex++) {
+            const { vtxos, page } = await this.indexerProvider.getVtxos({
+                scripts,
+                pageIndex,
+                pageSize,
+            });
+            for (const vtxo of vtxos) {
+                const outpoint = `${vtxo.txid}:${vtxo.vout}`;
+                if (seen.has(outpoint)) continue;
+                seen.add(outpoint);
+                all.push(vtxo);
+            }
+            if (!page || vtxos.length < pageSize) return all;
+        }
+    }
+
+    /**
+     * Complete any sweep a previous `claimCash` registered but never finalized.
+     * A thin variant of {@link finalizePendingTxs}, scoped to the arkcash key:
+     * the intent is signed with it, and so are the returned checkpoints.
+     *
+     * @param vtxos - VTXOs at the arkcash contract's own pkScript, spent ones
+     * included (a registered sweep marks its input spent). Any other outpoint —
+     * subdust above all — would make the proof invalid, since it describes every
+     * input by that pkScript.
+     * @returns How many pending transactions were finalized.
+     */
+    private async finalizePendingCashTxs(
+        cash: ArkCash,
+        vtxos: VirtualCoin[],
+        cashScript: DefaultVtxo.Script,
+    ): Promise<number> {
+        const inputs = vtxos.map((vtxo) => ({
+            ...vtxo,
+            forfeitTapLeafScript: cashScript.forfeit(),
+            intentTapLeafScript: cashScript.forfeit(),
+            tapTree: cashScript.encode(),
+        }));
+        if (inputs.length === 0) return 0;
+
+        const identity = cash.identity;
+        const message: Intent.GetPendingTxMessage = { type: "get-pending-tx", expire_at: 0 };
+        const proof = Intent.create(message, inputs, []);
+        // Every proof input is an arkcash input — index 0 is the synthetic
+        // BIP-322 toSpend reference mirroring input 1's script. Signing them by
+        // explicit index surfaces a failure instead of shipping a half-signed
+        // proof for the server to reject.
+        const signedProof = await identity.sign(
+            proof,
+            Array.from({ length: inputs.length + 1 }, (_, i) => i),
+        );
+
+        const pendingTxs = await this.arkProvider.getPendingTxs({
+            proof: base64.encode(signedProof.toPSBT()),
+            message,
+        });
+
+        let finalized = 0;
+        for (const pendingTx of pendingTxs) {
+            try {
+                // These checkpoints already carry the server's signature; the
+                // arkcash key adds its own share in place.
+                const finalCheckpoints = await Promise.all(
+                    pendingTx.signedCheckpointTxs.map(async (checkpoint) => {
+                        const signed = await identity.sign(
+                            Transaction.fromPSBT(base64.decode(checkpoint)),
+                        );
+                        return base64.encode(signed.toPSBT());
+                    }),
+                );
+                await this.arkProvider.finalizeTx(pendingTx.arkTxid, finalCheckpoints);
+                finalized++;
+            } catch (error) {
+                console.error(`Failed to finalize pending arkcash tx ${pendingTx.arkTxid}:`, error);
+            }
+        }
+
+        return finalized;
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -4135,15 +4135,16 @@ export class Wallet extends ReadonlyWallet implements IWallet {
     async claimCash(cashStr: string): Promise<ArkCashClaimResult> {
         const cash = ArkCash.fromString(cashStr);
         const cashScript = cash.vtxoScript;
-        const cashAddress = cash.address(this.network.hrp);
         const cashPkScript = hex.encode(cashScript.pkScript);
-        const cashSubdustPkScript = hex.encode(cashAddress.subdustPkScript);
 
         // One unfiltered query: the server's state filters are mutually
         // exclusive, so any filter here would hide the very states this method
-        // reports. Both scripts are queried in the same call — subdust arkcash
-        // lives at the OP_RETURN script and would otherwise vanish silently.
-        const scripts = [cashPkScript, cashSubdustPkScript];
+        // reports. Only the P2TR script is queried — the indexer rejects a
+        // non-P2TR (OP_RETURN) query script outright, and it keys every vtxo,
+        // subdust included, by its taproot key, so subdust arkcash comes back
+        // under this same script. It is told apart by its below-dust value, not
+        // by its script (the indexer always reports the P2TR form).
+        const scripts = [cashPkScript];
         let vtxos = await this.fetchAllVtxos(scripts);
 
         if (vtxos.length === 0) {
@@ -4151,7 +4152,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         }
 
         const myPkScript = ArkAddress.decode(await this.getAddress()).pkScript;
-        let { spendable, unclaimed } = this.classifyCashVtxos(vtxos, cashSubdustPkScript);
+        let { spendable, unclaimed } = this.classifyCashVtxos(vtxos);
         let swept = 0;
 
         // Drain first: a previous claim may have registered a sweep it never
@@ -4163,10 +4164,11 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         // a sweep marks its input spent, so the very inputs needing a drain are
         // the ones classified `already-spent` — gating on `spendable` would
         // skip the drain exactly when it is needed. Subdust must stay out
-        // regardless: the proof describes every input by the contract's own
+        // regardless: the proof describes every input by the contract's P2TR
         // pkScript, which is a lie for an OP_RETURN outpoint and would have the
-        // server reject the whole proof.
-        const drainable = vtxos.filter((vtxo) => vtxo.script === cashPkScript);
+        // server reject the whole proof. It is excluded by value, since the
+        // indexer reports subdust under that same P2TR script.
+        const drainable = vtxos.filter((vtxo) => !isSubdust(vtxo, this.dustAmount));
         if (drainable.length > 0) {
             let drained = { count: 0, swept: 0, claimed: new Set<string>() };
             try {
@@ -4187,7 +4189,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 // now stale: re-read it, or we would re-sweep an outpoint we
                 // just spent and report the rejection as a failure.
                 vtxos = await this.fetchAllVtxos(scripts);
-                ({ spendable, unclaimed } = this.classifyCashVtxos(vtxos, cashSubdustPkScript));
+                ({ spendable, unclaimed } = this.classifyCashVtxos(vtxos));
 
                 // The drain moved these to this wallet, so they are swept by
                 // this call — the re-read above sees them spent and would
@@ -4249,21 +4251,23 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      * Split the VTXOs at an arkcash address into the ones the thin sweep can
      * move and the ones it can only report.
      */
-    private classifyCashVtxos(
-        vtxos: VirtualCoin[],
-        cashSubdustPkScript: string,
-    ): { spendable: VirtualCoin[]; unclaimed: ArkCashUnclaimedVtxo[] } {
+    private classifyCashVtxos(vtxos: VirtualCoin[]): {
+        spendable: VirtualCoin[];
+        unclaimed: ArkCashUnclaimedVtxo[];
+    } {
         const spendable: VirtualCoin[] = [];
         const unclaimed: ArkCashUnclaimedVtxo[] = [];
 
         for (const vtxo of vtxos) {
             if (!isSpendable(vtxo)) {
                 unclaimed.push(cashReport(vtxo, "already-spent"));
-            } else if (vtxo.script === cashSubdustPkScript || isSubdust(vtxo, this.dustAmount)) {
-                // Subdust sits at an OP_RETURN script: no forfeit leaf, nothing
-                // to spend, and no settlement can lift it out on its own.
-                // Checked before the swept case, which would otherwise claim
-                // these are recoverable. createCash now prevents minting them.
+            } else if (isSubdust(vtxo, this.dustAmount)) {
+                // Subdust lives at an OP_RETURN output: no forfeit leaf, nothing
+                // to spend, and no settlement can lift it out on its own. The
+                // indexer reports it under the P2TR script and flags it swept,
+                // so it is told apart by value and checked before the swept
+                // case, which would otherwise claim it is recoverable.
+                // createCash now prevents minting them.
                 unclaimed.push(cashReport(vtxo, "subdust"));
             } else if (isRecoverable(vtxo)) {
                 // The server swept the batch at expiry. The funds are still

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -11,6 +11,7 @@ import {
     ArkProvider,
     BatchFinalizationEvent,
     BatchStartedEvent,
+    PendingTx,
     RestArkProvider,
     SettlementEvent,
     SignedIntent,
@@ -63,6 +64,7 @@ import {
     byValueDescending,
     DEFAULT_RENEWAL_CONFIG,
     DEFAULT_SETTLEMENT_CONFIG,
+    MAX_INPUTS_PER_INTENT,
     MAX_VTXOS_PER_SETTLEMENT,
     SettlementConfig,
     VtxoManager,
@@ -403,6 +405,31 @@ export interface ArkCashClaimResult {
         amount: number;
         vtxos: ArkCashUnclaimedVtxo[];
     };
+}
+
+/**
+ * Thrown when {@link Wallet.createCash} funds the note but its `send` call
+ * fails after the transaction may already have been submitted.
+ *
+ * The whole value of the note lives in `cash`: it carries the private key that
+ * controls the funded output. If `send` committed and this error is discarded,
+ * the sats are stranded at an address only this token can reach. Callers that
+ * cannot rule out a post-submit failure must persist `cash` — passing it to
+ * {@link Wallet.claimCash} recovers the funds whether or not the send landed.
+ */
+export class ArkCashCreateError extends Error {
+    constructor(
+        /** The encoded arkcash token controlling the funded output. */
+        readonly cash: string,
+        /** The original failure from `send`. */
+        readonly cause: unknown,
+    ) {
+        super(
+            `Failed to create ArkCash: send failed after the note may have been submitted. ` +
+                `Recover with claimCash using the token on this error's \`cash\` field.`,
+        );
+        this.name = "ArkCashCreateError";
+    }
 }
 
 /**
@@ -3888,8 +3915,6 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             return { finalized: [], pending: [] };
         }
 
-        const MAX_INPUTS_PER_INTENT = 20;
-
         if (!vtxos || vtxos.length === 0) {
             // Batch all scripts into a single indexer call
             const scriptMap = await this.getScriptMap();
@@ -4073,10 +4098,19 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             cashHrp,
         );
         const address = cash.address(this.network.hrp).encode();
+        const cashStr = cash.toString();
 
-        await this.send({ address, amount });
+        try {
+            await this.send({ address, amount });
+        } catch (error) {
+            // `send` may fail after the tx was submitted, leaving the note
+            // funded but its token unreturned. Surface the token on the error
+            // so the caller can recover the funds with `claimCash` instead of
+            // stranding them at an address only this token can reach.
+            throw new ArkCashCreateError(cashStr, error);
+        }
 
-        return cash.toString();
+        return cashStr;
     }
 
     /**
@@ -4305,21 +4339,36 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         if (inputs.length === 0) return result;
 
         const identity = cash.identity;
-        const message: Intent.GetPendingTxMessage = { type: "get-pending-tx", expire_at: 0 };
-        const proof = Intent.create(message, inputs, []);
-        // Every proof input is an arkcash input — index 0 is the synthetic
-        // BIP-322 toSpend reference mirroring input 1's script. Signing them by
-        // explicit index surfaces a failure instead of shipping a half-signed
-        // proof for the server to reject.
-        const signedProof = await identity.sign(
-            proof,
-            Array.from({ length: inputs.length + 1 }, (_, i) => i),
-        );
 
-        const pendingTxs = await this.arkProvider.getPendingTxs({
-            proof: base64.encode(signedProof.toPSBT()),
-            message,
-        });
+        // A get-pending-tx proof carries every input, and the server caps an
+        // intent at MAX_INPUTS_PER_INTENT inputs — the same ceiling
+        // finalizePendingTxs chunks against. Split into batches, sign and submit
+        // one proof each, and dedupe the returned txs by arkTxid so a tx that
+        // surfaces under two batches is finalized once.
+        const seenTxids = new Set<string>();
+        const pendingTxs: PendingTx[] = [];
+        for (let i = 0; i < inputs.length; i += MAX_INPUTS_PER_INTENT) {
+            const batch = inputs.slice(i, i + MAX_INPUTS_PER_INTENT);
+            const message: Intent.GetPendingTxMessage = { type: "get-pending-tx", expire_at: 0 };
+            const proof = Intent.create(message, batch, []);
+            // Every proof input is an arkcash input — index 0 is the synthetic
+            // BIP-322 toSpend reference mirroring input 1's script. Signing them
+            // by explicit index surfaces a failure instead of shipping a
+            // half-signed proof for the server to reject.
+            const signedProof = await identity.sign(
+                proof,
+                Array.from({ length: batch.length + 1 }, (_, j) => j),
+            );
+            const batchPending = await this.arkProvider.getPendingTxs({
+                proof: base64.encode(signedProof.toPSBT()),
+                message,
+            });
+            for (const pendingTx of batchPending) {
+                if (seenTxids.has(pendingTx.arkTxid)) continue;
+                seenTxids.add(pendingTx.arkTxid);
+                pendingTxs.push(pendingTx);
+            }
+        }
 
         const myPkScriptHex = hex.encode(myPkScript);
 

--- a/packages/ts-sdk/test/arkcash.test.ts
+++ b/packages/ts-sdk/test/arkcash.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { ArkCash } from "../src/arkcash";
+import { hex } from "@scure/base";
+import { pubSchnorr } from "@scure/btc-signer/utils.js";
+
+describe("ArkCash", () => {
+    const testPrivKey = hex.decode(
+        "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+    );
+    // Server pubkey must be a valid x-only secp256k1 public key
+    const serverPrivKey = hex.decode(
+        "a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0",
+    );
+    const testServerPubKey = pubSchnorr(serverPrivKey);
+
+    describe("encode/decode roundtrip", () => {
+        it("should roundtrip with blocks timelock", () => {
+            const cash = new ArkCash(testPrivKey, testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+
+            const encoded = cash.toString();
+            expect(encoded.startsWith("arkcash1")).toBe(true);
+
+            const decoded = ArkCash.fromString(encoded);
+            expect(hex.encode(decoded.privateKey)).toBe(hex.encode(testPrivKey));
+            expect(hex.encode(decoded.serverPubKey)).toBe(hex.encode(testServerPubKey));
+            expect(decoded.csvTimelock.type).toBe("blocks");
+            expect(decoded.csvTimelock.value).toBe(144n);
+            expect(decoded.hrp).toBe("arkcash");
+        });
+
+        it("should roundtrip with seconds timelock", () => {
+            const cash = new ArkCash(testPrivKey, testServerPubKey, {
+                type: "seconds",
+                value: 512n,
+            });
+
+            const encoded = cash.toString();
+            const decoded = ArkCash.fromString(encoded);
+            expect(decoded.csvTimelock.type).toBe("seconds");
+            expect(decoded.csvTimelock.value).toBe(512n);
+        });
+
+        it("should roundtrip with custom HRP", () => {
+            const cash = new ArkCash(
+                testPrivKey,
+                testServerPubKey,
+                {
+                    type: "blocks",
+                    value: 144n,
+                },
+                "tarkcash",
+            );
+
+            const encoded = cash.toString();
+            expect(encoded.startsWith("tarkcash1")).toBe(true);
+
+            const decoded = ArkCash.fromString(encoded);
+            expect(decoded.hrp).toBe("tarkcash");
+        });
+    });
+
+    describe("key derivation", () => {
+        it("should derive correct public key", () => {
+            const cash = new ArkCash(testPrivKey, testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+
+            const expectedPubKey = pubSchnorr(testPrivKey);
+            expect(hex.encode(cash.publicKey)).toBe(hex.encode(expectedPubKey));
+        });
+
+        it("should return a SingleKey identity", async () => {
+            const cash = new ArkCash(testPrivKey, testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+
+            const identity = cash.identity;
+            const pubKey = await identity.xOnlyPublicKey();
+            expect(hex.encode(pubKey)).toBe(hex.encode(cash.publicKey));
+        });
+    });
+
+    describe("vtxo script", () => {
+        it("should create a valid DefaultVtxo script", () => {
+            const cash = new ArkCash(testPrivKey, testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+
+            const script = cash.vtxoScript;
+            expect(script).toBeDefined();
+            expect(script.pkScript).toBeDefined();
+            expect(script.pkScript.length).toBeGreaterThan(0);
+        });
+
+        it("should derive a valid ArkAddress", () => {
+            const cash = new ArkCash(testPrivKey, testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+
+            const address = cash.address("tark");
+            const encoded = address.encode();
+            expect(encoded.startsWith("tark1")).toBe(true);
+        });
+    });
+
+    describe("generate", () => {
+        it("should generate a random ArkCash", () => {
+            const cash = ArkCash.generate(testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+
+            expect(cash.privateKey.length).toBe(32);
+            expect(cash.publicKey.length).toBe(32);
+            expect(hex.encode(cash.serverPubKey)).toBe(hex.encode(testServerPubKey));
+        });
+
+        it("should generate unique keys each time", () => {
+            const cash1 = ArkCash.generate(testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+            const cash2 = ArkCash.generate(testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+
+            expect(hex.encode(cash1.privateKey)).not.toBe(hex.encode(cash2.privateKey));
+        });
+    });
+
+    describe("validation", () => {
+        it("should throw on invalid private key length", () => {
+            expect(
+                () =>
+                    new ArkCash(new Uint8Array(16), testServerPubKey, {
+                        type: "blocks",
+                        value: 144n,
+                    }),
+            ).toThrow("Invalid private key length");
+        });
+
+        it("should throw on invalid server pubkey length", () => {
+            expect(
+                () =>
+                    new ArkCash(testPrivKey, new Uint8Array(16), {
+                        type: "blocks",
+                        value: 144n,
+                    }),
+            ).toThrow("Invalid server public key length");
+        });
+
+        it("should throw on invalid bech32m string", () => {
+            expect(() => ArkCash.fromString("notvalid")).toThrow();
+        });
+
+        it("should throw on wrong data length", () => {
+            expect(() => ArkCash.fromString("arkcash1qqqqqqqqq0saqvp")).toThrow();
+        });
+    });
+});

--- a/packages/ts-sdk/test/arkcash.test.ts
+++ b/packages/ts-sdk/test/arkcash.test.ts
@@ -136,6 +136,54 @@ describe("ArkCash", () => {
         });
     });
 
+    describe("defensive key copies", () => {
+        it("is unaffected by mutating the buffers passed to the constructor", () => {
+            const priv = testPrivKey.slice();
+            const server = testServerPubKey.slice();
+            const cash = new ArkCash(priv, server, { type: "blocks", value: 144n });
+
+            const encodedBefore = cash.toString();
+            const pubBefore = hex.encode(cash.publicKey);
+
+            // Mutating the caller's buffers must not change the note.
+            priv.fill(0);
+            server.fill(0);
+
+            expect(cash.toString()).toBe(encodedBefore);
+            expect(hex.encode(cash.privateKey)).toBe(hex.encode(testPrivKey));
+            expect(hex.encode(cash.serverPubKey)).toBe(hex.encode(testServerPubKey));
+            expect(hex.encode(cash.publicKey)).toBe(pubBefore);
+        });
+
+        it("is unaffected by mutating the buffers returned from getters", () => {
+            const cash = new ArkCash(testPrivKey, testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+
+            const encodedBefore = cash.toString();
+            cash.privateKey.fill(0);
+            cash.serverPubKey.fill(0);
+            cash.publicKey.fill(0);
+
+            expect(cash.toString()).toBe(encodedBefore);
+            expect(hex.encode(cash.privateKey)).toBe(hex.encode(testPrivKey));
+            expect(hex.encode(cash.serverPubKey)).toBe(hex.encode(testServerPubKey));
+            expect(hex.encode(cash.publicKey)).toBe(hex.encode(pubSchnorr(testPrivKey)));
+        });
+
+        it("returns a distinct copy on each getter access", () => {
+            const cash = new ArkCash(testPrivKey, testServerPubKey, {
+                type: "blocks",
+                value: 144n,
+            });
+
+            expect(cash.privateKey).not.toBe(cash.privateKey);
+            expect(cash.serverPubKey).not.toBe(cash.serverPubKey);
+            expect(cash.publicKey).not.toBe(cash.publicKey);
+        });
+    });
+
     describe("validation", () => {
         it("should throw on invalid private key length", () => {
             expect(

--- a/packages/ts-sdk/test/arkcashClaim.test.ts
+++ b/packages/ts-sdk/test/arkcashClaim.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { base64, hex } from "@scure/base";
-import { Wallet } from "../src/wallet/wallet";
+import { Transaction } from "@scure/btc-signer";
+import { Wallet, ArkCashCreateError } from "../src/wallet/wallet";
 import { InMemoryWalletRepository } from "../src/repositories/inMemory/walletRepository";
 import { InMemoryContractRepository } from "../src/repositories/inMemory/contractRepository";
 import { SingleKey } from "../src/identity/singleKey";
@@ -104,6 +105,14 @@ function spentCashVtxo(cashPkScript: string): VirtualCoin {
     } as VirtualCoin;
 }
 
+/** A distinct spent arkcash VTXO, one per index, all at the same pkScript. */
+function spentCashVtxoAt(cashPkScript: string, index: number): VirtualCoin {
+    return {
+        ...spentCashVtxo(cashPkScript),
+        txid: index.toString(16).padStart(64, "0"),
+    };
+}
+
 /**
  * The pending sweep the crashed claim left on the server: the offchain tx it
  * built and submitted but never finalized, paying `destinationPkScript`.
@@ -188,6 +197,87 @@ describe("claimCash drain-pending accounting", () => {
         expect(result.swept).toBe(0);
         expect(result.unclaimed.vtxos).toEqual([
             { txid: CASH_TXID, vout: 0, value: CASH_VALUE, reason: "already-spent" },
+        ]);
+    });
+
+    it("chunks the drain proof into batches of at most 20 inputs", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const finalizeTx = vi.fn(async () => {});
+        const getPendingTxs = vi.fn();
+
+        // 45 spent inputs → 3 proofs (20 + 20 + 5). Each proof carries the
+        // batch's inputs plus the synthetic BIP-322 toSpend reference.
+        const drainable = Array.from({ length: 45 }, (_, i) => spentCashVtxoAt(cashPkScript, i));
+        const wallet = await makeWallet(cashIndexer(cashPkScript, drainable), {
+            getPendingTxs,
+            finalizeTx,
+        });
+
+        // Every batch surfaces the same pending sweep; dedup by arkTxid must
+        // collapse them so the tx is finalized exactly once.
+        const myPkScript = ArkAddress.decode(await wallet.getAddress()).pkScript;
+        getPendingTxs.mockResolvedValue([pendingSweep(cash, myPkScript)]);
+
+        await wallet.claimCash(cash.toString());
+
+        expect(getPendingTxs).toHaveBeenCalledTimes(3);
+        for (const [{ proof }] of getPendingTxs.mock.calls as [{ proof: string }][]) {
+            const inputs = Transaction.fromPSBT(base64.decode(proof), {
+                allowUnknown: true,
+            }).inputsLength;
+            expect(inputs).toBeLessThanOrEqual(20 + 1);
+        }
+        // Same arkTxid across all batches → finalized once, not three times.
+        expect(finalizeTx).toHaveBeenCalledOnce();
+    });
+
+    it("surfaces the recoverable token when the funding send fails", async () => {
+        const wallet = await makeWallet(cashIndexer("x", []), {});
+
+        // send fails after the note may already have been submitted; the token
+        // controlling the funded output must not be lost.
+        const sendError = new Error("submitted then crashed");
+        vi.spyOn(wallet, "send").mockRejectedValue(sendError);
+
+        const err = await wallet
+            .createCash(5000)
+            .then(() => null)
+            .catch((e) => e);
+
+        expect(err).toBeInstanceOf(ArkCashCreateError);
+        expect(err.cause).toBe(sendError);
+        // The carried token round-trips back to a usable arkcash note.
+        expect(() => ArkCash.fromString(err.cash)).not.toThrow();
+        expect(err.cash.startsWith("tarkcash1")).toBe(true);
+    });
+
+    it("preserves the empty-input behavior", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const finalizeTx = vi.fn(async () => {});
+        const getPendingTxs = vi.fn(async () => []);
+
+        // Only a subdust VTXO (at the OP_RETURN script) is present: nothing is
+        // drainable, so no proof is ever built or submitted.
+        const cashSubdustPkScript = hex.encode(cash.address("tark").subdustPkScript);
+        const subdust: VirtualCoin = {
+            ...spentCashVtxo(cashPkScript),
+            script: cashSubdustPkScript,
+            isSpent: false,
+        };
+        const wallet = await makeWallet(cashIndexer(cashSubdustPkScript, [subdust]), {
+            getPendingTxs,
+            finalizeTx,
+        });
+
+        const result = await wallet.claimCash(cash.toString());
+
+        expect(getPendingTxs).not.toHaveBeenCalled();
+        expect(finalizeTx).not.toHaveBeenCalled();
+        expect(result.swept).toBe(0);
+        expect(result.unclaimed.vtxos).toEqual([
+            { txid: CASH_TXID, vout: 0, value: CASH_VALUE, reason: "subdust" },
         ]);
     });
 });

--- a/packages/ts-sdk/test/arkcashClaim.test.ts
+++ b/packages/ts-sdk/test/arkcashClaim.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi } from "vitest";
+import { base64, hex } from "@scure/base";
+import { Wallet } from "../src/wallet/wallet";
+import { InMemoryWalletRepository } from "../src/repositories/inMemory/walletRepository";
+import { InMemoryContractRepository } from "../src/repositories/inMemory/contractRepository";
+import { SingleKey } from "../src/identity/singleKey";
+import { ArkCash } from "../src/arkcash";
+import { ArkAddress } from "../src/script/address";
+import { CSVMultisigTapscript } from "../src/script/tapscript";
+import { buildOffchainTx } from "../src/utils/arkTransaction";
+import type { VirtualCoin } from "../src/wallet";
+
+// claimCash's accounting across the drain-pending path: a claim interrupted
+// between submitTx and finalizeTx leaves a pending sweep on the server, and the
+// re-run that completes it must report the funds as swept — the VTXO reads back
+// spent, so the naive classification calls money this very call just moved
+// "unclaimed".
+
+const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const CHECKPOINT_TAPSCRIPT =
+    "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac";
+
+const info = {
+    signerPubkey: SERVER_PUBKEY_HEX,
+    forfeitPubkey: SERVER_PUBKEY_HEX,
+    network: "mutinynet",
+    batchExpiry: 144n,
+    unilateralExitDelay: 144n,
+    boardingExitDelay: 604672n,
+    roundInterval: 144n,
+    dust: 1000n,
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    checkpointTapscript: CHECKPOINT_TAPSCRIPT,
+    deprecatedSigners: [],
+    digest: "d",
+    fees: { intentFee: {}, txFeeRate: "0" },
+    serviceStatus: {},
+    sessionDuration: 3600n,
+    utxoMaxAmount: -1n,
+    utxoMinAmount: 0n,
+    vtxoMaxAmount: -1n,
+    vtxoMinAmount: 0n,
+    version: "1",
+};
+
+const CASH_TXID = "a".repeat(64);
+const CASH_VALUE = 5000;
+
+function idleOnchain() {
+    return {
+        getCoins: vi.fn(async () => []),
+        getTransactions: vi.fn(async () => []),
+        getTxOutspends: vi.fn(async () => []),
+        getTxStatus: vi.fn(async () => ({ confirmed: false })),
+        getChainTip: vi.fn(async () => ({ height: 0, hash: "", time: 0 })),
+        broadcastTransaction: vi.fn(async () => "txid"),
+        watchAddresses: vi.fn(async () => () => {}),
+    } as never;
+}
+
+/** Indexer that only knows about the arkcash address. */
+function cashIndexer(cashPkScript: string, vtxos: VirtualCoin[]) {
+    return {
+        getVtxos: vi.fn(async (opts?: { scripts?: string[] }) => ({
+            vtxos: opts?.scripts?.includes(cashPkScript) ? vtxos : [],
+        })),
+        subscribeForScripts: vi.fn(async () => "sub-id"),
+        unsubscribeForScripts: vi.fn(async () => {}),
+        getSubscription: vi.fn(async function* (_subId: string, abortSignal: AbortSignal) {
+            await new Promise<void>((resolve) => {
+                if (abortSignal?.aborted) return resolve();
+                abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+            });
+        }),
+        watchAddresses: vi.fn(async () => () => {}),
+    } as never;
+}
+
+async function makeWallet(indexerProvider: never, arkProvider: Record<string, unknown>) {
+    return Wallet.create({
+        identity: SingleKey.fromHex("1".repeat(64)),
+        settlementConfig: false,
+        arkProvider: { getInfo: vi.fn(async () => info), ...arkProvider } as never,
+        indexerProvider,
+        onchainProvider: idleOnchain(),
+        storage: {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        },
+    });
+}
+
+/** The arkcash VTXO as it reads back after a sweep was registered: spent. */
+function spentCashVtxo(cashPkScript: string): VirtualCoin {
+    return {
+        txid: CASH_TXID,
+        vout: 0,
+        value: CASH_VALUE,
+        script: cashPkScript,
+        status: { confirmed: true },
+        virtualStatus: { state: "preconfirmed" },
+        isSpent: true,
+        createdAt: new Date(),
+    } as VirtualCoin;
+}
+
+/**
+ * The pending sweep the crashed claim left on the server: the offchain tx it
+ * built and submitted but never finalized, paying `destinationPkScript`.
+ */
+function pendingSweep(cash: ArkCash, destinationPkScript: Uint8Array) {
+    const cashScript = cash.vtxoScript;
+    const offchainTx = buildOffchainTx(
+        [
+            {
+                txid: CASH_TXID,
+                vout: 0,
+                value: CASH_VALUE,
+                tapLeafScript: cashScript.forfeit(),
+                tapTree: cashScript.encode(),
+            },
+        ],
+        [{ script: destinationPkScript, amount: BigInt(CASH_VALUE) }],
+        CSVMultisigTapscript.decode(hex.decode(CHECKPOINT_TAPSCRIPT)),
+    );
+
+    return {
+        arkTxid: "b".repeat(64),
+        finalArkTx: base64.encode(offchainTx.arkTx.toPSBT()),
+        signedCheckpointTxs: offchainTx.checkpoints.map((c) => base64.encode(c.toPSBT())),
+    };
+}
+
+const makeCash = () =>
+    ArkCash.generate(
+        hex.decode(SERVER_PUBKEY_HEX).slice(1),
+        { type: "blocks", value: 144n },
+        "tarkcash",
+    );
+
+describe("claimCash drain-pending accounting", () => {
+    it("reports a drained sweep as swept, not unclaimed", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const finalizeTx = vi.fn(async () => {});
+        const getPendingTxs = vi.fn();
+
+        const wallet = await makeWallet(cashIndexer(cashPkScript, [spentCashVtxo(cashPkScript)]), {
+            getPendingTxs,
+            finalizeTx,
+        });
+
+        // The crashed claim swept to this very wallet.
+        const myPkScript = ArkAddress.decode(await wallet.getAddress()).pkScript;
+        getPendingTxs.mockResolvedValue([pendingSweep(cash, myPkScript)]);
+
+        const result = await wallet.claimCash(cash.toString());
+
+        expect(finalizeTx).toHaveBeenCalledOnce();
+        expect(result.swept).toBe(CASH_VALUE);
+        expect(result.unclaimed.amount).toBe(0);
+        expect(result.unclaimed.vtxos).toEqual([]);
+    });
+
+    it("does not credit itself a drained sweep that pays someone else", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const finalizeTx = vi.fn(async () => {});
+        const getPendingTxs = vi.fn();
+
+        const wallet = await makeWallet(cashIndexer(cashPkScript, [spentCashVtxo(cashPkScript)]), {
+            getPendingTxs,
+            finalizeTx,
+        });
+
+        // A different claimer won the race and crashed mid-claim: finalizing
+        // their sweep is still correct, but it pays them, not us.
+        const stranger = ArkCash.generate(
+            hex.decode(SERVER_PUBKEY_HEX).slice(1),
+            { type: "blocks", value: 144n },
+            "tarkcash",
+        );
+        getPendingTxs.mockResolvedValue([pendingSweep(cash, stranger.vtxoScript.pkScript)]);
+
+        const result = await wallet.claimCash(cash.toString());
+
+        expect(finalizeTx).toHaveBeenCalledOnce();
+        expect(result.swept).toBe(0);
+        expect(result.unclaimed.vtxos).toEqual([
+            { txid: CASH_TXID, vout: 0, value: CASH_VALUE, reason: "already-spent" },
+        ]);
+    });
+});

--- a/packages/ts-sdk/test/arkcashClaim.test.ts
+++ b/packages/ts-sdk/test/arkcashClaim.test.ts
@@ -258,15 +258,17 @@ describe("claimCash drain-pending accounting", () => {
         const finalizeTx = vi.fn(async () => {});
         const getPendingTxs = vi.fn(async () => []);
 
-        // Only a subdust VTXO (at the OP_RETURN script) is present: nothing is
-        // drainable, so no proof is ever built or submitted.
-        const cashSubdustPkScript = hex.encode(cash.address("tark").subdustPkScript);
+        // Only a subdust VTXO is present. The indexer keys it by the taproot
+        // key and reports it under the P2TR script (never the OP_RETURN form),
+        // flagged swept, with a below-dust value. It is excluded from the drain
+        // by value, so no proof is ever built or submitted.
+        const subdustValue = 500; // < info.dust (1000)
         const subdust: VirtualCoin = {
             ...spentCashVtxo(cashPkScript),
-            script: cashSubdustPkScript,
+            value: subdustValue,
             isSpent: false,
         };
-        const wallet = await makeWallet(cashIndexer(cashSubdustPkScript, [subdust]), {
+        const wallet = await makeWallet(cashIndexer(cashPkScript, [subdust]), {
             getPendingTxs,
             finalizeTx,
         });
@@ -277,7 +279,7 @@ describe("claimCash drain-pending accounting", () => {
         expect(finalizeTx).not.toHaveBeenCalled();
         expect(result.swept).toBe(0);
         expect(result.unclaimed.vtxos).toEqual([
-            { txid: CASH_TXID, vout: 0, value: CASH_VALUE, reason: "subdust" },
+            { txid: CASH_TXID, vout: 0, value: subdustValue, reason: "subdust" },
         ]);
     });
 });

--- a/packages/ts-sdk/test/e2e/ark.test.ts
+++ b/packages/ts-sdk/test/e2e/ark.test.ts
@@ -19,6 +19,7 @@ import {
     EsploraProvider,
     InMemoryWalletRepository,
     InMemoryContractRepository,
+    ArkCash,
     RestDelegateProvider,
 } from "../../src";
 import {
@@ -2381,4 +2382,92 @@ describe("Asset integration tests", () => {
             expect(delegateUnspent.length).toBeGreaterThan(0);
         },
     );
+});
+
+describe("ArkCash", () => {
+    beforeEach(beforeEachFaucet, 20000);
+
+    const fundedWallet = async (amount: number) => {
+        const w = await createTestArkWallet();
+        faucetOffchain(await w.wallet.getAddress(), amount);
+        await waitFor(async () => (await w.wallet.getVtxos()).length > 0);
+        return w;
+    };
+
+    it("should send and claim arkcash (happy path)", async () => {
+        const alice = await fundedWallet(10000);
+        const bob = await createTestArkWallet();
+
+        // Alice creates cash — Bob never shares an address
+        const cashStr = await alice.wallet.createCash(5000);
+        expect(cashStr).toMatch(/cash1/);
+
+        const result = await bob.wallet.claimCash(cashStr);
+        expect(result.swept).toBe(5000);
+        expect(result.unclaimed.amount).toBe(0);
+        expect(result.unclaimed.vtxos).toEqual([]);
+
+        await waitFor(async () => (await bob.wallet.getBalance()).total >= 5000);
+
+        // Sweep-or-report persists nothing: no arkcash contract may reach Bob's
+        // repository, or his own renewal/recovery would settle an input he
+        // cannot sign and reject the whole batch.
+        const manager = await bob.wallet.getContractManager();
+        const contracts = await manager.getContracts();
+        const cashScript = hex.encode(ArkCash.fromString(cashStr).vtxoScript.pkScript);
+        expect(contracts.some((c) => c.script === cashScript)).toBe(false);
+    }, 60_000);
+
+    it("should report an already-claimed arkcash instead of sweeping it", async () => {
+        const alice = await fundedWallet(10000);
+        const bob = await createTestArkWallet();
+        const charlie = await createTestArkWallet();
+
+        const cashStr = await alice.wallet.createCash(5000);
+
+        await bob.wallet.claimCash(cashStr);
+        await waitFor(async () => (await bob.wallet.getBalance()).total >= 5000);
+
+        // The VTXO still exists, it is just spent — Charlie is told it was
+        // already claimed rather than that the arkcash is unknown.
+        const result = await charlie.wallet.claimCash(cashStr);
+        expect(result.swept).toBe(0);
+        expect(result.unclaimed.amount).toBe(5000);
+        expect(result.unclaimed.vtxos).toHaveLength(1);
+        expect(result.unclaimed.vtxos[0].reason).toBe("already-spent");
+    }, 90_000);
+
+    it("should throw when the arkcash was never funded", async () => {
+        const alice = await fundedWallet(10000);
+        const info = await alice.wallet.arkProvider.getInfo();
+        const cash = ArkCash.generate(
+            hex.decode(info.signerPubkey).slice(1),
+            { type: "blocks", value: 144n },
+            "tarkcash",
+        );
+
+        await expect(alice.wallet.claimCash(cash.toString())).rejects.toThrow("No VTXOs found");
+    }, 30_000);
+
+    it("should reject invalid createCash amounts", async () => {
+        const alice = await fundedWallet(10000);
+
+        for (const amount of [0, -1, 0.5, NaN, Infinity, 1]) {
+            await expect(alice.wallet.createCash(amount)).rejects.toThrow("Invalid ArkCash amount");
+        }
+    }, 30_000);
+
+    it("should claim each arkcash independently", async () => {
+        const alice = await fundedWallet(30000);
+        const bob = await createTestArkWallet();
+
+        const cash1 = await alice.wallet.createCash(5000);
+        await waitFor(async () => (await alice.wallet.getVtxos()).length > 0);
+        const cash2 = await alice.wallet.createCash(3000);
+
+        expect((await bob.wallet.claimCash(cash1)).swept).toBe(5000);
+        expect((await bob.wallet.claimCash(cash2)).swept).toBe(3000);
+
+        await waitFor(async () => (await bob.wallet.getBalance()).total >= 8000);
+    }, 120_000);
 });


### PR DESCRIPTION
Supersedes #337. Stacked on #620 — review that first; this diff shows its commits until it merges.

**NOTE**: this PR still gates subdust amounts. There is another PR coming that will remove the check and support subdust claim via settlement. I postponed it to maintain a reasonable size.

Adds ArkCash: a bearer instrument that carries its own key, so funds can be handed over without the receiver sharing an address. Short-lived by design — mint, hand over, claim promptly.

- `createCash(amount)` mints one, rejecting anything that is not a whole number of sats at or above dust (below dust it would mint an OP_RETURN output that is unspendable as cash).
- `claimCash(str)` sweeps every spendable VTXO in its own offchain tx via the thin single-key signer from #620, and reports the rest — `swept`, `subdust`, `already-spent`, `has-assets`, `sweep-failed` — with per-VTXO reasons.

It never imports a contract. The wallet only holds contracts it can sign, so an arkcash import would be an unsignable input in the owner's renewal/recovery bundle and reject the whole settle. One tx per VTXO keeps a stale input from blocking the rest, and caps each output at one VTXO's value.

A claim interrupted between submit and finalize is recovered by re-running it: the pending sweep is drained first, scoped to the arkcash key (the wallet's own `finalizePendingTxs` cannot reach it — wrong key, unwatched script). A drained tx is credited only for what it pays this wallet; one left by another claimer is still finalized to unstick the funds, but reported as `already-spent`.

Return shape is `{ swept, unclaimed: { amount, vtxos } }`, documented as open so further buckets can be added without a break.

Swept VTXOs are reported, not recovered: they need a settlement, which no sweep can do. Asset-bearing VTXOs are reported too, since the BTC-only sweep would burn the assets.

Unit tests and typecheck pass. The regtest e2e is the merge gate here and still needs a run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArkCash bearer instruments for securely transferring Ark funds as encoded cash strings.
  * Wallets can now create cash strings for specified amounts and claim them into spendable balances.
  * Claims report swept funds and any unclaimed amounts with clear reasons.
  * Exported ArkCash functionality and related result types through the TypeScript SDK.
  * Added a Node.js example demonstrating the complete create-and-claim flow.

* **Tests**
  * Added coverage for serialization, validation, claiming, recovery scenarios, and end-to-end transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->