### PR TITLE
feat: enforce agreed amounts on swap funding and claims

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -24,6 +24,7 @@ import {
     VHTLC,
     ArkInfo,
     isRecoverable,
+    hasTerminalSpend,
     ArkTxInput,
     Identity,
     VirtualCoin,
@@ -542,6 +543,16 @@ export class ArkadeSwaps {
             throw new SwapError({ message: "Preimage hash does not match invoice payment hash" });
         }
 
+        // `onchainAmount` is the agreed amount `claimVHTLC` later enforces
+        // against the lockup, and the wire type marks it optional. Require it
+        // here, before the invoice is handed out: absent, the claim-side check
+        // has no authority to compare against and degrades to a warning.
+        if (typeof swapResponse.onchainAmount !== "number") {
+            throw new SwapError({
+                message: `Swap ${swapResponse.id}: response carries no claim-side amount`,
+            });
+        }
+
         const pendingSwap: BoltzReverseSwap = {
             id: swapResponse.id,
             type: "reverse",
@@ -628,12 +639,12 @@ export class ArkadeSwaps {
                 scripts: [hex.encode(vhtlcScript.pkScript)],
             });
             rawVtxos = result.vtxos;
-            unspentVtxos = result.vtxos.filter((vtxo) => !vtxo.isSpent);
+            unspentVtxos = result.vtxos.filter((vtxo) => !hasTerminalSpend(vtxo));
             const total = unspentVtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
             if (
                 unspentVtxos.length > 0 &&
                 (typeof expected !== "number" ||
-                    rawVtxos.some((vtxo) => vtxo.isSpent) ||
+                    rawVtxos.some(hasTerminalSpend) ||
                     total >= expected)
             ) {
                 break;
@@ -661,7 +672,7 @@ export class ArkadeSwaps {
                 `Swap ${pendingSwap.id}: no agreed claim amount on record — ` +
                     `skipping the lockup amount check`,
             );
-        } else if (!rawVtxos.some((vtxo) => vtxo.isSpent) && total < expected) {
+        } else if (!rawVtxos.some(hasTerminalSpend) && total < expected) {
             throw new LockupAmountMismatchError({
                 swapId: pendingSwap.id,
                 expectedAmount: expected,
@@ -964,8 +975,10 @@ export class ArkadeSwaps {
         arkInfoPromise.catch(() => {});
 
         // Fetch the advertised fee schedule concurrently too: the response's
-        // expected funding amount is reconciled against it below.
-        const feesPromise = this.getFees();
+        // expected funding amount is reconciled against it below. Only the
+        // submarine schedule is read, so it is fetched on its own rather than
+        // through `getFees()`, which also depends on the reverse endpoint.
+        const feesPromise = this.swapProvider.getSubmarineFees();
         feesPromise.catch(() => {});
 
         // make submarine swap request
@@ -1014,12 +1027,12 @@ export class ArkadeSwaps {
     private async assertSubmarineExpectedAmount(
         response: CreateSubmarineSwapResponse,
         invoice: string,
-        feesPromise: Promise<FeesResponse>,
+        feesPromise: Promise<FeesResponse["submarine"]>,
     ): Promise<void> {
         if (typeof response.expectedAmount !== "number") return;
         const invoiceSats = decodeInvoice(invoice).amountSats;
         if (!invoiceSats) return;
-        const { submarine } = await feesPromise;
+        const submarine = await feesPromise;
         const maxAcceptable =
             invoiceSats +
             submarine.minerFees +
@@ -1975,7 +1988,10 @@ export class ArkadeSwaps {
         }
 
         // After a renegotiation the agreed amount supersedes the requested
-        // server lock, so the exact-delivery fee derives from it too.
+        // server lock, so the exact-delivery fee derives from it too. A quote
+        // accepted with slippage can land below `amount`, making the surplus
+        // negative; the `> fee` comparison below then falls back to the
+        // estimated fee, which is the intended behaviour.
         const feeToDeliverExactAmount = BigInt(
             pendingSwap.request.serverLockAmount
                 ? (expected ?? pendingSwap.request.serverLockAmount) - pendingSwap.amount
@@ -2412,15 +2428,18 @@ export class ArkadeSwaps {
 
         // The indexer may lag the lockup tx — and may briefly surface only
         // part of a split lockup — so retry until the spendable set covers
-        // the agreed amount or the attempts run out.
+        // the agreed amount or the attempts run out. `hasTerminalSpend` rather
+        // than `isSpent`: a VTXO consumed by a batch round carries `settledBy`
+        // and need not carry `isSpent`, and counting one of those as spendable
+        // would both inflate the total and hide that a claim already ran.
         let spendable: VirtualCoin[] = [];
         let partiallyClaimed = false;
         for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
             const { vtxos } = await this.indexerProvider.getVtxos({
                 scripts: [hex.encode(vhtlcScript.pkScript)],
             });
-            spendable = vtxos.filter((vtxo) => !vtxo.isSpent);
-            partiallyClaimed = vtxos.some((vtxo) => vtxo.isSpent);
+            spendable = vtxos.filter((vtxo) => !hasTerminalSpend(vtxo));
+            partiallyClaimed = vtxos.some(hasTerminalSpend);
             const total = spendable.reduce((sum, vtxo) => sum + vtxo.value, 0);
             if (
                 spendable.length > 0 &&
@@ -3039,6 +3058,10 @@ export class ArkadeSwaps {
      * storage failure must not surface as a rejected renegotiation.
      */
     private async recordAcceptedQuote(swapId: string, amount: number): Promise<void> {
+        // Mirror first: the storage write below is awaited, and a status
+        // update landing in that window would save the monitored copy while
+        // it still lacks the field.
+        this.swapManager?.noteAcceptedQuote(swapId, amount);
         try {
             const stored = (
                 await this.swapRepository.getAllSwaps<BoltzChainSwap>({
@@ -3052,7 +3075,6 @@ export class ArkadeSwaps {
         } catch (error) {
             logger.error(`Failed to record accepted quote for swap ${swapId}:`, error);
         }
-        this.swapManager?.noteAcceptedQuote(swapId, amount);
     }
 
     private async resolveEffectiveFloor(

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -543,10 +543,9 @@ export class ArkadeSwaps {
             throw new SwapError({ message: "Preimage hash does not match invoice payment hash" });
         }
 
-        // `onchainAmount` is the agreed amount `claimVHTLC` later enforces
-        // against the lockup, and the wire type marks it optional. Require it
-        // here, before the invoice is handed out: absent, the claim-side check
-        // has no authority to compare against and degrades to a warning.
+        // `onchainAmount` is the agreed amount `claimVHTLC` later enforces, and
+        // the wire type marks it optional. Require it here, before the invoice
+        // is handed out, rather than leaving the claim nothing to compare against.
         if (typeof swapResponse.onchainAmount !== "number") {
             throw new SwapError({
                 message: `Swap ${swapResponse.id}: response carries no claim-side amount`,
@@ -662,10 +661,10 @@ export class ArkadeSwaps {
         }
 
         // Claiming publishes the preimage, which is what lets the counterparty
-        // settle the Lightning side in full, so the locked total must cover
-        // the amount confirmed at creation before the first claim. Once part
-        // of the lockup is already spent an earlier claim has disclosed it,
-        // and the remainder is swept unconditionally.
+        // settle the Lightning side in full, so the locked total must cover the
+        // agreed amount before the first claim. Once part of the lockup is
+        // spent an earlier claim has already disclosed it, and the remainder is
+        // swept unconditionally.
         const total = unspentVtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
         if (typeof expected !== "number") {
             logger.warn(
@@ -974,10 +973,9 @@ export class ArkadeSwaps {
         // rejection.
         arkInfoPromise.catch(() => {});
 
-        // Fetch the advertised fee schedule concurrently too: the response's
-        // expected funding amount is reconciled against it below. Only the
-        // submarine schedule is read, so it is fetched on its own rather than
-        // through `getFees()`, which also depends on the reverse endpoint.
+        // Same treatment for the fee schedule the funding amount is bounded
+        // against. Only the submarine half is read, so `getSubmarineFees` keeps
+        // this off the reverse endpoint `getFees` would also pull in.
         const feesPromise = this.swapProvider.getSubmarineFees();
         feesPromise.catch(() => {});
 
@@ -1001,8 +999,6 @@ export class ArkadeSwaps {
         // reconcile never reaches storage.
         await this.buildSubmarineVHTLCContext(pendingSwap, await arkInfoPromise);
 
-        // The expected funding amount must reconcile with the invoice plus the
-        // advertised fee schedule — also before anything is persisted or funded.
         await this.assertSubmarineExpectedAmount(swapResponse, invoice, feesPromise);
 
         // save pending swap to storage
@@ -1018,11 +1014,9 @@ export class ArkadeSwaps {
 
     /**
      * Bound a submarine swap's `expectedAmount` to the invoice amount plus the
-     * advertised submarine fee schedule: the percentage fee over the invoice,
-     * rounded up, plus miner fees. A consistent server's response always
+     * advertised submarine fee schedule. A consistent server's response always
      * reconciles with its own advertised fees, so anything above the bound is
-     * rejected before the swap is persisted or funded. Amountless invoices
-     * carry no local baseline and are not bounded.
+     * rejected. Amountless invoices carry no local baseline and are not bounded.
      */
     private async assertSubmarineExpectedAmount(
         response: CreateSubmarineSwapResponse,
@@ -1875,9 +1869,8 @@ export class ArkadeSwaps {
                         await updateSwapStatus();
                         await this.quoteSwap(swap.response.id, quoteOptionsForSwap(swap)).then(
                             (accepted) => {
-                                // Mirror onto the local copy: later
-                                // updateSwapStatus() saves would otherwise
-                                // write the pre-quote snapshot back out.
+                                // Mirror it, or a later updateSwapStatus()
+                                // save writes the pre-quote snapshot back out.
                                 swap.acceptedQuoteAmount = accepted;
                             },
                             (err) => {
@@ -1967,10 +1960,9 @@ export class ArkadeSwaps {
         );
         const swapOutput = detectSwapOutput(musig.aggPubkey, lockupTx);
 
-        // The lockup must cover the agreed amount before the claim proceeds —
-        // requesting the cooperative signature discloses the preimage, which
-        // completes the swap on the counterparty's side. Refusing keeps the
-        // ARK lockup recoverable through the regular refund path.
+        // Same guard as `claimVHTLC`, with the disclosure one step earlier: the
+        // preimage goes out in the cooperative-signature request below, not in
+        // a witness. Refusing keeps the ARK lockup on its regular refund track.
         const expected = await this.expectedClaimAmount(pendingSwap);
         if (expected === undefined) {
             logger.warn(
@@ -1989,9 +1981,8 @@ export class ArkadeSwaps {
 
         // After a renegotiation the agreed amount supersedes the requested
         // server lock, so the exact-delivery fee derives from it too. A quote
-        // accepted with slippage can land below `amount`, making the surplus
-        // negative; the `> fee` comparison below then falls back to the
-        // estimated fee, which is the intended behaviour.
+        // accepted with slippage can land below `amount`; the surplus then goes
+        // negative and the `> fee` comparison below falls back to the estimate.
         const feeToDeliverExactAmount = BigInt(
             pendingSwap.request.serverLockAmount
                 ? (expected ?? pendingSwap.request.serverLockAmount) - pendingSwap.amount
@@ -2286,9 +2277,8 @@ export class ArkadeSwaps {
                         await updateSwapStatus();
                         await this.quoteSwap(swap.response.id, quoteOptionsForSwap(swap)).then(
                             (accepted) => {
-                                // Mirror onto the local copy: later
-                                // updateSwapStatus() saves would otherwise
-                                // write the pre-quote snapshot back out.
+                                // Mirror it, or a later updateSwapStatus()
+                                // save writes the pre-quote snapshot back out.
                                 swap.acceptedQuoteAmount = accepted;
                             },
                             (err) => {
@@ -2426,12 +2416,11 @@ export class ArkadeSwaps {
 
         const expected = await this.expectedClaimAmount(pendingSwap);
 
-        // The indexer may lag the lockup tx — and may briefly surface only
-        // part of a split lockup — so retry until the spendable set covers
-        // the agreed amount or the attempts run out. `hasTerminalSpend` rather
-        // than `isSpent`: a VTXO consumed by a batch round carries `settledBy`
-        // and need not carry `isSpent`, and counting one of those as spendable
-        // would both inflate the total and hide that a claim already ran.
+        // The indexer may lag the lockup tx — and may briefly surface only part
+        // of a split lockup — so retry until the spendable set covers the agreed
+        // amount or the attempts run out. `hasTerminalSpend` rather than
+        // `isSpent`: a VTXO consumed by a batch round carries `settledBy` and
+        // need not carry `isSpent`.
         let spendable: VirtualCoin[] = [];
         let partiallyClaimed = false;
         for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
@@ -2455,11 +2444,9 @@ export class ArkadeSwaps {
             throw new Error(`Swap ${pendingSwap.id}: no spendable virtual coins found`);
         }
 
-        // Claiming discloses the preimage, so the locked total must cover the
-        // agreed amount before the first claim; refusing keeps the swap on its
-        // regular refund track. Once part of the lockup is already spent an
-        // earlier claim has disclosed it, and the remainder is swept
-        // unconditionally.
+        // Same guard as `claimVHTLC`: the claim witness discloses the preimage,
+        // so the lockup must cover the agreed amount before the first claim,
+        // and a partly spent lockup is swept unconditionally.
         const total = spendable.reduce((sum, vtxo) => sum + vtxo.value, 0);
         if (expected === undefined) {
             logger.warn(
@@ -2485,9 +2472,9 @@ export class ArkadeSwaps {
         });
 
         // Claim the whole spendable set, not just the first VTXO: live VTXOs
-        // together in one offchain tx, swept (recoverable) VTXOs per VTXO via
-        // a batch round. The offchain claim tx is the swap's completion; its
-        // id is the txid callers expect back from waitAndClaimArk.
+        // together in one offchain tx, swept ones per VTXO via a batch round.
+        // The first claim tx is the swap's completion, and its id is the txid
+        // callers expect back from waitAndClaimArk.
         const live = spendable.filter((vtxo) => !isRecoverable(vtxo));
         const recoverable = spendable.filter((vtxo) => isRecoverable(vtxo));
 
@@ -2824,9 +2811,8 @@ export class ArkadeSwaps {
 
         const swapResponse = await this.swapProvider.createChainSwap(swapRequest);
 
-        // The response's claim-side amount is what claims later enforce as the
-        // agreed amount; when the server lock was computed locally it must be
-        // echoed verbatim. Checked before the swap is persisted or funded.
+        // The response's claim-side amount is what claims later enforce, so
+        // when the server lock was computed locally it must be echoed verbatim.
         if (
             serverLockAmount !== undefined &&
             swapResponse.claimDetails.amount !== serverLockAmount
@@ -3050,17 +3036,14 @@ export class ArkadeSwaps {
     }
 
     /**
-     * Persist an accepted renegotiation amount as the swap's agreed amount,
-     * and mirror it onto the SwapManager's monitored copy — the manager saves
-     * that copy on every status update, and a stale snapshot would otherwise
-     * write the field back out (the same hazard `claimTxid` mirroring covers).
-     * Best-effort on the acceptance path: the quote is already posted, so a
-     * storage failure must not surface as a rejected renegotiation.
+     * Persist an accepted renegotiation amount as the swap's agreed amount, and
+     * mirror it onto the SwapManager's monitored copy (see `noteAcceptedQuote`).
+     * Best-effort: the quote is already posted, so a storage failure must not
+     * surface as a rejected renegotiation.
      */
     private async recordAcceptedQuote(swapId: string, amount: number): Promise<void> {
-        // Mirror first: the storage write below is awaited, and a status
-        // update landing in that window would save the monitored copy while
-        // it still lacks the field.
+        // Mirror before the awaited write, or a status update landing in that
+        // window saves the monitored copy while it still lacks the field.
         this.swapManager?.noteAcceptedQuote(swapId, amount);
         try {
             const stored = (

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -10,6 +10,8 @@ import {
     QuoteRejectedError,
     VHTLCAddressMismatchError,
     CooperativeSignRefusedError,
+    LockupAmountMismatchError,
+    ExpectedAmountExceededError,
 } from "./errors";
 import {
     ArkAddress,
@@ -59,6 +61,7 @@ import {
     BoltzSwapStatus,
     GetSwapStatusResponse,
     CreateSubmarineSwapRequest,
+    CreateSubmarineSwapResponse,
     CreateReverseSwapRequest,
     CreateChainSwapRequest,
     isSubmarineFinalStatus,
@@ -219,7 +222,7 @@ const CLAIM_VTXO_RETRY_DELAY_MS = 500;
 // formats may lack it — in that case, fall through without a floor (the
 // repository lookup will then resolve no_baseline and abort the renegotiation).
 const quoteOptionsForSwap = (swap: BoltzChainSwap): QuoteSwapOptions | undefined => {
-    const amount = swap.response?.claimDetails?.amount;
+    const amount = swap.acceptedQuoteAmount ?? swap.response?.claimDetails?.amount;
     return typeof amount === "number" ? { minAcceptableAmount: amount } : undefined;
 };
 
@@ -612,9 +615,12 @@ export class ArkadeSwaps {
 
         // Retry while waiting for an *actionable* (unspent) VTXO to appear at
         // the VHTLC script. A spent VTXO showing up early must not abort the
-        // wait, so we break only once the unspent subset is non-empty. The
+        // wait, so we break only once the unspent subset is non-empty — and,
+        // when an agreed amount is on record, once it covers that amount, so
+        // a split lockup the indexer surfaces piecemeal is not misread. The
         // last raw response is kept so the post-retry branch can distinguish
         // "not found" from "already spent" for diagnostics.
+        const expected = pendingSwap.response.onchainAmount;
         let unspentVtxos: VirtualCoin[] = [];
         let rawVtxos: VirtualCoin[] = [];
         for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
@@ -623,7 +629,13 @@ export class ArkadeSwaps {
             });
             rawVtxos = result.vtxos;
             unspentVtxos = result.vtxos.filter((vtxo) => !vtxo.isSpent);
-            if (unspentVtxos.length > 0) {
+            const total = unspentVtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
+            if (
+                unspentVtxos.length > 0 &&
+                (typeof expected !== "number" ||
+                    rawVtxos.some((vtxo) => vtxo.isSpent) ||
+                    total >= expected)
+            ) {
                 break;
             }
             if (attempt < CLAIM_VTXO_RETRY_ATTEMPTS) {
@@ -636,6 +648,26 @@ export class ArkadeSwaps {
                 throw new Error(`Swap ${pendingSwap.id}: no spendable virtual coins found`);
             }
             throw new Error(`Swap ${pendingSwap.id}: VHTLC is already spent`);
+        }
+
+        // Claiming publishes the preimage, which is what lets the counterparty
+        // settle the Lightning side in full, so the locked total must cover
+        // the amount confirmed at creation before the first claim. Once part
+        // of the lockup is already spent an earlier claim has disclosed it,
+        // and the remainder is swept unconditionally.
+        const total = unspentVtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
+        if (typeof expected !== "number") {
+            logger.warn(
+                `Swap ${pendingSwap.id}: no agreed claim amount on record — ` +
+                    `skipping the lockup amount check`,
+            );
+        } else if (!rawVtxos.some((vtxo) => vtxo.isSpent) && total < expected) {
+            throw new LockupAmountMismatchError({
+                swapId: pendingSwap.id,
+                expectedAmount: expected,
+                lockedAmount: total,
+                pendingSwap,
+            });
         }
 
         const vhtlcIdentity = claimVHTLCIdentity(signer, preimage);
@@ -674,7 +706,7 @@ export class ArkadeSwaps {
                         vhtlcIdentity,
                         vhtlcScript,
                         serverXOnly,
-                        input,
+                        [input],
                         output,
                         arkInfo,
                         this.arkProvider,
@@ -931,6 +963,11 @@ export class ArkadeSwaps {
         // rejection.
         arkInfoPromise.catch(() => {});
 
+        // Fetch the advertised fee schedule concurrently too: the response's
+        // expected funding amount is reconciled against it below.
+        const feesPromise = this.getFees();
+        feesPromise.catch(() => {});
+
         // make submarine swap request
         const swapResponse = await this.swapProvider.createSubmarineSwap(swapRequest);
 
@@ -951,6 +988,10 @@ export class ArkadeSwaps {
         // reconcile never reaches storage.
         await this.buildSubmarineVHTLCContext(pendingSwap, await arkInfoPromise);
 
+        // The expected funding amount must reconcile with the invoice plus the
+        // advertised fee schedule — also before anything is persisted or funded.
+        await this.assertSubmarineExpectedAmount(swapResponse, invoice, feesPromise);
+
         // save pending swap to storage
         await this.savePendingSubmarineSwap(pendingSwap);
 
@@ -960,6 +1001,36 @@ export class ArkadeSwaps {
         }
 
         return pendingSwap;
+    }
+
+    /**
+     * Bound a submarine swap's `expectedAmount` to the invoice amount plus the
+     * advertised submarine fee schedule: the percentage fee over the invoice,
+     * rounded up, plus miner fees. A consistent server's response always
+     * reconciles with its own advertised fees, so anything above the bound is
+     * rejected before the swap is persisted or funded. Amountless invoices
+     * carry no local baseline and are not bounded.
+     */
+    private async assertSubmarineExpectedAmount(
+        response: CreateSubmarineSwapResponse,
+        invoice: string,
+        feesPromise: Promise<FeesResponse>,
+    ): Promise<void> {
+        if (typeof response.expectedAmount !== "number") return;
+        const invoiceSats = decodeInvoice(invoice).amountSats;
+        if (!invoiceSats) return;
+        const { submarine } = await feesPromise;
+        const maxAcceptable =
+            invoiceSats +
+            submarine.minerFees +
+            Math.ceil((invoiceSats * submarine.percentage) / 100);
+        if (response.expectedAmount > maxAcceptable) {
+            throw new ExpectedAmountExceededError({
+                swapId: response.id,
+                expectedAmount: response.expectedAmount,
+                maxAcceptable,
+            });
+        }
     }
 
     /**
@@ -1789,7 +1860,13 @@ export class ArkadeSwaps {
                     }
                     case "transaction.lockupFailed":
                         await updateSwapStatus();
-                        await this.quoteSwap(swap.response.id, quoteOptionsForSwap(swap)).catch(
+                        await this.quoteSwap(swap.response.id, quoteOptionsForSwap(swap)).then(
+                            (accepted) => {
+                                // Mirror onto the local copy: later
+                                // updateSwapStatus() saves would otherwise
+                                // write the pre-quote snapshot back out.
+                                swap.acceptedQuoteAmount = accepted;
+                            },
                             (err) => {
                                 reject(
                                     new SwapError({
@@ -1877,9 +1954,31 @@ export class ArkadeSwaps {
         );
         const swapOutput = detectSwapOutput(musig.aggPubkey, lockupTx);
 
+        // The lockup must cover the agreed amount before the claim proceeds —
+        // requesting the cooperative signature discloses the preimage, which
+        // completes the swap on the counterparty's side. Refusing keeps the
+        // ARK lockup recoverable through the regular refund path.
+        const expected = await this.expectedClaimAmount(pendingSwap);
+        if (expected === undefined) {
+            logger.warn(
+                `Swap ${pendingSwap.id}: no agreed claim amount on record — ` +
+                    `skipping the lockup amount check`,
+            );
+        } else if (swapOutput.amount! < BigInt(expected)) {
+            throw new LockupAmountMismatchError({
+                swapId: pendingSwap.id,
+                expectedAmount: expected,
+                lockedAmount: Number(swapOutput.amount!),
+                isRefundable: true,
+                pendingSwap,
+            });
+        }
+
+        // After a renegotiation the agreed amount supersedes the requested
+        // server lock, so the exact-delivery fee derives from it too.
         const feeToDeliverExactAmount = BigInt(
             pendingSwap.request.serverLockAmount
-                ? pendingSwap.request.serverLockAmount - pendingSwap.amount
+                ? (expected ?? pendingSwap.request.serverLockAmount) - pendingSwap.amount
                 : 0,
         );
 
@@ -2169,7 +2268,13 @@ export class ArkadeSwaps {
                         break;
                     case "transaction.lockupFailed":
                         await updateSwapStatus();
-                        await this.quoteSwap(swap.response.id, quoteOptionsForSwap(swap)).catch(
+                        await this.quoteSwap(swap.response.id, quoteOptionsForSwap(swap)).then(
+                            (accepted) => {
+                                // Mirror onto the local copy: later
+                                // updateSwapStatus() saves would otherwise
+                                // write the pre-quote snapshot back out.
+                                swap.acceptedQuoteAmount = accepted;
+                            },
                             (err) => {
                                 reject(
                                     new SwapError({
@@ -2263,6 +2368,28 @@ export class ArkadeSwaps {
     }
 
     /**
+     * The agreed claim-side amount for a chain swap: the latest accepted
+     * renegotiation when one exists, else the amount Boltz confirmed at
+     * creation. Prefers the stored record over the caller's copy — status
+     * callbacks carry snapshots taken before a renegotiation may have run.
+     * Undefined only for legacy persisted swaps carrying neither value.
+     */
+    private async expectedClaimAmount(pendingSwap: BoltzChainSwap): Promise<number | undefined> {
+        const stored = (
+            await this.swapRepository.getAllSwaps<BoltzChainSwap>({
+                id: pendingSwap.id,
+                type: "chain",
+            })
+        )?.[0];
+        return (
+            stored?.acceptedQuoteAmount ??
+            pendingSwap.acceptedQuoteAmount ??
+            stored?.response?.claimDetails?.amount ??
+            pendingSwap.response?.claimDetails?.amount
+        );
+    }
+
+    /**
      * Claim sats on ARK chain by claiming the VHTLC.
      * Refactored to use claimVHTLCIdentity + claimVHTLCwithOffchainTx utilities.
      * @param pendingSwap - The pending chain swap.
@@ -2281,62 +2408,104 @@ export class ArkadeSwaps {
             arkInfo,
         );
 
-        let vtxo;
+        const expected = await this.expectedClaimAmount(pendingSwap);
+
+        // The indexer may lag the lockup tx — and may briefly surface only
+        // part of a split lockup — so retry until the spendable set covers
+        // the agreed amount or the attempts run out.
+        let spendable: VirtualCoin[] = [];
+        let partiallyClaimed = false;
         for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
-            const spendableVtxos = await this.indexerProvider.getVtxos({
+            const { vtxos } = await this.indexerProvider.getVtxos({
                 scripts: [hex.encode(vhtlcScript.pkScript)],
-                spendableOnly: true,
             });
-            if (spendableVtxos.vtxos.length > 0) {
-                vtxo = spendableVtxos.vtxos[0];
+            spendable = vtxos.filter((vtxo) => !vtxo.isSpent);
+            partiallyClaimed = vtxos.some((vtxo) => vtxo.isSpent);
+            const total = spendable.reduce((sum, vtxo) => sum + vtxo.value, 0);
+            if (
+                spendable.length > 0 &&
+                (expected === undefined || partiallyClaimed || total >= expected)
+            )
                 break;
-            }
             if (attempt < CLAIM_VTXO_RETRY_ATTEMPTS) {
                 await new Promise((resolve) => setTimeout(resolve, CLAIM_VTXO_RETRY_DELAY_MS));
             }
         }
 
-        if (!vtxo) {
+        if (spendable.length === 0) {
             throw new Error(`Swap ${pendingSwap.id}: no spendable virtual coins found`);
         }
 
-        const input = {
-            ...vtxo,
-            tapLeafScript: vhtlcScript.claim(),
-            tapTree: vhtlcScript.encode(),
-        };
-
-        const output = {
-            amount: BigInt(vtxo.value),
-            script: ArkAddress.decode(address).pkScript,
-        };
+        // Claiming discloses the preimage, so the locked total must cover the
+        // agreed amount before the first claim; refusing keeps the swap on its
+        // regular refund track. Once part of the lockup is already spent an
+        // earlier claim has disclosed it, and the remainder is swept
+        // unconditionally.
+        const total = spendable.reduce((sum, vtxo) => sum + vtxo.value, 0);
+        if (expected === undefined) {
+            logger.warn(
+                `Swap ${pendingSwap.id}: no agreed claim amount on record — ` +
+                    `skipping the lockup amount check`,
+            );
+        } else if (!partiallyClaimed && total < expected) {
+            throw new LockupAmountMismatchError({
+                swapId: pendingSwap.id,
+                expectedAmount: expected,
+                lockedAmount: total,
+                pendingSwap,
+            });
+        }
 
         // Use shared identity utility for preimage witness
         const vhtlcIdentity = claimVHTLCIdentity(await this.swapSigner(pendingSwap), preimage);
+        const outputScript = ArkAddress.decode(address).pkScript;
+        const toInput = (vtxo: VirtualCoin) => ({
+            ...vtxo,
+            tapLeafScript: vhtlcScript.claim(),
+            tapTree: vhtlcScript.encode(),
+        });
 
-        // The claim transaction we broadcast is the swap's on-chain completion;
-        // its id is the txid callers expect back from waitAndClaimArk.
-        const txid = isRecoverable(vtxo)
-            ? await this.joinBatch(vhtlcIdentity, input, output, arkInfo)
-            : await claimVHTLCwithOffchainTx(
-                  vhtlcIdentity,
-                  vhtlcScript,
-                  serverXOnlyPublicKey,
-                  input,
-                  output,
-                  arkInfo,
-                  this.arkProvider,
-              );
+        // Claim the whole spendable set, not just the first VTXO: live VTXOs
+        // together in one offchain tx, swept (recoverable) VTXOs per VTXO via
+        // a batch round. The offchain claim tx is the swap's completion; its
+        // id is the txid callers expect back from waitAndClaimArk.
+        const live = spendable.filter((vtxo) => !isRecoverable(vtxo));
+        const recoverable = spendable.filter((vtxo) => isRecoverable(vtxo));
+
+        let txid: string | undefined;
+        if (live.length > 0) {
+            txid = await claimVHTLCwithOffchainTx(
+                vhtlcIdentity,
+                vhtlcScript,
+                serverXOnlyPublicKey,
+                live.map(toInput),
+                {
+                    amount: BigInt(live.reduce((sum, vtxo) => sum + vtxo.value, 0)),
+                    script: outputScript,
+                },
+                arkInfo,
+                this.arkProvider,
+            );
+        }
+        for (const vtxo of recoverable) {
+            const batchTxid = await this.joinBatch(
+                vhtlcIdentity,
+                toInput(vtxo),
+                { amount: BigInt(vtxo.value), script: outputScript },
+                arkInfo,
+            );
+            txid ??= batchTxid;
+        }
 
         // update the pending swap on storage
         const finalStatus = await this.getSwapStatus(pendingSwap.id);
         await this.savePendingChainSwap({
             ...pendingSwap,
             status: finalStatus.status,
-            claimTxid: txid,
+            claimTxid: txid!,
         });
 
-        return { txid };
+        return { txid: txid! };
     }
 
     /**
@@ -2636,6 +2805,20 @@ export class ArkadeSwaps {
 
         const swapResponse = await this.swapProvider.createChainSwap(swapRequest);
 
+        // The response's claim-side amount is what claims later enforce as the
+        // agreed amount; when the server lock was computed locally it must be
+        // echoed verbatim. Checked before the swap is persisted or funded.
+        if (
+            serverLockAmount !== undefined &&
+            swapResponse.claimDetails.amount !== serverLockAmount
+        ) {
+            throw new SwapError({
+                message:
+                    `Swap ${swapResponse.id}: claim-side amount ${swapResponse.claimDetails.amount} ` +
+                    `does not match the requested server lock amount ${serverLockAmount}`,
+            });
+        }
+
         const pendingSwap: BoltzChainSwap = {
             amount,
             createdAt: Math.floor(Date.now() / 1000),
@@ -2815,6 +2998,7 @@ export class ArkadeSwaps {
         const amount = await this.getSwapQuote(swapId);
         this.validateQuote(amount, effectiveFloor);
         await this.swapProvider.postChainQuote(swapId, { amount });
+        await this.recordAcceptedQuote(swapId, amount);
         return amount;
     }
 
@@ -2842,7 +3026,33 @@ export class ArkadeSwaps {
         const effectiveFloor = await this.resolveEffectiveFloor(swapId, options);
         this.validateQuote(amount, effectiveFloor);
         await this.swapProvider.postChainQuote(swapId, { amount });
+        await this.recordAcceptedQuote(swapId, amount);
         return amount;
+    }
+
+    /**
+     * Persist an accepted renegotiation amount as the swap's agreed amount,
+     * and mirror it onto the SwapManager's monitored copy — the manager saves
+     * that copy on every status update, and a stale snapshot would otherwise
+     * write the field back out (the same hazard `claimTxid` mirroring covers).
+     * Best-effort on the acceptance path: the quote is already posted, so a
+     * storage failure must not surface as a rejected renegotiation.
+     */
+    private async recordAcceptedQuote(swapId: string, amount: number): Promise<void> {
+        try {
+            const stored = (
+                await this.swapRepository.getAllSwaps<BoltzChainSwap>({
+                    id: swapId,
+                    type: "chain",
+                })
+            )?.[0];
+            if (stored) {
+                await this.savePendingChainSwap({ ...stored, acceptedQuoteAmount: amount });
+            }
+        } catch (error) {
+            logger.error(`Failed to record accepted quote for swap ${swapId}:`, error);
+        }
+        this.swapManager?.noteAcceptedQuote(swapId, amount);
     }
 
     private async resolveEffectiveFloor(
@@ -2876,9 +3086,11 @@ export class ArkadeSwaps {
             type: "chain",
         });
         const stored = swaps[0];
-        // Defensive: persisted swaps from older formats may not have a
+        // Prefer the latest accepted renegotiation so repeated renegotiations
+        // floor on the current agreement, not the original amount. Defensive
+        // on claimDetails: persisted swaps from older formats may not have a
         // populated claimDetails.amount even though the type marks it required.
-        const amount = stored?.response?.claimDetails?.amount;
+        const amount = stored?.acceptedQuoteAmount ?? stored?.response?.claimDetails?.amount;
         if (typeof amount !== "number") {
             throw new QuoteRejectedError({ reason: "no_baseline" });
         }

--- a/packages/boltz-swap/src/boltz-swap-provider.ts
+++ b/packages/boltz-swap/src/boltz-swap-provider.ts
@@ -1022,14 +1022,29 @@ export class BoltzSwapProvider {
         return this.network;
     }
 
+    /**
+     * Returns the current submarine swap fees from Boltz.
+     *
+     * Split out of {@link getFees} so callers that only need the submarine
+     * schedule do not also depend on the reverse pairs endpoint: `getFees`
+     * fetches both under a `Promise.all` and rejects if either fails.
+     */
+    async getSubmarineFees(): Promise<FeesResponse["submarine"]> {
+        const submarine = await this.pairsMetadata(
+            "/v2/swap/submarine",
+            isGetSubmarinePairsResponse,
+            "error fetching submarine fees",
+        );
+        return {
+            percentage: submarine.ARK.BTC.fees.percentage,
+            minerFees: submarine.ARK.BTC.fees.minerFees,
+        };
+    }
+
     /** Returns current Lightning swap fees (submarine + reverse) from Boltz. */
     async getFees(): Promise<FeesResponse> {
         const [submarine, reverse] = await Promise.all([
-            this.pairsMetadata(
-                "/v2/swap/submarine",
-                isGetSubmarinePairsResponse,
-                "error fetching submarine fees",
-            ),
+            this.getSubmarineFees(),
             this.pairsMetadata(
                 "/v2/swap/reverse",
                 isGetReversePairsResponse,
@@ -1037,10 +1052,7 @@ export class BoltzSwapProvider {
             ),
         ]);
         return {
-            submarine: {
-                percentage: submarine.ARK.BTC.fees.percentage,
-                minerFees: submarine.ARK.BTC.fees.minerFees,
-            },
+            submarine,
             reverse: {
                 percentage: reverse.BTC.ARK.fees.percentage,
                 minerFees: reverse.BTC.ARK.fees.minerFees,

--- a/packages/boltz-swap/src/boltz-swap-provider.ts
+++ b/packages/boltz-swap/src/boltz-swap-provider.ts
@@ -1023,11 +1023,9 @@ export class BoltzSwapProvider {
     }
 
     /**
-     * Returns the current submarine swap fees from Boltz.
-     *
-     * Split out of {@link getFees} so callers that only need the submarine
-     * schedule do not also depend on the reverse pairs endpoint: `getFees`
-     * fetches both under a `Promise.all` and rejects if either fails.
+     * Returns the current submarine swap fees from Boltz. Split out of
+     * {@link getFees}, which also fetches the reverse pairs and rejects if
+     * either endpoint fails.
      */
     async getSubmarineFees(): Promise<FeesResponse["submarine"]> {
         const submarine = await this.pairsMetadata(

--- a/packages/boltz-swap/src/errors.ts
+++ b/packages/boltz-swap/src/errors.ts
@@ -221,13 +221,8 @@ export class CooperativeSignRefusedError extends SwapError {
 
 /**
  * Thrown when a chain swap's claim-side lockup holds less than the agreed
- * amount — `acceptedQuoteAmount` when a renegotiated quote was accepted,
- * `response.claimDetails.amount` otherwise. The claim is not performed, so
- * the preimage is never disclosed; the funded side stays recoverable through
- * the regular refund paths.
- *
- * Past the service-worker boundary only `message` survives, so the swap id
- * and both amounts are carried there.
+ * amount. The claim is not performed, so the preimage is never disclosed and
+ * the funded side stays recoverable through the regular refund paths.
  */
 export class LockupAmountMismatchError extends SwapError {
     public readonly swapId: string;
@@ -256,9 +251,6 @@ export class LockupAmountMismatchError extends SwapError {
  * plus the advertised submarine fee schedule. The response of a consistent
  * server always reconciles with its own advertised fees, so the swap is
  * rejected before it is persisted or funded.
- *
- * Past the service-worker boundary only `message` survives, so the swap id
- * and both amounts are carried there.
  */
 export class ExpectedAmountExceededError extends SwapError {
     public readonly swapId: string;

--- a/packages/boltz-swap/src/errors.ts
+++ b/packages/boltz-swap/src/errors.ts
@@ -219,6 +219,69 @@ export class CooperativeSignRefusedError extends SwapError {
     }
 }
 
+/**
+ * Thrown when a chain swap's claim-side lockup holds less than the agreed
+ * amount — `acceptedQuoteAmount` when a renegotiated quote was accepted,
+ * `response.claimDetails.amount` otherwise. The claim is not performed, so
+ * the preimage is never disclosed; the funded side stays recoverable through
+ * the regular refund paths.
+ *
+ * Past the service-worker boundary only `message` survives, so the swap id
+ * and both amounts are carried there.
+ */
+export class LockupAmountMismatchError extends SwapError {
+    public readonly swapId: string;
+    public readonly expectedAmount: number;
+    public readonly lockedAmount: number;
+
+    constructor(
+        options: ErrorOptions & { swapId: string; expectedAmount: number; lockedAmount: number },
+    ) {
+        super({
+            ...options,
+            message:
+                options.message ??
+                `Swap ${options.swapId}: claim-side lockup holds ${options.lockedAmount} sats, ` +
+                    `below the agreed ${options.expectedAmount} sats — not claiming`,
+        });
+        this.name = "LockupAmountMismatchError";
+        this.swapId = options.swapId;
+        this.expectedAmount = options.expectedAmount;
+        this.lockedAmount = options.lockedAmount;
+    }
+}
+
+/**
+ * Thrown when a submarine swap's `expectedAmount` exceeds the invoice amount
+ * plus the advertised submarine fee schedule. The response of a consistent
+ * server always reconciles with its own advertised fees, so the swap is
+ * rejected before it is persisted or funded.
+ *
+ * Past the service-worker boundary only `message` survives, so the swap id
+ * and both amounts are carried there.
+ */
+export class ExpectedAmountExceededError extends SwapError {
+    public readonly swapId: string;
+    public readonly expectedAmount: number;
+    public readonly maxAcceptable: number;
+
+    constructor(
+        options: ErrorOptions & { swapId: string; expectedAmount: number; maxAcceptable: number },
+    ) {
+        super({
+            ...options,
+            message:
+                options.message ??
+                `Swap ${options.swapId}: expected funding amount ${options.expectedAmount} sats ` +
+                    `exceeds the invoice amount plus advertised fees (${options.maxAcceptable} sats)`,
+        });
+        this.name = "ExpectedAmountExceededError";
+        this.swapId = options.swapId;
+        this.expectedAmount = options.expectedAmount;
+        this.maxAcceptable = options.maxAcceptable;
+    }
+}
+
 /** Reason a `quoteSwap` was rejected before being posted to Boltz. */
 export type QuoteRejectionReason =
     | "below_floor"

--- a/packages/boltz-swap/src/index.ts
+++ b/packages/boltz-swap/src/index.ts
@@ -52,6 +52,8 @@ export {
     QuoteRejectedError,
     VHTLCAddressMismatchError,
     CooperativeSignRefusedError,
+    LockupAmountMismatchError,
+    ExpectedAmountExceededError,
 } from "./errors";
 export type { QuoteRejectionReason } from "./errors";
 export {

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -1373,8 +1373,8 @@ export class SwapManager implements SwapManagerClient {
      * Mirror an accepted renegotiation amount onto the monitored copy of a
      * chain swap. The manager saves that copy on every status update, so
      * without the mirror a save from the pre-quote snapshot would drop the
-     * field just persisted by `quoteSwap`/`acceptSwapQuote` — the same
-     * clobbering hazard `rememberChainClaim` covers for the claim txid.
+     * field `quoteSwap`/`acceptSwapQuote` just persisted — the same clobbering
+     * hazard `rememberChainClaim` covers for the claim txid.
      */
     noteAcceptedQuote(swapId: string, amount: number): void {
         const swap = this.monitoredSwaps.get(swapId);

--- a/packages/boltz-swap/src/swap-manager.ts
+++ b/packages/boltz-swap/src/swap-manager.ts
@@ -1370,6 +1370,20 @@ export class SwapManager implements SwapManagerClient {
     }
 
     /**
+     * Mirror an accepted renegotiation amount onto the monitored copy of a
+     * chain swap. The manager saves that copy on every status update, so
+     * without the mirror a save from the pre-quote snapshot would drop the
+     * field just persisted by `quoteSwap`/`acceptSwapQuote` — the same
+     * clobbering hazard `rememberChainClaim` covers for the claim txid.
+     */
+    noteAcceptedQuote(swapId: string, amount: number): void {
+        const swap = this.monitoredSwaps.get(swapId);
+        if (swap && isPendingChainSwap(swap)) {
+            swap.acceptedQuoteAmount = amount;
+        }
+    }
+
+    /**
      * Execute refund action for chain swap Ark to Btc
      */
     private async executeRefundArkAction(

--- a/packages/boltz-swap/src/types.ts
+++ b/packages/boltz-swap/src/types.ts
@@ -345,6 +345,12 @@ export interface BoltzChainSwap {
      * swaps we have not claimed yet.
      */
     claimTxid?: string;
+    /**
+     * Latest renegotiated claim-side amount accepted via `quoteSwap` /
+     * `acceptSwapQuote`. Supersedes `response.claimDetails.amount` as the
+     * agreed amount once set. Absent when the swap was never renegotiated.
+     */
+    acceptedQuoteAmount?: number;
 }
 
 /** Union type of all pending swap types. */

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -248,11 +248,11 @@ export const joinBatch = async (
 };
 
 /**
- * Claims a VHTLC using an offchain transaction.
+ * Claims one or more VTXOs at a VHTLC using a single offchain transaction.
  * @param identity
  * @param vhtlcScript
  * @param serverXOnlyPublicKey
- * @param input
+ * @param inputs - VTXOs at the VHTLC script, all spent through the claim leaf.
  * @param output
  * @param arkInfo
  * @param arkProvider
@@ -262,7 +262,7 @@ export const claimVHTLCwithOffchainTx = async (
     identity: Identity,
     vhtlcScript: VHTLC.Script,
     serverXOnlyPublicKey: Uint8Array,
-    input: ArkTxInput,
+    inputs: ArkTxInput[],
     output: TransactionOutput,
     arkInfo: ArkInfo,
     arkProvider: ArkProvider,
@@ -272,7 +272,7 @@ export const claimVHTLCwithOffchainTx = async (
     const serverUnrollScript = CSVMultisigTapscript.decode(rawCheckpointTapscript);
 
     // create the offchain transaction to claim the VHTLC
-    const { arkTx, checkpoints } = buildOffchainTx([input], [output], serverUnrollScript);
+    const { arkTx, checkpoints } = buildOffchainTx(inputs, [output], serverUnrollScript);
 
     // sign and submit the virtual transaction
     const signedArkTx = await identity.sign(arkTx);

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -37,7 +37,7 @@ import { schnorr } from "@noble/curves/secp256k1.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { ripemd160 } from "@noble/hashes/legacy.js";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
-import { Address, OutScript, Script, ScriptNum } from "@scure/btc-signer";
+import { Address, OutScript, Script, ScriptNum, Transaction } from "@scure/btc-signer";
 import { decodeInvoice } from "../src/utils/decoding";
 import { resolveVhtlcTimeouts } from "../src/utils/restoration";
 import { logger } from "../src/logger";
@@ -587,13 +587,19 @@ describe("ArkadeSwaps", () => {
         } as unknown as BoltzChainSwap;
     };
 
+    const mockSubmarineFees = {
+        submarine: { percentage: 0.1, minerFees: 200 },
+        reverse: { percentage: 0.25, minerFees: { claim: 100, lockup: 100 } },
+    };
+
     /**
-     * Let `createSubmarineSwap`'s lockup-address check pass: the canned Boltz
-     * response is not a real VHTLC, and these tests cover request/response
-     * behavior rather than the check itself.
+     * Let `createSubmarineSwap`'s lockup-address and expected-amount checks
+     * pass: the canned Boltz response is not a real VHTLC, and these tests
+     * cover request/response behavior rather than the checks themselves.
      */
     const stubLockupValidation = () => {
         vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
+        vi.spyOn(swaps, "getFees").mockResolvedValue(mockSubmarineFees as any);
         return vi.spyOn(swaps as any, "buildSubmarineVHTLCContext").mockResolvedValue({} as any);
     };
 
@@ -1006,6 +1012,7 @@ describe("ArkadeSwaps", () => {
                         response: {
                             ...createReverseSwapResponse,
                             lockupAddress: mockVHTLC.vhtlcAddress,
+                            onchainAmount: mock.amount,
                         },
                         status: "swap.created",
                     };
@@ -1219,6 +1226,48 @@ describe("ArkadeSwaps", () => {
                 expect(manager.addSwap).not.toHaveBeenCalled();
             });
 
+            // invoice 3_000_000 sats + 200 miner fee + 0.1% (3000) = 3_003_200
+            const submarineFeeCeiling =
+                mock.invoice.amount +
+                mockSubmarineFees.submarine.minerFees +
+                Math.ceil((mock.invoice.amount * mockSubmarineFees.submarine.percentage) / 100);
+
+            it("rejects an expected amount above the invoice plus advertised fees", async () => {
+                // arrange
+                stubLockupValidation();
+                const manager = { addSwap: vi.fn() };
+                (swaps as any).swapManager = manager;
+                vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce({
+                    ...createSubmarineSwapResponse,
+                    expectedAmount: submarineFeeCeiling + 1,
+                });
+
+                // act & assert
+                await expect(
+                    swaps.createSubmarineSwap({ invoice: mock.invoice.address }),
+                ).rejects.toThrow(/exceeds the invoice amount plus advertised fees/);
+                expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+                expect(manager.addSwap).not.toHaveBeenCalled();
+            });
+
+            it("accepts an expected amount at the advertised fee ceiling", async () => {
+                // arrange
+                stubLockupValidation();
+                vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce({
+                    ...createSubmarineSwapResponse,
+                    expectedAmount: submarineFeeCeiling,
+                });
+
+                // act
+                const pendingSwap = await swaps.createSubmarineSwap({
+                    invoice: mock.invoice.address,
+                });
+
+                // assert
+                expect(pendingSwap.response.expectedAmount).toBe(submarineFeeCeiling);
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledOnce();
+            });
+
             it("should get correct swap status", async () => {
                 // arrange
                 stubLockupValidation();
@@ -1308,6 +1357,27 @@ describe("ArkadeSwaps", () => {
                 expect(sendSpy).not.toHaveBeenCalled();
                 expect(fundedSpy).not.toHaveBeenCalled();
                 expect(settlementSpy).not.toHaveBeenCalled();
+            });
+
+            it("does not fund a swap whose expected amount exceeds the fee ceiling", async () => {
+                // arrange: the real createSubmarineSwap runs, its amount check fails
+                const validationStub = stubLockupValidation();
+                validationStub.mockResolvedValue({} as any);
+                const ceiling =
+                    mock.invoice.amount +
+                    mockSubmarineFees.submarine.minerFees +
+                    Math.ceil((mock.invoice.amount * mockSubmarineFees.submarine.percentage) / 100);
+                vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce({
+                    ...createSubmarineSwapResponse,
+                    expectedAmount: ceiling + 1,
+                });
+                const sendSpy = vi.spyOn(wallet, "send");
+
+                // act & assert
+                await expect(
+                    swaps.sendLightningPayment({ invoice: mock.invoice.address }),
+                ).rejects.toThrow(/exceeds the invoice amount plus advertised fees/);
+                expect(sendSpy).not.toHaveBeenCalled();
             });
 
             it("should warn on waitFor funded when the SwapManager is disabled", async () => {
@@ -1720,6 +1790,92 @@ describe("ArkadeSwaps", () => {
             });
         });
 
+        describe("claimBtc — lockup amount", () => {
+            const arkToBtcSwap = (): BoltzChainSwap => ({
+                ...makeBtcChainSwap("BTC"),
+                toAddress: mock.address.btc,
+            });
+
+            const lockupTxHex = (swap: BoltzChainSwap, amount: bigint): string => {
+                const { tree } = deserializeSwapTree(swap.response.claimDetails.swapTree!);
+                const musig = tweakMusig(
+                    createMusig(btcEphemeralPriv, [btcBoltzPub, btcEphemeralPub]),
+                    tree,
+                );
+                const tx = new Transaction();
+                tx.addInput({ txid: randomBytes(32), index: 0 });
+                tx.addOutput({ script: p2trScript(musig.aggPubkey), amount });
+                return tx.hex;
+            };
+
+            const arrange = (
+                swap: BoltzChainSwap,
+                lockedAmount: bigint,
+                stored: BoltzChainSwap[] = [],
+            ) => {
+                vi.spyOn(arkProvider, "getInfo").mockResolvedValue(mockArkInfo);
+                mockSwapRepository.getAllSwaps.mockResolvedValue(stored);
+                vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                    status: "transaction.server.confirmed",
+                    transaction: { hex: lockupTxHex(swap, lockedAmount) },
+                } as any);
+                return vi.spyOn(swapProvider, "postChainClaimDetails").mockResolvedValue({} as any);
+            };
+
+            it("does not request the claim signature for a lockup below the agreed amount", async () => {
+                const swap = arkToBtcSwap();
+                const post = arrange(swap, BigInt(mock.amount - 1));
+
+                await expect(swaps.claimBtc(swap)).rejects.toThrow(/below the agreed/);
+                expect(post).not.toHaveBeenCalled();
+            });
+
+            it("proceeds when the lockup matches the agreed amount", async () => {
+                const swap = arkToBtcSwap();
+                const post = arrange(swap, BigInt(mock.amount));
+
+                // the stubbed claim details carry no signature, so the claim
+                // fails after the request — the amount check has passed by then
+                await expect(swaps.claimBtc(swap)).rejects.toThrow(
+                    /invalid signature data from server/,
+                );
+                expect(post).toHaveBeenCalledOnce();
+            });
+
+            it("claims against the latest accepted renegotiation amount", async () => {
+                const swap = arkToBtcSwap();
+                const renegotiated = mock.amount - 5000;
+                const post = arrange(swap, BigInt(renegotiated), [
+                    { ...swap, acceptedQuoteAmount: renegotiated },
+                ]);
+
+                await expect(swaps.claimBtc(swap)).rejects.toThrow(
+                    /invalid signature data from server/,
+                );
+                expect(post).toHaveBeenCalledOnce();
+            });
+
+            it("derives the exact-delivery fee from the renegotiated amount", async () => {
+                const renegotiated = mock.amount - 5000;
+                const base = arkToBtcSwap();
+                const swap: BoltzChainSwap = {
+                    ...base,
+                    amount: renegotiated - 1000,
+                    request: { ...base.request, serverLockAmount: mock.amount },
+                };
+                const post = arrange(swap, BigInt(renegotiated), [
+                    { ...swap, acceptedQuoteAmount: renegotiated },
+                ]);
+
+                await expect(swaps.claimBtc(swap)).rejects.toThrow(
+                    /invalid signature data from server/,
+                );
+                const toSign = (post.mock.calls[0][1] as any).toSign;
+                const claimTx = Transaction.fromRaw(hex.decode(toSign.transaction));
+                expect(claimTx.getOutput(0).amount).toBe(BigInt(renegotiated - 1000));
+            });
+        });
+
         describe("createChainSwap", () => {
             it("should create a chain swap from Ark to Btc", async () => {
                 // arrange
@@ -1745,6 +1901,52 @@ describe("ArkadeSwaps", () => {
                 expect(pendingSwap.response.lockupDetails.lockupAddress).toBe(mock.address.ark);
                 expect(pendingSwap.status).toEqual("swap.created");
                 expect(pendingSwap.toAddress).toBe(mock.address.btc);
+            });
+
+            it("rejects a response whose claim amount differs from the computed server lock", async () => {
+                // receiver-lock case: serverLockAmount = receiverLockAmount +
+                // user claim fee, and the response must echo it verbatim
+                vi.spyOn(swapProvider, "getChainFees").mockResolvedValueOnce({
+                    minerFees: { server: 50, user: { claim: 21, lockup: 30 } },
+                    percentage: 0.5,
+                });
+                vi.spyOn(swapProvider, "createChainSwap").mockResolvedValueOnce(
+                    createBtcArkChainSwapResponse,
+                );
+
+                await expect(
+                    swaps.createChainSwap({
+                        to: "ARK",
+                        from: "BTC",
+                        receiverLockAmount: mock.amount,
+                        toAddress: mock.address.ark,
+                    }),
+                ).rejects.toThrow(/does not match the requested server lock amount/);
+                expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+            });
+
+            it("accepts a response whose claim amount matches the computed server lock", async () => {
+                vi.spyOn(swapProvider, "getChainFees").mockResolvedValueOnce({
+                    minerFees: { server: 50, user: { claim: 21, lockup: 30 } },
+                    percentage: 0.5,
+                });
+                vi.spyOn(swapProvider, "createChainSwap").mockResolvedValueOnce({
+                    ...createBtcArkChainSwapResponse,
+                    claimDetails: {
+                        ...createBtcArkChainSwapResponse.claimDetails,
+                        amount: mock.amount + 21,
+                    },
+                });
+
+                const pendingSwap = await swaps.createChainSwap({
+                    to: "ARK",
+                    from: "BTC",
+                    receiverLockAmount: mock.amount,
+                    toAddress: mock.address.ark,
+                });
+
+                expect(pendingSwap.request.serverLockAmount).toBe(mock.amount + 21);
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledOnce();
             });
         });
 
@@ -1981,6 +2183,61 @@ describe("ArkadeSwaps", () => {
                 expect(postSpy).toHaveBeenCalledWith(mock.id, {
                     amount: 1234,
                 });
+            });
+
+            it("persists the accepted amount as the swap's agreed amount", async () => {
+                // arrange
+                mockSwapRepository.getAllSwaps.mockResolvedValue([mockArkBtcChainSwap]);
+                vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
+                    amount: mock.amount,
+                });
+                vi.spyOn(swapProvider, "postChainQuote").mockResolvedValueOnce({});
+
+                // act
+                await swaps.quoteSwap(mock.id);
+
+                // assert
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        id: mock.id,
+                        acceptedQuoteAmount: mock.amount,
+                    }),
+                );
+            });
+
+            it("floors repeated renegotiations on the latest accepted amount", async () => {
+                // arrange — the stored acceptance sits below claimDetails.amount;
+                // a quote between the two passes only if the floor tracks it
+                const stored = {
+                    ...mockArkBtcChainSwap,
+                    acceptedQuoteAmount: mock.amount - 10000,
+                };
+                mockSwapRepository.getAllSwaps.mockResolvedValue([stored]);
+                vi.spyOn(swapProvider, "getChainQuote").mockResolvedValueOnce({
+                    amount: mock.amount - 5000,
+                });
+                const postSpy = vi.spyOn(swapProvider, "postChainQuote").mockResolvedValueOnce({});
+
+                // act & assert
+                await expect(swaps.quoteSwap(mock.id)).resolves.toBe(mock.amount - 5000);
+                expect(postSpy).toHaveBeenCalledOnce();
+            });
+
+            it("acceptSwapQuote persists the accepted amount", async () => {
+                // arrange
+                mockSwapRepository.getAllSwaps.mockResolvedValue([mockArkBtcChainSwap]);
+                vi.spyOn(swapProvider, "postChainQuote").mockResolvedValueOnce({});
+
+                // act
+                await swaps.acceptSwapQuote(mock.id, 1234, { minAcceptableAmount: 1000 });
+
+                // assert
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        id: mock.id,
+                        acceptedQuoteAmount: 1234,
+                    }),
+                );
             });
 
             it.each([
@@ -2466,6 +2723,157 @@ describe("ArkadeSwaps", () => {
                 } finally {
                     vi.useRealTimers();
                 }
+            });
+
+            describe("lockup amount and multi-VTXO claim", () => {
+                const chainVtxo = (
+                    value: number,
+                    opts: { swept?: boolean; isSpent?: boolean } = {},
+                ) => ({
+                    txid: hex.encode(randomBytes(32)),
+                    vout: 0,
+                    value,
+                    status: { confirmed: true, blockHeight: 100, blockHash: "abc" },
+                    virtualStatus: {
+                        state: opts.swept ? ("swept" as const) : ("settled" as const),
+                    },
+                    isSpent: opts.isSpent ?? false,
+                    isUnrolled: false,
+                    createdAt: new Date(),
+                });
+
+                const arrange = (vtxos: any[], stored: BoltzChainSwap[] = []) => {
+                    const pendingSwap: BoltzChainSwap = {
+                        ...mockBtcArkChainSwap,
+                        preimage: hex.encode(mockPreimage),
+                    };
+                    vi.mocked(claimVHTLCwithOffchainTx).mockResolvedValue("a".repeat(64));
+                    vi.spyOn(arkProvider, "getInfo").mockResolvedValue(mockArkInfo);
+                    vi.spyOn(swaps, "createVHTLCScript").mockReturnValue(mockBtcArkVHTLC);
+                    vi.mocked(wallet.getAddress).mockResolvedValue(mock.address.ark);
+                    mockSwapRepository.getAllSwaps.mockResolvedValue(stored);
+                    vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({ vtxos } as any);
+                    vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                        status: "transaction.claimed",
+                    } as any);
+                    const joinBatchSpy = vi
+                        .spyOn(swaps as any, "joinBatch")
+                        .mockResolvedValue(mock.txid);
+                    return { pendingSwap, joinBatchSpy };
+                };
+
+                it("does not claim a lockup below the agreed amount", async () => {
+                    vi.useFakeTimers();
+                    try {
+                        const { pendingSwap, joinBatchSpy } = arrange([
+                            chainVtxo(mock.amount - 10000),
+                        ]);
+
+                        const promise = swaps.claimArk(pendingSwap);
+                        promise.catch(() => {});
+                        await vi.advanceTimersByTimeAsync(1000);
+
+                        await expect(promise).rejects.toThrow(/below the agreed/);
+                        expect(vi.mocked(claimVHTLCwithOffchainTx)).not.toHaveBeenCalled();
+                        expect(joinBatchSpy).not.toHaveBeenCalled();
+                        expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+                    } finally {
+                        vi.useRealTimers();
+                    }
+                });
+
+                it("does not claim a split lockup summing below the agreed amount", async () => {
+                    vi.useFakeTimers();
+                    try {
+                        const { pendingSwap, joinBatchSpy } = arrange([
+                            chainVtxo(30000),
+                            chainVtxo(10000),
+                        ]);
+
+                        const promise = swaps.claimArk(pendingSwap);
+                        promise.catch(() => {});
+                        await vi.advanceTimersByTimeAsync(1000);
+
+                        await expect(promise).rejects.toThrow(/below the agreed/);
+                        expect(vi.mocked(claimVHTLCwithOffchainTx)).not.toHaveBeenCalled();
+                        expect(joinBatchSpy).not.toHaveBeenCalled();
+                    } finally {
+                        vi.useRealTimers();
+                    }
+                });
+
+                it("claims a split lockup in one offchain transaction", async () => {
+                    const vtxoA = chainVtxo(30000);
+                    const vtxoB = chainVtxo(20000);
+                    const { pendingSwap } = arrange([vtxoA, vtxoB]);
+
+                    await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
+                        txid: "a".repeat(64),
+                    });
+
+                    const offchainSpy = vi.mocked(claimVHTLCwithOffchainTx);
+                    expect(offchainSpy).toHaveBeenCalledOnce();
+                    const inputs = offchainSpy.mock.calls[0][3] as any[];
+                    expect(inputs.map((i) => i.txid)).toEqual([vtxoA.txid, vtxoB.txid]);
+                    expect((offchainSpy.mock.calls[0][4] as any).amount).toBe(50000n);
+                    expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                        expect.objectContaining({ claimTxid: "a".repeat(64) }),
+                    );
+                });
+
+                it("partitions swept and live VTXOs between batch and offchain claim", async () => {
+                    const live = chainVtxo(30000);
+                    const swept = chainVtxo(20000, { swept: true });
+                    const { pendingSwap, joinBatchSpy } = arrange([live, swept]);
+
+                    await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
+                        txid: "a".repeat(64),
+                    });
+
+                    const offchainSpy = vi.mocked(claimVHTLCwithOffchainTx);
+                    expect(offchainSpy).toHaveBeenCalledOnce();
+                    const inputs = offchainSpy.mock.calls[0][3] as any[];
+                    expect(inputs.map((i) => i.txid)).toEqual([live.txid]);
+                    expect((offchainSpy.mock.calls[0][4] as any).amount).toBe(30000n);
+                    expect(joinBatchSpy).toHaveBeenCalledOnce();
+                    expect((joinBatchSpy.mock.calls[0][1] as any).txid).toBe(swept.txid);
+                    expect((joinBatchSpy.mock.calls[0][2] as any).amount).toBe(20000n);
+                });
+
+                it("claims the remainder when part of the lockup is already spent", async () => {
+                    const { pendingSwap } = arrange([
+                        chainVtxo(35000, { isSpent: true }),
+                        chainVtxo(15000),
+                    ]);
+
+                    await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
+                        txid: "a".repeat(64),
+                    });
+
+                    const offchainSpy = vi.mocked(claimVHTLCwithOffchainTx);
+                    expect(offchainSpy).toHaveBeenCalledOnce();
+                    expect((offchainSpy.mock.calls[0][3] as any[]).length).toBe(1);
+                    expect((offchainSpy.mock.calls[0][4] as any).amount).toBe(15000n);
+                });
+
+                it("claims against the latest accepted renegotiation amount", async () => {
+                    const renegotiated = mock.amount - 10000;
+                    const base: BoltzChainSwap = {
+                        ...mockBtcArkChainSwap,
+                        preimage: hex.encode(mockPreimage),
+                    };
+                    const { pendingSwap } = arrange(
+                        [chainVtxo(renegotiated)],
+                        [{ ...base, acceptedQuoteAmount: renegotiated }],
+                    );
+
+                    await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
+                        txid: "a".repeat(64),
+                    });
+                    expect(
+                        (vi.mocked(claimVHTLCwithOffchainTx).mock.calls[0][4] as any).amount,
+                    ).toBe(BigInt(renegotiated));
+                });
             });
         });
 
@@ -5344,7 +5752,7 @@ describe("ArkadeSwaps", () => {
             },
         };
 
-        const buildPendingSwap = (): BoltzReverseSwap => ({
+        const buildPendingSwap = (onchainAmount: number | undefined = 50000): BoltzReverseSwap => ({
             id: mock.id,
             type: "reverse",
             createdAt: Date.now(),
@@ -5353,6 +5761,7 @@ describe("ArkadeSwaps", () => {
             response: {
                 ...createReverseSwapResponse,
                 lockupAddress: mockVHTLC.vhtlcAddress,
+                onchainAmount,
             },
             status: "swap.created",
         });
@@ -5399,8 +5808,8 @@ describe("ArkadeSwaps", () => {
 
             const offchainSpy = vi.mocked(claimVHTLCwithOffchainTx);
             expect(offchainSpy).toHaveBeenCalledTimes(2);
-            expect((offchainSpy.mock.calls[0][3] as any).txid).toBe(txidA);
-            expect((offchainSpy.mock.calls[1][3] as any).txid).toBe(txidB);
+            expect((offchainSpy.mock.calls[0][3] as any)[0].txid).toBe(txidA);
+            expect((offchainSpy.mock.calls[1][3] as any)[0].txid).toBe(txidB);
             expect(joinBatchSpy).not.toHaveBeenCalled();
             expect(swapStatusSpy).toHaveBeenCalledTimes(1);
             expect(mockSwapRepository.saveSwap).toHaveBeenCalledTimes(1);
@@ -5428,7 +5837,7 @@ describe("ArkadeSwaps", () => {
             expect((joinBatchSpy.mock.calls[0][1] as any).txid).toBe(txidA);
             const offchainSpy = vi.mocked(claimVHTLCwithOffchainTx);
             expect(offchainSpy).toHaveBeenCalledTimes(1);
-            expect((offchainSpy.mock.calls[0][3] as any).txid).toBe(txidB);
+            expect((offchainSpy.mock.calls[0][3] as any)[0].txid).toBe(txidB);
         });
 
         it("ignores spent VTXOs but still claims the unspent ones", async () => {
@@ -5535,6 +5944,69 @@ describe("ArkadeSwaps", () => {
             } finally {
                 vi.useRealTimers();
             }
+        });
+
+        it("does not claim a lockup summing below the confirmed amount", async () => {
+            vi.useFakeTimers();
+            try {
+                const vtxos = [recoverableVtxo(txidA, 0), recoverableVtxo(txidB, 1)];
+                vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                    vtxos: vtxos as any,
+                });
+                const joinBatchSpy = vi
+                    .spyOn(swaps as any, "joinBatch")
+                    .mockResolvedValue(undefined);
+
+                // two 50k VTXOs against a 150k confirmed amount — the shortfall
+                // retries (indexer lag on a split lockup) before rejecting
+                const promise = swaps.claimVHTLC(buildPendingSwap(150000));
+                promise.catch(() => {});
+                await vi.advanceTimersByTimeAsync(1000);
+
+                await expect(promise).rejects.toThrow(/below the agreed/);
+                expect(joinBatchSpy).not.toHaveBeenCalled();
+                expect(claimVHTLCwithOffchainTx).not.toHaveBeenCalled();
+                expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("claims the remainder when part of the lockup is already spent", async () => {
+            const vtxos = [
+                { ...recoverableVtxo(txidA, 0), isSpent: true },
+                recoverableVtxo(txidB, 1),
+            ];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+            const joinBatchSpy = vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
+
+            // the remaining 50k does not cover the 100k confirmed amount, but
+            // an earlier claim already spent part of the lockup
+            await expect(swaps.claimVHTLC(buildPendingSwap(100000))).resolves.toBeUndefined();
+            expect(joinBatchSpy).toHaveBeenCalledTimes(1);
+            expect((joinBatchSpy.mock.calls[0][1] as any).txid).toBe(txidB);
+        });
+
+        it("warns and still claims when no confirmed amount is on record", async () => {
+            const vtxos = [recoverableVtxo(txidA, 0)];
+            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
+                vtxos: vtxos as any,
+            });
+            const joinBatchSpy = vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
+            const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+            // an explicit `undefined` argument would take the builder's
+            // default, so drop the field from the built swap instead
+            const legacySwap = buildPendingSwap();
+            delete (legacySwap.response as any).onchainAmount;
+
+            await expect(swaps.claimVHTLC(legacySwap)).resolves.toBeUndefined();
+            expect(joinBatchSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringMatching(/skipping the lockup amount check/),
+            );
         });
     });
 

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -822,8 +822,7 @@ describe("ArkadeSwaps", () => {
             });
 
             // `onchainAmount` is the authority the claim later enforces, so a
-            // response without it is rejected while nothing is committed —
-            // rather than leaving the claim with nothing to compare against.
+            // response without it is rejected while nothing is committed.
             it("rejects a response carrying no claim-side amount", async () => {
                 // arrange
                 const { onchainAmount: _omitted, ...withoutAmount } = createReverseSwapResponse;
@@ -1243,10 +1242,9 @@ describe("ArkadeSwaps", () => {
                 expect(manager.addSwap).not.toHaveBeenCalled();
             });
 
-            // invoice 3_000_000 sats + 200 miner fee + 0.1% (3000). Pinned as a
-            // literal rather than recomputed from the implementation's formula,
-            // so a change to that formula moves the assertion instead of the
-            // boundary moving with it.
+            // invoice 3_000_000 sats + 200 miner fee + 0.1% (3000). A literal,
+            // so a change to the production formula moves the assertion rather
+            // than the boundary it asserts against.
             const submarineFeeCeiling = 3_003_200;
 
             it("rejects an expected amount above the invoice plus advertised fees", async () => {
@@ -2876,10 +2874,8 @@ describe("ArkadeSwaps", () => {
                     );
                 });
 
-                // A VTXO consumed by a batch round carries `settledBy` and need
-                // not carry `isSpent`. Counting one as spendable would inflate
-                // the total past the agreed amount and re-feed a spent input to
-                // the claim.
+                // Counting a batch-consumed VTXO as spendable would inflate the
+                // total past the agreed amount and re-feed a spent input.
                 it("treats a VTXO consumed by a batch round as already claimed", async () => {
                     const settled = chainVtxo(35000, { settledBy: "b".repeat(64) });
                     const remainder = chainVtxo(15000);

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -599,7 +599,7 @@ describe("ArkadeSwaps", () => {
      */
     const stubLockupValidation = () => {
         vi.mocked(arkProvider.getInfo).mockResolvedValue(mockArkInfo);
-        vi.spyOn(swaps, "getFees").mockResolvedValue(mockSubmarineFees as any);
+        vi.spyOn(swapProvider, "getSubmarineFees").mockResolvedValue(mockSubmarineFees.submarine);
         return vi.spyOn(swaps as any, "buildSubmarineVHTLCContext").mockResolvedValue({} as any);
     };
 
@@ -819,6 +819,23 @@ describe("ArkadeSwaps", () => {
                 expect(pendingSwap.response.onchainAmount).toBe(mock.invoice.amount);
                 expect(pendingSwap.response.refundPublicKey).toBe(compressedPubkeys.boltz);
                 expect(pendingSwap.status).toEqual("swap.created");
+            });
+
+            // `onchainAmount` is the authority the claim later enforces, so a
+            // response without it is rejected while nothing is committed —
+            // rather than leaving the claim with nothing to compare against.
+            it("rejects a response carrying no claim-side amount", async () => {
+                // arrange
+                const { onchainAmount: _omitted, ...withoutAmount } = createReverseSwapResponse;
+                vi.spyOn(swapProvider, "createReverseSwap").mockImplementationOnce(
+                    reverseSwapResponseFor(withoutAmount as CreateReverseSwapResponse),
+                );
+
+                // act & assert
+                await expect(
+                    swaps.createReverseSwap({ amount: mock.invoice.amount }),
+                ).rejects.toThrow(/carries no claim-side amount/);
+                expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
             });
 
             it("should get correct swap status", async () => {
@@ -1226,11 +1243,11 @@ describe("ArkadeSwaps", () => {
                 expect(manager.addSwap).not.toHaveBeenCalled();
             });
 
-            // invoice 3_000_000 sats + 200 miner fee + 0.1% (3000) = 3_003_200
-            const submarineFeeCeiling =
-                mock.invoice.amount +
-                mockSubmarineFees.submarine.minerFees +
-                Math.ceil((mock.invoice.amount * mockSubmarineFees.submarine.percentage) / 100);
+            // invoice 3_000_000 sats + 200 miner fee + 0.1% (3000). Pinned as a
+            // literal rather than recomputed from the implementation's formula,
+            // so a change to that formula moves the assertion instead of the
+            // boundary moving with it.
+            const submarineFeeCeiling = 3_003_200;
 
             it("rejects an expected amount above the invoice plus advertised fees", async () => {
                 // arrange
@@ -1363,10 +1380,8 @@ describe("ArkadeSwaps", () => {
                 // arrange: the real createSubmarineSwap runs, its amount check fails
                 const validationStub = stubLockupValidation();
                 validationStub.mockResolvedValue({} as any);
-                const ceiling =
-                    mock.invoice.amount +
-                    mockSubmarineFees.submarine.minerFees +
-                    Math.ceil((mock.invoice.amount * mockSubmarineFees.submarine.percentage) / 100);
+                // invoice 3_000_000 sats + 200 miner fee + 0.1% (3000)
+                const ceiling = 3_003_200;
                 vi.spyOn(swapProvider, "createSubmarineSwap").mockResolvedValueOnce({
                     ...createSubmarineSwapResponse,
                     expectedAmount: ceiling + 1,
@@ -2728,8 +2743,9 @@ describe("ArkadeSwaps", () => {
             describe("lockup amount and multi-VTXO claim", () => {
                 const chainVtxo = (
                     value: number,
-                    opts: { swept?: boolean; isSpent?: boolean } = {},
+                    opts: { swept?: boolean; isSpent?: boolean; settledBy?: string } = {},
                 ) => ({
+                    ...(opts.settledBy ? { settledBy: opts.settledBy } : {}),
                     txid: hex.encode(randomBytes(32)),
                     vout: 0,
                     value,
@@ -2838,6 +2854,46 @@ describe("ArkadeSwaps", () => {
                     expect(joinBatchSpy).toHaveBeenCalledOnce();
                     expect((joinBatchSpy.mock.calls[0][1] as any).txid).toBe(swept.txid);
                     expect((joinBatchSpy.mock.calls[0][2] as any).amount).toBe(20000n);
+                });
+
+                it("claims a fully swept lockup through batch rounds only", async () => {
+                    const sweptA = chainVtxo(30000, { swept: true });
+                    const sweptB = chainVtxo(20000, { swept: true });
+                    const { pendingSwap, joinBatchSpy } = arrange([sweptA, sweptB]);
+
+                    await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
+                        txid: mock.txid,
+                    });
+
+                    expect(vi.mocked(claimVHTLCwithOffchainTx)).not.toHaveBeenCalled();
+                    expect(joinBatchSpy).toHaveBeenCalledTimes(2);
+                    expect(joinBatchSpy.mock.calls.map((call) => (call[1] as any).txid)).toEqual([
+                        sweptA.txid,
+                        sweptB.txid,
+                    ]);
+                    expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                        expect.objectContaining({ claimTxid: mock.txid }),
+                    );
+                });
+
+                // A VTXO consumed by a batch round carries `settledBy` and need
+                // not carry `isSpent`. Counting one as spendable would inflate
+                // the total past the agreed amount and re-feed a spent input to
+                // the claim.
+                it("treats a VTXO consumed by a batch round as already claimed", async () => {
+                    const settled = chainVtxo(35000, { settledBy: "b".repeat(64) });
+                    const remainder = chainVtxo(15000);
+                    const { pendingSwap } = arrange([settled, remainder]);
+
+                    await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
+                        txid: "a".repeat(64),
+                    });
+
+                    const offchainSpy = vi.mocked(claimVHTLCwithOffchainTx);
+                    expect(offchainSpy).toHaveBeenCalledOnce();
+                    const inputs = offchainSpy.mock.calls[0][3] as any[];
+                    expect(inputs.map((i) => i.txid)).toEqual([remainder.txid]);
+                    expect((offchainSpy.mock.calls[0][4] as any).amount).toBe(15000n);
                 });
 
                 it("claims the remainder when part of the lockup is already spent", async () => {

--- a/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
+++ b/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
@@ -96,7 +96,7 @@ function arkProviderStub(
     return {
         submitTx: vi.fn(async (arkTxB64: string, checkpointsB64: string[]) => {
             const submitted = Transaction.fromPSBT(base64.decode(arkTxB64));
-            const signedArk = await serverKey.sign(submitted, [0]);
+            const signedArk = await serverKey.sign(submitted);
             return {
                 arkTxid: overrideArkTxid ?? submitted.id,
                 finalArkTx: base64.encode(signedArk.toPSBT()),
@@ -128,7 +128,7 @@ describe("claimVHTLCwithOffchainTx checkpoint reconciliation", () => {
             ourKey,
             vhtlcScript,
             server,
-            input,
+            [input],
             output,
             arkInfo,
             arkProvider,
@@ -141,6 +141,31 @@ describe("claimVHTLCwithOffchainTx checkpoint reconciliation", () => {
         expect(arkProvider.finalizeTx).toHaveBeenCalledTimes(1);
     });
 
+    it("claims two VTXOs at the script in one offchain tx", async () => {
+        const { vhtlcScript, server, input, output, arkInfo } = await fixture();
+        const input2: ArkTxInput = { ...input, txid: "22".repeat(32), vout: 1 };
+        const arkProvider = arkProviderStub(serverSigned);
+
+        const arkTxid = await claimVHTLCwithOffchainTx(
+            ourKey,
+            vhtlcScript,
+            server,
+            [input, input2],
+            { ...output, amount: BigInt(VALUE * 2) },
+            arkInfo,
+            arkProvider,
+        );
+
+        const [submittedArkB64, submittedCheckpoints] = arkProvider.submitTx.mock.calls[0] as [
+            string,
+            string[],
+        ];
+        expect(submittedCheckpoints).toHaveLength(2);
+        expect(arkTxid).toBe(Transaction.fromPSBT(base64.decode(submittedArkB64)).id);
+        const finalized = arkProvider.finalizeTx.mock.calls[0][1] as string[];
+        expect(finalized).toHaveLength(2);
+    });
+
     it("rejects a response whose arkTxid is not the submitted tx", async () => {
         const { vhtlcScript, server, input, output, arkInfo } = await fixture();
         const arkProvider = arkProviderStub(serverSigned, "cd".repeat(32));
@@ -150,7 +175,7 @@ describe("claimVHTLCwithOffchainTx checkpoint reconciliation", () => {
                 ourKey,
                 vhtlcScript,
                 server,
-                input,
+                [input],
                 output,
                 arkInfo,
                 arkProvider,
@@ -168,7 +193,7 @@ describe("claimVHTLCwithOffchainTx checkpoint reconciliation", () => {
                 ourKey,
                 vhtlcScript,
                 server,
-                input,
+                [input],
                 output,
                 arkInfo,
                 arkProvider,


### PR DESCRIPTION
- `claimArk` and `claimVHTLC` claim every spendable VTXO at the lockup script, not only the first
- all three claim paths check the locked total against the agreed amount before claiming; a partially claimed lockup sweeps the remainder
- accepted renegotiation quotes are persisted (`acceptedQuoteAmount`) and floor later renegotiations
- `createChainSwap` requires the response to echo the locally computed server lock amount
- `createSubmarineSwap` bounds `expectedAmount` to the invoice plus the advertised fee schedule; nothing is persisted or funded on a mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for claiming multiple VTXOs in a single offchain transaction.
  * Added persistence and tracking of renegotiated quote amounts.
  * Added support for recoverable chain-claim paths and persisted claim transaction IDs.

* **Bug Fixes**
  * Improved validation of lockup and funding amounts against agreed amounts and invoice fees.
  * Added retries while waiting for sufficient funds to appear.
  * Added clear errors when received amounts are below or above acceptable limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->