### PR TITLE
fix(core): make the contract pipeline safe for non-wallet-owned contract types

### DIFF
--- a/packages/ts-sdk/src/arkade/contract.ts
+++ b/packages/ts-sdk/src/arkade/contract.ts
@@ -456,9 +456,16 @@ export class ArkadeContract<P extends Program = Program> {
     /**
      * Persist this contract through the wallet's {@link IContractManager} so it
      * is tracked like any other contract type: stored in the contract
-     * repository, watched for VTXO events, counted in repository-backed
-     * balances, and re-derivable offline via the `"arkade"` contract handler.
-     * Idempotent — re-registering the same script is a no-op.
+     * repository, watched for VTXO events, visible to `wallet.getVtxos()` and
+     * the transaction history, and re-derivable offline via the `"arkade"`
+     * contract handler. Idempotent — re-registering the same script is a no-op.
+     *
+     * Registering does NOT add this contract's VTXOs to `wallet.getBalance()`.
+     * That balance is scoped to the contract types the wallet owns outright
+     * (`default`/`delegate`) — the same scope `getWalletScripts()` uses — and an
+     * arkade contract is program-gated rather than unilaterally spendable by the
+     * wallet key. Use {@link ArkadeContract.getBalance} for this contract's own
+     * balance.
      */
     async register(options?: {
         label?: string;

--- a/packages/ts-sdk/src/contracts/handlers/arkade.ts
+++ b/packages/ts-sdk/src/contracts/handlers/arkade.ts
@@ -149,8 +149,13 @@ function pathsFor(
  * signer keys) as string params, so any contract created via
  * `arkade.contract(program, args)` participates in the standard contract
  * pipeline: ContractManager persistence and validation, watcher events,
- * repository-backed balances, and offline script re-derivation. Rebuild a
+ * repository-backed VTXO tracking, and offline script re-derivation. Rebuild a
  * callable contract from a stored row with `ArkadeContract.fromContract`.
+ *
+ * Tracked is not the same as counted: `wallet.getBalance()` is scoped to the
+ * wallet-owned types (`default`/`delegate`), so these VTXOs are visible to
+ * `wallet.getVtxos()` but excluded from wallet balance. See
+ * {@link ArkadeContract.register}.
  */
 export const ArkadeContractHandler: ContractHandler<ArkadeContractParams, ArkadeProgramScript> &
     TapscriptDeriving<ArkadeProgramScript> = {

--- a/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
@@ -1,7 +1,14 @@
 import { hex } from "@scure/base";
 import { VHTLC } from "../../script/vhtlc";
 import { RelativeTimelock } from "../../script/tapscript";
-import { Contract, ContractHandler, PathContext, PathSelection } from "../types";
+import {
+    Contract,
+    ContractHandler,
+    DerivedContractTapscripts,
+    PathContext,
+    PathSelection,
+    TapscriptDeriving,
+} from "../types";
 import { isCltvSatisfied, isCsvSpendable, resolveRole } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 
@@ -34,7 +41,8 @@ export interface VHTLCContractParams {
  * - unilateralRefund: Sender + Receiver after CSV delay
  * - unilateralRefundWithoutReceiver: Sender after CSV delay
  */
-export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Script> = {
+export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Script> &
+    TapscriptDeriving<VHTLC.Script> = {
     type: "vhtlc",
 
     createScript(params: Record<string, string>): VHTLC.Script {
@@ -69,6 +77,52 @@ export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Sc
             unilateralRefundWithoutReceiverDelay: sequenceToTimelock(
                 Number(params.refundNoReceiverDelay),
             ),
+        };
+    },
+
+    /**
+     * VHTLC has no single (owner + server) "forfeit" leaf like
+     * `default`/`delegate`/`boarding` — it exposes 6 role- and
+     * condition-gated paths (claim / refund / refundWithoutReceiver, each
+     * with a unilateral variant), and which one applies depends on
+     * `contract.params` (role, preimage) and timing, not just the script.
+     *
+     * VHTLC VTXOs are in practice NOT spent through this generic
+     * forfeit/intent path: a consumer resolves the role-specific leaf it
+     * needs (`claim()` / `refund()` / `refundWithoutReceiver()`) and builds
+     * `ArkTxInput.tapLeafScript` from it directly, never reading
+     * `ExtendedVirtualCoin.forfeitTapLeafScript`/`intentTapLeafScript`.
+     * These fields exist here only so
+     * `ContractWatcher`/`ContractManager.annotateVtxos` don't crash on a
+     * registered `vhtlc` contract, and so a valid `tapTree` is available for
+     * encoding/inspection.
+     *
+     * We return `claim()` — the receiver+server path gated on a HASH160
+     * preimage — specifically because it CANNOT be completed by the wallet's
+     * *other* generic forfeit-signing path,
+     * `Wallet.handleSettlementFinalizationEvent` (`wallet/wallet.ts`), which
+     * never supplies the required preimage witness element. That path is
+     * reachable from `wallet.settle()` (called with no params) and
+     * `VtxoManager.recoverVtxos()`, and — unlike `getWalletScripts()` /
+     * `getScriptMap()`, which deliberately scope to
+     * `type: ["default", "delegate"]` — `Wallet.getVtxos()` /
+     * `ContractManager.getContractsWithVtxos()` do NOT filter by contract
+     * type, so a live `vhtlc` contract's VTXO is a candidate input there
+     * today. Picking `claim()` makes any such accidental inclusion fail
+     * closed (invalid/incomplete witness) instead of risking a leaf that
+     * could be fully signed (e.g. `refundWithoutReceiver()`, if the wallet
+     * happens to hold the "sender" role's key).
+     *
+     * This is a mitigation, not a fix — the recommended follow-up is to
+     * exclude non-wallet-owned contract types from the generic
+     * settle/recovery input set.
+     */
+    deriveTapscripts(script: VHTLC.Script, _contract: Contract): DerivedContractTapscripts {
+        const claim = script.claim();
+        return {
+            forfeitTapLeafScript: claim,
+            intentTapLeafScript: claim,
+            tapTree: script.encode(),
         };
     },
 

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -812,6 +812,13 @@ export type GetVtxosFilter = {
 
     /** Include virtual outputs that have been unrolled onchain. */
     withUnrolled?: boolean;
+
+    /**
+     * Restrict to virtual outputs owned by contract(s) of the given type(s)
+     * (e.g. "default", "delegate", "vhtlc"). Defaults to every contract type
+     * when omitted.
+     */
+    type?: string | string[];
 };
 
 /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1351,7 +1351,11 @@ export class WalletMessageHandler
     private async handleGetBalance() {
         const [boardingUtxos, allVtxos, pendingOutpoints] = await Promise.all([
             this.getAllBoardingUtxos(),
-            this.getVtxosFromRepo(),
+            // Scoped to the wallet's own receiving contracts, mirroring
+            // ReadonlyWallet.getBalance. Contract types the wallet does not own
+            // outright ("vhtlc" escrow) are tracked and readable through
+            // GET_VTXOS, but are not spendable balance.
+            this.getVtxosFromRepo(["default", "delegate"]),
             this.readonlyWallet
                 ? this.readonlyWallet.pendingRecoveryOutpoints()
                 : Promise.resolve(new Set<string>()),
@@ -1368,8 +1372,9 @@ export class WalletMessageHandler
             }
         }
 
-        // offchain — bucketed from a single repo read, with the same capability reads
-        // Wallet.getBalance uses so the two agree. No chain tip: this is an offline-first read.
+        // offchain — bucketed from a single repo read, with the same contract-type
+        // scope and the same capability reads Wallet.getBalance uses so the two
+        // agree. No chain tip: this is an offline-first read.
         const now = { timestamp: new Date() };
 
         let settled = 0;
@@ -1437,10 +1442,10 @@ export class WalletMessageHandler
         return this.readonlyWallet.getBoardingUtxos();
     }
     /**
-     * Get spendable vtxos from the repository
+     * Get spendable vtxos from the repository, optionally scoped to contract type(s).
      */
-    private async getSpendableVtxos() {
-        const vtxos = await this.getVtxosFromRepo();
+    private async getSpendableVtxos(type?: string | string[]) {
+        const vtxos = await this.getVtxosFromRepo(type);
         return vtxos.filter((v) => !hasTerminalSpend(v));
     }
 
@@ -1721,7 +1726,7 @@ export class WalletMessageHandler
         if (!this.readonlyWallet) {
             throw new WalletNotInitializedError();
         }
-        const vtxos = await this.getSpendableVtxos();
+        const vtxos = await this.getSpendableVtxos(message.payload.filter?.type);
         const dustAmount = this.readonlyWallet.dustAmount;
         const includeRecoverable = message.payload.filter?.withRecoverable ?? false;
         const filteredVtxos = includeRecoverable
@@ -1767,8 +1772,13 @@ export class WalletMessageHandler
     /**
      * Read all virtual outputs from the repository, aggregated across all contract
      * addresses and the wallet's primary address, with deduplication.
+     *
+     * @param type - Optional contract type(s) to scope to, matching
+     * {@link GetVtxosFilter.type} on the core wallet. Omit for every type.
      */
-    private async getVtxosFromRepo(): Promise<NormalizedExtendedVirtualCoin[]> {
+    private async getVtxosFromRepo(
+        type?: string | string[],
+    ): Promise<NormalizedExtendedVirtualCoin[]> {
         if (!this.walletRepository || !this.readonlyWallet) return [];
         const seen = new Set<string>();
         const allVtxos: NormalizedExtendedVirtualCoin[] = [];
@@ -1788,9 +1798,20 @@ export class WalletMessageHandler
         // each bucket by its owning contract script before deduplication so a
         // wrong-script row never wins the txid:vout race.
         const manager = await this.readonlyWallet.getContractManager();
-        const contracts = await manager.getContracts();
+        const contracts = await manager.getContracts(type ? { type } : undefined);
         for (const contract of contracts) {
             addVtxos(await getVtxosForContract(this.walletRepository, contract));
+        }
+
+        // The primary-address bucket is the wallet's own "default" contract, so
+        // a scope that excludes "default" must exclude this bucket too —
+        // otherwise `getVtxos({ type: "vhtlc" })` would leak the wallet's own
+        // outputs into a vhtlc-scoped read.
+        const scopeIncludesDefault =
+            type === undefined ||
+            (Array.isArray(type) ? type.includes("default") : type === "default");
+        if (!scopeIncludesDefault) {
+            return allVtxos;
         }
 
         // Also check the wallet's primary address. Decode it to its script

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -1038,7 +1038,16 @@ export class ReadonlyWallet implements IReadonlyWallet {
     async getBalance(): Promise<WalletBalance> {
         const [boardingUtxos, vtxos, pendingOutpoints] = await Promise.all([
             this.getBoardingUtxos(),
-            this.getVtxos(),
+            // Scoped to the wallet's own receiving contracts (default +
+            // delegate), same as getWalletScripts(). Excludes contract types
+            // the wallet does not own outright, such as "vhtlc": HTLC escrow
+            // is not spendable balance until it resolves — by claim or
+            // refund — into a wallet-owned contract.
+            this.getVtxos({
+                withRecoverable: true,
+                withUnrolled: false,
+                type: ["default", "delegate"],
+            }),
             this.pendingRecoveryOutpoints(),
         ]);
         const isPendingRecovery = (coin: ExtendedVirtualCoin) =>
@@ -1138,12 +1147,14 @@ export class ReadonlyWallet implements IReadonlyWallet {
     /**
      * Return virtual outputs tracked by the wallet.
      *
-     * @param filter - Optional flags controlling whether recoverable or unrolled VTXOs are included
+     * @param filter - Optional flags controlling whether recoverable or unrolled VTXOs are included, and which contract type(s) to scope to
      */
     async getVtxos(filter?: GetVtxosFilter): Promise<NormalizedExtendedVirtualCoin[]> {
         const f = filter ?? { withRecoverable: true, withUnrolled: false };
         const contractManager = await this.getContractManager();
-        const vtxos = await contractManager.getContractsWithVtxos();
+        const vtxos = await contractManager.getContractsWithVtxos(
+            f.type ? { type: f.type } : undefined,
+        );
 
         // No chain tip, for the same reason as `getBalance`, which this must agree with.
         const now = { timestamp: new Date() };

--- a/packages/ts-sdk/test/wallet-balance-contract-scope.test.ts
+++ b/packages/ts-sdk/test/wallet-balance-contract-scope.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { hex } from "@scure/base";
 import {
+    arkade,
+    ArkadeContractHandler,
     ReadonlyWallet,
     InMemoryWalletRepository,
     InMemoryContractRepository,
@@ -9,6 +11,7 @@ import {
     type OnchainProvider,
     type ExtendedVirtualCoin,
 } from "../src";
+import { TEST_PUB_KEY, TEST_SERVER_PUB_KEY, TEST_DELEGATE_PUB_KEY } from "./contracts/helpers";
 import type { ArkInfo } from "../src/providers/ark";
 import type { Contract } from "../src/contracts/types";
 import { VHTLCContractHandler } from "../src/contracts/handlers/vhtlc";
@@ -84,11 +87,37 @@ const vtxoAt = (script: string, txid: string, value: number): ExtendedVirtualCoi
         virtualStatus: { state: "settled" },
     }) as unknown as ExtendedVirtualCoin;
 
+/** A wallet whose repository holds exactly one contract, funded with one VTXO. */
+async function walletHolding(contract: Contract, txidByte: string, value: number) {
+    const walletRepository = new InMemoryWalletRepository();
+    const contractRepository = new InMemoryContractRepository();
+
+    await contractRepository.saveContract(contract);
+    await saveVtxosForContract(walletRepository, contract, [
+        vtxoAt(contract.script, txidByte.repeat(64), value),
+    ]);
+
+    const identity = ReadonlySingleKey.fromPublicKey(
+        await SingleKey.fromHex(privKeyHex).compressedPublicKey(),
+    );
+    return ReadonlyWallet.create({
+        identity,
+        arkServerUrl: "http://localhost:7070",
+        arkProvider: {
+            getInfo: async () => arkInfo(),
+        } as Partial<ArkProvider> as ArkProvider,
+        indexerProvider: quietIndexer(),
+        // getBalance also sums boarding UTXOs; keep that side empty so the
+        // assertions below are about contract-type scope alone.
+        onchainProvider: {
+            getCoins: async () => [],
+        } as Partial<OnchainProvider> as OnchainProvider,
+        storage: { walletRepository, contractRepository },
+    });
+}
+
 describe("getBalance contract-type scope", () => {
     async function walletWithEscrow() {
-        const walletRepository = new InMemoryWalletRepository();
-        const contractRepository = new InMemoryContractRepository();
-
         const vhtlcScript = VHTLCContractHandler.createScript(vhtlcParams);
         const vhtlcContract: Contract = {
             type: "vhtlc",
@@ -98,29 +127,7 @@ describe("getBalance contract-type scope", () => {
             state: "active",
             createdAt: Date.now(),
         };
-        await contractRepository.saveContract(vhtlcContract);
-        await saveVtxosForContract(walletRepository, vhtlcContract, [
-            vtxoAt(vhtlcContract.script, "e".repeat(64), ESCROW_SATS),
-        ]);
-
-        const identity = ReadonlySingleKey.fromPublicKey(
-            await SingleKey.fromHex(privKeyHex).compressedPublicKey(),
-        );
-        const wallet = await ReadonlyWallet.create({
-            identity,
-            arkServerUrl: "http://localhost:7070",
-            arkProvider: {
-                getInfo: async () => arkInfo(),
-            } as Partial<ArkProvider> as ArkProvider,
-            indexerProvider: quietIndexer(),
-            // getBalance also sums boarding UTXOs; keep that side empty so the
-            // assertions below are about contract-type scope alone.
-            onchainProvider: {
-                getCoins: async () => [],
-            } as Partial<OnchainProvider> as OnchainProvider,
-            storage: { walletRepository, contractRepository },
-        });
-
+        const wallet = await walletHolding(vhtlcContract, "e", ESCROW_SATS);
         return { wallet, vhtlcContract };
     }
 
@@ -158,5 +165,84 @@ describe("getBalance contract-type scope", () => {
         expect(
             (await wallet.getVtxos({ type: ["vhtlc", "default"] })).map((v) => v.script),
         ).toEqual([vhtlcContract.script]);
+    });
+});
+
+/**
+ * Unlike `vhtlc`, an `arkade` contract is registrable today through public API
+ * (`ArkadeContract.register()`), so the `["default", "delegate"]` balance scope
+ * is an observable behavior change for it rather than a latent one.
+ *
+ * The intended behavior is exclusion, for the same reason as vhtlc: an arkade
+ * contract is program-gated, not unilaterally spendable by the wallet key, and
+ * it carries its own `ArkadeContract.getBalance()` for per-contract accounting.
+ * These tests pin that decision so it cannot be reverted silently.
+ */
+describe("getBalance contract-type scope - arkade program contracts", () => {
+    const ARKADE_SATS = 25_000;
+
+    /** Multisig + CSV-exit program — the "default vtxo" shape as a Program. */
+    const multisigProgram = {
+        version: 0,
+        params: ["server", "user"],
+        functions: {
+            cooperative: { tapscript: { signers: ["$user", "$server"] } },
+            exit: {
+                tapscript: {
+                    signers: ["$user"],
+                    csv: { type: "blocks", value: 144n },
+                },
+            },
+        },
+    } satisfies arkade.Program;
+
+    async function walletWithArkadeContract() {
+        const params = ArkadeContractHandler.serializeParams({
+            program: multisigProgram,
+            args: { user: TEST_PUB_KEY, server: TEST_SERVER_PUB_KEY },
+            serverKey: TEST_SERVER_PUB_KEY,
+            userKey: TEST_PUB_KEY,
+            emulatorKey: TEST_DELEGATE_PUB_KEY,
+        });
+        const script = ArkadeContractHandler.createScript(params);
+        const arkadeContract: Contract = {
+            type: "arkade",
+            params,
+            script: hex.encode(script.pkScript),
+            address: "ark1arkade-program",
+            state: "active",
+            createdAt: Date.now(),
+        };
+        const wallet = await walletHolding(arkadeContract, "a", ARKADE_SATS);
+        return { wallet, arkadeContract };
+    }
+
+    it("excludes a registered arkade contract from every balance bucket", async () => {
+        const { wallet } = await walletWithArkadeContract();
+
+        const balance = await wallet.getBalance();
+
+        expect(balance.total).toBe(0);
+        expect(balance.available).toBe(0);
+    });
+
+    it("still tracks the arkade VTXO through the unfiltered getVtxos()", async () => {
+        const { wallet, arkadeContract } = await walletWithArkadeContract();
+
+        const vtxos = await wallet.getVtxos();
+
+        // Registering is still meaningful: the contract is watched and its
+        // VTXOs remain readable — they just aren't wallet balance.
+        expect(vtxos.map((v) => v.script)).toContain(arkadeContract.script);
+        expect(vtxos.reduce((sum, v) => sum + v.value, 0)).toBe(ARKADE_SATS);
+    });
+
+    it("scopes getVtxos to the arkade type on request", async () => {
+        const { wallet, arkadeContract } = await walletWithArkadeContract();
+
+        expect(await wallet.getVtxos({ type: ["default", "delegate"] })).toEqual([]);
+        expect((await wallet.getVtxos({ type: "arkade" })).map((v) => v.script)).toEqual([
+            arkadeContract.script,
+        ]);
     });
 });

--- a/packages/ts-sdk/test/wallet-balance-contract-scope.test.ts
+++ b/packages/ts-sdk/test/wallet-balance-contract-scope.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+import {
+    ReadonlyWallet,
+    InMemoryWalletRepository,
+    InMemoryContractRepository,
+    type ArkProvider,
+    type IndexerProvider,
+    type OnchainProvider,
+    type ExtendedVirtualCoin,
+} from "../src";
+import type { ArkInfo } from "../src/providers/ark";
+import type { Contract } from "../src/contracts/types";
+import { VHTLCContractHandler } from "../src/contracts/handlers/vhtlc";
+import { saveVtxosForContract } from "../src/contracts/vtxoOwnership";
+import { timelockToSequence } from "../src/utils/timelock";
+import { ReadonlySingleKey, SingleKey } from "../src/identity/singleKey";
+
+/**
+ * `getBalance()` must count only the contracts the wallet owns outright.
+ * A `vhtlc` contract is escrow — the wallet is one of two parties on it and
+ * cannot spend it unilaterally — so its VTXOs are not spendable balance, even
+ * though they are legitimately tracked and must stay visible to `getVtxos()`.
+ */
+
+const serverKeyHex = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const privKeyHex = "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2";
+
+const arkInfo = (): ArkInfo => ({
+    boardingExitDelay: 144n,
+    checkpointTapscript:
+        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+    deprecatedSigners: [],
+    digest: "d",
+    dust: 1000n,
+    fees: { intentFee: {}, txFeeRate: "0" },
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    forfeitPubkey: serverKeyHex,
+    network: "mutinynet",
+    serviceStatus: {},
+    sessionDuration: 3600n,
+    signerPubkey: serverKeyHex,
+    unilateralExitDelay: 144n,
+    utxoMaxAmount: -1n,
+    utxoMinAmount: 0n,
+    version: "1",
+    vtxoMaxAmount: -1n,
+    vtxoMinAmount: 0n,
+});
+
+// The wallet reads VTXO state from the repository; the indexer only needs to
+// satisfy the watcher's subscription calls and report nothing new.
+const quietIndexer = () =>
+    ({
+        getVtxos: async () => ({ vtxos: [] }),
+        subscribeForScripts: async () => "sub-1",
+        unsubscribeForScripts: async () => undefined,
+        getSubscription: async function* () {},
+    }) as Partial<IndexerProvider> as IndexerProvider;
+
+const vhtlcParams = {
+    sender: "0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+    receiver: "1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+    server: "aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+    hash: "4d487dd3753a89bc9fe98401d1196523058251fc",
+    refundLocktime: "800000",
+    claimDelay: timelockToSequence({ type: "blocks", value: 17n }).toString(),
+    refundDelay: timelockToSequence({ type: "blocks", value: 144n }).toString(),
+    refundNoReceiverDelay: timelockToSequence({ type: "blocks", value: 144n }).toString(),
+};
+
+const ESCROW_SATS = 50_000;
+
+const vtxoAt = (script: string, txid: string, value: number): ExtendedVirtualCoin =>
+    ({
+        txid,
+        vout: 0,
+        value,
+        script,
+        status: { confirmed: true },
+        createdAt: new Date(),
+        isUnrolled: false,
+        isSpent: false,
+        virtualStatus: { state: "settled" },
+    }) as unknown as ExtendedVirtualCoin;
+
+describe("getBalance contract-type scope", () => {
+    async function walletWithEscrow() {
+        const walletRepository = new InMemoryWalletRepository();
+        const contractRepository = new InMemoryContractRepository();
+
+        const vhtlcScript = VHTLCContractHandler.createScript(vhtlcParams);
+        const vhtlcContract: Contract = {
+            type: "vhtlc",
+            params: vhtlcParams,
+            script: hex.encode(vhtlcScript.pkScript),
+            address: "ark1vhtlc-escrow",
+            state: "active",
+            createdAt: Date.now(),
+        };
+        await contractRepository.saveContract(vhtlcContract);
+        await saveVtxosForContract(walletRepository, vhtlcContract, [
+            vtxoAt(vhtlcContract.script, "e".repeat(64), ESCROW_SATS),
+        ]);
+
+        const identity = ReadonlySingleKey.fromPublicKey(
+            await SingleKey.fromHex(privKeyHex).compressedPublicKey(),
+        );
+        const wallet = await ReadonlyWallet.create({
+            identity,
+            arkServerUrl: "http://localhost:7070",
+            arkProvider: {
+                getInfo: async () => arkInfo(),
+            } as Partial<ArkProvider> as ArkProvider,
+            indexerProvider: quietIndexer(),
+            // getBalance also sums boarding UTXOs; keep that side empty so the
+            // assertions below are about contract-type scope alone.
+            onchainProvider: {
+                getCoins: async () => [],
+            } as Partial<OnchainProvider> as OnchainProvider,
+            storage: { walletRepository, contractRepository },
+        });
+
+        return { wallet, vhtlcContract };
+    }
+
+    it("excludes vhtlc escrow from every balance bucket", async () => {
+        const { wallet } = await walletWithEscrow();
+
+        const balance = await wallet.getBalance();
+
+        // Not merely absent from `available` — escrow must not leak into
+        // settled/preconfirmed/recoverable/total either.
+        expect(balance.total).toBe(0);
+        expect(balance.available).toBe(0);
+    });
+
+    it("still reports the escrow VTXO through the unfiltered getVtxos()", async () => {
+        const { wallet, vhtlcContract } = await walletWithEscrow();
+
+        const vtxos = await wallet.getVtxos();
+
+        // The exclusion is a balance-accounting decision, not a tracking one:
+        // recovery and inspection paths still need to see the escrow.
+        expect(vtxos.map((v) => v.script)).toContain(vhtlcContract.script);
+        expect(vtxos.reduce((sum, v) => sum + v.value, 0)).toBe(ESCROW_SATS);
+    });
+
+    it("scopes getVtxos to the requested contract type", async () => {
+        const { wallet, vhtlcContract } = await walletWithEscrow();
+
+        expect(await wallet.getVtxos({ type: ["default", "delegate"] })).toEqual([]);
+        expect((await wallet.getVtxos({ type: "vhtlc" })).map((v) => v.script)).toEqual([
+            vhtlcContract.script,
+        ]);
+        // An array is membership across the listed types, not an intersection
+        // and not just the first entry.
+        expect(
+            (await wallet.getVtxos({ type: ["vhtlc", "default"] })).map((v) => v.script),
+        ).toEqual([vhtlcContract.script]);
+    });
+});

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -1421,7 +1421,14 @@ describe("WalletMessageHandler repo-backed reads", () => {
             dustAmount: 546n,
             pendingRecoveryOutpoints: vi.fn().mockResolvedValue(new Set<string>()),
             getContractManager: vi.fn().mockResolvedValue({
-                getContracts: vi.fn().mockResolvedValue(contracts),
+                // Honors the `type` filter the way every real ContractRepository
+                // does. A mock that ignored it would hide exactly the bug this
+                // scoping exists to prevent.
+                getContracts: vi.fn().mockImplementation(async (filter?: any) => {
+                    if (!filter?.type) return contracts;
+                    const wanted = Array.isArray(filter.type) ? filter.type : [filter.type];
+                    return contracts.filter((c) => wanted.includes(c.type));
+                }),
                 onContractEvent: vi.fn().mockReturnValue(vi.fn()),
             }),
             onchainProvider: {
@@ -1612,10 +1619,10 @@ describe("WalletMessageHandler repo-backed reads", () => {
         expect(vtxos).toHaveLength(2);
     });
 
-    it("GET_BALANCE accounts for VTXOs from all contracts", async () => {
+    it("GET_BALANCE accounts for VTXOs from all wallet-owned contracts", async () => {
         const contracts = [
-            { address: "contract-1", script: "s1" },
-            { address: "contract-2", script: "s2" },
+            { address: "contract-1", script: "s1", type: "default" },
+            { address: "contract-2", script: "s2", type: "delegate" },
         ];
         setupHandler(contracts);
 
@@ -1671,6 +1678,113 @@ describe("WalletMessageHandler repo-backed reads", () => {
         // Should not appear twice
         const vtxos = (response as any).payload.vtxos;
         expect(vtxos).toHaveLength(1);
+    });
+
+    // The service worker is a second implementation of IWallet, and callers
+    // hold it interchangeably with the core Wallet. Balance scope and the
+    // getVtxos `type` filter must therefore behave identically in both, or the
+    // same call returns different answers depending on which one you got.
+    describe("contract-type scope parity with ReadonlyWallet", () => {
+        const scopedContracts = [
+            { address: "wallet-addr", script: "s-default", type: "default" },
+            { address: "escrow-addr", script: "s-vhtlc", type: "vhtlc" },
+        ];
+
+        const seedScopedVtxos = async () => {
+            await walletRepo.saveVtxos("wallet-addr", [
+                createMockExtendedVtxo({
+                    txid: "aa".repeat(32),
+                    value: 10000,
+                    virtualStatus: { state: "settled" },
+                    script: "s-default",
+                }),
+            ]);
+            await walletRepo.saveVtxos("escrow-addr", [
+                createMockExtendedVtxo({
+                    txid: "bb".repeat(32),
+                    value: 50000,
+                    virtualStatus: { state: "settled" },
+                    script: "s-vhtlc",
+                }),
+            ]);
+        };
+
+        it("GET_BALANCE excludes vhtlc escrow from every bucket", async () => {
+            setupHandler(scopedContracts);
+            await seedScopedVtxos();
+
+            const response = await updater.handleMessage({
+                ...baseMessage(),
+                type: "GET_BALANCE",
+            } as any);
+
+            // Only the 10000 default-contract VTXO. The 50000 escrow must not
+            // leak into settled/available/total.
+            expect(response).toMatchObject({
+                type: "BALANCE",
+                payload: { settled: 10000, available: 10000, total: 10000 },
+            });
+        });
+
+        it("GET_VTXOS still reports escrow when unscoped", async () => {
+            setupHandler(scopedContracts);
+            await seedScopedVtxos();
+
+            const response = await updater.handleMessage({
+                ...baseMessage(),
+                type: "GET_VTXOS",
+                payload: { filter: { withRecoverable: true } },
+            } as any);
+
+            const scripts = (response as any).payload.vtxos.map((v: any) => v.script);
+            expect(scripts).toContain("s-vhtlc");
+            expect(scripts).toContain("s-default");
+        });
+
+        it("GET_VTXOS honors filter.type rather than silently ignoring it", async () => {
+            setupHandler(scopedContracts);
+            await seedScopedVtxos();
+
+            const ask = async (type: string | string[]) => {
+                const response = await updater.handleMessage({
+                    ...baseMessage(),
+                    type: "GET_VTXOS",
+                    payload: { filter: { withRecoverable: true, type } },
+                } as any);
+                return (response as any).payload.vtxos.map((v: any) => v.script).sort();
+            };
+
+            expect(await ask("vhtlc")).toEqual(["s-vhtlc"]);
+            expect(await ask(["default", "delegate"])).toEqual(["s-default"]);
+            // Membership across the listed types, not an intersection.
+            expect(await ask(["default", "vhtlc"])).toEqual(["s-default", "s-vhtlc"]);
+        });
+
+        it("does not leak the wallet's primary-address bucket into a non-default scope", async () => {
+            // The primary-address bucket is read separately from the contract
+            // buckets, so it needs its own gate — otherwise a vhtlc-scoped read
+            // picks up the wallet's own outputs.
+            setupHandler(scopedContracts);
+            await seedScopedVtxos();
+            await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [
+                createMockExtendedVtxo({
+                    txid: "cc".repeat(32),
+                    value: 7000,
+                    virtualStatus: { state: "settled" },
+                    script: TEST_DEFAULT_SCRIPT,
+                }),
+            ]);
+
+            const response = await updater.handleMessage({
+                ...baseMessage(),
+                type: "GET_VTXOS",
+                payload: { filter: { withRecoverable: true, type: "vhtlc" } },
+            } as any);
+
+            const scripts = (response as any).payload.vtxos.map((v: any) => v.script);
+            expect(scripts).toEqual(["s-vhtlc"]);
+            expect(scripts).not.toContain(TEST_DEFAULT_SCRIPT);
+        });
     });
 
     it("finalizePendingTxs receives repo-backed VTXOs filtered by state", async () => {

--- a/packages/ts-sdk/test/wallet/utils.test.ts
+++ b/packages/ts-sdk/test/wallet/utils.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { hex } from "@scure/base";
 
 import type { Contract } from "../../src/contracts/types";
 import { contractHandlers } from "../../src/contracts/handlers";
+import { VHTLCContractHandler } from "../../src/contracts/handlers/vhtlc";
 import { extendVirtualCoinForContract, type ContractTapscriptCache } from "../../src/wallet/utils";
+import { timelockToSequence } from "../../src/utils/timelock";
 import {
     createDefaultContractParams,
     createDelegateContractParams,
     createMockVtxo,
+    testDefaultScript,
+    testDelegateScript,
     TEST_DEFAULT_SCRIPT,
     TEST_DELEGATE_SCRIPT,
 } from "../contracts/helpers";
@@ -25,6 +30,30 @@ const delegateContract: Contract = {
     params: createDelegateContractParams(),
     script: TEST_DELEGATE_SCRIPT,
     address: "ark1delegate",
+    state: "active",
+    createdAt: Date.now(),
+};
+
+// Same test keys/params shape used by test/contracts/handlers.test.ts's
+// VHTLCContractHandler suite.
+const vhtlcParams = {
+    sender: "0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+    receiver: "1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+    server: "aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+    hash: "4d487dd3753a89bc9fe98401d1196523058251fc",
+    refundLocktime: "800000",
+    claimDelay: timelockToSequence({ type: "blocks", value: 17n }).toString(),
+    refundDelay: timelockToSequence({ type: "blocks", value: 144n }).toString(),
+    refundNoReceiverDelay: timelockToSequence({ type: "blocks", value: 144n }).toString(),
+};
+const vhtlcScript = VHTLCContractHandler.createScript(vhtlcParams);
+const TEST_VHTLC_SCRIPT = hex.encode(vhtlcScript.pkScript);
+
+const vhtlcContract: Contract = {
+    type: "vhtlc",
+    params: vhtlcParams,
+    script: TEST_VHTLC_SCRIPT,
+    address: "ark1vhtlc",
     state: "active",
     createdAt: Date.now(),
 };
@@ -102,6 +131,83 @@ describe("extendVirtualCoinForContract", () => {
         const map = new Map<string, Contract>([[bogus.script, bogus]]);
 
         expect(() => extendVirtualCoinForContract(vtxo, map)).toThrow(/handler/);
+    });
+});
+
+describe("extendVirtualCoinForContract - vhtlc contracts (regression: VHTLC has no forfeit())", () => {
+    it("annotates a vhtlc-contract vtxo without throwing", () => {
+        // Before the fix, deriveContractTapscripts cast every contract's
+        // script to `DefaultVtxo.Script | DelegateVtxo.Script` and called
+        // `.forfeit()` on it unconditionally. VHTLC.Script has no `.forfeit()`,
+        // so this crashed with "script.forfeit is not a function" the moment a
+        // vhtlc contract's VTXO was registered and annotated by
+        // ContractWatcher.emitVtxoEvent / ContractManager.annotateVtxos —
+        // this is that exact crash path.
+        const vtxo = createMockVtxo({ script: TEST_VHTLC_SCRIPT });
+
+        expect(() => extendVirtualCoinForContract(vtxo, vhtlcContract)).not.toThrow();
+    });
+
+    it("returns a valid tapTree and structurally-valid forfeit/intent leaves", () => {
+        const vtxo = createMockVtxo({ script: TEST_VHTLC_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(vtxo, vhtlcContract);
+
+        expect(extended.tapTree).toEqual(vhtlcScript.encode());
+        expect(extended.forfeitTapLeafScript).toBeDefined();
+        expect(extended.intentTapLeafScript).toBeDefined();
+        // Structurally valid: one of the VHTLC script's own registered
+        // leaves (findLeaf would throw on a fabricated/unregistered script),
+        // not an empty or made-up placeholder.
+        expect(extended.forfeitTapLeafScript[1]).toEqual(vhtlcScript.claim()[1]);
+        expect(extended.intentTapLeafScript[1]).toEqual(vhtlcScript.claim()[1]);
+    });
+
+    it("resolves via map the same way as a direct Contract", () => {
+        const vtxo = createMockVtxo({ script: TEST_VHTLC_SCRIPT });
+        const map = new Map<string, Contract>([[vhtlcContract.script, vhtlcContract]]);
+
+        expect(() => extendVirtualCoinForContract(vtxo, map)).not.toThrow();
+    });
+});
+
+describe("extendVirtualCoinForContract - default/delegate/boarding stay forfeit-based (no regression)", () => {
+    it("default contract still returns the forfeit leaf", () => {
+        const vtxo = createMockVtxo({ script: TEST_DEFAULT_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(vtxo, defaultContract);
+
+        expect(extended.forfeitTapLeafScript).toEqual(testDefaultScript.forfeit());
+        expect(extended.intentTapLeafScript).toEqual(testDefaultScript.forfeit());
+        expect(extended.tapTree).toEqual(testDefaultScript.encode());
+    });
+
+    it("delegate contract still returns the forfeit leaf", () => {
+        const vtxo = createMockVtxo({ script: TEST_DELEGATE_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(vtxo, delegateContract);
+
+        expect(extended.forfeitTapLeafScript).toEqual(testDelegateScript.forfeit());
+        expect(extended.intentTapLeafScript).toEqual(testDelegateScript.forfeit());
+        expect(extended.tapTree).toEqual(testDelegateScript.encode());
+    });
+
+    it("boarding contract still returns the forfeit leaf (shares DefaultVtxo.Script)", () => {
+        const boardingContract: Contract = {
+            type: "boarding",
+            params: createDefaultContractParams(),
+            script: TEST_DEFAULT_SCRIPT,
+            address: "ark1boarding",
+            state: "active",
+            createdAt: Date.now(),
+        };
+        const vtxo = createMockVtxo({ script: TEST_DEFAULT_SCRIPT });
+
+        const extended = extendVirtualCoinForContract(vtxo, boardingContract);
+
+        expect(extended.forfeitTapLeafScript).toEqual(testDefaultScript.forfeit());
+        expect(extended.intentTapLeafScript).toEqual(testDefaultScript.forfeit());
+        expect(extended.tapTree).toEqual(testDefaultScript.encode());
     });
 });
 


### PR DESCRIPTION
Three related core issues that surface once a contract type the wallet doesn't own outright is registered with the `ContractManager`. The `vhtlc` crash has no trigger on `master` today, since nothing registers one yet. The balance-scope half does have a trigger: `arkade` contracts are registrable right now through public API — see §3.

### 1. Annotating a `vhtlc` contract crashes

`deriveContractTapscripts` casts every contract's script to `DefaultVtxo.Script | DelegateVtxo.Script` and calls `.forfeit()` on it. `VHTLC.Script` has no `.forfeit()`, so annotating a registered `vhtlc` contract's VTXO threw `script.forfeit is not a function` out of `ContractWatcher.emitVtxoEvent` / `ContractManager.annotateVtxos`.

Fixed by implementing the existing `TapscriptDeriving` capability on `VHTLCContractHandler` — the annotation pipeline already checks for it (that's how `arkade` program-compiled contracts are handled).

It returns `claim()` as both the forfeit and intent leaf. That choice is deliberate and documented in the handler: VHTLC has no single owner+server forfeit leaf, and since `Wallet.getVtxos()` / `ContractManager.getContractsWithVtxos()` don't filter by contract type, a live `vhtlc` VTXO is a candidate input to the generic settle/recover path — which never supplies a preimage witness. `claim()` makes any such accidental inclusion fail closed with an incomplete witness, rather than risking a leaf the wallet could fully sign.

### 2. Escrow counted as spendable balance

`getBalance()` summed `getVtxos()` across every contract type, so a `vhtlc` contract's VTXOs would be reported as spendable — funds the user can't actually spend unilaterally.

Adds an optional `type` scope to `GetVtxosFilter` (mirroring `ContractManager`'s existing `getContracts({type})` filter) and has `getBalance()` request only `default`/`delegate` — the same scope `getWalletScripts()` already uses for the wallet's own receiving addresses.

`getVtxos()` is unchanged for callers that want the full set: this is a balance-accounting decision, not a tracking one, and recovery/inspection paths still need to see escrow.

### 3. Behavior change: `arkade` contracts also leave wallet balance

The `["default", "delegate"]` scope excludes more than `vhtlc`. `arkade` is the other registered non-wallet type, and unlike `vhtlc` it is registrable today: `ArkadeContract.register()` is public API. So this is an **observable behavior change**, not a latent fix — a registered arkade contract's VTXOs stop counting toward `wallet.getBalance()`.

That exclusion is intended, for the same reason as escrow: an arkade contract is program-gated rather than unilaterally spendable by the wallet key, and `ArkadeContract.getBalance()` already exists for per-contract accounting. Registration still means everything else it meant — repository persistence, watcher events, visibility to `wallet.getVtxos()` and transaction history.

Both docstrings that promised the old behavior (`ArkadeContract.register()` and `ArkadeContractHandler`) said registration made a contract "counted in repository-backed balances". Corrected, and the decision is pinned by tests so it can't flip back unnoticed.

### 4. Service worker parity

`ServiceWorkerWallet` is a second implementation of `IWallet` and callers hold the two interchangeably, so the scope had to land in both or the same call would return different answers depending on which one you got.

`handleGetBalance` read via `getVtxosFromRepo()`, which queried `manager.getContracts()` unfiltered — so escrow still counted as spendable balance there, while the comment above that read claimed the two implementations agree. `handleGetVtxos` separately dropped the new `filter.type` (the wire type is already `GetVtxosFilter` and the client forwards it; only the handler discarded it).

`getVtxosFromRepo()` now takes a contract-type scope. One subtlety: it reads the wallet's primary-address bucket separately from the contract buckets as a legacy-row safety net, so that bucket needs its own gate — it's the wallet's own `default` contract and must not appear in, say, a `type: "vhtlc"` read. The other three call sites (transaction history, pending-tx recovery, cache refresh) stay unscoped, matching core, where `getTransactionHistory()` and `pendingRecoveryOutpoints()` also use an unscoped `getContractsWithVtxos()`.

`ExpoWallet` needed no change — its `getBalance`/`getVtxos` are one-line delegations to the core `Wallet`.

### Tests

- 4 regression tests pinning the annotation crash path, plus coverage that `default`/`delegate`/`boarding` stay forfeit-based.
- 3 tests for the vhtlc balance scope: escrow excluded from every balance bucket, still visible through unfiltered `getVtxos()`, and `type` filtering both ways. Verified these fail against `master` (escrow reads as 50,000 spendable sats).
- 3 tests pinning the arkade decision: excluded from balance, still tracked by `getVtxos()`, scopeable by type. The pair is self-validating — one asserts the VTXO is present and worth 25,000, so the `total: 0` assertion can't pass vacuously.
- 4 service worker parity tests, including the primary-address leak. Verified 3 of the 4 fail with the source fix stashed; the fourth is a non-regression guard that correctly passes either way. The shared `setupHandler` mock now honors the `type` filter the way every real `ContractRepository` does — a mock that ignored it would have hidden this bug.

Full `ts-sdk` suite green (2147), `boltz-swap` unaffected (487).

### Known gap, not addressed here — tracked in #657

Balance is now scoped, but coin selection is not: `sendBitcoin` uses `getVtxos({ withRecoverable: false })` and `settle` uses `getVtxos({ withRecoverable: true })`, both unscoped by type, as do `VtxoManager`'s auto-renewal and `recoverVtxos()`. So a `vhtlc` or `arkade` VTXO can still be selected as an input despite never appearing in balance.

For `vhtlc` the `claim()` leaf in §1 makes that fail closed — but round-wide, not per-input: one escrow input fails the entire settlement, which would block auto-renewal of the wallet's own funds. For `arkade` the derived leaf is the *collaborative* one, explicitly chosen to mirror `forfeit()`, so it may sign fully rather than fail closed. Scoping the selection paths is a larger semantic change with open sub-decisions, so it is tracked separately in #657.

---

Extracted from #612, which is where the first two bugs were found. That PR stays open and will rebase onto these.
