### PR TITLE
fix(boltz-swap): guard waitAndClaim against double claim

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -720,10 +720,14 @@ export class ArkadeSwaps {
                         await saveStatus();
                         // Both statuses fire for the same lockup; a second
                         // claim would fail on the spent VHTLC and reject the
-                        // promise despite the first claim succeeding.
+                        // promise despite the first claim succeeding. Reset on
+                        // failure so the other status can still retry the claim.
                         if (claimStarted) return;
                         claimStarted = true;
-                        this.claimVHTLC(pendingSwap).catch(reject);
+                        this.claimVHTLC(pendingSwap).catch((error) => {
+                            claimStarted = false;
+                            reject(error);
+                        });
                         break;
                     case "invoice.settled": {
                         await saveStatus();

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -704,6 +704,7 @@ export class ArkadeSwaps {
 
         // Otherwise use manual monitoring
         return new Promise<{ txid: string }>((resolve, reject) => {
+            let claimStarted = false;
             const onStatusUpdate = async (status: BoltzSwapStatus, data: any) => {
                 const saveStatus = (additionalFields?: Partial<BoltzReverseSwap>) =>
                     updateReverseSwapStatus(
@@ -717,6 +718,11 @@ export class ArkadeSwaps {
                     case "transaction.mempool":
                     case "transaction.confirmed":
                         await saveStatus();
+                        // Both statuses fire for the same lockup; a second
+                        // claim would fail on the spent VHTLC and reject the
+                        // promise despite the first claim succeeding.
+                        if (claimStarted) return;
+                        claimStarted = true;
                         this.claimVHTLC(pendingSwap).catch(reject);
                         break;
                     case "invoice.settled": {

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -1107,6 +1107,35 @@ describe("ArkadeSwaps", () => {
                 expect(result.txid).toBe(mock.txid);
                 expect(claimVHTLC).toHaveBeenCalledTimes(1);
             });
+
+            it("should retry the claim on the confirmed status when the mempool claim fails", async () => {
+                // arrange
+                const pendingSwap = mockReverseSwap;
+
+                const claimVHTLC = vi
+                    .spyOn(swaps, "claimVHTLC")
+                    .mockRejectedValueOnce(new Error("indexer not ready"))
+                    .mockResolvedValueOnce(undefined);
+                vi.spyOn(swapProvider, "getReverseSwapTxId").mockResolvedValue({
+                    id: mock.txid,
+                    timeoutBlockHeight: 123,
+                });
+                let monitorDone: Promise<void> = Promise.resolve();
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation((_id, update) => {
+                    monitorDone = (async () => {
+                        await update("transaction.mempool");
+                        await update("transaction.confirmed");
+                        await update("invoice.settled");
+                    })();
+                    return monitorDone;
+                });
+
+                // act & assert: the first failure rejects the promise, but the
+                // confirmed status still retries the claim in the background.
+                await expect(swaps.waitAndClaim(pendingSwap)).rejects.toThrow("indexer not ready");
+                await monitorDone;
+                expect(claimVHTLC).toHaveBeenCalledTimes(2);
+            });
         });
     });
 

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -1084,6 +1084,29 @@ describe("ArkadeSwaps", () => {
                     "Transaction ID not available for settled swap",
                 );
             });
+
+            it("should claim only once when the lockup is seen in mempool and then confirms", async () => {
+                // arrange
+                const pendingSwap = mockReverseSwap;
+
+                const claimVHTLC = vi.spyOn(swaps, "claimVHTLC").mockResolvedValue(undefined);
+                vi.spyOn(swapProvider, "getReverseSwapTxId").mockResolvedValue({
+                    id: mock.txid,
+                    timeoutBlockHeight: 123,
+                });
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(async (_id, update) => {
+                    await update("transaction.mempool");
+                    await update("transaction.confirmed");
+                    await update("invoice.settled");
+                });
+
+                // act
+                const result = await swaps.waitAndClaim(pendingSwap);
+
+                // assert
+                expect(result.txid).toBe(mock.txid);
+                expect(claimVHTLC).toHaveBeenCalledTimes(1);
+            });
         });
     });
 


### PR DESCRIPTION
`waitAndClaim` handles `transaction.mempool` and `transaction.confirmed` in the same case body, and both invoke `claimVHTLC` unguarded. The second claim finds the VHTLC spent, throws, and lands in `.catch(reject)` — rejecting a swap whose first claim succeeded, since the promise only resolves later at `invoice.settled`.

Adds the `claimStarted` guard already used by `waitAndClaimBtc` (`arkade-swaps.ts:1714`) and `waitAndClaimArk` (`:2074`).

Test drives mempool → confirmed → settled and asserts a single claim; it fails with 2 calls without the guard.

Related: #612, which will eventually replace these monitor loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reverse swaps occasionally attempting to claim the same payment multiple times when transaction status updates were repeated.
  * Improved claim reliability across mempool, confirmation, and settlement status changes, including correct retry behavior after a failed attempt.

* **Tests**
  * Added regression coverage to verify reverse swaps are claimed exactly once when statuses progress normally and to validate retry behavior when the initial claim fails during the mempool phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->