### PR TITLE
feat: reconcile server responses with locally derived data

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -899,6 +899,9 @@ export class ArkadeSwaps {
      * @param args.invoice - BOLT11 Lightning invoice to pay.
      * @returns The pending submarine swap, added to SwapManager if enabled.
      * @throws {SwapError} If invoice is missing or key retrieval fails.
+     * @throws {VHTLCAddressMismatchError} If the lockup address Boltz returned
+     * is not the VHTLC reconstructed from the swap parameters. Nothing is
+     * persisted or registered in that case. Requires a reachable ark server.
      */
     async createSubmarineSwap(args: SendLightningPaymentRequest): Promise<BoltzSubmarineSwap> {
         const signingDescriptor = await this.currentSigningDescriptor();
@@ -918,6 +921,15 @@ export class ArkadeSwaps {
             refundPublicKey,
         };
 
+        // Fetch server info concurrently with the swap request: the VHTLC
+        // reconstruction below needs it, and it must be fresh — a signer
+        // rotation would make a cached snapshot reconstruct the wrong address.
+        const arkInfoPromise = this.arkProvider.getInfo();
+        // Awaited only after the swap request, which may reject first; keep a
+        // handler attached so that ordering never surfaces as an unhandled
+        // rejection.
+        arkInfoPromise.catch(() => {});
+
         // make submarine swap request
         const swapResponse = await this.swapProvider.createSubmarineSwap(swapRequest);
 
@@ -931,6 +943,12 @@ export class ArkadeSwaps {
             status: "invoice.set",
             signingDescriptor,
         };
+
+        // The lockup address must be the VHTLC these swap parameters describe —
+        // it is the script the refund paths later reconstruct from them. Checked
+        // before the swap is persisted or funded, so a swap that does not
+        // reconcile never reaches storage.
+        await this.buildSubmarineVHTLCContext(pendingSwap, await arkInfoPromise);
 
         // save pending swap to storage
         await this.savePendingSubmarineSwap(pendingSwap);

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -2,6 +2,7 @@ import {
     ArkInfo,
     ArkProvider,
     ArkTxInput,
+    assertSubmittedArkTxid,
     Batch,
     buildOffchainTx,
     getSequence,
@@ -279,6 +280,9 @@ export const claimVHTLCwithOffchainTx = async (
         base64.encode(signedArkTx.toPSBT()),
         checkpoints.map((c) => base64.encode(c.toPSBT())),
     );
+    // The returned arkTxid keys finalizeTx and is what this function returns;
+    // reject a response that does not refer to the tx just submitted.
+    assertSubmittedArkTxid({ arkTxid, finalArkTx }, signedArkTx, "submitTx");
 
     // verify the server signed the transaction with correct key on the claim leaf
     const finalTx = Transaction.fromPSBT(base64.decode(finalArkTx));
@@ -356,6 +360,9 @@ export const refundWithoutReceiverVHTLCwithOffchainTx = async (
         base64.encode(signedArkTx.toPSBT()),
         checkpoints.map((c) => base64.encode(c.toPSBT())),
     );
+    // The returned arkTxid keys finalizeTx and is what this function returns;
+    // reject a response that does not refer to the tx just submitted.
+    assertSubmittedArkTxid({ arkTxid, finalArkTx }, signedArkTx, "submitTx");
 
     // verify the server signed the transaction with correct key on the refundWithoutReceiver leaf
     const finalTx = Transaction.fromPSBT(base64.decode(finalArkTx));
@@ -481,6 +488,9 @@ export const refundVHTLCwithOffchainTx = async (
         base64.encode(combinedSignedRefundTx.toPSBT()),
         [base64.encode(unsignedCheckpointTx.toPSBT())],
     );
+    // The returned arkTxid keys finalizeTx; reject a response that does not
+    // refer to the tx just submitted.
+    assertSubmittedArkTxid({ arkTxid, finalArkTx }, combinedSignedRefundTx, "submitTx");
 
     // verify the final tx is properly signed
     const tx = Transaction.fromPSBT(base64.decode(finalArkTx));

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -6,6 +6,7 @@ import {
     buildOffchainTx,
     getSequence,
     Identity,
+    matchServerCheckpoints,
     Intent,
     getNetwork,
     networks,
@@ -289,18 +290,21 @@ export const claimVHTLCwithOffchainTx = async (
         }
     }
 
-    // verify and sign the checkpoint transactions pre signed by the server
+    // Reconcile each returned checkpoint with the one submitted before
+    // co-signing it: the signature check below confirms who signed, the txid
+    // match confirms which transaction.
     const finalCheckpoints = await Promise.all(
-        signedCheckpointTxs.map(async (c, idx) => {
-            const tx = Transaction.fromPSBT(base64.decode(c));
-            const checkpointLeaf = checkpoints[idx].getInput(0).tapLeafScript![0];
-            const cpLeafHash = tapLeafHash(scriptFromTapLeafScript(checkpointLeaf));
-            if (!verifySignatures(tx, 0, [serverPubkeyHex], cpLeafHash)) {
-                throw new Error("Invalid server signature in checkpoint transaction");
-            }
-            const signedCheckpoint = await identity.sign(tx, [0]);
-            return base64.encode(signedCheckpoint.toPSBT());
-        }),
+        matchServerCheckpoints(signedCheckpointTxs, checkpoints, "submitTx").map(
+            async ({ server, local }) => {
+                const checkpointLeaf = local.getInput(0).tapLeafScript![0];
+                const cpLeafHash = tapLeafHash(scriptFromTapLeafScript(checkpointLeaf));
+                if (!verifySignatures(server, 0, [serverPubkeyHex], cpLeafHash)) {
+                    throw new Error("Invalid server signature in checkpoint transaction");
+                }
+                const signedCheckpoint = await identity.sign(server, [0]);
+                return base64.encode(signedCheckpoint.toPSBT());
+            },
+        ),
     );
 
     // submit the final transaction to the Ark provider
@@ -365,18 +369,20 @@ export const refundWithoutReceiverVHTLCwithOffchainTx = async (
         }
     }
 
-    // verify and sign the checkpoint transactions pre signed by the server
+    // Same as the claim path: reconcile each returned checkpoint with the one
+    // submitted before adding our share.
     const finalCheckpoints = await Promise.all(
-        signedCheckpointTxs.map(async (c, idx) => {
-            const tx = Transaction.fromPSBT(base64.decode(c));
-            const checkpointLeaf = checkpoints[idx].getInput(0).tapLeafScript![0];
-            const cpLeafHash = tapLeafHash(scriptFromTapLeafScript(checkpointLeaf));
-            if (!verifySignatures(tx, 0, [serverPubkeyHex], cpLeafHash)) {
-                throw new Error("Invalid server signature in checkpoint transaction");
-            }
-            const signedCheckpoint = await identity.sign(tx, [0]);
-            return base64.encode(signedCheckpoint.toPSBT());
-        }),
+        matchServerCheckpoints(signedCheckpointTxs, checkpoints, "submitTx").map(
+            async ({ server, local }) => {
+                const checkpointLeaf = local.getInput(0).tapLeafScript![0];
+                const cpLeafHash = tapLeafHash(scriptFromTapLeafScript(checkpointLeaf));
+                if (!verifySignatures(server, 0, [serverPubkeyHex], cpLeafHash)) {
+                    throw new Error("Invalid server signature in checkpoint transaction");
+                }
+                const signedCheckpoint = await identity.sign(server, [0]);
+                return base64.encode(signedCheckpoint.toPSBT());
+            },
+        ),
     );
 
     // submit the final transaction to the Ark provider
@@ -489,15 +495,15 @@ export const refundVHTLCwithOffchainTx = async (
         throw new Error("Invalid refund transaction");
     }
 
-    // validate we received exactly one checkpoint transaction
-    if (signedCheckpointTxs.length !== 1) {
-        throw new Error(
-            `Expected one signed checkpoint transaction, got ${signedCheckpointTxs.length}`,
-        );
-    }
-
-    // verify and combine the checkpoint signatures
-    const serverSignedCheckpointTx = Transaction.fromPSBT(base64.decode(signedCheckpointTxs[0]));
+    // Reconcile the returned checkpoint with the one submitted. The merge below
+    // grafts signatures computed over our own checkpoint's sighash, so a
+    // divergence would surface later as an unusable transaction; state the
+    // requirement here instead of relying on that.
+    const [{ server: serverSignedCheckpointTx }] = matchServerCheckpoints(
+        signedCheckpointTxs,
+        [unsignedCheckpointTx],
+        "submitTx",
+    );
     const serverPubkeyHex = hex.encode(serverXOnlyPublicKey);
     if (!verifySignatures(serverSignedCheckpointTx, 0, [serverPubkeyHex], checkpointLeafHash)) {
         throw new Error("Invalid server signature in checkpoint transaction");

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -41,6 +41,7 @@ import { Address, OutScript, Script, ScriptNum } from "@scure/btc-signer";
 import { decodeInvoice } from "../src/utils/decoding";
 import { resolveVhtlcTimeouts } from "../src/utils/restoration";
 import { logger } from "../src/logger";
+import { VHTLCAddressMismatchError } from "../src/errors";
 import { pubECDSA } from "@scure/btc-signer/utils.js";
 import { create as createMusig } from "../src/utils/musig";
 import { deserializeSwapTree, tweakMusig, p2trScript } from "../src/utils/boltz-swap-tx";
@@ -583,6 +584,16 @@ describe("ArkadeSwaps", () => {
                 lockupDetails: to === "ARK" ? btcDetails : arkDetails,
             },
         } as unknown as BoltzChainSwap;
+    };
+
+    /**
+     * Let `createSubmarineSwap`'s lockup-address check pass: the canned Boltz
+     * response is not a real VHTLC, and these tests cover request/response
+     * behavior rather than the check itself.
+     */
+    const stubLockupValidation = () => {
+        vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+        return vi.spyOn(swaps as any, "buildSubmarineVHTLCContext").mockResolvedValue({} as any);
     };
 
     beforeEach(async () => {
@@ -1164,6 +1175,7 @@ describe("ArkadeSwaps", () => {
         describe("Submarine Swaps", () => {
             it("should create a submarine swap", async () => {
                 // arrange
+                stubLockupValidation();
                 vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
                     createSubmarineSwapResponse,
                 );
@@ -1179,8 +1191,36 @@ describe("ArkadeSwaps", () => {
                 expect(pendingSwap.response).toEqual(createSubmarineSwapResponse);
             });
 
+            // The refund paths reconstruct the VHTLC from the swap parameters,
+            // so a lockup address that does not reconcile with them is rejected
+            // before the swap is persisted.
+            it("rejects a swap whose lockup address is not the reconstructed VHTLC", async () => {
+                // arrange
+                vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+                const manager = { addSwap: vi.fn() };
+                (swaps as any).swapManager = manager;
+                vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
+                    createSubmarineSwapResponse,
+                );
+                vi.spyOn(swaps as any, "buildSubmarineVHTLCContext").mockRejectedValue(
+                    new VHTLCAddressMismatchError({
+                        swapId: mock.id,
+                        lockupAddress: mock.address.ark,
+                        tried: 1,
+                    }),
+                );
+
+                // act & assert
+                await expect(
+                    swaps.createSubmarineSwap({ invoice: mock.invoice.address }),
+                ).rejects.toBeInstanceOf(VHTLCAddressMismatchError);
+                expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+                expect(manager.addSwap).not.toHaveBeenCalled();
+            });
+
             it("should get correct swap status", async () => {
                 // arrange
+                stubLockupValidation();
                 vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
                     createSubmarineSwapResponse,
                 );
@@ -1241,6 +1281,32 @@ describe("ArkadeSwaps", () => {
                 expect(result.amount).toBe(mock.invoice.amount);
                 expect(result.preimage).toBeUndefined();
                 expect(result.txid).toBe(mock.txid);
+            });
+
+            it("does not fund a swap whose lockup address failed verification", async () => {
+                // arrange: the real createSubmarineSwap runs, its VHTLC check fails
+                vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+                vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
+                    createSubmarineSwapResponse,
+                );
+                vi.spyOn(swaps as any, "buildSubmarineVHTLCContext").mockRejectedValue(
+                    new VHTLCAddressMismatchError({
+                        swapId: mock.id,
+                        lockupAddress: mock.address.ark,
+                        tried: 1,
+                    }),
+                );
+                const sendSpy = vi.spyOn(wallet, "send");
+                const fundedSpy = vi.spyOn(swaps, "waitForSwapFunded");
+                const settlementSpy = vi.spyOn(swaps, "waitForSwapSettlement");
+
+                // act & assert
+                await expect(
+                    swaps.sendLightningPayment({ invoice: mock.invoice.address }),
+                ).rejects.toBeInstanceOf(VHTLCAddressMismatchError);
+                expect(sendSpy).not.toHaveBeenCalled();
+                expect(fundedSpy).not.toHaveBeenCalled();
+                expect(settlementSpy).not.toHaveBeenCalled();
             });
 
             it("should warn on waitFor funded when the SwapManager is disabled", async () => {
@@ -2983,6 +3049,7 @@ describe("ArkadeSwaps", () => {
 
             it("should save submarine swap when creating swap", async () => {
                 // arrange
+                stubLockupValidation();
                 vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
                     createSubmarineSwapResponse,
                 );
@@ -5609,6 +5676,7 @@ describe("ArkadeSwaps", () => {
 
         it("creates a submarine swap under the current index", async () => {
             rotateWallet();
+            stubLockupValidation();
             vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce(
                 createSubmarineSwapResponse,
             );

--- a/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
+++ b/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from "vitest";
+import { base64, hex } from "@scure/base";
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+    buildOffchainTx,
+    CSVMultisigTapscript,
+    SingleKey,
+    Transaction,
+    type ArkInfo,
+    type ArkProvider,
+    type ArkTxInput,
+} from "@arkade-os/sdk";
+import { claimVHTLCwithOffchainTx, createVHTLCScript } from "../src/utils/vhtlc";
+
+// The claim path co-signs a checkpoint arkd returns. The signature check
+// confirms who signed it; the txid match confirms it is the checkpoint that was
+// submitted, which is what the ark tx signed alongside it spends.
+
+const ourKey = SingleKey.fromHex("11".repeat(32));
+const boltzKey = SingleKey.fromHex("22".repeat(32));
+const serverKey = SingleKey.fromHex("33".repeat(32));
+const foreignKey = SingleKey.fromHex("44".repeat(32));
+
+const P2TR = new Uint8Array([0x51, 0x20, ...new Uint8Array(32).fill(0xab)]);
+const VALUE = 10_000;
+
+async function unrollScript(key: SingleKey) {
+    return CSVMultisigTapscript.encode({
+        timelock: { type: "blocks", value: 10n },
+        pubkeys: [await key.xOnlyPublicKey()],
+    });
+}
+
+async function fixture() {
+    const [ours, boltz, server] = await Promise.all([
+        ourKey.xOnlyPublicKey(),
+        boltzKey.xOnlyPublicKey(),
+        serverKey.xOnlyPublicKey(),
+    ]);
+
+    const { vhtlcScript } = createVHTLCScript({
+        network: "regtest",
+        preimageHash: sha256(new Uint8Array(32).fill(7)),
+        receiverPubkey: hex.encode(ours),
+        senderPubkey: hex.encode(boltz),
+        serverPubkey: hex.encode(server),
+        timeoutBlockHeights: {
+            refund: 100,
+            unilateralClaim: 10,
+            unilateralRefund: 20,
+            unilateralRefundWithoutReceiver: 30,
+        },
+    });
+
+    const input: ArkTxInput = {
+        txid: "11".repeat(32),
+        vout: 0,
+        value: VALUE,
+        tapLeafScript: vhtlcScript.claim(),
+        tapTree: vhtlcScript.encode(),
+    };
+    const output = { script: P2TR, amount: BigInt(VALUE) };
+    const arkInfo = {
+        checkpointTapscript: hex.encode((await unrollScript(serverKey)).script),
+    } as ArkInfo;
+
+    return { vhtlcScript, server, input, output, arkInfo };
+}
+
+/**
+ * A well-formed, correctly signed checkpoint for the same VTXO that is not the
+ * one submitted — it is locked to a different server key, so it has a different
+ * txid. Signed on the same claim leaf, so it satisfies the signature check and
+ * only the txid tells it apart.
+ */
+async function divergentCheckpoint(input: ArkTxInput): Promise<string> {
+    const { checkpoints } = buildOffchainTx(
+        [input],
+        [{ script: P2TR, amount: BigInt(VALUE) }],
+        await unrollScript(foreignKey),
+    );
+    const signed = await serverKey.sign(checkpoints[0], [0]);
+    return base64.encode(signed.toPSBT());
+}
+
+/**
+ * arkd as the claim path expects it: co-signs the ark tx (so the pre-checkpoint
+ * signature check passes) and answers with `checkpointResponse`.
+ */
+function arkProviderStub(checkpointResponse: (submitted: string[]) => Promise<string[]>) {
+    return {
+        submitTx: vi.fn(async (arkTxB64: string, checkpointsB64: string[]) => {
+            const signedArk = await serverKey.sign(Transaction.fromPSBT(base64.decode(arkTxB64)), [
+                0,
+            ]);
+            return {
+                arkTxid: "cd".repeat(32),
+                finalArkTx: base64.encode(signedArk.toPSBT()),
+                signedCheckpointTxs: await checkpointResponse(checkpointsB64),
+            };
+        }),
+        finalizeTx: vi.fn(async () => {}),
+    } as unknown as ArkProvider & {
+        submitTx: ReturnType<typeof vi.fn>;
+        finalizeTx: ReturnType<typeof vi.fn>;
+    };
+}
+
+const serverSigned = async (checkpointsB64: string[]) =>
+    Promise.all(
+        checkpointsB64.map(async (c) =>
+            base64.encode(
+                (await serverKey.sign(Transaction.fromPSBT(base64.decode(c)), [0])).toPSBT(),
+            ),
+        ),
+    );
+
+describe("claimVHTLCwithOffchainTx checkpoint reconciliation", () => {
+    it("claims when arkd returns the checkpoint that was submitted", async () => {
+        const { vhtlcScript, server, input, output, arkInfo } = await fixture();
+        const arkProvider = arkProviderStub(serverSigned);
+
+        const arkTxid = await claimVHTLCwithOffchainTx(
+            ourKey,
+            vhtlcScript,
+            server,
+            input,
+            output,
+            arkInfo,
+            arkProvider,
+        );
+
+        expect(arkTxid).toBe("cd".repeat(32));
+        expect(arkProvider.finalizeTx).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not co-sign a checkpoint it did not submit", async () => {
+        const { vhtlcScript, server, input, output, arkInfo } = await fixture();
+        const arkProvider = arkProviderStub(async () => [await divergentCheckpoint(input)]);
+
+        await expect(
+            claimVHTLCwithOffchainTx(
+                ourKey,
+                vhtlcScript,
+                server,
+                input,
+                output,
+                arkInfo,
+                arkProvider,
+            ),
+        ).rejects.toThrow(/does not match any submitted checkpoint/);
+        expect(arkProvider.finalizeTx).not.toHaveBeenCalled();
+    });
+});

--- a/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
+++ b/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
@@ -85,16 +85,20 @@ async function divergentCheckpoint(input: ArkTxInput): Promise<string> {
 
 /**
  * arkd as the claim path expects it: co-signs the ark tx (so the pre-checkpoint
- * signature check passes) and answers with `checkpointResponse`.
+ * signature check passes), echoes the submitted tx's id as `arkTxid` unless
+ * `overrideArkTxid` fakes a misrouted response, and answers with
+ * `checkpointResponse`.
  */
-function arkProviderStub(checkpointResponse: (submitted: string[]) => Promise<string[]>) {
+function arkProviderStub(
+    checkpointResponse: (submitted: string[]) => Promise<string[]>,
+    overrideArkTxid?: string,
+) {
     return {
         submitTx: vi.fn(async (arkTxB64: string, checkpointsB64: string[]) => {
-            const signedArk = await serverKey.sign(Transaction.fromPSBT(base64.decode(arkTxB64)), [
-                0,
-            ]);
+            const submitted = Transaction.fromPSBT(base64.decode(arkTxB64));
+            const signedArk = await serverKey.sign(submitted, [0]);
             return {
-                arkTxid: "cd".repeat(32),
+                arkTxid: overrideArkTxid ?? submitted.id,
                 finalArkTx: base64.encode(signedArk.toPSBT()),
                 signedCheckpointTxs: await checkpointResponse(checkpointsB64),
             };
@@ -130,8 +134,29 @@ describe("claimVHTLCwithOffchainTx checkpoint reconciliation", () => {
             arkProvider,
         );
 
-        expect(arkTxid).toBe("cd".repeat(32));
+        const submittedId = Transaction.fromPSBT(
+            base64.decode(arkProvider.submitTx.mock.calls[0][0] as string),
+        ).id;
+        expect(arkTxid).toBe(submittedId);
         expect(arkProvider.finalizeTx).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a response whose arkTxid is not the submitted tx", async () => {
+        const { vhtlcScript, server, input, output, arkInfo } = await fixture();
+        const arkProvider = arkProviderStub(serverSigned, "cd".repeat(32));
+
+        await expect(
+            claimVHTLCwithOffchainTx(
+                ourKey,
+                vhtlcScript,
+                server,
+                input,
+                output,
+                arkInfo,
+                arkProvider,
+            ),
+        ).rejects.toThrow(/submitTx returned ark txid/);
+        expect(arkProvider.finalizeTx).not.toHaveBeenCalled();
     });
 
     it("does not co-sign a checkpoint it did not submit", async () => {

--- a/packages/ts-sdk/src/arkade/batch.ts
+++ b/packages/ts-sdk/src/arkade/batch.ts
@@ -30,7 +30,10 @@ import { VtxoScript } from "../script/base";
 import { CSVMultisigTapscript } from "../script/tapscript";
 import { Transaction } from "../utils/transaction";
 import { validateConnectorsTxGraph, validateVtxoTxGraph } from "../tree/validation";
-import { validateBatchRecipients } from "../wallet/validation";
+import {
+    assertFinalCommitmentMatchesValidated,
+    validateBatchRecipients,
+} from "../wallet/validation";
 import { buildForfeitTx } from "../forfeit";
 import { Batch } from "../wallet/batch";
 import { Intent } from "../intent";
@@ -81,6 +84,9 @@ export function createArkadeBatchHandler(
 ): Batch.Handler {
     let batchId: string;
     let sweepTapTreeRoot: Uint8Array;
+    // Assigned only after the tree it commits to has been validated, so it
+    // always names a commitment tx this handler has checked.
+    let validatedCommitmentTxid: string | undefined;
 
     return {
         onBatchStarted: async (event: BatchStartedEvent): Promise<{ skip: boolean }> => {
@@ -133,6 +139,8 @@ export function createArkadeBatchHandler(
                 throw new Error("Shared output not found");
             }
 
+            validatedCommitmentTxid = commitmentTx.id;
+
             await session.init(vtxoTree, sweepTapTreeRoot, sharedOutput.amount);
 
             const pubkey = hex.encode(await session.getPublicKey());
@@ -169,6 +177,11 @@ export function createArkadeBatchHandler(
             }
 
             let commitmentPsbt = Transaction.fromPSBT(base64.decode(event.commitmentTx));
+            assertFinalCommitmentMatchesValidated(
+                commitmentPsbt,
+                validatedCommitmentTxid,
+                "arkade batch finalization",
+            );
             const signedForfeits: string[] = [];
             let connectorIndex = 0;
             const connectorLeaves = connectorTree?.leaves() || [];

--- a/packages/ts-sdk/src/arkade/contract.ts
+++ b/packages/ts-sdk/src/arkade/contract.ts
@@ -78,7 +78,7 @@ import type { VirtualCoin } from "../wallet";
 import { getNormalizedVtxos, hasTerminalSpend } from "../wallet";
 import { CSVMultisigTapscript } from "../script/tapscript";
 import type { TapLeafScript } from "../script/base";
-import { buildOffchainTx, type ArkTxInput } from "../utils/arkTransaction";
+import { buildOffchainTx, matchServerCheckpoints, type ArkTxInput } from "../utils/arkTransaction";
 import { ConditionWitness, PrevArkTxField, setArkPsbtField } from "../utils/unknownFields";
 import { Transaction } from "../utils/transaction";
 import { ANCHOR_PKSCRIPT } from "../utils/anchor";
@@ -706,13 +706,10 @@ export class ArkadeTransactionBuilder {
             base64.encode(signedArk.toPSBT()),
             checkpoints.map((c) => base64.encode(c.toPSBT())),
         );
+        const matched = matchServerCheckpoints(res.signedCheckpointTxs, checkpoints, "submitTx");
         const finalCps = await Promise.all(
-            res.signedCheckpointTxs.map(async (b) =>
-                base64.encode(
-                    (
-                        await client.identity!.sign(Transaction.fromPSBT(base64.decode(b)), [0])
-                    ).toPSBT(),
-                ),
+            matched.map(async ({ server }) =>
+                base64.encode((await client.identity!.sign(server, [0])).toPSBT()),
             ),
         );
         await client.arkProvider.finalizeTx(res.arkTxid, finalCps);

--- a/packages/ts-sdk/src/arkade/contract.ts
+++ b/packages/ts-sdk/src/arkade/contract.ts
@@ -78,7 +78,12 @@ import type { VirtualCoin } from "../wallet";
 import { getNormalizedVtxos, hasTerminalSpend } from "../wallet";
 import { CSVMultisigTapscript } from "../script/tapscript";
 import type { TapLeafScript } from "../script/base";
-import { buildOffchainTx, matchServerCheckpoints, type ArkTxInput } from "../utils/arkTransaction";
+import {
+    assertSubmittedArkTxid,
+    buildOffchainTx,
+    matchServerCheckpoints,
+    type ArkTxInput,
+} from "../utils/arkTransaction";
 import { ConditionWitness, PrevArkTxField, setArkPsbtField } from "../utils/unknownFields";
 import { Transaction } from "../utils/transaction";
 import { ANCHOR_PKSCRIPT } from "../utils/anchor";
@@ -706,6 +711,7 @@ export class ArkadeTransactionBuilder {
             base64.encode(signedArk.toPSBT()),
             checkpoints.map((c) => base64.encode(c.toPSBT())),
         );
+        assertSubmittedArkTxid(res, signedArk, "submitTx");
         const matched = matchServerCheckpoints(res.signedCheckpointTxs, checkpoints, "submitTx");
         const finalCps = await Promise.all(
             matched.map(async ({ server }) =>

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -211,6 +211,7 @@ import {
 import {
     hasBoardingTxExpired,
     buildOffchainTx,
+    assertSubmittedArkTxid,
     matchServerCheckpoints,
     verifyTapscriptSignatures,
     ArkTxInput,
@@ -530,6 +531,7 @@ export {
     PrevoutTxField,
     // Utils
     buildOffchainTx,
+    assertSubmittedArkTxid,
     matchServerCheckpoints,
     verifyTapscriptSignatures,
     waitForIncomingFunds,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -211,6 +211,7 @@ import {
 import {
     hasBoardingTxExpired,
     buildOffchainTx,
+    matchServerCheckpoints,
     verifyTapscriptSignatures,
     ArkTxInput,
     OffchainTx,
@@ -297,6 +298,7 @@ import {
     isArkError,
     maybeArkError,
     ProviderUnavailableError,
+    ServerResponseMismatchError,
 } from "./providers/errors";
 import type { ProviderKind } from "./providers/errors";
 import { isRetryableProviderError } from "./providers/availability";
@@ -528,6 +530,7 @@ export {
     PrevoutTxField,
     // Utils
     buildOffchainTx,
+    matchServerCheckpoints,
     verifyTapscriptSignatures,
     waitForIncomingFunds,
     hasBoardingTxExpired,
@@ -605,6 +608,7 @@ export {
     isArkError,
     maybeArkError,
     ProviderUnavailableError,
+    ServerResponseMismatchError,
     isRetryableProviderError,
     DescriptorSigningProviderMissingError,
     MissingSigningDescriptorError,

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -78,6 +78,26 @@ export class ProviderUnavailableError extends Error {
 }
 
 /**
+ * A response does not reconcile with what the SDK submitted or already
+ * validated — a checkpoint tx whose txid is not among those submitted, a
+ * commitment tx that differs from the one validated at tree signing. Terminal
+ * rather than retryable: the two are equal by construction in a well-formed
+ * exchange, so the same request would produce the same outcome.
+ *
+ * Own-properties do not cross the service-worker `postMessage` boundary (see
+ * {@link ProviderKind}), so `retryable` is an in-process convenience and every
+ * distinguishing detail belongs in `name`/`message`.
+ */
+export class ServerResponseMismatchError extends Error {
+    readonly retryable = false;
+
+    constructor(message: string, options?: { cause?: unknown }) {
+        super(message, { cause: options?.cause });
+        this.name = "ServerResponseMismatchError";
+    }
+}
+
+/**
  * Throw a typed {@link ProviderUnavailableError} for a temporary HTTP response
  * (429 rate-limit or any 5xx), otherwise return. `fetch()` resolves — rather
  * than rejects — on HTTP error status, so status-code classification has to live

--- a/packages/ts-sdk/src/utils/arkTransaction.ts
+++ b/packages/ts-sdk/src/utils/arkTransaction.ts
@@ -410,7 +410,7 @@ export interface OffchainTxSubmitProvider {
     submitTx(
         signedArkTx: string,
         checkpointTxs: string[],
-    ): Promise<{ arkTxid: string; signedCheckpointTxs: string[] }>;
+    ): Promise<{ arkTxid: string; finalArkTx?: string; signedCheckpointTxs: string[] }>;
     finalizeTx(arkTxid: string, finalCheckpointTxs: string[]): Promise<void>;
 }
 
@@ -493,6 +493,36 @@ export function matchServerCheckpoints(
         byTxid.delete(server.id);
         return { server, local };
     });
+}
+
+/**
+ * Assert a `submitTx` response refers to the ark transaction just submitted.
+ *
+ * The returned `arkTxid` is what gets passed to `finalizeTx` and persisted by
+ * callers, so a stale or misrouted response must be rejected before either
+ * happens: it must equal the locally signed transaction's txid, and when the
+ * response carries the counter-signed `finalArkTx`, that transaction's txid
+ * must match too. Server signatures live in the witness and cannot
+ * legitimately change either — with the same taproot-only caveat as
+ * {@link matchServerCheckpoints}.
+ */
+export function assertSubmittedArkTxid(
+    response: { arkTxid: string; finalArkTx?: string },
+    signedArkTx: Transaction,
+    context: string,
+): void {
+    if (response.arkTxid !== signedArkTx.id) {
+        throw new ServerResponseMismatchError(
+            `${context} returned ark txid ${response.arkTxid}, expected ${signedArkTx.id}`,
+        );
+    }
+    if (response.finalArkTx === undefined) return;
+    const finalTxid = Transaction.fromPSBT(base64.decode(response.finalArkTx)).id;
+    if (finalTxid !== signedArkTx.id) {
+        throw new ServerResponseMismatchError(
+            `${context} returned final ark tx ${finalTxid}, expected ${signedArkTx.id}`,
+        );
+    }
 }
 
 /**
@@ -589,10 +619,12 @@ export async function submitOffchainTx(
     // finalize, its recovery hook can retry from persisted state.
     await hooks?.beforeSubmit?.();
 
-    const { arkTxid, signedCheckpointTxs } = await provider.submitTx(
+    const response = await provider.submitTx(
         base64.encode(signedArkTx.toPSBT()),
         offchainTx.checkpoints.map((c) => base64.encode(c.toPSBT())),
     );
+    assertSubmittedArkTxid(response, signedArkTx, "submitTx");
+    const { arkTxid, signedCheckpointTxs } = response;
 
     // The server returns one signed checkpoint per submitted checkpoint, and
     // each must be one we built: nothing below signs a checkpoint that has not

--- a/packages/ts-sdk/src/utils/arkTransaction.ts
+++ b/packages/ts-sdk/src/utils/arkTransaction.ts
@@ -17,6 +17,7 @@ import { setArkPsbtField, VtxoTaprootTree } from "./unknownFields";
 import { Transaction } from "./transaction";
 import { ArkAddress } from "../script/address";
 import { Extension } from "../extension";
+import { ServerResponseMismatchError } from "../providers/errors";
 
 export type ArkTxInput = {
     // the script used to spend the virtual output
@@ -128,7 +129,15 @@ function buildVirtualTx(inputs: ArkTxInput[], outputs: TransactionOutput[]) {
     return tx;
 }
 
-function buildCheckpointTx(
+/**
+ * Build the checkpoint transaction spending `vtxo`, plus the input that spends
+ * it (the ark tx's actual input).
+ *
+ * A pure function of `(vtxo, serverUnrollScript)` — nothing here is
+ * server-supplied — so finalization paths can rebuild the checkpoint they
+ * expect from their own VTXO data and reject any other one.
+ */
+export function buildCheckpointTx(
     vtxo: ArkTxInput,
     serverUnrollScript: CSVMultisigTapscript.Type,
 ): { tx: Transaction; input: ArkTxInput } {
@@ -438,6 +447,109 @@ export interface OffchainTxSigner {
 }
 
 /**
+ * Pair each server-returned checkpoint PSBT with the locally built checkpoint
+ * of the same txid, rejecting anything else.
+ *
+ * The ark tx signed just above spends each checkpoint at `checkpointTxid:0`, so
+ * the response is only usable if it carries the same txids: a checkpoint with
+ * any other txid leaves that ark tx unspendable. The two sets are therefore
+ * equal by construction, and this pairing is what the signing step below
+ * consumes.
+ *
+ * Matching is by txid rather than by position — nothing in the wire contract
+ * promises arkd echoes checkpoints in submission order — while the result keeps
+ * the server's order, so nothing downstream is reordered.
+ *
+ * Comparing txids is sound while checkpoint inputs are taproot-only: witness
+ * data does not affect the txid, so the server's signature cannot change it. A
+ * future P2SH-wrapped/scriptSig input could acquire a `finalScriptSig`
+ * server-side and legitimately change txid; that protocol shape would need a
+ * different comparison target.
+ */
+export function matchServerCheckpoints(
+    serverCheckpointTxs: string[],
+    expectedCheckpoints: Transaction[],
+    context: string,
+): { server: Transaction; local: Transaction }[] {
+    if (serverCheckpointTxs.length !== expectedCheckpoints.length) {
+        throw new ServerResponseMismatchError(
+            `${context} returned ${serverCheckpointTxs.length} checkpoints, expected ${expectedCheckpoints.length}`,
+        );
+    }
+
+    // Checkpoints spend distinct VTXOs, so their txids are distinct and the map
+    // cannot collapse two entries. Deleting on match keeps a duplicated server
+    // txid from satisfying two slots; with equal counts that gives a bijection.
+    const byTxid = new Map(expectedCheckpoints.map((c) => [c.id, c]));
+
+    return serverCheckpointTxs.map((encoded, index) => {
+        const server = Transaction.fromPSBT(base64.decode(encoded));
+        const local = byTxid.get(server.id);
+        if (!local) {
+            throw new ServerResponseMismatchError(
+                `${context} checkpoint ${index} txid ${server.id} does not match any submitted checkpoint`,
+            );
+        }
+        byTxid.delete(server.id);
+        return { server, local };
+    });
+}
+
+/**
+ * Assert every checkpoint in `checkpoints` is the one this wallet would build
+ * for one of `inputs`, by rebuilding it from local VTXO data.
+ *
+ * Used by the finalization paths, which resume a transaction submitted in an
+ * earlier process and so have no locally built set to compare against. The
+ * expected checkpoint is a pure function of `(VTXO, server unroll script)`, so
+ * it can simply be derived again.
+ *
+ * `unrollCandidates` accepts more than one script because the checkpoint output
+ * commits to the server key that was current when it was built — a tx submitted
+ * before a signer rotation and finalized after it must still match.
+ */
+export function assertCheckpointsMatchInputs(
+    checkpoints: Transaction[],
+    inputs: ArkTxInput[],
+    unrollCandidates: CSVMultisigTapscript.Type[],
+    context: string,
+): void {
+    const byOutpoint = new Map(inputs.map((input) => [`${input.txid}:${input.vout}`, input]));
+
+    for (const [index, checkpoint] of checkpoints.entries()) {
+        if (checkpoint.inputsLength !== 1) {
+            throw new ServerResponseMismatchError(
+                `${context}: checkpoint ${index} spends ${checkpoint.inputsLength} inputs, expected 1`,
+            );
+        }
+
+        const spent = checkpoint.getInput(0);
+        if (!spent.txid || spent.index === undefined) {
+            throw new ServerResponseMismatchError(
+                `${context}: checkpoint ${index} has no input outpoint`,
+            );
+        }
+
+        const outpoint = `${hex.encode(spent.txid)}:${spent.index}`;
+        const input = byOutpoint.get(outpoint);
+        if (!input) {
+            throw new ServerResponseMismatchError(
+                `${context}: checkpoint ${index} spends ${outpoint}, which is not one of the requested virtual outputs`,
+            );
+        }
+
+        const rebuilt = unrollCandidates.some(
+            (unroll) => buildCheckpointTx(input, unroll).tx.id === checkpoint.id,
+        );
+        if (!rebuilt) {
+            throw new ServerResponseMismatchError(
+                `${context}: checkpoint ${index} txid ${checkpoint.id} differs from the checkpoint built locally for ${outpoint}`,
+            );
+        }
+    }
+}
+
+/**
  * Submit a pre-built offchain transaction to the Ark server and finalize it.
  *
  * Owns the submit → checkpoint-sign → finalize sequence shared by every Ark
@@ -482,28 +594,26 @@ export async function submitOffchainTx(
         offchainTx.checkpoints.map((c) => base64.encode(c.toPSBT())),
     );
 
-    // The server returns one signed checkpoint per submitted checkpoint; both
-    // branches below pair them positionally. A short response would silently
-    // drop the tail (→ incomplete finalizeTx), a long one would carry
-    // checkpoints that were never built.
-    if (signedCheckpointTxs.length !== offchainTx.checkpoints.length) {
-        throw new Error(
-            `submitTx returned ${signedCheckpointTxs.length} checkpoints, expected ${offchainTx.checkpoints.length}`,
-        );
-    }
+    // The server returns one signed checkpoint per submitted checkpoint, and
+    // each must be one we built: nothing below signs a checkpoint that has not
+    // been matched to a local one.
+    const matched = matchServerCheckpoints(signedCheckpointTxs, offchainTx.checkpoints, "submitTx");
 
     let finalCheckpoints: string[];
     if (userSignedCheckpoints) {
-        finalCheckpoints = signedCheckpointTxs.map((c, i) => {
-            const serverSigned = Transaction.fromPSBT(base64.decode(c));
-            combineTapscriptSigs(userSignedCheckpoints[i], serverSigned);
-            return base64.encode(serverSigned.toPSBT());
+        // The signer's array is positional against `offchainTx.checkpoints`, so
+        // it is indexed by txid too rather than paired with the server's order.
+        const userByTxid = new Map(
+            userSignedCheckpoints.map((c, i) => [offchainTx.checkpoints[i].id, c] as const),
+        );
+        finalCheckpoints = matched.map(({ server, local }) => {
+            combineTapscriptSigs(userByTxid.get(local.id)!, server);
+            return base64.encode(server.toPSBT());
         });
     } else {
         finalCheckpoints = await Promise.all(
-            signedCheckpointTxs.map(async (c) => {
-                const tx = Transaction.fromPSBT(base64.decode(c));
-                const signed = await signer.signCheckpoint(tx);
+            matched.map(async ({ server }) => {
+                const signed = await signer.signCheckpoint(server);
                 return base64.encode(signed.toPSBT());
             }),
         );

--- a/packages/ts-sdk/src/wallet/validation.ts
+++ b/packages/ts-sdk/src/wallet/validation.ts
@@ -6,6 +6,7 @@ import { Packet } from "../extension/asset";
 import { Extension } from "../extension";
 import { Address, OutScript } from "@scure/btc-signer";
 import type { Network } from "../networks";
+import { ServerResponseMismatchError } from "../providers/errors";
 
 export const ErrOffchainOutputNotFound = (address: string) =>
     new Error(`offchain send output not found: ${address}`);
@@ -23,6 +24,30 @@ export const ErrOnchainOutputNotFound = (address: string) =>
     new Error(`onchain output not found: ${address}`);
 export const ErrInvalidOffchainOutputAmount = (address: string) =>
     new Error(`invalid offchain output ${address}, missing amount`);
+
+/**
+ * Assert the commitment tx received at batch finalization is the one validated
+ * at tree signing.
+ *
+ * The vtxo tree co-signed at tree signing spends `commitmentTxid:0`, so a
+ * finalization commitment carrying another txid does not correspond to the tree
+ * that was validated. The two are the same transaction by construction.
+ *
+ * No-op when `validatedCommitmentTxid` is undefined: tree signing was skipped
+ * (not a cosigner, or an onchain-only settle), so there is nothing to compare
+ * against.
+ */
+export function assertFinalCommitmentMatchesValidated(
+    finalCommitmentTx: Transaction,
+    validatedCommitmentTxid: string | undefined,
+    context: string,
+): void {
+    if (!validatedCommitmentTxid) return;
+    if (finalCommitmentTx.id === validatedCommitmentTxid) return;
+    throw new ServerResponseMismatchError(
+        `${context}: finalization commitment tx ${finalCommitmentTx.id} differs from the validated commitment tx ${validatedCommitmentTxid}`,
+    );
+}
 
 /**
  * Validates both offchain and onchain recipients.

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -8,6 +8,7 @@ import { DefaultVtxo } from "../script/default";
 import { DEFAULT_ARKADE_SERVER_URL, getNetwork, Network, NetworkName } from "../networks";
 import { ESPLORA_URL, EsploraProvider, OnchainProvider } from "../providers/onchain";
 import {
+    ArkInfo,
     ArkProvider,
     BatchFinalizationEvent,
     BatchStartedEvent,
@@ -21,7 +22,7 @@ import {
 import { SignerSession } from "../tree/signingSession";
 import { buildForfeitTx } from "../forfeit";
 import { validateConnectorsTxGraph, validateVtxoTxGraph } from "../tree/validation";
-import { validateBatchRecipients } from "./validation";
+import { assertFinalCommitmentMatchesValidated, validateBatchRecipients } from "./validation";
 import { Identity, ReadonlyIdentity, isBatchSignable } from "../identity";
 import {
     canRecoverOnchain,
@@ -66,8 +67,9 @@ import {
 import { createAssetPacket, selectCoinsWithAsset, selectedCoinsToAssetInputs } from "./asset";
 import { VtxoScript } from "../script/base";
 import { CSVMultisigTapscript, RelativeTimelock } from "../script/tapscript";
-import { toXOnlySignerHex } from "./signerRotation";
+import { signerSetFromInfo, toXOnlySignerHex } from "./signerRotation";
 import {
+    assertCheckpointsMatchInputs,
     buildOffchainTx,
     hasBoardingTxExpired,
     isValidArkAddress,
@@ -3628,11 +3630,17 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         inputs: SettleParams["inputs"],
         forfeitOutputScript: Bytes,
         connectorsGraph?: TxTree,
+        validatedCommitmentTxid?: string,
     ) {
         // the signed forfeits transactions to submit
         const signedForfeits: string[] = [];
 
         let settlementPsbt = Transaction.fromPSBT(base64.decode(event.commitmentTx));
+        assertFinalCommitmentMatchesValidated(
+            settlementPsbt,
+            validatedCommitmentTxid,
+            "settlement finalization",
+        );
         let hasBoardingUtxos = false;
 
         let connectorIndex = 0;
@@ -3795,6 +3803,9 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         session?: SignerSession,
     ): Batch.Handler {
         let sweepTapTreeRoot: Uint8Array | undefined;
+        // Assigned only after the tree it commits to has been validated, so it
+        // always names a commitment tx this handler has checked.
+        let validatedCommitmentTxid: string | undefined;
         return {
             onBatchStarted: async (event: BatchStartedEvent): Promise<{ skip: boolean }> => {
                 const utf8IntentId = new TextEncoder().encode(intentId);
@@ -3871,6 +3882,8 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                     throw new Error("Shared output not found");
                 }
 
+                validatedCommitmentTxid = commitmentTx.id;
+
                 await session.init(vtxoTree, sweepTapTreeRoot, sharedOutput.amount);
 
                 const pubkey = hex.encode(await session.getPublicKey());
@@ -3914,6 +3927,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                     inputs,
                     this.forfeitOutputScript,
                     connectorTree,
+                    validatedCommitmentTxid,
                 );
             },
         };
@@ -4140,6 +4154,15 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
             batches.push(vtxos.slice(i, i + MAX_INPUTS_PER_INTENT));
         }
 
+        const unrollCandidates = this.checkpointUnrollCandidates(await this.arkProvider.getInfo());
+        // Checked against every VTXO of this run, not the chunk that produced
+        // the proof: a pending tx spends whatever the interrupted send did, and
+        // its inputs can straddle two chunks.
+        const checkpointInputs = vtxos.map((vtxo) => ({
+            ...vtxo,
+            tapLeafScript: vtxo.forfeitTapLeafScript,
+        }));
+
         // Track seen arkTxids so parallel batches don't finalize the same tx twice
         const seen = new Set<string>();
 
@@ -4159,6 +4182,16 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                     try {
                         const checkpointTxs = pendingTx.signedCheckpointTxs.map((c) =>
                             Transaction.fromPSBT(base64.decode(c)),
+                        );
+                        // The send that registered this tx ran in an earlier
+                        // process, so its checkpoints are rebuilt here rather
+                        // than recalled. A tx that does not reconcile is left
+                        // pending for the next init to re-check.
+                        assertCheckpointsMatchInputs(
+                            checkpointTxs,
+                            checkpointInputs,
+                            unrollCandidates,
+                            `pending tx ${pendingTx.arkTxid}`,
                         );
                         const checkpointJobs = checkpointTxs.map((tx) =>
                             this.inputSigningJobsFromWitnessUtxos(tx),
@@ -4232,6 +4265,34 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         }
 
         return { finalized, pending };
+    }
+
+    /**
+     * The server unroll scripts a pending checkpoint may legitimately have been
+     * built under: this wallet's configured one, the server's current one, and
+     * one per deprecated signer (same closure, deprecated key). A tx submitted
+     * before a signer rotation was built under the old key, so rebuilding
+     * against the current key alone would leave it pending forever.
+     */
+    private checkpointUnrollCandidates(info: ArkInfo): CSVMultisigTapscript.Type[] {
+        const current = CSVMultisigTapscript.decode(hex.decode(info.checkpointTapscript));
+        const candidates = [this._serverUnrollScript, current];
+        for (const deprecated of signerSetFromInfo(info).deprecated.keys()) {
+            candidates.push(
+                CSVMultisigTapscript.encode({
+                    ...current.params,
+                    pubkeys: [hex.decode(deprecated)],
+                }),
+            );
+        }
+
+        const seen = new Set<string>();
+        return candidates.filter((candidate) => {
+            const script = hex.encode(candidate.script);
+            if (seen.has(script)) return false;
+            seen.add(script);
+            return true;
+        });
     }
 
     private async hasPendingTxFlag(): Promise<boolean> {
@@ -4564,7 +4625,10 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
             }
         }
 
+        if (pendingTxs.length === 0) return result;
+
         const myPkScriptHex = hex.encode(myPkScript);
+        const unrollCandidates = this.checkpointUnrollCandidates(await this.arkProvider.getInfo());
 
         for (const pendingTx of pendingTxs) {
             try {
@@ -4572,6 +4636,15 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                 // arkadeCash key adds its own share in place.
                 const checkpointTxs = pendingTx.signedCheckpointTxs.map((checkpoint) =>
                     Transaction.fromPSBT(base64.decode(checkpoint)),
+                );
+                assertCheckpointsMatchInputs(
+                    checkpointTxs,
+                    inputs.map((input) => ({
+                        ...input,
+                        tapLeafScript: input.forfeitTapLeafScript,
+                    })),
+                    unrollCandidates,
+                    `pending arkadeCash tx ${pendingTx.arkTxid}`,
                 );
                 const finalCheckpoints = await Promise.all(
                     checkpointTxs.map(async (checkpoint) =>
@@ -5149,29 +5222,35 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                 );
             }
 
-            const safeLength = Math.min(inputs.length, signedCheckpointTxs.length);
+            // Keyed by the outpoint each checkpoint spends, never by position:
+            // `submitTx` may return its checkpoints in any order (they are
+            // matched by txid, not index), so pairing this array with `inputs`
+            // positionally would record every VTXO as spent by another one's
+            // checkpoint.
+            const checkpointIdByOutpoint = new Map<string, string>();
+            for (const encoded of signedCheckpointTxs) {
+                const checkpoint = Transaction.fromPSBT(base64.decode(encoded));
+                for (let i = 0; i < checkpoint.inputsLength; i++) {
+                    const input = checkpoint.getInput(i);
+                    if (!input.txid) continue;
+                    checkpointIdByOutpoint.set(
+                        `${hex.encode(input.txid)}:${input.index}`,
+                        checkpoint.id,
+                    );
+                }
+            }
+
             const cm = await this.getContractManager();
             const annotatedInputs = await cm.annotateVtxos(inputs);
-            for (const [inputIndex, vtxo] of annotatedInputs.entries()) {
+            for (const vtxo of annotatedInputs) {
                 const spentFacts = { ...vtxo, isSpent: true };
-                if (inputIndex < safeLength && signedCheckpointTxs[inputIndex]) {
-                    const checkpoint = Transaction.fromPSBT(
-                        base64.decode(signedCheckpointTxs[inputIndex]),
-                    );
-
-                    spentVtxos.push({
-                        ...spentFacts,
-                        virtualStatus: toVirtualStatus(spentFacts),
-                        spentBy: checkpoint.id,
-                        arkTxId: arkTxid,
-                    });
-                } else {
-                    spentVtxos.push({
-                        ...spentFacts,
-                        virtualStatus: toVirtualStatus(spentFacts),
-                        arkTxId: arkTxid,
-                    });
-                }
+                const spentBy = checkpointIdByOutpoint.get(`${vtxo.txid}:${vtxo.vout}`);
+                spentVtxos.push({
+                    ...spentFacts,
+                    virtualStatus: toVirtualStatus(spentFacts),
+                    ...(spentBy ? { spentBy } : {}),
+                    arkTxId: arkTxid,
+                });
 
                 for (const id of vtxo.commitmentTxIds) {
                     commitmentTxIds.add(id);

--- a/packages/ts-sdk/test/arkTransactionSubmit.test.ts
+++ b/packages/ts-sdk/test/arkTransactionSubmit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { base64 } from "@scure/base";
-import { Transaction } from "@scure/btc-signer";
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { Transaction } from "../src/utils/transaction";
 import {
     submitOffchainTx,
     type OffchainTx,
@@ -8,72 +9,104 @@ import {
     type OffchainTxSubmitProvider,
 } from "../src/utils/arkTransaction";
 
-// The checkpoint contents are irrelevant here: these tests pin the count
-// invariants around submit/finalize, which are enforced before any signature is
-// inspected. Empty PSBTs keep the fixtures honest about that.
-function offchainTx(checkpointCount: number): OffchainTx {
+const P2TR = new Uint8Array([0x51, 0x20, ...new Uint8Array(32).fill(0xab)]);
+
+/** Deterministic x-only pubkey; PSBT encoding rejects arbitrary 32 bytes. */
+const key = (seed: number) => schnorr.getPublicKey(new Uint8Array(32).fill(seed));
+const SERVER_KEY = key(7);
+
+// Distinguishable checkpoints: each spends a different outpoint, so the txid
+// matching under test has something to tell them apart. Every one carries a
+// tapScriptSig standing in for the server's share, which the merge branch
+// concatenates the user's onto.
+function checkpoint(seed: number): Transaction {
+    const tx = new Transaction();
+    tx.addInput({
+        txid: new Uint8Array(32).fill(seed),
+        index: 0,
+        witnessUtxo: { script: P2TR, amount: 1000n },
+    });
+    tx.addOutput({ script: P2TR, amount: 900n });
+    tx.updateInput(0, {
+        tapScriptSig: [
+            [{ pubKey: SERVER_KEY, leafHash: new Uint8Array(32) }, new Uint8Array(64).fill(0xff)],
+        ],
+    });
+    return tx;
+}
+
+/** A copy of `tx` carrying an extra tapScriptSig keyed by `seed`. */
+function userSigned(tx: Transaction, seed: number): Transaction {
+    const copy = Transaction.fromPSBT(tx.toPSBT());
+    copy.updateInput(0, {
+        tapScriptSig: [
+            [{ pubKey: key(seed), leafHash: new Uint8Array(32) }, new Uint8Array(64).fill(seed)],
+        ],
+    });
+    return copy;
+}
+
+function offchainTx(checkpoints: Transaction[]): OffchainTx {
+    return { arkTx: new Transaction(), checkpoints };
+}
+
+function encode(checkpoints: Transaction[]): string[] {
+    return checkpoints.map((c) => base64.encode(c.toPSBT()));
+}
+
+// `userSignedCheckpoints` selects the batch (merge) branch vs the sign-after
+// branch, which is what these tests steer.
+function signer(userSignedCheckpoints?: Transaction[]): OffchainTxSigner & {
+    signCheckpoint: ReturnType<typeof vi.fn>;
+} {
     return {
-        arkTx: new Transaction({ allowUnknown: true, allowUnknownOutputs: true }),
-        checkpoints: Array.from(
-            { length: checkpointCount },
-            () => new Transaction({ allowUnknown: true, allowUnknownOutputs: true }),
-        ),
+        signArkTx: async (arkTx) => ({ arkTx, userSignedCheckpoints }),
+        signCheckpoint: vi.fn(async (checkpoint: Transaction) => checkpoint),
     };
 }
 
-function encoded(count: number): string[] {
-    return Array.from({ length: count }, () =>
-        base64.encode(new Transaction({ allowUnknown: true }).toPSBT()),
-    );
-}
-
-// Signs nothing; `userSignedCheckpoints` selects the batch (merge) branch vs the
-// sign-after branch, which is all these tests need to steer.
-function signer(userSignedCheckpointCount?: number): OffchainTxSigner {
-    return {
-        signArkTx: async (arkTx) => ({
-            arkTx,
-            userSignedCheckpoints:
-                userSignedCheckpointCount === undefined
-                    ? undefined
-                    : Array.from(
-                          { length: userSignedCheckpointCount },
-                          () => new Transaction({ allowUnknown: true }),
-                      ),
-        }),
-        signCheckpoint: async (checkpoint) => checkpoint,
-    };
-}
-
-function provider(signedCheckpointCount: number): OffchainTxSubmitProvider & {
+function provider(signedCheckpointTxs: string[]): OffchainTxSubmitProvider & {
     submitTx: ReturnType<typeof vi.fn>;
     finalizeTx: ReturnType<typeof vi.fn>;
 } {
     return {
-        submitTx: vi.fn(async () => ({
-            arkTxid: "txid",
-            signedCheckpointTxs: encoded(signedCheckpointCount),
-        })),
+        submitTx: vi.fn(async () => ({ arkTxid: "txid", signedCheckpointTxs })),
         finalizeTx: vi.fn(async () => {}),
     };
 }
 
+/** Txids of the checkpoints handed to `finalizeTx`, in the order they arrived. */
+function finalizedTxids(p: { finalizeTx: ReturnType<typeof vi.fn> }): string[] {
+    return (p.finalizeTx.mock.calls[0][1] as string[]).map(
+        (c) => Transaction.fromPSBT(base64.decode(c)).id,
+    );
+}
+
+/** Pubkeys of the tapScriptSigs on input 0 of each finalized checkpoint (PSBT-sorted). */
+function finalizedSigners(p: { finalizeTx: ReturnType<typeof vi.fn> }): string[][] {
+    return (p.finalizeTx.mock.calls[0][1] as string[]).map((c) =>
+        (Transaction.fromPSBT(base64.decode(c)).getInput(0).tapScriptSig ?? [])
+            .map(([data]) => hex.encode(data.pubKey))
+            .sort(),
+    );
+}
+
 describe("submitOffchainTx checkpoint count guards", () => {
     it("rejects a truncated submitTx response on the sign-after path", async () => {
-        const p = provider(1);
+        const p = provider(encode([checkpoint(1)]));
 
-        await expect(submitOffchainTx(p, offchainTx(2), signer())).rejects.toThrow(
-            /submitTx returned 1 checkpoints, expected 2/,
-        );
+        await expect(
+            submitOffchainTx(p, offchainTx([checkpoint(1), checkpoint(2)]), signer()),
+        ).rejects.toThrow(/submitTx returned 1 checkpoints, expected 2/);
         expect(p.finalizeTx).not.toHaveBeenCalled();
     });
 
     it("rejects an overlong submitTx response on the sign-after path", async () => {
-        const p = provider(3);
+        const p = provider(encode([checkpoint(1), checkpoint(2), checkpoint(3)]));
 
-        await expect(submitOffchainTx(p, offchainTx(2), signer())).rejects.toThrow(
-            /submitTx returned 3 checkpoints, expected 2/,
-        );
+        await expect(
+            submitOffchainTx(p, offchainTx([checkpoint(1), checkpoint(2)]), signer()),
+        ).rejects.toThrow(/submitTx returned 3 checkpoints, expected 2/);
         expect(p.finalizeTx).not.toHaveBeenCalled();
     });
 
@@ -81,19 +114,27 @@ describe("submitOffchainTx checkpoint count guards", () => {
     // and a server that were truncated by the same amount agreed with each other
     // while still dropping a checkpoint. Both are checked against the built set.
     it("rejects equally truncated signer and server arrays", async () => {
-        const p = provider(1);
+        const p = provider(encode([checkpoint(1)]));
 
-        await expect(submitOffchainTx(p, offchainTx(2), signer(1))).rejects.toThrow(
-            /signer returned 1 signed checkpoints, expected 2/,
-        );
+        await expect(
+            submitOffchainTx(
+                p,
+                offchainTx([checkpoint(1), checkpoint(2)]),
+                signer([checkpoint(1)]),
+            ),
+        ).rejects.toThrow(/signer returned 1 signed checkpoints, expected 2/);
     });
 
     it("rejects a miscounting signer before submitting", async () => {
-        const p = provider(2);
+        const p = provider(encode([checkpoint(1), checkpoint(2)]));
 
-        await expect(submitOffchainTx(p, offchainTx(2), signer(1))).rejects.toThrow(
-            /signer returned 1 signed checkpoints, expected 2/,
-        );
+        await expect(
+            submitOffchainTx(
+                p,
+                offchainTx([checkpoint(1), checkpoint(2)]),
+                signer([checkpoint(1)]),
+            ),
+        ).rejects.toThrow(/signer returned 1 signed checkpoints, expected 2/);
         // Failing before submitTx is the point: a tx registered server-side but
         // never finalized would be left pending with no local recovery path.
         expect(p.submitTx).not.toHaveBeenCalled();
@@ -101,12 +142,76 @@ describe("submitOffchainTx checkpoint count guards", () => {
     });
 
     it("finalizes every checkpoint when the counts line up", async () => {
-        const p = provider(2);
+        const p = provider(encode([checkpoint(1), checkpoint(2)]));
 
-        const { arkTxid } = await submitOffchainTx(p, offchainTx(2), signer());
+        const { arkTxid } = await submitOffchainTx(
+            p,
+            offchainTx([checkpoint(1), checkpoint(2)]),
+            signer(),
+        );
 
         expect(arkTxid).toBe("txid");
         expect(p.finalizeTx).toHaveBeenCalledTimes(1);
         expect(p.finalizeTx.mock.calls[0][1]).toHaveLength(2);
+    });
+});
+
+describe("submitOffchainTx checkpoint txid matching", () => {
+    it("accepts reordered server checkpoints and finalizes in the server's order", async () => {
+        const local = [checkpoint(1), checkpoint(2)];
+        const p = provider(encode([local[1], local[0]]));
+
+        await submitOffchainTx(p, offchainTx(local), signer());
+
+        expect(finalizedTxids(p)).toEqual([local[1].id, local[0].id]);
+    });
+
+    it("rejects an unsubmitted checkpoint on the sign-after path", async () => {
+        const local = [checkpoint(1), checkpoint(2)];
+        const unsubmitted = checkpoint(9);
+        const p = provider(encode([local[0], unsubmitted]));
+        const s = signer();
+
+        await expect(submitOffchainTx(p, offchainTx(local), s)).rejects.toThrow(
+            new RegExp(`submitTx checkpoint 1 txid ${unsubmitted.id} does not match`),
+        );
+        expect(s.signCheckpoint).not.toHaveBeenCalled();
+        expect(p.finalizeTx).not.toHaveBeenCalled();
+    });
+
+    it("merges user signatures by txid when the server reorders (batch path)", async () => {
+        const local = [checkpoint(1), checkpoint(2)];
+        const p = provider(encode([local[1], local[0]]));
+
+        await submitOffchainTx(
+            p,
+            offchainTx(local),
+            signer([userSigned(local[0], 1), userSigned(local[1], 2)]),
+        );
+
+        expect(finalizedTxids(p)).toEqual([local[1].id, local[0].id]);
+        // Each server checkpoint carries the user share built for *its* txid,
+        // appended to the server's own — never the one at the same position.
+        expect(finalizedSigners(p)).toEqual([
+            [hex.encode(SERVER_KEY), hex.encode(key(2))].sort(),
+            [hex.encode(SERVER_KEY), hex.encode(key(1))].sort(),
+        ]);
+    });
+
+    it("rejects an unsubmitted checkpoint on the batch path", async () => {
+        const local = [checkpoint(1), checkpoint(2)];
+        const unsubmitted = checkpoint(9);
+        const p = provider(encode([unsubmitted, local[1]]));
+
+        await expect(
+            submitOffchainTx(
+                p,
+                offchainTx(local),
+                signer([userSigned(local[0], 1), userSigned(local[1], 2)]),
+            ),
+        ).rejects.toThrow(
+            new RegExp(`submitTx checkpoint 0 txid ${unsubmitted.id} does not match`),
+        );
+        expect(p.finalizeTx).not.toHaveBeenCalled();
     });
 });

--- a/packages/ts-sdk/test/arkTransactionSubmit.test.ts
+++ b/packages/ts-sdk/test/arkTransactionSubmit.test.ts
@@ -65,12 +65,22 @@ function signer(userSignedCheckpoints?: Transaction[]): OffchainTxSigner & {
     };
 }
 
-function provider(signedCheckpointTxs: string[]): OffchainTxSubmitProvider & {
+// Echoes the submitted ark tx's id (and optionally overrides it or attaches a
+// finalArkTx) so the arkTxid reconciliation guard passes unless a test says
+// otherwise.
+function provider(
+    signedCheckpointTxs: string[],
+    overrides?: { arkTxid?: string; finalArkTx?: string },
+): OffchainTxSubmitProvider & {
     submitTx: ReturnType<typeof vi.fn>;
     finalizeTx: ReturnType<typeof vi.fn>;
 } {
     return {
-        submitTx: vi.fn(async () => ({ arkTxid: "txid", signedCheckpointTxs })),
+        submitTx: vi.fn(async (arkTxB64: string) => ({
+            arkTxid: overrides?.arkTxid ?? Transaction.fromPSBT(base64.decode(arkTxB64)).id,
+            finalArkTx: overrides?.finalArkTx,
+            signedCheckpointTxs,
+        })),
         finalizeTx: vi.fn(async () => {}),
     };
 }
@@ -143,16 +153,52 @@ describe("submitOffchainTx checkpoint count guards", () => {
 
     it("finalizes every checkpoint when the counts line up", async () => {
         const p = provider(encode([checkpoint(1), checkpoint(2)]));
+        const otx = offchainTx([checkpoint(1), checkpoint(2)]);
 
-        const { arkTxid } = await submitOffchainTx(
-            p,
-            offchainTx([checkpoint(1), checkpoint(2)]),
-            signer(),
-        );
+        const { arkTxid } = await submitOffchainTx(p, otx, signer());
 
-        expect(arkTxid).toBe("txid");
+        expect(arkTxid).toBe(otx.arkTx.id);
         expect(p.finalizeTx).toHaveBeenCalledTimes(1);
         expect(p.finalizeTx.mock.calls[0][1]).toHaveLength(2);
+    });
+});
+
+describe("submitOffchainTx ark txid reconciliation", () => {
+    it("rejects a response whose arkTxid is not the submitted tx", async () => {
+        const p = provider(encode([checkpoint(1)]), { arkTxid: "ff".repeat(32) });
+        const s = signer();
+
+        await expect(submitOffchainTx(p, offchainTx([checkpoint(1)]), s)).rejects.toThrow(
+            /submitTx returned ark txid/,
+        );
+        expect(s.signCheckpoint).not.toHaveBeenCalled();
+        expect(p.finalizeTx).not.toHaveBeenCalled();
+    });
+
+    it("rejects a finalArkTx that is not the submitted tx", async () => {
+        // Correct arkTxid but a finalArkTx carrying some other transaction —
+        // isolates the finalArkTx half of the guard.
+        const foreign = checkpoint(3);
+        const p = provider(encode([checkpoint(1)]), {
+            finalArkTx: base64.encode(foreign.toPSBT()),
+        });
+
+        await expect(submitOffchainTx(p, offchainTx([checkpoint(1)]), signer())).rejects.toThrow(
+            new RegExp(`submitTx returned final ark tx ${foreign.id}`),
+        );
+        expect(p.finalizeTx).not.toHaveBeenCalled();
+    });
+
+    it("accepts a finalArkTx echoing the submitted tx", async () => {
+        const otx = offchainTx([checkpoint(1)]);
+        const p = provider(encode([checkpoint(1)]), {
+            finalArkTx: base64.encode(otx.arkTx.toPSBT()),
+        });
+
+        const { arkTxid } = await submitOffchainTx(p, otx, signer());
+
+        expect(arkTxid).toBe(otx.arkTx.id);
+        expect(p.finalizeTx).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/packages/ts-sdk/test/arkade-batch.test.ts
+++ b/packages/ts-sdk/test/arkade-batch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { base64, hex } from "@scure/base";
 import { sha256 } from "@scure/btc-signer/utils.js";
+import { Address } from "@scure/btc-signer";
 
 // The handler must delegate graph/recipient validation to the shared
 // validators; mock both so the test drives only the wiring.
@@ -8,7 +9,9 @@ vi.mock("../src/tree/validation", () => ({
     validateVtxoTxGraph: vi.fn(),
     validateConnectorsTxGraph: vi.fn(),
 }));
-vi.mock("../src/wallet/validation", () => ({
+// The commitment-equality assertion stays real: it is under test below.
+vi.mock("../src/wallet/validation", async (importActual) => ({
+    ...(await importActual<typeof import("../src/wallet/validation")>()),
     validateBatchRecipients: vi.fn(),
 }));
 
@@ -38,14 +41,36 @@ function makeSession() {
     } as unknown as SignerSession;
 }
 
+const FORFEIT_ADDRESS = Address(networks.regtest).encode({
+    type: "tr",
+    pubkey: hex.decode("22".repeat(32)),
+});
+
 function makeArkProvider() {
     return {
         confirmRegistration: vi.fn(async () => {}),
-        getInfo: vi.fn(async () => ({ forfeitPubkey: "02" + "22".repeat(32) })),
+        getInfo: vi.fn(async () => ({
+            forfeitPubkey: "02" + "22".repeat(32),
+            forfeitAddress: FORFEIT_ADDRESS,
+            dust: 1000,
+        })),
         submitTreeNonces: vi.fn(async () => {}),
         submitTreeSignatures: vi.fn(async () => {}),
         submitSignedForfeitTxs: vi.fn(async () => {}),
     } as unknown as ArkProvider;
+}
+
+function makeEmulator() {
+    return {
+        submitFinalization: vi.fn(async () => ({ signedForfeits: [], signedCommitmentTx: null })),
+    } as unknown as EmulatorProvider;
+}
+
+/** A commitment tx PSBT; `amount` makes distinct fixtures distinguishable. */
+function commitment(amount: bigint): string {
+    const tx = new Transaction({ allowUnknownOutputs: true });
+    tx.addOutput({ script: new Uint8Array([0x51]), amount });
+    return base64.encode(tx.toPSBT());
 }
 
 function makeEvents() {
@@ -69,7 +94,12 @@ function makeEvents() {
     return { batchStarted, treeSigningStarted, vtxoTree };
 }
 
-function makeHandler(session: SignerSession, arkProvider: ArkProvider, recipients?: Recipient[]) {
+function makeHandler(
+    session: SignerSession,
+    arkProvider: ArkProvider,
+    recipients?: Recipient[],
+    emulator: EmulatorProvider = {} as unknown as EmulatorProvider,
+) {
     return createArkadeBatchHandler(
         INTENT_ID,
         [],
@@ -78,7 +108,7 @@ function makeHandler(session: SignerSession, arkProvider: ArkProvider, recipient
         {} as unknown as Intent.RegisterMessage,
         session,
         arkProvider,
-        {} as unknown as EmulatorProvider,
+        emulator,
         networks.regtest,
         recipients,
     );
@@ -137,5 +167,44 @@ describe("createArkadeBatchHandler recipient validation", () => {
 
         expect(skip).toBe(false);
         expect(validateBatchRecipients).not.toHaveBeenCalled();
+    });
+});
+
+describe("createArkadeBatchHandler commitment tx equality", () => {
+    beforeEach(() => {
+        vi.mocked(validateBatchRecipients).mockReset();
+        vi.mocked(validateVtxoTxGraph).mockReset();
+    });
+
+    async function runUntilFinalization(finalCommitmentTx: string) {
+        const arkProvider = makeArkProvider();
+        const emulator = makeEmulator();
+        const handler = makeHandler(makeSession(), arkProvider, undefined, emulator);
+        const { batchStarted, treeSigningStarted, vtxoTree } = makeEvents();
+
+        await handler.onBatchStarted(batchStarted);
+        await handler.onTreeSigningStarted(treeSigningStarted, vtxoTree);
+
+        return {
+            arkProvider,
+            finalize: handler.onBatchFinalization({ commitmentTx: finalCommitmentTx } as never),
+        };
+    }
+
+    it("rejects a finalization commitment tx that differs from the validated one", async () => {
+        const { arkProvider, finalize } = await runUntilFinalization(commitment(9999n));
+
+        await expect(finalize).rejects.toThrow(
+            /finalization commitment tx .* differs from the validated commitment tx/,
+        );
+        expect(arkProvider.submitSignedForfeitTxs).not.toHaveBeenCalled();
+    });
+
+    it("accepts the validated commitment tx at finalization", async () => {
+        // Same 5000n output as makeEvents' tree-signing commitment.
+        const { arkProvider, finalize } = await runUntilFinalization(commitment(5000n));
+
+        await finalize;
+        expect(arkProvider.submitSignedForfeitTxs).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/ts-sdk/test/arkade-features.test.ts
+++ b/packages/ts-sdk/test/arkade-features.test.ts
@@ -74,10 +74,24 @@ function mockIdentity(key = xOnly()) {
     return { identity, sign, key };
 }
 
+/** A valid PSBT that is not any of the submitted checkpoints. */
+function foreignCheckpoint(): string {
+    const tx = new Transaction();
+    tx.addInput({
+        txid: new Uint8Array(32).fill(0x11),
+        index: 0,
+        witnessUtxo: { script: p2tr(), amount: 1000n },
+    });
+    tx.addOutput({ script: p2tr(), amount: 900n });
+    return base64.encode(tx.toPSBT());
+}
+
 function providers(
     server: Uint8Array,
     emulatorKey: Uint8Array,
     coins: { txid: string; vout: number; value: number }[],
+    /** Rewrites what arkd answers `submitTx` with (default: echo). */
+    checkpointResponse: (cps: string[]) => string[] = (cps) => cps,
 ) {
     const checkpointTapscript = hex.encode(
         CSVMultisigTapscript.encode({ timelock: { type: "blocks", value: 10n }, pubkeys: [server] })
@@ -92,7 +106,11 @@ function providers(
             captured.arkTx = arkTx;
             captured.cps = cps;
             captured.via = "ark";
-            return { arkTxid: "arktxid", finalArkTx: arkTx, signedCheckpointTxs: cps };
+            return {
+                arkTxid: "arktxid",
+                finalArkTx: arkTx,
+                signedCheckpointTxs: checkpointResponse(cps),
+            };
         }),
         finalizeTx: vi.fn(async () => {}),
     };
@@ -283,6 +301,64 @@ describe("ArkadeContract — extended features", () => {
         expect(arkProvider.submitTx).toHaveBeenCalled();
         expect(arkProvider.finalizeTx).toHaveBeenCalled();
         expect(emulator.submitTx).not.toHaveBeenCalled();
+    });
+
+    // A pure-tapscript spend with one funded input: two checkpoints, so the
+    // server's response order can differ from the submission order.
+    async function sendTwoCheckpointSpend(
+        checkpointResponse?: (cps: string[]) => string[],
+    ): Promise<{ arkProvider: ReturnType<typeof providers>["arkProvider"]; send: Promise<void> }> {
+        const { identity } = mockIdentity();
+        const { arkProvider, indexer, emulator } = providers(
+            server,
+            emulatorKey,
+            [COIN],
+            checkpointResponse,
+        );
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            emulator,
+            indexer,
+            identity,
+            network: networks.regtest,
+        });
+        const c = ark.contract({
+            version: 0,
+            params: ["server", "user"],
+            functions: {
+                exit: {
+                    tapscript: {
+                        signers: ["$user", "$server"],
+                        csv: { type: "blocks", value: 20n },
+                    },
+                },
+            },
+        });
+        const send = c.functions
+            .exit()
+            .from(COIN)
+            .fund([fundingCoin(60_000)])
+            .to(p2tr(receiver), AMOUNT)
+            .change(p2tr())
+            .send()
+            .then(() => undefined);
+        return { arkProvider, send };
+    }
+
+    it("arkd path finalizes reordered server checkpoints in the server's order", async () => {
+        const { arkProvider, send } = await sendTwoCheckpointSpend((cps) => [...cps].reverse());
+        await send;
+
+        const submitted = arkProvider.submitTx.mock.calls[0][1] as string[];
+        expect(arkProvider.finalizeTx.mock.calls[0][1]).toEqual([...submitted].reverse());
+    });
+
+    it("arkd path rejects a checkpoint it did not submit", async () => {
+        const unsubmitted = foreignCheckpoint();
+        const { arkProvider, send } = await sendTwoCheckpointSpend((cps) => [unsubmitted, cps[1]]);
+
+        await expect(send).rejects.toThrow(/does not match any submitted checkpoint/);
+        expect(arkProvider.finalizeTx).not.toHaveBeenCalled();
     });
 
     it("rejects Arkade opcodes inside a tapscript segment", async () => {

--- a/packages/ts-sdk/test/arkade-features.test.ts
+++ b/packages/ts-sdk/test/arkade-features.test.ts
@@ -107,7 +107,7 @@ function providers(
             captured.cps = cps;
             captured.via = "ark";
             return {
-                arkTxid: "arktxid",
+                arkTxid: Transaction.fromPSBT(base64.decode(arkTx)).id,
                 finalArkTx: arkTx,
                 signedCheckpointTxs: checkpointResponse(cps),
             };

--- a/packages/ts-sdk/test/arkadeCashClaim.test.ts
+++ b/packages/ts-sdk/test/arkadeCashClaim.test.ts
@@ -117,12 +117,17 @@ function spentCashVtxoAt(cashPkScript: string, index: number): VirtualCoin {
  * The pending sweep the crashed claim left on the server: the offchain tx it
  * built and submitted but never finalized, paying `destinationPkScript`.
  */
-function pendingSweep(cash: ArkadeCash, destinationPkScript: Uint8Array) {
+function pendingSweep(
+    cash: ArkadeCash,
+    destinationPkScript: Uint8Array,
+    txid = CASH_TXID,
+    serverUnrollScript = CSVMultisigTapscript.decode(hex.decode(CHECKPOINT_TAPSCRIPT)),
+) {
     const cashScript = cash.vtxoScript;
     const offchainTx = buildOffchainTx(
         [
             {
-                txid: CASH_TXID,
+                txid,
                 vout: 0,
                 value: CASH_VALUE,
                 tapLeafScript: cashScript.forfeit(),
@@ -130,7 +135,7 @@ function pendingSweep(cash: ArkadeCash, destinationPkScript: Uint8Array) {
             },
         ],
         [{ script: destinationPkScript, amount: BigInt(CASH_VALUE) }],
-        CSVMultisigTapscript.decode(hex.decode(CHECKPOINT_TAPSCRIPT)),
+        serverUnrollScript,
     );
 
     return {
@@ -138,6 +143,14 @@ function pendingSweep(cash: ArkadeCash, destinationPkScript: Uint8Array) {
         finalArkTx: base64.encode(offchainTx.arkTx.toPSBT()),
         signedCheckpointTxs: offchainTx.checkpoints.map((c) => base64.encode(c.toPSBT())),
     };
+}
+
+/** A checkpoint unroll script under a server key this wallet does not use. */
+function foreignUnrollScript() {
+    return CSVMultisigTapscript.encode({
+        ...CSVMultisigTapscript.decode(hex.decode(CHECKPOINT_TAPSCRIPT)).params,
+        pubkeys: [new Uint8Array(32).fill(9)],
+    });
 }
 
 const makeCash = () =>
@@ -217,7 +230,7 @@ describe("claimCash drain-pending accounting", () => {
         // Every batch surfaces the same pending sweep; dedup by arkTxid must
         // collapse them so the tx is finalized exactly once.
         const myPkScript = ArkAddress.decode(await wallet.getAddress()).pkScript;
-        getPendingTxs.mockResolvedValue([pendingSweep(cash, myPkScript)]);
+        getPendingTxs.mockResolvedValue([pendingSweep(cash, myPkScript, drainable[0].txid)]);
 
         await wallet.claimCash(cash.toString());
 
@@ -229,6 +242,71 @@ describe("claimCash drain-pending accounting", () => {
             expect(inputs).toBeLessThanOrEqual(20 + 1);
         }
         // Same arkTxid across all batches → finalized once, not three times.
+        expect(finalizeTx).toHaveBeenCalledOnce();
+    });
+
+    // The drain co-signs checkpoints returned by the server, so each one must
+    // reconcile with the checkpoint this wallet builds for that VTXO.
+    it("leaves a pending tx alone when its checkpoint does not rebuild", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const finalizeTx = vi.fn(async () => {});
+        const getPendingTxs = vi.fn();
+
+        const wallet = await makeWallet(cashIndexer(cashPkScript, [spentCashVtxo(cashPkScript)]), {
+            getPendingTxs,
+            finalizeTx,
+        });
+
+        const myPkScript = ArkAddress.decode(await wallet.getAddress()).pkScript;
+        // Same VTXO, but a checkpoint locked to a different server key: its
+        // output script — and so its txid — is not the one we build.
+        getPendingTxs.mockResolvedValue([
+            pendingSweep(cash, myPkScript, CASH_TXID, foreignUnrollScript()),
+        ]);
+
+        const result = await wallet.claimCash(cash.toString());
+
+        expect(finalizeTx).not.toHaveBeenCalled();
+        expect(result.swept).toBe(0);
+        expect(result.unclaimed.vtxos).toEqual([
+            { txid: CASH_TXID, vout: 0, value: CASH_VALUE, reason: "already-spent" },
+        ]);
+    });
+
+    it("finalizes a checkpoint built under a deprecated signer", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const finalizeTx = vi.fn(async () => {});
+        const getPendingTxs = vi.fn();
+
+        // The sweep was submitted before a signer rotation, so its checkpoint
+        // is locked to the now-deprecated key.
+        const deprecated = hex.encode(new Uint8Array(32).fill(3));
+        const wallet = await makeWallet(cashIndexer(cashPkScript, [spentCashVtxo(cashPkScript)]), {
+            getPendingTxs,
+            finalizeTx,
+            getInfo: vi.fn(async () => ({
+                ...info,
+                deprecatedSigners: [{ pubkey: deprecated, cutoffDate: 0n }],
+            })),
+        });
+
+        const myPkScript = ArkAddress.decode(await wallet.getAddress()).pkScript;
+        getPendingTxs.mockResolvedValue([
+            pendingSweep(
+                cash,
+                myPkScript,
+                CASH_TXID,
+                CSVMultisigTapscript.encode({
+                    ...CSVMultisigTapscript.decode(hex.decode(CHECKPOINT_TAPSCRIPT)).params,
+                    pubkeys: [hex.decode(deprecated)],
+                }),
+            ),
+        ]);
+
+        await wallet.claimCash(cash.toString());
+
         expect(finalizeTx).toHaveBeenCalledOnce();
     });
 

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -1284,7 +1284,7 @@ describe("Wallet HD rotation", () => {
                 .mockImplementation(async (arkTxB64, checkpointsB64) => {
                     submittedArkTxB64 = arkTxB64;
                     return {
-                        arkTxid: "ee".repeat(32),
+                        arkTxid: Transaction.fromPSBT(base64.decode(arkTxB64)).id,
                         finalArkTx: arkTxB64,
                         signedCheckpointTxs: checkpointsB64,
                     };
@@ -1338,7 +1338,7 @@ describe("Wallet HD rotation", () => {
                 .mockImplementation(async (arkTxB64, checkpointsB64) => {
                     submittedArkTxB64 = arkTxB64;
                     return {
-                        arkTxid: "cc".repeat(32),
+                        arkTxid: Transaction.fromPSBT(base64.decode(arkTxB64)).id,
                         finalArkTx: arkTxB64,
                         signedCheckpointTxs: checkpointsB64,
                     };
@@ -1558,7 +1558,7 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
 
         vi.spyOn(wallet.arkProvider, "submitTx").mockImplementation(
             async (arkTxB64, checkpointsB64) => ({
-                arkTxid: "cc".repeat(32),
+                arkTxid: Transaction.fromPSBT(base64.decode(arkTxB64)).id,
                 finalArkTx: arkTxB64,
                 signedCheckpointTxs: checkpointsB64,
             }),
@@ -1596,7 +1596,7 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
         const submitSpy = vi
             .spyOn(wallet.arkProvider, "submitTx")
             .mockImplementation(async (arkTxB64, checkpointsB64) => ({
-                arkTxid: "ab".repeat(32),
+                arkTxid: Transaction.fromPSBT(base64.decode(arkTxB64)).id,
                 finalArkTx: arkTxB64,
                 // Server adds its share to the *unsigned* checkpoints it
                 // was handed — exactly what arkd does in production.
@@ -1647,7 +1647,7 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
                     checkpointsB64.map((c) => serverSignCheckpoint(c)),
                 );
                 return {
-                    arkTxid: "ab".repeat(32),
+                    arkTxid: Transaction.fromPSBT(base64.decode(arkTxB64)).id,
                     finalArkTx: arkTxB64,
                     // One more checkpoint than the user signed → mismatch.
                     signedCheckpointTxs: [...signed, signed[0]],
@@ -1879,24 +1879,23 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
     }
 
     // Drive a successful send round-trip (server signs checkpoints, finalize
-    // resolves) and return the arkTxid the wallet recorded against. `reorder`
-    // rearranges the server's response, which submitTx is free to do.
+    // resolves), echoing the submitted tx's id as arkTxid the way arkd does.
+    // `reorder` rearranges the server's response, which submitTx is free to do.
     function stubSendRoundTrip(
         wallet: Awaited<ReturnType<typeof makeStaticBatchWallet>>["wallet"],
         reorder: (checkpoints: string[]) => string[] = (c) => c,
     ) {
-        const arkTxid = "ab".repeat(32);
         const submitSpy = vi
             .spyOn(wallet.arkProvider, "submitTx")
             .mockImplementation(async (arkTxB64, checkpointsB64) => ({
-                arkTxid,
+                arkTxid: Transaction.fromPSBT(base64.decode(arkTxB64)).id,
                 finalArkTx: arkTxB64,
                 signedCheckpointTxs: reorder(
                     await Promise.all(checkpointsB64.map((c) => serverSignCheckpoint(c))),
                 ),
             }));
         const finalizeSpy = vi.spyOn(wallet.arkProvider, "finalizeTx").mockResolvedValue(undefined);
-        return { arkTxid, submitSpy, finalizeSpy };
+        return { submitSpy, finalizeSpy };
     }
 
     // `spentBy` must name the checkpoint that actually spends the VTXO. The
@@ -1939,10 +1938,12 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
     it("sendSelectedVtxosToSelf persists the full-value self output when there is no change", async () => {
         const { wallet } = await makeStaticBatchWallet();
         const coin = makeMigratableCoin(wallet);
-        const { arkTxid } = stubSendRoundTrip(wallet);
+        const { submitSpy } = stubSendRoundTrip(wallet);
 
-        const returned = await wallet.sendSelectedVtxosToSelf([coin]);
-        expect(returned).toBe(arkTxid);
+        const arkTxid = await wallet.sendSelectedVtxosToSelf([coin]);
+        expect(arkTxid).toBe(
+            Transaction.fromPSBT(base64.decode(submitSpy.mock.calls[0][0] as string)).id,
+        );
 
         // The self output (output index 0) is persisted at the FULL input value
         // even though there is no separate change output, on the wallet's own
@@ -1975,9 +1976,9 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
                 { assetId: assetB, amount: 7n },
             ],
         });
-        const { arkTxid } = stubSendRoundTrip(wallet);
+        stubSendRoundTrip(wallet);
 
-        await wallet.sendSelectedVtxosToSelf([coin]);
+        const arkTxid = await wallet.sendSelectedVtxosToSelf([coin]);
 
         const primaryAddress = await wallet.getAddress();
         const persisted = await (wallet as any).walletRepository.getVtxos(primaryAddress);

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -10,6 +10,7 @@ import {
     DefaultVtxo,
     MissingSigningDescriptorError,
     buildOffchainTx,
+    CSVMultisigTapscript,
     type BatchSignableIdentity,
     type Identity,
     type SignRequest,
@@ -1445,14 +1446,21 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
         };
     }
 
-    async function makeStaticBatchWallet(contractRepo?: InMemoryContractRepository) {
+    async function makeStaticBatchWallet(
+        contractRepo?: InMemoryContractRepository,
+        // Undecorated identity → `isBatchSignable` is false and the signer
+        // router path runs instead.
+        batchSignable = true,
+    ) {
         // Use a baseline SingleKey wallet (no HD rotation): every input
         // routes to the identity, so canBatch returns true and the batch
         // path is exercised.
         const base = SingleKey.fromHex(
             "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2",
         );
-        const identity = makeBatchSignable(base);
+        const identity = batchSignable
+            ? makeBatchSignable(base)
+            : (base as unknown as ReturnType<typeof makeBatchSignable>);
         const wallet = await Wallet.create({
             identity,
             arkServerUrl: "http://localhost:7070",
@@ -1718,6 +1726,138 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
         await wallet.dispose();
     });
 
+    // ── finalizePendingTxs: checkpoints are rebuilt before co-signing ──
+
+    // The pending tx the server reports for `coin`, its checkpoint built under
+    // `unroll` (defaults to the wallet's own, i.e. what an honest server
+    // returns) and carrying the server's signature.
+    async function pendingTxFor(
+        wallet: Awaited<ReturnType<typeof makeStaticBatchWallet>>["wallet"],
+        coin: ExtendedVirtualCoin,
+        unroll: CSVMultisigTapscript.Type = wallet.serverUnrollScript,
+    ) {
+        const offchain = buildOffchainTx(
+            [{ ...coin, tapLeafScript: coin.forfeitTapLeafScript }],
+            [{ amount: BigInt(coin.value - 1000), script: wallet.arkAddress.pkScript }],
+            unroll,
+        );
+        return {
+            arkTxid: "cd".repeat(32),
+            signedCheckpointTxs: [
+                await serverSignCheckpoint(base64.encode(offchain.checkpoints[0].toPSBT())),
+            ],
+        };
+    }
+
+    /** A checkpoint unroll script under a server key this wallet does not use. */
+    function foreignUnrollScript(
+        wallet: Awaited<ReturnType<typeof makeStaticBatchWallet>>["wallet"],
+    ) {
+        // prettier-ignore
+        return CSVMultisigTapscript.encode({
+            ...wallet.serverUnrollScript.params,
+            pubkeys: [new Uint8Array(32).fill(9)],
+        });
+    }
+
+    async function runFinalizePending(
+        wallet: Awaited<ReturnType<typeof makeStaticBatchWallet>>["wallet"],
+        coins: ExtendedVirtualCoin[],
+        pendingTx: { arkTxid: string; signedCheckpointTxs: string[] },
+    ) {
+        await (wallet as any).setPendingTxFlag(true);
+        vi.spyOn(wallet.arkProvider, "getPendingTxs").mockResolvedValue([pendingTx] as never);
+        const finalizeSpy = vi.spyOn(wallet.arkProvider, "finalizeTx").mockResolvedValue(undefined);
+        const result = await wallet.finalizePendingTxs(coins);
+        return { result, finalizeSpy };
+    }
+
+    it("leaves a pending tx alone when its checkpoint does not rebuild", async () => {
+        const { wallet } = await makeStaticBatchWallet();
+        const coin = makeBaselineCoin(wallet);
+        // Same VTXO, but a checkpoint locked to a different server key.
+        const pending = await pendingTxFor(wallet, coin, foreignUnrollScript(wallet));
+
+        const { result, finalizeSpy } = await runFinalizePending(wallet, [coin], pending);
+
+        expect(finalizeSpy).not.toHaveBeenCalled();
+        expect(result.finalized).toEqual([]);
+        expect(result.pending).toEqual([pending.arkTxid]);
+
+        await wallet.dispose();
+    });
+
+    it("leaves a pending tx alone when its checkpoint spends an unrelated VTXO", async () => {
+        const { wallet } = await makeStaticBatchWallet();
+        const coin = makeBaselineCoin(wallet);
+        const other = { ...coin, txid: "22".repeat(32) };
+        const pending = await pendingTxFor(wallet, other);
+
+        const { result, finalizeSpy } = await runFinalizePending(wallet, [coin], pending);
+
+        expect(finalizeSpy).not.toHaveBeenCalled();
+        expect(result.finalized).toEqual([]);
+
+        await wallet.dispose();
+    });
+
+    // The proof is chunked at MAX_INPUTS_PER_INTENT, but an interrupted send
+    // spent whatever it spent: its checkpoints are matched against every VTXO
+    // of the run, not just the chunk whose proof surfaced the tx.
+    it("finalizes a pending tx whose input falls in a later proof chunk", async () => {
+        const { wallet } = await makeStaticBatchWallet();
+        const base = makeBaselineCoin(wallet);
+        const coins = Array.from({ length: 21 }, (_, i) => ({
+            ...base,
+            txid: i.toString(16).padStart(64, "0"),
+        }));
+        const pending = await pendingTxFor(wallet, coins[20]);
+
+        const { result, finalizeSpy } = await runFinalizePending(wallet, coins, pending);
+
+        expect(finalizeSpy).toHaveBeenCalledTimes(1);
+        expect(result.finalized).toEqual([pending.arkTxid]);
+
+        await wallet.dispose();
+    });
+
+    it("finalizes a rebuilt checkpoint on the signer-router path", async () => {
+        const { wallet } = await makeStaticBatchWallet(undefined, false);
+        const coin = makeBaselineCoin(wallet);
+        const pending = await pendingTxFor(wallet, coin);
+
+        const { result, finalizeSpy } = await runFinalizePending(wallet, [coin], pending);
+
+        expect(finalizeSpy).toHaveBeenCalledTimes(1);
+        expect(result.finalized).toEqual([pending.arkTxid]);
+
+        await wallet.dispose();
+    });
+
+    // A send submitted before a signer rotation must still finalize after it,
+    // or its funds stay pending forever.
+    it("finalizes a checkpoint built under a now-deprecated signer", async () => {
+        const { wallet } = await makeStaticBatchWallet();
+        const coin = makeBaselineCoin(wallet);
+        const deprecated = new Uint8Array(32).fill(3);
+        const deprecatedUnroll = CSVMultisigTapscript.encode({
+            ...wallet.serverUnrollScript.params,
+            pubkeys: [deprecated],
+        });
+        vi.spyOn(wallet.arkProvider, "getInfo").mockResolvedValue({
+            ...mockArkInfo,
+            deprecatedSigners: [{ pubkey: hex.encode(deprecated), cutoffDate: 0n }],
+        } as never);
+
+        const pending = await pendingTxFor(wallet, coin, deprecatedUnroll);
+        const { result, finalizeSpy } = await runFinalizePending(wallet, [coin], pending);
+
+        expect(finalizeSpy).toHaveBeenCalledTimes(1);
+        expect(result.finalized).toEqual([pending.arkTxid]);
+
+        await wallet.dispose();
+    });
+
     // ── sendSelectedVtxosToSelf: the deprecated-signer VTXO migration primitive ──
 
     // A spendable, batch-expiry-bearing baseline coin: the migration primitive
@@ -1739,9 +1879,11 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
     }
 
     // Drive a successful send round-trip (server signs checkpoints, finalize
-    // resolves) and return the arkTxid the wallet recorded against.
+    // resolves) and return the arkTxid the wallet recorded against. `reorder`
+    // rearranges the server's response, which submitTx is free to do.
     function stubSendRoundTrip(
         wallet: Awaited<ReturnType<typeof makeStaticBatchWallet>>["wallet"],
+        reorder: (checkpoints: string[]) => string[] = (c) => c,
     ) {
         const arkTxid = "ab".repeat(32);
         const submitSpy = vi
@@ -1749,13 +1891,50 @@ describe("Wallet batch signing (BatchSignableIdentity)", () => {
             .mockImplementation(async (arkTxB64, checkpointsB64) => ({
                 arkTxid,
                 finalArkTx: arkTxB64,
-                signedCheckpointTxs: await Promise.all(
-                    checkpointsB64.map((c) => serverSignCheckpoint(c)),
+                signedCheckpointTxs: reorder(
+                    await Promise.all(checkpointsB64.map((c) => serverSignCheckpoint(c))),
                 ),
             }));
         const finalizeSpy = vi.spyOn(wallet.arkProvider, "finalizeTx").mockResolvedValue(undefined);
         return { arkTxid, submitSpy, finalizeSpy };
     }
+
+    // `spentBy` must name the checkpoint that actually spends the VTXO. The
+    // server may answer submitTx in any order, so reading its array by input
+    // index would cross-assign the two.
+    it("records spentBy by outpoint when the server reorders its checkpoints", async () => {
+        const { wallet } = await makeStaticBatchWallet();
+        const coins = [
+            makeMigratableCoin(wallet),
+            makeMigratableCoin(wallet, { txid: "33".repeat(32) }),
+        ];
+        const { submitSpy } = stubSendRoundTrip(wallet, (checkpoints) =>
+            [...checkpoints].reverse(),
+        );
+
+        await wallet.sendSelectedVtxosToSelf(coins);
+
+        // Submitted checkpoints are positional against `coins`.
+        const submitted = submitSpy.mock.calls[0][1] as string[];
+        const expected = new Map(
+            coins.map((coin, i) => [
+                coin.txid,
+                Transaction.fromPSBT(base64.decode(submitted[i])).id,
+            ]),
+        );
+
+        const persisted = await (wallet as any).walletRepository.getVtxos(
+            await wallet.getAddress(),
+        );
+        for (const coin of coins) {
+            const spent = persisted.find(
+                (v: ExtendedVirtualCoin) => v.txid === coin.txid && v.isSpent,
+            );
+            expect(spent?.spentBy).toBe(expected.get(coin.txid));
+        }
+
+        await wallet.dispose();
+    });
 
     it("sendSelectedVtxosToSelf persists the full-value self output when there is no change", async () => {
         const { wallet } = await makeStaticBatchWallet();


### PR DESCRIPTION
Checkpoint and commitment transactions returned by the server are now reconciled with what the SDK submitted, or already validated, before they are co-signed. Each case compares a txid against a value the SDK derives locally, so a response that does not correspond to the exchange it belongs to is rejected instead of being carried forward.

## What is reconciled

- **`submitTx` responses** — each returned checkpoint is paired with the submitted checkpoint of the same txid (`matchServerCheckpoints`). The signed ark tx spends each checkpoint at `checkpointTxid:0`, so the two sets are equal by construction. Applied in `submitOffchainTx` (both the batch-merge and sign-after branches), the pure-tapscript `ArkadeContract` path, and the three boltz-swap VHTLC spend paths.
- **Pending-tx finalization** — `finalizePendingTxs` / `finalizePendingCashTxs` resume a send registered by an earlier process, so there is no locally built set to compare against; the expected checkpoint is a pure function of `(VTXO, server unroll script)` and is simply rebuilt (`assertCheckpointsMatchInputs`). Candidate unroll scripts cover the current signer plus each deprecated one, so a tx submitted before a signer rotation still finalizes after it.
- **Batch finalization** — the commitment tx received at finalization is compared with the one validated at tree signing, which the vtxo tree co-signed there commits to. Applies to `Wallet.createBatchHandler` and `createArkadeBatchHandler`; no-op when tree signing was skipped.
- **Submarine swaps** — `createSubmarineSwap` reconstructs the VHTLC from the swap parameters and reconciles it with the lockup address before the swap is persisted or funded. This is the same reconstruction the refund paths already perform, moved ahead of funding.

## Ordering and compatibility

Matching is by txid, not by position: nothing in the wire contract promises checkpoints come back in submission order. Every array keeps the order it had — `finalizeTx` still receives the server's order, and `submitOffchainTx` / `ArkadeSpendResult` still return the raw server response.

`spentBy` is now keyed by the outpoint each checkpoint spends rather than by array index, so it names the checkpoint that actually spends each VTXO regardless of response order.

No public signature changes. The only behavioural change is additive rejection; inputs accepted today are still accepted. Mismatches raise the new exported `ServerResponseMismatchError` (`retryable = false`, mirroring `ProviderUnavailableError`; all detail in `name`/`message`, which are what survive the service-worker boundary). Pending-tx finalization skips the offending tx and leaves it pending for the next init, matching the existing per-tx `catch`.

One new dependency: `createSubmarineSwap` now needs a reachable ark server for `getInfo` (fetched concurrently with the Boltz request). That is a new failure mode for existing callers, including the expo and service-worker re-exports.

## Tests

Unit: reordered-but-complete responses accepted with order preserved, unmatched checkpoints rejected before any signing, rotation-era checkpoints still finalized, commitment mismatch aborts before forfeit submission, submarine swap not persisted or funded when the lockup address does not reconcile, `spentBy` correct under a reordered response. Full suite green (ts-sdk 2247, boltz-swap 551).

Integration, against regtest: `ts-sdk` — offchain roundtrip, boarding settle and pending-tx finalization all pass, which is the main check that the rebuild agrees with real arkd. `boltz-swap` — full e2e suite passed, exercising `sendLightningPayment` through the new lockup reconciliation.

Two gaps worth naming: the boltz-swap VHTLC checkpoint matching landed after that e2e run, so it is unit-covered only and deserves a re-run; and `arkade/contract.ts`'s pure-tapscript path remains outside the integration suite, as its existing `NOTE` already records.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for swap lockup addresses, commitments, and checkpoint transactions.
  * Prevented funding, signing, settlement, or persistence when server responses differ from validated data.
  * Improved handling of reordered checkpoints and deprecated signer keys.
  * Corrected transaction and VTXO associations during recovery and settlement.

* **New Features**
  * Exposed checkpoint-building and server-response matching utilities.
  * Added a non-retryable error for mismatched server responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->