### PR TITLE
chore: shrink AGENTS.md and extract lazy skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,6 @@
 
 This file provides guidance to AI coding assistants when working with code in this repository.
 
-## Project Overview
-
-**arkade-monorepo** — A pnpm workspace monorepo for the Arkade Bitcoin wallet ecosystem. Contains two published packages: `@arkade-os/sdk` (Bitcoin wallet SDK with Taproot/Ark protocol) and `@arkade-os/boltz-swap` (Lightning/chain swaps via Boltz). Both target browser, Node.js, and React Native (Expo).
-
 ## Reference Implementation & Technical Direction
 
 **The .NET Ark SDK (`NArk`, ArkLabsHQ) is the reference implementation for this TypeScript SDK** —
@@ -37,119 +33,24 @@ Keep the dependency and ownership direction clear: plugins may depend on and con
 ## Commands
 
 ```bash
-# Monorepo-wide
-pnpm run build                # Build all packages (ts-sdk must build before boltz-swap)
-pnpm test                     # Run all unit and integration tests
-pnpm run test:unit            # Run all unit tests
-pnpm run test:integration     # Run all integration tests against the root regtest stack
-pnpm run lint                 # Check formatting (prettier)
-
-# Per-package (from repo root)
-pnpm -C packages/ts-sdk test              # Unit tests for SDK
-pnpm -C packages/ts-sdk test:unit         # Unit tests excluding e2e
-pnpm -C packages/boltz-swap test          # Unit tests for boltz-swap
-pnpm -C packages/boltz-swap test:unit     # Unit tests excluding e2e
-
-# Single test file
-pnpm -C packages/ts-sdk vitest run test/wallet.test.ts
-pnpm -C packages/boltz-swap vitest run test/swap-manager.test.ts
-
-# Single test by name
-pnpm -C packages/ts-sdk vitest run -t "test name pattern"
-
-# Integration tests (require Docker regtest stack)
-# `test:integration` runs each package's full cycle (reset + up + setup + test)
-# via `scripts/regtest.sh <pkg> cycle`, using packages/<pkg>/.env.regtest.
-pnpm run test:integration              # Both packages, end-to-end
-pnpm run test:integration:ts-sdk       # ts-sdk only
-pnpm run test:integration:boltz-swap   # boltz-swap only
-
-# Per-package stack control (replace :ts-sdk with :boltz-swap for the other)
-pnpm run regtest:up:ts-sdk
-pnpm run regtest:setup:ts-sdk
-pnpm run regtest:test:ts-sdk                            # whole e2e suite
-pnpm run regtest:test:ts-sdk test/e2e/asset.test.ts    # or selected files only
-pnpm run regtest:down:ts-sdk
-pnpm run regtest:reset:ts-sdk
-
-# CI fans the ts-sdk e2e suite out across parallel groups by passing each group's
-# file list to `regtest:test` (see the `integration` matrix in .github/workflows/ci.yml).
-
-# Release (package-scoped; target = sdk | boltz-swap | all)
-pnpm run release -- boltz-swap patch          # Boltz bugfix only
-pnpm run release -- sdk patch                 # SDK + dependent boltz-swap patch
-pnpm run release -- sdk prepatch --preid beta # Mirrors prerelease into boltz-swap
-pnpm run release -- all patch                 # Bump both
-pnpm run release:dry-run -- sdk patch         # Preview without changes
-pnpm run release:cleanup                      # Auto-detect dirty release artifacts
+pnpm run build       # Build all packages — ts-sdk must build before boltz-swap
+pnpm run test:unit   # All unit tests
+pnpm run lint        # Check formatting (prettier)
+pnpm -C packages/ts-sdk vitest run test/wallet.test.ts   # Single test file
 ```
 
-Tags are `@arkade-os/sdk/<version>` and `@arkade-os/boltz-swap/<version>` (no `v<version>`). Releasing SDK implies a dependent boltz-swap release because boltz-swap depends on SDK via `workspace:*`; override with `--boltz-bump <bump-or-version>`. The script runs tests, builds, commits, tags, publishes to npm (requires local npm credentials), and pushes commit + tags to `origin`.
+Release and regtest/integration workflows are documented in `CONTRIBUTING.md`.
 
-## Code Style
+## Contracts Subsystem Ownership
 
-- **Prettier**: double quotes, semicolons, trailing commas (all), 100 char width, 4-space indent
-- **Package manager**: pnpm 10.25.x only (enforced). Node >=24.15.0 (see `.nvmrc`)
-- **TypeScript**: 5.9, strict mode, target ES2022, module resolution "bundler"
+The `src/contracts/` pipeline is event-driven with strict ownership rules:
 
-## Architecture
+- `ContractWatcher` is event-only: emits `vtxo_received`/`vtxo_spent`, never writes to repositories, never reads VTXO state from `IndexerProvider`.
+- `ContractManager` owns orchestration: subscribes to watcher events, fetches fresh VTXO data from `IndexerProvider`, and is the **only** component that writes VTXO/contract state to repositories.
+- `Wallet`/`ReadonlyWallet` read balance and VTXO state from repositories only (offline-first); any indexer synchronization is delegated to `ContractManager`.
+- Repositories are the system of record and are mutated exclusively by `ContractManager`.
 
-### Workspace Structure
-
-```
-config/              # Shared configs (tsconfig.base.json, vitest.base.ts)
-packages/
-  ts-sdk/            # @arkade-os/sdk — core Bitcoin wallet SDK
-  boltz-swap/        # @arkade-os/boltz-swap — Boltz submarine swaps (depends on ts-sdk)
-regtest/             # Git submodule (arkade-regtest) — shared regtest environment
-scripts/
-  release.mjs        # Root package-scoped release orchestrator (SDK first, then boltz-swap)
-  release.sh         # Thin wrapper that execs release.mjs
-```
-
-### `@arkade-os/sdk` (packages/ts-sdk)
-
-Multi-entry dual ESM/CJS build via `tsup` (see `tsup.config.ts`). Subpath exports cover adapters, repositories (sqlite/realm), the Expo worker, and the Expo wallet (including its background-task entry).
-
-Key layers:
-- **Wallet** (`src/wallet/`) — `Wallet` (signing), `ReadonlyWallet` (watch-only), `OnchainWallet` (on-chain UTXOs). Service worker variants communicate via `MessageBus`.
-- **Providers** (`src/providers/`) — `ArkProvider` (Ark server/SSE), `IndexerProvider` (VTXO queries), `OnchainProvider` (Esplora). Each has REST and Expo-compatible implementations.
-- **Repositories** (`src/repositories/`) — `WalletRepository` and `ContractRepository` interfaces with IndexedDB, InMemory, FileSystem, AsyncStorage, SQLite, and Realm backends. Interfaces carry `readonly version: N` to force compile-time updates on schema changes.
-- **Contracts** (`src/contracts/`) — Event-driven pipeline with strict ownership rules:
-  - `ContractWatcher` is event-only: emits `vtxo_received`/`vtxo_spent`, never writes to repositories, never reads VTXO state from `IndexerProvider`.
-  - `ContractManager` owns orchestration: subscribes to watcher events, fetches fresh VTXO data from `IndexerProvider`, and is the **only** component that writes VTXO/contract state to repositories.
-  - `Wallet`/`ReadonlyWallet` read balance and VTXO state from repositories only (offline-first); any indexer synchronization is delegated to `ContractManager`.
-  - Repositories are the system of record and are mutated exclusively by `ContractManager`.
-- **Service Worker** (`src/worker/`) — `MessageBus` orchestrator with pluggable `MessageHandler`s and tick-based scheduling.
-- **Bitcoin primitives** — `src/script/` (tapscript, VHTLC, Ark addresses), `src/musig2/` (MuSig2), `src/tree/` (transaction trees), `src/forfeit.ts` (unilateral exit).
-
-### `@arkade-os/boltz-swap` (packages/boltz-swap)
-
-Built with `tsup` (multi-entry ESM+CJS+dts). Depends on `@arkade-os/sdk` via `workspace:*`.
-
-Key components:
-- **ArkadeSwaps** (`src/arkade-swaps.ts`) — Main class orchestrating swap lifecycle.
-- **BoltzSwapProvider** (`src/boltz-swap-provider.ts`) — Boltz API integration for swap creation/monitoring.
-- **SwapManager** (`src/swap-manager.ts`) — Autonomous background swap monitoring and execution.
-- **Repositories** (`src/repositories/`) — `SwapRepository` interface with IndexedDB, InMemory, SQLite, and Realm implementations.
-- Swap types: Reverse (Lightning→Ark), Submarine (Ark→Lightning), Chain (ARK↔BTC on-chain).
-
-### Integration Testing Stack (regtest/)
-
-Git submodule pointing to [arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest). Manages a Docker Compose stack (Bitcoin Core, Fulcrum, mempool, NBXplorer, arkd, boltz, LND, fulmine, and supporting services) driven by the in-house Node CLI `regtest.mjs`. Use `node regtest/regtest.mjs start` / `stop` / `clean` (or the `scripts/regtest.sh` controller). Run `git submodule update --init` after cloning.
-
-### Shared Config Pattern
-
-Packages extend shared base configs from `config/`:
-- `tsconfig.json` extends `../../config/tsconfig.base.json`
-- `vitest.config.ts` merges with `../../config/vitest.base.ts`
-
-### Testing
-
-- Vitest with `globals: true`, `fileParallelism: false`
-- ts-sdk uses `test/polyfill.js` (IndexedDB shim + EventSource polyfill for Node)
-- boltz-swap uses `test/setup.ts`
-- Integration tests live in `test/e2e/` within each package and require the Docker regtest stack
+Repository interfaces carry `readonly version: N` to force compile-time updates on schema changes.
 
 ## Local Scratch Files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing
+
+## Integration testing (regtest stack)
+
+Integration tests live in `test/e2e/` within each package and require the Docker regtest stack.
+
+`test:integration` runs each package's full cycle (reset + up + setup + test) via
+`scripts/regtest.sh <pkg> cycle`, using `packages/<pkg>/.env.regtest`.
+
+```bash
+pnpm run test:integration              # Both packages, end-to-end
+pnpm run test:integration:ts-sdk       # ts-sdk only
+pnpm run test:integration:boltz-swap   # boltz-swap only
+```
+
+### Per-package stack control
+
+Replace `:ts-sdk` with `:boltz-swap` for the other package.
+
+```bash
+pnpm run regtest:up:ts-sdk
+pnpm run regtest:setup:ts-sdk
+pnpm run regtest:test:ts-sdk                          # whole e2e suite
+pnpm run regtest:test:ts-sdk test/e2e/asset.test.ts   # or selected files only
+pnpm run regtest:down:ts-sdk
+pnpm run regtest:reset:ts-sdk
+```
+
+CI fans the ts-sdk e2e suite out across parallel groups by passing each group's file list to
+`regtest:test` (see the `integration` matrix in `.github/workflows/ci.yml`).
+
+### The stack itself
+
+`regtest/` is a git submodule pointing to
+[arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest). It manages a Docker Compose stack
+(Bitcoin Core, Fulcrum, mempool, NBXplorer, arkd, boltz, LND, fulmine, and supporting services)
+driven by the in-house Node CLI `regtest.mjs`. Use `node regtest/regtest.mjs start` / `stop` /
+`clean`, or the `scripts/regtest.sh` controller.
+
+Run `git submodule update --init` after cloning.
+
+## Releasing
+
+Package-scoped release orchestrator. Target is `sdk`, `boltz-swap`, or `all`.
+
+```bash
+pnpm run release -- boltz-swap patch          # Boltz bugfix only
+pnpm run release -- sdk patch                 # SDK + dependent boltz-swap patch
+pnpm run release -- sdk prepatch --preid beta # Mirrors prerelease into boltz-swap
+pnpm run release -- all patch                 # Bump both
+pnpm run release:dry-run -- sdk patch         # Preview without changes
+pnpm run release:cleanup                      # Auto-detect dirty release artifacts
+```
+
+Tags are `@arkade-os/sdk/<version>` and `@arkade-os/boltz-swap/<version>` (no `v<version>`).
+
+Releasing SDK implies a dependent boltz-swap release because boltz-swap depends on SDK via
+`workspace:*`; override with `--boltz-bump <bump-or-version>`.
+
+The script runs tests, builds, commits, tags, publishes to npm (requires local npm credentials),
+and pushes commit + tags to `origin`.

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -1247,9 +1247,11 @@ This is required for MuSig2 settlements and cryptographic operations.
 
 ### Contract Management
 
-Both `Wallet` and `ServiceWorkerWallet` use a `ContractManager` internally to watch for virtual outputs. This provides resilient connection handling with automatic reconnection and failsafe polling - for your wallet's default address and any external contracts you register (Boltz swaps, HTLCs, etc.).
+Both `Wallet` and `ServiceWorkerWallet` use a `ContractManager` internally to watch for virtual outputs and persist them into repositories. This provides resilient connection handling with automatic reconnection and failsafe polling - for your wallet's default address and any external contracts you register (Boltz swaps, HTLCs, etc.).
 
-When you call `wallet.notifyIncomingFunds()` or use `waitForIncomingFunds()`, it uses the ContractManager under the hood, giving you automatic reconnection and failsafe polling for free - no code changes needed.
+When you call `wallet.notifyIncomingFunds()` or use `waitForIncomingFunds()`, it uses the ContractManager under the hood, giving you automatic reconnection and repository-backed event replay for free - no code changes needed.
+
+`watcherConfig.failsafePollIntervalMs` (default `20_000`) controls how often the watcher replays repository changes into contract events; it does not fetch fresh VTXOs from the indexer.
 
 For advanced use cases, you can access the ContractManager directly to register external contracts:
 
@@ -1312,21 +1314,22 @@ const allPaths = await manager.getAllSpendingPaths({
 // Fetch contracts together with their current virtual outputs
 const contractsWithVtxos = await manager.getContractsWithVtxos()
 
-// Force a full refresh from the indexer when needed
+// Force an indexer refresh of the watched contracts when needed
 await manager.refreshVtxos()
 
 // Stop watching
 unsubscribe()
 ```
 
-The watcher features:
-- **Automatic reconnection** with exponential backoff (1s → 30s max)
-- **Failsafe polling** every 60 seconds to catch missed events
-- **Immediate sync** on connection and after failures
+Contract freshness behavior:
+- **Automatic reconnection** with exponential backoff (1s → 5s max)
+- **Immediate sync** on manager initialization, subscription reconnect, and contract events
+- **Failsafe polling** every 20 seconds by default to catch missed events, configurable via `watcherConfig.failsafePollIntervalMs`
+- **Manual refresh** through `manager.refreshVtxos()`; pass `{ includeInactive: true }` to sweep every repository contract
 
 ### Repository Pattern
 
-Most users don't need to touch repositories directly — `Wallet` and `ContractManager` already read and write through them. They are documented here for advanced integrations (custom storage backends, offline-first apps, repository inspection).
+Most users don't need to touch repositories directly — `Wallet` reads through them and `ContractManager` owns VTXO/contract synchronization into them. They are documented here for advanced integrations (custom storage backends, offline-first apps, repository inspection).
 
 ```typescript
 // Wallet repository — VTXOs, UTXOs, transaction history, settings

--- a/packages/ts-sdk/src/worker/expo/README.md
+++ b/packages/ts-sdk/src/worker/expo/README.md
@@ -111,6 +111,7 @@ Foreground (app active):
   setInterval calls runForegroundPoll()
   → runTasks() dispatches to ContractPollProcessor
   → Processor fetches VTXOs from indexer, saves to repository
+  → Wallet reads consume the updated repository state
   → Results acknowledged immediately, task re-seeded
 
 Background (15+ min later):


### PR DESCRIPTION
Trims `AGENTS.md` down to what a session can't reconstruct from the codebase itself. Release and regtest workflows move to `CONTRIBUTING.md`, where they're read on demand instead of loaded into every session.

`AGENTS.md` is loaded into context on every session:

|        | chars | est. tokens |
| ------ | ----- | ----------- |
| before | 9,863 | ~2,470      |
| after  | 3,664 | ~920        |

**~1,550 est. tokens saved per session (−63%).**

**Cut** — all reconstructible from the repo: the directory tree, Code Style (restated `.prettierrc` / `engines` / `tsconfig.base.json` verbatim, and `pnpm lint` enforces it anyway), the per-package layer tours, shared-config and vitest sections, and the command lines already present as `package.json` scripts.

**Kept** — not derivable: the NArk reference-implementation direction, the core/plugin dependency rules, the Contracts ownership invariants, and repo etiquette.

Also corrects two stale defaults in `packages/ts-sdk/README.md`: reconnect backoff cap 30s → 5s and failsafe polling 60s → 20s, both per `DEFAULT_CONTRACT_WATCHER_CONFIG`.
