### PR TITLE
fix: HD wallets restore

### DIFF
--- a/packages/boltz-swap/package.json
+++ b/packages/boltz-swap/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@arkade-os/boltz-swap",
-    "version": "0.3.53",
+    "version": "0.3.54-rc.0",
     "type": "module",
     "description": "A production-ready TypeScript package that brings Boltz submarine-swaps to Arkade.",
     "main": "./dist/index.js",

--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@arkade-os/sdk",
-    "version": "0.4.48",
+    "version": "0.4.49-rc.0",
     "description": "TypeScript SDK for building Bitcoin wallets using the Arkade protocol",
     "type": "module",
     "main": "./dist/index.cjs",

--- a/packages/ts-sdk/src/contracts/constants.ts
+++ b/packages/ts-sdk/src/contracts/constants.ts
@@ -20,5 +20,10 @@ export const DEFAULT_PAGE_SIZE = 500;
  * `414`s: a few hundred contracts is ~28 KB. 32 keeps a request at ~2.6 KB —
  * well inside any plausible limit, since `arkd`'s real ceiling is unpublished
  * and 16 is the largest batch observed working in the wild.
+ *
+ * Shared by `wallet/vtxo.ts`'s `getAllNormalizedVtxos` and the discovery
+ * handlers' batched `detectUsedScripts` probe (which also gets a 10-index scan
+ * window collapsed into 1-2 requests as a side effect) so the two can't drift
+ * onto different budgets for the same URL constraint.
  */
 export const SCRIPT_QUERY_CHUNK_SIZE = 32;

--- a/packages/ts-sdk/src/contracts/constants.ts
+++ b/packages/ts-sdk/src/contracts/constants.ts
@@ -1,14 +1,24 @@
 /**
  * Default indexer pagination size for batched VTXO queries (`getVtxos`).
  *
- * Shared by {@link ContractManager}'s bulk history sync and the discovery
- * handlers' batched `detectUsedScripts` probe so the two can't drift. It lives
- * in its own leaf module (importing nothing) so both the manager and the
- * handler layer can use it without a `handlers → contractManager` import cycle —
- * contractManager imports the handler registry, so the handlers must not import
- * back from contractManager.
+ * Shared by {@link ContractManager}'s bulk history sync, the discovery
+ * handlers' batched `detectUsedScripts` probe, and `wallet/vtxo.ts`'s chunked
+ * reader so they can't drift. It lives in its own leaf module (importing
+ * nothing) so every layer can use it without a `handlers → contractManager`
+ * import cycle — contractManager imports the handler registry, so the handlers
+ * must not import back from contractManager.
  *
  * Large enough that a single wallet index's candidate scripts resolve in one
  * page in the common case.
  */
 export const DEFAULT_PAGE_SIZE = 500;
+
+/**
+ * Maximum scripts per `getVtxos` query string.
+ *
+ * Scripts cost ~77 bytes each in the URL, so an unbounded wallet-derived list
+ * `414`s: a few hundred contracts is ~28 KB. 32 keeps a request at ~2.6 KB —
+ * well inside any plausible limit, since `arkd`'s real ceiling is unpublished
+ * and 16 is the largest batch observed working in the wild.
+ */
+export const SCRIPT_QUERY_CHUNK_SIZE = 32;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -778,8 +778,15 @@ export class ContractManager implements IContractManager {
      *   can surface hits above the failed index that a serial scan would never
      *   have reached, so a truncated batched scan discovers a superset — never
      *   a subset — of the serial one.
+     * - The whole scan runs inside one coalesced subscription scope, so N
+     *   discovered contracts cost ONE `subscribeForScripts` instead of N
+     *   growing ones (see {@link ContractWatcher.withCoalescedSubscription}).
      */
-    async scanContracts(opts: ScanContractsOptions): Promise<ScanResult> {
+    scanContracts(opts: ScanContractsOptions): Promise<ScanResult> {
+        return this.watcher.withCoalescedSubscription(() => this.runScan(opts));
+    }
+
+    private async runScan(opts: ScanContractsOptions): Promise<ScanResult> {
         const gapLimit = opts.gapLimit ?? 20;
         if (!Number.isInteger(gapLimit) || gapLimit <= 0) {
             throw new Error(

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -19,6 +19,7 @@ import { ContractWatcher, ContractWatcherConfig } from "./contractWatcher";
 import { contractHandlers } from "./handlers";
 import { ExtendedVirtualCoin, Outpoint, VirtualCoin } from "../wallet";
 import {
+    getAllNormalizedVtxos,
     getNormalizedVtxos,
     normalizeVtxo,
     type NormalizedExtendedVirtualCoin,
@@ -1347,13 +1348,13 @@ export class ContractManager implements IContractManager {
      * window (e.g. a spend that hasn't settled yet).
      */
     private async reconcilePendingFrontier(contracts: Contract[]): Promise<void> {
-        const scripts = contracts.map((c) => c.script);
         const scriptToContract = new Map<string, Contract>(contracts.map((c) => [c.script, c]));
 
-        const { vtxos } = await getNormalizedVtxos(this.config.indexerProvider, {
-            scripts,
-            pendingOnly: true,
-        });
+        const vtxos = await getAllNormalizedVtxos(
+            this.config.indexerProvider,
+            contracts.map((c) => c.script),
+            { pendingOnly: true },
+        );
 
         // Share the annotation path with external callers so the two entry
         // points can't drift.
@@ -1446,16 +1447,14 @@ export class ContractManager implements IContractManager {
             return new Map();
         }
 
-        // Batch all scripts into a single indexer call per page to minimise
-        // round-trips. Results are keyed by script so we can distribute them
-        // back to the correct contract afterwards. Always fetches the full
-        // history (spent/swept included) so the repo is the source of truth.
+        // Results are keyed by script so we can distribute them back to the
+        // correct contract afterwards. Always fetches the full history
+        // (spent/swept included) so the repo is the source of truth.
         const scriptToContract = new Map<string, Contract>(contracts.map((c) => [c.script, c]));
         const result = new Map<string, ExtendedContractVtxo[]>(
             contracts.map((c) => [c.script, []]),
         );
 
-        const scripts = contracts.map((c) => c.script);
         const windowOpts = syncWindow
             ? {
                   ...(syncWindow.after !== undefined && {
@@ -1466,33 +1465,24 @@ export class ContractManager implements IContractManager {
                   }),
               }
             : {};
-        let pageIndex = 0;
-        let hasMore = true;
 
-        while (hasMore) {
-            const { vtxos, page } = await getNormalizedVtxos(this.config.indexerProvider, {
-                scripts,
-                ...windowOpts,
-                pageIndex,
-                pageSize,
+        const vtxos = await getAllNormalizedVtxos(
+            this.config.indexerProvider,
+            contracts.map((c) => c.script),
+            { ...windowOpts, pageSize },
+        );
+
+        // Match virtual outputs back to their contract via the script field
+        // populated by the indexer, then share the annotation path with
+        // external callers via annotateVtxos so the two entry points can't
+        // drift.
+        const owned = vtxos.filter((v) => scriptToContract.has(v.script));
+        const annotated = await this.annotateVtxos(owned);
+        for (const vtxo of annotated) {
+            result.get(vtxo.script)!.push({
+                ...vtxo,
+                contractScript: vtxo.script,
             });
-
-            // Match virtual outputs back to their contract via the script field
-            // populated by the indexer, then share the annotation path with
-            // external callers via annotateVtxos so the two entry points can't
-            // drift.
-            const owned = vtxos.filter((v) => scriptToContract.has(v.script));
-            const annotated = await this.annotateVtxos(owned);
-            for (const vtxo of annotated) {
-                result.get(vtxo.script)!.push({
-                    ...vtxo,
-                    contractScript: vtxo.script,
-                });
-            }
-
-            hasMore = page ? vtxos.length === pageSize : false;
-            pageIndex++;
-            if (hasMore) await new Promise((r) => setTimeout(r, 500));
         }
 
         return result;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -7,7 +7,10 @@ import {
     ContractEvent,
     ContractEventCallback,
     ContractState,
+    ContractHandler,
     ContractWithVtxos,
+    Discoverable,
+    DiscoveredContract,
     DiscoveryDeps,
     GetContractsFilter,
     PathContext,
@@ -113,13 +116,31 @@ export type RefreshVtxosOptions = {
 };
 
 /**
- * A single `Discoverable` handler's `discoverAt` rejection, captured during
- * a {@link IContractManager.scanContracts} run instead of aborting the loop.
+ * A single `Discoverable` handler's discovery failure, captured during a
+ * {@link IContractManager.scanContracts} run instead of aborting the loop.
+ *
+ * TODO(next major): rename `index` → `fromIndex` so the pair reads
+ * `fromIndex`/`toIndex`. It stays `index` here only to keep this exported
+ * shape backward-compatible.
  */
 export interface HandlerError {
     handler: string;
+    /** The failed index, or the first index of a failed `discoverRange` window. */
     index: number;
+    /** Inclusive end of a failed `discoverRange` window; absent for a single index. */
+    toIndex?: number;
     error: unknown;
+}
+
+/**
+ * One handler's answer for a whole scan window: hits per index, the indices it
+ * could not answer for, and its failures keyed by the index each is anchored
+ * at (a batched failure anchors at the range's first index).
+ */
+interface HandlerWindowProbe {
+    found: Map<number, DiscoveredContract[]>;
+    indeterminate: Set<number>;
+    errors: Map<number, HandlerError>;
 }
 
 /**
@@ -143,7 +164,7 @@ export interface ScanResult {
      * when the scan closed a genuine gap.
      */
     truncatedAt?: number;
-    /** Per-handler `discoverAt` failures. Non-empty implies `truncatedAt` is set. */
+    /** Per-handler discovery failures. Non-empty implies `truncatedAt` is set. */
     handlerErrors: HandlerError[];
 }
 
@@ -154,11 +175,13 @@ export interface ScanContractsOptions {
     /** Default 20. A non-positive / non-integer value throws. */
     gapLimit?: number;
     /**
-     * Number of HD indices probed concurrently per window (default
-     * {@link DEFAULT_SCAN_BATCH}). Pure latency knob: the gap loop stays
-     * gap-limit bounded and the discovered set is identical regardless of
-     * batch size. A non-positive / non-integer value throws. Ignored when
-     * `hd` is false (the static pass probes only index 0).
+     * Number of HD indices probed per window (default
+     * {@link DEFAULT_SCAN_BATCH}). The gap loop stays gap-limit bounded and
+     * the discovered set is identical regardless of batch size; the window is
+     * also the unit a batching handler ({@link Discoverable.discoverRange})
+     * collapses into one request, so it doubles as the batch width. A
+     * non-positive / non-integer value throws. Ignored when `hd` is false (the
+     * static pass probes only index 0).
      */
     batchSize?: number;
     /** HD mode → unbounded gap loop guided by the gap counter; false → probe only index 0 (single static pass). */
@@ -308,11 +331,12 @@ export interface IContractManager extends Disposable {
      * resets the gap counter, so swap discovery keeps the HD window open.
      *
      * Error contract (safety-critical — see spec §4):
-     * - A handler's `discoverAt` rejecting is **collected** into
-     *   `handlerErrors` and makes its index *indeterminate*: it never
-     *   advances the gap counter, and the scan **stops verifying** there
-     *   rather than closing a window it never observed close. It still
-     *   never throws.
+     * - A handler's discovery rejecting is **collected** into `handlerErrors`
+     *   and makes its index *indeterminate*: it never advances the gap
+     *   counter, and the scan **stops verifying** there rather than closing a
+     *   window it never observed close. A batched
+     *   {@link Discoverable.discoverRange} failure makes its whole requested
+     *   range indeterminate. It still never throws.
      * - A fatal operational error — `materialize()` throwing, or
      *   `createContract` rejecting — **propagates** out of `scanContracts`
      *   (it invalidates the gap-window signal, so a silent truncation
@@ -725,21 +749,27 @@ export class ContractManager implements IContractManager {
      * Safety-critical invariants (spec §2.C / §4):
      * - `opts.materialize(i)` throwing is structural/fatal: it is NOT
      *   wrapped — it propagates and aborts the scan.
-     * - A `discoverAt` rejection is collected into `handlerErrors` and makes
-     *   its index *indeterminate*: it does NOT advance the gap counter, and
-     *   the scan stops verifying there, reporting `truncatedAt`. Only an index
+     * - A discovery rejection is collected into `handlerErrors` and makes its
+     *   index *indeterminate*: it does NOT advance the gap counter, and the
+     *   scan stops verifying there, reporting `truncatedAt`. Only an index
      *   every handler answered for can be a confirmed miss.
      * - `persistAndWatchContract` rejecting is operational/fatal and
-     *   propagates (only `discoverAt` is guarded).
-     * - Within an index the handler probes run concurrently (independent
-     *   network reads); their hits are persisted sequentially in
-     *   `discoverables` order to preserve the first-wins collision tie-break.
-     * - Indices are probed `batchSize` at a time (a second concurrency layer
-     *   over the per-index probes), but each window is CAPPED to
+     *   propagates (only the handler calls are guarded).
+     * - A handler exposing {@link Discoverable.discoverRange} is asked for the
+     *   whole window in ONE call instead of one per index — the batching that
+     *   keeps a large restore from bursting into an operator's rate limiter.
+     *   Its failures are therefore range-wide: every index in the window goes
+     *   indeterminate and truncation lands on the window's first index. Its
+     *   answer must cover every requested index; an incomplete map is treated
+     *   as a rejection (see `Discoverable.discoverRange`).
+     * - Handlers are probed concurrently (independent network reads); their
+     *   hits are persisted sequentially in `discoverables` order to preserve
+     *   the first-wins collision tie-break.
+     * - Indices are probed `batchSize` at a time, but each window is CAPPED to
      *   `gapLimit - unused` indices — the most a serial scan could still reach
      *   before the gap window is guaranteed to close. So every index probed in
      *   a window is one a one-index-at-a-time scan would also reach: nothing is
-     *   over-scanned, nothing is discarded, and `materialize`/`discoverAt` are
+     *   over-scanned, nothing is discarded, and `materialize`/discovery are
      *   invoked on exactly the same index set. The window's hits are still
      *   processed strictly in ascending index order, so the discovered set,
      *   persisted rows, `highestConfirmedUsedIndex`, and `handlerErrors` are
@@ -793,27 +823,81 @@ export class ContractManager implements IContractManager {
         let unused = 0;
         let i = 0;
 
-        // Probe one index's discoverable handlers CONCURRENTLY: they are
-        // independent network reads (indexer / on-chain explorer), so
-        // overlapping them cuts per-index latency. Each probe's try/catch
-        // mirrors the former serial guard, capturing a discoverAt rejection
-        // (or synchronous throw) instead of propagating it, so one failing
-        // handler never aborts the others. Materialization failure is
-        // fatal/structural — it is NOT guarded and propagates.
-        const probeIndex = async (index: number) => {
-            const descriptor = opts.materialize(index);
-            return Promise.all(
-                discoverables.map(async (h) => {
-                    try {
-                        return {
-                            ok: true as const,
-                            found: await h.discoverAt(index, descriptor, opts.deps),
-                        };
-                    } catch (error) {
-                        return { ok: false as const, error };
-                    }
-                }),
-            );
+        // Probe one handler over a whole window. Handlers that batch
+        // (`discoverRange`) answer the window in one round-trip; the rest are
+        // fanned out per index as before. Either way a rejection is captured,
+        // never propagated, so one failing handler cannot abort the others.
+        const probeHandler = async (
+            h: ContractHandler<unknown> & Discoverable,
+            entries: { index: number; descriptor: string }[],
+        ): Promise<HandlerWindowProbe> => {
+            const probe: HandlerWindowProbe = {
+                found: new Map(),
+                indeterminate: new Set(),
+                // Keyed by the index the failure is ANCHORED at, so errors stay
+                // reported in ascending-index order below, exactly as the
+                // per-index path reports them.
+                errors: new Map(),
+            };
+
+            if (!h.discoverRange) {
+                await Promise.all(
+                    entries.map(async ({ index, descriptor }) => {
+                        try {
+                            probe.found.set(
+                                index,
+                                await h.discoverAt(index, descriptor, opts.deps),
+                            );
+                        } catch (error) {
+                            probe.indeterminate.add(index);
+                            probe.errors.set(index, { handler: h.type, index, error });
+                        }
+                    }),
+                );
+                return probe;
+            }
+
+            const from = entries[0].index;
+            const to = entries[entries.length - 1].index;
+            // A batched failure is coarser than a per-index one: the whole
+            // requested range goes indeterminate, so the scan truncates at its
+            // first index. That is the accepted price of batching — retry is
+            // idempotent.
+            const failRange = (error: unknown) => {
+                for (const e of entries) probe.indeterminate.add(e.index);
+                probe.errors.set(from, {
+                    handler: h.type,
+                    index: from,
+                    ...(to > from && { toIndex: to }),
+                    error,
+                });
+            };
+
+            let ranged: Map<number, DiscoveredContract[]>;
+            try {
+                ranged = await h.discoverRange(entries, opts.deps);
+            } catch (error) {
+                failRange(error);
+                return probe;
+            }
+
+            for (const e of entries) {
+                const found = ranged.get(e.index);
+                if (found) probe.found.set(e.index, found);
+            }
+            // Enforce the coverage contract rather than trusting it: reading an
+            // absent index as "nothing here" would turn a third-party
+            // handler's bug into a silently under-reported restore. Hits it did
+            // return are affirmative data and are kept.
+            const missing = entries.find((e) => !ranged.has(e.index));
+            if (missing) {
+                failRange(
+                    new Error(
+                        `${h.type}.discoverRange resolved without index ${missing.index} of the requested range [${from}..${to}]`,
+                    ),
+                );
+            }
+            return probe;
         };
 
         while (i <= maxIdx && unused < gapLimit) {
@@ -825,9 +909,17 @@ export class ContractManager implements IContractManager {
             // reach — nothing is over-scanned or discarded, and the discovered
             // set stays byte-for-byte identical to the serial path.
             const windowEnd = Math.min(maxIdx, i + Math.min(batchSize, gapLimit - unused) - 1);
-            const windowIndices: number[] = [];
-            for (let idx = i; idx <= windowEnd; idx++) windowIndices.push(idx);
-            const windowProbes = await Promise.all(windowIndices.map(probeIndex));
+            const entries: { index: number; descriptor: string }[] = [];
+            // Materialize ascending and up front: a throw here is
+            // structural/fatal and must propagate before any probe is issued.
+            for (let idx = i; idx <= windowEnd; idx++) {
+                entries.push({ index: idx, descriptor: opts.materialize(idx) });
+            }
+            // Handlers run CONCURRENTLY — independent network reads (indexer /
+            // on-chain explorer), so overlapping them cuts window latency.
+            const windowProbes = await Promise.all(
+                discoverables.map((h) => probeHandler(h, entries)),
+            );
 
             // Process the window strictly in ASCENDING index order, and within
             // each index persist in the original `discoverables` order — that
@@ -835,23 +927,14 @@ export class ContractManager implements IContractManager {
             // default/delegate), so it must not be reordered. Only the I/O
             // above overlapped. A persistAndWatchContract rejection stays
             // operational/fatal (unguarded), matching the materialize contract.
-            for (let w = 0; w < windowIndices.length; w++) {
-                const index = windowIndices[w];
-                const probes = windowProbes[w];
+            for (const { index } of entries) {
                 let hitAtThisIndex = false;
                 let indeterminate = false;
-                for (let h = 0; h < discoverables.length; h++) {
-                    const probe = probes[h];
-                    if (!probe.ok) {
-                        handlerErrors.push({
-                            handler: discoverables[h].type,
-                            index,
-                            error: probe.error,
-                        });
-                        indeterminate = true;
-                        continue;
-                    }
-                    for (const c of probe.found) {
+                for (const probe of windowProbes) {
+                    const error = probe.errors.get(index);
+                    if (error) handlerErrors.push(error);
+                    if (probe.indeterminate.has(index)) indeterminate = true;
+                    for (const c of probe.found.get(index) ?? []) {
                         await this.persistAndWatchContract(c); // idempotent (script-keyed)
                         hitAtThisIndex = true;
                     }

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -563,9 +563,14 @@ export class ContractWatcher {
      * running), and every subscribe posts the *whole* accumulated script list —
      * so a restore scan that discovers N contracts sends N growing POSTs,
      * quadratic in script-slots. Inside this scope those updates are only
-     * marked dirty; the flush is guaranteed on both the success and the error
-     * path, and the failsafe poll covers the window where a just-added contract
-     * is not yet streaming.
+     * marked dirty, flushed once on the way out (success and error path alike).
+     *
+     * A contract added inside the scope is therefore not streaming until the
+     * flush. Nothing in the watcher closes that window — the failsafe poll
+     * replays repository state and cannot see VTXOs no one has fetched yet. The
+     * one caller, `scanContracts`, is covered because `Wallet.restore` follows
+     * it with a bulk `refreshVtxos`. A new caller must provide its own
+     * equivalent catch-up, or keep the scope short enough not to need one.
      */
     async withCoalescedSubscription<T>(fn: () => Promise<T>): Promise<T> {
         this.subscriptionBatchDepth++;

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -140,6 +140,9 @@ export class ContractWatcher {
     private reconnectAttempts = 0;
     private reconnectTimeoutId?: ReturnType<typeof setTimeout>;
     private failsafePollIntervalId?: ReturnType<typeof setInterval>;
+    /** See {@link withCoalescedSubscription}. */
+    private subscriptionBatchDepth = 0;
+    private subscriptionUpdateDeferred = false;
 
     /**
      * Create a contract watcher with the given providers and polling settings.
@@ -552,7 +555,38 @@ export class ContractWatcher {
         }
     }
 
+    /**
+     * Run `fn` with subscription updates coalesced into a single
+     * `subscribeForScripts` on the way out.
+     *
+     * {@link addContract} re-subscribes eagerly (the watcher may already be
+     * running), and every subscribe posts the *whole* accumulated script list —
+     * so a restore scan that discovers N contracts sends N growing POSTs,
+     * quadratic in script-slots. Inside this scope those updates are only
+     * marked dirty; the flush is guaranteed on both the success and the error
+     * path, and the failsafe poll covers the window where a just-added contract
+     * is not yet streaming.
+     */
+    async withCoalescedSubscription<T>(fn: () => Promise<T>): Promise<T> {
+        this.subscriptionBatchDepth++;
+        try {
+            return await fn();
+        } finally {
+            this.subscriptionBatchDepth--;
+            if (this.subscriptionBatchDepth === 0 && this.subscriptionUpdateDeferred) {
+                this.subscriptionUpdateDeferred = false;
+                // Never throws (see tryUpdateSubscription), so a flush cannot
+                // mask an error `fn` was already rejecting with.
+                if (this.isWatching) await this.tryUpdateSubscription();
+            }
+        }
+    }
+
     private async tryUpdateSubscription() {
+        if (this.subscriptionBatchDepth > 0) {
+            this.subscriptionUpdateDeferred = true;
+            return;
+        }
         const hadSubscription = this.subscriptionId !== undefined;
         try {
             await this.updateSubscription();

--- a/packages/ts-sdk/src/contracts/handlers/boarding.ts
+++ b/packages/ts-sdk/src/contracts/handlers/boarding.ts
@@ -5,7 +5,7 @@ import type { DiscoveredContract, DiscoveryDeps } from "../types";
 import { DefaultContractHandler, DefaultContractParams } from "./default";
 import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
 import { timelockToSequence } from "../../utils/timelock";
-import { WALLET_RECEIVE_SOURCE } from "../metadata";
+import { rotatedReceiveMetadata } from "./helpers";
 
 /**
  * Typed parameters for boarding contracts.
@@ -172,14 +172,7 @@ export const BoardingContractHandler: ContractHandler<BoardingContractParams, De
                 // newest boarding address and descriptor-aware signing can
                 // recover the per-index key (plan §6-II/§6-III.3). The index-0
                 // baseline stays untagged, matching `default`/`delegate`.
-                ...(index > 0
-                    ? {
-                          metadata: {
-                              source: WALLET_RECEIVE_SOURCE,
-                              signingDescriptor: descriptor,
-                          },
-                      }
-                    : {}),
+                ...rotatedReceiveMetadata(index, descriptor),
             },
         ];
     },

--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -3,7 +3,7 @@ import { DefaultVtxo } from "../../script/default";
 import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
-import { isCsvSpendable, detectUsedScripts } from "./helpers";
+import { isCsvSpendable, discoverIndexerCandidates } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 import {
     normalizeToDescriptor,
@@ -144,68 +144,73 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
         descriptor: string,
         deps: DiscoveryDeps,
     ): Promise<DiscoveredContract[]> {
-        const pubKey = deriveDescriptorLeafPubKey(descriptor);
-        // Build the candidate set for this wallet index: the current signer
-        // first, then any deprecated signers (so a VTXO minted under a
-        // now-rotated server key is still discovered), each crossed with the
-        // CSV-timelock matrix. Dedup by scriptHex — a deprecated signer that
-        // produced no rotation yields the same scripts as the current key, so
-        // it must neither be probed nor emitted twice; the current signer wins
-        // the attribution.
-        const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
-        const seen = new Set<string>();
-        const candidates: {
-            serverPubKey: Uint8Array;
-            csvTimelock: RelativeTimelock;
-            script: DefaultVtxo.Script;
-            scriptHex: string;
-        }[] = [];
-        for (const serverPubKey of signers) {
-            for (const csvTimelock of deps.csvTimelocks) {
-                const script = new DefaultVtxo.Script({
-                    pubKey,
-                    serverPubKey,
-                    csvTimelock,
-                });
-                const scriptHex = hex.encode(script.pkScript);
-                if (seen.has(scriptHex)) continue;
-                seen.add(scriptHex);
-                candidates.push({ serverPubKey, csvTimelock, script, scriptHex });
-            }
-        }
-
-        // One batched indexer query over every candidate, instead of one call
-        // per (signer × CSV) variant.
-        const used = await detectUsedScripts(
-            deps.indexerProvider,
-            candidates.map((c) => c.scriptHex),
-        );
-
-        const out: DiscoveredContract[] = [];
-        for (const c of candidates) {
-            if (!used.has(c.scriptHex)) continue;
-            // The matched signer is threaded through the script (already built),
-            // the persisted params, and the encoded address so signing/forfeit
-            // later resolves the right key.
-            out.push({
-                type: "default",
-                params: {
-                    pubKey: hex.encode(pubKey),
-                    serverPubKey: hex.encode(c.serverPubKey),
-                    csvTimelock: timelockToSequence(c.csvTimelock).toString(),
-                },
-                script: c.scriptHex,
-                address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
-                ...(index > 0
-                    ? {
-                          metadata: {
-                              source: WALLET_RECEIVE_SOURCE,
-                              signingDescriptor: descriptor,
-                          },
-                      }
-                    : {}),
-            });
-        }
-        return out;
+        return (await discoverDefaultRange([{ index, descriptor }], deps)).get(index) ?? [];
     },
+
+    discoverRange: discoverDefaultRange,
 };
+
+/**
+ * Candidate scripts for one wallet index: the current signer first, then any
+ * deprecated signers (so a VTXO minted under a now-rotated server key is still
+ * discovered), each crossed with the CSV-timelock matrix. Dedup by scriptHex —
+ * a deprecated signer that produced no rotation yields the same scripts as the
+ * current key, so it must neither be probed nor emitted twice; the current
+ * signer wins the attribution.
+ */
+function buildDefaultCandidates(descriptor: string, deps: DiscoveryDeps): DefaultCandidate[] {
+    const pubKey = deriveDescriptorLeafPubKey(descriptor);
+    const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
+    const seen = new Set<string>();
+    const candidates: DefaultCandidate[] = [];
+    for (const serverPubKey of signers) {
+        for (const csvTimelock of deps.csvTimelocks) {
+            const script = new DefaultVtxo.Script({ pubKey, serverPubKey, csvTimelock });
+            const scriptHex = hex.encode(script.pkScript);
+            if (seen.has(scriptHex)) continue;
+            seen.add(scriptHex);
+            candidates.push({ pubKey, serverPubKey, csvTimelock, script, scriptHex });
+        }
+    }
+    return candidates;
+}
+
+interface DefaultCandidate {
+    pubKey: Uint8Array;
+    serverPubKey: Uint8Array;
+    csvTimelock: RelativeTimelock;
+    script: DefaultVtxo.Script;
+    scriptHex: string;
+}
+
+function discoverDefaultRange(
+    entries: readonly { index: number; descriptor: string }[],
+    deps: DiscoveryDeps,
+): Promise<Map<number, DiscoveredContract[]>> {
+    return discoverIndexerCandidates(
+        deps.indexerProvider,
+        entries,
+        (_index, descriptor) => buildDefaultCandidates(descriptor, deps),
+        // The matched signer is threaded through the script (already built),
+        // the persisted params, and the encoded address so signing/forfeit
+        // later resolves the right key.
+        (c, index, descriptor) => ({
+            type: "default",
+            params: {
+                pubKey: hex.encode(c.pubKey),
+                serverPubKey: hex.encode(c.serverPubKey),
+                csvTimelock: timelockToSequence(c.csvTimelock).toString(),
+            },
+            script: c.scriptHex,
+            address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
+            ...(index > 0
+                ? {
+                      metadata: {
+                          source: WALLET_RECEIVE_SOURCE,
+                          signingDescriptor: descriptor,
+                      },
+                  }
+                : {}),
+        }),
+    );
+}

--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -3,14 +3,16 @@ import { DefaultVtxo } from "../../script/default";
 import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
-import { isCsvSpendable, discoverIndexerCandidates } from "./helpers";
-import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 import {
-    normalizeToDescriptor,
-    extractPubKey,
-    deriveDescriptorLeafPubKey,
-} from "../../identity/descriptor";
-import { WALLET_RECEIVE_SOURCE } from "../metadata";
+    isCsvSpendable,
+    discoverIndexerCandidates,
+    discoverAtViaRange,
+    extractPubKeyBytes,
+    deserializeCsvTimelock,
+    rotatedReceiveMetadata,
+} from "./helpers";
+import { timelockToSequence } from "../../utils/timelock";
+import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
 
 /**
  * Typed parameters for DefaultVtxo contracts.
@@ -19,13 +21,6 @@ export interface DefaultContractParams {
     pubKey: Uint8Array;
     serverPubKey: Uint8Array;
     csvTimelock: RelativeTimelock;
-}
-
-/**
- * Extract pubkey bytes from a descriptor or hex string.
- */
-function extractPubKeyBytes(value: string): Uint8Array {
-    return hex.decode(extractPubKey(normalizeToDescriptor(value)));
 }
 
 /**
@@ -53,18 +48,10 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
     },
 
     deserializeParams(params: Record<string, string>): DefaultContractParams {
-        // csvTimelock may be absent on legacy/minimal params (e.g. hex pubkeys
-        // with no timelock). DefaultVtxo.Script no longer applies its own
-        // fallback, so restore it here rather than feeding sequenceToTimelock
-        // a NaN (which silently decodes to a zero timelock).
-        const csvTimelock =
-            params.csvTimelock !== undefined && params.csvTimelock !== ""
-                ? sequenceToTimelock(Number(params.csvTimelock))
-                : DefaultVtxo.Script.DEFAULT_TIMELOCK;
         return {
             pubKey: extractPubKeyBytes(params.pubKey),
             serverPubKey: extractPubKeyBytes(params.serverPubKey),
-            csvTimelock,
+            csvTimelock: deserializeCsvTimelock(params.csvTimelock),
         };
     },
 
@@ -139,13 +126,7 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
         return paths;
     },
 
-    async discoverAt(
-        index: number,
-        descriptor: string,
-        deps: DiscoveryDeps,
-    ): Promise<DiscoveredContract[]> {
-        return (await discoverDefaultRange([{ index, descriptor }], deps)).get(index) ?? [];
-    },
+    discoverAt: discoverAtViaRange(discoverDefaultRange),
 
     discoverRange: discoverDefaultRange,
 };
@@ -203,14 +184,7 @@ function discoverDefaultRange(
             },
             script: c.scriptHex,
             address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
-            ...(index > 0
-                ? {
-                      metadata: {
-                          source: WALLET_RECEIVE_SOURCE,
-                          signingDescriptor: descriptor,
-                      },
-                  }
-                : {}),
+            ...rotatedReceiveMetadata(index, descriptor),
         }),
     );
 }

--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -4,15 +4,17 @@ import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
 import {
-    isCsvSpendable,
     discoverIndexerCandidates,
     discoverAtViaRange,
     extractPubKeyBytes,
     deserializeCsvTimelock,
     rotatedReceiveMetadata,
+    buildSignerTimelockCandidates,
+    selectForfeitOrExitPath,
+    forfeitExitAllPaths,
+    forfeitExitSpendablePaths,
 } from "./helpers";
 import { timelockToSequence } from "../../utils/timelock";
-import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
 
 /**
  * Typed parameters for DefaultVtxo contracts.
@@ -60,22 +62,7 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
         contract: Contract,
         context: PathContext,
     ): PathSelection | null {
-        if (context.collaborative) {
-            // Use forfeit path for collaborative spending
-            return { leaf: script.forfeit() };
-        }
-
-        // Use exit path for unilateral exit (only if CSV is satisfied)
-        const sequence = contract.params.csvTimelock
-            ? Number(contract.params.csvTimelock)
-            : undefined;
-        if (!isCsvSpendable(context, sequence)) {
-            return null;
-        }
-        return {
-            leaf: script.exit(),
-            sequence,
-        };
+        return selectForfeitOrExitPath(script, contract, context);
     },
 
     getAllSpendingPaths(
@@ -83,21 +70,7 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
         contract: Contract,
         context: PathContext,
     ): PathSelection[] {
-        const paths: PathSelection[] = [];
-
-        // Forfeit path available with server cooperation
-        if (context.collaborative) {
-            paths.push({ leaf: script.forfeit() });
-        }
-
-        // Exit path always possible (CSV checked at tx time)
-        const exitPath: PathSelection = { leaf: script.exit() };
-        if (contract.params.csvTimelock) {
-            exitPath.sequence = Number(contract.params.csvTimelock);
-        }
-        paths.push(exitPath);
-
-        return paths;
+        return forfeitExitAllPaths(script, contract, context);
     },
 
     getSpendablePaths(
@@ -105,64 +78,13 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
         contract: Contract,
         context: PathContext,
     ): PathSelection[] {
-        const paths: PathSelection[] = [];
-
-        if (context.collaborative) {
-            paths.push({ leaf: script.forfeit() });
-        }
-
-        const exitSequence = contract.params.csvTimelock
-            ? Number(contract.params.csvTimelock)
-            : undefined;
-
-        if (isCsvSpendable(context, exitSequence)) {
-            const exitPath: PathSelection = { leaf: script.exit() };
-            if (exitSequence !== undefined) {
-                exitPath.sequence = exitSequence;
-            }
-            paths.push(exitPath);
-        }
-
-        return paths;
+        return forfeitExitSpendablePaths(script, contract, context);
     },
 
     discoverAt: discoverAtViaRange(discoverDefaultRange),
 
     discoverRange: discoverDefaultRange,
 };
-
-/**
- * Candidate scripts for one wallet index: the current signer first, then any
- * deprecated signers (so a VTXO minted under a now-rotated server key is still
- * discovered), each crossed with the CSV-timelock matrix. Dedup by scriptHex —
- * a deprecated signer that produced no rotation yields the same scripts as the
- * current key, so it must neither be probed nor emitted twice; the current
- * signer wins the attribution.
- */
-function buildDefaultCandidates(descriptor: string, deps: DiscoveryDeps): DefaultCandidate[] {
-    const pubKey = deriveDescriptorLeafPubKey(descriptor);
-    const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
-    const seen = new Set<string>();
-    const candidates: DefaultCandidate[] = [];
-    for (const serverPubKey of signers) {
-        for (const csvTimelock of deps.csvTimelocks) {
-            const script = new DefaultVtxo.Script({ pubKey, serverPubKey, csvTimelock });
-            const scriptHex = hex.encode(script.pkScript);
-            if (seen.has(scriptHex)) continue;
-            seen.add(scriptHex);
-            candidates.push({ pubKey, serverPubKey, csvTimelock, script, scriptHex });
-        }
-    }
-    return candidates;
-}
-
-interface DefaultCandidate {
-    pubKey: Uint8Array;
-    serverPubKey: Uint8Array;
-    csvTimelock: RelativeTimelock;
-    script: DefaultVtxo.Script;
-    scriptHex: string;
-}
 
 function discoverDefaultRange(
     entries: readonly { index: number; descriptor: string }[],
@@ -171,7 +93,8 @@ function discoverDefaultRange(
     return discoverIndexerCandidates(
         deps.indexerProvider,
         entries,
-        (_index, descriptor) => buildDefaultCandidates(descriptor, deps),
+        (_index, descriptor) =>
+            buildSignerTimelockCandidates(descriptor, deps, (opts) => new DefaultVtxo.Script(opts)),
         // The matched signer is threaded through the script (already built),
         // the persisted params, and the encoded address so signing/forfeit
         // later resolves the right key.

--- a/packages/ts-sdk/src/contracts/handlers/delegate.ts
+++ b/packages/ts-sdk/src/contracts/handlers/delegate.ts
@@ -4,15 +4,17 @@ import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
 import {
-    isCsvSpendable,
     discoverIndexerCandidates,
     discoverAtViaRange,
     extractPubKeyBytes,
     deserializeCsvTimelock,
     rotatedReceiveMetadata,
+    buildSignerTimelockCandidates,
+    selectForfeitOrExitPath,
+    forfeitExitAllPaths,
+    forfeitExitSpendablePaths,
 } from "./helpers";
 import { timelockToSequence } from "../../utils/timelock";
-import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
 
 /**
  * Typed parameters for DelegateVtxo contracts.
@@ -64,20 +66,7 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
         contract: Contract,
         context: PathContext,
     ): PathSelection | null {
-        if (context.collaborative) {
-            return { leaf: script.forfeit() };
-        }
-
-        const sequence = contract.params.csvTimelock
-            ? Number(contract.params.csvTimelock)
-            : undefined;
-        if (!isCsvSpendable(context, sequence)) {
-            return null;
-        }
-        return {
-            leaf: script.exit(),
-            sequence,
-        };
+        return selectForfeitOrExitPath(script, contract, context);
     },
 
     getAllSpendingPaths(
@@ -85,24 +74,12 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
         contract: Contract,
         context: PathContext,
     ): PathSelection[] {
-        const paths: PathSelection[] = [];
-
-        if (context.collaborative) {
-            paths.push({ leaf: script.forfeit() });
-        }
-
-        const exitPath: PathSelection = { leaf: script.exit() };
-        if (contract.params.csvTimelock) {
-            exitPath.sequence = Number(contract.params.csvTimelock);
-        }
-        paths.push(exitPath);
-
-        // Delegate path (Alice + Delegate + Server) — collaborative only
-        if (context.collaborative) {
-            paths.push({ leaf: script.delegate() });
-        }
-
-        return paths;
+        return [
+            ...forfeitExitAllPaths(script, contract, context),
+            // Delegate path (Alice + Delegate + Server) — collaborative only,
+            // and last so the shared forfeit/exit ordering is unchanged.
+            ...(context.collaborative ? [{ leaf: script.delegate() }] : []),
+        ];
     },
 
     getSpendablePaths(
@@ -110,25 +87,7 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
         contract: Contract,
         context: PathContext,
     ): PathSelection[] {
-        const paths: PathSelection[] = [];
-
-        if (context.collaborative) {
-            paths.push({ leaf: script.forfeit() });
-        }
-
-        const exitSequence = contract.params.csvTimelock
-            ? Number(contract.params.csvTimelock)
-            : undefined;
-
-        if (isCsvSpendable(context, exitSequence)) {
-            const exitPath: PathSelection = { leaf: script.exit() };
-            if (exitSequence !== undefined) {
-                exitPath.sequence = exitSequence;
-            }
-            paths.push(exitPath);
-        }
-
-        return paths;
+        return forfeitExitSpendablePaths(script, contract, context);
     },
 
     discoverAt: discoverAtViaRange(discoverDelegateRange),
@@ -136,69 +95,28 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
     discoverRange: discoverDelegateRange,
 };
 
-interface DelegateCandidate {
-    pubKey: Uint8Array;
-    serverPubKey: Uint8Array;
-    delegatePubKey: Uint8Array;
-    csvTimelock: RelativeTimelock;
-    script: DelegateVtxo.Script;
-    scriptHex: string;
-}
-
-/**
- * Candidate scripts for one wallet index: current signer first, then any
- * deprecated signers, each crossed with the CSV-timelock matrix (see
- * `DefaultContractHandler` for the rationale). Dedup by scriptHex so a
- * non-rotating signer is neither probed nor emitted twice; the current signer
- * wins the attribution.
- */
-function buildDelegateCandidates(
-    descriptor: string,
-    deps: DiscoveryDeps & { delegatePubKey: Uint8Array },
-): DelegateCandidate[] {
-    const pubKey = deriveDescriptorLeafPubKey(descriptor);
-    const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
-    const seen = new Set<string>();
-    const candidates: DelegateCandidate[] = [];
-    for (const serverPubKey of signers) {
-        for (const csvTimelock of deps.csvTimelocks) {
-            const script = new DelegateVtxo.Script({
-                pubKey,
-                serverPubKey,
-                delegatePubKey: deps.delegatePubKey,
-                csvTimelock,
-            });
-            const scriptHex = hex.encode(script.pkScript);
-            if (seen.has(scriptHex)) continue;
-            seen.add(scriptHex);
-            candidates.push({
-                pubKey,
-                serverPubKey,
-                delegatePubKey: deps.delegatePubKey,
-                csvTimelock,
-                script,
-                scriptHex,
-            });
-        }
-    }
-    return candidates;
-}
-
 function discoverDelegateRange(
     entries: readonly { index: number; descriptor: string }[],
     deps: DiscoveryDeps,
 ): Promise<Map<number, DiscoveredContract[]>> {
     // Not a delegate wallet: still answer for every requested index, since an
     // omission would read as indeterminate and truncate the scan.
-    if (!deps.delegatePubKey) {
+    const delegatePubKey = deps.delegatePubKey;
+    if (!delegatePubKey) {
         return Promise.resolve(new Map(entries.map((e) => [e.index, []])));
     }
-    const delegateDeps = { ...deps, delegatePubKey: deps.delegatePubKey };
 
     return discoverIndexerCandidates(
         deps.indexerProvider,
         entries,
-        (_index, descriptor) => buildDelegateCandidates(descriptor, delegateDeps),
+        // The delegate key is constant across the cross-product, so it rides
+        // the closure rather than being repeated on every candidate.
+        (_index, descriptor) =>
+            buildSignerTimelockCandidates(
+                descriptor,
+                deps,
+                (opts) => new DelegateVtxo.Script({ ...opts, delegatePubKey }),
+            ),
         // The matched signer is threaded through script, params, and address so
         // signing/forfeit later resolves the right key.
         (c, index, descriptor) => ({
@@ -206,7 +124,7 @@ function discoverDelegateRange(
             params: {
                 pubKey: hex.encode(c.pubKey),
                 serverPubKey: hex.encode(c.serverPubKey),
-                delegatePubKey: hex.encode(c.delegatePubKey),
+                delegatePubKey: hex.encode(delegatePubKey),
                 csvTimelock: timelockToSequence(c.csvTimelock).toString(),
             },
             script: c.scriptHex,

--- a/packages/ts-sdk/src/contracts/handlers/delegate.ts
+++ b/packages/ts-sdk/src/contracts/handlers/delegate.ts
@@ -3,7 +3,7 @@ import { DelegateVtxo } from "../../script/delegate";
 import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
-import { isCsvSpendable, detectUsedScripts } from "./helpers";
+import { isCsvSpendable, discoverIndexerCandidates } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../metadata";
@@ -131,68 +131,95 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
         descriptor: string,
         deps: DiscoveryDeps,
     ): Promise<DiscoveredContract[]> {
-        if (!deps.delegatePubKey) return [];
-        const pubKey = deriveDescriptorLeafPubKey(descriptor);
-        // Build the candidate set: current signer first, then any deprecated
-        // signers, each crossed with the CSV-timelock matrix (see
-        // DefaultContractHandler.discoverAt for the rationale). Dedup by
-        // scriptHex so a non-rotating signer is neither probed nor emitted
-        // twice; the current signer wins the attribution.
-        const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
-        const seen = new Set<string>();
-        const candidates: {
-            serverPubKey: Uint8Array;
-            csvTimelock: RelativeTimelock;
-            script: DelegateVtxo.Script;
-            scriptHex: string;
-        }[] = [];
-        for (const serverPubKey of signers) {
-            for (const csvTimelock of deps.csvTimelocks) {
-                const script = new DelegateVtxo.Script({
-                    pubKey,
-                    serverPubKey,
-                    delegatePubKey: deps.delegatePubKey,
-                    csvTimelock,
-                });
-                const scriptHex = hex.encode(script.pkScript);
-                if (seen.has(scriptHex)) continue;
-                seen.add(scriptHex);
-                candidates.push({ serverPubKey, csvTimelock, script, scriptHex });
-            }
-        }
+        return (await discoverDelegateRange([{ index, descriptor }], deps)).get(index) ?? [];
+    },
 
-        // One batched indexer query over every candidate, instead of one call
-        // per (signer × CSV) variant.
-        const used = await detectUsedScripts(
-            deps.indexerProvider,
-            candidates.map((c) => c.scriptHex),
-        );
+    discoverRange: discoverDelegateRange,
+};
 
-        const out: DiscoveredContract[] = [];
-        for (const c of candidates) {
-            if (!used.has(c.scriptHex)) continue;
-            // The matched signer is threaded through script, params, and
-            // address so signing/forfeit later resolves the right key.
-            out.push({
-                type: "delegate",
-                params: {
-                    pubKey: hex.encode(pubKey),
-                    serverPubKey: hex.encode(c.serverPubKey),
-                    delegatePubKey: hex.encode(deps.delegatePubKey),
-                    csvTimelock: timelockToSequence(c.csvTimelock).toString(),
-                },
-                script: c.scriptHex,
-                address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
-                ...(index > 0
-                    ? {
-                          metadata: {
-                              source: WALLET_RECEIVE_SOURCE,
-                              signingDescriptor: descriptor,
-                          },
-                      }
-                    : {}),
+interface DelegateCandidate {
+    pubKey: Uint8Array;
+    serverPubKey: Uint8Array;
+    delegatePubKey: Uint8Array;
+    csvTimelock: RelativeTimelock;
+    script: DelegateVtxo.Script;
+    scriptHex: string;
+}
+
+/**
+ * Candidate scripts for one wallet index: current signer first, then any
+ * deprecated signers, each crossed with the CSV-timelock matrix (see
+ * `DefaultContractHandler` for the rationale). Dedup by scriptHex so a
+ * non-rotating signer is neither probed nor emitted twice; the current signer
+ * wins the attribution.
+ */
+function buildDelegateCandidates(
+    descriptor: string,
+    deps: DiscoveryDeps & { delegatePubKey: Uint8Array },
+): DelegateCandidate[] {
+    const pubKey = deriveDescriptorLeafPubKey(descriptor);
+    const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
+    const seen = new Set<string>();
+    const candidates: DelegateCandidate[] = [];
+    for (const serverPubKey of signers) {
+        for (const csvTimelock of deps.csvTimelocks) {
+            const script = new DelegateVtxo.Script({
+                pubKey,
+                serverPubKey,
+                delegatePubKey: deps.delegatePubKey,
+                csvTimelock,
+            });
+            const scriptHex = hex.encode(script.pkScript);
+            if (seen.has(scriptHex)) continue;
+            seen.add(scriptHex);
+            candidates.push({
+                pubKey,
+                serverPubKey,
+                delegatePubKey: deps.delegatePubKey,
+                csvTimelock,
+                script,
+                scriptHex,
             });
         }
-        return out;
-    },
-};
+    }
+    return candidates;
+}
+
+function discoverDelegateRange(
+    entries: readonly { index: number; descriptor: string }[],
+    deps: DiscoveryDeps,
+): Promise<Map<number, DiscoveredContract[]>> {
+    // Not a delegate wallet: still answer for every requested index, since an
+    // omission would read as indeterminate and truncate the scan.
+    if (!deps.delegatePubKey) {
+        return Promise.resolve(new Map(entries.map((e) => [e.index, []])));
+    }
+    const delegateDeps = { ...deps, delegatePubKey: deps.delegatePubKey };
+
+    return discoverIndexerCandidates(
+        deps.indexerProvider,
+        entries,
+        (_index, descriptor) => buildDelegateCandidates(descriptor, delegateDeps),
+        // The matched signer is threaded through script, params, and address so
+        // signing/forfeit later resolves the right key.
+        (c, index, descriptor) => ({
+            type: "delegate",
+            params: {
+                pubKey: hex.encode(c.pubKey),
+                serverPubKey: hex.encode(c.serverPubKey),
+                delegatePubKey: hex.encode(c.delegatePubKey),
+                csvTimelock: timelockToSequence(c.csvTimelock).toString(),
+            },
+            script: c.scriptHex,
+            address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
+            ...(index > 0
+                ? {
+                      metadata: {
+                          source: WALLET_RECEIVE_SOURCE,
+                          signingDescriptor: descriptor,
+                      },
+                  }
+                : {}),
+        }),
+    );
+}

--- a/packages/ts-sdk/src/contracts/handlers/delegate.ts
+++ b/packages/ts-sdk/src/contracts/handlers/delegate.ts
@@ -3,10 +3,16 @@ import { DelegateVtxo } from "../../script/delegate";
 import { RelativeTimelock } from "../../script/tapscript";
 import { Contract, ContractHandler, Discoverable, PathContext, PathSelection } from "../types";
 import type { DiscoveredContract, DiscoveryDeps } from "../types";
-import { isCsvSpendable, discoverIndexerCandidates } from "./helpers";
-import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
+import {
+    isCsvSpendable,
+    discoverIndexerCandidates,
+    discoverAtViaRange,
+    extractPubKeyBytes,
+    deserializeCsvTimelock,
+    rotatedReceiveMetadata,
+} from "./helpers";
+import { timelockToSequence } from "../../utils/timelock";
 import { deriveDescriptorLeafPubKey } from "../../identity/descriptor";
-import { WALLET_RECEIVE_SOURCE } from "../metadata";
 
 /**
  * Typed parameters for DelegateVtxo contracts.
@@ -45,12 +51,11 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
     },
 
     deserializeParams(params: Record<string, string>): DelegateContractParams {
-        const csvTimelock = sequenceToTimelock(Number(params.csvTimelock));
         return {
-            pubKey: hex.decode(params.pubKey),
-            serverPubKey: hex.decode(params.serverPubKey),
-            delegatePubKey: hex.decode(params.delegatePubKey),
-            csvTimelock,
+            pubKey: extractPubKeyBytes(params.pubKey),
+            serverPubKey: extractPubKeyBytes(params.serverPubKey),
+            delegatePubKey: extractPubKeyBytes(params.delegatePubKey),
+            csvTimelock: deserializeCsvTimelock(params.csvTimelock),
         };
     },
 
@@ -126,13 +131,7 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
         return paths;
     },
 
-    async discoverAt(
-        index: number,
-        descriptor: string,
-        deps: DiscoveryDeps,
-    ): Promise<DiscoveredContract[]> {
-        return (await discoverDelegateRange([{ index, descriptor }], deps)).get(index) ?? [];
-    },
+    discoverAt: discoverAtViaRange(discoverDelegateRange),
 
     discoverRange: discoverDelegateRange,
 };
@@ -212,14 +211,7 @@ function discoverDelegateRange(
             },
             script: c.scriptHex,
             address: c.script.address(deps.network.hrp, c.serverPubKey).encode(),
-            ...(index > 0
-                ? {
-                      metadata: {
-                          source: WALLET_RECEIVE_SOURCE,
-                          signingDescriptor: descriptor,
-                      },
-                  }
-                : {}),
+            ...rotatedReceiveMetadata(index, descriptor),
         }),
     );
 }

--- a/packages/ts-sdk/src/contracts/handlers/helpers.ts
+++ b/packages/ts-sdk/src/contracts/handlers/helpers.ts
@@ -1,8 +1,13 @@
+import { hex } from "@scure/base";
 import { sequenceToTimelock } from "../../utils/timelock";
 import { Contract, DiscoveredContract, PathContext } from "../types";
-import { isDescriptor, extractPubKey } from "../../identity/descriptor";
+import type { Discoverable, DiscoveryDeps } from "../types";
+import { isDescriptor, extractPubKey, normalizeToDescriptor } from "../../identity/descriptor";
 import type { IndexerProvider } from "../../providers/indexer";
 import { getNormalizedVtxos } from "../../wallet/vtxo";
+import { DefaultVtxo } from "../../script/default";
+import type { RelativeTimelock } from "../../script/tapscript";
+import { WALLET_RECEIVE_SOURCE } from "../metadata";
 import { DEFAULT_PAGE_SIZE, SCRIPT_QUERY_CHUNK_SIZE } from "../constants";
 
 /**
@@ -70,6 +75,36 @@ export function resolveRole(
     }
 
     return undefined;
+}
+
+/**
+ * Extract pubkey bytes from a persisted param that may hold either a
+ * descriptor or a raw hex key.
+ *
+ * Shared by every descriptor-capable handler (`default` / `delegate` /
+ * `boarding` — see `DESCRIPTOR_CAPABLE_CONTRACT_TYPES`) so a rotated row whose
+ * key param was persisted in descriptor form deserializes identically
+ * whichever handler owns it.
+ */
+export function extractPubKeyBytes(value: string): Uint8Array {
+    return hex.decode(extractPubKey(normalizeToDescriptor(value)));
+}
+
+/**
+ * Decode a persisted `csvTimelock` param, restoring the default when absent.
+ *
+ * The param may be missing or empty on legacy/minimal rows (e.g. hex pubkeys
+ * written with no timelock). The script classes no longer apply their own
+ * fallback, and an unguarded decode does *not* fail loudly: `Number("")` /
+ * `Number(undefined)` is `NaN`, and `bip68.decode(NaN)` returns
+ * `{ blocks: 0 }`, so `sequenceToTimelock` silently yields a zero timelock —
+ * an exit path that reads as immediately spendable. Restore the documented
+ * default instead of decoding a NaN.
+ */
+export function deserializeCsvTimelock(value: string | undefined): RelativeTimelock {
+    return value !== undefined && value !== ""
+        ? sequenceToTimelock(Number(value))
+        : DefaultVtxo.Script.DEFAULT_TIMELOCK;
 }
 
 /**
@@ -213,4 +248,38 @@ export async function discoverIndexerCandidates<C extends { scriptHex: string }>
         );
     }
     return out;
+}
+
+/**
+ * Metadata tagging a discovered contract as one of the wallet's own rotating
+ * receive addresses — spread into a {@link DiscoveredContract} literal.
+ *
+ * Only *rotated* rows (index > 0) are tagged, so boot resolution can find the
+ * newest address and descriptor-aware signing can recover the per-index key.
+ * The index-0 baseline stays untagged across every handler.
+ */
+export function rotatedReceiveMetadata(
+    index: number,
+    descriptor: string,
+): Pick<DiscoveredContract, "metadata"> {
+    return index > 0
+        ? { metadata: { source: WALLET_RECEIVE_SOURCE, signingDescriptor: descriptor } }
+        : {};
+}
+
+/**
+ * Derive a handler's {@link Discoverable.discoverAt} from its
+ * {@link Discoverable.discoverRange}: per-index discovery is just a range of
+ * one, so the two verbs cannot drift into reporting different contracts for
+ * the same wallet state.
+ *
+ * The `?? []` mirrors `discoverRange`'s coverage contract from the caller's
+ * side — a range that omitted the requested index reports a miss here rather
+ * than `undefined`.
+ */
+export function discoverAtViaRange(
+    discoverRange: NonNullable<Discoverable["discoverRange"]>,
+): Discoverable["discoverAt"] {
+    return async (index: number, descriptor: string, deps: DiscoveryDeps) =>
+        (await discoverRange([{ index, descriptor }], deps)).get(index) ?? [];
 }

--- a/packages/ts-sdk/src/contracts/handlers/helpers.ts
+++ b/packages/ts-sdk/src/contracts/handlers/helpers.ts
@@ -1,9 +1,9 @@
 import { sequenceToTimelock } from "../../utils/timelock";
-import { Contract, PathContext } from "../types";
+import { Contract, DiscoveredContract, PathContext } from "../types";
 import { isDescriptor, extractPubKey } from "../../identity/descriptor";
 import type { IndexerProvider } from "../../providers/indexer";
 import { getNormalizedVtxos } from "../../wallet/vtxo";
-import { DEFAULT_PAGE_SIZE } from "../constants";
+import { DEFAULT_PAGE_SIZE, SCRIPT_QUERY_CHUNK_SIZE } from "../constants";
 
 /**
  * Extract raw hex pubkey from a value that may be a descriptor or raw hex.
@@ -121,10 +121,10 @@ export function isCsvSpendable(context: PathContext, sequence?: number): boolean
 }
 
 /**
- * Batched discovery probe for a single wallet index: given the candidate
- * pkScripts a `discoverAt` built (the signer × CSV-timelock cross-product,
- * already deduped), return the subset the indexer has at least one VTXO for —
- * in any state, since restore counts a spent-but-used script as activity.
+ * Batched discovery probe: given candidate pkScripts a discovery pass built
+ * (the signer × CSV-timelock cross-product, possibly across several wallet
+ * indices), return the subset the indexer has at least one VTXO for — in any
+ * state, since restore counts a spent-but-used script as activity.
  *
  * Collapses what used to be one `getVtxos` call per candidate script into a
  * single call per page, the same batching shape as
@@ -134,32 +134,83 @@ export function isCsvSpendable(context: PathContext, sequence?: number): boolean
  * all are seen), and otherwise to the end of history, so the discovered set is
  * identical to the prior per-script path — a heavily-reused candidate cannot
  * starve another candidate off the first page.
+ *
+ * Scripts beyond {@link SCRIPT_QUERY_CHUNK_SIZE} are split into sequential
+ * chunks (a URL-length budget, see the constant). Chunks are issued serially,
+ * not concurrently: pacing the indexer is the point of batching here. A chunk
+ * rejecting rejects the whole call — callers treat a partial answer as
+ * indeterminate, so there is no partial-result channel to leak into.
  */
 export async function detectUsedScripts(
     indexerProvider: IndexerProvider,
     scriptHexes: string[],
 ): Promise<Set<string>> {
     const used = new Set<string>();
-    if (scriptHexes.length === 0) return used;
+    // Distinct indices can derive the same script (e.g. an unrotated signer),
+    // and a duplicate would only pad the query string.
+    const unique = [...new Set(scriptHexes)];
 
-    // `scripts` stays the full candidate set across pages so the indexer's
-    // pagination is consistent; `remaining` only drives the early stop.
-    const remaining = new Set(scriptHexes);
-    let pageIndex = 0;
-    let hasMore = true;
-    while (hasMore && remaining.size > 0) {
-        const { vtxos, page } = await getNormalizedVtxos(indexerProvider, {
-            scripts: scriptHexes,
-            pageIndex,
-            pageSize: DEFAULT_PAGE_SIZE,
-        });
-        for (const vtxo of vtxos) {
-            if (remaining.delete(vtxo.script)) used.add(vtxo.script);
+    for (let offset = 0; offset < unique.length; offset += SCRIPT_QUERY_CHUNK_SIZE) {
+        const scripts = unique.slice(offset, offset + SCRIPT_QUERY_CHUNK_SIZE);
+        // `scripts` stays the full chunk across pages so the indexer's
+        // pagination is consistent; `remaining` only drives the early stop.
+        const remaining = new Set(scripts);
+        let pageIndex = 0;
+        let hasMore = true;
+        while (hasMore && remaining.size > 0) {
+            const { vtxos, page } = await getNormalizedVtxos(indexerProvider, {
+                scripts,
+                pageIndex,
+                pageSize: DEFAULT_PAGE_SIZE,
+            });
+            for (const vtxo of vtxos) {
+                if (remaining.delete(vtxo.script)) used.add(vtxo.script);
+            }
+            // Same end-of-history heuristic as fetchContractVtxosBulk: a short
+            // page (or absent page metadata) means there is nothing left to
+            // fetch.
+            hasMore = page ? vtxos.length === DEFAULT_PAGE_SIZE : false;
+            pageIndex++;
         }
-        // Same end-of-history heuristic as fetchContractVtxosBulk: a short page
-        // (or absent page metadata) means there is nothing left to fetch.
-        hasMore = page ? vtxos.length === DEFAULT_PAGE_SIZE : false;
-        pageIndex++;
     }
     return used;
+}
+
+/**
+ * Shared body of an indexer-backed handler's `discoverAt` / `discoverRange`.
+ *
+ * Both verbs are this one function — per-index discovery is just a range of
+ * one — so the two paths cannot drift into reporting different contracts for
+ * the same wallet state. Every I/O the pass needs is the single
+ * {@link detectUsedScripts} call over the union of all indices' candidates,
+ * which is what turns a 10-index window's ~20 concurrent 2-script requests
+ * into 1-2 sequential batched ones.
+ *
+ * The returned map covers **every** requested index (empty array when nothing
+ * hit), satisfying the `discoverRange` coverage contract the scanner enforces.
+ */
+export async function discoverIndexerCandidates<C extends { scriptHex: string }>(
+    indexerProvider: IndexerProvider,
+    entries: readonly { index: number; descriptor: string }[],
+    buildCandidates: (index: number, descriptor: string) => C[],
+    emit: (candidate: C, index: number, descriptor: string) => DiscoveredContract,
+): Promise<Map<number, DiscoveredContract[]>> {
+    const perIndex = entries.map((entry) => ({
+        ...entry,
+        candidates: buildCandidates(entry.index, entry.descriptor),
+    }));
+
+    const used = await detectUsedScripts(
+        indexerProvider,
+        perIndex.flatMap((e) => e.candidates.map((c) => c.scriptHex)),
+    );
+
+    const out = new Map<number, DiscoveredContract[]>();
+    for (const { index, descriptor, candidates } of perIndex) {
+        out.set(
+            index,
+            candidates.filter((c) => used.has(c.scriptHex)).map((c) => emit(c, index, descriptor)),
+        );
+    }
+    return out;
 }

--- a/packages/ts-sdk/src/contracts/handlers/helpers.ts
+++ b/packages/ts-sdk/src/contracts/handlers/helpers.ts
@@ -1,11 +1,17 @@
 import { hex } from "@scure/base";
 import { sequenceToTimelock } from "../../utils/timelock";
-import { Contract, DiscoveredContract, PathContext } from "../types";
+import { Contract, DiscoveredContract, PathContext, PathSelection } from "../types";
 import type { Discoverable, DiscoveryDeps } from "../types";
-import { isDescriptor, extractPubKey, normalizeToDescriptor } from "../../identity/descriptor";
+import {
+    isDescriptor,
+    extractPubKey,
+    normalizeToDescriptor,
+    deriveDescriptorLeafPubKey,
+} from "../../identity/descriptor";
 import type { IndexerProvider } from "../../providers/indexer";
 import { getNormalizedVtxos } from "../../wallet/vtxo";
 import { DefaultVtxo } from "../../script/default";
+import type { TapLeafScript } from "../../script/base";
 import type { RelativeTimelock } from "../../script/tapscript";
 import { WALLET_RECEIVE_SOURCE } from "../metadata";
 import { DEFAULT_PAGE_SIZE, SCRIPT_QUERY_CHUNK_SIZE } from "../constants";
@@ -156,6 +162,99 @@ export function isCsvSpendable(context: PathContext, sequence?: number): boolean
 }
 
 /**
+ * The tapleaf surface shared by `DefaultVtxo.Script` and
+ * `DelegateVtxo.Script`. Structural rather than nominal: the two classes are
+ * siblings (delegate wraps a default rather than extending it), so a shared
+ * interface is what lets both feed the forfeit/exit path helpers below.
+ */
+export interface ForfeitExitScript {
+    forfeit(): TapLeafScript;
+    exit(): TapLeafScript;
+}
+
+/**
+ * BIP68 sequence for a contract's exit path, or `undefined` when the contract
+ * carries no `csvTimelock` param (an exit with no relative timelock).
+ */
+export function exitSequence(contract: Contract): number | undefined {
+    return contract.params.csvTimelock ? Number(contract.params.csvTimelock) : undefined;
+}
+
+/**
+ * The `forfeit`-or-`exit` selection every forfeit/exit contract shares:
+ * collaborative spending takes the forfeit path, otherwise the exit path once
+ * its CSV has matured. Returns null when neither is available.
+ */
+export function selectForfeitOrExitPath(
+    script: ForfeitExitScript,
+    contract: Contract,
+    context: PathContext,
+): PathSelection | null {
+    if (context.collaborative) {
+        return { leaf: script.forfeit() };
+    }
+
+    const sequence = exitSequence(contract);
+    if (!isCsvSpendable(context, sequence)) {
+        return null;
+    }
+    return { leaf: script.exit(), sequence };
+}
+
+/**
+ * Every forfeit/exit path that exists at all: forfeit when the server
+ * cooperates, plus exit unconditionally (its CSV is checked at tx build time,
+ * not here).
+ */
+export function forfeitExitAllPaths(
+    script: ForfeitExitScript,
+    contract: Contract,
+    context: PathContext,
+): PathSelection[] {
+    const paths: PathSelection[] = [];
+
+    if (context.collaborative) {
+        paths.push({ leaf: script.forfeit() });
+    }
+
+    const exitPath: PathSelection = { leaf: script.exit() };
+    const sequence = exitSequence(contract);
+    if (sequence !== undefined) {
+        exitPath.sequence = sequence;
+    }
+    paths.push(exitPath);
+
+    return paths;
+}
+
+/**
+ * The subset of {@link forfeitExitAllPaths} spendable *right now* — the exit
+ * path is dropped until its CSV has matured.
+ */
+export function forfeitExitSpendablePaths(
+    script: ForfeitExitScript,
+    contract: Contract,
+    context: PathContext,
+): PathSelection[] {
+    const paths: PathSelection[] = [];
+
+    if (context.collaborative) {
+        paths.push({ leaf: script.forfeit() });
+    }
+
+    const sequence = exitSequence(contract);
+    if (isCsvSpendable(context, sequence)) {
+        const exitPath: PathSelection = { leaf: script.exit() };
+        if (sequence !== undefined) {
+            exitPath.sequence = sequence;
+        }
+        paths.push(exitPath);
+    }
+
+    return paths;
+}
+
+/**
  * Batched discovery probe: given candidate pkScripts a discovery pass built
  * (the signer × CSV-timelock cross-product, possibly across several wallet
  * indices), return the subset the indexer has at least one VTXO for — in any
@@ -248,6 +347,56 @@ export async function discoverIndexerCandidates<C extends { scriptHex: string }>
         );
     }
     return out;
+}
+
+/**
+ * One probe candidate: a built script plus the (signer, timelock) pair that
+ * produced it, so the matched signer can be threaded into the emitted
+ * contract's params and address.
+ */
+export interface SignerCandidate<S> {
+    pubKey: Uint8Array;
+    serverPubKey: Uint8Array;
+    csvTimelock: RelativeTimelock;
+    script: S;
+    scriptHex: string;
+}
+
+/**
+ * Candidate scripts for one wallet index: the current signer first, then any
+ * deprecated signers (so a VTXO minted under a now-rotated server key is still
+ * discovered), each crossed with the CSV-timelock matrix.
+ *
+ * Dedup by scriptHex — a deprecated signer that produced no rotation yields
+ * the same scripts as the current key, so it must neither be probed nor
+ * emitted twice; the current signer wins the attribution by being first.
+ *
+ * `makeScript` is the only per-contract-type part, which is what lets
+ * `default` and `delegate` share one cross-product.
+ */
+export function buildSignerTimelockCandidates<S extends { pkScript: Uint8Array }>(
+    descriptor: string,
+    deps: DiscoveryDeps,
+    makeScript: (opts: {
+        pubKey: Uint8Array;
+        serverPubKey: Uint8Array;
+        csvTimelock: RelativeTimelock;
+    }) => S,
+): SignerCandidate<S>[] {
+    const pubKey = deriveDescriptorLeafPubKey(descriptor);
+    const signers = [deps.serverPubKey, ...(deps.deprecatedSignerPubKeys ?? [])];
+    const seen = new Set<string>();
+    const candidates: SignerCandidate<S>[] = [];
+    for (const serverPubKey of signers) {
+        for (const csvTimelock of deps.csvTimelocks) {
+            const script = makeScript({ pubKey, serverPubKey, csvTimelock });
+            const scriptHex = hex.encode(script.pkScript);
+            if (seen.has(scriptHex)) continue;
+            seen.add(scriptHex);
+            candidates.push({ pubKey, serverPubKey, csvTimelock, script, scriptHex });
+        }
+    }
+    return candidates;
 }
 
 /**

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -316,6 +316,28 @@ export interface Discoverable {
         descriptor: string,
         deps: DiscoveryDeps,
     ): Promise<DiscoveredContract[]>;
+
+    /**
+     * Optional: answer for a whole scan window in one batched round-trip.
+     * The scanner prefers it over per-index `discoverAt` calls when present,
+     * which is what keeps a 10-index window to 1-2 indexer requests instead
+     * of one per index. Handlers whose source is inherently per-address (e.g.
+     * boarding, on Esplora) implement only `discoverAt`.
+     *
+     * **All-or-nothing per call.** Either resolve with a map covering *every*
+     * requested index (empty array = confirmed miss), or reject — a handler
+     * whose inner chunk fails partway must discard the partial results and
+     * reject, because a missing index would otherwise read as "no funds here"
+     * and let restore close its gap window on a failed request. The scanner
+     * enforces this rather than trusting it: an incomplete map is treated as a
+     * rejection, making the whole requested range indeterminate (hits present
+     * in it are still persisted) and truncating the scan at the range's first
+     * index. Indices that were not requested are ignored.
+     */
+    discoverRange?(
+        entries: readonly { index: number; descriptor: string }[],
+        deps: DiscoveryDeps,
+    ): Promise<Map<number, DiscoveredContract[]>>;
 }
 
 /** Duck-typed guard (mirrors `hasReceiveRotatorFactory`). */

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -756,6 +756,7 @@ export {
     canRecoverOnchain,
     canSpendOffchain,
     convertVtxo,
+    getAllNormalizedVtxos,
     getNormalizedVtxos,
     hasTerminalSpend,
     isExpired,
@@ -768,6 +769,7 @@ export {
     type NormalizedExtendedVirtualCoin,
     type NormalizedVirtualCoin,
     type TimeHeight,
+    type VtxoScriptQuery,
 } from "./vtxo";
 
 /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1863,6 +1863,11 @@ export class WalletMessageHandler
                     txid,
                     vout: 0,
                 }));
+                // Outpoints cost about what scripts do in the query string, so
+                // this spends nearly the whole URL budget that
+                // SCRIPT_QUERY_CHUNK_SIZE leaves unspent. Left as-is because
+                // this path has never 414'd; lower it to the shared constant if
+                // it ever does.
                 const BATCH_SIZE = 100;
                 for (let i = 0; i < outpoints.length; i += BATCH_SIZE) {
                     const res = await getNormalizedVtxos(this.indexerProvider, {

--- a/packages/ts-sdk/src/wallet/vtxo.ts
+++ b/packages/ts-sdk/src/wallet/vtxo.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE, SCRIPT_QUERY_CHUNK_SIZE } from "../contracts/constants";
 import type { GetVtxosOptions, IndexerProvider, PageResponse, Vtxo } from "../providers/indexer";
 import type { OnchainProvider } from "../providers/onchain";
 import type { ExtendedVirtualCoin, VirtualCoin, VirtualStatus } from "./index";
@@ -241,6 +242,51 @@ export async function getNormalizedVtxos(
 ): Promise<{ vtxos: NormalizedVirtualCoin[]; page?: PageResponse }> {
     const { vtxos, page } = await provider.getVtxos(opts);
     return { vtxos: vtxos.map(normalizeVtxo), page };
+}
+
+/** Everything a script query can filter on, minus the cursor this reader owns. */
+export type VtxoScriptQuery = Omit<GetVtxosOptions, "scripts" | "outpoints" | "pageIndex">;
+
+/**
+ * Read every virtual output for an arbitrary number of scripts.
+ *
+ * @remarks
+ * Scripts travel in the query string, so a wallet-derived list must be chunked
+ * at {@link SCRIPT_QUERY_CHUNK_SIZE} or the request `414`s. Chunks run
+ * sequentially — that pacing is the point, since this path can now run wide —
+ * and each is paged to exhaustion, so callers cannot silently receive page one.
+ */
+export async function getAllNormalizedVtxos(
+    provider: Pick<IndexerProvider, "getVtxos">,
+    scripts: string[],
+    opts: VtxoScriptQuery = {},
+): Promise<NormalizedVirtualCoin[]> {
+    const { pageSize = DEFAULT_PAGE_SIZE, ...filters } = opts;
+    const all: NormalizedVirtualCoin[] = [];
+
+    for (let i = 0; i < scripts.length; i += SCRIPT_QUERY_CHUNK_SIZE) {
+        const chunk = scripts.slice(i, i + SCRIPT_QUERY_CHUNK_SIZE);
+        let pageIndex = 0;
+        let hasMore = true;
+
+        while (hasMore) {
+            const { vtxos, page } = await getNormalizedVtxos(provider, {
+                ...filters,
+                scripts: chunk,
+                pageIndex,
+                pageSize,
+            });
+            all.push(...vtxos);
+
+            // A short page means the last one: providers that omit `page`
+            // entirely are treated as unpaged.
+            hasMore = page ? vtxos.length === pageSize : false;
+            pageIndex++;
+            if (hasMore) await new Promise((r) => setTimeout(r, 500));
+        }
+    }
+
+    return all;
 }
 
 // --- capabilities ------------------------------------------------------------------------------

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -26,6 +26,7 @@ import { Identity, ReadonlyIdentity, isBatchSignable } from "../identity";
 import {
     canRecoverOnchain,
     canSpendOffchain,
+    getAllNormalizedVtxos,
     getNormalizedVtxos,
     hasTerminalSpend,
     isVirtualCoin,
@@ -1653,9 +1654,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
     async fetchPendingTxs(): Promise<string[]> {
         // get non-swept virtual outputs, rely on the indexer only in case DB doesn't have the right state
         const scripts = await this.getWalletScripts();
-        let { vtxos } = await getNormalizedVtxos(this.indexerProvider, {
-            scripts,
-        });
+        const vtxos = await getAllNormalizedVtxos(this.indexerProvider, scripts);
         return vtxos
             .filter(
                 (vtxo) =>
@@ -3949,14 +3948,12 @@ export class Wallet extends ReadonlyWallet implements IWallet {
         }
 
         if (!vtxos || vtxos.length === 0) {
-            // Batch all scripts into a single indexer call
             const scriptMap = await this.getScriptMap();
             const allExtended: ExtendedVirtualCoin[] = [];
 
-            const allScripts = [...scriptMap.keys()];
-            const { vtxos: fetchedVtxos } = await getNormalizedVtxos(this.indexerProvider, {
-                scripts: allScripts,
-            });
+            const fetchedVtxos = await getAllNormalizedVtxos(this.indexerProvider, [
+                ...scriptMap.keys(),
+            ]);
 
             for (const vtxo of fetchedVtxos) {
                 const vtxoScript = scriptMap.get(vtxo.script);

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2556,7 +2556,13 @@ export class Wallet extends ReadonlyWallet implements IWallet {
 
         // Inline pull BEFORE surfacing any handler errors so safely
         // discovered funds are always recovered (spec §3.B / §4).
-        await manager.refreshVtxos({ includeInactive: true });
+        //
+        // `after: 0` is load-bearing: the scan just discovered these
+        // contracts, so their first sync must span all of history. Without
+        // it the pull inherits the global delta cursor — already advanced
+        // to "now" by the boot-time reconcile that ran before the scan —
+        // and silently recovers only the last OVERLAP_MS of their history.
+        await manager.refreshVtxos({ includeInactive: true, after: 0 });
 
         const causes = result.handlerErrors.map((e) =>
             e.error instanceof Error ? e.error : new Error(String(e.error)),

--- a/packages/ts-sdk/test/contractWatcher-subscription-batch.test.ts
+++ b/packages/ts-sdk/test/contractWatcher-subscription-batch.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { ContractWatcher } from "../src/contracts/contractWatcher";
+import { InMemoryWalletRepository } from "../src";
+import type { Contract } from "../src/contracts/types";
+import type { IndexerProvider } from "../src/providers/indexer";
+
+function makeWatcher() {
+    const subscribeCalls: string[][] = [];
+    const indexerProvider = {
+        async getVtxos() {
+            return { vtxos: [] };
+        },
+        async subscribeForScripts(scripts: string[]) {
+            subscribeCalls.push(scripts);
+            return "sub-1";
+        },
+        async unsubscribeForScripts() {},
+        // Idle stream: resolves only when the watcher aborts.
+        async *getSubscription(_id: string, abortSignal: AbortSignal) {
+            await new Promise<void>((resolve) => {
+                if (abortSignal.aborted) return resolve();
+                abortSignal.addEventListener("abort", () => resolve(), { once: true });
+            });
+        },
+    } as unknown as IndexerProvider;
+
+    const watcher = new ContractWatcher({
+        indexerProvider,
+        walletRepository: new InMemoryWalletRepository(),
+        failsafePollIntervalMs: 60_000,
+    });
+    return { watcher, subscribeCalls };
+}
+
+const contractAt = (script: string): Contract => ({
+    type: "default",
+    params: { script },
+    script,
+    address: `ark1q${script}`,
+    createdAt: Date.now(),
+    state: "active",
+});
+
+describe("ContractWatcher.withCoalescedSubscription", () => {
+    it("issues one subscribe for a batch of adds, carrying the full set", async () => {
+        const { watcher, subscribeCalls } = makeWatcher();
+        const stop = await watcher.startWatching(() => {});
+        try {
+            subscribeCalls.length = 0;
+            await watcher.withCoalescedSubscription(async () => {
+                for (const s of ["aa", "bb", "cc"]) await watcher.addContract(contractAt(s));
+                // Deferred, not merely reordered: nothing goes out mid-batch.
+                expect(subscribeCalls).toHaveLength(0);
+            });
+            expect(subscribeCalls).toEqual([["aa", "bb", "cc"]]);
+        } finally {
+            stop();
+        }
+    });
+
+    it("flushes on the error path too", async () => {
+        // A scan that aborts mid-way still registered contracts with the
+        // watcher; leaving them unsubscribed would silently stop streaming
+        // their events until the next unrelated update.
+        const { watcher, subscribeCalls } = makeWatcher();
+        const stop = await watcher.startWatching(() => {});
+        try {
+            subscribeCalls.length = 0;
+            await expect(
+                watcher.withCoalescedSubscription(async () => {
+                    await watcher.addContract(contractAt("aa"));
+                    throw new Error("scan aborted");
+                }),
+            ).rejects.toThrow("scan aborted");
+            expect(subscribeCalls).toEqual([["aa"]]);
+        } finally {
+            stop();
+        }
+    });
+
+    it("does not defer updates made outside the scope", async () => {
+        const { watcher, subscribeCalls } = makeWatcher();
+        const stop = await watcher.startWatching(() => {});
+        try {
+            subscribeCalls.length = 0;
+            await watcher.addContract(contractAt("aa"));
+            expect(subscribeCalls).toEqual([["aa"]]);
+        } finally {
+            stop();
+        }
+    });
+});

--- a/packages/ts-sdk/test/contracts/handlers/delegate.test.ts
+++ b/packages/ts-sdk/test/contracts/handlers/delegate.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+import { DelegateContractHandler } from "../../../src/contracts/handlers/delegate";
+import { DefaultVtxo } from "../../../src";
+
+const TEST_PUB_KEY_HEX = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const TEST_SERVER_PUB_KEY_HEX = "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+const TEST_DELEGATE_PUB_KEY_HEX =
+    "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
+const TEST_PUB_KEY = hex.decode(TEST_PUB_KEY_HEX);
+const TEST_SERVER_PUB_KEY = hex.decode(TEST_SERVER_PUB_KEY_HEX);
+const TEST_DELEGATE_PUB_KEY = hex.decode(TEST_DELEGATE_PUB_KEY_HEX);
+
+// The delegate handler deserializes through the same shared helpers as
+// `default` (`extractPubKeyBytes` / `deserializeCsvTimelock`). These cases pin
+// that parity: before the helpers were shared, delegate decoded keys with a
+// raw `hex.decode` and fed `Number(params.csvTimelock)` straight into
+// `sequenceToTimelock`, so a descriptor-form key threw and an absent timelock
+// silently decoded to zero blocks.
+describe("DelegateContractHandler param deserialization", () => {
+    it("deserializes hex pubkeys to bytes", () => {
+        const params = DelegateContractHandler.deserializeParams({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+            delegatePubKey: TEST_DELEGATE_PUB_KEY_HEX,
+            csvTimelock: "144",
+        });
+        expect(params.pubKey).toEqual(TEST_PUB_KEY);
+        expect(params.serverPubKey).toEqual(TEST_SERVER_PUB_KEY);
+        expect(params.delegatePubKey).toEqual(TEST_DELEGATE_PUB_KEY);
+    });
+
+    it("deserializes descriptor-form pubkeys to bytes, like default", () => {
+        const params = DelegateContractHandler.deserializeParams({
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
+            delegatePubKey: `tr(${TEST_DELEGATE_PUB_KEY_HEX})`,
+            csvTimelock: "144",
+        });
+        expect(params.pubKey).toEqual(TEST_PUB_KEY);
+        expect(params.serverPubKey).toEqual(TEST_SERVER_PUB_KEY);
+        expect(params.delegatePubKey).toEqual(TEST_DELEGATE_PUB_KEY);
+    });
+
+    it("falls back to the default timelock when csvTimelock is absent", () => {
+        const params = DelegateContractHandler.deserializeParams({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+            delegatePubKey: TEST_DELEGATE_PUB_KEY_HEX,
+        });
+        // Not `{ type: "blocks", value: 0n }`, which is what an unguarded
+        // `sequenceToTimelock(NaN)` yields.
+        expect(params.csvTimelock).toEqual(DefaultVtxo.Script.DEFAULT_TIMELOCK);
+    });
+
+    it("falls back to the default timelock when csvTimelock is empty", () => {
+        const params = DelegateContractHandler.deserializeParams({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+            delegatePubKey: TEST_DELEGATE_PUB_KEY_HEX,
+            csvTimelock: "",
+        });
+        expect(params.csvTimelock).toEqual(DefaultVtxo.Script.DEFAULT_TIMELOCK);
+    });
+
+    it("round-trips params through serialize/deserialize", () => {
+        const serialized = DelegateContractHandler.serializeParams({
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            delegatePubKey: TEST_DELEGATE_PUB_KEY,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
+        });
+        expect(DelegateContractHandler.deserializeParams(serialized)).toEqual({
+            pubKey: TEST_PUB_KEY,
+            serverPubKey: TEST_SERVER_PUB_KEY,
+            delegatePubKey: TEST_DELEGATE_PUB_KEY,
+            csvTimelock: DefaultVtxo.Script.DEFAULT_TIMELOCK,
+        });
+    });
+
+    it("builds the same pkScript from descriptor and hex params", () => {
+        const fromHex = DelegateContractHandler.createScript({
+            pubKey: TEST_PUB_KEY_HEX,
+            serverPubKey: TEST_SERVER_PUB_KEY_HEX,
+            delegatePubKey: TEST_DELEGATE_PUB_KEY_HEX,
+            csvTimelock: "144",
+        });
+        const fromDescriptor = DelegateContractHandler.createScript({
+            pubKey: `tr(${TEST_PUB_KEY_HEX})`,
+            serverPubKey: `tr(${TEST_SERVER_PUB_KEY_HEX})`,
+            delegatePubKey: `tr(${TEST_DELEGATE_PUB_KEY_HEX})`,
+            csvTimelock: "144",
+        });
+        expect(hex.encode(fromDescriptor.pkScript)).toBe(hex.encode(fromHex.pkScript));
+    });
+});

--- a/packages/ts-sdk/test/contracts/manager.test.ts
+++ b/packages/ts-sdk/test/contracts/manager.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../src";
 import { ContractRepository } from "../../src/repositories";
 import { contractHandlers } from "../../src/contracts/handlers";
+import { OVERLAP_MS } from "../../src/utils/syncCursors";
 import { hex } from "@scure/base";
 import {
     createDefaultContractParams,
@@ -802,6 +803,49 @@ describe("ContractManager", () => {
 
             // Cursor untouched — caller-supplied windows are targeted and
             // must not move the global high-water mark.
+            const stateAfter = await repo.getWalletState();
+            expect(stateAfter?.lastSyncTime).toBe(SEEDED_CURSOR);
+        });
+
+        // Regression for restore's bulk hydration: contracts a scan just
+        // discovered have no prior sync state, so their first fetch must be
+        // unbounded. `after: 0` bypasses the cursor the boot-time reconcile
+        // already advanced past their history.
+        it("`after: 0` fetches history predating the cursor without advancing it", async () => {
+            const { mgr, repo } = await makeFreshManager();
+
+            await repo.saveWalletState({
+                lastSyncTime: SEEDED_CURSOR,
+                settings: { vtxoCursorMigrated: true },
+            });
+
+            const ancient = new Date(Date.now() - 30 * OVERLAP_MS);
+            (mockIndexer.getVtxos as any).mockClear();
+            // Honours the `after` bound, so a cursor-derived window would
+            // come back empty — without this the assertions pass either way.
+            (mockIndexer.getVtxos as any).mockImplementation(async (opts: any) => {
+                const vtxo = createMockVtxo({
+                    script: TEST_DEFAULT_SCRIPT,
+                    createdAt: ancient,
+                });
+                const visible = !opts?.after || ancient.getTime() > opts.after;
+                return { vtxos: visible ? [vtxo] : [] };
+            });
+
+            await mgr.refreshVtxos({ includeInactive: true, after: 0 });
+
+            const calls = (mockIndexer.getVtxos as any).mock.calls;
+            expect(calls.length).toBeGreaterThan(0);
+            for (const args of calls) {
+                expect(args[0]?.after).toBe(0);
+            }
+
+            const stored = await repo.getVtxos("address");
+            expect(stored).toHaveLength(1);
+            expect(stored[0].createdAt).toEqual(ancient);
+
+            // Same invariant as the explicit-window case above: a targeted
+            // superset fetch must not move the global watermark.
             const stateAfter = await repo.getWalletState();
             expect(stateAfter?.lastSyncTime).toBe(SEEDED_CURSOR);
         });

--- a/packages/ts-sdk/test/discovery-batching.test.ts
+++ b/packages/ts-sdk/test/discovery-batching.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { detectUsedScripts } from "../src/contracts/handlers/helpers";
+import { DefaultContractHandler } from "../src/contracts/handlers/default";
+import { DelegateContractHandler } from "../src/contracts/handlers/delegate";
+import { SCRIPT_QUERY_CHUNK_SIZE } from "../src/contracts/constants";
+import type { DiscoveredContract, DiscoveryDeps } from "../src/contracts/types";
+import type { IndexerProvider } from "../src/providers/indexer";
+
+/**
+ * Indexer that reports one VTXO per requested script present in `used`, and
+ * records the script list of every call so a test can assert on request COUNT
+ * and per-request width — the two properties Phase 2 exists to change.
+ */
+function makeIndexer(used: Set<string>, onCall?: (scripts: string[]) => void) {
+    const calls: string[][] = [];
+    const indexerProvider = {
+        async getVtxos({ scripts }: { scripts?: string[] }) {
+            const list = scripts ?? [];
+            calls.push(list);
+            onCall?.(list);
+            return {
+                vtxos: list
+                    .filter((s) => used.has(s))
+                    .map((script) => ({ script }) as unknown as never),
+            };
+        },
+    } as unknown as IndexerProvider;
+    return { indexerProvider, calls };
+}
+
+/** Distinct x-only pubkeys, so every index derives a distinct script. */
+function descriptorAt(index: number): string {
+    const priv = new Uint8Array(32).fill(1);
+    priv[31] = index + 1;
+    return `tr(${hex.encode(schnorr.getPublicKey(priv))})`;
+}
+
+function makeDeps(indexerProvider: IndexerProvider, delegate = false): DiscoveryDeps {
+    const deps: DiscoveryDeps = {
+        indexerProvider,
+        onchainProvider: {} as DiscoveryDeps["onchainProvider"],
+        network: { hrp: "ark" } as DiscoveryDeps["network"],
+        serverPubKey: new Uint8Array(32).fill(9),
+        csvTimelocks: [
+            { value: 144n, type: "blocks" },
+            { value: 512n, type: "seconds" },
+        ],
+    };
+    return delegate ? { ...deps, delegatePubKey: new Uint8Array(32).fill(7) } : deps;
+}
+
+const scriptsOf = (found: DiscoveredContract[]) => found.map((c) => c.script);
+
+describe("detectUsedScripts chunking", () => {
+    it("splits past the chunk cap and unions the results", async () => {
+        const all = Array.from({ length: 70 }, (_, i) => `aa${i.toString(16).padStart(4, "0")}`);
+        const used = new Set([all[0], all[40], all[69]]);
+        const { indexerProvider, calls } = makeIndexer(used);
+
+        const found = await detectUsedScripts(indexerProvider, all);
+
+        expect(found).toEqual(used);
+        expect(calls).toHaveLength(Math.ceil(70 / SCRIPT_QUERY_CHUNK_SIZE));
+        expect(calls.every((c) => c.length <= SCRIPT_QUERY_CHUNK_SIZE)).toBe(true);
+        // Every script was asked about exactly once.
+        expect(calls.flat().sort()).toEqual([...all].sort());
+    });
+
+    it("collapses duplicate scripts instead of padding the query string", async () => {
+        const { indexerProvider, calls } = makeIndexer(new Set());
+        await detectUsedScripts(indexerProvider, ["aa", "bb", "aa", "bb"]);
+        expect(calls).toEqual([["aa", "bb"]]);
+    });
+
+    it("rejects when a later chunk fails, discarding the earlier chunk's hits", async () => {
+        // All-or-nothing: a partial answer would let the scanner read an
+        // unprobed script as "unused" and close the gap window on a failure.
+        const all = Array.from({ length: 40 }, (_, i) => `bb${i.toString(16).padStart(4, "0")}`);
+        let seen = 0;
+        const { indexerProvider } = makeIndexer(new Set(all), () => {
+            if (++seen === 2) throw new Error("rate limited");
+        });
+
+        await expect(detectUsedScripts(indexerProvider, all)).rejects.toThrow("rate limited");
+    });
+});
+
+describe("Discoverable.discoverRange", () => {
+    const entries = Array.from({ length: 10 }, (_, i) => ({
+        index: i,
+        descriptor: descriptorAt(i),
+    }));
+
+    for (const [name, handler, delegate] of [
+        ["default", DefaultContractHandler, false],
+        ["delegate", DelegateContractHandler, true],
+    ] as const) {
+        it(`${name}: discovers exactly what per-index discoverAt discovers`, async () => {
+            // Pick a hit by probing index 4 first, then assert both verbs
+            // agree — the batched path must not become a second source of
+            // truth about which contracts a wallet owns.
+            const probe = makeIndexer(new Set());
+            await handler.discoverAt(
+                4,
+                entries[4].descriptor,
+                makeDeps(probe.indexerProvider, delegate),
+            );
+            const used = new Set([probe.calls.flat()[0]]);
+
+            const perIndex = makeIndexer(used);
+            const serial: Record<number, string[]> = {};
+            for (const e of entries) {
+                serial[e.index] = scriptsOf(
+                    await handler.discoverAt(
+                        e.index,
+                        e.descriptor,
+                        makeDeps(perIndex.indexerProvider, delegate),
+                    ),
+                );
+            }
+
+            const batched = makeIndexer(used);
+            const ranged = await handler.discoverRange!(
+                entries,
+                makeDeps(batched.indexerProvider, delegate),
+            );
+
+            expect(Object.fromEntries([...ranged].map(([i, f]) => [i, scriptsOf(f)]))).toEqual(
+                serial,
+            );
+            expect(serial[4]).toHaveLength(1);
+        });
+
+        it(`${name}: answers a whole window in one request instead of one per index`, async () => {
+            const { indexerProvider, calls } = makeIndexer(new Set());
+            await handler.discoverRange!(entries, makeDeps(indexerProvider, delegate));
+            // 10 indices × 2 csvTimelocks = 20 scripts, one chunk.
+            expect(calls).toHaveLength(1);
+            expect(calls[0]).toHaveLength(20);
+        });
+
+        it(`${name}: covers every requested index`, async () => {
+            const { indexerProvider } = makeIndexer(new Set());
+            const ranged = await handler.discoverRange!(
+                entries,
+                makeDeps(indexerProvider, delegate),
+            );
+            expect([...ranged.keys()]).toEqual(entries.map((e) => e.index));
+        });
+    }
+
+    it("delegate: covers every requested index even when the wallet has no delegate key", async () => {
+        // An omitted index reads as indeterminate and truncates the scan, so
+        // "nothing to discover" must still be answered per index.
+        const { indexerProvider, calls } = makeIndexer(new Set());
+        const ranged = await DelegateContractHandler.discoverRange!(
+            entries,
+            makeDeps(indexerProvider, false),
+        );
+        expect([...ranged.keys()]).toEqual(entries.map((e) => e.index));
+        expect([...ranged.values()].every((f) => f.length === 0)).toBe(true);
+        expect(calls).toHaveLength(0);
+    });
+});

--- a/packages/ts-sdk/test/helpers/restoreWallet.ts
+++ b/packages/ts-sdk/test/helpers/restoreWallet.ts
@@ -108,13 +108,13 @@ function uniqueTxid(script: string): string {
 }
 
 /** A settled, unspent, confirmed VTXO of `value` sats locked by `script`. */
-function makeVtxo(script: string, value: number): VirtualCoin {
+function makeVtxo(script: string, value: number, createdAt: Date = new Date()): VirtualCoin {
     return {
         txid: uniqueTxid(script),
         vout: 0,
         value,
         status: { confirmed: true },
-        createdAt: new Date(),
+        createdAt,
         script,
         isUnrolled: false,
         isSpent: false,
@@ -132,24 +132,38 @@ function makeVtxo(script: string, value: number): VirtualCoin {
  * empty. The remaining `IndexerProvider` surface is stubbed because the
  * restore path never touches it.
  *
- * `getVtxosCalls` counts the `scripts`-shaped probes so a test can
- * assert the scan ran exactly once when calls coalesce.
+ * The `after` lower bound is honoured, so a caller that queries with a
+ * delta-sync window cannot see VTXOs minted before it. Without this a
+ * test cannot distinguish a windowed fetch from an unbounded one.
+ *
+ * `getVtxosCalls` records the `scripts`-shaped probes so a test can
+ * assert the scan ran exactly once when calls coalesce, and inspect the
+ * window each probe carried.
  */
 export interface MockIndexer extends IndexerProvider {
     usedScripts: Set<string>;
-    getVtxosCalls: { scripts: string[] }[];
+    /** Per-script VTXO creation time; scripts absent from the map mint at "now". */
+    vtxoCreatedAt: Map<string, Date>;
+    getVtxosCalls: { scripts: string[]; after?: number }[];
 }
 
 function makeMockIndexer(usedScripts: Set<string>): MockIndexer {
-    const getVtxosCalls: { scripts: string[] }[] = [];
+    const getVtxosCalls: { scripts: string[]; after?: number }[] = [];
+    const vtxoCreatedAt = new Map<string, Date>();
     const indexer = {
         usedScripts,
+        vtxoCreatedAt,
         getVtxosCalls,
-        async getVtxos(opts?: { scripts?: string[]; outpoints?: unknown[] }) {
+        async getVtxos(opts?: { scripts?: string[]; outpoints?: unknown[]; after?: number }) {
             const scripts = opts?.scripts;
             if (!scripts) return { vtxos: [] };
-            getVtxosCalls.push({ scripts });
-            const vtxos = scripts.filter((s) => usedScripts.has(s)).map((s) => makeVtxo(s, 50_000));
+            getVtxosCalls.push({ scripts, after: opts?.after });
+            // `after: 0` is the bootstrap sentinel — unbounded, same as omitting it.
+            const after = opts?.after;
+            const vtxos = scripts
+                .filter((s) => usedScripts.has(s))
+                .map((s) => makeVtxo(s, 50_000, vtxoCreatedAt.get(s)))
+                .filter((v) => !after || v.createdAt.getTime() > after);
             return { vtxos };
         },
         async getAssetDetails() {

--- a/packages/ts-sdk/test/helpers/restoreWallet.ts
+++ b/packages/ts-sdk/test/helpers/restoreWallet.ts
@@ -138,22 +138,26 @@ function makeVtxo(script: string, value: number, createdAt: Date = new Date()): 
  *
  * `getVtxosCalls` records the `scripts`-shaped probes so a test can
  * assert the scan ran exactly once when calls coalesce, and inspect the
- * window each probe carried.
+ * window each probe carried; `subscribeCalls` records each subscription
+ * POST's script list for the same reason.
  */
 export interface MockIndexer extends IndexerProvider {
     usedScripts: Set<string>;
     /** Per-script VTXO creation time; scripts absent from the map mint at "now". */
     vtxoCreatedAt: Map<string, Date>;
     getVtxosCalls: { scripts: string[]; after?: number }[];
+    subscribeCalls: string[][];
 }
 
 function makeMockIndexer(usedScripts: Set<string>): MockIndexer {
     const getVtxosCalls: { scripts: string[]; after?: number }[] = [];
     const vtxoCreatedAt = new Map<string, Date>();
+    const subscribeCalls: string[][] = [];
     const indexer = {
         usedScripts,
         vtxoCreatedAt,
         getVtxosCalls,
+        subscribeCalls,
         async getVtxos(opts?: { scripts?: string[]; outpoints?: unknown[]; after?: number }) {
             const scripts = opts?.scripts;
             if (!scripts) return { vtxos: [] };
@@ -169,7 +173,8 @@ function makeMockIndexer(usedScripts: Set<string>): MockIndexer {
         async getAssetDetails() {
             throw new Error("getAssetDetails not used by restore");
         },
-        async subscribeForScripts() {
+        async subscribeForScripts(scripts: string[]) {
+            subscribeCalls.push(scripts);
             return "sub-1";
         },
         async unsubscribeForScripts() {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -17,6 +17,7 @@ import { VtxoScript } from "../src/script/base";
 import type { RelativeTimelock } from "../src/script/tapscript";
 import { contractHandlers } from "../src/contracts/handlers";
 import { makeManagerForTest, makeDeps } from "./helpers/scanManager";
+import { getSyncCursor, OVERLAP_MS } from "../src/utils/syncCursors";
 import {
     installRestoreHarness,
     teardownRestoreHarness,
@@ -1133,6 +1134,47 @@ describe("Wallet.restore", () => {
             expect(await hdProvider.getCurrentSigningDescriptor()).toBe(
                 hdProvider.materializeDescriptorAt(2),
             );
+            const balance = await wallet.getBalance();
+            expect(balance.total).toBeGreaterThan(0);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("HD: recovers history older than the delta-sync overlap window", async () => {
+        // Regression: the boot-time reconcile advances the global sync
+        // cursor to "now" before the scan has discovered anything, so
+        // restore's bulk hydration used to inherit a 24h delta window and
+        // silently recover only recent VTXOs from contracts it had just
+        // found for the first time.
+        const { wallet, indexer, hdProvider, walletRepository } = await makeHdWalletForTest();
+        try {
+            const serverPubKey = wallet.offchainTapscript.options.serverPubKey;
+            const scriptsAt = (index: number) =>
+                wallet.walletContractTimelocks.map((csvTimelock) =>
+                    hex.encode(
+                        new DefaultVtxo.Script({
+                            pubKey: deriveDescriptorLeafPubKey(
+                                hdProvider.materializeDescriptorAt(index),
+                            ),
+                            serverPubKey,
+                            csvTimelock,
+                        }).pkScript,
+                    ),
+                );
+            const ancient = new Date(Date.now() - 30 * OVERLAP_MS);
+            for (const s of scriptsAt(2)) {
+                indexer.usedScripts.add(s);
+                indexer.vtxoCreatedAt.set(s, ancient);
+            }
+
+            // Force the boot-time reconcile so the cursor is already at
+            // "now" when the scan runs — the ordering the bug depends on.
+            await wallet.getContractManager();
+            expect(await getSyncCursor(walletRepository)).toBeGreaterThan(0);
+
+            await wallet.restore({ gapLimit: 5 });
+
             const balance = await wallet.getBalance();
             expect(balance.total).toBeGreaterThan(0);
         } finally {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -526,6 +526,34 @@ function makeFakeHandler(type: string, discoverAt: (index: number) => any[] | Pr
     return { handler, calls };
 }
 
+/**
+ * Batching variant of {@link makeFakeHandler}: answers a whole window through
+ * `discoverRange`. `answer` returns the map the handler resolves with (or
+ * throws), letting a test drive the contract violations the scanner must
+ * defend against.
+ */
+function makeFakeRangeHandler(
+    type: string,
+    answer: (entries: readonly { index: number }[]) => Map<number, any[]>,
+) {
+    const ranges: number[][] = [];
+    const handler = {
+        ...makeFakeHandler(type, () => []).handler,
+        async discoverRange(entries: readonly { index: number; descriptor: string }[]) {
+            ranges.push(entries.map((e) => e.index));
+            return answer(entries);
+        },
+    };
+    return { handler, ranges };
+}
+
+const fakeHit = (type: string, script: string) => ({
+    type,
+    params: { script },
+    script,
+    address: "ark1qswap",
+});
+
 describe("ContractManager.scanContracts", () => {
     // A valid static tr(<x-only pubkey>) descriptor. The scanner asks EVERY
     // registered Discoverable handler — including the real default/delegate
@@ -803,6 +831,133 @@ describe("ContractManager.scanContracts", () => {
         }
     });
 
+    it("prefers discoverRange over per-index discoverAt", async () => {
+        const { handler, ranges } = makeFakeRangeHandler("rangefake", (entries) => {
+            return new Map(entries.map((e) => [e.index, []]));
+        });
+        register("rangefake", handler);
+        const mgr = await makeManagerForTest();
+        try {
+            await mgr.scanContracts({
+                gapLimit: 10,
+                batchSize: 4,
+                hd: true,
+                materialize,
+                deps: makeDeps(),
+            });
+            // Three windows of 4/4/2 — never one call per index.
+            expect(ranges).toEqual([
+                [0, 1, 2, 3],
+                [4, 5, 6, 7],
+                [8, 9],
+            ]);
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("a discoverRange rejection makes its WHOLE window indeterminate", async () => {
+        // The batched analogue of the Finding 1 regression: one failed request
+        // now spans a window, so the entire window must go indeterminate —
+        // reading any of it as "unused" would close the gap window on a
+        // failure. Truncation lands on the window's first index, coarser than
+        // discoverAt's exact index; retry is idempotent.
+        const failing = makeFakeRangeHandler("rangefake", () => {
+            throw new Error("rate limited");
+        });
+        const hitAt14 = makeFakeHandler("swapfake", (i) =>
+            i === 14 ? [fakeHit("swapfake", "aabb")] : [],
+        );
+        register("rangefake", failing.handler);
+        register("swapfake", hitAt14.handler);
+        const mgr = await makeManagerForTest();
+        try {
+            const res = await mgr.scanContracts({
+                gapLimit: 20,
+                batchSize: 10, // windows [0..9], [10..19]
+                hd: true,
+                materialize,
+                deps: makeDeps(),
+            });
+            expect(res.truncatedAt).toBe(0);
+            expect(res.handlerErrors).toHaveLength(1);
+            expect(res.handlerErrors[0]).toMatchObject({
+                handler: "rangefake",
+                index: 0,
+                toIndex: 9,
+            });
+            // Only the first window ran: the scan stopped at the truncation.
+            expect(failing.ranges).toEqual([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]);
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("keeps another handler's hit found inside a failed discoverRange window", async () => {
+        // Rule 5 unchanged under batching: a co-probed handler's confirmed hit
+        // is real data. Dropping it would let index 14 be re-issued as a fresh
+        // receive address once a caller swallows the restore error.
+        const failing = makeFakeRangeHandler("rangefake", () => {
+            throw new Error("rate limited");
+        });
+        const hitAt14 = makeFakeHandler("swapfake", (i) =>
+            i === 14 ? [fakeHit("swapfake", "aabb")] : [],
+        );
+        register("rangefake", failing.handler);
+        register("swapfake", hitAt14.handler);
+        const mgr = await makeManagerForTest();
+        try {
+            const res = await mgr.scanContracts({
+                gapLimit: 20,
+                batchSize: 20, // one window covering 0..19, so 14 is probed
+                hd: true,
+                materialize,
+                deps: makeDeps(),
+            });
+            expect(res.truncatedAt).toBe(0);
+            expect(res.highestConfirmedUsedIndex).toBe(14);
+            const [c] = await mgr.getContracts({ script: "aabb" });
+            expect(c?.type).toBe("swapfake");
+        } finally {
+            mgr.dispose();
+        }
+    });
+
+    it("treats an incomplete discoverRange map as a rejection, naming the missing index", async () => {
+        // `Discoverable` is public API, so a third-party discoverRange can be
+        // buggy. Reading an absent index as "no contracts here" would
+        // reintroduce Finding 1 through a plugin — silently, and with a whole
+        // window's blast radius.
+        const partial = makeFakeRangeHandler("rangefake", (entries) => {
+            const map = new Map<number, any[]>(
+                entries.filter((e) => e.index !== 3).map((e) => [e.index, []]),
+            );
+            map.set(2, [fakeHit("rangefake", "ccdd")]);
+            return map;
+        });
+        register("rangefake", partial.handler);
+        const mgr = await makeManagerForTest();
+        try {
+            const res = await mgr.scanContracts({
+                gapLimit: 5,
+                batchSize: 5,
+                hd: true,
+                materialize,
+                deps: makeDeps(),
+            });
+            expect(res.truncatedAt).toBe(0);
+            expect(res.handlerErrors).toHaveLength(1);
+            expect(res.handlerErrors[0]).toMatchObject({ index: 0, toIndex: 4 });
+            expect((res.handlerErrors[0].error as Error).message).toContain("index 3");
+            // Hits the buggy handler DID return are affirmative data.
+            expect(res.highestConfirmedUsedIndex).toBe(2);
+            const [c] = await mgr.getContracts({ script: "ccdd" });
+            expect(c?.type).toBe("rangefake");
+        } finally {
+            mgr.dispose();
+        }
+    });
+
     it("a materialize() throw is fatal — it propagates, not collected", async () => {
         const { handler } = makeFakeHandler("swapfake", () => []);
         register("swapfake", handler);
@@ -863,20 +1018,26 @@ describe("ContractManager.scanContracts", () => {
         // first so such a collision resolves to a `boarding` row (keeping the
         // on-chain UTXO visible to the type-gated getBoardingUtxos). Guards
         // against a future reorder of the registered handlers.
+        // Each handler is spied at the entry point the scanner actually uses:
+        // boarding is per-index, the indexer-backed pair is batched.
         const order: string[] = [];
         const spies = [
             vi.spyOn(BoardingContractHandler, "discoverAt").mockImplementation(async () => {
                 order.push("boarding");
                 return [];
             }),
-            vi.spyOn(DefaultContractHandler, "discoverAt").mockImplementation(async () => {
-                order.push("default");
-                return [];
-            }),
-            vi.spyOn(DelegateContractHandler, "discoverAt").mockImplementation(async () => {
-                order.push("delegate");
-                return [];
-            }),
+            vi
+                .spyOn(DefaultContractHandler, "discoverRange")
+                .mockImplementation(async (entries) => {
+                    order.push("default");
+                    return new Map(entries.map((e) => [e.index, []]));
+                }),
+            vi
+                .spyOn(DelegateContractHandler, "discoverRange")
+                .mockImplementation(async (entries) => {
+                    order.push("delegate");
+                    return new Map(entries.map((e) => [e.index, []]));
+                }),
         ];
         const mgr = await makeManagerForTest();
         try {
@@ -1177,6 +1338,42 @@ describe("Wallet.restore", () => {
 
             const balance = await wallet.getBalance();
             expect(balance.total).toBeGreaterThan(0);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("restores a deep rotation within a bounded number of indexer calls", async () => {
+        // The rate-limiting incident in numbers: this scan probes 33 indices,
+        // which cost 33+ indexer requests per handler before batching. The
+        // bound is what keeps a large restore from bursting into an operator's
+        // limiter — a regression here is invisible to every other assertion.
+        const { wallet, indexer, hdProvider } = await makeHdWalletForTest();
+        try {
+            const serverPubKey = wallet.offchainTapscript.options.serverPubKey;
+            for (const csvTimelock of wallet.walletContractTimelocks) {
+                indexer.usedScripts.add(
+                    hex.encode(
+                        new DefaultVtxo.Script({
+                            pubKey: deriveDescriptorLeafPubKey(
+                                hdProvider.materializeDescriptorAt(12),
+                            ),
+                            serverPubKey,
+                            csvTimelock,
+                        }).pkScript,
+                    ),
+                );
+            }
+
+            indexer.getVtxosCalls.length = 0;
+            await wallet.restore({ gapLimit: 20 });
+
+            // Indices 0..32 probed (the hit at 12 reopens the window), in 4
+            // windows of ≤10 → one batched call each, plus the inline pull.
+            expect(await hdProvider.getCurrentSigningDescriptor()).toBe(
+                hdProvider.materializeDescriptorAt(12),
+            );
+            expect(indexer.getVtxosCalls.length).toBeLessThanOrEqual(8);
         } finally {
             await wallet.dispose();
         }

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -1379,6 +1379,43 @@ describe("Wallet.restore", () => {
         }
     });
 
+    it("re-subscribes ONCE for a scan that discovers several contracts", async () => {
+        // Every subscribe posts the whole accumulated script list, so one per
+        // discovered contract is quadratic in script-slots. The scan coalesces
+        // them into a single POST carrying the final set.
+        const { wallet, indexer, hdProvider } = await makeHdWalletForTest();
+        try {
+            const serverPubKey = wallet.offchainTapscript.options.serverPubKey;
+            const funded: string[] = [];
+            for (const index of [1, 2, 3]) {
+                for (const csvTimelock of wallet.walletContractTimelocks) {
+                    const script = hex.encode(
+                        new DefaultVtxo.Script({
+                            pubKey: deriveDescriptorLeafPubKey(
+                                hdProvider.materializeDescriptorAt(index),
+                            ),
+                            serverPubKey,
+                            csvTimelock,
+                        }).pkScript,
+                    );
+                    indexer.usedScripts.add(script);
+                    funded.push(script);
+                }
+            }
+
+            indexer.subscribeCalls.length = 0;
+            await wallet.restore({ gapLimit: 5 });
+
+            expect(indexer.subscribeCalls).toHaveLength(1);
+            // The one POST carries every discovered script, not a prefix.
+            for (const script of funded) {
+                expect(indexer.subscribeCalls[0]).toContain(script);
+            }
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
     it("HD: a funded boarding index is recovered via the on-chain probe (advances watermark)", async () => {
         const { wallet, hdProvider, fundedOnchain } = await makeHdWalletForTest();
         try {

--- a/packages/ts-sdk/test/vtxo-query-chunking.test.ts
+++ b/packages/ts-sdk/test/vtxo-query-chunking.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    ContractManager,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    type IndexerProvider,
+    type VirtualCoin,
+} from "../src";
+import type { Contract } from "../src/contracts";
+import { SCRIPT_QUERY_CHUNK_SIZE } from "../src/contracts/constants";
+import { updateWalletState } from "../src/utils/syncCursors";
+import { getAllNormalizedVtxos } from "../src/wallet/vtxo";
+import { createDefaultContractParams, createMockIndexerProvider } from "./contracts/helpers";
+import {
+    installRestoreHarness,
+    makeStaticWalletForTest,
+    teardownRestoreHarness,
+} from "./helpers/restoreWallet";
+
+const CAP = SCRIPT_QUERY_CHUNK_SIZE;
+
+/** Distinct, P2TR-shaped pkScripts. */
+const scriptAt = (i: number) => "5120" + i.toString(16).padStart(64, "0");
+const scripts = (n: number) => Array.from({ length: n }, (_, i) => scriptAt(i));
+
+const contractAt = (i: number): Contract => ({
+    type: "default",
+    params: createDefaultContractParams(),
+    script: scriptAt(i),
+    address: `addr-${i}`,
+    state: "active",
+    createdAt: 1,
+});
+
+const vtxoFor = (script: string, n: number): VirtualCoin => ({
+    txid: script.slice(4, 68).replace(/^.{2}/, n.toString(16).padStart(2, "0")),
+    vout: 0,
+    value: 1000,
+    status: { confirmed: true },
+    virtualStatus: { state: "settled" },
+    createdAt: new Date(),
+    isUnrolled: false,
+    isSpent: false,
+    script,
+});
+
+/**
+ * Records every `scripts`-shaped query and answers each with one VTXO per
+ * requested script, spread over `pagesPerChunk` pages so the chunk/page nesting
+ * is exercised rather than assumed.
+ */
+function recordingIndexer(pagesPerChunk = 1): {
+    indexer: IndexerProvider;
+    calls: { scripts: string[]; pageIndex: number; pendingOnly?: boolean }[];
+} {
+    const calls: { scripts: string[]; pageIndex: number; pendingOnly?: boolean }[] = [];
+    const indexer = createMockIndexerProvider();
+    (indexer.getVtxos as any).mockImplementation(
+        async (opts?: {
+            scripts?: string[];
+            pageIndex?: number;
+            pageSize?: number;
+            pendingOnly?: boolean;
+        }) => {
+            if (!opts?.scripts) return { vtxos: [] };
+            const pageIndex = opts.pageIndex ?? 0;
+            const pageSize = opts.pageSize ?? 500;
+            calls.push({ scripts: opts.scripts, pageIndex, pendingOnly: opts.pendingOnly });
+            const page = { current: pageIndex, next: pageIndex + 1, total: pagesPerChunk };
+            // A full page keeps the reader going; the last one is short.
+            const last = pageIndex === pagesPerChunk - 1;
+            const count = last ? opts.scripts.length : pageSize;
+            const vtxos = Array.from({ length: count }, (_, k) =>
+                vtxoFor(opts.scripts![k % opts.scripts!.length], pageIndex * 1000 + k),
+            );
+            return { vtxos, page };
+        },
+    );
+    return { indexer, calls };
+}
+
+const widest = (calls: { scripts: string[] }[]) => Math.max(...calls.map((c) => c.scripts.length));
+
+describe("getAllNormalizedVtxos", () => {
+    it("chunks a script list past the cap and unions every chunk's results", async () => {
+        const { indexer, calls } = recordingIndexer();
+        const all = scripts(CAP * 3 + 7);
+
+        const vtxos = await getAllNormalizedVtxos(indexer, all);
+
+        expect(calls).toHaveLength(4);
+        expect(widest(calls)).toBeLessThanOrEqual(CAP);
+        // The union is the part that can silently drop scripts.
+        expect(new Set(vtxos.map((v) => v.script))).toEqual(new Set(all));
+    });
+
+    it("pages each chunk to exhaustion, restarting the cursor per chunk", async () => {
+        const { indexer, calls } = recordingIndexer(2);
+
+        await getAllNormalizedVtxos(indexer, scripts(CAP + 1), { pageSize: 2 });
+
+        expect(calls.map((c) => c.pageIndex)).toEqual([0, 1, 0, 1]);
+        expect(widest(calls)).toBeLessThanOrEqual(CAP);
+    });
+
+    it("makes no request for an empty script list", async () => {
+        const { indexer, calls } = recordingIndexer();
+        expect(await getAllNormalizedVtxos(indexer, [])).toEqual([]);
+        expect(calls).toHaveLength(0);
+    });
+});
+
+describe("ContractManager script queries stay under the URL cap", () => {
+    const managers: ContractManager[] = [];
+    afterEach(async () => {
+        while (managers.length) await managers.pop()!.dispose();
+    });
+
+    const boot = async (indexer: IndexerProvider, contractCount: number) => {
+        const contractRepository = new InMemoryContractRepository();
+        for (let i = 0; i < contractCount; i++) {
+            await contractRepository.saveContract(contractAt(i));
+        }
+        const manager = await ContractManager.create({
+            indexerProvider: indexer,
+            contractRepository,
+            walletRepository: new InMemoryWalletRepository(),
+            watcherConfig: { failsafePollIntervalMs: 1_000_000, reconnectDelayMs: 1_000_000 },
+        });
+        managers.push(manager);
+        return manager;
+    };
+
+    // The boot guard: an oversized URL is a terminal 414, so before chunking a
+    // large wallet failed to construct outright.
+    it("boots a large wallet without an oversized request", async () => {
+        const { indexer, calls } = recordingIndexer();
+
+        await boot(indexer, CAP * 4);
+
+        // Both boot queries must be chunked: the sync, and the pending-frontier
+        // reconcile that runs over the full watched set right after it.
+        expect(calls.some((c) => c.pendingOnly)).toBe(true);
+        expect(widest(calls)).toBeLessThanOrEqual(CAP);
+    });
+
+    it("returns vtxos for every contract across chunks", async () => {
+        const { indexer, calls } = recordingIndexer();
+        const count = CAP * 2 + 5;
+        const manager = await boot(indexer, count);
+        calls.length = 0;
+
+        const withVtxos = await manager.getContractsWithVtxos();
+
+        expect(widest(calls)).toBeLessThanOrEqual(CAP);
+        for (let i = 0; i < count; i++) {
+            const entry = withVtxos.find((c) => c.contract.script === scriptAt(i));
+            expect(entry?.vtxos.length).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe("Wallet script queries stay under the URL cap", () => {
+    beforeEach(installRestoreHarness);
+    afterEach(() => {
+        teardownRestoreHarness();
+        vi.restoreAllMocks();
+    });
+
+    /** A wallet whose contract repository already holds `count` contracts. */
+    const walletWithContracts = async (count: number) => {
+        const handle = await makeStaticWalletForTest();
+        for (let i = 0; i < count; i++) {
+            await handle.contractRepository.saveContract(contractAt(i));
+        }
+        handle.indexer.getVtxosCalls.length = 0;
+        return handle;
+    };
+
+    it("chunks fetchPendingTxs", async () => {
+        const handle = await walletWithContracts(CAP * 3);
+
+        await handle.wallet.fetchPendingTxs();
+
+        expect(widest(handle.indexer.getVtxosCalls)).toBeLessThanOrEqual(CAP);
+    });
+
+    it("chunks finalizePendingTxs", async () => {
+        const handle = await walletWithContracts(CAP * 3);
+        await updateWalletState(handle.walletRepository, (state) => ({
+            ...state,
+            settings: { ...state.settings, hasPendingTx: true },
+        }));
+
+        await handle.wallet.finalizePendingTxs();
+
+        expect(handle.indexer.getVtxosCalls.length).toBeGreaterThan(0);
+        expect(widest(handle.indexer.getVtxosCalls)).toBeLessThanOrEqual(CAP);
+    });
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -217,6 +217,11 @@ Options:
 Releasing SDK implies a dependent boltz-swap release because boltz-swap
 depends on SDK via workspace:* (pnpm rewrites this to an exact version on
 pack/publish).
+
+Stable releases (patch/minor/major or a literal non-prerelease version) must
+be run from master. Prerelease releases (prepatch/preminor/premajor/
+prerelease, or a literal -alpha/-beta/-rc/-next version) may be run from any
+branch and publish under a matching npm dist-tag, never 'latest'.
 `,
     );
 }
@@ -404,11 +409,15 @@ function gitCurrentBranch() {
     }).trim();
 }
 
-function assertReleaseBranch() {
+function assertReleaseBranch(plan) {
+    const isPrerelease = [...plan.values()].some((v) => parseVersion(v.next).pre);
+    if (isPrerelease) return;
+
     const branch = gitCurrentBranch();
     if (branch !== RELEASE_BRANCH) {
         die(
-            `Releases must be run from ${RELEASE_BRANCH}; current branch is ${branch || "detached HEAD"}`,
+            `Stable releases must be run from ${RELEASE_BRANCH}; current branch is ${branch || "detached HEAD"}. ` +
+                `Prerelease versions (prepatch/preminor/premajor/prerelease, or a literal -alpha/-beta/-rc/-next version) may be run from any branch.`,
         );
     }
 }
@@ -589,7 +598,7 @@ function dryRun(args) {
 
 function release(args) {
     const plan = computeTargetVersions(args);
-    assertReleaseBranch();
+    assertReleaseBranch(plan);
     summarizePlan({ ...args, plan });
 
     if (!gitClean()) {


### PR DESCRIPTION
Discovery for HD-wallets with address rotation can compound quickly into a large number of requests: the wallet used to verify this has more than 370 contracts which results in 429 and 414 errors against the indexer.

This feature branch was published as RC: 

```
    "@arkade-os/boltz-swap": "0.3.54-rc.0",
    "@arkade-os/sdk": "0.4.49-rc.0",
```

Testable on different networks via: https://github.com/arkade-os/wallet/pull/816 (see the Cloudflare jobs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more efficient contract discovery across index ranges, with improved handling of incomplete or failed lookups.
  * Added complete VTXO retrieval with automatic query chunking and pagination.
  * Exposed new wallet VTXO retrieval utilities.

* **Bug Fixes**
  * Improved wallet restore and synchronization to recover older VTXO history reliably.
  * Reduced redundant subscription updates during contract scans.
  * Improved handling of rotated receive addresses and missing timelock values.

* **Chores**
  * Updated package versions for the release candidate.
  * Prereleases can now be published from non-master branches with the appropriate distribution tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->