### PR TITLE
Add fallback to /v1/blocks endpoint in EsploraProvider

### DIFF
--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -360,7 +360,15 @@ export class EsploraProvider implements OnchainProvider {
         // spec — electrs happens to serve it as an alias for `/blocks`, but a
         // strict backend like mempool returns an empty array, which surfaced here
         // as "No chain tip found". `/blocks` works across every Esplora backend.
-        const tipBlocks = await baseFetch(`${this.baseUrl}/blocks`);
+        let tipBlocks = await baseFetch(`${this.baseUrl}/blocks`);
+        if (tipBlocks.status === 404) {
+            // Instances backed only by the mempool backend (no electrs REST
+            // passthrough) — e.g. the default mutinynet deployment at
+            // mempool.mutinynet.arkade.sh — don't serve `/blocks` at all. They
+            // expose the same newest-first array at `/v1/blocks`, which
+            // mempool.space serves too.
+            tipBlocks = await baseFetch(`${this.baseUrl}/v1/blocks`);
+        }
         if (!tipBlocks.ok) {
             throw new Error(`Failed to get chain tip: ${tipBlocks.statusText}`);
         }

--- a/packages/ts-sdk/test/esplora.test.ts
+++ b/packages/ts-sdk/test/esplora.test.ts
@@ -124,4 +124,82 @@ describe("EsploraProvider", () => {
             );
         });
     });
+
+    describe("getChainTip", () => {
+        const mockBlocks = [
+            { id: "tip-hash", height: 800000, mediantime: 1700000000 },
+            { id: "prev-hash", height: 799999, mediantime: 1699999000 },
+        ];
+        const expectedTip = { hash: "tip-hash", height: 800000, time: 1700000000 };
+
+        it("should fetch the tip from /blocks", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve(mockBlocks),
+            });
+
+            const provider = new EsploraProvider("http://localhost:3000");
+            const tip = await provider.getChainTip();
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(mockFetch).toHaveBeenCalledWith("http://localhost:3000/blocks");
+            expect(tip).toEqual(expectedTip);
+        });
+
+        it("should fall back to /v1/blocks when /blocks returns 404", async () => {
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: false,
+                    status: 404,
+                    statusText: "Not Found",
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve(mockBlocks),
+                });
+
+            const provider = new EsploraProvider("http://localhost:3000");
+            const tip = await provider.getChainTip();
+
+            expect(mockFetch).toHaveBeenNthCalledWith(1, "http://localhost:3000/blocks");
+            expect(mockFetch).toHaveBeenNthCalledWith(2, "http://localhost:3000/v1/blocks");
+            expect(tip).toEqual(expectedTip);
+        });
+
+        it("should throw when the /v1/blocks fallback also fails", async () => {
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: false,
+                    status: 404,
+                    statusText: "Not Found",
+                })
+                .mockResolvedValueOnce({
+                    ok: false,
+                    status: 404,
+                    statusText: "Not Found",
+                });
+
+            const provider = new EsploraProvider("http://localhost:3000");
+            await expect(provider.getChainTip()).rejects.toThrow(
+                "Failed to get chain tip: Not Found",
+            );
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
+        it("should not fall back on non-404 errors", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 503,
+                statusText: "Service Unavailable",
+            });
+
+            const provider = new EsploraProvider("http://localhost:3000");
+            await expect(provider.getChainTip()).rejects.toThrow(
+                "Failed to get chain tip: Service Unavailable",
+            );
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
Enhanced the `EsploraProvider.getChainTip()` method to handle Esplora backends that don't serve the `/blocks` endpoint by falling back to the `/v1/blocks` endpoint.

## Changes
- **Modified `EsploraProvider.getChainTip()`**: Added fallback logic to attempt `/v1/blocks` when the primary `/blocks` endpoint returns a 404 error
  - Only falls back on 404 responses; other error statuses are treated as fatal
  - Maintains backward compatibility with backends that serve `/blocks`
  - Supports mempool-only deployments (e.g., mutinynet) that expose the blocks array at `/v1/blocks`

- **Added comprehensive test coverage** for the new fallback behavior:
  - Successful fetch from `/blocks`
  - Fallback to `/v1/blocks` on 404
  - Error handling when both endpoints fail
  - Non-404 errors don't trigger fallback

## Implementation Details
The fallback is triggered only on 404 status codes, ensuring that transient errors (5xx) or other client errors don't mask the actual issue. This approach maintains compatibility across different Esplora backend implementations while providing a graceful degradation path for backends with limited endpoint support.

https://claude.ai/code/session_01JN59xDAqYtFmPcVR5GGJjh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain tip retrieval by automatically using a compatible fallback endpoint when the primary endpoint is unavailable.
  * Preserved existing validation and error handling, including correct behavior for non-404 errors.

* **Tests**
  * Added coverage for successful retrieval, fallback behavior, and related error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->