### PR TITLE
feat: bind recipient addresses to wallet network and operator

### DIFF
--- a/packages/ts-sdk/src/wallet/signerRotation.ts
+++ b/packages/ts-sdk/src/wallet/signerRotation.ts
@@ -59,8 +59,12 @@ export interface SignerSet {
      * Deprecated signers keyed by x-only hex, mapped to their cutoff. The cutoff
      * is always a bigint (arkd advertises it non-nullable); `0n` means "no cutoff
      * advertised" (→ `DUE_NOW`).
+     *
+     * Read-only: the wallet hands out its live `_deprecatedSigners` here rather
+     * than a copy, and that map drives coin selection and the pendingRecovery
+     * balance bucket. A holder must not write through it.
      */
-    deprecated: Map<string, bigint>;
+    deprecated: ReadonlyMap<string, bigint>;
 }
 
 /**

--- a/packages/ts-sdk/src/wallet/utils.ts
+++ b/packages/ts-sdk/src/wallet/utils.ts
@@ -212,8 +212,7 @@ type ValidatedRecipient = Required<Omit<Recipient, "extensions">> & {
 };
 
 /**
- * Wallet-side context a recipient Arkade address must match: the wallet's
- * bech32 prefix and the operator signer set. An address failing either check
+ * What a recipient Arkade address must match. An address failing either check
  * belongs to another network or operator, so this wallet's operator cannot
  * create the VTXO where the recipient's wallet expects it.
  */
@@ -223,9 +222,8 @@ export type RecipientAddressContext = {
 };
 
 /**
- * Assert a decoded recipient address is bound to this wallet's network and
- * operator. The embedded server key may be the current signer or a deprecated
- * signer whose rotation cutoff has not passed.
+ * The embedded server key may be the current signer or a deprecated signer
+ * whose rotation cutoff has not passed.
  */
 export function assertRecipientArkAddress(
     encoded: string,

--- a/packages/ts-sdk/src/wallet/utils.ts
+++ b/packages/ts-sdk/src/wallet/utils.ts
@@ -12,6 +12,7 @@ import { contractHandlers } from "../contracts/handlers";
 import { DefaultVtxo } from "../script/default";
 import { DelegateVtxo } from "../script/delegate";
 import type { ReadonlyWallet } from "./wallet";
+import { classifyAgainstSignerSet, type SignerSet } from "./signerRotation";
 import { hex } from "@scure/base";
 import { Bytes } from "@scure/btc-signer/utils.js";
 
@@ -210,9 +211,50 @@ type ValidatedRecipient = Required<Omit<Recipient, "extensions">> & {
     extensions?: Recipient["extensions"];
 };
 
+/**
+ * Wallet-side context a recipient Arkade address must match: the wallet's
+ * bech32 prefix and the operator signer set. An address failing either check
+ * belongs to another network or operator, so this wallet's operator cannot
+ * create the VTXO where the recipient's wallet expects it.
+ */
+export type RecipientAddressContext = {
+    hrp: string;
+    signerSet: SignerSet;
+};
+
+/**
+ * Assert a decoded recipient address is bound to this wallet's network and
+ * operator. The embedded server key may be the current signer or a deprecated
+ * signer whose rotation cutoff has not passed.
+ */
+export function assertRecipientArkAddress(
+    encoded: string,
+    address: ArkAddress,
+    context: RecipientAddressContext,
+): void {
+    if (address.hrp !== context.hrp) {
+        throw new Error(
+            `Invalid Arkade address ${encoded}: expected prefix "${context.hrp}", got "${address.hrp}"`,
+        );
+    }
+    const { status } = classifyAgainstSignerSet(
+        hex.encode(address.serverPubKey),
+        context.signerSet,
+    );
+    if (status === "UNKNOWN_SIGNER") {
+        throw new Error(`Invalid Arkade address ${encoded}: unknown operator signer key`);
+    }
+    if (status === "EXPIRED") {
+        throw new Error(
+            `Invalid Arkade address ${encoded}: operator signer key is past its rotation cutoff`,
+        );
+    }
+}
+
 export function validateRecipients(
     recipients: Recipient[],
     dustAmount: number,
+    context: RecipientAddressContext,
 ): ValidatedRecipient[] {
     const validatedRecipients: ValidatedRecipient[] = [];
 
@@ -223,6 +265,8 @@ export function validateRecipients(
         } catch (e) {
             throw new Error(`Invalid Arkade address: ${recipient.address}`);
         }
+
+        assertRecipientArkAddress(recipient.address, address, context);
 
         const amount = recipient.amount || dustAmount;
         if (amount <= 0) {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2106,7 +2106,9 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
     private async handleServerInfoChanged(info: {
         signerPubkey: string;
         checkpointTapscript: string;
-        deprecatedSigners?: readonly { pubkey?: string }[];
+        // cutoffs included: recipient-address binding rejects past-cutoff
+        // signers, so a narrower shape here would read EXPIRED as DUE_NOW
+        deprecatedSigners?: readonly { pubkey?: string; cutoffDate?: bigint }[];
     }): Promise<void> {
         this.refreshDeprecatedSigners(info);
         try {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -726,11 +726,9 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }
 
     /**
-     * Context recipient Arkade addresses are validated against: the wallet's
-     * network prefix and the operator signer set (current plus cached
-     * deprecated signers, cutoffs included). `serverPubKey` defaults to the
-     * live key; spend paths that snapshot it against mid-flight rotation pass
-     * their snapshot so the check reads from the same epoch.
+     * `serverPubKey` defaults to the live key; spend paths that snapshot it
+     * against mid-flight rotation pass their snapshot, so the check reads from
+     * one rotation epoch.
      */
     protected recipientAddressContext(
         serverPubKey: Bytes = this._arkServerPublicKey,
@@ -2106,8 +2104,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
     private async handleServerInfoChanged(info: {
         signerPubkey: string;
         checkpointTapscript: string;
-        // cutoffs included: recipient-address binding rejects past-cutoff
-        // signers, so a narrower shape here would read EXPIRED as DUE_NOW
+        // without cutoffDate a past-cutoff signer reads as DUE_NOW
         deprecatedSigners?: readonly { pubkey?: string; cutoffDate?: bigint }[];
     }): Promise<void> {
         this.refreshDeprecatedSigners(info);
@@ -3396,8 +3393,8 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         for (const [index, output] of params.outputs.entries()) {
             let script: Bytes | undefined;
 
-            // decode-or-undefined only: a binding failure below must surface
-            // as its own error, not fall through to the onchain branch
+            // decode only: a binding failure must surface as its own error,
+            // not fall through to the onchain branch
             let arkAddress: ArkAddress | undefined;
             try {
                 arkAddress = ArkAddress.decode(output.address);
@@ -3406,13 +3403,11 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
             }
 
             if (arkAddress) {
-                // offchain
                 recipientContext ??= this.recipientAddressContext();
                 assertRecipientArkAddress(output.address, arkAddress, recipientContext);
                 script = arkAddress.pkScript;
                 hasOffchainOutputs = true;
             } else {
-                // onchain
                 const addr = Address(this.network).decode(output.address);
                 script = OutScript.encode(addr);
                 onchainOutputIndexes.push(index);

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -102,7 +102,12 @@ import type { IntentRepository, ArkIntent, ArkIntentState } from "../repositorie
 import { isTerminalIntentState } from "../repositories/intentRepository";
 import type { VirtualTxRepository } from "../repositories/virtualTxRepository";
 import { wrapHandlerWithIntentPersistence } from "./intentPersistenceHandler";
-import { extendCoinWithTapscript, validateRecipients } from "./utils";
+import {
+    assertRecipientArkAddress,
+    extendCoinWithTapscript,
+    validateRecipients,
+    type RecipientAddressContext,
+} from "./utils";
 import {
     captureExitBranch,
     DEFAULT_EXIT_CAPTURE_MODE,
@@ -718,6 +723,25 @@ export class ReadonlyWallet implements IReadonlyWallet {
             toXOnlySignerHex(hex.encode(this.boardingTapscript.options.serverPubKey)),
             ...this._deprecatedSigners.keys(),
         ]);
+    }
+
+    /**
+     * Context recipient Arkade addresses are validated against: the wallet's
+     * network prefix and the operator signer set (current plus cached
+     * deprecated signers, cutoffs included). `serverPubKey` defaults to the
+     * live key; spend paths that snapshot it against mid-flight rotation pass
+     * their snapshot so the check reads from the same epoch.
+     */
+    protected recipientAddressContext(
+        serverPubKey: Bytes = this._arkServerPublicKey,
+    ): RecipientAddressContext {
+        return {
+            hrp: this.network.hrp,
+            signerSet: {
+                active: toXOnlySignerHex(hex.encode(serverPubKey)),
+                deprecated: this._deprecatedSigners,
+            },
+        };
     }
 
     /**
@@ -3159,6 +3183,11 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                 };
 
                 const outputAddress = ArkAddress.decode(params.address);
+                assertRecipientArkAddress(
+                    params.address,
+                    outputAddress,
+                    this.recipientAddressContext(serverPubKey),
+                );
                 const outputScript =
                     BigInt(params.amount) < this.dustAmount
                         ? outputAddress.subdustPkScript
@@ -3361,14 +3390,26 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         const outputs: TransactionOutput[] = [];
         let hasOffchainOutputs = false;
 
+        let recipientContext: RecipientAddressContext | undefined;
         for (const [index, output] of params.outputs.entries()) {
             let script: Bytes | undefined;
+
+            // decode-or-undefined only: a binding failure below must surface
+            // as its own error, not fall through to the onchain branch
+            let arkAddress: ArkAddress | undefined;
             try {
-                // offchain
-                const addr = ArkAddress.decode(output.address);
-                script = addr.pkScript;
-                hasOffchainOutputs = true;
+                arkAddress = ArkAddress.decode(output.address);
             } catch {
+                arkAddress = undefined;
+            }
+
+            if (arkAddress) {
+                // offchain
+                recipientContext ??= this.recipientAddressContext();
+                assertRecipientArkAddress(output.address, arkAddress, recipientContext);
+                script = arkAddress.pkScript;
+                hasOffchainOutputs = true;
+            } else {
                 // onchain
                 const addr = Address(this.network).decode(output.address);
                 script = OutScript.encode(addr);
@@ -4749,7 +4790,11 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         const address = outputAddress.encode();
 
         // validate recipients and populate undefined amount with dust amount
-        const recipients = validateRecipients(args, Number(this.dustAmount));
+        const recipients = validateRecipients(
+            args,
+            Number(this.dustAmount),
+            this.recipientAddressContext(serverPubKey),
+        );
 
         const allVirtualCoins = await this.getVtxos({
             withRecoverable: false,

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -3038,7 +3038,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                     cb: (info: {
                         signerPubkey: string;
                         checkpointTapscript: string;
-                        deprecatedSigners?: readonly { pubkey?: string }[];
+                        deprecatedSigners?: readonly { pubkey?: string; cutoffDate?: bigint }[];
                     }) => void,
                 ): () => void;
             }>;

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -162,6 +162,37 @@ describe("Wallet recipient address binding", () => {
         ).rejects.toThrow(/unknown operator signer key/);
     });
 
+    it("carries cached deprecated signers, cutoffs included, into the recipient context", async () => {
+        const cutoff = BigInt(NOW_SECONDS + 100_000);
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: () =>
+                Promise.resolve({
+                    ...mockArkInfo,
+                    deprecatedSigners: [
+                        { pubkey: hex.encode(DEPRECATED_XONLY), cutoffDate: cutoff.toString() },
+                    ],
+                }),
+        });
+
+        const wallet = await Wallet.create({
+            identity: mockIdentity,
+            arkServerUrl: "http://localhost:7070",
+        });
+
+        const context = (
+            wallet as unknown as { recipientAddressContext(): RecipientAddressContext }
+        ).recipientAddressContext();
+        expect(context.signerSet.deprecated.get(hex.encode(DEPRECATED_XONLY))).toBe(cutoff);
+
+        // an address minted under that signer stays payable until the cutoff
+        const encoded = encodeAddr(DEPRECATED_XONLY, "tark");
+        expect(() =>
+            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), context),
+        ).not.toThrow();
+    });
+
     it("settle rejects a foreign offchain output with the binding error", async () => {
         const wallet = await Wallet.create({
             identity: mockIdentity,

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -186,7 +186,6 @@ describe("Wallet recipient address binding", () => {
         ).recipientAddressContext();
         expect(context.signerSet.deprecated.get(hex.encode(DEPRECATED_XONLY))).toBe(cutoff);
 
-        // an address minted under that signer stays payable until the cutoff
         const encoded = encodeAddr(DEPRECATED_XONLY, "tark");
         expect(() =>
             assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), context),

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { hex } from "@scure/base";
+import { Wallet, SingleKey } from "../src";
+import { ArkAddress } from "../src/script/address";
+import {
+    assertRecipientArkAddress,
+    validateRecipients,
+    type RecipientAddressContext,
+} from "../src/wallet/utils";
+
+// Mock fetch
+const { mockFetch } = vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+}));
+
+vi.mock("../src/utils/fetch", () => ({
+    fetch: mockFetch,
+    baseFetch: mockFetch,
+}));
+
+const SERVER_KEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const SERVER_XONLY = hex.decode(SERVER_KEY_HEX).slice(1);
+const DEPRECATED_XONLY = new Uint8Array(32).fill(0x88);
+const FOREIGN_XONLY = new Uint8Array(32).fill(0x77);
+const VTXO_KEY = new Uint8Array(32).fill(0xaa);
+
+const encodeAddr = (serverPubKey: Uint8Array, hrp: string) =>
+    new ArkAddress(serverPubKey, VTXO_KEY, hrp).encode();
+
+const NOW_SECONDS = Math.floor(Date.now() / 1000);
+
+function makeContext(deprecated?: Map<string, bigint>): RecipientAddressContext {
+    return {
+        hrp: "tark",
+        signerSet: {
+            active: hex.encode(SERVER_XONLY),
+            deprecated: deprecated ?? new Map(),
+        },
+    };
+}
+
+describe("assertRecipientArkAddress", () => {
+    it("rejects an address with another network's prefix", () => {
+        const encoded = encodeAddr(SERVER_XONLY, "ark");
+        expect(() =>
+            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext()),
+        ).toThrow(/expected prefix "tark", got "ark"/);
+    });
+
+    it("rejects an address embedding an unknown operator signer key", () => {
+        const encoded = encodeAddr(FOREIGN_XONLY, "tark");
+        expect(() =>
+            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext()),
+        ).toThrow(/unknown operator signer key/);
+    });
+
+    it("accepts an address embedding the current signer key", () => {
+        const encoded = encodeAddr(SERVER_XONLY, "tark");
+        expect(() =>
+            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext()),
+        ).not.toThrow();
+    });
+
+    it("accepts a deprecated signer key before its cutoff", () => {
+        const encoded = encodeAddr(DEPRECATED_XONLY, "tark");
+        const deprecated = new Map([[hex.encode(DEPRECATED_XONLY), BigInt(NOW_SECONDS + 100_000)]]);
+        expect(() =>
+            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext(deprecated)),
+        ).not.toThrow();
+    });
+
+    it("accepts a deprecated signer key with no advertised cutoff", () => {
+        const encoded = encodeAddr(DEPRECATED_XONLY, "tark");
+        const deprecated = new Map([[hex.encode(DEPRECATED_XONLY), 0n]]);
+        expect(() =>
+            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext(deprecated)),
+        ).not.toThrow();
+    });
+
+    it("rejects a deprecated signer key past its cutoff", () => {
+        const encoded = encodeAddr(DEPRECATED_XONLY, "tark");
+        const deprecated = new Map([[hex.encode(DEPRECATED_XONLY), 1n]]);
+        expect(() =>
+            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext(deprecated)),
+        ).toThrow(/past its rotation cutoff/);
+    });
+});
+
+describe("validateRecipients address binding", () => {
+    it("rejects a recipient list containing a foreign-operator address", () => {
+        expect(() =>
+            validateRecipients(
+                [{ address: encodeAddr(FOREIGN_XONLY, "tark"), amount: 2000 }],
+                1000,
+                makeContext(),
+            ),
+        ).toThrow(/unknown operator signer key/);
+    });
+
+    it("accepts a recipient list bound to the wallet's operator", () => {
+        const validated = validateRecipients(
+            [{ address: encodeAddr(SERVER_XONLY, "tark"), amount: 2000 }],
+            1000,
+            makeContext(),
+        );
+        expect(validated).toHaveLength(1);
+    });
+});
+
+describe("Wallet recipient address binding", () => {
+    const mockIdentity = SingleKey.fromHex(
+        "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2",
+    );
+
+    const mockArkInfo = {
+        signerPubkey: SERVER_KEY_HEX,
+        forfeitPubkey: SERVER_KEY_HEX,
+        batchExpiry: BigInt(144),
+        unilateralExitDelay: BigInt(144),
+        boardingExitDelay: BigInt(144),
+        roundInterval: BigInt(144),
+        network: "mutinynet",
+        dust: BigInt(1000),
+        forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+        checkpointTapscript:
+            "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+    };
+
+    beforeEach(() => {
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockArkInfo),
+        });
+    });
+
+    it("send rejects an address from another network before spending", async () => {
+        const wallet = await Wallet.create({
+            identity: mockIdentity,
+            arkServerUrl: "http://localhost:7070",
+        });
+        const fetchCallsAfterCreate = mockFetch.mock.calls.length;
+
+        await expect(
+            wallet.send({ address: encodeAddr(SERVER_XONLY, "ark"), amount: 2000 }),
+        ).rejects.toThrow(/expected prefix "tark", got "ark"/);
+        expect(mockFetch.mock.calls.length).toBe(fetchCallsAfterCreate);
+    });
+
+    it("sendBitcoin with selected vtxos rejects a foreign-operator address", async () => {
+        const wallet = await Wallet.create({
+            identity: mockIdentity,
+            arkServerUrl: "http://localhost:7070",
+        });
+
+        await expect(
+            wallet.sendBitcoin({
+                address: encodeAddr(FOREIGN_XONLY, "tark"),
+                amount: 2000,
+                selectedVtxos: [{ value: 100_000 } as never],
+            }),
+        ).rejects.toThrow(/unknown operator signer key/);
+    });
+
+    it("settle rejects a foreign offchain output with the binding error", async () => {
+        const wallet = await Wallet.create({
+            identity: mockIdentity,
+            arkServerUrl: "http://localhost:7070",
+        });
+
+        await expect(
+            wallet.settle({
+                inputs: [],
+                outputs: [{ address: encodeAddr(SERVER_XONLY, "ark"), amount: 2000n }],
+            }),
+        ).rejects.toThrow(/expected prefix "tark", got "ark"/);
+    });
+});

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { hex } from "@scure/base";
 import {
+    ArkAddress,
     Wallet,
     SingleKey,
     OnchainWallet,
@@ -2055,6 +2056,13 @@ describe("Wallet._settleImpl", () => {
             const thisArg: any = {
                 network: "mutinynet",
                 dustAmount: 330n,
+                recipientAddressContext: () => ({
+                    hrp: "tark",
+                    signerSet: {
+                        active: hex.encode(ArkAddress.decode(walletAddress).serverPubKey),
+                        deprecated: new Map(),
+                    },
+                }),
                 arkProvider: {
                     getInfo: vi.fn().mockResolvedValue({ fees: { intentFee } }),
                 },


### PR DESCRIPTION
## What

Recipient Arkade addresses are now validated against the wallet's own context before any funds move. A new `assertRecipientArkAddress` (in `wallet/utils.ts`, reusing `classifyAgainstSignerSet`) checks:

- the bech32 prefix matches the wallet's network (`ark` vs `tark`), and
- the embedded server key is the wallet's current operator signer, or a deprecated signer whose rotation cutoff has not passed (`CURRENT`/`MIGRATABLE`/`DUE_NOW` accepted; `UNKNOWN_SIGNER`/`EXPIRED` rejected).

Previously both fields were decoded and discarded, so an honest paste of a testnet or foreign-operator address was accepted — producing a VTXO at an output key the recipient's wallet (watching a different operator's indexer) would never see. No escape hatch is added: cross-operator transfer is not a defined feature.

## Where it applies

- `send` — via `validateRecipients`, which now takes the wallet context.
- `sendBitcoin` — the selected-VTXOs path, which decoded the address directly.
- `settle` — the output classification loop, restructured so a binding failure surfaces as its own error instead of falling through to the onchain-address branch. Context is built lazily, only when an offchain output is present.

Payment-rail classification (`arkTarget`/`isValidArkAddress`) stays format-only by design: the rails execute through `wallet.send`, so enforcement at the validator covers them without changing public predicates.

Sweep of the remaining `ArkAddress.decode` sites in the SDK: all are the wallet's own address (`ramps`, `asset-manager`, `vtxo-manager`, settle/change paths), format-only checks, server-response validation (`wallet/validation.ts`), or the delegate path whose address comes from the configured delegate provider rather than user input.

## Compatibility

`validateRecipients` is module-internal (not exported from the package index); its only caller is `Wallet._sendImpl`. The rotation-window case is covered: an address issued just before a signer rotation stays payable until the advertised cutoff.

## Tests

11 new tests in `test/recipient-address-binding.test.ts`: validator-level policy (prefix, unknown operator, current key, deprecated pre/post-cutoff, no-cutoff sentinel) and wallet-level wiring for `send`, `sendBitcoin` and `settle`. Rejection tests verified to fail with the guard removed while accept tests stay green. Full unit suites, lint and build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure recipient Arkade addresses match the wallet’s network and recognized signer keys.
  * Rejected addresses using unknown or expired signer keys.
  * Accepted addresses signed by current or valid deprecated signer keys.
  * Applied validation across Bitcoin sends, regular sends, and settlement transactions.
  * Prevented invalid recipient addresses from proceeding to payment processing.
  * Improved handling of Arkade and on-chain settlement outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->