### PR TITLE
Fix restore under indexer rate limiting

### DIFF
--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -308,15 +308,17 @@ export interface IContractManager extends Disposable {
      *
      * Error contract (safety-critical — see spec §4):
      * - A handler's `discoverAt` rejecting is **collected** into
-     *   `handlerErrors` and the loop **continues**; it never aborts the
-     *   scan or throws.
+     *   `handlerErrors` and makes its index *indeterminate*: it never
+     *   advances the gap counter, and the scan **stops verifying** there
+     *   rather than closing a window it never observed close. It still
+     *   never throws.
      * - A fatal operational error — `materialize()` throwing, or
      *   `createContract` rejecting — **propagates** out of `scanContracts`
      *   (it invalidates the gap-window signal, so a silent truncation
      *   would risk hiding user funds).
      *
      * @param opts See {@link ScanContractsOptions}.
-     * @returns `{ lastIndexUsed, handlerErrors }` — the caller surfaces
+     * @returns See {@link ScanResult}. The caller surfaces `truncatedAt` /
      *   `handlerErrors` *after* the inline VTXO pull.
      */
     scanContracts(opts: ScanContractsOptions): Promise<ScanResult>;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -123,14 +123,26 @@ export interface HandlerError {
 
 /**
  * Outcome of a {@link IContractManager.scanContracts} run.
- *
- * `lastIndexUsed` is the highest HD index at which any handler discovered a
- * contract (`-1` if nothing was found). `handlerErrors` collects per-handler
- * `discoverAt` failures — non-empty means the gap window may have closed
- * early and the caller should surface this (the scan itself still resolved).
  */
 export interface ScanResult {
+    /** @deprecated Alias of {@link ScanResult.highestConfirmedUsedIndex}. */
     lastIndexUsed: number;
+    /**
+     * Highest HD index at which any handler confirmed a contract (`-1` if none),
+     * including hits past {@link ScanResult.truncatedAt}. Safe to record
+     * unconditionally: the HD watermark it feeds is a monotonic max over a scan
+     * that always restarts at 0, so it cannot skip an index — while withholding
+     * it risks re-issuing a funded index as a fresh receive address.
+     */
+    highestConfirmedUsedIndex: number;
+    /**
+     * First index a handler failed at, making it *indeterminate* — neither a hit
+     * nor a confirmed miss. The scan stops there, so indices `>= truncatedAt` are
+     * unverified and the caller must retry (scanning is idempotent). `undefined`
+     * when the scan closed a genuine gap.
+     */
+    truncatedAt?: number;
+    /** Per-handler `discoverAt` failures. Non-empty implies `truncatedAt` is set. */
     handlerErrors: HandlerError[];
 }
 
@@ -710,9 +722,10 @@ export class ContractManager implements IContractManager {
      * Safety-critical invariants (spec §2.C / §4):
      * - `opts.materialize(i)` throwing is structural/fatal: it is NOT
      *   wrapped — it propagates and aborts the scan.
-     * - A `discoverAt` rejection is collected into `handlerErrors` and the
-     *   loop continues (the gap counter still advances for that index if no
-     *   other handler hit it).
+     * - A `discoverAt` rejection is collected into `handlerErrors` and makes
+     *   its index *indeterminate*: it does NOT advance the gap counter, and
+     *   the scan stops verifying there, reporting `truncatedAt`. Only an index
+     *   every handler answered for can be a confirmed miss.
      * - `persistAndWatchContract` rejecting is operational/fatal and
      *   propagates (only `discoverAt` is guarded).
      * - Within an index the handler probes run concurrently (independent
@@ -726,8 +739,12 @@ export class ContractManager implements IContractManager {
      *   over-scanned, nothing is discarded, and `materialize`/`discoverAt` are
      *   invoked on exactly the same index set. The window's hits are still
      *   processed strictly in ascending index order, so the discovered set,
-     *   persisted rows, `lastIndexUsed`, and `handlerErrors` are byte-for-byte
-     *   identical to the serial path — only the wall-clock differs.
+     *   persisted rows, `highestConfirmedUsedIndex`, and `handlerErrors` are
+     *   byte-for-byte identical to the serial path — only the wall-clock
+     *   differs. Truncation is the one exception: a window's concurrent probes
+     *   can surface hits above the failed index that a serial scan would never
+     *   have reached, so a truncated batched scan discovers a superset — never
+     *   a subset — of the serial one.
      */
     async scanContracts(opts: ScanContractsOptions): Promise<ScanResult> {
         const gapLimit = opts.gapLimit ?? 20;
@@ -768,7 +785,8 @@ export class ContractManager implements IContractManager {
 
         const maxIdx = opts.hd ? SCAN_MAX_INDEX : 0;
         const handlerErrors: HandlerError[] = [];
-        let lastIndexUsed = -1;
+        let highestConfirmedUsedIndex = -1;
+        let truncatedAt: number | undefined;
         let unused = 0;
         let i = 0;
 
@@ -818,6 +836,7 @@ export class ContractManager implements IContractManager {
                 const index = windowIndices[w];
                 const probes = windowProbes[w];
                 let hitAtThisIndex = false;
+                let indeterminate = false;
                 for (let h = 0; h < discoverables.length; h++) {
                     const probe = probes[h];
                     if (!probe.ok) {
@@ -826,6 +845,7 @@ export class ContractManager implements IContractManager {
                             index,
                             error: probe.error,
                         });
+                        indeterminate = true;
                         continue;
                     }
                     for (const c of probe.found) {
@@ -834,13 +854,22 @@ export class ContractManager implements IContractManager {
                     }
                 }
 
-                if (hitAtThisIndex) {
-                    lastIndexUsed = index;
-                    unused = 0;
-                } else {
-                    unused += 1;
-                }
+                // Three outcomes, not two: hit, confirmed miss, and
+                // indeterminate — nobody observed this index to be empty.
+                // Counting the third as a miss is what let a rate-limited scan
+                // close its gap window on failed requests rather than on absent
+                // funds, and return a wallet missing money.
+                if (indeterminate && truncatedAt === undefined) truncatedAt = index;
+                if (hitAtThisIndex) highestConfirmedUsedIndex = index;
+
+                // Past the truncation point only hits count; nothing may become
+                // a confirmed miss, so the gap window cannot close across it.
+                if (truncatedAt !== undefined) continue;
+                if (hitAtThisIndex) unused = 0;
+                else unused += 1;
             }
+
+            if (truncatedAt !== undefined) break;
             i = windowEnd + 1;
         }
 
@@ -848,8 +877,9 @@ export class ContractManager implements IContractManager {
         // scan was truncated. Surface loudly (matching the materialize-
         // fatal contract) rather than silently returning a partial
         // result, since the caller cannot otherwise distinguish "no
-        // more funds past lastIndexUsed" from "we stopped scanning".
-        if (opts.hd && i > maxIdx && unused < gapLimit) {
+        // more funds past lastIndexUsed" from "we stopped scanning". A
+        // truncated scan exits early by design, so it is excluded here.
+        if (opts.hd && truncatedAt === undefined && i > maxIdx && unused < gapLimit) {
             throw new Error(
                 `scanContracts: reached SCAN_MAX_INDEX (${SCAN_MAX_INDEX}) without closing the ` +
                     `${gapLimit}-index gap window; a Discoverable handler may be returning ` +
@@ -857,7 +887,12 @@ export class ContractManager implements IContractManager {
             );
         }
 
-        return { lastIndexUsed, handlerErrors };
+        return {
+            lastIndexUsed: highestConfirmedUsedIndex,
+            highestConfirmedUsedIndex,
+            ...(truncatedAt !== undefined && { truncatedAt }),
+            handlerErrors,
+        };
     }
 
     /**

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -14,6 +14,7 @@ import type { IntentFeeConfig } from "../arkfee";
 import { Intent } from "../intent";
 import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
 import { fetch } from "../utils/fetch";
+import { rateGate } from "./rateGate";
 
 /**
  * Thrown by {@link RestArkProvider} when arkd rejects a request with
@@ -347,6 +348,10 @@ export class RestArkProvider implements ArkProvider {
             throw toProviderUnavailable(err, "arkade");
         }
         if (response.ok) return response;
+        // Report-only (see rateGate): this POST is never delayed or retried.
+        if (response.status === 429) {
+            rateGate.reportRateLimited(url, response.headers?.get("retry-after"));
+        }
         // Read the body first: error classification must branch on its content,
         // not just the HTTP status. arkd is behind grpc-gateway, which renders
         // application-level errors across the 4xx AND 5xx range (gRPC INTERNAL ->
@@ -393,8 +398,13 @@ export class RestArkProvider implements ArkProvider {
 
     async getInfo(): Promise<ArkInfo> {
         const url = `${this.serverUrl}/v1/info`;
-        const response = await fetch(url);
+        // Wait + report (see rateGate): shares an origin, and a limiter, with
+        // the indexer.
+        const response = await rateGate.run(url, () => fetch(url));
         if (!response.ok) {
+            if (response.status === 429) {
+                rateGate.reportRateLimited(url, response.headers?.get("retry-after"));
+            }
             const errorText = await response.text();
             // A 429 or 5xx means the operator is up but temporarily unable to
             // serve — a retryable availability failure, not a config/auth error.

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -400,11 +400,8 @@ export class RestArkProvider implements ArkProvider {
         const url = `${this.serverUrl}/v1/info`;
         // Wait + report (see rateGate): shares an origin, and a limiter, with
         // the indexer.
-        const response = await rateGate.run(url, () => fetch(url));
+        const response = await rateGate.runHttp(url, () => fetch(url));
         if (!response.ok) {
-            if (response.status === 429) {
-                rateGate.reportRateLimited(url, response.headers?.get("retry-after"));
-            }
             const errorText = await response.text();
             // A 429 or 5xx means the operator is up but temporarily unable to
             // serve — a retryable availability failure, not a config/auth error.

--- a/packages/ts-sdk/src/providers/delegate.ts
+++ b/packages/ts-sdk/src/providers/delegate.ts
@@ -1,6 +1,7 @@
 import { Intent } from "../intent";
 import { SignedIntent } from "./ark";
 import { baseFetch } from "../utils/fetch";
+import { rateGate } from "./rateGate";
 
 /**
  * Delegate identity and fee information returned by `getDelegateInfo`.
@@ -119,9 +120,14 @@ export class RestDelegateProvider implements DelegateProvider {
     async getDelegateInfo(): Promise<DelegateInfo> {
         /** TODO: Update later once Fulmine URL changed */
         const url = `${this.url}/v1/delegator/info`;
-        const response = await baseFetch(url);
+        // Wait + report (see rateGate). Origin-keyed, so a delegate on its own
+        // host is throttled independently of the operator's.
+        const response = await rateGate.run(url, () => baseFetch(url));
 
         if (!response.ok) {
+            if (response.status === 429) {
+                rateGate.reportRateLimited(url, response.headers?.get("retry-after"));
+            }
             const errorText = await response.text();
             throw new Error(`Failed to get delegate info: ${errorText}`);
         }

--- a/packages/ts-sdk/src/providers/delegate.ts
+++ b/packages/ts-sdk/src/providers/delegate.ts
@@ -122,12 +122,9 @@ export class RestDelegateProvider implements DelegateProvider {
         const url = `${this.url}/v1/delegator/info`;
         // Wait + report (see rateGate). Origin-keyed, so a delegate on its own
         // host is throttled independently of the operator's.
-        const response = await rateGate.run(url, () => baseFetch(url));
+        const response = await rateGate.runHttp(url, () => baseFetch(url));
 
         if (!response.ok) {
-            if (response.status === 429) {
-                rateGate.reportRateLimited(url, response.headers?.get("retry-after"));
-            }
             const errorText = await response.text();
             throw new Error(`Failed to get delegate info: ${errorText}`);
         }

--- a/packages/ts-sdk/src/providers/indexer.ts
+++ b/packages/ts-sdk/src/providers/indexer.ts
@@ -6,7 +6,18 @@ import { eventSourceIterator, isEventSourceError } from "./utils";
 import { MetadataList } from "../extension/asset";
 import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
 import { baseFetch } from "../utils/fetch";
-import { throwIfHttpUnavailable, toProviderUnavailable } from "./errors";
+import { ProviderUnavailableError, throwIfHttpUnavailable, toProviderUnavailable } from "./errors";
+import { rateGate } from "./rateGate";
+
+/**
+ * Attempts (initial + retries) before an availability failure surfaces. Small
+ * on purpose: the shared cooldown in {@link rateGate} does the rate-limit work,
+ * and a long ladder only delays an honest error.
+ */
+const INDEXER_MAX_ATTEMPTS = 3;
+
+/** First retry delay; doubled per attempt. */
+const INDEXER_RETRY_BASE_MS = 250;
 
 /**
  * `baseFetch` for indexer requests with availability classification: a transport
@@ -15,15 +26,31 @@ import { throwIfHttpUnavailable, toProviderUnavailable } from "./errors";
  * paths can catch it and fall back to repository state. Other non-2xx responses
  * are returned unchanged for each method to reject with its descriptive
  * (terminal) error.
+ *
+ * Every REST indexer call funnels through here, so this is where politeness
+ * lives: each attempt goes through the origin-scoped {@link rateGate}, and a
+ * bounded retry ladder gives `ProviderUnavailableError.retryable` some teeth.
+ * `Retry-After` is read here, while the `Response` is in hand, and fed to the
+ * gate — never attached to the typed error, since per-instance `Error`
+ * own-properties do not survive the service-worker `postMessage` boundary.
+ * Only the retries-exhausted failure reaches the caller, in its previous shape.
  */
 async function indexerFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-    let res: Response;
-    try {
-        res = await baseFetch(input, init);
-    } catch (err) {
-        throw toProviderUnavailable(err, "indexer");
-    }
-    if (!res.ok) {
+    for (let attempt = 1; ; attempt++) {
+        const lastAttempt = attempt >= INDEXER_MAX_ATTEMPTS;
+        let res: Response;
+        try {
+            res = await rateGate.run(input, () => baseFetch(input, init));
+        } catch (err) {
+            const mapped = toProviderUnavailable(err, "indexer");
+            // Only a transport failure is retryable; anything else is terminal.
+            if (lastAttempt || !(mapped instanceof ProviderUnavailableError)) throw mapped;
+            await sleep(retryDelayMs(attempt));
+            continue;
+        }
+
+        if (res.ok) return res;
+
         // Pass the body so a 5xx carrying a structured arkd error (grpc-gateway
         // maps gRPC INTERNAL -> HTTP 500) stays terminal instead of being
         // misclassified as a retryable availability failure. If the body can't be
@@ -34,10 +61,34 @@ async function indexerFetch(input: RequestInfo | URL, init?: RequestInit): Promi
         } catch {
             body = undefined;
         }
-        throwIfHttpUnavailable(res, "indexer", body);
+
+        // Before classifying, so a 429 pauses the origin even on the attempt
+        // we are about to give up on.
+        if (res.status === 429) {
+            rateGate.reportRateLimited(input, res.headers?.get("retry-after"));
+        }
+
+        try {
+            throwIfHttpUnavailable(res, "indexer", body);
+        } catch (err) {
+            if (lastAttempt) throw err;
+            // Exponential backoff only — the gate re-applies the shared cooldown
+            // with per-waiter jitter on the next `run()`. Sleeping the cooldown
+            // here too would wake the herd in lockstep.
+            await sleep(retryDelayMs(attempt));
+            continue;
+        }
+
+        // Terminal non-2xx: hand it back for the caller's descriptive error.
+        return res;
     }
-    return res;
 }
+
+function retryDelayMs(attempt: number): number {
+    return INDEXER_RETRY_BASE_MS * 2 ** (attempt - 1);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 export type PaginationOptions = {
     pageIndex?: number;

--- a/packages/ts-sdk/src/providers/indexer.ts
+++ b/packages/ts-sdk/src/providers/indexer.ts
@@ -29,18 +29,26 @@ const INDEXER_RETRY_BASE_MS = 250;
  *
  * Every REST indexer call funnels through here, so this is where politeness
  * lives: each attempt goes through the origin-scoped {@link rateGate}, and a
- * bounded retry ladder gives `ProviderUnavailableError.retryable` some teeth.
+ * bounded retry ladder — GET/HEAD only — gives `ProviderUnavailableError`'s
+ * `retryable` some teeth.
  * `Retry-After` is read here, while the `Response` is in hand, and fed to the
  * gate — never attached to the typed error, since per-instance `Error`
  * own-properties do not survive the service-worker `postMessage` boundary.
  * Only the retries-exhausted failure reaches the caller, in its previous shape.
  */
 async function indexerFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    // Retry only what is safe to send twice. A subscribe POST whose response is
+    // lost would otherwise be re-sent without a subscriptionId, creating a
+    // second subscription and leaking the first. Non-GETs still wait behind the
+    // cooldown and still report a 429 — only the replay is withheld.
+    const method = (init?.method ?? "GET").toUpperCase();
+    const maxAttempts = method === "GET" || method === "HEAD" ? INDEXER_MAX_ATTEMPTS : 1;
+
     for (let attempt = 1; ; attempt++) {
-        const lastAttempt = attempt >= INDEXER_MAX_ATTEMPTS;
+        const lastAttempt = attempt >= maxAttempts;
         let res: Response;
         try {
-            res = await rateGate.run(input, () => baseFetch(input, init));
+            res = await rateGate.runHttp(input, () => baseFetch(input, init));
         } catch (err) {
             const mapped = toProviderUnavailable(err, "indexer");
             // Only a transport failure is retryable; anything else is terminal.
@@ -60,12 +68,6 @@ async function indexerFetch(input: RequestInfo | URL, init?: RequestInit): Promi
             body = await res.clone().text();
         } catch {
             body = undefined;
-        }
-
-        // Before classifying, so a 429 pauses the origin even on the attempt
-        // we are about to give up on.
-        if (res.status === 429) {
-            rateGate.reportRateLimited(input, res.headers?.get("retry-after"));
         }
 
         try {

--- a/packages/ts-sdk/src/providers/rateGate.ts
+++ b/packages/ts-sdk/src/providers/rateGate.ts
@@ -8,8 +8,9 @@
  * shared, keyed by **origin** (`/v1/info` and `/v1/indexer/*` are one host
  * behind one limiter). Callers use one of two verbs:
  *
- * - **Wait + report** ({@link OriginRateGate.run}) — idempotent GETs, where
- *   delaying a send is always safe.
+ * - **Wait + report** ({@link OriginRateGate.runHttp}) — indexer and operator
+ *   reads, where delaying a send is safe. Waiting is separate from retrying:
+ *   an indexer POST waits and reports but is not replayed (see `indexerFetch`).
  * - **Report-only** ({@link OriginRateGate.reportRateLimited}) — intent and
  *   settlement POSTs, which feed the shared signal but never wait or retry:
  *   batch sessions have deadlines, and these POSTs are not idempotent at the
@@ -124,6 +125,24 @@ export class OriginRateGate {
         } finally {
             this.release(state);
         }
+    }
+
+    /**
+     * {@link run} for a request whose response the gate should inspect: a `429`
+     * is recorded *before* the slot is released. Reporting after `run()` resolves
+     * is too late — `release()` hands the slot to the next queued waiter, which
+     * resumes, sees no cooldown, and sends into the limiter that just refused us.
+     *
+     * Prefer this over `run` for anything returning a `Response`.
+     */
+    runHttp(input: RequestInfo | URL, fn: () => Promise<Response>): Promise<Response> {
+        return this.run(input, async () => {
+            const response = await fn();
+            if (response.status === 429) {
+                this.reportRateLimited(input, response.headers?.get("retry-after"));
+            }
+            return response;
+        });
     }
 
     /**

--- a/packages/ts-sdk/src/providers/rateGate.ts
+++ b/packages/ts-sdk/src/providers/rateGate.ts
@@ -57,8 +57,13 @@ export function parseRetryAfterMs(header: string | null | undefined): number | u
     if (trimmed === "") return undefined;
 
     const seconds = Number(trimmed);
-    if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+    // A negative delta is malformed — delta-seconds is non-negative — so there
+    // is no valid reading of it. Fall back to the caller's default instead of
+    // clamping to 0, which would mean "no cooldown at all".
+    if (Number.isFinite(seconds)) return seconds < 0 ? undefined : seconds * 1000;
 
+    // Unlike a negative delta, a past HTTP-date is well-formed and does mean
+    // "retry now", so it clamps rather than falling back.
     const at = Date.parse(trimmed);
     if (!Number.isNaN(at)) return Math.max(0, at - Date.now());
 

--- a/packages/ts-sdk/src/providers/rateGate.ts
+++ b/packages/ts-sdk/src/providers/rateGate.ts
@@ -1,0 +1,185 @@
+/**
+ * Origin-scoped politeness gate for outbound provider requests.
+ *
+ * Per-request retry alone cannot survive a rate limiter: under a burst every
+ * in-flight request gets the same `429` and the same `Retry-After`, sleeps
+ * independently, and wakes in unison to re-trip it — while requests queued
+ * behind them learn nothing from the `429` at all. So the backoff state is
+ * shared, keyed by **origin** (`/v1/info` and `/v1/indexer/*` are one host
+ * behind one limiter). Callers use one of two verbs:
+ *
+ * - **Wait + report** ({@link OriginRateGate.run}) — idempotent GETs, where
+ *   delaying a send is always safe.
+ * - **Report-only** ({@link OriginRateGate.reportRateLimited}) — intent and
+ *   settlement POSTs, which feed the shared signal but never wait or retry:
+ *   batch sessions have deadlines, and these POSTs are not idempotent at the
+ *   application level, so a certain missed round beats a possible `429`.
+ */
+
+/** Per-origin in-flight cap on the wait+report path (the browser per-host cap). */
+const DEFAULT_MAX_CONCURRENT = 6;
+
+/** Cooldown applied to a `429` that carries no usable `Retry-After`. */
+const DEFAULT_COOLDOWN_MS = 5_000;
+
+/** Ceiling on a single cooldown, so a bogus `Retry-After` can't wedge the wallet. */
+const MAX_COOLDOWN_MS = 60_000;
+
+/** Upper bound of the random delay decorrelating waiters released together. */
+const DEFAULT_JITTER_MS = 500;
+
+export interface RateGateOptions {
+    maxConcurrent?: number;
+    defaultCooldownMs?: number;
+    maxCooldownMs?: number;
+    jitterMs?: number;
+}
+
+interface OriginState {
+    /** Epoch ms before which no gated request to this origin may be sent. */
+    blockedUntil: number;
+    /** In-flight gated requests. */
+    active: number;
+    /** FIFO of waiters parked on the concurrency cap. */
+    queue: (() => void)[];
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Parse a `Retry-After` header into milliseconds, in either spec encoding
+ * (delta-seconds or HTTP-date). `undefined` when absent or unparseable.
+ */
+export function parseRetryAfterMs(header: string | null | undefined): number | undefined {
+    if (header === null || header === undefined) return undefined;
+    const trimmed = header.trim();
+    // Checked before Number(), which maps "" to 0.
+    if (trimmed === "") return undefined;
+
+    const seconds = Number(trimmed);
+    if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+
+    const at = Date.parse(trimmed);
+    if (!Number.isNaN(at)) return Math.max(0, at - Date.now());
+
+    return undefined;
+}
+
+/** Derive the origin key for a `fetch` input, tolerating the three input shapes. */
+export function requestOrigin(input: RequestInfo | URL): string {
+    let url: string;
+    if (typeof input === "string") {
+        url = input;
+    } else if (input instanceof URL) {
+        url = input.href;
+    } else {
+        url = input.url;
+    }
+    try {
+        return new URL(url).origin;
+    } catch {
+        // Unparseable (e.g. relative): key on the raw string. Grouping is then
+        // wrong, but only ever over- or under-shares a cooldown.
+        return url;
+    }
+}
+
+/** Shared cooldown + concurrency state, keyed by origin. */
+export class OriginRateGate {
+    private readonly states = new Map<string, OriginState>();
+    private readonly maxConcurrent: number;
+    private readonly defaultCooldownMs: number;
+    private readonly maxCooldownMs: number;
+    private readonly jitterMs: number;
+
+    constructor(options?: RateGateOptions) {
+        this.maxConcurrent = options?.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+        this.defaultCooldownMs = options?.defaultCooldownMs ?? DEFAULT_COOLDOWN_MS;
+        this.maxCooldownMs = options?.maxCooldownMs ?? MAX_COOLDOWN_MS;
+        this.jitterMs = options?.jitterMs ?? DEFAULT_JITTER_MS;
+    }
+
+    /**
+     * Run `fn` under the origin's concurrency cap and behind any active
+     * cooldown. Put only the request in `fn`: the slot is released as soon as
+     * it settles, so body parsing doesn't hold one.
+     */
+    async run<T>(input: RequestInfo | URL, fn: () => Promise<T>): Promise<T> {
+        const state = this.stateFor(requestOrigin(input));
+        await this.acquire(state);
+        try {
+            // Re-checked after each sleep, so a `429` seen by another request
+            // while this one waits extends the wait instead of slipping through.
+            for (;;) {
+                const remaining = state.blockedUntil - Date.now();
+                if (remaining <= 0) break;
+                await sleep(remaining + Math.random() * this.jitterMs);
+            }
+            return await fn();
+        } finally {
+            this.release(state);
+        }
+    }
+
+    /**
+     * Record an observed `429`, pausing every gated request to that origin.
+     * Monotonic: a shorter cooldown never shortens one already in effect.
+     */
+    reportRateLimited(input: RequestInfo | URL, retryAfterHeader?: string | null): void {
+        const cooldown = Math.min(
+            parseRetryAfterMs(retryAfterHeader) ?? this.defaultCooldownMs,
+            this.maxCooldownMs,
+        );
+        const state = this.stateFor(requestOrigin(input));
+        state.blockedUntil = Math.max(state.blockedUntil, Date.now() + cooldown);
+    }
+
+    /** Milliseconds left on `input` origin's cooldown; `0` when not cooling down. */
+    cooldownRemainingMs(input: RequestInfo | URL): number {
+        const state = this.states.get(requestOrigin(input));
+        if (!state) return 0;
+        return Math.max(0, state.blockedUntil - Date.now());
+    }
+
+    /**
+     * Drop all per-origin state, so test suites don't inherit each other's
+     * cooldowns. Waiters queued on the discarded state still drain normally.
+     */
+    reset(): void {
+        this.states.clear();
+    }
+
+    private stateFor(origin: string): OriginState {
+        let state = this.states.get(origin);
+        if (!state) {
+            state = { blockedUntil: 0, active: 0, queue: [] };
+            this.states.set(origin, state);
+        }
+        return state;
+    }
+
+    private acquire(state: OriginState): Promise<void> {
+        if (state.active < this.maxConcurrent) {
+            state.active += 1;
+            return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+            state.queue.push(() => {
+                state.active += 1;
+                resolve();
+            });
+        });
+    }
+
+    private release(state: OriginState): void {
+        state.active -= 1;
+        const next = state.queue.shift();
+        if (next) next();
+    }
+}
+
+/**
+ * Process-wide gate shared by every provider fetch path. Origin keying keeps
+ * embedders on several operators from cross-throttling each other.
+ */
+export const rateGate = new OriginRateGate();

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2544,19 +2544,36 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             deps,
         });
 
-        if (hd && result.lastIndexUsed >= 0) {
-            await provider.advanceLastIndexUsed(result.lastIndexUsed);
+        // Advanced even on a truncated scan: a caller that swallows the error
+        // below would otherwise be handed an already-funded index as a fresh
+        // receive address. See `ScanResult.highestConfirmedUsedIndex`.
+        if (hd && result.highestConfirmedUsedIndex >= 0) {
+            await provider.advanceLastIndexUsed(result.highestConfirmedUsedIndex);
         }
 
         // Inline pull BEFORE surfacing any handler errors so safely
         // discovered funds are always recovered (spec §3.B / §4).
         await manager.refreshVtxos({ includeInactive: true });
 
+        const causes = result.handlerErrors.map((e) =>
+            e.error instanceof Error ? e.error : new Error(String(e.error)),
+        );
+
+        if (result.truncatedAt !== undefined) {
+            throw new AggregateError(
+                causes,
+                `restore: scan truncated at index ${result.truncatedAt}; indices >= ` +
+                    `${result.truncatedAt} are unverified (${result.handlerErrors.length} ` +
+                    `discovery handler failure(s)). Retry is safe (idempotent).`,
+            );
+        }
+
+        // Unreachable via `ContractManager`, which always pairs errors with
+        // `truncatedAt`; kept so a third-party `IContractManager` that doesn't
+        // still fails loudly.
         if (result.handlerErrors.length > 0) {
             throw new AggregateError(
-                result.handlerErrors.map((e) =>
-                    e.error instanceof Error ? e.error : new Error(String(e.error)),
-                ),
+                causes,
                 `restore: ${result.handlerErrors.length} discovery handler(s) failed; ` +
                     `the gap window may have closed early — retry is safe (idempotent).`,
             );

--- a/packages/ts-sdk/test/e2e/utils.ts
+++ b/packages/ts-sdk/test/e2e/utils.ts
@@ -240,6 +240,20 @@ export function mineBlocks(n: number = 1): void {
     execCommand(`node regtest/regtest.mjs mine ${n}`);
 }
 
+/**
+ * Bitcoin Core's block count, read straight from the node.
+ *
+ * Every indexer in the stack (mempool/Fulcrum behind EsploraProvider, nbxplorer
+ * behind arkd) trails this by an unbounded amount — right after `mineBlocks(10)`
+ * they still report the pre-mine tip for a second or two. Use this, not an
+ * indexer's tip, whenever a test needs a height no consumer can already be past:
+ * every indexer height is <= this one, so a locktime built on it is guaranteed
+ * immature everywhere at the moment it is read.
+ */
+export function coreBlockCount(): number {
+    return Number(execCommand(`node regtest/regtest.mjs rpc getblockcount`));
+}
+
 export async function createVtxo(alice: TestArkWallet, amount: number): Promise<string> {
     const address = await alice.wallet.getAddress();
     if (!address) throw new Error("Offchain address not defined.");

--- a/packages/ts-sdk/test/e2e/vhtlc.test.ts
+++ b/packages/ts-sdk/test/e2e/vhtlc.test.ts
@@ -23,6 +23,7 @@ import {
 import {
     arkdExec,
     beforeEachFaucet,
+    coreBlockCount,
     createTestArkWallet,
     createTestIdentity,
     execCommand,
@@ -277,18 +278,21 @@ describe("vhtlc", () => {
             // seconds-CLTV would need both wall-clock passage and a later block to
             // carry that time forward, so neither mining nor waiting alone gets there.
             //
-            // The buffer is squeezed between two bounds. Below it, the locktime must
-            // not already be matured against arkd's own nbxplorer-derived tip, which
-            // is a separate indexing pipeline from the mempool/Fulcrum one `height`
-            // comes from; a few blocks of slack cover that skew, and with
+            // The baseline comes from Bitcoin Core, not from an indexer. arkd matures
+            // the CLTV against its nbxplorer-derived tip, and every indexer in the
+            // stack trails Core by an unbounded amount: the preceding test mines 10
+            // blocks and returns, so an EsploraProvider tip read here can still be
+            // those 10 blocks stale — a locktime built on it is then *already* matured
+            // against arkd, and the premature-rejection assertion below fails. Core's
+            // count is an upper bound on every indexer, so `+5` is immature everywhere.
+            //
+            // The buffer stays small because the whole maturation must fit inside the
+            // funding VTXO's batch lifetime — ARKD_VTXO_TREE_EXPIRY=20 blocks — an
+            // expired batch makes the input recoverable-only, and the retry then fails
+            // VTXO_RECOVERABLE instead of exercising the regression. With
             // AUTOMINE_INTERVAL=0 (see .env.regtest) nothing advances the tip between
-            // this read and the first submitTx below. Above it, the whole maturation
-            // must fit inside the funding VTXO's batch lifetime —
-            // ARKD_VTXO_TREE_EXPIRY=20 blocks — because an expired batch makes the
-            // input recoverable-only, and the retry then fails VTXO_RECOVERABLE
-            // instead of exercising the regression.
-            const { height } = await onchainProvider.getChainTip();
-            const refundLocktime = BigInt(height + 5);
+            // this read and the first submitTx below.
+            const refundLocktime = BigInt(coreBlockCount() + 5);
 
             const preimageHash = hash160(new TextEncoder().encode("preimage"));
             const vhtlcScript = new VHTLC.Script({

--- a/packages/ts-sdk/test/provider-availability.test.ts
+++ b/packages/ts-sdk/test/provider-availability.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RestIndexerProvider, RestArkProvider, ProviderUnavailableError, ArkError } from "../src";
 import { throwIfHttpUnavailable, toProviderUnavailable } from "../src/providers/errors";
 import { FetchError } from "../src/utils/fetch";
+import { rateGate } from "../src/providers/rateGate";
 
 const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
 
@@ -77,11 +78,17 @@ describe("toProviderUnavailable", () => {
 });
 
 describe("RestIndexerProvider availability classification", () => {
-    beforeEach(() => mockFetch.mockReset());
+    beforeEach(() => {
+        mockFetch.mockReset();
+        rateGate.reset();
+    });
     const provider = () => new RestIndexerProvider("http://localhost:7070");
 
+    // `indexerFetch` retries availability failures, so these mocks must answer
+    // every attempt, not just the first — the assertion is about the error that
+    // surfaces after the ladder is exhausted.
     it("maps a 503 response to ProviderUnavailableError(indexer)", async () => {
-        mockFetch.mockResolvedValueOnce({
+        mockFetch.mockResolvedValue({
             ok: false,
             status: 503,
             statusText: "Service Unavailable",
@@ -90,13 +97,33 @@ describe("RestIndexerProvider availability classification", () => {
             name: "ProviderUnavailableError",
             message: expect.stringContaining("indexer unavailable"),
         });
+        expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
     it("maps a transport failure to ProviderUnavailableError(indexer)", async () => {
-        mockFetch.mockRejectedValueOnce(new FetchError("down", { url: "u" }));
+        mockFetch.mockRejectedValue(new FetchError("down", { url: "u" }));
         await expect(provider().getVtxos({ scripts: ["s"] })).rejects.toBeInstanceOf(
             ProviderUnavailableError,
         );
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("retries a 503 and succeeds on a later attempt", async () => {
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: "Service Unavailable" })
+            .mockResolvedValueOnce({ ok: true, json: async () => ({ vtxos: [] }) });
+        await expect(provider().getVtxos({ scripts: ["s"] })).resolves.toMatchObject({
+            vtxos: [],
+        });
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not retry a terminal 404", async () => {
+        mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: "Not Found" });
+        await expect(provider().getVtxos({ scripts: ["s"] })).rejects.toThrow(
+            /Failed to fetch vtxos/,
+        );
+        expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it("leaves a 404 as a terminal plain Error (not unavailable)", async () => {

--- a/packages/ts-sdk/test/provider-availability.test.ts
+++ b/packages/ts-sdk/test/provider-availability.test.ts
@@ -118,6 +118,21 @@ describe("RestIndexerProvider availability classification", () => {
         expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
+    it("does not retry a subscribe POST", async () => {
+        // Replaying a subscribe whose response was lost would create a second
+        // subscription and leak the first — it carries no subscriptionId to
+        // make the retry idempotent.
+        mockFetch.mockResolvedValue({
+            ok: false,
+            status: 503,
+            statusText: "Service Unavailable",
+        });
+        await expect(provider().subscribeForScripts(["s"])).rejects.toBeInstanceOf(
+            ProviderUnavailableError,
+        );
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
     it("does not retry a terminal 404", async () => {
         mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: "Not Found" });
         await expect(provider().getVtxos({ scripts: ["s"] })).rejects.toThrow(

--- a/packages/ts-sdk/test/rate-gate.test.ts
+++ b/packages/ts-sdk/test/rate-gate.test.ts
@@ -54,6 +54,16 @@ describe("parseRetryAfterMs", () => {
         expect(parseRetryAfterMs(undefined)).toBeUndefined();
         expect(parseRetryAfterMs("")).toBeUndefined();
         expect(parseRetryAfterMs("soon")).toBeUndefined();
+        // Malformed rather than "retry now": clamping to 0 would read as no
+        // cooldown, so these must fall back to the caller's default.
+        expect(parseRetryAfterMs("-5")).toBeUndefined();
+        expect(parseRetryAfterMs("Infinity")).toBeUndefined();
+    });
+
+    it("a negative Retry-After still applies the default cooldown", () => {
+        const gate = new OriginRateGate({ defaultCooldownMs: 5_000 });
+        gate.reportRateLimited("https://a.example/x", "-5");
+        expect(gate.cooldownRemainingMs("https://a.example/x")).toBeGreaterThan(4_000);
     });
 });
 

--- a/packages/ts-sdk/test/rate-gate.test.ts
+++ b/packages/ts-sdk/test/rate-gate.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { RestIndexerProvider, RestArkProvider } from "../src";
+import {
+    OriginRateGate,
+    parseRetryAfterMs,
+    rateGate,
+    requestOrigin,
+} from "../src/providers/rateGate";
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
+
+vi.mock("../src/utils/fetch", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../src/utils/fetch")>();
+    return { ...actual, fetch: mockFetch, baseFetch: mockFetch };
+});
+
+/** A `429` carrying `Retry-After`, shaped like the Cloudflare response in the HAR. */
+function rateLimited(retryAfter = "10") {
+    return {
+        ok: false,
+        status: 429,
+        statusText: "Too Many Requests",
+        headers: new Headers({ "retry-after": retryAfter }),
+        clone: () => ({ text: async () => "" }),
+        text: async () => "",
+    };
+}
+
+function ok(body: unknown) {
+    return { ok: true, headers: new Headers(), json: async () => body };
+}
+
+describe("parseRetryAfterMs", () => {
+    it("parses delta-seconds", () => {
+        expect(parseRetryAfterMs("10")).toBe(10_000);
+        expect(parseRetryAfterMs(" 2 ")).toBe(2_000);
+        expect(parseRetryAfterMs("0")).toBe(0);
+    });
+
+    it("parses an HTTP-date relative to now", () => {
+        vi.useFakeTimers();
+        try {
+            vi.setSystemTime(new Date("2026-07-20T20:00:00Z"));
+            expect(parseRetryAfterMs("Mon, 20 Jul 2026 20:00:30 GMT")).toBe(30_000);
+            // A date already in the past clamps to zero rather than going negative.
+            expect(parseRetryAfterMs("Mon, 20 Jul 2026 19:59:00 GMT")).toBe(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("returns undefined for absent / unparseable values", () => {
+        expect(parseRetryAfterMs(null)).toBeUndefined();
+        expect(parseRetryAfterMs(undefined)).toBeUndefined();
+        expect(parseRetryAfterMs("")).toBeUndefined();
+        expect(parseRetryAfterMs("soon")).toBeUndefined();
+    });
+});
+
+describe("requestOrigin", () => {
+    it("collapses paths on the same host to one key", () => {
+        // /v1/info and /v1/indexer/* share a limiter, so a 429 on one must
+        // pause the other.
+        expect(requestOrigin("https://arkade.computer/v1/info")).toBe("https://arkade.computer");
+        expect(requestOrigin("https://arkade.computer/v1/indexer/vtxos?a=b")).toBe(
+            "https://arkade.computer",
+        );
+    });
+
+    it("keeps distinct hosts distinct", () => {
+        expect(requestOrigin("https://a.example/x")).not.toBe(requestOrigin("https://b.example/x"));
+    });
+
+    it("falls back to the raw string when unparseable", () => {
+        expect(requestOrigin("/relative/path")).toBe("/relative/path");
+    });
+});
+
+describe("OriginRateGate", () => {
+    it("caps concurrency per origin", async () => {
+        const gate = new OriginRateGate({ maxConcurrent: 2 });
+        let inFlight = 0;
+        let peak = 0;
+        const release: (() => void)[] = [];
+
+        const runs = Array.from({ length: 6 }, () =>
+            gate.run("https://a.example/x", () => {
+                inFlight += 1;
+                peak = Math.max(peak, inFlight);
+                return new Promise<void>((resolve) =>
+                    release.push(() => {
+                        inFlight -= 1;
+                        resolve();
+                    }),
+                );
+            }),
+        );
+
+        // Let the first cohort start, then drain one at a time.
+        await Promise.resolve();
+        expect(peak).toBe(2);
+        while (release.length > 0) {
+            release.shift()!();
+            await Promise.resolve();
+            await Promise.resolve();
+        }
+        await Promise.all(runs);
+        expect(peak).toBe(2);
+    });
+
+    it("does not let one origin's cooldown block another", async () => {
+        const gate = new OriginRateGate();
+        gate.reportRateLimited("https://a.example/x", "10");
+        expect(gate.cooldownRemainingMs("https://a.example/y")).toBeGreaterThan(0);
+        expect(gate.cooldownRemainingMs("https://b.example/y")).toBe(0);
+        await expect(gate.run("https://b.example/y", async () => "ran")).resolves.toBe("ran");
+    });
+
+    it("takes the longest cooldown, never a shorter one", () => {
+        const gate = new OriginRateGate();
+        gate.reportRateLimited("https://a.example/x", "30");
+        const long = gate.cooldownRemainingMs("https://a.example/x");
+        gate.reportRateLimited("https://a.example/x", "1");
+        expect(gate.cooldownRemainingMs("https://a.example/x")).toBe(long);
+    });
+
+    it("clamps an absurd Retry-After", () => {
+        const gate = new OriginRateGate({ maxCooldownMs: 60_000 });
+        gate.reportRateLimited("https://a.example/x", "999999");
+        expect(gate.cooldownRemainingMs("https://a.example/x")).toBeLessThanOrEqual(60_000);
+    });
+
+    it("applies a default cooldown when Retry-After is missing", () => {
+        const gate = new OriginRateGate({ defaultCooldownMs: 5_000 });
+        gate.reportRateLimited("https://a.example/x", null);
+        expect(gate.cooldownRemainingMs("https://a.example/x")).toBeGreaterThan(4_000);
+    });
+});
+
+describe("shared cooldown across requests (herd regression)", () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+        rateGate.reset();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+        rateGate.reset();
+    });
+
+    it("one observed 429 pauses requests that never saw it", async () => {
+        // The regression this gate exists for: per-request backoff leaves every
+        // other request ignorant of the 429, so they fire into the cooldown.
+        vi.useFakeTimers();
+        const indexer = new RestIndexerProvider("http://localhost:7070");
+
+        mockFetch.mockResolvedValueOnce(rateLimited("10"));
+        const first = indexer.getVtxos({ scripts: ["a"] }).catch((e) => e);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        // A request that never saw a 429 itself must not reach the network.
+        mockFetch.mockResolvedValue(ok({ vtxos: [] }));
+        const newcomer = indexer.getVtxos({ scripts: ["b"] });
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        // ...until the cooldown plus jitter expires.
+        await vi.advanceTimersByTimeAsync(6_000);
+        await expect(newcomer).resolves.toMatchObject({ vtxos: [] });
+        expect(mockFetch.mock.calls.length).toBeGreaterThan(1);
+        await first;
+    });
+
+    it("a herd released by one cooldown resumes staggered, not in lockstep", async () => {
+        vi.useFakeTimers();
+        const indexer = new RestIndexerProvider("http://localhost:7070");
+
+        mockFetch.mockResolvedValueOnce(rateLimited("10"));
+        const first = indexer.getVtxos({ scripts: ["a"] }).catch((e) => e);
+        await vi.advanceTimersByTimeAsync(1);
+
+        const sendTimes: number[] = [];
+        mockFetch.mockImplementation(async () => {
+            sendTimes.push(Date.now());
+            return ok({ vtxos: [] });
+        });
+
+        const herd = Array.from({ length: 5 }, (_, i) => indexer.getVtxos({ scripts: [`h${i}`] }));
+        await vi.advanceTimersByTimeAsync(20_000);
+        await Promise.all(herd);
+        await first;
+
+        expect(sendTimes.length).toBeGreaterThanOrEqual(5);
+        // Leaving at one instant is what re-trips the limiter.
+        expect(new Set(sendTimes).size).toBeGreaterThan(1);
+    });
+
+    it("an indexer 429 also gates an ark-provider read on the same origin", async () => {
+        vi.useFakeTimers();
+        const indexer = new RestIndexerProvider("http://localhost:7070");
+        const ark = new RestArkProvider("http://localhost:7070");
+
+        mockFetch.mockResolvedValueOnce(rateLimited("10"));
+        const first = indexer.getVtxos({ scripts: ["a"] }).catch((e) => e);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        // Different provider class, same host, same limiter.
+        mockFetch.mockResolvedValue(ok({}));
+        const info = ark.getInfo().catch((e) => e);
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(20_000);
+        await info;
+        await first;
+        expect(mockFetch.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it("a settlement POST is sent during a cooldown, and reports its own 429 without retrying", async () => {
+        vi.useFakeTimers();
+        const indexer = new RestIndexerProvider("http://localhost:7070");
+        const ark = new RestArkProvider("http://localhost:7070");
+
+        mockFetch.mockResolvedValueOnce(rateLimited("10"));
+        const first = indexer.getVtxos({ scripts: ["a"] }).catch((e) => e);
+        await vi.advanceTimersByTimeAsync(1);
+        const beforePost = mockFetch.mock.calls.length;
+        const cooldownBefore = rateGate.cooldownRemainingMs("http://localhost:7070");
+
+        mockFetch.mockResolvedValueOnce(rateLimited("30"));
+        const submitted = ark.submitTx("tx", []).catch((e) => e);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(mockFetch).toHaveBeenCalledTimes(beforePost + 1);
+
+        await submitted;
+        // Sent once, never retried — but its 429 still extended the cooldown.
+        expect(mockFetch).toHaveBeenCalledTimes(beforePost + 1);
+        expect(rateGate.cooldownRemainingMs("http://localhost:7070")).toBeGreaterThan(
+            cooldownBefore,
+        );
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        await first;
+    });
+
+    it("retries a 429 and succeeds once the cooldown lifts", async () => {
+        vi.useFakeTimers();
+        const indexer = new RestIndexerProvider("http://localhost:7070");
+        mockFetch.mockResolvedValueOnce(rateLimited("1")).mockResolvedValue(ok({ vtxos: [] }));
+
+        const pending = indexer.getVtxos({ scripts: ["a"] });
+        await vi.advanceTimersByTimeAsync(10_000);
+        await expect(pending).resolves.toMatchObject({ vtxos: [] });
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/ts-sdk/test/rate-gate.test.ts
+++ b/packages/ts-sdk/test/rate-gate.test.ts
@@ -145,6 +145,40 @@ describe("OriginRateGate", () => {
         gate.reportRateLimited("https://a.example/x", null);
         expect(gate.cooldownRemainingMs("https://a.example/x")).toBeGreaterThan(4_000);
     });
+
+    it("a queued waiter does not send into the cooldown the released request just earned", async () => {
+        // `release()` hands the slot on inside run()'s finally. Reporting the
+        // 429 after run() resolves is too late: the waiter resumes first, sees
+        // blockedUntil === 0, and sends. runHttp reports before releasing.
+        vi.useFakeTimers();
+        try {
+            const gate = new OriginRateGate({ maxConcurrent: 1, jitterMs: 0 });
+            const url = "https://a.example/x";
+            const sent: string[] = [];
+
+            const first = gate.runHttp(url, async () => {
+                sent.push("first");
+                return { status: 429, headers: new Headers({ "retry-after": "30" }) } as Response;
+            });
+            const second = gate.runHttp(url, async () => {
+                sent.push("second");
+                return { status: 200, headers: new Headers() } as Response;
+            });
+
+            await first;
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(sent).toEqual(["first"]);
+            expect(gate.cooldownRemainingMs(url)).toBeGreaterThan(29_000);
+
+            await vi.advanceTimersByTimeAsync(31_000);
+            await second;
+            expect(sent).toEqual(["first", "second"]);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });
 
 describe("shared cooldown across requests (herd regression)", () => {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -649,9 +649,10 @@ describe("ContractManager.scanContracts", () => {
         }
     });
 
-    it("a discoverAt error is collected but the loop completes the gap window", async () => {
-        // Always throws → loop must still terminate via the gap counter
-        // (unused reaches gapLimit) and surface one error per probed index.
+    it("an always-failing handler terminates the scan at index 0, gap window unclosed", async () => {
+        // Every index indeterminate → the gap counter never advances and the
+        // loop terminates on truncation instead. The first window is already in
+        // flight, so all its errors are collected; nothing beyond it is probed.
         const { handler } = makeFakeHandler("boomfake", () => {
             throw new Error("handler down");
         });
@@ -664,11 +665,138 @@ describe("ContractManager.scanContracts", () => {
                 materialize,
                 deps: makeDeps(),
             });
-            // 3 unused indices (0,1,2) close the window; one error each.
-            expect(res.lastIndexUsed).toBe(-1);
+            expect(res.highestConfirmedUsedIndex).toBe(-1);
+            expect(res.truncatedAt).toBe(0);
             expect(res.handlerErrors).toHaveLength(3);
             expect(res.handlerErrors.map((e) => e.index)).toEqual([0, 1, 2]);
             expect(res.handlerErrors.every((e) => e.handler === "boomfake")).toBe(true);
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("a failed probe is INDETERMINATE, not unused: the gap window cannot close across it", async () => {
+        // Regression for the rate-limiting incident: a failure at index 3 used
+        // to increment `unused`, so under a 429 storm the window closed on
+        // failed requests rather than absent funds and restore under-reported.
+        const { handler, calls } = makeFakeHandler("boomfake", (i) => {
+            if (i === 3) throw new Error("rate limited");
+            return [];
+        });
+        register("boomfake", handler);
+        const mgr = await makeManagerForTest();
+        try {
+            const res = await mgr.scanContracts({
+                gapLimit: 20,
+                batchSize: 1,
+                hd: true,
+                materialize,
+                deps: makeDeps(),
+            });
+            expect(res.truncatedAt).toBe(3);
+            expect(res.handlerErrors).toHaveLength(1);
+            expect(res.handlerErrors[0]).toMatchObject({ handler: "boomfake", index: 3 });
+            // Stopped verifying AT the hole — never probed past it.
+            expect(calls).toEqual([0, 1, 2, 3]);
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("a clean scan reports no truncation", async () => {
+        const { handler } = makeFakeHandler("swapfake", () => []);
+        register("swapfake", handler);
+        const mgr = await makeManagerForTest();
+        try {
+            const res = await mgr.scanContracts({
+                gapLimit: 3,
+                hd: true,
+                materialize,
+                deps: makeDeps(),
+            });
+            expect(res.truncatedAt).toBeUndefined();
+            expect(res.handlerErrors).toEqual([]);
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("keeps a confirmed hit found PAST the truncation point (address-reuse guard)", async () => {
+        // Concurrent probing means a failure at index 1 can arrive alongside a
+        // real hit at index 4. Dropping that hit would let index 4 be re-issued
+        // as a fresh receive address.
+        const hitAt4 = makeFakeHandler("swapfake", (i) =>
+            i === 4
+                ? [
+                      {
+                          type: "swapfake",
+                          params: { script: "aabb" },
+                          script: "aabb",
+                          address: "ark1qswap",
+                      },
+                  ]
+                : [],
+        );
+        const failAt1 = makeFakeHandler("boomfake", (i) => {
+            if (i === 1) throw new Error("rate limited");
+            return [];
+        });
+        register("swapfake", hitAt4.handler);
+        register("boomfake", failAt1.handler);
+        const mgr = await makeManagerForTest();
+        try {
+            const res = await mgr.scanContracts({
+                gapLimit: 10,
+                batchSize: 10, // one window covers 0..9, so index 4 is probed
+                hd: true,
+                materialize,
+                deps: makeDeps(),
+            });
+            expect(res.truncatedAt).toBe(1);
+            expect(res.highestConfirmedUsedIndex).toBe(4);
+            expect(res.lastIndexUsed).toBe(4); // deprecated alias stays faithful
+            // Persisted, not merely counted.
+            const [c] = await mgr.getContracts({ script: "aabb" });
+            expect(c?.type).toBe("swapfake");
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("a hit past the truncation point does NOT reopen the gap window", async () => {
+        // A hit above `truncatedAt` advances the watermark but must not reset
+        // `unused` and resume scanning: indices below it are still unverified.
+        const failAt0 = makeFakeHandler("boomfake", (i) => {
+            if (i === 0) throw new Error("rate limited");
+            return [];
+        });
+        const hitAt5 = makeFakeHandler("swapfake", (i) =>
+            i === 5
+                ? [
+                      {
+                          type: "swapfake",
+                          params: { script: "ccdd" },
+                          script: "ccdd",
+                          address: "ark1qswap",
+                      },
+                  ]
+                : [],
+        );
+        register("boomfake", failAt0.handler);
+        register("swapfake", hitAt5.handler);
+        const mgr = await makeManagerForTest();
+        try {
+            const res = await mgr.scanContracts({
+                gapLimit: 10,
+                batchSize: 10,
+                hd: true,
+                materialize,
+                deps: makeDeps(),
+            });
+            expect(res.truncatedAt).toBe(0);
+            expect(res.highestConfirmedUsedIndex).toBe(5);
+            // Exactly one window: no second window was dispatched past the hit.
+            expect(hitAt5.calls).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         } finally {
             mgr.dispose();
         }
@@ -1676,11 +1804,70 @@ describe("Wallet.restore", () => {
             expect(((err as AggregateError).errors[0] as Error).message).toBe(
                 "swap source unreachable",
             );
+            // Names the exact unverified boundary, not a guess at one.
+            expect((err as AggregateError).message).toMatch(
+                /scan truncated at index 0; indices >= 0 are unverified/,
+            );
 
             // Despite the throwing handler, the inline refreshVtxos ran
             // first so the default-handler funds were still recovered.
             const balance = await wallet.getBalance();
             expect(balance.total).toBeGreaterThan(0);
+        } finally {
+            contractHandlers.unregister(fakeType);
+            await wallet.dispose();
+        }
+    });
+
+    it("a truncated scan still advances the watermark past a confirmed hit (address reuse)", async () => {
+        // A caller that ignores the restore error then asks for a receive
+        // address. `getNextSigningDescriptor` allocates `lastIndexUsed + 1`, so
+        // withholding the hit at index 2 would re-issue a funded address.
+        const { wallet, indexer, hdProvider } = await makeHdWalletForTest();
+        const fakeType = "restore-truncate-fake";
+        const fake = {
+            type: fakeType,
+            createScript: (params: Record<string, string>) =>
+                ({ pkScript: hex.decode(params.script || "00") }) as any,
+            serializeParams: (p: any) => p,
+            deserializeParams: (p: any) => p,
+            selectPath: () => null,
+            getAllSpendingPaths: () => [],
+            getSpendablePaths: () => [],
+            async discoverAt(index: number) {
+                if (index === 0) throw new Error("indexer rate limited");
+                return [];
+            },
+        };
+        contractHandlers.register(fake as any);
+        try {
+            const serverPubKey = wallet.offchainTapscript.options.serverPubKey;
+            for (const csvTimelock of wallet.walletContractTimelocks) {
+                indexer.usedScripts.add(
+                    hex.encode(
+                        new DefaultVtxo.Script({
+                            pubKey: deriveDescriptorLeafPubKey(
+                                hdProvider.materializeDescriptorAt(2),
+                            ),
+                            serverPubKey,
+                            csvTimelock,
+                        }).pkScript,
+                    ),
+                );
+            }
+
+            const err = await wallet.restore({ gapLimit: 10 }).then(
+                () => undefined,
+                (e) => e,
+            );
+            // Fails loudly (index 0 unverified)...
+            expect(err).toBeInstanceOf(AggregateError);
+            expect((err as AggregateError).message).toMatch(/scan truncated at index 0/);
+
+            // ...yet still allocates 3, never re-handing out the funded 2.
+            expect(await hdProvider.getNextSigningDescriptor()).toBe(
+                hdProvider.materializeDescriptorAt(3),
+            );
         } finally {
             contractHandlers.unregister(fakeType);
             await wallet.dispose();


### PR DESCRIPTION
Restoring a large HD wallet floods the indexer with small requests and trips the operator's rate limiter. Two problems follow from that, fixed here.

**A rate-limited probe was read as "index unused."** A `discoverAt` rejection incremented the gap counter, so the scan's window closed on failed requests rather than on absent funds — restore could return a wallet missing money while reporting success. A failed probe is now *indeterminate*: it does not advance the gap counter, and the scan stops there and reports where.

`ScanResult` gains `highestConfirmedUsedIndex` and `truncatedAt`; `lastIndexUsed` stays as a deprecated alias, so consumers are unaffected. Confirmed hits found above the truncation point are still persisted and still advance the HD watermark — otherwise a caller that swallows the restore error could be handed an already-funded index as a fresh receive address.

**Nothing throttled or backed off.** There was no concurrency limit anywhere and no retry on any indexer GET; `Retry-After` was never read. New origin-keyed gate holding a shared cooldown and an in-flight cap:

- Idempotent GETs (indexer, `getInfo`, delegate info) wait behind the cooldown and report into it.
- Intent/settlement POSTs report only — never delayed, never retried. Batch sessions have deadlines and these POSTs are not idempotent.
- Waiters resume with independent jitter, so a herd released by one expiring cooldown does not re-form into the burst that earned the 429.
- `indexerFetch` retries availability failures a bounded number of times. `Retry-After` is read off the response and fed to the gate, never attached to the typed error — per-instance `Error` properties do not survive the service-worker `postMessage` boundary.

### Notes for review

- Restore will now fail *more often but honestly* — it reports an unverified range instead of a plausible wrong answer. The retry absorbs transient 429s before they reach the scanner, which is what keeps that tolerable.
- `highestConfirmedUsedIndex` is a required field, so this is source-breaking for anyone *implementing* `IContractManager` (nothing in the repo does). It cannot be optional without being untrustworthy.
- The boarding-before-default first-wins tie-break is untouched; its test still pins it.

Follow-up, not in this PR: collapsing the per-index request fan-out using the indexer's existing batch support, which is what actually cuts request volume.

### Testing

New `test/rate-gate.test.ts` covers cooldown sharing, origin scoping, jittered resume, and the report-only path. `test/restore.test.ts` gains the indeterminate-probe regression and the address-reuse guard. Full unit suite green.

Not done: re-capturing a HAR against a live operator to diff request counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced contract scanning to report confirmed vs indeterminate results, including the highest confirmed index and an optional truncation point when verification can’t complete.
  * Added shared request throttling with 429-based cooldown tracking across provider requests.
  * Added attempt-limited retries for temporary indexer availability failures.
* **Bug Fixes**
  * Wallet restoration now advances from the highest confirmed index and prevents reusing a previously funded receive address even when scanning is truncated.
  * Restore scan errors now explicitly indicate the unverified range and that retrying is safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->