### PR TITLE
fix: expo background interval is in minutes, not seconds

### DIFF
--- a/packages/ts-sdk/src/wallet/expo/background.ts
+++ b/packages/ts-sdk/src/wallet/expo/background.ts
@@ -165,7 +165,7 @@ export async function registerExpoBackgroundTask(
     options?: { minimumInterval?: number },
 ): Promise<void> {
     await BackgroundTask.registerTaskAsync(taskName, {
-        minimumInterval: (options?.minimumInterval ?? 15) * 60,
+        minimumInterval: options?.minimumInterval ?? 15,
     });
 }
 

--- a/packages/ts-sdk/test/wallet/expo/background.test.ts
+++ b/packages/ts-sdk/test/wallet/expo/background.test.ts
@@ -185,8 +185,18 @@ describe("expo background task helpers", () => {
         await unregisterExpoBackgroundTask("ark-background-task");
 
         expect(registerTaskAsyncMock).toHaveBeenCalledWith("ark-background-task", {
-            minimumInterval: 17 * 60,
+            minimumInterval: 17,
         });
         expect(unregisterTaskAsyncMock).toHaveBeenCalledWith("ark-background-task");
+    });
+
+    it("defaults the background interval to 15 minutes", async () => {
+        const { registerExpoBackgroundTask } = await loadBackground();
+
+        await registerExpoBackgroundTask("ark-background-task");
+
+        expect(registerTaskAsyncMock).toHaveBeenCalledWith("ark-background-task", {
+            minimumInterval: 15,
+        });
     });
 });


### PR DESCRIPTION
registerExpoBackgroundTask multiplied `minimumInterval` by 60, but `expo-background-task` already takes minutes — the default 15 scheduled background sync every ~15h instead of every 15m.

The boltz-swap equivalent already passes the value raw and is unchanged.