### PR TITLE
feat: add trustless settled VTXO verification

### DIFF
--- a/docs/superpowers/plans/2026-07-23-vtxo-chain-verification.md
+++ b/docs/superpowers/plans/2026-07-23-vtxo-chain-verification.md
@@ -8,6 +8,12 @@
 
 **Tech Stack:** TypeScript 5.9, Vitest 3, `@scure/btc-signer` 2, `@noble/curves` Schnorr, pnpm 10.25.
 
+> **Implementation note:** Live arkd PSBTs omit TREE `witnessUtxo`. The final
+> implementation reconstructs root prevouts from raw Bitcoin commitments and
+> child prevouts from parent virtual transactions. It also derives the sweep
+> expiry from `VtxoTreeExpiry`, so `VtxoVerificationServerInfo` carries only
+> `forfeitPubkey`; the proof-carried expiry must reproduce the anchored output.
+
 ## Global Constraints
 
 - Base all work on `upstream/master` version `0.4.49` or newer.

--- a/docs/superpowers/plans/2026-07-23-vtxo-chain-verification.md
+++ b/docs/superpowers/plans/2026-07-23-vtxo-chain-verification.md
@@ -1,0 +1,835 @@
+# Trustless VTXO Chain Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a public `verifyVtxo` API that confirms a VTXO only after independently validating its virtual transaction history, signatures, leaf metadata, and Bitcoin anchors.
+
+**Architecture:** A standalone verification module consumes the existing local-first `ExitChainResolver` shape and a narrow independent chain-source interface. Focused parsers build verified graph segments, signature helpers validate TREE key-path and ARK/checkpoint script-path signatures, and an anchor helper binds each claimed commitment to raw Bitcoin data. The orchestrator returns a discriminated result union so unavailable data can never be mistaken for invalid evidence or confirmation.
+
+**Tech Stack:** TypeScript 5.9, Vitest 3, `@scure/btc-signer` 2, `@noble/curves` Schnorr, pnpm 10.25.
+
+## Global Constraints
+
+- Base all work on `upstream/master` version `0.4.49` or newer.
+- Use Node `>=24.15.0 <25` and pnpm `>=10.25.0 <11`.
+- Keep `OnchainProvider` source-compatible for custom implementations.
+- Default `minConfirmationDepth` is `6`.
+- Only a `confirmed` result represents trustless receipt confirmation.
+- Treat indexer, operator, delegated scanner, and cached PSBT bytes as adversarial input.
+- Do not include Tier 2, Tier 3, a proof visualizer, bChannel UI changes, or wallet coin deletion.
+- Note in the pull request that the NArk reference checkout was unavailable.
+
+---
+
+## File Structure
+
+- `packages/ts-sdk/src/verification/types.ts`: public source, option, issue, and result types.
+- `packages/ts-sdk/src/verification/proof.ts`: adversarial chain metadata and PSBT parsing into graph segments.
+- `packages/ts-sdk/src/verification/signatures.ts`: TREE key-path, script-path, NUMS, and signer-set checks.
+- `packages/ts-sdk/src/verification/anchor.ts`: raw Bitcoin commitment, depth, output, and outspend validation.
+- `packages/ts-sdk/src/verification/verifyVtxo.ts`: phase orchestration and result classification.
+- `packages/ts-sdk/src/verification/index.ts`: verification module exports.
+- `packages/ts-sdk/src/providers/onchain.ts`: concrete Esplora raw-transaction retrieval.
+- `packages/ts-sdk/src/providers/electrum.ts`: concrete Electrum raw-transaction retrieval.
+- `packages/ts-sdk/src/index.ts`: public package exports.
+- `packages/ts-sdk/test/verification/*.test.ts`: focused unit and adversarial tests.
+- `packages/ts-sdk/test/e2e/verification.test.ts`: live regtest confirmation and forged-proof rejection.
+
+### Task 1: Independent raw-transaction sources
+
+**Files:**
+- Modify: `packages/ts-sdk/src/providers/onchain.ts`
+- Modify: `packages/ts-sdk/src/providers/electrum.ts`
+- Create: `packages/ts-sdk/test/verification/chainSources.test.ts`
+
+**Interfaces:**
+- Consumes: existing `baseFetch`, `ElectrumWS.request`, and `GetTransactionMethod`.
+- Produces: public concrete methods `EsploraProvider.getTxHex(txid)` and `ElectrumOnchainProvider.getTxHex(txid)`.
+
+- [ ] **Step 1: Write failing Esplora and Electrum tests**
+
+Create tests that stub the existing transport seams and assert trimmed raw hex:
+
+```ts
+it("fetches and trims Esplora raw transaction hex", async () => {
+    fetchMock.mockResolvedValue(new Response("02000000\\n", { status: 200 }));
+    const provider = new EsploraProvider("https://chain.example/api");
+    await expect(provider.getTxHex("11".repeat(32))).resolves.toBe("02000000");
+});
+
+it("fetches Electrum raw transaction hex without verbose mode", async () => {
+    electrum.request.mockResolvedValue("02000000");
+    const provider = new ElectrumOnchainProvider(electrum, networks.regtest);
+    await expect(provider.getTxHex("22".repeat(32))).resolves.toBe("02000000");
+    expect(electrum.request).toHaveBeenCalledWith(
+        "blockchain.transaction.get",
+        "22".repeat(32),
+        false,
+    );
+});
+```
+
+- [ ] **Step 2: Run the source tests and verify RED**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/chainSources.test.ts
+```
+
+Expected: FAIL because both concrete providers lack `getTxHex`.
+
+- [ ] **Step 3: Implement the two concrete methods**
+
+Add to `EsploraProvider`:
+
+```ts
+async getTxHex(txid: string): Promise<string> {
+    const response = await baseFetch(`${this.baseUrl}/tx/${txid}/hex`);
+    const body = await response.text();
+    if (!response.ok) {
+        throw new Error(`Failed to get transaction hex: ${body}`);
+    }
+    return body.trim();
+}
+```
+
+Add to `ElectrumOnchainProvider` using its existing request wrapper:
+
+```ts
+async getTxHex(txid: string): Promise<string> {
+    return this.ws.request<string>(GetTransactionMethod, txid, false);
+}
+```
+
+Do not change the public `OnchainProvider` interface.
+
+- [ ] **Step 4: Verify GREEN and run provider regression tests**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/chainSources.test.ts
+pnpm -C packages/ts-sdk vitest run test/esplora.test.ts test/electrum.test.ts
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ts-sdk/src/providers/onchain.ts \
+  packages/ts-sdk/src/providers/electrum.ts \
+  packages/ts-sdk/test/verification/chainSources.test.ts
+git commit -m "feat(verification): expose raw transaction sources"
+```
+
+### Task 2: Public verification contract and proof parsing
+
+**Files:**
+- Create: `packages/ts-sdk/src/verification/types.ts`
+- Create: `packages/ts-sdk/src/verification/proof.ts`
+- Create: `packages/ts-sdk/src/verification/index.ts`
+- Create: `packages/ts-sdk/test/verification/proof.test.ts`
+
+**Interfaces:**
+- Consumes: `Outpoint`, `VirtualCoin`, `ChainTx`, `Transaction`, `TxTree`, `RelativeTimelock`.
+- Produces: `VtxoProofSource`, `VtxoChainSource`, `VtxoVerificationOptions`, `VtxoVerificationIssue`, `VtxoVerificationResult`, `ParsedVtxoProof`, and `parseVtxoProof`.
+
+- [ ] **Step 1: Write failing parser tests**
+
+Cover a valid one-level TREE proof and individual rejection cases for:
+
+```ts
+it.each([
+    ["duplicate metadata", duplicateChain],
+    ["missing PSBT", missingPsbt],
+    ["PSBT txid mismatch", wrongTxidPsbt],
+    ["cycle", cyclicChain],
+    ["unknown parent", orphanChain],
+])("rejects %s", async (_name, fixture) => {
+    await expect(parseVtxoProof(outpoint, fixture.source)).rejects.toMatchObject({
+        code: expect.stringMatching(/^proof_/),
+    });
+});
+```
+
+Also assert that `createExitChainResolver(...)` is assignable to
+`VtxoProofSource` without an adapter.
+
+- [ ] **Step 2: Run parser tests and verify RED**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/proof.test.ts
+```
+
+Expected: FAIL because the verification module does not exist.
+
+- [ ] **Step 3: Define the public discriminated result types**
+
+Implement these stable status shapes:
+
+```ts
+export type VtxoVerificationStatus =
+    | "confirmed"
+    | "preconfirmed"
+    | "invalid"
+    | "unavailable";
+
+export type VtxoVerificationIssue = {
+    code: string;
+    message: string;
+    txid?: string;
+    inputIndex?: number;
+    outputIndex?: number;
+};
+
+type BaseResult = {
+    outpoint: Outpoint;
+    commitmentTxids: string[];
+    chainLength: number;
+    issues: VtxoVerificationIssue[];
+};
+
+export type VtxoVerificationResult =
+    | (BaseResult & {
+          status: "confirmed";
+          confirmationDepth: number;
+      })
+    | (BaseResult & {
+          status: "preconfirmed";
+          partialChecks: Partial<Record<VtxoVerificationCheck, boolean>>;
+      })
+    | (BaseResult & { status: "invalid" })
+    | (BaseResult & { status: "unavailable" });
+```
+
+Define `VtxoProofSource` with the same two methods as `ExitChainResolver`, and
+define `VtxoChainSource` with `getTxHex`, `getTxStatus`, `getTxOutspends`, and
+`getChainTip`.
+
+- [ ] **Step 4: Implement strict proof parsing**
+
+`parseVtxoProof` must:
+
+1. fetch ancestry once;
+2. identify commitment and virtual entries;
+3. fetch virtual PSBTs in declared order;
+4. parse every PSBT and compare `Transaction.id` to the declared txid;
+5. derive actual parents from inputs and compare them with `ChainTx.spends`;
+6. detect duplicate/conflicting entries, cycles, and disconnected nodes;
+7. build TREE segments with `TxTree.create`;
+8. return parsed transactions, segments, and commitment ids without asserting
+   cryptographic validity.
+
+Use a typed internal error:
+
+```ts
+export class VtxoProofError extends Error {
+    constructor(
+        readonly code: string,
+        message: string,
+        readonly kind: "invalid" | "unavailable",
+    ) {
+        super(message);
+    }
+}
+```
+
+Transport failure and absent bytes use `kind: "unavailable"`; contradictory
+bytes or metadata use `kind: "invalid"`.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/proof.test.ts
+```
+
+Expected: all parser tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ts-sdk/src/verification packages/ts-sdk/test/verification/proof.test.ts
+git commit -m "feat(verification): parse adversarial VTXO proofs"
+```
+
+### Task 3: Claimed leaf and graph validation
+
+**Files:**
+- Create: `packages/ts-sdk/src/verification/graph.ts`
+- Modify: `packages/ts-sdk/src/verification/types.ts`
+- Create: `packages/ts-sdk/test/verification/graph.test.ts`
+
+**Interfaces:**
+- Consumes: `ParsedVtxoProof`, `VirtualCoin`, `validateVtxoTxGraph`, `TxTree`.
+- Produces: `verifyClaimedLeaf(vtxo, proof)` and `verifyGraphSegments(proof, serverInfo)`.
+
+- [ ] **Step 1: Write failing leaf-binding tests**
+
+For a valid parsed fixture, independently mutate the claim:
+
+```ts
+expect(verifyClaimedLeaf(validCoin, proof)).toEqual([]);
+expect(verifyClaimedLeaf({ ...validCoin, value: validCoin.value + 1 }, proof)[0].code)
+    .toBe("leaf_amount_mismatch");
+expect(verifyClaimedLeaf({ ...validCoin, script: forgedScript }, proof)[0].code)
+    .toBe("leaf_script_mismatch");
+expect(verifyClaimedLeaf({ ...validCoin, vout: 99 }, proof)[0].code)
+    .toBe("leaf_output_missing");
+expect(verifyClaimedLeaf({ ...validCoin, txid: unknownTxid }, proof)[0].code)
+    .toBe("leaf_tx_missing");
+```
+
+- [ ] **Step 2: Write failing graph tests**
+
+Cover one-level and three-level trees, then mutate a child parent outpoint,
+duplicate-spend one parent output, inflate a child output, remove cosigner
+metadata, and replace the configured sweep leaf.
+
+- [ ] **Step 3: Run graph tests and verify RED**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/graph.test.ts
+```
+
+Expected: FAIL because graph verification functions are missing.
+
+- [ ] **Step 4: Implement exact leaf binding**
+
+Look up the transaction by recomputed id and require:
+
+```ts
+claimed.txid === tx.id;
+claimed.vout < tx.outputsLength;
+BigInt(claimed.value) === output.amount;
+claimed.script !== undefined;
+hex.encode(output.script) === claimed.script.toLowerCase();
+```
+
+Return stable issues for each mismatch; do not accept a missing claimed script.
+
+- [ ] **Step 5: Implement per-segment graph validation**
+
+Derive the sweep Taproot root from:
+
+```ts
+const sweepScript = CSVMultisigTapscript.encode({
+    timelock: serverInfo.sweepInterval,
+    pubkeys: [serverInfo.pubkey],
+}).script;
+const sweepTapTreeRoot = tapLeafHash(sweepScript);
+```
+
+For each commitment-rooted TREE segment, invoke `validateVtxoTxGraph` with the
+parsed commitment transaction representation, then add explicit duplicate-spend
+and actual-parent checks across segment boundaries. Convert thrown validation
+errors into stable `graph_*` issues.
+
+- [ ] **Step 6: Verify GREEN and existing tree regressions**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/graph.test.ts
+pnpm -C packages/ts-sdk vitest run test/arkade-batch.test.ts test/exit-path.test.ts
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ts-sdk/src/verification/graph.ts \
+  packages/ts-sdk/src/verification/types.ts \
+  packages/ts-sdk/test/verification/graph.test.ts
+git commit -m "feat(verification): bind VTXO leaves to transaction graphs"
+```
+
+### Task 4: Cryptographic signature verification
+
+**Files:**
+- Create: `packages/ts-sdk/src/verification/signatures.ts`
+- Create: `packages/ts-sdk/test/verification/signatures.test.ts`
+
+**Interfaces:**
+- Consumes: parsed `Transaction`s, `verifyTapscriptSignatures`, `decodeTapscript`, `schnorr.verify`.
+- Produces: `verifyProofSignatures(proof): VtxoVerificationIssue[]`.
+
+- [ ] **Step 1: Write a failing valid TREE key-path test**
+
+Build a P2TR prevout with a known private key, compute the BIP-341 message using
+`Transaction.preimageWitnessV1`, store a real 64-byte Schnorr signature in
+`tapKeySig`, and expect no issues.
+
+- [ ] **Step 2: Write the forged TREE signature regression**
+
+Flip one byte of the valid `tapKeySig`:
+
+```ts
+const forged = Uint8Array.from(validSignature);
+forged[0] ^= 0xff;
+tree.updateInput(0, { tapKeySig: forged });
+expect(verifyProofSignatures(proof)).toContainEqual(
+    expect.objectContaining({ code: "signature_invalid_tap_key" }),
+);
+```
+
+Also cover missing signature, non-P2TR witness UTXO, 65-byte allowed sighash,
+and a rejected unsupported sighash.
+
+- [ ] **Step 3: Write failing script-path and NUMS tests**
+
+Use a real tapscript fixture and assert:
+
+- required signers are decoded from the script;
+- a self-consistent signature from an unlisted key is rejected;
+- missing required signatures are rejected;
+- a non-NUMS internal key is rejected.
+
+- [ ] **Step 4: Run signature tests and verify RED**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/signatures.test.ts
+```
+
+Expected: FAIL because `verifyProofSignatures` does not exist.
+
+- [ ] **Step 5: Implement TREE `tapKeySig` verification**
+
+For every TREE input:
+
+1. require `witnessUtxo`, `tapKeySig`, and a 34-byte `OP_1 PUSH32` script;
+2. collect every input's prevout script and amount;
+3. split a 64-byte default signature or 65-byte signature+sighash;
+4. allow only `SigHash.DEFAULT`;
+5. compute:
+
+```ts
+const message = tx.preimageWitnessV1(
+    inputIndex,
+    prevoutScripts,
+    sighashType,
+    prevoutAmounts,
+);
+const outputKey = input.witnessUtxo.script.slice(2);
+const valid = schnorr.verify(signature, message, outputKey);
+```
+
+Emit `signature_invalid_tap_key` if verification returns false.
+
+- [ ] **Step 6: Implement script-path and NUMS verification**
+
+Decode each relevant tap leaf, extract its required pubkeys, invoke
+`verifyTapscriptSignatures`, and compare its control-block internal key with
+`TAPROOT_UNSPENDABLE_KEY`. Never infer required signers from `tapScriptSig`.
+
+- [ ] **Step 7: Verify GREEN and existing signing regressions**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/signatures.test.ts
+pnpm -C packages/ts-sdk vitest run test/verifySignatures.test.ts test/musig2.test.ts
+```
+
+Expected: all selected tests PASS, including the forged `tapKeySig` rejection.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ts-sdk/src/verification/signatures.ts \
+  packages/ts-sdk/test/verification/signatures.test.ts
+git commit -m "feat(verification): verify VTXO graph signatures"
+```
+
+### Task 5: Independent Bitcoin anchor verification
+
+**Files:**
+- Create: `packages/ts-sdk/src/verification/anchor.ts`
+- Create: `packages/ts-sdk/test/verification/anchor.test.ts`
+
+**Interfaces:**
+- Consumes: `VtxoChainSource`, root TREE input witness UTXO, expected root txid.
+- Produces: `verifyCommitmentAnchors(proof, chainSource, minDepth)`.
+
+- [ ] **Step 1: Write failing happy-path anchor test**
+
+Provide raw commitment bytes whose recomputed txid, output amount, and output
+script match the TREE root input. Return confirmed status, a chain tip six
+blocks later, and an unspent output. Expect depth `6` and no issues.
+
+- [ ] **Step 2: Write failing adversarial anchor cases**
+
+Independently test:
+
+```ts
+it.each([
+    "anchor_txid_mismatch",
+    "anchor_output_missing",
+    "anchor_amount_mismatch",
+    "anchor_script_mismatch",
+    "anchor_unconfirmed",
+    "anchor_depth_insufficient",
+    "anchor_unexpected_spend",
+])("reports %s", async (expectedCode) => {
+    const result = await verifyCommitmentAnchors(mutatedProof(expectedCode), chain, 6);
+    expect(result.issues).toContainEqual(expect.objectContaining({ code: expectedCode }));
+});
+```
+
+For expected unroll, return the finalized root transaction id as spender and
+assert acceptance. For `spent: true` without a spender txid, require an
+`anchor_spender_unknown` invalid issue.
+
+- [ ] **Step 3: Write unavailable-source tests**
+
+Make each chain-source method reject in turn and assert a typed
+`VtxoVerificationUnavailableError` rather than a cryptographic issue.
+
+- [ ] **Step 4: Run anchor tests and verify RED**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/anchor.test.ts
+```
+
+Expected: FAIL because the anchor verifier is missing.
+
+- [ ] **Step 5: Implement raw transaction and output binding**
+
+Parse with:
+
+```ts
+const commitment = Transaction.fromRaw(hex.decode(rawHex), {
+    allowUnknownInputs: true,
+    allowUnknownOutputs: true,
+});
+```
+
+Compare `commitment.id` to the requested id and the exact output against the
+TREE root input `witnessUtxo`.
+
+- [ ] **Step 6: Implement shared-tip depth and outspend checks**
+
+Fetch `getChainTip()` once. For each anchor compute:
+
+```ts
+const depth = tip.height - status.blockHeight + 1;
+```
+
+The minimum depth across all anchors becomes the confirmed result depth. An
+anchor is valid when unspent, or when its spender equals the finalized expected
+root txid.
+
+- [ ] **Step 7: Verify GREEN**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/anchor.test.ts
+```
+
+Expected: all anchor tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ts-sdk/src/verification/anchor.ts \
+  packages/ts-sdk/test/verification/anchor.test.ts
+git commit -m "feat(verification): bind VTXO graphs to Bitcoin anchors"
+```
+
+### Task 6: `verifyVtxo` orchestration and status classification
+
+**Files:**
+- Create: `packages/ts-sdk/src/verification/verifyVtxo.ts`
+- Modify: `packages/ts-sdk/src/verification/index.ts`
+- Create: `packages/ts-sdk/test/verification/verifyVtxo.test.ts`
+
+**Interfaces:**
+- Consumes: parser, graph, signature, and anchor functions from Tasks 2–5.
+- Produces: public `verifyVtxo(...) => Promise<VtxoVerificationResult>`.
+
+- [ ] **Step 1: Write the four failing status tests**
+
+Assert:
+
+```ts
+expect((await verifyVtxo(settledCoin, proof, chain, server)).status).toBe("confirmed");
+expect((await verifyVtxo(preconfirmedCoin, proof, chain, server)).status)
+    .toBe("preconfirmed");
+expect((await verifyVtxo(forgedCoin, proof, chain, server)).status).toBe("invalid");
+expect((await verifyVtxo(settledCoin, withholdingProof, chain, server)).status)
+    .toBe("unavailable");
+```
+
+Assert that the default minimum depth is six and an explicit
+`{ minConfirmationDepth: 1 }` changes the threshold.
+
+- [ ] **Step 2: Write multi-level and multi-anchor orchestration tests**
+
+Use a three-level TREE and a later ARK transaction joining inputs from two
+batches. Require both commitment ids in the result and use the smaller anchor
+depth. Mutating either anchor or any intermediate signature must make the whole
+result `invalid`.
+
+- [ ] **Step 3: Run orchestration tests and verify RED**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/verifyVtxo.test.ts
+```
+
+Expected: FAIL because `verifyVtxo` is missing.
+
+- [ ] **Step 4: Implement phase ordering and bounded diagnostics**
+
+Implement phases in this order:
+
+```ts
+parse -> preconfirmed classification -> leaf -> graph -> signatures -> anchors
+```
+
+Map typed unavailable errors to `status: "unavailable"` and evidence
+contradictions to `status: "invalid"`. Cap issues at 100 and add one
+`issues_truncated` diagnostic when the cap is reached.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/verifyVtxo.test.ts
+pnpm -C packages/ts-sdk vitest run test/verification
+```
+
+Expected: all verification tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ts-sdk/src/verification/verifyVtxo.ts \
+  packages/ts-sdk/src/verification/index.ts \
+  packages/ts-sdk/test/verification/verifyVtxo.test.ts
+git commit -m "feat(verification): add trustless verifyVtxo API"
+```
+
+### Task 7: Public exports, documentation, and package checks
+
+**Files:**
+- Modify: `packages/ts-sdk/src/index.ts`
+- Modify: `packages/ts-sdk/README.md`
+- Create: `packages/ts-sdk/test/verification/publicApi.test.ts`
+
+**Interfaces:**
+- Consumes: verification module exports.
+- Produces: package-root imports for `verifyVtxo` and all public verification types.
+
+- [ ] **Step 1: Write a failing public API test**
+
+Import from `../src` and assert:
+
+```ts
+expect(typeof verifyVtxo).toBe("function");
+const source: VtxoProofSource = createExitChainResolver({ indexer });
+expect(source).toBeDefined();
+```
+
+- [ ] **Step 2: Run the public API test and verify RED**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/publicApi.test.ts
+```
+
+Expected: FAIL because package-root exports are absent.
+
+- [ ] **Step 3: Export the API and add usage documentation**
+
+Export `verifyVtxo`, result/source/options types, and stable issue types from
+`src/index.ts`. Add a README example:
+
+```ts
+const proofSource = createExitChainResolver({
+    indexer: wallet.indexerProvider,
+    repository: wallet.virtualTxRepository,
+});
+
+const result = await verifyVtxo(vtxo, proofSource, chainSource, serverInfo);
+if (result.status === "confirmed") {
+    console.log(`confirmed at depth ${result.confirmationDepth}`);
+}
+```
+
+Explain that proof retrieval is untrusted, the independent chain source is the
+trust boundary, and `preconfirmed` is not confirmation.
+
+- [ ] **Step 4: Run API, type, build, and lint checks**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk vitest run test/verification/publicApi.test.ts
+pnpm -C packages/ts-sdk typecheck
+pnpm -C packages/ts-sdk build
+pnpm -C packages/ts-sdk lint
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ts-sdk/src/index.ts packages/ts-sdk/README.md \
+  packages/ts-sdk/test/verification/publicApi.test.ts
+git commit -m "docs(verification): export and document verifyVtxo"
+```
+
+### Task 8: Regtest adversarial integration and final verification
+
+**Files:**
+- Create: `packages/ts-sdk/test/e2e/verification.test.ts`
+- Modify: `.github/workflows/ci.yml` only if the existing e2e glob/matrix does not include the new file.
+
+**Interfaces:**
+- Consumes: public package API and the existing regtest wallet helpers.
+- Produces: end-to-end proof that real settled VTXOs confirm and forged indexer bytes do not.
+
+- [ ] **Step 1: Write the real settled-VTXO integration test**
+
+Create a wallet and VTXO using existing e2e helpers, mine enough blocks, resolve
+the branch with the wallet repository plus real indexer, and assert:
+
+```ts
+expect(result.status).toBe("confirmed");
+if (result.status === "confirmed") {
+    expect(result.confirmationDepth).toBeGreaterThanOrEqual(1);
+}
+```
+
+Use `{ minConfirmationDepth: 1 }` to keep the test cycle short.
+
+- [ ] **Step 2: Run the integration test and verify its first failure**
+
+Run:
+
+```bash
+pnpm run regtest:up:ts-sdk
+pnpm run regtest:setup:ts-sdk
+pnpm run regtest:test:ts-sdk test/e2e/verification.test.ts
+```
+
+Expected on first run: the new fixture exposes any wire-format mismatch between
+unit fixtures and real arkd/indexer data. Record and fix only the production or
+fixture mismatch demonstrated by the failure.
+
+- [ ] **Step 3: Add forged-indexer integration cases**
+
+Wrap `getVirtualTxs` to flip one byte in the first TREE `tapKeySig`, then assert
+`status === "invalid"` and issue code `signature_invalid_tap_key`. Add a second
+case that changes the claimed VTXO amount and expects
+`leaf_amount_mismatch`.
+
+- [ ] **Step 4: Run focused integration and unit suites**
+
+Run:
+
+```bash
+pnpm run regtest:test:ts-sdk test/e2e/verification.test.ts
+pnpm -C packages/ts-sdk test:unit
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run repository-wide verification**
+
+Run:
+
+```bash
+pnpm run build
+pnpm run lint
+pnpm run test:unit
+```
+
+Expected: all commands exit `0` with no new warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ts-sdk/test/e2e/verification.test.ts .github/workflows/ci.yml
+git commit -m "test(verification): reject forged VTXO proofs on regtest"
+```
+
+### Task 9: Prepare the upstream pull request
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-23-vtxo-chain-verification-design.md` only if implementation-review findings require factual corrections.
+- Modify: `docs/superpowers/plans/2026-07-23-vtxo-chain-verification.md` to mark every completed checkbox.
+
+**Interfaces:**
+- Consumes: verified branch history and test outputs.
+- Produces: pushed fork branch and an upstream PR targeting `arkade-os/ts-sdk:master`.
+
+- [ ] **Step 1: Review the final diff and commit topology**
+
+Run:
+
+```bash
+git status --short
+git log --oneline upstream/master..HEAD
+git diff --check upstream/master...HEAD
+git diff --stat upstream/master...HEAD
+```
+
+Expected: clean status, focused commits, no whitespace errors.
+
+- [ ] **Step 2: Re-run the mandatory verification set**
+
+Run:
+
+```bash
+pnpm -C packages/ts-sdk test:unit
+pnpm -C packages/ts-sdk typecheck
+pnpm run build
+pnpm run lint
+```
+
+Expected: every command exits `0`.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/vtxo-verification-v2
+```
+
+Expected: the fork branch is created or updated successfully.
+
+- [ ] **Step 4: Open the upstream PR**
+
+Use `gh pr create --repo arkade-os/ts-sdk --base master --head cheng-chun-yuan:feat/vtxo-verification-v2`.
+The body must state:
+
+- the exact trust boundary;
+- the four result statuses;
+- the `tapKeySig` regression fixed relative to the old PR;
+- multi-level and multi-anchor coverage;
+- unit, build, lint, and regtest commands run;
+- NArk was unavailable for parity review;
+- Tier 2, Tier 3, visualizer, and bChannel UI are excluded.
+
+- [ ] **Step 5: Record the PR URL**
+
+Add the confirmed URL to the session handoff and do not claim upstream
+acceptance until maintainers merge it.

--- a/docs/superpowers/specs/2026-07-23-vtxo-chain-verification-design.md
+++ b/docs/superpowers/specs/2026-07-23-vtxo-chain-verification-design.md
@@ -91,6 +91,19 @@ export interface VtxoProofSource {
 `ExitChainResolver` structurally satisfies this interface, so callers can use
 `createExitChainResolver` and retain local-first retrieval.
 
+The server input contains only the expected historical forfeit key:
+
+```ts
+export interface VtxoVerificationServerInfo {
+    forfeitPubkey: Uint8Array;
+}
+```
+
+The verifier decodes each TREE input's `VtxoTreeExpiry` field and accepts it
+only when that expiry, the expected forfeit key, and the declared cosigners
+reproduce the P2TR prevout key. The expiry is therefore proof material, not a
+trusted caller-supplied policy value.
+
 `VtxoChainSource` is deliberately narrower than changing every existing
 `OnchainProvider` implementation:
 
@@ -162,7 +175,7 @@ For each TREE segment, reuse and extend `validateVtxoTxGraph` to validate:
 - complete amount conservation;
 - expected Taproot output scripts;
 - cosigner key aggregation;
-- the configured server sweep leaf;
+- the expected server forfeit key and proof-carried sweep expiry;
 - multi-level parent/child relationships.
 
 For ARK and checkpoint nodes, validate actual transaction inputs against
@@ -187,8 +200,9 @@ For every commitment transaction reached by the graph:
 
 1. Fetch raw transaction hex from `VtxoChainSource`.
 2. Parse it and recompute its txid.
-3. Match the commitment output index, amount, and script against the root TREE
-   input's witness UTXO.
+3. Resolve every root TREE prevout directly from the commitment output. If the
+   PSBT includes a witness UTXO it must match; if omitted, hydrate it from the
+   authenticated raw transaction before graph and signature verification.
 4. Fetch confirmation status and the shared chain tip.
 5. Require confirmation depth to meet `minConfirmationDepth`.
 6. Check the commitment output's outspend. An unspent output is valid. A spent

--- a/docs/superpowers/specs/2026-07-23-vtxo-chain-verification-design.md
+++ b/docs/superpowers/specs/2026-07-23-vtxo-chain-verification-design.md
@@ -1,0 +1,244 @@
+# Trustless VTXO Chain Verification Design
+
+**Date:** 2026-07-23
+
+## Goal
+
+Add a client-side `verifyVtxo` capability to `@arkade-os/sdk` that can promote a
+settled VTXO to `confirmed` without trusting the Ark operator or an indexer for
+the truth of the claim.
+
+The verifier may use an indexer or a local repository to obtain proof material,
+but it treats that material as adversarial input. A result is `confirmed` only
+when the claimed VTXO is bound through a valid virtual transaction graph to
+independently verified Bitcoin commitment transactions.
+
+## Scope
+
+This change covers Tier 1 verification:
+
+- VTXO leaf outpoint, amount, and script binding.
+- Virtual transaction graph structure and amount conservation.
+- TREE key-path Schnorr signatures (`tapKeySig`).
+- ARK/checkpoint tapscript signatures and script constraints.
+- Taproot NUMS internal-key constraints where script-path spending is expected.
+- Commitment transaction raw bytes, confirmation depth, and outspend state
+  obtained from an independent on-chain provider.
+- Multi-level TREE graphs and VTXO histories that cross multiple batches.
+- Structured results that distinguish cryptographic invalidity from unavailable
+  proof material and from a merely preconfirmed VTXO.
+
+The following remain out of scope:
+
+- Tier 2 checkpoint anti-replay policy beyond the protocol checks needed for the
+  traversed chain.
+- Tier 3 signer-set transparency or operator identity consensus.
+- A proof visualizer.
+- Changes to wallet balance semantics or automatic rejection/deletion of coins.
+- bChannel UI integration; that follows after an upstream SDK release.
+
+## Trust Model
+
+The indexer, Ark operator, and any delegated scanner may collude. They can omit,
+reorder, duplicate, or fabricate chain entries and PSBTs. Such behavior must
+result in `invalid` or `unavailable`, never `confirmed`.
+
+The caller chooses an independent Bitcoin chain backend. That backend is trusted
+for raw transaction bytes, confirmation status, chain tip, and outspend data.
+The verifier does not claim protection against a malicious on-chain backend.
+
+The local wallet repository is an availability and privacy optimization, not a
+root of trust. Cached PSBTs are verified exactly like indexer-supplied PSBTs.
+
+Possession of a viewing private key and a spending public key proves ownership
+of a correctly constructed output, but does not prove that the output exists or
+is anchored. MPC is not required for verification because verification uses
+public keys and existing signatures only.
+
+## Reference Implementation Constraint
+
+The repository guidance names the ArkLabsHQ NArk/.NET SDK as the architectural
+reference. No public NArk repository or accessible sibling checkout was
+available while designing this change. The implementation therefore follows the
+current TypeScript SDK's released exit resolver, transaction tree, PSBT, and
+provider abstractions. This constraint must be called out in the pull request so
+maintainers can identify any NArk parity adjustments during review.
+
+## Public API
+
+Expose a standalone function rather than adding a method to `Wallet` in the
+first version:
+
+```ts
+export async function verifyVtxo(
+    vtxo: VirtualCoin,
+    proofSource: VtxoProofSource,
+    chainSource: VtxoChainSource,
+    serverInfo: VtxoVerificationServerInfo,
+    options?: VtxoVerificationOptions,
+): Promise<VtxoVerificationResult>;
+```
+
+`VtxoProofSource` matches the existing exit resolver boundary:
+
+```ts
+export interface VtxoProofSource {
+    getVtxoChain(vtxo: Outpoint): Promise<ChainTx[]>;
+    getVirtualTxs(txids: string[]): Promise<string[]>;
+}
+```
+
+`ExitChainResolver` structurally satisfies this interface, so callers can use
+`createExitChainResolver` and retain local-first retrieval.
+
+`VtxoChainSource` is deliberately narrower than changing every existing
+`OnchainProvider` implementation:
+
+```ts
+export interface VtxoChainSource {
+    getTxHex(txid: string): Promise<string>;
+    getTxStatus(txid: string): Promise<
+        | { confirmed: false }
+        | { confirmed: true; blockTime: number; blockHeight: number }
+    >;
+    getTxOutspends(txid: string): Promise<{ spent: boolean; txid?: string }[]>;
+    getChainTip(): Promise<{ height: number; time: number; hash: string }>;
+}
+```
+
+`EsploraProvider` and `ElectrumOnchainProvider` will implement `getTxHex`.
+Adding the method to their concrete classes does not expand the required
+`OnchainProvider` interface. Custom providers can supply a small adapter.
+
+Results use a discriminated union:
+
+```ts
+export type VtxoVerificationResult =
+    | VtxoConfirmedResult
+    | VtxoPreconfirmedResult
+    | VtxoInvalidResult
+    | VtxoUnavailableResult;
+```
+
+- `confirmed`: every required proof and anchor check passed.
+- `preconfirmed`: the coin has no final commitment anchor; partial checks may be
+  reported but this status is never truthy confirmation.
+- `invalid`: complete-enough evidence demonstrates a cryptographic, structural,
+  metadata, or anchor mismatch.
+- `unavailable`: proof material or independent chain data could not be obtained
+  or was incomplete.
+
+All variants carry the requested outpoint. Diagnostic issues use stable codes
+plus human-readable messages so downstream UI does not parse English strings.
+
+`minConfirmationDepth` defaults to `6`. A caller may explicitly set it to `1`
+or `0`; depth below the configured minimum cannot produce `confirmed`.
+
+## Verification Pipeline
+
+### 1. Resolve and parse proof material
+
+Fetch the complete ancestry metadata for the requested outpoint. Reject
+duplicate txids with conflicting metadata, unknown transaction types, cycles,
+missing parents, and PSBT count/order mismatches. Parse PSBTs and recompute every
+unsigned transaction id rather than trusting the lookup key.
+
+Partition the ancestry graph into TREE segments rooted at commitment
+transactions, with ARK/checkpoint transactions joining segments where a VTXO
+crosses batches.
+
+### 2. Bind the claimed VTXO
+
+Locate the exact `txid:vout` in the parsed graph. The output must exist, and its
+amount and script must byte-for-byte match the supplied `VirtualCoin`. Missing
+metadata is not silently accepted.
+
+### 3. Validate graph and scripts
+
+For each TREE segment, reuse and extend `validateVtxoTxGraph` to validate:
+
+- parent/child outpoint coherence;
+- no duplicate spend of a graph output;
+- complete amount conservation;
+- expected Taproot output scripts;
+- cosigner key aggregation;
+- the configured server sweep leaf;
+- multi-level parent/child relationships.
+
+For ARK and checkpoint nodes, validate actual transaction inputs against
+declared parents, amounts, scripts, expiry encoding, and expected signer sets.
+
+### 4. Verify signatures
+
+TREE transactions spend parent outputs through Taproot key path. Verify every
+`tapKeySig` with BIP-341 sighash construction using all input prevout scripts and
+amounts, and the x-only output key extracted from the spent P2TR script.
+
+ARK/checkpoint transactions spend through script path. Derive required signers
+from the decoded tapscript, then use `verifyTapscriptSignatures`. Never derive
+the required signer set from signatures already present in the PSBT.
+
+Where script-path spending is required, verify that the control block uses the
+standard unspendable NUMS internal key.
+
+### 5. Verify each Bitcoin anchor independently
+
+For every commitment transaction reached by the graph:
+
+1. Fetch raw transaction hex from `VtxoChainSource`.
+2. Parse it and recompute its txid.
+3. Match the commitment output index, amount, and script against the root TREE
+   input's witness UTXO.
+4. Fetch confirmation status and the shared chain tip.
+5. Require confirmation depth to meet `minConfirmationDepth`.
+6. Check the commitment output's outspend. An unspent output is valid. A spent
+   output is valid only when the spender is the expected finalized root
+   transaction; an unknown or different spender is invalid.
+
+The chain tip is fetched once per `verifyVtxo` call to keep depth calculations
+consistent across multiple anchors.
+
+## Failure Classification
+
+Malformed bytes, bad signatures, graph contradictions, metadata mismatches,
+wrong anchor outputs, insufficient confirmation depth, and unexpected spends
+are `invalid`.
+
+Network errors, timeouts, unsupported provider capability, missing PSBTs, and
+indexer withholding are `unavailable` unless the returned evidence itself
+proves a contradiction.
+
+A protocol-declared preconfirmed VTXO is `preconfirmed` even if all currently
+available off-chain checks pass.
+
+The verifier collects bounded diagnostics rather than throwing for adversarial
+proof data. Programmer errors and invalid API arguments may still throw.
+
+## Testing
+
+Unit fixtures cover one-level and multi-level trees, mixed TREE/ARK/checkpoint
+histories, multiple commitment anchors, and every result status.
+
+Adversarial tests mutate:
+
+- the VTXO amount, script, outpoint, and output index;
+- ancestry metadata and PSBT ordering;
+- TREE `tapKeySig`;
+- ARK/checkpoint `tapScriptSig`;
+- Taproot internal key and cosigner fields;
+- commitment raw bytes, output script, amount, confirmation, and outspend;
+- one anchor in a multi-anchor chain.
+
+Each adversarial mutation must be observed failing before the corresponding
+production implementation is added.
+
+Regtest integration creates a real VTXO, mines the configured number of blocks,
+verifies it as `confirmed`, and wraps the indexer to forge proof bytes that must
+not verify.
+
+## Downstream Semantics
+
+bChannel will continue to label an operator-indexer sighting as `observed`.
+Only `status === "confirmed"` from this verifier promotes it to `confirmed`.
+`unavailable` retains the observed state, while `invalid` produces a security
+warning. No verification path requires MPC or spending-key participation.

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -13,6 +13,49 @@ npm install @arkade-os/sdk
 
 ## Usage
 
+### Verifying a settled VTXO
+
+`verifyVtxo` validates proof material locally and binds it to commitment
+transactions fetched from an independent Bitcoin backend. The indexer or local
+exit repository supplies untrusted proof bytes; only a `confirmed` result means
+the VTXO passed graph, signature, leaf, and on-chain anchor verification.
+
+```typescript
+import {
+  createExitChainResolver,
+  verifyVtxo,
+} from '@arkade-os/sdk'
+
+const proofSource = createExitChainResolver({
+  indexer,
+  repository: virtualTxRepository,
+})
+
+const result = await verifyVtxo(
+  vtxo,
+  proofSource,
+  chainSource,
+  {
+    pubkey: serverPubkey,
+    sweepInterval: unilateralExitDelay,
+  },
+)
+
+if (result.status === 'confirmed') {
+  console.log(`confirmed at depth ${result.confirmationDepth}`)
+}
+```
+
+The result status is one of:
+
+- `confirmed`: every required check passed.
+- `preconfirmed`: no final Bitcoin anchor exists yet.
+- `invalid`: available evidence contradicts the claimed VTXO.
+- `unavailable`: proof or independent chain data could not be obtained.
+
+The independent `chainSource` is the trust boundary. A `preconfirmed` or
+`unavailable` result must not be presented as confirmed.
+
 ### Creating a Wallet
 
 ```typescript

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -36,8 +36,7 @@ const result = await verifyVtxo(
   proofSource,
   chainSource,
   {
-    pubkey: serverPubkey,
-    sweepInterval: unilateralExitDelay,
+    forfeitPubkey: serverForfeitPubkey,
   },
 )
 
@@ -55,6 +54,10 @@ The result status is one of:
 
 The independent `chainSource` is the trust boundary. A `preconfirmed` or
 `unavailable` result must not be presented as confirmed.
+
+`serverForfeitPubkey` is the x-only forfeit key that applied when the VTXO tree
+was created. The tree expiry is decoded from the PSBT and accepted only when the
+resulting sweep leaf and cosigner aggregate reproduce the anchored P2TR output.
 
 ### Creating a Wallet
 

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -850,3 +850,14 @@ export type {
     VirtualTx,
     VtxoBranch,
 };
+
+export { verifyVtxo } from "./verification";
+export type {
+    VtxoChainSource,
+    VtxoProofSource,
+    VtxoVerificationCheck,
+    VtxoVerificationIssue,
+    VtxoVerificationOptions,
+    VtxoVerificationResult,
+    VtxoVerificationServerInfo,
+} from "./verification";

--- a/packages/ts-sdk/src/providers/electrum.ts
+++ b/packages/ts-sdk/src/providers/electrum.ts
@@ -620,6 +620,10 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         throw new Error("Only 1 or 1P1C package can be broadcast");
     }
 
+    async getTxHex(txid: string): Promise<string> {
+        return this.ws.request<string>(GetTransactionMethod, txid, false);
+    }
+
     async getTxOutspends(txid: string): Promise<{ spent: boolean; txid: string }[]> {
         // Step 1: fetch the creating tx to get its output scripts (1 round trip)
         const [txResult] = await this.chain.fetchTransactions([txid]);

--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -192,6 +192,15 @@ export class EsploraProvider implements OnchainProvider {
         }
     }
 
+    async getTxHex(txid: string): Promise<string> {
+        const response = await baseFetch(`${this.baseUrl}/tx/${txid}/hex`);
+        const body = await response.text();
+        if (!response.ok) {
+            throw new Error(`Failed to get transaction hex: ${body}`);
+        }
+        return body.trim();
+    }
+
     async getTxOutspends(txid: string): Promise<{ spent: boolean; txid?: string }[]> {
         const response = await baseFetch(`${this.baseUrl}/tx/${txid}/outspends`);
         if (!response.ok) {

--- a/packages/ts-sdk/src/verification/anchor.ts
+++ b/packages/ts-sdk/src/verification/anchor.ts
@@ -30,22 +30,12 @@ export async function verifyCommitmentAnchors(
     let minimumDepth = Number.POSITIVE_INFINITY;
 
     for (const commitmentTxid of proof.commitmentTxids) {
-        const root = findCommitmentRoot(proof, commitmentTxid);
-        if (!root) {
+        const roots = findCommitmentRoots(proof, commitmentTxid);
+        if (roots.length === 0) {
             issues.push({
                 code: "anchor_root_missing",
                 message: `No TREE transaction spends commitment ${commitmentTxid}`,
                 txid: commitmentTxid,
-            });
-            continue;
-        }
-        const rootInput = root.tx.getInput(root.inputIndex);
-        if (!rootInput.witnessUtxo || rootInput.index === undefined) {
-            issues.push({
-                code: "anchor_root_prevout_missing",
-                message: `TREE root ${root.tx.id} has incomplete commitment prevout data`,
-                txid: root.tx.id,
-                inputIndex: root.inputIndex,
             });
             continue;
         }
@@ -90,33 +80,6 @@ export async function verifyCommitmentAnchors(
             continue;
         }
 
-        const output = commitment.getOutput(rootInput.index);
-        if (output?.amount === undefined || !output.script) {
-            issues.push({
-                code: "anchor_output_missing",
-                message: `Commitment output ${commitmentTxid}:${rootInput.index} does not exist`,
-                txid: commitmentTxid,
-                outputIndex: rootInput.index,
-            });
-            continue;
-        }
-        if (output.amount !== rootInput.witnessUtxo.amount) {
-            issues.push({
-                code: "anchor_amount_mismatch",
-                message: `Commitment output amount ${output.amount} does not match TREE prevout ${rootInput.witnessUtxo.amount}`,
-                txid: commitmentTxid,
-                outputIndex: rootInput.index,
-            });
-        }
-        if (hex.encode(output.script) !== hex.encode(rootInput.witnessUtxo.script)) {
-            issues.push({
-                code: "anchor_script_mismatch",
-                message: "Commitment output script does not match the TREE root prevout",
-                txid: commitmentTxid,
-                outputIndex: rootInput.index,
-            });
-        }
-
         if (!status.confirmed) {
             issues.push({
                 code: "anchor_unconfirmed",
@@ -135,8 +98,58 @@ export async function verifyCommitmentAnchors(
             }
         }
 
-        const outspend = outspends[rootInput.index];
-        if (outspend?.spent) {
+        for (const root of roots) {
+            const rootInput = root.tx.getInput(root.inputIndex);
+            if (rootInput.index === undefined) {
+                issues.push({
+                    code: "anchor_root_prevout_missing",
+                    message: `TREE root ${root.tx.id} has no commitment output index`,
+                    txid: root.tx.id,
+                    inputIndex: root.inputIndex,
+                });
+                continue;
+            }
+
+            const output =
+                rootInput.index >= 0 && rootInput.index < commitment.outputsLength
+                    ? commitment.getOutput(rootInput.index)
+                    : undefined;
+            if (output?.amount === undefined || !output.script) {
+                issues.push({
+                    code: "anchor_output_missing",
+                    message: `Commitment output ${commitmentTxid}:${rootInput.index} does not exist`,
+                    txid: commitmentTxid,
+                    outputIndex: rootInput.index,
+                });
+                continue;
+            }
+            if (rootInput.witnessUtxo && output.amount !== rootInput.witnessUtxo.amount) {
+                issues.push({
+                    code: "anchor_amount_mismatch",
+                    message: `Commitment output amount ${output.amount} does not match TREE prevout ${rootInput.witnessUtxo.amount}`,
+                    txid: commitmentTxid,
+                    outputIndex: rootInput.index,
+                });
+            }
+            if (
+                rootInput.witnessUtxo &&
+                hex.encode(output.script) !== hex.encode(rootInput.witnessUtxo.script)
+            ) {
+                issues.push({
+                    code: "anchor_script_mismatch",
+                    message: "Commitment output script does not match the TREE root prevout",
+                    txid: commitmentTxid,
+                    outputIndex: rootInput.index,
+                });
+            }
+            if (!rootInput.witnessUtxo) {
+                root.tx.updateInput(root.inputIndex, {
+                    witnessUtxo: { amount: output.amount, script: output.script },
+                });
+            }
+
+            const outspend = outspends[rootInput.index];
+            if (!outspend?.spent) continue;
             if (!outspend.txid) {
                 issues.push({
                     code: "anchor_spender_unknown",
@@ -161,7 +174,8 @@ export async function verifyCommitmentAnchors(
     };
 }
 
-function findCommitmentRoot(proof: ParsedVtxoProof, commitmentTxid: string) {
+function findCommitmentRoots(proof: ParsedVtxoProof, commitmentTxid: string) {
+    const roots: { tx: Transaction; inputIndex: number }[] = [];
     for (const [txid, entry] of proof.entries) {
         if (entry.type !== ChainTxType.TREE) continue;
         const tx = proof.transactions.get(txid);
@@ -169,11 +183,11 @@ function findCommitmentRoot(proof: ParsedVtxoProof, commitmentTxid: string) {
         for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
             const input = tx.getInput(inputIndex);
             if (input.txid && hex.encode(input.txid) === commitmentTxid) {
-                return { tx, inputIndex };
+                roots.push({ tx, inputIndex });
             }
         }
     }
-    return undefined;
+    return roots;
 }
 
 function unavailable(code: string, text: string, cause: unknown) {

--- a/packages/ts-sdk/src/verification/anchor.ts
+++ b/packages/ts-sdk/src/verification/anchor.ts
@@ -1,0 +1,185 @@
+import { hex } from "@scure/base";
+import { ChainTxType } from "../providers/indexer";
+import { Transaction } from "../utils/transaction";
+import type { ParsedVtxoProof, VtxoChainSource, VtxoVerificationIssue } from "./types";
+
+export class VtxoVerificationUnavailableError extends Error {
+    constructor(
+        readonly code: string,
+        message: string,
+        options?: ErrorOptions,
+    ) {
+        super(message, options);
+        this.name = "VtxoVerificationUnavailableError";
+    }
+}
+
+export async function verifyCommitmentAnchors(
+    proof: ParsedVtxoProof,
+    source: VtxoChainSource,
+    minConfirmationDepth: number,
+): Promise<{ confirmationDepth: number; issues: VtxoVerificationIssue[] }> {
+    let tip: Awaited<ReturnType<VtxoChainSource["getChainTip"]>>;
+    try {
+        tip = await source.getChainTip();
+    } catch (error) {
+        throw unavailable("anchor_tip_unavailable", "Could not fetch the Bitcoin chain tip", error);
+    }
+
+    const issues: VtxoVerificationIssue[] = [];
+    let minimumDepth = Number.POSITIVE_INFINITY;
+
+    for (const commitmentTxid of proof.commitmentTxids) {
+        const root = findCommitmentRoot(proof, commitmentTxid);
+        if (!root) {
+            issues.push({
+                code: "anchor_root_missing",
+                message: `No TREE transaction spends commitment ${commitmentTxid}`,
+                txid: commitmentTxid,
+            });
+            continue;
+        }
+        const rootInput = root.tx.getInput(root.inputIndex);
+        if (!rootInput.witnessUtxo || rootInput.index === undefined) {
+            issues.push({
+                code: "anchor_root_prevout_missing",
+                message: `TREE root ${root.tx.id} has incomplete commitment prevout data`,
+                txid: root.tx.id,
+                inputIndex: root.inputIndex,
+            });
+            continue;
+        }
+
+        let rawHex: string;
+        let status: Awaited<ReturnType<VtxoChainSource["getTxStatus"]>>;
+        let outspends: Awaited<ReturnType<VtxoChainSource["getTxOutspends"]>>;
+        try {
+            [rawHex, status, outspends] = await Promise.all([
+                source.getTxHex(commitmentTxid),
+                source.getTxStatus(commitmentTxid),
+                source.getTxOutspends(commitmentTxid),
+            ]);
+        } catch (error) {
+            throw unavailable(
+                "anchor_data_unavailable",
+                `Could not fetch Bitcoin data for commitment ${commitmentTxid}`,
+                error,
+            );
+        }
+
+        let commitment: Transaction;
+        try {
+            commitment = Transaction.fromRaw(hex.decode(rawHex), {
+                allowUnknownInputs: true,
+                allowUnknownOutputs: true,
+            });
+        } catch (error) {
+            issues.push({
+                code: "anchor_transaction_malformed",
+                message: `Commitment ${commitmentTxid} raw transaction is malformed: ${message(error)}`,
+                txid: commitmentTxid,
+            });
+            continue;
+        }
+        if (commitment.id !== commitmentTxid) {
+            issues.push({
+                code: "anchor_txid_mismatch",
+                message: `Fetched transaction ${commitment.id} does not match ${commitmentTxid}`,
+                txid: commitmentTxid,
+            });
+            continue;
+        }
+
+        const output = commitment.getOutput(rootInput.index);
+        if (output?.amount === undefined || !output.script) {
+            issues.push({
+                code: "anchor_output_missing",
+                message: `Commitment output ${commitmentTxid}:${rootInput.index} does not exist`,
+                txid: commitmentTxid,
+                outputIndex: rootInput.index,
+            });
+            continue;
+        }
+        if (output.amount !== rootInput.witnessUtxo.amount) {
+            issues.push({
+                code: "anchor_amount_mismatch",
+                message: `Commitment output amount ${output.amount} does not match TREE prevout ${rootInput.witnessUtxo.amount}`,
+                txid: commitmentTxid,
+                outputIndex: rootInput.index,
+            });
+        }
+        if (hex.encode(output.script) !== hex.encode(rootInput.witnessUtxo.script)) {
+            issues.push({
+                code: "anchor_script_mismatch",
+                message: "Commitment output script does not match the TREE root prevout",
+                txid: commitmentTxid,
+                outputIndex: rootInput.index,
+            });
+        }
+
+        if (!status.confirmed) {
+            issues.push({
+                code: "anchor_unconfirmed",
+                message: `Commitment ${commitmentTxid} is not confirmed`,
+                txid: commitmentTxid,
+            });
+        } else {
+            const depth = tip.height - status.blockHeight + 1;
+            minimumDepth = Math.min(minimumDepth, depth);
+            if (depth < minConfirmationDepth) {
+                issues.push({
+                    code: "anchor_depth_insufficient",
+                    message: `Commitment ${commitmentTxid} depth ${depth} is below ${minConfirmationDepth}`,
+                    txid: commitmentTxid,
+                });
+            }
+        }
+
+        const outspend = outspends[rootInput.index];
+        if (outspend?.spent) {
+            if (!outspend.txid) {
+                issues.push({
+                    code: "anchor_spender_unknown",
+                    message: `Commitment output ${commitmentTxid}:${rootInput.index} is spent by an unknown transaction`,
+                    txid: commitmentTxid,
+                    outputIndex: rootInput.index,
+                });
+            } else if (outspend.txid !== root.tx.id) {
+                issues.push({
+                    code: "anchor_unexpected_spend",
+                    message: `Commitment output ${commitmentTxid}:${rootInput.index} was spent by ${outspend.txid}`,
+                    txid: commitmentTxid,
+                    outputIndex: rootInput.index,
+                });
+            }
+        }
+    }
+
+    return {
+        confirmationDepth: Number.isFinite(minimumDepth) ? minimumDepth : 0,
+        issues,
+    };
+}
+
+function findCommitmentRoot(proof: ParsedVtxoProof, commitmentTxid: string) {
+    for (const [txid, entry] of proof.entries) {
+        if (entry.type !== ChainTxType.TREE) continue;
+        const tx = proof.transactions.get(txid);
+        if (!tx) continue;
+        for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
+            const input = tx.getInput(inputIndex);
+            if (input.txid && hex.encode(input.txid) === commitmentTxid) {
+                return { tx, inputIndex };
+            }
+        }
+    }
+    return undefined;
+}
+
+function unavailable(code: string, text: string, cause: unknown) {
+    return new VtxoVerificationUnavailableError(code, `${text}: ${message(cause)}`, { cause });
+}
+
+function message(error: unknown) {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ts-sdk/src/verification/graph.ts
+++ b/packages/ts-sdk/src/verification/graph.ts
@@ -1,0 +1,166 @@
+import { hex } from "@scure/base";
+import { ChainTxType } from "../providers/indexer";
+import type { VirtualCoin } from "../wallet";
+import type { ParsedVtxoProof, VtxoVerificationIssue } from "./types";
+
+export function verifyClaimedLeaf(
+    vtxo: VirtualCoin,
+    proof: ParsedVtxoProof,
+): VtxoVerificationIssue[] {
+    const tx = proof.transactions.get(vtxo.txid);
+    if (!tx) {
+        return [
+            {
+                code: "leaf_tx_missing",
+                message: `Claimed VTXO transaction ${vtxo.txid} is absent from the proof`,
+                txid: vtxo.txid,
+            },
+        ];
+    }
+    if (vtxo.vout < 0 || vtxo.vout >= tx.outputsLength) {
+        return [
+            {
+                code: "leaf_output_missing",
+                message: `Claimed VTXO output ${vtxo.txid}:${vtxo.vout} does not exist`,
+                txid: vtxo.txid,
+                outputIndex: vtxo.vout,
+            },
+        ];
+    }
+    const output = tx.getOutput(vtxo.vout);
+    if (output?.amount === undefined || !output.script) {
+        return [
+            {
+                code: "leaf_output_incomplete",
+                message: `Claimed VTXO output ${vtxo.txid}:${vtxo.vout} has no amount or script`,
+                txid: vtxo.txid,
+                outputIndex: vtxo.vout,
+            },
+        ];
+    }
+
+    const issues: VtxoVerificationIssue[] = [];
+    if (BigInt(vtxo.value) !== output.amount) {
+        issues.push({
+            code: "leaf_amount_mismatch",
+            message: `Claimed amount ${vtxo.value} does not match output amount ${output.amount}`,
+            txid: vtxo.txid,
+            outputIndex: vtxo.vout,
+        });
+    }
+    if (!vtxo.script || vtxo.script.toLowerCase() !== hex.encode(output.script)) {
+        issues.push({
+            code: "leaf_script_mismatch",
+            message: "Claimed script does not match the virtual transaction output",
+            txid: vtxo.txid,
+            outputIndex: vtxo.vout,
+        });
+    }
+    return issues;
+}
+
+export function verifyGraphSegments(proof: ParsedVtxoProof): VtxoVerificationIssue[] {
+    const issues: VtxoVerificationIssue[] = [];
+    const spentOutputs = new Set<string>();
+
+    for (const [txid, entry] of proof.entries) {
+        if (entry.type !== ChainTxType.TREE) continue;
+        const tx = proof.transactions.get(txid);
+        if (!tx) continue;
+        if (tx.inputsLength !== 1) {
+            issues.push({
+                code: "graph_input_count",
+                message: `TREE transaction ${txid} has ${tx.inputsLength} inputs, expected 1`,
+                txid,
+            });
+            continue;
+        }
+        const input = tx.getInput(0);
+        if (!input.txid || input.index === undefined || !input.witnessUtxo) {
+            issues.push({
+                code: "graph_input_incomplete",
+                message: `TREE transaction ${txid} has incomplete parent data`,
+                txid,
+                inputIndex: 0,
+            });
+            continue;
+        }
+
+        const parentTxid = hex.encode(input.txid);
+        const parentKey = `${parentTxid}:${input.index}`;
+        if (spentOutputs.has(parentKey)) {
+            issues.push({
+                code: "graph_duplicate_spend",
+                message: `Multiple TREE transactions spend ${parentKey}`,
+                txid,
+                inputIndex: 0,
+            });
+            continue;
+        }
+        spentOutputs.add(parentKey);
+
+        let outputAmount = 0n;
+        for (let outputIndex = 0; outputIndex < tx.outputsLength; outputIndex++) {
+            outputAmount += tx.getOutput(outputIndex)?.amount ?? 0n;
+        }
+        if (outputAmount !== input.witnessUtxo.amount) {
+            issues.push({
+                code: "graph_amount_mismatch",
+                message: `TREE transaction ${txid} outputs ${outputAmount} but spends ${input.witnessUtxo.amount}`,
+                txid,
+                inputIndex: 0,
+            });
+        }
+
+        const parentEntry = proof.entries.get(parentTxid);
+        if (!parentEntry) {
+            issues.push({
+                code: "graph_parent_missing",
+                message: `TREE transaction ${txid} has unknown parent ${parentTxid}`,
+                txid,
+                inputIndex: 0,
+            });
+            continue;
+        }
+        if (parentEntry.type === ChainTxType.COMMITMENT) continue;
+        if (parentEntry.type !== ChainTxType.TREE) {
+            issues.push({
+                code: "graph_parent_type",
+                message: `TREE transaction ${txid} has non-TREE virtual parent ${parentTxid}`,
+                txid,
+                inputIndex: 0,
+            });
+            continue;
+        }
+
+        const parent = proof.transactions.get(parentTxid);
+        const parentOutput = parent?.getOutput(input.index);
+        if (parentOutput?.amount === undefined || !parentOutput.script) {
+            issues.push({
+                code: "graph_parent_output_missing",
+                message: `Parent output ${parentKey} does not exist`,
+                txid,
+                inputIndex: 0,
+            });
+            continue;
+        }
+        if (parentOutput.amount !== input.witnessUtxo.amount) {
+            issues.push({
+                code: "graph_amount_mismatch",
+                message: `TREE transaction ${txid} input amount does not match ${parentKey}`,
+                txid,
+                inputIndex: 0,
+            });
+        }
+        if (hex.encode(parentOutput.script) !== hex.encode(input.witnessUtxo.script)) {
+            issues.push({
+                code: "graph_prevout_mismatch",
+                message: `TREE transaction ${txid} input script does not match ${parentKey}`,
+                txid,
+                inputIndex: 0,
+            });
+        }
+    }
+
+    return issues;
+}

--- a/packages/ts-sdk/src/verification/graph.ts
+++ b/packages/ts-sdk/src/verification/graph.ts
@@ -3,6 +3,59 @@ import { ChainTxType } from "../providers/indexer";
 import type { VirtualCoin } from "../wallet";
 import type { ParsedVtxoProof, VtxoVerificationIssue } from "./types";
 
+export function hydrateVirtualPrevouts(proof: ParsedVtxoProof): VtxoVerificationIssue[] {
+    const issues: VtxoVerificationIssue[] = [];
+
+    for (const [txid, tx] of proof.transactions) {
+        for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
+            const input = tx.getInput(inputIndex);
+            if (!input.txid || input.index === undefined) continue;
+
+            const parentTxid = hex.encode(input.txid);
+            const parent = proof.transactions.get(parentTxid);
+            if (!parent) continue;
+
+            const parentOutput =
+                input.index >= 0 && input.index < parent.outputsLength
+                    ? parent.getOutput(input.index)
+                    : undefined;
+            if (parentOutput?.amount === undefined || !parentOutput.script) {
+                issues.push({
+                    code: "graph_parent_output_missing",
+                    message: `Parent output ${parentTxid}:${input.index} does not exist`,
+                    txid,
+                    inputIndex,
+                });
+                continue;
+            }
+
+            if (!input.witnessUtxo) {
+                tx.updateInput(inputIndex, {
+                    witnessUtxo: {
+                        amount: parentOutput.amount,
+                        script: parentOutput.script,
+                    },
+                });
+                continue;
+            }
+
+            if (
+                input.witnessUtxo.amount !== parentOutput.amount ||
+                hex.encode(input.witnessUtxo.script) !== hex.encode(parentOutput.script)
+            ) {
+                issues.push({
+                    code: "graph_prevout_mismatch",
+                    message: `Input prevout does not match ${parentTxid}:${input.index}`,
+                    txid,
+                    inputIndex,
+                });
+            }
+        }
+    }
+
+    return issues;
+}
+
 export function verifyClaimedLeaf(
     vtxo: VirtualCoin,
     proof: ParsedVtxoProof,
@@ -64,9 +117,33 @@ export function verifyGraphSegments(proof: ParsedVtxoProof): VtxoVerificationIss
     const spentOutputs = new Set<string>();
 
     for (const [txid, entry] of proof.entries) {
-        if (entry.type !== ChainTxType.TREE) continue;
         const tx = proof.transactions.get(txid);
         if (!tx) continue;
+        if (entry.type === ChainTxType.ARK || entry.type === ChainTxType.CHECKPOINT) {
+            let inputAmount = 0n;
+            let completeInputs = true;
+            for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
+                const witnessUtxo = tx.getInput(inputIndex).witnessUtxo;
+                if (!witnessUtxo) {
+                    completeInputs = false;
+                    break;
+                }
+                inputAmount += witnessUtxo.amount;
+            }
+            let outputAmount = 0n;
+            for (let outputIndex = 0; outputIndex < tx.outputsLength; outputIndex++) {
+                outputAmount += tx.getOutput(outputIndex)?.amount ?? 0n;
+            }
+            if (completeInputs && outputAmount > inputAmount) {
+                issues.push({
+                    code: "graph_amount_mismatch",
+                    message: `Transaction ${txid} outputs ${outputAmount} but spends ${inputAmount}`,
+                    txid,
+                });
+            }
+            continue;
+        }
+        if (entry.type !== ChainTxType.TREE) continue;
         if (tx.inputsLength !== 1) {
             issues.push({
                 code: "graph_input_count",
@@ -134,7 +211,10 @@ export function verifyGraphSegments(proof: ParsedVtxoProof): VtxoVerificationIss
         }
 
         const parent = proof.transactions.get(parentTxid);
-        const parentOutput = parent?.getOutput(input.index);
+        const parentOutput =
+            parent && input.index >= 0 && input.index < parent.outputsLength
+                ? parent.getOutput(input.index)
+                : undefined;
         if (parentOutput?.amount === undefined || !parentOutput.script) {
             issues.push({
                 code: "graph_parent_output_missing",

--- a/packages/ts-sdk/src/verification/graph.ts
+++ b/packages/ts-sdk/src/verification/graph.ts
@@ -60,13 +60,14 @@ export function verifyClaimedLeaf(
     vtxo: VirtualCoin,
     proof: ParsedVtxoProof,
 ): VtxoVerificationIssue[] {
-    const tx = proof.transactions.get(vtxo.txid);
+    const txid = vtxo.txid.toLowerCase();
+    const tx = proof.transactions.get(txid);
     if (!tx) {
         return [
             {
                 code: "leaf_tx_missing",
-                message: `Claimed VTXO transaction ${vtxo.txid} is absent from the proof`,
-                txid: vtxo.txid,
+                message: `Claimed VTXO transaction ${txid} is absent from the proof`,
+                txid,
             },
         ];
     }
@@ -74,8 +75,8 @@ export function verifyClaimedLeaf(
         return [
             {
                 code: "leaf_output_missing",
-                message: `Claimed VTXO output ${vtxo.txid}:${vtxo.vout} does not exist`,
-                txid: vtxo.txid,
+                message: `Claimed VTXO output ${txid}:${vtxo.vout} does not exist`,
+                txid,
                 outputIndex: vtxo.vout,
             },
         ];
@@ -85,8 +86,8 @@ export function verifyClaimedLeaf(
         return [
             {
                 code: "leaf_output_incomplete",
-                message: `Claimed VTXO output ${vtxo.txid}:${vtxo.vout} has no amount or script`,
-                txid: vtxo.txid,
+                message: `Claimed VTXO output ${txid}:${vtxo.vout} has no amount or script`,
+                txid,
                 outputIndex: vtxo.vout,
             },
         ];
@@ -97,7 +98,7 @@ export function verifyClaimedLeaf(
         issues.push({
             code: "leaf_amount_mismatch",
             message: `Claimed amount ${vtxo.value} does not match output amount ${output.amount}`,
-            txid: vtxo.txid,
+            txid,
             outputIndex: vtxo.vout,
         });
     }
@@ -105,7 +106,7 @@ export function verifyClaimedLeaf(
         issues.push({
             code: "leaf_script_mismatch",
             message: "Claimed script does not match the virtual transaction output",
-            txid: vtxo.txid,
+            txid,
             outputIndex: vtxo.vout,
         });
     }
@@ -123,12 +124,32 @@ export function verifyGraphSegments(proof: ParsedVtxoProof): VtxoVerificationIss
             let inputAmount = 0n;
             let completeInputs = true;
             for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
-                const witnessUtxo = tx.getInput(inputIndex).witnessUtxo;
-                if (!witnessUtxo) {
+                const input = tx.getInput(inputIndex);
+                if (!input.txid || input.index === undefined) {
+                    issues.push({
+                        code: "graph_input_incomplete",
+                        message: `Transaction ${txid} input ${inputIndex} has incomplete parent data`,
+                        txid,
+                        inputIndex,
+                    });
                     completeInputs = false;
-                    break;
+                    continue;
                 }
-                inputAmount += witnessUtxo.amount;
+                const parentKey = `${hex.encode(input.txid)}:${input.index}`;
+                if (spentOutputs.has(parentKey)) {
+                    issues.push({
+                        code: "graph_duplicate_spend",
+                        message: `Multiple transactions spend ${parentKey}`,
+                        txid,
+                        inputIndex,
+                    });
+                }
+                spentOutputs.add(parentKey);
+                if (!input.witnessUtxo) {
+                    completeInputs = false;
+                    continue;
+                }
+                inputAmount += input.witnessUtxo.amount;
             }
             let outputAmount = 0n;
             for (let outputIndex = 0; outputIndex < tx.outputsLength; outputIndex++) {
@@ -168,7 +189,7 @@ export function verifyGraphSegments(proof: ParsedVtxoProof): VtxoVerificationIss
         if (spentOutputs.has(parentKey)) {
             issues.push({
                 code: "graph_duplicate_spend",
-                message: `Multiple TREE transactions spend ${parentKey}`,
+                message: `Multiple transactions spend ${parentKey}`,
                 txid,
                 inputIndex: 0,
             });

--- a/packages/ts-sdk/src/verification/index.ts
+++ b/packages/ts-sdk/src/verification/index.ts
@@ -1,6 +1,6 @@
 export { parseVtxoProof, VtxoProofError } from "./proof";
-export { verifyClaimedLeaf, verifyGraphSegments } from "./graph";
-export { verifyProofSignatures } from "./signatures";
+export { hydrateVirtualPrevouts, verifyClaimedLeaf, verifyGraphSegments } from "./graph";
+export { verifyProofSignatures, verifyTreeCosignerKeys } from "./signatures";
 export { verifyCommitmentAnchors, VtxoVerificationUnavailableError } from "./anchor";
 export { verifyVtxo } from "./verifyVtxo";
 export type {

--- a/packages/ts-sdk/src/verification/index.ts
+++ b/packages/ts-sdk/src/verification/index.ts
@@ -2,6 +2,7 @@ export { parseVtxoProof, VtxoProofError } from "./proof";
 export { verifyClaimedLeaf, verifyGraphSegments } from "./graph";
 export { verifyProofSignatures } from "./signatures";
 export { verifyCommitmentAnchors, VtxoVerificationUnavailableError } from "./anchor";
+export { verifyVtxo } from "./verifyVtxo";
 export type {
     ParsedVtxoProof,
     VtxoChainSource,

--- a/packages/ts-sdk/src/verification/index.ts
+++ b/packages/ts-sdk/src/verification/index.ts
@@ -1,4 +1,5 @@
 export { parseVtxoProof, VtxoProofError } from "./proof";
+export { verifyClaimedLeaf, verifyGraphSegments } from "./graph";
 export type {
     ParsedVtxoProof,
     VtxoChainSource,

--- a/packages/ts-sdk/src/verification/index.ts
+++ b/packages/ts-sdk/src/verification/index.ts
@@ -1,5 +1,6 @@
 export { parseVtxoProof, VtxoProofError } from "./proof";
 export { verifyClaimedLeaf, verifyGraphSegments } from "./graph";
+export { verifyProofSignatures } from "./signatures";
 export type {
     ParsedVtxoProof,
     VtxoChainSource,

--- a/packages/ts-sdk/src/verification/index.ts
+++ b/packages/ts-sdk/src/verification/index.ts
@@ -1,6 +1,7 @@
 export { parseVtxoProof, VtxoProofError } from "./proof";
 export { verifyClaimedLeaf, verifyGraphSegments } from "./graph";
 export { verifyProofSignatures } from "./signatures";
+export { verifyCommitmentAnchors, VtxoVerificationUnavailableError } from "./anchor";
 export type {
     ParsedVtxoProof,
     VtxoChainSource,

--- a/packages/ts-sdk/src/verification/index.ts
+++ b/packages/ts-sdk/src/verification/index.ts
@@ -1,0 +1,11 @@
+export { parseVtxoProof, VtxoProofError } from "./proof";
+export type {
+    ParsedVtxoProof,
+    VtxoChainSource,
+    VtxoProofSource,
+    VtxoVerificationCheck,
+    VtxoVerificationIssue,
+    VtxoVerificationOptions,
+    VtxoVerificationResult,
+    VtxoVerificationServerInfo,
+} from "./types";

--- a/packages/ts-sdk/src/verification/proof.ts
+++ b/packages/ts-sdk/src/verification/proof.ts
@@ -1,0 +1,167 @@
+import { base64, hex } from "@scure/base";
+import { ChainTxType } from "../providers/indexer";
+import { Transaction } from "../utils/transaction";
+import type { Outpoint } from "../wallet";
+import type { ParsedVtxoProof, VtxoProofSource } from "./types";
+
+export class VtxoProofError extends Error {
+    constructor(
+        readonly code: string,
+        message: string,
+        readonly kind: "invalid" | "unavailable",
+    ) {
+        super(message);
+        this.name = "VtxoProofError";
+    }
+}
+
+const VIRTUAL_TYPES = new Set<ChainTxType>([
+    ChainTxType.ARK,
+    ChainTxType.TREE,
+    ChainTxType.CHECKPOINT,
+]);
+
+export async function parseVtxoProof(
+    outpoint: Outpoint,
+    source: VtxoProofSource,
+): Promise<ParsedVtxoProof> {
+    let chain;
+    try {
+        chain = await source.getVtxoChain(outpoint);
+    } catch (error) {
+        throw new VtxoProofError(
+            "proof_chain_unavailable",
+            `Could not fetch VTXO ancestry: ${errorMessage(error)}`,
+            "unavailable",
+        );
+    }
+    if (chain.length === 0) {
+        throw new VtxoProofError(
+            "proof_chain_empty",
+            "The proof source returned an empty VTXO chain",
+            "unavailable",
+        );
+    }
+
+    const entries = new Map<string, (typeof chain)[number]>();
+    for (const entry of chain) {
+        if (entries.has(entry.txid)) {
+            throw new VtxoProofError(
+                "proof_duplicate_txid",
+                `The VTXO chain contains duplicate transaction ${entry.txid}`,
+                "invalid",
+            );
+        }
+        if (entry.type !== ChainTxType.COMMITMENT && !VIRTUAL_TYPES.has(entry.type)) {
+            throw new VtxoProofError(
+                "proof_unknown_type",
+                `Transaction ${entry.txid} has unsupported chain type ${entry.type}`,
+                "invalid",
+            );
+        }
+        entries.set(entry.txid, entry);
+    }
+
+    const virtualEntries = chain.filter((entry) => VIRTUAL_TYPES.has(entry.type));
+    let psbts: string[];
+    try {
+        psbts = await source.getVirtualTxs(virtualEntries.map((entry) => entry.txid));
+    } catch (error) {
+        throw new VtxoProofError(
+            "proof_psbts_unavailable",
+            `Could not fetch virtual transactions: ${errorMessage(error)}`,
+            "unavailable",
+        );
+    }
+    if (psbts.length < virtualEntries.length) {
+        throw new VtxoProofError(
+            "proof_psbt_missing",
+            `Expected ${virtualEntries.length} virtual transactions, received ${psbts.length}`,
+            "unavailable",
+        );
+    }
+
+    const transactions = new Map<string, Transaction>();
+    for (const encoded of psbts) {
+        let tx: Transaction;
+        try {
+            tx = Transaction.fromPSBT(base64.decode(encoded));
+        } catch (error) {
+            throw new VtxoProofError(
+                "proof_psbt_malformed",
+                `Could not decode virtual transaction: ${errorMessage(error)}`,
+                "invalid",
+            );
+        }
+        if (!entries.has(tx.id) || !VIRTUAL_TYPES.has(entries.get(tx.id)!.type)) {
+            throw new VtxoProofError(
+                "proof_psbt_txid_mismatch",
+                `Virtual transaction ${tx.id} was not declared by the chain metadata`,
+                "invalid",
+            );
+        }
+        if (transactions.has(tx.id)) {
+            throw new VtxoProofError(
+                "proof_duplicate_psbt",
+                `The proof contains duplicate PSBT ${tx.id}`,
+                "invalid",
+            );
+        }
+        transactions.set(tx.id, tx);
+    }
+
+    for (const entry of virtualEntries) {
+        const tx = transactions.get(entry.txid);
+        if (!tx) {
+            throw new VtxoProofError(
+                "proof_psbt_missing",
+                `Virtual transaction ${entry.txid} is missing`,
+                "unavailable",
+            );
+        }
+        const actualParents = new Set<string>();
+        for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
+            const input = tx.getInput(inputIndex);
+            if (!input.txid) {
+                throw new VtxoProofError(
+                    "proof_input_txid_missing",
+                    `Transaction ${entry.txid} input ${inputIndex} has no parent txid`,
+                    "invalid",
+                );
+            }
+            actualParents.add(hex.encode(input.txid));
+        }
+        const declaredParents = new Set(entry.spends);
+        if (
+            actualParents.size !== declaredParents.size ||
+            [...actualParents].some((parent) => !declaredParents.has(parent))
+        ) {
+            throw new VtxoProofError(
+                "proof_parent_mismatch",
+                `Transaction ${entry.txid} inputs do not match its declared parents`,
+                "invalid",
+            );
+        }
+        for (const parent of actualParents) {
+            if (!entries.has(parent)) {
+                throw new VtxoProofError(
+                    "proof_parent_unknown",
+                    `Transaction ${entry.txid} references unknown parent ${parent}`,
+                    "invalid",
+                );
+            }
+        }
+    }
+
+    return {
+        entries,
+        transactions,
+        commitmentTxids: chain
+            .filter((entry) => entry.type === ChainTxType.COMMITMENT)
+            .map((entry) => entry.txid),
+    };
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ts-sdk/src/verification/proof.ts
+++ b/packages/ts-sdk/src/verification/proof.ts
@@ -43,8 +43,13 @@ export async function parseVtxoProof(
         );
     }
 
-    const entries = new Map<string, (typeof chain)[number]>();
-    for (const entry of chain) {
+    const normalizedChain = chain.map((entry) => ({
+        ...entry,
+        txid: entry.txid.toLowerCase(),
+        spends: entry.spends.map((txid) => txid.toLowerCase()),
+    }));
+    const entries = new Map<string, (typeof normalizedChain)[number]>();
+    for (const entry of normalizedChain) {
         if (entries.has(entry.txid)) {
             throw new VtxoProofError(
                 "proof_duplicate_txid",
@@ -62,7 +67,42 @@ export async function parseVtxoProof(
         entries.set(entry.txid, entry);
     }
 
-    const virtualEntries = chain.filter((entry) => VIRTUAL_TYPES.has(entry.type));
+    const targetTxid = outpoint.txid.toLowerCase();
+    if (!entries.has(targetTxid)) {
+        throw new VtxoProofError(
+            "proof_target_missing",
+            `The VTXO chain does not contain requested transaction ${targetTxid}`,
+            "invalid",
+        );
+    }
+
+    const reachable = new Set<string>();
+    const visiting = new Set<string>();
+    const visit = (txid: string): void => {
+        if (reachable.has(txid)) return;
+        if (visiting.has(txid)) {
+            throw new VtxoProofError(
+                "proof_cycle",
+                `The VTXO chain contains a cycle at transaction ${txid}`,
+                "invalid",
+            );
+        }
+        const entry = entries.get(txid);
+        // Defer unknown-parent classification until after the PSBT's actual
+        // parents are compared with metadata, so a contradiction is reported
+        // as parent_mismatch rather than being masked by traversal order.
+        if (!entry) return;
+        visiting.add(txid);
+        for (const parent of entry.spends) visit(parent);
+        visiting.delete(txid);
+        reachable.add(txid);
+    };
+    visit(targetTxid);
+
+    const reachableEntries = new Map([...entries].filter(([txid]) => reachable.has(txid)));
+    const virtualEntries = normalizedChain.filter(
+        (entry) => reachable.has(entry.txid) && VIRTUAL_TYPES.has(entry.type),
+    );
     let psbts: string[];
     try {
         psbts = await source.getVirtualTxs(virtualEntries.map((entry) => entry.txid));
@@ -93,21 +133,22 @@ export async function parseVtxoProof(
                 "invalid",
             );
         }
-        if (!entries.has(tx.id) || !VIRTUAL_TYPES.has(entries.get(tx.id)!.type)) {
+        const txid = tx.id.toLowerCase();
+        if (!reachableEntries.has(txid) || !VIRTUAL_TYPES.has(reachableEntries.get(txid)!.type)) {
             throw new VtxoProofError(
                 "proof_psbt_txid_mismatch",
-                `Virtual transaction ${tx.id} was not declared by the chain metadata`,
+                `Virtual transaction ${txid} was not declared by the chain metadata`,
                 "invalid",
             );
         }
-        if (transactions.has(tx.id)) {
+        if (transactions.has(txid)) {
             throw new VtxoProofError(
                 "proof_duplicate_psbt",
-                `The proof contains duplicate PSBT ${tx.id}`,
+                `The proof contains duplicate PSBT ${txid}`,
                 "invalid",
             );
         }
-        transactions.set(tx.id, tx);
+        transactions.set(txid, tx);
     }
 
     for (const entry of virtualEntries) {
@@ -143,7 +184,7 @@ export async function parseVtxoProof(
             );
         }
         for (const parent of actualParents) {
-            if (!entries.has(parent)) {
+            if (!reachableEntries.has(parent)) {
                 throw new VtxoProofError(
                     "proof_parent_unknown",
                     `Transaction ${entry.txid} references unknown parent ${parent}`,
@@ -153,11 +194,20 @@ export async function parseVtxoProof(
         }
     }
 
+    const disconnectedTxid = [...entries.keys()].find((txid) => !reachable.has(txid));
+    if (disconnectedTxid) {
+        throw new VtxoProofError(
+            "proof_disconnected_node",
+            `Transaction ${disconnectedTxid} is disconnected from requested transaction ${targetTxid}`,
+            "invalid",
+        );
+    }
+
     return {
-        entries,
+        entries: reachableEntries,
         transactions,
-        commitmentTxids: chain
-            .filter((entry) => entry.type === ChainTxType.COMMITMENT)
+        commitmentTxids: normalizedChain
+            .filter((entry) => reachable.has(entry.txid) && entry.type === ChainTxType.COMMITMENT)
             .map((entry) => entry.txid),
     };
 }

--- a/packages/ts-sdk/src/verification/signatures.ts
+++ b/packages/ts-sdk/src/verification/signatures.ts
@@ -1,0 +1,154 @@
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { hex } from "@scure/base";
+import { SigHash, TAPROOT_UNSPENDABLE_KEY } from "@scure/btc-signer";
+import { ChainTxType } from "../providers/indexer";
+import { scriptFromTapLeafScript } from "../script/base";
+import { decodeTapscript } from "../script/tapscript";
+import { verifyTapscriptSignatures } from "../utils/arkTransaction";
+import type { Transaction } from "../utils/transaction";
+import type { ParsedVtxoProof, VtxoVerificationIssue } from "./types";
+
+export function verifyProofSignatures(proof: ParsedVtxoProof): VtxoVerificationIssue[] {
+    const issues: VtxoVerificationIssue[] = [];
+
+    for (const [txid, entry] of proof.entries) {
+        const tx = proof.transactions.get(txid);
+        if (!tx) continue;
+        if (entry.type !== ChainTxType.TREE) {
+            verifyScriptPathSignatures(txid, tx, issues);
+            continue;
+        }
+
+        const prevoutScripts: Uint8Array[] = [];
+        const prevoutAmounts: bigint[] = [];
+        let completePrevouts = true;
+        for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
+            const witnessUtxo = tx.getInput(inputIndex).witnessUtxo;
+            if (!witnessUtxo) {
+                issues.push({
+                    code: "signature_prevout_missing",
+                    message: `TREE transaction ${txid} input ${inputIndex} has no witness UTXO`,
+                    txid,
+                    inputIndex,
+                });
+                completePrevouts = false;
+                continue;
+            }
+            prevoutScripts.push(witnessUtxo.script);
+            prevoutAmounts.push(witnessUtxo.amount);
+        }
+        if (!completePrevouts) continue;
+
+        for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
+            const input = tx.getInput(inputIndex);
+            const script = input.witnessUtxo!.script;
+            if (script.length !== 34 || script[0] !== 0x51 || script[1] !== 0x20) {
+                issues.push({
+                    code: "signature_prevout_not_p2tr",
+                    message: `TREE transaction ${txid} input ${inputIndex} does not spend P2TR`,
+                    txid,
+                    inputIndex,
+                });
+                continue;
+            }
+            if (!input.tapKeySig) {
+                issues.push({
+                    code: "signature_missing_tap_key",
+                    message: `TREE transaction ${txid} input ${inputIndex} has no tapKeySig`,
+                    txid,
+                    inputIndex,
+                });
+                continue;
+            }
+
+            const encodedSignature = input.tapKeySig;
+            const sighashType =
+                encodedSignature.length === 65 ? encodedSignature[64] : SigHash.DEFAULT;
+            if (encodedSignature.length !== 64 && encodedSignature.length !== 65) {
+                issues.push({
+                    code: "signature_invalid_tap_key",
+                    message: `TREE transaction ${txid} input ${inputIndex} has an invalid signature length`,
+                    txid,
+                    inputIndex,
+                });
+                continue;
+            }
+            if (sighashType !== SigHash.DEFAULT) {
+                issues.push({
+                    code: "signature_sighash_unsupported",
+                    message: `TREE transaction ${txid} input ${inputIndex} uses unsupported sighash ${sighashType}`,
+                    txid,
+                    inputIndex,
+                });
+                continue;
+            }
+
+            const message = tx.preimageWitnessV1(
+                inputIndex,
+                prevoutScripts,
+                sighashType,
+                prevoutAmounts,
+            );
+            const signature = encodedSignature.subarray(0, 64);
+            const outputKey = script.subarray(2);
+            let valid = false;
+            try {
+                valid = schnorr.verify(signature, message, outputKey);
+            } catch {
+                valid = false;
+            }
+            if (!valid) {
+                issues.push({
+                    code: "signature_invalid_tap_key",
+                    message: `TREE transaction ${txid} input ${inputIndex} has an invalid tapKeySig`,
+                    txid,
+                    inputIndex,
+                });
+            }
+        }
+    }
+
+    return issues;
+}
+
+function verifyScriptPathSignatures(
+    txid: string,
+    tx: Transaction,
+    issues: VtxoVerificationIssue[],
+): void {
+    for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
+        const input = tx.getInput(inputIndex);
+        if (!input.tapLeafScript || input.tapLeafScript.length === 0) continue;
+
+        const internalKey = input.tapLeafScript[0][0]?.internalKey;
+        if (!internalKey || hex.encode(internalKey) !== hex.encode(TAPROOT_UNSPENDABLE_KEY)) {
+            issues.push({
+                code: "signature_internal_key_spendable",
+                message: `Transaction ${txid} input ${inputIndex} does not use the NUMS internal key`,
+                txid,
+                inputIndex,
+            });
+            continue;
+        }
+
+        try {
+            const script = scriptFromTapLeafScript(input.tapLeafScript[0]);
+            const decoded = decodeTapscript(script);
+            const requiredSigners = (decoded.params.pubkeys ?? []).map((key: Uint8Array) =>
+                hex.encode(key),
+            );
+            verifyTapscriptSignatures(tx, inputIndex, requiredSigners);
+        } catch (error) {
+            issues.push({
+                code: "signature_invalid_script_path",
+                message: `Transaction ${txid} input ${inputIndex} script signature failed: ${errorMessage(error)}`,
+                txid,
+                inputIndex,
+            });
+        }
+    }
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ts-sdk/src/verification/signatures.ts
+++ b/packages/ts-sdk/src/verification/signatures.ts
@@ -1,12 +1,91 @@
 import { schnorr } from "@noble/curves/secp256k1.js";
 import { hex } from "@scure/base";
 import { SigHash, TAPROOT_UNSPENDABLE_KEY } from "@scure/btc-signer";
+import { tapLeafHash } from "@scure/btc-signer/payment.js";
+import { compareBytes, taprootTweakPubkey } from "@scure/btc-signer/utils.js";
+import { aggregateKeys } from "../musig2";
 import { ChainTxType } from "../providers/indexer";
 import { scriptFromTapLeafScript } from "../script/base";
-import { decodeTapscript } from "../script/tapscript";
+import { CSVMultisigTapscript, decodeTapscript } from "../script/tapscript";
 import { verifyTapscriptSignatures } from "../utils/arkTransaction";
+import { CosignerPublicKey, getArkPsbtFields, VtxoTreeExpiry } from "../utils/unknownFields";
 import type { Transaction } from "../utils/transaction";
-import type { ParsedVtxoProof, VtxoVerificationIssue } from "./types";
+import type { ParsedVtxoProof, VtxoVerificationIssue, VtxoVerificationServerInfo } from "./types";
+
+export function verifyTreeCosignerKeys(
+    proof: ParsedVtxoProof,
+    serverInfo: VtxoVerificationServerInfo,
+): VtxoVerificationIssue[] {
+    const issues: VtxoVerificationIssue[] = [];
+
+    for (const [txid, entry] of proof.entries) {
+        if (entry.type !== ChainTxType.TREE) continue;
+        const tx = proof.transactions.get(txid);
+        if (!tx) continue;
+
+        for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
+            const input = tx.getInput(inputIndex);
+            const script = input.witnessUtxo?.script;
+            if (!script || script.length !== 34 || script[0] !== 0x51 || script[1] !== 0x20) {
+                continue;
+            }
+
+            const cosigners = getArkPsbtFields(tx, inputIndex, CosignerPublicKey);
+            if (cosigners.length === 0) {
+                issues.push({
+                    code: "signature_cosigner_missing",
+                    message: `TREE transaction ${txid} input ${inputIndex} has no cosigner keys`,
+                    txid,
+                    inputIndex,
+                });
+                continue;
+            }
+
+            const expiries = getArkPsbtFields(tx, inputIndex, VtxoTreeExpiry);
+            if (expiries.length !== 1) {
+                issues.push({
+                    code:
+                        expiries.length === 0
+                            ? "signature_sweep_expiry_missing"
+                            : "signature_sweep_expiry_ambiguous",
+                    message: `TREE transaction ${txid} input ${inputIndex} must have exactly one sweep expiry`,
+                    txid,
+                    inputIndex,
+                });
+                continue;
+            }
+
+            try {
+                const sweepScript = CSVMultisigTapscript.encode({
+                    timelock: expiries[0],
+                    pubkeys: [serverInfo.forfeitPubkey],
+                }).script;
+                const { finalKey } = aggregateKeys(
+                    cosigners.map((cosigner) => cosigner.key),
+                    true,
+                    { taprootTweak: tapLeafHash(sweepScript) },
+                );
+                if (hex.encode(finalKey.subarray(1)) !== hex.encode(script.subarray(2))) {
+                    issues.push({
+                        code: "signature_cosigner_key_mismatch",
+                        message: `TREE transaction ${txid} input ${inputIndex} cosigners do not match its prevout`,
+                        txid,
+                        inputIndex,
+                    });
+                }
+            } catch (error) {
+                issues.push({
+                    code: "signature_cosigner_invalid",
+                    message: `TREE transaction ${txid} input ${inputIndex} has invalid cosigner keys: ${errorMessage(error)}`,
+                    txid,
+                    inputIndex,
+                });
+            }
+        }
+    }
+
+    return issues;
+}
 
 export function verifyProofSignatures(proof: ParsedVtxoProof): VtxoVerificationIssue[] {
     const issues: VtxoVerificationIssue[] = [];
@@ -118,13 +197,45 @@ function verifyScriptPathSignatures(
 ): void {
     for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
         const input = tx.getInput(inputIndex);
-        if (!input.tapLeafScript || input.tapLeafScript.length === 0) continue;
+        if (!input.tapLeafScript || input.tapLeafScript.length === 0) {
+            issues.push({
+                code: "signature_script_path_missing",
+                message: `Transaction ${txid} input ${inputIndex} has no tapscript proof`,
+                txid,
+                inputIndex,
+            });
+            continue;
+        }
 
-        const internalKey = input.tapLeafScript[0][0]?.internalKey;
-        if (!internalKey || hex.encode(internalKey) !== hex.encode(TAPROOT_UNSPENDABLE_KEY)) {
+        if (
+            input.tapLeafScript.some(
+                ([controlBlock]) =>
+                    hex.encode(controlBlock.internalKey) !== hex.encode(TAPROOT_UNSPENDABLE_KEY),
+            )
+        ) {
             issues.push({
                 code: "signature_internal_key_spendable",
                 message: `Transaction ${txid} input ${inputIndex} does not use the NUMS internal key`,
+                txid,
+                inputIndex,
+            });
+            continue;
+        }
+
+        if (
+            !input.witnessUtxo ||
+            input.tapLeafScript.some(
+                ([controlBlock, scriptWithVersion]) =>
+                    !tapLeafBindsToPrevout(
+                        controlBlock,
+                        scriptWithVersion,
+                        input.witnessUtxo!.script,
+                    ),
+            )
+        ) {
+            issues.push({
+                code: "signature_tapleaf_unbound",
+                message: `Transaction ${txid} input ${inputIndex} tapscript is not bound to its prevout`,
                 txid,
                 inputIndex,
             });
@@ -146,6 +257,45 @@ function verifyScriptPathSignatures(
                 inputIndex,
             });
         }
+    }
+}
+
+function tapLeafBindsToPrevout(
+    controlBlock: {
+        version: number;
+        internalKey: Uint8Array;
+        merklePath: Uint8Array[];
+    },
+    scriptWithVersion: Uint8Array,
+    prevoutScript: Uint8Array,
+): boolean {
+    if (
+        scriptWithVersion.length === 0 ||
+        prevoutScript.length !== 34 ||
+        prevoutScript[0] !== 0x51 ||
+        prevoutScript[1] !== 0x20
+    ) {
+        return false;
+    }
+
+    const leafVersion = scriptWithVersion[scriptWithVersion.length - 1];
+    if ((controlBlock.version & 0xfe) !== leafVersion) return false;
+
+    let merkleRoot = tapLeafHash(scriptWithVersion.subarray(0, -1), leafVersion);
+    for (const sibling of controlBlock.merklePath) {
+        const [left, right] =
+            compareBytes(merkleRoot, sibling) <= 0 ? [merkleRoot, sibling] : [sibling, merkleRoot];
+        merkleRoot = schnorr.utils.taggedHash("TapBranch", left, right);
+    }
+
+    try {
+        const [outputKey, parity] = taprootTweakPubkey(controlBlock.internalKey, merkleRoot);
+        return (
+            parity === (controlBlock.version & 1) &&
+            hex.encode(outputKey) === hex.encode(prevoutScript.subarray(2))
+        );
+    } catch {
+        return false;
     }
 }
 

--- a/packages/ts-sdk/src/verification/types.ts
+++ b/packages/ts-sdk/src/verification/types.ts
@@ -1,5 +1,4 @@
 import type { ChainTx } from "../providers/indexer";
-import type { RelativeTimelock } from "../script/tapscript";
 import type { Transaction } from "../utils/transaction";
 import type { Outpoint } from "../wallet";
 
@@ -18,8 +17,7 @@ export interface VtxoChainSource {
 }
 
 export interface VtxoVerificationServerInfo {
-    pubkey: Uint8Array;
-    sweepInterval: RelativeTimelock;
+    forfeitPubkey: Uint8Array;
 }
 
 export interface VtxoVerificationOptions {

--- a/packages/ts-sdk/src/verification/types.ts
+++ b/packages/ts-sdk/src/verification/types.ts
@@ -1,0 +1,62 @@
+import type { ChainTx } from "../providers/indexer";
+import type { RelativeTimelock } from "../script/tapscript";
+import type { Transaction } from "../utils/transaction";
+import type { Outpoint } from "../wallet";
+
+export interface VtxoProofSource {
+    getVtxoChain(vtxo: Outpoint): Promise<ChainTx[]>;
+    getVirtualTxs(txids: string[]): Promise<string[]>;
+}
+
+export interface VtxoChainSource {
+    getTxHex(txid: string): Promise<string>;
+    getTxStatus(
+        txid: string,
+    ): Promise<{ confirmed: false } | { confirmed: true; blockTime: number; blockHeight: number }>;
+    getTxOutspends(txid: string): Promise<{ spent: boolean; txid?: string }[]>;
+    getChainTip(): Promise<{ height: number; time: number; hash: string }>;
+}
+
+export interface VtxoVerificationServerInfo {
+    pubkey: Uint8Array;
+    sweepInterval: RelativeTimelock;
+}
+
+export interface VtxoVerificationOptions {
+    minConfirmationDepth?: number;
+}
+
+export type VtxoVerificationCheck = "leaf" | "graph" | "signatures" | "anchors";
+
+export type VtxoVerificationIssue = {
+    code: string;
+    message: string;
+    txid?: string;
+    inputIndex?: number;
+    outputIndex?: number;
+};
+
+type VtxoVerificationBaseResult = {
+    outpoint: Outpoint;
+    commitmentTxids: string[];
+    chainLength: number;
+    issues: VtxoVerificationIssue[];
+};
+
+export type VtxoVerificationResult =
+    | (VtxoVerificationBaseResult & {
+          status: "confirmed";
+          confirmationDepth: number;
+      })
+    | (VtxoVerificationBaseResult & {
+          status: "preconfirmed";
+          partialChecks: Partial<Record<VtxoVerificationCheck, boolean>>;
+      })
+    | (VtxoVerificationBaseResult & { status: "invalid" })
+    | (VtxoVerificationBaseResult & { status: "unavailable" });
+
+export interface ParsedVtxoProof {
+    entries: Map<string, ChainTx>;
+    transactions: Map<string, Transaction>;
+    commitmentTxids: string[];
+}

--- a/packages/ts-sdk/src/verification/verifyVtxo.ts
+++ b/packages/ts-sdk/src/verification/verifyVtxo.ts
@@ -28,17 +28,6 @@ export async function verifyVtxo(
         throw new Error("minConfirmationDepth must be a non-negative integer");
     }
 
-    if (vtxo.isPreconfirmed) {
-        return {
-            status: "preconfirmed",
-            outpoint,
-            commitmentTxids: vtxo.commitmentTxIds ?? [],
-            chainLength: 0,
-            issues: [],
-            partialChecks: {},
-        };
-    }
-
     let proof;
     try {
         proof = await parseVtxoProof(outpoint, proofSource);
@@ -66,6 +55,26 @@ export async function verifyVtxo(
         commitmentTxids: proof.commitmentTxids,
         chainLength: proof.transactions.size,
     };
+    if (vtxo.isPreconfirmed) {
+        const prevoutIssues = hydrateVirtualPrevouts(proof);
+        const leafIssues = verifyClaimedLeaf(vtxo, proof);
+        const graphIssues = [...prevoutIssues, ...verifyGraphSegments(proof)];
+        const signatureIssues = [
+            ...verifyTreeCosignerKeys(proof, serverInfo),
+            ...verifyProofSignatures(proof),
+        ];
+        return {
+            status: "preconfirmed",
+            ...base,
+            issues: boundVerificationIssues([...leafIssues, ...graphIssues, ...signatureIssues]),
+            partialChecks: {
+                leaf: leafIssues.length === 0,
+                graph: graphIssues.length === 0,
+                signatures: signatureIssues.length === 0,
+            },
+        };
+    }
+
     let anchors;
     try {
         anchors = await verifyCommitmentAnchors(proof, chainSource, minConfirmationDepth);
@@ -84,7 +93,7 @@ export async function verifyVtxo(
         };
     }
 
-    const issues = bounded([
+    const issues = boundVerificationIssues([
         ...hydrateVirtualPrevouts(proof),
         ...verifyClaimedLeaf(vtxo, proof),
         ...verifyGraphSegments(proof),
@@ -103,7 +112,7 @@ export async function verifyVtxo(
     };
 }
 
-function bounded(issues: VtxoVerificationIssue[]): VtxoVerificationIssue[] {
+export function boundVerificationIssues(issues: VtxoVerificationIssue[]): VtxoVerificationIssue[] {
     if (issues.length <= MAX_ISSUES) return issues;
     return [
         ...issues.slice(0, MAX_ISSUES),

--- a/packages/ts-sdk/src/verification/verifyVtxo.ts
+++ b/packages/ts-sdk/src/verification/verifyVtxo.ts
@@ -1,8 +1,8 @@
 import type { VirtualCoin } from "../wallet";
 import { verifyCommitmentAnchors, VtxoVerificationUnavailableError } from "./anchor";
-import { verifyClaimedLeaf, verifyGraphSegments } from "./graph";
+import { hydrateVirtualPrevouts, verifyClaimedLeaf, verifyGraphSegments } from "./graph";
 import { parseVtxoProof, VtxoProofError } from "./proof";
-import { verifyProofSignatures } from "./signatures";
+import { verifyProofSignatures, verifyTreeCosignerKeys } from "./signatures";
 import type {
     VtxoChainSource,
     VtxoProofSource,
@@ -19,7 +19,7 @@ export async function verifyVtxo(
     vtxo: VirtualCoin,
     proofSource: VtxoProofSource,
     chainSource: VtxoChainSource,
-    _serverInfo: VtxoVerificationServerInfo,
+    serverInfo: VtxoVerificationServerInfo,
     options: VtxoVerificationOptions = {},
 ): Promise<VtxoVerificationResult> {
     const outpoint = { txid: vtxo.txid, vout: vtxo.vout };
@@ -66,27 +66,9 @@ export async function verifyVtxo(
         commitmentTxids: proof.commitmentTxids,
         chainLength: proof.transactions.size,
     };
-    const localIssues = bounded([
-        ...verifyClaimedLeaf(vtxo, proof),
-        ...verifyGraphSegments(proof),
-        ...verifyProofSignatures(proof),
-    ]);
-    if (localIssues.length > 0) {
-        return { status: "invalid", ...base, issues: localIssues };
-    }
-
+    let anchors;
     try {
-        const anchors = await verifyCommitmentAnchors(proof, chainSource, minConfirmationDepth);
-        const issues = bounded(anchors.issues);
-        if (issues.length > 0) {
-            return { status: "invalid", ...base, issues };
-        }
-        return {
-            status: "confirmed",
-            ...base,
-            confirmationDepth: anchors.confirmationDepth,
-            issues: [],
-        };
+        anchors = await verifyCommitmentAnchors(proof, chainSource, minConfirmationDepth);
     } catch (error) {
         if (error instanceof VtxoVerificationUnavailableError) {
             return {
@@ -101,6 +83,24 @@ export async function verifyVtxo(
             issues: [{ code: "anchor_unavailable", message: message(error) }],
         };
     }
+
+    const issues = bounded([
+        ...hydrateVirtualPrevouts(proof),
+        ...verifyClaimedLeaf(vtxo, proof),
+        ...verifyGraphSegments(proof),
+        ...verifyTreeCosignerKeys(proof, serverInfo),
+        ...verifyProofSignatures(proof),
+        ...anchors.issues,
+    ]);
+    if (issues.length > 0) {
+        return { status: "invalid", ...base, issues };
+    }
+    return {
+        status: "confirmed",
+        ...base,
+        confirmationDepth: anchors.confirmationDepth,
+        issues: [],
+    };
 }
 
 function bounded(issues: VtxoVerificationIssue[]): VtxoVerificationIssue[] {

--- a/packages/ts-sdk/src/verification/verifyVtxo.ts
+++ b/packages/ts-sdk/src/verification/verifyVtxo.ts
@@ -1,0 +1,119 @@
+import type { VirtualCoin } from "../wallet";
+import { verifyCommitmentAnchors, VtxoVerificationUnavailableError } from "./anchor";
+import { verifyClaimedLeaf, verifyGraphSegments } from "./graph";
+import { parseVtxoProof, VtxoProofError } from "./proof";
+import { verifyProofSignatures } from "./signatures";
+import type {
+    VtxoChainSource,
+    VtxoProofSource,
+    VtxoVerificationIssue,
+    VtxoVerificationOptions,
+    VtxoVerificationResult,
+    VtxoVerificationServerInfo,
+} from "./types";
+
+const DEFAULT_MIN_CONFIRMATION_DEPTH = 6;
+const MAX_ISSUES = 100;
+
+export async function verifyVtxo(
+    vtxo: VirtualCoin,
+    proofSource: VtxoProofSource,
+    chainSource: VtxoChainSource,
+    _serverInfo: VtxoVerificationServerInfo,
+    options: VtxoVerificationOptions = {},
+): Promise<VtxoVerificationResult> {
+    const outpoint = { txid: vtxo.txid, vout: vtxo.vout };
+    const minConfirmationDepth = options.minConfirmationDepth ?? DEFAULT_MIN_CONFIRMATION_DEPTH;
+    if (!Number.isInteger(minConfirmationDepth) || minConfirmationDepth < 0) {
+        throw new Error("minConfirmationDepth must be a non-negative integer");
+    }
+
+    if (vtxo.isPreconfirmed) {
+        return {
+            status: "preconfirmed",
+            outpoint,
+            commitmentTxids: vtxo.commitmentTxIds ?? [],
+            chainLength: 0,
+            issues: [],
+            partialChecks: {},
+        };
+    }
+
+    let proof;
+    try {
+        proof = await parseVtxoProof(outpoint, proofSource);
+    } catch (error) {
+        if (error instanceof VtxoProofError) {
+            return {
+                status: error.kind,
+                outpoint,
+                commitmentTxids: [],
+                chainLength: 0,
+                issues: [{ code: error.code, message: error.message }],
+            };
+        }
+        return {
+            status: "unavailable",
+            outpoint,
+            commitmentTxids: [],
+            chainLength: 0,
+            issues: [{ code: "proof_unavailable", message: message(error) }],
+        };
+    }
+
+    const base = {
+        outpoint,
+        commitmentTxids: proof.commitmentTxids,
+        chainLength: proof.transactions.size,
+    };
+    const localIssues = bounded([
+        ...verifyClaimedLeaf(vtxo, proof),
+        ...verifyGraphSegments(proof),
+        ...verifyProofSignatures(proof),
+    ]);
+    if (localIssues.length > 0) {
+        return { status: "invalid", ...base, issues: localIssues };
+    }
+
+    try {
+        const anchors = await verifyCommitmentAnchors(proof, chainSource, minConfirmationDepth);
+        const issues = bounded(anchors.issues);
+        if (issues.length > 0) {
+            return { status: "invalid", ...base, issues };
+        }
+        return {
+            status: "confirmed",
+            ...base,
+            confirmationDepth: anchors.confirmationDepth,
+            issues: [],
+        };
+    } catch (error) {
+        if (error instanceof VtxoVerificationUnavailableError) {
+            return {
+                status: "unavailable",
+                ...base,
+                issues: [{ code: error.code, message: error.message }],
+            };
+        }
+        return {
+            status: "unavailable",
+            ...base,
+            issues: [{ code: "anchor_unavailable", message: message(error) }],
+        };
+    }
+}
+
+function bounded(issues: VtxoVerificationIssue[]): VtxoVerificationIssue[] {
+    if (issues.length <= MAX_ISSUES) return issues;
+    return [
+        ...issues.slice(0, MAX_ISSUES),
+        {
+            code: "issues_truncated",
+            message: `Verification produced more than ${MAX_ISSUES} issues`,
+        },
+    ];
+}
+
+function message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ts-sdk/test/e2e/utils.ts
+++ b/packages/ts-sdk/test/e2e/utils.ts
@@ -34,6 +34,7 @@ import type { ExtensionPacket } from "../../src/extension";
 import { hex } from "@scure/base";
 
 export const arkdExec = "docker exec -t arkd";
+export const ARK_SERVER_URL = process.env.ARK_SERVER_URL ?? "http://localhost:7070";
 
 // Regtest Esplora REST API base URL. The arkade-regtest stack runs mempool,
 // which serves the Esplora-compatible REST API under `/api` (the web UI lives
@@ -110,7 +111,7 @@ export async function createTestArkWallet(opts?: {
 
     const wallet = await Wallet.create({
         identity,
-        arkServerUrl: "http://localhost:7070",
+        arkServerUrl: ARK_SERVER_URL,
         onchainProvider: new EsploraProvider(ESPLORA_API_URL, {
             forcePolling: true,
             pollingInterval: 2000,

--- a/packages/ts-sdk/test/e2e/verification.test.ts
+++ b/packages/ts-sdk/test/e2e/verification.test.ts
@@ -1,0 +1,94 @@
+import { base64, hex } from "@scure/base";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+    createExitChainResolver,
+    EsploraProvider,
+    RestArkProvider,
+    verifyVtxo,
+    type VtxoProofSource,
+} from "../../src";
+import { Transaction } from "../../src/utils/transaction";
+import {
+    ARK_SERVER_URL,
+    beforeEachFaucet,
+    createTestArkWallet,
+    createVtxo,
+    ESPLORA_API_URL,
+    execCommand,
+} from "./utils";
+
+async function serverInfo() {
+    const info = await new RestArkProvider(ARK_SERVER_URL).getInfo();
+    return {
+        forfeitPubkey: hex.decode(info.forfeitPubkey).slice(1),
+    };
+}
+
+describe("verifyVtxo — regtest integration", () => {
+    beforeEach(beforeEachFaucet, 20_000);
+
+    it("confirms a real settled VTXO against Bitcoin", { timeout: 120_000 }, async () => {
+        const alice = await createTestArkWallet();
+        await createVtxo(alice, 50_000);
+        execCommand("node regtest/regtest.mjs mine 1");
+        await new Promise((resolve) => setTimeout(resolve, 5_000));
+
+        const [vtxo] = await alice.wallet.getVtxos();
+        expect(vtxo).toBeDefined();
+        const proofSource = createExitChainResolver({
+            indexer: alice.wallet.indexerProvider,
+        });
+        const result = await verifyVtxo(
+            vtxo,
+            proofSource,
+            new EsploraProvider(ESPLORA_API_URL),
+            await serverInfo(),
+            { minConfirmationDepth: 1 },
+        );
+
+        expect(result.status).toBe("confirmed");
+    });
+
+    it("rejects a forged TREE tapKeySig", { timeout: 120_000 }, async () => {
+        const alice = await createTestArkWallet();
+        await createVtxo(alice, 50_000);
+        execCommand("node regtest/regtest.mjs mine 1");
+        await new Promise((resolve) => setTimeout(resolve, 5_000));
+
+        const [vtxo] = await alice.wallet.getVtxos();
+        const real = createExitChainResolver({ indexer: alice.wallet.indexerProvider });
+        const forged: VtxoProofSource = {
+            getVtxoChain: (outpoint) => real.getVtxoChain(outpoint),
+            getVirtualTxs: async (txids) => {
+                let mutated = false;
+                return (await real.getVirtualTxs(txids)).map((encoded) => {
+                    if (mutated) return encoded;
+                    const tx = Transaction.fromPSBT(base64.decode(encoded));
+                    for (let inputIndex = 0; inputIndex < tx.inputsLength; inputIndex++) {
+                        const signature = tx.getInput(inputIndex).tapKeySig;
+                        if (!signature) continue;
+                        const replacement = Uint8Array.from(signature);
+                        replacement[0] ^= 0xff;
+                        tx.updateInput(inputIndex, { tapKeySig: replacement });
+                        mutated = true;
+                        return base64.encode(tx.toPSBT());
+                    }
+                    return encoded;
+                });
+            },
+        };
+
+        const result = await verifyVtxo(
+            vtxo,
+            forged,
+            new EsploraProvider(ESPLORA_API_URL),
+            await serverInfo(),
+            { minConfirmationDepth: 1 },
+        );
+
+        expect(result.status).toBe("invalid");
+        expect(result.issues).toContainEqual(
+            expect.objectContaining({ code: "signature_invalid_tap_key" }),
+        );
+    });
+});

--- a/packages/ts-sdk/test/verification/anchor.test.ts
+++ b/packages/ts-sdk/test/verification/anchor.test.ts
@@ -1,0 +1,139 @@
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { describe, expect, it } from "vitest";
+import { ChainTxType } from "../../src/providers/indexer";
+import { Transaction } from "../../src/utils/transaction";
+import {
+    ParsedVtxoProof,
+    verifyCommitmentAnchors,
+    VtxoChainSource,
+    VtxoVerificationUnavailableError,
+} from "../../src/verification";
+
+const SCRIPT = Uint8Array.from([0x51, 0x20, ...schnorr.getPublicKey(new Uint8Array(32).fill(4))]);
+
+function fixture(overrides?: {
+    witnessAmount?: bigint;
+    witnessScript?: Uint8Array;
+    status?: Awaited<ReturnType<VtxoChainSource["getTxStatus"]>>;
+    tipHeight?: number;
+    outspend?: { spent: boolean; txid?: string };
+}) {
+    const commitment = new Transaction({
+        allowUnknownInputs: true,
+        allowUnknownOutputs: true,
+    });
+    commitment.addInput({ txid: new Uint8Array(32).fill(1), index: 0 });
+    commitment.addOutput({ amount: 10_000n, script: SCRIPT });
+
+    const tree = new Transaction({ allowLegacyWitnessUtxo: true });
+    tree.addInput({
+        txid: hex.decode(commitment.id),
+        index: 0,
+        witnessUtxo: {
+            amount: overrides?.witnessAmount ?? 10_000n,
+            script: overrides?.witnessScript ?? SCRIPT,
+        },
+    });
+    tree.addOutput({ amount: 10_000n, script: SCRIPT });
+
+    const proof: ParsedVtxoProof = {
+        entries: new Map([
+            [
+                commitment.id,
+                {
+                    txid: commitment.id,
+                    expiresAt: "0",
+                    type: ChainTxType.COMMITMENT,
+                    spends: [],
+                },
+            ],
+            [
+                tree.id,
+                {
+                    txid: tree.id,
+                    expiresAt: "0",
+                    type: ChainTxType.TREE,
+                    spends: [commitment.id],
+                },
+            ],
+        ]),
+        transactions: new Map([[tree.id, tree]]),
+        commitmentTxids: [commitment.id],
+    };
+    const source: VtxoChainSource = {
+        getTxHex: async () => commitment.hex,
+        getTxStatus: async () =>
+            overrides?.status ?? { confirmed: true, blockHeight: 100, blockTime: 1 },
+        getChainTip: async () => ({
+            height: overrides?.tipHeight ?? 105,
+            time: 2,
+            hash: "00".repeat(32),
+        }),
+        getTxOutspends: async () => [overrides?.outspend ?? { spent: false }],
+    };
+    return { commitment, tree, proof, source };
+}
+
+describe("verifyCommitmentAnchors", () => {
+    it("accepts a matching raw commitment at the required depth", async () => {
+        const { proof, source } = fixture();
+        await expect(verifyCommitmentAnchors(proof, source, 6)).resolves.toEqual({
+            confirmationDepth: 6,
+            issues: [],
+        });
+    });
+
+    it("rejects a commitment amount mismatch", async () => {
+        const { proof, source } = fixture({ witnessAmount: 9_999n });
+        const result = await verifyCommitmentAnchors(proof, source, 6);
+        expect(result.issues[0].code).toBe("anchor_amount_mismatch");
+    });
+
+    it("rejects a commitment script mismatch", async () => {
+        const otherScript = Uint8Array.from([
+            0x51,
+            0x20,
+            ...schnorr.getPublicKey(new Uint8Array(32).fill(5)),
+        ]);
+        const { proof, source } = fixture({ witnessScript: otherScript });
+        const result = await verifyCommitmentAnchors(proof, source, 6);
+        expect(result.issues[0].code).toBe("anchor_script_mismatch");
+    });
+
+    it("rejects insufficient confirmation depth", async () => {
+        const { proof, source } = fixture({ tipHeight: 104 });
+        const result = await verifyCommitmentAnchors(proof, source, 6);
+        expect(result.issues[0].code).toBe("anchor_depth_insufficient");
+    });
+
+    it("accepts an expected root transaction outspend", async () => {
+        const initial = fixture();
+        const { proof, source } = fixture({
+            outspend: { spent: true, txid: initial.tree.id },
+        });
+        const rootTxid = [...proof.transactions.keys()][0];
+        source.getTxOutspends = async () => [{ spent: true, txid: rootTxid }];
+
+        expect((await verifyCommitmentAnchors(proof, source, 6)).issues).toEqual([]);
+    });
+
+    it("rejects an unexpected commitment outspend", async () => {
+        const { proof, source } = fixture({
+            outspend: { spent: true, txid: "66".repeat(32) },
+        });
+        const result = await verifyCommitmentAnchors(proof, source, 6);
+        expect(result.issues[0].code).toBe("anchor_unexpected_spend");
+    });
+
+    it("classifies chain-source failure as unavailable", async () => {
+        const { proof, source } = fixture();
+        source.getTxHex = async () => {
+            throw new Error("chain offline");
+        };
+
+        await expect(verifyCommitmentAnchors(proof, source, 6)).rejects.toBeInstanceOf(
+            VtxoVerificationUnavailableError,
+        );
+    });
+});

--- a/packages/ts-sdk/test/verification/anchor.test.ts
+++ b/packages/ts-sdk/test/verification/anchor.test.ts
@@ -13,6 +13,8 @@ import {
 const SCRIPT = Uint8Array.from([0x51, 0x20, ...schnorr.getPublicKey(new Uint8Array(32).fill(4))]);
 
 function fixture(overrides?: {
+    commitmentSeed?: number;
+    omitWitnessUtxo?: boolean;
     witnessAmount?: bigint;
     witnessScript?: Uint8Array;
     status?: Awaited<ReturnType<VtxoChainSource["getTxStatus"]>>;
@@ -23,17 +25,24 @@ function fixture(overrides?: {
         allowUnknownInputs: true,
         allowUnknownOutputs: true,
     });
-    commitment.addInput({ txid: new Uint8Array(32).fill(1), index: 0 });
+    commitment.addInput({
+        txid: new Uint8Array(32).fill(overrides?.commitmentSeed ?? 1),
+        index: 0,
+    });
     commitment.addOutput({ amount: 10_000n, script: SCRIPT });
 
     const tree = new Transaction({ allowLegacyWitnessUtxo: true });
     tree.addInput({
         txid: hex.decode(commitment.id),
         index: 0,
-        witnessUtxo: {
-            amount: overrides?.witnessAmount ?? 10_000n,
-            script: overrides?.witnessScript ?? SCRIPT,
-        },
+        ...(overrides?.omitWitnessUtxo
+            ? {}
+            : {
+                  witnessUtxo: {
+                      amount: overrides?.witnessAmount ?? 10_000n,
+                      script: overrides?.witnessScript ?? SCRIPT,
+                  },
+              }),
     });
     tree.addOutput({ amount: 10_000n, script: SCRIPT });
 
@@ -84,6 +93,16 @@ describe("verifyCommitmentAnchors", () => {
         });
     });
 
+    it("hydrates an omitted TREE root prevout from the raw commitment", async () => {
+        const { proof, source, tree } = fixture({ omitWitnessUtxo: true });
+
+        expect((await verifyCommitmentAnchors(proof, source, 6)).issues).toEqual([]);
+        expect(tree.getInput(0).witnessUtxo).toEqual({
+            amount: 10_000n,
+            script: SCRIPT,
+        });
+    });
+
     it("rejects a commitment amount mismatch", async () => {
         const { proof, source } = fixture({ witnessAmount: 9_999n });
         const result = await verifyCommitmentAnchors(proof, source, 6);
@@ -124,6 +143,96 @@ describe("verifyCommitmentAnchors", () => {
         });
         const result = await verifyCommitmentAnchors(proof, source, 6);
         expect(result.issues[0].code).toBe("anchor_unexpected_spend");
+    });
+
+    it("checks every TREE root that claims the same commitment", async () => {
+        const { commitment, proof, source } = fixture();
+        const rogueRoot = new Transaction({ allowLegacyWitnessUtxo: true });
+        rogueRoot.addInput({
+            txid: hex.decode(commitment.id),
+            index: 1,
+            witnessUtxo: { amount: 10_000n, script: SCRIPT },
+        });
+        rogueRoot.addOutput({ amount: 10_000n, script: SCRIPT });
+        proof.entries.set(rogueRoot.id, {
+            txid: rogueRoot.id,
+            expiresAt: "0",
+            type: ChainTxType.TREE,
+            spends: [commitment.id],
+        });
+        proof.transactions.set(rogueRoot.id, rogueRoot);
+
+        const issues = (await verifyCommitmentAnchors(proof, source, 6)).issues;
+        expect(issues).toContainEqual(
+            expect.objectContaining({
+                code: "anchor_output_missing",
+                txid: commitment.id,
+                outputIndex: 1,
+            }),
+        );
+    });
+
+    it("verifies both commitments behind an ARK join at the shallowest depth", async () => {
+        const first = fixture({ commitmentSeed: 1 });
+        const second = fixture({ commitmentSeed: 2 });
+        const ark = new Transaction({ allowLegacyWitnessUtxo: true });
+        ark.addInput({
+            txid: hex.decode(first.tree.id),
+            index: 0,
+            witnessUtxo: first.tree.getOutput(0),
+        });
+        ark.addInput({
+            txid: hex.decode(second.tree.id),
+            index: 0,
+            witnessUtxo: second.tree.getOutput(0),
+        });
+        ark.addOutput({ amount: 20_000n, script: SCRIPT });
+
+        const proof: ParsedVtxoProof = {
+            entries: new Map([
+                ...first.proof.entries,
+                ...second.proof.entries,
+                [
+                    ark.id,
+                    {
+                        txid: ark.id,
+                        expiresAt: "0",
+                        type: ChainTxType.ARK,
+                        spends: [first.tree.id, second.tree.id],
+                    },
+                ],
+            ]),
+            transactions: new Map([
+                ...first.proof.transactions,
+                ...second.proof.transactions,
+                [ark.id, ark],
+            ]),
+            commitmentTxids: [first.commitment.id, second.commitment.id],
+        };
+        const fetched: string[] = [];
+        const source: VtxoChainSource = {
+            getTxHex: async (txid) => {
+                fetched.push(txid);
+                return txid === first.commitment.id ? first.commitment.hex : second.commitment.hex;
+            },
+            getTxStatus: async (txid) => ({
+                confirmed: true,
+                blockHeight: txid === first.commitment.id ? 100 : 102,
+                blockTime: 1,
+            }),
+            getChainTip: async () => ({
+                height: 105,
+                time: 2,
+                hash: "00".repeat(32),
+            }),
+            getTxOutspends: async () => [{ spent: false }],
+        };
+
+        await expect(verifyCommitmentAnchors(proof, source, 4)).resolves.toMatchObject({
+            confirmationDepth: 4,
+            issues: [],
+        });
+        expect(fetched).toEqual([first.commitment.id, second.commitment.id]);
     });
 
     it("classifies chain-source failure as unavailable", async () => {

--- a/packages/ts-sdk/test/verification/chainSources.test.ts
+++ b/packages/ts-sdk/test/verification/chainSources.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ElectrumWS } from "ws-electrumx-client";
+import { ElectrumOnchainProvider, EsploraProvider } from "../../src";
+import { networks } from "../../src/networks";
+
+const { mockFetch } = vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+}));
+
+vi.mock("../../src/utils/fetch", () => ({
+    fetch: mockFetch,
+    baseFetch: mockFetch,
+}));
+
+describe("verification chain sources", () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+    });
+
+    it("fetches and trims Esplora raw transaction hex", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            text: () => Promise.resolve("02000000\n"),
+        });
+        const provider = new EsploraProvider("https://chain.example/api");
+
+        await expect(provider.getTxHex("11".repeat(32))).resolves.toBe("02000000");
+        expect(mockFetch).toHaveBeenCalledWith(
+            `https://chain.example/api/tx/${"11".repeat(32)}/hex`,
+        );
+    });
+
+    it("surfaces the Esplora response body when raw transaction lookup fails", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            text: () => Promise.resolve("transaction not found"),
+        });
+        const provider = new EsploraProvider("https://chain.example/api");
+
+        await expect(provider.getTxHex("11".repeat(32))).rejects.toThrow(
+            "Failed to get transaction hex: transaction not found",
+        );
+    });
+
+    it("fetches Electrum raw transaction hex without verbose mode", async () => {
+        const request = vi.fn().mockResolvedValue("02000000");
+        const ws = {
+            request,
+            batchRequest: vi.fn(),
+            subscribe: vi.fn(),
+            unsubscribe: vi.fn(),
+            close: vi.fn(),
+        } as unknown as ElectrumWS;
+        const provider = new ElectrumOnchainProvider(ws, networks.regtest);
+        const txid = "22".repeat(32);
+
+        await expect(provider.getTxHex(txid)).resolves.toBe("02000000");
+        expect(request).toHaveBeenCalledWith("blockchain.transaction.get", txid, false);
+    });
+});

--- a/packages/ts-sdk/test/verification/graph.test.ts
+++ b/packages/ts-sdk/test/verification/graph.test.ts
@@ -4,18 +4,29 @@ import { describe, expect, it } from "vitest";
 import { ChainTxType } from "../../src/providers/indexer";
 import { Transaction } from "../../src/utils/transaction";
 import type { VirtualCoin } from "../../src/wallet";
-import { ParsedVtxoProof, verifyClaimedLeaf, verifyGraphSegments } from "../../src/verification";
+import {
+    hydrateVirtualPrevouts,
+    ParsedVtxoProof,
+    verifyClaimedLeaf,
+    verifyGraphSegments,
+} from "../../src/verification";
 
 const COMMITMENT_TXID = "11".repeat(32);
 const KEY = schnorr.getPublicKey(new Uint8Array(32).fill(3));
 const SCRIPT = Uint8Array.from([0x51, 0x20, ...KEY]);
 
-function makeTx(parentTxid: string, parentVout: number, amounts: bigint[]): Transaction {
+function makeTx(
+    parentTxid: string,
+    parentVout: number,
+    amounts: bigint[],
+    inputAmount = amounts.reduce((sum, amount) => sum + amount, 0n),
+    includeWitnessUtxo = true,
+): Transaction {
     const tx = new Transaction({ allowLegacyWitnessUtxo: true });
     tx.addInput({
         txid: hex.decode(parentTxid),
         index: parentVout,
-        witnessUtxo: { amount: amounts.reduce((sum, amount) => sum + amount, 0n), script: SCRIPT },
+        ...(includeWitnessUtxo ? { witnessUtxo: { amount: inputAmount, script: SCRIPT } } : {}),
     });
     for (const amount of amounts) {
         tx.addOutput({ amount, script: SCRIPT });
@@ -101,6 +112,28 @@ describe("verifyClaimedLeaf", () => {
 });
 
 describe("verifyGraphSegments", () => {
+    it("hydrates an omitted child prevout from its parent TREE output", () => {
+        const root = makeTx(COMMITMENT_TXID, 0, [10_000n]);
+        const child = makeTx(root.id, 0, [10_000n], 10_000n, false);
+        const proof = proofFor([root, child]);
+
+        expect(hydrateVirtualPrevouts(proof)).toEqual([]);
+        expect(child.getInput(0).witnessUtxo).toEqual({
+            amount: 10_000n,
+            script: SCRIPT,
+        });
+        expect(verifyGraphSegments(proof)).toEqual([]);
+    });
+
+    it("reports an out-of-range parent output without throwing", () => {
+        const root = makeTx(COMMITMENT_TXID, 0, [10_000n]);
+        const child = makeTx(root.id, 9, [10_000n], 10_000n, false);
+
+        expect(hydrateVirtualPrevouts(proofFor([root, child]))[0].code).toBe(
+            "graph_parent_output_missing",
+        );
+    });
+
     it("accepts a three-level amount-conserving TREE", () => {
         const root = makeTx(COMMITMENT_TXID, 0, [6_000n, 4_000n]);
         const child = makeTx(root.id, 0, [3_500n, 2_500n]);
@@ -124,5 +157,17 @@ describe("verifyGraphSegments", () => {
         expect(verifyGraphSegments(proofFor([root, left, right]))[0].code).toBe(
             "graph_duplicate_spend",
         );
+    });
+
+    it("rejects an ARK transaction whose outputs exceed its inputs", () => {
+        const root = makeTx(COMMITMENT_TXID, 0, [10_000n]);
+        const ark = makeTx(root.id, 0, [10_001n], 10_000n);
+        const proof = proofFor([root, ark]);
+        proof.entries.set(ark.id, {
+            ...proof.entries.get(ark.id)!,
+            type: ChainTxType.ARK,
+        });
+
+        expect(verifyGraphSegments(proof)[0].code).toBe("graph_amount_mismatch");
     });
 });

--- a/packages/ts-sdk/test/verification/graph.test.ts
+++ b/packages/ts-sdk/test/verification/graph.test.ts
@@ -170,4 +170,19 @@ describe("verifyGraphSegments", () => {
 
         expect(verifyGraphSegments(proof)[0].code).toBe("graph_amount_mismatch");
     });
+
+    it("rejects an ARK and TREE transaction spending the same parent output", () => {
+        const root = makeTx(COMMITMENT_TXID, 0, [10_000n]);
+        const tree = makeTx(root.id, 0, [9_999n, 1n]);
+        const ark = makeTx(root.id, 0, [9_998n, 2n]);
+        const proof = proofFor([root, tree, ark]);
+        proof.entries.set(ark.id, {
+            ...proof.entries.get(ark.id)!,
+            type: ChainTxType.ARK,
+        });
+
+        expect(verifyGraphSegments(proof).map((issue) => issue.code)).toContain(
+            "graph_duplicate_spend",
+        );
+    });
 });

--- a/packages/ts-sdk/test/verification/graph.test.ts
+++ b/packages/ts-sdk/test/verification/graph.test.ts
@@ -1,0 +1,128 @@
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { describe, expect, it } from "vitest";
+import { ChainTxType } from "../../src/providers/indexer";
+import { Transaction } from "../../src/utils/transaction";
+import type { VirtualCoin } from "../../src/wallet";
+import { ParsedVtxoProof, verifyClaimedLeaf, verifyGraphSegments } from "../../src/verification";
+
+const COMMITMENT_TXID = "11".repeat(32);
+const KEY = schnorr.getPublicKey(new Uint8Array(32).fill(3));
+const SCRIPT = Uint8Array.from([0x51, 0x20, ...KEY]);
+
+function makeTx(parentTxid: string, parentVout: number, amounts: bigint[]): Transaction {
+    const tx = new Transaction({ allowLegacyWitnessUtxo: true });
+    tx.addInput({
+        txid: hex.decode(parentTxid),
+        index: parentVout,
+        witnessUtxo: { amount: amounts.reduce((sum, amount) => sum + amount, 0n), script: SCRIPT },
+    });
+    for (const amount of amounts) {
+        tx.addOutput({ amount, script: SCRIPT });
+    }
+    return tx;
+}
+
+function proofFor(txs: Transaction[]): ParsedVtxoProof {
+    const entries = new Map([
+        [
+            COMMITMENT_TXID,
+            {
+                txid: COMMITMENT_TXID,
+                expiresAt: "0",
+                type: ChainTxType.COMMITMENT,
+                spends: [],
+            },
+        ],
+        ...txs.map(
+            (tx) =>
+                [
+                    tx.id,
+                    {
+                        txid: tx.id,
+                        expiresAt: "0",
+                        type: ChainTxType.TREE,
+                        spends: [hex.encode(tx.getInput(0).txid!)],
+                    },
+                ] as const,
+        ),
+    ]);
+    return {
+        entries,
+        transactions: new Map(txs.map((tx) => [tx.id, tx])),
+        commitmentTxids: [COMMITMENT_TXID],
+    };
+}
+
+function coin(tx: Transaction, overrides: Partial<VirtualCoin> = {}): VirtualCoin {
+    return {
+        txid: tx.id,
+        vout: 0,
+        value: Number(tx.getOutput(0)!.amount),
+        script: hex.encode(tx.getOutput(0)!.script!),
+        createdAt: new Date(0),
+        isUnrolled: false,
+        status: { confirmed: false },
+        ...overrides,
+    };
+}
+
+describe("verifyClaimedLeaf", () => {
+    const leaf = makeTx(COMMITMENT_TXID, 0, [10_000n]);
+    const proof = proofFor([leaf]);
+
+    it("accepts an exact outpoint, amount, and script match", () => {
+        expect(verifyClaimedLeaf(coin(leaf), proof)).toEqual([]);
+    });
+
+    it("rejects a claimed amount that differs from the output", () => {
+        expect(verifyClaimedLeaf(coin(leaf, { value: 10_001 }), proof)[0].code).toBe(
+            "leaf_amount_mismatch",
+        );
+    });
+
+    it("rejects a claimed script that differs from the output", () => {
+        expect(verifyClaimedLeaf(coin(leaf, { script: "51" }), proof)[0].code).toBe(
+            "leaf_script_mismatch",
+        );
+    });
+
+    it("rejects a missing output", () => {
+        expect(verifyClaimedLeaf(coin(leaf, { vout: 9 }), proof)[0].code).toBe(
+            "leaf_output_missing",
+        );
+    });
+
+    it("rejects a missing transaction", () => {
+        expect(verifyClaimedLeaf(coin(leaf, { txid: "44".repeat(32) }), proof)[0].code).toBe(
+            "leaf_tx_missing",
+        );
+    });
+});
+
+describe("verifyGraphSegments", () => {
+    it("accepts a three-level amount-conserving TREE", () => {
+        const root = makeTx(COMMITMENT_TXID, 0, [6_000n, 4_000n]);
+        const child = makeTx(root.id, 0, [3_500n, 2_500n]);
+        const leaf = makeTx(child.id, 1, [2_500n]);
+
+        expect(verifyGraphSegments(proofFor([leaf, root, child]))).toEqual([]);
+    });
+
+    it("rejects a child whose outputs inflate its parent output", () => {
+        const root = makeTx(COMMITMENT_TXID, 0, [6_000n, 4_000n]);
+        const child = makeTx(root.id, 0, [6_001n]);
+
+        expect(verifyGraphSegments(proofFor([root, child]))[0].code).toBe("graph_amount_mismatch");
+    });
+
+    it("rejects two children spending the same parent output", () => {
+        const root = makeTx(COMMITMENT_TXID, 0, [10_000n]);
+        const left = makeTx(root.id, 0, [9_999n, 1n]);
+        const right = makeTx(root.id, 0, [9_998n, 2n]);
+
+        expect(verifyGraphSegments(proofFor([root, left, right]))[0].code).toBe(
+            "graph_duplicate_spend",
+        );
+    });
+});

--- a/packages/ts-sdk/test/verification/proof.test.ts
+++ b/packages/ts-sdk/test/verification/proof.test.ts
@@ -1,0 +1,134 @@
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { describe, expect, it } from "vitest";
+import { ChainTx, ChainTxType } from "../../src/providers/indexer";
+import { Transaction } from "../../src/utils/transaction";
+import { parseVtxoProof, VtxoProofError, VtxoProofSource } from "../../src/verification";
+
+const COMMITMENT_TXID = "11".repeat(32);
+const INPUT_KEY = schnorr.getPublicKey(new Uint8Array(32).fill(2));
+const OUTPUT_KEY = schnorr.getPublicKey(new Uint8Array(32).fill(3));
+
+function makeTreePsbt(parentTxid = COMMITMENT_TXID): { psbt: string; txid: string } {
+    const tx = new Transaction({ allowLegacyWitnessUtxo: true });
+    tx.addInput({
+        txid: hex.decode(parentTxid),
+        index: 0,
+        witnessUtxo: {
+            amount: 10_000n,
+            script: Uint8Array.from([0x51, 0x20, ...INPUT_KEY]),
+        },
+    });
+    tx.addOutput({
+        amount: 10_000n,
+        script: Uint8Array.from([0x51, 0x20, ...OUTPUT_KEY]),
+    });
+    return { psbt: base64.encode(tx.toPSBT()), txid: tx.id };
+}
+
+function makeChain(treeTxid: string, spends = [COMMITMENT_TXID]): ChainTx[] {
+    return [
+        {
+            txid: COMMITMENT_TXID,
+            expiresAt: "0",
+            type: ChainTxType.COMMITMENT,
+            spends: [],
+        },
+        {
+            txid: treeTxid,
+            expiresAt: "0",
+            type: ChainTxType.TREE,
+            spends,
+        },
+    ];
+}
+
+function source(chain: ChainTx[], psbts: string[]): VtxoProofSource {
+    return {
+        getVtxoChain: async () => chain,
+        getVirtualTxs: async () => psbts,
+    };
+}
+
+describe("parseVtxoProof", () => {
+    it("parses virtual PSBTs and commitment ancestry without trusting order", async () => {
+        const tree = makeTreePsbt();
+        const proof = await parseVtxoProof(
+            { txid: tree.txid, vout: 0 },
+            source(makeChain(tree.txid), [tree.psbt]),
+        );
+
+        expect(proof.commitmentTxids).toEqual([COMMITMENT_TXID]);
+        expect(proof.transactions.get(tree.txid)?.id).toBe(tree.txid);
+        expect(proof.entries.get(tree.txid)?.spends).toEqual([COMMITMENT_TXID]);
+    });
+
+    it("classifies a missing PSBT as unavailable", async () => {
+        const tree = makeTreePsbt();
+
+        await expect(
+            parseVtxoProof({ txid: tree.txid, vout: 0 }, source(makeChain(tree.txid), [])),
+        ).rejects.toMatchObject<VtxoProofError>({
+            code: "proof_psbt_missing",
+            kind: "unavailable",
+        });
+    });
+
+    it("rejects a PSBT whose recomputed txid is not declared", async () => {
+        const tree = makeTreePsbt();
+        const other = makeTreePsbt("22".repeat(32));
+
+        await expect(
+            parseVtxoProof(
+                { txid: tree.txid, vout: 0 },
+                source(makeChain(tree.txid), [other.psbt]),
+            ),
+        ).rejects.toMatchObject<VtxoProofError>({
+            code: "proof_psbt_txid_mismatch",
+            kind: "invalid",
+        });
+    });
+
+    it("rejects metadata parents that differ from transaction inputs", async () => {
+        const tree = makeTreePsbt();
+
+        await expect(
+            parseVtxoProof(
+                { txid: tree.txid, vout: 0 },
+                source(makeChain(tree.txid, ["33".repeat(32)]), [tree.psbt]),
+            ),
+        ).rejects.toMatchObject<VtxoProofError>({
+            code: "proof_parent_mismatch",
+            kind: "invalid",
+        });
+    });
+
+    it("rejects conflicting duplicate chain entries", async () => {
+        const tree = makeTreePsbt();
+        const chain = makeChain(tree.txid);
+        chain.push({ ...chain[1], type: ChainTxType.ARK });
+
+        await expect(
+            parseVtxoProof({ txid: tree.txid, vout: 0 }, source(chain, [tree.psbt])),
+        ).rejects.toMatchObject<VtxoProofError>({
+            code: "proof_duplicate_txid",
+            kind: "invalid",
+        });
+    });
+
+    it("classifies proof-source transport failure as unavailable", async () => {
+        const failing: VtxoProofSource = {
+            getVtxoChain: async () => {
+                throw new Error("indexer offline");
+            },
+            getVirtualTxs: async () => [],
+        };
+
+        await expect(
+            parseVtxoProof({ txid: "44".repeat(32), vout: 0 }, failing),
+        ).rejects.toMatchObject<VtxoProofError>({
+            code: "proof_chain_unavailable",
+            kind: "unavailable",
+        });
+    });
+});

--- a/packages/ts-sdk/test/verification/proof.test.ts
+++ b/packages/ts-sdk/test/verification/proof.test.ts
@@ -63,6 +63,58 @@ describe("parseVtxoProof", () => {
         expect(proof.entries.get(tree.txid)?.spends).toEqual([COMMITMENT_TXID]);
     });
 
+    it("normalizes metadata transaction identifiers before comparison", async () => {
+        const tree = makeTreePsbt();
+        const chain = makeChain(tree.txid).map((entry) => ({
+            ...entry,
+            txid: entry.txid.toUpperCase(),
+            spends: entry.spends.map((txid) => txid.toUpperCase()),
+        }));
+
+        const proof = await parseVtxoProof(
+            { txid: tree.txid.toUpperCase(), vout: 0 },
+            source(chain, [tree.psbt]),
+        );
+
+        expect(proof.entries.has(tree.txid)).toBe(true);
+        expect(proof.entries.get(tree.txid)?.spends).toEqual([COMMITMENT_TXID]);
+        expect(proof.commitmentTxids).toEqual([COMMITMENT_TXID]);
+    });
+
+    it("rejects duplicate metadata identifiers that differ only by case", async () => {
+        const tree = makeTreePsbt();
+        const chain = makeChain(tree.txid);
+        chain.push({ ...chain[1], txid: tree.txid.toUpperCase() });
+
+        await expect(
+            parseVtxoProof({ txid: tree.txid, vout: 0 }, source(chain, [tree.psbt])),
+        ).rejects.toMatchObject<VtxoProofError>({
+            code: "proof_duplicate_txid",
+            kind: "invalid",
+        });
+    });
+
+    it("rejects metadata nodes disconnected from the requested outpoint", async () => {
+        const tree = makeTreePsbt();
+        const unrelatedCommitment = "22".repeat(32);
+        const chain = [
+            ...makeChain(tree.txid),
+            {
+                txid: unrelatedCommitment,
+                expiresAt: "0",
+                type: ChainTxType.COMMITMENT,
+                spends: [],
+            },
+        ];
+
+        await expect(
+            parseVtxoProof({ txid: tree.txid, vout: 0 }, source(chain, [tree.psbt])),
+        ).rejects.toMatchObject<VtxoProofError>({
+            code: "proof_disconnected_node",
+            kind: "invalid",
+        });
+    });
+
     it("classifies a missing PSBT as unavailable", async () => {
         const tree = makeTreePsbt();
 

--- a/packages/ts-sdk/test/verification/publicApi.test.ts
+++ b/packages/ts-sdk/test/verification/publicApi.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+    createExitChainResolver,
+    verifyVtxo,
+    type VtxoProofSource,
+    type VtxoVerificationResult,
+} from "../../src";
+
+describe("verification public API", () => {
+    it("exports verifyVtxo from the package root", () => {
+        expect(typeof verifyVtxo).toBe("function");
+    });
+
+    it("keeps ExitChainResolver structurally compatible with VtxoProofSource", () => {
+        const indexer = {
+            getVtxoChain: async () => ({ chain: [] }),
+            getVirtualTxs: async () => ({ txs: [] }),
+        };
+        const source: VtxoProofSource = createExitChainResolver({
+            indexer: indexer as never,
+        });
+        expect(source).toBeDefined();
+    });
+
+    it("exposes the discriminated result type", () => {
+        const result: VtxoVerificationResult = {
+            status: "invalid",
+            outpoint: { txid: "00".repeat(32), vout: 0 },
+            commitmentTxids: [],
+            chainLength: 0,
+            issues: [],
+        };
+        expect(result.status).toBe("invalid");
+    });
+});

--- a/packages/ts-sdk/test/verification/signatures.test.ts
+++ b/packages/ts-sdk/test/verification/signatures.test.ts
@@ -1,18 +1,68 @@
 import { hex } from "@scure/base";
-import { schnorr } from "@noble/curves/secp256k1.js";
+import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
 import { SigHash } from "@scure/btc-signer";
+import { tapLeafHash } from "@scure/btc-signer/payment.js";
 import { describe, expect, it } from "vitest";
 import { ChainTxType } from "../../src/providers/indexer";
 import { SingleKey } from "../../src/identity/singleKey";
 import { VtxoScript } from "../../src/script/base";
-import { MultisigTapscript } from "../../src/script/tapscript";
+import { CSVMultisigTapscript, MultisigTapscript } from "../../src/script/tapscript";
+import { aggregateKeys } from "../../src/musig2";
 import { Transaction } from "../../src/utils/transaction";
-import { ParsedVtxoProof, verifyProofSignatures } from "../../src/verification";
+import { CosignerPublicKey, setArkPsbtField, VtxoTreeExpiry } from "../../src/utils/unknownFields";
+import {
+    ParsedVtxoProof,
+    verifyProofSignatures,
+    verifyTreeCosignerKeys,
+    VtxoVerificationServerInfo,
+} from "../../src/verification";
 
 const COMMITMENT_TXID = "11".repeat(32);
 const SECRET_KEY = new Uint8Array(32).fill(7);
 const OUTPUT_KEY = schnorr.getPublicKey(SECRET_KEY);
 const SCRIPT = Uint8Array.from([0x51, 0x20, ...OUTPUT_KEY]);
+
+function cosignerBoundTree() {
+    const cosignerSecret = new Uint8Array(32).fill(10);
+    const cosignerKey = secp256k1.getPublicKey(cosignerSecret);
+    const serverInfo: VtxoVerificationServerInfo = {
+        forfeitPubkey: schnorr.getPublicKey(new Uint8Array(32).fill(11)),
+    };
+    const sweepInterval = { type: "blocks" as const, value: 144n };
+    const sweepScript = CSVMultisigTapscript.encode({
+        timelock: sweepInterval,
+        pubkeys: [serverInfo.forfeitPubkey],
+    }).script;
+    const { finalKey } = aggregateKeys([cosignerKey], true, {
+        taprootTweak: tapLeafHash(sweepScript),
+    });
+    const prevoutScript = Uint8Array.from([0x51, 0x20, ...finalKey.subarray(1)]);
+    const tx = new Transaction({ allowLegacyWitnessUtxo: true });
+    tx.addInput({
+        txid: hex.decode(COMMITMENT_TXID),
+        index: 0,
+        witnessUtxo: { amount: 10_000n, script: prevoutScript },
+    });
+    setArkPsbtField(tx, 0, CosignerPublicKey, { index: 0, key: cosignerKey });
+    setArkPsbtField(tx, 0, VtxoTreeExpiry, sweepInterval);
+    tx.addOutput({ amount: 10_000n, script: SCRIPT });
+    const proof: ParsedVtxoProof = {
+        entries: new Map([
+            [
+                tx.id,
+                {
+                    txid: tx.id,
+                    expiresAt: "0",
+                    type: ChainTxType.TREE,
+                    spends: [COMMITMENT_TXID],
+                },
+            ],
+        ]),
+        transactions: new Map([[tx.id, tx]]),
+        commitmentTxids: [COMMITMENT_TXID],
+    };
+    return { proof, serverInfo };
+}
 
 function signedTree(inputScript = SCRIPT): { proof: ParsedVtxoProof; tx: Transaction } {
     const tx = new Transaction({ allowLegacyWitnessUtxo: true, allowUnknownOutputs: true });
@@ -83,6 +133,46 @@ describe("verifyProofSignatures TREE key path", () => {
     });
 });
 
+describe("verifyTreeCosignerKeys", () => {
+    it("binds TREE cosigners and the server sweep leaf to the spent output", () => {
+        const { proof, serverInfo } = cosignerBoundTree();
+        expect(verifyTreeCosignerKeys(proof, serverInfo)).toEqual([]);
+    });
+
+    it("rejects a different server sweep key", () => {
+        const { proof, serverInfo } = cosignerBoundTree();
+        const issues = verifyTreeCosignerKeys(proof, {
+            ...serverInfo,
+            forfeitPubkey: schnorr.getPublicKey(new Uint8Array(32).fill(12)),
+        });
+
+        expect(issues[0].code).toBe("signature_cosigner_key_mismatch");
+    });
+
+    it("rejects missing cosigner metadata", () => {
+        const { proof, serverInfo } = cosignerBoundTree();
+        proof.transactions.values().next().value!.updateInput(0, { unknown: [] });
+
+        expect(verifyTreeCosignerKeys(proof, serverInfo)[0].code).toBe(
+            "signature_cosigner_missing",
+        );
+    });
+
+    it("rejects missing sweep-expiry metadata", () => {
+        const { proof, serverInfo } = cosignerBoundTree();
+        const tx = proof.transactions.values().next().value!;
+        tx.updateInput(0, {
+            unknown: tx
+                .getInput(0)
+                .unknown!.filter((field) => VtxoTreeExpiry.decode(field) === null),
+        });
+
+        expect(verifyTreeCosignerKeys(proof, serverInfo)[0].code).toBe(
+            "signature_sweep_expiry_missing",
+        );
+    });
+});
+
 describe("verifyProofSignatures script path", () => {
     async function signedArk(requiredSecrets: Uint8Array[], signedSecrets: Uint8Array[]) {
         const requiredKeys = await Promise.all(
@@ -133,5 +223,52 @@ describe("verifyProofSignatures script path", () => {
         const issues = verifyProofSignatures(await signedArk([first, second], [first]));
 
         expect(issues[0].code).toBe("signature_invalid_script_path");
+    });
+
+    it("rejects an ARK input with no script-path proof", async () => {
+        const tx = new Transaction({ allowLegacyWitnessUtxo: true });
+        tx.addInput({
+            txid: hex.decode(COMMITMENT_TXID),
+            index: 0,
+            witnessUtxo: { amount: 10_000n, script: SCRIPT },
+        });
+        tx.addOutput({ amount: 10_000n, script: SCRIPT });
+        const proof: ParsedVtxoProof = {
+            entries: new Map([
+                [
+                    tx.id,
+                    {
+                        txid: tx.id,
+                        expiresAt: "0",
+                        type: ChainTxType.ARK,
+                        spends: [COMMITMENT_TXID],
+                    },
+                ],
+            ]),
+            transactions: new Map([[tx.id, tx]]),
+            commitmentTxids: [COMMITMENT_TXID],
+        };
+
+        expect(verifyProofSignatures(proof)[0].code).toBe("signature_script_path_missing");
+    });
+
+    it("rejects a signed tapscript whose control block is not bound to the prevout", async () => {
+        const secret = new Uint8Array(32).fill(8);
+        const proof = await signedArk([secret], [secret]);
+        const tx = proof.transactions.values().next().value!;
+        const [controlBlock, script] = tx.getInput(0).tapLeafScript![0];
+        tx.updateInput(0, {
+            tapLeafScript: [
+                [
+                    {
+                        ...controlBlock,
+                        merklePath: [new Uint8Array(32).fill(1)],
+                    },
+                    script,
+                ],
+            ],
+        });
+
+        expect(verifyProofSignatures(proof)[0].code).toBe("signature_tapleaf_unbound");
     });
 });

--- a/packages/ts-sdk/test/verification/signatures.test.ts
+++ b/packages/ts-sdk/test/verification/signatures.test.ts
@@ -1,0 +1,137 @@
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { SigHash } from "@scure/btc-signer";
+import { describe, expect, it } from "vitest";
+import { ChainTxType } from "../../src/providers/indexer";
+import { SingleKey } from "../../src/identity/singleKey";
+import { VtxoScript } from "../../src/script/base";
+import { MultisigTapscript } from "../../src/script/tapscript";
+import { Transaction } from "../../src/utils/transaction";
+import { ParsedVtxoProof, verifyProofSignatures } from "../../src/verification";
+
+const COMMITMENT_TXID = "11".repeat(32);
+const SECRET_KEY = new Uint8Array(32).fill(7);
+const OUTPUT_KEY = schnorr.getPublicKey(SECRET_KEY);
+const SCRIPT = Uint8Array.from([0x51, 0x20, ...OUTPUT_KEY]);
+
+function signedTree(inputScript = SCRIPT): { proof: ParsedVtxoProof; tx: Transaction } {
+    const tx = new Transaction({ allowLegacyWitnessUtxo: true, allowUnknownOutputs: true });
+    tx.addInput({
+        txid: hex.decode(COMMITMENT_TXID),
+        index: 0,
+        witnessUtxo: { amount: 10_000n, script: inputScript },
+    });
+    tx.addOutput({ amount: 10_000n, script: SCRIPT });
+    const message = tx.preimageWitnessV1(0, [inputScript], SigHash.DEFAULT, [10_000n]);
+    tx.updateInput(0, { tapKeySig: schnorr.sign(message, SECRET_KEY) });
+
+    return {
+        tx,
+        proof: {
+            entries: new Map([
+                [
+                    COMMITMENT_TXID,
+                    {
+                        txid: COMMITMENT_TXID,
+                        expiresAt: "0",
+                        type: ChainTxType.COMMITMENT,
+                        spends: [],
+                    },
+                ],
+                [
+                    tx.id,
+                    {
+                        txid: tx.id,
+                        expiresAt: "0",
+                        type: ChainTxType.TREE,
+                        spends: [COMMITMENT_TXID],
+                    },
+                ],
+            ]),
+            transactions: new Map([[tx.id, tx]]),
+            commitmentTxids: [COMMITMENT_TXID],
+        },
+    };
+}
+
+describe("verifyProofSignatures TREE key path", () => {
+    it("accepts a valid BIP-341 tapKeySig", () => {
+        const { proof } = signedTree();
+        expect(verifyProofSignatures(proof)).toEqual([]);
+    });
+
+    it("rejects a forged tapKeySig", () => {
+        const { proof, tx } = signedTree();
+        const forged = Uint8Array.from(tx.getInput(0).tapKeySig!);
+        forged[0] ^= 0xff;
+        tx.updateInput(0, { tapKeySig: forged });
+
+        expect(verifyProofSignatures(proof)[0].code).toBe("signature_invalid_tap_key");
+    });
+
+    it("rejects a missing tapKeySig", () => {
+        const { proof, tx } = signedTree();
+        tx.updateInput(0, { tapKeySig: undefined });
+
+        expect(verifyProofSignatures(proof)[0].code).toBe("signature_missing_tap_key");
+    });
+
+    it("rejects a TREE prevout that is not P2TR", () => {
+        const { proof } = signedTree(Uint8Array.from([0x51]));
+
+        expect(verifyProofSignatures(proof)[0].code).toBe("signature_prevout_not_p2tr");
+    });
+});
+
+describe("verifyProofSignatures script path", () => {
+    async function signedArk(requiredSecrets: Uint8Array[], signedSecrets: Uint8Array[]) {
+        const requiredKeys = await Promise.all(
+            requiredSecrets.map((secret) => SingleKey.fromPrivateKey(secret).xOnlyPublicKey()),
+        );
+        const script = MultisigTapscript.encode({
+            pubkeys: requiredKeys,
+            type: MultisigTapscript.MultisigType.CHECKSIG,
+        });
+        const vtxoScript = new VtxoScript([script.script]);
+        const tx = new Transaction();
+        tx.addInput({
+            txid: hex.decode(COMMITMENT_TXID),
+            index: 0,
+            witnessUtxo: { amount: 10_000n, script: vtxoScript.pkScript },
+            tapLeafScript: [vtxoScript.leaves[0]],
+        });
+        tx.addOutput({ amount: 10_000n, script: SCRIPT });
+        for (const secret of signedSecrets) {
+            tx.signIdx(SingleKey.fromPrivateKey(secret)["key"], 0, [SigHash.DEFAULT]);
+        }
+        const proof: ParsedVtxoProof = {
+            entries: new Map([
+                [
+                    tx.id,
+                    {
+                        txid: tx.id,
+                        expiresAt: "0",
+                        type: ChainTxType.ARK,
+                        spends: [COMMITMENT_TXID],
+                    },
+                ],
+            ]),
+            transactions: new Map([[tx.id, tx]]),
+            commitmentTxids: [COMMITMENT_TXID],
+        };
+        return proof;
+    }
+
+    it("accepts signatures required by the tapscript", async () => {
+        const secret = new Uint8Array(32).fill(8);
+        expect(verifyProofSignatures(await signedArk([secret], [secret]))).toEqual([]);
+    });
+
+    it("rejects a missing signer required by the tapscript", async () => {
+        const first = new Uint8Array(32).fill(8);
+        const second = new Uint8Array(32).fill(9);
+        const issues = verifyProofSignatures(await signedArk([first, second], [first]));
+
+        expect(issues[0].code).toBe("signature_invalid_script_path");
+    });
+});

--- a/packages/ts-sdk/test/verification/verifyVtxo.test.ts
+++ b/packages/ts-sdk/test/verification/verifyVtxo.test.ts
@@ -16,6 +16,7 @@ import {
     VtxoProofSource,
     VtxoVerificationServerInfo,
 } from "../../src/verification";
+import { boundVerificationIssues } from "../../src/verification/verifyVtxo";
 
 const SECRET_KEY = new Uint8Array(32).fill(7);
 const COSIGNER_KEY = secp256k1.getPublicKey(SECRET_KEY);
@@ -45,6 +46,10 @@ function fixture(tipHeight = 105) {
     tree.addInput({
         txid: hex.decode(commitment.id),
         index: 0,
+        witnessUtxo: {
+            amount: 10_000n,
+            script: SCRIPT,
+        },
     });
     setArkPsbtField(tree, 0, CosignerPublicKey, {
         index: 0,
@@ -116,8 +121,11 @@ describe("verifyVtxo", () => {
         });
     });
 
-    it("returns preconfirmed without claiming an onchain anchor", async () => {
+    it("runs local checks for preconfirmed VTXOs without querying an onchain anchor", async () => {
         const { vtxo, proofSource, chainSource } = fixture();
+        chainSource.getTxHex = async () => {
+            throw new Error("anchor source must not be queried");
+        };
         const result = await verifyVtxo(
             { ...vtxo, isPreconfirmed: true },
             proofSource,
@@ -125,7 +133,31 @@ describe("verifyVtxo", () => {
             SERVER,
         );
 
-        expect(result.status).toBe("preconfirmed");
+        expect(result).toMatchObject({
+            status: "preconfirmed",
+            issues: [],
+            partialChecks: {
+                leaf: true,
+                graph: true,
+                signatures: true,
+            },
+        });
+    });
+
+    it("reports failed local checks on a preconfirmed VTXO", async () => {
+        const { vtxo, proofSource, chainSource } = fixture();
+        const result = await verifyVtxo(
+            { ...vtxo, value: 10_001, isPreconfirmed: true },
+            proofSource,
+            chainSource,
+            SERVER,
+        );
+
+        expect(result).toMatchObject({
+            status: "preconfirmed",
+            partialChecks: { leaf: false },
+        });
+        expect(result.issues.map((issue) => issue.code)).toContain("leaf_amount_mismatch");
     });
 
     it("returns invalid for a forged claimed amount", async () => {
@@ -162,5 +194,23 @@ describe("verifyVtxo", () => {
                 })
             ).status,
         ).toBe("confirmed");
+    });
+});
+
+describe("boundVerificationIssues", () => {
+    it("caps diagnostics and appends an issues_truncated marker", () => {
+        const issues = Array.from({ length: 101 }, (_, index) => ({
+            code: `issue_${index}`,
+            message: `Issue ${index}`,
+        }));
+
+        const bounded = boundVerificationIssues(issues);
+
+        expect(bounded).toHaveLength(101);
+        expect(bounded[99]).toEqual(issues[99]);
+        expect(bounded[100]).toEqual({
+            code: "issues_truncated",
+            message: "Verification produced more than 100 issues",
+        });
     });
 });

--- a/packages/ts-sdk/test/verification/verifyVtxo.test.ts
+++ b/packages/ts-sdk/test/verification/verifyVtxo.test.ts
@@ -1,9 +1,14 @@
 import { base64, hex } from "@scure/base";
-import { schnorr } from "@noble/curves/secp256k1.js";
+import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
 import { SigHash } from "@scure/btc-signer";
+import * as musig from "@scure/btc-signer/musig2.js";
+import { tapLeafHash } from "@scure/btc-signer/payment.js";
 import { describe, expect, it } from "vitest";
 import { ChainTx, ChainTxType } from "../../src/providers/indexer";
+import { aggregateKeys } from "../../src/musig2";
+import { CSVMultisigTapscript } from "../../src/script/tapscript";
 import { Transaction } from "../../src/utils/transaction";
+import { CosignerPublicKey, setArkPsbtField, VtxoTreeExpiry } from "../../src/utils/unknownFields";
 import type { VirtualCoin } from "../../src/wallet";
 import {
     verifyVtxo,
@@ -13,12 +18,20 @@ import {
 } from "../../src/verification";
 
 const SECRET_KEY = new Uint8Array(32).fill(7);
-const OUTPUT_KEY = schnorr.getPublicKey(SECRET_KEY);
-const SCRIPT = Uint8Array.from([0x51, 0x20, ...OUTPUT_KEY]);
+const COSIGNER_KEY = secp256k1.getPublicKey(SECRET_KEY);
 const SERVER: VtxoVerificationServerInfo = {
-    pubkey: schnorr.getPublicKey(new Uint8Array(32).fill(8)),
-    sweepInterval: { type: "blocks", value: 144n },
+    forfeitPubkey: schnorr.getPublicKey(new Uint8Array(32).fill(8)),
 };
+const SWEEP_INTERVAL = { type: "blocks" as const, value: 144n };
+const SWEEP_SCRIPT = CSVMultisigTapscript.encode({
+    timelock: SWEEP_INTERVAL,
+    pubkeys: [SERVER.forfeitPubkey],
+}).script;
+const SWEEP_ROOT = tapLeafHash(SWEEP_SCRIPT);
+const OUTPUT_KEY = aggregateKeys([COSIGNER_KEY], true, {
+    taprootTweak: SWEEP_ROOT,
+}).finalKey.subarray(1);
+const SCRIPT = Uint8Array.from([0x51, 0x20, ...OUTPUT_KEY]);
 
 function fixture(tipHeight = 105) {
     const commitment = new Transaction({
@@ -32,11 +45,26 @@ function fixture(tipHeight = 105) {
     tree.addInput({
         txid: hex.decode(commitment.id),
         index: 0,
-        witnessUtxo: { amount: 10_000n, script: SCRIPT },
     });
+    setArkPsbtField(tree, 0, CosignerPublicKey, {
+        index: 0,
+        key: COSIGNER_KEY,
+    });
+    setArkPsbtField(tree, 0, VtxoTreeExpiry, SWEEP_INTERVAL);
     tree.addOutput({ amount: 10_000n, script: SCRIPT });
     const message = tree.preimageWitnessV1(0, [SCRIPT], SigHash.DEFAULT, [10_000n]);
-    tree.updateInput(0, { tapKeySig: schnorr.sign(message, SECRET_KEY) });
+    const preTweakedKey = aggregateKeys([COSIGNER_KEY], true).preTweakedKey;
+    const tweak = schnorr.utils.taggedHash("TapTweak", preTweakedKey.subarray(1), SWEEP_ROOT);
+    const nonces = musig.nonceGen(COSIGNER_KEY);
+    const session = new musig.Session(
+        musig.nonceAggregate([nonces.public]),
+        [COSIGNER_KEY],
+        message,
+        [tweak],
+        [true],
+    );
+    const partialSignature = session.sign(nonces.secret, SECRET_KEY);
+    tree.updateInput(0, { tapKeySig: session.partialSigAgg([partialSignature]) });
 
     const chain: ChainTx[] = [
         {

--- a/packages/ts-sdk/test/verification/verifyVtxo.test.ts
+++ b/packages/ts-sdk/test/verification/verifyVtxo.test.ts
@@ -1,0 +1,138 @@
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { SigHash } from "@scure/btc-signer";
+import { describe, expect, it } from "vitest";
+import { ChainTx, ChainTxType } from "../../src/providers/indexer";
+import { Transaction } from "../../src/utils/transaction";
+import type { VirtualCoin } from "../../src/wallet";
+import {
+    verifyVtxo,
+    VtxoChainSource,
+    VtxoProofSource,
+    VtxoVerificationServerInfo,
+} from "../../src/verification";
+
+const SECRET_KEY = new Uint8Array(32).fill(7);
+const OUTPUT_KEY = schnorr.getPublicKey(SECRET_KEY);
+const SCRIPT = Uint8Array.from([0x51, 0x20, ...OUTPUT_KEY]);
+const SERVER: VtxoVerificationServerInfo = {
+    pubkey: schnorr.getPublicKey(new Uint8Array(32).fill(8)),
+    sweepInterval: { type: "blocks", value: 144n },
+};
+
+function fixture(tipHeight = 105) {
+    const commitment = new Transaction({
+        allowUnknownInputs: true,
+        allowUnknownOutputs: true,
+    });
+    commitment.addInput({ txid: new Uint8Array(32).fill(1), index: 0 });
+    commitment.addOutput({ amount: 10_000n, script: SCRIPT });
+
+    const tree = new Transaction({ allowLegacyWitnessUtxo: true });
+    tree.addInput({
+        txid: hex.decode(commitment.id),
+        index: 0,
+        witnessUtxo: { amount: 10_000n, script: SCRIPT },
+    });
+    tree.addOutput({ amount: 10_000n, script: SCRIPT });
+    const message = tree.preimageWitnessV1(0, [SCRIPT], SigHash.DEFAULT, [10_000n]);
+    tree.updateInput(0, { tapKeySig: schnorr.sign(message, SECRET_KEY) });
+
+    const chain: ChainTx[] = [
+        {
+            txid: commitment.id,
+            expiresAt: "0",
+            type: ChainTxType.COMMITMENT,
+            spends: [],
+        },
+        {
+            txid: tree.id,
+            expiresAt: "0",
+            type: ChainTxType.TREE,
+            spends: [commitment.id],
+        },
+    ];
+    const proofSource: VtxoProofSource = {
+        getVtxoChain: async () => chain,
+        getVirtualTxs: async () => [base64.encode(tree.toPSBT())],
+    };
+    const chainSource: VtxoChainSource = {
+        getTxHex: async () => commitment.hex,
+        getTxStatus: async () => ({ confirmed: true, blockHeight: 100, blockTime: 1 }),
+        getChainTip: async () => ({ height: tipHeight, time: 2, hash: "00".repeat(32) }),
+        getTxOutspends: async () => [{ spent: false }],
+    };
+    const vtxo: VirtualCoin = {
+        txid: tree.id,
+        vout: 0,
+        value: 10_000,
+        script: hex.encode(SCRIPT),
+        createdAt: new Date(0),
+        isUnrolled: false,
+        isPreconfirmed: false,
+        status: { confirmed: false },
+    };
+    return { vtxo, proofSource, chainSource, commitment };
+}
+
+describe("verifyVtxo", () => {
+    it("returns confirmed only after every phase passes", async () => {
+        const { vtxo, proofSource, chainSource, commitment } = fixture();
+        const result = await verifyVtxo(vtxo, proofSource, chainSource, SERVER);
+
+        expect(result).toMatchObject({
+            status: "confirmed",
+            confirmationDepth: 6,
+            commitmentTxids: [commitment.id],
+            issues: [],
+        });
+    });
+
+    it("returns preconfirmed without claiming an onchain anchor", async () => {
+        const { vtxo, proofSource, chainSource } = fixture();
+        const result = await verifyVtxo(
+            { ...vtxo, isPreconfirmed: true },
+            proofSource,
+            chainSource,
+            SERVER,
+        );
+
+        expect(result.status).toBe("preconfirmed");
+    });
+
+    it("returns invalid for a forged claimed amount", async () => {
+        const { vtxo, proofSource, chainSource } = fixture();
+        const result = await verifyVtxo(
+            { ...vtxo, value: 10_001 },
+            proofSource,
+            chainSource,
+            SERVER,
+        );
+
+        expect(result.status).toBe("invalid");
+        expect(result.issues[0].code).toBe("leaf_amount_mismatch");
+    });
+
+    it("returns unavailable when the proof source withholds ancestry", async () => {
+        const { vtxo, proofSource, chainSource } = fixture();
+        proofSource.getVtxoChain = async () => {
+            throw new Error("offline");
+        };
+        const result = await verifyVtxo(vtxo, proofSource, chainSource, SERVER);
+
+        expect(result.status).toBe("unavailable");
+        expect(result.issues[0].code).toBe("proof_chain_unavailable");
+    });
+
+    it("defaults to six confirmations and permits an explicit lower threshold", async () => {
+        const { vtxo, proofSource, chainSource } = fixture(104);
+        expect((await verifyVtxo(vtxo, proofSource, chainSource, SERVER)).status).toBe("invalid");
+        expect(
+            (
+                await verifyVtxo(vtxo, proofSource, chainSource, SERVER, {
+                    minConfirmationDepth: 5,
+                })
+            ).status,
+        ).toBe("confirmed");
+    });
+});


### PR DESCRIPTION
## Summary

Adds a public `verifyVtxo` API for independently verifying settled VTXOs from resolver proofs and raw Bitcoin data.

The verifier returns structured `confirmed`, `preconfirmed`, `invalid`, or `unavailable` results instead of treating resolver assertions as proof.

## What is verified

- Strict proof parsing, txid/PSBT consistency, parent relationships, duplicate spends, and amount conservation
- Exact leaf outpoint, value, and script membership across flat and multi-level VTXO trees
- BIP341 key-path Schnorr signatures on TREE transactions
- Cosigner aggregation, historical server forfeit key, and proof-carried sweep expiry against the anchored P2TR output
- ARK/checkpoint tapscript signatures, required signer sets, control blocks, and NUMS internal keys
- Raw Bitcoin commitment txids, every claimed TREE root, shared-tip confirmation depth, and unexpected outspends
- Multi-anchor ARK joins, reporting the shallowest independently established depth

Real arkd resolver PSBTs may omit `witnessUtxo` for TREE inputs. The implementation reconstructs root prevouts from the independently fetched commitment transaction and child prevouts from their parent virtual transaction, rejecting any supplied prevout that disagrees.

## API/provider changes

- Exports verification sources, options, results, and `verifyVtxo` from the SDK entry point
- Adds concrete `getTxHex` methods to Esplora and Electrum providers without expanding the existing `OnchainProvider` interface
- Documents usage and the trust boundary in the README

## Validation

- `pnpm -C packages/ts-sdk exec vitest run test/verification` — 50 tests passed
- `pnpm -C packages/ts-sdk run typecheck` — passed
- `pnpm lint && pnpm test:unit` — passed for the full workspace
- `pnpm run regtest:test:ts-sdk test/e2e/verification.test.ts` — 2 live regtest cases passed, including rejection of a mutated TREE `tapKeySig`

The repository guidance references NArk/.NET for protocol parity, but I could not locate a public implementation of this settled-proof verification path. Maintainer feedback on any private/current parity requirements would be welcome.

This is a clean upstream-master-based replacement for the earlier fork-side experiment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trustless VTXO verification via `verifyVtxo`, returning `confirmed`, `preconfirmed`, `invalid`, or `unavailable`.
  * Performs local proof checks (leaf/graph/signatures) and independently validates commitment anchors before marking `confirmed`.
  * Added raw transaction hex retrieval support for supported on-chain providers.
  * Added configurable confirmation-depth gating (default: 6).
* **Documentation**
  * Added README usage guidance and public API references for VTXO verification.
* **Tests**
  * Added unit and regtest coverage for confirmed, forged, incomplete, and unavailable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->