### PR TITLE
fix: recover co-sign updates dropped by the swap lock

### DIFF
--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -1206,6 +1206,13 @@ export class SwapManager implements SwapManagerClient {
                         this.actionExecutedListeners.forEach((listener) =>
                             listener(swap, "claimArk"),
                         );
+                        // transaction.claim.pending can land while the claim
+                        // above is still in flight, where the in-progress lock
+                        // drops it; the status then never changes again, so no
+                        // later update re-triggers the co-sign. Pick it up here
+                        // instead — the claim it must be ordered after has just
+                        // completed.
+                        await this.signServerClaimIfSignable(swap);
                     } else if (swap.request.to === "BTC") {
                         logger.log(`Auto-claiming BTC chain swap ${swap.id}`);
                         await this.executeClaimBtcAction(swap);
@@ -1262,23 +1269,8 @@ export class SwapManager implements SwapManagerClient {
                             `Chain swap ${swap.id} expired: BTC lockup will be refunded by Boltz after timelock`,
                         );
                     }
-                } else if (swap.request.to === "ARK" && isChainSignableStatus(swap.status)) {
-                    logger.log(
-                        `Auto-signing server's cooperative claim for ARK chain swap ${swap.id}`,
-                    );
-                    try {
-                        const signed = await this.executeSignServerClaimAction(swap);
-                        if (signed) {
-                            this.actionExecutedListeners.forEach((listener) =>
-                                listener(swap, "signServerClaim"),
-                            );
-                        }
-                    } catch (error) {
-                        logger.error(
-                            `Non-fatal: failed to sign server claim for swap ${swap.id}:`,
-                            error,
-                        );
-                    }
+                } else {
+                    await this.signServerClaimIfSignable(swap);
                 }
             }
         } catch (error) {
@@ -1330,7 +1322,7 @@ export class SwapManager implements SwapManagerClient {
         }
 
         const claimPromise = this.claimArkCallback(swap);
-        this.rememberChainClaim(swap.id, claimPromise);
+        this.rememberChainClaim(swap, claimPromise);
         await claimPromise;
     }
 
@@ -1344,7 +1336,7 @@ export class SwapManager implements SwapManagerClient {
         }
 
         const claimPromise = this.claimBtcCallback(swap);
-        this.rememberChainClaim(swap.id, claimPromise);
+        this.rememberChainClaim(swap, claimPromise);
         await claimPromise;
     }
 
@@ -1356,14 +1348,25 @@ export class SwapManager implements SwapManagerClient {
      * window where the txid is not yet captured when transaction.claimed
      * arrives. Defensive against callbacks that don't return a promise (older
      * integrations, test doubles): those simply fall back to getSwapStatus.
+     *
+     * Also mirrors the claim txid onto the monitored swap. The claim callback
+     * persists it against its own pre-claim snapshot, so without the mirror the
+     * next status update would save this stale copy back over the stored record
+     * and drop the txid.
      */
     private rememberChainClaim(
-        swapId: string,
+        swap: BoltzChainSwap,
         claimPromise: Promise<{ txid?: string } | void>,
     ): void {
-        if (claimPromise) {
-            this.chainClaimPromises.set(swapId, claimPromise);
-        }
+        if (!claimPromise) return;
+        this.chainClaimPromises.set(swap.id, claimPromise);
+        claimPromise.then(
+            (result) => {
+                if (result?.txid) swap.claimTxid = result.txid;
+            },
+            // The claim's rejection is surfaced by executeAutonomousAction.
+            () => {},
+        );
     }
 
     /**
@@ -1378,6 +1381,30 @@ export class SwapManager implements SwapManagerClient {
         }
 
         return this.refundArkCallback(swap);
+    }
+
+    /**
+     * Co-sign the server's claim when the swap is in a signable state.
+     *
+     * Called both from the signable-status branch and right after our own
+     * ARK claim, which is where a claim.pending update dropped by the
+     * in-progress lock is recovered. Failure is non-fatal: without our
+     * signature the counterparty falls back to the script path.
+     */
+    private async signServerClaimIfSignable(swap: BoltzChainSwap): Promise<void> {
+        if (swap.request.to !== "ARK" || !isChainSignableStatus(swap.status)) return;
+
+        logger.log(`Auto-signing server's cooperative claim for ARK chain swap ${swap.id}`);
+        try {
+            const signed = await this.executeSignServerClaimAction(swap);
+            if (signed) {
+                this.actionExecutedListeners.forEach((listener) =>
+                    listener(swap, "signServerClaim"),
+                );
+            }
+        } catch (error) {
+            logger.error(`Non-fatal: failed to sign server claim for swap ${swap.id}:`, error);
+        }
     }
 
     /**

--- a/packages/boltz-swap/test/swap-manager.test.ts
+++ b/packages/boltz-swap/test/swap-manager.test.ts
@@ -2212,4 +2212,136 @@ describe("SwapManager", () => {
             }
         });
     });
+
+    describe("Chain claim txid persistence", () => {
+        const claimTxid = "f".repeat(64);
+
+        // BTC => ARK: the side the manager claims itself via claimArk.
+        const btcToArkSwap: BoltzChainSwap = {
+            ...mockChainSwap,
+            status: "swap.created",
+            request: { ...mockChainSwap.request, from: "BTC", to: "ARK" },
+        };
+
+        const triggerStatus = async (status: string) => {
+            await mockWebSocket.onmessage({
+                data: JSON.stringify({
+                    event: "update",
+                    args: [{ id: btcToArkSwap.id, status }],
+                }),
+            });
+        };
+
+        beforeEach(() => {
+            global.fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ status: "swap.created" }),
+                    headers: new Headers({ "content-length": "100" }),
+                } as Response),
+            );
+        });
+
+        afterEach(async () => {
+            await swapManager?.stop();
+        });
+
+        it("keeps the claim txid stored across later status updates", async () => {
+            // Mirrors the repository: saveSwap replaces the whole record.
+            const stored = new Map<string, BoltzChainSwap>();
+            const saveSwap = vi.fn(async (swap: BoltzChainSwap) => {
+                stored.set(swap.id, clone(swap));
+            });
+            // Mirrors ArkadeSwaps.claimArk: persists the txid against its own
+            // snapshot without mutating the caller's swap.
+            const claimArk = vi.fn(async (swap: BoltzChainSwap) => {
+                stored.set(swap.id, { ...clone(swap), claimTxid });
+                return { txid: claimTxid };
+            });
+
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ claimArk, saveSwap }));
+
+            await swapManager.start([clone(btcToArkSwap)]);
+            mockWebSocket.onopen();
+
+            await triggerStatus("transaction.server.mempool");
+            expect(claimArk).toHaveBeenCalledTimes(1);
+            expect(stored.get(btcToArkSwap.id)?.claimTxid).toBe(claimTxid);
+
+            // The next status saves the monitored swap again — it must carry
+            // the claim txid rather than write the pre-claim snapshot back.
+            await triggerStatus("transaction.claim.pending");
+            expect(stored.get(btcToArkSwap.id)?.claimTxid).toBe(claimTxid);
+        });
+
+        it("co-signs after the claim lands when claim.pending raced it", async () => {
+            let releaseClaim: (() => void) | undefined;
+            const claimArk = vi.fn(
+                () =>
+                    new Promise<{ txid: string }>((resolve) => {
+                        releaseClaim = () => resolve({ txid: claimTxid });
+                    }),
+            );
+            const signServerClaim = vi.fn(async () => {});
+
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ claimArk, signServerClaim }));
+
+            await swapManager.start([clone(btcToArkSwap)]);
+            mockWebSocket.onopen();
+
+            const claiming = triggerStatus("transaction.server.mempool");
+            await sleep(5);
+            expect(claimArk).toHaveBeenCalledTimes(1);
+
+            // The co-sign request lands while the claim is still in flight:
+            // the in-progress lock drops it, and Boltz sends no further
+            // update for an unchanged status.
+            await triggerStatus("transaction.claim.pending");
+            expect(signServerClaim).not.toHaveBeenCalled();
+
+            releaseClaim!();
+            await claiming;
+            await sleep(5);
+            expect(signServerClaim).toHaveBeenCalledTimes(1);
+        });
+
+        it("co-signs exactly once when claim.pending follows a settled claim", async () => {
+            const claimArk = vi.fn(async () => ({ txid: claimTxid }));
+            const signServerClaim = vi.fn(async () => {});
+
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ claimArk, signServerClaim }));
+
+            await swapManager.start([clone(btcToArkSwap)]);
+            mockWebSocket.onopen();
+
+            await triggerStatus("transaction.server.mempool");
+            expect(signServerClaim).not.toHaveBeenCalled();
+
+            await triggerStatus("transaction.claim.pending");
+            expect(signServerClaim).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not record a txid when the claim fails", async () => {
+            const stored = new Map<string, BoltzChainSwap>();
+            const saveSwap = vi.fn(async (swap: BoltzChainSwap) => {
+                stored.set(swap.id, clone(swap));
+            });
+            const claimArk = vi.fn(async () => {
+                throw new Error("claim failed");
+            });
+
+            swapManager = new SwapManager(swapProvider, swapManagerConfig);
+            swapManager.setCallbacks(makeCallbacks({ claimArk, saveSwap }));
+
+            await swapManager.start([clone(btcToArkSwap)]);
+            mockWebSocket.onopen();
+
+            await triggerStatus("transaction.server.mempool");
+            await triggerStatus("transaction.claim.pending");
+            expect(stored.get(btcToArkSwap.id)?.claimTxid).toBeUndefined();
+        });
+    });
 });


### PR DESCRIPTION
transaction.claim.pending can land while the manager's own ARK claim still holds the per-swap in-progress lock. The update is dropped at the lock guard, and since Boltz sends no further update for an unchanged status, the cooperative claim is never signed until a restart sweep.

- Re-check signability right after our own claim completes, where the missed status is recovered; a no-op when the status moved on.
- Mirror the claim txid onto the monitored swap so later manager saves stop overwriting the stored `claimTxid` with the pre-claim snapshot.

Follow-up to #671.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autonomous chain-swap processing by completing server co-signing promptly after claims finish.
  * Preserved claim transaction IDs across subsequent status updates.
  * Prevented duplicate co-signing, including when claim events race or arrive after completion.
  * Ensured failed claims do not store transaction IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->