### PR TITLE
feat(boltz-swap): walletless non-interactive reverse swap for arbitrary receivers

### DIFF
--- a/packages/boltz-swap/src/index.ts
+++ b/packages/boltz-swap/src/index.ts
@@ -8,6 +8,12 @@ export const sdkVersion = `boltz-swap/${version}`;
 
 export { ArkadeSwaps } from "./arkade-swaps";
 export type { QuoteSwapOptions } from "./arkade-swaps";
+export { createNonInteractiveReverseSwap } from "./non-interactive-reverse-swap";
+export type {
+    CreateNonInteractiveReverseSwapArgs,
+    NonInteractiveReverseSwap,
+} from "./non-interactive-reverse-swap";
+export { CovclaimdProvider } from "./covclaimd-provider";
 export type { BoltzSwapStatus, SubmarineProgressionStatus } from "./boltz-swap-provider";
 export {
     BoltzSwapProvider,

--- a/packages/boltz-swap/src/non-interactive-reverse-swap.ts
+++ b/packages/boltz-swap/src/non-interactive-reverse-swap.ts
@@ -1,0 +1,111 @@
+import { hex } from "@scure/base";
+import { randomBytes } from "@noble/hashes/utils.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { ArkAddress } from "@arkade-os/sdk";
+import type {
+    BoltzSwapProvider,
+    CreateReverseSwapRequest,
+    CreateReverseSwapResponse,
+} from "./boltz-swap-provider";
+import type { CovclaimdProvider } from "./covclaimd-provider";
+import { eciesEncrypt } from "./utils/covclaimd-ecies";
+import { enforcePayTo } from "./utils/vhtlc";
+import { decodeInvoice } from "./utils/decoding";
+import { SwapError } from "./errors";
+
+/** Inputs for a server-orchestrated non-interactive reverse swap. */
+export interface CreateNonInteractiveReverseSwapArgs {
+    /** Boltz provider (`new BoltzSwapProvider(...)`). */
+    swapProvider: BoltzSwapProvider;
+    /** covclaimd client (`new CovclaimdProvider(url)`). */
+    covclaimd: CovclaimdProvider;
+    /** Invoice amount in satoshis. */
+    amount: number;
+    /** Receiver's compressed claim public key (33 bytes / 66 hex chars). */
+    claimPublicKey: string;
+    /** Receiver's Arkade address — the covenant claim is constrained to pay it. */
+    claimAddress: string;
+    /** Optional invoice description. */
+    description?: string;
+    /** Optional invoice description hash (mutually exclusive with `description`). */
+    descriptionHash?: string;
+}
+
+/** Result of a non-interactive reverse swap. `preimage` is returned for record-keeping;
+ *  the caller never needs it to claim (covclaimd does that), but may keep it to prove
+ *  settlement (e.g. LUD-21 verify). */
+export interface NonInteractiveReverseSwap {
+    id: string;
+    invoice: string;
+    preimage: string;
+    preimageHash: string;
+    lockupAddress: string;
+    response: CreateReverseSwapResponse;
+}
+
+/**
+ * Create a non-interactive reverse swap (Lightning → Arkade) for an **arbitrary
+ * receiver**, with no wallet. This is {@link ArkadeSwaps.createReverseSwap} in
+ * `nonInteractive` mode, minus the wallet: instead of reading the receiver's
+ * identity from `this.wallet`, the caller supplies the receiver's public
+ * `claimPublicKey` + `claimAddress`. A fresh preimage is generated internally,
+ * encrypted to covclaimd, and the VHTLC claim is covenant-constrained (via
+ * `enforcePayTo`) to pay the receiver — so covclaimd learns the preimage but
+ * cannot redirect the funds, and the receiver never needs to be online or
+ * expose a signing key.
+ *
+ * Intended for services (e.g. an LNURL server) that mint invoices on behalf of
+ * offline users.
+ */
+export async function createNonInteractiveReverseSwap(
+    args: CreateNonInteractiveReverseSwapArgs,
+): Promise<NonInteractiveReverseSwap> {
+    const { swapProvider, covclaimd, amount, claimPublicKey, claimAddress } = args;
+    if (amount <= 0) throw new SwapError({ message: "Amount must be greater than 0" });
+
+    // covclaimd's keys must be available before we commit to a swap.
+    const covPubKeys = await covclaimd.getPubKeys();
+
+    const preimage = randomBytes(32);
+    const preimageHash = hex.encode(sha256(preimage));
+
+    const swapRequest: CreateReverseSwapRequest = {
+        invoiceAmount: amount,
+        claimPublicKey,
+        preimageHash,
+        ...(args.descriptionHash !== undefined
+            ? { descriptionHash: args.descriptionHash }
+            : args.description?.trim()
+              ? { description: args.description.trim() }
+              : {}),
+        nonInteractiveClaim: { claimAddress },
+    };
+
+    const response = await swapProvider.createReverseSwap(swapRequest);
+
+    const decoded = decodeInvoice(response.invoice);
+    if (decoded.paymentHash !== preimageHash) {
+        throw new SwapError({ message: "Preimage hash does not match invoice payment hash" });
+    }
+    if (!response.lockupAddress) {
+        throw new SwapError({ message: "reverse swap response missing lockupAddress" });
+    }
+
+    // Hand covclaimd the encrypted preimage + the pay-to-receiver covenant so it
+    // can claim the VHTLC on the offline receiver's behalf.
+    const receiverTapKey = ArkAddress.decode(claimAddress).vtxoTaprootKey;
+    await covclaimd.reveal({
+        swapAddress: response.lockupAddress,
+        ciphertext: eciesEncrypt(covPubKeys.covclaimdPubKey, preimage),
+        arkadeScript: enforcePayTo(receiverTapKey),
+    });
+
+    return {
+        id: response.id,
+        invoice: response.invoice,
+        preimage: hex.encode(preimage),
+        preimageHash,
+        lockupAddress: response.lockupAddress,
+        response,
+    };
+}

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -27,6 +27,7 @@ import {
     ArkInfo,
     getNetwork,
     maybeArkError,
+    ArkAddress,
 } from "@arkade-os/sdk";
 import { VHTLC } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
@@ -39,6 +40,7 @@ import { Address, OutScript, Script, ScriptNum } from "@scure/btc-signer";
 import { decodeInvoice } from "../src/utils/decoding";
 import { CovclaimdProvider } from "../src/covclaimd-provider";
 import { eciesDecrypt } from "../src/utils/covclaimd-ecies";
+import { createNonInteractiveReverseSwap } from "../src/non-interactive-reverse-swap";
 import { logger } from "../src/logger";
 import { pubECDSA } from "@scure/btc-signer/utils.js";
 import { create as createMusig } from "../src/utils/musig";
@@ -48,6 +50,7 @@ import {
     createVHTLCScript as createVHTLCScriptReal,
     refundVHTLCwithOffchainTx,
     refundWithoutReceiverVHTLCwithOffchainTx,
+    enforcePayTo,
 } from "../src/utils/vhtlc";
 import { BoltzRefundError, InvoiceFailedToPayError, SwapError } from "../src/errors";
 
@@ -915,6 +918,63 @@ describe("ArkadeSwaps", () => {
                 expect(revealArg.swapAddress).toBe(mock.lockupAddress);
                 expect(eciesDecrypt(covclaimdSecretKey, revealArg.ciphertext)).toEqual(
                     hex.decode(pendingSwap.preimage!),
+                );
+            });
+
+            it("createNonInteractiveReverseSwap: walletless helper delegates an arbitrary receiver's claim to covclaimd", async () => {
+                // The lnurl-server case: a service mints an invoice for an offline
+                // user whose keys it does not hold. Prove Boltz is asked to pay the
+                // *user's* claim identity, and covclaimd gets a reveal packet that
+                // decrypts to this swap's preimage, constrained to pay the user.
+                const covclaimdSecretKey = schnorr.utils.randomSecretKey();
+                const covclaimdPubKey = secp256k1.getPublicKey(covclaimdSecretKey, true);
+                const emulatorPubKey = secp256k1.getPublicKey(
+                    schnorr.utils.randomSecretKey(),
+                    true,
+                );
+                vi.spyOn(CovclaimdProvider.prototype, "getPubKeys").mockResolvedValue({
+                    covclaimdPubKey,
+                    emulatorPubKey,
+                });
+                const revealSpy = vi
+                    .spyOn(CovclaimdProvider.prototype, "reveal")
+                    .mockResolvedValue(undefined);
+                const createSpy = vi
+                    .spyOn(swapProvider, "createReverseSwap")
+                    .mockImplementationOnce(reverseSwapResponseFor(createReverseSwapResponse));
+
+                const userClaimPublicKey = hex.encode(
+                    secp256k1.getPublicKey(schnorr.utils.randomSecretKey(), true),
+                );
+                const receiveAddress = mock.address.ark;
+
+                const result = await createNonInteractiveReverseSwap({
+                    swapProvider,
+                    covclaimd: new CovclaimdProvider("http://cov:7071"),
+                    amount: mock.invoice.amount,
+                    claimPublicKey: userClaimPublicKey,
+                    claimAddress: receiveAddress,
+                });
+
+                // Boltz was asked to pay the user, with the user's claim key — no wallet involved.
+                expect(createSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        invoiceAmount: mock.invoice.amount,
+                        claimPublicKey: userClaimPublicKey,
+                        preimageHash: expect.any(String),
+                        nonInteractiveClaim: { claimAddress: receiveAddress },
+                    }),
+                );
+
+                // covclaimd received the encrypted preimage + the pay-to-receiver covenant.
+                expect(revealSpy).toHaveBeenCalledOnce();
+                const revealArg = revealSpy.mock.calls[0]![0];
+                expect(revealArg.swapAddress).toBe(mock.lockupAddress);
+                expect(eciesDecrypt(covclaimdSecretKey, revealArg.ciphertext)).toEqual(
+                    hex.decode(result.preimage),
+                );
+                expect(revealArg.arkadeScript).toEqual(
+                    enforcePayTo(ArkAddress.decode(receiveAddress).vtxoTaprootKey),
                 );
             });
         });


### PR DESCRIPTION
Builds on #613. That PR added non-interactive reverse swaps, but through `ArkadeSwaps.createReverseSwap`, which reads the receiver from `this.wallet` (`claimAddress = await this.wallet.getAddress()`, and the claim key from the wallet identity). That's right for a wallet claiming its own swap while offline, but it means a *service* — say an LNURL server minting invoices for users whose keys it doesn't hold — can't use it, because it has no wallet for the receiver.

The primitives underneath are already receiver-agnostic (`nonInteractiveClaim.claimAddress`, `enforcePayTo(receiverTapKey)`, and `CovclaimdProvider` all take arbitrary values), so this adds a small walletless helper that drives them directly:

```ts
const { invoice, preimage } = await createNonInteractiveReverseSwap({
  swapProvider, covclaimd, amount,
  claimPublicKey, // receiver's compressed pubkey
  claimAddress,   // receiver's Arkade address
});
```

It's `createReverseSwap` in `nonInteractive` mode minus the wallet: generate a preimage, request the swap with the caller-supplied claim identity, verify the invoice commits to the preimage hash, then hand covclaimd the ECIES-encrypted preimage plus the `enforcePayTo` covenant so it can only pay the receiver. Same anti-theft guarantee as #613 — covclaimd learns the preimage but can't redirect the funds. I also exported `CovclaimdProvider`, which a caller needs but the package index didn't re-export.

It's additive — no change to `ArkadeSwaps` or existing behaviour. I made it a standalone function since a server has no wallet to hang a method on, but if you'd rather it live on `ArkadeSwaps` (e.g. `createReverseSwapFor`) or be named differently, happy to move it. I couldn't run the regtest/e2e stack locally, so the on-chain path is unverified from my side.

For tests I added a unit test next to #613's own non-interactive one: it asserts Boltz is asked to pay the receiver's `claimAddress`/`claimPublicKey`, and that covclaimd's reveal packet decrypts back to the swap's preimage under the pay-to-receiver covenant. `typecheck` and the full `boltz-swap` unit suite (444 tests) pass.

Context: this unblocks server-side offline Lightning receive in the lnurl-server — a service-side companion to the wallet-side flow #613 enables.