### PR TITLE
feat(swaps): deterministic boltz preimage

### DIFF
--- a/packages/boltz-swap/README.md
+++ b/packages/boltz-swap/README.md
@@ -242,6 +242,23 @@ if (info.status === 'recoverable') {
 > [!NOTE]
 > This only scans swaps stored in your local repository. It does not discover swaps that exist on Boltz but are missing locally.
 
+### Recovery from Seed
+
+`restoreSwaps()` asks Boltz for the swaps held under the wallet's keys and rebuilds
+them locally — including swaps this device never stored, e.g. after a wipe.
+
+On an HD wallet (`walletMode: 'hd'`) each swap is created under its own signing
+descriptor, and the preimage of reverse and chain swaps is derived from that
+descriptor's key. A restored swap therefore comes back with a usable `preimage` and
+can be claimed from the seed alone. The scheme is shared with the .NET SDK, so a swap
+created by either is recoverable by the other.
+
+Two cases still return `preimage: ""` and need the original secret via
+`enrichReverseSwapPreimage()`: swaps created before this scheme, and swaps created by
+a wallet with no HD state (a static wallet, or a custom identity that cannot sign
+deterministically) — those keep a random preimage, and swap creation logs a warning
+saying so.
+
 ### Cleanup
 
 ```typescript

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -27,6 +27,7 @@ import {
     getNetwork,
     deriveDescriptorLeafCompressedPubKey,
     isHDWalletCapable,
+    signingDescriptorIndex,
     type NetworkName,
 } from "@arkade-os/sdk";
 import type {
@@ -92,6 +93,7 @@ import {
 } from "./utils/boltz-swap-tx";
 import { decodeInvoice, getInvoicePaymentHash } from "./utils/decoding";
 import { normalizeToXOnlyKey } from "./utils/signatures";
+import { derivePreimage } from "./utils/preimage";
 import { extractInvoiceAmount, resolveVhtlcTimeouts } from "./utils/restoration";
 import { SwapManager, SwapManagerClient } from "./swap-manager";
 import {
@@ -212,6 +214,15 @@ const canRecoverViaBoltz3of3 = (
 // may lag behind the on-chain lockup tx, so retry a few times before giving up.
 const CLAIM_VTXO_RETRY_ATTEMPTS = 3;
 const CLAIM_VTXO_RETRY_DELAY_MS = 500;
+
+// A swap burns an HD index that leaves no on-chain footprint, so the wallet's
+// restore gap-scan cannot see it and the allocation watermark can sit below a
+// live swap. Restore therefore probes this many indices past the watermark,
+// mirroring the scan's own gap limit, and repeats from the watermark each hit
+// advances — bounded by MAX_RESTORE_INDEX, which matches NArk's
+// RecoveryOptions.MaxIndex.
+const RESTORE_LOOK_AHEAD = 20;
+const MAX_RESTORE_INDEX = 10_000;
 
 // Build the QuoteSwapOptions for an autopilot renegotiation. The type marks
 // `claimDetails.amount` as required, but a swap restored from older persisted
@@ -499,7 +510,7 @@ export class ArkadeSwaps {
         // validate amount
         if (args.amount <= 0) throw new SwapError({ message: "Amount must be greater than 0" });
 
-        const signingDescriptor = await this.currentSigningDescriptor();
+        const signingDescriptor = await this.allocateSigningDescriptor();
         const claimPublicKey = hex.encode(
             await (await this.swapSigner({ signingDescriptor })).compressedPublicKey(),
         );
@@ -508,8 +519,7 @@ export class ArkadeSwaps {
                 message: "Failed to get claim public key from wallet",
             });
 
-        // create random preimage and its hash
-        const preimage = randomBytes(32);
+        const preimage = await this.deriveSwapPreimage(signingDescriptor);
         const preimageHash = hex.encode(sha256(preimage));
         if (!preimageHash) throw new SwapError({ message: "Failed to get preimage hash" });
 
@@ -901,7 +911,7 @@ export class ArkadeSwaps {
      * @throws {SwapError} If invoice is missing or key retrieval fails.
      */
     async createSubmarineSwap(args: SendLightningPaymentRequest): Promise<BoltzSubmarineSwap> {
-        const signingDescriptor = await this.currentSigningDescriptor();
+        const signingDescriptor = await this.allocateSigningDescriptor();
         const refundPublicKey = hex.encode(
             await (await this.swapSigner({ signingDescriptor })).compressedPublicKey(),
         );
@@ -2431,19 +2441,18 @@ export class ArkadeSwaps {
             throw new SwapError({ message: "Invalid lock amount" });
         }
 
-        // create random preimage and its hash
-        const preimage = randomBytes(32);
-        const preimageHash = hex.encode(sha256(preimage));
-        if (!preimageHash) throw new SwapError({ message: "Failed to get preimage hash" });
-
         // ephemeral keys for BTC chain claim/refund
         const ephemeralKey = secp256k1.utils.randomSecretKey();
 
         // Only the ARK leg is ours; the BTC leg is signed by the ephemeral key.
-        const signingDescriptor = await this.currentSigningDescriptor();
+        const signingDescriptor = await this.allocateSigningDescriptor();
         const arkPublicKey = hex.encode(
             await (await this.swapSigner({ signingDescriptor })).compressedPublicKey(),
         );
+
+        const preimage = await this.deriveSwapPreimage(signingDescriptor);
+        const preimageHash = hex.encode(sha256(preimage));
+        if (!preimageHash) throw new SwapError({ message: "Failed to get preimage hash" });
 
         const refundPublicKey =
             to === "ARK" ? hex.encode(secp256k1.getPublicKey(ephemeralKey)) : arkPublicKey;
@@ -3266,15 +3275,42 @@ export class ArkadeSwaps {
     // =========================================================================
 
     /**
-     * The HD descriptor a swap created now should be bound to, or `undefined`
-     * for static wallets and HD wallets that have never rotated. Swap creation
-     * never allocates an index of its own: rotation is driven by the wallet's
-     * receive events, and a swap simply rides the index that is current.
+     * Allocate the HD descriptor a new swap binds to, or `undefined` for
+     * static wallets. Every swap gets a fresh index: two swaps sharing one
+     * would derive the same preimage — and a preimage published by the first
+     * settlement leaves the second's Lightning payment claimable by any
+     * routing node.
      */
-    private async currentSigningDescriptor(): Promise<string | undefined> {
-        return isHDWalletCapable(this.wallet)
-            ? this.wallet.getCurrentSigningDescriptor()
-            : undefined;
+    private async allocateSigningDescriptor(): Promise<string | undefined> {
+        return isHDWalletCapable(this.wallet) ? this.wallet.getNextSigningDescriptor() : undefined;
+    }
+
+    /**
+     * The preimage of a swap bound to `signingDescriptor`, derived from that
+     * descriptor's key so a wallet restored from seed alone can re-derive it
+     * and claim the VHTLC.
+     *
+     * Falls back to randomness — loudly, since the swap is then unrecoverable
+     * — when there is no descriptor (static / `auto` wallets, which would
+     * otherwise derive one preimage for every swap from the shared baseline
+     * key) or the identity cannot sign deterministically (custom signer).
+     */
+    private async deriveSwapPreimage(signingDescriptor: string | undefined): Promise<Uint8Array> {
+        if (signingDescriptor) {
+            try {
+                return await derivePreimage(await this.swapSigner({ signingDescriptor }));
+            } catch (error) {
+                logger.warn(
+                    "Deterministic preimage derivation failed; the swap will not be recoverable from seed",
+                    error,
+                );
+            }
+        } else {
+            logger.warn(
+                "Wallet allocates no HD signing descriptor; the swap will not be recoverable from seed",
+            );
+        }
+        return randomBytes(32);
     }
 
     /**
@@ -3293,25 +3329,75 @@ export class ArkadeSwaps {
      * Every compressed key the wallet may hold swaps under: one per used HD
      * signing descriptor plus the baseline identity key, which covers static
      * wallets and swaps created before descriptor binding existed.
+     *
+     * `lookAhead` widens the set past the allocation watermark. A swap burns
+     * an index with no on-chain footprint until it is claimed, so the restore
+     * gap-scan cannot see it and a swap created just before the device was
+     * lost sits above the watermark.
      */
-    private async swapOwnerKeys(): Promise<SwapOwnerKey[]> {
+    private async swapOwnerKeys(opts?: { lookAhead?: number }): Promise<SwapOwnerKey[]> {
         const identityKey = hex.encode(await this.wallet.identity.compressedPublicKey());
         if (!identityKey) throw new Error("Failed to get public key from wallet");
 
         const keys = new Map<string, SwapOwnerKey>([[identityKey, { publicKey: identityKey }]]);
         if (!isHDWalletCapable(this.wallet)) return [...keys.values()];
 
-        for (const signingDescriptor of await this.wallet.getUsedSigningDescriptors()) {
+        for (const signingDescriptor of await this.wallet.getUsedSigningDescriptors(opts)) {
             try {
                 const publicKey = hex.encode(
                     deriveDescriptorLeafCompressedPubKey(signingDescriptor),
                 );
-                if (!keys.has(publicKey)) keys.set(publicKey, { publicKey, signingDescriptor });
+                // A descriptor whose key coincides with the baseline identity
+                // key (index 0 on a wallet whose seed key is the leaf key)
+                // must keep its descriptor: preimage derivation needs a
+                // descriptor identity to run under.
+                if (!keys.get(publicKey)?.signingDescriptor) {
+                    keys.set(publicKey, { publicKey, signingDescriptor });
+                }
             } catch (error) {
                 logger.warn(`Skipping signing descriptor with no derivable key`, error);
             }
         }
         return [...keys.values()];
+    }
+
+    /**
+     * Re-derive the preimage of a restored swap from the descriptor key that
+     * owns it, returning `""` when it does not reproduce `preimageHash` — a
+     * legacy swap created with a random preimage, for which
+     * {@link enrichReverseSwapPreimage} stays the manual path. Restore never
+     * fabricates a preimage.
+     */
+    private async restoredSwapPreimage(
+        owner: SwapOwnerKey,
+        preimageHash: string | undefined,
+        swapId: string,
+    ): Promise<string> {
+        if (!owner.signingDescriptor || !preimageHash) return "";
+        try {
+            const signer = await this.swapSigner({ signingDescriptor: owner.signingDescriptor });
+            const preimage = await derivePreimage(signer);
+            if (hex.encode(sha256(preimage)) !== preimageHash) return "";
+            return hex.encode(preimage);
+        } catch (error) {
+            logger.warn(`Swap ${swapId}: could not re-derive preimage`, error);
+            return "";
+        }
+    }
+
+    /**
+     * Raise the wallet's allocation watermark to an attributed swap's index so
+     * a restored wallet never reallocates — and so never re-derives the
+     * preimage of — an index a live swap already burned. Monotonic, so the
+     * call order across swaps does not matter.
+     */
+    private async claimRestoredIndex(descriptor: string | undefined): Promise<void> {
+        if (!descriptor || !isHDWalletCapable(this.wallet)) return;
+        try {
+            await this.wallet.advanceSigningDescriptorWatermark(descriptor);
+        } catch (error) {
+            logger.warn(`Failed to advance the HD watermark past ${descriptor}`, error);
+        }
     }
 
     /**
@@ -3385,16 +3471,20 @@ export class ArkadeSwaps {
      * seed — come back claimable/refundable. A swap no key of ours reproduces
      * is skipped, never recorded under the wrong key.
      *
-     * Note: restored swaps may lack local-only data such as the original
-     * Lightning invoice or preimage. They are intended primarily for
-     * display/monitoring and are not automatically wired into the SwapManager.
+     * Reverse and chain swaps come back with their preimage re-derived from
+     * the owning descriptor key, so a wallet restored from seed alone can
+     * claim them. A swap created before deterministic preimages keeps
+     * `preimage: ""` — {@link enrichReverseSwapPreimage} is its manual path.
+     *
+     * Note: restored swaps may lack other local-only data such as the original
+     * Lightning invoice. They are intended primarily for display/monitoring
+     * and are not automatically wired into the SwapManager.
      */
     async restoreSwaps(boltzFees?: FeesResponse): Promise<{
         chainSwaps: BoltzChainSwap[];
         reverseSwaps: BoltzReverseSwap[];
         submarineSwaps: BoltzSubmarineSwap[];
     }> {
-        const candidates = await this.swapOwnerKeys();
         const fees = boltzFees ?? (await this.swapProvider.getFees());
         const arkInfo = await this.arkProvider.getInfo();
 
@@ -3402,212 +3492,253 @@ export class ArkadeSwaps {
         const reverseSwaps: BoltzReverseSwap[] = [];
         const submarineSwaps: BoltzSubmarineSwap[] = [];
 
-        const restoredSwaps = await this.swapProvider.restoreSwaps(
-            candidates.map((c) => c.publicKey),
-        );
-
         const skip = (id: string) =>
             logger.warn(`Skipping restored swap ${id}: not attributable to any wallet key`);
 
-        for (const swap of restoredSwaps) {
-            const { id, createdAt, status } = swap;
+        // Gap-limit semantics, batched: query the look-ahead band, let an
+        // attributed swap in it advance the watermark, and re-query the band
+        // that advance opened up. A round that queries no new key is the
+        // fixpoint. `seenSwapIds` keeps the result arrays and the per-swap
+        // side calls below single-shot across rounds.
+        const seenSwapIds = new Set<string>();
+        const queriedKeys = new Set<string>();
+        let cappedKeys = 0;
 
-            if (isRestoredReverseSwap(swap)) {
-                const { amount, lockupAddress, serverPublicKey, tree } = swap.claimDetails;
-                const preimageHash = swap.claimDetails.preimageHash ?? swap.preimageHash;
-                const timeoutBlockHeights = resolveVhtlcTimeouts(
-                    tree,
-                    swap.claimDetails.timeoutBlockHeights,
-                );
+        for (;;) {
+            const candidates = await this.swapOwnerKeys({ lookAhead: RESTORE_LOOK_AHEAD });
+            const unqueried = candidates.filter((c) => !queriedKeys.has(c.publicKey));
+            const fresh = unqueried.filter(
+                (c) => signingDescriptorIndex(c.signingDescriptor) <= MAX_RESTORE_INDEX,
+            );
+            cappedKeys += unqueried.length - fresh.length;
+            if (fresh.length === 0) break;
+            for (const c of fresh) queriedKeys.add(c.publicKey);
 
-                const owner =
-                    preimageHash && timeoutBlockHeights
-                        ? this.matchSwapOwner({
-                              arkInfo,
-                              candidates,
-                              ourRole: "receiver",
-                              counterpartyPubkey: serverPublicKey,
-                              preimageHash,
-                              timeoutBlockHeights,
-                              lockupAddress,
-                              swapId: id,
-                          })
-                        : undefined;
-                if (!owner) {
-                    skip(id);
-                    continue;
-                }
+            const restoredSwaps = await this.swapProvider.restoreSwaps(
+                fresh.map((c) => c.publicKey),
+            );
 
-                reverseSwaps.push({
-                    id,
-                    createdAt,
-                    request: {
-                        invoiceAmount: extractInvoiceAmount(amount, fees),
-                        claimPublicKey: owner.publicKey,
-                        preimageHash,
-                    },
-                    response: {
-                        id,
-                        invoice: swap.invoice ?? "",
-                        onchainAmount: amount,
-                        lockupAddress,
-                        refundPublicKey: serverPublicKey,
-                        timeoutBlockHeights,
-                    },
-                    status,
-                    type: "reverse",
-                    preimage: "",
-                    signingDescriptor: owner.signingDescriptor,
-                } as BoltzReverseSwap);
-            } else if (isRestoredSubmarineSwap(swap)) {
-                const { amount, lockupAddress, serverPublicKey, tree } = swap.refundDetails;
-                const preimageHash = swap.preimageHash ?? swap.refundDetails.preimageHash;
-                const timeoutBlockHeights = resolveVhtlcTimeouts(
-                    tree,
-                    swap.refundDetails.timeoutBlockHeights,
-                );
+            for (const swap of restoredSwaps) {
+                if (seenSwapIds.has(swap.id)) continue;
+                seenSwapIds.add(swap.id);
+                const { id, createdAt, status } = swap;
 
-                const owner =
-                    preimageHash && timeoutBlockHeights
-                        ? this.matchSwapOwner({
-                              arkInfo,
-                              candidates,
-                              ourRole: "sender",
-                              counterpartyPubkey: serverPublicKey,
-                              preimageHash,
-                              timeoutBlockHeights,
-                              lockupAddress,
-                              swapId: id,
-                          })
-                        : undefined;
-                if (!owner) {
-                    skip(id);
-                    continue;
-                }
+                if (isRestoredReverseSwap(swap)) {
+                    const { amount, lockupAddress, serverPublicKey, tree } = swap.claimDetails;
+                    const preimageHash = swap.claimDetails.preimageHash ?? swap.preimageHash;
+                    const timeoutBlockHeights = resolveVhtlcTimeouts(
+                        tree,
+                        swap.claimDetails.timeoutBlockHeights,
+                    );
 
-                let preimage = "";
-                // Skip preimage fetch for terminal swaps — nothing actionable
-                // and it avoids unnecessary API calls / 429s.
-                if (!isSubmarineFinalStatus(status)) {
-                    try {
-                        const data = await this.swapProvider.getSwapPreimage(swap.id);
-                        preimage = data.preimage;
-                    } catch (error) {
-                        logger.warn(`Failed to restore preimage for submarine swap ${id}`, error);
+                    const owner =
+                        preimageHash && timeoutBlockHeights
+                            ? this.matchSwapOwner({
+                                  arkInfo,
+                                  candidates,
+                                  ourRole: "receiver",
+                                  counterpartyPubkey: serverPublicKey,
+                                  preimageHash,
+                                  timeoutBlockHeights,
+                                  lockupAddress,
+                                  swapId: id,
+                              })
+                            : undefined;
+                    if (!owner) {
+                        skip(id);
+                        continue;
                     }
-                }
 
-                submarineSwaps.push({
-                    id,
-                    type: "submarine",
-                    createdAt,
-                    preimage,
-                    preimageHash: swap.preimageHash,
-                    status,
-                    request: {
-                        invoice: swap.invoice ?? "",
-                        refundPublicKey: owner.publicKey,
-                    },
-                    response: {
+                    await this.claimRestoredIndex(owner.signingDescriptor);
+
+                    reverseSwaps.push({
                         id,
-                        address: lockupAddress,
-                        expectedAmount: amount,
-                        claimPublicKey: serverPublicKey,
-                        timeoutBlockHeights,
-                    },
-                    signingDescriptor: owner.signingDescriptor,
-                } as BoltzSubmarineSwap);
-            } else if (isRestoredChainSwap(swap)) {
-                // The ARK leg is the one we hold a key on: our refund leg when
-                // we locked ARK, our claim leg when we receive it.
-                const weLockArk = swap.from === "ARK";
-                const arkLeg = weLockArk ? swap.refundDetails : swap.claimDetails;
-                if (!arkLeg) continue;
-                // The leg we funded, and the only one we can refund. For BTC→ARK
-                // that is the BTC leg, which Boltz may omit — the ARK leg is not
-                // a stand-in for it: `lockupDetails` is what callers pay into and
-                // refund from, so an ark address there would mis-route a BTC
-                // refund. Leave it absent instead of wrong.
-                const lockupLeg = swap.refundDetails;
+                        createdAt,
+                        request: {
+                            invoiceAmount: extractInvoiceAmount(amount, fees),
+                            claimPublicKey: owner.publicKey,
+                            preimageHash,
+                        },
+                        response: {
+                            id,
+                            invoice: swap.invoice ?? "",
+                            onchainAmount: amount,
+                            lockupAddress,
+                            refundPublicKey: serverPublicKey,
+                            timeoutBlockHeights,
+                        },
+                        status,
+                        type: "reverse",
+                        preimage: await this.restoredSwapPreimage(owner, preimageHash, id),
+                        signingDescriptor: owner.signingDescriptor,
+                    } as BoltzReverseSwap);
+                } else if (isRestoredSubmarineSwap(swap)) {
+                    const { amount, lockupAddress, serverPublicKey, tree } = swap.refundDetails;
+                    const preimageHash = swap.preimageHash ?? swap.refundDetails.preimageHash;
+                    const timeoutBlockHeights = resolveVhtlcTimeouts(
+                        tree,
+                        swap.refundDetails.timeoutBlockHeights,
+                    );
 
-                const arkTimeouts = resolveVhtlcTimeouts(arkLeg.tree, arkLeg.timeoutBlockHeights);
-                const owner =
-                    swap.preimageHash && arkTimeouts
-                        ? this.matchSwapOwner({
-                              arkInfo,
-                              candidates,
-                              ourRole: weLockArk ? "sender" : "receiver",
-                              counterpartyPubkey: arkLeg.serverPublicKey,
-                              preimageHash: swap.preimageHash,
-                              timeoutBlockHeights: arkTimeouts,
-                              lockupAddress: arkLeg.lockupAddress,
-                              swapId: id,
-                          })
-                        : undefined;
-                if (!owner) {
-                    skip(id);
-                    continue;
-                }
+                    const owner =
+                        preimageHash && timeoutBlockHeights
+                            ? this.matchSwapOwner({
+                                  arkInfo,
+                                  candidates,
+                                  ourRole: "sender",
+                                  counterpartyPubkey: serverPublicKey,
+                                  preimageHash,
+                                  timeoutBlockHeights,
+                                  lockupAddress,
+                                  swapId: id,
+                              })
+                            : undefined;
+                    if (!owner) {
+                        skip(id);
+                        continue;
+                    }
 
-                // Falls back to the ARK leg only as a display amount when our
-                // lockup leg is missing.
-                const amount = lockupLeg?.amount ?? arkLeg.amount;
-                chainSwaps.push({
-                    id,
-                    type: "chain",
-                    createdAt,
-                    preimage: "",
-                    ephemeralKey: "",
-                    feeSatsPerByte: 1,
-                    amount,
-                    status,
-                    request: {
-                        to: swap.to,
-                        from: swap.from,
+                    await this.claimRestoredIndex(owner.signingDescriptor);
+
+                    // Boltz owns a submarine swap's preimage; nothing to derive.
+                    let preimage = "";
+                    // Skip preimage fetch for terminal swaps — nothing actionable
+                    // and it avoids unnecessary API calls / 429s.
+                    if (!isSubmarineFinalStatus(status)) {
+                        try {
+                            const data = await this.swapProvider.getSwapPreimage(swap.id);
+                            preimage = data.preimage;
+                        } catch (error) {
+                            logger.warn(
+                                `Failed to restore preimage for submarine swap ${id}`,
+                                error,
+                            );
+                        }
+                    }
+
+                    submarineSwaps.push({
+                        id,
+                        type: "submarine",
+                        createdAt,
+                        preimage,
                         preimageHash: swap.preimageHash,
-                        // Only the ARK leg is ours; the BTC leg is signed by an
-                        // ephemeral key restore cannot recover.
-                        claimPublicKey: weLockArk ? "" : owner.publicKey,
-                        feeSatsPerByte: 1,
-                        refundPublicKey: weLockArk ? owner.publicKey : "",
-                        serverLockAmount: amount,
-                        userLockAmount: amount,
-                    },
-                    response: {
+                        status,
+                        request: {
+                            invoice: swap.invoice ?? "",
+                            refundPublicKey: owner.publicKey,
+                        },
+                        response: {
+                            id,
+                            address: lockupAddress,
+                            expectedAmount: amount,
+                            claimPublicKey: serverPublicKey,
+                            timeoutBlockHeights,
+                        },
+                        signingDescriptor: owner.signingDescriptor,
+                    } as BoltzSubmarineSwap);
+                } else if (isRestoredChainSwap(swap)) {
+                    // The ARK leg is the one we hold a key on: our refund leg when
+                    // we locked ARK, our claim leg when we receive it.
+                    const weLockArk = swap.from === "ARK";
+                    const arkLeg = weLockArk ? swap.refundDetails : swap.claimDetails;
+                    if (!arkLeg) continue;
+                    // The leg we funded, and the only one we can refund. For BTC→ARK
+                    // that is the BTC leg, which Boltz may omit — the ARK leg is not
+                    // a stand-in for it: `lockupDetails` is what callers pay into and
+                    // refund from, so an ark address there would mis-route a BTC
+                    // refund. Leave it absent instead of wrong.
+                    const lockupLeg = swap.refundDetails;
+
+                    const arkTimeouts = resolveVhtlcTimeouts(
+                        arkLeg.tree,
+                        arkLeg.timeoutBlockHeights,
+                    );
+                    const owner =
+                        swap.preimageHash && arkTimeouts
+                            ? this.matchSwapOwner({
+                                  arkInfo,
+                                  candidates,
+                                  ourRole: weLockArk ? "sender" : "receiver",
+                                  counterpartyPubkey: arkLeg.serverPublicKey,
+                                  preimageHash: swap.preimageHash,
+                                  timeoutBlockHeights: arkTimeouts,
+                                  lockupAddress: arkLeg.lockupAddress,
+                                  swapId: id,
+                              })
+                            : undefined;
+                    if (!owner) {
+                        skip(id);
+                        continue;
+                    }
+
+                    await this.claimRestoredIndex(owner.signingDescriptor);
+
+                    // Falls back to the ARK leg only as a display amount when our
+                    // lockup leg is missing.
+                    const amount = lockupLeg?.amount ?? arkLeg.amount;
+                    chainSwaps.push({
                         id,
-                        ...(lockupLeg
-                            ? {
-                                  lockupDetails: {
-                                      amount: lockupLeg.amount,
-                                      lockupAddress: lockupLeg.lockupAddress,
-                                      serverPublicKey: lockupLeg.serverPublicKey,
-                                      timeoutBlockHeight: lockupLeg.timeoutBlockHeight,
-                                      timeouts: resolveVhtlcTimeouts(
-                                          lockupLeg.tree,
-                                          lockupLeg.timeoutBlockHeights,
-                                      ),
-                                  },
-                              }
-                            : {}),
-                        // Claiming ARK reads its VHTLC from claimDetails.
-                        ...(swap.claimDetails
-                            ? {
-                                  claimDetails: {
-                                      amount: swap.claimDetails.amount,
-                                      lockupAddress: swap.claimDetails.lockupAddress,
-                                      serverPublicKey: swap.claimDetails.serverPublicKey,
-                                      timeoutBlockHeight: swap.claimDetails.timeoutBlockHeight,
-                                      timeouts: resolveVhtlcTimeouts(
-                                          swap.claimDetails.tree,
-                                          swap.claimDetails.timeoutBlockHeights,
-                                      ),
-                                  },
-                              }
-                            : {}),
-                    },
-                    signingDescriptor: owner.signingDescriptor,
-                } as BoltzChainSwap);
+                        type: "chain",
+                        createdAt,
+                        preimage: await this.restoredSwapPreimage(owner, swap.preimageHash, id),
+                        ephemeralKey: "",
+                        feeSatsPerByte: 1,
+                        amount,
+                        status,
+                        request: {
+                            to: swap.to,
+                            from: swap.from,
+                            preimageHash: swap.preimageHash,
+                            // Only the ARK leg is ours; the BTC leg is signed by an
+                            // ephemeral key restore cannot recover.
+                            claimPublicKey: weLockArk ? "" : owner.publicKey,
+                            feeSatsPerByte: 1,
+                            refundPublicKey: weLockArk ? owner.publicKey : "",
+                            serverLockAmount: amount,
+                            userLockAmount: amount,
+                        },
+                        response: {
+                            id,
+                            ...(lockupLeg
+                                ? {
+                                      lockupDetails: {
+                                          amount: lockupLeg.amount,
+                                          lockupAddress: lockupLeg.lockupAddress,
+                                          serverPublicKey: lockupLeg.serverPublicKey,
+                                          timeoutBlockHeight: lockupLeg.timeoutBlockHeight,
+                                          timeouts: resolveVhtlcTimeouts(
+                                              lockupLeg.tree,
+                                              lockupLeg.timeoutBlockHeights,
+                                          ),
+                                      },
+                                  }
+                                : {}),
+                            // Claiming ARK reads its VHTLC from claimDetails.
+                            ...(swap.claimDetails
+                                ? {
+                                      claimDetails: {
+                                          amount: swap.claimDetails.amount,
+                                          lockupAddress: swap.claimDetails.lockupAddress,
+                                          serverPublicKey: swap.claimDetails.serverPublicKey,
+                                          timeoutBlockHeight: swap.claimDetails.timeoutBlockHeight,
+                                          timeouts: resolveVhtlcTimeouts(
+                                              swap.claimDetails.tree,
+                                              swap.claimDetails.timeoutBlockHeights,
+                                          ),
+                                      },
+                                  }
+                                : {}),
+                        },
+                        signingDescriptor: owner.signingDescriptor,
+                    } as BoltzChainSwap);
+                }
             }
+        }
+
+        if (cappedKeys > 0) {
+            logger.warn(
+                `Restore stopped at HD index ${MAX_RESTORE_INDEX}: ${cappedKeys} higher key(s) were not queried`,
+            );
         }
 
         return { chainSwaps, reverseSwaps, submarineSwaps };

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -3508,6 +3508,9 @@ export class ArkadeSwaps {
             const candidates = await this.swapOwnerKeys({ lookAhead: RESTORE_LOOK_AHEAD });
             const fresh = candidates.filter((c) => {
                 if (queriedKeys.has(c.publicKey)) return false;
+                // The cap only bounds HD-derived descriptor indices. The baseline
+                // identity key has no descriptor, so it remains queryable for
+                // static wallets and pre-descriptor-binding swaps.
                 if (signingDescriptorIndex(c.signingDescriptor) > MAX_RESTORE_INDEX) {
                     cappedKeys.add(c.publicKey);
                     return false;

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -3466,10 +3466,10 @@ export class ArkadeSwaps {
      * Restore swaps from Boltz API.
      *
      * Queries the whole key set the wallet may have used ({@link swapOwnerKeys})
-     * and attributes each restored swap to the key that actually owns it, so
-     * swaps created under a rotated HD index — or by another SDK sharing the
-     * seed — come back claimable/refundable. A swap no key of ours reproduces
-     * is skipped, never recorded under the wrong key.
+     * and attributes each restored swap to the queried key that actually owns
+     * it, so swaps created under a rotated HD index — or by another SDK sharing
+     * the seed — come back claimable/refundable. A swap no queried key
+     * reproduces is skipped, never recorded under the wrong key.
      *
      * Reverse and chain swaps come back with their preimage re-derived from
      * the owning descriptor key, so a wallet restored from seed alone can
@@ -3538,7 +3538,7 @@ export class ArkadeSwaps {
                         preimageHash && timeoutBlockHeights
                             ? this.matchSwapOwner({
                                   arkInfo,
-                                  candidates,
+                                  candidates: fresh,
                                   ourRole: "receiver",
                                   counterpartyPubkey: serverPublicKey,
                                   preimageHash,
@@ -3587,7 +3587,7 @@ export class ArkadeSwaps {
                         preimageHash && timeoutBlockHeights
                             ? this.matchSwapOwner({
                                   arkInfo,
-                                  candidates,
+                                  candidates: fresh,
                                   ourRole: "sender",
                                   counterpartyPubkey: serverPublicKey,
                                   preimageHash,
@@ -3660,7 +3660,7 @@ export class ArkadeSwaps {
                         swap.preimageHash && arkTimeouts
                             ? this.matchSwapOwner({
                                   arkInfo,
-                                  candidates,
+                                  candidates: fresh,
                                   ourRole: weLockArk ? "sender" : "receiver",
                                   counterpartyPubkey: arkLeg.serverPublicKey,
                                   preimageHash: swap.preimageHash,

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -3502,15 +3502,18 @@ export class ArkadeSwaps {
         // side calls below single-shot across rounds.
         const seenSwapIds = new Set<string>();
         const queriedKeys = new Set<string>();
-        let cappedKeys = 0;
+        const cappedKeys = new Set<string>();
 
         for (;;) {
             const candidates = await this.swapOwnerKeys({ lookAhead: RESTORE_LOOK_AHEAD });
-            const unqueried = candidates.filter((c) => !queriedKeys.has(c.publicKey));
-            const fresh = unqueried.filter(
-                (c) => signingDescriptorIndex(c.signingDescriptor) <= MAX_RESTORE_INDEX,
-            );
-            cappedKeys += unqueried.length - fresh.length;
+            const fresh = candidates.filter((c) => {
+                if (queriedKeys.has(c.publicKey)) return false;
+                if (signingDescriptorIndex(c.signingDescriptor) > MAX_RESTORE_INDEX) {
+                    cappedKeys.add(c.publicKey);
+                    return false;
+                }
+                return true;
+            });
             if (fresh.length === 0) break;
             for (const c of fresh) queriedKeys.add(c.publicKey);
 
@@ -3735,9 +3738,9 @@ export class ArkadeSwaps {
             }
         }
 
-        if (cappedKeys > 0) {
+        if (cappedKeys.size > 0) {
             logger.warn(
-                `Restore stopped at HD index ${MAX_RESTORE_INDEX}: ${cappedKeys} higher key(s) were not queried`,
+                `Restore stopped at HD index ${MAX_RESTORE_INDEX}: ${cappedKeys.size} higher key(s) were not queried`,
             );
         }
 

--- a/packages/boltz-swap/src/utils/preimage.ts
+++ b/packages/boltz-swap/src/utils/preimage.ts
@@ -47,20 +47,37 @@ export function buildPreimageMessage(xonly: Uint8Array, index: number): Uint8Arr
 }
 
 /**
- * Derive a swap preimage from `identity`'s own key:
+ * Derive a swap preimage from the key owned by `identity`:
  * `sha256(BIP340_sign(sha256(message), aux_rand = 0))`.
  *
- * Same identity and index always yield the same preimage, so a wallet
- * restored from seed can re-derive the secret a rediscovered swap needs. The
- * signing key and the key in the message are necessarily the same one —
- * passing a key in separately would let create-time and restore-time diverge.
+ * Same identity always yields the same preimage, so a wallet restored from seed
+ * can re-derive the secret a rediscovered swap needs. The signing key and the
+ * key in the message are necessarily the same one; passing a key in separately
+ * would let create-time and restore-time diverge.
  *
- * `index` exists for the message format (and the cross-SDK vectors); callers
- * pass 0. Never falls back to randomness: that policy belongs to the caller.
+ * Live swaps intentionally fix the message index to 0. If a future live scheme
+ * needs another derivation dimension, bump the preimage tag and persist enough
+ * metadata to restore it instead of selecting another index here. Never falls
+ * back to randomness: that policy belongs to the caller.
  *
  * @throws if `identity` cannot sign deterministically.
  */
-export async function derivePreimage(identity: Identity, index = 0): Promise<Uint8Array> {
+export async function derivePreimage(identity: Identity): Promise<Uint8Array> {
+    return derivePreimageForMessageIndex(identity, 0);
+}
+
+/**
+ * Derive a preimage for a specific message index.
+ *
+ * @param index Message-format index. Must be 0 for live swaps; non-zero values
+ * are cross-SDK vector coverage only.
+ * @internal Live swap callers must use {@link derivePreimage}, which fixes the
+ * index to 0.
+ */
+export async function derivePreimageForMessageIndex(
+    identity: Identity,
+    index: number,
+): Promise<Uint8Array> {
     if (!isDeterministicSigner(identity)) {
         throw new Error("Identity cannot derive a deterministic preimage");
     }

--- a/packages/boltz-swap/src/utils/preimage.ts
+++ b/packages/boltz-swap/src/utils/preimage.ts
@@ -1,0 +1,69 @@
+import { Identity } from "@arkade-os/sdk";
+import { sha256 } from "@noble/hashes/sha2.js";
+
+/**
+ * Domain separation tag for the swap preimage scheme. Protocol+provider
+ * scoped rather than SDK scoped: every Arkade SDK implementing this derives
+ * the same preimage, so a swap created by one is recoverable by another.
+ * `-v1` leaves room for a scheme bump.
+ */
+const PREIMAGE_TAG = "Arkade-Boltz-Preimage-v1";
+const PREIMAGE_TAG_BYTES = new TextEncoder().encode(PREIMAGE_TAG);
+
+/** An {@link Identity} that can produce a deterministic BIP-340 signature. */
+export interface DeterministicSigner {
+    signSchnorrDeterministic(messageHash: Uint8Array): Promise<Uint8Array>;
+}
+
+/** Structural probe for {@link DeterministicSigner}. */
+export function isDeterministicSigner(value: unknown): value is DeterministicSigner {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof (value as DeterministicSigner).signSchnorrDeterministic === "function"
+    );
+}
+
+/**
+ * The message that gets BIP-340 signed: `tag ‖ xonly(32) ‖ u32le(index)`.
+ *
+ * Anchored on the canonical x-only key rather than the descriptor string: a
+ * restore reconstructs a *bare* receiver descriptor, which serialises
+ * differently from the HD signing descriptor used at create time, so only the
+ * key makes both sides agree.
+ */
+export function buildPreimageMessage(xonly: Uint8Array, index: number): Uint8Array {
+    if (xonly.length !== 32) {
+        throw new Error(`Preimage message needs a 32-byte x-only key, got ${xonly.length}`);
+    }
+    if (!Number.isInteger(index) || index < 0 || index > 0xffffffff) {
+        throw new Error(`Preimage index must fit a u32, got ${index}`);
+    }
+    const message = new Uint8Array(PREIMAGE_TAG_BYTES.length + 32 + 4);
+    message.set(PREIMAGE_TAG_BYTES, 0);
+    message.set(xonly, PREIMAGE_TAG_BYTES.length);
+    new DataView(message.buffer).setUint32(PREIMAGE_TAG_BYTES.length + 32, index, true);
+    return message;
+}
+
+/**
+ * Derive a swap preimage from `identity`'s own key:
+ * `sha256(BIP340_sign(sha256(message), aux_rand = 0))`.
+ *
+ * Same identity and index always yield the same preimage, so a wallet
+ * restored from seed can re-derive the secret a rediscovered swap needs. The
+ * signing key and the key in the message are necessarily the same one —
+ * passing a key in separately would let create-time and restore-time diverge.
+ *
+ * `index` exists for the message format (and the cross-SDK vectors); callers
+ * pass 0. Never falls back to randomness: that policy belongs to the caller.
+ *
+ * @throws if `identity` cannot sign deterministically.
+ */
+export async function derivePreimage(identity: Identity, index = 0): Promise<Uint8Array> {
+    if (!isDeterministicSigner(identity)) {
+        throw new Error("Identity cannot derive a deterministic preimage");
+    }
+    const message = buildPreimageMessage(await identity.xOnlyPublicKey(), index);
+    return sha256(await identity.signSchnorrDeterministic(sha256(message)));
+}

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3773,6 +3773,47 @@ describe("ArkadeSwaps", () => {
                 };
             };
 
+            /** A chain swap owned by the ARK leg key at `index`, on a derived preimage. */
+            const derivedChainAt = async (
+                hd: ReturnType<typeof installHdWallet>,
+                index: number,
+                id: string,
+                direction: "arkToBtc" | "btcToArk",
+            ) => {
+                const preimage = await hd.preimageAt(index);
+                const preimageHash = hex.encode(sha256(preimage));
+                if (direction === "arkToBtc") {
+                    return {
+                        swap: {
+                            ...pendingChain,
+                            id,
+                            preimageHash,
+                            refundDetails: makeDetails({
+                                ourRole: "sender" as const,
+                                preimageHash,
+                                timeoutBlockHeights: serverTimeouts,
+                                ourKey: hd.keyAt(index),
+                            }),
+                        },
+                        preimage: hex.encode(preimage),
+                    };
+                }
+                return {
+                    swap: {
+                        ...btcToArk,
+                        id,
+                        preimageHash,
+                        claimDetails: makeDetails({
+                            ourRole: "receiver" as const,
+                            preimageHash,
+                            timeoutBlockHeights: serverTimeouts,
+                            ourKey: hd.keyAt(index),
+                        }),
+                    },
+                    preimage: hex.encode(preimage),
+                };
+            };
+
             /** Answer a restore query with whichever fixtures the keys own. */
             const restoreByKey = (owned: { key: string; swap: any }[]) =>
                 vi
@@ -3795,6 +3836,42 @@ describe("ArkadeSwaps", () => {
                 // identity to derive under.
                 expect(result.reverseSwaps[0].signingDescriptor).toBe(hd.descriptorAt(0));
                 expect(result.reverseSwaps[0].preimage).toBe(preimage);
+            });
+
+            it("re-derives the preimage of an ARK-lockup chain swap", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(3);
+                const { swap, preimage } = await derivedChainAt(
+                    hd,
+                    3,
+                    "chain-ark-lockup",
+                    "arkToBtc",
+                );
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([swap]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.chainSwaps[0].signingDescriptor).toBe(hd.descriptorAt(3));
+                expect(result.chainSwaps[0].preimage).toBe(preimage);
+            });
+
+            it("re-derives the preimage of an ARK-claim chain swap", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(4);
+                const { swap, preimage } = await derivedChainAt(
+                    hd,
+                    4,
+                    "chain-ark-claim",
+                    "btcToArk",
+                );
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([swap]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.chainSwaps[0].signingDescriptor).toBe(hd.descriptorAt(4));
+                expect(result.chainSwaps[0].preimage).toBe(preimage);
             });
 
             it("leaves a legacy random-preimage swap unclaimed rather than guessing", async () => {

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3525,6 +3525,12 @@ describe("ArkadeSwaps", () => {
                 (wallet as any).getCurrentSigningDescriptor = vi
                     .fn()
                     .mockResolvedValue(rotatedDescriptor);
+                (wallet as any).getNextSigningDescriptor = vi
+                    .fn()
+                    .mockResolvedValue(rotatedDescriptor);
+                (wallet as any).advanceSigningDescriptorWatermark = vi
+                    .fn()
+                    .mockResolvedValue(undefined);
                 (wallet as any).signerForDescriptor = vi.fn().mockResolvedValue(identity);
             };
 
@@ -5589,13 +5595,17 @@ describe("ArkadeSwaps", () => {
             (wallet as any).getCurrentSigningDescriptor = vi
                 .fn()
                 .mockResolvedValue(rotatedDescriptor);
+            (wallet as any).getNextSigningDescriptor = vi.fn().mockResolvedValue(rotatedDescriptor);
             (wallet as any).getUsedSigningDescriptors = vi
                 .fn()
                 .mockResolvedValue([rotatedDescriptor]);
+            (wallet as any).advanceSigningDescriptorWatermark = vi
+                .fn()
+                .mockResolvedValue(undefined);
             (wallet as any).signerForDescriptor = vi.fn().mockResolvedValue(rotatedIdentity);
         };
 
-        it("creates a reverse swap under the current index", async () => {
+        it("creates a reverse swap under a freshly allocated index", async () => {
             rotateWallet();
             vi.spyOn(swapProvider, "createReverseSwap").mockImplementationOnce(
                 reverseSwapResponseFor(createReverseSwapResponse),
@@ -5607,7 +5617,7 @@ describe("ArkadeSwaps", () => {
             expect(pendingSwap.signingDescriptor).toBe(rotatedDescriptor);
         });
 
-        it("creates a submarine swap under the current index", async () => {
+        it("creates a submarine swap under a freshly allocated index", async () => {
             rotateWallet();
             vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
                 createSubmarineSwapResponse,
@@ -5621,7 +5631,7 @@ describe("ArkadeSwaps", () => {
             expect(pendingSwap.signingDescriptor).toBe(rotatedDescriptor);
         });
 
-        it("binds only the ARK leg of a chain swap to the current index", async () => {
+        it("binds only the ARK leg of a chain swap to a freshly allocated index", async () => {
             rotateWallet();
             vi.spyOn(swapProvider, "createChainSwap").mockResolvedValueOnce(
                 createArkBtcChainSwapResponse,

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -28,8 +28,10 @@ import {
     getNetwork,
     maybeArkError,
     MnemonicIdentity,
+    DescriptorIdentity,
     deriveDescriptorLeafCompressedPubKey,
 } from "@arkade-os/sdk";
+import { derivePreimage } from "../src/utils/preimage";
 import { VHTLC } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
 import { randomBytes } from "@noble/hashes/utils.js";
@@ -113,6 +115,56 @@ const reverseSwapResponseFor =
         decodeInvoiceOverride.paymentHash = req.preimageHash;
         return response;
     };
+
+const HD_MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+/**
+ * Turn the mock wallet into an HD wallet with a live allocation watermark, so
+ * allocation, the restore look-ahead band and the watermark advance behave as
+ * they do on a real `Wallet` instead of returning canned values.
+ */
+function installHdWallet(wallet: any) {
+    const identity = MnemonicIdentity.fromMnemonic(HD_MNEMONIC, { isMainnet: false });
+    const descriptorAt = (index: number) => identity.descriptor.replace("/*)", `/${index})`);
+    const keyAt = (index: number) =>
+        hex.encode(deriveDescriptorLeafCompressedPubKey(descriptorAt(index)));
+    let watermark = -1;
+
+    wallet.identity = identity;
+    wallet.getNextSigningDescriptor = vi.fn(async () => descriptorAt(++watermark));
+    wallet.getCurrentSigningDescriptor = vi.fn(async () =>
+        watermark < 0 ? undefined : descriptorAt(watermark),
+    );
+    wallet.getUsedSigningDescriptors = vi.fn(async (opts?: { lookAhead?: number }) =>
+        Array.from({ length: watermark + 1 + (opts?.lookAhead ?? 0) }, (_, i) => descriptorAt(i)),
+    );
+    wallet.advanceSigningDescriptorWatermark = vi.fn(async (descriptor: string) => {
+        const index = Number(descriptor.match(/\/(\d+)\)$/)![1]);
+        if (index > watermark) watermark = index;
+    });
+    wallet.signerForDescriptor = vi.fn(
+        async (descriptor: string) =>
+            new DescriptorIdentity({ descriptor, signer: identity, base: identity }),
+    );
+
+    return {
+        descriptorAt,
+        keyAt,
+        preimageAt: (index: number) =>
+            derivePreimage(
+                new DescriptorIdentity({
+                    descriptor: descriptorAt(index),
+                    signer: identity,
+                    base: identity,
+                }),
+            ),
+        watermark: () => watermark,
+        setWatermark: (index: number) => {
+            watermark = index;
+        },
+    };
+}
 
 // Mock WebSocket - this needs to be at the top level
 vi.mock("ws", () => {
@@ -3695,6 +3747,161 @@ describe("ArkadeSwaps", () => {
                 );
             });
         });
+
+        describe("deterministic preimage recovery", () => {
+            /** A reverse swap owned by the key at `index`, on a derived preimage. */
+            const derivedReverseAt = async (
+                hd: ReturnType<typeof installHdWallet>,
+                index: number,
+                id: string,
+            ) => {
+                const preimage = await hd.preimageAt(index);
+                const preimageHash = hex.encode(sha256(preimage));
+                return {
+                    swap: {
+                        ...pendingReverse,
+                        id,
+                        preimageHash,
+                        claimDetails: makeDetails({
+                            ourRole: "receiver" as const,
+                            preimageHash,
+                            timeoutBlockHeights: serverTimeouts,
+                            ourKey: hd.keyAt(index),
+                        }),
+                    },
+                    preimage: hex.encode(preimage),
+                };
+            };
+
+            /** Answer a restore query with whichever fixtures the keys own. */
+            const restoreByKey = (owned: { key: string; swap: any }[]) =>
+                vi
+                    .spyOn(swapProvider, "restoreSwaps")
+                    .mockImplementation(async (keys: string[]) =>
+                        owned.filter((o) => keys.includes(o.key)).map((o) => o.swap),
+                    );
+
+            it("re-derives the preimage of a swap held at index 0", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(0);
+                const { swap, preimage } = await derivedReverseAt(hd, 0, "rev-index-0");
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([swap]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                // The baseline identity key *is* the index-0 leaf key: the owner
+                // must still carry the descriptor, or there is no descriptor
+                // identity to derive under.
+                expect(result.reverseSwaps[0].signingDescriptor).toBe(hd.descriptorAt(0));
+                expect(result.reverseSwaps[0].preimage).toBe(preimage);
+            });
+
+            it("leaves a legacy random-preimage swap unclaimed rather than guessing", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(0);
+                const legacy = {
+                    ...pendingReverse,
+                    id: "rev-legacy",
+                    claimDetails: makeDetails({
+                        ourRole: "receiver" as const,
+                        preimageHash: reversePreimageHash,
+                        timeoutBlockHeights: serverTimeouts,
+                        ourKey: hd.keyAt(0),
+                    }),
+                };
+                vi.spyOn(swapProvider, "restoreSwaps").mockResolvedValueOnce([legacy]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.reverseSwaps).toHaveLength(1);
+                expect(result.reverseSwaps[0].preimage).toBe("");
+            });
+
+            it("finds a swap burned above the watermark and moves the watermark past it", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(0);
+                const { swap, preimage } = await derivedReverseAt(hd, 5, "rev-above");
+                const restoreSpy = restoreByKey([{ key: hd.keyAt(5), swap }]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(restoreSpy.mock.calls[0][0]).toContain(hd.keyAt(5));
+                expect(result.reverseSwaps[0].preimage).toBe(preimage);
+                // The next allocation must not reissue the recovered index.
+                expect(await wallet.getNextSigningDescriptor()).toBe(hd.descriptorAt(6));
+            });
+
+            it("iterates the band to a fixpoint so a hit extends the reach", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(0);
+                const near = await derivedReverseAt(hd, 18, "rev-near");
+                const far = await derivedReverseAt(hd, 30, "rev-far");
+                const restoreSpy = restoreByKey([
+                    { key: hd.keyAt(18), swap: near.swap },
+                    { key: hd.keyAt(30), swap: far.swap },
+                ]);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                // Index 30 is outside the first 20-wide band; the hit at 18
+                // advances the watermark and the extended band reaches it.
+                expect(result.reverseSwaps.map((s) => s.id).sort()).toEqual([
+                    "rev-far",
+                    "rev-near",
+                ]);
+                expect(restoreSpy.mock.calls[1][0]).not.toContain(hd.keyAt(18));
+                expect(hd.watermark()).toBe(30);
+            });
+
+            it("stops after one query when the band comes back dry", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(0);
+                const restoreSpy = vi
+                    .spyOn(swapProvider, "restoreSwaps")
+                    .mockResolvedValue([] as any);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                await swaps.restoreSwaps();
+
+                expect(restoreSpy).toHaveBeenCalledOnce();
+            });
+
+            it("returns a swap seen in several rounds once, fetching its preimage once", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(0);
+                const repeated = {
+                    ...pendingSubmarine,
+                    id: "sub-repeated",
+                    refundDetails: makeDetails({
+                        ourRole: "sender" as const,
+                        preimageHash: submarinePreimageHash,
+                        timeoutBlockHeights: serverTimeouts,
+                        ourKey: hd.keyAt(10),
+                    }),
+                };
+                // Answers every round with the same swap: the dedupe, not the
+                // query shape, is what has to keep the result single.
+                const restoreSpy = vi
+                    .spyOn(swapProvider, "restoreSwaps")
+                    .mockResolvedValue([repeated] as any);
+                const getPreimageSpy = vi
+                    .spyOn(swapProvider, "getSwapPreimage")
+                    .mockResolvedValue({ preimage: hex.encode(randomBytes(32)) } as any);
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.submarineSwaps).toHaveLength(1);
+                expect(getPreimageSpy).toHaveBeenCalledOnce();
+                // Round 2 re-sees the swap, makes no progress, and ends the loop.
+                expect(restoreSpy).toHaveBeenCalledTimes(2);
+                expect(hd.watermark()).toBe(10);
+            });
+        });
     });
 
     describe("refundVHTLC — VTXO selection", () => {
@@ -5673,6 +5880,68 @@ describe("ArkadeSwaps", () => {
 
             expect(pendingSwap.request.claimPublicKey).toBe(compressedPubkeys.alice);
             expect(pendingSwap.signingDescriptor).toBeUndefined();
+        });
+
+        describe("deterministic preimages", () => {
+            it("allocates a fresh index per swap, so no two share a preimage", async () => {
+                const hd = installHdWallet(wallet);
+                vi.spyOn(swapProvider, "createReverseSwap").mockImplementation(
+                    reverseSwapResponseFor(createReverseSwapResponse),
+                );
+                vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValue(
+                    createSubmarineSwapResponse,
+                );
+
+                const first = await swaps.createReverseSwap({ amount: mock.invoice.amount });
+                const submarine = await swaps.createSubmarineSwap({
+                    invoice: mock.invoice.address,
+                });
+                const second = await swaps.createReverseSwap({ amount: mock.invoice.amount });
+
+                expect([
+                    first.signingDescriptor,
+                    submarine.signingDescriptor,
+                    second.signingDescriptor,
+                ]).toEqual([hd.descriptorAt(0), hd.descriptorAt(1), hd.descriptorAt(2)]);
+                expect(second.preimage).not.toBe(first.preimage);
+                expect(second.request.preimageHash).not.toBe(first.request.preimageHash);
+                // Submarine derives no preimage — Boltz owns it — but still
+                // gets its own refund key.
+                expect(submarine.request.refundPublicKey).toBe(hd.keyAt(1));
+                expect(hd.watermark()).toBe(2);
+            });
+
+            it("derives from the swap's descriptor key, not the baseline key", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(4);
+                vi.spyOn(swapProvider, "createReverseSwap").mockImplementationOnce(
+                    reverseSwapResponseFor(createReverseSwapResponse),
+                );
+
+                const pendingSwap = await swaps.createReverseSwap({
+                    amount: mock.invoice.amount,
+                });
+
+                expect(pendingSwap.signingDescriptor).toBe(hd.descriptorAt(5));
+                expect(pendingSwap.preimage).toBe(hex.encode(await hd.preimageAt(5)));
+                expect(pendingSwap.preimage).not.toBe(hex.encode(await hd.preimageAt(0)));
+            });
+
+            it("falls back to a random preimage, loudly, on a wallet with no HD state", async () => {
+                const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+                vi.spyOn(swapProvider, "createReverseSwap").mockImplementation(
+                    reverseSwapResponseFor(createReverseSwapResponse),
+                );
+
+                const first = await swaps.createReverseSwap({ amount: mock.invoice.amount });
+                const second = await swaps.createReverseSwap({ amount: mock.invoice.amount });
+
+                expect(hex.decode(first.preimage)).toHaveLength(32);
+                expect(second.preimage).not.toBe(first.preimage);
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining("not be recoverable from seed"),
+                );
+            });
         });
 
         describe("claim and refund routing", () => {

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -3934,6 +3934,32 @@ describe("ArkadeSwaps", () => {
                 expect(hd.watermark()).toBe(30);
             });
 
+            it("does not attribute a restore response outside the queried key batch", async () => {
+                const hd = installHdWallet(wallet);
+                hd.setWatermark(0);
+                const near = await derivedReverseAt(hd, 18, "rev-near");
+                const speculative = await derivedReverseAt(hd, 5, "rev-speculative");
+                let round = 0;
+                const restoreSpy = vi
+                    .spyOn(swapProvider, "restoreSwaps")
+                    .mockImplementation(async (keys: string[]) => {
+                        round += 1;
+                        if (round === 1) return [near.swap] as any;
+                        if (round === 2) {
+                            expect(keys).not.toContain(hd.keyAt(5));
+                            return [speculative.swap] as any;
+                        }
+                        return [] as any;
+                    });
+                vi.spyOn(swapProvider, "getFees").mockResolvedValueOnce(mockFees as any);
+
+                const result = await swaps.restoreSwaps();
+
+                expect(result.reverseSwaps.map((s) => s.id)).toEqual(["rev-near"]);
+                expect(restoreSpy).toHaveBeenCalledTimes(2);
+                expect(hd.watermark()).toBe(18);
+            });
+
             it("stops after one query when the band comes back dry", async () => {
                 const hd = installHdWallet(wallet);
                 hd.setWatermark(0);

--- a/packages/boltz-swap/test/fixtures/preimage_vectors.json
+++ b/packages/boltz-swap/test/fixtures/preimage_vectors.json
@@ -1,0 +1,205 @@
+{
+    "seed": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    "vectors": {
+        "mainnet": {
+            "keyIndexed": {
+                "0": [
+                    {
+                        "derivationIndex": 0,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc11500000000",
+                        "expectedPreimage": "c14fc895dc5c88e914921d3fa040e524cfc6f108d572585d0aa5647de16b5812"
+                    },
+                    {
+                        "derivationIndex": 1,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc11501000000",
+                        "expectedPreimage": "00c75291aff2edd52d1c2692b5ed76c5fc014bc3c71b802778983692cbf518a6"
+                    },
+                    {
+                        "derivationIndex": 7,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc11507000000",
+                        "expectedPreimage": "f42acccc0669eb4b17005832a9f04f988aca905e3d667a805d58f5ab6425b528"
+                    },
+                    {
+                        "derivationIndex": 42,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc1152a000000",
+                        "expectedPreimage": "311dbd2eb9519c5ca9363b8a74c5815434c1268f49e88b575004a4c6e81679ad"
+                    },
+                    {
+                        "derivationIndex": 100,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc11564000000",
+                        "expectedPreimage": "8a4b49724da28ba7249b52a41cb4cdc0815e89c852ebce886df7eee363897d31"
+                    },
+                    {
+                        "derivationIndex": 999,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115e7030000",
+                        "expectedPreimage": "2b8341e645bcc9b683dcbc73f8ae9a1176eb319549cb3ee38cb828add82896a2"
+                    }
+                ],
+                "1": [
+                    {
+                        "derivationIndex": 0,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763183dfe85a3151d2517290da461fe2815591ef69f2b18a2ce63f01697a8b31314500000000",
+                        "expectedPreimage": "16591d1af0f9b378f16e7f90de5dacd2d32ab91f392f04f90767b28aa1dfc840"
+                    },
+                    {
+                        "derivationIndex": 1,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763183dfe85a3151d2517290da461fe2815591ef69f2b18a2ce63f01697a8b31314501000000",
+                        "expectedPreimage": "487b6e9818bcf2f3a923ce7fd304cd103b44ff95cb26ef8e2105d06154327561"
+                    },
+                    {
+                        "derivationIndex": 7,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763183dfe85a3151d2517290da461fe2815591ef69f2b18a2ce63f01697a8b31314507000000",
+                        "expectedPreimage": "b1fca45c669ce75ece08d141cc639c4f37534c10f12d18444f0845caa0b76493"
+                    },
+                    {
+                        "derivationIndex": 42,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763183dfe85a3151d2517290da461fe2815591ef69f2b18a2ce63f01697a8b3131452a000000",
+                        "expectedPreimage": "673faf5e09f9f795c1fe28e98e32dc4eb01863c50d167a99d7cffd7312ff3289"
+                    },
+                    {
+                        "derivationIndex": 100,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763183dfe85a3151d2517290da461fe2815591ef69f2b18a2ce63f01697a8b31314564000000",
+                        "expectedPreimage": "d76cd8b85d5fe0998b108589b9e73a7de1f945047cbe3e726dcedd404eb4984d"
+                    },
+                    {
+                        "derivationIndex": 999,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763183dfe85a3151d2517290da461fe2815591ef69f2b18a2ce63f01697a8b313145e7030000",
+                        "expectedPreimage": "6e4a5b596cb0100db4e27a9af4aa16ae75a7a40e714ef642cf87ba26f417d3b5"
+                    }
+                ],
+                "2": [
+                    {
+                        "derivationIndex": 0,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631a730a23ce8b47248a5ddfb32eef75262d91f0b55b084dd1ff0d2f9e032e0e53300000000",
+                        "expectedPreimage": "1da8a08eda71d0f95ce3decb251932448a025b42666be92ad2fd623802696a45"
+                    },
+                    {
+                        "derivationIndex": 1,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631a730a23ce8b47248a5ddfb32eef75262d91f0b55b084dd1ff0d2f9e032e0e53301000000",
+                        "expectedPreimage": "23650f7be6150d94947710a1bb8a1f59f4428acbbfb047c3238bdc2a1fc9b36f"
+                    },
+                    {
+                        "derivationIndex": 7,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631a730a23ce8b47248a5ddfb32eef75262d91f0b55b084dd1ff0d2f9e032e0e53307000000",
+                        "expectedPreimage": "75c826b8b858e44df633647f74ab87f50798a97bd831cc5b48b43da88627bc4c"
+                    },
+                    {
+                        "derivationIndex": 42,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631a730a23ce8b47248a5ddfb32eef75262d91f0b55b084dd1ff0d2f9e032e0e5332a000000",
+                        "expectedPreimage": "858c3ef9924411b33605f7b31bacb8a37bf242852fd967916bff13ad59e0521f"
+                    },
+                    {
+                        "derivationIndex": 100,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631a730a23ce8b47248a5ddfb32eef75262d91f0b55b084dd1ff0d2f9e032e0e53364000000",
+                        "expectedPreimage": "6f53e9733263b65e56500ddabb7cf2d5e018e971397cec4d36abb88a1f3fdd82"
+                    },
+                    {
+                        "derivationIndex": 999,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631a730a23ce8b47248a5ddfb32eef75262d91f0b55b084dd1ff0d2f9e032e0e533e7030000",
+                        "expectedPreimage": "1106b669ec51196a763d99758ee4c20a7e1509f55e6b96e3cd12371687aef30e"
+                    }
+                ]
+            }
+        },
+        "regtest": {
+            "keyIndexed": {
+                "0": [
+                    {
+                        "derivationIndex": 0,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763155355ca83c973f1d97ce0e3843c85d78905af16b4dc531bc488e57212d23011600000000",
+                        "expectedPreimage": "59aa31de540a5e112ed6067c2dbda885f05f108aeca46cfe90ffbad21f3b3cdf"
+                    },
+                    {
+                        "derivationIndex": 1,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763155355ca83c973f1d97ce0e3843c85d78905af16b4dc531bc488e57212d23011601000000",
+                        "expectedPreimage": "c7c7ccac369aa529154f07a27c49d4e44a4f439c02bc41c5154d4e463f9a202e"
+                    },
+                    {
+                        "derivationIndex": 7,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763155355ca83c973f1d97ce0e3843c85d78905af16b4dc531bc488e57212d23011607000000",
+                        "expectedPreimage": "61a2ee48eff7eba221b6b0dcddd4b81564de9f5cb858922a74891cb0da8faa55"
+                    },
+                    {
+                        "derivationIndex": 42,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763155355ca83c973f1d97ce0e3843c85d78905af16b4dc531bc488e57212d2301162a000000",
+                        "expectedPreimage": "624818916ee2a8cd33beb4872c90acb730f2653b59556ce953f48772809a7870"
+                    },
+                    {
+                        "derivationIndex": 100,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763155355ca83c973f1d97ce0e3843c85d78905af16b4dc531bc488e57212d23011664000000",
+                        "expectedPreimage": "03777072f60da751e66dd8e3751cd144f3f08287938a0bbcaa0046ff886d3853"
+                    },
+                    {
+                        "derivationIndex": 999,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d763155355ca83c973f1d97ce0e3843c85d78905af16b4dc531bc488e57212d230116e7030000",
+                        "expectedPreimage": "5744216916a4ba7ecfdc72ba6ccac1d9fbc0779ba31edf2e613ad2d9dd765766"
+                    }
+                ],
+                "1": [
+                    {
+                        "derivationIndex": 0,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d76313058679f6d60b87ef921d98a2a9a1f1e0779dae27bedbd1cdb2f147a07835ac900000000",
+                        "expectedPreimage": "418eca194076bc70a423bd1ad129d409e772cb330cae0673e6fb4bf61c7a8c32"
+                    },
+                    {
+                        "derivationIndex": 1,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d76313058679f6d60b87ef921d98a2a9a1f1e0779dae27bedbd1cdb2f147a07835ac901000000",
+                        "expectedPreimage": "0244a05bda4716f5fb789b69e65f4b525e27180fa37e7732bddbe1c3529fe9b8"
+                    },
+                    {
+                        "derivationIndex": 7,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d76313058679f6d60b87ef921d98a2a9a1f1e0779dae27bedbd1cdb2f147a07835ac907000000",
+                        "expectedPreimage": "cfc98230be7cbba3792617b5d127f76b6aaf3c9e758d6dbd300a4d9af977d184"
+                    },
+                    {
+                        "derivationIndex": 42,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d76313058679f6d60b87ef921d98a2a9a1f1e0779dae27bedbd1cdb2f147a07835ac92a000000",
+                        "expectedPreimage": "8d0ac2c2052434f7abe1a9cb270a92b307b25577cf174ac0fbef059624b24c7a"
+                    },
+                    {
+                        "derivationIndex": 100,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d76313058679f6d60b87ef921d98a2a9a1f1e0779dae27bedbd1cdb2f147a07835ac964000000",
+                        "expectedPreimage": "2cd3c5a6b5a7b9e34c238893393c4b7a3e1796fadd846d339a30369c562da076"
+                    },
+                    {
+                        "derivationIndex": 999,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d76313058679f6d60b87ef921d98a2a9a1f1e0779dae27bedbd1cdb2f147a07835ac9e7030000",
+                        "expectedPreimage": "b5e66dd8fd2830c6c903a22be276f95c8096c60bd17b10274c31b36da21718c2"
+                    }
+                ],
+                "2": [
+                    {
+                        "derivationIndex": 0,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631b68df382cad577d8304d5a8e640c3cb42d77c10016ab754caa4d6e68b6cb296d00000000",
+                        "expectedPreimage": "b60fe5b91198f10ad037a3cf66c86e7c6f6e051cbe7c11fc3a537402ece7dfa4"
+                    },
+                    {
+                        "derivationIndex": 1,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631b68df382cad577d8304d5a8e640c3cb42d77c10016ab754caa4d6e68b6cb296d01000000",
+                        "expectedPreimage": "48e843aae11c713ce1825f014588a60f056f9054faeb0691512a958e50a7919e"
+                    },
+                    {
+                        "derivationIndex": 7,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631b68df382cad577d8304d5a8e640c3cb42d77c10016ab754caa4d6e68b6cb296d07000000",
+                        "expectedPreimage": "2d00446bc04cabbaf18d36b2bb0bc63a13826484d46c3b6a8668eb27f41e84c8"
+                    },
+                    {
+                        "derivationIndex": 42,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631b68df382cad577d8304d5a8e640c3cb42d77c10016ab754caa4d6e68b6cb296d2a000000",
+                        "expectedPreimage": "3fe3cb1ed35d0c462e25ac779b1bf9bdce4bbd15ecbd4095c025cc52ca230a41"
+                    },
+                    {
+                        "derivationIndex": 100,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631b68df382cad577d8304d5a8e640c3cb42d77c10016ab754caa4d6e68b6cb296d64000000",
+                        "expectedPreimage": "6694f07c6d55d73b67aedbd24f5da61d03acd595eae577d13a1d2bf7bc9972a0"
+                    },
+                    {
+                        "derivationIndex": 999,
+                        "expectedPreimageMessage": "41726b6164652d426f6c747a2d507265696d6167652d7631b68df382cad577d8304d5a8e640c3cb42d77c10016ab754caa4d6e68b6cb296de7030000",
+                        "expectedPreimage": "5db561e82482824d09ebb504f11ecd467c83ea8225a32f77f1013e1adba03591"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/packages/boltz-swap/test/preimage.test.ts
+++ b/packages/boltz-swap/test/preimage.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { hex } from "@scure/base";
 import { DescriptorIdentity, MnemonicIdentity, SeedIdentity, SingleKey } from "@arkade-os/sdk";
 import { expand, networks } from "@bitcoinerlab/descriptors-scure";
-import { buildPreimageMessage, derivePreimage } from "../src/utils/preimage";
+import {
+    buildPreimageMessage,
+    derivePreimage,
+    derivePreimageForMessageIndex,
+} from "../src/utils/preimage";
 import vectors from "./fixtures/preimage_vectors.json";
 
 /**
@@ -67,6 +71,13 @@ describe("swap preimage derivation", () => {
             expect(at1).not.toEqual(at0);
         });
 
+        it("uses the index-0 message for live swaps", async () => {
+            const descriptorIdentity = descriptorIdentityAt(identity, 0);
+
+            await expect(derivePreimage(descriptorIdentity)).resolves.toEqual(
+                await derivePreimageForMessageIndex(descriptorIdentity, 0),
+            );
+        });
         it("throws rather than falling back for an identity that cannot sign deterministically", async () => {
             await expect(derivePreimage(SingleKey.fromHex("11".repeat(32)))).rejects.toThrow(
                 /deterministic/,
@@ -92,7 +103,7 @@ describe("swap preimage derivation", () => {
                             await descriptorIdentity.xOnlyPublicKey(),
                             entry.derivationIndex,
                         );
-                        const preimage = await derivePreimage(
+                        const preimage = await derivePreimageForMessageIndex(
                             descriptorIdentity,
                             entry.derivationIndex,
                         );

--- a/packages/boltz-swap/test/preimage.test.ts
+++ b/packages/boltz-swap/test/preimage.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { hex } from "@scure/base";
+import { DescriptorIdentity, MnemonicIdentity, SeedIdentity, SingleKey } from "@arkade-os/sdk";
+import { expand, networks } from "@bitcoinerlab/descriptors-scure";
+import { buildPreimageMessage, derivePreimage } from "../src/utils/preimage";
+import vectors from "./fixtures/preimage_vectors.json";
+
+/**
+ * Materialize the account template at `index`, the same way
+ * `HDDescriptorProvider` does, and pin an identity to it.
+ */
+const descriptorIdentityAt = (identity: SeedIdentity, index: number): DescriptorIdentity => {
+    const template = identity.descriptor;
+    const network = template.includes("tpub") ? networks.testnet : networks.bitcoin;
+    const keyExpression = expand({ descriptor: template, network, index }).expansionMap?.["@0"]
+        ?.keyExpression;
+    return new DescriptorIdentity({
+        descriptor: `tr(${keyExpression})`,
+        signer: identity,
+        base: identity,
+    });
+};
+
+describe("swap preimage derivation", () => {
+    const identity = MnemonicIdentity.fromMnemonic(vectors.seed, { isMainnet: false });
+
+    describe("buildPreimageMessage", () => {
+        const xonly = new Uint8Array(32).fill(0xab);
+
+        it("is tag ‖ xonly ‖ u32le(index)", () => {
+            const message = buildPreimageMessage(xonly, 1);
+
+            expect(message).toHaveLength(24 + 32 + 4);
+            expect(new TextDecoder().decode(message.subarray(0, 24))).toBe(
+                "Arkade-Boltz-Preimage-v1",
+            );
+            expect(message.subarray(24, 56)).toEqual(xonly);
+            expect(message.subarray(56)).toEqual(new Uint8Array([1, 0, 0, 0]));
+        });
+
+        it("rejects a key that is not 32 bytes", () => {
+            expect(() => buildPreimageMessage(new Uint8Array(33), 0)).toThrow(/32-byte/);
+        });
+
+        it("rejects an index that does not fit a u32", () => {
+            expect(() => buildPreimageMessage(xonly, -1)).toThrow(/u32/);
+            expect(() => buildPreimageMessage(xonly, 0x1_0000_0000)).toThrow(/u32/);
+            expect(() => buildPreimageMessage(xonly, 1.5)).toThrow(/u32/);
+        });
+    });
+
+    describe("derivePreimage", () => {
+        it("is stable across calls", async () => {
+            const descriptorIdentity = descriptorIdentityAt(identity, 0);
+
+            const first = await derivePreimage(descriptorIdentity);
+            const second = await derivePreimage(descriptorIdentity);
+
+            expect(first).toHaveLength(32);
+            expect(second).toEqual(first);
+        });
+
+        it("differs per descriptor index", async () => {
+            const at0 = await derivePreimage(descriptorIdentityAt(identity, 0));
+            const at1 = await derivePreimage(descriptorIdentityAt(identity, 1));
+
+            expect(at1).not.toEqual(at0);
+        });
+
+        it("throws rather than falling back for an identity that cannot sign deterministically", async () => {
+            await expect(derivePreimage(SingleKey.fromHex("11".repeat(32)))).rejects.toThrow(
+                /deterministic/,
+            );
+        });
+    });
+
+    /**
+     * Cross-SDK vectors from NArk (`NArk.Tests/Assets/Fixtures/preimage_vectors.json`).
+     * A failure here means the scheme diverged and swaps created by one SDK are no
+     * longer recoverable by the other.
+     */
+    describe("NArk cross-SDK vectors", () => {
+        for (const [network, { keyIndexed }] of Object.entries(vectors.vectors)) {
+            const seedIdentity = MnemonicIdentity.fromMnemonic(vectors.seed, {
+                isMainnet: network === "mainnet",
+            });
+            for (const [keyIndex, entries] of Object.entries(keyIndexed)) {
+                const descriptorIdentity = descriptorIdentityAt(seedIdentity, Number(keyIndex));
+                for (const entry of entries) {
+                    it(`${network} key ${keyIndex} derivation ${entry.derivationIndex}`, async () => {
+                        const message = buildPreimageMessage(
+                            await descriptorIdentity.xOnlyPublicKey(),
+                            entry.derivationIndex,
+                        );
+                        const preimage = await derivePreimage(
+                            descriptorIdentity,
+                            entry.derivationIndex,
+                        );
+
+                        expect(hex.encode(message)).toBe(entry.expectedPreimageMessage);
+                        expect(hex.encode(preimage)).toBe(entry.expectedPreimage);
+                    });
+                }
+            }
+        }
+    });
+});

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -27,6 +27,7 @@ import type {
     HDDeterministicSignCapable,
 } from "./identity";
 import { isHDWalletCapable } from "./wallet/hdWalletCapable";
+import { signingDescriptorIndex } from "./wallet/walletReceiveRotator";
 import type { HDWalletCapable } from "./wallet/hdWalletCapable";
 import { ArkAddress } from "./script/address";
 import { VHTLC } from "./script/vhtlc";
@@ -440,6 +441,7 @@ export {
     DescriptorIdentity,
     isHDDeterministicSignCapable,
     isHDWalletCapable,
+    signingDescriptorIndex,
     deriveDescriptorLeafCompressedPubKey,
     OnchainWallet,
     Ramps,

--- a/packages/ts-sdk/src/wallet/hdWalletCapable.ts
+++ b/packages/ts-sdk/src/wallet/hdWalletCapable.ts
@@ -18,11 +18,33 @@ export interface HDWalletCapable {
     getCurrentSigningDescriptor(): Promise<string | undefined>;
 
     /**
+     * Allocate a fresh descriptor by advancing the wallet's HD watermark, or
+     * `undefined` for static / `auto` wallets. Required by consumers that
+     * derive a secret from the descriptor key — two artifacts sharing an index
+     * would share that secret. Rides the same monotonic, mutex-guarded
+     * allocator as receive rotation, so the bump is the reservation.
+     */
+    getNextSigningDescriptor(): Promise<string | undefined>;
+
+    /**
      * Every descriptor the wallet may hold keys under, ascending by index:
      * the allocation watermark's band plus any descriptor persisted on a
      * contract. Empty for static wallets.
+     *
+     * `lookAhead` appends the descriptors just past the watermark, for
+     * consumers whose indices leave no on-chain footprint (a swap burns an
+     * index that the restore gap-scan cannot see) and so may sit above it.
      */
-    getUsedSigningDescriptors(): Promise<string[]>;
+    getUsedSigningDescriptors(opts?: { lookAhead?: number }): Promise<string[]>;
+
+    /**
+     * Monotonically raise the allocation watermark to `descriptor`'s index so
+     * a later allocation cannot reissue it. No-op for static wallets, for a
+     * descriptor that is not ours, and for an index at or below the current
+     * watermark. Throws on a descriptor with no parseable trailing index —
+     * treating one as index 0 would silently drop the protection.
+     */
+    advanceSigningDescriptorWatermark(descriptor: string): Promise<void>;
 
     /**
      * An {@link Identity} whose keys and signatures are those of `descriptor`.
@@ -38,7 +60,9 @@ export function isHDWalletCapable(value: unknown): value is HDWalletCapable {
     const v = value as Record<string, unknown>;
     return (
         typeof v.getCurrentSigningDescriptor === "function" &&
+        typeof v.getNextSigningDescriptor === "function" &&
         typeof v.getUsedSigningDescriptors === "function" &&
+        typeof v.advanceSigningDescriptorWatermark === "function" &&
         typeof v.signerForDescriptor === "function"
     );
 }

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -132,7 +132,11 @@ import { BoardingContractHandler } from "../contracts/handlers/boarding";
 import { timelockToSequence } from "../utils/timelock";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
 import { validateVtxosForScript, saveVtxosForContract } from "../contracts/vtxoOwnership";
-import { WalletReceiveRotator, signingDescriptorIndex } from "./walletReceiveRotator";
+import {
+    WalletReceiveRotator,
+    requireSigningDescriptorIndex,
+    signingDescriptorIndex,
+} from "./walletReceiveRotator";
 import { HDDescriptorProvider } from "./hdDescriptorProvider";
 import { DescriptorProvider } from "../identity/descriptorProvider";
 import { DescriptorIdentity } from "../identity/descriptorIdentity";
@@ -2309,6 +2313,15 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
     }
 
     /**
+     * @see HDWalletCapable.getNextSigningDescriptor
+     */
+    async getNextSigningDescriptor(): Promise<string | undefined> {
+        const provider = this._descriptorProvider;
+        if (!(provider instanceof HDDescriptorProvider)) return undefined;
+        return provider.getNextSigningDescriptor();
+    }
+
+    /**
      * @see HDWalletCapable.getUsedSigningDescriptors
      *
      * Union of the watermark band and the descriptors persisted on contracts:
@@ -2316,12 +2329,13 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
      * alone would miss indices allocated for something the wallet never
      * persisted (a swap, an externally issued invoice).
      */
-    async getUsedSigningDescriptors(): Promise<string[]> {
+    async getUsedSigningDescriptors(opts?: { lookAhead?: number }): Promise<string[]> {
         const provider = this._descriptorProvider;
         const descriptors = new Set<string>();
         if (provider instanceof HDDescriptorProvider) {
             const lastIndexUsed = await provider.getLastIndexUsed();
-            for (let i = 0; i <= (lastIndexUsed ?? -1); i++) {
+            const lookAhead = Math.max(0, Math.trunc(opts?.lookAhead ?? 0));
+            for (let i = 0; i <= (lastIndexUsed ?? -1) + lookAhead; i++) {
                 descriptors.add(provider.materializeDescriptorAt(i));
             }
         }
@@ -2334,6 +2348,17 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         return [...descriptors].sort(
             (a, b) => signingDescriptorIndex(a) - signingDescriptorIndex(b),
         );
+    }
+
+    /**
+     * @see HDWalletCapable.advanceSigningDescriptorWatermark
+     */
+    async advanceSigningDescriptorWatermark(descriptor: string): Promise<void> {
+        const provider = this._descriptorProvider;
+        if (!(provider instanceof HDDescriptorProvider)) return;
+        const index = requireSigningDescriptorIndex(descriptor);
+        if (!provider.isOurs(descriptor)) return;
+        await provider.advanceLastIndexUsed(index);
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
+++ b/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
@@ -146,6 +146,22 @@ export function signingDescriptorIndex(descriptor: unknown): number {
 }
 
 /**
+ * Strict counterpart of {@link signingDescriptorIndex}: throws instead of
+ * defaulting to 0. For callers that act on the index — advancing the
+ * allocation watermark — where a silent 0 turns a caller bug (a bare
+ * `tr(pubkey)` descriptor, say) into a no-op that drops the very protection
+ * the call exists to provide.
+ */
+export function requireSigningDescriptorIndex(descriptor: string): number {
+    const m = descriptor.match(/\/(\d+)\)\s*$/);
+    const n = m ? Number(m[1]) : NaN;
+    if (!Number.isInteger(n) || n < 0) {
+        throw new Error(`Descriptor carries no HD child index: ${descriptor}`);
+    }
+    return n;
+}
+
+/**
  * Thrown when a descriptor expected to be rangeable (have a wildcard
  * leaf) cannot produce a leaf pubkey. Surfaces from the rotator's
  * `defaultBoot` path so `resolveBoot` can distinguish a legitimate

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -919,6 +919,89 @@ describe("Wallet HD rotation", () => {
      *   - `INVALID_INTENT_PROOF (23): input 0 has no tapscript signatures`
      *     (auto-renewal)
      */
+    // Surface consumers that derive a secret from the descriptor key (Boltz
+    // swap preimages) need: allocate an index of their own, look past the
+    // watermark on restore, and push the watermark past what they found.
+    describe("allocator surface", () => {
+        const indexOf = (descriptor: string) => Number(descriptor.match(/\/(\d+)\)$/)![1]);
+
+        it("allocates a fresh descriptor per call and moves the watermark", async () => {
+            const repo = new InMemoryWalletRepository();
+            const wallet = await makeHdWallet(repo);
+
+            const first = await wallet.getNextSigningDescriptor();
+            const second = await wallet.getNextSigningDescriptor();
+
+            expect(first).toBeDefined();
+            expect(second).not.toBe(first);
+            expect(indexOf(second!)).toBe(indexOf(first!) + 1);
+            expect((await repo.getWalletState())?.settings?.hd.lastIndexUsed).toBe(
+                indexOf(second!),
+            );
+            await wallet.dispose();
+        });
+
+        it("extends the used-descriptor band by the requested look-ahead", async () => {
+            const wallet = await makeHdWallet();
+
+            const used = await wallet.getUsedSigningDescriptors();
+            const withLookAhead = await wallet.getUsedSigningDescriptors({ lookAhead: 20 });
+
+            expect(indexOf(withLookAhead[withLookAhead.length - 1])).toBe(
+                indexOf(used[used.length - 1]) + 20,
+            );
+            await wallet.dispose();
+        });
+
+        it("advances the watermark past a descriptor, never rewinding it", async () => {
+            const repo = new InMemoryWalletRepository();
+            const wallet = await makeHdWallet(repo);
+            const band = await wallet.getUsedSigningDescriptors({ lookAhead: 20 });
+
+            await wallet.advanceSigningDescriptorWatermark(band[15]);
+            expect((await repo.getWalletState())?.settings?.hd.lastIndexUsed).toBe(15);
+
+            await wallet.advanceSigningDescriptorWatermark(band[3]);
+            expect((await repo.getWalletState())?.settings?.hd.lastIndexUsed).toBe(15);
+
+            expect(indexOf((await wallet.getNextSigningDescriptor())!)).toBe(16);
+            await wallet.dispose();
+        });
+
+        it("rejects a descriptor with no HD child index rather than treating it as index 0", async () => {
+            const repo = new InMemoryWalletRepository();
+            const wallet = await makeHdWallet(repo);
+            const before = (await repo.getWalletState())?.settings?.hd.lastIndexUsed;
+
+            await expect(
+                wallet.advanceSigningDescriptorWatermark(`tr(${SERVER_PUBKEY_HEX})`),
+            ).rejects.toThrow(/no HD child index/);
+
+            expect((await repo.getWalletState())?.settings?.hd.lastIndexUsed).toBe(before);
+            await wallet.dispose();
+        });
+
+        it("is inert on a static wallet", async () => {
+            const repo = new InMemoryWalletRepository();
+            const wallet = await Wallet.create({
+                identity: MnemonicIdentity.fromMnemonic(MNEMONIC, { isMainnet: false }),
+                walletMode: "static",
+                arkServerUrl: "http://localhost:7070",
+                storage: {
+                    walletRepository: repo,
+                    contractRepository: new InMemoryContractRepository(),
+                },
+            });
+
+            expect(await wallet.getNextSigningDescriptor()).toBeUndefined();
+            await expect(
+                wallet.advanceSigningDescriptorWatermark("tr(xpub/0/9)"),
+            ).resolves.toBeUndefined();
+            expect(await wallet.getUsedSigningDescriptors({ lookAhead: 20 })).toEqual([]);
+            await wallet.dispose();
+        });
+    });
+
     describe("signing after rotation", () => {
         // mockArkInfo.signerPubkey is the compressed form (0x02 prefix).
         // Strip the byte to match how `Wallet.create` materializes


### PR DESCRIPTION
Derive a swap's preimage from its own HD signing descriptor key instead of `randomBytes(32)`, so a wallet restored from seed alone can rediscover an outstanding swap via Boltz `/v2/swap/restore` and re-derive the secret needed to claim the VHTLC. Today a restored reverse swap comes back with `preimage: ""` and is display-only.

Scheme is NArk's (`SwapsManagementService.cs`), verbatim so recovery is two-way across SDKs:

```
preimage = SHA256( BIP340_sign( descriptor_key,
                                SHA256("Arkade-Boltz-Preimage-v1" ‖ xonly(32) ‖ u32le(index)),
                                aux_rand = 32 × 0x00 ) )
```

All 36 of NArk's pinned vectors (`preimage_vectors.json`, mainnet + regtest × keyIndex 0/1/2 × derivationIndex 0/1/7/42/100/999) are ported and pass.

## Changes

- **ts-sdk** — `HDWalletCapable` gains `getNextSigningDescriptor()`, `getUsedSigningDescriptors({ lookAhead })` and `advanceSigningDescriptorWatermark()`. Exposure-only over machinery `HDDescriptorProvider` already has; no new allocator, no new persistence.
- **boltz-swap** — `utils/preimage.ts` (`buildPreimageMessage` / `derivePreimage`); create-time derivation for reverse and chain swaps; restore-time re-derivation with a hash check.
- **Restore** now iterates a 20-wide look-ahead band past the watermark to a fixpoint, since a swap burns an index with no on-chain footprint and the gap-scan cannot see it. Delta queries per round, dedupe by swap id, watermark advanced on every attributed swap.

## Reverses #662's "swap creation never allocates an index"

Deliberately. The read-only peek is fund-loss-unsafe once a secret is derived from the descriptor key: two swaps created before any funds land would share a descriptor, hence a preimage and a payment hash. Once the first settles its preimage is public, so the second's hash condition gates nothing. Allocation is per swap for all three types, matching NArk.

## Scope: HD wallets only

Static / `auto` wallets have no descriptor provider, so every swap would share the baseline key and — with `index` pinned to 0 — derive an identical preimage. They keep `randomBytes(32)` plus a `logger.warn` that the swap will not be seed-recoverable. This is a deliberate divergence from NArk, whose swap creation is HD-only.

## Notes

- Partially overlaps #612, which registers each swap's VHTLC as a `vhtlc` contract (Phase 1, landed there) and plans a `Discoverable` handler for swap rediscovery (Phase 4, not started). The two touch the same create paths in `arkade-swaps.ts`, so whichever lands second needs a rebase. #612's contract rows do not currently carry `signingDescriptor`; stamping it in `swapToContractParams` would put swap indices in the restore candidate set for free on any device that still has its rows — it does not remove the need for the look-ahead loop, which exists for the from-seed case where there are no rows.
- Follow-up needed on double-allocated indices: `updateWalletState` is a per-process promise chain, so two contexts (tab + service worker) can in principle allocate the same index, and two preimage-deriving swaps on one index share a preimage. Very narrow edge case — it needs two contexts creating a reverse or chain swap within the same read-modify-write window (an address or a submarine swap sharing the index is harmless, since neither derives a secret), and the likely outcome is Boltz rejecting the duplicate payment hash rather than any loss. The exposure already exists for receive rotation and boarding; swaps inherit it rather than add a new mechanism. Hardening belongs at the `updateWalletState` choke point once, for every consumer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic swap preimage generation for supported HD wallets.
  * Improved swap recovery across descriptor ranges, including legacy and incomplete swaps.
  * Added HD wallet descriptor allocation, look-ahead scanning, and watermark management.
  * Documented seed-based swap recovery and cross-SDK restoration.

* **Bug Fixes**
  * Improved handling of duplicate, terminal, unowned, and previously restored swaps.
  * Added fallback warnings for wallets that do not support deterministic signing.

* **Tests**
  * Expanded coverage for HD descriptor rotation, deterministic preimages, recovery scenarios, and cross-network compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->