### PR TITLE
fix(contracts): keep retired contracts in background coverage

### DIFF
--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -98,10 +98,10 @@ export type RefreshVtxosOptions = {
     before?: number;
     /**
      * When true and `scripts` is not set, refresh every contract in
-     * the repository — including those marked `inactive` and those
-     * that have dropped out of the watcher's active set. Useful for
-     * "did anyone send funds to a stale rotated display address?"
-     * audits.
+     * the repository rather than the watcher's watched set. Retirement
+     * no longer narrows that set (see
+     * {@link ContractWatcher.getWatchedContracts}), so this only differs
+     * for repository rows the watcher never registered.
      *
      * Because this is a *superset* of the watcher's watched set, the
      * cursor invariant still holds and the cursor advances normally
@@ -1225,9 +1225,8 @@ export class ContractManager implements IContractManager {
      * have data we'd skip).
      *
      * `includeInactive: true` (and no `scripts`) widens the refresh to
-     * every contract in the repository, including ones marked
-     * `inactive` and ones that have dropped out of the watcher's
-     * active set. This is a *superset* of the watched set, so the
+     * every contract in the repository, including rows the watcher
+     * never registered. This is a *superset* of the watched set, so the
      * cursor invariant still holds and the cursor advances normally.
      *
      * `after` / `before` apply a caller-supplied time window. The
@@ -1382,11 +1381,11 @@ export class ContractManager implements IContractManager {
      * Sync virtual outputs for the given contracts against the indexer.
      *
      * When `options.contracts` is omitted the sync covers the full
-     * watched set (active contracts plus any inactive contracts still
-     * holding cached VTXOs) and the global cursor is advanced on
-     * success. Passing an explicit subset leaves the cursor alone so a
-     * narrow poll can't hide data that other contracts still need to
-     * pick up.
+     * watched set — every registered contract, retired ones included
+     * (see {@link ContractWatcher.getWatchedContracts}) — and the global
+     * cursor is advanced on success. Passing an explicit subset leaves
+     * the cursor alone so a narrow poll can't hide data that other
+     * contracts still need to pick up.
      */
     private async syncContracts(options: {
         contracts?: Contract[];

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -93,8 +93,19 @@ const SCAN_MAX_INDEX = 10_000;
 const DEFAULT_SCAN_BATCH = 10;
 
 export type RefreshVtxosOptions = {
+    /**
+     * Narrow the refresh to these scripts. A subset query, so the
+     * cursor is not advanced: contracts outside the list may have data
+     * we'd skip.
+     */
     scripts?: string[];
+    /**
+     * Time window overriding the cursor-derived one. The cursor never
+     * advances on a windowed query because the window may skip data
+     * outside its bounds.
+     */
     after?: number;
+    /** @see after */
     before?: number;
     /**
      * When true and `scripts` is not set, refresh every contract in
@@ -103,12 +114,9 @@ export type RefreshVtxosOptions = {
      * retirement doesn't narrow that set
      * (see {@link ContractWatcher.getWatchedContracts}).
      *
-     * Because this is a *superset* of the watcher's watched set, the
-     * cursor invariant still holds and the cursor advances normally
-     * (unless an explicit `after` / `before` window is also supplied).
-     *
-     * Ignored when `scripts` is set (the explicit list already
-     * specifies what to refresh, regardless of contract state).
+     * Because this is a *superset* of the watched set, the cursor
+     * invariant still holds and the cursor advances normally (unless
+     * `after` / `before` is also supplied).
      *
      * @defaultValue `false`
      */
@@ -1217,21 +1225,10 @@ export class ContractManager implements IContractManager {
     /**
      * Force refresh virtual outputs from the indexer.
      *
-     * Without options, re-fetches every contract in the watcher's
-     * watched set and advances the global cursor.
-     *
-     * `scripts` narrows the refresh to a specific list (subset query —
-     * cursor is not advanced because contracts outside the list may
-     * have data we'd skip).
-     *
-     * `includeInactive: true` (and no `scripts`) widens the refresh to
-     * every contract in the repository, including rows the watcher
-     * never registered. This is a *superset* of the watched set, so the
-     * cursor invariant still holds and the cursor advances normally.
-     *
-     * `after` / `before` apply a caller-supplied time window. The
-     * cursor never advances on a windowed query because the window
-     * may skip data outside its bounds.
+     * Without options, re-fetches the watcher's watched set and
+     * advances the global cursor. Each option narrows or widens that
+     * scope and may hold the cursor back — see
+     * {@link RefreshVtxosOptions}.
      */
     async refreshVtxos(opts?: RefreshVtxosOptions): Promise<void> {
         const contracts = opts?.scripts

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -98,10 +98,10 @@ export type RefreshVtxosOptions = {
     before?: number;
     /**
      * When true and `scripts` is not set, refresh every contract in
-     * the repository rather than the watcher's watched set. Retirement
-     * no longer narrows that set (see
-     * {@link ContractWatcher.getWatchedContracts}), so this only differs
-     * for repository rows the watcher never registered.
+     * the repository rather than the watcher's watched set — which
+     * differs only for rows the watcher never registered, since
+     * retirement doesn't narrow that set
+     * (see {@link ContractWatcher.getWatchedContracts}).
      *
      * Because this is a *superset* of the watcher's watched set, the
      * cursor invariant still holds and the cursor advances normally
@@ -1381,11 +1381,10 @@ export class ContractManager implements IContractManager {
      * Sync virtual outputs for the given contracts against the indexer.
      *
      * When `options.contracts` is omitted the sync covers the full
-     * watched set — every registered contract, retired ones included
-     * (see {@link ContractWatcher.getWatchedContracts}) — and the global
-     * cursor is advanced on success. Passing an explicit subset leaves
-     * the cursor alone so a narrow poll can't hide data that other
-     * contracts still need to pick up.
+     * watched set ({@link ContractWatcher.getWatchedContracts}) and the
+     * global cursor is advanced on success. Passing an explicit subset
+     * leaves the cursor alone so a narrow poll can't hide data that
+     * other contracts still need to pick up.
      */
     private async syncContracts(options: {
         contracts?: Contract[];

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -275,12 +275,15 @@ export interface IContractManager extends Disposable {
     ): Promise<Contract>;
 
     /**
-     * Convenience helper to update only the contract state.
+     * Convenience helper to update only the contract state. Note
+     * `inactive` does not stop watching; see {@link ContractState} and
+     * {@link deleteContract}.
      */
     setContractState(script: string, state: ContractState): Promise<void>;
 
     /**
-     * Delete a contract by script and stop watching it (if applicable).
+     * Delete a contract by script and stop watching it. This — not
+     * retiring via {@link setContractState} — is the stop-watching path.
      */
     deleteContract(script: string): Promise<void>;
 
@@ -513,8 +516,8 @@ export class ContractManager implements IContractManager {
      * Static factory method for creating a new ContractManager.
      * Initialize the manager by loading persisted contracts and starting to watch.
      *
-     * After initialization, the manager automatically watches all active contracts
-     * and contracts with virtual outputs. Use `onContractEvent()` to register event callbacks.
+     * After initialization, the manager automatically watches every persisted
+     * contract. Use `onContractEvent()` to register event callbacks.
      *
      * @param config ContractManagerConfig
      */
@@ -1131,14 +1134,18 @@ export class ContractManager implements IContractManager {
     }
 
     /**
-     * Set a contract's state.
+     * Set a contract's state. Retiring (`inactive`) keeps it watched;
+     * see {@link ContractState}. To stop watching, use
+     * {@link deleteContract}.
      */
     async setContractState(script: string, state: ContractState): Promise<void> {
         await this.updateContract(script, { state });
     }
 
     /**
-     * Delete a contract.
+     * Delete a contract. Also removes it from the watcher — the only way
+     * to stop watching a contract (retiring it via
+     * {@link setContractState} does not).
      *
      * @param script - Contract script
      */

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -180,11 +180,10 @@ export class ContractWatcher {
         // app launch and can confuse consumers that react to the event.
         await this.seedLastKnownVtxos(state);
 
-        // If we're already watching, poll to discover virtual outputs and update subscription
+        // If we're already watching, poll to seed virtual outputs and fold
+        // this script into the subscription.
         if (this.isWatching) {
-            // Poll first to discover virtual outputs (may affect whether we watch this contract).
             await this.pollContracts([contract.script]);
-            // Update subscription based on active state and virtual outputs.
             await this.tryUpdateSubscription();
         }
     }
@@ -313,7 +312,7 @@ export class ContractWatcher {
     }
 
     /**
-     * Start watching for virtual output events across all active contracts.
+     * Start watching for virtual output events across all watched contracts.
      */
     async startWatching(callback: ContractEventCallback): Promise<() => void> {
         if (this.isWatching) {
@@ -380,7 +379,7 @@ export class ContractWatcher {
     }
 
     /**
-     * Force a poll of all active contracts.
+     * Force a poll of all watched contracts.
      * Useful for manual refresh or after app resume.
      */
     async forcePoll(): Promise<void> {

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -160,9 +160,10 @@ export class ContractWatcher {
     /**
      * Add a contract to be watched.
      *
-     * Every contract is immediately subscribed and polled, whatever its
-     * state — see {@link getWatchedContracts} for why retirement can't
-     * remove coverage.
+     * Once watching, every contract is subscribed and polled whatever
+     * its state.
+     *
+     * @see getWatchedContracts
      */
     async addContract(contract: Contract): Promise<void> {
         const state: ContractState = {
@@ -256,22 +257,15 @@ export class ContractWatcher {
     }
 
     /**
-     * Contracts the watcher tracks: **every** registered contract,
-     * including retired (`inactive`) ones that hold no known virtual
-     * outputs.
+     * Every registered contract, retired (`inactive`) ones included.
      *
-     * This is the single source of truth for "contracts whose VTXO state
-     * we still care about" — callers and the subscription itself fan out
-     * over the same set so nothing is reconciled that isn't also watched.
-     *
-     * Retirement must never narrow this set. An Ark receive address can be
-     * paid again after the wallet has rotated past it, so a retired,
-     * fully-spent contract dropped from here leaves *every* background
-     * channel at once — this accessor feeds both the subscription and the
-     * indexer sweep scope — and a real payment to it becomes invisible
-     * until some foreground read happens to sweep it. Retirement therefore
-     * controls sweep *cadence* and receive-address selection, never
-     * coverage.
+     * Feeds both the subscription and the indexer sweep scope, so
+     * narrowing it drops a contract from every background channel at
+     * once. Nothing may be narrowed out: an Ark receive address can be
+     * paid again after the wallet has rotated past it, and a payment
+     * that lands outside every background channel is invisible until
+     * some foreground read happens to sweep it. Retirement therefore
+     * governs receive-address selection, not coverage.
      */
     getWatchedContracts(): Contract[] {
         return this.getAllContracts();
@@ -626,8 +620,7 @@ export class ContractWatcher {
     /**
      * Update the subscription with scripts that should be watched.
      *
-     * @see getWatchedContracts — the subscription covers every registered
-     * contract, retired ones included.
+     * @see getWatchedContracts
      */
     private async updateSubscription(): Promise<void> {
         const scriptsToWatch = this.getWatchedContracts().map((c) => c.script);

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -160,10 +160,9 @@ export class ContractWatcher {
     /**
      * Add a contract to be watched.
      *
-     * Active contracts are immediately subscribed.
-     *
-     * All contracts are polled to discover any existing virtual outputs
-     * (which may cause them to be watched even if inactive).
+     * Every contract is immediately subscribed and polled, whatever its
+     * state — see {@link getWatchedContracts} for why retirement can't
+     * remove coverage.
      */
     async addContract(contract: Contract): Promise<void> {
         const state: ContractState = {
@@ -257,20 +256,25 @@ export class ContractWatcher {
     }
 
     /**
-     * Contracts the watcher is actually tracking:
-     * - all active contracts, plus
-     * - inactive contracts that still hold known virtual outputs
-     *   (the subscription keeps watching them so `vtxo_spent` events for
-     *   those unspent outputs are still observed).
+     * Contracts the watcher tracks: **every** registered contract,
+     * including retired (`inactive`) ones that hold no known virtual
+     * outputs.
      *
      * This is the single source of truth for "contracts whose VTXO state
      * we still care about" — callers and the subscription itself fan out
      * over the same set so nothing is reconciled that isn't also watched.
+     *
+     * Retirement must never narrow this set. An Ark receive address can be
+     * paid again after the wallet has rotated past it, so a retired,
+     * fully-spent contract dropped from here leaves *every* background
+     * channel at once — this accessor feeds both the subscription and the
+     * indexer sweep scope — and a real payment to it becomes invisible
+     * until some foreground read happens to sweep it. Retirement therefore
+     * controls sweep *cadence* and receive-address selection, never
+     * coverage.
      */
     getWatchedContracts(): Contract[] {
-        return Array.from(this.contracts.values())
-            .filter((s) => s.contract.state === "active" || s.lastKnownVtxos.size > 0)
-            .map((s) => s.contract);
+        return this.getAllContracts();
     }
 
     /**
@@ -622,7 +626,8 @@ export class ContractWatcher {
     /**
      * Update the subscription with scripts that should be watched.
      *
-     * Watches both active contracts and contracts with virtual outputs.
+     * @see getWatchedContracts — the subscription covers every registered
+     * contract, retired ones included.
      */
     private async updateSubscription(): Promise<void> {
         const scriptsToWatch = this.getWatchedContracts().map((c) => c.script);

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -9,7 +9,12 @@ import type { OnchainProvider } from "../providers/onchain";
 import type { Network } from "../networks";
 
 /**
- * Contract state indicating whether it should be actively monitored.
+ * Contract lifecycle state. Both states stay monitored — the watcher
+ * subscribes and sweeps every registered contract regardless
+ * (see {@link ContractWatcher.getWatchedContracts}), because a retired
+ * receive address can still be paid. `inactive` only demotes a contract
+ * out of receive-address selection; it does **not** unsubscribe it.
+ * Use {@link IContractManager.deleteContract} to stop watching.
  */
 export type ContractState = "active" | "inactive";
 

--- a/packages/ts-sdk/test/contracts/manager.test.ts
+++ b/packages/ts-sdk/test/contracts/manager.test.ts
@@ -347,11 +347,9 @@ describe("ContractManager", () => {
     });
 
     describe("refreshVtxos includeInactive", () => {
-        // Default `refreshVtxos()` syncs the watched set — every
-        // contract registered with the watcher, retired ones included.
-        // `includeInactive: true` widens the query to every row in the
-        // repository, which now differs only for rows the watcher never
-        // registered.
+        // Default `refreshVtxos()` syncs the watched set;
+        // `includeInactive: true` widens it to every repository row,
+        // which differs only for rows the watcher never registered.
         //
         // The manager validates that `script` is derived from `params`,
         // so these tests seed the repository directly with synthetic
@@ -413,19 +411,15 @@ describe("ContractManager", () => {
 
             await manager.refreshVtxos();
 
-            // The raw-seeded script bypassed `createContract`, so the
-            // watcher never saw it and the default path can't cover it.
-            // `includeInactive` is the explicit override.
+            // `seedRaw` bypasses `createContract`, so the watcher never
+            // saw this script.
             const requested = collectRequestedScripts(mockIndexer);
             expect(requested.has(inactiveScript)).toBe(false);
         });
 
         it("default path still covers contracts the watcher transitioned to inactive", async () => {
-            // The production path: a contract registered through
-            // `manager.createContract` is later retired via
-            // `setContractState`. It must stay in the watched set —
-            // a retired receive address can be paid again, and dropping
-            // it here is what left it outside every background channel.
+            // The production shape the `seedRaw` variants can't reach: a
+            // registered contract later retired via `setContractState`.
             await seedActive();
             await manager.createContract({
                 type: "default",
@@ -571,11 +565,9 @@ describe("ContractManager", () => {
     });
 
     describe("retired contract coverage", () => {
-        // A rotated-past receive address can be paid again. Retiring it
-        // must therefore change sweep cadence and receive-address
-        // selection only — never coverage. These tests assert detection
-        // through *background* channels with no read API involved, so
-        // they keep guarding once reads become repository-only.
+        // Detection is asserted through *background* channels only, with
+        // no read API involved, so these keep guarding once reads become
+        // repository-only.
 
         it("a retired, fully-spent contract that receives is picked up by the reconnect sweep", async () => {
             const walletRepo = new InMemoryWalletRepository();
@@ -597,9 +589,8 @@ describe("ContractManager", () => {
                     script: TEST_DEFAULT_SCRIPT,
                     address: "retired-address",
                 });
-                // Rotated past: retired with no VTXOs left, so neither
-                // arm of the old `active || lastKnownVtxos.size > 0`
-                // filter would have kept it.
+                // Retired with no VTXOs left: neither arm of the old
+                // `active || lastKnownVtxos.size > 0` filter held it.
                 await mgr.setContractState(TEST_DEFAULT_SCRIPT, "inactive");
 
                 const incoming = createMockContractVtxo(TEST_DEFAULT_SCRIPT, {
@@ -608,8 +599,7 @@ describe("ContractManager", () => {
                 (mockIndexer.getVtxos as any).mockClear();
                 (mockIndexer.getVtxos as any).mockResolvedValue({ vtxos: [incoming] });
 
-                // Background channel: the reconnect reconcile. No read
-                // API is called anywhere in this test.
+                // Background channel: the reconnect reconcile.
                 await (mgr as any).handleContractEvent({
                     type: "connection_reset",
                     timestamp: Date.now(),

--- a/packages/ts-sdk/test/contracts/manager.test.ts
+++ b/packages/ts-sdk/test/contracts/manager.test.ts
@@ -347,11 +347,11 @@ describe("ContractManager", () => {
     });
 
     describe("refreshVtxos includeInactive", () => {
-        // Default `refreshVtxos()` syncs only the watched set
-        // (active contracts + inactives that still have known VTXOs).
-        // `includeInactive: true` widens the query to every contract in
-        // the repository — the audit path for "did anyone send funds
-        // to a stale rotated address?".
+        // Default `refreshVtxos()` syncs the watched set — every
+        // contract registered with the watcher, retired ones included.
+        // `includeInactive: true` widens the query to every row in the
+        // repository, which now differs only for rows the watcher never
+        // registered.
         //
         // The manager validates that `script` is derived from `params`,
         // so these tests seed the repository directly with synthetic
@@ -404,7 +404,7 @@ describe("ContractManager", () => {
             expect(requested.has(inactiveScript)).toBe(true);
         });
 
-        it("default path (no flag) skips inactive contracts that have no known VTXOs", async () => {
+        it("default path (no flag) skips repository rows the watcher never registered", async () => {
             await seedActive();
             await seedRaw(inactiveScript, "stale-address", "inactive");
 
@@ -413,22 +413,19 @@ describe("ContractManager", () => {
 
             await manager.refreshVtxos();
 
-            // The inactive script must NOT appear in any `scripts`
-            // filter — that's the privacy/perf saving the watcher
-            // gives us. `includeInactive` is the explicit override.
+            // The raw-seeded script bypassed `createContract`, so the
+            // watcher never saw it and the default path can't cover it.
+            // `includeInactive` is the explicit override.
             const requested = collectRequestedScripts(mockIndexer);
             expect(requested.has(inactiveScript)).toBe(false);
         });
 
-        it("default path skips contracts the watcher itself transitioned to inactive", async () => {
-            // The `seedRaw` variants above prove unmanaged repository
-            // rows are ignored. This test exercises the path that
-            // actually happens in production: a contract registered
-            // through `manager.createContract` is later transitioned
-            // to `inactive` via `setContractState`. If the watcher
-            // leaked the now-inactive script back into its watched
-            // set, the default `refreshVtxos()` would still hit the
-            // indexer for it — defeating the privacy/perf rationale.
+        it("default path still covers contracts the watcher transitioned to inactive", async () => {
+            // The production path: a contract registered through
+            // `manager.createContract` is later retired via
+            // `setContractState`. It must stay in the watched set —
+            // a retired receive address can be paid again, and dropping
+            // it here is what left it outside every background channel.
             await seedActive();
             await manager.createContract({
                 type: "default",
@@ -446,7 +443,7 @@ describe("ContractManager", () => {
 
             const requested = collectRequestedScripts(mockIndexer);
             expect(requested.has(TEST_DEFAULT_SCRIPT)).toBe(true);
-            expect(requested.has(SECOND_DEFAULT_SCRIPT)).toBe(false);
+            expect(requested.has(SECOND_DEFAULT_SCRIPT)).toBe(true);
         });
 
         it("explicit scripts filter takes precedence over includeInactive", async () => {
@@ -567,6 +564,90 @@ describe("ContractManager", () => {
 
                 const stateAfter = await walletRepo.getWalletState();
                 expect(stateAfter?.lastSyncTime).toBe(SEEDED_CURSOR);
+            } finally {
+                await mgr.dispose();
+            }
+        });
+    });
+
+    describe("retired contract coverage", () => {
+        // A rotated-past receive address can be paid again. Retiring it
+        // must therefore change sweep cadence and receive-address
+        // selection only — never coverage. These tests assert detection
+        // through *background* channels with no read API involved, so
+        // they keep guarding once reads become repository-only.
+
+        it("a retired, fully-spent contract that receives is picked up by the reconnect sweep", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const contractRepo = new InMemoryContractRepository();
+            const mgr = await ContractManager.create({
+                indexerProvider: mockIndexer,
+                contractRepository: contractRepo,
+                walletRepository: walletRepo,
+                watcherConfig: {
+                    failsafePollIntervalMs: 1000,
+                    reconnectDelayMs: 500,
+                },
+            });
+
+            try {
+                await mgr.createContract({
+                    type: "default",
+                    params: createDefaultContractParams(),
+                    script: TEST_DEFAULT_SCRIPT,
+                    address: "retired-address",
+                });
+                // Rotated past: retired with no VTXOs left, so neither
+                // arm of the old `active || lastKnownVtxos.size > 0`
+                // filter would have kept it.
+                await mgr.setContractState(TEST_DEFAULT_SCRIPT, "inactive");
+
+                const incoming = createMockContractVtxo(TEST_DEFAULT_SCRIPT, {
+                    txid: "ab".repeat(32),
+                });
+                (mockIndexer.getVtxos as any).mockClear();
+                (mockIndexer.getVtxos as any).mockResolvedValue({ vtxos: [incoming] });
+
+                // Background channel: the reconnect reconcile. No read
+                // API is called anywhere in this test.
+                await (mgr as any).handleContractEvent({
+                    type: "connection_reset",
+                    timestamp: Date.now(),
+                });
+
+                expect(collectRequestedScripts(mockIndexer).has(TEST_DEFAULT_SCRIPT)).toBe(true);
+                const stored = await walletRepo.getVtxos("retired-address");
+                expect(stored.map((v) => v.txid)).toContain(incoming.txid);
+            } finally {
+                await mgr.dispose();
+            }
+        });
+
+        it("keeps a retired contract in the subscription", async () => {
+            const mgr = await ContractManager.create({
+                indexerProvider: mockIndexer,
+                contractRepository: new InMemoryContractRepository(),
+                walletRepository: new InMemoryWalletRepository(),
+                watcherConfig: {
+                    failsafePollIntervalMs: 1000,
+                    reconnectDelayMs: 500,
+                },
+            });
+
+            try {
+                await mgr.createContract({
+                    type: "default",
+                    params: createDefaultContractParams(),
+                    script: TEST_DEFAULT_SCRIPT,
+                    address: "retired-address",
+                });
+                (mockIndexer.subscribeForScripts as any).mockClear();
+                await mgr.setContractState(TEST_DEFAULT_SCRIPT, "inactive");
+
+                const subscribed = (mockIndexer.subscribeForScripts as any).mock.calls.flatMap(
+                    (c: any) => c[0],
+                );
+                expect(subscribed).toContain(TEST_DEFAULT_SCRIPT);
             } finally {
                 await mgr.dispose();
             }

--- a/packages/ts-sdk/test/contracts/watcher.test.ts
+++ b/packages/ts-sdk/test/contracts/watcher.test.ts
@@ -51,7 +51,10 @@ describe("ContractWatcher", () => {
         expect(mockIndexer.subscribeForScripts).toHaveBeenCalledWith([contract.script], undefined);
     });
 
-    it("should exclude inactive contracts without VTXOs from watching", async () => {
+    it("should subscribe inactive contracts without VTXOs", async () => {
+        // A rotated-past receive address can be paid again, so retiring
+        // it must not drop it from the subscription — that would make a
+        // later payment invisible to every background channel.
         await watcher.startWatching(() => {});
 
         const contract: Contract = {
@@ -64,7 +67,7 @@ describe("ContractWatcher", () => {
         };
 
         await watcher.addContract(contract);
-        expect(mockIndexer.subscribeForScripts).not.toHaveBeenCalled();
+        expect(mockIndexer.subscribeForScripts).toHaveBeenCalledWith([contract.script], undefined);
     });
 
     it("should unsubscribe from scripts when stopped", async () => {

--- a/packages/ts-sdk/test/contracts/watcher.test.ts
+++ b/packages/ts-sdk/test/contracts/watcher.test.ts
@@ -52,9 +52,7 @@ describe("ContractWatcher", () => {
     });
 
     it("should subscribe inactive contracts without VTXOs", async () => {
-        // A rotated-past receive address can be paid again, so retiring
-        // it must not drop it from the subscription — that would make a
-        // later payment invisible to every background channel.
+        // A rotated-past receive address can still be paid.
         await watcher.startWatching(() => {});
 
         const contract: Contract = {

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -502,11 +502,9 @@ describe("Wallet HD rotation", () => {
         });
 
         it("second rotation deactivates the previous tagged display contract", async () => {
-            // Privacy: once we've moved past a tagged display address we
-            // stop handing it out — `state: 'inactive'` filters it out of
-            // future `pickActiveReceive` lookups. It stays fully watched;
-            // retirement never narrows coverage, because the address can
-            // still be paid.
+            // Privacy: `state: 'inactive'` stops `pickActiveReceive`
+            // handing the address out again. It stays fully watched —
+            // retirement never narrows coverage.
             const walletRepo = new InMemoryWalletRepository();
             const contractRepo = new InMemoryContractRepository();
             const wallet = await makeHdWallet(walletRepo, contractRepo);

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -502,12 +502,11 @@ describe("Wallet HD rotation", () => {
         });
 
         it("second rotation deactivates the previous tagged display contract", async () => {
-            // Privacy + watch-set hygiene: once we've moved past a
-            // tagged display address, we stop accepting new arrivals
-            // there. The watcher keeps tracking it as long as it has
-            // unspent VTXOs, but `state: 'inactive'` filters it out of
-            // future `pickActiveReceive` lookups and shrinks the
-            // long-term watch surface.
+            // Privacy: once we've moved past a tagged display address we
+            // stop handing it out — `state: 'inactive'` filters it out of
+            // future `pickActiveReceive` lookups. It stays fully watched;
+            // retirement never narrows coverage, because the address can
+            // still be paid.
             const walletRepo = new InMemoryWalletRepository();
             const contractRepo = new InMemoryContractRepository();
             const wallet = await makeHdWallet(walletRepo, contractRepo);


### PR DESCRIPTION
Part of the ongoing work on steady-state performance for large HD wallets. This one is a correctness fix that has to land before the polling changes, not a performance change itself.

## The defect

`ContractWatcher.getWatchedContracts()` filtered on `state === "active" || lastKnownVtxos.size > 0`. That accessor is the sole input to **both** `updateSubscription` and the watcher-driven sync scope, so a receive address that was retired (`walletReceiveRotator` deactivates the previous tagged contract on rotation) and then fully spent satisfied neither arm and dropped out of every background channel at once.

An Ark receive address can be paid again after the wallet has rotated past it, so a later payment to such an address is real — and invisible to the subscription and the periodic sweep alike. Retire-then-spend and spend-then-retire both reach the same state.

Today this is latency rather than loss on the in-process wallet, because the read paths (`getVtxos` / `getBalance` / `getTransactionHistory`) still sweep inactive contracts and act as an accidental safety net. On the service-worker wallet, whose reads are already repository-only, nothing sweeps the retired script until an explicit `RELOAD_WALLET`. The upcoming work makes in-process reads repository-only too, which removes the safety net — hence fixing this first.

## The fix

The watched set is now every registered contract. Retirement governs receive-address selection (`pickActiveReceive` keeps skipping inactive contracts), not coverage.

No new indexer traffic in practice: post-restore every contract is already `active`, so the set is unchanged there. The narrowing only ever applied to rotated-past addresses.

## Tests

Two regression tests asserting detection through *background* channels with no read API involved, so they keep guarding once reads become repository-only:

- a retired, fully-spent contract that receives is queried by the reconnect reconcile and the VTXO lands in the wallet repository;
- a retired contract stays in the subscription script set.

Three existing tests pinned the old behavior and were inverted rather than extended. A fourth still passes but for a different reason (it seeds the repository directly, bypassing the watcher) and was renamed to say so.

## Scope checked

`boltz-swap` is unaffected: it registers no contracts with `ContractManager` and never writes contract state — swaps live in `SwapRepository` and it queries the indexer directly. An embedder registering a VHTLC via `createContract` was exposed to the same bug and is covered by this fix, since it sits at the accessor rather than being special-cased to receive addresses.

Full unit suite green in both packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Retired or inactive contracts remain monitored for incoming activity.
  * Inactive contracts are no longer selected for new receive addresses, while existing coverage continues.
  * Reconnection and background monitoring now continue to detect activity across all registered contracts.
  * Contract refresh and synchronization behavior is clarified, including when updates advance synchronization progress.

* **Documentation**
  * Clarified how to retire contracts and how to fully stop monitoring them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->