### PR TITLE
feat: pin and validate vhtlc batch commitments

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -31,6 +31,7 @@ import {
     deriveDescriptorLeafCompressedPubKey,
     isHDWalletCapable,
     type NetworkName,
+    type Recipient,
 } from "@arkade-os/sdk";
 import type {
     Chain,
@@ -185,6 +186,8 @@ type RefundWithoutReceiverContext = {
     serverXOnlyPublicKey: Uint8Array;
     refundWithoutReceiverLeaf: ArkTxInput["tapLeafScript"];
     outputScript: Uint8Array;
+    /** Address `outputScript` was derived from, for batch recipient validation. */
+    address: string;
 };
 
 const dedupeVtxos = (vtxos: VirtualCoin[]): VirtualCoin[] => [
@@ -700,7 +703,10 @@ export class ArkadeSwaps {
 
             try {
                 if (isRecoverable(vtxo)) {
-                    await this.joinBatch(vhtlcIdentity, input, output, arkInfo);
+                    await this.joinBatch(vhtlcIdentity, input, output, arkInfo, true, {
+                        address,
+                        amount: vtxo.value,
+                    });
                 } else {
                     await claimVHTLCwithOffchainTx(
                         vhtlcIdentity,
@@ -1308,6 +1314,7 @@ export class ArkadeSwaps {
             serverXOnlyPublicKey,
             refundWithoutReceiverLeaf,
             outputScript,
+            address,
         };
 
         // Refund every unspent VTXO at the contract address.
@@ -2133,6 +2140,7 @@ export class ArkadeSwaps {
             serverXOnlyPublicKey,
             refundWithoutReceiverLeaf,
             outputScript,
+            address,
         };
 
         const outcome = await this.refundVtxos({
@@ -2493,6 +2501,8 @@ export class ArkadeSwaps {
                 toInput(vtxo),
                 { amount: BigInt(vtxo.value), script: outputScript },
                 arkInfo,
+                true,
+                { address, amount: vtxo.value },
             );
             txid ??= batchTxid;
         }
@@ -3164,8 +3174,17 @@ export class ArkadeSwaps {
         output: TransactionOutput,
         arkInfo: ArkInfo,
         isRecoverable = true,
+        recipient?: Recipient,
     ): Promise<string> {
-        return joinBatch(this.arkProvider, identity, input, output, arkInfo, isRecoverable);
+        return joinBatch(
+            this.arkProvider,
+            identity,
+            input,
+            output,
+            arkInfo,
+            isRecoverable,
+            recipient,
+        );
     }
 
     /**
@@ -3187,7 +3206,10 @@ export class ArkadeSwaps {
         };
         const output = { amount: BigInt(vtxo.value), script: ctx.outputScript };
         if (isRecoverable(vtxo)) {
-            await this.joinBatch(ctx.identity, input, output, ctx.arkInfo, true);
+            await this.joinBatch(ctx.identity, input, output, ctx.arkInfo, true, {
+                address: ctx.address,
+                amount: vtxo.value,
+            });
         } else {
             await refundWithoutReceiverVHTLCwithOffchainTx(
                 ctx.identity,

--- a/packages/boltz-swap/src/batch.ts
+++ b/packages/boltz-swap/src/batch.ts
@@ -3,6 +3,8 @@ import {
     BatchFinalizationEvent,
     BatchStartedEvent,
     CSVMultisigTapscript,
+    Network,
+    Recipient,
     SignerSession,
     Transaction,
     TreeNoncesEvent,
@@ -10,6 +12,8 @@ import {
     TxTree,
     validateVtxoTxGraph,
     validateConnectorsTxGraph,
+    validateBatchRecipients,
+    assertFinalCommitmentMatchesValidated,
     Identity,
     VtxoScript,
     buildForfeitTx,
@@ -29,6 +33,8 @@ export function createVHTLCBatchHandler(
     identity: Identity,
     session: SignerSession,
     sweepPublicKey: Uint8Array,
+    network: Network,
+    recipient?: Recipient,
     forfeitOutputScript?: Bytes, // undefined if recoverable
     connectorIndex: number = 0,
 ) {
@@ -37,6 +43,7 @@ export function createVHTLCBatchHandler(
     const intentIdHashStr = hex.encode(intentIdHash);
 
     let sweepTapTreeRoot: Uint8Array | undefined;
+    let validatedCommitmentTxid: string | undefined;
 
     return {
         onBatchStarted: async (event: BatchStartedEvent): Promise<{ skip: boolean }> => {
@@ -93,7 +100,11 @@ export function createVHTLCBatchHandler(
             const commitmentTx = Transaction.fromPSBT(base64.decode(event.unsignedCommitmentTx));
             validateVtxoTxGraph(vtxoTree, commitmentTx, sweepTapTreeRoot);
 
-            // TODO check if our registered outputs are in the vtxo tree
+            if (recipient) {
+                validateBatchRecipients(commitmentTx, vtxoTree.leaves(), [recipient], network);
+            }
+            // record only after validation so a rejected tree never pins a txid
+            validatedCommitmentTxid = commitmentTx.id;
 
             const sharedOutput = commitmentTx.getOutput(0);
             if (!sharedOutput?.amount) {
@@ -134,6 +145,19 @@ export function createVHTLCBatchHandler(
                 // no need to create a forfeit transaction, skip
                 return;
             }
+
+            // this handler always cosigns the tree (no skipVtxoTreeSigning path),
+            // so a finalization without a pinned commitment tx is protocol-invalid
+            if (!validatedCommitmentTxid) {
+                throw new Error(
+                    "BatchFinalizationEvent: commitment tx was not validated at tree signing",
+                );
+            }
+            assertFinalCommitmentMatchesValidated(
+                Transaction.fromPSBT(base64.decode(event.commitmentTx)),
+                validatedCommitmentTxid,
+                "vhtlc batch finalization",
+            );
 
             if (!connectorTree) {
                 throw new Error("BatchFinalizationEvent: expected connector tree to be defined");

--- a/packages/boltz-swap/src/expo/arkade-lightning.ts
+++ b/packages/boltz-swap/src/expo/arkade-lightning.ts
@@ -31,6 +31,7 @@ import {
     type ArkInfo,
     type ArkTxInput,
     type Identity,
+    type Recipient,
     type VHTLC,
 } from "@arkade-os/sdk";
 import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
@@ -414,8 +415,9 @@ export class ExpoArkadeSwaps implements IArkadeSwaps {
         output: TransactionOutput,
         arkInfo: ArkInfo,
         isRecoverable?: boolean,
+        recipient?: Recipient,
     ): Promise<string> {
-        return this.inner.joinBatch(identity, input, output, arkInfo, isRecoverable);
+        return this.inner.joinBatch(identity, input, output, arkInfo, isRecoverable, recipient);
     }
 
     createVHTLCScript(params: {

--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -12,6 +12,7 @@ import {
     getNetwork,
     networks,
     NetworkName,
+    Recipient,
     VHTLC,
     VtxoScript,
     VtxoTaprootTree,
@@ -153,6 +154,7 @@ export const candidateServerPubkeys = (arkInfo: ArkInfo): string[] => {
  * @param input - The input vtxo.
  * @param output - The output script.
  * @param forfeitPublicKey - The forfeit public key.
+ * @param recipient - The expected destination, validated against the vtxo tree leaves.
  * @returns The commitment transaction ID.
  */
 export const joinBatch = async (
@@ -166,6 +168,7 @@ export const joinBatch = async (
         network,
     }: Pick<ArkInfo, "forfeitPubkey" | "forfeitAddress" | "network">,
     isRecoverable = true,
+    recipient?: Recipient,
 ): Promise<string> => {
     const signerSession = identity.signerSession();
     const signerPublicKey = await signerSession.getPublicKey();
@@ -210,9 +213,9 @@ export const joinBatch = async (
         proof: base64.encode(signedRegisterIntent.toPSBT()),
     });
 
-    const decodedAddress = Address(
-        network in networks ? networks[network as keyof typeof networks] : networks.bitcoin,
-    ).decode(forfeitAddress);
+    const btcNetwork =
+        network in networks ? networks[network as keyof typeof networks] : networks.bitcoin;
+    const decodedAddress = Address(btcNetwork).decode(forfeitAddress);
 
     try {
         const handler = createVHTLCBatchHandler(
@@ -222,6 +225,8 @@ export const joinBatch = async (
             identity,
             signerSession,
             normalizeToXOnlyKey(forfeitPubkey, "forfeit"),
+            btcNetwork,
+            recipient,
             isRecoverable ? undefined : OutScript.encode(decodedAddress),
         );
 

--- a/packages/boltz-swap/test/batch.test.ts
+++ b/packages/boltz-swap/test/batch.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { base64, hex } from "@scure/base";
+import { sha256 } from "@noble/hashes/sha2.js";
+
+// Graph validation is delegated to the shared validators; mock both so the
+// tests drive the handler's wiring. Recipient validation and the
+// commitment-equality assertion stay real: they are under test below.
+vi.mock("@arkade-os/sdk", async (importActual) => ({
+    ...(await importActual<typeof import("@arkade-os/sdk")>()),
+    validateVtxoTxGraph: vi.fn(),
+    validateConnectorsTxGraph: vi.fn(),
+}));
+
+import {
+    ArkAddress,
+    SingleKey,
+    Transaction,
+    networks,
+    validateVtxoTxGraph,
+    type ArkProvider,
+    type ArkTxInput,
+    type BatchStartedEvent,
+    type Identity,
+    type Recipient,
+    type SignerSession,
+    type TreeSigningStartedEvent,
+    type TxTree,
+} from "@arkade-os/sdk";
+import { createVHTLCBatchHandler } from "../src/batch";
+import { createVHTLCScript } from "../src/utils/vhtlc";
+
+const INTENT_ID = "intent-123";
+const SIGNER_XONLY = "11".repeat(32);
+const P2TR = new Uint8Array([0x51, 0x20, ...new Uint8Array(32).fill(0xab)]);
+
+const ourKey = SingleKey.fromHex("11".repeat(32));
+const boltzKey = SingleKey.fromHex("22".repeat(32));
+const serverKey = SingleKey.fromHex("33".repeat(32));
+
+async function makeVhtlcInput(): Promise<ArkTxInput> {
+    const [ours, boltz, server] = await Promise.all([
+        ourKey.xOnlyPublicKey(),
+        boltzKey.xOnlyPublicKey(),
+        serverKey.xOnlyPublicKey(),
+    ]);
+    const { vhtlcScript } = createVHTLCScript({
+        network: "regtest",
+        preimageHash: sha256(new Uint8Array(32).fill(7)),
+        receiverPubkey: hex.encode(ours),
+        senderPubkey: hex.encode(boltz),
+        serverPubkey: hex.encode(server),
+        timeoutBlockHeights: {
+            refund: 100,
+            unilateralClaim: 10,
+            unilateralRefund: 20,
+            unilateralRefundWithoutReceiver: 30,
+        },
+    });
+    return {
+        txid: "11".repeat(32),
+        vout: 0,
+        value: 10_000,
+        tapLeafScript: vhtlcScript.claim(),
+        tapTree: vhtlcScript.encode(),
+    };
+}
+
+const RECIPIENT_ADDRESS = new ArkAddress(
+    hex.decode("33".repeat(32)),
+    hex.decode("aa".repeat(32)),
+    "tark",
+).encode();
+const RECIPIENT: Recipient = { address: RECIPIENT_ADDRESS, amount: 10_000 };
+
+function makeSession(): SignerSession {
+    return {
+        getPublicKey: vi.fn(async () => hex.decode("02" + SIGNER_XONLY)),
+        init: vi.fn(async () => {}),
+        getNonces: vi.fn(async () => ({}) as never),
+        aggregatedNonces: vi.fn(),
+        sign: vi.fn(),
+    } as unknown as SignerSession;
+}
+
+function makeArkProvider() {
+    return {
+        confirmRegistration: vi.fn(async () => {}),
+        submitTreeNonces: vi.fn(async () => {}),
+        submitTreeSignatures: vi.fn(async () => {}),
+        submitSignedForfeitTxs: vi.fn(async () => {}),
+    } as unknown as ArkProvider;
+}
+
+const identityStub = { sign: vi.fn(async (tx: Transaction) => tx) } as unknown as Identity;
+
+/** A commitment tx PSBT; `amount` makes distinct fixtures distinguishable. */
+function commitment(amount: bigint): string {
+    const tx = new Transaction({ allowUnknownOutputs: true });
+    tx.addOutput({ script: new Uint8Array([0x51]), amount });
+    return base64.encode(tx.toPSBT());
+}
+
+/** A vtxo tree whose single leaf pays `amount` to the recipient address. */
+function treeWithLeafPaying(amount: bigint): TxTree {
+    const leaf = new Transaction({ allowUnknownOutputs: true });
+    leaf.addOutput({ script: ArkAddress.decode(RECIPIENT_ADDRESS).pkScript, amount });
+    return { leaves: () => [leaf] } as unknown as TxTree;
+}
+
+function connectorTreeWithLeaf(): TxTree {
+    const connector = new Transaction({ allowUnknownOutputs: true });
+    connector.addOutput({ script: P2TR, amount: 1000n });
+    return { leaves: () => [connector] } as unknown as TxTree;
+}
+
+const batchStarted = {
+    id: "batch-1",
+    intentIdHashes: [hex.encode(sha256(new TextEncoder().encode(INTENT_ID)))],
+    batchExpiry: 100n,
+} as unknown as BatchStartedEvent;
+
+function treeSigningStarted(commitmentTx: string): TreeSigningStartedEvent {
+    return {
+        id: "batch-1",
+        cosignersPublicKeys: ["02" + SIGNER_XONLY],
+        unsignedCommitmentTx: commitmentTx,
+    } as unknown as TreeSigningStartedEvent;
+}
+
+async function makeHandler(opts?: { recipient?: Recipient; recoverable?: boolean }) {
+    const arkProvider = makeArkProvider();
+    const handler = createVHTLCBatchHandler(
+        INTENT_ID,
+        await makeVhtlcInput(),
+        arkProvider,
+        identityStub,
+        makeSession(),
+        hex.decode("44".repeat(32)),
+        networks.regtest,
+        opts?.recipient,
+        opts?.recoverable ? undefined : P2TR,
+    );
+    return { handler, arkProvider };
+}
+
+beforeEach(() => {
+    vi.mocked(validateVtxoTxGraph).mockReset();
+});
+
+describe("createVHTLCBatchHandler commitment tx pinning", () => {
+    it("rejects a finalization commitment tx that differs from the validated one", async () => {
+        const { handler, arkProvider } = await makeHandler();
+
+        await handler.onBatchStarted(batchStarted);
+        await handler.onTreeSigningStarted(
+            treeSigningStarted(commitment(5000n)),
+            treeWithLeafPaying(10_000n),
+        );
+
+        await expect(
+            handler.onBatchFinalization(
+                { commitmentTx: commitment(9999n) } as never,
+                undefined,
+                connectorTreeWithLeaf(),
+            ),
+        ).rejects.toThrow(/finalization commitment tx .* differs from the validated commitment tx/);
+        expect(arkProvider.submitSignedForfeitTxs).not.toHaveBeenCalled();
+    });
+
+    it("rejects forfeit finalization when the tree signing step never ran", async () => {
+        const { handler, arkProvider } = await makeHandler();
+
+        await handler.onBatchStarted(batchStarted);
+
+        await expect(
+            handler.onBatchFinalization(
+                { commitmentTx: commitment(5000n) } as never,
+                undefined,
+                connectorTreeWithLeaf(),
+            ),
+        ).rejects.toThrow(/commitment tx was not validated at tree signing/);
+        expect(arkProvider.submitSignedForfeitTxs).not.toHaveBeenCalled();
+    });
+
+    it("submits the forfeit when the finalization commitment tx matches", async () => {
+        const { handler, arkProvider } = await makeHandler();
+
+        await handler.onBatchStarted(batchStarted);
+        await handler.onTreeSigningStarted(
+            treeSigningStarted(commitment(5000n)),
+            treeWithLeafPaying(10_000n),
+        );
+        await handler.onBatchFinalization(
+            { commitmentTx: commitment(5000n) } as never,
+            undefined,
+            connectorTreeWithLeaf(),
+        );
+
+        expect(arkProvider.submitSignedForfeitTxs).toHaveBeenCalledTimes(1);
+    });
+
+    it("still skips finalization for a recoverable input", async () => {
+        const { handler, arkProvider } = await makeHandler({ recoverable: true });
+
+        await handler.onBatchStarted(batchStarted);
+        await handler.onBatchFinalization(
+            { commitmentTx: commitment(5000n) } as never,
+            undefined,
+            connectorTreeWithLeaf(),
+        );
+
+        expect(arkProvider.submitSignedForfeitTxs).not.toHaveBeenCalled();
+    });
+});
+
+describe("createVHTLCBatchHandler recipient validation", () => {
+    it("validates the recipient against the vtxo tree leaves before submitting nonces", async () => {
+        const { handler, arkProvider } = await makeHandler({ recipient: RECIPIENT });
+
+        await handler.onBatchStarted(batchStarted);
+        const { skip } = await handler.onTreeSigningStarted(
+            treeSigningStarted(commitment(5000n)),
+            treeWithLeafPaying(10_000n),
+        );
+
+        expect(skip).toBe(false);
+        expect(validateVtxoTxGraph).toHaveBeenCalledTimes(1);
+        expect(arkProvider.submitTreeNonces).toHaveBeenCalledTimes(1);
+    });
+
+    it("aborts tree signing when no leaf pays the recipient", async () => {
+        const { handler, arkProvider } = await makeHandler({ recipient: RECIPIENT });
+
+        await handler.onBatchStarted(batchStarted);
+        await expect(
+            handler.onTreeSigningStarted(
+                treeSigningStarted(commitment(5000n)),
+                treeWithLeafPaying(9000n),
+            ),
+        ).rejects.toThrow(/offchain send output not found/);
+        expect(arkProvider.submitTreeNonces).not.toHaveBeenCalled();
+    });
+});

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -307,6 +307,10 @@ import type { ServerInfoSource } from "./wallet/arkInfoSnapshot";
 import type { ProviderConnectionState } from "./wallet/wallet";
 import type { ContractSyncState } from "./contracts/contractManager";
 import { validateVtxoTxGraph, validateConnectorsTxGraph } from "./tree/validation";
+import {
+    validateBatchRecipients,
+    assertFinalCommitmentMatchesValidated,
+} from "./wallet/validation";
 import { buildForfeitTx } from "./forfeit";
 import { IndexedDBWalletRepository } from "./repositories/indexedDB/walletRepository";
 import { IndexedDBContractRepository } from "./repositories/indexedDB/contractRepository";
@@ -619,6 +623,8 @@ export {
     Batch,
     validateVtxoTxGraph,
     validateConnectorsTxGraph,
+    validateBatchRecipients,
+    assertFinalCommitmentMatchesValidated,
     buildForfeitTx,
     isRecoverable,
     isSpendable,


### PR DESCRIPTION
## What

`createVHTLCBatchHandler` — the batch handler used by boltz-swap's VHTLC claim/refund batch paths — now enforces the same protocol invariants as the wallet's batch handlers:

- **Recipient validation at tree signing.** The registered destination is validated against the vtxo tree leaves via the shared `validateBatchRecipients` (closes the long-standing `TODO` in `batch.ts`). The recipient is threaded through `joinBatch` from the claim/refund call sites, which already hold the destination address.
- **Commitment tx pinning.** The commitment txid validated at tree signing is recorded (after validation) and the finalization commitment must match it via `assertFinalCommitmentMatchesValidated`. Since this handler always cosigns the tree, reaching forfeit finalization without a pinned commitment is protocol-invalid and rejects — stricter than the wallet handlers' no-op, deliberately.
- `validateBatchRecipients` and `assertFinalCommitmentMatchesValidated` are re-exported from the SDK index (core capabilities flow outward to plugins, as with `matchServerCheckpoints`).

## Compatibility

- `ArkadeSwaps.joinBatch` gains an **optional** `recipient` parameter (threaded through the expo wrapper); omitting it skips recipient validation but commitment pinning always applies. All internal call sites pass it.
- The recoverable path (no forfeit) is unchanged: finalization still returns early.

## Base branch

Based on `feat/chain-swap-claim-amounts` (#673) because that PR reshaped the claim/refund call sites this change threads the recipient through; retarget to `master` when #673 merges.

## Tests

6 new tests in `packages/boltz-swap/test/batch.test.ts` driving the handler directly (commitment mismatch, finalization without tree signing, missing recipient leaf, happy path, recoverable skip). Each guard verified to fail with its `src` change removed. Full unit suites, lint and build green.