### PR TITLE
fix(boltz-swap): block-denominated locktimes after the regtest upgrade

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -7,7 +7,6 @@ ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.9-rc.0
 ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.9-rc.0
 
 # Shared regtest tuning used across the SDK repos
-ARKD_SCHEDULER_TYPE=block
 ARKD_VTXO_TREE_EXPIRY=20
 ARKD_BOARDING_EXIT_DELAY=40
 ARKD_CHECKPOINT_EXIT_DELAY=20

--- a/packages/boltz-swap/.env.regtest
+++ b/packages/boltz-swap/.env.regtest
@@ -5,8 +5,6 @@ BOLTZ_IMAGE=boltz/boltz:latest
 ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.9-rc.0
 ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.9-rc.0
 
-# Match wallet's existing arkd config
-ARKD_SCHEDULER_TYPE=gocron
 # All five must be set and share a type. Blocks (<512) is required: Boltz emits
 # block-denominated VHTLC locktimes, and arkd only accepts those when its own
 # vtxo tree expiry is block-typed (Settings.AllowCSVBlockType).

--- a/packages/boltz-swap/.env.regtest
+++ b/packages/boltz-swap/.env.regtest
@@ -7,8 +7,18 @@ ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.9-rc.0
 
 # Match wallet's existing arkd config
 ARKD_SCHEDULER_TYPE=gocron
-ARKD_VTXO_TREE_EXPIRY=5120
-ARKD_BOARDING_EXIT_DELAY=7200
+# All five must be set and share a type. Blocks (<512) is required: Boltz emits
+# block-denominated VHTLC locktimes, and arkd only accepts those when its own
+# vtxo tree expiry is block-typed (Settings.AllowCSVBlockType).
+ARKD_VTXO_TREE_EXPIRY=180
+ARKD_BOARDING_EXIT_DELAY=180
+ARKD_UNILATERAL_EXIT_DELAY=5
+ARKD_PUBLIC_UNILATERAL_EXIT_DELAY=5
+ARKD_CHECKPOINT_EXIT_DELAY=5
+
+# Required with block-denominated locktimes: background mining would advance the
+# tip and fire sweeps/expiry mid-suite.
+AUTOMINE_INTERVAL=0
 ARKD_SESSION_DURATION=10
 ARKD_ROUND_INTERVAL=3
 ARKD_LOG_LEVEL=6

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -16,6 +16,7 @@ import {
     IndexerProvider,
     isArkError,
     IWallet,
+    OnchainProvider,
     VHTLC,
     ArkInfo,
     isRecoverable,
@@ -189,8 +190,34 @@ const canRecoverViaBoltz3of3 = (
  * timestamp semantics). Compare against wall-clock seconds; never against
  * chain tip height.
  */
-const isSubmarineRefundLocktimeReached = (refundTimestamp: number): boolean =>
-    Math.floor(Date.now() / 1000) >= refundTimestamp;
+/**
+ * BIP65 threshold: a locktime below this is a block height, at or above it a
+ * Unix timestamp in seconds.
+ */
+const LOCKTIME_HEIGHT_THRESHOLD = 500_000_000;
+
+/**
+ * Whether an absolute (CLTV) refund locktime has been reached.
+ *
+ * Boltz emits either form depending on its `useLocktimeSeconds` setting, so
+ * dispatch on the BIP65 threshold rather than assuming a timestamp. A
+ * block-height locktime with no known chain tip counts as not reached: that
+ * defers to the cooperative refund path instead of attempting a spend the
+ * server would reject as immature.
+ */
+const isRefundLocktimeReached = (locktime: number, chainTipHeight?: number): boolean =>
+    locktime < LOCKTIME_HEIGHT_THRESHOLD
+        ? chainTipHeight !== undefined && chainTipHeight >= locktime
+        : Math.floor(Date.now() / 1000) >= locktime;
+
+/**
+ * When to retry a locktime that has not been reached. A block height carries no
+ * wall-clock deadline, so re-poll on the block-interval cadence instead.
+ */
+const refundRetryAt = (locktime: number): number =>
+    locktime < LOCKTIME_HEIGHT_THRESHOLD
+        ? Math.floor(Date.now() / 1000) + CLTV_IMMATURE_RETRY_SEC
+        : locktime;
 
 /**
  * How long to wait before re-attempting a spend the server rejected as
@@ -232,6 +259,8 @@ export class ArkadeSwaps {
     readonly swapProvider: BoltzSwapProvider;
     /** Provider for querying VTXO state on the Ark indexer. */
     readonly indexerProvider: IndexerProvider;
+    /** Provider for chain-tip lookups, or null if the wallet exposes none. */
+    readonly onchainProvider: OnchainProvider | null;
     /** Background swap monitor, or null if not enabled. */
     readonly swapManager: SwapManager | null = null;
     /** Storage backend for persisting swap data. */
@@ -283,6 +312,9 @@ export class ArkadeSwaps {
         if (!indexerProvider)
             throw new Error("Indexer provider is required either in wallet or config.");
         this.indexerProvider = indexerProvider;
+
+        this.onchainProvider =
+            config.onchainProvider ?? (config.wallet as any).onchainProvider ?? null;
 
         this.swapProvider = config.swapProvider;
 
@@ -1025,14 +1057,30 @@ export class ArkadeSwaps {
         };
     }
 
+    /**
+     * Chain tip height, or undefined when unavailable. Only block-height
+     * locktimes need it, so callers resolve it lazily.
+     */
+    private async chainTipHeight(): Promise<number | undefined> {
+        if (!this.onchainProvider) return undefined;
+        try {
+            const { height } = await this.onchainProvider.getChainTip();
+            return height;
+        } catch (error) {
+            logger.warn(`Failed to fetch chain tip: ${error}`);
+            return undefined;
+        }
+    }
+
     private submarineRecoveryInfoFromLookup(
         swap: BoltzSubmarineSwap,
         lookup: Pick<SubmarineVHTLCLookup, "vhtlcTimeouts" | "refundableVtxos" | "diagnostic">,
+        chainTipHeight?: number,
     ): SubmarineRecoveryInfo {
         const { refundableVtxos, diagnostic, vhtlcTimeouts } = lookup;
 
         if (refundableVtxos.length > 0) {
-            const cltvSatisfied = isSubmarineRefundLocktimeReached(vhtlcTimeouts.refund);
+            const cltvSatisfied = isRefundLocktimeReached(vhtlcTimeouts.refund, chainTipHeight);
             const amountSats = refundableVtxos.reduce((sum, vtxo) => sum + Number(vtxo.value), 0);
             const isRecoverable = cltvSatisfied || canRecoverViaBoltz3of3(refundableVtxos, swap);
             return {
@@ -1193,7 +1241,7 @@ export class ArkadeSwaps {
             };
         }
 
-        return this.submarineRecoveryInfoFromLookup(swap, lookup);
+        return this.submarineRecoveryInfoFromLookup(swap, lookup, await this.chainTipHeight());
     }
 
     /**
@@ -1283,6 +1331,9 @@ export class ArkadeSwaps {
             }
         }
 
+        // One tip lookup for the whole batch — every swap resolves against it.
+        const chainTipHeight = await this.chainTipHeight();
+
         return prepared.map((item) => {
             if ("error" in item) {
                 return {
@@ -1297,10 +1348,14 @@ export class ArkadeSwaps {
 
             const refundableVtxos =
                 refundableByScript.get(item.context.vhtlcPkScriptHex.toLowerCase()) ?? [];
-            return this.submarineRecoveryInfoFromLookup(item.swap, {
-                ...item.context,
-                refundableVtxos,
-            });
+            return this.submarineRecoveryInfoFromLookup(
+                item.swap,
+                {
+                    ...item.context,
+                    refundableVtxos,
+                },
+                chainTipHeight,
+            );
         });
     }
 
@@ -2800,7 +2855,7 @@ export class ArkadeSwaps {
             // mid-loop is observed by every branch. Once it has passed, the
             // refundWithoutReceiver leaf is spendable — settle it offchain for a
             // live VTXO, or via a batch round for a swept one.
-            if (isSubmarineRefundLocktimeReached(refundLocktime)) {
+            if (isRefundLocktimeReached(refundLocktime, await this.chainTipHeight())) {
                 if (await this.trySettleRefundWithoutReceiver(swapId, refundContext, vtxo)) {
                     sweptCount++;
                 } else {
@@ -2819,7 +2874,7 @@ export class ArkadeSwaps {
                         `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
                         `Refund will be retried after locktime.`,
                 );
-                defer(refundLocktime);
+                defer(refundRetryAt(refundLocktime));
                 continue;
             }
 
@@ -2859,7 +2914,7 @@ export class ArkadeSwaps {
 
                 // Re-check the locktime — wall clock may have advanced while
                 // talking to Boltz.
-                if (!isSubmarineRefundLocktimeReached(refundLocktime)) {
+                if (!isRefundLocktimeReached(refundLocktime, await this.chainTipHeight())) {
                     logger.error(
                         `Swap ${swapId}: Boltz rejected VTXO outpoint and ` +
                             `refundWithoutReceiver locktime has not passed yet ` +
@@ -2867,7 +2922,7 @@ export class ArkadeSwaps {
                             `locktime=${refundLocktime}). ` +
                             `Refund will be retried after locktime.`,
                     );
-                    defer(refundLocktime);
+                    defer(refundRetryAt(refundLocktime));
                     continue;
                 }
 

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -233,7 +233,6 @@ export class ArkadeSwaps {
     /** Storage backend for persisting swap data. */
     readonly swapRepository: SwapRepository;
 
-    /** Latch for {@link ArkadeSwaps.warnMissingOnchainProviderOnce}. */
     private missingOnchainProviderWarned = false;
 
     /**
@@ -1033,11 +1032,7 @@ export class ArkadeSwaps {
         };
     }
 
-    /**
-     * Chain tip height, or undefined when unavailable. Only block-height
-     * locktimes need it, so callers resolve it lazily via
-     * {@link ArkadeSwaps.chainTipSnapshotFor}.
-     */
+    /** Chain tip height, or undefined when unavailable. */
     private async chainTipHeight(): Promise<number | undefined> {
         if (!this.onchainProvider) return undefined;
         try {
@@ -1055,23 +1050,15 @@ export class ArkadeSwaps {
      * runs with `useLocktimeSeconds`, that is every one of them.
      */
     private async chainTipSnapshotFor(locktimes: number[]): Promise<ChainTipSnapshot> {
-        if (!locktimes.some(isBlockHeightLocktime)) return { resolved: true };
-        return { resolved: true, height: await this.chainTipHeight() };
+        if (!locktimes.some(isBlockHeightLocktime)) return {};
+        return { height: await this.chainTipHeight() };
     }
 
     /**
-     * Whether a refund locktime has been reached, against an already-resolved
-     * chain tip.
-     *
-     * Warns (once) when a block-height locktime cannot be resolved because no
-     * `OnchainProvider` is configured — that combination means the locktime can
-     * never be observed as reached and the refund defers forever, which the log
-     * would otherwise report as the ordinary "locktime has not passed".
-     *
-     * The warn condition is the null provider, *not* the undefined height: a
-     * height is also undefined after a transient fetch failure, which
-     * {@link ArkadeSwaps.chainTipHeight} already logs and which "no provider
-     * configured" would misdiagnose.
+     * Whether a refund locktime has been reached, against an already-resolved chain
+     * tip. Warns once if a block-height locktime meets an absent provider — the
+     * condition is the null provider, not the undefined height, which a transient
+     * fetch failure also produces (and which {@link ArkadeSwaps.chainTipHeight} logs).
      */
     private isRefundLocktimeReachedAt(locktime: number, tip: ChainTipSnapshot): boolean {
         if (isBlockHeightLocktime(locktime) && tip.height === undefined && !this.onchainProvider) {
@@ -1080,11 +1067,7 @@ export class ArkadeSwaps {
         return isRefundLocktimeReached(locktime, tip.height);
     }
 
-    /**
-     * Latched per instance rather than per module: a module-level latch would
-     * swallow the warning for every instance after the first — across networks,
-     * and across every test but the first to run.
-     */
+    /** Latched per instance: a module-level latch would silence every instance but the first. */
     private warnMissingOnchainProviderOnce(locktime: number): void {
         if (this.missingOnchainProviderWarned) return;
         this.missingOnchainProviderWarned = true;
@@ -1365,8 +1348,6 @@ export class ArkadeSwaps {
             }
         }
 
-        // One tip lookup for the whole batch — every swap resolves against it —
-        // and none at all unless some swap's locktime is block-denominated.
         const chainTip = await this.chainTipSnapshotFor(
             prepared.flatMap((item) =>
                 "error" in item ? [] : [item.context.vhtlcTimeouts.refund],
@@ -2888,12 +2869,9 @@ export class ArkadeSwaps {
             retryAt = retryAt === undefined ? candidate : Math.min(retryAt, candidate);
         };
 
-        // `refundLocktime` is per-swap, so it is constant across this loop and one
-        // tip lookup serves every iteration — and none at all for a timestamp
-        // locktime, which resolves against the wall clock. A block landing
-        // mid-loop is therefore not observed until the next scan; that only
-        // defers a VTXO that just matured, the same direction the loop already
-        // errs in, and `retryAt` brings it back.
+        // `refundLocktime` is constant across the loop, so one lookup serves it. A
+        // block landing mid-loop defers a just-matured VTXO until the next scan;
+        // `retryAt` brings it back.
         const chainTip = await this.chainTipSnapshotFor([refundLocktime]);
 
         for (const vtxo of vtxos) {

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -220,6 +220,17 @@ const refundRetryAt = (locktime: number): number =>
         : locktime;
 
 /**
+ * The value a refund locktime was actually compared against, for logging: the
+ * chain tip height for a block-height locktime, wall-clock seconds otherwise.
+ * Reporting the wrong one makes a block height read as catastrophically overdue
+ * against a ~1.7e9 timestamp.
+ */
+const refundLocktimeBasis = (locktime: number, chainTipHeight?: number): string =>
+    locktime < LOCKTIME_HEIGHT_THRESHOLD
+        ? `chainTipHeight=${chainTipHeight ?? "unknown"}`
+        : `currentTimestamp=${Math.floor(Date.now() / 1000)}`;
+
+/**
  * How long to wait before re-attempting a spend the server rejected as
  * CLTV-immature. It matures the locktime against the chain tip block's
  * timestamp rather than its wall clock, so the rejection clears once a later
@@ -313,8 +324,14 @@ export class ArkadeSwaps {
             throw new Error("Indexer provider is required either in wallet or config.");
         this.indexerProvider = indexerProvider;
 
-        this.onchainProvider =
-            config.onchainProvider ?? (config.wallet as any).onchainProvider ?? null;
+        // `IWallet` does not declare `onchainProvider` — only some implementations
+        // carry one (`ServiceWorkerWallet`, for instance, does not) — so narrow on
+        // the property rather than asserting it exists.
+        const walletOnchainProvider =
+            "onchainProvider" in config.wallet
+                ? (config.wallet.onchainProvider as OnchainProvider | undefined)
+                : undefined;
+        this.onchainProvider = config.onchainProvider ?? walletOnchainProvider ?? null;
 
         this.swapProvider = config.swapProvider;
 
@@ -2855,7 +2872,8 @@ export class ArkadeSwaps {
             // mid-loop is observed by every branch. Once it has passed, the
             // refundWithoutReceiver leaf is spendable — settle it offchain for a
             // live VTXO, or via a batch round for a swept one.
-            if (isRefundLocktimeReached(refundLocktime, await this.chainTipHeight())) {
+            const tipHeight = await this.chainTipHeight();
+            if (isRefundLocktimeReached(refundLocktime, tipHeight)) {
                 if (await this.trySettleRefundWithoutReceiver(swapId, refundContext, vtxo)) {
                     sweptCount++;
                 } else {
@@ -2871,8 +2889,8 @@ export class ArkadeSwaps {
                     `Swap ${swapId}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
                         `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
                         `(refundLocktime=${refundLocktime}, ` +
-                        `currentTimestamp=${Math.floor(Date.now() / 1000)}). ` +
-                        `Refund will be retried after locktime.`,
+                        `${refundLocktimeBasis(refundLocktime, tipHeight)}). ` +
+                        `Refund will be retried once the locktime is reached.`,
                 );
                 defer(refundRetryAt(refundLocktime));
                 continue;
@@ -2912,15 +2930,17 @@ export class ArkadeSwaps {
                     throw error;
                 }
 
-                // Re-check the locktime — wall clock may have advanced while
-                // talking to Boltz.
-                if (!isRefundLocktimeReached(refundLocktime, await this.chainTipHeight())) {
+                // Re-check the locktime — the clock or the chain tip may have
+                // advanced while talking to Boltz, so re-resolve rather than
+                // reusing the tip read at the top of this iteration.
+                const recheckTipHeight = await this.chainTipHeight();
+                if (!isRefundLocktimeReached(refundLocktime, recheckTipHeight)) {
                     logger.error(
                         `Swap ${swapId}: Boltz rejected VTXO outpoint and ` +
                             `refundWithoutReceiver locktime has not passed yet ` +
-                            `(currentTimestamp=${Math.floor(Date.now() / 1000)}, ` +
+                            `(${refundLocktimeBasis(refundLocktime, recheckTipHeight)}, ` +
                             `locktime=${refundLocktime}). ` +
-                            `Refund will be retried after locktime.`,
+                            `Refund will be retried once the locktime is reached.`,
                     );
                     defer(refundRetryAt(refundLocktime));
                     continue;

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -103,6 +103,14 @@ import { IndexedDbSwapRepository } from "./repositories/IndexedDb/swap-repositor
 import { SwapRepository } from "./repositories/swap-repository";
 import { claimVHTLCIdentity } from "./utils/identity";
 import {
+    CLTV_IMMATURE_RETRY_SEC,
+    isBlockHeightLocktime,
+    isRefundLocktimeReached,
+    refundLocktimeBasis,
+    refundRetryAt,
+    type ChainTipSnapshot,
+} from "./utils/locktime";
+import {
     candidateServerPubkeys,
     claimVHTLCwithOffchainTx,
     createVHTLCScript,
@@ -123,8 +131,9 @@ type SubmarineVHTLCContext = {
     vhtlcAddress: string;
     vhtlcPkScriptHex: string;
     /**
-     * VHTLC timeout fields from the Boltz response. `refund` is an absolute
-     * Unix timestamp (CLTV); the unilateral fields are BIP68 relative delays.
+     * VHTLC timeout fields from the Boltz response. `refund` is an absolute CLTV
+     * locktime in either BIP65 form (see {@link VhtlcTimeouts}); the unilateral
+     * fields are BIP68 relative delays.
      */
     vhtlcTimeouts: NonNullable<BoltzSubmarineSwap["response"]["timeoutBlockHeights"]>;
     ourXOnlyPublicKey: Uint8Array;
@@ -185,59 +194,6 @@ const canRecoverViaBoltz3of3 = (
     return refundableVtxos.some((vtxo) => !vtxo.isSpent && !isRecoverable(vtxo));
 };
 
-/**
- * Boltz Ark VHTLCs encode `refund` as an absolute Unix timestamp (CLTV with
- * timestamp semantics). Compare against wall-clock seconds; never against
- * chain tip height.
- */
-/**
- * BIP65 threshold: a locktime below this is a block height, at or above it a
- * Unix timestamp in seconds.
- */
-const LOCKTIME_HEIGHT_THRESHOLD = 500_000_000;
-
-/**
- * Whether an absolute (CLTV) refund locktime has been reached.
- *
- * Boltz emits either form depending on its `useLocktimeSeconds` setting, so
- * dispatch on the BIP65 threshold rather than assuming a timestamp. A
- * block-height locktime with no known chain tip counts as not reached: that
- * defers to the cooperative refund path instead of attempting a spend the
- * server would reject as immature.
- */
-const isRefundLocktimeReached = (locktime: number, chainTipHeight?: number): boolean =>
-    locktime < LOCKTIME_HEIGHT_THRESHOLD
-        ? chainTipHeight !== undefined && chainTipHeight >= locktime
-        : Math.floor(Date.now() / 1000) >= locktime;
-
-/**
- * When to retry a locktime that has not been reached. A block height carries no
- * wall-clock deadline, so re-poll on the block-interval cadence instead.
- */
-const refundRetryAt = (locktime: number): number =>
-    locktime < LOCKTIME_HEIGHT_THRESHOLD
-        ? Math.floor(Date.now() / 1000) + CLTV_IMMATURE_RETRY_SEC
-        : locktime;
-
-/**
- * The value a refund locktime was actually compared against, for logging: the
- * chain tip height for a block-height locktime, wall-clock seconds otherwise.
- * Reporting the wrong one makes a block height read as catastrophically overdue
- * against a ~1.7e9 timestamp.
- */
-const refundLocktimeBasis = (locktime: number, chainTipHeight?: number): string =>
-    locktime < LOCKTIME_HEIGHT_THRESHOLD
-        ? `chainTipHeight=${chainTipHeight ?? "unknown"}`
-        : `currentTimestamp=${Math.floor(Date.now() / 1000)}`;
-
-/**
- * How long to wait before re-attempting a spend the server rejected as
- * CLTV-immature. It matures the locktime against the chain tip block's
- * timestamp rather than its wall clock, so the rejection clears once a later
- * block lands — on the order of one block interval, not of the locktime itself.
- */
-const CLTV_IMMATURE_RETRY_SEC = 60;
-
 // Retry policy for fetching the lockup VTXO when claiming a swap: the indexer
 // may lag behind the on-chain lockup tx, so retry a few times before giving up.
 const CLAIM_VTXO_RETRY_ATTEMPTS = 3;
@@ -276,6 +232,9 @@ export class ArkadeSwaps {
     readonly swapManager: SwapManager | null = null;
     /** Storage backend for persisting swap data. */
     readonly swapRepository: SwapRepository;
+
+    /** Latch for {@link ArkadeSwaps.warnMissingOnchainProviderOnce}. */
+    private missingOnchainProviderWarned = false;
 
     /**
      * Creates an ArkadeSwaps instance, auto-detecting the network from the wallet's Ark server.
@@ -1076,7 +1035,8 @@ export class ArkadeSwaps {
 
     /**
      * Chain tip height, or undefined when unavailable. Only block-height
-     * locktimes need it, so callers resolve it lazily.
+     * locktimes need it, so callers resolve it lazily via
+     * {@link ArkadeSwaps.chainTipSnapshotFor}.
      */
     private async chainTipHeight(): Promise<number | undefined> {
         if (!this.onchainProvider) return undefined;
@@ -1089,15 +1049,68 @@ export class ArkadeSwaps {
         }
     }
 
+    /**
+     * Resolve the chain tip once for a set of locktimes, skipping the fetch
+     * entirely when none of them is block-denominated — on mainnet, where Boltz
+     * runs with `useLocktimeSeconds`, that is every one of them.
+     */
+    private async chainTipSnapshotFor(locktimes: number[]): Promise<ChainTipSnapshot> {
+        if (!locktimes.some(isBlockHeightLocktime)) return { resolved: true };
+        return { resolved: true, height: await this.chainTipHeight() };
+    }
+
+    /**
+     * Whether a refund locktime has been reached, against an already-resolved
+     * chain tip.
+     *
+     * Warns (once) when a block-height locktime cannot be resolved because no
+     * `OnchainProvider` is configured — that combination means the locktime can
+     * never be observed as reached and the refund defers forever, which the log
+     * would otherwise report as the ordinary "locktime has not passed".
+     *
+     * The warn condition is the null provider, *not* the undefined height: a
+     * height is also undefined after a transient fetch failure, which
+     * {@link ArkadeSwaps.chainTipHeight} already logs and which "no provider
+     * configured" would misdiagnose.
+     */
+    private isRefundLocktimeReachedAt(locktime: number, tip: ChainTipSnapshot): boolean {
+        if (isBlockHeightLocktime(locktime) && tip.height === undefined && !this.onchainProvider) {
+            this.warnMissingOnchainProviderOnce(locktime);
+        }
+        return isRefundLocktimeReached(locktime, tip.height);
+    }
+
+    /**
+     * Latched per instance rather than per module: a module-level latch would
+     * swallow the warning for every instance after the first — across networks,
+     * and across every test but the first to run.
+     */
+    private warnMissingOnchainProviderOnce(locktime: number): void {
+        if (this.missingOnchainProviderWarned) return;
+        this.missingOnchainProviderWarned = true;
+        logger.warn(
+            `ArkadeSwaps: refund locktime ${locktime} is a block height, but no ` +
+                `OnchainProvider is configured — the chain tip cannot be read, so the ` +
+                `locktime will never be observed as reached and affected refunds will ` +
+                `defer indefinitely instead of maturing. Pass \`onchainProvider\` to ` +
+                `ArkadeSwaps, or use a wallet that carries one (in the Expo background ` +
+                `task, set \`esploraUrl\` in the swap background config).`,
+        );
+    }
+
+    /**
+     * Stays synchronous — the caller resolves the chain tip, so a batch can hoist
+     * one lookup across every swap it maps over.
+     */
     private submarineRecoveryInfoFromLookup(
         swap: BoltzSubmarineSwap,
         lookup: Pick<SubmarineVHTLCLookup, "vhtlcTimeouts" | "refundableVtxos" | "diagnostic">,
-        chainTipHeight?: number,
+        tip: ChainTipSnapshot,
     ): SubmarineRecoveryInfo {
         const { refundableVtxos, diagnostic, vhtlcTimeouts } = lookup;
 
         if (refundableVtxos.length > 0) {
-            const cltvSatisfied = isRefundLocktimeReached(vhtlcTimeouts.refund, chainTipHeight);
+            const cltvSatisfied = this.isRefundLocktimeReachedAt(vhtlcTimeouts.refund, tip);
             const amountSats = refundableVtxos.reduce((sum, vtxo) => sum + Number(vtxo.value), 0);
             const isRecoverable = cltvSatisfied || canRecoverViaBoltz3of3(refundableVtxos, swap);
             return {
@@ -1258,7 +1271,11 @@ export class ArkadeSwaps {
             };
         }
 
-        return this.submarineRecoveryInfoFromLookup(swap, lookup, await this.chainTipHeight());
+        return this.submarineRecoveryInfoFromLookup(
+            swap,
+            lookup,
+            await this.chainTipSnapshotFor([lookup.vhtlcTimeouts.refund]),
+        );
     }
 
     /**
@@ -1348,8 +1365,13 @@ export class ArkadeSwaps {
             }
         }
 
-        // One tip lookup for the whole batch — every swap resolves against it.
-        const chainTipHeight = await this.chainTipHeight();
+        // One tip lookup for the whole batch — every swap resolves against it —
+        // and none at all unless some swap's locktime is block-denominated.
+        const chainTip = await this.chainTipSnapshotFor(
+            prepared.flatMap((item) =>
+                "error" in item ? [] : [item.context.vhtlcTimeouts.refund],
+            ),
+        );
 
         return prepared.map((item) => {
             if ("error" in item) {
@@ -1371,7 +1393,7 @@ export class ArkadeSwaps {
                     ...item.context,
                     refundableVtxos,
                 },
-                chainTipHeight,
+                chainTip,
             );
         });
     }
@@ -2781,9 +2803,10 @@ export class ArkadeSwaps {
     /**
      * {@link settleRefundWithoutReceiver}, deferring instead of failing when the server
      * rejects the spend as CLTV-immature ({@link ArkErrorName.FORFEIT_CLOSURE_LOCKED}):
-     * we gate on the local wall clock, the server on the chain tip's, which lags. The
-     * server-authoritative sibling of the wall-clock deferral the pre-CLTV branches
-     * already implement. Anything else propagates.
+     * we gate on our own reading of the locktime — wall clock or chain tip, per its
+     * BIP65 form — the server on the chain tip block's timestamp, which lags. The
+     * server-authoritative sibling of the deferral the pre-CLTV branches already
+     * implement. Anything else propagates.
      *
      * Only `submitTx` can raise it, so this is a pass-through for recoverable VTXOs,
      * which settle via a batch round.
@@ -2817,7 +2840,8 @@ export class ArkadeSwaps {
      * Refund every VTXO at a swap's VHTLC address back to the wallet, shared by
      * {@link ArkadeSwaps.refundVHTLC} (submarine) and {@link ArkadeSwaps.refundArk}
      * (chain). Path selection per VTXO:
-     * - CLTV elapsed by our wall clock → `refundWithoutReceiver` (offchain for a
+     * - CLTV elapsed against the wall clock or the chain tip, per the locktime's
+     *   BIP65 form → `refundWithoutReceiver` (offchain for a
      *   live VTXO, via a batch round for a swept one — see
      *   {@link settleRefundWithoutReceiver}), or skipped if the server defers it as
      *   still immature (see {@link trySettleRefundWithoutReceiver}).
@@ -2864,16 +2888,23 @@ export class ArkadeSwaps {
             retryAt = retryAt === undefined ? candidate : Math.min(retryAt, candidate);
         };
 
+        // `refundLocktime` is per-swap, so it is constant across this loop and one
+        // tip lookup serves every iteration — and none at all for a timestamp
+        // locktime, which resolves against the wall clock. A block landing
+        // mid-loop is therefore not observed until the next scan; that only
+        // defers a VTXO that just matured, the same direction the loop already
+        // errs in, and `retryAt` brings it back.
+        const chainTip = await this.chainTipSnapshotFor([refundLocktime]);
+
         for (const vtxo of vtxos) {
             const isRecoverableVtxo = isRecoverable(vtxo);
             const output = { amount: BigInt(vtxo.value), script: outputScript };
 
-            // Re-evaluate the locktime per iteration so a CLTV that elapses
-            // mid-loop is observed by every branch. Once it has passed, the
-            // refundWithoutReceiver leaf is spendable — settle it offchain for a
-            // live VTXO, or via a batch round for a swept one.
-            const tipHeight = await this.chainTipHeight();
-            if (isRefundLocktimeReached(refundLocktime, tipHeight)) {
+            // Re-evaluate the locktime per iteration so a timestamp CLTV that
+            // elapses mid-loop is observed by every branch. Once it has passed,
+            // the refundWithoutReceiver leaf is spendable — settle it offchain
+            // for a live VTXO, or via a batch round for a swept one.
+            if (this.isRefundLocktimeReachedAt(refundLocktime, chainTip)) {
                 if (await this.trySettleRefundWithoutReceiver(swapId, refundContext, vtxo)) {
                     sweptCount++;
                 } else {
@@ -2889,7 +2920,7 @@ export class ArkadeSwaps {
                     `Swap ${swapId}: recoverable VTXO ${vtxo.txid}:${vtxo.vout} ` +
                         `cannot be refunded yet — refundWithoutReceiver locktime has not passed ` +
                         `(refundLocktime=${refundLocktime}, ` +
-                        `${refundLocktimeBasis(refundLocktime, tipHeight)}). ` +
+                        `${refundLocktimeBasis(refundLocktime, chainTip.height)}). ` +
                         `Refund will be retried once the locktime is reached.`,
                 );
                 defer(refundRetryAt(refundLocktime));
@@ -2932,13 +2963,13 @@ export class ArkadeSwaps {
 
                 // Re-check the locktime — the clock or the chain tip may have
                 // advanced while talking to Boltz, so re-resolve rather than
-                // reusing the tip read at the top of this iteration.
-                const recheckTipHeight = await this.chainTipHeight();
-                if (!isRefundLocktimeReached(refundLocktime, recheckTipHeight)) {
+                // reusing the tip hoisted above this loop.
+                const recheckTip = await this.chainTipSnapshotFor([refundLocktime]);
+                if (!this.isRefundLocktimeReachedAt(refundLocktime, recheckTip)) {
                     logger.error(
                         `Swap ${swapId}: Boltz rejected VTXO outpoint and ` +
                             `refundWithoutReceiver locktime has not passed yet ` +
-                            `(${refundLocktimeBasis(refundLocktime, recheckTipHeight)}, ` +
+                            `(${refundLocktimeBasis(refundLocktime, recheckTip.height)}, ` +
                             `locktime=${refundLocktime}). ` +
                             `Refund will be retried once the locktime is reached.`,
                     );

--- a/packages/boltz-swap/src/expo/arkade-lightning.ts
+++ b/packages/boltz-swap/src/expo/arkade-lightning.ts
@@ -146,11 +146,20 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
             );
         }
 
+        // Best-effort, unlike arkServerUrl above, which throws when underivable:
+        // `EsploraProvider.baseUrl` is TS-private and the OnchainProvider
+        // interface exposes no URL at all, so a non-Esplora implementation
+        // legitimately yields nothing. The background task falls back to the
+        // network default in that case.
+        const derivedEsploraUrl = (inner.onchainProvider as unknown as { baseUrl?: string } | null)
+            ?.baseUrl;
+
         // Persist config for background handler rehydration
         const bgConfig: PersistedSwapBackgroundConfig = {
             boltzApiUrl: config.swapProvider.getApiUrl(),
             arkServerUrl,
             network: config.swapProvider.getNetwork(),
+            esploraUrl: config.esploraUrl ?? derivedEsploraUrl ?? undefined,
         };
         await taskQueue.persistConfig(bgConfig);
 

--- a/packages/boltz-swap/src/expo/background.ts
+++ b/packages/boltz-swap/src/expo/background.ts
@@ -22,7 +22,13 @@ import * as BackgroundTask from "expo-background-task";
 import type { TaskItem } from "@arkade-os/sdk/worker/expo";
 import { runTasks } from "@arkade-os/sdk/worker/expo";
 import { ExpoArkProvider, ExpoIndexerProvider } from "@arkade-os/sdk/adapters/expo";
-import { getRandomId, type IWallet, type NetworkName } from "@arkade-os/sdk";
+import {
+    ESPLORA_URL,
+    EsploraProvider,
+    getRandomId,
+    type IWallet,
+    type NetworkName,
+} from "@arkade-os/sdk";
 import { BoltzSwapProvider } from "../boltz-swap-provider";
 import { swapsPollProcessor, SWAP_POLL_TASK_TYPE } from "./swapsPollProcessor";
 import type {
@@ -127,6 +133,17 @@ export function defineExpoSwapBackgroundTask(
 
             const arkProvider = new ExpoArkProvider(config.arkServerUrl);
             const indexerProvider = new ExpoIndexerProvider(config.arkServerUrl);
+            // No Expo-specific variant needed, unlike the two above: those exist
+            // because of SSE/EventSource, and EsploraProvider uses neither —
+            // getChainTip is a plain fetch, and its only other transport is
+            // WebSocket, which React Native supports natively.
+            //
+            // The URL argument is not optional in practice: the no-arg
+            // constructor defaults to the *default* network's endpoint,
+            // regardless of the network we persisted.
+            const onchainProvider = new EsploraProvider(
+                config.esploraUrl ?? ESPLORA_URL[config.network],
+            );
             const swapProvider = new BoltzSwapProvider({
                 network: config.network,
                 apiUrl: config.boltzApiUrl,
@@ -152,6 +169,7 @@ export function defineExpoSwapBackgroundTask(
                 swapProvider,
                 arkProvider,
                 indexerProvider,
+                onchainProvider,
                 identity,
                 wallet,
             };

--- a/packages/boltz-swap/src/expo/background.ts
+++ b/packages/boltz-swap/src/expo/background.ts
@@ -133,14 +133,10 @@ export function defineExpoSwapBackgroundTask(
 
             const arkProvider = new ExpoArkProvider(config.arkServerUrl);
             const indexerProvider = new ExpoIndexerProvider(config.arkServerUrl);
-            // No Expo-specific variant needed, unlike the two above: those exist
-            // because of SSE/EventSource, and EsploraProvider uses neither —
-            // getChainTip is a plain fetch, and its only other transport is
-            // WebSocket, which React Native supports natively.
-            //
-            // The URL argument is not optional in practice: the no-arg
-            // constructor defaults to the *default* network's endpoint,
-            // regardless of the network we persisted.
+            // No Expo variant needed: the two above exist for SSE/EventSource, which
+            // EsploraProvider does not use. The URL argument is not optional in
+            // practice — the no-arg constructor defaults to the *default* network's
+            // endpoint, regardless of the network we persisted.
             const onchainProvider = new EsploraProvider(
                 config.esploraUrl ?? ESPLORA_URL[config.network],
             );

--- a/packages/boltz-swap/src/expo/swapsPollProcessor.ts
+++ b/packages/boltz-swap/src/expo/swapsPollProcessor.ts
@@ -67,8 +67,6 @@ export const swapsPollProcessor: TaskProcessor<SwapTaskDependencies> = {
             wallet,
             arkProvider,
             indexerProvider,
-            // Explicit: `wallet` here is the background shim, which carries no
-            // providers for ArkadeSwaps to fall back to.
             onchainProvider,
             swapProvider,
             swapManager: false,

--- a/packages/boltz-swap/src/expo/swapsPollProcessor.ts
+++ b/packages/boltz-swap/src/expo/swapsPollProcessor.ts
@@ -38,7 +38,14 @@ export const swapsPollProcessor: TaskProcessor<SwapTaskDependencies> = {
         item: TaskItem,
         deps: SwapTaskDependencies,
     ): Promise<Omit<TaskResult, "id" | "executedAt">> {
-        const { swapRepository, swapProvider, wallet, arkProvider, indexerProvider } = deps;
+        const {
+            swapRepository,
+            swapProvider,
+            wallet,
+            arkProvider,
+            indexerProvider,
+            onchainProvider,
+        } = deps;
 
         const allSwaps = await swapRepository.getAllSwaps();
 
@@ -60,6 +67,9 @@ export const swapsPollProcessor: TaskProcessor<SwapTaskDependencies> = {
             wallet,
             arkProvider,
             indexerProvider,
+            // Explicit: `wallet` here is the background shim, which carries no
+            // providers for ArkadeSwaps to fall back to.
+            onchainProvider,
             swapProvider,
             swapManager: false,
             swapRepository,

--- a/packages/boltz-swap/src/expo/types.ts
+++ b/packages/boltz-swap/src/expo/types.ts
@@ -1,4 +1,10 @@
-import type { ArkProvider, Identity, IndexerProvider, IWallet } from "@arkade-os/sdk";
+import type {
+    ArkProvider,
+    Identity,
+    IndexerProvider,
+    IWallet,
+    OnchainProvider,
+} from "@arkade-os/sdk";
 import type { AsyncStorageTaskQueue } from "@arkade-os/sdk/worker/expo";
 import type { BoltzSwapProvider } from "../boltz-swap-provider";
 import type { SwapRepository } from "../repositories/swap-repository";
@@ -17,6 +23,12 @@ export interface SwapTaskDependencies {
     swapProvider: BoltzSwapProvider;
     arkProvider: ArkProvider;
     indexerProvider: IndexerProvider;
+    /**
+     * Chain-tip source for resolving block-height refund locktimes. The
+     * background wallet is a shim carrying no providers, so without this the
+     * tip is unreadable and such refunds never mature.
+     */
+    onchainProvider: OnchainProvider;
     identity: Identity;
     wallet: IWallet;
 }
@@ -32,6 +44,12 @@ export interface PersistedSwapBackgroundConfig {
     boltzApiUrl: string;
     arkServerUrl: string;
     network: Network;
+    /**
+     * Esplora base URL for chain-tip lookups. Optional, and absent from configs
+     * written before it existed, so the background task falls back to the
+     * network default — the same fallback `Wallet.create` applies.
+     */
+    esploraUrl?: string;
 }
 
 /**
@@ -72,6 +90,15 @@ export interface ExpoArkadeSwapsConfig extends ArkadeSwapsConfig {
      * ExpoArkadeSwaps will attempt to derive it from the ArkProvider.
      */
     arkServerUrl?: string;
+    /**
+     * Esplora base URL (e.g. "https://mempool.space/api").
+     *
+     * Recommended for type-safe background rehydration, where it is what makes
+     * block-height refund locktimes resolvable. If omitted, ExpoArkadeSwaps
+     * attempts to derive it from the resolved OnchainProvider, and the
+     * background task falls back to the network default.
+     */
+    esploraUrl?: string;
     background: ExpoSwapBackgroundConfig;
 }
 

--- a/packages/boltz-swap/src/index.ts
+++ b/packages/boltz-swap/src/index.ts
@@ -85,6 +85,7 @@ export type {
     IncomingPaymentSubscription,
     ArkadeSwapsConfig,
     ArkadeSwapsCreateConfig,
+    SerializableSwapManagerConfig,
     BoltzSubmarineSwap,
     PendingSubmarineSwap, // deprecated
     BoltzReverseSwap,

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -29,6 +29,7 @@ import {
     BoltzSubmarineSwap,
     type SendLightningPaymentRequest,
     type OptimisticSendLightningPaymentResponse,
+    type SerializableSwapManagerConfig,
     type SubmarineRecoveryInfo,
     type SubmarineRecoveryResult,
     type SubmarineRefundOutcome,
@@ -61,15 +62,29 @@ export class HandlerNotInitializedError extends Error {
     }
 }
 
+/**
+ * Every field here crosses a `postMessage` boundary, so nothing that structured
+ * clone rejects may survive the `Omit`: the providers are live objects (the ark
+ * and indexer ones are rebuilt worker-side from `arkServerUrl`), and
+ * `swapManager` is re-added in its serializable projection because
+ * `SwapManagerConfig.events` holds function callbacks.
+ */
 export type RequestInitArkSwaps = RequestEnvelope & {
     type: "INIT_ARKADE_SWAPS";
     payload: Omit<
         ArkadeSwapsConfig,
-        "wallet" | "swapRepository" | "swapProvider" | "indexerProvider"
+        | "wallet"
+        | "swapRepository"
+        | "swapProvider"
+        | "indexerProvider"
+        | "arkProvider"
+        | "onchainProvider"
+        | "swapManager"
     > & {
         network: Network;
         arkServerUrl: string;
         referralId?: string;
+        swapManager?: SerializableSwapManagerConfig;
         swapProvider: {
             baseUrl: string;
         };

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -66,8 +66,7 @@ export class HandlerNotInitializedError extends Error {
  * Every field here crosses a `postMessage` boundary, so nothing that structured
  * clone rejects may survive the `Omit`: the providers are live objects (the ark
  * and indexer ones are rebuilt worker-side from `arkServerUrl`), and
- * `swapManager` is re-added in its serializable projection because
- * `SwapManagerConfig.events` holds function callbacks.
+ * `swapManager` is re-added in its {@link SerializableSwapManagerConfig} projection.
  */
 export type RequestInitArkSwaps = RequestEnvelope & {
     type: "INIT_ARKADE_SWAPS";

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -17,6 +17,7 @@ import {
     SendLightningPaymentRequest,
     SendLightningPaymentResponse,
     OptimisticSendLightningPaymentResponse,
+    SerializableSwapManagerConfig,
     SubmarineRecoveryInfo,
     SubmarineRecoveryResult,
     SubmarineRefundOutcome,
@@ -83,6 +84,7 @@ import {
     enrichSubmarineSwapInvoice as _enrichSubmarineSwapInvoice,
 } from "../utils/swap-helpers";
 import type { Actions, SwapManagerClient } from "../swap-manager";
+import { logger } from "../logger";
 
 // Check by error message content instead of instanceof because postMessage uses the
 // structured clone algorithm which strips the prototype chain — the page
@@ -138,16 +140,50 @@ function getRequestDedupKey(request: ArkadeSwapsUpdaterRequest): string {
     return JSON.stringify(rest);
 }
 
-export type SvcWrkArkadeSwapsConfig = Pick<
-    ArkadeSwapsConfig,
-    "swapManager" | "swapProvider" | "swapRepository"
-> & {
+export type SvcWrkArkadeSwapsConfig = Pick<ArkadeSwapsConfig, "swapProvider" | "swapRepository"> & {
     serviceWorker: ServiceWorker;
     messageTag?: string;
     network: Network;
     arkServerUrl: string;
     referralId?: string;
+    /**
+     * Background swap monitoring, same semantics as {@link ArkadeSwapsConfig.swapManager}
+     * (omitted means enabled), minus `events`: the manager runs in the worker, so
+     * callbacks cannot cross the boundary. Use {@link ServiceWorkerArkadeSwaps.onSwapUpdate}
+     * and friends instead.
+     */
+    swapManager?: SerializableSwapManagerConfig;
 };
+
+/**
+ * Drop the fields of a swap-manager config that cannot cross the `postMessage`
+ * boundary. The type-level removal in {@link SvcWrkArkadeSwapsConfig} steers
+ * TypeScript callers away from `events`, but `Omit` is not exact — a pre-typed
+ * (non-literal) config still assigns through width subtyping, and JS callers see
+ * no types at all — so this is the backstop that keeps `sendMessage` from
+ * throwing `DataCloneError`.
+ */
+export function toSerializableSwapManagerConfig(
+    swapManager: SerializableSwapManagerConfig,
+): SerializableSwapManagerConfig {
+    if (typeof swapManager === "boolean") return swapManager;
+
+    const { events, ...rest } = swapManager as typeof swapManager & {
+        events?: Record<string, unknown>;
+    };
+
+    if (events && Object.keys(events).length > 0) {
+        logger.warn(
+            "ArkadeSwaps: swapManager.events was dropped from the service-worker init " +
+                "payload — callbacks cannot be structured-cloned to the worker, and the " +
+                "SwapManager runs there. Register listeners with the ServiceWorkerArkadeSwaps " +
+                "on/off methods (onSwapUpdate, onSwapCompleted, onSwapFailed, " +
+                "onActionExecuted, onWebSocketConnected, onWebSocketDisconnected) instead.",
+        );
+    }
+
+    return rest;
+}
 
 export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
     private eventListenerInitialized = false;
@@ -186,18 +222,29 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
 
         const swapRepository = config.swapRepository ?? new IndexedDbSwapRepository();
 
+        // Match the core semantics of `ArkadeSwaps` (arkade-swaps.ts): an omitted
+        // `swapManager` means enabled-with-defaults. Resolving it here rather than
+        // reading omitted as disabled keeps the client's view of the worker
+        // truthful — the worker autostarts a manager either way, and the previous
+        // `Boolean(config.swapManager)` left `getSwapManager()` null and
+        // `stopSwapManager()` a silent no-op against a manager that was running.
+        const resolvedSwapManager = config.swapManager ?? true;
+
         const svcArkadeSwaps = new ServiceWorkerArkadeSwaps(
             messageTag,
             config.serviceWorker,
             swapRepository,
-            Boolean(config.swapManager),
+            resolvedSwapManager !== false,
         );
 
+        // Strip at build time, not send time: the payload is cached below and
+        // replayed verbatim by the reinit path, so a send-time strip would leave
+        // the cached copy carrying the un-cloneable callbacks.
         const initPayload: RequestInitArkSwaps["payload"] = {
             network: config.network,
             arkServerUrl: config.arkServerUrl,
             swapProvider: { baseUrl: config.swapProvider.getApiUrl() },
-            swapManager: config.swapManager,
+            swapManager: toSerializableSwapManagerConfig(resolvedSwapManager),
             referralId: config.referralId,
         };
 

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -148,20 +148,15 @@ export type SvcWrkArkadeSwapsConfig = Pick<ArkadeSwapsConfig, "swapProvider" | "
     referralId?: string;
     /**
      * Background swap monitoring, same semantics as {@link ArkadeSwapsConfig.swapManager}
-     * (omitted means enabled), minus `events`: the manager runs in the worker, so
-     * callbacks cannot cross the boundary. Use {@link ServiceWorkerArkadeSwaps.onSwapUpdate}
-     * and friends instead.
+     * (omitted means enabled), minus `events` — see {@link SerializableSwapManagerConfig}.
      */
     swapManager?: SerializableSwapManagerConfig;
 };
 
 /**
- * Drop the fields of a swap-manager config that cannot cross the `postMessage`
- * boundary. The type-level removal in {@link SvcWrkArkadeSwapsConfig} steers
- * TypeScript callers away from `events`, but `Omit` is not exact — a pre-typed
- * (non-literal) config still assigns through width subtyping, and JS callers see
- * no types at all — so this is the backstop that keeps `sendMessage` from
- * throwing `DataCloneError`.
+ * Runtime backstop for {@link SerializableSwapManagerConfig}: `Omit` is not exact,
+ * so a pre-typed (non-literal) config still assigns `events` through width
+ * subtyping, and JS callers see no types at all.
  */
 export function toSerializableSwapManagerConfig(
     swapManager: SerializableSwapManagerConfig,

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -375,6 +375,9 @@ export interface ArkadeSwapsConfig {
  * listeners through `ServiceWorkerArkadeSwaps.on*` instead. Everything else in
  * `SwapManagerConfig` is a number or boolean, as is `autoStart`, so this
  * projection is exact.
+ *
+ * Enforced at runtime by `toSerializableSwapManagerConfig`, since `Omit` alone
+ * does not stop a pre-typed config from carrying `events` through.
  */
 export type SerializableSwapManagerConfig =
     | boolean

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -234,8 +234,10 @@ export interface SubmarineRecoveryInfo {
     /** Total satoshis across the unspent VTXOs. */
     amountSats: number;
     /**
-     * Absolute Unix-timestamp CLTV from the swap's VHTLC, when available.
-     * Compared against wall-clock seconds for refund readiness.
+     * Absolute CLTV locktime from the swap's VHTLC, when available. Either BIP65
+     * form: a block height below 500_000_000, a Unix timestamp in seconds at or
+     * above it. Refund readiness compares it against the chain tip or the wall
+     * clock accordingly.
      */
     refundLocktime?: number;
     /** Reason populated when `status === "invalid_swap"`. */
@@ -362,6 +364,21 @@ export interface ArkadeSwapsConfig {
      */
     swapRepository?: SwapRepository;
 }
+
+/**
+ * The subset of {@link ArkadeSwapsConfig.swapManager} that survives a
+ * `postMessage` structured clone.
+ *
+ * `events` is a bag of function callbacks, which structured clone rejects with a
+ * `DataCloneError` — and which could never fire across the boundary anyway,
+ * since the manager lives in the worker. Service-worker clients register
+ * listeners through `ServiceWorkerArkadeSwaps.on*` instead. Everything else in
+ * `SwapManagerConfig` is a number or boolean, as is `autoStart`, so this
+ * projection is exact.
+ */
+export type SerializableSwapManagerConfig =
+    | boolean
+    | (Omit<SwapManagerConfig, "events"> & { autoStart?: boolean });
 
 /**
  * Configuration for {@link ArkadeSwaps.create} — same as ArkadeSwapsConfig but

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -1,4 +1,10 @@
-import { ArkProvider, IndexerProvider, IWallet, NetworkName } from "@arkade-os/sdk";
+import {
+    ArkProvider,
+    IndexerProvider,
+    IWallet,
+    NetworkName,
+    OnchainProvider,
+} from "@arkade-os/sdk";
 import {
     CreateReverseSwapResponse,
     CreateSubmarineSwapResponse,
@@ -337,6 +343,11 @@ export interface ArkadeSwapsConfig {
     swapProvider: BoltzSwapProvider;
     /** Explicit IndexerProvider. Falls back to wallet.indexerProvider if omitted. */
     indexerProvider?: IndexerProvider;
+    /**
+     * Explicit OnchainProvider. Falls back to wallet.onchainProvider if omitted.
+     * Used to resolve block-height refund locktimes against the chain tip.
+     */
+    onchainProvider?: OnchainProvider;
     /**
      * Background swap monitoring and autonomous actions (enabled by default).
      * - `undefined` or `true`: SwapManager enabled with default configuration

--- a/packages/boltz-swap/src/utils/locktime.ts
+++ b/packages/boltz-swap/src/utils/locktime.ts
@@ -1,0 +1,70 @@
+/**
+ * Absolute (CLTV) refund-locktime arithmetic.
+ *
+ * Boltz emits a VHTLC `refund` locktime in either BIP65 form depending on its
+ * `useLocktimeSeconds` setting, so every comparison here dispatches on the
+ * threshold rather than assuming a timestamp. Kept free of any class or provider
+ * dependency so the branch logic is testable on its own; the decision about
+ * *warning* when a block-height locktime meets an absent `OnchainProvider` lives
+ * on `ArkadeSwaps`, which is what knows whether a provider was configured.
+ */
+
+/**
+ * BIP65 threshold: a locktime below this is a block height, at or above it a
+ * Unix timestamp in seconds.
+ */
+export const LOCKTIME_HEIGHT_THRESHOLD = 500_000_000;
+
+/**
+ * How long to wait before re-attempting a spend the server rejected as
+ * CLTV-immature. It matures the locktime against the chain tip block's
+ * timestamp rather than its wall clock, so the rejection clears once a later
+ * block lands — on the order of one block interval, not of the locktime itself.
+ */
+export const CLTV_IMMATURE_RETRY_SEC = 60;
+
+/** Whether `locktime` is denominated in block heights rather than Unix seconds. */
+export const isBlockHeightLocktime = (locktime: number): boolean =>
+    locktime < LOCKTIME_HEIGHT_THRESHOLD;
+
+/**
+ * Whether an absolute (CLTV) refund locktime has been reached.
+ *
+ * A block-height locktime with no known chain tip counts as not reached: that
+ * defers to the cooperative refund path instead of attempting a spend the
+ * server would reject as immature.
+ */
+export const isRefundLocktimeReached = (locktime: number, chainTipHeight?: number): boolean =>
+    isBlockHeightLocktime(locktime)
+        ? chainTipHeight !== undefined && chainTipHeight >= locktime
+        : Math.floor(Date.now() / 1000) >= locktime;
+
+/**
+ * When to retry a locktime that has not been reached. A block height carries no
+ * wall-clock deadline, so re-poll on the block-interval cadence instead.
+ */
+export const refundRetryAt = (locktime: number): number =>
+    isBlockHeightLocktime(locktime)
+        ? Math.floor(Date.now() / 1000) + CLTV_IMMATURE_RETRY_SEC
+        : locktime;
+
+/**
+ * The value a refund locktime was actually compared against, for logging: the
+ * chain tip height for a block-height locktime, wall-clock seconds otherwise.
+ * Reporting the wrong one makes a block height read as catastrophically overdue
+ * against a ~1.7e9 timestamp.
+ */
+export const refundLocktimeBasis = (locktime: number, chainTipHeight?: number): string =>
+    isBlockHeightLocktime(locktime)
+        ? `chainTipHeight=${chainTipHeight ?? "unknown"}`
+        : `currentTimestamp=${Math.floor(Date.now() / 1000)}`;
+
+/**
+ * A chain tip that has already been resolved. `height` is `undefined` when the
+ * lookup was attempted and came back empty — deliberately distinct from "not
+ * looked up yet", which a bare `tip?: number` could not express. That
+ * distinction is what lets a batch hoist one fetch for many swaps: with a plain
+ * optional, a hoisted fetch that failed would look identical to no fetch and
+ * every swap would retry it, each paying its own failure latency and log line.
+ */
+export type ChainTipSnapshot = { resolved: true; height?: number };

--- a/packages/boltz-swap/src/utils/locktime.ts
+++ b/packages/boltz-swap/src/utils/locktime.ts
@@ -3,10 +3,7 @@
  *
  * Boltz emits a VHTLC `refund` locktime in either BIP65 form depending on its
  * `useLocktimeSeconds` setting, so every comparison here dispatches on the
- * threshold rather than assuming a timestamp. Kept free of any class or provider
- * dependency so the branch logic is testable on its own; the decision about
- * *warning* when a block-height locktime meets an absent `OnchainProvider` lives
- * on `ArkadeSwaps`, which is what knows whether a provider was configured.
+ * threshold rather than assuming a timestamp.
  */
 
 /**
@@ -60,11 +57,10 @@ export const refundLocktimeBasis = (locktime: number, chainTipHeight?: number): 
         : `currentTimestamp=${Math.floor(Date.now() / 1000)}`;
 
 /**
- * A chain tip that has already been resolved. `height` is `undefined` when the
- * lookup was attempted and came back empty — deliberately distinct from "not
- * looked up yet", which a bare `tip?: number` could not express. That
- * distinction is what lets a batch hoist one fetch for many swaps: with a plain
- * optional, a hoisted fetch that failed would look identical to no fetch and
- * every swap would retry it, each paying its own failure latency and log line.
+ * A chain tip that has already been resolved: holding one means the lookup ran,
+ * so `height` being `undefined` says it came back empty, not that it is still
+ * pending. That is what lets a batch hoist one fetch for many swaps — a callee
+ * handed this must never re-fetch, or a failed hoisted lookup becomes one failed
+ * attempt per swap.
  */
-export type ChainTipSnapshot = { resolved: true; height?: number };
+export type ChainTipSnapshot = { height?: number };

--- a/packages/boltz-swap/src/utils/scripts.ts
+++ b/packages/boltz-swap/src/utils/scripts.ts
@@ -5,10 +5,9 @@ import { ripemd160 } from "@noble/hashes/legacy.js";
 
 /**
  * Boltz-Ark VHTLC timeouts. See {@link ./vhtlc.ts#VhtlcTimeouts} for the
- * canonical definition; this duplicate exists only to keep the legacy
- * `createVHTLCScript` exported from this module type-aligned. `refund` is an
- * absolute Unix timestamp; the unilateral fields are BIP68 relative delays
- * (seconds when ≥ 512).
+ * canonical definition — including which BIP65 form `refund` takes — this
+ * duplicate exists only to keep the legacy `createVHTLCScript` exported from
+ * this module type-aligned.
  */
 export type VhtlcTimeouts = {
     refund: number;

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -68,8 +68,7 @@ const toBip68RelativeTimelock = (value: number) =>
  * @param args.preimageHash - The SHA256 digest of the preimage (not the raw preimage or RIPEMD160 hash).
  * The function will apply ripemd160(preimageHash) internally to create the final commitment.
  * @param args.timeoutBlockHeights - Boltz timeout fields. Despite the legacy
- *   field name, see {@link VhtlcTimeouts} for the actual semantics — `refund`
- *   is a Unix timestamp, the unilateral fields are BIP68 relative delays.
+ *   field name, see {@link VhtlcTimeouts} for the actual semantics.
  * @returns The created VHTLC script and address.
  */
 export const createVHTLCScript = (args: {

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -32,8 +32,9 @@ import { TransactionOutput, TransactionInput } from "@scure/btc-signer/psbt.js";
  * Boltz-Ark VHTLC timeouts. The shape matches Boltz's `timeoutBlockHeights`
  * API field, but the legacy name is misleading — these are not all block
  * heights:
- * - `refund` is an absolute Unix timestamp in seconds (CLTV with timestamp
- *   semantics, BIP65 threshold ≥ 500_000_000).
+ * - `refund` is an absolute CLTV locktime, in either form Boltz's
+ *   `useLocktimeSeconds` setting produces: a block height below the BIP65
+ *   threshold of 500_000_000, a Unix timestamp in seconds at or above it.
  * - `unilateralClaim`, `unilateralRefund`, `unilateralRefundWithoutReceiver`
  *   are BIP68 *relative* delays measured from the lockup confirmation. Values
  *   ≥ 512 are interpreted as seconds (BIP68 type-flag). For Boltz Ark mainnet

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3701,9 +3701,10 @@ describe("ArkadeSwaps", () => {
             });
 
             describe("server-side CLTV deferral (FORFEIT_CLOSURE_LOCKED)", () => {
-                // Our locktime gate reads the wall clock, arkd's reads the lagging
-                // chain tip, so it routinely rejects a refund we consider mature. That
-                // is self-healing: a deferral the caller retries, never a swap failure.
+                // Our locktime gate reads the wall clock (these fixtures are
+                // timestamp-denominated), arkd's reads the lagging chain tip block,
+                // so it routinely rejects a refund we consider mature. That is
+                // self-healing: a deferral the caller retries, never a swap failure.
 
                 /**
                  * Build the error as the wire delivers it — through the same
@@ -4015,12 +4016,13 @@ describe("ArkadeSwaps", () => {
             expect(info.vtxoCount).toBe(1);
         });
 
-        it("compares refund against wall-clock Unix time, never chain height", async () => {
-            // Regression: the legacy block-height locktime path queried
-            // swapProvider.getChainHeight(). Boltz Ark VHTLCs always encode
-            // refund as a Unix timestamp, so the wall-clock check is the
-            // only path. This test pins that by failing if we ever reach
-            // for the chain tip again.
+        it("compares a timestamp-denominated refund against wall-clock Unix time", async () => {
+            // Regression: the legacy path queried swapProvider.getChainHeight()
+            // for every locktime. A timestamp-denominated refund resolves
+            // against the wall clock alone, so no chain-tip lookup of any kind
+            // should happen. Height-denominated refunds do consult the tip —
+            // see the OnchainProvider cases in test/locktime.test.ts and the
+            // block-height suite below.
             const swap = swapWithRefund(claimedSwap, pastRefund());
             mockSelection({ recoverable: [makeVtxo(lockupTxid, 0)] });
             const chainHeightSpy = vi.spyOn(swapProvider, "getChainHeight");
@@ -4397,8 +4399,10 @@ describe("ArkadeSwaps", () => {
     });
 
     // =========================================================================
-    // Regressions: VHTLC refund readiness uses wall-clock time, not chain
-    // height. Boltz Ark VHTLCs encode `refund` as an absolute Unix timestamp.
+    // Regressions: VHTLC refund readiness for *timestamp-denominated* locktimes,
+    // which Boltz emits when `useLocktimeSeconds` is on (all of mainnet today).
+    // These resolve against the wall clock and never touch the chain tip; the
+    // block-height form is covered in test/locktime.test.ts.
     // =========================================================================
     describe("Submarine refund readiness — timestamp vs chain height", () => {
         const lockupTxid = hex.encode(randomBytes(32));

--- a/packages/boltz-swap/test/chain-tip-resolution.test.ts
+++ b/packages/boltz-swap/test/chain-tip-resolution.test.ts
@@ -63,7 +63,7 @@ describe("ArkadeSwaps chain-tip resolution", () => {
             const tip = await swaps.chainTipSnapshotFor([TIMESTAMP_LOCKTIME, TIMESTAMP_LOCKTIME]);
 
             expect(provider.getChainTip).not.toHaveBeenCalled();
-            expect(tip).toEqual({ resolved: true });
+            expect(tip).toEqual({});
         });
 
         it("fetches once for a batch containing any block-denominated locktime", async () => {
@@ -77,16 +77,17 @@ describe("ArkadeSwaps chain-tip resolution", () => {
             ]);
 
             expect(provider.getChainTip).toHaveBeenCalledTimes(1);
-            expect(tip).toEqual({ resolved: true, height: 210_000 });
+            expect(tip).toEqual({ height: 210_000 });
         });
 
-        it("reports a resolved-but-empty snapshot when the fetch fails", async () => {
+        it("reports an empty snapshot when the fetch fails, rather than throwing", async () => {
             const provider = { getChainTip: vi.fn().mockRejectedValue(new Error("network down")) };
             const swaps = makeSwaps(provider);
 
-            // `resolved: true` with no height is what stops callers from
-            // re-fetching per swap after a failed hoisted lookup.
-            expect(await swaps.chainTipSnapshotFor([HEIGHT_LOCKTIME])).toEqual({ resolved: true });
+            expect(await swaps.chainTipSnapshotFor([HEIGHT_LOCKTIME])).toEqual({});
+            // Distinguishes this from the skipped-fetch case above, which is now
+            // value-identical: the lookup ran and came back empty.
+            expect(provider.getChainTip).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -132,9 +133,7 @@ describe("ArkadeSwaps chain-tip resolution", () => {
 
             expect(swaps.isRefundLocktimeReachedAt(HEIGHT_LOCKTIME, tip)).toBe(false);
 
-            // Same undefined height, different cause: a transient fetch failure
-            // is already logged by chainTipHeight, and "no provider configured"
-            // would misdiagnose it.
+            // Same undefined height as the no-provider case, different cause.
             expect(missingProviderWarnings()).toHaveLength(0);
             expect(warnSpy).toHaveBeenCalledWith(
                 expect.stringMatching(/Failed to fetch chain tip/),
@@ -151,8 +150,7 @@ describe("ArkadeSwaps chain-tip resolution", () => {
 
             expect(swaps.isRefundLocktimeReachedAt(HEIGHT_LOCKTIME, tip)).toBe(false);
 
-            // The batch path hoists one fetch for N swaps; re-resolving here
-            // would restore N attempts, each paying its own failure latency.
+            // Re-resolving here would restore one failing fetch per swap in a batch.
             expect(provider.getChainTip).not.toHaveBeenCalled();
         });
 

--- a/packages/boltz-swap/test/chain-tip-resolution.test.ts
+++ b/packages/boltz-swap/test/chain-tip-resolution.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ArkadeSwaps } from "../src/arkade-swaps";
+import { BoltzSwapProvider } from "../src/boltz-swap-provider";
+import type { ChainTipSnapshot } from "../src/utils/locktime";
+
+/**
+ * Chain-tip resolution on `ArkadeSwaps`: the laziness that keeps a timestamp
+ * locktime off the network, and the warn latch that makes a missing
+ * `OnchainProvider` diagnosable instead of silently deferring refunds forever.
+ *
+ * The pure threshold arithmetic these sit on top of is covered in
+ * test/locktime.test.ts; what needs an instance is precisely the part that
+ * consults `this.onchainProvider`.
+ */
+
+const HEIGHT_LOCKTIME = 200_000;
+const TIMESTAMP_LOCKTIME = 1_800_000_000;
+
+// Matches the phrasing of warnMissingOnchainProviderOnce, loosely enough to
+// survive rewording but tightly enough to not match the fetch-failure warning.
+const MISSING_PROVIDER_WARNING = /no\s+OnchainProvider is configured/i;
+
+type Swaps = ArkadeSwaps & {
+    chainTipSnapshotFor(locktimes: number[]): Promise<ChainTipSnapshot>;
+    isRefundLocktimeReachedAt(locktime: number, tip: ChainTipSnapshot): boolean;
+};
+
+function makeSwaps(onchainProvider?: unknown, wallet?: unknown): Swaps {
+    const arkProvider = { getInfo: vi.fn() } as any;
+    const indexerProvider = { getVtxos: vi.fn() } as any;
+    return new ArkadeSwaps({
+        wallet: (wallet ?? { identity: {}, arkProvider, indexerProvider }) as any,
+        arkProvider,
+        indexerProvider,
+        onchainProvider: onchainProvider as any,
+        swapProvider: new BoltzSwapProvider({ network: "regtest" }),
+        swapRepository: { getAllSwaps: vi.fn() } as any,
+        swapManager: false,
+    }) as Swaps;
+}
+
+const providerAt = (height: number) => ({ getChainTip: vi.fn().mockResolvedValue({ height }) });
+
+describe("ArkadeSwaps chain-tip resolution", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const missingProviderWarnings = () =>
+        warnSpy.mock.calls.filter(([first]) => MISSING_PROVIDER_WARNING.test(String(first)));
+
+    describe("chainTipSnapshotFor laziness", () => {
+        it("skips the fetch entirely when no locktime is block-denominated", async () => {
+            const provider = providerAt(210_000);
+            const swaps = makeSwaps(provider);
+
+            const tip = await swaps.chainTipSnapshotFor([TIMESTAMP_LOCKTIME, TIMESTAMP_LOCKTIME]);
+
+            expect(provider.getChainTip).not.toHaveBeenCalled();
+            expect(tip).toEqual({ resolved: true });
+        });
+
+        it("fetches once for a batch containing any block-denominated locktime", async () => {
+            const provider = providerAt(210_000);
+            const swaps = makeSwaps(provider);
+
+            const tip = await swaps.chainTipSnapshotFor([
+                TIMESTAMP_LOCKTIME,
+                HEIGHT_LOCKTIME,
+                HEIGHT_LOCKTIME + 1,
+            ]);
+
+            expect(provider.getChainTip).toHaveBeenCalledTimes(1);
+            expect(tip).toEqual({ resolved: true, height: 210_000 });
+        });
+
+        it("reports a resolved-but-empty snapshot when the fetch fails", async () => {
+            const provider = { getChainTip: vi.fn().mockRejectedValue(new Error("network down")) };
+            const swaps = makeSwaps(provider);
+
+            // `resolved: true` with no height is what stops callers from
+            // re-fetching per swap after a failed hoisted lookup.
+            expect(await swaps.chainTipSnapshotFor([HEIGHT_LOCKTIME])).toEqual({ resolved: true });
+        });
+    });
+
+    describe("missing-provider warning", () => {
+        it("warns exactly once across repeated block-height evaluations", async () => {
+            const swaps = makeSwaps(undefined, { identity: {} });
+            const tip = await swaps.chainTipSnapshotFor([HEIGHT_LOCKTIME]);
+
+            for (let i = 0; i < 5; i++) {
+                expect(swaps.isRefundLocktimeReachedAt(HEIGHT_LOCKTIME, tip)).toBe(false);
+            }
+
+            expect(missingProviderWarnings()).toHaveLength(1);
+        });
+
+        it("latches per instance, so a second instance warns again", async () => {
+            for (const _ of [0, 1]) {
+                const swaps = makeSwaps(undefined, { identity: {} });
+                const tip = await swaps.chainTipSnapshotFor([HEIGHT_LOCKTIME]);
+                swaps.isRefundLocktimeReachedAt(HEIGHT_LOCKTIME, tip);
+            }
+
+            // A module-scoped latch would report 1 here — and would silence the
+            // warning for every test after the first, and for a second network.
+            expect(missingProviderWarnings()).toHaveLength(2);
+        });
+
+        it("does not warn when the locktime is a timestamp", async () => {
+            const swaps = makeSwaps(undefined, { identity: {} });
+            const tip = await swaps.chainTipSnapshotFor([TIMESTAMP_LOCKTIME]);
+
+            swaps.isRefundLocktimeReachedAt(TIMESTAMP_LOCKTIME, tip);
+
+            // The absent provider is harmless on the timestamp path — which is
+            // all of mainnet — so warning there would be a false alarm.
+            expect(missingProviderWarnings()).toHaveLength(0);
+        });
+
+        it("does not warn when a configured provider's getChainTip rejects", async () => {
+            const provider = { getChainTip: vi.fn().mockRejectedValue(new Error("network down")) };
+            const swaps = makeSwaps(provider);
+            const tip = await swaps.chainTipSnapshotFor([HEIGHT_LOCKTIME]);
+
+            expect(swaps.isRefundLocktimeReachedAt(HEIGHT_LOCKTIME, tip)).toBe(false);
+
+            // Same undefined height, different cause: a transient fetch failure
+            // is already logged by chainTipHeight, and "no provider configured"
+            // would misdiagnose it.
+            expect(missingProviderWarnings()).toHaveLength(0);
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringMatching(/Failed to fetch chain tip/),
+            );
+        });
+    });
+
+    describe("evaluating against a pre-resolved snapshot", () => {
+        it("does not re-fetch when the snapshot carries no height", async () => {
+            const provider = { getChainTip: vi.fn().mockRejectedValue(new Error("network down")) };
+            const swaps = makeSwaps(provider);
+            const tip = await swaps.chainTipSnapshotFor([HEIGHT_LOCKTIME]);
+            provider.getChainTip.mockClear();
+
+            expect(swaps.isRefundLocktimeReachedAt(HEIGHT_LOCKTIME, tip)).toBe(false);
+
+            // The batch path hoists one fetch for N swaps; re-resolving here
+            // would restore N attempts, each paying its own failure latency.
+            expect(provider.getChainTip).not.toHaveBeenCalled();
+        });
+
+        it("resolves the locktime against the snapshot's height", async () => {
+            const swaps = makeSwaps(providerAt(HEIGHT_LOCKTIME));
+            const tip = await swaps.chainTipSnapshotFor([HEIGHT_LOCKTIME]);
+
+            expect(swaps.isRefundLocktimeReachedAt(HEIGHT_LOCKTIME, tip)).toBe(true);
+            expect(swaps.isRefundLocktimeReachedAt(HEIGHT_LOCKTIME + 1, tip)).toBe(false);
+        });
+    });
+
+    describe("onchainProvider resolution from the wallet", () => {
+        // Regression for the service-worker path: worker-side, MessageBus builds
+        // a real `Wallet` (which always constructs an EsploraProvider) and hands
+        // it to ArkadeSwaps without an explicit onchainProvider. If the wallet
+        // fallback broke, that context would silently lose block-height refunds.
+        it("falls back to the wallet's provider when config omits one", () => {
+            const walletProvider = providerAt(210_000);
+            const swaps = makeSwaps(undefined, {
+                identity: {},
+                onchainProvider: walletProvider,
+            });
+
+            expect(swaps.onchainProvider).toBe(walletProvider);
+        });
+
+        it("prefers an explicit provider over the wallet's", () => {
+            const explicit = providerAt(1);
+            const swaps = makeSwaps(explicit, {
+                identity: {},
+                onchainProvider: providerAt(2),
+            });
+
+            expect(swaps.onchainProvider).toBe(explicit);
+        });
+
+        it("is null when neither the config nor the wallet carries one", () => {
+            // ServiceWorkerWallet is the real instance of this shape: it holds
+            // URL strings, not provider objects.
+            expect(makeSwaps(undefined, { identity: {} }).onchainProvider).toBeNull();
+        });
+    });
+});

--- a/packages/boltz-swap/test/expo/swaps-poll-processor.test.ts
+++ b/packages/boltz-swap/test/expo/swaps-poll-processor.test.ts
@@ -109,6 +109,7 @@ describe("swapsPollProcessor", () => {
             swapProvider: mockSwapProvider as BoltzSwapProvider,
             arkProvider: {} as any,
             indexerProvider: {} as any,
+            onchainProvider: { getChainTip: vi.fn() } as any,
             identity: {} as any,
             wallet: {} as any,
         };
@@ -116,6 +117,18 @@ describe("swapsPollProcessor", () => {
 
     it("should have the correct task type", () => {
         expect(swapsPollProcessor.taskType).toBe(SWAP_POLL_TASK_TYPE);
+    });
+
+    it("passes the onchain provider through to ArkadeSwaps", async () => {
+        // The background wallet is a shim with no providers, so ArkadeSwaps has
+        // nothing to fall back to: without this explicitly threaded through,
+        // onchainProvider resolves to null and block-height refund locktimes
+        // never mature.
+        await swapsPollProcessor.execute(createTaskItem(), deps);
+
+        expect(ArkadeSwaps).toHaveBeenCalledWith(
+            expect.objectContaining({ onchainProvider: deps.onchainProvider }),
+        );
     });
 
     it("should return success with no swaps", async () => {

--- a/packages/boltz-swap/test/locktime.test.ts
+++ b/packages/boltz-swap/test/locktime.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+    CLTV_IMMATURE_RETRY_SEC,
+    LOCKTIME_HEIGHT_THRESHOLD,
+    isBlockHeightLocktime,
+    isRefundLocktimeReached,
+    refundLocktimeBasis,
+    refundRetryAt,
+} from "../src/utils/locktime";
+
+// A fixed wall clock, well past any timestamp locktime built from it.
+const NOW_SEC = 1_800_000_000;
+
+const freezeClock = () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_SEC * 1000);
+};
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("BIP65 denomination boundary", () => {
+    it("treats 499_999_999 as a block height and 500_000_000 as a timestamp", () => {
+        expect(isBlockHeightLocktime(LOCKTIME_HEIGHT_THRESHOLD - 1)).toBe(true);
+        expect(isBlockHeightLocktime(LOCKTIME_HEIGHT_THRESHOLD)).toBe(false);
+        expect(LOCKTIME_HEIGHT_THRESHOLD).toBe(500_000_000);
+    });
+});
+
+describe("isRefundLocktimeReached", () => {
+    describe("timestamp-denominated locktime", () => {
+        it("falls back to the wall clock and ignores an absent tip", () => {
+            freezeClock();
+            expect(isRefundLocktimeReached(NOW_SEC - 1)).toBe(true);
+            expect(isRefundLocktimeReached(NOW_SEC + 1)).toBe(false);
+        });
+
+        it("is unaffected by the tip when one is supplied", () => {
+            freezeClock();
+            // A tip far below the locktime must not make an elapsed timestamp
+            // read as unreached — the two are different units entirely.
+            expect(isRefundLocktimeReached(NOW_SEC - 1, 100)).toBe(true);
+            expect(isRefundLocktimeReached(NOW_SEC + 1, 999_999_999)).toBe(false);
+        });
+
+        it("treats an exactly-equal timestamp as reached", () => {
+            freezeClock();
+            expect(isRefundLocktimeReached(NOW_SEC)).toBe(true);
+        });
+    });
+
+    describe("block-height locktime", () => {
+        const HEIGHT = 200_000;
+
+        it("is not reached when the tip is below the locktime", () => {
+            expect(isRefundLocktimeReached(HEIGHT, HEIGHT - 1)).toBe(false);
+        });
+
+        it("is reached when the tip is exactly at the locktime", () => {
+            expect(isRefundLocktimeReached(HEIGHT, HEIGHT)).toBe(true);
+        });
+
+        it("is reached when the tip is above the locktime", () => {
+            expect(isRefundLocktimeReached(HEIGHT, HEIGHT + 1)).toBe(true);
+        });
+
+        it("counts as not reached when the tip is unknown", () => {
+            // The conservative direction: defer to the cooperative refund path
+            // rather than attempt a spend the server would reject as immature.
+            expect(isRefundLocktimeReached(HEIGHT, undefined)).toBe(false);
+        });
+
+        it("does not fall back to the wall clock when the tip is unknown", () => {
+            freezeClock();
+            // Wall-clock seconds dwarf any plausible height, so a wall-clock
+            // fallback here would report every height locktime as long elapsed.
+            expect(isRefundLocktimeReached(HEIGHT)).toBe(false);
+        });
+    });
+});
+
+describe("refundRetryAt", () => {
+    it("re-polls a block height on the block-interval cadence", () => {
+        freezeClock();
+        // A height carries no wall-clock deadline, so there is nothing to wait
+        // *until* — only a cadence to wait *for*.
+        expect(refundRetryAt(200_000)).toBe(NOW_SEC + CLTV_IMMATURE_RETRY_SEC);
+    });
+
+    it("waits until the locktime itself for a timestamp", () => {
+        freezeClock();
+        expect(refundRetryAt(NOW_SEC + 3600)).toBe(NOW_SEC + 3600);
+    });
+});
+
+describe("refundLocktimeBasis", () => {
+    it("reports the chain tip for a block height", () => {
+        expect(refundLocktimeBasis(200_000, 199_000)).toBe("chainTipHeight=199000");
+    });
+
+    it("reports an unknown tip rather than omitting it", () => {
+        expect(refundLocktimeBasis(200_000, undefined)).toBe("chainTipHeight=unknown");
+    });
+
+    it("reports the wall clock for a timestamp, ignoring any tip", () => {
+        freezeClock();
+        expect(refundLocktimeBasis(NOW_SEC + 10, 199_000)).toBe(`currentTimestamp=${NOW_SEC}`);
+    });
+});

--- a/packages/boltz-swap/test/serviceWorker/arkade-swaps-runtime.test.ts
+++ b/packages/boltz-swap/test/serviceWorker/arkade-swaps-runtime.test.ts
@@ -1074,3 +1074,115 @@ describe("quote rejection error reconstruction", () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// create(): init payload is structured-cloneable, and the swapManager default
+// ---------------------------------------------------------------------------
+
+describe("create() init payload", () => {
+    let fakeSw: FakeServiceWorker;
+    let sendMessageSpy: ReturnType<typeof vi.spyOn>;
+
+    const baseConfig = {
+        swapProvider: { getApiUrl: () => "http://example.com" } as any,
+        network: "regtest" as const,
+        arkServerUrl: "http://ark.example.com",
+    };
+
+    const createWith = async (overrides: Record<string, unknown>) => {
+        const runtime = await ServiceWorkerArkadeSwaps.create({
+            ...baseConfig,
+            serviceWorker: fakeSw as any,
+            ...overrides,
+        } as any);
+        const sent = sendMessageSpy.mock.calls[0][0] as RequestInitArkSwaps;
+        return { runtime, payload: sent.payload };
+    };
+
+    beforeEach(() => {
+        fakeSw = new FakeServiceWorker();
+        Object.defineProperty(globalThis, "navigator", {
+            configurable: true,
+            value: { serviceWorker: fakeSw },
+        });
+        sendMessageSpy = vi.spyOn(ServiceWorkerArkadeSwaps.prototype as any, "sendMessage");
+        sendMessageSpy.mockResolvedValue({
+            id: "init",
+            tag: TAG,
+            type: "ARKADE_SWAPS_INITIALIZED",
+        } as any);
+    });
+
+    afterEach(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).navigator;
+        vi.restoreAllMocks();
+    });
+
+    it("strips swapManager.events and warns exactly once", async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        // Cast to simulate the width-subtyping hole the types cannot close: a
+        // pre-typed (non-literal) config carrying `events` assigns fine, and a
+        // JS caller never sees the types at all.
+        const { payload } = await createWith({
+            swapManager: {
+                pollInterval: 1234,
+                autoStart: false,
+                events: { onSwapUpdate: () => {}, onSwapFailed: () => {} },
+            },
+        });
+
+        expect(payload.swapManager).not.toHaveProperty("events");
+        // Everything cloneable survives — dropping autoStart would silently
+        // re-enable a manager the caller asked not to start.
+        expect(payload.swapManager).toEqual({ pollInterval: 1234, autoStart: false });
+        expect(structuredClone(payload)).toEqual(payload);
+        expect(
+            warnSpy.mock.calls.filter(([first]) =>
+                /swapManager\.events was dropped/.test(String(first)),
+            ),
+        ).toHaveLength(1);
+    });
+
+    it("does not warn when events is absent or empty", async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await createWith({ swapManager: { pollInterval: 1, events: {} } });
+
+        expect(
+            warnSpy.mock.calls.filter(([f]) => /events was dropped/.test(String(f))),
+        ).toHaveLength(0);
+    });
+
+    it("treats an omitted swapManager as enabled, matching the worker", async () => {
+        const { runtime, payload } = await createWith({});
+
+        // The worker maps `undefined` to enabled-with-defaults and autostarts,
+        // so the client reading omitted as *disabled* left getSwapManager() null
+        // and stopSwapManager() a no-op against a manager that was running.
+        expect(payload.swapManager).toBe(true);
+        expect(runtime.getSwapManager()).not.toBeNull();
+        await expect(runtime.startSwapManager()).resolves.toBeUndefined();
+    });
+
+    it("propagates an explicit false and disables the client APIs", async () => {
+        const { runtime, payload } = await createWith({ swapManager: false });
+
+        expect(payload.swapManager).toBe(false);
+        expect(runtime.getSwapManager()).toBeNull();
+        await expect(runtime.startSwapManager()).rejects.toThrow(/not enabled/i);
+    });
+
+    it("omits every non-cloneable field even when the caller supplies one", async () => {
+        const { payload } = await createWith({
+            arkProvider: { subscribe: () => {} },
+            onchainProvider: { getChainTip: () => {} },
+        });
+
+        expect(payload).not.toHaveProperty("arkProvider");
+        expect(payload).not.toHaveProperty("onchainProvider");
+        expect(payload).not.toHaveProperty("wallet");
+        expect(structuredClone(payload)).toEqual(payload);
+    });
+});

--- a/packages/boltz-swap/test/serviceWorker/init-payload.test-d.ts
+++ b/packages/boltz-swap/test/serviceWorker/init-payload.test-d.ts
@@ -1,0 +1,65 @@
+import { describe, it, expectTypeOf } from "vitest";
+import type { RequestInitArkSwaps } from "../../src/serviceWorker/arkade-swaps-message-handler";
+import type { SvcWrkArkadeSwapsConfig } from "../../src/serviceWorker/arkade-swaps-runtime";
+import type { SerializableSwapManagerConfig } from "../../src/types";
+
+/**
+ * The init payload crosses a `postMessage` boundary, so structured clone must be
+ * able to carry every field: no live provider objects, no functions.
+ *
+ * A `structuredClone` round-trip test would only catch fields the test happened
+ * to populate — it cannot notice a provider field that a future commit adds to
+ * `ArkadeSwapsConfig` and forgets to add to the payload's `Omit` list. These
+ * assertions do, because they are about the type rather than an instance.
+ *
+ * These only bite under Vitest's typecheck mode — see tsconfig.typecheck.json.
+ */
+
+type Payload = RequestInitArkSwaps["payload"];
+
+describe("RequestInitArkSwaps payload is structured-cloneable", () => {
+    it("omits every live provider", () => {
+        // Providers hold SSE/EventSource connections and cannot be cloned; the
+        // worker rebuilds the ark and indexer ones from `arkServerUrl`.
+        expectTypeOf<Payload>().not.toHaveProperty("arkProvider");
+        expectTypeOf<Payload>().not.toHaveProperty("indexerProvider");
+        expectTypeOf<Payload>().not.toHaveProperty("onchainProvider");
+    });
+
+    it("omits the wallet and the repository", () => {
+        expectTypeOf<Payload>().not.toHaveProperty("wallet");
+        expectTypeOf<Payload>().not.toHaveProperty("swapRepository");
+    });
+
+    it("carries swapManager only in its serializable projection", () => {
+        // The full config type would admit `events`, a bag of callbacks that
+        // structured clone rejects outright with a DataCloneError.
+        expectTypeOf<Payload["swapManager"]>().toEqualTypeOf<
+            SerializableSwapManagerConfig | undefined
+        >();
+        expectTypeOf<Exclude<Payload["swapManager"], boolean | undefined>>().not.toHaveProperty(
+            "events",
+        );
+    });
+
+    it("reduces swapProvider to a plain URL holder", () => {
+        expectTypeOf<Payload["swapProvider"]>().toEqualTypeOf<{ baseUrl: string }>();
+    });
+});
+
+describe("SvcWrkArkadeSwapsConfig steers callers away from events", () => {
+    it("accepts a swap-manager config without events", () => {
+        expectTypeOf<{ pollInterval: number; autoStart: boolean }>().toMatchTypeOf<
+            NonNullable<SvcWrkArkadeSwapsConfig["swapManager"]>
+        >();
+    });
+
+    it("rejects an events literal at the client call site", () => {
+        // This is the check that actually fires for callers: an excess-property
+        // check against an object literal. Width subtyping lets a pre-typed
+        // config through, which is why create() also strips at runtime.
+        expectTypeOf<
+            Exclude<SvcWrkArkadeSwapsConfig["swapManager"], boolean | undefined>
+        >().not.toHaveProperty("events");
+    });
+});

--- a/packages/boltz-swap/tsconfig.typecheck.json
+++ b/packages/boltz-swap/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+// Type-test config for Vitest's typecheck mode.
+//
+// The package tsconfig excludes `test/` — production builds and `pnpm typecheck`
+// must keep ignoring it — but that means `.test-d.ts` assertions would never be
+// checked by anything: Vitest transpiles tests through esbuild, which strips
+// types without checking them, so an `expectTypeOf` assertion in a plain test
+// file is a runtime no-op that passes green regardless of what it claims.
+//
+// This config includes the type-test files (and only those, not the runtime
+// `.test.ts` suites, which have never been typechecked) so the assertions
+// actually bite.
+{
+    "extends": "./tsconfig.json",
+    "include": ["src/**/*.ts", "test/**/*.test-d.ts", "../../config/types/**/*.d.ts"],
+    "exclude": ["node_modules", "dist", "test/e2e", "src/repositories/realm"]
+}

--- a/packages/boltz-swap/vitest.config.ts
+++ b/packages/boltz-swap/vitest.config.ts
@@ -7,6 +7,14 @@ export default mergeConfig(
     defineConfig({
         test: {
             setupFiles: ["./test/setup.ts"],
+            typecheck: {
+                // `.test-d.ts` assertions are no-ops unless tsc actually runs:
+                // esbuild strips their types without checking them. The dedicated
+                // tsconfig is required too — the package one excludes `test/`, so
+                // the checker would never see these files.
+                enabled: true,
+                tsconfig: "./tsconfig.typecheck.json",
+            },
         },
     }),
 );

--- a/packages/boltz-swap/vitest.config.ts
+++ b/packages/boltz-swap/vitest.config.ts
@@ -8,10 +8,8 @@ export default mergeConfig(
         test: {
             setupFiles: ["./test/setup.ts"],
             typecheck: {
-                // `.test-d.ts` assertions are no-ops unless tsc actually runs:
-                // esbuild strips their types without checking them. The dedicated
-                // tsconfig is required too — the package one excludes `test/`, so
-                // the checker would never see these files.
+                // See tsconfig.typecheck.json — `.test-d.ts` assertions are no-ops
+                // without it.
                 enabled: true,
                 tsconfig: "./tsconfig.typecheck.json",
             },

--- a/packages/ts-sdk/.env.regtest
+++ b/packages/ts-sdk/.env.regtest
@@ -3,8 +3,7 @@
 ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.14
 ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.14
 
-# Match old ts-sdk docker-compose arkd config (block scheduler needs CSV block type)
-ARKD_SCHEDULER_TYPE=block
+# Match old ts-sdk docker-compose arkd config
 ARKD_VTXO_TREE_EXPIRY=20
 ARKD_BOARDING_EXIT_DELAY=40
 ARKD_CHECKPOINT_EXIT_DELAY=20


### PR DESCRIPTION
Bumps the regtest submodule to the block-based-config merge. Everything else here
follows from that.

regtest dropped the `ARKD_*` locktime defaults and `useLocktimeSeconds` from the
Boltz config, so Boltz now emits **block-denominated** VHTLC locktimes where it
previously emitted Unix timestamps. That broke arkd startup (mixed-type config),
and then exposed the fact that boltz-swap compared every refund locktime against
the wall clock — a block height read as decades overdue, so refunds either fired
early or, once gated, deferred forever with no signal.

The fixes, in order:

- **regtest config** — move the arkd locktimes to blocks so the stack starts.
- **locktime resolution** — dispatch on the BIP65 threshold: heights resolve
  against the chain tip, timestamps against the wall clock. New `utils/locktime.ts`.
- **log basis** — report the value actually compared against, not always a timestamp.
- **the silent hole** — a block-height locktime with no `OnchainProvider` can never
  be observed as reached. Now warns once instead of deferring indefinitely.
- **Expo background task** — that path had no chain-tip source at all; threads an
  `EsploraProvider` through, plus `esploraUrl` in the persisted background config.

Last commit is comment/doc cleanup over the four before it — no behaviour change.

Chain-tip lookups are lazy and hoisted: a timestamp locktime makes no network
call, and a batch resolves the tip once for all swaps. Mainnet runs
`useLocktimeSeconds`, so it stays on the timestamp path throughout.

## Testing

New unit coverage for the threshold arithmetic, chain-tip resolution/laziness, and
the service-worker init payload (type-level, via a dedicated typecheck config —
`.test-d.ts` assertions were previously no-ops under esbuild). Unit suite green
for both packages.
