### PR TITLE
feat: validate settlement recipients when tree signing is skipped

### DIFF
--- a/packages/ts-sdk/src/arkade/batch.ts
+++ b/packages/ts-sdk/src/arkade/batch.ts
@@ -33,6 +33,7 @@ import { validateConnectorsTxGraph, validateVtxoTxGraph } from "../tree/validati
 import {
     assertFinalCommitmentMatchesValidated,
     validateBatchRecipients,
+    validateBatchRecipientsWithoutTree,
 } from "../wallet/validation";
 import { buildForfeitTx } from "../forfeit";
 import { Batch } from "../wallet/batch";
@@ -77,8 +78,10 @@ export function createArkadeBatchHandler(
     network: Network,
     /**
      * Expected recipients of the settlement, validated against the virtual
-     * output tree before co-signing it (mirrors `Wallet.createBatchHandler`).
-     * Without this the handler signs whatever tree the server proposes.
+     * output tree before co-signing it, and — when tree signing did not run —
+     * against the commitment tx before signing anything at finalization
+     * (mirrors `Wallet.createBatchHandler`). Without this the handler signs
+     * whatever the server proposes, on both paths.
      */
     recipients?: Recipient[],
 ): Batch.Handler {
@@ -182,6 +185,13 @@ export function createArkadeBatchHandler(
                 validatedCommitmentTxid,
                 "arkade batch finalization",
             );
+
+            // No validated txid means tree signing never ran, so the recipients
+            // have not been checked yet and this commitment tx is the only thing
+            // to check them against. Before any signature is handed over.
+            if (!validatedCommitmentTxid && recipients && recipients.length > 0) {
+                validateBatchRecipientsWithoutTree(commitmentPsbt, recipients, network);
+            }
             const signedForfeits: string[] = [];
             let connectorIndex = 0;
             const connectorLeaves = connectorTree?.leaves() || [];

--- a/packages/ts-sdk/src/providers/errors.ts
+++ b/packages/ts-sdk/src/providers/errors.ts
@@ -55,7 +55,9 @@ export function isArkError(error: unknown, name?: ArkErrorName): error is ArkErr
  * {@link ProviderUnavailableError} message and the wallet's
  * `ProviderConnectionState`; it is deliberately *not* carried as a structured
  * field on the error, since custom `Error` own-properties do not survive the
- * service-worker `postMessage` boundary (only `name`/`message`/`cause` do).
+ * service-worker `postMessage` boundary. Structured clone keeps `message`,
+ * `stack` and `cause`, drops own-properties, and normalizes a custom `name` to
+ * `"Error"` — only the built-in error names survive it.
  */
 export type ProviderKind = "arkade" | "indexer";
 
@@ -84,9 +86,10 @@ export class ProviderUnavailableError extends Error {
  * rather than retryable: the two are equal by construction in a well-formed
  * exchange, so the same request would produce the same outcome.
  *
- * Own-properties do not cross the service-worker `postMessage` boundary (see
- * {@link ProviderKind}), so `retryable` is an in-process convenience and every
- * distinguishing detail belongs in `name`/`message`.
+ * Neither own-properties nor a custom `name` cross the service-worker
+ * `postMessage` boundary (see {@link ProviderKind}), so `retryable` and `name`
+ * are in-process conveniences and every distinguishing detail belongs in
+ * `message` — the one field a consumer past the boundary can still branch on.
  */
 export class ServerResponseMismatchError extends Error {
     readonly retryable = false;

--- a/packages/ts-sdk/src/wallet/validation.ts
+++ b/packages/ts-sdk/src/wallet/validation.ts
@@ -8,20 +8,34 @@ import { Address, OutScript } from "@scure/btc-signer";
 import type { Network } from "../networks";
 import { ServerResponseMismatchError } from "../providers/errors";
 
+// A requested recipient is absent from what the server built. Message text is
+// stable and greppable: past the service-worker boundary `message` is the only
+// field left to branch on, so it is the whole signal.
 export const ErrOffchainOutputNotFound = (address: string) =>
-    new Error(`offchain send output not found: ${address}`);
+    new ServerResponseMismatchError(`offchain send output not found: ${address}`);
 export const ErrInvalidAssetOutputAmount = (got: bigint, want: bigint, assetId: string) =>
-    new Error(`invalid asset output amount for ${assetId}: got ${got}, want ${want}`);
+    new ServerResponseMismatchError(
+        `invalid asset output amount for ${assetId}: got ${got}, want ${want}`,
+    );
 export const ErrAssetGroupNotFound = (assetId: string) =>
-    new Error(`asset group not found in batch leaf: ${assetId}`);
+    new ServerResponseMismatchError(`asset group not found in batch leaf: ${assetId}`);
 export const ErrAssetOutputNotFound = (assetId: string, outputIndex: number) =>
-    new Error(`asset output not found in asset group ${assetId} at index ${outputIndex}`);
+    new ServerResponseMismatchError(
+        `asset output not found in asset group ${assetId} at index ${outputIndex}`,
+    );
+export const ErrOnchainOutputNotFound = (address: string) =>
+    new ServerResponseMismatchError(`onchain output not found: ${address}`);
+export const ErrUnvalidatedOffchainOutput = (address: string) =>
+    new ServerResponseMismatchError(
+        `offchain output ${address} cannot be validated: virtual output tree signing did not run`,
+    );
+
+// Malformed recipient list from the caller, not a server response: plain
+// `Error`, since there is nothing for a consumer to branch on.
 export const ErrInvalidOnchainOutputAmount = (address: string) =>
     new Error(`invalid onchain output amount: ${address}`);
 export const ErrInvalidOnchainOutputAssets = (address: string) =>
     new Error(`onchain output ${address} cannot have assets`);
-export const ErrOnchainOutputNotFound = (address: string) =>
-    new Error(`onchain output not found: ${address}`);
 export const ErrInvalidOffchainOutputAmount = (address: string) =>
     new Error(`invalid offchain output ${address}, missing amount`);
 
@@ -55,6 +69,10 @@ export function assertFinalCommitmentMatchesValidated(
  * Onchain recipients are validated against the round transaction outputs (amounts and scripts)
  * via validateOnchainRecipient.
  *
+ * Presence only: the commitment tx and the tree are shared with every other intent in the batch,
+ * so outputs paying someone else are legitimate and cannot be rejected. What this asserts is that
+ * a settlement cannot consume our inputs and pay us nothing.
+ *
  * @param commitmentTx - The commitment transaction to validate against
  * @param vtxoTreeLeaves - The vtxo tree leaves to validate against
  * @param recipients - The expected recipients to validate (both offchain and onchain)
@@ -81,6 +99,38 @@ export function validateBatchRecipients(
         }
 
         validateOffchainRecipient(vtxoTreeLeaves, arkAddress, recipient, usedOutputs);
+    }
+}
+
+/**
+ * Same guarantee as {@link validateBatchRecipients}, for a batch whose virtual
+ * output tree was never validated — an onchain-only settle skips tree signing,
+ * so the commitment tx received at finalization is the only artifact to check
+ * against.
+ *
+ * Offchain recipients are rejected rather than checked: a leaf paying the right
+ * script proves nothing until {@link validateVtxoTxGraph} has shown the tree is
+ * rooted in the commitment tx, and that only runs during tree signing. A caller
+ * reaching finalization with offchain recipients and no signing session has
+ * asked for a settlement this function cannot vouch for.
+ *
+ * @throws if a recipient is absent from the commitment tx outputs, or is offchain
+ */
+export function validateBatchRecipientsWithoutTree(
+    commitmentTx: Transaction,
+    recipients: Recipient[],
+    network: Network,
+): void {
+    const usedOnchainOutputs = new Set<number>();
+    for (const recipient of recipients) {
+        try {
+            ArkAddress.decode(recipient.address);
+        } catch {
+            validateOnchainRecipient(commitmentTx, recipient, network, usedOnchainOutputs);
+            continue;
+        }
+
+        throw ErrUnvalidatedOffchainOutput(recipient.address);
     }
 }
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -22,7 +22,11 @@ import {
 import { SignerSession } from "../tree/signingSession";
 import { buildForfeitTx } from "../forfeit";
 import { validateConnectorsTxGraph, validateVtxoTxGraph } from "../tree/validation";
-import { assertFinalCommitmentMatchesValidated, validateBatchRecipients } from "./validation";
+import {
+    assertFinalCommitmentMatchesValidated,
+    validateBatchRecipients,
+    validateBatchRecipientsWithoutTree,
+} from "./validation";
 import { Identity, ReadonlyIdentity, isBatchSignable } from "../identity";
 import {
     canRecoverOnchain,
@@ -3629,6 +3633,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         event: BatchFinalizationEvent,
         inputs: SettleParams["inputs"],
         forfeitOutputScript: Bytes,
+        expectedRecipients: Recipient[],
         connectorsGraph?: TxTree,
         validatedCommitmentTxid?: string,
     ) {
@@ -3641,6 +3646,14 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
             validatedCommitmentTxid,
             "settlement finalization",
         );
+
+        // No validated txid means tree signing never ran (onchain-only settle),
+        // so the recipients have not been checked yet and this commitment tx is
+        // the only thing to check them against. Before any signature is handed
+        // over, in either direction: boarding inputs below, forfeits after.
+        if (!validatedCommitmentTxid && expectedRecipients.length > 0) {
+            validateBatchRecipientsWithoutTree(settlementPsbt, expectedRecipients, this.network);
+        }
         let hasBoardingUtxos = false;
 
         let connectorIndex = 0;
@@ -3926,6 +3939,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                     event,
                     inputs,
                     this.forfeitOutputScript,
+                    expectedRecipients,
                     connectorTree,
                     validatedCommitmentTxid,
                 );

--- a/packages/ts-sdk/test/arkade-batch.test.ts
+++ b/packages/ts-sdk/test/arkade-batch.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { base64, hex } from "@scure/base";
 import { sha256 } from "@scure/btc-signer/utils.js";
-import { Address } from "@scure/btc-signer";
+import { Address, OutScript } from "@scure/btc-signer";
 
 // The handler must delegate graph/recipient validation to the shared
 // validators; mock both so the test drives only the wiring.
@@ -16,7 +16,7 @@ vi.mock("../src/wallet/validation", async (importActual) => ({
 }));
 
 import { createArkadeBatchHandler } from "../src/arkade/batch";
-import { validateBatchRecipients } from "../src/wallet/validation";
+import { validateBatchRecipients, ErrOffchainOutputNotFound } from "../src/wallet/validation";
 import { validateVtxoTxGraph } from "../src/tree/validation";
 import { Transaction } from "../src/utils/transaction";
 import { networks } from "../src/networks";
@@ -143,7 +143,7 @@ describe("createArkadeBatchHandler recipient validation", () => {
     it("aborts signing when a recipient is missing from the tree", async () => {
         const session = makeSession();
         vi.mocked(validateBatchRecipients).mockImplementation(() => {
-            throw new Error("offchain send output not found: ark1qexample");
+            throw ErrOffchainOutputNotFound("ark1qexample");
         });
         const handler = makeHandler(session, makeArkProvider(), [
             { address: "ark1qexample", amount: 1000 },
@@ -203,6 +203,91 @@ describe("createArkadeBatchHandler commitment tx equality", () => {
     it("accepts the validated commitment tx at finalization", async () => {
         // Same 5000n output as makeEvents' tree-signing commitment.
         const { arkProvider, finalize } = await runUntilFinalization(commitment(5000n));
+
+        await finalize;
+        expect(arkProvider.submitSignedForfeitTxs).toHaveBeenCalledTimes(1);
+    });
+});
+
+// A batch that never signs the tree (onchain-only outputs) reaches finalization
+// with no validated commitment txid, so recipients have not been checked yet.
+describe("createArkadeBatchHandler finalization without tree signing", () => {
+    beforeEach(() => {
+        vi.mocked(validateBatchRecipients).mockReset();
+        vi.mocked(validateVtxoTxGraph).mockReset();
+    });
+
+    const ONCHAIN_ADDRESS = Address(networks.regtest).encode({
+        type: "tr",
+        pubkey: hex.decode("33".repeat(32)),
+    });
+
+    /** A commitment tx paying `amount` to `ONCHAIN_ADDRESS`. */
+    function onchainCommitment(amount: bigint): string {
+        const tx = new Transaction({ allowUnknownOutputs: true });
+        tx.addOutput({
+            script: OutScript.encode(Address(networks.regtest).decode(ONCHAIN_ADDRESS)),
+            amount,
+        });
+        return base64.encode(tx.toPSBT());
+    }
+
+    async function finalizeWithout(commitmentTx: string, recipients?: Recipient[]) {
+        const arkProvider = makeArkProvider();
+        const emulator = makeEmulator();
+        const handler = makeHandler(makeSession(), arkProvider, recipients, emulator);
+
+        await handler.onBatchStarted(makeEvents().batchStarted);
+
+        return {
+            arkProvider,
+            emulator,
+            finalize: handler.onBatchFinalization({ commitmentTx } as never),
+        };
+    }
+
+    it("rejects a commitment tx that does not pay the requested recipient", async () => {
+        const { arkProvider, emulator, finalize } = await finalizeWithout(onchainCommitment(900n), [
+            { address: ONCHAIN_ADDRESS, amount: 1000 },
+        ]);
+
+        await expect(finalize).rejects.toThrow(/onchain output not found/);
+        expect(emulator.submitFinalization).not.toHaveBeenCalled();
+        expect(arkProvider.submitSignedForfeitTxs).not.toHaveBeenCalled();
+    });
+
+    it("accepts a commitment tx paying the requested recipient exactly", async () => {
+        const { arkProvider, finalize } = await finalizeWithout(onchainCommitment(1000n), [
+            { address: ONCHAIN_ADDRESS, amount: 1000 },
+        ]);
+
+        await finalize;
+        expect(arkProvider.submitSignedForfeitTxs).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-check recipients when tree signing already validated them", async () => {
+        const arkProvider = makeArkProvider();
+        const handler = makeHandler(
+            makeSession(),
+            arkProvider,
+            [{ address: ONCHAIN_ADDRESS, amount: 1000 }],
+            makeEmulator(),
+        );
+        const { batchStarted, treeSigningStarted, vtxoTree } = makeEvents();
+
+        await handler.onBatchStarted(batchStarted);
+        await handler.onTreeSigningStarted(treeSigningStarted, vtxoTree);
+
+        // makeEvents' commitment pays no one; only the finalization-time guard
+        // would object, and it must stay disarmed here.
+        await handler.onBatchFinalization({ commitmentTx: commitment(5000n) } as never);
+
+        expect(validateBatchRecipients).toHaveBeenCalledTimes(1);
+        expect(arkProvider.submitSignedForfeitTxs).toHaveBeenCalledTimes(1);
+    });
+
+    it("stays permissive when no recipients are provided (compat)", async () => {
+        const { arkProvider, finalize } = await finalizeWithout(onchainCommitment(900n));
 
         await finalize;
         expect(arkProvider.submitSignedForfeitTxs).toHaveBeenCalledTimes(1);

--- a/packages/ts-sdk/test/batch-recipient-validation.test.ts
+++ b/packages/ts-sdk/test/batch-recipient-validation.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi } from "vitest";
+import { base64, hex } from "@scure/base";
+import { Address, OutScript, TaprootControlBlock } from "@scure/btc-signer";
+
+import { Wallet } from "../src";
+import {
+    validateBatchRecipientsWithoutTree,
+    ErrOnchainOutputNotFound,
+    ErrUnvalidatedOffchainOutput,
+} from "../src/wallet/validation";
+import { ServerResponseMismatchError } from "../src/providers/errors";
+import { Transaction } from "../src/utils/transaction";
+import { networks } from "../src/networks";
+import type { TapLeafScript } from "../src/script/base";
+import type { ExtendedCoin, Recipient } from "../src/wallet";
+import type { BatchFinalizationEvent } from "../src/providers/ark";
+
+const NETWORK = networks.regtest;
+
+const ONCHAIN_ADDRESS = Address(NETWORK).encode({
+    type: "tr",
+    pubkey: hex.decode("33".repeat(32)),
+});
+const OTHER_ONCHAIN_ADDRESS = Address(NETWORK).encode({
+    type: "tr",
+    pubkey: hex.decode("44".repeat(32)),
+});
+const OFFCHAIN_ADDRESS =
+    "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g";
+
+const pkScript = (address: string) => OutScript.encode(Address(NETWORK).decode(address));
+
+/** A commitment tx paying `outputs`, plus the shared batch output at index 0. */
+function commitmentTx(outputs: { address: string; amount: bigint }[]): Transaction {
+    const tx = new Transaction({ allowUnknownOutputs: true });
+    tx.addOutput({ script: new Uint8Array([0x51]), amount: 5_000n });
+    for (const output of outputs) {
+        tx.addOutput({ script: pkScript(output.address), amount: output.amount });
+    }
+    return tx;
+}
+
+describe("validateBatchRecipientsWithoutTree", () => {
+    it("accepts a recipient present with the exact script and amount", () => {
+        const tx = commitmentTx([{ address: ONCHAIN_ADDRESS, amount: 1_000n }]);
+
+        expect(() =>
+            validateBatchRecipientsWithoutTree(
+                tx,
+                [{ address: ONCHAIN_ADDRESS, amount: 1_000 }],
+                NETWORK,
+            ),
+        ).not.toThrow();
+    });
+
+    it("rejects a recipient absent from the commitment tx outputs", () => {
+        const tx = commitmentTx([{ address: OTHER_ONCHAIN_ADDRESS, amount: 1_000n }]);
+
+        expect(() =>
+            validateBatchRecipientsWithoutTree(
+                tx,
+                [{ address: ONCHAIN_ADDRESS, amount: 1_000 }],
+                NETWORK,
+            ),
+        ).toThrow(ErrOnchainOutputNotFound(ONCHAIN_ADDRESS).message);
+    });
+
+    it("rejects a recipient paid the wrong amount", () => {
+        const tx = commitmentTx([{ address: ONCHAIN_ADDRESS, amount: 999n }]);
+
+        expect(() =>
+            validateBatchRecipientsWithoutTree(
+                tx,
+                [{ address: ONCHAIN_ADDRESS, amount: 1_000 }],
+                NETWORK,
+            ),
+        ).toThrow(/onchain output not found/);
+    });
+
+    it("does not let one output satisfy two identical recipients", () => {
+        const tx = commitmentTx([{ address: ONCHAIN_ADDRESS, amount: 1_000n }]);
+        const recipients: Recipient[] = [
+            { address: ONCHAIN_ADDRESS, amount: 1_000 },
+            { address: ONCHAIN_ADDRESS, amount: 1_000 },
+        ];
+
+        expect(() => validateBatchRecipientsWithoutTree(tx, recipients, NETWORK)).toThrow(
+            /onchain output not found/,
+        );
+    });
+
+    it("accepts two identical recipients paid by two outputs", () => {
+        const tx = commitmentTx([
+            { address: ONCHAIN_ADDRESS, amount: 1_000n },
+            { address: ONCHAIN_ADDRESS, amount: 1_000n },
+        ]);
+        const recipients: Recipient[] = [
+            { address: ONCHAIN_ADDRESS, amount: 1_000 },
+            { address: ONCHAIN_ADDRESS, amount: 1_000 },
+        ];
+
+        expect(() => validateBatchRecipientsWithoutTree(tx, recipients, NETWORK)).not.toThrow();
+    });
+
+    it("rejects an offchain recipient: without a validated tree there is nothing to check it against", () => {
+        const tx = commitmentTx([{ address: ONCHAIN_ADDRESS, amount: 1_000n }]);
+
+        expect(() =>
+            validateBatchRecipientsWithoutTree(
+                tx,
+                [{ address: OFFCHAIN_ADDRESS, amount: 1_000 }],
+                NETWORK,
+            ),
+        ).toThrow(ErrUnvalidatedOffchainOutput(OFFCHAIN_ADDRESS).message);
+    });
+
+    it("raises a terminal ServerResponseMismatchError, not a retryable one", () => {
+        const tx = commitmentTx([]);
+
+        try {
+            validateBatchRecipientsWithoutTree(
+                tx,
+                [{ address: ONCHAIN_ADDRESS, amount: 1_000 }],
+                NETWORK,
+            );
+            expect.unreachable("expected a rejection");
+        } catch (e) {
+            expect(e).toBeInstanceOf(ServerResponseMismatchError);
+            expect((e as ServerResponseMismatchError).retryable).toBe(false);
+            expect((e as Error).name).toBe("ServerResponseMismatchError");
+            // `message` is the only part of the above that survives a
+            // structured clone, so it carries the whole signal
+            expect((e as Error).message).toMatch(/onchain output not found/);
+        }
+    });
+});
+
+function tapLeaf(): TapLeafScript {
+    const controlBlock = TaprootControlBlock.decode(
+        new Uint8Array([0xc0, ...new Uint8Array(32).fill(1)]),
+    );
+    // PSBT stores the leaf version as the script's trailing byte; it must match
+    // the control block's or `updateInput` rejects the pair.
+    const script = new Uint8Array(20).fill(2);
+    script[script.length - 1] = 0xc0;
+    return [controlBlock, script];
+}
+
+const BOARDING_INPUT = {
+    txid: "aa".repeat(32),
+    vout: 0,
+    value: 10_000,
+    status: { confirmed: true },
+    forfeitTapLeafScript: tapLeaf(),
+    intentTapLeafScript: tapLeaf(),
+    tapTree: new Uint8Array([0x00]),
+} as unknown as ExtendedCoin;
+
+/** Commitment tx spending the boarding input and paying `outputs`. */
+function finalizationEvent(outputs: { address: string; amount: bigint }[]): BatchFinalizationEvent {
+    const tx = commitmentTx(outputs);
+    tx.addInput({
+        txid: hex.decode(BOARDING_INPUT.txid),
+        index: BOARDING_INPUT.vout,
+        witnessUtxo: {
+            script: pkScript(ONCHAIN_ADDRESS),
+            amount: BigInt(BOARDING_INPUT.value),
+        },
+    });
+    return { id: "batch-1", commitmentTx: base64.encode(tx.toPSBT()) } as BatchFinalizationEvent;
+}
+
+/**
+ * An onchain-only settle: `skipVtxoTreeSigning` means `onTreeSigningStarted`
+ * never runs, so the handler reaches finalization with no validated commitment
+ * txid and recipients that have never been checked.
+ */
+function onchainOnlyHandler(recipients: Recipient[]) {
+    // Signing a boarding input replaces the psbt with the signer's return value;
+    // a fake standing in for a signed one keeps the test off real key material.
+    const signed = {
+        inputsLength: 1,
+        getInput: () => ({ tapScriptSig: [{}] }),
+        toPSBT: () => new Uint8Array([1]),
+    };
+    const thisArg: any = {
+        network: NETWORK,
+        forfeitOutputScript: pkScript(OTHER_ONCHAIN_ADDRESS),
+        dustAmount: 1_000,
+        arkProvider: {
+            confirmRegistration: vi.fn(async () => {}),
+            submitSignedForfeitTxs: vi.fn(async () => {}),
+        },
+        _signerRouter: { sign: vi.fn(async () => signed) },
+        handleSettlementFinalizationEvent: (Wallet.prototype as any)
+            .handleSettlementFinalizationEvent,
+    };
+
+    const handler = (Wallet.prototype as any).createBatchHandler.call(
+        thisArg,
+        "intent-1",
+        [BOARDING_INPUT],
+        recipients,
+        undefined,
+    );
+
+    return { handler, thisArg };
+}
+
+describe("Wallet.createBatchHandler onchain-only finalization", () => {
+    it("does not sign when the commitment tx omits the requested onchain recipient", async () => {
+        const { handler, thisArg } = onchainOnlyHandler([
+            { address: ONCHAIN_ADDRESS, amount: 1_000 },
+        ]);
+
+        await expect(
+            handler.onBatchFinalization(
+                finalizationEvent([{ address: OTHER_ONCHAIN_ADDRESS, amount: 1_000n }]),
+            ),
+        ).rejects.toThrow(/onchain output not found/);
+
+        expect(thisArg._signerRouter.sign).not.toHaveBeenCalled();
+        expect(thisArg.arkProvider.submitSignedForfeitTxs).not.toHaveBeenCalled();
+    });
+
+    it("does not sign when the requested onchain recipient is paid the wrong amount", async () => {
+        const { handler, thisArg } = onchainOnlyHandler([
+            { address: ONCHAIN_ADDRESS, amount: 1_000 },
+        ]);
+
+        await expect(
+            handler.onBatchFinalization(
+                finalizationEvent([{ address: ONCHAIN_ADDRESS, amount: 900n }]),
+            ),
+        ).rejects.toThrow(/onchain output not found/);
+
+        expect(thisArg._signerRouter.sign).not.toHaveBeenCalled();
+        expect(thisArg.arkProvider.submitSignedForfeitTxs).not.toHaveBeenCalled();
+    });
+
+    it("signs the boarding input when the recipient is paid exactly as requested", async () => {
+        const { handler, thisArg } = onchainOnlyHandler([
+            { address: ONCHAIN_ADDRESS, amount: 1_000 },
+        ]);
+
+        await handler.onBatchFinalization(
+            finalizationEvent([{ address: ONCHAIN_ADDRESS, amount: 1_000n }]),
+        );
+
+        expect(thisArg._signerRouter.sign).toHaveBeenCalledTimes(1);
+        expect(thisArg.arkProvider.submitSignedForfeitTxs).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps signing when no recipients were declared (compat)", async () => {
+        const { handler, thisArg } = onchainOnlyHandler([]);
+
+        await handler.onBatchFinalization(
+            finalizationEvent([{ address: OTHER_ONCHAIN_ADDRESS, amount: 1_000n }]),
+        );
+
+        expect(thisArg._signerRouter.sign).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Stacked on #669 — base is `feat/server-response-mismatch-guards`, since this builds on the commitment-txid state that PR introduces. Retarget to `master` once #669 merges.

## Problem

`validateBatchRecipients` — the check that a settlement pays the recipients we asked for — is called from exactly one place: inside the `onTreeSigningStarted` batch hook. A settle with no offchain outputs sets `skipVtxoTreeSigning: !hasOffchainOutputs`, so `Batch.join` goes straight from `BatchStarted` to `TreeNoncesAggregated` and that hook never fires. The wallet then signs boarding inputs and forfeits against a commitment tx whose outputs were never compared with the requested recipients. A full collaborative exit takes this path.

## Change

Validate at the finalization funnel, gated on the tree-signing check not having run. `validatedCommitmentTxid` is exactly the "tree signing ran and validated" flag, so the guard arms only where nothing has been checked yet.

- `wallet/validation.ts` — `validateBatchRecipientsWithoutTree(commitmentTx, recipients, network)`, reusing the existing `validateOnchainRecipient`. Offchain recipients are rejected rather than checked: a leaf paying the right script proves nothing until `validateVtxoTxGraph` has rooted the tree in the commitment tx, and that only runs during tree signing.
- `wallet.ts` — `handleSettlementFinalizationEvent` takes the expected recipients and validates immediately after `assertFinalCommitmentMatchesValidated`, before boarding-input signing, forfeit signing and `submitSignedForfeitTxs`.
- `arkade/batch.ts` — same guard in `onBatchFinalization`.

No public signature changes; the only behavioural change is additive rejection.

## Scope of the property

Presence only. The commitment tx and the vtxo tree are shared with every other intent in the batch, so outputs paying someone else are legitimate and cannot be rejected. What this asserts is that a settlement cannot consume our inputs and pay us nothing. The docstring says so, so the limit is not mistaken for something stronger.

Note that arkd rejects intents mixing onchain inputs with onchain outputs, so on a well-behaved server an onchain-only settle is always VTXO-funded and only forfeits are signed. The boarding-signing arm of the guard covers the case where that does not hold.

## Error type

The recipient error factories are split by who is at fault. The ones meaning "the response does not contain what we submitted" (`ErrOffchainOutputNotFound`, `ErrOnchainOutputNotFound`, the three asset ones, and the new `ErrUnvalidatedOffchainOutput`) now construct `ServerResponseMismatchError` — terminal, `retryable = false`, message text unchanged. `ErrInvalidOnchainOutputAmount`, `ErrInvalidOnchainOutputAssets` and `ErrInvalidOffchainOutputAmount` fire on a malformed caller recipient list, not on a response, and stay plain `Error`.

Also corrects a documentation error in `providers/errors.ts`: structured clone keeps `message`, `stack` and `cause`, drops own-properties, and normalizes a custom `name` to `"Error"`. Past the service-worker boundary `message` is the only field left to branch on — `name` is not, as those comments claimed.

## Why the guard cannot false-reject an honest server

The amount registered in the intent is the amount that must appear: the SDK nets fees client-side before registering (`Ramps` deducts `evalOnchainOutput`, settle's auto-select deducts `evalOffchainOutput`), arkd derives the receiver amount from the proof tx output and copies it into the commitment tx unchanged, commitment miner fees come from the server's own wallet, and there is no dedup, dust-trimming or rounding of receiver outputs. Output *position* varies between batch shapes; the guard scans outputs index-agnostically.

## Testing

- New `test/batch-recipient-validation.test.ts` (11 cases) and 4 new cases in `test/arkade-batch.test.ts`, covering absent recipient, wrong amount, two recipients against one output, offchain rejection, the terminal error shape, and that the guard stays disarmed when tree signing already validated.
- Each guard was checked to fail without the fix: reverting only the two `src` call sites turns the three handler-level rejection tests red.
- Full unit suite green (ts-sdk 2262 passed / 1 skipped, boltz-swap 551), lint, build.
- **Integration not run** — the regtest stack was unavailable. `test/e2e/ark.test.ts`'s collaborative exit is the acceptance test here and worth running before merge: it is an onchain-only settle that validated nothing before this change, and `validateOnchainRecipient` has never executed against a live server on any e2e path.

## Not in scope

- Any "the tx pays nobody unexpected" check — not enforceable on a shared batch tx.
- `createVHTLCBatchHandler` in `boltz-swap` has no recipient validation on either path. Different gap: its driver never passes `skipVtxoTreeSigning`, so it does not have the split fixed here. Follow-up.
- When a registered boarding input is absent from the commitment tx, `wallet.ts` falls through silently while `arkade/batch.ts` raises a named error. Bookkeeping divergence, follow-up.