### PR TITLE
fix(HD): chunk script lists in getVtxos queries

### DIFF
--- a/packages/ts-sdk/src/contracts/constants.ts
+++ b/packages/ts-sdk/src/contracts/constants.ts
@@ -1,14 +1,24 @@
 /**
  * Default indexer pagination size for batched VTXO queries (`getVtxos`).
  *
- * Shared by {@link ContractManager}'s bulk history sync and the discovery
- * handlers' batched `detectUsedScripts` probe so the two can't drift. It lives
- * in its own leaf module (importing nothing) so both the manager and the
- * handler layer can use it without a `handlers → contractManager` import cycle —
- * contractManager imports the handler registry, so the handlers must not import
- * back from contractManager.
+ * Shared by {@link ContractManager}'s bulk history sync, the discovery
+ * handlers' batched `detectUsedScripts` probe, and `wallet/vtxo.ts`'s chunked
+ * reader so they can't drift. It lives in its own leaf module (importing
+ * nothing) so every layer can use it without a `handlers → contractManager`
+ * import cycle — contractManager imports the handler registry, so the handlers
+ * must not import back from contractManager.
  *
  * Large enough that a single wallet index's candidate scripts resolve in one
  * page in the common case.
  */
 export const DEFAULT_PAGE_SIZE = 500;
+
+/**
+ * Maximum scripts per `getVtxos` query string.
+ *
+ * Scripts cost ~77 bytes each in the URL, so an unbounded wallet-derived list
+ * `414`s: a few hundred contracts is ~28 KB. 32 keeps a request at ~2.6 KB —
+ * well inside any plausible limit, since `arkd`'s real ceiling is unpublished
+ * and 16 is the largest batch observed working in the wild.
+ */
+export const SCRIPT_QUERY_CHUNK_SIZE = 32;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -19,6 +19,7 @@ import { ContractWatcher, ContractWatcherConfig } from "./contractWatcher";
 import { contractHandlers } from "./handlers";
 import { ExtendedVirtualCoin, Outpoint, VirtualCoin } from "../wallet";
 import {
+    getAllNormalizedVtxos,
     getNormalizedVtxos,
     normalizeVtxo,
     type NormalizedExtendedVirtualCoin,
@@ -1347,13 +1348,13 @@ export class ContractManager implements IContractManager {
      * window (e.g. a spend that hasn't settled yet).
      */
     private async reconcilePendingFrontier(contracts: Contract[]): Promise<void> {
-        const scripts = contracts.map((c) => c.script);
         const scriptToContract = new Map<string, Contract>(contracts.map((c) => [c.script, c]));
 
-        const { vtxos } = await getNormalizedVtxos(this.config.indexerProvider, {
-            scripts,
-            pendingOnly: true,
-        });
+        const vtxos = await getAllNormalizedVtxos(
+            this.config.indexerProvider,
+            contracts.map((c) => c.script),
+            { pendingOnly: true },
+        );
 
         // Share the annotation path with external callers so the two entry
         // points can't drift.
@@ -1446,16 +1447,14 @@ export class ContractManager implements IContractManager {
             return new Map();
         }
 
-        // Batch all scripts into a single indexer call per page to minimise
-        // round-trips. Results are keyed by script so we can distribute them
-        // back to the correct contract afterwards. Always fetches the full
-        // history (spent/swept included) so the repo is the source of truth.
+        // Results are keyed by script so we can distribute them back to the
+        // correct contract afterwards. Always fetches the full history
+        // (spent/swept included) so the repo is the source of truth.
         const scriptToContract = new Map<string, Contract>(contracts.map((c) => [c.script, c]));
         const result = new Map<string, ExtendedContractVtxo[]>(
             contracts.map((c) => [c.script, []]),
         );
 
-        const scripts = contracts.map((c) => c.script);
         const windowOpts = syncWindow
             ? {
                   ...(syncWindow.after !== undefined && {
@@ -1466,33 +1465,24 @@ export class ContractManager implements IContractManager {
                   }),
               }
             : {};
-        let pageIndex = 0;
-        let hasMore = true;
 
-        while (hasMore) {
-            const { vtxos, page } = await getNormalizedVtxos(this.config.indexerProvider, {
-                scripts,
-                ...windowOpts,
-                pageIndex,
-                pageSize,
+        const vtxos = await getAllNormalizedVtxos(
+            this.config.indexerProvider,
+            contracts.map((c) => c.script),
+            { ...windowOpts, pageSize },
+        );
+
+        // Match virtual outputs back to their contract via the script field
+        // populated by the indexer, then share the annotation path with
+        // external callers via annotateVtxos so the two entry points can't
+        // drift.
+        const owned = vtxos.filter((v) => scriptToContract.has(v.script));
+        const annotated = await this.annotateVtxos(owned);
+        for (const vtxo of annotated) {
+            result.get(vtxo.script)!.push({
+                ...vtxo,
+                contractScript: vtxo.script,
             });
-
-            // Match virtual outputs back to their contract via the script field
-            // populated by the indexer, then share the annotation path with
-            // external callers via annotateVtxos so the two entry points can't
-            // drift.
-            const owned = vtxos.filter((v) => scriptToContract.has(v.script));
-            const annotated = await this.annotateVtxos(owned);
-            for (const vtxo of annotated) {
-                result.get(vtxo.script)!.push({
-                    ...vtxo,
-                    contractScript: vtxo.script,
-                });
-            }
-
-            hasMore = page ? vtxos.length === pageSize : false;
-            pageIndex++;
-            if (hasMore) await new Promise((r) => setTimeout(r, 500));
         }
 
         return result;

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -756,6 +756,7 @@ export {
     canRecoverOnchain,
     canSpendOffchain,
     convertVtxo,
+    getAllNormalizedVtxos,
     getNormalizedVtxos,
     hasTerminalSpend,
     isExpired,
@@ -768,6 +769,7 @@ export {
     type NormalizedExtendedVirtualCoin,
     type NormalizedVirtualCoin,
     type TimeHeight,
+    type VtxoScriptQuery,
 } from "./vtxo";
 
 /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1863,6 +1863,11 @@ export class WalletMessageHandler
                     txid,
                     vout: 0,
                 }));
+                // Outpoints cost about what scripts do in the query string, so
+                // this spends nearly the whole URL budget that
+                // SCRIPT_QUERY_CHUNK_SIZE leaves unspent. Left as-is because
+                // this path has never 414'd; lower it to the shared constant if
+                // it ever does.
                 const BATCH_SIZE = 100;
                 for (let i = 0; i < outpoints.length; i += BATCH_SIZE) {
                     const res = await getNormalizedVtxos(this.indexerProvider, {

--- a/packages/ts-sdk/src/wallet/vtxo.ts
+++ b/packages/ts-sdk/src/wallet/vtxo.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE, SCRIPT_QUERY_CHUNK_SIZE } from "../contracts/constants";
 import type { GetVtxosOptions, IndexerProvider, PageResponse, Vtxo } from "../providers/indexer";
 import type { OnchainProvider } from "../providers/onchain";
 import type { ExtendedVirtualCoin, VirtualCoin, VirtualStatus } from "./index";
@@ -241,6 +242,51 @@ export async function getNormalizedVtxos(
 ): Promise<{ vtxos: NormalizedVirtualCoin[]; page?: PageResponse }> {
     const { vtxos, page } = await provider.getVtxos(opts);
     return { vtxos: vtxos.map(normalizeVtxo), page };
+}
+
+/** Everything a script query can filter on, minus the cursor this reader owns. */
+export type VtxoScriptQuery = Omit<GetVtxosOptions, "scripts" | "outpoints" | "pageIndex">;
+
+/**
+ * Read every virtual output for an arbitrary number of scripts.
+ *
+ * @remarks
+ * Scripts travel in the query string, so a wallet-derived list must be chunked
+ * at {@link SCRIPT_QUERY_CHUNK_SIZE} or the request `414`s. Chunks run
+ * sequentially — that pacing is the point, since this path can now run wide —
+ * and each is paged to exhaustion, so callers cannot silently receive page one.
+ */
+export async function getAllNormalizedVtxos(
+    provider: Pick<IndexerProvider, "getVtxos">,
+    scripts: string[],
+    opts: VtxoScriptQuery = {},
+): Promise<NormalizedVirtualCoin[]> {
+    const { pageSize = DEFAULT_PAGE_SIZE, ...filters } = opts;
+    const all: NormalizedVirtualCoin[] = [];
+
+    for (let i = 0; i < scripts.length; i += SCRIPT_QUERY_CHUNK_SIZE) {
+        const chunk = scripts.slice(i, i + SCRIPT_QUERY_CHUNK_SIZE);
+        let pageIndex = 0;
+        let hasMore = true;
+
+        while (hasMore) {
+            const { vtxos, page } = await getNormalizedVtxos(provider, {
+                ...filters,
+                scripts: chunk,
+                pageIndex,
+                pageSize,
+            });
+            all.push(...vtxos);
+
+            // A short page means the last one: providers that omit `page`
+            // entirely are treated as unpaged.
+            hasMore = page ? vtxos.length === pageSize : false;
+            pageIndex++;
+            if (hasMore) await new Promise((r) => setTimeout(r, 500));
+        }
+    }
+
+    return all;
 }
 
 // --- capabilities ------------------------------------------------------------------------------

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -26,6 +26,7 @@ import { Identity, ReadonlyIdentity, isBatchSignable } from "../identity";
 import {
     canRecoverOnchain,
     canSpendOffchain,
+    getAllNormalizedVtxos,
     getNormalizedVtxos,
     hasTerminalSpend,
     isVirtualCoin,
@@ -1653,9 +1654,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
     async fetchPendingTxs(): Promise<string[]> {
         // get non-swept virtual outputs, rely on the indexer only in case DB doesn't have the right state
         const scripts = await this.getWalletScripts();
-        let { vtxos } = await getNormalizedVtxos(this.indexerProvider, {
-            scripts,
-        });
+        const vtxos = await getAllNormalizedVtxos(this.indexerProvider, scripts);
         return vtxos
             .filter(
                 (vtxo) =>
@@ -3949,14 +3948,12 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         }
 
         if (!vtxos || vtxos.length === 0) {
-            // Batch all scripts into a single indexer call
             const scriptMap = await this.getScriptMap();
             const allExtended: ExtendedVirtualCoin[] = [];
 
-            const allScripts = [...scriptMap.keys()];
-            const { vtxos: fetchedVtxos } = await getNormalizedVtxos(this.indexerProvider, {
-                scripts: allScripts,
-            });
+            const fetchedVtxos = await getAllNormalizedVtxos(this.indexerProvider, [
+                ...scriptMap.keys(),
+            ]);
 
             for (const vtxo of fetchedVtxos) {
                 const vtxoScript = scriptMap.get(vtxo.script);

--- a/packages/ts-sdk/test/vtxo-query-chunking.test.ts
+++ b/packages/ts-sdk/test/vtxo-query-chunking.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    ContractManager,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    type IndexerProvider,
+    type VirtualCoin,
+} from "../src";
+import type { Contract } from "../src/contracts";
+import { SCRIPT_QUERY_CHUNK_SIZE } from "../src/contracts/constants";
+import { updateWalletState } from "../src/utils/syncCursors";
+import { getAllNormalizedVtxos } from "../src/wallet/vtxo";
+import { createDefaultContractParams, createMockIndexerProvider } from "./contracts/helpers";
+import {
+    installRestoreHarness,
+    makeStaticWalletForTest,
+    teardownRestoreHarness,
+} from "./helpers/restoreWallet";
+
+const CAP = SCRIPT_QUERY_CHUNK_SIZE;
+
+/** Distinct, P2TR-shaped pkScripts. */
+const scriptAt = (i: number) => "5120" + i.toString(16).padStart(64, "0");
+const scripts = (n: number) => Array.from({ length: n }, (_, i) => scriptAt(i));
+
+const contractAt = (i: number): Contract => ({
+    type: "default",
+    params: createDefaultContractParams(),
+    script: scriptAt(i),
+    address: `addr-${i}`,
+    state: "active",
+    createdAt: 1,
+});
+
+const vtxoFor = (script: string, n: number): VirtualCoin => ({
+    txid: script.slice(4, 68).replace(/^.{2}/, n.toString(16).padStart(2, "0")),
+    vout: 0,
+    value: 1000,
+    status: { confirmed: true },
+    virtualStatus: { state: "settled" },
+    createdAt: new Date(),
+    isUnrolled: false,
+    isSpent: false,
+    script,
+});
+
+/**
+ * Records every `scripts`-shaped query and answers each with one VTXO per
+ * requested script, spread over `pagesPerChunk` pages so the chunk/page nesting
+ * is exercised rather than assumed.
+ */
+function recordingIndexer(pagesPerChunk = 1): {
+    indexer: IndexerProvider;
+    calls: { scripts: string[]; pageIndex: number; pendingOnly?: boolean }[];
+} {
+    const calls: { scripts: string[]; pageIndex: number; pendingOnly?: boolean }[] = [];
+    const indexer = createMockIndexerProvider();
+    (indexer.getVtxos as any).mockImplementation(
+        async (opts?: {
+            scripts?: string[];
+            pageIndex?: number;
+            pageSize?: number;
+            pendingOnly?: boolean;
+        }) => {
+            if (!opts?.scripts) return { vtxos: [] };
+            const pageIndex = opts.pageIndex ?? 0;
+            const pageSize = opts.pageSize ?? 500;
+            calls.push({ scripts: opts.scripts, pageIndex, pendingOnly: opts.pendingOnly });
+            const page = { current: pageIndex, next: pageIndex + 1, total: pagesPerChunk };
+            // A full page keeps the reader going; the last one is short.
+            const last = pageIndex === pagesPerChunk - 1;
+            const count = last ? opts.scripts.length : pageSize;
+            const vtxos = Array.from({ length: count }, (_, k) =>
+                vtxoFor(opts.scripts![k % opts.scripts!.length], pageIndex * 1000 + k),
+            );
+            return { vtxos, page };
+        },
+    );
+    return { indexer, calls };
+}
+
+const widest = (calls: { scripts: string[] }[]) => Math.max(...calls.map((c) => c.scripts.length));
+
+describe("getAllNormalizedVtxos", () => {
+    it("chunks a script list past the cap and unions every chunk's results", async () => {
+        const { indexer, calls } = recordingIndexer();
+        const all = scripts(CAP * 3 + 7);
+
+        const vtxos = await getAllNormalizedVtxos(indexer, all);
+
+        expect(calls).toHaveLength(4);
+        expect(widest(calls)).toBeLessThanOrEqual(CAP);
+        // The union is the part that can silently drop scripts.
+        expect(new Set(vtxos.map((v) => v.script))).toEqual(new Set(all));
+    });
+
+    it("pages each chunk to exhaustion, restarting the cursor per chunk", async () => {
+        const { indexer, calls } = recordingIndexer(2);
+
+        await getAllNormalizedVtxos(indexer, scripts(CAP + 1), { pageSize: 2 });
+
+        expect(calls.map((c) => c.pageIndex)).toEqual([0, 1, 0, 1]);
+        expect(widest(calls)).toBeLessThanOrEqual(CAP);
+    });
+
+    it("makes no request for an empty script list", async () => {
+        const { indexer, calls } = recordingIndexer();
+        expect(await getAllNormalizedVtxos(indexer, [])).toEqual([]);
+        expect(calls).toHaveLength(0);
+    });
+});
+
+describe("ContractManager script queries stay under the URL cap", () => {
+    const managers: ContractManager[] = [];
+    afterEach(async () => {
+        while (managers.length) await managers.pop()!.dispose();
+    });
+
+    const boot = async (indexer: IndexerProvider, contractCount: number) => {
+        const contractRepository = new InMemoryContractRepository();
+        for (let i = 0; i < contractCount; i++) {
+            await contractRepository.saveContract(contractAt(i));
+        }
+        const manager = await ContractManager.create({
+            indexerProvider: indexer,
+            contractRepository,
+            walletRepository: new InMemoryWalletRepository(),
+            watcherConfig: { failsafePollIntervalMs: 1_000_000, reconnectDelayMs: 1_000_000 },
+        });
+        managers.push(manager);
+        return manager;
+    };
+
+    // The boot guard: an oversized URL is a terminal 414, so before chunking a
+    // large wallet failed to construct outright.
+    it("boots a large wallet without an oversized request", async () => {
+        const { indexer, calls } = recordingIndexer();
+
+        await boot(indexer, CAP * 4);
+
+        // Both boot queries must be chunked: the sync, and the pending-frontier
+        // reconcile that runs over the full watched set right after it.
+        expect(calls.some((c) => c.pendingOnly)).toBe(true);
+        expect(widest(calls)).toBeLessThanOrEqual(CAP);
+    });
+
+    it("returns vtxos for every contract across chunks", async () => {
+        const { indexer, calls } = recordingIndexer();
+        const count = CAP * 2 + 5;
+        const manager = await boot(indexer, count);
+        calls.length = 0;
+
+        const withVtxos = await manager.getContractsWithVtxos();
+
+        expect(widest(calls)).toBeLessThanOrEqual(CAP);
+        for (let i = 0; i < count; i++) {
+            const entry = withVtxos.find((c) => c.contract.script === scriptAt(i));
+            expect(entry?.vtxos.length).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe("Wallet script queries stay under the URL cap", () => {
+    beforeEach(installRestoreHarness);
+    afterEach(() => {
+        teardownRestoreHarness();
+        vi.restoreAllMocks();
+    });
+
+    /** A wallet whose contract repository already holds `count` contracts. */
+    const walletWithContracts = async (count: number) => {
+        const handle = await makeStaticWalletForTest();
+        for (let i = 0; i < count; i++) {
+            await handle.contractRepository.saveContract(contractAt(i));
+        }
+        handle.indexer.getVtxosCalls.length = 0;
+        return handle;
+    };
+
+    it("chunks fetchPendingTxs", async () => {
+        const handle = await walletWithContracts(CAP * 3);
+
+        await handle.wallet.fetchPendingTxs();
+
+        expect(widest(handle.indexer.getVtxosCalls)).toBeLessThanOrEqual(CAP);
+    });
+
+    it("chunks finalizePendingTxs", async () => {
+        const handle = await walletWithContracts(CAP * 3);
+        await updateWalletState(handle.walletRepository, (state) => ({
+            ...state,
+            settings: { ...state.settings, hasPendingTx: true },
+        }));
+
+        await handle.wallet.finalizePendingTxs();
+
+        expect(handle.indexer.getVtxosCalls.length).toBeGreaterThan(0);
+        expect(widest(handle.indexer.getVtxosCalls)).toBeLessThanOrEqual(CAP);
+    });
+});


### PR DESCRIPTION
## Problem

Scripts travel in the `getVtxos` query string at ~77 bytes each, and four call sites passed an unbounded, wallet-derived script list. A wallet holding a few hundred contracts builds a ~28 KB URL and gets a **414** — which `errors.ts` classifies as terminal, not retryable.

Symptoms, in order of severity:

| Site | Set | Trigger | Effect |
|---|---|---|---|
| `fetchContractVtxosBulk` | all persisted contracts | every sync | `refreshVtxos` and `getContractsWithVtxos` both fail → **zero balance, no history** |
| `reconcilePendingFrontier` | full watched set | boot + SSE reconnect | rethrows out of `initialize` → **the wallet fails to construct**; silently swallowed on reconnect |
| `fetchPendingTxs` | every historical default+delegate script | public API | 414 outright |
| `finalizePendingTxs` | same set | interrupted-send recovery | 414 outright |

The lower three were also **unpaged** — a single call, page 1 only, no `hasMore` check — a pre-existing silent-truncation bug on large wallets.

## Fix

One shared primitive rather than four hand-rolled chunk loops: `getAllNormalizedVtxos` in `wallet/vtxo.ts`, beside `getNormalizedVtxos` (already the only sanctioned way SDK logic reads VTXOs from an `IndexerProvider`). It chunks scripts at `SCRIPT_QUERY_CHUNK_SIZE`, pages each chunk to exhaustion, and unions the results — so the three unpaged sites get paging for free.

Chunk size is **32** (~2.6 KB/request). Deliberately conservative: `arkd`'s real URL ceiling is unpublished and 16 is the largest batch observed working in the wild, so the measured headroom stays unspent.

`fetchContractVtxosBulk` keeps its per-script map and annotation and only delegates fetching, so its result shape is unchanged.

Not changed: the service-worker history path batches *outpoints* at 100 (~7.7 KB) — same URL budget, different param. It has never 414'd, so it is left as-is with a comment pointing at the shared constant.

## Tests

`test/vtxo-query-chunking.test.ts` — the primitive (chunk boundaries, cross-chunk union, per-chunk page cursor) plus each of the four sites asserting no request exceeds the cap, including the boot-path guard for the failed-construction mode. Verified to fail without the fix.

Full unit suite passes. The 6 failing `migrations.test.ts` SQLite cases are a pre-existing missing native binding in my environment, reproduced on a clean checkout of `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving complete VTXO sets across multiple pages and script-query chunks.
  * Exposed new wallet utilities and query types for advanced VTXO retrieval.
  * Added safeguards to keep script queries within URL size limits.

* **Bug Fixes**
  * Improved pending transaction, contract, and wallet reconciliation to include all matching VTXOs when pagination is required.

* **Tests**
  * Added coverage for chunked queries, pagination, empty inputs, and wallet and contract workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->