### PR TITLE
perf(history): batch tx-time indexer reads

### DIFF
--- a/packages/ts-sdk/src/contracts/constants.ts
+++ b/packages/ts-sdk/src/contracts/constants.ts
@@ -27,3 +27,10 @@ export const DEFAULT_PAGE_SIZE = 500;
  * onto different budgets for the same URL constraint.
  */
 export const SCRIPT_QUERY_CHUNK_SIZE = 32;
+
+/**
+ * Maximum outpoints per `getVtxos` query string. ~79 encoded bytes each, so 64
+ * is ~5 KB — real margin under the common 8 KB request-line ceiling, against
+ * the same unpublished `arkd` limit that budgets scripts at 32.
+ */
+export const OUTPOINT_QUERY_CHUNK_SIZE = 64;

--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -68,9 +68,12 @@ function subtractAssets(spent: VirtualCoin[], change: VirtualCoin[]): Asset[] | 
  * spending tx left no change output in the wallet. Exactly the loop's fetch set.
  */
 function collectArkTxidsNeedingCreatedAt(vtxos: NormalizedVirtualCoin[]): string[] {
+    // Set, not a scan per vtxo: this runs over the whole history, and the wallets
+    // that need the batching are the ones large enough for O(n²) to hurt.
+    const ownTxids = new Set(vtxos.map((v) => v.txid));
     const txids = new Set<string>();
     for (const vtxo of vtxos) {
-        if (vtxo.isSpent && vtxo.arkTxId && !vtxos.some((v) => v.txid === vtxo.arkTxId)) {
+        if (vtxo.isSpent && vtxo.arkTxId && !ownTxids.has(vtxo.arkTxId)) {
             txids.add(vtxo.arkTxId);
         }
     }

--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -64,23 +64,47 @@ function subtractAssets(spent: VirtualCoin[], change: VirtualCoin[]): Asset[] | 
 }
 
 /**
+ * Ark txids the main loop needs a `createdAt` for: spent virtual outputs whose
+ * spending tx left no change output in the wallet. Exactly the loop's fetch set.
+ */
+function collectArkTxidsNeedingCreatedAt(vtxos: VirtualCoin[]): string[] {
+    const txids = new Set<string>();
+    for (const vtxo of vtxos) {
+        if (vtxo.isSpent && vtxo.arkTxId && !vtxos.some((v) => v.txid === vtxo.arkTxId)) {
+            txids.add(vtxo.arkTxId);
+        }
+    }
+    return [...txids];
+}
+
+/**
  * Builds the transaction history by analyzing virtual outputs, boarding transactions, and ignored commitments.
  * History is sorted from newest to oldest and is composed only of SENT and RECEIVED transactions.
  *
  * @param {VirtualCoin[]} vtxos - An array of virtual outputs representing the user's transactions and balances.
  * @param {ArkTransaction[]} allBoardingTxs - An array of boarding transactions to include in the history.
  * @param {Set<string>} commitmentsToIgnore - A set of commitment IDs that should be excluded from processing.
+ * @param resolveTxCreatedAt - Batched `createdAt` resolver, called at most once; missing txids
+ * fall back to the spent output's `createdAt + 1`.
  * @return {ExtendedArkTransaction[]} A sorted array of extended Arkade transactions, representing the transaction history.
  */
 export async function buildTransactionHistory(
     vtxos: VirtualCoin[],
     allBoardingTxs: ArkTransaction[],
     commitmentsToIgnore: Set<string>,
-    getTxCreatedAt?: (txid: string) => Promise<number | undefined>,
+    resolveTxCreatedAt?: (txids: string[]) => Promise<Map<string, number>>,
 ): Promise<ExtendedArkTransaction[]> {
     const fromOldestVtxo = vtxos
         .map(normalizeVtxo)
         .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+    const txidsNeedingCreatedAt = resolveTxCreatedAt
+        ? collectArkTxidsNeedingCreatedAt(fromOldestVtxo)
+        : [];
+    const resolvedCreatedAt =
+        txidsNeedingCreatedAt.length > 0
+            ? await resolveTxCreatedAt!(txidsNeedingCreatedAt)
+            : new Map<string, number>();
     const unmatchedSettledBoardingTxs = allBoardingTxs
         .filter(isSettledBoardingReceive)
         .sort((a, b) => a.createdAt - b.createdAt);
@@ -166,10 +190,7 @@ export async function buildTransactionHistory(
                     txTime = changes[0].createdAt.getTime();
                 } else {
                     txAmount = spentAmount;
-                    // TODO: fetch the virtual output with /v1/indexer/vtxos?outpoints=<vtxo.arkTxid:0> to know when the tx was made
-                    txTime = getTxCreatedAt
-                        ? ((await getTxCreatedAt(vtxo.arkTxId!)) ?? vtxo.createdAt.getTime() + 1)
-                        : vtxo.createdAt.getTime() + 1;
+                    txTime = resolvedCreatedAt.get(vtxo.arkTxId) ?? vtxo.createdAt.getTime() + 1;
                 }
 
                 const assets = subtractAssets(allSpent, changes);

--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -1,5 +1,5 @@
 import { ArkTransaction, Asset, TxKey, TxType, VirtualCoin } from "../wallet";
-import { normalizeVtxo } from "../wallet/vtxo";
+import { normalizeVtxo, type NormalizedVirtualCoin } from "../wallet/vtxo";
 
 type ExtendedArkTransaction = ArkTransaction & {
     tag: "offchain" | "boarding" | "exit" | "batch";
@@ -67,7 +67,7 @@ function subtractAssets(spent: VirtualCoin[], change: VirtualCoin[]): Asset[] | 
  * Ark txids the main loop needs a `createdAt` for: spent virtual outputs whose
  * spending tx left no change output in the wallet. Exactly the loop's fetch set.
  */
-function collectArkTxidsNeedingCreatedAt(vtxos: VirtualCoin[]): string[] {
+function collectArkTxidsNeedingCreatedAt(vtxos: NormalizedVirtualCoin[]): string[] {
     const txids = new Set<string>();
     for (const vtxo of vtxos) {
         if (vtxo.isSpent && vtxo.arkTxId && !vtxos.some((v) => v.txid === vtxo.arkTxId)) {
@@ -102,8 +102,8 @@ export async function buildTransactionHistory(
         ? collectArkTxidsNeedingCreatedAt(fromOldestVtxo)
         : [];
     const resolvedCreatedAt =
-        txidsNeedingCreatedAt.length > 0
-            ? await resolveTxCreatedAt!(txidsNeedingCreatedAt)
+        resolveTxCreatedAt && txidsNeedingCreatedAt.length > 0
+            ? await resolveTxCreatedAt(txidsNeedingCreatedAt)
             : new Map<string, number>();
     const unmatchedSettledBoardingTxs = allBoardingTxs
         .filter(isSettledBoardingReceive)

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -38,7 +38,7 @@ import { DelegateInfo } from "../../providers/delegate";
 import {
     canRecoverOnchain,
     canSpendOffchain,
-    getNormalizedVtxos,
+    fetchVtxoCreatedAtByTxid,
     hasTerminalSpend,
     type NormalizedExtendedVirtualCoin,
 } from "../vtxo";
@@ -1820,8 +1820,8 @@ export class WalletMessageHandler
     }
 
     /**
-     * Build transaction history from cached virtual outputs without hitting the indexer.
-     * Falls back to indexer only for uncached transaction timestamps.
+     * Build transaction history from cached virtual outputs, hitting the indexer only for
+     * uncached timestamps. Best-effort, like the plain Wallet path.
      */
     private async buildTransactionHistoryFromCache(
         vtxos: ExtendedVirtualCoin[],
@@ -1830,61 +1830,12 @@ export class WalletMessageHandler
 
         const { boardingTxs, commitmentsToIgnore } = await this.readonlyWallet.getBoardingTxs();
 
-        // Build a lookup for cached virtual output timestamps, keyed by txid.
-        // Multiple virtual outputs can share a txid (different vouts) — we keep the
-        // earliest createdAt so the history ordering is stable.
-        const vtxoCreatedAt = new Map<string, number>();
-        for (const vtxo of vtxos) {
-            const existing = vtxoCreatedAt.get(vtxo.txid);
-            const ts = vtxo.createdAt.getTime();
-            if (existing === undefined || ts < existing) {
-                vtxoCreatedAt.set(vtxo.txid, ts);
-            }
-        }
+        const indexerProvider = this.indexerProvider;
+        const resolveTxCreatedAt = indexerProvider
+            ? (txids: string[]) => fetchVtxoCreatedAtByTxid(indexerProvider, txids)
+            : undefined;
 
-        // Pre-fetch uncached timestamps in a single batched indexer call.
-        // buildTransactionHistory needs these for spent-offchain virtual outputs with
-        // no change outputs (i.e. arkTxId is set but no virtual output has txid === arkTxId).
-        if (this.indexerProvider) {
-            const uncachedTxids = new Set<string>();
-            for (const vtxo of vtxos) {
-                if (
-                    vtxo.isSpent &&
-                    vtxo.arkTxId &&
-                    !vtxoCreatedAt.has(vtxo.arkTxId) &&
-                    !vtxos.some((v) => v.txid === vtxo.arkTxId)
-                ) {
-                    uncachedTxids.add(vtxo.arkTxId);
-                }
-            }
-
-            if (uncachedTxids.size > 0) {
-                const outpoints = [...uncachedTxids].map((txid) => ({
-                    txid,
-                    vout: 0,
-                }));
-                // Outpoints cost about what scripts do in the query string, so
-                // this spends nearly the whole URL budget that
-                // SCRIPT_QUERY_CHUNK_SIZE leaves unspent. Left as-is because
-                // this path has never 414'd; lower it to the shared constant if
-                // it ever does.
-                const BATCH_SIZE = 100;
-                for (let i = 0; i < outpoints.length; i += BATCH_SIZE) {
-                    const res = await getNormalizedVtxos(this.indexerProvider, {
-                        outpoints: outpoints.slice(i, i + BATCH_SIZE),
-                    });
-                    for (const v of res.vtxos) {
-                        vtxoCreatedAt.set(v.txid, v.createdAt.getTime());
-                    }
-                }
-            }
-        }
-
-        const getTxCreatedAt = async (txid: string): Promise<number | undefined> => {
-            return vtxoCreatedAt.get(txid);
-        };
-
-        return buildTransactionHistory(vtxos, boardingTxs, commitmentsToIgnore, getTxCreatedAt);
+        return buildTransactionHistory(vtxos, boardingTxs, commitmentsToIgnore, resolveTxCreatedAt);
     }
 
     private async ensureContractEventBroadcasting() {

--- a/packages/ts-sdk/src/wallet/vtxo.ts
+++ b/packages/ts-sdk/src/wallet/vtxo.ts
@@ -1,4 +1,9 @@
-import { DEFAULT_PAGE_SIZE, SCRIPT_QUERY_CHUNK_SIZE } from "../contracts/constants";
+import {
+    DEFAULT_PAGE_SIZE,
+    OUTPOINT_QUERY_CHUNK_SIZE,
+    SCRIPT_QUERY_CHUNK_SIZE,
+} from "../contracts/constants";
+import { isRetryableProviderError } from "../providers/availability";
 import type { GetVtxosOptions, IndexerProvider, PageResponse, Vtxo } from "../providers/indexer";
 import type { OnchainProvider } from "../providers/onchain";
 import type { ExtendedVirtualCoin, VirtualCoin, VirtualStatus } from "./index";
@@ -287,6 +292,38 @@ export async function getAllNormalizedVtxos(
     }
 
     return all;
+}
+
+/**
+ * Resolve `createdAt` (epoch ms) for txids by querying each txid's output 0 as a virtual
+ * outpoint, chunked at {@link OUTPOINT_QUERY_CHUNK_SIZE}. `pageSize` is explicit because the
+ * provider omits `page.size` when unset and a server default below the chunk size would
+ * silently short-page. Best-effort: a retryable failure drops its chunk and leaves the map
+ * partial; terminal errors propagate.
+ */
+export async function fetchVtxoCreatedAtByTxid(
+    provider: Pick<IndexerProvider, "getVtxos">,
+    txids: string[],
+): Promise<Map<string, number>> {
+    const unique = [...new Set(txids)].filter((txid) => txid !== "");
+    const createdAt = new Map<string, number>();
+
+    for (let i = 0; i < unique.length; i += OUTPOINT_QUERY_CHUNK_SIZE) {
+        const chunk = unique.slice(i, i + OUTPOINT_QUERY_CHUNK_SIZE);
+        try {
+            const { vtxos } = await getNormalizedVtxos(provider, {
+                outpoints: chunk.map((txid) => ({ txid, vout: 0 })),
+                pageSize: DEFAULT_PAGE_SIZE,
+            });
+            for (const v of vtxos) {
+                createdAt.set(v.txid, v.createdAt.getTime());
+            }
+        } catch (err) {
+            if (!isRetryableProviderError(err)) throw err;
+        }
+    }
+
+    return createdAt;
 }
 
 // --- capabilities ------------------------------------------------------------------------------

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -26,6 +26,7 @@ import { Identity, ReadonlyIdentity, isBatchSignable } from "../identity";
 import {
     canRecoverOnchain,
     canSpendOffchain,
+    fetchVtxoCreatedAtByTxid,
     getAllNormalizedVtxos,
     getNormalizedVtxos,
     hasTerminalSpend,
@@ -105,7 +106,6 @@ import {
 } from "./exit/capture";
 import { createExitChainResolver, ExitDataSource } from "./exit/resolver";
 import { ArkError, type ProviderKind } from "../providers/errors";
-import { isRetryableProviderError } from "../providers/availability";
 import {
     resolveArkInfo,
     saveValidatedArkInfoSnapshot,
@@ -1191,19 +1191,17 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
         const { boardingTxs, commitmentsToIgnore } = await this.getBoardingTxs();
 
-        const getTxCreatedAt = (txid: string) =>
-            getNormalizedVtxos(this.indexerProvider, { outpoints: [{ txid, vout: 0 }] })
-                .then((res) => res.vtxos[0]?.createdAt.getTime())
-                // Best-effort createdAt enrichment: when the indexer is
-                // unavailable, leave it undefined (history still builds from
-                // repository VTXOs) rather than failing the whole read. Terminal
-                // failures still propagate.
-                .catch((err) => {
-                    if (isRetryableProviderError(err)) return undefined;
-                    throw err;
-                });
+        // Best-effort: a retryable indexer failure yields a partial map, not a
+        // failed read; terminal failures still propagate.
+        const resolveTxCreatedAt = (txids: string[]) =>
+            fetchVtxoCreatedAtByTxid(this.indexerProvider, txids);
 
-        return buildTransactionHistory(allVtxos, boardingTxs, commitmentsToIgnore, getTxCreatedAt);
+        return buildTransactionHistory(
+            allVtxos,
+            boardingTxs,
+            commitmentsToIgnore,
+            resolveTxCreatedAt,
+        );
     }
 
     /**

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import transactionHistory from "./fixtures/transaction_history.json";
 import { VirtualCoin, TxType, ArkTransaction } from "../src/wallet";
 import { buildTransactionHistory } from "../src/utils/transactionHistory";
@@ -1007,6 +1007,97 @@ describe("buildTransactionHistory", () => {
         });
     });
 
+    describe("batched createdAt resolver", () => {
+        const baseDate = new Date("2025-11-01T10:00:00Z");
+
+        const spentVtxo = (txid: string, arkTxId: string, createdAt = baseDate): VirtualCoin => ({
+            txid,
+            vout: 0,
+            value: 1000,
+            status: { confirmed: false },
+            virtualStatus: { state: "preconfirmed" },
+            createdAt,
+            isUnrolled: false,
+            isSpent: true,
+            arkTxId,
+        });
+
+        it("calls the resolver once with all distinct txids, deduped", async () => {
+            const resolver = vi.fn((txids: string[]) =>
+                Promise.resolve(new Map(txids.map((t, i) => [t, 1_700_000_000_000 + i] as const))),
+            );
+
+            const txs = await buildTransactionHistory(
+                [
+                    spentVtxo("in-a", "ark-tx-1"),
+                    spentVtxo("in-b", "ark-tx-1", new Date(baseDate.getTime() + 1000)),
+                    spentVtxo("in-c", "ark-tx-2"),
+                ],
+                [],
+                new Set(),
+                resolver,
+            );
+
+            expect(resolver).toHaveBeenCalledTimes(1);
+            expect(resolver.mock.calls[0][0].slice().sort()).toStrictEqual([
+                "ark-tx-1",
+                "ark-tx-2",
+            ]);
+
+            const sentTxs = txs.filter((t) => t.type === TxType.TxSent);
+            expect(sentTxs).toHaveLength(2);
+            const byTxid = new Map(sentTxs.map((t) => [t.key.arkTxid, t.createdAt]));
+            expect(byTxid.get("ark-tx-1")).toBe(1_700_000_000_000);
+            expect(byTxid.get("ark-tx-2")).toBe(1_700_000_000_001);
+        });
+
+        it("does not call the resolver when every spending tx has a change output", async () => {
+            const resolver = vi.fn((txids: string[]) => Promise.resolve(new Map<string, number>()));
+
+            const changeVtxo: VirtualCoin = {
+                txid: "ark-tx-1",
+                vout: 0,
+                value: 400,
+                status: { confirmed: false },
+                virtualStatus: { state: "preconfirmed" },
+                createdAt: new Date(baseDate.getTime() + 1000),
+                isUnrolled: false,
+                isSpent: false,
+            };
+
+            const txs = await buildTransactionHistory(
+                [spentVtxo("in-a", "ark-tx-1"), changeVtxo],
+                [],
+                new Set(),
+                resolver,
+            );
+
+            expect(resolver).not.toHaveBeenCalled();
+            const sentTxs = txs.filter((t) => t.type === TxType.TxSent);
+            expect(sentTxs).toHaveLength(1);
+            expect(sentTxs[0].createdAt).toBe(baseDate.getTime() + 1000);
+        });
+
+        it("falls back to createdAt + 1 for txids missing from a partial map", async () => {
+            const resolver = vi.fn((_txids: string[]) =>
+                Promise.resolve(new Map([["ark-tx-1", 1_700_000_000_000]])),
+            );
+
+            const txs = await buildTransactionHistory(
+                [spentVtxo("in-a", "ark-tx-1"), spentVtxo("in-b", "ark-tx-2")],
+                [],
+                new Set(),
+                resolver,
+            );
+
+            const sentTxs = txs.filter((t) => t.type === TxType.TxSent);
+            expect(sentTxs).toHaveLength(2);
+            const byTxid = new Map(sentTxs.map((t) => [t.key.arkTxid, t.createdAt]));
+            expect(byTxid.get("ark-tx-1")).toBe(1_700_000_000_000);
+            expect(byTxid.get("ark-tx-2")).toBe(baseDate.getTime() + 1);
+        });
+    });
+
     describe("Handles real-life histories correctly", () => {
         transactionHistory.forEach(
             ({
@@ -1019,8 +1110,16 @@ describe("buildTransactionHistory", () => {
                 sendAllTxTime,
             }) => {
                 it(`should handle history from ${address}`, async () => {
-                    const getTxCreatedAt = sendAllTxTime
-                        ? (txid: string) => Promise.resolve((sendAllTxTime as any)[txid] ?? 0)
+                    // `?? 0` matches the pre-batching callback: absent txids resolve to 0.
+                    const resolveTxCreatedAt = sendAllTxTime
+                        ? (txids: string[]) =>
+                              Promise.resolve(
+                                  new Map(
+                                      txids.map(
+                                          (t) => [t, (sendAllTxTime as any)[t] ?? 0] as const,
+                                      ),
+                                  ),
+                              )
                         : undefined;
                     const transactions = await buildTransactionHistory(
                         vtxos.map((_) => ({
@@ -1029,7 +1128,7 @@ describe("buildTransactionHistory", () => {
                         })) as VirtualCoin[],
                         allBoardingTxs as ArkTransaction[],
                         new Set(commitmentsToIgnore),
-                        getTxCreatedAt,
+                        resolveTxCreatedAt,
                     );
                     expect(transactions).toStrictEqual(expected);
 

--- a/packages/ts-sdk/test/vtxo-query-chunking.test.ts
+++ b/packages/ts-sdk/test/vtxo-query-chunking.test.ts
@@ -4,6 +4,7 @@ import {
     InMemoryContractRepository,
     InMemoryWalletRepository,
     type IndexerProvider,
+    TxType,
     type VirtualCoin,
 } from "../src";
 import type { Contract } from "../src/contracts";
@@ -298,5 +299,94 @@ describe("Wallet script queries stay under the URL cap", () => {
 
         expect(handle.indexer.getVtxosCalls.length).toBeGreaterThan(0);
         expect(widest(handle.indexer.getVtxosCalls)).toBeLessThanOrEqual(CAP);
+    });
+});
+
+/**
+ * The wiring, end to end: history used to issue one indexer request per spent
+ * VTXO, sequentially, repeating for every VTXO sharing an `arkTxId`. The unit
+ * tests above pin the resolver; these pin that `Wallet` actually reaches it.
+ */
+describe("Wallet.getTransactionHistory batches createdAt lookups", () => {
+    beforeEach(installRestoreHarness);
+    afterEach(() => {
+        teardownRestoreHarness();
+        vi.restoreAllMocks();
+    });
+
+    const arkTxIdAt = (i: number) => "f" + (i + 1).toString(16).padStart(63, "0");
+
+    /**
+     * A wallet holding one spent VTXO per contract, each spent by a distinct
+     * `arkTxId` unless `sharedArkTxId` — the send-everything shape, whose
+     * `createdAt` lives only at the indexer. Returns the outpoint-shaped queries
+     * `getTransactionHistory` makes.
+     */
+    const walletWithSpentVtxos = async (count: number, sharedArkTxId?: string) => {
+        const handle = await makeStaticWalletForTest();
+        const spent = new Map(
+            Array.from({ length: count }, (_, i) => {
+                const script = scriptAt(i);
+                return [
+                    script,
+                    {
+                        ...vtxoFor(script, i),
+                        isSpent: true,
+                        arkTxId: sharedArkTxId ?? arkTxIdAt(i),
+                    },
+                ] as const;
+            }),
+        );
+        for (const script of spent.keys()) {
+            await handle.contractRepository.saveContract(
+                contractAt(Number.parseInt(script.slice(4), 16)),
+            );
+        }
+
+        const outpointCalls: { txid: string; vout: number }[][] = [];
+        handle.indexer.getVtxos = (async (opts?: {
+            scripts?: string[];
+            outpoints?: { txid: string; vout: number }[];
+        }) => {
+            if (opts?.outpoints) {
+                outpointCalls.push(opts.outpoints);
+                return {
+                    vtxos: opts.outpoints.map((o) => ({
+                        ...vtxoFor(scriptAt(0), 0),
+                        txid: o.txid,
+                        createdAt: new Date(1_700_000_000_000),
+                    })),
+                };
+            }
+            return { vtxos: (opts?.scripts ?? []).map((s) => spent.get(s)).filter(Boolean) };
+        }) as IndexerProvider["getVtxos"];
+
+        return { wallet: handle.wallet, outpointCalls };
+    };
+
+    it("issues one request per chunk of txids, not one per spent vtxo", async () => {
+        const count = OUTPOINT_QUERY_CHUNK_SIZE + 5;
+        const { wallet, outpointCalls } = await walletWithSpentVtxos(count);
+
+        const history = await wallet.getTransactionHistory();
+
+        // Pre-batching: `count` sequential single-outpoint requests.
+        expect(outpointCalls.map((c) => c.length)).toEqual([OUTPOINT_QUERY_CHUNK_SIZE, 5]);
+        // Every fetched timestamp lands, so no send falls back to createdAt + 1.
+        const sent = history.filter((tx) => tx.type === TxType.TxSent);
+        expect(sent).toHaveLength(count);
+        for (const tx of sent) {
+            expect(tx.createdAt).toBe(1_700_000_000_000);
+        }
+    });
+
+    it("does not re-request a txid shared by several vtxos", async () => {
+        const shared = arkTxIdAt(0);
+        const { wallet, outpointCalls } = await walletWithSpentVtxos(5, shared);
+
+        await wallet.getTransactionHistory();
+
+        expect(outpointCalls).toHaveLength(1);
+        expect(outpointCalls[0]).toEqual([{ txid: shared, vout: 0 }]);
     });
 });

--- a/packages/ts-sdk/test/vtxo-query-chunking.test.ts
+++ b/packages/ts-sdk/test/vtxo-query-chunking.test.ts
@@ -7,9 +7,10 @@ import {
     type VirtualCoin,
 } from "../src";
 import type { Contract } from "../src/contracts";
-import { SCRIPT_QUERY_CHUNK_SIZE } from "../src/contracts/constants";
+import { OUTPOINT_QUERY_CHUNK_SIZE, SCRIPT_QUERY_CHUNK_SIZE } from "../src/contracts/constants";
+import { ProviderUnavailableError } from "../src/providers/errors";
 import { updateWalletState } from "../src/utils/syncCursors";
-import { getAllNormalizedVtxos } from "../src/wallet/vtxo";
+import { fetchVtxoCreatedAtByTxid, getAllNormalizedVtxos } from "../src/wallet/vtxo";
 import { createDefaultContractParams, createMockIndexerProvider } from "./contracts/helpers";
 import {
     installRestoreHarness,
@@ -107,6 +108,107 @@ describe("getAllNormalizedVtxos", () => {
         const { indexer, calls } = recordingIndexer();
         expect(await getAllNormalizedVtxos(indexer, [])).toEqual([]);
         expect(calls).toHaveLength(0);
+    });
+});
+
+describe("fetchVtxoCreatedAtByTxid", () => {
+    const OCAP = OUTPOINT_QUERY_CHUNK_SIZE;
+
+    const txidAt = (i: number) => i.toString(16).padStart(64, "0");
+    const txids = (n: number) => Array.from({ length: n }, (_, i) => txidAt(i));
+
+    /**
+     * Answers each `outpoints` query with one VTXO per outpoint, `createdAt`
+     * derived from the txid. `failChunk` makes the Nth request throw `error`.
+     */
+    function outpointRecordingIndexer(opts?: { failChunk?: number; error?: Error }): {
+        indexer: IndexerProvider;
+        calls: { outpoints: { txid: string; vout: number }[]; pageSize?: number }[];
+    } {
+        const calls: { outpoints: { txid: string; vout: number }[]; pageSize?: number }[] = [];
+        const indexer = createMockIndexerProvider();
+        (indexer.getVtxos as any).mockImplementation(
+            async (o?: { outpoints?: { txid: string; vout: number }[]; pageSize?: number }) => {
+                if (!o?.outpoints) return { vtxos: [] };
+                calls.push({ outpoints: o.outpoints, pageSize: o.pageSize });
+                if (opts?.failChunk !== undefined && calls.length - 1 === opts.failChunk) {
+                    throw opts.error ?? new ProviderUnavailableError("indexer down");
+                }
+                const vtxos = o.outpoints.map((op) => ({
+                    ...vtxoFor(scriptAt(0), 0),
+                    txid: op.txid,
+                    createdAt: new Date(parseInt(op.txid.slice(-8), 16) * 1000),
+                }));
+                return { vtxos };
+            },
+        );
+        return { indexer, calls };
+    }
+
+    it("chunks a txid list past the cap and unions every chunk's results", async () => {
+        const { indexer, calls } = outpointRecordingIndexer();
+        const all = txids(OCAP * 2 + 5);
+
+        const times = await fetchVtxoCreatedAtByTxid(indexer, all);
+
+        expect(calls.map((c) => c.outpoints.length)).toEqual([OCAP, OCAP, 5]);
+        expect(times.size).toBe(all.length);
+        for (const [i, txid] of all.entries()) {
+            expect(times.get(txid)).toBe(i * 1000);
+        }
+    });
+
+    it("dedupes txids and skips blanks", async () => {
+        const { indexer, calls } = outpointRecordingIndexer();
+
+        const times = await fetchVtxoCreatedAtByTxid(indexer, [
+            txidAt(1),
+            "",
+            txidAt(2),
+            txidAt(1),
+        ]);
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].outpoints.map((o) => o.txid)).toEqual([txidAt(1), txidAt(2)]);
+        expect(times.size).toBe(2);
+    });
+
+    it("makes no request for an empty txid list", async () => {
+        const { indexer, calls } = outpointRecordingIndexer();
+        expect((await fetchVtxoCreatedAtByTxid(indexer, [])).size).toBe(0);
+        expect(calls).toHaveLength(0);
+    });
+
+    it("requests a page size that covers a full chunk", async () => {
+        const { indexer, calls } = outpointRecordingIndexer();
+
+        await fetchVtxoCreatedAtByTxid(indexer, txids(OCAP + 1));
+
+        for (const call of calls) {
+            expect(call.pageSize).toBeGreaterThanOrEqual(OCAP);
+        }
+    });
+
+    it("keeps going past a retryable chunk failure and returns a partial map", async () => {
+        const { indexer, calls } = outpointRecordingIndexer({ failChunk: 0 });
+        const all = txids(OCAP + 5);
+
+        const times = await fetchVtxoCreatedAtByTxid(indexer, all);
+
+        expect(calls).toHaveLength(2);
+        expect(times.size).toBe(5);
+        for (const txid of all.slice(OCAP)) {
+            expect(times.has(txid)).toBe(true);
+        }
+    });
+
+    it("propagates a terminal error", async () => {
+        const { indexer } = outpointRecordingIndexer({
+            failChunk: 0,
+            error: new Error("bad request"),
+        });
+
+        await expect(fetchVtxoCreatedAtByTxid(indexer, txids(3))).rejects.toThrow("bad request");
     });
 });
 


### PR DESCRIPTION
`buildTransactionHistory` resolved each spent-with-no-change ark txid with its own sequential `/v1/indexer/vtxos` call — one round trip per txid. Uncovered by ArkLabsHQ/coinflip#112: 123 txids ≈ 22s of history load, growing linearly.

- collect the needed txids up front and resolve them once through a shared `fetchVtxoCreatedAtByTxid`, chunked at a new `OUTPOINT_QUERY_CHUNK_SIZE` (64, ~5 KB of query string)
- both the plain `Wallet` and the service-worker path now use the same resolver; the worker's hand-rolled batch loop is gone, and it inherits the wallet's best-effort semantics (retryable indexer failure → partial map + fallback timestamps, terminal errors propagate)
- `pageSize` is set explicitly so a low server-side page default can't silently short-page a chunk

123 requests → 2 for the coinflip case; their app-side `txTimeCache` workaround can be dropped once this ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction history timestamps for spent offchain transactions through batched lookups.
  * Added best-effort fallback behavior when timestamp information is unavailable.
  * Improved handling of large transaction ID batches, duplicate entries, and temporary service failures.
  * Ensured terminal service errors are surfaced appropriately while recoverable failures can return partial results.

* **Tests**
  * Added coverage for batched timestamp resolution, chunking, fallback behavior, partial results, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->