### PR TITLE
feat: expose createCash/claimCash through the service worker

### DIFF
--- a/packages/boltz-swap/src/expo/background.ts
+++ b/packages/boltz-swap/src/expo/background.ts
@@ -68,6 +68,8 @@ function createBackgroundWalletShim(args: {
         getDelegatorManager: async () => notImplemented("getDelegatorManager"),
         sendBitcoin: async () => notImplemented("sendBitcoin"),
         send: async () => notImplemented("send"),
+        createCash: async () => notImplemented("createCash"),
+        claimCash: async () => notImplemented("claimCash"),
         settle: async () => notImplemented("settle"),
         clear: async () => notImplemented("clear"),
         assetManager: new Proxy({} as IWallet["assetManager"], {

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -1,5 +1,5 @@
 import { hex } from "@scure/base";
-import { Wallet, type ProviderConnectionState } from "../wallet";
+import { Wallet, type ArkCashClaimResult, type ProviderConnectionState } from "../wallet";
 import type { Activity, ActivityRegistry } from "../activity";
 import { RestArkProvider } from "../../providers/ark";
 import type {
@@ -360,6 +360,14 @@ export class ExpoWallet implements IWallet {
 
     send(...recipients: [Recipient, ...Recipient[]]): Promise<string> {
         return this.wallet.send(...recipients);
+    }
+
+    createCash(amount: number): Promise<string> {
+        return this.wallet.createCash(amount);
+    }
+
+    claimCash(cashStr: string): Promise<ArkCashClaimResult> {
+        return this.wallet.claimCash(cashStr);
     }
 
     get assetManager(): IAssetManager {

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -1,5 +1,5 @@
 import { hex } from "@scure/base";
-import { Wallet, type ArkCashClaimResult, type ProviderConnectionState } from "../wallet";
+import { Wallet, type ArkadeCashClaimResult, type ProviderConnectionState } from "../wallet";
 import type { Activity, ActivityRegistry } from "../activity";
 import { RestArkProvider } from "../../providers/ark";
 import type {
@@ -366,7 +366,7 @@ export class ExpoWallet implements IWallet {
         return this.wallet.createCash(amount);
     }
 
-    claimCash(cashStr: string): Promise<ArkCashClaimResult> {
+    claimCash(cashStr: string): Promise<ArkadeCashClaimResult> {
         return this.wallet.claimCash(cashStr);
     }
 

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -16,7 +16,7 @@ import {
 } from "../repositories";
 import { IContractManager } from "../contracts/contractManager";
 import { IDelegateManager } from "./delegate";
-import type { ArkCashClaimResult } from "./wallet";
+import type { ArkadeCashClaimResult } from "./wallet";
 import type { Activity, ActivityRegistry } from "./activity";
 import type { ExitCaptureMode } from "./exit/capture";
 import type { ExitDataSource } from "./exit/resolver";
@@ -888,22 +888,22 @@ export interface IWallet extends IReadonlyWallet {
     send(...recipients: [Recipient, ...Recipient[]]): Promise<string>;
 
     /**
-     * Mint an ArkCash bearer note funded with `amount` sats.
+     * Mint an ArkadeCash bearer note funded with `amount` sats.
      *
      * @param amount - Sats to fund; whole number >= dust
-     * @returns The encoded arkcash token (bearer instrument)
-     * @throws ArkCashCreateError carrying the recovery token if funding lands
+     * @returns The encoded arkadeCash token (bearer instrument)
+     * @throws ArkadeCashCreateError carrying the recovery token if funding lands
      * but the send fails
      */
     createCash(amount: number): Promise<string>;
 
     /**
-     * Claim an ArkCash bearer note: sweep what can be swept, report the rest.
+     * Claim an ArkadeCash bearer note: sweep what can be swept, report the rest.
      *
-     * @param cashStr - The encoded arkcash token
+     * @param cashStr - The encoded arkadeCash token
      * @returns Swept total and the report of what was left behind
      */
-    claimCash(cashStr: string): Promise<ArkCashClaimResult>;
+    claimCash(cashStr: string): Promise<ArkadeCashClaimResult>;
 
     // TODO: this needs to be async or find a workaround
     /** Asset manager bound to this wallet instance. */

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -16,6 +16,7 @@ import {
 } from "../repositories";
 import { IContractManager } from "../contracts/contractManager";
 import { IDelegateManager } from "./delegate";
+import type { ArkCashClaimResult } from "./wallet";
 import type { Activity, ActivityRegistry } from "./activity";
 import type { ExitCaptureMode } from "./exit/capture";
 import type { ExitDataSource } from "./exit/resolver";
@@ -885,6 +886,24 @@ export interface IWallet extends IReadonlyWallet {
      * ```
      */
     send(...recipients: [Recipient, ...Recipient[]]): Promise<string>;
+
+    /**
+     * Mint an ArkCash bearer note funded with `amount` sats.
+     *
+     * @param amount - Sats to fund; whole number >= dust
+     * @returns The encoded arkcash token (bearer instrument)
+     * @throws ArkCashCreateError carrying the recovery token if funding lands
+     * but the send fails
+     */
+    createCash(amount: number): Promise<string>;
+
+    /**
+     * Claim an ArkCash bearer note: sweep what can be swept, report the rest.
+     *
+     * @param cashStr - The encoded arkcash token
+     * @returns Swept total and the report of what was left behind
+     */
+    claimCash(cashStr: string): Promise<ArkCashClaimResult>;
 
     // TODO: this needs to be async or find a workaround
     /** Asset manager bound to this wallet instance. */

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -39,8 +39,8 @@ import { DelegateInfo } from "../../providers/delegate";
 import {
     ReadonlyWallet,
     Wallet,
-    ArkCashCreateError,
-    type ArkCashClaimResult,
+    ArkadeCashCreateError,
+    type ArkadeCashClaimResult,
     type ProviderConnectionState,
 } from "../wallet";
 import type {
@@ -115,46 +115,46 @@ export function deserializeAggregateError(payload: SerializedAggregateError): Ag
 }
 
 /**
- * Wire form of {@link ArkCashCreateError}. The `cash` token controls the funded
+ * Wire form of {@link ArkadeCashCreateError}. The `cash` token controls the funded
  * output and is the only way to recover it, so it must cross the boundary that
  * structured-clone would otherwise strip along with the error's prototype.
  */
-export type SerializedArkCashCreateError = {
-    name: "ArkCashCreateError";
+export type SerializedArkadeCashCreateError = {
+    name: "ArkadeCashCreateError";
     message: string;
     cash: string;
     cause?: { name: string; message: string };
 };
 
-export function isSerializedArkCashCreateError(
+export function isSerializedArkadeCashCreateError(
     value: unknown,
-): value is SerializedArkCashCreateError {
+): value is SerializedArkadeCashCreateError {
     if (!value || typeof value !== "object") return false;
-    const v = value as Partial<SerializedArkCashCreateError>;
-    return v.name === "ArkCashCreateError" && typeof v.cash === "string";
+    const v = value as Partial<SerializedArkadeCashCreateError>;
+    return v.name === "ArkadeCashCreateError" && typeof v.cash === "string";
 }
 
-/** Worker-side serializer for {@link ArkCashCreateError}. */
-export function serializeArkCashCreateError(
-    error: ArkCashCreateError,
-): SerializedArkCashCreateError {
+/** Worker-side serializer for {@link ArkadeCashCreateError}. */
+export function serializeArkadeCashCreateError(
+    error: ArkadeCashCreateError,
+): SerializedArkadeCashCreateError {
     const cause =
         error.cause instanceof Error
             ? { name: error.cause.name, message: error.cause.message }
             : error.cause !== undefined
               ? { name: "Error", message: String(error.cause) }
               : undefined;
-    return { name: "ArkCashCreateError", message: error.message, cash: error.cash, cause };
+    return { name: "ArkadeCashCreateError", message: error.message, cash: error.cash, cause };
 }
 
-/** Page-side reconstructor: rebuild {@link ArkCashCreateError} from the wire form. */
-export function deserializeArkCashCreateError(
-    payload: SerializedArkCashCreateError,
-): ArkCashCreateError {
+/** Page-side reconstructor: rebuild {@link ArkadeCashCreateError} from the wire form. */
+export function deserializeArkadeCashCreateError(
+    payload: SerializedArkadeCashCreateError,
+): ArkadeCashCreateError {
     const cause = payload.cause
         ? Object.assign(new Error(payload.cause.message), { name: payload.cause.name })
         : undefined;
-    return new ArkCashCreateError(payload.cash, cause);
+    return new ArkadeCashCreateError(payload.cash, cause);
 }
 
 export class ReadonlyWalletError extends Error {
@@ -468,7 +468,7 @@ export type RequestClaimCash = RequestEnvelope & {
 };
 export type ResponseClaimCash = ResponseEnvelope & {
     type: "CLAIM_CASH_SUCCESS";
-    payload: { result: ArkCashClaimResult };
+    payload: { result: ArkadeCashClaimResult };
 };
 
 export type RequestGetAssetDetails = RequestEnvelope & {
@@ -1211,16 +1211,16 @@ export class WalletMessageHandler
                 }
                 case "CREATE_CASH": {
                     const { amount } = (message as RequestCreateCash).payload;
-                    // ArkCashCreateError carries the recovery token; serialize it
+                    // ArkadeCashCreateError carries the recovery token; serialize it
                     // explicitly so the token survives the postMessage boundary.
                     let cash: string;
                     try {
                         cash = await this.requireWallet().createCash(amount);
                     } catch (error) {
-                        if (error instanceof ArkCashCreateError) {
+                        if (error instanceof ArkadeCashCreateError) {
                             return this.tagged({
                                 id,
-                                error: serializeArkCashCreateError(error) as unknown as Error,
+                                error: serializeArkadeCashCreateError(error) as unknown as Error,
                             });
                         }
                         throw error;

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -36,7 +36,13 @@ import {
     WalletBalance,
 } from "../index";
 import { DelegateInfo } from "../../providers/delegate";
-import { ReadonlyWallet, Wallet, type ProviderConnectionState } from "../wallet";
+import {
+    ReadonlyWallet,
+    Wallet,
+    ArkCashCreateError,
+    type ArkCashClaimResult,
+    type ProviderConnectionState,
+} from "../wallet";
 import type {
     DeprecatedSignerMigrationReport,
     DeprecatedSignerReport,
@@ -106,6 +112,49 @@ export function deserializeAggregateError(payload: SerializedAggregateError): Ag
         return err;
     });
     return new AggregateError(errs, payload.message);
+}
+
+/**
+ * Wire form of {@link ArkCashCreateError}. The `cash` token controls the funded
+ * output and is the only way to recover it, so it must cross the boundary that
+ * structured-clone would otherwise strip along with the error's prototype.
+ */
+export type SerializedArkCashCreateError = {
+    name: "ArkCashCreateError";
+    message: string;
+    cash: string;
+    cause?: { name: string; message: string };
+};
+
+export function isSerializedArkCashCreateError(
+    value: unknown,
+): value is SerializedArkCashCreateError {
+    if (!value || typeof value !== "object") return false;
+    const v = value as Partial<SerializedArkCashCreateError>;
+    return v.name === "ArkCashCreateError" && typeof v.cash === "string";
+}
+
+/** Worker-side serializer for {@link ArkCashCreateError}. */
+export function serializeArkCashCreateError(
+    error: ArkCashCreateError,
+): SerializedArkCashCreateError {
+    const cause =
+        error.cause instanceof Error
+            ? { name: error.cause.name, message: error.cause.message }
+            : error.cause !== undefined
+              ? { name: "Error", message: String(error.cause) }
+              : undefined;
+    return { name: "ArkCashCreateError", message: error.message, cash: error.cash, cause };
+}
+
+/** Page-side reconstructor: rebuild {@link ArkCashCreateError} from the wire form. */
+export function deserializeArkCashCreateError(
+    payload: SerializedArkCashCreateError,
+): ArkCashCreateError {
+    const cause = payload.cause
+        ? Object.assign(new Error(payload.cause.message), { name: payload.cause.name })
+        : undefined;
+    return new ArkCashCreateError(payload.cash, cause);
 }
 
 export class ReadonlyWalletError extends Error {
@@ -402,6 +451,24 @@ export type RequestSend = RequestEnvelope & {
 export type ResponseSend = ResponseEnvelope & {
     type: "SEND_SUCCESS";
     payload: { txid: string };
+};
+
+export type RequestCreateCash = RequestEnvelope & {
+    type: "CREATE_CASH";
+    payload: { amount: number };
+};
+export type ResponseCreateCash = ResponseEnvelope & {
+    type: "CREATE_CASH_SUCCESS";
+    payload: { cash: string };
+};
+
+export type RequestClaimCash = RequestEnvelope & {
+    type: "CLAIM_CASH";
+    payload: { cash: string };
+};
+export type ResponseClaimCash = ResponseEnvelope & {
+    type: "CLAIM_CASH_SUCCESS";
+    payload: { result: ArkCashClaimResult };
 };
 
 export type RequestGetAssetDetails = RequestEnvelope & {
@@ -716,6 +783,8 @@ export type WalletUpdaterRequest =
     | RequestRefreshVtxos
     | RequestRefreshOutpoints
     | RequestSend
+    | RequestCreateCash
+    | RequestClaimCash
     | RequestGetAssetDetails
     | RequestIssue
     | RequestReissue
@@ -764,6 +833,8 @@ export type WalletUpdaterResponse = ResponseEnvelope &
         | ResponseRefreshOutpoints
         | ResponseContractEvent
         | ResponseSend
+        | ResponseCreateCash
+        | ResponseClaimCash
         | ResponseGetAssetDetails
         | ResponseIssue
         | ResponseReissue
@@ -1136,6 +1207,37 @@ export class WalletMessageHandler
                         id,
                         type: "SEND_SUCCESS",
                         payload: { txid },
+                    });
+                }
+                case "CREATE_CASH": {
+                    const { amount } = (message as RequestCreateCash).payload;
+                    // ArkCashCreateError carries the recovery token; serialize it
+                    // explicitly so the token survives the postMessage boundary.
+                    let cash: string;
+                    try {
+                        cash = await this.requireWallet().createCash(amount);
+                    } catch (error) {
+                        if (error instanceof ArkCashCreateError) {
+                            return this.tagged({
+                                id,
+                                error: serializeArkCashCreateError(error) as unknown as Error,
+                            });
+                        }
+                        throw error;
+                    }
+                    return this.tagged({
+                        id,
+                        type: "CREATE_CASH_SUCCESS",
+                        payload: { cash },
+                    });
+                }
+                case "CLAIM_CASH": {
+                    const { cash } = (message as RequestClaimCash).payload;
+                    const result = await this.requireWallet().claimCash(cash);
+                    return this.tagged({
+                        id,
+                        type: "CLAIM_CASH_SUCCESS",
+                        payload: { result },
                     });
                 }
                 case "GET_ASSET_DETAILS": {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -83,6 +83,10 @@ import {
     ResponseGetAllSpendingPaths,
     RequestSend,
     ResponseSend,
+    RequestCreateCash,
+    ResponseCreateCash,
+    RequestClaimCash,
+    ResponseClaimCash,
     RequestGetAssetDetails,
     ResponseGetAssetDetails,
     RequestIssue,
@@ -120,6 +124,8 @@ import {
     DEFAULT_MESSAGE_TAG,
     deserializeAggregateError,
     isSerializedAggregateError,
+    deserializeArkCashCreateError,
+    isSerializedArkCashCreateError,
 } from "./wallet-message-handler";
 import type {
     Contract,
@@ -156,7 +162,11 @@ import {
     MESSAGE_BUS_NOT_INITIALIZED,
     ServiceWorkerTimeoutError,
 } from "../../worker/errors";
-import { getArkadeServerUrl, type ProviderConnectionState } from "../wallet";
+import {
+    getArkadeServerUrl,
+    type ArkCashClaimResult,
+    type ProviderConnectionState,
+} from "../wallet";
 
 function isMessageBusNotInitializedError(error: unknown): boolean {
     return error instanceof Error && error.message.includes(MESSAGE_BUS_NOT_INITIALIZED);
@@ -213,6 +223,8 @@ export const DEFAULT_MESSAGE_TIMEOUTS: Readonly<Record<RequestType, number>> = {
     // are retained only for type completeness and are never enforced.
     SEND_BITCOIN: 50_000,
     SEND: 50_000,
+    CREATE_CASH: 50_000,
+    CLAIM_CASH: 50_000,
     SETTLE: 50_000,
     ISSUE: 50_000,
     REISSUE: 50_000,
@@ -1677,6 +1689,43 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
             return (response as ResponseSend).payload.txid;
         } catch (error) {
             throw new Error(`Send failed: ${error}`);
+        }
+    }
+
+    async createCash(amount: number): Promise<string> {
+        const message: RequestCreateCash = {
+            tag: this.messageTag,
+            type: "CREATE_CASH",
+            id: getRandomId(),
+            payload: { amount },
+        };
+
+        try {
+            const response = await this.sendMessage(message);
+            return (response as ResponseCreateCash).payload.cash;
+        } catch (error) {
+            // Rebuild the typed error before the generic wrap so the recovery
+            // token on `.cash` reaches the caller.
+            if (isSerializedArkCashCreateError(error)) {
+                throw deserializeArkCashCreateError(error);
+            }
+            throw new Error(`Failed to create ArkCash: ${error}`);
+        }
+    }
+
+    async claimCash(cash: string): Promise<ArkCashClaimResult> {
+        const message: RequestClaimCash = {
+            tag: this.messageTag,
+            type: "CLAIM_CASH",
+            id: getRandomId(),
+            payload: { cash },
+        };
+
+        try {
+            const response = await this.sendMessage(message);
+            return (response as ResponseClaimCash).payload.result;
+        } catch (error) {
+            throw new Error(`Failed to claim ArkCash: ${error}`);
         }
     }
 

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -124,8 +124,8 @@ import {
     DEFAULT_MESSAGE_TAG,
     deserializeAggregateError,
     isSerializedAggregateError,
-    deserializeArkCashCreateError,
-    isSerializedArkCashCreateError,
+    deserializeArkadeCashCreateError,
+    isSerializedArkadeCashCreateError,
 } from "./wallet-message-handler";
 import type {
     Contract,
@@ -164,7 +164,7 @@ import {
 } from "../../worker/errors";
 import {
     getArkadeServerUrl,
-    type ArkCashClaimResult,
+    type ArkadeCashClaimResult,
     type ProviderConnectionState,
 } from "../wallet";
 
@@ -1706,14 +1706,14 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
         } catch (error) {
             // Rebuild the typed error before the generic wrap so the recovery
             // token on `.cash` reaches the caller.
-            if (isSerializedArkCashCreateError(error)) {
-                throw deserializeArkCashCreateError(error);
+            if (isSerializedArkadeCashCreateError(error)) {
+                throw deserializeArkadeCashCreateError(error);
             }
-            throw new Error(`Failed to create ArkCash: ${error}`);
+            throw new Error(`Failed to create ArkadeCash: ${error}`);
         }
     }
 
-    async claimCash(cash: string): Promise<ArkCashClaimResult> {
+    async claimCash(cash: string): Promise<ArkadeCashClaimResult> {
         const message: RequestClaimCash = {
             tag: this.messageTag,
             type: "CLAIM_CASH",
@@ -1725,7 +1725,7 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
             const response = await this.sendMessage(message);
             return (response as ResponseClaimCash).payload.result;
         } catch (error) {
-            throw new Error(`Failed to claim ArkCash: ${error}`);
+            throw new Error(`Failed to claim ArkadeCash: ${error}`);
         }
     }
 

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -9,6 +9,7 @@ import {
     MnemonicIdentity,
     SeedIdentity,
     ReadonlyDescriptorIdentity,
+    ArkCashCreateError,
     type ContractSyncState,
 } from "../../src";
 import { ServiceWorkerWallet } from "../../src/wallet/serviceWorker/wallet";
@@ -677,6 +678,83 @@ describe("ServiceWorkerWallet", () => {
         expect((agg.errors[0] as Error).name).toBe("HandlerAError");
         expect((agg.errors[0] as Error).message).toBe("handler-a-failed");
         expect((agg.errors[1] as Error).message).toBe("handler-b-failed");
+    });
+
+    it("createCash() forwards the amount and returns the token", async () => {
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => {
+            if (message.type !== "CREATE_CASH") return null;
+            return {
+                id: message.id,
+                tag: messageTag,
+                type: "CREATE_CASH_SUCCESS",
+                payload: { cash: "arkcash1token" },
+            };
+        });
+
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createSWWallet(serviceWorker as any, messageTag);
+        await expect(wallet.createCash(5000)).resolves.toBe("arkcash1token");
+        expect(serviceWorker.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tag: messageTag,
+                type: "CREATE_CASH",
+                payload: { amount: 5000 },
+            }),
+        );
+    });
+
+    it("createCash() reconstructs a worker-side ArkCashCreateError with its token", async () => {
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => {
+            if (message.type !== "CREATE_CASH") return null;
+            return {
+                id: message.id,
+                tag: messageTag,
+                error: {
+                    name: "ArkCashCreateError",
+                    message: "send failed",
+                    cash: "arkcash1recover",
+                },
+            };
+        });
+
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createSWWallet(serviceWorker as any, messageTag);
+        let caught: unknown;
+        try {
+            await wallet.createCash(5000);
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught).toBeInstanceOf(ArkCashCreateError);
+        expect((caught as ArkCashCreateError).cash).toBe("arkcash1recover");
+    });
+
+    it("claimCash() forwards the token and returns the claim result", async () => {
+        const result = { swept: 5000, unclaimed: { amount: 0, vtxos: [] } };
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => {
+            if (message.type !== "CLAIM_CASH") return null;
+            return {
+                id: message.id,
+                tag: messageTag,
+                type: "CLAIM_CASH_SUCCESS",
+                payload: { result },
+            };
+        });
+
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createSWWallet(serviceWorker as any, messageTag);
+        await expect(wallet.claimCash("arkcash1token")).resolves.toEqual(result);
+        expect(serviceWorker.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tag: messageTag,
+                type: "CLAIM_CASH",
+                payload: { cash: "arkcash1token" },
+            }),
+        );
     });
 
     it("restore() propagates non-AggregateError failures as-is", async () => {

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -9,7 +9,7 @@ import {
     MnemonicIdentity,
     SeedIdentity,
     ReadonlyDescriptorIdentity,
-    ArkCashCreateError,
+    ArkadeCashCreateError,
     type ContractSyncState,
 } from "../../src";
 import { ServiceWorkerWallet } from "../../src/wallet/serviceWorker/wallet";
@@ -704,14 +704,14 @@ describe("ServiceWorkerWallet", () => {
         );
     });
 
-    it("createCash() reconstructs a worker-side ArkCashCreateError with its token", async () => {
+    it("createCash() reconstructs a worker-side ArkadeCashCreateError with its token", async () => {
         const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => {
             if (message.type !== "CREATE_CASH") return null;
             return {
                 id: message.id,
                 tag: messageTag,
                 error: {
-                    name: "ArkCashCreateError",
+                    name: "ArkadeCashCreateError",
                     message: "send failed",
                     cash: "arkcash1recover",
                 },
@@ -728,8 +728,8 @@ describe("ServiceWorkerWallet", () => {
             caught = err;
         }
 
-        expect(caught).toBeInstanceOf(ArkCashCreateError);
-        expect((caught as ArkCashCreateError).cash).toBe("arkcash1recover");
+        expect(caught).toBeInstanceOf(ArkadeCashCreateError);
+        expect((caught as ArkadeCashCreateError).cash).toBe("arkcash1recover");
     });
 
     it("claimCash() forwards the token and returns the claim result", async () => {

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -5,8 +5,10 @@ import {
     WalletMessageHandler,
     serializeMigrationReport,
     deserializeMigrationReport,
+    isSerializedArkCashCreateError,
+    deserializeArkCashCreateError,
 } from "../src/wallet/serviceWorker/wallet-message-handler";
-import { InMemoryWalletRepository } from "../src";
+import { InMemoryWalletRepository, ArkCashCreateError } from "../src";
 import {
     createMockExtendedVtxo,
     createMockIndexerProvider,
@@ -112,6 +114,67 @@ describe("WalletMessageHandler handleMessage", () => {
             tag: updater.messageTag,
             type: "SEND_BITCOIN_SUCCESS",
             payload: { txid: "tx" },
+        });
+    });
+
+    it("handles CREATE_CASH messages", async () => {
+        (updater as any).readonlyWallet = {};
+        (updater as any).wallet = {
+            createCash: vi.fn().mockResolvedValue("arkcash1token"),
+        };
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "CREATE_CASH",
+            payload: { amount: 5000 },
+        } as any);
+
+        expect((updater as any).wallet.createCash).toHaveBeenCalledWith(5000);
+        expect(response).toMatchObject({
+            tag: updater.messageTag,
+            type: "CREATE_CASH_SUCCESS",
+            payload: { cash: "arkcash1token" },
+        });
+    });
+
+    it("serializes ArkCashCreateError so the recovery token survives", async () => {
+        (updater as any).readonlyWallet = {};
+        const original = new ArkCashCreateError("arkcash1recover", new Error("send blew up"));
+        (updater as any).wallet = {
+            createCash: vi.fn().mockRejectedValue(original),
+        };
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "CREATE_CASH",
+            payload: { amount: 5000 },
+        } as any);
+
+        expect(isSerializedArkCashCreateError(response.error)).toBe(true);
+
+        const rebuilt = deserializeArkCashCreateError(response.error as any);
+        expect(rebuilt).toBeInstanceOf(ArkCashCreateError);
+        expect(rebuilt.cash).toBe("arkcash1recover");
+    });
+
+    it("handles CLAIM_CASH messages", async () => {
+        (updater as any).readonlyWallet = {};
+        const result = { swept: 5000, unclaimed: { amount: 0, vtxos: [] } };
+        (updater as any).wallet = {
+            claimCash: vi.fn().mockResolvedValue(result),
+        };
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "CLAIM_CASH",
+            payload: { cash: "arkcash1token" },
+        } as any);
+
+        expect((updater as any).wallet.claimCash).toHaveBeenCalledWith("arkcash1token");
+        expect(response).toMatchObject({
+            tag: updater.messageTag,
+            type: "CLAIM_CASH_SUCCESS",
+            payload: { result },
         });
     });
 

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -5,10 +5,10 @@ import {
     WalletMessageHandler,
     serializeMigrationReport,
     deserializeMigrationReport,
-    isSerializedArkCashCreateError,
-    deserializeArkCashCreateError,
+    isSerializedArkadeCashCreateError,
+    deserializeArkadeCashCreateError,
 } from "../src/wallet/serviceWorker/wallet-message-handler";
-import { InMemoryWalletRepository, ArkCashCreateError } from "../src";
+import { InMemoryWalletRepository, ArkadeCashCreateError } from "../src";
 import {
     createMockExtendedVtxo,
     createMockIndexerProvider,
@@ -137,9 +137,9 @@ describe("WalletMessageHandler handleMessage", () => {
         });
     });
 
-    it("serializes ArkCashCreateError so the recovery token survives", async () => {
+    it("serializes ArkadeCashCreateError so the recovery token survives", async () => {
         (updater as any).readonlyWallet = {};
-        const original = new ArkCashCreateError("arkcash1recover", new Error("send blew up"));
+        const original = new ArkadeCashCreateError("arkcash1recover", new Error("send blew up"));
         (updater as any).wallet = {
             createCash: vi.fn().mockRejectedValue(original),
         };
@@ -150,10 +150,10 @@ describe("WalletMessageHandler handleMessage", () => {
             payload: { amount: 5000 },
         } as any);
 
-        expect(isSerializedArkCashCreateError(response.error)).toBe(true);
+        expect(isSerializedArkadeCashCreateError(response.error)).toBe(true);
 
-        const rebuilt = deserializeArkCashCreateError(response.error as any);
-        expect(rebuilt).toBeInstanceOf(ArkCashCreateError);
+        const rebuilt = deserializeArkadeCashCreateError(response.error as any);
+        expect(rebuilt).toBeInstanceOf(ArkadeCashCreateError);
         expect(rebuilt.cash).toBe("arkcash1recover");
     });
 


### PR DESCRIPTION
## Problem

`createCash`/`claimCash` existed only on the base `Wallet` class, which runs inside the service worker and is unreachable from the UI. `ServiceWorkerWallet` had no forwarders, and `WalletMessageHandler` had no message types for them — so ArkCash could not cross the worker boundary at all.

## Changes

- **`IWallet`** — `createCash`/`claimCash` are now part of the interface, so every implementation provides them.
- **Message types** — `CREATE_CASH`/`CLAIM_CASH` request/response pairs, union entries, handler `switch` cases, and 50s timeouts (matching `SEND`).
- **`ServiceWorkerWallet`** — page-side forwarders.
- **`ExpoWallet`** — delegates to the wrapped wallet.

### Error fidelity

`createCash` throws `ArkCashCreateError` carrying the `cash` bearer token — the only way to recover funds when the note is funded but the send fails. Structured-clone strips custom own properties (and the prototype) across `postMessage`, so the token is serialized explicitly and reconstructed page-side, mirroring the existing `AggregateError` round-trip.

## Tests

- Handler: `CREATE_CASH`/`CLAIM_CASH` dispatch, and `ArkCashCreateError` surviving serialize→deserialize with `.cash` intact.
- Page side: forwarder wiring plus worker-side `ArkCashCreateError` reconstruction.

Full unit suite green (1986 passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArkadeCash creation and claiming across standard, Expo, and service-worker wallets.
  * Added transport support for ArkadeCash operations, including recovery details for creation errors.
  * Renamed the public cash API from ArkCash to ArkadeCash, including encoding and validation updates.

* **Documentation**
  * Updated examples, comments, README commands, and test references to use ArkadeCash terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->