### PR TITLE
feat(boltz): HD swap keys and multi-key restore

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -3522,8 +3522,13 @@ export class ArkadeSwaps {
                 // we locked ARK, our claim leg when we receive it.
                 const weLockArk = swap.from === "ARK";
                 const arkLeg = weLockArk ? swap.refundDetails : swap.claimDetails;
-                const lockupLeg = swap.refundDetails ?? arkLeg;
-                if (!arkLeg || !lockupLeg) continue;
+                if (!arkLeg) continue;
+                // The leg we funded, and the only one we can refund. For BTC→ARK
+                // that is the BTC leg, which Boltz may omit — the ARK leg is not
+                // a stand-in for it: `lockupDetails` is what callers pay into and
+                // refund from, so an ark address there would mis-route a BTC
+                // refund. Leave it absent instead of wrong.
+                const lockupLeg = swap.refundDetails;
 
                 const arkTimeouts = resolveVhtlcTimeouts(arkLeg.tree, arkLeg.timeoutBlockHeights);
                 const owner =
@@ -3544,7 +3549,9 @@ export class ArkadeSwaps {
                     continue;
                 }
 
-                const { amount } = lockupLeg;
+                // Falls back to the ARK leg only as a display amount when our
+                // lockup leg is missing.
+                const amount = lockupLeg?.amount ?? arkLeg.amount;
                 chainSwaps.push({
                     id,
                     type: "chain",
@@ -3568,16 +3575,20 @@ export class ArkadeSwaps {
                     },
                     response: {
                         id,
-                        lockupDetails: {
-                            amount: lockupLeg.amount,
-                            lockupAddress: lockupLeg.lockupAddress,
-                            serverPublicKey: lockupLeg.serverPublicKey,
-                            timeoutBlockHeight: lockupLeg.timeoutBlockHeight,
-                            timeouts: resolveVhtlcTimeouts(
-                                lockupLeg.tree,
-                                lockupLeg.timeoutBlockHeights,
-                            ),
-                        },
+                        ...(lockupLeg
+                            ? {
+                                  lockupDetails: {
+                                      amount: lockupLeg.amount,
+                                      lockupAddress: lockupLeg.lockupAddress,
+                                      serverPublicKey: lockupLeg.serverPublicKey,
+                                      timeoutBlockHeight: lockupLeg.timeoutBlockHeight,
+                                      timeouts: resolveVhtlcTimeouts(
+                                          lockupLeg.tree,
+                                          lockupLeg.timeoutBlockHeights,
+                                      ),
+                                  },
+                              }
+                            : {}),
                         // Claiming ARK reads its VHTLC from claimDetails.
                         ...(swap.claimDetails
                             ? {

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -8,6 +8,7 @@ import {
     TransactionRefundedError,
     BoltzRefundError,
     QuoteRejectedError,
+    VHTLCAddressMismatchError,
 } from "./errors";
 import {
     ArkAddress,
@@ -3094,11 +3095,11 @@ export class ArkadeSwaps {
                 ),
             };
         }
-        throw new Error(
-            `Swap ${args.swapId}: VHTLC address mismatch. Expected ${args.lockupAddress}; ` +
-                `no current or deprecated server signer (${candidates.length} candidate(s) tried) ` +
-                `reproduced it`,
-        );
+        throw new VHTLCAddressMismatchError({
+            swapId: args.swapId,
+            lockupAddress: args.lockupAddress,
+            tried: candidates.length,
+        });
     }
 
     // =========================================================================
@@ -3320,9 +3321,11 @@ export class ArkadeSwaps {
      * signer (current + deprecated), so a swap that straddles an arkd signer
      * rotation still resolves.
      *
-     * `undefined` means no key of ours reproduces the address: the swap is not
-     * attributable and must be skipped rather than recorded under a key that
-     * cannot spend it.
+     * `undefined` means the swap is not attributable and must be skipped rather
+     * than recorded under a key that cannot spend it — either no key of ours
+     * reproduces the address, or the VHTLC could not be rebuilt at all (logged
+     * with its cause). Failures stay scoped to this swap: one unusable entry in
+     * the restore set must not cost the caller every other swap.
      */
     private matchSwapOwner(args: {
         arkInfo: ArkInfo;
@@ -3335,11 +3338,19 @@ export class ArkadeSwaps {
         lockupAddress: string;
         swapId: string;
     }): SwapOwnerKey | undefined {
+        let preimageHash: Uint8Array;
+        try {
+            preimageHash = hex.decode(args.preimageHash);
+        } catch (error) {
+            logger.warn(`Swap ${args.swapId}: malformed preimage hash, cannot attribute`, error);
+            return undefined;
+        }
+
         for (const candidate of args.candidates) {
             try {
                 this.resolveVHTLCForLockup({
                     arkInfo: args.arkInfo,
-                    preimageHash: hex.decode(args.preimageHash),
+                    preimageHash,
                     receiverPubkey:
                         args.ourRole === "receiver" ? candidate.publicKey : args.counterpartyPubkey,
                     senderPubkey:
@@ -3349,8 +3360,17 @@ export class ArkadeSwaps {
                     swapId: args.swapId,
                 });
                 return candidate;
-            } catch {
-                continue;
+            } catch (error) {
+                // A mismatch is the expected outcome for every key but the owning
+                // one. Anything else (unusable key length, malformed counterparty
+                // key, a builder bug) is a real failure that would otherwise be
+                // indistinguishable from "not ours" — surface it, then keep
+                // probing so a single bad candidate cannot hide a good one.
+                if (error instanceof VHTLCAddressMismatchError) continue;
+                logger.warn(
+                    `Swap ${args.swapId}: candidate key ${candidate.publicKey} failed to rebuild the VHTLC`,
+                    error,
+                );
             }
         }
         return undefined;
@@ -3387,9 +3407,7 @@ export class ArkadeSwaps {
         );
 
         const skip = (id: string) =>
-            logger.warn(
-                `Skipping restored swap ${id}: no wallet key reproduces its lockup address`,
-            );
+            logger.warn(`Skipping restored swap ${id}: not attributable to any wallet key`);
 
         for (const swap of restoredSwaps) {
             const { id, createdAt, status } = swap;

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -146,6 +146,8 @@ type SubmarineVHTLCContext = {
      * fields are BIP68 relative delays.
      */
     vhtlcTimeouts: NonNullable<BoltzSubmarineSwap["response"]["timeoutBlockHeights"]>;
+    /** Signer for the swap's key — descriptor-scoped when the swap is bound. */
+    identity: Identity;
     ourXOnlyPublicKey: Uint8Array;
     serverXOnlyPublicKey: Uint8Array;
     boltzXOnlyPublicKey: Uint8Array;
@@ -173,6 +175,7 @@ type SubmarineScanPrepared =
  */
 type RefundWithoutReceiverContext = {
     arkInfo: ArkInfo;
+    identity: Identity;
     vhtlcScript: VHTLC.Script;
     serverXOnlyPublicKey: Uint8Array;
     refundWithoutReceiverLeaf: ArkTxInput["tapLeafScript"];
@@ -495,7 +498,10 @@ export class ArkadeSwaps {
         // validate amount
         if (args.amount <= 0) throw new SwapError({ message: "Amount must be greater than 0" });
 
-        const claimPublicKey = hex.encode(await this.wallet.identity.compressedPublicKey());
+        const signingDescriptor = await this.currentSigningDescriptor();
+        const claimPublicKey = hex.encode(
+            await (await this.swapSigner({ signingDescriptor })).compressedPublicKey(),
+        );
         if (!claimPublicKey)
             throw new SwapError({
                 message: "Failed to get claim public key from wallet",
@@ -539,6 +545,7 @@ export class ArkadeSwaps {
             request: swapRequest,
             response: swapResponse,
             status: "swap.created",
+            signingDescriptor,
         };
 
         // save pending swap to storage
@@ -573,9 +580,10 @@ export class ArkadeSwaps {
         const preimage = hex.decode(pendingSwap.preimage);
         const arkInfo = await this.arkProvider.getInfo();
         const address = await this.wallet.getAddress();
+        const signer = await this.swapSigner(pendingSwap);
 
         const receiverXOnly = normalizeToXOnlyKey(
-            await this.wallet.identity.xOnlyPublicKey(),
+            await signer.xOnlyPublicKey(),
             "our",
             pendingSwap.id,
         );
@@ -628,7 +636,7 @@ export class ArkadeSwaps {
             throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
         }
 
-        const vhtlcIdentity = claimVHTLCIdentity(this.wallet.identity, preimage);
+        const vhtlcIdentity = claimVHTLCIdentity(signer, preimage);
         const outputScript = ArkAddress.decode(address).pkScript;
 
         // Asymmetry with `refundArk` is deliberate: this path is all-or-
@@ -892,7 +900,10 @@ export class ArkadeSwaps {
      * @throws {SwapError} If invoice is missing or key retrieval fails.
      */
     async createSubmarineSwap(args: SendLightningPaymentRequest): Promise<BoltzSubmarineSwap> {
-        const refundPublicKey = hex.encode(await this.wallet.identity.compressedPublicKey());
+        const signingDescriptor = await this.currentSigningDescriptor();
+        const refundPublicKey = hex.encode(
+            await (await this.swapSigner({ signingDescriptor })).compressedPublicKey(),
+        );
         if (!refundPublicKey)
             throw new SwapError({
                 message: "Failed to get refund public key from wallet",
@@ -917,6 +928,7 @@ export class ArkadeSwaps {
             request: swapRequest,
             response: swapResponse,
             status: "invoice.set",
+            signingDescriptor,
         };
 
         // save pending swap to storage
@@ -951,8 +963,9 @@ export class ArkadeSwaps {
 
         const resolvedArkInfo = arkInfo ?? (await this.arkProvider.getInfo());
 
+        const identity = await this.swapSigner(swap);
         const ourXOnlyPublicKey = normalizeToXOnlyKey(
-            await this.wallet.identity.xOnlyPublicKey(),
+            await identity.xOnlyPublicKey(),
             "our",
             swap.id,
         );
@@ -995,6 +1008,7 @@ export class ArkadeSwaps {
             vhtlcAddress,
             vhtlcPkScriptHex,
             vhtlcTimeouts,
+            identity,
             ourXOnlyPublicKey,
             serverXOnlyPublicKey,
             boltzXOnlyPublicKey,
@@ -1172,6 +1186,7 @@ export class ArkadeSwaps {
 
         const {
             arkInfo,
+            identity,
             vhtlcScript,
             vhtlcTimeouts,
             ourXOnlyPublicKey,
@@ -1197,6 +1212,7 @@ export class ArkadeSwaps {
         const refundWithoutReceiverLeaf = vhtlcScript.refundWithoutReceiver();
         const refundContext: RefundWithoutReceiverContext = {
             arkInfo,
+            identity,
             vhtlcScript,
             serverXOnlyPublicKey,
             refundWithoutReceiverLeaf,
@@ -1936,8 +1952,9 @@ export class ArkadeSwaps {
 
         const address = await this.wallet.getAddress();
 
+        const identity = await this.swapSigner(pendingSwap);
         const ourXOnlyPublicKey = normalizeToXOnlyKey(
-            await this.wallet.identity.xOnlyPublicKey(),
+            await identity.xOnlyPublicKey(),
             "user",
             pendingSwap.id,
         );
@@ -1992,6 +2009,7 @@ export class ArkadeSwaps {
         const refundLocktime = pendingSwap.response.lockupDetails.timeouts!.refund;
         const refundContext: RefundWithoutReceiverContext = {
             arkInfo,
+            identity,
             vhtlcScript,
             serverXOnlyPublicKey,
             refundWithoutReceiverLeaf,
@@ -2253,7 +2271,7 @@ export class ArkadeSwaps {
         };
 
         // Use shared identity utility for preimage witness
-        const vhtlcIdentity = claimVHTLCIdentity(this.wallet.identity, preimage);
+        const vhtlcIdentity = claimVHTLCIdentity(await this.swapSigner(pendingSwap), preimage);
 
         // The claim transaction we broadcast is the swap's on-chain completion;
         // its id is the txid callers expect back from waitAndClaimArk.
@@ -2420,10 +2438,14 @@ export class ArkadeSwaps {
         // ephemeral keys for BTC chain claim/refund
         const ephemeralKey = secp256k1.utils.randomSecretKey();
 
+        // Only the ARK leg is ours; the BTC leg is signed by the ephemeral key.
+        const signingDescriptor = await this.currentSigningDescriptor();
+        const arkPublicKey = hex.encode(
+            await (await this.swapSigner({ signingDescriptor })).compressedPublicKey(),
+        );
+
         const refundPublicKey =
-            to === "ARK"
-                ? hex.encode(secp256k1.getPublicKey(ephemeralKey))
-                : hex.encode(await this.wallet.identity.compressedPublicKey());
+            to === "ARK" ? hex.encode(secp256k1.getPublicKey(ephemeralKey)) : arkPublicKey;
 
         if (!refundPublicKey)
             throw new SwapError({
@@ -2431,9 +2453,7 @@ export class ArkadeSwaps {
             });
 
         const claimPublicKey =
-            to === "ARK"
-                ? hex.encode(await this.wallet.identity.compressedPublicKey())
-                : hex.encode(secp256k1.getPublicKey(ephemeralKey));
+            to === "ARK" ? arkPublicKey : hex.encode(secp256k1.getPublicKey(ephemeralKey));
 
         if (!claimPublicKey)
             throw new SwapError({
@@ -2462,6 +2482,7 @@ export class ArkadeSwaps {
             preimage: hex.encode(preimage),
             request: swapRequest,
             response: swapResponse,
+            signingDescriptor,
             status: "swap.created",
             toAddress: args.toAddress,
             type: "chain",
@@ -2791,10 +2812,10 @@ export class ArkadeSwaps {
         };
         const output = { amount: BigInt(vtxo.value), script: ctx.outputScript };
         if (isRecoverable(vtxo)) {
-            await this.joinBatch(this.wallet.identity, input, output, ctx.arkInfo, true);
+            await this.joinBatch(ctx.identity, input, output, ctx.arkInfo, true);
         } else {
             await refundWithoutReceiverVHTLCwithOffchainTx(
-                this.wallet.identity,
+                ctx.identity,
                 ctx.vhtlcScript,
                 ctx.serverXOnlyPublicKey,
                 input,
@@ -2945,7 +2966,7 @@ export class ArkadeSwaps {
                 boltzCallCount++;
                 await refundVHTLCwithOffchainTx(
                     swapId,
-                    this.wallet.identity,
+                    refundContext.identity,
                     this.arkProvider,
                     boltzXOnlyPublicKey,
                     ourXOnlyPublicKey,
@@ -3242,6 +3263,30 @@ export class ArkadeSwaps {
     // =========================================================================
     // Swap restoration and enrichment
     // =========================================================================
+
+    /**
+     * The HD descriptor a swap created now should be bound to, or `undefined`
+     * for static wallets and HD wallets that have never rotated. Swap creation
+     * never allocates an index of its own: rotation is driven by the wallet's
+     * receive events, and a swap simply rides the index that is current.
+     */
+    private async currentSigningDescriptor(): Promise<string | undefined> {
+        return isHDWalletCapable(this.wallet)
+            ? this.wallet.getCurrentSigningDescriptor()
+            : undefined;
+    }
+
+    /**
+     * The identity that owns a swap's VHTLC legs. Swaps stored before
+     * descriptor binding — and every swap of a static wallet — carry no
+     * descriptor and stay on the baseline identity.
+     */
+    private async swapSigner(swap: { signingDescriptor?: string }): Promise<Identity> {
+        if (!swap.signingDescriptor || !isHDWalletCapable(this.wallet)) {
+            return this.wallet.identity;
+        }
+        return this.wallet.signerForDescriptor(swap.signingDescriptor);
+    }
 
     /**
      * Every compressed key the wallet may hold swaps under: one per used HD

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -24,6 +24,8 @@ import {
     Identity,
     VirtualCoin,
     getNetwork,
+    deriveDescriptorLeafCompressedPubKey,
+    isHDWalletCapable,
     type NetworkName,
 } from "@arkade-os/sdk";
 import type {
@@ -119,6 +121,14 @@ import {
     refundWithoutReceiverVHTLCwithOffchainTx,
     type VhtlcTimeouts,
 } from "./utils/vhtlc";
+
+/** A wallet key a swap may be locked to, with the descriptor that derives it. */
+type SwapOwnerKey = {
+    /** Compressed public key, hex. */
+    publicKey: string;
+    /** Absent for the baseline identity key. */
+    signingDescriptor?: string;
+};
 
 type SubmarineVHTLCDiagnostic = {
     totalVtxoCount: number;
@@ -3234,7 +3244,81 @@ export class ArkadeSwaps {
     // =========================================================================
 
     /**
+     * Every compressed key the wallet may hold swaps under: one per used HD
+     * signing descriptor plus the baseline identity key, which covers static
+     * wallets and swaps created before descriptor binding existed.
+     */
+    private async swapOwnerKeys(): Promise<SwapOwnerKey[]> {
+        const identityKey = hex.encode(await this.wallet.identity.compressedPublicKey());
+        if (!identityKey) throw new Error("Failed to get public key from wallet");
+
+        const keys = new Map<string, SwapOwnerKey>([[identityKey, { publicKey: identityKey }]]);
+        if (!isHDWalletCapable(this.wallet)) return [...keys.values()];
+
+        for (const signingDescriptor of await this.wallet.getUsedSigningDescriptors()) {
+            try {
+                const publicKey = hex.encode(
+                    deriveDescriptorLeafCompressedPubKey(signingDescriptor),
+                );
+                if (!keys.has(publicKey)) keys.set(publicKey, { publicKey, signingDescriptor });
+            } catch (error) {
+                logger.warn(`Skipping signing descriptor with no derivable key`, error);
+            }
+        }
+        return [...keys.values()];
+    }
+
+    /**
+     * Find which of our keys owns a restored swap by rebuilding its VHTLC until
+     * the lockup address matches — Boltz's own `keyIndex` says nothing about
+     * our derivation. Probes every candidate key against every candidate server
+     * signer (current + deprecated), so a swap that straddles an arkd signer
+     * rotation still resolves.
+     *
+     * `undefined` means no key of ours reproduces the address: the swap is not
+     * attributable and must be skipped rather than recorded under a key that
+     * cannot spend it.
+     */
+    private matchSwapOwner(args: {
+        arkInfo: ArkInfo;
+        candidates: SwapOwnerKey[];
+        /** Our side of this VHTLC — claim leg for reverse, refund leg for submarine. */
+        ourRole: "receiver" | "sender";
+        counterpartyPubkey: string;
+        preimageHash: string;
+        timeoutBlockHeights: VhtlcTimeouts;
+        lockupAddress: string;
+        swapId: string;
+    }): SwapOwnerKey | undefined {
+        for (const candidate of args.candidates) {
+            try {
+                this.resolveVHTLCForLockup({
+                    arkInfo: args.arkInfo,
+                    preimageHash: hex.decode(args.preimageHash),
+                    receiverPubkey:
+                        args.ourRole === "receiver" ? candidate.publicKey : args.counterpartyPubkey,
+                    senderPubkey:
+                        args.ourRole === "sender" ? candidate.publicKey : args.counterpartyPubkey,
+                    timeoutBlockHeights: args.timeoutBlockHeights,
+                    lockupAddress: args.lockupAddress,
+                    swapId: args.swapId,
+                });
+                return candidate;
+            } catch {
+                continue;
+            }
+        }
+        return undefined;
+    }
+
+    /**
      * Restore swaps from Boltz API.
+     *
+     * Queries the whole key set the wallet may have used ({@link swapOwnerKeys})
+     * and attributes each restored swap to the key that actually owns it, so
+     * swaps created under a rotated HD index — or by another SDK sharing the
+     * seed — come back claimable/refundable. A swap no key of ours reproduces
+     * is skipped, never recorded under the wrong key.
      *
      * Note: restored swaps may lack local-only data such as the original
      * Lightning invoice or preimage. They are intended primarily for
@@ -3245,36 +3329,58 @@ export class ArkadeSwaps {
         reverseSwaps: BoltzReverseSwap[];
         submarineSwaps: BoltzSubmarineSwap[];
     }> {
-        const publicKey = hex.encode(await this.wallet.identity.compressedPublicKey());
-        if (!publicKey) throw new Error("Failed to get public key from wallet");
-
+        const candidates = await this.swapOwnerKeys();
         const fees = boltzFees ?? (await this.swapProvider.getFees());
+        const arkInfo = await this.arkProvider.getInfo();
 
         const chainSwaps: BoltzChainSwap[] = [];
         const reverseSwaps: BoltzReverseSwap[] = [];
         const submarineSwaps: BoltzSubmarineSwap[] = [];
 
-        const restoredSwaps = await this.swapProvider.restoreSwaps(publicKey);
+        const restoredSwaps = await this.swapProvider.restoreSwaps(
+            candidates.map((c) => c.publicKey),
+        );
+
+        const skip = (id: string) =>
+            logger.warn(
+                `Skipping restored swap ${id}: no wallet key reproduces its lockup address`,
+            );
 
         for (const swap of restoredSwaps) {
             const { id, createdAt, status } = swap;
 
             if (isRestoredReverseSwap(swap)) {
-                const {
-                    amount,
-                    lockupAddress,
-                    preimageHash,
-                    serverPublicKey,
+                const { amount, lockupAddress, serverPublicKey, tree } = swap.claimDetails;
+                const preimageHash = swap.claimDetails.preimageHash ?? swap.preimageHash;
+                const timeoutBlockHeights = resolveVhtlcTimeouts(
                     tree,
-                    timeoutBlockHeights,
-                } = swap.claimDetails;
+                    swap.claimDetails.timeoutBlockHeights,
+                );
+
+                const owner =
+                    preimageHash && timeoutBlockHeights
+                        ? this.matchSwapOwner({
+                              arkInfo,
+                              candidates,
+                              ourRole: "receiver",
+                              counterpartyPubkey: serverPublicKey,
+                              preimageHash,
+                              timeoutBlockHeights,
+                              lockupAddress,
+                              swapId: id,
+                          })
+                        : undefined;
+                if (!owner) {
+                    skip(id);
+                    continue;
+                }
 
                 reverseSwaps.push({
                     id,
                     createdAt,
                     request: {
                         invoiceAmount: extractInvoiceAmount(amount, fees),
-                        claimPublicKey: publicKey,
+                        claimPublicKey: owner.publicKey,
                         preimageHash,
                     },
                     response: {
@@ -3283,15 +3389,38 @@ export class ArkadeSwaps {
                         onchainAmount: amount,
                         lockupAddress,
                         refundPublicKey: serverPublicKey,
-                        timeoutBlockHeights: resolveVhtlcTimeouts(tree, timeoutBlockHeights),
+                        timeoutBlockHeights,
                     },
                     status,
                     type: "reverse",
                     preimage: "",
+                    signingDescriptor: owner.signingDescriptor,
                 } as BoltzReverseSwap);
             } else if (isRestoredSubmarineSwap(swap)) {
-                const { amount, lockupAddress, serverPublicKey, tree, timeoutBlockHeights } =
-                    swap.refundDetails;
+                const { amount, lockupAddress, serverPublicKey, tree } = swap.refundDetails;
+                const preimageHash = swap.preimageHash ?? swap.refundDetails.preimageHash;
+                const timeoutBlockHeights = resolveVhtlcTimeouts(
+                    tree,
+                    swap.refundDetails.timeoutBlockHeights,
+                );
+
+                const owner =
+                    preimageHash && timeoutBlockHeights
+                        ? this.matchSwapOwner({
+                              arkInfo,
+                              candidates,
+                              ourRole: "sender",
+                              counterpartyPubkey: serverPublicKey,
+                              preimageHash,
+                              timeoutBlockHeights,
+                              lockupAddress,
+                              swapId: id,
+                          })
+                        : undefined;
+                if (!owner) {
+                    skip(id);
+                    continue;
+                }
 
                 let preimage = "";
                 // Skip preimage fetch for terminal swaps — nothing actionable
@@ -3314,29 +3443,45 @@ export class ArkadeSwaps {
                     status,
                     request: {
                         invoice: swap.invoice ?? "",
-                        refundPublicKey: publicKey,
+                        refundPublicKey: owner.publicKey,
                     },
                     response: {
                         id,
                         address: lockupAddress,
                         expectedAmount: amount,
                         claimPublicKey: serverPublicKey,
-                        timeoutBlockHeights: resolveVhtlcTimeouts(tree, timeoutBlockHeights),
+                        timeoutBlockHeights,
                     },
+                    signingDescriptor: owner.signingDescriptor,
                 } as BoltzSubmarineSwap);
             } else if (isRestoredChainSwap(swap)) {
-                const refundDetails = swap.refundDetails;
-                if (!refundDetails) continue;
+                // The ARK leg is the one we hold a key on: our refund leg when
+                // we locked ARK, our claim leg when we receive it.
+                const weLockArk = swap.from === "ARK";
+                const arkLeg = weLockArk ? swap.refundDetails : swap.claimDetails;
+                const lockupLeg = swap.refundDetails ?? arkLeg;
+                if (!arkLeg || !lockupLeg) continue;
 
-                const {
-                    amount,
-                    lockupAddress,
-                    serverPublicKey,
-                    timeoutBlockHeight,
-                    tree,
-                    timeoutBlockHeights,
-                } = refundDetails;
+                const arkTimeouts = resolveVhtlcTimeouts(arkLeg.tree, arkLeg.timeoutBlockHeights);
+                const owner =
+                    swap.preimageHash && arkTimeouts
+                        ? this.matchSwapOwner({
+                              arkInfo,
+                              candidates,
+                              ourRole: weLockArk ? "sender" : "receiver",
+                              counterpartyPubkey: arkLeg.serverPublicKey,
+                              preimageHash: swap.preimageHash,
+                              timeoutBlockHeights: arkTimeouts,
+                              lockupAddress: arkLeg.lockupAddress,
+                              swapId: id,
+                          })
+                        : undefined;
+                if (!owner) {
+                    skip(id);
+                    continue;
+                }
 
+                const { amount } = lockupLeg;
                 chainSwaps.push({
                     id,
                     type: "chain",
@@ -3350,22 +3495,43 @@ export class ArkadeSwaps {
                         to: swap.to,
                         from: swap.from,
                         preimageHash: swap.preimageHash,
-                        claimPublicKey: "",
+                        // Only the ARK leg is ours; the BTC leg is signed by an
+                        // ephemeral key restore cannot recover.
+                        claimPublicKey: weLockArk ? "" : owner.publicKey,
                         feeSatsPerByte: 1,
-                        refundPublicKey: "",
+                        refundPublicKey: weLockArk ? owner.publicKey : "",
                         serverLockAmount: amount,
                         userLockAmount: amount,
                     },
                     response: {
                         id,
                         lockupDetails: {
-                            amount,
-                            lockupAddress,
-                            serverPublicKey,
-                            timeoutBlockHeight,
-                            timeouts: resolveVhtlcTimeouts(tree, timeoutBlockHeights),
+                            amount: lockupLeg.amount,
+                            lockupAddress: lockupLeg.lockupAddress,
+                            serverPublicKey: lockupLeg.serverPublicKey,
+                            timeoutBlockHeight: lockupLeg.timeoutBlockHeight,
+                            timeouts: resolveVhtlcTimeouts(
+                                lockupLeg.tree,
+                                lockupLeg.timeoutBlockHeights,
+                            ),
                         },
+                        // Claiming ARK reads its VHTLC from claimDetails.
+                        ...(swap.claimDetails
+                            ? {
+                                  claimDetails: {
+                                      amount: swap.claimDetails.amount,
+                                      lockupAddress: swap.claimDetails.lockupAddress,
+                                      serverPublicKey: swap.claimDetails.serverPublicKey,
+                                      timeoutBlockHeight: swap.claimDetails.timeoutBlockHeight,
+                                      timeouts: resolveVhtlcTimeouts(
+                                          swap.claimDetails.tree,
+                                          swap.claimDetails.timeoutBlockHeights,
+                                      ),
+                                  },
+                              }
+                            : {}),
                     },
+                    signingDescriptor: owner.signingDescriptor,
                 } as BoltzChainSwap);
             }
         }

--- a/packages/boltz-swap/src/boltz-swap-provider.ts
+++ b/packages/boltz-swap/src/boltz-swap-provider.ts
@@ -809,7 +809,11 @@ export const isTree = (data: any): data is Tree => {
 export type Details = {
     tree: Tree;
     amount?: number;
-    keyIndex: number;
+    /**
+     * Boltz's own key index for the swap. Carries no information about which
+     * of *our* keys owns it — attribution matches the lockup address locally.
+     */
+    keyIndex?: number;
     transaction?: {
         id: string;
         vout: number;
@@ -827,7 +831,7 @@ export const isDetails = (data: any): data is Details => {
         typeof data === "object" &&
         isTree(data.tree) &&
         (data.amount === undefined || typeof data.amount === "number") &&
-        typeof data.keyIndex === "number" &&
+        (data.keyIndex === undefined || typeof data.keyIndex === "number") &&
         (data.transaction === undefined ||
             (data.transaction &&
                 typeof data.transaction === "object" &&
@@ -928,9 +932,7 @@ export const isRestoredReverseSwap = (data: any): data is RestoredReverseSwap =>
     );
 };
 
-export type CreateSwapsRestoreRequest = {
-    publicKey: string;
-};
+export type CreateSwapsRestoreRequest = { publicKey: string } | { publicKeys: string[] };
 
 export type CreateSwapsRestoreResponse = (
     | RestoredChainSwap
@@ -990,6 +992,9 @@ export class BoltzSwapProvider {
 
     /** Pair-metadata cache lifetime — 15 min, matching NArk's `CachedBoltzClient`. */
     private static readonly PAIRS_CACHE_TTL_MS = 15 * 60 * 1000;
+
+    /** Keys per `/v2/swap/restore` request. @see restoreSwaps */
+    private static readonly RESTORE_KEYS_PER_REQUEST = 100;
 
     /** @param config Provider configuration with network and optional API URL. */
     constructor(config: SwapProviderConfig) {
@@ -1631,24 +1636,42 @@ export class BoltzSwapProvider {
         return response;
     }
 
-    /** Restores swaps from Boltz API using the wallet's public key. */
-    async restoreSwaps(publicKey: string): Promise<CreateSwapsRestoreResponse> {
-        const requestBody: CreateSwapsRestoreRequest = {
-            publicKey,
-        };
+    /**
+     * Restores swaps from Boltz API for one key or a set of keys.
+     *
+     * An HD wallet spreads its swaps across every index that has been current,
+     * so restore has to ask about all of them. The set is chunked (Boltz
+     * documents no array limit, so the bound is defensive) and the chunk
+     * responses are concatenated; a failed chunk fails the whole restore rather
+     * than returning a silently partial set.
+     *
+     * Non-ARK legs are dropped — the same filter NArk applies.
+     */
+    async restoreSwaps(keys: string | string[]): Promise<CreateSwapsRestoreResponse> {
+        const publicKeys = typeof keys === "string" ? [keys] : keys;
+        if (publicKeys.length === 0) return [];
 
-        const response = await this.request<CreateSwapsRestoreResponse>(
-            "/v2/swap/restore",
-            "POST",
-            requestBody,
-        );
+        const restored: CreateSwapsRestoreResponse = [];
+        for (let i = 0; i < publicKeys.length; i += BoltzSwapProvider.RESTORE_KEYS_PER_REQUEST) {
+            const chunk = publicKeys.slice(i, i + BoltzSwapProvider.RESTORE_KEYS_PER_REQUEST);
+            const requestBody: CreateSwapsRestoreRequest =
+                typeof keys === "string" ? { publicKey: keys } : { publicKeys: chunk };
 
-        if (!isCreateSwapsRestoreResponse(response))
-            throw new SchemaError({
-                message: "Invalid schema in response for swap restoration",
-            });
+            const response = await this.request<CreateSwapsRestoreResponse>(
+                "/v2/swap/restore",
+                "POST",
+                requestBody,
+            );
 
-        return response;
+            if (!isCreateSwapsRestoreResponse(response))
+                throw new SchemaError({
+                    message: "Invalid schema in response for swap restoration",
+                });
+
+            restored.push(...response);
+        }
+
+        return restored.filter((swap) => swap.from === "ARK" || swap.to === "ARK");
     }
 
     /**

--- a/packages/boltz-swap/src/errors.ts
+++ b/packages/boltz-swap/src/errors.ts
@@ -166,6 +166,32 @@ export class TransactionRefundedError extends SwapError {
     }
 }
 
+/**
+ * Thrown when no candidate server signer reproduces a swap's lockup address.
+ *
+ * Typed because callers that probe many keys (restore attribution) must tell an
+ * expected mismatch — every key but the owning one — apart from a real failure
+ * to rebuild the VHTLC, which would otherwise be swallowed as "not ours".
+ */
+export class VHTLCAddressMismatchError extends SwapError {
+    public readonly swapId: string;
+    public readonly lockupAddress: string;
+
+    constructor(options: ErrorOptions & { swapId: string; lockupAddress: string; tried: number }) {
+        super({
+            ...options,
+            message:
+                options.message ??
+                `Swap ${options.swapId}: VHTLC address mismatch. Expected ${options.lockupAddress}; ` +
+                    `no current or deprecated server signer (${options.tried} candidate(s) tried) ` +
+                    `reproduced it`,
+        });
+        this.name = "VHTLCAddressMismatchError";
+        this.swapId = options.swapId;
+        this.lockupAddress = options.lockupAddress;
+    }
+}
+
 /** Reason a `quoteSwap` was rejected before being posted to Boltz. */
 export type QuoteRejectionReason =
     | "below_floor"

--- a/packages/boltz-swap/src/index.ts
+++ b/packages/boltz-swap/src/index.ts
@@ -50,6 +50,7 @@ export {
     TransactionFailedError,
     BoltzRefundError,
     QuoteRejectedError,
+    VHTLCAddressMismatchError,
 } from "./errors";
 export type { QuoteRejectionReason } from "./errors";
 export {

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -171,6 +171,11 @@ export interface BoltzReverseSwap {
     request: CreateReverseSwapRequest;
     /** Boltz API response with lockup address, invoice, and timeout details. */
     response: CreateReverseSwapResponse;
+    /**
+     * Materialized HD descriptor whose key owns this swap's VHTLC. Absent for
+     * swaps bound to the wallet's baseline identity key.
+     */
+    signingDescriptor?: string;
 }
 
 /** Tracks an in-progress submarine swap (Arkade → Lightning). */
@@ -197,6 +202,11 @@ export interface BoltzSubmarineSwap {
     request: CreateSubmarineSwapRequest;
     /** Boltz API response with payment address and expected amount. */
     response: CreateSubmarineSwapResponse;
+    /**
+     * Materialized HD descriptor whose key owns this swap's VHTLC. Absent for
+     * swaps bound to the wallet's baseline identity key.
+     */
+    signingDescriptor?: string;
 }
 
 /**
@@ -320,6 +330,11 @@ export interface BoltzChainSwap {
     request: CreateChainSwapRequest;
     /** Boltz API response with lockup and claim details. */
     response: CreateChainSwapResponse;
+    /**
+     * Materialized HD descriptor whose key owns this swap's VHTLC. Absent for
+     * swaps bound to the wallet's baseline identity key.
+     */
+    signingDescriptor?: string;
     /** Destination address for the received funds. */
     toAddress?: string;
     /** Swap amount in satoshis. */

--- a/packages/boltz-swap/src/utils/identity.ts
+++ b/packages/boltz-swap/src/utils/identity.ts
@@ -2,13 +2,22 @@ import { ConditionWitness, setArkPsbtField, Identity, Transaction } from "@arkad
 
 /**
  * Creates a VHTLC identity handling the claim preimage reveal.
+ *
+ * Delegates member by member rather than spreading `identity`: a spread copies
+ * own properties only, so a class-based identity (`SingleKey`, `SeedIdentity`,
+ * `DescriptorIdentity`) would lose every prototype method — including the
+ * `signerSession()` a batch join needs.
+ *
  * @param identity - The base identity to wrap.
  * @param preimage - The preimage to reveal. optional.
  * @returns The wrapped identity.
  */
 export function claimVHTLCIdentity(identity: Identity, preimage: Uint8Array): Identity {
     return {
-        ...identity,
+        xOnlyPublicKey: () => identity.xOnlyPublicKey(),
+        compressedPublicKey: () => identity.compressedPublicKey(),
+        signerSession: () => identity.signerSession(),
+        signMessage: (message, signatureType) => identity.signMessage(message, signatureType),
         sign: async (tx: Transaction, inputIndexes?: number[]): Promise<Transaction> => {
             const cpy = tx.clone();
             let signedTx = await identity.sign(cpy, inputIndexes);

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -5488,4 +5488,169 @@ describe("ArkadeSwaps", () => {
             ).rejects.toThrow(/invalid BTC address/);
         });
     });
+    describe("HD index binding", () => {
+        const rotatedIdentity = SingleKey.fromPrivateKey(seckeys.fulmine);
+        const rotatedDescriptor = "tr([73c5da0a/86'/1'/0']tpubROTATED/0/7)";
+        const rotatedXOnly = hex.encode(mock.pubkeys.fulmine);
+
+        /** Turn the mock wallet into an HD wallet parked on a rotated index. */
+        const rotateWallet = () => {
+            (wallet as any).getCurrentSigningDescriptor = vi
+                .fn()
+                .mockResolvedValue(rotatedDescriptor);
+            (wallet as any).getUsedSigningDescriptors = vi
+                .fn()
+                .mockResolvedValue([rotatedDescriptor]);
+            (wallet as any).signerForDescriptor = vi.fn().mockResolvedValue(rotatedIdentity);
+        };
+
+        it("creates a reverse swap under the current index", async () => {
+            rotateWallet();
+            vi.spyOn(swapProvider, "createReverseSwap").mockImplementationOnce(
+                reverseSwapResponseFor(createReverseSwapResponse),
+            );
+
+            const pendingSwap = await swaps.createReverseSwap({ amount: mock.invoice.amount });
+
+            expect(pendingSwap.request.claimPublicKey).toBe(compressedPubkeys.fulmine);
+            expect(pendingSwap.signingDescriptor).toBe(rotatedDescriptor);
+        });
+
+        it("creates a submarine swap under the current index", async () => {
+            rotateWallet();
+            vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
+                createSubmarineSwapResponse,
+            );
+
+            const pendingSwap = await swaps.createSubmarineSwap({
+                invoice: mock.invoice.address,
+            });
+
+            expect(pendingSwap.request.refundPublicKey).toBe(compressedPubkeys.fulmine);
+            expect(pendingSwap.signingDescriptor).toBe(rotatedDescriptor);
+        });
+
+        it("binds only the ARK leg of a chain swap to the current index", async () => {
+            rotateWallet();
+            vi.spyOn(swapProvider, "createChainSwap").mockResolvedValueOnce(
+                createArkBtcChainSwapResponse,
+            );
+
+            const arkToBtc = await swaps.createChainSwap({
+                to: "BTC",
+                from: "ARK",
+                feeSatsPerByte: 1,
+                senderLockAmount: mock.amount,
+                toAddress: mock.address.btc,
+            });
+
+            expect(arkToBtc.request.refundPublicKey).toBe(compressedPubkeys.fulmine);
+            expect(arkToBtc.request.claimPublicKey).not.toBe(compressedPubkeys.fulmine);
+            expect(arkToBtc.signingDescriptor).toBe(rotatedDescriptor);
+
+            vi.spyOn(swapProvider, "createChainSwap").mockResolvedValueOnce(
+                createBtcArkChainSwapResponse,
+            );
+            const btcToArk = await swaps.createChainSwap({
+                to: "ARK",
+                from: "BTC",
+                feeSatsPerByte: 1,
+                senderLockAmount: mock.amount,
+                toAddress: mock.address.ark,
+            });
+
+            expect(btcToArk.request.claimPublicKey).toBe(compressedPubkeys.fulmine);
+            expect(btcToArk.request.refundPublicKey).not.toBe(compressedPubkeys.fulmine);
+        });
+
+        it("stays on the baseline key when the wallet has no HD state", async () => {
+            vi.spyOn(swapProvider, "createReverseSwap").mockImplementationOnce(
+                reverseSwapResponseFor(createReverseSwapResponse),
+            );
+
+            const pendingSwap = await swaps.createReverseSwap({ amount: mock.invoice.amount });
+
+            expect(pendingSwap.request.claimPublicKey).toBe(compressedPubkeys.alice);
+            expect(pendingSwap.signingDescriptor).toBeUndefined();
+        });
+
+        describe("claim and refund routing", () => {
+            const mockVHTLC = {
+                vhtlcAddress: mock.lockupAddress,
+                vhtlcScript: {
+                    claimScript: new Uint8Array([1]),
+                    refundScript: new Uint8Array([1]),
+                    pkScript: new Uint8Array([2]),
+                    claim: () => [{}, new Uint8Array([3]), 0xc0] as any,
+                    refund: () => [{}, new Uint8Array([3]), 0xc0] as any,
+                    refundWithoutReceiver: () => [{}, new Uint8Array([3]), 0xc0] as any,
+                    encode: () => [] as any,
+                },
+            };
+
+            const reverseSwapWith = (signingDescriptor?: string): BoltzReverseSwap => ({
+                id: mock.id,
+                type: "reverse",
+                createdAt: Date.now(),
+                preimage: hex.encode(randomBytes(32)),
+                request: createReverseSwapRequest,
+                response: { ...createReverseSwapResponse, lockupAddress: mock.lockupAddress },
+                status: "swap.created",
+                signingDescriptor,
+            });
+
+            let scriptSpy: ReturnType<typeof vi.spyOn>;
+
+            beforeEach(() => {
+                vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+                vi.mocked(wallet.getAddress).mockResolvedValue(mock.address.ark);
+                scriptSpy = vi.spyOn(swaps, "createVHTLCScript").mockReturnValue(mockVHTLC as any);
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({ vtxos: [] as any });
+            });
+
+            it("claims a bound reverse swap with the swap's key", async () => {
+                rotateWallet();
+
+                // No VTXOs at the lockup: the claim throws after the VHTLC has
+                // been rebuilt, which is the part under test.
+                await expect(swaps.claimVHTLC(reverseSwapWith(rotatedDescriptor))).rejects.toThrow(
+                    /no spendable virtual coins/,
+                );
+
+                expect(wallet.signerForDescriptor).toHaveBeenCalledWith(rotatedDescriptor);
+                expect((scriptSpy.mock.calls[0][0] as any).receiverPubkey).toBe(rotatedXOnly);
+            });
+
+            it("claims an unbound reverse swap with the baseline key", async () => {
+                rotateWallet();
+
+                await expect(swaps.claimVHTLC(reverseSwapWith())).rejects.toThrow(
+                    /no spendable virtual coins/,
+                );
+
+                expect(wallet.signerForDescriptor).not.toHaveBeenCalled();
+                expect((scriptSpy.mock.calls[0][0] as any).receiverPubkey).toBe(
+                    hex.encode(mock.pubkeys.alice),
+                );
+            });
+
+            it("refunds a bound submarine swap with the swap's key", async () => {
+                rotateWallet();
+                const submarineSwap: BoltzSubmarineSwap = {
+                    id: mock.id,
+                    type: "submarine",
+                    createdAt: Date.now(),
+                    status: "invoice.set",
+                    request: createSubmarineSwapRequest,
+                    response: { ...createSubmarineSwapResponse, address: mock.lockupAddress },
+                    signingDescriptor: rotatedDescriptor,
+                };
+
+                await expect(swaps.refundVHTLC(submarineSwap)).rejects.toThrow(/VHTLC not found/);
+
+                expect(wallet.signerForDescriptor).toHaveBeenCalledWith(rotatedDescriptor);
+                expect((scriptSpy.mock.calls[0][0] as any).senderPubkey).toBe(rotatedXOnly);
+            });
+        });
+    });
 });

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3565,6 +3565,58 @@ describe("ArkadeSwaps", () => {
                 expect(result.reverseSwaps).toHaveLength(0);
             });
 
+            it("skips a swap with a malformed preimage hash without dropping the rest", async () => {
+                const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+                const brokenReverse = {
+                    ...pendingReverse,
+                    id: "rev-bad-preimage",
+                    preimageHash: "zz",
+                    claimDetails: { ...pendingReverse.claimDetails, preimageHash: "zz" },
+                };
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([
+                    brokenReverse,
+                    pendingChain,
+                ]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.reverseSwaps).toHaveLength(0);
+                expect(result.chainSwaps).toHaveLength(1);
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining("malformed preimage hash"),
+                    expect.anything(),
+                );
+            });
+
+            it("skips an unbuildable swap, logs the cause, and keeps the rest", async () => {
+                const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+                const brokenReverse = {
+                    ...pendingReverse,
+                    id: "rev-bad-server-key",
+                    claimDetails: {
+                        ...pendingReverse.claimDetails,
+                        // Boltz key of an impossible length: no candidate of ours
+                        // can rebuild the VHTLC at all.
+                        serverPublicKey: hex.encode(randomBytes(31)),
+                    },
+                };
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([
+                    brokenReverse,
+                    pendingChain,
+                ]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.reverseSwaps).toHaveLength(0);
+                expect(result.chainSwaps).toHaveLength(1);
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining("failed to rebuild the VHTLC"),
+                    expect.objectContaining({ message: expect.stringContaining("key length") }),
+                );
+            });
+
             it("gives a restored ARK-lockup chain swap a usable refund key", async () => {
                 vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([pendingChain]);
                 vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -27,6 +27,8 @@ import {
     ArkInfo,
     getNetwork,
     maybeArkError,
+    MnemonicIdentity,
+    deriveDescriptorLeafCompressedPubKey,
 } from "@arkade-os/sdk";
 import { VHTLC } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
@@ -37,6 +39,7 @@ import { ripemd160 } from "@noble/hashes/legacy.js";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { Address, OutScript, Script, ScriptNum } from "@scure/btc-signer";
 import { decodeInvoice } from "../src/utils/decoding";
+import { resolveVhtlcTimeouts } from "../src/utils/restoration";
 import { logger } from "../src/logger";
 import { pubECDSA } from "@scure/btc-signer/utils.js";
 import { create as createMusig } from "../src/utils/musig";
@@ -3166,69 +3169,6 @@ describe("ArkadeSwaps", () => {
             unilateralRefundLeaf: mockLeaf,
             unilateralRefundWithoutBoltzLeaf: mockLeaf,
         };
-        const mockDetails = {
-            tree: mockTree,
-            amount: 50000,
-            keyIndex: 0,
-            lockupAddress: "mock-lockup",
-            serverPublicKey: compressedPubkeys.boltz,
-            timeoutBlockHeight: 100,
-        };
-
-        const pendingReverse = {
-            id: "rev-pending",
-            type: "reverse" as const,
-            to: "ARK" as const,
-            from: "BTC" as const,
-            status: "swap.created" as BoltzSwapStatus,
-            createdAt: 1000,
-            preimageHash: hex.encode(sha256(randomBytes(32))),
-            claimDetails: mockDetails,
-        };
-
-        const finalReverse = {
-            ...pendingReverse,
-            id: "rev-final",
-            status: "invoice.settled" as BoltzSwapStatus,
-        };
-
-        const pendingSubmarine = {
-            id: "sub-pending",
-            type: "submarine" as const,
-            to: "BTC" as const,
-            from: "ARK" as const,
-            status: "transaction.mempool" as BoltzSwapStatus,
-            createdAt: 2000,
-            preimageHash: hex.encode(sha256(randomBytes(32))),
-            refundDetails: mockDetails,
-        };
-
-        const finalSubmarine = {
-            ...pendingSubmarine,
-            id: "sub-final",
-            status: "transaction.claimed" as BoltzSwapStatus,
-        };
-
-        const pendingChain = {
-            id: "chain-pending",
-            type: "chain" as const,
-            to: "BTC" as const,
-            from: "ARK" as const,
-            status: "transaction.server.mempool" as BoltzSwapStatus,
-            createdAt: 3000,
-            preimageHash: hex.encode(sha256(randomBytes(32))),
-            refundDetails: {
-                ...mockDetails,
-                tree: mockTree,
-            },
-        };
-
-        const finalChain = {
-            ...pendingChain,
-            id: "chain-final",
-            status: "transaction.claimed" as BoltzSwapStatus,
-        };
-
         const mockFees = {
             submarine: { percentage: 0.1, minerFees: 100 },
             reverse: {
@@ -3280,6 +3220,113 @@ describe("ArkadeSwaps", () => {
             unilateralRefund: 19456,
             unilateralRefundWithoutReceiver: 38400,
         };
+
+        // Restore attributes a swap by rebuilding its VHTLC until the lockup
+        // address matches, so fixtures must carry a real address built from the
+        // same key pair and timeouts Boltz would have used.
+        const makeDetails = (opts: {
+            ourRole: "receiver" | "sender";
+            preimageHash: string;
+            tree?: any;
+            timeoutBlockHeights?: typeof serverTimeouts;
+            ourKey?: string;
+        }) => {
+            const tree = opts.tree ?? mockTree;
+            const ourKey = opts.ourKey ?? compressedPubkeys.alice;
+            const timeouts = resolveVhtlcTimeouts(tree, opts.timeoutBlockHeights);
+            const lockupAddress = timeouts
+                ? createVHTLCScriptReal({
+                      network: "regtest",
+                      preimageHash: hex.decode(opts.preimageHash),
+                      receiverPubkey:
+                          opts.ourRole === "receiver" ? ourKey : compressedPubkeys.boltz,
+                      senderPubkey: opts.ourRole === "sender" ? ourKey : compressedPubkeys.boltz,
+                      serverPubkey: hex.encode(mock.pubkeys.server),
+                      timeoutBlockHeights: timeouts,
+                  }).vhtlcAddress
+                : "unresolvable-lockup";
+            return {
+                tree,
+                amount: 50000,
+                keyIndex: 0,
+                lockupAddress,
+                serverPublicKey: compressedPubkeys.boltz,
+                timeoutBlockHeight: 100,
+                ...(opts.timeoutBlockHeights
+                    ? { timeoutBlockHeights: opts.timeoutBlockHeights }
+                    : {}),
+            };
+        };
+
+        const reversePreimageHash = hex.encode(sha256(randomBytes(32)));
+        const pendingReverse = {
+            id: "rev-pending",
+            type: "reverse" as const,
+            to: "ARK" as const,
+            from: "BTC" as const,
+            status: "swap.created" as BoltzSwapStatus,
+            createdAt: 1000,
+            preimageHash: reversePreimageHash,
+            claimDetails: makeDetails({
+                ourRole: "receiver",
+                preimageHash: reversePreimageHash,
+                timeoutBlockHeights: serverTimeouts,
+            }),
+        };
+
+        const finalReverse = {
+            ...pendingReverse,
+            id: "rev-final",
+            status: "invoice.settled" as BoltzSwapStatus,
+        };
+
+        const submarinePreimageHash = hex.encode(sha256(randomBytes(32)));
+        const pendingSubmarine = {
+            id: "sub-pending",
+            type: "submarine" as const,
+            to: "BTC" as const,
+            from: "ARK" as const,
+            status: "transaction.mempool" as BoltzSwapStatus,
+            createdAt: 2000,
+            preimageHash: submarinePreimageHash,
+            refundDetails: makeDetails({
+                ourRole: "sender",
+                preimageHash: submarinePreimageHash,
+                timeoutBlockHeights: serverTimeouts,
+            }),
+        };
+
+        const finalSubmarine = {
+            ...pendingSubmarine,
+            id: "sub-final",
+            status: "transaction.claimed" as BoltzSwapStatus,
+        };
+
+        const chainPreimageHash = hex.encode(sha256(randomBytes(32)));
+        const pendingChain = {
+            id: "chain-pending",
+            type: "chain" as const,
+            to: "BTC" as const,
+            from: "ARK" as const,
+            status: "transaction.server.mempool" as BoltzSwapStatus,
+            createdAt: 3000,
+            preimageHash: chainPreimageHash,
+            refundDetails: makeDetails({
+                ourRole: "sender",
+                preimageHash: chainPreimageHash,
+                timeoutBlockHeights: serverTimeouts,
+            }),
+        };
+
+        const finalChain = {
+            ...pendingChain,
+            id: "chain-final",
+            status: "transaction.claimed" as BoltzSwapStatus,
+        };
+
+        beforeEach(() => {
+            vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+        });
 
         it("should include terminal swaps in results without extra API fetches", async () => {
             const restoreSpy = vi
@@ -3359,15 +3406,7 @@ describe("ArkadeSwaps", () => {
         });
 
         it("populates chain lockupDetails.timeouts from server-provided timeoutBlockHeights", async () => {
-            const chainWithTimeouts = {
-                ...pendingChain,
-                refundDetails: {
-                    ...mockDetails,
-                    tree: mockTree,
-                    timeoutBlockHeights: serverTimeouts,
-                },
-            };
-            vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([chainWithTimeouts]);
+            vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([pendingChain]);
             vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
 
             const result = await swaps.restoreSwaps();
@@ -3379,7 +3418,11 @@ describe("ArkadeSwaps", () => {
         it("derives chain lockupDetails.timeouts from the VHTLC tree when timeoutBlockHeights is absent", async () => {
             const chainDerived = {
                 ...pendingChain,
-                refundDetails: { ...mockDetails, tree: realVhtlcTree },
+                refundDetails: makeDetails({
+                    ourRole: "sender",
+                    preimageHash: chainPreimageHash,
+                    tree: realVhtlcTree,
+                }),
             };
             vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([chainDerived]);
             vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
@@ -3389,34 +3432,47 @@ describe("ArkadeSwaps", () => {
             expect(result.chainSwaps[0].response.lockupDetails.timeouts).toEqual(derivedTimeouts);
         });
 
-        it("leaves chain lockupDetails.timeouts undefined when the tree is incomplete (zero-guard)", async () => {
-            // pendingChain uses the empty mockTree and carries no timeoutBlockHeights,
-            // so every derived locktime is 0 — the guard must skip rather than build a
-            // VHTLC with zeroed timeouts (which would fail refundArk's address check).
-            vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([pendingChain]);
+        it("skips a chain swap whose timeouts cannot be resolved (zero-guard)", async () => {
+            // An empty tree with no timeoutBlockHeights derives every locktime as
+            // 0: the VHTLC can't be rebuilt, so the swap can't be attributed to
+            // any of our keys and must be dropped rather than mis-recorded.
+            const chainUnresolvable = {
+                ...pendingChain,
+                refundDetails: makeDetails({
+                    ourRole: "sender",
+                    preimageHash: chainPreimageHash,
+                }),
+            };
+            vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([chainUnresolvable]);
             vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
 
             const result = await swaps.restoreSwaps();
 
-            expect(result.chainSwaps[0].response.lockupDetails.timeouts).toBeUndefined();
+            expect(result.chainSwaps).toHaveLength(0);
         });
 
         it("applies the same timeouts resolution to restored reverse and submarine swaps", async () => {
             const reverseDerived = {
                 ...pendingReverse,
                 id: "rev-derived",
-                claimDetails: { ...mockDetails, tree: realVhtlcTree },
+                claimDetails: makeDetails({
+                    ourRole: "receiver",
+                    preimageHash: reversePreimageHash,
+                    tree: realVhtlcTree,
+                }),
             };
             const submarineDerived = {
                 ...pendingSubmarine,
                 id: "sub-derived",
-                refundDetails: { ...mockDetails, tree: realVhtlcTree },
+                refundDetails: makeDetails({
+                    ourRole: "sender",
+                    preimageHash: submarinePreimageHash,
+                    tree: realVhtlcTree,
+                }),
             };
             vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([
                 reverseDerived,
                 submarineDerived,
-                pendingReverse, // empty tree -> undefined
-                pendingSubmarine, // empty tree -> undefined
             ]);
             vi.spyOn(swapProvider, "getSwapPreimage").mockResolvedValue({
                 preimage: hex.encode(randomBytes(32)),
@@ -3425,21 +3481,122 @@ describe("ArkadeSwaps", () => {
 
             const result = await swaps.restoreSwaps();
 
-            const byId = <T extends { id: string }>(swaps: T[], id: string) =>
-                swaps.find((s) => s.id === id)!;
+            expect(result.reverseSwaps[0].response.timeoutBlockHeights).toEqual(derivedTimeouts);
+            expect(result.submarineSwaps[0].response.timeoutBlockHeights).toEqual(derivedTimeouts);
+        });
 
-            expect(byId(result.reverseSwaps, "rev-derived").response.timeoutBlockHeights).toEqual(
-                derivedTimeouts,
+        describe("multi-key attribution", () => {
+            const hdIdentity = MnemonicIdentity.fromMnemonic(
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+                { isMainnet: false },
             );
-            expect(
-                byId(result.reverseSwaps, "rev-pending").response.timeoutBlockHeights,
-            ).toBeUndefined();
-            expect(byId(result.submarineSwaps, "sub-derived").response.timeoutBlockHeights).toEqual(
-                derivedTimeouts,
-            );
-            expect(
-                byId(result.submarineSwaps, "sub-pending").response.timeoutBlockHeights,
-            ).toBeUndefined();
+            const rotatedDescriptor = hdIdentity.descriptor.replace("/*)", "/7)");
+            const rotatedKey = hex.encode(deriveDescriptorLeafCompressedPubKey(rotatedDescriptor));
+
+            /** Wallet reporting one rotated descriptor beyond the baseline key. */
+            const withRotatedDescriptor = () => {
+                (wallet as any).getUsedSigningDescriptors = vi
+                    .fn()
+                    .mockResolvedValue([rotatedDescriptor]);
+                (wallet as any).getCurrentSigningDescriptor = vi
+                    .fn()
+                    .mockResolvedValue(rotatedDescriptor);
+                (wallet as any).signerForDescriptor = vi.fn().mockResolvedValue(identity);
+            };
+
+            it("queries every used descriptor key alongside the identity key", async () => {
+                withRotatedDescriptor();
+                const restoreSpy = vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                await swaps.restoreSwaps();
+
+                expect(restoreSpy).toHaveBeenCalledWith([compressedPubkeys.alice, rotatedKey]);
+            });
+
+            it("attributes a swap locked to a rotated key and records its descriptor", async () => {
+                withRotatedDescriptor();
+                const rotatedReverse = {
+                    ...pendingReverse,
+                    id: "rev-rotated",
+                    claimDetails: makeDetails({
+                        ourRole: "receiver",
+                        preimageHash: reversePreimageHash,
+                        timeoutBlockHeights: serverTimeouts,
+                        ourKey: rotatedKey,
+                    }),
+                };
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([rotatedReverse]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.reverseSwaps).toHaveLength(1);
+                expect(result.reverseSwaps[0].request.claimPublicKey).toBe(rotatedKey);
+                expect(result.reverseSwaps[0].signingDescriptor).toBe(rotatedDescriptor);
+            });
+
+            it("leaves the baseline key undescribed", async () => {
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([pendingReverse]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.reverseSwaps[0].request.claimPublicKey).toBe(compressedPubkeys.alice);
+                expect(result.reverseSwaps[0].signingDescriptor).toBeUndefined();
+            });
+
+            it("skips a swap no key of ours reproduces", async () => {
+                const foreignReverse = {
+                    ...pendingReverse,
+                    id: "rev-foreign",
+                    claimDetails: makeDetails({
+                        ourRole: "receiver",
+                        preimageHash: reversePreimageHash,
+                        timeoutBlockHeights: serverTimeouts,
+                        ourKey: compressedPubkeys.fulmine,
+                    }),
+                };
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([foreignReverse]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.reverseSwaps).toHaveLength(0);
+            });
+
+            it("gives a restored ARK-lockup chain swap a usable refund key", async () => {
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([pendingChain]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.chainSwaps[0].request.refundPublicKey).toBe(compressedPubkeys.alice);
+            });
+
+            it("gives a restored ARK-claim chain swap a usable claim key", async () => {
+                const btcToArk = {
+                    id: "chain-to-ark",
+                    type: "chain" as const,
+                    to: "ARK" as const,
+                    from: "BTC" as const,
+                    status: "transaction.server.mempool" as BoltzSwapStatus,
+                    createdAt: 4000,
+                    preimageHash: chainPreimageHash,
+                    claimDetails: makeDetails({
+                        ourRole: "receiver",
+                        preimageHash: chainPreimageHash,
+                        timeoutBlockHeights: serverTimeouts,
+                    }),
+                };
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([btcToArk]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.chainSwaps[0].request.claimPublicKey).toBe(compressedPubkeys.alice);
+                expect(result.chainSwaps[0].response.claimDetails.timeouts).toEqual(serverTimeouts);
+            });
         });
     });
 

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3485,6 +3485,30 @@ describe("ArkadeSwaps", () => {
             expect(result.submarineSwaps[0].response.timeoutBlockHeights).toEqual(derivedTimeouts);
         });
 
+        /** BTC leg of a BTC→ARK chain swap: the leg we lock and could refund. */
+        const btcLockupDetails = {
+            tree: mockTree,
+            amount: 60000,
+            lockupAddress: "bcrt1qlockupaddress",
+            serverPublicKey: compressedPubkeys.boltz,
+            timeoutBlockHeight: 200,
+        };
+
+        const btcToArk = {
+            id: "chain-to-ark",
+            type: "chain" as const,
+            to: "ARK" as const,
+            from: "BTC" as const,
+            status: "transaction.server.mempool" as BoltzSwapStatus,
+            createdAt: 4000,
+            preimageHash: chainPreimageHash,
+            claimDetails: makeDetails({
+                ourRole: "receiver",
+                preimageHash: chainPreimageHash,
+                timeoutBlockHeights: serverTimeouts,
+            }),
+        };
+
         describe("multi-key attribution", () => {
             const hdIdentity = MnemonicIdentity.fromMnemonic(
                 "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
@@ -3627,20 +3651,6 @@ describe("ArkadeSwaps", () => {
             });
 
             it("gives a restored ARK-claim chain swap a usable claim key", async () => {
-                const btcToArk = {
-                    id: "chain-to-ark",
-                    type: "chain" as const,
-                    to: "ARK" as const,
-                    from: "BTC" as const,
-                    status: "transaction.server.mempool" as BoltzSwapStatus,
-                    createdAt: 4000,
-                    preimageHash: chainPreimageHash,
-                    claimDetails: makeDetails({
-                        ourRole: "receiver",
-                        preimageHash: chainPreimageHash,
-                        timeoutBlockHeights: serverTimeouts,
-                    }),
-                };
                 vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([btcToArk]);
                 vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
 
@@ -3648,6 +3658,35 @@ describe("ArkadeSwaps", () => {
 
                 expect(result.chainSwaps[0].request.claimPublicKey).toBe(compressedPubkeys.alice);
                 expect(result.chainSwaps[0].response.claimDetails.timeouts).toEqual(serverTimeouts);
+            });
+
+            it("keeps the BTC leg as the lockup details of a BTC→ARK swap", async () => {
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([
+                    { ...btcToArk, refundDetails: btcLockupDetails },
+                ]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.chainSwaps[0].response.lockupDetails.lockupAddress).toBe(
+                    btcLockupDetails.lockupAddress,
+                );
+                expect(result.chainSwaps[0].amount).toBe(btcLockupDetails.amount);
+            });
+
+            it("omits lockup details rather than substituting the ARK leg", async () => {
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([btcToArk]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                // Boltz omitted the BTC leg: the swap stays claimable, but
+                // nothing may present the ARK leg as a BTC lockup.
+                expect(result.chainSwaps).toHaveLength(1);
+                expect(result.chainSwaps[0].response.lockupDetails).toBeUndefined();
+                expect(result.chainSwaps[0].response.claimDetails.lockupAddress).toBe(
+                    btcToArk.claimDetails.lockupAddress,
+                );
             });
         });
     });

--- a/packages/boltz-swap/test/boltz-swap-provider.test.ts
+++ b/packages/boltz-swap/test/boltz-swap-provider.test.ts
@@ -1335,4 +1335,79 @@ describe("BoltzSwapProvider", () => {
             }
         });
     });
+    describe("restoreSwaps", () => {
+        const restoredSwap = (id: string) => ({
+            id,
+            type: "reverse",
+            to: "ARK",
+            from: "BTC",
+            status: "swap.created",
+            createdAt: 1,
+            claimDetails: {
+                tree: {
+                    claimLeaf: { version: 0, output: "" },
+                    refundLeaf: { version: 0, output: "" },
+                },
+                lockupAddress: "lockup",
+                serverPublicKey: mockHexCompressedPubKey,
+            },
+        });
+
+        const bodyOf = (mockFetch: any, call = 0) => JSON.parse(mockFetch.mock.calls[call][1].body);
+
+        it("sends a single key as publicKey", async () => {
+            const mockFetch = vi.fn(() => createFetchResponse([]));
+            vi.stubGlobal("fetch", mockFetch);
+
+            await provider.restoreSwaps(mockHexCompressedPubKey);
+
+            expect(bodyOf(mockFetch)).toEqual({ publicKey: mockHexCompressedPubKey });
+        });
+
+        it("sends a key set as publicKeys", async () => {
+            const mockFetch = vi.fn(() => createFetchResponse([]));
+            vi.stubGlobal("fetch", mockFetch);
+
+            await provider.restoreSwaps([mockHexCompressedPubKey]);
+
+            expect(bodyOf(mockFetch)).toEqual({ publicKeys: [mockHexCompressedPubKey] });
+        });
+
+        it("chunks at 100 keys and concatenates the responses", async () => {
+            const keys = Array.from({ length: 250 }, (_, i) => `key-${i}`);
+            const mockFetch = vi
+                .fn()
+                .mockReturnValueOnce(createFetchResponse([restoredSwap("a")]))
+                .mockReturnValueOnce(createFetchResponse([restoredSwap("b")]))
+                .mockReturnValueOnce(createFetchResponse([restoredSwap("c")]));
+            vi.stubGlobal("fetch", mockFetch);
+
+            const restored = await provider.restoreSwaps(keys);
+
+            expect(mockFetch).toHaveBeenCalledTimes(3);
+            expect(bodyOf(mockFetch, 0).publicKeys).toHaveLength(100);
+            expect(bodyOf(mockFetch, 2).publicKeys).toEqual(keys.slice(200));
+            expect(restored.map((s) => s.id)).toEqual(["a", "b", "c"]);
+        });
+
+        it("does not call the API for an empty key set", async () => {
+            const mockFetch = vi.fn(() => createFetchResponse([]));
+            vi.stubGlobal("fetch", mockFetch);
+
+            expect(await provider.restoreSwaps([])).toEqual([]);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it("drops swaps with no ARK leg", async () => {
+            const btcOnly = { ...restoredSwap("btc"), to: "BTC", from: "BTC", type: "chain" };
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(() => createFetchResponse([btcOnly, restoredSwap("ark")])),
+            );
+
+            const restored = await provider.restoreSwaps(["a", "b"]);
+
+            expect(restored.map((s) => s.id)).toEqual(["ark"]);
+        });
+    });
 });

--- a/packages/boltz-swap/test/e2e/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/e2e/arkade-swaps.test.ts
@@ -51,6 +51,16 @@ const payInvoice = async (invoice: string) => {
     return execAsync(`${lncli} payinvoice --force ${invoice}`);
 };
 
+/**
+ * Pays an invoice out of band, once the caller is already waiting on the swap.
+ * Never resolves, so it can be raced against the wait: only a payment *failure*
+ * settles it, turning what would be a claim timeout into the real error.
+ */
+const payInvoiceOrFail = (invoice: string): Promise<never> =>
+    sleep(1000)
+        .then(() => payInvoice(invoice))
+        .then(() => new Promise<never>(() => {}));
+
 const getNewLightningInvoice = async (
     amount: number,
 ): Promise<{ invoice: string; r_hash: string }> => {
@@ -1722,14 +1732,11 @@ describe("ArkadeSwaps", () => {
                 hex.encode(await hdWallet.identity.compressedPublicKey()),
             );
 
-            sleep(1000).then(() =>
-                payInvoice(pendingSwap.response.invoice).catch((err) =>
-                    console.error("Error paying invoice:", err),
-                ),
-            );
-
             // Claiming proves the VHTLC was signed with the rotated key.
-            const { txid } = await hdSwaps.waitAndClaim(pendingSwap);
+            const { txid } = await Promise.race([
+                hdSwaps.waitAndClaim(pendingSwap),
+                payInvoiceOrFail(pendingSwap.response.invoice),
+            ]);
             expect(txid).toHaveLength(64);
 
             // A restore that only knew the baseline key would miss it.

--- a/packages/boltz-swap/test/e2e/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/e2e/arkade-swaps.test.ts
@@ -13,6 +13,7 @@ import {
     Identity,
     Wallet,
     SingleKey,
+    SeedIdentity,
     EsploraProvider,
     ArkNote,
     InMemoryWalletRepository,
@@ -20,6 +21,7 @@ import {
 } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
 import { schnorr } from "@noble/curves/secp256k1.js";
+import { randomBytes } from "@noble/hashes/utils.js";
 import { decodeInvoice } from "../../src/utils/decoding";
 import { pubECDSA, sha256 } from "@scure/btc-signer/utils.js";
 import { candidateServerPubkeys } from "../../src/utils/vhtlc";
@@ -1687,6 +1689,54 @@ describe("ArkadeSwaps", () => {
                     swapId: "deprecated-signer-recon-neg",
                 }),
             ).toThrow(/VHTLC address mismatch/);
+        }, 60_000);
+    });
+    describe("HD swap keys", () => {
+        it("creates, claims and restores a swap bound to a rotated HD index", async () => {
+            const hdWallet = await Wallet.create({
+                identity: SeedIdentity.fromSeed(randomBytes(64), { isMainnet: false }),
+                walletMode: "hd",
+                arkServerUrl: arkUrl,
+                settlementConfig: false,
+                storage: createWalletStorage(),
+            });
+
+            // Boarding shares the HD index stream, so allocating one moves
+            // the wallet off index 0 without needing an incoming payment.
+            await hdWallet.getNewBoardingAddress();
+            const descriptor = await hdWallet.getCurrentSigningDescriptor();
+            expect(descriptor).toBeDefined();
+
+            const hdSwaps = new ArkadeSwaps({
+                wallet: hdWallet,
+                swapProvider,
+                arkProvider,
+                indexerProvider,
+                swapRepository: new InMemorySwapRepository(),
+                swapManager: false,
+            });
+
+            const pendingSwap = await hdSwaps.createReverseSwap({ amount: 1000 });
+            expect(pendingSwap.signingDescriptor).toBe(descriptor);
+            expect(pendingSwap.request.claimPublicKey).not.toBe(
+                hex.encode(await hdWallet.identity.compressedPublicKey()),
+            );
+
+            sleep(1000).then(() =>
+                payInvoice(pendingSwap.response.invoice).catch((err) =>
+                    console.error("Error paying invoice:", err),
+                ),
+            );
+
+            // Claiming proves the VHTLC was signed with the rotated key.
+            const { txid } = await hdSwaps.waitAndClaim(pendingSwap);
+            expect(txid).toHaveLength(64);
+
+            // A restore that only knew the baseline key would miss it.
+            const restored = await hdSwaps.restoreSwaps();
+            const match = restored.reverseSwaps.find((s) => s.id === pendingSwap.id);
+            expect(match?.request.claimPublicKey).toBe(pendingSwap.request.claimPublicKey);
+            expect(match?.signingDescriptor).toBe(descriptor);
         }, 60_000);
     });
 });

--- a/packages/ts-sdk/src/identity/descriptor.ts
+++ b/packages/ts-sdk/src/identity/descriptor.ts
@@ -162,6 +162,39 @@ export function deriveDescriptorLeafPubKey(descriptor: string): Uint8Array {
     return key.pubkey;
 }
 
+/**
+ * Compressed (33-byte) counterpart of {@link deriveDescriptorLeafPubKey}, for
+ * protocols that key on the parity byte (Boltz swap keys).
+ *
+ * Only HD descriptors are supported: a bare `tr(xonly)` has lost its parity and
+ * synthesizing `02||xonly` would silently produce the wrong key half the time.
+ */
+export function deriveDescriptorLeafCompressedPubKey(descriptor: string): Uint8Array {
+    const network = isMainnetDescriptor(descriptor) ? networks.bitcoin : networks.testnet;
+    let expansion;
+    try {
+        expansion = expand({ descriptor, network });
+    } catch (e) {
+        throw new Error(
+            `Cannot derive compressed leaf pubkey from descriptor (length=${descriptor.length}): ` +
+                `ensure it is materialized (no wildcard) and parsable.`,
+            { cause: e },
+        );
+    }
+    const key = expansion.expansionMap?.["@0"];
+    if (!key?.bip32) {
+        throw new Error(
+            `Cannot derive compressed leaf pubkey from descriptor (length=${descriptor.length}): ` +
+                `not an HD descriptor, so the key parity is unrecoverable.`,
+        );
+    }
+    // derivePath returns a fresh node; keyPath is relative to the xpub and the
+    // library's derivePath prepends "m/" itself.
+    return key.keyPath
+        ? key.bip32.derivePath(key.keyPath.replace(/^\//, "")).publicKey
+        : key.bip32.publicKey;
+}
+
 /** Parsed HD descriptor components. */
 export interface ParsedHDDescriptor {
     fingerprint: string;

--- a/packages/ts-sdk/src/identity/descriptorIdentity.ts
+++ b/packages/ts-sdk/src/identity/descriptorIdentity.ts
@@ -1,0 +1,121 @@
+import { Identity } from ".";
+import { DescriptorProvider } from "./descriptorProvider";
+import { deriveDescriptorLeafCompressedPubKey, deriveDescriptorLeafPubKey } from "./descriptor";
+import { SignerSession } from "../tree/signingSession";
+import { Transaction } from "../utils/transaction";
+
+/**
+ * Descriptor-scoped signing surface — the two members every
+ * {@link DescriptorProvider} and every `HDCapableIdentity` share.
+ */
+export type DescriptorSigner = Pick<
+    DescriptorProvider,
+    "signWithDescriptor" | "signMessageWithDescriptor"
+>;
+
+/**
+ * Per-descriptor deterministic Schnorr signing. Separate from the baseline
+ * `DeterministicSignCapable` marker because the seed holder — not the
+ * descriptor — is the only party that can derive the key at an index.
+ */
+export interface HDDeterministicSignCapable {
+    /** BIP-340 sign `messageHash` with the descriptor's key and aux_rand = 0. */
+    signSchnorrDeterministicWithDescriptor(
+        descriptor: string,
+        messageHash: Uint8Array,
+    ): Promise<Uint8Array>;
+}
+
+/** Type guard for {@link HDDeterministicSignCapable}. */
+export function isHDDeterministicSignCapable(value: unknown): value is HDDeterministicSignCapable {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof (value as HDDeterministicSignCapable).signSchnorrDeterministicWithDescriptor ===
+            "function"
+    );
+}
+
+/** Constructor arguments for {@link DescriptorIdentity}. */
+export interface DescriptorIdentityOptions {
+    /** Materialized descriptor (no wildcard) this identity is pinned to. */
+    descriptor: string;
+    /** Descriptor-aware signer — an `HDDescriptorProvider` or an HD identity. */
+    signer: DescriptorSigner;
+    /**
+     * Seed-holding identity behind `signer`. Backs the members that are not
+     * descriptor-scoped in the provider contract: musig2 sessions and
+     * deterministic Schnorr.
+     */
+    base: Identity;
+}
+
+/**
+ * {@link Identity} pinned to one materialized HD descriptor: every key and
+ * signature it produces belongs to that index rather than to the wallet's
+ * baseline key.
+ *
+ * Lets components that take a plain `Identity` (VHTLC claim/refund, batch
+ * joins) operate on a rotated index without knowing about descriptors.
+ *
+ * Deliberately does NOT satisfy `isBatchSignable`, `isHDCapableIdentity`, or
+ * `hasToReadonly` — it is a leaf signer, not another HD root.
+ */
+export class DescriptorIdentity implements Identity {
+    private readonly descriptor: string;
+    private readonly signer: DescriptorSigner;
+    private readonly base: Identity;
+
+    constructor({ descriptor, signer, base }: DescriptorIdentityOptions) {
+        this.descriptor = descriptor;
+        this.signer = signer;
+        this.base = base;
+    }
+
+    async xOnlyPublicKey(): Promise<Uint8Array> {
+        return deriveDescriptorLeafPubKey(this.descriptor);
+    }
+
+    async compressedPublicKey(): Promise<Uint8Array> {
+        return deriveDescriptorLeafCompressedPubKey(this.descriptor);
+    }
+
+    async sign(tx: Transaction, inputIndexes?: number[]): Promise<Transaction> {
+        const [signed] = await this.signer.signWithDescriptor([
+            { descriptor: this.descriptor, tx, inputIndexes },
+        ]);
+        if (!signed) {
+            throw new Error(`Descriptor signer returned no transaction for ${this.descriptor}`);
+        }
+        return signed;
+    }
+
+    async signMessage(
+        message: Uint8Array,
+        signatureType: "schnorr" | "ecdsa" = "schnorr",
+    ): Promise<Uint8Array> {
+        return this.signer.signMessageWithDescriptor(this.descriptor, message, signatureType);
+    }
+
+    /**
+     * Delegated: `TreeSignerSession.random()` consults no key material, so the
+     * session is index-independent.
+     */
+    signerSession(): SignerSession {
+        return this.base.signerSession();
+    }
+
+    /**
+     * Throws rather than falling back to the baseline key: a preimage derived
+     * from the wrong index is unrecoverable, and callers probe this member
+     * through a structural guard that cannot tell the two apart.
+     */
+    async signSchnorrDeterministic(messageHash: Uint8Array): Promise<Uint8Array> {
+        if (!isHDDeterministicSignCapable(this.base)) {
+            throw new Error(
+                `Identity cannot sign deterministically for descriptor ${this.descriptor}`,
+            );
+        }
+        return this.base.signSchnorrDeterministicWithDescriptor(this.descriptor, messageHash);
+    }
+}

--- a/packages/ts-sdk/src/identity/index.ts
+++ b/packages/ts-sdk/src/identity/index.ts
@@ -92,8 +92,17 @@ export {
     normalizeToDescriptor,
     extractPubKey,
     parseHDDescriptor,
+    deriveDescriptorLeafCompressedPubKey,
 } from "./descriptor";
 export type { ParsedHDDescriptor } from "./descriptor";
+
+// Descriptor-scoped identity adapter
+export { DescriptorIdentity, isHDDeterministicSignCapable } from "./descriptorIdentity";
+export type {
+    DescriptorIdentityOptions,
+    DescriptorSigner,
+    HDDeterministicSignCapable,
+} from "./descriptorIdentity";
 
 // Descriptor provider interface
 export type { DescriptorProvider, DescriptorSigningRequest } from "./descriptorProvider";

--- a/packages/ts-sdk/src/identity/seedIdentity.ts
+++ b/packages/ts-sdk/src/identity/seedIdentity.ts
@@ -293,6 +293,22 @@ export class SeedIdentity implements HDCapableIdentity {
         return this.signMessageWithKey(key, message, signatureType);
     }
 
+    /**
+     * BIP-340 sign `messageHash` with the key derived from `descriptor`,
+     * aux_rand = 0. Backs {@link DescriptorIdentity.signSchnorrDeterministic},
+     * which swap preimage derivation reads through.
+     */
+    async signSchnorrDeterministicWithDescriptor(
+        descriptor: string,
+        messageHash: Uint8Array,
+    ): Promise<Uint8Array> {
+        if (!this.isOurs(descriptor)) {
+            throw new Error(`Descriptor ${descriptor} does not belong to this identity`);
+        }
+        const key = this.derivePrivateKeyForDescriptor(descriptor);
+        return schnorr.signAsync(messageHash, key, new Uint8Array(32));
+    }
+
     // ── internal helpers ─────────────────────────────────────────────
 
     private derivePrivateKeyForDescriptor(descriptor: string): Uint8Array {

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -17,7 +17,17 @@ import {
     BatchSignableIdentity,
     SignRequest,
     isBatchSignable,
+    DescriptorIdentity,
+    isHDDeterministicSignCapable,
+    deriveDescriptorLeafCompressedPubKey,
 } from "./identity";
+import type {
+    DescriptorIdentityOptions,
+    DescriptorSigner,
+    HDDeterministicSignCapable,
+} from "./identity";
+import { isHDWalletCapable } from "./wallet/hdWalletCapable";
+import type { HDWalletCapable } from "./wallet/hdWalletCapable";
 import { ArkAddress } from "./script/address";
 import { VHTLC } from "./script/vhtlc";
 import { DefaultVtxo } from "./script/default";
@@ -427,6 +437,10 @@ export {
     MnemonicIdentity,
     ReadonlyDescriptorIdentity,
     isBatchSignable,
+    DescriptorIdentity,
+    isHDDeterministicSignCapable,
+    isHDWalletCapable,
+    deriveDescriptorLeafCompressedPubKey,
     OnchainWallet,
     Ramps,
     DustChangeError,
@@ -672,6 +686,10 @@ export type {
     MnemonicOptions,
     NetworkOptions,
     DescriptorOptions,
+    DescriptorIdentityOptions,
+    DescriptorSigner,
+    HDDeterministicSignCapable,
+    HDWalletCapable,
     // Indexer types
     IndexerProvider,
     PageResponse,

--- a/packages/ts-sdk/src/wallet/hdWalletCapable.ts
+++ b/packages/ts-sdk/src/wallet/hdWalletCapable.ts
@@ -1,0 +1,44 @@
+import { Identity } from "../identity";
+
+/**
+ * Capability a wallet exposes so descriptor-blind consumers — Boltz swaps and
+ * other plugins — can bind the artifacts they create to the wallet's current
+ * HD index and later enumerate every index that has been used.
+ *
+ * Probed structurally ({@link isHDWalletCapable}) rather than widening
+ * `IWallet`: plugins must keep working against wallets that predate it, and a
+ * static wallet answers "no HD state" through the same three methods.
+ */
+export interface HDWalletCapable {
+    /**
+     * The descriptor at the wallet's current receive index, or `undefined` for
+     * static / `auto` wallets and HD wallets that have never rotated. Callers
+     * fall back to the identity key.
+     */
+    getCurrentSigningDescriptor(): Promise<string | undefined>;
+
+    /**
+     * Every descriptor the wallet may hold keys under, ascending by index:
+     * the allocation watermark's band plus any descriptor persisted on a
+     * contract. Empty for static wallets.
+     */
+    getUsedSigningDescriptors(): Promise<string[]>;
+
+    /**
+     * An {@link Identity} whose keys and signatures are those of `descriptor`.
+     * Returns the wallet identity itself when the wallet has no descriptor
+     * signer.
+     */
+    signerForDescriptor(descriptor: string): Promise<Identity>;
+}
+
+/** Structural type guard for {@link HDWalletCapable}. */
+export function isHDWalletCapable(value: unknown): value is HDWalletCapable {
+    if (typeof value !== "object" || value === null) return false;
+    const v = value as Record<string, unknown>;
+    return (
+        typeof v.getCurrentSigningDescriptor === "function" &&
+        typeof v.getUsedSigningDescriptors === "function" &&
+        typeof v.signerForDescriptor === "function"
+    );
+}

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -135,6 +135,8 @@ import { validateVtxosForScript, saveVtxosForContract } from "../contracts/vtxoO
 import { WalletReceiveRotator, signingDescriptorIndex } from "./walletReceiveRotator";
 import { HDDescriptorProvider } from "./hdDescriptorProvider";
 import { DescriptorProvider } from "../identity/descriptorProvider";
+import { DescriptorIdentity } from "../identity/descriptorIdentity";
+import { HDWalletCapable } from "./hdWalletCapable";
 import { deriveDescriptorLeafPubKey } from "../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../contracts/metadata";
 import { CandidateDeps, DiscoveryDeps } from "../contracts/types";
@@ -2029,7 +2031,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
  * });
  * ```
  */
-export class Wallet extends ReadonlyWallet implements IWallet {
+export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
     static MIN_FEE_RATE = 1; // sats/vbyte
 
     override readonly identity: Identity;
@@ -2297,6 +2299,54 @@ export class Wallet extends ReadonlyWallet implements IWallet {
             console.warn("look-ahead refill after boarding allocation failed", e);
         }
         return newBoarding.onchainAddress(this.network);
+    }
+
+    /**
+     * @see HDWalletCapable.getCurrentSigningDescriptor
+     */
+    async getCurrentSigningDescriptor(): Promise<string | undefined> {
+        const provider = this._descriptorProvider;
+        if (!(provider instanceof HDDescriptorProvider)) return undefined;
+        return provider.getCurrentSigningDescriptor();
+    }
+
+    /**
+     * @see HDWalletCapable.getUsedSigningDescriptors
+     *
+     * Union of the watermark band and the descriptors persisted on contracts:
+     * the band alone would miss rows a restore scan wrote, and the contracts
+     * alone would miss indices allocated for something the wallet never
+     * persisted (a swap, an externally issued invoice).
+     */
+    async getUsedSigningDescriptors(): Promise<string[]> {
+        const provider = this._descriptorProvider;
+        const descriptors = new Set<string>();
+        if (provider instanceof HDDescriptorProvider) {
+            const lastIndexUsed = await provider.getLastIndexUsed();
+            for (let i = 0; i <= (lastIndexUsed ?? -1); i++) {
+                descriptors.add(provider.materializeDescriptorAt(i));
+            }
+        }
+        for (const contract of await this.contractRepository.getContracts()) {
+            const descriptor = contract.metadata?.signingDescriptor;
+            if (typeof descriptor === "string" && descriptor.length > 0) {
+                descriptors.add(descriptor);
+            }
+        }
+        return [...descriptors].sort(
+            (a, b) => signingDescriptorIndex(a) - signingDescriptorIndex(b),
+        );
+    }
+
+    /**
+     * @see HDWalletCapable.signerForDescriptor
+     */
+    async signerForDescriptor(descriptor: string): Promise<Identity> {
+        const provider = this._descriptorProvider;
+        if (!(provider instanceof HDDescriptorProvider) || !provider.isOurs(descriptor)) {
+            return this.identity;
+        }
+        return new DescriptorIdentity({ descriptor, signer: provider, base: this.identity });
     }
 
     /**

--- a/packages/ts-sdk/test/descriptorIdentity.test.ts
+++ b/packages/ts-sdk/test/descriptorIdentity.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { mnemonicToSeedSync } from "@scure/bip39";
+import { HDKey, networks } from "@bitcoinerlab/descriptors-scure";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/secp256k1";
+import { MnemonicIdentity } from "../src/identity/seedIdentity";
+import {
+    DescriptorIdentity,
+    isHDDeterministicSignCapable,
+} from "../src/identity/descriptorIdentity";
+import { deriveDescriptorLeafCompressedPubKey } from "../src/identity/descriptor";
+import { isBatchSignable } from "../src/identity";
+import { isHDCapableIdentity } from "../src/identity/hdCapableIdentity";
+
+const TEST_MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, { isMainnet: false });
+const descriptorAt = (index: number) => identity.descriptor.replace("/*)", `/${index})`);
+
+/** The key the descriptor's index resolves to, straight from the seed. */
+function seedKeyAt(index: number): { privateKey: Uint8Array; publicKey: Uint8Array } {
+    const master = HDKey.fromMasterSeed(mnemonicToSeedSync(TEST_MNEMONIC), networks.testnet.bip32);
+    const node = master.derive(`m/86'/1'/0'/0/${index}`);
+    return { privateKey: node.privateKey!, publicKey: node.publicKey! };
+}
+
+describe("deriveDescriptorLeafCompressedPubKey", () => {
+    it("matches the seed-derived compressed key at a rotated index", () => {
+        expect(hex.encode(deriveDescriptorLeafCompressedPubKey(descriptorAt(7)))).toBe(
+            hex.encode(seedKeyAt(7).publicKey),
+        );
+    });
+
+    it("rejects a bare tr(xonly) descriptor rather than guessing parity", () => {
+        const xonly = hex.encode(seedKeyAt(0).publicKey.subarray(1));
+        expect(() => deriveDescriptorLeafCompressedPubKey(`tr(${xonly})`)).toThrow(
+            /parity is unrecoverable/,
+        );
+    });
+});
+
+describe("DescriptorIdentity", () => {
+    const at = (index: number) =>
+        new DescriptorIdentity({
+            descriptor: descriptorAt(index),
+            signer: identity,
+            base: identity,
+        });
+
+    it("exposes the descriptor's keys, not the baseline identity's", async () => {
+        const adapter = at(3);
+        expect(hex.encode(await adapter.compressedPublicKey())).toBe(
+            hex.encode(seedKeyAt(3).publicKey),
+        );
+        expect(hex.encode(await adapter.xOnlyPublicKey())).toBe(
+            hex.encode(seedKeyAt(3).publicKey.subarray(1)),
+        );
+        expect(hex.encode(await adapter.compressedPublicKey())).not.toBe(
+            hex.encode(await identity.compressedPublicKey()),
+        );
+    });
+
+    it("index 0 is the baseline identity key", async () => {
+        expect(hex.encode(await at(0).compressedPublicKey())).toBe(
+            hex.encode(await identity.compressedPublicKey()),
+        );
+    });
+
+    it("signs messages with the descriptor key", async () => {
+        const adapter = at(5);
+        const message = new Uint8Array(32).fill(9);
+        const signature = await adapter.signMessage(message, "schnorr");
+        expect(await schnorr.verifyAsync(signature, message, await adapter.xOnlyPublicKey())).toBe(
+            true,
+        );
+    });
+
+    it("signs deterministically with the descriptor key", async () => {
+        const adapter = at(5);
+        const hash = new Uint8Array(32).fill(4);
+        const first = await adapter.signSchnorrDeterministic(hash);
+        const second = await adapter.signSchnorrDeterministic(hash);
+        expect(hex.encode(first)).toBe(hex.encode(second));
+        expect(await schnorr.verifyAsync(first, hash, await adapter.xOnlyPublicKey())).toBe(true);
+        expect(hex.encode(first)).not.toBe(hex.encode(await at(0).signSchnorrDeterministic(hash)));
+    });
+
+    it("matches a raw BIP-340 signature with aux_rand = 0", async () => {
+        const hash = new Uint8Array(32).fill(1);
+        const expected = await schnorr.signAsync(hash, seedKeyAt(2).privateKey, new Uint8Array(32));
+        expect(hex.encode(await at(2).signSchnorrDeterministic(hash))).toBe(hex.encode(expected));
+    });
+
+    it("passes the deterministic-signing probe, fails the HD-root probes", () => {
+        const adapter = at(1);
+        expect(isHDDeterministicSignCapable(adapter)).toBe(false);
+        expect(typeof adapter.signSchnorrDeterministic).toBe("function");
+        expect(isBatchSignable(adapter)).toBe(false);
+        expect(isHDCapableIdentity(adapter)).toBe(false);
+        expect("toReadonly" in adapter).toBe(false);
+    });
+
+    it("throws when the base identity cannot sign deterministically", async () => {
+        const adapter = new DescriptorIdentity({
+            descriptor: descriptorAt(1),
+            signer: identity,
+            base: { ...identity, signSchnorrDeterministicWithDescriptor: undefined } as any,
+        });
+        await expect(adapter.signSchnorrDeterministic(new Uint8Array(32))).rejects.toThrow(
+            /cannot sign deterministically/,
+        );
+    });
+
+    it("refuses a descriptor from another seed", async () => {
+        const foreign = MnemonicIdentity.fromMnemonic(
+            "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+            { isMainnet: false },
+        );
+        const adapter = new DescriptorIdentity({
+            descriptor: foreign.descriptor.replace("/*)", "/0)"),
+            signer: identity,
+            base: identity,
+        });
+        await expect(adapter.signMessage(new Uint8Array(32))).rejects.toThrow(
+            /does not belong to this identity/,
+        );
+    });
+});

--- a/packages/ts-sdk/test/hdWalletCapable.test.ts
+++ b/packages/ts-sdk/test/hdWalletCapable.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { hex } from "@scure/base";
+import {
+    Wallet,
+    MnemonicIdentity,
+    SingleKey,
+    InMemoryWalletRepository,
+    InMemoryContractRepository,
+    isHDWalletCapable,
+} from "../src";
+import { deriveDescriptorLeafCompressedPubKey } from "../src/identity/descriptor";
+import { HDDescriptorProvider } from "../src/wallet/hdDescriptorProvider";
+
+const MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+const mockArkInfo = {
+    signerPubkey: SERVER_PUBKEY_HEX,
+    forfeitPubkey: SERVER_PUBKEY_HEX,
+    batchExpiry: BigInt(144),
+    unilateralExitDelay: BigInt(144),
+    boardingExitDelay: BigInt(144),
+    roundInterval: BigInt(144),
+    network: "mutinynet",
+    dust: BigInt(1000),
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    checkpointTapscript:
+        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+};
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
+
+vi.mock("../src/utils/fetch", () => ({
+    fetch: mockFetch,
+    baseFetch: mockFetch,
+}));
+
+const MockEventSource = vi.fn().mockImplementation((url: string) => ({
+    url,
+    onmessage: null,
+    onerror: null,
+    close: vi.fn(),
+}));
+
+beforeEach(() => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    mockFetch.mockReset();
+    mockFetch.mockImplementation((url: string) => {
+        const reply = (body: unknown) => Promise.resolve({ ok: true, json: async () => body });
+        if (url.includes("/info")) return reply(mockArkInfo);
+        if (url.includes("subscribe") || url.includes("subscriptions"))
+            return reply({ subscriptionId: "sub-1" });
+        if (url.includes("vtxo") || url.includes("scripts")) return reply({ vtxos: [] });
+        return reply([]);
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function makeWallet(opts: { hd: boolean; contractRepo?: InMemoryContractRepository }) {
+    return Wallet.create({
+        identity: opts.hd
+            ? MnemonicIdentity.fromMnemonic(MNEMONIC, { isMainnet: false })
+            : SingleKey.fromHex("ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2"),
+        walletMode: opts.hd ? "hd" : "static",
+        arkServerUrl: "http://localhost:7070",
+        storage: {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: opts.contractRepo ?? new InMemoryContractRepository(),
+        },
+    });
+}
+
+describe("HDWalletCapable", () => {
+    it("Wallet passes the capability probe", async () => {
+        const wallet = await makeWallet({ hd: true });
+        expect(isHDWalletCapable(wallet)).toBe(true);
+        await wallet.dispose();
+    });
+
+    it("a static wallet reports no HD state and signs with its identity", async () => {
+        const wallet = await makeWallet({ hd: false });
+        expect(await wallet.getCurrentSigningDescriptor()).toBeUndefined();
+        expect(await wallet.getUsedSigningDescriptors()).toEqual([]);
+        expect(await wallet.signerForDescriptor("tr(deadbeef)")).toBe(wallet.identity);
+        await wallet.dispose();
+    });
+
+    it("a fresh HD wallet is bound to index 0", async () => {
+        const wallet = await makeWallet({ hd: true });
+        const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+        expect(await wallet.getCurrentSigningDescriptor()).toBe(
+            provider.materializeDescriptorAt(0),
+        );
+        expect(await wallet.getUsedSigningDescriptors()).toEqual([
+            provider.materializeDescriptorAt(0),
+        ]);
+        await wallet.dispose();
+    });
+
+    it("enumerates the whole watermark band, ascending", async () => {
+        const wallet = await makeWallet({ hd: true });
+        const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+        await provider.advanceLastIndexUsed(3);
+        expect(await wallet.getUsedSigningDescriptors()).toEqual(
+            [0, 1, 2, 3].map((i) => provider.materializeDescriptorAt(i)),
+        );
+        await wallet.dispose();
+    });
+
+    it("includes descriptors persisted on contracts beyond the watermark", async () => {
+        const contractRepo = new InMemoryContractRepository();
+        const wallet = await makeWallet({ hd: true, contractRepo });
+        const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+        const outOfBand = provider.materializeDescriptorAt(9);
+        await contractRepo.saveContract({
+            id: "restored-9",
+            type: "default",
+            params: {},
+            script: "00",
+            address: "ark1restored",
+            state: "active",
+            createdAt: Date.now(),
+            metadata: { signingDescriptor: outOfBand },
+        } as any);
+
+        expect(await wallet.getUsedSigningDescriptors()).toEqual([
+            provider.materializeDescriptorAt(0),
+            outOfBand,
+        ]);
+        await wallet.dispose();
+    });
+
+    it("signerForDescriptor scopes keys to the descriptor", async () => {
+        const wallet = await makeWallet({ hd: true });
+        const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+        const descriptor = provider.materializeDescriptorAt(4);
+        const signer = await wallet.signerForDescriptor(descriptor);
+
+        expect(hex.encode(await signer.compressedPublicKey())).toBe(
+            hex.encode(deriveDescriptorLeafCompressedPubKey(descriptor)),
+        );
+        expect(hex.encode(await signer.compressedPublicKey())).not.toBe(
+            hex.encode(await wallet.identity.compressedPublicKey()),
+        );
+        await wallet.dispose();
+    });
+
+    it("signerForDescriptor falls back to the identity for a foreign descriptor", async () => {
+        const wallet = await makeWallet({ hd: true });
+        const foreign = MnemonicIdentity.fromMnemonic(
+            "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+            { isMainnet: false },
+        ).descriptor.replace("/*)", "/0)");
+        expect(await wallet.signerForDescriptor(foreign)).toBe(wallet.identity);
+        await wallet.dispose();
+    });
+});


### PR DESCRIPTION
Swaps are no longer pinned to the wallet's index-0 key.

- **core**: `DescriptorIdentity` (an `Identity` scoped to one materialized HD descriptor) and the `HDWalletCapable` probe on `Wallet` — current descriptor, used descriptors, `signerForDescriptor`.
- **restore**: query Boltz with every key the wallet may have used (chunked at 100), and attribute each restored swap by rebuilding its VHTLC until the lockup address matches. Fills the claim/refund keys, including the chain-swap ones that were empty; unattributable swaps are skipped instead of recorded under a key that cannot spend them.
- **creation**: swaps bind to the current signing descriptor and persist it; claim/refund sign with that key. Absent descriptor ⇒ baseline identity, so stored swaps and static wallets are unchanged.

Also fixes `claimVHTLCIdentity`, which spread the identity and so dropped every prototype method of a class-based one (including the `signerSession()` a batch join needs).

Left out: deriving the swap preimage from the owner key, which needs `derivePreimage` from #590. The adapter already implements `signSchnorrDeterministic`, so once #590 lands index-N swaps get the right preimage rather than silently falling back to random bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HD wallet support for swap signing, including reverse, submarine, refund, claim, settlement, and chain swaps.
  * Swap records now preserve the signing key information needed for future claims and refunds.
  * Added support for restoring swaps across multiple wallet keys, including automatic key attribution.
  * Added public SDK capabilities for descriptor-based signing and HD wallet detection.

* **Bug Fixes**
  * Improved swap restoration and signing reliability for rotated HD wallet keys.
  * Corrected identity delegation to preserve all signing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->