### PR TITLE
feat(exit): cancel a running unilateral-exit Executor with an AbortSignal

### DIFF
--- a/packages/ts-sdk/src/wallet/exit/executor.ts
+++ b/packages/ts-sdk/src/wallet/exit/executor.ts
@@ -1,6 +1,24 @@
 import { OnchainProvider } from "../../providers/onchain";
 import { ExitPackage, ExitStep, SweepStep } from "./types";
 
+/**
+ * `AbortSignal.prototype.throwIfAborted` is not reliably present on Hermes /
+ * React Native, and this SDK ships Expo providers — so resolve the error here.
+ * A spec-compliant engine supplies `signal.reason` (a DOMException named
+ * "AbortError"); otherwise fall back to an Error carrying the same `name`, so
+ * consumers can always match on `err.name === "AbortError"`.
+ */
+function abortErrorFor(signal: AbortSignal): unknown {
+    if (signal.reason !== undefined) return signal.reason;
+    const e = new Error("The operation was aborted");
+    e.name = "AbortError";
+    return e;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) throw abortErrorFor(signal);
+}
+
 export type ExecutorEvent = {
     stepIndex: number;
     kind: ExitStep["kind"];
@@ -38,17 +56,49 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
 
     private readonly feeWallet?: ExitFeeWallet;
 
+    private readonly signal?: AbortSignal;
+
     constructor(
         readonly pkg: ExitPackage,
         readonly provider: OnchainProvider,
-        opts?: { pollIntervalMs?: number; feeWallet?: ExitFeeWallet },
+        opts?: {
+            pollIntervalMs?: number;
+            feeWallet?: ExitFeeWallet;
+            /** Abort to stop execution. Iteration then rejects with an error
+             * whose `name` is "AbortError". Already-broadcast transactions are
+             * not recalled; the executor is idempotent, so a later run resumes. */
+            signal?: AbortSignal;
+        },
     ) {
         this.pollIntervalMs = opts?.pollIntervalMs ?? 5_000;
         this.feeWallet = opts?.feeWallet;
+        this.signal = opts?.signal;
     }
 
+    /**
+     * Poll delay. Nearly all wall-clock time is spent here, so it must be the
+     * thing that reacts to abort — checking only between polls would leave
+     * cancellation up to a full interval late and the timer still pending.
+     */
     private sleep(): Promise<void> {
-        return new Promise((r) => setTimeout(r, this.pollIntervalMs));
+        const signal = this.signal;
+        if (!signal) return new Promise((r) => setTimeout(r, this.pollIntervalMs));
+        return new Promise((resolve, reject) => {
+            if (signal.aborted) return reject(abortErrorFor(signal));
+            const onAbort = () => {
+                clearTimeout(timer);
+                reject(abortErrorFor(signal));
+            };
+            // `{ once: true }` releases the listener on the abort path; the
+            // explicit removal covers the timeout path. A long exit sleeps
+            // hundreds of times, so an unreleased listener would just trade a
+            // polling leak for a listener leak.
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, this.pollIntervalMs);
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     private async status(txid: string): Promise<TxStatus | undefined> {
@@ -63,11 +113,15 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
         for (;;) {
             const s = await this.status(txid);
             if (s?.confirmed) return s;
+            // Checked here as well as inside sleep() so an abort that lands
+            // during the status read doesn't cost one more network poll.
+            throwIfAborted(this.signal);
             await this.sleep();
         }
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<ExecutorEvent> {
+        throwIfAborted(this.signal); // before anything is broadcast
         const dead = new Set<string>(); // outpoints whose branch failed
 
         if (this.pkg.validUntil && Date.now() / 1000 > this.pkg.validUntil) {
@@ -195,6 +249,7 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
         while (done.size < pending.length) {
             for (const { index, step } of pending) {
                 if (done.has(index)) continue;
+                throwIfAborted(this.signal);
 
                 const swept = await this.status(step.txid);
                 if (swept?.confirmed) {

--- a/packages/ts-sdk/test/exit-executor.test.ts
+++ b/packages/ts-sdk/test/exit-executor.test.ts
@@ -380,3 +380,213 @@ describe("Executor", () => {
         expect(events[0].maturesAtTime).toBe(60_000 + 512);
     });
 });
+
+describe("Executor cancellation", () => {
+    /** A package whose single step never confirms, so the executor parks in
+     * waitConfirmed — the loop that `iterator.return()` cannot interrupt. */
+    function neverConfirmingPkg() {
+        const script = scriptedProvider();
+        script.register("parent1-hex", P1);
+        const pkg = pkgOf([
+            {
+                kind: "package",
+                parentTxid: P1,
+                parentHex: "parent1-hex",
+                childTxid: C1,
+                childHex: "child1-hex",
+                forVtxos: [`${P1}:0`],
+            },
+        ]);
+        return { script, pkg };
+    }
+
+    it("rejects with AbortError when aborted while waiting for confirmation", async () => {
+        const { script, pkg } = neverConfirmingPkg();
+        const ac = new AbortController();
+        const executor = new Executor(pkg, script.provider, {
+            pollIntervalMs: 5,
+            signal: ac.signal,
+        });
+
+        const events: ExecutorEvent[] = [];
+        const consumed = (async () => {
+            for await (const e of executor) events.push(e);
+        })();
+
+        // Let it broadcast and enter waitConfirmed, then stop it.
+        await new Promise((r) => setTimeout(r, 30));
+        ac.abort();
+
+        await expect(consumed).rejects.toMatchObject({ name: "AbortError" });
+        // It broadcast once and never progressed past the un-confirming step.
+        expect(script.broadcasts).toHaveLength(1);
+        expect(events.map((e) => e.status)).toEqual(["broadcast"]);
+    });
+
+    it("throws before broadcasting anything when the signal is already aborted", async () => {
+        const { script, pkg } = neverConfirmingPkg();
+        const ac = new AbortController();
+        ac.abort();
+        const executor = new Executor(pkg, script.provider, {
+            pollIntervalMs: 5,
+            signal: ac.signal,
+        });
+
+        await expect(
+            (async () => {
+                for await (const _ of executor) void _;
+            })(),
+        ).rejects.toMatchObject({ name: "AbortError" });
+        expect(script.broadcasts).toEqual([]);
+    });
+
+    it("rejects when aborted during the sweep wait loop, broadcasting no sweep", async () => {
+        const script = scriptedProvider();
+        script.register("parent1-hex", P1);
+        script.register("sweep1-hex", SW1);
+        const pkg = pkgOf([
+            {
+                kind: "package",
+                parentTxid: P1,
+                parentHex: "parent1-hex",
+                childTxid: C1,
+                childHex: "child1-hex",
+                forVtxos: [`${P1}:0`],
+            },
+            {
+                kind: "sweep",
+                vtxo: `${P1}:0`,
+                txid: SW1,
+                hex: "sweep1-hex",
+                dependsOnTxid: P1,
+                // Far in the future, so the sweep never matures on its own.
+                delay: { type: "blocks", value: 10_000 },
+            },
+        ]);
+
+        const ac = new AbortController();
+        const executor = new Executor(pkg, script.provider, {
+            pollIntervalMs: 5,
+            signal: ac.signal,
+        });
+
+        const consumed = (async () => {
+            for await (const e of executor) {
+                if (e.status === "broadcast" && e.txid) script.confirm(e.txid);
+            }
+        })();
+
+        await new Promise((r) => setTimeout(r, 40));
+        ac.abort();
+
+        await expect(consumed).rejects.toMatchObject({ name: "AbortError" });
+        // Only the package was broadcast; the sweep never went out.
+        expect(script.broadcasts).toEqual([["parent1-hex", "child1-hex"]]);
+    });
+
+    // The whole point of making sleep() abortable rather than only checking
+    // `aborted` between polls: abort latency must track the signal, not the
+    // poll interval.
+    it("aborts promptly rather than waiting out the poll interval", async () => {
+        const { script, pkg } = neverConfirmingPkg();
+        const ac = new AbortController();
+        const executor = new Executor(pkg, script.provider, {
+            pollIntervalMs: 10_000,
+            signal: ac.signal,
+        });
+
+        const consumed = (async () => {
+            for await (const _ of executor) void _;
+        })();
+
+        await new Promise((r) => setTimeout(r, 20));
+        const started = Date.now();
+        ac.abort();
+        await expect(consumed).rejects.toMatchObject({ name: "AbortError" });
+        expect(Date.now() - started).toBeLessThan(1_000);
+    });
+
+    it("removes every abort listener it registers", async () => {
+        const { script, pkg } = neverConfirmingPkg();
+        const ac = new AbortController();
+        let added = 0;
+        let removed = 0;
+        // Wrap the real signal so listener bookkeeping stays honest while abort
+        // still works for real.
+        const signal = new Proxy(ac.signal, {
+            get(target, prop) {
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<AbortSignal["addEventListener"]>) => {
+                        added++;
+                        return target.addEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return (...args: Parameters<AbortSignal["removeEventListener"]>) => {
+                        removed++;
+                        return target.removeEventListener(...args);
+                    };
+                }
+                const v = Reflect.get(target, prop, target);
+                return typeof v === "function" ? v.bind(target) : v;
+            },
+        });
+
+        const executor = new Executor(pkg, script.provider, { pollIntervalMs: 5, signal });
+        const consumed = (async () => {
+            for await (const _ of executor) void _;
+        })();
+
+        // Long enough for many sleep cycles to complete via timeout.
+        await new Promise((r) => setTimeout(r, 60));
+        ac.abort();
+        await expect(consumed).rejects.toMatchObject({ name: "AbortError" });
+
+        expect(added).toBeGreaterThan(1);
+        // Every registration is released: timeouts remove explicitly, the abort
+        // path is registered with { once: true }.
+        expect(added - removed).toBeLessThanOrEqual(1);
+    });
+
+    it("behaves exactly as before when no signal is passed", async () => {
+        const script = scriptedProvider();
+        script.register("parent1-hex", P1);
+        script.register("sweep1-hex", SW1);
+        const pkg = pkgOf([
+            {
+                kind: "package",
+                parentTxid: P1,
+                parentHex: "parent1-hex",
+                childTxid: C1,
+                childHex: "child1-hex",
+                forVtxos: [`${P1}:0`],
+            },
+            {
+                kind: "sweep",
+                vtxo: `${P1}:0`,
+                txid: SW1,
+                hex: "sweep1-hex",
+                dependsOnTxid: P1,
+                delay: { type: "blocks", value: 10 },
+            },
+        ]);
+
+        const executor = new Executor(pkg, script.provider, { pollIntervalMs: 1 });
+        const events = await run(
+            executor,
+            (e, s) => {
+                if (e.status === "broadcast" && e.txid) s.confirm(e.txid);
+                if (e.status === "waiting_csv") s.tip.height = e.maturesAtHeight!;
+            },
+            script,
+        );
+
+        expect(events.map((e) => `${e.kind}:${e.status}`)).toEqual([
+            "package:broadcast",
+            "package:confirmed",
+            "sweep:waiting_csv",
+            "sweep:broadcast",
+            "sweep:confirmed",
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

`UnilateralExit.Executor` cannot be stopped. A consumer that wants to abandon a running exit — the user pressed "Start over", or the component unmounted — has no way to say so.

The obvious remedy does not work. `iterator.return()` cannot interrupt an async generator parked in an `await` loop containing no `yield`, and `waitConfirmed` is exactly that:

```ts
private async waitConfirmed(txid: string): Promise<TxStatus> {
    for (;;) {
        const s = await this.status(txid);
        if (s?.confirmed) return s;
        await this.sleep();      // <- no yield anywhere in this loop
    }
}
```

Reproduced against a generator of the same shape: after `return()`, polling continued (2 → 12 polls over 600 ms) and the promise returned by `return()` stayed pending. The result is a leaked poll loop for the life of the process, and if the watched transaction never confirms, forever.

It was not a fund-safety bug — the queued return completion is processed at the next `yield`, which precedes the next step's broadcast, so no further transactions went out. But nothing could stop the polling.

## What this adds

An optional `signal` on the existing constructor opts:

```ts
const ac = new AbortController();
const executor = new UnilateralExit.Executor(pkg, provider, {
    feeWallet,
    signal: ac.signal,
});

try {
    for await (const ev of executor) { /* ... */ }
} catch (e) {
    if ((e as Error).name === "AbortError") return;  // stopped on purpose
    throw e;
}

ac.abort();   // resolves in milliseconds, not one poll interval
```

Purely additive: a new optional field on an already-optional bag. With no `signal`, behaviour is byte-identical, and `ExecutorEvent["status"]` is unchanged — so no consumer switching exhaustively on it breaks.

## Design notes

- **`sleep()` is what became abortable**, rather than adding `aborted` checks at loop tops. Nearly all wall-clock time is spent there, so checking only between polls would leave cancellation up to a full `pollIntervalMs` late (5 s by default) with the timer still pending. Two extra checks remain — after each `status()` in `waitConfirmed`, and at the top of each pending sweep iteration — purely so an abort never costs one further network poll.
- **Never between build and broadcast.** No check sits between `feeWallet.bumpAnchor()` and `provider.broadcastTransaction()`, so a step is either broadcast in full or not attempted. Abort can't strand half a 1P1C package.
- **Listener hygiene is part of the fix.** Each `sleep()` registers an abort listener and a long exit sleeps hundreds of times; the abort path uses `{ once: true }` and the timeout path removes explicitly. Otherwise this would trade a polling leak for a listener leak.
- **A local `throwIfAborted` helper** instead of `AbortSignal.prototype.throwIfAborted`, which is not reliably present on Hermes / React Native — and this SDK ships Expo providers. It prefers `signal.reason` when set, so on a spec-compliant engine consumers get the standard `DOMException`; otherwise an `Error` carrying the same `name`. The documented contract is therefore `err.name === "AbortError"`, not `instanceof DOMException`.

## Behaviour change to be aware of

Abort **throws**. A consumer iterating with `for await` and no `try/catch` will now see a rejection where previously there was none — but only if it passes a signal and aborts it, which is new API. This was chosen over a clean return because a clean return is indistinguishable from genuine completion, which would force every consumer to keep its own `cancelled` flag.

In-flight provider HTTP calls are deliberately **not** aborted: `getTxStatus` and `broadcastTransaction` take no signal, and threading one through would change the `OnchainProvider` interface and every implementation of it. A request that completes after abort is harmless — its result is discarded.

## Test plan

Six new unit tests in `test/exit-executor.test.ts`, on the existing `scriptedProvider` harness:

1. Abort while parked in `waitConfirmed` rejects with `AbortError` and issues no further broadcasts — the direct regression test.
2. An already-aborted signal throws before anything is broadcast.
3. Abort during the sweep wait loop rejects and broadcasts no sweep.
4. **Abort latency is bounded by the signal, not the poll interval** — with `pollIntervalMs: 10_000` the rejection lands in under a second. This is the test that distinguishes a genuinely abortable `sleep` from one merely checked between polls.
5. Abort listeners are balanced after many sleep cycles.
6. With no signal, the full package → sweep flow is unchanged.

Full package unit suite: 2199 passed / 1 skipped, up from 2193 / 1 — exactly the six added. `typecheck` and `lint` (including both `check:vtxo` guards) clean.

Integration tests were not run locally — they need the Docker regtest stack, and `test/e2e/unilateralExit.test.ts` covers this path in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cooperative cancellation support for wallet exit execution through an optional abort signal.
  - Execution now stops promptly while waiting for confirmations or sweep operations.
  - Aborted operations return a consistent `AbortError`.

- **Bug Fixes**
  - Improved cancellation responsiveness even when polling intervals are long.
  - Ensured cancellation resources are cleaned up correctly.
  - Preserved existing behavior when cancellation is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->