### PR TITLE
fix(wallet): batch getTransactionHistory's createdAt lookups

### DIFF
--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -1191,17 +1191,74 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
         const { boardingTxs, commitmentsToIgnore } = await this.getBoardingTxs();
 
-        const getTxCreatedAt = (txid: string) =>
-            getNormalizedVtxos(this.indexerProvider, { outpoints: [{ txid, vout: 0 }] })
-                .then((res) => res.vtxos[0]?.createdAt.getTime())
-                // Best-effort createdAt enrichment: when the indexer is
-                // unavailable, leave it undefined (history still builds from
-                // repository VTXOs) rather than failing the whole read. Terminal
-                // failures still propagate.
-                .catch((err) => {
-                    if (isRetryableProviderError(err)) return undefined;
-                    throw err;
-                });
+        // Timestamps we already hold, earliest per txid so history ordering is
+        // stable. Free: no indexer round trip.
+        const vtxoCreatedAt = new Map<string, number>();
+        for (const vtxo of allVtxos) {
+            const existing = vtxoCreatedAt.get(vtxo.txid);
+            const ts = vtxo.createdAt.getTime();
+            if (existing === undefined || ts < existing) {
+                vtxoCreatedAt.set(vtxo.txid, ts);
+            }
+        }
+
+        // Pre-fetch whatever is left in BATCHED indexer calls.
+        // buildTransactionHistory needs these for spent offchain virtual outputs
+        // with no change output (arkTxId set, but no virtual output has
+        // txid === arkTxId).
+        //
+        // This used to be one indexer request per txid, and because
+        // buildTransactionHistory awaits getTxCreatedAt inside its per-VTXO
+        // loop, they ran strictly sequentially and repeated for every VTXO
+        // sharing an arkTxId. MEASURED in a browser HAR against mutinynet: 348
+        // single-outpoint requests covering only 123 distinct txids — 92% of the
+        // page's total traffic — at a median 181ms each, 23.9s in one burst.
+        // Cost grew linearly with wallet history, so a large wallet could exceed
+        // a caller's timeout and fail the read outright.
+        //
+        // The service-worker path (WalletMessageHandler.getTransactionHistory)
+        // has always batched this; that implementation is mirrored here.
+        const knownTxids = new Set(allVtxos.map((v) => v.txid));
+        const uncachedTxids = new Set<string>();
+        for (const vtxo of allVtxos) {
+            if (
+                vtxo.isSpent &&
+                vtxo.arkTxId &&
+                !vtxoCreatedAt.has(vtxo.arkTxId) &&
+                !knownTxids.has(vtxo.arkTxId)
+            ) {
+                uncachedTxids.add(vtxo.arkTxId);
+            }
+        }
+
+        if (uncachedTxids.size > 0) {
+            const outpoints = [...uncachedTxids].map((txid) => ({ txid, vout: 0 }));
+            // Same size the service-worker path uses. Outpoints cost about what
+            // scripts do in the query string, so this spends nearly the whole URL
+            // budget SCRIPT_QUERY_CHUNK_SIZE leaves unspent; lower it to the
+            // shared constant if this ever 414s.
+            const BATCH_SIZE = 100;
+            for (let i = 0; i < outpoints.length; i += BATCH_SIZE) {
+                try {
+                    const res = await getNormalizedVtxos(this.indexerProvider, {
+                        outpoints: outpoints.slice(i, i + BATCH_SIZE),
+                    });
+                    for (const v of res.vtxos) {
+                        vtxoCreatedAt.set(v.txid, v.createdAt.getTime());
+                    }
+                } catch (err) {
+                    // Best-effort createdAt enrichment, unchanged in spirit from
+                    // the per-txid version: when the indexer is unavailable leave
+                    // these undefined (history still builds from repository
+                    // VTXOs) rather than failing the whole read. Terminal
+                    // failures still propagate.
+                    if (!isRetryableProviderError(err)) throw err;
+                }
+            }
+        }
+
+        const getTxCreatedAt = async (txid: string): Promise<number | undefined> =>
+            vtxoCreatedAt.get(txid);
 
         return buildTransactionHistory(allVtxos, boardingTxs, commitmentsToIgnore, getTxCreatedAt);
     }

--- a/packages/ts-sdk/test/wallet/transactionHistoryBatching.test.ts
+++ b/packages/ts-sdk/test/wallet/transactionHistoryBatching.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+    makeStaticWalletForTest,
+    installRestoreHarness,
+    teardownRestoreHarness,
+} from "../helpers/restoreWallet";
+import { FetchError } from "../../src/utils/fetch";
+
+/**
+ * `Wallet.getTransactionHistory()` must ask the indexer for missing `createdAt`
+ * timestamps in BATCHES, not one request per transaction.
+ *
+ * It previously did one request per txid, and because `buildTransactionHistory`
+ * awaits `getTxCreatedAt` inside its per-VTXO loop those ran strictly
+ * sequentially — and repeated for every VTXO sharing an `arkTxId`. MEASURED in a
+ * browser HAR against mutinynet: 348 single-outpoint requests covering only 123
+ * distinct txids, 92% of the page's total traffic, median 181ms each, 23.9s in
+ * one burst. Cost grew linearly with wallet history, so a large wallet could
+ * exceed a caller's timeout and fail the read outright.
+ *
+ * The service-worker path (`WalletMessageHandler.getTransactionHistory`) has
+ * always batched this; these tests pin the same behaviour on the plain `Wallet`.
+ */
+
+/** A spent virtual output whose arkTxId is NOT among the wallet's own vtxos, so
+ *  its createdAt has to be fetched — exactly the case that hit the indexer. */
+function spentVtxo(txid: string, arkTxId: string, createdAtMs = 1_700_000_000_000) {
+    return {
+        txid,
+        vout: 0,
+        value: 1000,
+        createdAt: new Date(createdAtMs),
+        isSpent: true,
+        arkTxId,
+        virtualStatus: { state: "settled", commitmentTxIds: ["c".repeat(64)] },
+        status: { isLeaf: false, confirmed: true },
+        settledBy: undefined,
+    };
+}
+
+const hex64 = (n: number, fill = "a") => String(n).padStart(64, fill);
+
+describe("Wallet.getTransactionHistory batches createdAt lookups", () => {
+    beforeEach(() => installRestoreHarness());
+    afterEach(() => teardownRestoreHarness());
+
+    /** Point the wallet at a fixed vtxo set and neutralise boarding. */
+    async function walletOver(vtxos: unknown[]) {
+        const handle = await makeStaticWalletForTest();
+        const w = handle.wallet as unknown as Record<string, unknown>;
+        vi.spyOn(w as never, "getContractManager" as never).mockResolvedValue({
+            getContractsWithVtxos: async () => [{ vtxos }],
+        } as never);
+        vi.spyOn(w as never, "getBoardingTxs" as never).mockResolvedValue({
+            boardingTxs: [],
+            commitmentsToIgnore: new Set<string>(),
+        } as never);
+        return handle;
+    }
+
+    it("issues ONE indexer request for many distinct txids, not one each", async () => {
+        // 30 vtxos, 30 distinct arkTxIds needing a timestamp.
+        const vtxos = Array.from({ length: 30 }, (_v, i) =>
+            spentVtxo(hex64(i, "a"), hex64(i, "b")),
+        );
+        const { wallet, indexer } = await walletOver(vtxos);
+        const spy = vi.spyOn(indexer, "getVtxos");
+        spy.mockClear();
+
+        await wallet.getTransactionHistory();
+
+        const outpointCalls = spy.mock.calls.filter(([opts]) =>
+            Array.isArray((opts as { outpoints?: unknown[] })?.outpoints),
+        );
+        // Pre-fix: 30 separate requests. Now: one, carrying all 30.
+        expect(outpointCalls).toHaveLength(1);
+        expect((outpointCalls[0][0] as { outpoints: unknown[] }).outpoints).toHaveLength(30);
+    });
+
+    it("does not re-request a txid shared by several vtxos", async () => {
+        // Five vtxos, ONE shared arkTxId — the source of the ~2.8x duplication.
+        const shared = hex64(0, "b");
+        const vtxos = Array.from({ length: 5 }, (_v, i) => spentVtxo(hex64(i, "a"), shared));
+        const { wallet, indexer } = await walletOver(vtxos);
+        const spy = vi.spyOn(indexer, "getVtxos");
+        spy.mockClear();
+
+        await wallet.getTransactionHistory();
+
+        const outpointCalls = spy.mock.calls.filter(([opts]) =>
+            Array.isArray((opts as { outpoints?: unknown[] })?.outpoints),
+        );
+        expect(outpointCalls).toHaveLength(1);
+        expect((outpointCalls[0][0] as { outpoints: unknown[] }).outpoints).toHaveLength(1);
+    });
+
+    it("chunks beyond the batch size instead of sending one giant query", async () => {
+        // 205 distinct txids at BATCH_SIZE 100 -> 100 / 100 / 5.
+        const vtxos = Array.from({ length: 205 }, (_v, i) =>
+            spentVtxo(hex64(i, "a"), hex64(i, "b")),
+        );
+        const { wallet, indexer } = await walletOver(vtxos);
+        const spy = vi.spyOn(indexer, "getVtxos");
+        spy.mockClear();
+
+        await wallet.getTransactionHistory();
+
+        const sizes = spy.mock.calls
+            .map(([opts]) => (opts as { outpoints?: unknown[] })?.outpoints)
+            .filter(Array.isArray)
+            .map((o) => o.length);
+        expect(sizes).toEqual([100, 100, 5]);
+    });
+
+    it("asks for nothing when every timestamp is already known locally", async () => {
+        // arkTxId matches a vtxo the wallet already holds, so no fetch is needed.
+        const a = hex64(1, "a");
+        const vtxos = [spentVtxo(a, a)];
+        const { wallet, indexer } = await walletOver(vtxos);
+        const spy = vi.spyOn(indexer, "getVtxos");
+        spy.mockClear();
+
+        await wallet.getTransactionHistory();
+
+        const outpointCalls = spy.mock.calls.filter(([opts]) =>
+            Array.isArray((opts as { outpoints?: unknown[] })?.outpoints),
+        );
+        expect(outpointCalls).toHaveLength(0);
+    });
+
+    it("still builds history when the indexer batch fails retryably", async () => {
+        const vtxos = [spentVtxo(hex64(1, "a"), hex64(1, "b"))];
+        const { wallet, indexer } = await walletOver(vtxos);
+        // A genuine FetchError, which isRetryableProviderError recognises — an
+        // ad-hoc Error with the same `name` does NOT, so the fixture has to be
+        // the real type or this test proves nothing.
+        vi.spyOn(indexer, "getVtxos").mockRejectedValue(
+            new FetchError("fetch failed", { url: "http://localhost:7070" }),
+        );
+
+        // Best-effort enrichment: an unavailable indexer must not fail the read.
+        await expect(wallet.getTransactionHistory()).resolves.toBeInstanceOf(Array);
+    });
+});


### PR DESCRIPTION
`Wallet.getTransactionHistory()` asks the indexer for one outpoint at a time. Because `buildTransactionHistory` awaits `getTxCreatedAt` **inside** its per-VTXO loop, those requests run strictly sequentially — and repeat for every VTXO sharing an `arkTxId`.

## Measured

From a browser HAR against mutinynet, a wallet with roughly 120 transactions opening an activity view:

| | |
|---|---|
| `/v1/indexer/vtxos` requests | **379** — 92% of the page's total traffic |
| carrying exactly **one** outpoint | **348** |
| distinct txids behind those 348 | **123** → ~2.8x duplication |
| per request | median 181ms, p90 210ms, max 1,830ms |
| total | **23.9s**, one sequential burst |

Because nothing runs concurrently, coalescing in-flight requests cannot help here — only knowing the txids up front can.

## Why this is more than a latency issue

Cost grows linearly with wallet history. The application that reported it bounds the read with a 60s timeout, so once a wallet's history is roughly 2.5x this size the call exceeds it and the history view fails outright — and stays failed, worsening with every transaction. Heaviest users hit it first.

## The fix

`WalletMessageHandler.getTransactionHistory` (the service-worker path) has always batched this. That implementation is mirrored into `Wallet`:

- fill timestamps from the VTXOs already in hand — earliest per txid, so ordering stays stable — which needs no network at all;
- collect only the spent `arkTxId`s that remain unknown;
- fetch those in chunks of `BATCH_SIZE = 100`, the same size the service-worker path uses;
- `getTxCreatedAt` becomes a map lookup.

Two deliberate differences from the mirrored version:

- **Retryable-error tolerance is preserved.** The per-txid version tolerated an unavailable indexer by leaving `createdAt` undefined so history still built from repository VTXOs; the service-worker version has no such catch. Keeping it means the batch path degrades the same way it always did, and terminal failures still propagate.
- **`knownTxids` is a `Set`,** so the "is this `arkTxId` one of our own VTXOs?" check is O(1). A literal port would leave an O(n²) scan, which matters precisely on the large wallets this fix targets.

## Tests

Five, in `test/wallet/transactionHistoryBatching.test.ts`. Two are **discriminating** regression guards — verified by reverting the source change and re-running, where they fail with:

```
expected [ …(30) ] to have a length of 1 but got 30
expected [ Array(205) ] to deeply equal [ 100, 100, 5 ]
```

The other three pin behaviour that already held and would otherwise be easy to regress: no re-request for a txid shared by several VTXOs, no request at all when every timestamp is known locally, and history still building when the indexer batch fails retryably (using a real `FetchError`, since an ad-hoc `Error` with the same `name` is not what `isRetryableProviderError` accepts).

## Verification

Rebased onto current `master` (`df02985e`) and re-run there, not just on the base I started from:

- `tsc --noEmit` clean
- `pnpm -r lint` clean — prettier, `virtualStatus` guard, provider-boundary guard
- `packages/ts-sdk`: **149 files / 2198 tests** passed, 1 skipped
- `packages/boltz-swap`: **21 files / 525 tests** passed

## Not verified

The end-to-end reduction against a live indexer. The tests prove the request shape and count; confirming the real-world win wants a fresh HAR after this ships, where the same page should drop from ~379 requests to under 40.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved transaction history loading by reducing the number of network requests needed to retrieve transaction timestamps.
  * Added batching for large transaction histories to support more efficient loading.

* **Reliability**
  * Transaction history remains available when retryable timestamp lookup requests fail.

* **Tests**
  * Added coverage for batching, deduplication, request limits, locally available timestamps, and retryable failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->