### PR TITLE
feat(core): security hardening ahead of the Swap entity migration

### DIFF
--- a/packages/boltz-swap/src/utils/signatures.ts
+++ b/packages/boltz-swap/src/utils/signatures.ts
@@ -10,7 +10,8 @@ import { hex } from "@scure/base";
  * @param inputIndex - The index of the input to check.
  * @param requiredSigners - Hex-encoded x-only public keys of all required signers.
  * @param expectedLeafHash - The tapscript leaf hash that signatures must commit to.
- * @returns `true` if all required signers have valid signatures on the expected leaf, `false` otherwise.
+ * @returns `true` if every signature on the input commits to the expected leaf and all
+ * required signers are present, `false` otherwise.
  */
 export const verifySignatures = (
     tx: Transaction,
@@ -19,18 +20,15 @@ export const verifySignatures = (
     expectedLeafHash: Uint8Array,
 ): boolean => {
     try {
-        // signatures should be valid
-        verifyTapscriptSignatures(tx, inputIndex, requiredSigners);
-
-        // signatures should sign the expected tapscript leaf
-        const input = tx.getInput(inputIndex);
-        const expectedHex = hex.encode(expectedLeafHash);
-        return requiredSigners.every((signer) =>
-            input.tapScriptSig?.some(
-                ([{ pubKey, leafHash }]) =>
-                    hex.encode(pubKey) === signer && hex.encode(leafHash) === expectedHex,
-            ),
+        verifyTapscriptSignatures(
+            tx,
+            inputIndex,
+            requiredSigners,
+            undefined,
+            undefined,
+            expectedLeafHash,
         );
+        return true;
     } catch (_) {
         return false;
     }

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -16,7 +16,7 @@ import {
     CSVMultisigTapscript,
     combineTapscriptSigs,
     Transaction,
-    TapLeafScript,
+    scriptFromTapLeafScript,
 } from "@arkade-os/sdk";
 import { logger } from "../logger";
 import { BoltzRefundError } from "../errors";
@@ -511,7 +511,3 @@ export const refundVHTLCwithOffchainTx = async (
     // finalize the transaction
     await arkProvider.finalizeTx(arkTxid, [base64.encode(finalCheckpointTx.toPSBT())]);
 };
-
-function scriptFromTapLeafScript(leaf: TapLeafScript): Uint8Array {
-    return leaf[1].subarray(0, leaf[1].length - 1); // remove the version byte
-}

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -29,6 +29,7 @@ import {
     TapLeafScript,
     TapTreeCoder,
     getSequence,
+    scriptFromTapLeafScript,
 } from "./script/base";
 import { assembleBtcdTaprootTree } from "./script/taprootTree";
 import {
@@ -457,6 +458,7 @@ export {
     VtxoScript,
     VHTLC,
     assembleBtcdTaprootTree,
+    scriptFromTapLeafScript,
 
     // Enums
     TxType,

--- a/packages/ts-sdk/src/musig2/index.ts
+++ b/packages/ts-sdk/src/musig2/index.ts
@@ -1,4 +1,4 @@
 export type { Nonces } from "./nonces";
 export { generateNonces, aggregateNonces } from "./nonces";
-export { PartialSig, sign } from "./sign";
+export { PartialSig, PartialSignatureError, sign, partialSigVerify } from "./sign";
 export { aggregateKeys } from "./keys";

--- a/packages/ts-sdk/src/musig2/keys.ts
+++ b/packages/ts-sdk/src/musig2/keys.ts
@@ -17,7 +17,8 @@ export function aggregateKeys(
     options: Partial<KeyAggOptions> = {},
 ): AggregateKey {
     if (sort) {
-        publicKeys = musig.sortKeys(publicKeys);
+        // sortKeys sorts in place; copy so the caller's array survives.
+        publicKeys = musig.sortKeys([...publicKeys]);
     }
 
     const { aggPublicKey: preTweakedKey } = musig.keyAggregate(publicKeys);

--- a/packages/ts-sdk/src/musig2/sign.ts
+++ b/packages/ts-sdk/src/musig2/sign.ts
@@ -76,7 +76,9 @@ function createSession(
     let tweakBytes: Uint8Array | undefined;
 
     if (options?.taprootTweak !== undefined) {
-        const { preTweakedKey } = aggregateKeys(keys, true);
+        // `keys` is already in the session's final order; the tweak must
+        // commit to that same order, so don't re-sort here.
+        const { preTweakedKey } = aggregateKeys(keys, false);
 
         tweakBytes = schnorr.utils.taggedHash(
             "TapTweak",

--- a/packages/ts-sdk/src/musig2/sign.ts
+++ b/packages/ts-sdk/src/musig2/sign.ts
@@ -1,4 +1,5 @@
 import * as musig from "@scure/btc-signer/musig2.js";
+import { hex } from "@scure/base";
 import { bytesToNumberBE } from "@noble/curves/utils.js";
 import { Point } from "@noble/secp256k1";
 import { aggregateKeys } from "./keys";
@@ -62,6 +63,37 @@ export class PartialSig {
     }
 }
 
+function createSession(
+    combinedNonce: Uint8Array,
+    publicKeys: Uint8Array[],
+    message: Uint8Array,
+    options?: SignOptions,
+): musig.Session {
+    // sortKeys sorts in place; copy so the caller's key order (and anything
+    // aligned with it, such as per-signer nonces) survives.
+    const keys = options?.sortKeys ? musig.sortKeys([...publicKeys]) : publicKeys;
+
+    let tweakBytes: Uint8Array | undefined;
+
+    if (options?.taprootTweak !== undefined) {
+        const { preTweakedKey } = aggregateKeys(keys, true);
+
+        tweakBytes = schnorr.utils.taggedHash(
+            "TapTweak",
+            preTweakedKey.subarray(1),
+            options.taprootTweak,
+        );
+    }
+
+    return new musig.Session(
+        combinedNonce,
+        keys,
+        message,
+        tweakBytes ? [tweakBytes] : undefined,
+        tweakBytes ? [true] : undefined,
+    );
+}
+
 /**
  * Generates a MuSig2 partial signature
  */
@@ -73,28 +105,65 @@ export function sign(
     message: Uint8Array,
     options?: SignOptions,
 ): PartialSig {
-    let tweakBytes: Uint8Array | undefined;
+    const session = createSession(combinedNonce, publicKeys, message, options);
+    const partialSig = session.sign(secNonce, privateKey);
+    return PartialSig.decode(partialSig);
+}
 
-    if (options?.taprootTweak !== undefined) {
-        const { preTweakedKey } = aggregateKeys(
-            options?.sortKeys ? musig.sortKeys(publicKeys) : publicKeys,
-            true,
-        );
+/**
+ * Verifies a single signer's MuSig2 partial signature.
+ *
+ * @param partialSig - The share to verify
+ * @param signerPublicKey - Public key of the signer that produced it
+ * @param pubNonces - Public nonce of every signer, parallel to `publicKeys`
+ * @param combinedNonce - The aggregated nonce the share was produced under
+ * @param publicKeys - Public keys of every signer
+ * @param message - The signed message
+ * @param options - Must match the options the share was produced with
+ * @throws PartialSignatureError if the inputs do not describe a coherent session
+ */
+export function partialSigVerify(
+    partialSig: PartialSig,
+    signerPublicKey: Uint8Array,
+    pubNonces: Uint8Array[],
+    combinedNonce: Uint8Array,
+    publicKeys: Uint8Array[],
+    message: Uint8Array,
+    options?: SignOptions,
+): boolean {
+    if (pubNonces.length !== publicKeys.length) {
+        throw new PartialSignatureError("pubNonces and publicKeys must have the same length");
+    }
 
-        tweakBytes = schnorr.utils.taggedHash(
-            "TapTweak",
-            preTweakedKey.subarray(1),
-            options.taprootTweak,
+    // The signer index addresses both arrays, so nonces must follow the key
+    // order the session uses — sort the pairs together rather than the keys alone.
+    const signers = publicKeys.map((publicKey, i) => ({
+        publicKey,
+        publicKeyHex: hex.encode(publicKey),
+        pubNonce: pubNonces[i],
+    }));
+
+    if (options?.sortKeys) {
+        signers.sort((a, b) =>
+            a.publicKeyHex < b.publicKeyHex ? -1 : a.publicKeyHex > b.publicKeyHex ? 1 : 0,
         );
     }
 
-    const session = new musig.Session(
+    const signerIndex = signers.findIndex((s) => s.publicKeyHex === hex.encode(signerPublicKey));
+    if (signerIndex === -1) {
+        throw new PartialSignatureError("signer public key is not part of the session");
+    }
+
+    const session = createSession(
         combinedNonce,
-        options?.sortKeys ? musig.sortKeys(publicKeys) : publicKeys,
+        signers.map((s) => s.publicKey),
         message,
-        tweakBytes ? [tweakBytes] : undefined,
-        tweakBytes ? [true] : undefined,
+        { ...options, sortKeys: false },
     );
-    const partialSig = session.sign(secNonce, privateKey);
-    return PartialSig.decode(partialSig);
+
+    return session.partialSigVerify(
+        partialSig.encode(),
+        signers.map((s) => s.pubNonce),
+        signerIndex,
+    );
 }

--- a/packages/ts-sdk/src/utils/arkTransaction.ts
+++ b/packages/ts-sdk/src/utils/arkTransaction.ts
@@ -211,6 +211,8 @@ function formatSighash(type: number): string {
  * @param requiredSigners List of required signer pubkeys (hex encoded)
  * @param excludePubkeys List of pubkeys to exclude from verification (hex encoded, e.g., server key not yet signed)
  * @param allowedSighashTypes List of allowed sighash types (defaults to [SigHash.DEFAULT])
+ * @param expectedLeafHash Tapscript leaf hash the signatures must commit to. When omitted, a
+ * signature over any leaf carried by the input is accepted.
  * @throws Error if verification fails
  */
 export function verifyTapscriptSignatures(
@@ -219,6 +221,7 @@ export function verifyTapscriptSignatures(
     requiredSigners: string[],
     excludePubkeys: string[] = [],
     allowedSighashTypes: number[] = [SigHash.DEFAULT],
+    expectedLeafHash?: Uint8Array,
 ): void {
     const input = tx.getInput(inputIndex);
 
@@ -240,6 +243,8 @@ export function verifyTapscriptSignatures(
         throw new Error(`Input ${inputIndex} is missing tapScriptSig`);
     }
 
+    const expectedLeafHashHex = expectedLeafHash ? hex.encode(expectedLeafHash) : undefined;
+
     // Verify each signature in tapScriptSig
     for (const [tapScriptSigData, signature] of input.tapScriptSig) {
         const pubKey = tapScriptSigData.pubKey;
@@ -248,6 +253,15 @@ export function verifyTapscriptSignatures(
         // Skip verification for excluded pubkeys
         if (excludePubkeys.includes(pubKeyHex)) {
             continue;
+        }
+
+        if (expectedLeafHashHex !== undefined) {
+            const signedLeafHex = hex.encode(tapScriptSigData.leafHash);
+            if (signedLeafHex !== expectedLeafHashHex) {
+                throw new Error(
+                    `Input ${inputIndex}: signature from ${pubKeyHex} commits to leaf ${signedLeafHex}, expected ${expectedLeafHashHex}`,
+                );
+            }
         }
 
         // Extract sighash type from signature

--- a/packages/ts-sdk/test/musig2.test.ts
+++ b/packages/ts-sdk/test/musig2.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { sign, aggregateKeys } from "../src/musig2";
+import {
+    sign,
+    aggregateKeys,
+    generateNonces,
+    aggregateNonces,
+    partialSigVerify,
+    PartialSig,
+} from "../src/musig2";
 import testData from "./fixtures/musig2.json";
 import { hex } from "@scure/base";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
 
 describe("musig2", () => {
     describe("aggregateKeys", () => {
@@ -35,6 +43,113 @@ describe("musig2", () => {
             );
 
             expect(hex.encode(signature.encode())).toBe(result);
+        });
+    });
+
+    describe("partialSigVerify", () => {
+        const taprootTweak = hex.decode(testData.signing.inputs.options.taprootTweak);
+        const message = hex.decode(testData.signing.inputs.message);
+        const options = { sortKeys: true, taprootTweak };
+
+        // Two-of-two session, both signers' shares produced against the same
+        // aggregated nonce — the shape tree signing uses. `order` fixes the
+        // caller's key order relative to the sorted order the session uses, so
+        // the nonce permutation is exercised deterministically.
+        function session(order: "sorted" | "reversed" = "reversed") {
+            const signers = [1, 2]
+                .map(() => {
+                    const secretKey = secp256k1.utils.randomSecretKey();
+                    const publicKey = secp256k1.getPublicKey(secretKey, true);
+                    return { secretKey, publicKey, ...generateNonces(publicKey) };
+                })
+                .sort((a, b) => {
+                    const cmp = hex.encode(a.publicKey) < hex.encode(b.publicKey) ? -1 : 1;
+                    return order === "sorted" ? cmp : -cmp;
+                });
+            const combinedNonce = aggregateNonces(signers.map((s) => s.pubNonce));
+            const publicKeys = signers.map((s) => s.publicKey);
+            const pubNonces = signers.map((s) => s.pubNonce);
+            const shares = signers.map((s) =>
+                sign(s.secNonce, s.secretKey, combinedNonce, publicKeys, message, options),
+            );
+            return { signers, combinedNonce, publicKeys, pubNonces, shares };
+        }
+
+        const verify = (
+            s: ReturnType<typeof session>,
+            share: PartialSig,
+            index: number,
+            pubNonces = s.pubNonces,
+        ) =>
+            partialSigVerify(
+                share,
+                s.signers[index].publicKey,
+                pubNonces,
+                s.combinedNonce,
+                s.publicKeys,
+                message,
+                options,
+            );
+
+        it.each(["sorted", "reversed"] as const)("accepts every valid share (%s keys)", (order) => {
+            const s = session(order);
+
+            expect(verify(s, s.shares[0], 0)).toBe(true);
+            expect(verify(s, s.shares[1], 1)).toBe(true);
+        });
+
+        it("rejects a tampered share", () => {
+            const s = session();
+            const tampered = s.shares[0].encode();
+            tampered[31] ^= 0x01;
+
+            expect(verify(s, PartialSig.decode(tampered), 0)).toBe(false);
+        });
+
+        it("rejects a share checked against the wrong nonce", () => {
+            const s = session();
+            const foreignNonce = generateNonces(s.signers[0].publicKey).pubNonce;
+
+            expect(verify(s, s.shares[0], 0, [foreignNonce, s.pubNonces[1]])).toBe(false);
+        });
+
+        it("rejects a share attributed to the other signer", () => {
+            const s = session();
+
+            expect(verify(s, s.shares[0], 1)).toBe(false);
+        });
+
+        it("throws when the signer is not part of the session", () => {
+            const s = session();
+            const outsider = secp256k1.getPublicKey(secp256k1.utils.randomSecretKey(), true);
+
+            expect(() =>
+                partialSigVerify(
+                    s.shares[0],
+                    outsider,
+                    s.pubNonces,
+                    s.combinedNonce,
+                    s.publicKeys,
+                    message,
+                    options,
+                ),
+            ).toThrow(/not part of the session/);
+        });
+
+        it("throws on a nonce/key count mismatch", () => {
+            const s = session();
+
+            expect(() =>
+                partialSigVerify(
+                    s.shares[0],
+                    s.signers[0].publicKey,
+                    [s.pubNonces[0]],
+                    s.combinedNonce,
+                    s.publicKeys,
+                    message,
+                    options,
+                ),
+            ).toThrow(/same length/);
         });
     });
 });

--- a/packages/ts-sdk/test/musig2.test.ts
+++ b/packages/ts-sdk/test/musig2.test.ts
@@ -22,6 +22,8 @@ describe("musig2", () => {
             });
             expect(hex.encode(preTweakedKey.slice(1))).toBe(expectedAggregatedKey);
             expect(hex.encode(finalKey.slice(1))).toBe(expectedFinalKey);
+            // fixture keys are unsorted: sorting must copy, not reorder the input
+            expect(publicKeys.map((key) => hex.encode(key))).toEqual(pubkeys);
         });
     });
 
@@ -55,7 +57,7 @@ describe("musig2", () => {
         // aggregated nonce — the shape tree signing uses. `order` fixes the
         // caller's key order relative to the sorted order the session uses, so
         // the nonce permutation is exercised deterministically.
-        function session(order: "sorted" | "reversed" = "reversed") {
+        function session(order: "sorted" | "reversed" = "reversed", opts = options) {
             const signers = [1, 2]
                 .map(() => {
                     const secretKey = secp256k1.utils.randomSecretKey();
@@ -70,7 +72,7 @@ describe("musig2", () => {
             const publicKeys = signers.map((s) => s.publicKey);
             const pubNonces = signers.map((s) => s.pubNonce);
             const shares = signers.map((s) =>
-                sign(s.secNonce, s.secretKey, combinedNonce, publicKeys, message, options),
+                sign(s.secNonce, s.secretKey, combinedNonce, publicKeys, message, opts),
             );
             return { signers, combinedNonce, publicKeys, pubNonces, shares };
         }
@@ -135,6 +137,35 @@ describe("musig2", () => {
                 ),
             ).toThrow(/not part of the session/);
         });
+
+        it.each([true, false])(
+            "sign and verify leave the caller's arrays untouched (sortKeys: %s)",
+            (sortKeys) => {
+                const opts = { sortKeys, taprootTweak };
+                const s = session("reversed", opts);
+                const keys = s.publicKeys.map((k) => hex.encode(k));
+                const nonces = s.pubNonces.map((n) => hex.encode(n));
+
+                // session() already ran sign() twice over this array; the
+                // reversed construction order must have survived it.
+                expect(keys).toEqual([...keys].sort().reverse());
+
+                expect(
+                    partialSigVerify(
+                        s.shares[0],
+                        s.signers[0].publicKey,
+                        s.pubNonces,
+                        s.combinedNonce,
+                        s.publicKeys,
+                        message,
+                        opts,
+                    ),
+                ).toBe(true);
+
+                expect(s.publicKeys.map((k) => hex.encode(k))).toEqual(keys);
+                expect(s.pubNonces.map((n) => hex.encode(n))).toEqual(nonces);
+            },
+        );
 
         it("throws on a nonce/key count mismatch", () => {
             const s = session();

--- a/packages/ts-sdk/test/verifySignatures.test.ts
+++ b/packages/ts-sdk/test/verifySignatures.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from "vitest";
 import { Transaction, SigHash } from "@scure/btc-signer";
 import { hex } from "@scure/base";
 import { randomPrivateKeyBytes } from "@scure/btc-signer/utils.js";
-import { VtxoScript } from "../src/script/base";
+import { tapLeafHash } from "@scure/btc-signer/payment.js";
+import { VtxoScript, TapLeafScript, scriptFromTapLeafScript } from "../src/script/base";
 import { MultisigTapscript } from "../src/script/tapscript";
 import { SingleKey } from "../src/identity/singleKey";
 import { verifyTapscriptSignatures, combineTapscriptSigs } from "../src/utils/arkTransaction";
@@ -210,6 +211,102 @@ describe("verifyTapscriptSignatures", async () => {
     // Note: Additional edge case tests (invalid signature, invalid length, missing tapLeafScript, etc.)
     // are skipped because the Transaction API doesn't allow easy manipulation of signed data.
     // The core functionality is well-tested by the positive test cases above.
+});
+
+describe("verifyTapscriptSignatures expectedLeafHash", async () => {
+    const alice = SingleKey.fromPrivateKey(randomPrivateKeyBytes());
+    const alicePubKey = await alice.xOnlyPublicKey();
+    const bob = SingleKey.fromPrivateKey(randomPrivateKeyBytes());
+    const bobPubKey = await bob.xOnlyPublicKey();
+
+    // Two single-signer leaves: each key can only sign its own leaf.
+    const scriptA = MultisigTapscript.encode({
+        pubkeys: [alicePubKey],
+        type: MultisigTapscript.MultisigType.CHECKSIG,
+    }).script;
+    const scriptB = MultisigTapscript.encode({
+        pubkeys: [bobPubKey],
+        type: MultisigTapscript.MultisigType.CHECKSIG,
+    }).script;
+    const vtxoScript = new VtxoScript([scriptA, scriptB]);
+
+    const leafOf = (script: Uint8Array): TapLeafScript =>
+        vtxoScript.leaves.find(
+            (leaf) => hex.encode(scriptFromTapLeafScript(leaf)) === hex.encode(script),
+        )!;
+
+    const leafHashOf = (script: Uint8Array): Uint8Array => {
+        const leaf = leafOf(script);
+        return tapLeafHash(scriptFromTapLeafScript(leaf), leaf[1][leaf[1].length - 1]);
+    };
+
+    // Both leaves are carried on the input, so a signature over either one is
+    // structurally valid — only expectedLeafHash distinguishes them.
+    function txSignedBy(signer: SingleKey): Transaction {
+        const tx = new Transaction();
+        tx.addInput({
+            txid: new Uint8Array(32).fill(0),
+            index: 0,
+            witnessUtxo: { script: vtxoScript.pkScript, amount: 1000n },
+            tapLeafScript: vtxoScript.leaves,
+        });
+        tx.addOutputAddress("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", 900n);
+        tx.signIdx(signer["key"], 0, [SigHash.DEFAULT]);
+        return tx;
+    }
+
+    it("accepts a signature on the expected leaf", () => {
+        const tx = txSignedBy(bob);
+
+        expect(() => {
+            verifyTapscriptSignatures(
+                tx,
+                0,
+                [hex.encode(bobPubKey)],
+                undefined,
+                undefined,
+                leafHashOf(scriptB),
+            );
+        }).not.toThrow();
+    });
+
+    it("rejects a signature valid over a different leaf", () => {
+        const tx = txSignedBy(bob);
+
+        expect(() => {
+            verifyTapscriptSignatures(
+                tx,
+                0,
+                [hex.encode(bobPubKey)],
+                undefined,
+                undefined,
+                leafHashOf(scriptA),
+            );
+        }).toThrow(/commits to leaf/);
+    });
+
+    it("accepts any carried leaf when expectedLeafHash is omitted", () => {
+        const tx = txSignedBy(bob);
+
+        expect(() => {
+            verifyTapscriptSignatures(tx, 0, [hex.encode(bobPubKey)]);
+        }).not.toThrow();
+    });
+
+    it("does not constrain the leaf of excluded pubkeys", () => {
+        const tx = txSignedBy(bob);
+
+        expect(() => {
+            verifyTapscriptSignatures(
+                tx,
+                0,
+                [],
+                [hex.encode(bobPubKey)],
+                undefined,
+                leafHashOf(scriptA),
+            );
+        }).not.toThrow();
+    });
 });
 
 describe("combineTapscriptSigs", async () => {


### PR DESCRIPTION
## Scope

Same lineage as #646 — additive core changes pulled ahead of the Swap entity migration into `ts-sdk`, so the refactor PR stays scoped to the VHTLC execution layer. No breaking changes.

## Description

- export `scriptFromTapLeafScript`; drop boltz-swap's byte-identical private copy
- `verifyTapscriptSignatures` accepted a signature over *any* leaf carried by the input. Optional `expectedLeafHash` (6th param) rejects the others; boltz-swap's `verifySignatures` now delegates instead of re-checking. Excluded pubkeys stay unconstrained
- add `partialSigVerify` to core `musig2/` — sessions previously aggregated whatever share they were given. Delegates to scure's `Session.partialSigVerify`; `sign()` shares the session builder, which no longer sorts the caller's key array in place

Tests cover the wrong-leaf rejection, and for `partialSigVerify`: valid shares under both key orderings, tampered share, wrong nonce, and misattributed signer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stricter Taproot signature verification for specific script leaves.
  - Exposed script and MuSig2 signature verification utilities through the SDK.
  - Improved multi-party signing support, including stable key ordering and partial signature validation.

- **Bug Fixes**
  - Prevented signing helpers from modifying caller-provided key and nonce lists.
  - Improved handling of Taproot key tweaks and signer ordering.

- **Tests**
  - Expanded coverage for valid, invalid, mismatched, and tampered signatures, including leaf restrictions and input preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->