### PR TITLE
docs(exit): state the real abort-reason contract; explain the listener slack

### DIFF
--- a/packages/ts-sdk/src/wallet/exit/executor.ts
+++ b/packages/ts-sdk/src/wallet/exit/executor.ts
@@ -2,11 +2,18 @@ import { OnchainProvider } from "../../providers/onchain";
 import { ExitPackage, ExitStep, SweepStep } from "./types";
 
 /**
- * `AbortSignal.prototype.throwIfAborted` is not reliably present on Hermes /
- * React Native, and this SDK ships Expo providers — so resolve the error here.
- * A spec-compliant engine supplies `signal.reason` (a DOMException named
- * "AbortError"); otherwise fall back to an Error carrying the same `name`, so
- * consumers can always match on `err.name === "AbortError"`.
+ * Resolve the value to throw for an aborted signal.
+ *
+ * `signal.reason` is forwarded verbatim, matching the platform: both
+ * `AbortSignal.prototype.throwIfAborted` and `fetch` throw a custom reason
+ * as-is — including non-`Error` values — so a consumer that calls
+ * `abort(new MyError())` catches `MyError` rather than something wrapping it.
+ * With a no-argument `abort()` a spec-compliant engine supplies a
+ * `DOMException` named `"AbortError"`.
+ *
+ * The fallback exists because `throwIfAborted` is not reliably present on
+ * Hermes / React Native, and this SDK ships Expo providers; there `reason` may
+ * be `undefined`, so an `Error` carrying the same `name` is constructed.
  */
 function abortErrorFor(signal: AbortSignal): unknown {
     if (signal.reason !== undefined) return signal.reason;
@@ -64,9 +71,15 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
         opts?: {
             pollIntervalMs?: number;
             feeWallet?: ExitFeeWallet;
-            /** Abort to stop execution. Iteration then rejects with an error
-             * whose `name` is "AbortError". Already-broadcast transactions are
-             * not recalled; the executor is idempotent, so a later run resumes. */
+            /** Abort to stop execution.
+             *
+             * Iteration then rejects with `signal.reason`. Calling `abort()`
+             * with no argument yields an error whose `name` is `"AbortError"`;
+             * a custom reason is forwarded as-is, matching `fetch` and
+             * `AbortSignal.prototype.throwIfAborted`.
+             *
+             * Already-broadcast transactions are not recalled; the executor is
+             * idempotent, so a later run resumes from the chain. */
             signal?: AbortSignal;
         },
     ) {

--- a/packages/ts-sdk/test/exit-executor.test.ts
+++ b/packages/ts-sdk/test/exit-executor.test.ts
@@ -487,6 +487,11 @@ describe("Executor cancellation", () => {
     // The whole point of making sleep() abortable rather than only checking
     // `aborted` between polls: abort latency must track the signal, not the
     // poll interval.
+    //
+    // This one needs the real clock. Fake timers would let the 10s interval
+    // elapse instantly, so the assertion would hold even for an implementation
+    // that merely checks `aborted` between polls — exactly the version this
+    // test exists to rule out. The 10s-vs-1s margin is the flake budget.
     it("aborts promptly rather than waiting out the poll interval", async () => {
         const { script, pkg } = neverConfirmingPkg();
         const ac = new AbortController();
@@ -543,8 +548,12 @@ describe("Executor cancellation", () => {
         await expect(consumed).rejects.toMatchObject({ name: "AbortError" });
 
         expect(added).toBeGreaterThan(1);
-        // Every registration is released: timeouts remove explicitly, the abort
-        // path is registered with { once: true }.
+        // Not `=== 0`: every sleep that ends by timing out calls
+        // removeEventListener explicitly, but the final sleep is the one that
+        // gets aborted, and its `{ once: true }` listener is dropped internally
+        // by the event target — that removal does not go through the proxied
+        // removeEventListener. So exactly one registration is unaccounted for,
+        // and a slack larger than 1 would mean a genuine leak.
         expect(added - removed).toBeLessThanOrEqual(1);
     });
 


### PR DESCRIPTION
Follow-up to #663, which merged before these review points were addressed. Comments only — no behaviour change, no API change.

## [M1] The `signal` JSDoc over-promised

It stated that iteration "rejects with an error whose `name` is `AbortError`", unconditionally. `abortErrorFor` forwards `signal.reason` verbatim, so that only holds for a no-argument `abort()`.

CodeRabbit proposed normalizing custom reasons into an `AbortError` carrying the original as `cause`. I checked the platform first:

```
throwIfAborted, abort(new Error("network"))  -> throws Error,  name "Error"
throwIfAborted, abort("just a string")       -> throws the string
fetch,          abort(new Error("custom"))   -> rejects with that Error verbatim
```

Forwarding the reason untouched *is* the convention, so the code was right and the doc was wrong. Normalizing would make this SDK deviate from `fetch`: someone calling `abort(new MyDomainError())` should catch `MyDomainError`, not dig it out of `.cause`. Arkana reached the same conclusion — narrow the doc.

The field JSDoc and `abortErrorFor`'s own comment now say the reason is forwarded as-is, that the no-arg case yields `AbortError`, and that the constructed fallback exists for Hermes / React Native where `reason` may be `undefined`.

## [L2] The listener-balance test's `<= 1` bound needed explaining

A reader would reasonably ask why it isn't `=== 0`. Verified the reason: with a proxied signal, sleeps that end by timing out call `removeEventListener` explicitly, but the sleep that gets aborted has its `{ once: true }` listener dropped internally by the event target, which does not route through the proxy. Exactly one registration is unaccounted for; a slack above 1 would be a real leak. That is now in the test.

## [L3] Why the latency test uses the real clock

Noted as mildly flake-prone. Keeping it, with a comment on why fake timers would be worse: they would let the 10s poll interval elapse instantly, so the assertion would pass for an implementation that merely checks `aborted` between polls — precisely the version the test exists to rule out. The 10s-vs-1s margin is the flake budget.

## Not applying: [L1] reorder `sleep()`'s listener registration before the `aborted` check

Arkana noted this is not a real race, and I could not construct one. The Promise executor body is synchronous, so nothing runs between the check and `addEventListener` — microtasks queued *before* the check still do not run mid-body:

```
aborted at check: false | interleaved during body: false
```

The reorder also requires moving `setTimeout` above the check, so an already-aborted signal would allocate a timer and immediately clear it — more work on a path that cannot execute. Happy to revisit given an engine where the executor body is interruptible.

## Also not in scope: [I1] e2e abort coverage

`test/e2e/` needs the Docker regtest stack. The unit tests cover the reproduced regression; an e2e smoke test driving a signal through the real provider chain would be a reasonable follow-up.

## Test plan

`exit-executor` suite 14/14, package typecheck, and lint (both `check:vtxo` guards) all pass. The diff is two doc comments and two test comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified cancellation behavior for exit transaction execution, including abort reasons, fallback errors, and platform compatibility.
  * Documented that already-broadcast transactions are not recalled after cancellation.
* **Tests**
  * Improved explanatory comments covering abort timing and cleanup listener accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->