### PR TITLE
feat(ArkadeCash): full subdust ArkCash claim via top-up recovery

### DIFF
--- a/packages/ts-sdk/examples/node/arkcash.ts
+++ b/packages/ts-sdk/examples/node/arkcash.ts
@@ -109,6 +109,11 @@ async function main() {
     console.log("[Bob]\tClaiming ArkCash...");
     const claim = await bobWallet.claimCash(cash);
     console.log("[Bob]\tSwept:", claim.swept, "sats");
+    if (claim.recovering.vtxos.length > 0) {
+        // Server-swept notes: imported for background recovery, arriving once
+        // the isolated recovery settlement finalizes.
+        console.log("[Bob]\tRecovering:", claim.recovering.amount, "sats", claim.recovering.vtxos);
+    }
     if (claim.unclaimed.vtxos.length > 0) {
         console.log("[Bob]\tUnclaimed:", claim.unclaimed.amount, "sats", claim.unclaimed.vtxos);
     }

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -78,6 +78,18 @@ export interface Contract {
 }
 
 /**
+ * True when a contract was imported solely so the wallet can recover its
+ * funds (see `Wallet.claimCash`'s server-swept branch), not as spendable
+ * wallet holdings. Such contracts are settled in their **own isolated intent**
+ * and are excluded from the wallet's own balance / renewal / recovery / coin
+ * selection, so a persistently rejected recovery input can never poison the
+ * wallet's own fund lifecycle.
+ */
+export function isRecoveryOnlyContract(contract: Contract): boolean {
+    return contract.metadata?.recoveryOnly === true;
+}
+
+/**
  * A virtual output that has been associated with a specific contract.
  */
 export type ContractVtxo = VirtualCoin &

--- a/packages/ts-sdk/src/identity/index.ts
+++ b/packages/ts-sdk/src/identity/index.ts
@@ -104,3 +104,6 @@ export { isHDCapableIdentity } from "./hdCapableIdentity";
 
 // Static descriptor provider (wrapper for legacy Identity)
 export { StaticDescriptorProvider } from "./staticDescriptorProvider";
+
+// Keyring descriptor provider (decorator adding raw external keys)
+export { KeyringDescriptorProvider } from "./keyringDescriptorProvider";

--- a/packages/ts-sdk/src/identity/keyringDescriptorProvider.ts
+++ b/packages/ts-sdk/src/identity/keyringDescriptorProvider.ts
@@ -114,11 +114,14 @@ export class KeyringDescriptorProvider implements DescriptorProvider {
      * unchanged.
      */
     async importKey(privateKey: Uint8Array): Promise<string> {
-        const pubKeyHex = hex.encode(pubSchnorr(privateKey));
+        // Clone: SingleKey retains the array by reference, and an import
+        // API must not alias a buffer the caller may zeroize or reuse.
+        const keyBytes = new Uint8Array(privateKey);
+        const pubKeyHex = hex.encode(pubSchnorr(keyBytes));
         await this.mutate((settings) => {
-            settings.keys[pubKeyHex] = hex.encode(privateKey);
+            settings.keys[pubKeyHex] = hex.encode(keyBytes);
         });
-        this.keys.set(pubKeyHex, SingleKey.fromPrivateKey(privateKey));
+        this.keys.set(pubKeyHex, SingleKey.fromPrivateKey(keyBytes));
         return `tr(${pubKeyHex})`;
     }
 

--- a/packages/ts-sdk/src/identity/keyringDescriptorProvider.ts
+++ b/packages/ts-sdk/src/identity/keyringDescriptorProvider.ts
@@ -261,6 +261,16 @@ function keyOf(descriptor: string): string | undefined {
  * absent) and return a clone safe for the caller to mutate. Trusting
  * storage blindly would let a corrupted repo surface as a signing
  * failure deep in a settlement; fail loud at the boundary instead.
+ *
+ * Both halves of every entry are checked, including that the pubkey the
+ * entry is *filed under* is the one its private key actually derives.
+ * That correspondence is what `isOurs` implicitly asserts: a mismatched
+ * pair would have the provider claim a descriptor and then sign it with
+ * the wrong key — a failure that would otherwise only surface when the
+ * server rejected the resulting settlement.
+ *
+ * Pubkeys are normalized to lowercase so the stored map keys match the
+ * canonical form {@link keyOf} produces for lookups.
  */
 function parseSettings(state: WalletState): KeyringSettings {
     const stored = state.settings?.[KEYRING_SETTINGS_KEY] as KeyringSettings | undefined;
@@ -268,14 +278,42 @@ function parseSettings(state: WalletState): KeyringSettings {
     if (typeof stored.keys !== "object" || stored.keys === null) {
         throw new Error("Corrupt keyring settings: `keys` is not an object.");
     }
-    for (const [pubKeyHex, privKeyHex] of Object.entries(stored.keys)) {
+
+    const keys: Record<string, string> = {};
+    for (const [storedPubKeyHex, privKeyHex] of Object.entries(stored.keys)) {
+        const pubKeyHex = storedPubKeyHex.toLowerCase();
+        if (!isHexOfBytes(pubKeyHex, 32)) {
+            throw new Error(
+                `Corrupt keyring settings: "${storedPubKeyHex}" is not a 32-byte hex x-only pubkey.`,
+            );
+        }
         if (typeof privKeyHex !== "string" || !isHexOfBytes(privKeyHex, 32)) {
             throw new Error(
                 `Corrupt keyring settings: entry ${pubKeyHex} is not a 32-byte hex private key.`,
             );
         }
+
+        let derivedPubKeyHex: string;
+        try {
+            derivedPubKeyHex = hex.encode(pubSchnorr(hex.decode(privKeyHex)));
+        } catch (e) {
+            // pubSchnorr rejects a key outside the curve order.
+            throw new Error(
+                `Corrupt keyring settings: entry ${pubKeyHex} is not a valid private key.`,
+                { cause: e },
+            );
+        }
+        if (derivedPubKeyHex !== pubKeyHex) {
+            throw new Error(
+                `Corrupt keyring settings: entry ${pubKeyHex} does not match its private key ` +
+                    `(which derives ${derivedPubKeyHex}). Refusing to sign with a key the ` +
+                    `descriptor does not name.`,
+            );
+        }
+
+        keys[pubKeyHex] = privKeyHex;
     }
-    return { keys: { ...stored.keys } };
+    return { keys };
 }
 
 function isHexOfBytes(value: string, bytes: number): boolean {

--- a/packages/ts-sdk/src/identity/keyringDescriptorProvider.ts
+++ b/packages/ts-sdk/src/identity/keyringDescriptorProvider.ts
@@ -1,0 +1,303 @@
+import { hex } from "@scure/base";
+import { pubSchnorr } from "@scure/btc-signer/utils.js";
+import { DescriptorProvider, DescriptorSigningRequest } from "./descriptorProvider";
+import { normalizeToDescriptor, extractPubKey } from "./descriptor";
+import { SingleKey } from "./singleKey";
+import { WalletRepository, WalletState } from "../repositories/walletRepository";
+import { updateWalletState } from "../utils/syncCursors";
+import { Transaction } from "../utils/transaction";
+
+/**
+ * Persisted keyring state stored under {@link WalletState.settings}`.keyring`.
+ * @internal
+ */
+interface KeyringSettings {
+    /**
+     * Imported raw keys, mapped x-only pubkey hex → private key hex. The
+     * pubkey is the map key (not the full descriptor) so lookups stay
+     * canonical regardless of how a caller spelled the descriptor.
+     */
+    keys: Record<string, string>;
+}
+
+/** Settings key under {@link WalletState.settings} where keyring state lives. */
+const KEYRING_SETTINGS_KEY = "keyring";
+
+/**
+ * A {@link DescriptorProvider} decorator that adds a **keyring**: raw
+ * private keys imported from outside the wallet's derivation tree, each
+ * addressed by a `tr(<pubkey>)` descriptor.
+ *
+ * Resolution is union-shaped — `signWithDescriptor` /
+ * `signMessageWithDescriptor` serve a descriptor from the wrapped
+ * provider's derivation tree *or* from the keyring, whichever owns it —
+ * so the wallet's existing descriptor routing
+ * (`InputSignerRouter`) signs foreign-key contracts with no changes: an
+ * imported contract carrying `metadata.signingDescriptor` is signable by
+ * construction rather than throwing `MissingSigningDescriptorError`.
+ *
+ * Allocation is *not* extended: `getNextSigningDescriptor` always
+ * delegates to the wrapped provider. The keyring holds foreign keys the
+ * wallet was handed; it never mints receive addresses.
+ *
+ * Lifecycle: entries persist under
+ * `WalletRepository.getWalletState().settings.keyring` (same
+ * no-migration pattern as `HDDescriptorProvider`), so an import survives
+ * the restarts a recovery spans, and {@link deleteKey} purges it when
+ * recovery completes.
+ *
+ * **Keys are stored unencrypted.** This is a deliberate, scoped
+ * decision: the intended use is a short-lived, purge-on-completion hold
+ * of a key that guards funds already destined for this wallet. At-rest
+ * encryption is a possible hardening follow-up. Do not use this to hold
+ * long-lived key material.
+ *
+ * @example
+ * ```ts
+ * const provider = await KeyringDescriptorProvider.create(hdProvider, walletRepo);
+ * const descriptor = await provider.importKey(foreignPrivKey);
+ * // descriptor: tr(<x-only pubkey hex>)
+ * // ... import a contract with metadata.signingDescriptor = descriptor,
+ * //     let the wallet's recovery machinery settle it, then:
+ * await provider.deleteKey(descriptor);
+ * ```
+ */
+export class KeyringDescriptorProvider implements DescriptorProvider {
+    /**
+     * In-memory mirror of the persisted keyring, keyed by x-only pubkey
+     * hex. Required because {@link isOurs} is synchronous while
+     * persistence is not; kept in lockstep with storage by
+     * {@link importKey} / {@link deleteKey}, and seeded at
+     * {@link create}.
+     */
+    private readonly keys: Map<string, SingleKey>;
+
+    private constructor(
+        /**
+         * The wrapped provider. Exposed so callers that need to reach a
+         * concrete provider type behind the decorator (e.g. the wallet's
+         * restore path, which branches on `HDDescriptorProvider`) can
+         * unwrap it rather than mis-classify the decorator.
+         */
+        readonly base: DescriptorProvider,
+        private readonly walletRepository: WalletRepository,
+        entries: Map<string, SingleKey>,
+    ) {
+        this.keys = entries;
+    }
+
+    /**
+     * Wrap `base` with a keyring, loading any previously imported keys
+     * from the repository. Unlike `HDDescriptorProvider.create`, this
+     * *does* read at construction: `isOurs` is synchronous and must be
+     * able to answer for persisted keys from the first call.
+     */
+    static async create(
+        base: DescriptorProvider,
+        walletRepository: WalletRepository,
+    ): Promise<KeyringDescriptorProvider> {
+        const state = await walletRepository.getWalletState();
+        const settings = parseSettings(state ?? {});
+        const entries = new Map<string, SingleKey>();
+        for (const [pubKeyHex, privKeyHex] of Object.entries(settings.keys)) {
+            entries.set(pubKeyHex, SingleKey.fromHex(privKeyHex));
+        }
+        const provider = new KeyringDescriptorProvider(base, walletRepository, entries);
+        forwardOptionalCapabilities(provider, base);
+        return provider;
+    }
+
+    /**
+     * Import a raw private key into the keyring and return its
+     * `tr(<x-only pubkey>)` descriptor handle. Idempotent: re-importing
+     * the same key returns the same descriptor and leaves storage
+     * unchanged.
+     */
+    async importKey(privateKey: Uint8Array): Promise<string> {
+        const pubKeyHex = hex.encode(pubSchnorr(privateKey));
+        await this.mutate((settings) => {
+            settings.keys[pubKeyHex] = hex.encode(privateKey);
+        });
+        this.keys.set(pubKeyHex, SingleKey.fromPrivateKey(privateKey));
+        return `tr(${pubKeyHex})`;
+    }
+
+    /**
+     * Purge a keyring entry. Returns `true` when an entry was removed,
+     * `false` when the descriptor was not in the keyring (already
+     * purged, or never ours) — so a repeated purge is a safe no-op.
+     */
+    async deleteKey(descriptor: string): Promise<boolean> {
+        const pubKeyHex = keyOf(descriptor);
+        if (!pubKeyHex || !this.keys.has(pubKeyHex)) return false;
+        await this.mutate((settings) => {
+            delete settings.keys[pubKeyHex];
+        });
+        this.keys.delete(pubKeyHex);
+        return true;
+    }
+
+    /** True iff `descriptor` resolves to a key held in the keyring. */
+    hasKey(descriptor: string): boolean {
+        const pubKeyHex = keyOf(descriptor);
+        return pubKeyHex !== undefined && this.keys.has(pubKeyHex);
+    }
+
+    /** The `tr(<pubkey>)` descriptors of every key currently held. */
+    listKeyringDescriptors(): string[] {
+        return Array.from(this.keys.keys(), (pubKeyHex) => `tr(${pubKeyHex})`);
+    }
+
+    /** Allocation is the wrapped provider's job; the keyring never mints. */
+    async getNextSigningDescriptor(): Promise<string> {
+        return this.base.getNextSigningDescriptor();
+    }
+
+    /** Ours iff the wrapped provider claims it, or the keyring holds it. */
+    isOurs(descriptor: string): boolean {
+        return this.base.isOurs(descriptor) || this.hasKey(descriptor);
+    }
+
+    /**
+     * Signs each request with the key its descriptor resolves to.
+     * Keyring-owned requests are signed here; every other request is
+     * handed to the wrapped provider in a single batched call, so a
+     * batch-signing identity behind a `StaticDescriptorProvider` still
+     * sees one interaction.
+     *
+     * Results are returned in request order regardless of how the
+     * requests split across the two signers.
+     */
+    async signWithDescriptor(requests: DescriptorSigningRequest[]): Promise<Transaction[]> {
+        const results = new Array<Transaction>(requests.length);
+        const delegated: { request: DescriptorSigningRequest; index: number }[] = [];
+
+        for (const [index, request] of requests.entries()) {
+            const key = this.resolveKey(request.descriptor);
+            if (key) {
+                results[index] = await key.sign(request.tx, request.inputIndexes);
+            } else {
+                delegated.push({ request, index });
+            }
+        }
+
+        if (delegated.length > 0) {
+            const signed = await this.base.signWithDescriptor(delegated.map((d) => d.request));
+            if (signed.length !== delegated.length) {
+                throw new Error(
+                    `Base provider returned ${signed.length} transactions, expected ${delegated.length}`,
+                );
+            }
+            for (const [i, { index }] of delegated.entries()) {
+                results[index] = signed[i];
+            }
+        }
+
+        return results;
+    }
+
+    /** Signs a message with the keyring key, or delegates to the base. */
+    async signMessageWithDescriptor(
+        descriptor: string,
+        message: Uint8Array,
+        type: "schnorr" | "ecdsa" = "schnorr",
+    ): Promise<Uint8Array> {
+        const key = this.resolveKey(descriptor);
+        if (key) return key.signMessage(message, type);
+        return this.base.signMessageWithDescriptor(descriptor, message, type);
+    }
+
+    // ── internals ────────────────────────────────────────────────────
+
+    /**
+     * The keyring key for `descriptor`, or `undefined` when the request
+     * belongs to the base provider. Base ownership wins on collision:
+     * a key already in the derivation tree keeps its established signing
+     * path, so importing it cannot reroute existing contracts.
+     */
+    private resolveKey(descriptor: string): SingleKey | undefined {
+        if (this.base.isOurs(descriptor)) return undefined;
+        const pubKeyHex = keyOf(descriptor);
+        return pubKeyHex ? this.keys.get(pubKeyHex) : undefined;
+    }
+
+    /**
+     * Read-modify-write the keyring settings inside the shared per-repo
+     * wallet-state mutex, so concurrent imports/purges — including those
+     * driven by separate provider instances on the same repo — cannot
+     * clobber each other's entries.
+     */
+    private async mutate(fn: (settings: KeyringSettings) => void): Promise<void> {
+        await updateWalletState(this.walletRepository, (state) => {
+            const settings = parseSettings(state);
+            fn(settings);
+            return {
+                ...state,
+                settings: {
+                    ...(state.settings ?? {}),
+                    [KEYRING_SETTINGS_KEY]: settings,
+                },
+            };
+        });
+    }
+}
+
+/**
+ * Canonical map key for a descriptor: its lowercase x-only pubkey hex,
+ * or `undefined` when the descriptor is not a bare `tr(<pubkey>)` (HD
+ * descriptors and malformed input included — neither can name a keyring
+ * entry).
+ */
+function keyOf(descriptor: string): string | undefined {
+    try {
+        return extractPubKey(normalizeToDescriptor(descriptor)).toLowerCase();
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Validate persisted keyring settings (or initialize a fresh record when
+ * absent) and return a clone safe for the caller to mutate. Trusting
+ * storage blindly would let a corrupted repo surface as a signing
+ * failure deep in a settlement; fail loud at the boundary instead.
+ */
+function parseSettings(state: WalletState): KeyringSettings {
+    const stored = state.settings?.[KEYRING_SETTINGS_KEY] as KeyringSettings | undefined;
+    if (!stored) return { keys: {} };
+    if (typeof stored.keys !== "object" || stored.keys === null) {
+        throw new Error("Corrupt keyring settings: `keys` is not an object.");
+    }
+    for (const [pubKeyHex, privKeyHex] of Object.entries(stored.keys)) {
+        if (typeof privKeyHex !== "string" || !isHexOfBytes(privKeyHex, 32)) {
+            throw new Error(
+                `Corrupt keyring settings: entry ${pubKeyHex} is not a 32-byte hex private key.`,
+            );
+        }
+    }
+    return { keys: { ...stored.keys } };
+}
+
+function isHexOfBytes(value: string, bytes: number): boolean {
+    return value.length === bytes * 2 && /^[0-9a-fA-F]+$/.test(value);
+}
+
+/**
+ * Mirror the wrapped provider's *optional* capabilities onto the
+ * decorator, so wrapping an `HDDescriptorProvider` doesn't silently
+ * disable receive rotation or the boot-time descriptor peek — both of
+ * which the wallet detects by duck-typed method presence.
+ *
+ * Forwarded dynamically rather than declared as methods, because a
+ * method that always exists would make the decorator claim capabilities
+ * a static base doesn't have — exactly the mis-classification the duck
+ * typing is there to prevent.
+ */
+function forwardOptionalCapabilities(target: KeyringDescriptorProvider, base: DescriptorProvider) {
+    for (const name of ["createReceiveRotator", "getCurrentSigningDescriptor"] as const) {
+        const method = (base as unknown as Record<string, unknown>)[name];
+        if (typeof method !== "function") continue;
+        (target as unknown as Record<string, unknown>)[name] = (...args: unknown[]) =>
+            (method as (...a: unknown[]) => unknown).apply(base, args);
+    }
+}

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -92,6 +92,7 @@ import {
     type ArkCashUnclaimedReason,
     type ArkCashUnclaimedVtxo,
     type ArkCashVtxoRef,
+    type ArkCashRecoveringVtxo,
     DescriptorSigningProviderMissingError,
     MissingSigningDescriptorError,
 } from "./wallet/wallet";
@@ -685,6 +686,7 @@ export type {
     ArkCashUnclaimedReason,
     ArkCashUnclaimedVtxo,
     ArkCashVtxoRef,
+    ArkCashRecoveringVtxo,
     SettlementConfig,
     IVtxoManager,
     RenewVtxosOptions,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -91,6 +91,7 @@ import {
     type ArkCashClaimResult,
     type ArkCashUnclaimedReason,
     type ArkCashUnclaimedVtxo,
+    type ArkCashVtxoRef,
     DescriptorSigningProviderMissingError,
     MissingSigningDescriptorError,
 } from "./wallet/wallet";
@@ -683,6 +684,7 @@ export type {
     ArkCashClaimResult,
     ArkCashUnclaimedReason,
     ArkCashUnclaimedVtxo,
+    ArkCashVtxoRef,
     SettlementConfig,
     IVtxoManager,
     RenewVtxosOptions,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -98,6 +98,9 @@ import { TxTree, TxTreeNode } from "./tree/txTree";
 import { SignerSession, TreeNonces, TreePartialSigs } from "./tree/signingSession";
 import { DustChangeError, Ramps } from "./wallet/ramps";
 import { HDDescriptorProvider } from "./wallet/hdDescriptorProvider";
+import { StaticDescriptorProvider } from "./identity/staticDescriptorProvider";
+import { KeyringDescriptorProvider } from "./identity/keyringDescriptorProvider";
+import type { DescriptorProvider, DescriptorSigningRequest } from "./identity/descriptorProvider";
 import { isVtxoExpiringSoon, VtxoManager } from "./wallet/vtxo-manager";
 import type {
     IVtxoManager,
@@ -401,6 +404,8 @@ export {
     isCooperativelyMigratable,
     toXOnlySignerHex,
     HDDescriptorProvider,
+    StaticDescriptorProvider,
+    KeyringDescriptorProvider,
     DelegateManagerImpl,
     DelegatorManagerImpl,
     RestDelegateProvider,
@@ -590,6 +595,10 @@ export type {
     BaseWalletConfig,
     WalletConfig,
     WalletMode,
+    // Referenced by WalletMode: consumers need these to name or implement
+    // a provider they pass to the wallet.
+    DescriptorProvider,
+    DescriptorSigningRequest,
     ReadonlyWalletConfig,
     ProviderClass,
     ArkTransaction,

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -8,6 +8,7 @@ import type {
     GetContractsFilter,
     PathSelection,
 } from "../../contracts";
+import { isRecoveryOnlyContract } from "../../contracts";
 import type {
     ContractSyncState,
     CreateContractParams,
@@ -974,7 +975,10 @@ export class WalletMessageHandler
                     });
                 }
                 case "GET_TRANSACTION_HISTORY": {
-                    const allVtxos = await this.getVtxosFromRepo();
+                    // Include recovery-only contracts: transaction history mirrors
+                    // the non-worker getTransactionHistory, which reads contracts
+                    // directly and does not exclude them (unlike balance/VTXOs).
+                    const allVtxos = await this.getVtxosFromRepo({ includeRecoveryOnly: true });
                     const transactions =
                         (await this.buildTransactionHistoryFromCache(allVtxos)) ?? [];
                     return this.tagged({
@@ -1589,8 +1593,11 @@ export class WalletMessageHandler
             return;
         }
 
-        // Read virtual outputs from repository (now populated by contract manager)
-        const vtxos = await this.getVtxosFromRepo();
+        // Read virtual outputs from repository (now populated by contract
+        // manager). Include recovery-only contracts here: these VTXOs feed the
+        // transaction-history cache below, and the non-worker
+        // getTransactionHistory includes them too (it reads contracts directly).
+        const vtxos = await this.getVtxosFromRepo({ includeRecoveryOnly: true });
 
         // Fetch boarding inputs across the full boarding-address set (current +
         // historical rotated; plan §6-IV.2). Fetch FIRST: getBoardingUtxos
@@ -1760,8 +1767,18 @@ export class WalletMessageHandler
     /**
      * Read all virtual outputs from the repository, aggregated across all contract
      * addresses and the wallet's primary address, with deduplication.
+     *
+     * Recovery-only contracts (imported by `claimCash` for server-swept
+     * arkcash) are excluded by default, mirroring {@link ReadonlyWallet.getVtxos}:
+     * they are settled in their own isolated intent and must stay out of the
+     * wallet's balance / VTXO / coin-selection / pending-tx views that read this.
+     * The transaction-history caller opts back in via `includeRecoveryOnly` to
+     * match the non-worker `getTransactionHistory`, which reads contracts
+     * directly and does include them.
      */
-    private async getVtxosFromRepo(): Promise<ExtendedVirtualCoin[]> {
+    private async getVtxosFromRepo({
+        includeRecoveryOnly = false,
+    }: { includeRecoveryOnly?: boolean } = {}): Promise<ExtendedVirtualCoin[]> {
         if (!this.walletRepository || !this.readonlyWallet) return [];
         const seen = new Set<string>();
         const allVtxos: ExtendedVirtualCoin[] = [];
@@ -1783,6 +1800,7 @@ export class WalletMessageHandler
         const manager = await this.readonlyWallet.getContractManager();
         const contracts = await manager.getContracts();
         for (const contract of contracts) {
+            if (!includeRecoveryOnly && isRecoveryOnlyContract(contract)) continue;
             addVtxos(await getVtxosForContract(this.walletRepository, contract));
         }
 

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -13,7 +13,8 @@ import {
 import { ArkInfo, ArkProvider, SettlementEvent } from "../providers/ark";
 import { ArkErrorName, isArkError, maybeArkError } from "../providers/errors";
 import type { BoardingUtxoGroup } from "./wallet";
-import type { ExtendedContractVtxo } from "../contracts/types";
+import type { Contract, ExtendedContractVtxo } from "../contracts/types";
+import { isRecoveryOnlyContract } from "../contracts/types";
 import {
     classifyAgainstSignerSet,
     isCooperativelyMigratable,
@@ -125,6 +126,16 @@ function assertSweepCapable(wallet: IWallet): asserts wallet is IWallet & SweepC
  * same origin will take turns, which is acceptable.
  */
 const BOARDING_POLL_LOCK_NAME = "arkade-boarding-poll";
+
+/**
+ * Web Locks name serializing imported-contract recovery (arkcash) across
+ * same-origin contexts. Separate from {@link BOARDING_POLL_LOCK_NAME} because
+ * the prompt `claimCash` kick runs this OUTSIDE the boarding-poll lock; a
+ * distinct name lets the recovery core nest safely under that lock when the
+ * poll drives it (Web Locks with `ifAvailable` never block, so no deadlock).
+ * Static for the same reason the boarding lock is: dedupe work per origin.
+ */
+const IMPORTED_RECOVERY_LOCK_NAME = "arkade-imported-recovery";
 
 /**
  * Run `fn` under an exclusive Web Lock when the runtime provides one
@@ -766,6 +777,26 @@ function isMigrationCapable(wallet: IWallet): wallet is IWallet & MigrationCapab
     );
 }
 
+/**
+ * A wallet that can purge a contract it imported purely for recovery (see
+ * `Wallet.claimCash`): removes the contract row and the keyring key backing
+ * it. Duck-typed like {@link MigrationCapableWallet} so proxy/watch-only
+ * wallets — which never import such contracts — are simply routed away.
+ */
+interface RecoveryContractCapableWallet {
+    removeRecoveryContract(script: string): Promise<void>;
+}
+
+/** Return whether a wallet can purge its imported recovery contracts. */
+function isRecoveryContractCapable(
+    wallet: IWallet,
+): wallet is IWallet & RecoveryContractCapableWallet {
+    return (
+        typeof (wallet as Partial<RecoveryContractCapableWallet>).removeRecoveryContract ===
+        "function"
+    );
+}
+
 /** A deprecated-signer VTXO paired with its signer classification. */
 interface ClassifiedVtxo {
     vtxo: ExtendedContractVtxo;
@@ -951,6 +982,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     private consecutivePollFailures = 0;
     private startupPollTimeoutId?: ReturnType<typeof setTimeout>;
     private static readonly MAX_BACKOFF_MS = 5 * 60 * 1000; // 5 minutes
+
+    // Serializes imported-recovery passes so the prompt claimCash kick and the
+    // poll loop can't settle the same imported (arkcash) contract twice.
+    private importedRecoveryInProgress = false;
 
     // Guards against renewal feedback loop: when renewVtxos() settles, the
     // server emits new VTXOs → vtxo_received → renewVtxos() again → infinite loop.
@@ -1170,6 +1205,175 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             includesSubdust,
             vtxoCount: vtxosToRecover.length,
         };
+    }
+
+    // ========== Imported Recovery (arkcash) ==========
+
+    /**
+     * Recover the funds of every contract imported purely for recovery (see
+     * `Wallet.claimCash`'s server-swept branch). Each imported contract is
+     * settled back to the wallet in its **own isolated intent**, so a
+     * persistently rejected input dents only its own recovery and never the
+     * wallet's own renewal/recovery bundle. Rotation-aware: a swept input
+     * minted under a now-deprecated signer re-mints under the active one.
+     *
+     * On a successful settlement the imported contract's VTXOs are spent, so
+     * the contract row and its keyring key are purged — the key at rest lives
+     * only for the recovery window.
+     *
+     * Self-contained and idempotent: safe to call repeatedly and never throws.
+     * `claimCash` kicks it promptly after an import; the poll loop retries it
+     * indefinitely on the normal cadence. Every failure is logged and retried.
+     */
+    async recoverImportedContracts(): Promise<void> {
+        const wallet = this.wallet;
+        // Only a signing wallet imports recovery contracts; proxy/watch-only
+        // wallets never have any, so there is nothing to do.
+        if (!isRecoveryContractCapable(wallet)) return;
+        // Fast per-instance skip so the prompt kick and this instance's own poll
+        // don't queue redundant passes. This is the ONLY serialization in Node/
+        // React Native, where the cross-instance lock below is a no-op.
+        if (this.importedRecoveryInProgress) return;
+        this.importedRecoveryInProgress = true;
+        try {
+            // Cross-instance serialization: the prompt `claimCash` kick and the
+            // poll loop both land here, and two tabs/workers can share one repo.
+            // Without a shared lock they submit duplicate recovery intents for
+            // the same swept VTXO, and the server's duplicated-input handling
+            // then issues a DeleteIntent that can cancel a sibling's valid
+            // recovery — the very race the boarding poll's lock prevents for its
+            // intents. `ifAvailable` never blocks (it runs or skips), so this
+            // cannot deadlock even when the poll drives it inside the boarding
+            // lock; a skipped cycle is retried by the next poll.
+            await runWithCrossInstanceLock(IMPORTED_RECOVERY_LOCK_NAME, () =>
+                this.recoverImportedContractsCore(wallet),
+            );
+        } finally {
+            this.importedRecoveryInProgress = false;
+        }
+    }
+
+    /**
+     * The recovery pass body, run under the imported-recovery cross-instance
+     * lock by {@link recoverImportedContracts}. Never throws — every failure is
+     * logged and retried on the next cycle.
+     */
+    private async recoverImportedContractsCore(
+        wallet: IWallet & RecoveryContractCapableWallet,
+    ): Promise<void> {
+        try {
+            const cm = await wallet.getContractManager();
+            // Cheap repo-only pre-check: the poll loop calls this every cycle,
+            // so avoid an indexer sync entirely when there is nothing imported.
+            const recoveryScripts = (await cm.getContracts())
+                .filter(isRecoveryOnlyContract)
+                .map((contract) => contract.script);
+            if (recoveryScripts.length === 0) return;
+
+            // Scope the VTXO sync to just the imported contracts.
+            const recoveryContracts = await cm.getContractsWithVtxos({ script: recoveryScripts });
+
+            const info = await this.getInfoProvider()?.getInfo();
+            const dustAmount = getDustAmount(wallet);
+
+            for (const { contract, vtxos } of recoveryContracts) {
+                try {
+                    await this.recoverOneImportedContract(
+                        wallet,
+                        contract,
+                        vtxos,
+                        info,
+                        dustAmount,
+                    );
+                } catch (error) {
+                    // Isolation: log and move on. A failing recovery is retried
+                    // next cycle and never touches the other contracts or the
+                    // wallet's own funds.
+                    console.error(
+                        `Imported arkcash recovery failed for contract ${contract.script}:`,
+                        error,
+                    );
+                }
+            }
+        } catch (error) {
+            // A top-level failure (e.g. the contract fetch) must not break the
+            // caller: both the poll loop and the claimCash kick rely on this
+            // being non-throwing.
+            console.error("Imported arkcash recovery pass failed:", error);
+        }
+    }
+
+    /**
+     * Settle one imported recovery contract's swept VTXOs back to the wallet,
+     * then purge the contract and its key once nothing spendable remains.
+     * Called only with a recovery-capable wallet (see
+     * {@link recoverImportedContracts}).
+     */
+    private async recoverOneImportedContract(
+        wallet: IWallet & RecoveryContractCapableWallet,
+        contract: Contract,
+        vtxos: ExtendedContractVtxo[],
+        info: ArkInfo | undefined,
+        dustAmount: bigint,
+    ): Promise<void> {
+        // Only swept-but-unspent VTXOs can be recovered; a re-run after a
+        // partial/complete recovery sees the rest already spent.
+        const recoverable = vtxos.filter((vtxo) => isRecoverable(vtxo));
+
+        // Cap to the server's intent-size and per-output limits, highest-value
+        // first (mirrors recoverVtxos); the overflow recovers next cycle. A
+        // lone arkcash VTXO — the common case — is unaffected.
+        const vtxoMaxAmount = info?.vtxoMaxAmount ?? -1n;
+        const batch =
+            recoverable.length > 0
+                ? capSettlementBatch(byValueDescending(recoverable), vtxoMaxAmount)
+                : [];
+
+        if (batch.length > 0) {
+            const totalAmount = batch.reduce((sum, vtxo) => sum + BigInt(vtxo.value), 0n);
+            // The highest-value fitting subset is still below dust — the server
+            // would reject it. Leave it for a later cycle. arkcash is >= dust by
+            // construction, so this only guards a pathological remainder.
+            if (totalAmount < dustAmount) return;
+
+            // Rotation guard: if a swept input is under a now-deprecated signer
+            // and the wallet's own snapshot is that old signer, pin the wallet
+            // to the active signer BEFORE reading its address, so the recovered
+            // output re-mints under the current key (mirrors recoverVtxos).
+            if (info && isMigrationCapable(wallet)) {
+                await this.rotateForRecoverableInputs(batch, info);
+            }
+
+            const arkAddress = await wallet.getAddress();
+            await wallet.settle({
+                inputs: batch,
+                outputs: [{ address: arkAddress, amount: totalAmount }],
+            });
+        }
+
+        // Purge only on AUTHORITATIVE evidence the funds are gone — never on an
+        // empty VTXO view. `createContract` tolerates a retryable hydration
+        // failure and `getContractsWithVtxos` falls back to (possibly empty)
+        // repo state on a retryable sync failure, so a transient indexer outage
+        // yields `vtxos = []` (hence `batch = []`). Deleting the key then would
+        // strand the funds before recovery ever ran, breaking the indefinite-
+        // retry guarantee. On an empty view, do nothing and retry next cycle.
+        //
+        // A non-empty view IS authoritative enough: a `spent` status only comes
+        // from the indexer and is terminal, and a settle we just made is itself
+        // authoritative. So purge once nothing spendable remains after this
+        // batch is spent; if any spendable VTXO is still there (an un-settled
+        // overflow, or fresh funds at the address), keep the contract for a
+        // later cycle.
+        if (vtxos.length === 0) return;
+
+        const spent = new Set(batch.map((vtxo) => `${vtxo.txid}:${vtxo.vout}`));
+        const stillSpendable = vtxos.some(
+            (vtxo) => isSpendable(vtxo) && !spent.has(`${vtxo.txid}:${vtxo.vout}`),
+        );
+        if (!stillSpendable) {
+            await wallet.removeRecoveryContract(contract.script);
+        }
     }
 
     // ========== Renewal Methods ==========
@@ -2544,6 +2748,16 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 if (migrationEnabled && isMigrationCapable(this.wallet)) {
                     await this.runMigrationPass();
                 }
+
+                // Recover funds of contracts imported for recovery (claimCash's
+                // server-swept branch), each in its own isolated intent.
+                // Self-serializing on its own cross-instance lock, so it stays
+                // coordinated with the prompt claimCash kick (which calls it
+                // outside this boarding lock) — the two never submit duplicate
+                // recovery intents. Self-contained (per-contract try/catch,
+                // never throws) so it neither stacks the poll backoff nor
+                // affects the wallet's own settle above.
+                await this.recoverImportedContracts();
             });
         } catch (e) {
             hadError = true;

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -270,6 +270,87 @@ export function capSettlementBatch<T extends { value: number }>(
     return batch;
 }
 
+/**
+ * Enrol a claimer top-up so an isolated arkcash recovery settle whose recovery
+ * inputs sum below dust can clear the server's below-dust-output rejection.
+ *
+ * `recoveryBatch` is the already-capped, value-descending set of recovery
+ * inputs (all subdust here — if any were >= dust the total would already clear
+ * dust and no top-up would be needed). `candidates` is the claimer wallet's
+ * pool of available BTC VTXOs. The combined `recoveryInputs + topUp` list must
+ * respect BOTH the server's intent-size cap ({@link MAX_VTXOS_PER_SETTLEMENT})
+ * and, on the single combined output, the `vtxoMaxAmount` ceiling
+ * (`< 0` disables it — the server's `-1` "no limit" sentinel).
+ *
+ * Returns the (possibly trimmed) recovery inputs and the chosen top-up, or
+ * `null` when the claimer lacks enough spendable BTC to reach dust — the caller
+ * then defers this contract to a later cycle.
+ *
+ * Selection favours the fewest extra slots:
+ * 1. Since `deficit = dust - recoveryTotal < dust`, any single VTXO whose value
+ *    is `>= deficit` clears dust on its own — so prefer the smallest such
+ *    candidate (one slot; the common case).
+ * 2. Otherwise accumulate largest-first (slot-minimising) within the remaining
+ *    slot budget, skipping any candidate that would breach `vtxoMaxAmount`.
+ * 3. If the recovery batch already fills every slot, drop its smallest inputs to
+ *    free room — a dropped subdust input raises the deficit but keeps it below
+ *    dust, so one >= dust top-up still covers it; the dropped inputs defer to
+ *    the next cycle like any cap overflow.
+ */
+export function selectTopUpForRecovery<R extends { value: number }, C extends { value: number }>(
+    recoveryBatch: R[],
+    candidates: C[],
+    dustAmount: bigint,
+    vtxoMaxAmount: bigint,
+): { recoveryInputs: R[]; topUp: C[] } | null {
+    // Free at least one slot for a top-up input. recoveryBatch is
+    // value-descending, so the smallest inputs sit at the end. A dropped input
+    // is a subdust remainder that recovers next cycle.
+    const recoveryInputs = [...recoveryBatch];
+    while (recoveryInputs.length >= MAX_VTXOS_PER_SETTLEMENT) {
+        recoveryInputs.pop();
+    }
+
+    const recoveryTotal = recoveryInputs.reduce((sum, vtxo) => sum + BigInt(vtxo.value), 0n);
+    // Defensive: the caller only enrols a top-up below dust, but if the trim
+    // never happened and the batch already clears dust, no top-up is needed.
+    if (recoveryTotal >= dustAmount) return { recoveryInputs, topUp: [] };
+
+    const deficit = dustAmount - recoveryTotal;
+    const slotBudget = MAX_VTXOS_PER_SETTLEMENT - recoveryInputs.length;
+    const fitsCeiling = (topUpTotal: bigint) =>
+        vtxoMaxAmount < 0n || recoveryTotal + topUpTotal <= vtxoMaxAmount;
+
+    // 1. Smallest single candidate that covers the deficit — one slot, and the
+    //    combined output stays under the per-output ceiling.
+    const ascending = [...candidates].sort((a, b) => a.value - b.value);
+    for (const candidate of ascending) {
+        const value = BigInt(candidate.value);
+        if (value >= deficit && fitsCeiling(value)) {
+            return { recoveryInputs, topUp: [candidate] };
+        }
+    }
+
+    // 2. No single candidate suffices: accumulate largest-first within the slot
+    //    and ceiling budget, mirroring capSettlementBatch's skip semantics.
+    const descending = [...candidates].sort((a, b) => b.value - a.value);
+    const topUp: C[] = [];
+    let topUpTotal = 0n;
+    for (const candidate of descending) {
+        if (topUp.length >= slotBudget) break;
+        const next = topUpTotal + BigInt(candidate.value);
+        if (!fitsCeiling(next)) continue;
+        topUp.push(candidate);
+        topUpTotal = next;
+        if (recoveryTotal + topUpTotal >= dustAmount) {
+            return { recoveryInputs, topUp };
+        }
+    }
+
+    // The claimer cannot reach dust with its available funds this cycle.
+    return null;
+}
+
 /** Default renewal threshold in seconds (3 days). */
 export const DEFAULT_THRESHOLD_SECONDS = 259_200;
 
@@ -785,6 +866,12 @@ function isMigrationCapable(wallet: IWallet): wallet is IWallet & MigrationCapab
  */
 interface RecoveryContractCapableWallet {
     removeRecoveryContract(script: string): Promise<void>;
+    /**
+     * Outpoints of the wallet's own VTXOs that are unspendable because their
+     * signer is past its cutoff (see {@link Wallet.pendingRecoveryOutpoints}).
+     * Used to keep such coins out of the recovery top-up pool.
+     */
+    pendingRecoveryOutpoints(): Promise<Set<string>>;
 }
 
 /** Return whether a wallet can purge its imported recovery contracts. */
@@ -793,7 +880,9 @@ function isRecoveryContractCapable(
 ): wallet is IWallet & RecoveryContractCapableWallet {
     return (
         typeof (wallet as Partial<RecoveryContractCapableWallet>).removeRecoveryContract ===
-        "function"
+            "function" &&
+        typeof (wallet as Partial<RecoveryContractCapableWallet>).pendingRecoveryOutpoints ===
+            "function"
     );
 }
 
@@ -1304,10 +1393,15 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     }
 
     /**
-     * Settle one imported recovery contract's swept VTXOs back to the wallet,
-     * then purge the contract and its key once nothing spendable remains.
-     * Called only with a recovery-capable wallet (see
+     * Settle one imported recovery contract's swept/subdust VTXOs back to the
+     * wallet, then purge the contract and its key once nothing spendable
+     * remains. Called only with a recovery-capable wallet (see
      * {@link recoverImportedContracts}).
+     *
+     * A lone subdust note cannot settle on its own (the server rejects a
+     * below-dust output), so when the recovery inputs sum below dust this enrols
+     * a claimer top-up inside the same isolated intent to clear dust — parking
+     * at most a few of the claimer's own VTXOs for this one attempt.
      */
     private async recoverOneImportedContract(
         wallet: IWallet & RecoveryContractCapableWallet,
@@ -1316,37 +1410,82 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         info: ArkInfo | undefined,
         dustAmount: bigint,
     ): Promise<void> {
-        // Only swept-but-unspent VTXOs can be recovered; a re-run after a
-        // partial/complete recovery sees the rest already spent.
-        const recoverable = vtxos.filter((vtxo) => isRecoverable(vtxo));
+        // Recoverable = swept-but-unspent OR still-spendable subdust. A subdust
+        // note has no spendable leaf, so like a swept one it can only move
+        // through a settlement — and a recovery-only contract exists purely to
+        // be drained, so ALL live subdust qualifies regardless of confirmation
+        // state (deliberately bypassing the wallet's own preconfirmed-only
+        // subdust rule, which is liquidity policy, not a protocol limit). A
+        // re-run after a partial/complete recovery sees the rest already spent.
+        const recoverable = vtxos.filter(
+            (vtxo) => isRecoverable(vtxo) || (isSubdust(vtxo, dustAmount) && isSpendable(vtxo)),
+        );
 
         // Cap to the server's intent-size and per-output limits, highest-value
         // first (mirrors recoverVtxos); the overflow recovers next cycle. A
         // lone arkcash VTXO — the common case — is unaffected.
         const vtxoMaxAmount = info?.vtxoMaxAmount ?? -1n;
-        const batch =
+        let recoveryInputs: ExtendedContractVtxo[] =
             recoverable.length > 0
                 ? capSettlementBatch(byValueDescending(recoverable), vtxoMaxAmount)
                 : [];
+        let topUp: ExtendedVirtualCoin[] = [];
 
-        if (batch.length > 0) {
-            const totalAmount = batch.reduce((sum, vtxo) => sum + BigInt(vtxo.value), 0n);
-            // The highest-value fitting subset is still below dust — the server
-            // would reject it. Leave it for a later cycle. arkcash is >= dust by
-            // construction, so this only guards a pathological remainder.
-            if (totalAmount < dustAmount) return;
+        if (recoveryInputs.length > 0) {
+            let totalAmount = recoveryInputs.reduce((sum, vtxo) => sum + BigInt(vtxo.value), 0n);
 
-            // Rotation guard: if a swept input is under a now-deprecated signer
-            // and the wallet's own snapshot is that old signer, pin the wallet
-            // to the active signer BEFORE reading its address, so the recovered
-            // output re-mints under the current key (mirrors recoverVtxos).
+            if (totalAmount < dustAmount) {
+                // The recovery inputs alone are below dust (a lone/aggregated
+                // subdust note), which the server would reject. Enrol a claimer
+                // top-up so this isolated intent clears dust. The top-up is
+                // reserved and released by settle for this attempt only, so it
+                // never touches the wallet's own renewal/recovery bundle and
+                // parks nothing between attempts.
+                const candidates = await this.availableTopUpVtxos(wallet);
+                const selection = selectTopUpForRecovery(
+                    recoveryInputs,
+                    candidates,
+                    dustAmount,
+                    vtxoMaxAmount,
+                );
+                if (!selection) {
+                    // Insufficient claimer funds this cycle: leave the contract
+                    // imported and retry once the wallet is funded. The claim
+                    // already reported these under `recovering`.
+                    console.warn(
+                        `Imported arkcash recovery for contract ${contract.script}: ` +
+                            `recovery inputs total ${totalAmount} < dust ${dustAmount} and no ` +
+                            `claimer top-up is available; deferring to a later cycle`,
+                    );
+                    return;
+                }
+                recoveryInputs = selection.recoveryInputs;
+                topUp = selection.topUp;
+                totalAmount = [...recoveryInputs, ...topUp].reduce(
+                    (sum, vtxo) => sum + BigInt(vtxo.value),
+                    0n,
+                );
+            }
+
+            // Rotation guard: if a recovery input is under a now-deprecated
+            // signer and the wallet's own snapshot is that old signer, pin the
+            // wallet to the active signer BEFORE reading its address, so the
+            // recovered output re-mints under the current key (mirrors
+            // recoverVtxos). Only the recovery inputs can carry a foreign/old
+            // signer; the top-up is the wallet's own current-signer coin.
             if (info && isMigrationCapable(wallet)) {
-                await this.rotateForRecoverableInputs(batch, info);
+                await this.rotateForRecoverableInputs(recoveryInputs, info);
             }
 
             const arkAddress = await wallet.getAddress();
+            // Mixed signing is native: the router resolves each input by its
+            // owning contract — the keyring descriptor for the recovery inputs,
+            // the baseline identity for the top-up — and builds forfeits only
+            // for the top-up (swept/subdust skip them). The single combined
+            // output (>= dust by construction) is a self-transfer to the
+            // claimer's own address, so no split accounting is needed.
             await wallet.settle({
-                inputs: batch,
+                inputs: [...recoveryInputs, ...topUp],
                 outputs: [{ address: arkAddress, amount: totalAmount }],
             });
         }
@@ -1367,13 +1506,47 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // later cycle.
         if (vtxos.length === 0) return;
 
-        const spent = new Set(batch.map((vtxo) => `${vtxo.txid}:${vtxo.vout}`));
+        // Only the recovery inputs (this contract's own VTXOs) count toward
+        // purge; the top-up is the wallet's own coin and never lives here. A
+        // subdust note still blocked on a top-up keeps isSpendable true, so the
+        // contract (and key) survive until its funds are actually settled.
+        const spent = new Set(recoveryInputs.map((vtxo) => `${vtxo.txid}:${vtxo.vout}`));
         const stillSpendable = vtxos.some(
             (vtxo) => isSpendable(vtxo) && !spent.has(`${vtxo.txid}:${vtxo.vout}`),
         );
         if (!stillSpendable) {
             await wallet.removeRecoveryContract(contract.script);
         }
+    }
+
+    /**
+     * The claimer wallet's pool of BTC VTXOs eligible to top up an isolated
+     * arkcash recovery settle to dust.
+     *
+     * Mirrors the send path's availability filter and adds an asset guard:
+     * - `withRecoverable: false` excludes the wallet's own swept/expired coins
+     *   (recovery-bound funds must not be entangled in the arkcash intent);
+     * - past-cutoff deprecated-signer coins are dropped — the operator will not
+     *   co-sign them, so one would fail the recovery settle at submit and, under
+     *   indefinite retry, wedge the loop on the top-up selector's own choice;
+     * - asset-bearing VTXOs are dropped — the recovery output is a single BTC
+     *   output, so a top-up must never risk burning assets.
+     *
+     * Reserved (pending-spend) outpoints and recovery-only contracts are already
+     * excluded at the {@link Wallet.getVtxos} choke point.
+     */
+    private async availableTopUpVtxos(
+        wallet: IWallet & RecoveryContractCapableWallet,
+    ): Promise<ExtendedVirtualCoin[]> {
+        const available = await wallet.getVtxos({ withRecoverable: false });
+        const pendingRecovery = await wallet.pendingRecoveryOutpoints();
+        return available.filter((vtxo) => {
+            if (vtxo.assets && vtxo.assets.length > 0) return false;
+            if (pendingRecovery.size && pendingRecovery.has(`${vtxo.txid}:${vtxo.vout}`)) {
+                return false;
+            }
+            return true;
+        });
     }
 
     // ========== Renewal Methods ==========

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -4185,13 +4185,15 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         const cashScript = cash.vtxoScript;
         const cashAddress = cash.address(this.network.hrp);
         const cashPkScript = hex.encode(cashScript.pkScript);
-        const cashSubdustPkScript = hex.encode(cashAddress.subdustPkScript);
 
-        // One unfiltered query: the server's state filters are mutually
-        // exclusive, so any filter here would hide the very states this method
-        // reports. Both scripts are queried in the same call — subdust arkcash
-        // lives at the OP_RETURN script and would otherwise vanish silently.
-        const scripts = [cashPkScript, cashSubdustPkScript];
+        // One unfiltered query over the contract's P2TR script: the server's
+        // state filters are mutually exclusive, so any filter here would hide
+        // the very states this method reports. Only the P2TR script is queried —
+        // the indexer rejects a non-P2TR (OP_RETURN) script outright, so subdust
+        // arkcash, which lives at the OP_RETURN script, is not visible here and
+        // is simply not reported. `createCash`'s dust floor keeps it from being
+        // minted in the first place.
+        const scripts = [cashPkScript];
         let vtxos = await this.fetchAllVtxos(scripts);
 
         if (vtxos.length === 0) {
@@ -4199,10 +4201,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         }
 
         const myPkScript = ArkAddress.decode(await this.getAddress()).pkScript;
-        let { spendable, recoverable, unclaimed } = this.classifyCashVtxos(
-            vtxos,
-            cashSubdustPkScript,
-        );
+        let { spendable, recoverable, unclaimed } = this.classifyCashVtxos(vtxos);
         let swept = 0;
 
         // Drain first: a previous claim may have registered a sweep it never
@@ -4213,10 +4212,8 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         // The candidate set is neither `spendable` nor everything. Registering
         // a sweep marks its input spent, so the very inputs needing a drain are
         // the ones classified `already-spent` — gating on `spendable` would
-        // skip the drain exactly when it is needed. Subdust must stay out
-        // regardless: the proof describes every input by the contract's own
-        // pkScript, which is a lie for an OP_RETURN outpoint and would have the
-        // server reject the whole proof.
+        // skip the drain exactly when it is needed. Every queried VTXO sits at
+        // the contract's own pkScript, so all of them are valid proof inputs.
         const drainable = vtxos.filter((vtxo) => vtxo.script === cashPkScript);
         if (drainable.length > 0) {
             let drained = { count: 0, swept: 0, claimed: new Set<string>() };
@@ -4238,10 +4235,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 // now stale: re-read it, or we would re-sweep an outpoint we
                 // just spent and report the rejection as a failure.
                 vtxos = await this.fetchAllVtxos(scripts);
-                ({ spendable, recoverable, unclaimed } = this.classifyCashVtxos(
-                    vtxos,
-                    cashSubdustPkScript,
-                ));
+                ({ spendable, recoverable, unclaimed } = this.classifyCashVtxos(vtxos));
 
                 // The drain moved these to this wallet, so they are swept by
                 // this call — the re-read above sees them spent and would
@@ -4410,10 +4404,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      * through a recovery settlement (`recoverable`), and the ones that can
      * only be reported (`unclaimed`).
      */
-    private classifyCashVtxos(
-        vtxos: VirtualCoin[],
-        cashSubdustPkScript: string,
-    ): {
+    private classifyCashVtxos(vtxos: VirtualCoin[]): {
         spendable: VirtualCoin[];
         recoverable: VirtualCoin[];
         unclaimed: ArkCashUnclaimedVtxo[];
@@ -4425,11 +4416,14 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         for (const vtxo of vtxos) {
             if (!isSpendable(vtxo)) {
                 unclaimed.push(cashReport(vtxo, "already-spent"));
-            } else if (vtxo.script === cashSubdustPkScript || isSubdust(vtxo, this.dustAmount)) {
-                // Subdust sits at an OP_RETURN script: no forfeit leaf, nothing
-                // to spend, and no settlement can lift it out on its own.
-                // Checked before the swept case, which would otherwise claim
-                // these are recoverable. createCash now prevents minting them.
+            } else if (isSubdust(vtxo, this.dustAmount)) {
+                // A below-dust VTXO at the P2TR script cannot be swept or
+                // settled on its own. Subdust arkcash actually lives at an
+                // OP_RETURN script (not queried — the indexer rejects non-P2TR
+                // scripts), so this is a defensive guard; createCash's dust
+                // floor prevents minting subdust in the first place. Checked
+                // before the swept case, which would otherwise call it
+                // recoverable.
                 unclaimed.push(cashReport(vtxo, "subdust"));
             } else if (vtxo.assets && vtxo.assets.length > 0) {
                 // The thin sweep builds a BTC-only output; sweeping an

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -119,6 +119,7 @@ import { validateVtxosForScript, saveVtxosForContract } from "../contracts/vtxoO
 import { WalletReceiveRotator, signingDescriptorIndex } from "./walletReceiveRotator";
 import { HDDescriptorProvider } from "./hdDescriptorProvider";
 import { DescriptorProvider } from "../identity/descriptorProvider";
+import { KeyringDescriptorProvider } from "../identity/keyringDescriptorProvider";
 import { deriveDescriptorLeafPubKey } from "../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../contracts/metadata";
 import { DiscoveryDeps } from "../contracts/types";
@@ -2435,7 +2436,12 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
     private async _runRestore(gapLimit: number): Promise<void> {
         const manager = await this.getContractManager();
-        const provider = this._descriptorProvider;
+        // Unwrap decorators before the HD check: a KeyringDescriptorProvider
+        // wrapping an HD provider is still an HD wallet for scan purposes,
+        // and the keyring's foreign keys are outside the derivation tree the
+        // gap scan walks — they contribute no indices to it.
+        const outer = this._descriptorProvider;
+        const provider = outer instanceof KeyringDescriptorProvider ? outer.base : outer;
         // Use `instanceof` rather than duck-typing the
         // materializeDescriptorAt / advanceLastIndexUsed surface: a
         // non-HD provider that happens to expose either method name

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -361,19 +361,16 @@ export interface BoardingUtxoGroup {
  * Why a VTXO at an arkcash address could neither be swept nor imported for
  * recovery by {@link Wallet.claimCash}.
  *
- * - `subdust` — below dust, so it sits at an OP_RETURN script with no spendable
- *   leaf. Unspendable as cash; `createCash` prevents minting these.
  * - `already-spent` — someone else claimed it first.
  * - `has-assets` — asset-bearing; the BTC-only sweep would burn the assets.
  * - `sweep-failed` — spendable, but its own sweep was rejected.
- * - `recovery-failed` — server-swept and recoverable in principle, but the
- *   import that hands it to the wallet's recovery machinery failed.
+ * - `recovery-failed` — server-swept or subdust and recoverable in principle,
+ *   but the import that hands it to the wallet's recovery machinery failed.
  *
- * A server-swept VTXO whose import *succeeds* is not reported here — it lands
- * in {@link ArkCashClaimResult.recovering} instead.
+ * A VTXO whose recovery import *succeeds* — server-swept or subdust — is not
+ * reported here: it lands in {@link ArkCashClaimResult.recovering} instead.
  */
 export type ArkCashUnclaimedReason =
-    | "subdust"
     | "already-spent"
     | "has-assets"
     | "sweep-failed"
@@ -394,6 +391,19 @@ export interface ArkCashVtxoRef {
     value: number;
 }
 
+/**
+ * A VTXO {@link Wallet.claimCash} imported for background recovery.
+ *
+ * `kind` explains why the funds cannot arrive instantly:
+ * - `swept` — the server swept the batch at expiry; only a settlement lifts it.
+ * - `subdust` — below dust, so it has no spendable leaf and cannot settle on
+ *   its own; recovery aggregates it with a claimer top-up to clear dust, which
+ *   may wait until the claimer wallet holds enough spendable BTC.
+ */
+export interface ArkCashRecoveringVtxo extends ArkCashVtxoRef {
+    kind: "swept" | "subdust";
+}
+
 /** A VTXO {@link Wallet.claimCash} left behind, with the reason why. */
 export interface ArkCashUnclaimedVtxo extends ArkCashVtxoRef {
     reason: ArkCashUnclaimedReason;
@@ -410,17 +420,18 @@ export interface ArkCashClaimResult {
     /** Satoshis swept to this wallet instantly (the thin single-key sweep). */
     swept: number;
     /**
-     * Server-swept VTXOs imported for recovery. These funds are not in the
-     * wallet yet: a swept VTXO can only move through a settlement, so
-     * `claimCash` imports it as a signable contract and hands it to the
-     * wallet's own recovery machinery, which settles it back (rotation-aware)
-     * on the normal retry cadence. The amount arrives as a fresh VTXO once
-     * that settlement finalizes.
+     * VTXOs imported for recovery — server-swept or subdust. These funds are
+     * not in the wallet yet: neither a swept nor a subdust VTXO can move
+     * through the thin sweep, so `claimCash` imports them as a signable
+     * contract and hands them to the wallet's own recovery machinery, which
+     * settles them back (rotation-aware, aggregating a claimer top-up when a
+     * subdust note needs to clear dust) on the normal retry cadence. The
+     * amount arrives as a fresh VTXO once that settlement finalizes.
      */
     recovering: {
         /** Satoshis imported for recovery. */
         amount: number;
-        vtxos: ArkCashVtxoRef[];
+        vtxos: ArkCashRecoveringVtxo[];
     };
     unclaimed: {
         /** Satoshis left behind. */
@@ -4122,21 +4133,28 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      *
      * ArkCash is a short-lived instrument: it carries a private key, so it is
      * meant to be handed over and claimed promptly, not held. A note left
-     * unclaimed past its batch expiry is swept by the server and `claimCash`
-     * can only report it, not move it.
+     * unclaimed past its batch expiry is swept by the server; `claimCash` still
+     * recovers it via an isolated settlement (rotation-aware) rather than
+     * losing it.
      *
-     * @param amount - Amount in satoshis to send. Must be a whole number of
-     * sats at or above the dust threshold — a below-dust amount would mint an
-     * OP_RETURN output that is unspendable as cash.
+     * A below-dust amount is allowed: it mints an OP_RETURN (subdust) output
+     * with no spendable leaf, so `claimCash` cannot thin-sweep it — it recovers
+     * it through a settlement that aggregates a claimer top-up to clear dust,
+     * which is slower and needs the claimer to hold enough spendable BTC.
+     *
+     * @param amount - Amount in satoshis to send. Must be a positive whole
+     * number of sats.
      * @returns The encoded arkcash string (e.g., "arkcash1...")
      */
     async createCash(amount: number): Promise<string> {
-        // A bare `amount < dust` guard would let NaN, Infinity and fractional
+        // A bare `amount <= 0` guard would let NaN, Infinity and fractional
         // amounts through (all compare false), and `send` itself defaults every
-        // falsy amount to a dust send rather than rejecting it.
-        if (!Number.isSafeInteger(amount) || amount < Number(this.dustAmount)) {
+        // falsy amount to a dust send rather than rejecting it. Subdust is now
+        // allowed (it routes to the OP_RETURN script via the send machinery),
+        // so only positivity and integrality are enforced.
+        if (!Number.isSafeInteger(amount) || amount <= 0) {
             throw new Error(
-                `Invalid ArkCash amount ${amount}: must be a whole number of sats >= dust (${this.dustAmount})`,
+                `Invalid ArkCash amount ${amount}: must be a positive whole number of sats`,
             );
         }
 
@@ -4167,9 +4185,11 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      * in the keyring) and handed to the wallet's own recovery machinery, which
      * settles it back on the normal retry cadence. That import is the only
      * thing `claimCash` persists, and the key is purged once recovery
-     * completes. Anything neither sweepable nor recoverable — subdust, already
-     * claimed, or asset-bearing — is returned in `unclaimed` with a per-VTXO
-     * reason and otherwise ignored.
+     * completes. A subdust note is imported the same way — it too can only move
+     * through a settlement — and recovery aggregates a claimer top-up to clear
+     * dust. Anything neither sweepable nor recoverable — already claimed or
+     * asset-bearing — is returned in `unclaimed` with a per-VTXO reason and
+     * otherwise ignored.
      *
      * The arkcash string is the recovery token: a claim interrupted between
      * submit and finalize is completed by simply re-running `claimCash`, which
@@ -4188,11 +4208,11 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
         // One unfiltered query over the contract's P2TR script: the server's
         // state filters are mutually exclusive, so any filter here would hide
-        // the very states this method reports. Only the P2TR script is queried —
-        // the indexer rejects a non-P2TR (OP_RETURN) script outright, so subdust
-        // arkcash, which lives at the OP_RETURN script, is not visible here and
-        // is simply not reported. `createCash`'s dust floor keeps it from being
-        // minted in the first place.
+        // the very states this method reports. Only the P2TR script is queried,
+        // and that is sufficient: the server indexes a VTXO under the P2TR
+        // script of its taproot key regardless of whether the output pays the
+        // spendable OP_1 or the subdust OP_RETURN wrapper, so a subdust arkcash
+        // note surfaces here too (it is then imported for recovery, not swept).
         const scripts = [cashPkScript];
         let vtxos = await this.fetchAllVtxos(scripts);
 
@@ -4288,12 +4308,21 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         // arkcash key as a signable contract and let the wallet's recovery
         // machinery settle it back. All recoverable VTXOs share the one arkcash
         // script, so a single import covers them.
-        const recovering: ArkCashVtxoRef[] = [];
+        const recovering: ArkCashRecoveringVtxo[] = [];
         if (recoverable.length > 0) {
             try {
                 await this.importArkCashForRecovery(cash, cashScript, cashAddress);
                 for (const vtxo of recoverable) {
-                    recovering.push({ txid: vtxo.txid, vout: vtxo.vout, value: vtxo.value });
+                    // A subdust note needs a claimer top-up to clear dust; a
+                    // swept ≥-dust note settles alone. `kind` lets callers
+                    // explain the difference in latency. One import covers both
+                    // (same script, same contract).
+                    recovering.push({
+                        txid: vtxo.txid,
+                        vout: vtxo.vout,
+                        value: vtxo.value,
+                        kind: isSubdust(vtxo, this.dustAmount) ? "subdust" : "swept",
+                    });
                 }
                 // Kick recovery promptly rather than waiting for the poll loop.
                 // Non-blocking: recovery is a full settlement (a batch round)
@@ -4416,27 +4445,21 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         for (const vtxo of vtxos) {
             if (!isSpendable(vtxo)) {
                 unclaimed.push(cashReport(vtxo, "already-spent"));
-            } else if (isSubdust(vtxo, this.dustAmount)) {
-                // A below-dust VTXO at the P2TR script cannot be swept or
-                // settled on its own. Subdust arkcash actually lives at an
-                // OP_RETURN script (not queried — the indexer rejects non-P2TR
-                // scripts), so this is a defensive guard; createCash's dust
-                // floor prevents minting subdust in the first place. Checked
-                // before the swept case, which would otherwise call it
-                // recoverable.
-                unclaimed.push(cashReport(vtxo, "subdust"));
             } else if (vtxo.assets && vtxo.assets.length > 0) {
-                // The thin sweep builds a BTC-only output; sweeping an
-                // asset-bearing VTXO with it would burn the assets. Detected up
-                // front rather than left to a server rejection. Checked before
-                // the swept case: a swept asset VTXO must stay report-only, not
-                // ride the BTC-only recovery import.
+                // The thin sweep and the BTC-only recovery settle both build a
+                // BTC-only output; moving an asset-bearing VTXO through either
+                // would burn the assets. Detected up front rather than left to
+                // a server rejection. Checked FIRST among the spendable cases:
+                // an asset-bearing swept or subdust VTXO must stay report-only,
+                // never ride the BTC-only recovery import.
                 unclaimed.push(cashReport(vtxo, "has-assets"));
-            } else if (isRecoverable(vtxo)) {
-                // The server swept the batch at expiry. The funds are still
-                // owed, but only a settlement can move them — no sweep can. The
-                // caller imports these as a signable contract and hands them to
-                // the wallet's recovery machinery.
+            } else if (isSubdust(vtxo, this.dustAmount) || isRecoverable(vtxo)) {
+                // Neither a below-dust VTXO (no spendable leaf; sits at the
+                // OP_RETURN script) nor a server-swept one (swept at batch
+                // expiry) can move through the thin sweep — only a settlement
+                // lifts them. The caller imports these as a signable contract
+                // and hands them to the wallet's recovery machinery, which
+                // settles them back (aggregating a claimer top-up for subdust).
                 recoverable.push(vtxo);
             } else {
                 spendable.push(vtxo);

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -120,9 +120,10 @@ import { WalletReceiveRotator, signingDescriptorIndex } from "./walletReceiveRot
 import { HDDescriptorProvider } from "./hdDescriptorProvider";
 import { DescriptorProvider } from "../identity/descriptorProvider";
 import { KeyringDescriptorProvider } from "../identity/keyringDescriptorProvider";
+import { StaticDescriptorProvider } from "../identity/staticDescriptorProvider";
 import { deriveDescriptorLeafPubKey } from "../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../contracts/metadata";
-import { DiscoveryDeps } from "../contracts/types";
+import { DiscoveryDeps, isRecoveryOnlyContract } from "../contracts/types";
 import { InputSignerRouter, InputSigningJob } from "./inputSignerRouter";
 import {
     DescriptorSigningProviderMissingError,
@@ -357,22 +358,26 @@ export interface BoardingUtxoGroup {
 }
 
 /**
- * Why a VTXO at an arkcash address could not be swept by {@link Wallet.claimCash}.
+ * Why a VTXO at an arkcash address could neither be swept nor imported for
+ * recovery by {@link Wallet.claimCash}.
  *
- * - `swept` — the server swept the batch at expiry. Recoverable in principle,
- *   but only through a settlement, which the thin sweep cannot do.
  * - `subdust` — below dust, so it sits at an OP_RETURN script with no spendable
  *   leaf. Unspendable as cash; `createCash` prevents minting these.
  * - `already-spent` — someone else claimed it first.
  * - `has-assets` — asset-bearing; the BTC-only sweep would burn the assets.
  * - `sweep-failed` — spendable, but its own sweep was rejected.
+ * - `recovery-failed` — server-swept and recoverable in principle, but the
+ *   import that hands it to the wallet's recovery machinery failed.
+ *
+ * A server-swept VTXO whose import *succeeds* is not reported here — it lands
+ * in {@link ArkCashClaimResult.recovering} instead.
  */
 export type ArkCashUnclaimedReason =
-    | "swept"
     | "subdust"
     | "already-spent"
     | "has-assets"
-    | "sweep-failed";
+    | "sweep-failed"
+    | "recovery-failed";
 
 const cashReport = (vtxo: VirtualCoin, reason: ArkCashUnclaimedReason): ArkCashUnclaimedVtxo => ({
     txid: vtxo.txid,
@@ -381,24 +386,42 @@ const cashReport = (vtxo: VirtualCoin, reason: ArkCashUnclaimedReason): ArkCashU
     reason,
 });
 
-/** A VTXO {@link Wallet.claimCash} left behind, with the reason why. */
-export interface ArkCashUnclaimedVtxo {
+/** Minimal outpoint + value identifying a VTXO in a claim report. */
+export interface ArkCashVtxoRef {
     txid: string;
     vout: number;
     /** Value in satoshis. */
     value: number;
+}
+
+/** A VTXO {@link Wallet.claimCash} left behind, with the reason why. */
+export interface ArkCashUnclaimedVtxo extends ArkCashVtxoRef {
     reason: ArkCashUnclaimedReason;
 }
 
 /**
- * Outcome of {@link Wallet.claimCash}: what was swept, and what was not.
+ * Outcome of {@link Wallet.claimCash}: what was swept instantly, what was
+ * imported for background recovery, and what was left behind.
  *
- * The shape is open — further buckets may be added alongside `unclaimed` as
- * more of the non-sweepable states become claimable.
+ * The shape is open — further buckets may be added as more of the
+ * non-sweepable states become claimable.
  */
 export interface ArkCashClaimResult {
-    /** Satoshis swept to this wallet. */
+    /** Satoshis swept to this wallet instantly (the thin single-key sweep). */
     swept: number;
+    /**
+     * Server-swept VTXOs imported for recovery. These funds are not in the
+     * wallet yet: a swept VTXO can only move through a settlement, so
+     * `claimCash` imports it as a signable contract and hands it to the
+     * wallet's own recovery machinery, which settles it back (rotation-aware)
+     * on the normal retry cadence. The amount arrives as a fresh VTXO once
+     * that settlement finalizes.
+     */
+    recovering: {
+        /** Satoshis imported for recovery. */
+        amount: number;
+        vtxos: ArkCashVtxoRef[];
+    };
     unclaimed: {
         /** Satoshis left behind. */
         amount: number;
@@ -1088,20 +1111,29 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const contractManager = await this.getContractManager();
         const vtxos = await contractManager.getContractsWithVtxos();
 
-        return vtxos
-            .flatMap((_) => _.vtxos)
-            .filter((vtxo) => {
-                if (this._pendingSpendOutpoints.has(`${vtxo.txid}:${vtxo.vout}`)) {
-                    return false;
-                }
-                if (isSpendable(vtxo)) {
-                    if (!f.withRecoverable && (isRecoverable(vtxo) || isExpired(vtxo))) {
+        return (
+            vtxos
+                // Recovery-only contracts (imported by claimCash for server-swept
+                // arkcash) are settled in their own isolated intent and must never
+                // enter the wallet's own balance / renewal / recovery / coin
+                // selection — all of which source their inputs here. Excluding them
+                // at this single choke point keeps a persistently rejected recovery
+                // input from poisoning the wallet's own fund lifecycle.
+                .filter(({ contract }) => !isRecoveryOnlyContract(contract))
+                .flatMap((_) => _.vtxos)
+                .filter((vtxo) => {
+                    if (this._pendingSpendOutpoints.has(`${vtxo.txid}:${vtxo.vout}`)) {
                         return false;
                     }
-                    return true;
-                }
-                return !!(f.withUnrolled && vtxo.isUnrolled);
-            });
+                    if (isSpendable(vtxo)) {
+                        if (!f.withRecoverable && (isRecoverable(vtxo) || isExpired(vtxo))) {
+                            return false;
+                        }
+                        return true;
+                    }
+                    return !!(f.withUnrolled && vtxo.isUnrolled);
+                })
+        );
     }
 
     /**
@@ -2039,6 +2071,27 @@ export class Wallet extends ReadonlyWallet implements IWallet {
      */
     private readonly _descriptorProvider?: DescriptorProvider;
 
+    /**
+     * Keyring holding foreign private keys imported outside the wallet's
+     * derivation tree (see {@link KeyringDescriptorProvider}). Wraps
+     * {@link _descriptorProvider} (or a {@link StaticDescriptorProvider}
+     * over the wallet identity when there is no HD provider) and is the
+     * descriptor provider {@link _signerRouter} actually signs through, so
+     * a contract carrying `metadata.signingDescriptor` for an imported key
+     * is signable by construction.
+     *
+     * Kept separate from {@link _descriptorProvider} on purpose: the latter
+     * still gates HD boarding/receive rotation (a `!provider` check means
+     * "static wallet, no rotation"), and wrapping it with a keyring for
+     * every wallet would break that gate. The keyring is orthogonal — it
+     * only ever adds foreign signable keys, never receive addresses.
+     *
+     * Populated for every {@link Wallet.create}d wallet; the constructor's
+     * param is optional so the router degrades to {@link _descriptorProvider}
+     * if a caller ever omits it.
+     */
+    private readonly _keyring?: KeyringDescriptorProvider;
+
     private readonly _signerRouter: InputSignerRouter;
 
     /**
@@ -2549,6 +2602,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         walletContractTimelocks?: RelativeTimelock[],
         receiveRotator?: WalletReceiveRotator,
         descriptorProvider?: DescriptorProvider,
+        keyring?: KeyringDescriptorProvider,
     ) {
         super(
             identity,
@@ -2596,10 +2650,14 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         this._serverUnrollScript = serverUnrollScript;
         this._receiveRotator = receiveRotator;
         this._descriptorProvider = descriptorProvider;
+        this._keyring = keyring;
         this._signerRouter = new InputSignerRouter({
             identity,
             contractRepository,
-            descriptorProvider,
+            // Sign through the keyring: it resolves the wrapped base
+            // provider's descriptors AND any imported foreign keys. Falls
+            // back to the bare base provider when no keyring was supplied.
+            descriptorProvider: keyring ?? descriptorProvider,
             boardingPkScript: boardingTapscript.pkScript,
         });
     }
@@ -2746,6 +2804,17 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         // baseline contracts.
         const boot = await WalletReceiveRotator.resolveBoot(config, setup);
 
+        // Wrap the resolved provider (or a static one over the wallet
+        // identity, for the common non-HD wallet) with a keyring so
+        // `claimCash` can import a foreign signable contract for recovery
+        // and the signer router can resolve it. This does NOT feed HD
+        // boarding/receive rotation — that still keys off `boot?.provider`
+        // below — so a static wallet keeps its single fixed address.
+        const keyring = await KeyringDescriptorProvider.create(
+            boot?.provider ?? (await StaticDescriptorProvider.create(config.identity)),
+            setup.walletRepository,
+        );
+
         const wallet = new Wallet(
             config.identity,
             setup.network,
@@ -2768,6 +2837,7 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             setup.walletContractTimelocks,
             boot?.rotator,
             boot?.provider,
+            keyring,
         );
         wallet._serverInfoSource = setup.serverInfoSource;
         // The response cleared construction validation — network/signer in
@@ -4086,23 +4156,29 @@ export class Wallet extends ReadonlyWallet implements IWallet {
     }
 
     /**
-     * Claim an ArkCash bearer instrument: sweep what can be swept, report the
-     * rest.
+     * Claim an ArkCash bearer instrument: sweep what can be swept, recover what
+     * was swept by the server, report the rest.
      *
      * Every spendable VTXO at the arkcash address is swept to this wallet in
      * its own offchain transaction, signed with the key carried by the arkcash
-     * string. Nothing is ever persisted: no contract is imported, and the
-     * arkcash key is not stored. Anything that cannot be swept — server-swept,
-     * subdust, already claimed, or asset-bearing — is returned in `unclaimed`
-     * with a per-VTXO reason and otherwise ignored.
+     * string. A VTXO the server already swept at batch expiry cannot move
+     * through the thin sweep — only a settlement can lift it — so it is
+     * **imported** as a signable `default` contract (the arkcash key is filed
+     * in the keyring) and handed to the wallet's own recovery machinery, which
+     * settles it back on the normal retry cadence. That import is the only
+     * thing `claimCash` persists, and the key is purged once recovery
+     * completes. Anything neither sweepable nor recoverable — subdust, already
+     * claimed, or asset-bearing — is returned in `unclaimed` with a per-VTXO
+     * reason and otherwise ignored.
      *
      * The arkcash string is the recovery token: a claim interrupted between
      * submit and finalize is completed by simply re-running `claimCash`, which
      * drains any pending arkcash transaction on the server before sweeping.
+     * The import is idempotent, so re-running is always safe.
      *
      * @param cashStr - The encoded arkcash string (e.g., "arkcash1...")
-     * @returns The swept total and the report of what was left behind. The
-     * shape is open: further buckets may be added alongside `unclaimed`.
+     * @returns What was swept instantly, what was imported for recovery, and
+     * what was left behind. The shape is open: further buckets may be added.
      */
     async claimCash(cashStr: string): Promise<ArkCashClaimResult> {
         const cash = ArkCash.fromString(cashStr);
@@ -4123,7 +4199,10 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         }
 
         const myPkScript = ArkAddress.decode(await this.getAddress()).pkScript;
-        let { spendable, unclaimed } = this.classifyCashVtxos(vtxos, cashSubdustPkScript);
+        let { spendable, recoverable, unclaimed } = this.classifyCashVtxos(
+            vtxos,
+            cashSubdustPkScript,
+        );
         let swept = 0;
 
         // Drain first: a previous claim may have registered a sweep it never
@@ -4159,7 +4238,10 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 // now stale: re-read it, or we would re-sweep an outpoint we
                 // just spent and report the rejection as a failure.
                 vtxos = await this.fetchAllVtxos(scripts);
-                ({ spendable, unclaimed } = this.classifyCashVtxos(vtxos, cashSubdustPkScript));
+                ({ spendable, recoverable, unclaimed } = this.classifyCashVtxos(
+                    vtxos,
+                    cashSubdustPkScript,
+                ));
 
                 // The drain moved these to this wallet, so they are swept by
                 // this call — the re-read above sees them spent and would
@@ -4208,8 +4290,39 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             }
         }
 
+        // Server-swept VTXOs can only move through a settlement, so import the
+        // arkcash key as a signable contract and let the wallet's recovery
+        // machinery settle it back. All recoverable VTXOs share the one arkcash
+        // script, so a single import covers them.
+        const recovering: ArkCashVtxoRef[] = [];
+        if (recoverable.length > 0) {
+            try {
+                await this.importArkCashForRecovery(cash, cashScript, cashAddress);
+                for (const vtxo of recoverable) {
+                    recovering.push({ txid: vtxo.txid, vout: vtxo.vout, value: vtxo.value });
+                }
+                // Kick recovery promptly rather than waiting for the poll loop.
+                // Non-blocking: recovery is a full settlement (a batch round)
+                // retried on the wallet's normal cadence, so claimCash must not
+                // await it. A kick failure is harmless — the poll loop retries.
+                void this.kickImportedRecovery();
+            } catch (error) {
+                // The import is local (keyring + contract writes) and rarely
+                // fails; if it does, report the funds rather than dropping them
+                // silently. They stay recoverable in principle by re-running.
+                console.error("Failed to import swept arkcash for recovery:", error);
+                for (const vtxo of recoverable) {
+                    unclaimed.push(cashReport(vtxo, "recovery-failed"));
+                }
+            }
+        }
+
         return {
             swept,
+            recovering: {
+                amount: recovering.reduce((total, vtxo) => total + vtxo.value, 0),
+                vtxos: recovering,
+            },
             unclaimed: {
                 amount: unclaimed.reduce((total, vtxo) => total + vtxo.value, 0),
                 vtxos: unclaimed,
@@ -4218,14 +4331,95 @@ export class Wallet extends ReadonlyWallet implements IWallet {
     }
 
     /**
-     * Split the VTXOs at an arkcash address into the ones the thin sweep can
-     * move and the ones it can only report.
+     * Import an arkcash instrument as a signable, recovery-only contract so the
+     * wallet's own recovery machinery can settle its server-swept VTXOs back.
+     *
+     * Two writes, both idempotent so a re-run (or a resumed claim) is safe:
+     * - the arkcash private key is filed in the keyring, returning its
+     *   `tr(<pubkey>)` descriptor;
+     * - a `default` contract for the arkcash script is registered carrying that
+     *   descriptor as `metadata.signingDescriptor` (so the signer router can
+     *   sign the swept inputs) and `metadata.recoveryOnly` (so the contract is
+     *   settled in its own isolated intent, never bundled into the wallet's own
+     *   renewal/recovery — a persistently rejected input then dents only its
+     *   own recovery, never the wallet's funds).
+     */
+    private async importArkCashForRecovery(
+        cash: ArkCash,
+        cashScript: DefaultVtxo.Script,
+        cashAddress: ArkAddress,
+    ): Promise<void> {
+        if (!this._keyring) {
+            throw new Error("Cannot import arkcash for recovery: wallet has no keyring");
+        }
+        const descriptor = await this._keyring.importKey(cash.privateKey);
+
+        const manager = await this.getContractManager();
+        await manager.createContract({
+            type: "default",
+            params: {
+                pubKey: hex.encode(cash.publicKey),
+                serverPubKey: hex.encode(cash.serverPubKey),
+                csvTimelock: timelockToSequence(cash.csvTimelock).toString(),
+            },
+            script: hex.encode(cashScript.pkScript),
+            address: cashAddress.encode(),
+            state: "active",
+            metadata: {
+                signingDescriptor: descriptor,
+                recoveryOnly: true,
+            },
+        });
+    }
+
+    /** Best-effort, non-blocking trigger of the isolated imported-recovery pass. */
+    private async kickImportedRecovery(): Promise<void> {
+        try {
+            const manager = await this.getVtxoManager();
+            await manager.recoverImportedContracts();
+        } catch (error) {
+            console.error("Failed to kick imported arkcash recovery:", error);
+        }
+    }
+
+    /**
+     * Retire a contract imported for recovery once its funds have been settled
+     * back: purge the keyring key that backed it, then delete the contract row.
+     * Ends the key-at-rest window opened by {@link importArkCashForRecovery}.
+     *
+     * Scoped to recovery-only contracts as a safety guard — it will not touch a
+     * regular wallet contract — and idempotent: a second call (the contract
+     * already gone) is a no-op. Invoked by the isolated recovery pass in
+     * `VtxoManager` (see its `RecoveryContractCapableWallet` capability).
+     */
+    async removeRecoveryContract(script: string): Promise<void> {
+        const manager = await this.getContractManager();
+        const [contract] = await manager.getContracts({ script });
+        if (!contract || !isRecoveryOnlyContract(contract)) return;
+
+        const descriptor = contract.metadata?.signingDescriptor;
+        if (typeof descriptor === "string" && this._keyring) {
+            await this._keyring.deleteKey(descriptor);
+        }
+        await manager.deleteContract(script);
+    }
+
+    /**
+     * Split the VTXOs at an arkcash address into three buckets: the ones the
+     * thin sweep can move (`spendable`), the server-swept ones that must go
+     * through a recovery settlement (`recoverable`), and the ones that can
+     * only be reported (`unclaimed`).
      */
     private classifyCashVtxos(
         vtxos: VirtualCoin[],
         cashSubdustPkScript: string,
-    ): { spendable: VirtualCoin[]; unclaimed: ArkCashUnclaimedVtxo[] } {
+    ): {
+        spendable: VirtualCoin[];
+        recoverable: VirtualCoin[];
+        unclaimed: ArkCashUnclaimedVtxo[];
+    } {
         const spendable: VirtualCoin[] = [];
+        const recoverable: VirtualCoin[] = [];
         const unclaimed: ArkCashUnclaimedVtxo[] = [];
 
         for (const vtxo of vtxos) {
@@ -4237,21 +4431,25 @@ export class Wallet extends ReadonlyWallet implements IWallet {
                 // Checked before the swept case, which would otherwise claim
                 // these are recoverable. createCash now prevents minting them.
                 unclaimed.push(cashReport(vtxo, "subdust"));
-            } else if (isRecoverable(vtxo)) {
-                // The server swept the batch at expiry. The funds are still
-                // owed, but only a settlement can move them — no sweep can.
-                unclaimed.push(cashReport(vtxo, "swept"));
             } else if (vtxo.assets && vtxo.assets.length > 0) {
                 // The thin sweep builds a BTC-only output; sweeping an
                 // asset-bearing VTXO with it would burn the assets. Detected up
-                // front rather than left to a server rejection.
+                // front rather than left to a server rejection. Checked before
+                // the swept case: a swept asset VTXO must stay report-only, not
+                // ride the BTC-only recovery import.
                 unclaimed.push(cashReport(vtxo, "has-assets"));
+            } else if (isRecoverable(vtxo)) {
+                // The server swept the batch at expiry. The funds are still
+                // owed, but only a settlement can move them — no sweep can. The
+                // caller imports these as a signable contract and hands them to
+                // the wallet's recovery machinery.
+                recoverable.push(vtxo);
             } else {
                 spendable.push(vtxo);
             }
         }
 
-        return { spendable, unclaimed };
+        return { spendable, recoverable, unclaimed };
     }
 
     /** Read every page of an unfiltered VTXO query for the given scripts. */

--- a/packages/ts-sdk/test/arkcashClaim.test.ts
+++ b/packages/ts-sdk/test/arkcashClaim.test.ts
@@ -104,6 +104,25 @@ function spentCashVtxo(cashPkScript: string): VirtualCoin {
     } as VirtualCoin;
 }
 
+/** The arkcash VTXO the server swept at batch expiry: swept but unspent. */
+function sweptCashVtxo(cashPkScript: string): VirtualCoin {
+    return {
+        txid: CASH_TXID,
+        vout: 0,
+        value: CASH_VALUE,
+        script: cashPkScript,
+        status: { confirmed: true },
+        virtualStatus: { state: "swept" },
+        isSpent: false,
+        createdAt: new Date(),
+    } as VirtualCoin;
+}
+
+/** White-box reach for the wallet's keyring (private) in these unit tests. */
+function keyringOf(wallet: Wallet) {
+    return (wallet as unknown as { _keyring: { hasKey(d: string): boolean } })._keyring;
+}
+
 /**
  * The pending sweep the crashed claim left on the server: the offchain tx it
  * built and submitted but never finalized, paying `destinationPkScript`.
@@ -189,5 +208,183 @@ describe("claimCash drain-pending accounting", () => {
         expect(result.unclaimed.vtxos).toEqual([
             { txid: CASH_TXID, vout: 0, value: CASH_VALUE, reason: "already-spent" },
         ]);
+    });
+});
+
+describe("claimCash import-for-recovery", () => {
+    // Claim a wallet holding a single server-swept arkcash VTXO. The kick is
+    // stubbed so the import artifacts can be inspected without a live recovery
+    // settlement racing the assertions.
+    async function claimSwept(cash: ArkCash) {
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const wallet = await makeWallet(cashIndexer(cashPkScript, [sweptCashVtxo(cashPkScript)]), {
+            getPendingTxs: vi.fn(async () => []),
+        });
+        const manager = await wallet.getVtxoManager();
+        const kick = vi.spyOn(manager, "recoverImportedContracts").mockResolvedValue();
+        const result = await wallet.claimCash(cash.toString());
+        return { wallet, manager, kick, result, cashPkScript };
+    }
+
+    it("imports a swept VTXO for recovery and reports it as recovering", async () => {
+        const cash = makeCash();
+        const { wallet, kick, result, cashPkScript } = await claimSwept(cash);
+
+        // Reported as recovering, not swept away, not left unclaimed.
+        expect(result.swept).toBe(0);
+        expect(result.recovering.amount).toBe(CASH_VALUE);
+        expect(result.recovering.vtxos).toEqual([{ txid: CASH_TXID, vout: 0, value: CASH_VALUE }]);
+        expect(result.unclaimed.vtxos).toEqual([]);
+
+        // Recovery was kicked promptly rather than left to the poll loop.
+        expect(kick).toHaveBeenCalledOnce();
+
+        // The arkcash key is filed in the keyring, and a signable recovery-only
+        // contract was registered at the arkcash script.
+        const descriptor = `tr(${hex.encode(cash.publicKey)})`;
+        expect(keyringOf(wallet).hasKey(descriptor)).toBe(true);
+        const cm = await wallet.getContractManager();
+        const [contract] = await cm.getContracts({ script: cashPkScript });
+        expect(contract.type).toBe("default");
+        expect(contract.metadata?.signingDescriptor).toBe(descriptor);
+        expect(contract.metadata?.recoveryOnly).toBe(true);
+    });
+
+    it("routes the imported input to the keyring, not the baseline identity", async () => {
+        const cash = makeCash();
+        const { wallet } = await claimSwept(cash);
+
+        // Reach the wallet's real signer router: this proves the keyring was
+        // wired into it (a bare descriptor provider would leave a static wallet
+        // unable to resolve the arkcash descriptor).
+        const router = (
+            wallet as unknown as {
+                _signerRouter: {
+                    classify(jobs: { index: number; lookupScript: Uint8Array }[]): Promise<{
+                        identityIndexes: number[];
+                        descriptorGroups: Map<string, number[]>;
+                    }>;
+                };
+            }
+        )._signerRouter;
+
+        const plan = await router.classify([{ index: 0, lookupScript: cash.vtxoScript.pkScript }]);
+
+        // Signable by construction: the swept input routes to its keyring
+        // descriptor rather than the baseline key, and classify does not throw
+        // MissingSigningDescriptorError.
+        expect(plan.identityIndexes).toEqual([]);
+        expect([...plan.descriptorGroups.keys()]).toEqual([`tr(${hex.encode(cash.publicKey)})`]);
+    });
+
+    it("excludes the imported recovery contract from the wallet's own VTXOs", async () => {
+        const cash = makeCash();
+        const { wallet } = await claimSwept(cash);
+
+        // getVtxos feeds balance / renewal / recovery / coin selection; the
+        // recovery-only VTXO must not appear there, or it would poison them.
+        expect(await wallet.getVtxos()).toEqual([]);
+        expect(await wallet.getVtxos({ withRecoverable: true })).toEqual([]);
+    });
+
+    it("is idempotent: re-claiming does not duplicate the import", async () => {
+        const cash = makeCash();
+        const { wallet, cashPkScript } = await claimSwept(cash);
+
+        const second = await wallet.claimCash(cash.toString());
+        expect(second.recovering.amount).toBe(CASH_VALUE);
+
+        const cm = await wallet.getContractManager();
+        expect(await cm.getContracts({ script: cashPkScript })).toHaveLength(1);
+    });
+
+    it("settles an imported contract in its own intent, then purges it", async () => {
+        const cash = makeCash();
+        const { wallet, manager, kick, cashPkScript } = await claimSwept(cash);
+        kick.mockRestore();
+
+        // Drive the isolated recovery with the settlement stubbed to succeed.
+        const settle = vi.spyOn(wallet, "settle").mockResolvedValue("recovery-txid");
+        await manager.recoverImportedContracts();
+
+        // Settled exactly the swept VTXO, to the wallet's own address.
+        expect(settle).toHaveBeenCalledOnce();
+        const params = settle.mock.calls[0][0]!;
+        expect(params.inputs.map((i) => `${i.txid}:${i.vout}`)).toEqual([`${CASH_TXID}:0`]);
+        expect(params.outputs).toEqual([
+            { address: await wallet.getAddress(), amount: BigInt(CASH_VALUE) },
+        ]);
+
+        // Cleaned up: contract row removed and keyring key purged.
+        const cm = await wallet.getContractManager();
+        expect(await cm.getContracts({ script: cashPkScript })).toEqual([]);
+        expect(keyringOf(wallet).hasKey(`tr(${hex.encode(cash.publicKey)})`)).toBe(false);
+    });
+
+    it("keeps the contract and key on an empty VTXO view (indexer outage)", async () => {
+        const cash = makeCash();
+        const { wallet, manager, kick, cashPkScript } = await claimSwept(cash);
+        kick.mockRestore();
+
+        const cm = await wallet.getContractManager();
+        const [contract] = await cm.getContracts({ script: cashPkScript });
+
+        // A transient indexer outage: createContract's hydration and the
+        // recovery sync both fall back to (empty) repo state, so the imported
+        // contract reports zero VTXOs. This must NOT be read as "recovered" —
+        // purging the key here would strand the funds before recovery ran.
+        vi.spyOn(cm, "getContractsWithVtxos").mockResolvedValue([{ contract, vtxos: [] }]);
+        const settle = vi.spyOn(wallet, "settle").mockResolvedValue("txid");
+
+        await manager.recoverImportedContracts();
+
+        // Nothing settled, so the key and contract must survive for the retry.
+        expect(settle).not.toHaveBeenCalled();
+        expect(keyringOf(wallet).hasKey(`tr(${hex.encode(cash.publicKey)})`)).toBe(true);
+        expect(await cm.getContracts({ script: cashPkScript })).toHaveLength(1);
+    });
+
+    it("skips recovery when another instance holds the cross-instance lock", async () => {
+        const cash = makeCash();
+        const { wallet, manager, kick } = await claimSwept(cash);
+        kick.mockRestore();
+        const settle = vi.spyOn(wallet, "settle").mockResolvedValue("txid");
+
+        // Simulate the Web Locks API with the imported-recovery lock already
+        // held by a sibling tab/worker on the same repo: `ifAvailable` yields
+        // null, so this instance must skip rather than submit a duplicate
+        // recovery intent (which the server's duplicated-input handling could
+        // resolve by DeleteIntent-ing the sibling's valid recovery).
+        const held = new Set<string>(["arkade-imported-recovery"]);
+        vi.stubGlobal("navigator", {
+            locks: {
+                request: async (
+                    name: string,
+                    opts: { ifAvailable?: boolean },
+                    cb: (lock: unknown) => Promise<void>,
+                ) => {
+                    if (opts?.ifAvailable && held.has(name)) return cb(null);
+                    held.add(name);
+                    try {
+                        return await cb({ name });
+                    } finally {
+                        held.delete(name);
+                    }
+                },
+            },
+        });
+
+        try {
+            // Lock held elsewhere → no duplicate submit.
+            await manager.recoverImportedContracts();
+            expect(settle).not.toHaveBeenCalled();
+
+            // Sibling releases the lock → this instance now recovers.
+            held.delete("arkade-imported-recovery");
+            await manager.recoverImportedContracts();
+            expect(settle).toHaveBeenCalledOnce();
+        } finally {
+            vi.unstubAllGlobals();
+        }
     });
 });

--- a/packages/ts-sdk/test/arkcashClaim.test.ts
+++ b/packages/ts-sdk/test/arkcashClaim.test.ts
@@ -118,6 +118,24 @@ function sweptCashVtxo(cashPkScript: string): VirtualCoin {
     } as VirtualCoin;
 }
 
+// dust in `info` is 1000n; 500 is below it.
+const SUBDUST_VALUE = 500;
+
+/** A below-dust arkcash VTXO: live, no spendable leaf, recovered via top-up. */
+function subdustCashVtxo(cashPkScript: string, assets?: unknown[]): VirtualCoin {
+    return {
+        txid: CASH_TXID,
+        vout: 0,
+        value: SUBDUST_VALUE,
+        script: cashPkScript,
+        status: { confirmed: true },
+        virtualStatus: { state: "preconfirmed" },
+        isSpent: false,
+        createdAt: new Date(),
+        assets,
+    } as VirtualCoin;
+}
+
 /** White-box reach for the wallet's keyring (private) in these unit tests. */
 function keyringOf(wallet: Wallet) {
     return (wallet as unknown as { _keyring: { hasKey(d: string): boolean } })._keyring;
@@ -233,7 +251,9 @@ describe("claimCash import-for-recovery", () => {
         // Reported as recovering, not swept away, not left unclaimed.
         expect(result.swept).toBe(0);
         expect(result.recovering.amount).toBe(CASH_VALUE);
-        expect(result.recovering.vtxos).toEqual([{ txid: CASH_TXID, vout: 0, value: CASH_VALUE }]);
+        expect(result.recovering.vtxos).toEqual([
+            { txid: CASH_TXID, vout: 0, value: CASH_VALUE, kind: "swept" },
+        ]);
         expect(result.unclaimed.vtxos).toEqual([]);
 
         // Recovery was kicked promptly rather than left to the poll loop.
@@ -285,6 +305,54 @@ describe("claimCash import-for-recovery", () => {
         // recovery-only VTXO must not appear there, or it would poison them.
         expect(await wallet.getVtxos()).toEqual([]);
         expect(await wallet.getVtxos({ withRecoverable: true })).toEqual([]);
+    });
+
+    it("imports a subdust VTXO for recovery and reports kind 'subdust'", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const wallet = await makeWallet(
+            cashIndexer(cashPkScript, [subdustCashVtxo(cashPkScript)]),
+            { getPendingTxs: vi.fn(async () => []) },
+        );
+        const manager = await wallet.getVtxoManager();
+        vi.spyOn(manager, "recoverImportedContracts").mockResolvedValue();
+
+        const result = await wallet.claimCash(cash.toString());
+
+        // A subdust note cannot thin-sweep — it is imported for recovery too.
+        expect(result.swept).toBe(0);
+        expect(result.recovering.amount).toBe(SUBDUST_VALUE);
+        expect(result.recovering.vtxos).toEqual([
+            { txid: CASH_TXID, vout: 0, value: SUBDUST_VALUE, kind: "subdust" },
+        ]);
+        expect(result.unclaimed.vtxos).toEqual([]);
+
+        // Same import machinery: keyring key + recovery-only contract.
+        expect(keyringOf(wallet).hasKey(`tr(${hex.encode(cash.publicKey)})`)).toBe(true);
+    });
+
+    it("reports an asset-bearing subdust VTXO as has-assets, not imported", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const wallet = await makeWallet(
+            cashIndexer(cashPkScript, [
+                subdustCashVtxo(cashPkScript, [{ assetId: "usd", amount: 1n }]),
+            ]),
+            { getPendingTxs: vi.fn(async () => []) },
+        );
+        const manager = await wallet.getVtxoManager();
+        vi.spyOn(manager, "recoverImportedContracts").mockResolvedValue();
+
+        const result = await wallet.claimCash(cash.toString());
+
+        // The has-assets check runs BEFORE the subdust/swept case, so an
+        // asset-bearing subdust VTXO stays report-only and is NOT imported into
+        // the BTC-only recovery settle.
+        expect(result.recovering.vtxos).toEqual([]);
+        expect(result.unclaimed.vtxos).toEqual([
+            { txid: CASH_TXID, vout: 0, value: SUBDUST_VALUE, reason: "has-assets" },
+        ]);
+        expect(keyringOf(wallet).hasKey(`tr(${hex.encode(cash.publicKey)})`)).toBe(false);
     });
 
     it("is idempotent: re-claiming does not duplicate the import", async () => {

--- a/packages/ts-sdk/test/e2e/ark.test.ts
+++ b/packages/ts-sdk/test/e2e/ark.test.ts
@@ -2477,7 +2477,9 @@ describe("ArkCash", () => {
     it("should reject invalid createCash amounts", async () => {
         const alice = await fundedWallet(10000);
 
-        for (const amount of [0, -1, 0.5, NaN, Infinity, 1]) {
+        // Subdust (e.g. 1) is now allowed — only non-positive/non-integer
+        // amounts are rejected.
+        for (const amount of [0, -1, 0.5, NaN, Infinity]) {
             await expect(alice.wallet.createCash(amount)).rejects.toThrow("Invalid ArkCash amount");
         }
     }, 30_000);
@@ -2613,5 +2615,93 @@ describe("ArkCash", () => {
 
         // The double claim recovered the single VTXO exactly once.
         expect((await bob.wallet.getBalance()).total).toBe(5000);
+    }, 240_000);
+
+    // ── subdust full claim (Phase 5 — see plans/pr-337-new-plan.md) ──
+
+    it("should recover a subdust arkcash via top-up aggregation", async () => {
+        const alice = await fundedWallet(10000);
+        // The claimer must hold spendable BTC: a subdust note cannot settle on
+        // its own, so recovery aggregates a claimer top-up to clear dust.
+        const bob = await fundedWallet(10000);
+
+        // A below-dust mint is allowed now; it lands at the OP_RETURN script.
+        const cashStr = await alice.wallet.createCash(1);
+        const cashScript = cashScriptOf(cashStr);
+        await waitForCashVtxo(bob, cashStr);
+
+        const bobBefore = (await bob.wallet.getBalance()).total;
+
+        // No spendable leaf → not swept away, imported for recovery as subdust.
+        const result = await bob.wallet.claimCash(cashStr);
+        expect(result.swept).toBe(0);
+        expect(result.recovering.amount).toBe(1);
+        expect(result.recovering.vtxos).toEqual([
+            expect.objectContaining({ value: 1, kind: "subdust" }),
+        ]);
+        expect(result.unclaimed.amount).toBe(0);
+
+        const manager = await bob.wallet.getContractManager();
+        expect(await manager.getContracts({ script: cashScript })).toHaveLength(1);
+
+        // Drive the isolated recovery: it settles the 1-sat note aggregated with
+        // a claimer top-up in a single mixed-key intent (the one new
+        // server-facing combination Phase 5 introduces).
+        const vtxoManager = await bob.wallet.getVtxoManager();
+        await waitFor(
+            async () => {
+                await vtxoManager.recoverImportedContracts();
+                return (await bob.wallet.getBalance()).total >= bobBefore + 1;
+            },
+            { timeout: 120_000, interval: 3000 },
+        );
+
+        // Net +1: the top-up is a self-transfer, only the note's value is new.
+        expect((await bob.wallet.getBalance()).total).toBe(bobBefore + 1);
+
+        // Recovery over: contract removed, key purged.
+        await waitFor(
+            async () => {
+                await vtxoManager.recoverImportedContracts();
+                return (await manager.getContracts({ script: cashScript })).length === 0;
+            },
+            { timeout: 30_000, interval: 2000 },
+        );
+    }, 240_000);
+
+    it("defers subdust recovery until the claimer wallet has funds", async () => {
+        const alice = await fundedWallet(10000);
+        // Unfunded claimer: no BTC to top up with, so recovery cannot proceed.
+        const bob = await createTestArkWallet();
+
+        const cashStr = await alice.wallet.createCash(1);
+        const cashScript = cashScriptOf(cashStr);
+        await waitForCashVtxo(bob, cashStr);
+
+        const result = await bob.wallet.claimCash(cashStr);
+        expect(result.recovering.amount).toBe(1);
+
+        const manager = await bob.wallet.getContractManager();
+        const vtxoManager = await bob.wallet.getVtxoManager();
+
+        // With no claimer funds the top-up selector finds nothing, so the pass
+        // defers this contract — it stays imported, the funds stay recoverable,
+        // and nothing is settled or purged.
+        await vtxoManager.recoverImportedContracts();
+        expect(await manager.getContracts({ script: cashScript })).toHaveLength(1);
+        expect((await bob.wallet.getBalance()).total).toBe(0);
+
+        // Fund the claimer → the next cycle aggregates a top-up and settles.
+        faucetOffchain(await bob.wallet.getAddress(), 10000);
+        await waitFor(async () => (await bob.wallet.getVtxos()).length > 0);
+
+        await waitFor(
+            async () => {
+                await vtxoManager.recoverImportedContracts();
+                return (await bob.wallet.getBalance()).total >= 10001;
+            },
+            { timeout: 120_000, interval: 3000 },
+        );
+        expect((await bob.wallet.getBalance()).total).toBe(10001);
     }, 240_000);
 });

--- a/packages/ts-sdk/test/e2e/ark.test.ts
+++ b/packages/ts-sdk/test/e2e/ark.test.ts
@@ -33,6 +33,7 @@ import {
     execCommand,
     faucetOffchain,
     faucetOnchain,
+    mineBlocks,
     setFees,
     waitFor,
 } from "./utils";
@@ -2394,6 +2395,28 @@ describe("ArkCash", () => {
         return w;
     };
 
+    /** pkScript (hex) an arkcash string's VTXOs live at. */
+    const cashScriptOf = (cashStr: string): string =>
+        hex.encode(ArkCash.fromString(cashStr).vtxoScript.pkScript);
+
+    /**
+     * Wait for a just-created arkcash's VTXO to be indexed before claiming it.
+     * `createCash` returns once the send is submitted, so a claim fired straight
+     * after can race the indexer and see zero VTXOs.
+     */
+    const waitForCashVtxo = async (
+        observer: Awaited<ReturnType<typeof createTestArkWallet>>,
+        cashStr: string,
+    ): Promise<void> => {
+        const cashScript = cashScriptOf(cashStr);
+        await waitFor(async () => {
+            const { vtxos } = await observer.wallet.indexerProvider.getVtxos({
+                scripts: [cashScript],
+            });
+            return vtxos.length > 0;
+        });
+    };
+
     it("should send and claim arkcash (happy path)", async () => {
         const alice = await fundedWallet(10000);
         const bob = await createTestArkWallet();
@@ -2401,6 +2424,7 @@ describe("ArkCash", () => {
         // Alice creates cash — Bob never shares an address
         const cashStr = await alice.wallet.createCash(5000);
         expect(cashStr).toMatch(/cash1/);
+        await waitForCashVtxo(bob, cashStr);
 
         const result = await bob.wallet.claimCash(cashStr);
         expect(result.swept).toBe(5000);
@@ -2424,6 +2448,7 @@ describe("ArkCash", () => {
         const charlie = await createTestArkWallet();
 
         const cashStr = await alice.wallet.createCash(5000);
+        await waitForCashVtxo(bob, cashStr);
 
         await bob.wallet.claimCash(cashStr);
         await waitFor(async () => (await bob.wallet.getBalance()).total >= 5000);
@@ -2465,9 +2490,128 @@ describe("ArkCash", () => {
         await waitFor(async () => (await alice.wallet.getVtxos()).length > 0);
         const cash2 = await alice.wallet.createCash(3000);
 
+        await waitForCashVtxo(bob, cash1);
+        await waitForCashVtxo(bob, cash2);
         expect((await bob.wallet.claimCash(cash1)).swept).toBe(5000);
         expect((await bob.wallet.claimCash(cash2)).swept).toBe(3000);
 
         await waitFor(async () => (await bob.wallet.getBalance()).total >= 8000);
     }, 120_000);
+
+    // ── server-swept recovery (hybrid L3 — see plans/pr-337-new-plan.md) ──
+
+    /**
+     * Create an arkcash from `alice` and force the server to sweep its VTXO at
+     * batch expiry (expiry = 20 blocks), so `claimCash` must take the
+     * import-for-recovery branch instead of the thin sweep. Returns the string
+     * and its script.
+     */
+    const sweptCash = async (
+        alice: Awaited<ReturnType<typeof fundedWallet>>,
+        observer: Awaited<ReturnType<typeof createTestArkWallet>>,
+        amount: number,
+    ): Promise<{ cashStr: string; cashScript: string }> => {
+        const cashStr = await alice.wallet.createCash(amount);
+        const cashScript = cashScriptOf(cashStr);
+
+        // Wait for the arkcash VTXO to land before mining it into expiry.
+        await waitForCashVtxo(observer, cashStr);
+
+        // Push past the batch expiry so the server sweeps the VTXO. 30 > 20
+        // blocks covers any offset between the funding batch and the tip.
+        mineBlocks(30);
+        await waitFor(
+            async () => {
+                const { vtxos } = await observer.wallet.indexerProvider.getVtxos({
+                    scripts: [cashScript],
+                });
+                return vtxos.some((v) => v.virtualStatus.state === "swept" && !v.isSpent);
+            },
+            { timeout: 60_000 },
+        );
+
+        return { cashStr, cashScript };
+    };
+
+    it("should recover a server-swept arkcash by importing it for recovery", async () => {
+        const alice = await fundedWallet(10000);
+        const bob = await createTestArkWallet();
+
+        const { cashStr, cashScript } = await sweptCash(alice, bob, 5000);
+
+        // A swept VTXO cannot move through the thin sweep — claimCash imports
+        // it as a signable recovery-only contract instead of reporting it.
+        const result = await bob.wallet.claimCash(cashStr);
+        expect(result.swept).toBe(0);
+        expect(result.recovering.amount).toBe(5000);
+        expect(result.recovering.vtxos).toHaveLength(1);
+        expect(result.unclaimed.amount).toBe(0);
+        // The old report-only behavior is gone: "swept" no longer surfaces.
+        expect(result.unclaimed.vtxos.some((v) => v.reason === "swept")).toBe(false);
+
+        // The import persisted exactly one recovery-only contract carrying a
+        // signing descriptor for the arkcash key.
+        const manager = await bob.wallet.getContractManager();
+        const imported = await manager.getContracts({ script: cashScript });
+        expect(imported).toHaveLength(1);
+        expect(imported[0].metadata?.recoveryOnly).toBe(true);
+        expect(typeof imported[0].metadata?.signingDescriptor).toBe("string");
+
+        // Drive the isolated recovery pass until the funds settle back to Bob.
+        // The pass is idempotent and self-serialized, so calling it each poll
+        // is safe whether or not the claimCash kick is still in flight.
+        const vtxoManager = await bob.wallet.getVtxoManager();
+        await waitFor(
+            async () => {
+                await vtxoManager.recoverImportedContracts();
+                return (await bob.wallet.getBalance()).total >= 5000;
+            },
+            { timeout: 120_000, interval: 3000 },
+        );
+
+        // Exactly the swept value arrived — no double-spend, no double-count.
+        expect((await bob.wallet.getBalance()).total).toBe(5000);
+
+        // Recovery over: the contract is removed and its keyring key purged.
+        await waitFor(
+            async () => {
+                await vtxoManager.recoverImportedContracts();
+                return (await manager.getContracts({ script: cashScript })).length === 0;
+            },
+            { timeout: 30_000, interval: 2000 },
+        );
+    }, 240_000);
+
+    it("should be idempotent when claimCash is re-run before recovery settles", async () => {
+        const alice = await fundedWallet(10000);
+        const bob = await createTestArkWallet();
+
+        const { cashStr, cashScript } = await sweptCash(alice, bob, 5000);
+
+        // Re-running the claim before recovery completes must not import a
+        // second contract or a second key, nor recover the funds twice.
+        const r1 = await bob.wallet.claimCash(cashStr);
+        expect(r1.recovering.amount).toBe(5000);
+        const r2 = await bob.wallet.claimCash(cashStr);
+        // The second run either re-imports idempotently (still recovering) or
+        // — if the kicked recovery already spent the VTXO — reports it spent;
+        // either way it neither throws nor double-counts.
+        expect(r2.recovering.amount + r2.swept).toBeLessThanOrEqual(5000);
+
+        const manager = await bob.wallet.getContractManager();
+        const imported = await manager.getContracts({ script: cashScript });
+        expect(imported.length).toBeLessThanOrEqual(1);
+
+        const vtxoManager = await bob.wallet.getVtxoManager();
+        await waitFor(
+            async () => {
+                await vtxoManager.recoverImportedContracts();
+                return (await bob.wallet.getBalance()).total >= 5000;
+            },
+            { timeout: 120_000, interval: 3000 },
+        );
+
+        // The double claim recovered the single VTXO exactly once.
+        expect((await bob.wallet.getBalance()).total).toBe(5000);
+    }, 240_000);
 });

--- a/packages/ts-sdk/test/exports-descriptor-providers.test.ts
+++ b/packages/ts-sdk/test/exports-descriptor-providers.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import * as root from "../src";
+import { SingleKey } from "../src/identity/singleKey";
+import { InMemoryWalletRepository } from "../src/repositories/inMemory/walletRepository";
+
+// `@arkade-os/sdk` publishes only the root entrypoint — there is no
+// `./identity` subpath — so a provider exported from the identity barrel
+// alone is unreachable to consumers and plugin packages. The descriptor
+// providers are the sanctioned way to hold a foreign signable contract,
+// so they must be constructible from the published surface.
+describe("descriptor providers are exported from the root entrypoint", () => {
+    it("exposes the provider classes as runtime values", () => {
+        expect(typeof root.StaticDescriptorProvider).toBe("function");
+        expect(typeof root.KeyringDescriptorProvider).toBe("function");
+        expect(typeof root.HDDescriptorProvider).toBe("function");
+    });
+
+    it("can build a keyring provider using only root exports", async () => {
+        const base = await root.StaticDescriptorProvider.create(
+            SingleKey.fromPrivateKey(new Uint8Array(32).fill(1)),
+        );
+        const provider = await root.KeyringDescriptorProvider.create(
+            base,
+            new InMemoryWalletRepository(),
+        );
+
+        const descriptor = await provider.importKey(new Uint8Array(32).fill(2));
+        expect(provider.isOurs(descriptor)).toBe(true);
+    });
+});

--- a/packages/ts-sdk/test/keyringDescriptorProvider.test.ts
+++ b/packages/ts-sdk/test/keyringDescriptorProvider.test.ts
@@ -122,11 +122,71 @@ describe("KeyringDescriptorProvider", () => {
             );
         });
 
-        it("throws on corrupt persisted state rather than deriving garbage", async () => {
+        it("throws when `keys` is not an object", async () => {
             const repo = new InMemoryWalletRepository();
-            await repo.saveWalletState({ settings: { keyring: { keys: { abcd: "not-a-key" } } } });
+            await repo.saveWalletState({ settings: { keyring: { keys: "nope" } } });
 
-            await expect(makeProvider(repo)).rejects.toThrow(/Corrupt keyring settings/);
+            await expect(makeProvider(repo)).rejects.toThrow(/`keys` is not an object/);
+        });
+
+        it("throws on a private key that is not 32-byte hex", async () => {
+            const repo = new InMemoryWalletRepository();
+            await repo.saveWalletState({
+                settings: { keyring: { keys: { [xOnlyHex(FOREIGN_PRIVKEY)]: "not-a-key" } } },
+            });
+
+            await expect(makeProvider(repo)).rejects.toThrow(/not a 32-byte hex private key/);
+        });
+
+        it("throws on a map key that is not a 32-byte hex pubkey", async () => {
+            const repo = new InMemoryWalletRepository();
+            await repo.saveWalletState({
+                settings: { keyring: { keys: { abcd: hex.encode(FOREIGN_PRIVKEY) } } },
+            });
+
+            await expect(makeProvider(repo)).rejects.toThrow(/not a 32-byte hex x-only pubkey/);
+        });
+
+        it("throws when an entry is filed under a pubkey its private key does not derive", async () => {
+            // the mismatch isOurs() would otherwise assert away: claims the
+            // descriptor, then signs it with the wrong key
+            const repo = new InMemoryWalletRepository();
+            await repo.saveWalletState({
+                settings: {
+                    keyring: {
+                        keys: { [xOnlyHex(OTHER_FOREIGN_PRIVKEY)]: hex.encode(FOREIGN_PRIVKEY) },
+                    },
+                },
+            });
+
+            await expect(makeProvider(repo)).rejects.toThrow(/does not match its private key/);
+        });
+
+        it("throws on a private key outside the curve order", async () => {
+            const repo = new InMemoryWalletRepository();
+            await repo.saveWalletState({
+                settings: { keyring: { keys: { [xOnlyHex(FOREIGN_PRIVKEY)]: "00".repeat(32) } } },
+            });
+
+            await expect(makeProvider(repo)).rejects.toThrow(/not a valid private key/);
+        });
+
+        it("normalizes an uppercase persisted pubkey so lookups still resolve", async () => {
+            const repo = new InMemoryWalletRepository();
+            await repo.saveWalletState({
+                settings: {
+                    keyring: {
+                        keys: {
+                            [xOnlyHex(FOREIGN_PRIVKEY).toUpperCase()]: hex.encode(FOREIGN_PRIVKEY),
+                        },
+                    },
+                },
+            });
+
+            const { provider } = await makeProvider(repo);
+
+            expect(provider.hasKey(foreignDescriptor)).toBe(true);
+            expect(provider.listKeyringDescriptors()).toEqual([foreignDescriptor]);
         });
     });
 

--- a/packages/ts-sdk/test/keyringDescriptorProvider.test.ts
+++ b/packages/ts-sdk/test/keyringDescriptorProvider.test.ts
@@ -79,6 +79,19 @@ describe("KeyringDescriptorProvider", () => {
             expect(provider.hasKey(foreignDescriptor)).toBe(true);
             expect(provider.hasKey(`tr(${xOnlyHex(OTHER_FOREIGN_PRIVKEY)})`)).toBe(true);
         });
+
+        it("owns its copy — zeroizing the caller's buffer does not break signing", async () => {
+            const caller = new Uint8Array(FOREIGN_PRIVKEY);
+            const descriptor = await provider.importKey(caller);
+            caller.fill(0);
+
+            const message = new Uint8Array(32).fill(9);
+            const sig = await provider.signMessageWithDescriptor(descriptor, message);
+
+            expect(
+                await schnorr.verifyAsync(sig, message, schnorr.getPublicKey(FOREIGN_PRIVKEY)),
+            ).toBe(true);
+        });
     });
 
     describe("persistence", () => {

--- a/packages/ts-sdk/test/keyringDescriptorProvider.test.ts
+++ b/packages/ts-sdk/test/keyringDescriptorProvider.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { hex } from "@scure/base";
+import { p2tr } from "@scure/btc-signer";
+import { schnorr } from "@noble/secp256k1";
+import { getNetwork } from "../src/networks";
+import { KeyringDescriptorProvider } from "../src/identity/keyringDescriptorProvider";
+import { StaticDescriptorProvider } from "../src/identity/staticDescriptorProvider";
+import { HDDescriptorProvider } from "../src/wallet/hdDescriptorProvider";
+import { MnemonicIdentity } from "../src/identity/seedIdentity";
+import { SingleKey } from "../src/identity/singleKey";
+import { InMemoryWalletRepository } from "../src/repositories/inMemory/walletRepository";
+import { WalletRepository } from "../src/repositories/walletRepository";
+import { Transaction } from "../src/utils/transaction";
+import type { DescriptorProvider } from "../src/identity/descriptorProvider";
+
+const network = getNetwork("regtest");
+
+// Wallet's own key vs. a key imported from outside the derivation tree.
+const BASE_PRIVKEY = new Uint8Array(32).fill(1);
+const FOREIGN_PRIVKEY = new Uint8Array(32).fill(2);
+const OTHER_FOREIGN_PRIVKEY = new Uint8Array(32).fill(3);
+
+const MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+function xOnlyHex(privKey: Uint8Array): string {
+    return hex.encode(schnorr.getPublicKey(privKey));
+}
+
+/** A key-path-spendable P2TR tx locked to `privKey`'s pubkey. */
+function makeSignableTx(privKey: Uint8Array): Transaction {
+    const pay = p2tr(schnorr.getPublicKey(privKey), undefined, network);
+    const tx = new Transaction();
+    tx.addInput({
+        txid: new Uint8Array(32).fill(9),
+        index: 0,
+        witnessUtxo: { script: pay.script, amount: 10_000n },
+        tapInternalKey: pay.tapInternalKey,
+    });
+    tx.addOutput({ script: pay.script, amount: 9_000n });
+    return tx;
+}
+
+async function makeProvider(repo?: WalletRepository) {
+    const walletRepo = repo ?? new InMemoryWalletRepository();
+    const base = await StaticDescriptorProvider.create(SingleKey.fromPrivateKey(BASE_PRIVKEY));
+    const provider = await KeyringDescriptorProvider.create(base, walletRepo);
+    return { provider, base, walletRepo };
+}
+
+describe("KeyringDescriptorProvider", () => {
+    let provider: KeyringDescriptorProvider;
+    let walletRepo: WalletRepository;
+    const baseDescriptor = `tr(${xOnlyHex(BASE_PRIVKEY)})`;
+    const foreignDescriptor = `tr(${xOnlyHex(FOREIGN_PRIVKEY)})`;
+
+    beforeEach(async () => {
+        ({ provider, walletRepo } = await makeProvider());
+    });
+
+    describe("importKey", () => {
+        it("returns the tr(<x-only pubkey>) descriptor handle", async () => {
+            expect(await provider.importKey(FOREIGN_PRIVKEY)).toBe(foreignDescriptor);
+        });
+
+        it("is idempotent — re-importing yields the same descriptor and one entry", async () => {
+            const first = await provider.importKey(FOREIGN_PRIVKEY);
+            const second = await provider.importKey(FOREIGN_PRIVKEY);
+
+            expect(second).toBe(first);
+            expect(provider.listKeyringDescriptors()).toEqual([foreignDescriptor]);
+        });
+
+        it("holds several keys at once", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+            await provider.importKey(OTHER_FOREIGN_PRIVKEY);
+
+            expect(provider.listKeyringDescriptors()).toHaveLength(2);
+            expect(provider.hasKey(foreignDescriptor)).toBe(true);
+            expect(provider.hasKey(`tr(${xOnlyHex(OTHER_FOREIGN_PRIVKEY)})`)).toBe(true);
+        });
+    });
+
+    describe("persistence", () => {
+        it("survives a restart — a fresh provider on the same repo resolves the key", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+
+            const { provider: rebooted } = await makeProvider(walletRepo);
+
+            expect(rebooted.hasKey(foreignDescriptor)).toBe(true);
+            expect(rebooted.isOurs(foreignDescriptor)).toBe(true);
+        });
+
+        it("stores keys under settings.keyring without touching other settings", async () => {
+            const repo = new InMemoryWalletRepository();
+            await repo.saveWalletState({ lastSyncTime: 12345, settings: { other: "preserved" } });
+            const { provider } = await makeProvider(repo);
+            await provider.importKey(FOREIGN_PRIVKEY);
+
+            const state = await repo.getWalletState();
+            expect(state?.settings?.other).toBe("preserved");
+            expect(state?.lastSyncTime).toBe(12345);
+            expect(state?.settings?.keyring.keys[xOnlyHex(FOREIGN_PRIVKEY)]).toBe(
+                hex.encode(FOREIGN_PRIVKEY),
+            );
+        });
+
+        it("writes nothing until a key is imported", async () => {
+            const state = await walletRepo.getWalletState();
+            expect(state?.settings?.keyring).toBeUndefined();
+        });
+
+        it("keeps concurrent imports on the same repo from clobbering each other", async () => {
+            const { provider: a } = await makeProvider(walletRepo);
+            const { provider: b } = await makeProvider(walletRepo);
+
+            await Promise.all([a.importKey(FOREIGN_PRIVKEY), b.importKey(OTHER_FOREIGN_PRIVKEY)]);
+
+            const { provider: rebooted } = await makeProvider(walletRepo);
+            expect(rebooted.listKeyringDescriptors().sort()).toEqual(
+                [foreignDescriptor, `tr(${xOnlyHex(OTHER_FOREIGN_PRIVKEY)})`].sort(),
+            );
+        });
+
+        it("throws on corrupt persisted state rather than deriving garbage", async () => {
+            const repo = new InMemoryWalletRepository();
+            await repo.saveWalletState({ settings: { keyring: { keys: { abcd: "not-a-key" } } } });
+
+            await expect(makeProvider(repo)).rejects.toThrow(/Corrupt keyring settings/);
+        });
+    });
+
+    describe("deleteKey", () => {
+        it("purges the entry from memory and from storage", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+
+            expect(await provider.deleteKey(foreignDescriptor)).toBe(true);
+            expect(provider.hasKey(foreignDescriptor)).toBe(false);
+
+            const { provider: rebooted } = await makeProvider(walletRepo);
+            expect(rebooted.hasKey(foreignDescriptor)).toBe(false);
+        });
+
+        it("returns false for an unknown descriptor and is a safe no-op when repeated", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+            await provider.deleteKey(foreignDescriptor);
+
+            expect(await provider.deleteKey(foreignDescriptor)).toBe(false);
+            expect(await provider.deleteKey(baseDescriptor)).toBe(false);
+        });
+
+        it("leaves the other keys intact", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+            await provider.importKey(OTHER_FOREIGN_PRIVKEY);
+            await provider.deleteKey(foreignDescriptor);
+
+            expect(provider.listKeyringDescriptors()).toEqual([
+                `tr(${xOnlyHex(OTHER_FOREIGN_PRIVKEY)})`,
+            ]);
+        });
+    });
+
+    describe("isOurs", () => {
+        it("claims the base provider's descriptor", () => {
+            expect(provider.isOurs(baseDescriptor)).toBe(true);
+        });
+
+        it("rejects a foreign descriptor before import and claims it after", async () => {
+            expect(provider.isOurs(foreignDescriptor)).toBe(false);
+            await provider.importKey(FOREIGN_PRIVKEY);
+            expect(provider.isOurs(foreignDescriptor)).toBe(true);
+        });
+
+        it("resolves a bare pubkey and mixed case to the same entry", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+
+            expect(provider.isOurs(xOnlyHex(FOREIGN_PRIVKEY))).toBe(true);
+            expect(provider.isOurs(foreignDescriptor.toUpperCase().replace("TR(", "tr("))).toBe(
+                true,
+            );
+        });
+
+        it("rejects malformed input", () => {
+            expect(provider.isOurs("tr()")).toBe(false);
+            expect(provider.isOurs("")).toBe(false);
+        });
+    });
+
+    describe("getNextSigningDescriptor", () => {
+        it("delegates to the base provider — the keyring never allocates", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+            expect(await provider.getNextSigningDescriptor()).toBe(baseDescriptor);
+        });
+    });
+
+    describe("signWithDescriptor", () => {
+        it("signs a keyring-owned input with the imported key", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+
+            const [signed] = await provider.signWithDescriptor([
+                { descriptor: foreignDescriptor, tx: makeSignableTx(FOREIGN_PRIVKEY) },
+            ]);
+
+            expect(signed.getInput(0).tapKeySig).toBeDefined();
+            signed.finalize();
+        });
+
+        it("delegates a base-owned input to the base provider", async () => {
+            const [signed] = await provider.signWithDescriptor([
+                { descriptor: baseDescriptor, tx: makeSignableTx(BASE_PRIVKEY) },
+            ]);
+
+            expect(signed.getInput(0).tapKeySig).toBeDefined();
+        });
+
+        it("splits a mixed batch and returns results in request order", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+
+            const signed = await provider.signWithDescriptor([
+                { descriptor: foreignDescriptor, tx: makeSignableTx(FOREIGN_PRIVKEY) },
+                { descriptor: baseDescriptor, tx: makeSignableTx(BASE_PRIVKEY) },
+                { descriptor: foreignDescriptor, tx: makeSignableTx(FOREIGN_PRIVKEY) },
+            ]);
+
+            expect(signed).toHaveLength(3);
+            for (const tx of signed) {
+                expect(tx.getInput(0).tapKeySig).toBeDefined();
+            }
+            // request order preserved: index 1 is the base-key tx
+            expect(hex.encode(signed[1].getInput(0)!.witnessUtxo!.script)).toBe(
+                hex.encode(p2tr(schnorr.getPublicKey(BASE_PRIVKEY), undefined, network).script),
+            );
+        });
+
+        it("hands the base provider its requests in one batched call", async () => {
+            const calls: number[] = [];
+            const base: DescriptorProvider = {
+                getNextSigningDescriptor: async () => baseDescriptor,
+                isOurs: (d) => d === baseDescriptor,
+                signWithDescriptor: async (requests) => {
+                    calls.push(requests.length);
+                    return requests.map((r) => r.tx);
+                },
+                signMessageWithDescriptor: async () => new Uint8Array(64),
+            };
+            const provider = await KeyringDescriptorProvider.create(
+                base,
+                new InMemoryWalletRepository(),
+            );
+            await provider.importKey(FOREIGN_PRIVKEY);
+
+            await provider.signWithDescriptor([
+                { descriptor: baseDescriptor, tx: makeSignableTx(BASE_PRIVKEY) },
+                { descriptor: foreignDescriptor, tx: makeSignableTx(FOREIGN_PRIVKEY) },
+                { descriptor: baseDescriptor, tx: makeSignableTx(BASE_PRIVKEY) },
+            ]);
+
+            expect(calls).toEqual([2]);
+        });
+
+        it("propagates the base provider's error for an unknown descriptor", async () => {
+            const unknown = `tr(${xOnlyHex(OTHER_FOREIGN_PRIVKEY)})`;
+
+            await expect(
+                provider.signWithDescriptor([
+                    { descriptor: unknown, tx: makeSignableTx(OTHER_FOREIGN_PRIVKEY) },
+                ]),
+            ).rejects.toThrow(/does not belong to this provider/);
+        });
+
+        it("keeps a key already in the base provider on the base signing path", async () => {
+            // importing the wallet's own key must not reroute its contracts
+            await provider.importKey(BASE_PRIVKEY);
+
+            const calls: string[] = [];
+            const base: DescriptorProvider = {
+                getNextSigningDescriptor: async () => baseDescriptor,
+                isOurs: (d) => d === baseDescriptor,
+                signWithDescriptor: async (requests) => {
+                    calls.push(...requests.map((r) => r.descriptor));
+                    return requests.map((r) => r.tx);
+                },
+                signMessageWithDescriptor: async () => new Uint8Array(64),
+            };
+            const wrapped = await KeyringDescriptorProvider.create(base, walletRepo);
+
+            await wrapped.signWithDescriptor([
+                { descriptor: baseDescriptor, tx: makeSignableTx(BASE_PRIVKEY) },
+            ]);
+
+            expect(calls).toEqual([baseDescriptor]);
+        });
+    });
+
+    describe("signMessageWithDescriptor", () => {
+        const message = new Uint8Array(32).fill(7);
+
+        it("signs with the imported key, verifiable against its pubkey", async () => {
+            await provider.importKey(FOREIGN_PRIVKEY);
+
+            const sig = await provider.signMessageWithDescriptor(foreignDescriptor, message);
+
+            expect(
+                await schnorr.verifyAsync(sig, message, schnorr.getPublicKey(FOREIGN_PRIVKEY)),
+            ).toBe(true);
+        });
+
+        it("delegates a base-owned descriptor to the base provider", async () => {
+            const sig = await provider.signMessageWithDescriptor(baseDescriptor, message);
+
+            expect(
+                await schnorr.verifyAsync(sig, message, schnorr.getPublicKey(BASE_PRIVKEY)),
+            ).toBe(true);
+        });
+    });
+
+    describe("decorating an HD provider", () => {
+        it("forwards allocation, rotation capability and the descriptor peek", async () => {
+            const repo = new InMemoryWalletRepository();
+            const hd = await HDDescriptorProvider.create(
+                MnemonicIdentity.fromMnemonic(MNEMONIC, { isMainnet: true }),
+                repo,
+            );
+            const wrapped = (await KeyringDescriptorProvider.create(
+                hd,
+                repo,
+            )) as KeyringDescriptorProvider & {
+                createReceiveRotator?: unknown;
+                getCurrentSigningDescriptor?: () => Promise<string | undefined>;
+            };
+
+            const first = await wrapped.getNextSigningDescriptor();
+            expect(first).toBe(await hd.materializeDescriptorAt(0));
+            expect(await wrapped.getNextSigningDescriptor()).toBe(
+                await hd.materializeDescriptorAt(1),
+            );
+
+            expect(typeof wrapped.createReceiveRotator).toBe("function");
+            expect(await wrapped.getCurrentSigningDescriptor!()).toBe(
+                await hd.materializeDescriptorAt(1),
+            );
+
+            // HD descriptors are the base's, imported keys are the keyring's
+            expect(wrapped.isOurs(first)).toBe(true);
+            expect(wrapped.hasKey(first)).toBe(false);
+            await wrapped.importKey(FOREIGN_PRIVKEY);
+            expect(wrapped.isOurs(foreignDescriptor)).toBe(true);
+        });
+
+        it("does not claim rotation capability a static base lacks", async () => {
+            const wrapped = provider as KeyringDescriptorProvider & {
+                createReceiveRotator?: unknown;
+                getCurrentSigningDescriptor?: unknown;
+            };
+
+            expect(wrapped.createReceiveRotator).toBeUndefined();
+            expect(wrapped.getCurrentSigningDescriptor).toBeUndefined();
+        });
+    });
+});

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -9,6 +9,7 @@ import {
     DEFAULT_THRESHOLD_MS,
     MAX_VTXOS_PER_SETTLEMENT,
     capSettlementBatch,
+    selectTopUpForRecovery,
     SettlementConfig,
 } from "../src/wallet/vtxo-manager";
 import { IWallet, ExtendedCoin, ExtendedVirtualCoin } from "../src/wallet";
@@ -159,6 +160,73 @@ describe("capSettlementBatch", () => {
         // Every candidate alone exceeds the ceiling — only reachable if the
         // server lowered it below all existing VTXOs.
         expect(capSettlementBatch(make([9000, 8000]), 5000n)).toEqual([]);
+    });
+});
+
+describe("selectTopUpForRecovery", () => {
+    const DUST = 1000n;
+    // Distinguishable outpoints so we can assert which candidate was chosen.
+    const rec = (values: number[]) => values.map((value, i) => ({ value, txid: `r${i}`, vout: 0 }));
+    const cand = (values: number[]) =>
+        values.map((value, i) => ({ value, txid: `c${i}`, vout: 0 }));
+
+    it("prefers the smallest single candidate that covers the deficit", () => {
+        // Recovery = 600 (deficit 400). Candidates 300 (<400), 500, 900 → pick
+        // 500 (smallest >= 400), one slot, even though 900 also covers it.
+        const result = selectTopUpForRecovery(rec([600]), cand([300, 900, 500]), DUST, -1n);
+        expect(result).not.toBeNull();
+        expect(result!.recoveryInputs.map((v) => v.value)).toEqual([600]);
+        expect(result!.topUp.map((v) => v.value)).toEqual([500]);
+    });
+
+    it("accumulates largest-first when no single candidate covers the deficit", () => {
+        // Recovery = 100 (deficit 900). No candidate alone >= 900. Largest-first
+        // 500 + 400 = 900 → total 1000 >= dust in two slots.
+        const result = selectTopUpForRecovery(rec([100]), cand([500, 400, 300, 200]), DUST, -1n);
+        expect(result).not.toBeNull();
+        expect(result!.topUp.map((v) => v.value)).toEqual([500, 400]);
+    });
+
+    it("returns null when the claimer cannot reach dust", () => {
+        // Recovery 100 + all candidates 100 + 100 = 300 < dust 1000.
+        expect(selectTopUpForRecovery(rec([100]), cand([100, 100]), DUST, -1n)).toBeNull();
+    });
+
+    it("returns null when there are no candidates", () => {
+        expect(selectTopUpForRecovery(rec([100]), cand([]), DUST, -1n)).toBeNull();
+    });
+
+    it("respects vtxoMaxAmount on the combined output in the single-candidate path", () => {
+        // Recovery 600, deficit 400, ceiling 1000. A single 900 covers the
+        // deficit but 600+900=1500 > 1000, so it is skipped for the 400 (which
+        // gives 1000, exactly the ceiling — accepted, strict > check).
+        const result = selectTopUpForRecovery(rec([600]), cand([400, 900]), DUST, 1000n);
+        expect(result).not.toBeNull();
+        expect(result!.topUp.map((v) => v.value)).toEqual([400]);
+    });
+
+    it("skips a ceiling-breaching candidate while accumulating", () => {
+        // Recovery 100, deficit 900, ceiling 1200. Largest-first 5000 breaches
+        // (100+5000 > 1200) and is skipped; 800 + 200 = 1000 → total 1100 <=
+        // 1200 and >= dust.
+        const result = selectTopUpForRecovery(rec([100]), cand([5000, 800, 200]), DUST, 1200n);
+        expect(result).not.toBeNull();
+        expect(result!.topUp.map((v) => v.value)).toEqual([800, 200]);
+    });
+
+    it("drops the smallest recovery inputs to free a slot when the batch fills the cap", () => {
+        // 50 subdust recovery inputs of 10 each (total 500 < dust). No slot is
+        // free for a top-up, so the smallest input is dropped to make room; one
+        // >= deficit candidate then clears dust.
+        const recovery = rec(Array.from({ length: MAX_VTXOS_PER_SETTLEMENT }, () => 10));
+        const result = selectTopUpForRecovery(recovery, cand([5000]), DUST, -1n);
+        expect(result).not.toBeNull();
+        expect(result!.recoveryInputs).toHaveLength(MAX_VTXOS_PER_SETTLEMENT - 1);
+        expect(result!.topUp.map((v) => v.value)).toEqual([5000]);
+        // Combined stays within the server's intent-size cap.
+        expect(result!.recoveryInputs.length + result!.topUp.length).toBeLessThanOrEqual(
+            MAX_VTXOS_PER_SETTLEMENT,
+        );
     });
 });
 

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -218,6 +218,51 @@ describe("WalletMessageHandler handleMessage", () => {
         });
     });
 
+    it("getVtxosFromRepo excludes recovery-only contracts, but includes them for history", async () => {
+        const repo = new InMemoryWalletRepository();
+
+        const SCRIPT_NORMAL = "5120" + "11".repeat(32);
+        const SCRIPT_RECOVERY = "5120" + "22".repeat(32);
+        const vtxo = (txid: string, script: string, state: string) =>
+            ({
+                txid: txid.repeat(64),
+                vout: 0,
+                value: 1000,
+                script,
+                status: { confirmed: true },
+                virtualStatus: { state },
+                isSpent: false,
+                createdAt: new Date(),
+            }) as any;
+
+        await repo.saveVtxos("addr-normal", [vtxo("n", SCRIPT_NORMAL, "settled")]);
+        await repo.saveVtxos("addr-recovery", [vtxo("r", SCRIPT_RECOVERY, "swept")]);
+
+        const normal = { type: "default", script: SCRIPT_NORMAL, address: "addr-normal" };
+        const recovery = {
+            type: "default",
+            script: SCRIPT_RECOVERY,
+            address: "addr-recovery",
+            metadata: { recoveryOnly: true, signingDescriptor: "tr(00)" },
+        };
+
+        (updater as any).walletRepository = repo;
+        (updater as any).readonlyWallet = {
+            getContractManager: async () => ({ getContracts: async () => [normal, recovery] }),
+            getAddress: async () => TEST_DEFAULT_ARK_ADDRESS,
+        };
+
+        // Default (balance / VTXOS / coin selection): recovery-only excluded.
+        const excluded = await (updater as any).getVtxosFromRepo();
+        expect(excluded.map((v: any) => v.script)).toEqual([SCRIPT_NORMAL]);
+
+        // History opt-in: recovery-only included (parity with non-worker).
+        const included = await (updater as any).getVtxosFromRepo({ includeRecoveryOnly: true });
+        expect(included.map((v: any) => v.script).sort()).toEqual(
+            [SCRIPT_NORMAL, SCRIPT_RECOVERY].sort(),
+        );
+    });
+
     it("handles GET_BOARDING_UTXOS messages", async () => {
         (updater as any).readonlyWallet = {};
         const utxos = [{ txid: "tx", vout: 0, value: 1, status: { confirmed: true } }];


### PR DESCRIPTION
Stacked on #624 (Phase 3/4). Final PR of the ArkCash hybrid-L3 stack
(#621 → #622 → #623 → #624 → this). See `plans/pr-337-new-plan.md`, Phase 5.

Makes a **below-dust ArkCash note fully claimable** instead of report-only.
Subdust claim becomes import-for-recovery (exactly like swept) plus top-up
aggregation inside the isolated per-contract recovery settle.

## Changes
- **Mint** (`createCash`): drop the dust floor; keep positivity/integrality.
  Below-dust mints route to the OP_RETURN subdust script via the send path.
- **Classify** (`classifyCashVtxos`): `has-assets` now checked *before* the
  subdust/swept case (asset-bearing subdust stays report-only, never imported
  into the BTC-only settle); subdust joins swept in the `recoverable` bucket.
  `"subdust"` dropped from `ArkCashUnclaimedReason`; `recovering.vtxos` gain
  `kind: "swept" | "subdust"`.
- **Recovery** (`recoverOneImportedContract`): broadened predicate to include
  live subdust; new `selectTopUpForRecovery` enrols a slot-budgeted claimer
  top-up (smallest single ≥-deficit VTXO, else largest-first; drops smallest
  recovery inputs to free a slot; respects `vtxoMaxAmount` on the combined
  output). Insufficient funds → defer, keep the contract imported. Top-up pool
  mirrors the send path's availability filter plus an asset guard.

## Isolation preserved
Foreign inputs never enter the wallet's own renewal/recovery bundle; the
top-up is reserved/released by `settle` for one attempt, parks nothing between
attempts, and the recovered output is a self-transfer to the claimer.

## Tests
- Unit: `selectTopUpForRecovery` budget cases + classifier reorder (asset
  subdust → `has-assets`, subdust → `recovering{kind:"subdust"}`).
- E2e: subdust recovery via mixed-key top-up settle; defer-until-funded.

Full unit suite + lint + build green; e2e needs the regtest stack.
