### PR TITLE
fix(snap): require user confirmation before signing, and show the requesting origin

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -8,7 +8,7 @@
     "directory": "packages/snap"
   },
   "source": {
-    "shasum": "aXZE8MGGsgfKCuCrnJHWOoJuoa8AUtQf5V3h3dhpyZc=",
+    "shasum": "ymjLDokY16utWLJoUsvFoUKEc/jsXEhCa6zIDGtzjQU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -28,7 +28,7 @@ import { getAddress, getPublicKey, signPsbt } from "./wallet";
  * @param args.request - The JSON-RPC request object.
  * @returns The result of the RPC method.
  */
-export const onRpcRequest: OnRpcRequestHandler = async ({ origin: _origin, request }) => {
+export const onRpcRequest: OnRpcRequestHandler = async ({ origin, request }) => {
     switch (request.method) {
         case "arkade_getPublicKey":
             // No params required
@@ -39,8 +39,9 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ origin: _origin, reque
             return await getAddress(request.params);
 
         case "arkade_signPsbt":
-            // Params validated inside signPsbt
-            return await signPsbt(request.params);
+            // Params validated inside signPsbt, which also prompts the user for
+            // confirmation and shows them the requesting origin.
+            return await signPsbt(request.params, origin);
 
         default:
             throw new Error(`Method not found: ${request.method}`);

--- a/packages/snap/src/wallet.ts
+++ b/packages/snap/src/wallet.ts
@@ -1,4 +1,5 @@
 import { Transaction, SingleKey, ArkAddress, DefaultVtxo } from "@arkade-os/sdk";
+import { divider, heading, panel, text } from "@metamask/snaps-sdk";
 import { base64, hex } from "@scure/base";
 
 import type { ArkadeAddress, PubKeyHex, XOnlyPubKeyHex } from "./types";
@@ -114,10 +115,15 @@ export async function getAddress(params: unknown): Promise<{ address: ArkadeAddr
 
 /**
  * Sign a PSBT with the snap's Bitcoin key.
+ *
+ * Prompts the user for confirmation before signing, showing the requesting
+ * origin. Any dapp with RPC access can call this, so the prompt is the only
+ * thing standing between a hostile page and a signature over the user's VTXOs.
  * @param params - The parameters object containing psbt and inputIndexes.
+ * @param origin - The origin of the requesting dapp, shown in the prompt.
  * @returns An object containing the signed PSBT in base64 format.
  */
-export async function signPsbt(params: unknown): Promise<{ psbt: string }> {
+export async function signPsbt(params: unknown, origin: string): Promise<{ psbt: string }> {
     // Validate params structure
     if (!params || typeof params !== "object") {
         throw new Error("Invalid params: expected object");
@@ -140,6 +146,35 @@ export async function signPsbt(params: unknown): Promise<{ psbt: string }> {
     }
 
     const tx = Transaction.fromPSBT(psbtBytes);
+
+    // Ask the user before touching key material.
+    //
+    // `endowment:rpc` is granted with `dapps: true`, so ANY page the user visits
+    // that can reach MetaMask may call arkade_signPsbt once the snap is
+    // installed. Without this gate a malicious dapp could obtain a signature
+    // over inputs of its choosing, including a spend of the user's VTXOs.
+    // Placed after decode so the prompt can describe the real transaction, and
+    // before snap_getEntropy so a rejection never unlocks the key.
+    const approved = await snap.request({
+        method: "snap_dialog",
+        params: {
+            type: "confirmation",
+            content: panel([
+                heading("Sign Arkade transaction?"),
+                text(`**${origin}** is requesting a signature.`),
+                divider(),
+                text(`Inputs to sign: **${validatedInputIndexes.join(", ")}**`),
+                text(`Transaction inputs: **${tx.inputsLength}**`),
+                text(`Transaction outputs: **${tx.outputsLength}**`),
+                divider(),
+                text("Only approve this if you recognise the site and expect this transaction."),
+            ]),
+        },
+    });
+
+    if (approved !== true) {
+        throw new Error("User rejected the signature request");
+    }
 
     // Get the private key and create identity (consistent with getAddress())
     const entropy = await snap.request({

--- a/packages/snap/test/sign-confirmation.test.ts
+++ b/packages/snap/test/sign-confirmation.test.ts
@@ -1,0 +1,95 @@
+import { Transaction } from "@arkade-os/sdk";
+import { base64 } from "@scure/base";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signPsbt } from "../src/wallet";
+
+// The confirmation gate is the only thing between a hostile dapp and a
+// signature over the user's VTXOs, so it gets tested against the real
+// signPsbt rather than the mock used by index.test.ts.
+
+type SnapRequest = (args: { method: string; params?: unknown }) => Promise<unknown>;
+
+const requestMock = vi.fn<SnapRequest>();
+
+/** Build a structurally valid PSBT so Transaction.fromPSBT succeeds. */
+function validPsbtBase64() {
+    const tx = new Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true });
+    return base64.encode(tx.toPSBT());
+}
+
+describe("signPsbt user confirmation", () => {
+    beforeEach(() => {
+        requestMock.mockReset();
+        (globalThis as Record<string, unknown>).snap = { request: requestMock };
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>).snap;
+    });
+
+    it("asks for confirmation and names the requesting origin", async () => {
+        requestMock.mockImplementation(async ({ method }) => {
+            if (method === "snap_dialog") return false;
+            throw new Error(`unexpected method ${method}`);
+        });
+
+        await expect(
+            signPsbt({ psbt: validPsbtBase64(), inputIndexes: [0] }, "https://evil.example"),
+        ).rejects.toThrow("User rejected the signature request");
+
+        const dialogCall = requestMock.mock.calls.find(([a]) => a.method === "snap_dialog");
+        expect(dialogCall).toBeDefined();
+        expect(JSON.stringify(dialogCall?.[0].params)).toContain("https://evil.example");
+    });
+
+    it("never touches key material when the user rejects", async () => {
+        requestMock.mockImplementation(async ({ method }) => {
+            if (method === "snap_dialog") return false;
+            throw new Error(`unexpected method ${method}`);
+        });
+
+        await expect(
+            signPsbt({ psbt: validPsbtBase64(), inputIndexes: [0] }, "https://evil.example"),
+        ).rejects.toThrow("User rejected");
+
+        // The critical assertion: a rejection must not reach snap_getEntropy.
+        const methods = requestMock.mock.calls.map(([a]) => a.method);
+        expect(methods).toContain("snap_dialog");
+        expect(methods).not.toContain("snap_getEntropy");
+    });
+
+    it("treats a non-true dialog result as a rejection", async () => {
+        requestMock.mockImplementation(async ({ method }) => {
+            if (method === "snap_dialog") return null;
+            throw new Error(`unexpected method ${method}`);
+        });
+
+        await expect(
+            signPsbt({ psbt: validPsbtBase64(), inputIndexes: [0] }, "https://dapp.example"),
+        ).rejects.toThrow("User rejected the signature request");
+    });
+
+    it("requests confirmation before entropy when the user approves", async () => {
+        const seen: string[] = [];
+        requestMock.mockImplementation(async ({ method }) => {
+            seen.push(method);
+            if (method === "snap_dialog") return true;
+            if (method === "snap_getEntropy") return `0x${"11".repeat(32)}`;
+            throw new Error(`unexpected method ${method}`);
+        });
+
+        await signPsbt(
+            { psbt: validPsbtBase64(), inputIndexes: [0] },
+            "https://dapp.example",
+        ).catch(() => {
+            // Signing an input-less PSBT may still fail downstream; ordering
+            // is what this test asserts.
+        });
+
+        expect(seen.indexOf("snap_dialog")).toBeGreaterThanOrEqual(0);
+        if (seen.includes("snap_getEntropy")) {
+            expect(seen.indexOf("snap_dialog")).toBeLessThan(seen.indexOf("snap_getEntropy"));
+        }
+    });
+});


### PR DESCRIPTION
> **Stacked on #654.** Base is `feat/port-arkade-packages`, because `packages/snap` only exists there. Merge #654 first, then retarget this to `master`.

Raised in review on #654 and split out because it changes signing behaviour for users of the **live** `@arkade-os/snap@0.1.2`, which is out of scope for a port.

## The problem

`arkade_signPsbt` decoded and signed **any PSBT any dapp provided**, with no confirmation, and `onRpcRequest` discarded the requesting origin entirely (`origin: _origin`).

The manifest declares `endowment:rpc` with `dapps: true`. So once a user installs the snap for one site, **any page they later visit that can reach MetaMask** could call `arkade_signPsbt` and obtain a signature over inputs of its choosing — including a PSBT spending the user's VTXOs to an attacker's address. The user saw nothing and had no way to know who was asking.

Verified against the code, not inferred: there is no `snap_dialog` call anywhere in `packages/snap/src`, and `origin` was explicitly discarded at the handler.

## The change

`signPsbt` now takes the origin and raises a `snap_dialog` confirmation showing it, alongside the input indexes and the transaction's input/output counts. Anything other than an explicit `true` is a rejection.

Placement matters and is deliberate:

- **after** PSBT decode, so the prompt can describe the real transaction
- **before** `snap_getEntropy`, so a rejection never unlocks key material

## Why the tests are trustworthy here

The existing suite could not have caught this: `index.test.ts` mocks the whole `../src/wallet` module, so the real `signPsbt` never runs. The 66 tests passed both before and after the vulnerability existed.

The four new tests exercise the actual implementation with a mocked `snap` global, and assert the ordering property directly — that a rejection reaches `snap_dialog` and never reaches `snap_getEntropy`.

I mutation-tested them rather than trusting a green run: neutralizing the gate (`if (approved !== true)` → `if (false)`) fails **3 of the 4**. Restored, 4/4 pass. The tests are load-bearing.

## Deliberately NOT addressed — these need your judgement

1. **No per-origin allowlist or persisted approval.** Every request prompts. Whether to remember approvals, and at what granularity (per-origin? per-session? per-amount?), is a product decision, and getting it wrong reintroduces the vulnerability quietly.
2. **The dialog shows input/output counts, not decoded amounts and destinations.** "How much, to whom" is what users actually need to make this decision. Rendering that safely from a PSBT deserves design input rather than my guess.
3. **`arkade_getAddress` still derives the vtxo taproot key from caller-supplied `signerPubkey` and `unilateralExitDelay`** with no consistency check against the server the user is actually on. A malicious dapp can request an address computed for its own server pubkey. Less severe alone since the snap holds no funds, but it compounds with the issue fixed here.

## Release impact

This changes signing behaviour for existing installs, so it reaches users **only on a version bump** — `0.1.2` can never be republished. The shasum moves:

```
before  aXZE8MGGsgfKCuCrnJHWOoJuoa8AUtQf5V3h3dhpyZc=
after   ymjLDokY16utWLJoUsvFoUKEc/jsXEhCa6zIDGtzjQU=
```

`mm-snap manifest` validates the result. The release hook added in #654 regenerates and re-verifies it at publish time.

## Test plan

- [x] `pnpm run lint` — green
- [x] `pnpm -r typecheck` — green, all 8 workspace members
- [x] `pnpm run test:unit` — 2706 passed, 1 skipped (snap 66 → 70)
- [x] `pnpm -C packages/snap build` — succeeds
- [x] `pnpm -C packages/snap manifest:check` — manifest valid
- [x] Mutation test — gate neutralized fails 3/4, restored passes 4/4
- [ ] **Manual:** install the built snap in MetaMask Flask and confirm the dialog renders legibly and that rejecting produces a clean error in the calling dapp. I have not rendered this dialog in a real MetaMask instance — the copy and layout are unverified visually.

## What I could not verify

Whether the `panel`/`heading`/`text` builders from `@metamask/snaps-sdk` 6.24 render as intended in current MetaMask Flask. The types check and the bundle builds, but that is not the same as seeing it on screen.
