### PR TITLE
fix: service-worker correctness batch

### DIFF
--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-message-handler.ts
@@ -774,7 +774,12 @@ export class ArkadeSwapsMessageHandler
     private async broadcastEvent(event: SwapManagerEventMessage): Promise<void> {
         const sw: any = self as any;
         if (!sw?.clients?.matchAll) return;
-        const clients = await sw.clients.matchAll();
+        // Same options as the core bus fan-out: pages loaded before the SW claimed
+        // them are uncontrolled and would otherwise miss every swap event.
+        const clients = await sw.clients.matchAll({
+            includeUncontrolled: true,
+            type: "window",
+        });
         for (const client of clients) {
             try {
                 (client as any).postMessage(event);

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -292,6 +292,8 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
         const tag = this.messageTag;
 
         const proxy = {
+            // No payload: the SW side loads pending swaps from the repository itself
+            // (see ArkadeSwaps.startSwapManager).
             start: async () => {
                 await send({
                     id: getRandomId(),

--- a/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
+++ b/packages/boltz-swap/src/serviceWorker/arkade-swaps-runtime.ts
@@ -67,7 +67,8 @@ import type {
 } from "./arkade-swaps-message-handler";
 import {
     getRandomId,
-    MESSAGE_BUS_NOT_INITIALIZED,
+    isMessageBusInitializingError,
+    isMessageBusNotInitializedError,
     ServiceWorkerTimeoutError,
     type ArkInfo,
     type ArkTxInput,
@@ -86,14 +87,16 @@ import {
 import type { Actions, SwapManagerClient } from "../swap-manager";
 import { logger } from "../logger";
 
-// Check by error message content instead of instanceof because postMessage uses the
-// structured clone algorithm which strips the prototype chain — the page
-// receives a plain Error, not the original MessageBusNotInitializedError.
-function isMessageBusNotInitializedError(error: unknown): boolean {
-    return error instanceof Error && error.message.includes(MESSAGE_BUS_NOT_INITIALIZED);
-}
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-// Same structured-clone caveat as above: match by message string. Triggered
+// Bounded backoff for waiting out an in-flight init: ~100ms, 200ms, … capped at
+// 2s, so a stuck init still surfaces an error instead of hanging the caller.
+const INIT_WAIT_BACKOFF_CAP_MS = 2_000;
+const MAX_INIT_WAITS = 8;
+const initWaitBackoffMs = (attempt: number) =>
+    Math.min(100 * 2 ** attempt, INIT_WAIT_BACKOFF_CAP_MS);
+
+// Matched by message string (structured clone strips the prototype chain). Triggered
 // when the bus has been re-initialized (e.g. by the wallet's restart-recovery
 // path) but the ArkadeSwaps handler's own init payload has not been re-sent,
 // leaving `handler.handler` undefined. Reinitialize from cached initPayload.
@@ -1177,10 +1180,19 @@ export class ServiceWorkerArkadeSwaps implements IArkadeSwaps {
             : DEFAULT_MESSAGE_TIMEOUT_MS;
 
         const maxRetries = 2;
-        for (let attempt = 0; ; attempt++) {
+        for (let attempt = 0, initWaits = 0; ; attempt++) {
             try {
                 return await this.sendMessageDirect(request, timeoutMs);
             } catch (error: any) {
+                // Must precede the not-initialized check: an in-flight init reports a
+                // superset message, and reinitializing would burn every retry at once.
+                if (isMessageBusInitializingError(error)) {
+                    if (initWaits >= MAX_INIT_WAITS) throw error;
+                    await sleep(initWaitBackoffMs(initWaits++));
+                    attempt--;
+                    continue;
+                }
+
                 const recoverable =
                     isMessageBusNotInitializedError(error) || isHandlerNotInitializedError(error);
                 if (!recoverable || attempt >= maxRetries) {

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -97,8 +97,12 @@ type SwapUpdateCallback = (swap: BoltzSwap, oldStatus: BoltzSwapStatus) => void;
 
 /** Public interface for SwapManager consumers. Provides swap monitoring, event subscription, and lifecycle control. */
 export interface SwapManagerClient {
-    /** Starts the manager, loading initial swaps and connecting WebSocket. */
-    start(pendingSwaps: BoltzSwap[]): Promise<void>;
+    /**
+     * Starts the manager, loading initial swaps and connecting WebSocket.
+     * Omit `pendingSwaps` when the implementation sources them itself — the
+     * service-worker proxy does, loading from the repository on the SW side.
+     */
+    start(pendingSwaps?: BoltzSwap[]): Promise<void>;
     /** Stops the manager, closes WebSocket, and clears all timers. */
     stop(): Promise<void>;
     /** Adds a new swap to be monitored. Immediately subscribes via WebSocket. */
@@ -415,7 +419,7 @@ export class SwapManager implements SwapManagerClient {
      * 3. Poll all swaps after connection
      * 4. Resume any actionable swaps
      */
-    async start(pendingSwaps: BoltzSwap[]): Promise<void> {
+    async start(pendingSwaps: BoltzSwap[] = []): Promise<void> {
         if (this.isRunning) {
             logger.warn("SwapManager is already running");
             return;

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -699,6 +699,19 @@ describe("ArkadeSwaps", () => {
         });
     });
 
+    describe("startSwapManager", () => {
+        it("starts the manager with the swaps loaded from the repository", async () => {
+            const stored = [{ id: "s1" }, { id: "s2" }];
+            mockSwapRepository.getAllSwaps.mockResolvedValueOnce(stored);
+            const manager = { start: vi.fn().mockResolvedValue(undefined) };
+            (swaps as any).swapManager = manager;
+
+            await swaps.startSwapManager();
+
+            expect(manager.start).toHaveBeenCalledWith(stored);
+        });
+    });
+
     describe("Receive from Lightning", () => {
         describe("Create Lightning Invoice", () => {
             it("should throw if amount is not > 0", async () => {

--- a/packages/boltz-swap/test/serviceWorker/arkade-swaps-message-handler.test.ts
+++ b/packages/boltz-swap/test/serviceWorker/arkade-swaps-message-handler.test.ts
@@ -54,6 +54,26 @@ describe("ArkadeSwapsMessageHandler broadcastEvent", () => {
     });
 });
 
+describe("ArkadeSwapsMessageHandler SM-START", () => {
+    // The runtime proxy sends SM-START with no payload: the SW side sources its
+    // swaps from the repository (see ArkadeSwaps.startSwapManager).
+    it("dispatches to the SW-side manager without a client swap set", async () => {
+        const arkadeSwaps = { startSwapManager: vi.fn().mockResolvedValue(undefined) };
+        const handler = new ArkadeSwapsMessageHandler({} as SwapRepository);
+        (handler as any).handler = arkadeSwaps;
+        (handler as any).wallet = {};
+
+        const response = await handler.handleMessage({
+            id: "req",
+            tag: handler.messageTag,
+            type: "SM-START",
+        } as any);
+
+        expect(response).toMatchObject({ type: "SM-STARTED" });
+        expect(arkadeSwaps.startSwapManager).toHaveBeenCalledWith();
+    });
+});
+
 describe("ArkadeSwapsMessageHandler long-running requests", () => {
     it("uses the exported long-running request set for bus timeout opt-out", () => {
         const handler = new ArkadeSwapsMessageHandler({} as SwapRepository);

--- a/packages/boltz-swap/test/serviceWorker/arkade-swaps-message-handler.test.ts
+++ b/packages/boltz-swap/test/serviceWorker/arkade-swaps-message-handler.test.ts
@@ -39,6 +39,19 @@ describe("ArkadeSwapsMessageHandler broadcastEvent", () => {
             expect.objectContaining({ type: "SM-EVENT-SWAP_UPDATE" }),
         );
     });
+
+    it("includes uncontrolled windows so pages before SW claim receive events", async () => {
+        await (handler as any).broadcastEvent({
+            tag: "TAG",
+            type: "SM-EVENT-SWAP_UPDATE",
+            payload: { swap: { id: "s1" }, oldStatus: "swap.created" as BoltzSwapStatus },
+        });
+
+        expect((globalThis as any).self.clients.matchAll).toHaveBeenCalledWith({
+            includeUncontrolled: true,
+            type: "window",
+        });
+    });
 });
 
 describe("ArkadeSwapsMessageHandler long-running requests", () => {

--- a/packages/boltz-swap/test/serviceWorker/arkade-swaps-runtime.test.ts
+++ b/packages/boltz-swap/test/serviceWorker/arkade-swaps-runtime.test.ts
@@ -10,7 +10,11 @@ import { BoltzSwapStatus } from "../../src/boltz-swap-provider";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { hex } from "@scure/base";
 import { decodeInvoice } from "../../src/utils/decoding";
-import { MESSAGE_BUS_NOT_INITIALIZED, ServiceWorkerTimeoutError } from "@arkade-os/sdk";
+import {
+    MESSAGE_BUS_INITIALIZING,
+    MESSAGE_BUS_NOT_INITIALIZED,
+    ServiceWorkerTimeoutError,
+} from "@arkade-os/sdk";
 import { QuoteRejectedError } from "../../src/errors";
 
 class FakeServiceWorker {
@@ -361,6 +365,7 @@ const createRuntimeWithConfig = (
 describe("sendMessage reinitialize on SW restart", () => {
     afterEach(() => {
         vi.unstubAllGlobals();
+        vi.useRealTimers();
     });
 
     it("retries after re-initializing when SW returns 'MessageBus not initialized'", async () => {
@@ -543,6 +548,80 @@ describe("sendMessage reinitialize on SW restart", () => {
             ([msg]: any) => msg.type === "INIT_ARKADE_SWAPS",
         );
         expect(initCalls).toHaveLength(1);
+    });
+
+    it("waits out an in-flight init without reinitializing or consuming retries", async () => {
+        vi.useFakeTimers();
+
+        // More initializing responses than the 2-retry budget: if they were
+        // classified as not-initialized the request would fail on the 3rd send.
+        let initializing = 3;
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => {
+            if (message.type !== "GET_FEES") return null;
+            if (initializing-- > 0) {
+                return {
+                    id: message.id,
+                    tag: TAG,
+                    error: new Error(MESSAGE_BUS_INITIALIZING),
+                };
+            }
+            return {
+                id: message.id,
+                tag: TAG,
+                type: "FEES",
+                payload: { minerFees: 7 },
+            };
+        });
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        const feesPromise = runtime.getFees();
+
+        // Backoff is 100ms, 200ms, 400ms
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(await feesPromise).toEqual({ minerFees: 7 });
+
+        const feesCalls = serviceWorker.postMessage.mock.calls.filter(
+            ([msg]: any) => msg.type === "GET_FEES",
+        );
+        expect(feesCalls).toHaveLength(4);
+
+        const initCalls = serviceWorker.postMessage.mock.calls.filter(
+            ([msg]: any) => msg.type === "INIT_ARKADE_SWAPS",
+        );
+        expect(initCalls).toHaveLength(0);
+    });
+
+    it("gives up on a stuck init instead of waiting forever", async () => {
+        vi.useFakeTimers();
+
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => ({
+            id: message.id,
+            tag: TAG,
+            error: new Error(MESSAGE_BUS_INITIALIZING),
+        }));
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const runtime = createRuntimeWithConfig(serviceWorker as any);
+        const assertion = expect(runtime.refreshSwapsStatus()).rejects.toThrow(
+            MESSAGE_BUS_INITIALIZING,
+        );
+
+        // Sum of the capped backoff over the 8 permitted waits
+        await vi.advanceTimersByTimeAsync(20_000);
+        await assertion;
+
+        const refreshCalls = serviceWorker.postMessage.mock.calls.filter(
+            ([msg]: any) => msg.type === "REFRESH_SWAPS_STATUS",
+        );
+        expect(refreshCalls).toHaveLength(9);
     });
 
     it("does not retry for errors other than 'not initialized'", async () => {

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -407,6 +407,8 @@ import {
     MessageBusInitializingError,
     MessageBusNotInitializedError,
     ServiceWorkerTimeoutError,
+    isMessageBusInitializingError,
+    isMessageBusNotInitializedError,
 } from "./worker/errors";
 import { AssetManager, ReadonlyAssetManager } from "./wallet/asset-manager";
 
@@ -475,6 +477,8 @@ export {
     MessageBusInitializingError,
     MessageBusNotInitializedError,
     ServiceWorkerTimeoutError,
+    isMessageBusInitializingError,
+    isMessageBusNotInitializedError,
     ServiceWorkerWallet,
     ServiceWorkerReadonlyWallet,
     DEFAULT_MESSAGE_TIMEOUTS,

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -151,20 +151,12 @@ import type { DelegateInfo } from "../../providers/delegate";
 import { getRandomId } from "../utils";
 import type { VirtualCoin } from "..";
 import {
-    MESSAGE_BUS_INITIALIZING,
-    MESSAGE_BUS_NOT_INITIALIZED,
+    isMessageBusInitializingError,
+    isMessageBusNotInitializedError,
     ServiceWorkerTimeoutError,
 } from "../../worker/errors";
 import { getArkadeServerUrl, type ProviderConnectionState } from "../wallet";
 import { normalizeVtxo, type NormalizedExtendedVirtualCoin } from "../vtxo";
-
-function isMessageBusNotInitializedError(error: unknown): boolean {
-    return error instanceof Error && error.message.includes(MESSAGE_BUS_NOT_INITIALIZED);
-}
-
-function isMessageBusInitializingError(error: unknown): boolean {
-    return error instanceof Error && error.message.includes(MESSAGE_BUS_INITIALIZING);
-}
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 

--- a/packages/ts-sdk/src/worker/errors.ts
+++ b/packages/ts-sdk/src/worker/errors.ts
@@ -24,3 +24,15 @@ export class ServiceWorkerTimeoutError extends Error {
         super(detail);
     }
 }
+
+// Match by message rather than instanceof: postMessage's structured clone strips
+// the prototype chain, so the page receives a plain Error.
+export function isMessageBusNotInitializedError(error: unknown): boolean {
+    return error instanceof Error && error.message.includes(MESSAGE_BUS_NOT_INITIALIZED);
+}
+
+// Callers must test this before isMessageBusNotInitializedError: the message is a
+// superset, so the broader check also matches an in-flight init.
+export function isMessageBusInitializingError(error: unknown): boolean {
+    return error instanceof Error && error.message.includes(MESSAGE_BUS_INITIALIZING);
+}


### PR DESCRIPTION
Three independent fixes in `packages/boltz-swap/src/serviceWorker/`, one commit each.

- **Init race** — `MESSAGE_BUS_INITIALIZING` is a superset of `MESSAGE_BUS_NOT_INITIALIZED`, so a concurrent bus init was read as a dead bus and burned both retries reinitializing with no backoff. The runtime now backs off and retries without consuming an attempt, mirroring `ServiceWorkerWallet`. Both classifiers move to `worker/errors` and are exported, replacing duplicated string matching in two packages.
- **Event broadcast** — the handler's fan-out called `clients.matchAll()` bare, so pages loaded before the SW claimed them missed every swap event. Now uses the same options as the core bus.
- **`SM-START` arity** — the proxy's `start()` sends no payload while the interface demanded `start(pendingSwaps)`. No swaps are lost (the SW loads them from the repository), so the parameter is now optional on both `SwapManagerClient` and `SwapManager`.

Five tests added. Full unit suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service worker communication with pages that are not yet controlled.
  * Added bounded retry and backoff handling during message-bus initialization, preventing unnecessary reinitialization and indefinite waits.
  * Improved swap manager startup by automatically loading stored swaps when no list is provided.

* **New Features**
  * Added shared SDK helpers for identifying message-bus initialization errors.

* **Tests**
  * Added coverage for pending swap loading, service worker event delivery, startup handling, and initialization retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->