### PR TITLE
feat: co-sign chain swap claims after our own claim

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -2398,18 +2398,27 @@ export class ArkadeSwaps {
     }
 
     /**
-     * Whether every given VTXO was spent by a transaction that paid this
-     * wallet — the ark tx that spent it created a VTXO at one of our scripts.
+     * Whether every ark tx that spent the given VTXOs paid our scripts at
+     * least the value it took from the lockup — the spend made us whole. A
+     * bare paid-us check would accept a post-locktime refund carrying a dust
+     * output to our address.
      *
      * Only the offchain path is attributable: a batch settlement records a
      * commitment tx shared with every other participant of that round, so it
-     * identifies nobody.
+     * identifies nobody. Trusts the indexer — this guards against a malicious
+     * counterparty, not a colluding operator.
      */
     private async spentIntoOurWallet(
         pendingSwap: BoltzChainSwap,
         spent: VirtualCoin[],
     ): Promise<boolean> {
         if (spent.some((vtxo) => !vtxo.arkTxId)) return false;
+
+        // Summed per spending tx, so one output cannot vouch for two vtxos.
+        const takenByTx = new Map<string, number>();
+        for (const vtxo of spent) {
+            takenByTx.set(vtxo.arkTxId!, (takenByTx.get(vtxo.arkTxId!) ?? 0) + vtxo.value);
+        }
 
         // The claim pays `wallet.getAddress()` as of claim time; `toAddress` is
         // what the caller asked for. Under HD rotation neither alone covers
@@ -2429,8 +2438,15 @@ export class ArkadeSwaps {
         const { vtxos } = await this.indexerProvider.getVtxos({
             scripts: [...new Set(scripts)],
         });
-        const ourTxids = new Set(vtxos.map((vtxo) => vtxo.txid));
-        return spent.every((vtxo) => ourTxids.has(vtxo.arkTxId!));
+        const receivedByTx = new Map<string, number>();
+        for (const vtxo of vtxos) {
+            receivedByTx.set(vtxo.txid, (receivedByTx.get(vtxo.txid) ?? 0) + vtxo.value);
+        }
+
+        // `>=`: an overpaying spend still makes us whole. If a future claim
+        // path deducts a fee from its output, this basis must follow it, or
+        // legacy fallbacks refuse (fail closed).
+        return [...takenByTx].every(([txid, taken]) => (receivedByTx.get(txid) ?? 0) >= taken);
     }
 
     /**

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -9,6 +9,7 @@ import {
     BoltzRefundError,
     QuoteRejectedError,
     VHTLCAddressMismatchError,
+    CooperativeSignRefusedError,
 } from "./errors";
 import {
     ArkAddress,
@@ -2117,7 +2118,12 @@ export class ArkadeSwaps {
                         if (claimStarted) return;
                         claimStarted = true;
                         claimPromise = this.claimArk(swap);
-                        claimPromise.catch(reject);
+                        // Mirror the claim onto the local copy: later
+                        // updateSwapStatus() saves would otherwise write it
+                        // back out of the pre-claim snapshot.
+                        claimPromise.then(({ txid }) => {
+                            swap.claimTxid = txid;
+                        }, reject);
                         break;
                     case "transaction.claimed": {
                         await updateSwapStatus();
@@ -2135,6 +2141,10 @@ export class ArkadeSwaps {
                     }
                     case "transaction.claim.pending":
                         await updateSwapStatus();
+                        // Let a claim already in flight land — and persist its
+                        // txid — before co-signing. Its failure is surfaced by
+                        // the handler that owns it.
+                        await claimPromise?.catch(() => {});
                         await this.signCooperativeClaimForServer(swap).catch((err) => {
                             logger.error(`Failed to sign cooperative claim for ${swap.id}:`, err);
                         });
@@ -2187,6 +2197,54 @@ export class ArkadeSwaps {
     }
 
     /**
+     * Rebuild the VHTLC script of a chain swap's claim side — the side we
+     * claim with the preimage. Resolves across current and deprecated signers
+     * so a swap locked under a now-rotated signer still reconstructs; the
+     * returned `serverXOnlyPublicKey` is the matched key and MUST be threaded
+     * into downstream signing.
+     */
+    private resolveClaimSideVHTLC(
+        pendingSwap: BoltzChainSwap,
+        arkInfo: ArkInfo,
+    ): { vhtlcScript: VHTLC.Script; serverXOnlyPublicKey: Uint8Array } {
+        if (!pendingSwap.response.claimDetails.serverPublicKey)
+            throw new Error(`Swap ${pendingSwap.id}: missing server public key in claim details`);
+
+        if (!pendingSwap.response.claimDetails.timeouts)
+            throw new Error(`Swap ${pendingSwap.id}: missing timeouts in claim details`);
+
+        const receiverXOnlyPublicKey = normalizeToXOnlyKey(
+            pendingSwap.request.claimPublicKey,
+            "receiver",
+        );
+
+        const senderXOnlyPublicKey = normalizeToXOnlyKey(
+            pendingSwap.response.claimDetails.serverPublicKey,
+            "sender",
+        );
+
+        try {
+            return this.resolveVHTLCForLockup({
+                arkInfo,
+                preimageHash: hex.decode(pendingSwap.request.preimageHash),
+                senderPubkey: hex.encode(senderXOnlyPublicKey),
+                receiverPubkey: hex.encode(receiverXOnlyPublicKey),
+                timeoutBlockHeights: pendingSwap.response.claimDetails.timeouts,
+                lockupAddress: pendingSwap.response.claimDetails.lockupAddress,
+                swapId: pendingSwap.id,
+            });
+        } catch (error) {
+            // Preserve the SwapError contract on a total mismatch.
+            throw new SwapError({
+                message:
+                    error instanceof Error
+                        ? error.message
+                        : "Unable to claim: invalid VHTLC address",
+            });
+        }
+    }
+
+    /**
      * Claim sats on ARK chain by claiming the VHTLC.
      * Refactored to use claimVHTLCIdentity + claimVHTLCwithOffchainTx utilities.
      * @param pendingSwap - The pending chain swap.
@@ -2196,50 +2254,14 @@ export class ArkadeSwaps {
         if (!pendingSwap.toAddress)
             throw new Error(`Swap ${pendingSwap.id}: destination address is required`);
 
-        if (!pendingSwap.response.claimDetails.serverPublicKey)
-            throw new Error(`Swap ${pendingSwap.id}: missing server public key in claim details`);
-
-        if (!pendingSwap.response.claimDetails.timeouts)
-            throw new Error(`Swap ${pendingSwap.id}: missing timeouts in claim details`);
-
         const arkInfo = await this.arkProvider.getInfo();
         const preimage = hex.decode(pendingSwap.preimage);
         const address = await this.wallet.getAddress();
 
-        // build expected VHTLC script
-        const receiverXOnlyPublicKey = normalizeToXOnlyKey(
-            pendingSwap.request.claimPublicKey,
-            "receiver",
+        const { vhtlcScript, serverXOnlyPublicKey } = this.resolveClaimSideVHTLC(
+            pendingSwap,
+            arkInfo,
         );
-
-        const senderXOnlyPublicKey = normalizeToXOnlyKey(
-            pendingSwap.response.claimDetails.serverPublicKey!,
-            "sender",
-        );
-
-        // Resolve across current + deprecated signers so a chain swap locked
-        // under a now-rotated signer still claims; preserve the SwapError
-        // contract on a total mismatch.
-        let vhtlcScript: VHTLC.Script;
-        let serverXOnlyPublicKey: Uint8Array;
-        try {
-            ({ vhtlcScript, serverXOnlyPublicKey } = this.resolveVHTLCForLockup({
-                arkInfo,
-                preimageHash: hex.decode(pendingSwap.request.preimageHash),
-                senderPubkey: hex.encode(senderXOnlyPublicKey),
-                receiverPubkey: hex.encode(receiverXOnlyPublicKey),
-                timeoutBlockHeights: pendingSwap.response.claimDetails.timeouts!,
-                lockupAddress: pendingSwap.response.claimDetails.lockupAddress,
-                swapId: pendingSwap.id,
-            }));
-        } catch (error) {
-            throw new SwapError({
-                message:
-                    error instanceof Error
-                        ? error.message
-                        : "Unable to claim: invalid VHTLC address",
-            });
-        }
 
         let vtxo;
         for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
@@ -2293,6 +2315,7 @@ export class ArkadeSwaps {
         await this.savePendingChainSwap({
             ...pendingSwap,
             status: finalStatus.status,
+            claimTxid: txid,
         });
 
         return { txid };
@@ -2326,7 +2349,51 @@ export class ArkadeSwaps {
     }
 
     /**
+     * Assert that we have already claimed a chain swap's claim side.
+     *
+     * The cooperative signature authorizes a bare 32-byte hash — the claim
+     * details endpoint returns no transaction — so our own claim is the only
+     * thing the signature can be ordered against. The claim also publishes the
+     * preimage, which is what makes the counterparty's own claim possible, so
+     * signing after it is the natural order rather than an extra requirement.
+     */
+    private async assertClaimSideClaimed(pendingSwap: BoltzChainSwap): Promise<void> {
+        if (pendingSwap.claimTxid) return;
+
+        // Status callbacks carry a snapshot taken before the claim ran, so
+        // re-read the record rather than trusting the caller's copy.
+        const [stored] = await this.swapRepository.getAllSwaps<BoltzChainSwap>({
+            id: pendingSwap.id,
+            type: "chain",
+        });
+        if (stored?.claimTxid) return;
+
+        // Swaps that predate `claimTxid` — restored ones included — carry no
+        // txid even once claimed, so fall back to the indexer: before the CLTV
+        // the preimage path is ours alone, so a fully spent lockup is our claim.
+        const arkInfo = await this.arkProvider.getInfo();
+        const { vhtlcScript } = this.resolveClaimSideVHTLC(pendingSwap, arkInfo);
+        const { vtxos } = await this.indexerProvider.getVtxos({
+            scripts: [hex.encode(vhtlcScript.pkScript)],
+        });
+        if (vtxos.length > 0 && vtxos.every((vtxo) => vtxo.isSpent)) return;
+
+        throw new CooperativeSignRefusedError({
+            swapId: pendingSwap.id,
+            reason:
+                vtxos.length === 0
+                    ? "no virtual coins found at the claim-side lockup"
+                    : "the claim-side lockup is not spent by this wallet",
+            pendingSwap,
+        });
+    }
+
+    /**
      * Sign a cooperative claim for the server in BTC => ARK swaps.
+     *
+     * Only signs once our own claim of the swap's claim side is established;
+     * the request arrives on a provider-reported status, which is not by
+     * itself evidence of that ordering.
      * @param pendingSwap - The pending chain swap.
      */
     async signCooperativeClaimForServer(pendingSwap: BoltzChainSwap): Promise<void> {
@@ -2335,6 +2402,8 @@ export class ArkadeSwaps {
 
         if (!pendingSwap.response.lockupDetails.serverPublicKey)
             throw new Error(`Swap ${pendingSwap.id}: missing server public key in lockup details`);
+
+        await this.assertClaimSideClaimed(pendingSwap);
 
         const claimDetails = await this.swapProvider.getChainClaimDetails(pendingSwap.id);
 

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -2369,23 +2369,82 @@ export class ArkadeSwaps {
         if (stored?.claimTxid) return;
 
         // Swaps that predate `claimTxid` — restored ones included — carry no
-        // txid even once claimed, so fall back to the indexer: before the CLTV
-        // the preimage path is ours alone, so a fully spent lockup is our claim.
+        // txid even once claimed, so fall back to the indexer.
         const arkInfo = await this.arkProvider.getInfo();
         const { vhtlcScript } = this.resolveClaimSideVHTLC(pendingSwap, arkInfo);
         const { vtxos } = await this.indexerProvider.getVtxos({
             scripts: [hex.encode(vhtlcScript.pkScript)],
         });
-        if (vtxos.length > 0 && vtxos.every((vtxo) => vtxo.isSpent)) return;
+        const spent = vtxos.filter((vtxo) => vtxo.isSpent);
+        if (vtxos.length > 0 && spent.length === vtxos.length) {
+            // `isSpent` says nothing about who spent it, so pin the spender:
+            // either the spending transaction paid us, or it ran while the
+            // sender's refund leaves were still locked, when no spend path
+            // exists that does not carry our signature.
+            if (await this.spentIntoOurWallet(pendingSwap, spent)) return;
+            if (!(await this.claimSideRefundReached(pendingSwap))) return;
+        }
 
         throw new CooperativeSignRefusedError({
             swapId: pendingSwap.id,
             reason:
                 vtxos.length === 0
                     ? "no virtual coins found at the claim-side lockup"
-                    : "the claim-side lockup is not spent by this wallet",
+                    : spent.length < vtxos.length
+                      ? "the claim-side lockup is not fully spent"
+                      : "the claim-side lockup spend is not attributable to this wallet",
             pendingSwap,
         });
+    }
+
+    /**
+     * Whether every given VTXO was spent by a transaction that paid this
+     * wallet — the ark tx that spent it created a VTXO at one of our scripts.
+     *
+     * Only the offchain path is attributable: a batch settlement records a
+     * commitment tx shared with every other participant of that round, so it
+     * identifies nobody.
+     */
+    private async spentIntoOurWallet(
+        pendingSwap: BoltzChainSwap,
+        spent: VirtualCoin[],
+    ): Promise<boolean> {
+        if (spent.some((vtxo) => !vtxo.arkTxId)) return false;
+
+        // The claim pays `wallet.getAddress()` as of claim time; `toAddress` is
+        // what the caller asked for. Under HD rotation neither alone covers
+        // every claim, so query both.
+        const scripts = [pendingSwap.toAddress, await this.wallet.getAddress()]
+            .filter((address): address is string => Boolean(address))
+            .flatMap((address) => {
+                try {
+                    return [hex.encode(ArkAddress.decode(address).pkScript)];
+                } catch {
+                    // Not an Ark address — a chain swap's BTC destination.
+                    return [];
+                }
+            });
+        if (scripts.length === 0) return false;
+
+        const { vtxos } = await this.indexerProvider.getVtxos({
+            scripts: [...new Set(scripts)],
+        });
+        const ourTxids = new Set(vtxos.map((vtxo) => vtxo.txid));
+        return spent.every((vtxo) => ourTxids.has(vtxo.arkTxId!));
+    }
+
+    /**
+     * Whether the claim-side refund locktime has been reached, i.e. the sender
+     * can spend the lockup without us. Unknown counts as reached: a
+     * block-height locktime with no chain tip cannot establish the window is
+     * still shut.
+     */
+    private async claimSideRefundReached(pendingSwap: BoltzChainSwap): Promise<boolean> {
+        const locktime = pendingSwap.response.claimDetails.timeouts?.refund;
+        if (locktime === undefined) return true;
+        const { height } = await this.chainTipSnapshotFor([locktime]);
+        if (isBlockHeightLocktime(locktime) && height === undefined) return true;
+        return isRefundLocktimeReached(locktime, height);
     }
 
     /**

--- a/packages/boltz-swap/src/errors.ts
+++ b/packages/boltz-swap/src/errors.ts
@@ -192,6 +192,33 @@ export class VHTLCAddressMismatchError extends SwapError {
     }
 }
 
+/**
+ * Thrown when a cooperative claim co-signature is requested for a chain swap
+ * whose claim side we have not claimed yet.
+ *
+ * Co-signing is a courtesy: the counterparty can always spend the claim leaf
+ * once it holds the preimage, so declining until our own claim is recorded
+ * costs it a larger transaction and nothing else. Non-fatal at every call
+ * site — the request is re-evaluated while the swap stays claimable.
+ *
+ * Past the service-worker boundary only `message` survives, so the swap id
+ * and the reason are carried there.
+ */
+export class CooperativeSignRefusedError extends SwapError {
+    public readonly swapId: string;
+
+    constructor(options: ErrorOptions & { swapId: string; reason: string }) {
+        super({
+            ...options,
+            message:
+                options.message ??
+                `Swap ${options.swapId}: not co-signing the counterparty claim — ${options.reason}`,
+        });
+        this.name = "CooperativeSignRefusedError";
+        this.swapId = options.swapId;
+    }
+}
+
 /** Reason a `quoteSwap` was rejected before being posted to Boltz. */
 export type QuoteRejectionReason =
     | "below_floor"

--- a/packages/boltz-swap/src/index.ts
+++ b/packages/boltz-swap/src/index.ts
@@ -51,6 +51,7 @@ export {
     BoltzRefundError,
     QuoteRejectedError,
     VHTLCAddressMismatchError,
+    CooperativeSignRefusedError,
 } from "./errors";
 export type { QuoteRejectionReason } from "./errors";
 export {

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -339,6 +339,12 @@ export interface BoltzChainSwap {
     toAddress?: string;
     /** Swap amount in satoshis. */
     amount: number;
+    /**
+     * Txid of our claim of the swap's claim side, recorded once the claim
+     * succeeds. Absent on swaps created before this field existed and on
+     * swaps we have not claimed yet.
+     */
+    claimTxid?: string;
 }
 
 /** Union type of all pending swap types. */

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -2426,7 +2426,7 @@ describe("ArkadeSwaps", () => {
                 vi.spyOn(swaps, "createVHTLCScript").mockReturnValue(mockBtcArkVHTLC);
             };
 
-            const lockupVtxo = (isSpent: boolean) => ({
+            const lockupVtxo = (isSpent: boolean, arkTxId?: string) => ({
                 txid: hex.encode(randomBytes(32)),
                 vout: 0,
                 value: mock.amount,
@@ -2435,6 +2435,21 @@ describe("ArkadeSwaps", () => {
                 isSpent,
                 isUnrolled: false,
                 createdAt: new Date(),
+                arkTxId,
+            });
+
+            const FUTURE_LOCKTIME = Math.floor(Date.now() / 1000) + 3600;
+            const PAST_LOCKTIME = Math.floor(Date.now() / 1000) - 3600;
+
+            const withRefundLocktime = (swap: BoltzChainSwap, refund: number): BoltzChainSwap => ({
+                ...swap,
+                response: {
+                    ...swap.response,
+                    claimDetails: {
+                        ...swap.response.claimDetails,
+                        timeouts: { ...swap.response.claimDetails.timeouts!, refund },
+                    },
+                },
             });
 
             it("signs once the swap carries our claim txid", async () => {
@@ -2484,9 +2499,34 @@ describe("ArkadeSwaps", () => {
                 expect(post).toHaveBeenCalledOnce();
             });
 
-            it("signs for a swap predating the claim txid field once its lockup is spent", async () => {
+            it("signs for a swap predating the claim txid field when the lockup was spent into our wallet", async () => {
+                // arrange — refund locktime long past: attribution stands on its own
+                const swap = withRefundLocktime(makeBtcChainSwap("ARK"), PAST_LOCKTIME);
+                mockSwapRepository.getAllSwaps.mockResolvedValue([swap]);
+                stubClaimSideVHTLC();
+                const arkTxId = hex.encode(randomBytes(32));
+                vi.spyOn(indexerProvider, "getVtxos")
+                    .mockResolvedValueOnce({ vtxos: [lockupVtxo(true, arkTxId)] as any })
+                    .mockResolvedValueOnce({
+                        vtxos: [{ ...lockupVtxo(false), txid: arkTxId }] as any,
+                    });
+                vi.spyOn(swapProvider, "getChainClaimDetails").mockResolvedValue(
+                    chainClaimDetails(swap),
+                );
+                const post = vi
+                    .spyOn(swapProvider, "postChainClaimDetails")
+                    .mockResolvedValue({} as any);
+
+                // act
+                await swaps.signCooperativeClaimForServer(swap);
+
+                // assert
+                expect(post).toHaveBeenCalledOnce();
+            });
+
+            it("signs for a swap predating the field when the lockup was spent before its refund locktime", async () => {
                 // arrange
-                const swap = makeBtcChainSwap("ARK");
+                const swap = withRefundLocktime(makeBtcChainSwap("ARK"), FUTURE_LOCKTIME);
                 mockSwapRepository.getAllSwaps.mockResolvedValue([swap]);
                 stubClaimSideVHTLC();
                 vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
@@ -2504,6 +2544,40 @@ describe("ArkadeSwaps", () => {
 
                 // assert
                 expect(post).toHaveBeenCalledOnce();
+            });
+
+            it("does not sign for an unattributable spend once the refund locktime has passed", async () => {
+                // arrange
+                const swap = withRefundLocktime(makeBtcChainSwap("ARK"), PAST_LOCKTIME);
+                mockSwapRepository.getAllSwaps.mockResolvedValue([swap]);
+                stubClaimSideVHTLC();
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                    vtxos: [lockupVtxo(true)] as any,
+                });
+                const getClaimDetails = vi.spyOn(swapProvider, "getChainClaimDetails");
+
+                // act & assert
+                await expect(swaps.signCooperativeClaimForServer(swap)).rejects.toBeInstanceOf(
+                    CooperativeSignRefusedError,
+                );
+                expect(getClaimDetails).not.toHaveBeenCalled();
+            });
+
+            it("does not sign for an unattributable spend when a block-height refund locktime cannot be evaluated", async () => {
+                // arrange — block-height locktime, no onchain provider to resolve the tip
+                const swap = makeBtcChainSwap("ARK");
+                mockSwapRepository.getAllSwaps.mockResolvedValue([swap]);
+                stubClaimSideVHTLC();
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                    vtxos: [lockupVtxo(true)] as any,
+                });
+                const getClaimDetails = vi.spyOn(swapProvider, "getChainClaimDetails");
+
+                // act & assert
+                await expect(swaps.signCooperativeClaimForServer(swap)).rejects.toBeInstanceOf(
+                    CooperativeSignRefusedError,
+                );
+                expect(getClaimDetails).not.toHaveBeenCalled();
             });
 
             it("does not sign while the claim-side lockup is unspent", async () => {

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -2524,6 +2524,82 @@ describe("ArkadeSwaps", () => {
                 expect(post).toHaveBeenCalledOnce();
             });
 
+            it("does not sign when the spend paid our wallet less than it took", async () => {
+                // arrange — spender pays us dust; an unrelated full-value
+                // vtxo must not count toward the spender's total.
+                const swap = withRefundLocktime(makeBtcChainSwap("ARK"), PAST_LOCKTIME);
+                mockSwapRepository.getAllSwaps.mockResolvedValue([swap]);
+                stubClaimSideVHTLC();
+                const arkTxId = hex.encode(randomBytes(32));
+                vi.spyOn(indexerProvider, "getVtxos")
+                    .mockResolvedValueOnce({ vtxos: [lockupVtxo(true, arkTxId)] as any })
+                    .mockResolvedValueOnce({
+                        vtxos: [
+                            { ...lockupVtxo(false), txid: arkTxId, value: 1 },
+                            lockupVtxo(false),
+                        ] as any,
+                    });
+                const post = vi.spyOn(swapProvider, "postChainClaimDetails");
+
+                // act & assert
+                await expect(swaps.signCooperativeClaimForServer(swap)).rejects.toBeInstanceOf(
+                    CooperativeSignRefusedError,
+                );
+                expect(post).not.toHaveBeenCalled();
+            });
+
+            it("signs when one spending tx covers several lockup vtxos in aggregate", async () => {
+                // arrange
+                const swap = withRefundLocktime(makeBtcChainSwap("ARK"), PAST_LOCKTIME);
+                mockSwapRepository.getAllSwaps.mockResolvedValue([swap]);
+                stubClaimSideVHTLC();
+                const arkTxId = hex.encode(randomBytes(32));
+                vi.spyOn(indexerProvider, "getVtxos")
+                    .mockResolvedValueOnce({
+                        vtxos: [lockupVtxo(true, arkTxId), lockupVtxo(true, arkTxId)] as any,
+                    })
+                    .mockResolvedValueOnce({
+                        vtxos: [
+                            { ...lockupVtxo(false), txid: arkTxId },
+                            { ...lockupVtxo(false), txid: arkTxId },
+                        ] as any,
+                    });
+                vi.spyOn(swapProvider, "getChainClaimDetails").mockResolvedValue(
+                    chainClaimDetails(swap),
+                );
+                const post = vi
+                    .spyOn(swapProvider, "postChainClaimDetails")
+                    .mockResolvedValue({} as any);
+
+                // act
+                await swaps.signCooperativeClaimForServer(swap);
+
+                // assert
+                expect(post).toHaveBeenCalledOnce();
+            });
+
+            it("does not sign when the spending tx covers only part of what it spent", async () => {
+                // arrange — one full-value output cannot vouch for two vtxos
+                const swap = withRefundLocktime(makeBtcChainSwap("ARK"), PAST_LOCKTIME);
+                mockSwapRepository.getAllSwaps.mockResolvedValue([swap]);
+                stubClaimSideVHTLC();
+                const arkTxId = hex.encode(randomBytes(32));
+                vi.spyOn(indexerProvider, "getVtxos")
+                    .mockResolvedValueOnce({
+                        vtxos: [lockupVtxo(true, arkTxId), lockupVtxo(true, arkTxId)] as any,
+                    })
+                    .mockResolvedValueOnce({
+                        vtxos: [{ ...lockupVtxo(false), txid: arkTxId }] as any,
+                    });
+                const post = vi.spyOn(swapProvider, "postChainClaimDetails");
+
+                // act & assert
+                await expect(swaps.signCooperativeClaimForServer(swap)).rejects.toBeInstanceOf(
+                    CooperativeSignRefusedError,
+                );
+                expect(post).not.toHaveBeenCalled();
+            });
+
             it("signs for a swap predating the field when the lockup was spent before its refund locktime", async () => {
                 // arrange
                 const swap = withRefundLocktime(makeBtcChainSwap("ARK"), FUTURE_LOCKTIME);

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -52,6 +52,7 @@ import {
 } from "../src/utils/vhtlc";
 import {
     BoltzRefundError,
+    CooperativeSignRefusedError,
     InvoiceFailedToPayError,
     SwapError,
     TransactionFailedError,
@@ -2393,11 +2394,166 @@ describe("ArkadeSwaps", () => {
                         expect.objectContaining({
                             id: mockBtcArkChainSwap.id,
                             status: "transaction.claimed",
+                            claimTxid: mock.txid,
                         }),
                     );
                 } finally {
                     vi.useRealTimers();
                 }
+            });
+        });
+
+        describe("signCooperativeClaimForServer", () => {
+            const transactionHash = randomBytes(32);
+
+            // The counterparty half of the MuSig2 session, as Boltz returns it.
+            const chainClaimDetails = (swap: BoltzChainSwap) => ({
+                publicKey: compressedPubkeys.boltz,
+                pubNonce: hex.encode(
+                    tweakMusig(
+                        createMusig(seckeys.boltz, [btcBoltzPub, btcEphemeralPub]),
+                        deserializeSwapTree(swap.response.lockupDetails.swapTree!).tree,
+                    )
+                        .message(transactionHash)
+                        .generateNonce().publicNonce,
+                ),
+                transactionHash: hex.encode(transactionHash),
+            });
+
+            /** Makes the claim-side VHTLC reconstruct to the stored lockup address. */
+            const stubClaimSideVHTLC = () => {
+                vi.spyOn(arkProvider, "getInfo").mockResolvedValue(mockArkInfo);
+                vi.spyOn(swaps, "createVHTLCScript").mockReturnValue(mockBtcArkVHTLC);
+            };
+
+            const lockupVtxo = (isSpent: boolean) => ({
+                txid: hex.encode(randomBytes(32)),
+                vout: 0,
+                value: mock.amount,
+                status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+                virtualStatus: { state: "pending" as const },
+                isSpent,
+                isUnrolled: false,
+                createdAt: new Date(),
+            });
+
+            it("signs once the swap carries our claim txid", async () => {
+                // arrange
+                const swap = { ...makeBtcChainSwap("ARK"), claimTxid: mock.txid };
+                vi.spyOn(swapProvider, "getChainClaimDetails").mockResolvedValue(
+                    chainClaimDetails(swap),
+                );
+                const post = vi
+                    .spyOn(swapProvider, "postChainClaimDetails")
+                    .mockResolvedValue({} as any);
+                const getVtxos = vi.spyOn(indexerProvider, "getVtxos");
+
+                // act
+                await swaps.signCooperativeClaimForServer(swap);
+
+                // assert
+                expect(post).toHaveBeenCalledWith(
+                    swap.response.id,
+                    expect.objectContaining({
+                        signature: expect.objectContaining({
+                            partialSignature: expect.any(String),
+                            pubNonce: expect.any(String),
+                        }),
+                    }),
+                );
+                expect(getVtxos).not.toHaveBeenCalled();
+            });
+
+            it("signs when the claim txid is on the stored record but not on the caller's copy", async () => {
+                // arrange
+                const swap = makeBtcChainSwap("ARK");
+                mockSwapRepository.getAllSwaps.mockResolvedValue([
+                    { ...swap, claimTxid: mock.txid },
+                ]);
+                vi.spyOn(swapProvider, "getChainClaimDetails").mockResolvedValue(
+                    chainClaimDetails(swap),
+                );
+                const post = vi
+                    .spyOn(swapProvider, "postChainClaimDetails")
+                    .mockResolvedValue({} as any);
+
+                // act
+                await swaps.signCooperativeClaimForServer(swap);
+
+                // assert
+                expect(post).toHaveBeenCalledOnce();
+            });
+
+            it("signs for a swap predating the claim txid field once its lockup is spent", async () => {
+                // arrange
+                const swap = makeBtcChainSwap("ARK");
+                mockSwapRepository.getAllSwaps.mockResolvedValue([swap]);
+                stubClaimSideVHTLC();
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                    vtxos: [lockupVtxo(true)] as any,
+                });
+                vi.spyOn(swapProvider, "getChainClaimDetails").mockResolvedValue(
+                    chainClaimDetails(swap),
+                );
+                const post = vi
+                    .spyOn(swapProvider, "postChainClaimDetails")
+                    .mockResolvedValue({} as any);
+
+                // act
+                await swaps.signCooperativeClaimForServer(swap);
+
+                // assert
+                expect(post).toHaveBeenCalledOnce();
+            });
+
+            it("does not sign while the claim-side lockup is unspent", async () => {
+                // arrange
+                const swap = makeBtcChainSwap("ARK");
+                mockSwapRepository.getAllSwaps.mockResolvedValue([swap]);
+                stubClaimSideVHTLC();
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                    vtxos: [lockupVtxo(true), lockupVtxo(false)] as any,
+                });
+                const getClaimDetails = vi.spyOn(swapProvider, "getChainClaimDetails");
+                const post = vi.spyOn(swapProvider, "postChainClaimDetails");
+
+                // act & assert
+                await expect(swaps.signCooperativeClaimForServer(swap)).rejects.toBeInstanceOf(
+                    CooperativeSignRefusedError,
+                );
+                expect(getClaimDetails).not.toHaveBeenCalled();
+                expect(post).not.toHaveBeenCalled();
+            });
+
+            it("does not sign when no virtual coins exist at the claim-side lockup", async () => {
+                // arrange
+                const swap = makeBtcChainSwap("ARK");
+                mockSwapRepository.getAllSwaps.mockResolvedValue([]);
+                stubClaimSideVHTLC();
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({ vtxos: [] });
+                const post = vi.spyOn(swapProvider, "postChainClaimDetails");
+
+                // act & assert
+                await expect(swaps.signCooperativeClaimForServer(swap)).rejects.toBeInstanceOf(
+                    CooperativeSignRefusedError,
+                );
+                expect(post).not.toHaveBeenCalled();
+            });
+
+            it("still rejects a claim response whose server key differs from the stored one", async () => {
+                // arrange
+                const swap = { ...makeBtcChainSwap("ARK"), claimTxid: mock.txid };
+                vi.spyOn(swapProvider, "getChainClaimDetails").mockResolvedValue({
+                    ...chainClaimDetails(swap),
+                    publicKey: compressedPubkeys.alice,
+                });
+                const post = vi.spyOn(swapProvider, "postChainClaimDetails");
+
+                // act & assert
+                await expect(swaps.signCooperativeClaimForServer(swap)).rejects.toThrow(
+                    /server public key mismatch/,
+                );
+                expect(post).not.toHaveBeenCalled();
             });
         });
 
@@ -2608,6 +2764,37 @@ describe("ArkadeSwaps", () => {
                 // assert — claim txid wins over the Boltz swap id / status
                 await expect(resultPromise).resolves.toEqual({ txid: mock.txid });
                 expect(getSwapStatus).not.toHaveBeenCalled();
+            });
+
+            it("co-signs only after the in-flight claim has landed", async () => {
+                // arrange
+                const pendingSwap: BoltzChainSwap = { ...mockBtcArkChainSwap };
+                let settleClaim: (result: { txid: string }) => void = () => {};
+                const claim = new Promise<{ txid: string }>((resolve) => {
+                    settleClaim = resolve;
+                });
+                vi.spyOn(swaps, "claimArk").mockReturnValue(claim);
+                const cosign = vi
+                    .spyOn(swaps, "signCooperativeClaimForServer")
+                    .mockResolvedValue(undefined);
+                vi.spyOn(swapProvider, "monitorSwap").mockImplementation(async (_id, callback) => {
+                    await callback("transaction.server.mempool", {});
+                    const pending = callback("transaction.claim.pending", {});
+                    await new Promise((resolve) => setTimeout(resolve, 5));
+                    expect(cosign).not.toHaveBeenCalled();
+                    settleClaim({ txid: mock.txid });
+                    await pending;
+                    await callback("transaction.claimed", {});
+                });
+
+                // act
+                const result = await swaps.waitAndClaimArk(pendingSwap);
+
+                // assert
+                expect(result).toEqual({ txid: mock.txid });
+                expect(cosign).toHaveBeenCalledWith(
+                    expect.objectContaining({ claimTxid: mock.txid }),
+                );
             });
 
             it("should reject with SwapExpiredError when swap expires", async () => {


### PR DESCRIPTION
Chain swaps ask us to co-sign the counterparty's cooperative claim of the
lockup we funded. The signature covers `transactionHash` — 32 opaque bytes;
`GET /v2/swap/chain/{id}/claim` returns no transaction — and the request
arrives on a provider-reported status, so nothing today ties it to the state
of our own claim.

This orders it against state we own: `signCooperativeClaimForServer` co-signs
only once we have claimed the swap's claim side.

- `BoltzChainSwap` gains `claimTxid`, recorded by `claimArk` when the claim
  resolves. `waitAndClaimArk` mirrors it onto its local copy so a later status
  save does not write it back out of a pre-claim snapshot, and lets an
  in-flight claim land before co-signing.
- The gate re-reads the persisted swap rather than trusting the caller's copy.
- Swaps predating the field — restored ones included — fall back to the
  indexer. `isSpent` alone does not identify the spender: past
  `claimDetails.timeouts.refund` the sender's refund leaf opens, so a fully
  spent lockup is accepted only when either the spending ark tx paid this
  wallet (`arkTxId` matches a VTXO at the destination or the current wallet
  address), or the refund locktime is provably still ahead — before it every
  VHTLC spend path carries our key. A block-height locktime with no chain tip
  counts as reached. A batch settlement is not attributable: its commitment tx
  is shared with the whole round.
- Otherwise it throws `CooperativeSignRefusedError` (exported). Co-signing is a
  courtesy, both call sites already treat failure as non-fatal, and the
  SwapManager poll re-evaluates while the swap stays claimable, so a refusal
  taken early self-heals.
- Claim-side VHTLC reconstruction moves into `resolveClaimSideVHTLC`, shared by
  `claimArk` and the gate; it keeps the signer-rotation candidate loop.

No public signature changes; the only behavioural change is that a co-signature
is deferred until our claim is established.

Validation: 10 new unit tests in `packages/boltz-swap/test/arkade-swaps.test.ts`
(happy path, stored-record read, attributed legacy spend, pre-locktime legacy
spend, four refusal cases, server-key mismatch, `waitAndClaimArk` ordering).
Each new guard was verified to fail with the `src` change removed. Full unit
suite, lint and build green. Not run: boltz-swap e2e (regtest stack down) —
worth one live chain swap before release, since the gate sits on a live-Boltz
path.
