### PR TITLE
cache ArkProvider getInfo

### DIFF
--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -235,7 +235,8 @@ Only `getInfo()` is cached; all other Ark provider methods pass through. The cac
 after the TTL and updates when the inner provider reports server-info changes, including
 signer rotation. Wrapping `RestArkProvider` preserves its `serverUrl`, so `Wallet.create`
 can still derive the default indexer URL. Expired refresh failures propagate;
-wallet boot fallback lives in the persisted ArkInfo snapshot.
+wallet boot fallback lives in the persisted ArkInfo snapshot. Call `dispose()` if the
+inner provider outlives the wrapper, to drop its server-info subscription.
 
 ### Onchain Providers
 

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -234,7 +234,8 @@ const wallet = await Wallet.create({ identity, arkProvider })
 Only `getInfo()` is cached; all other Ark provider methods pass through. The cache expires
 after the TTL and updates when the inner provider reports server-info changes, including
 signer rotation. Wrapping `RestArkProvider` preserves its `serverUrl`, so `Wallet.create`
-can still derive the default indexer URL.
+can still derive the default indexer URL. Expired refresh failures propagate;
+wallet boot fallback lives in the persisted ArkInfo snapshot.
 
 ### Onchain Providers
 

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -215,6 +215,27 @@ await wallet.send({ address: 'ark1q...', amount: 1000 })
 
 Identities without `signMultiple` continue to work unchanged — each checkpoint is signed individually via `sign()`.
 
+### Ark Provider Caching
+
+`RestArkProvider.getInfo()` fetches current Arkade server parameters on every call. Wrap it
+with `CachingArkProvider` when you reuse that response for fee, signer, or limit lookups:
+
+```typescript
+import { CachingArkProvider, RestArkProvider, Wallet } from '@arkade-os/sdk'
+
+const arkProvider = new CachingArkProvider(
+  new RestArkProvider('https://arkade.computer'),
+  60_000, // optional TTL in milliseconds; defaults to 60 seconds
+)
+
+const wallet = await Wallet.create({ identity, arkProvider })
+```
+
+Only `getInfo()` is cached; all other Ark provider methods pass through. The cache expires
+after the TTL and updates when the inner provider reports server-info changes, including
+signer rotation. Wrapping `RestArkProvider` preserves its `serverUrl`, so `Wallet.create`
+can still derive the default indexer URL.
+
 ### Onchain Providers
 
 Wallets read onchain state (UTXOs, transactions, fee rates, chain tip) through an `OnchainProvider`. The SDK ships with two implementations and a single transport-agnostic interface so you can swap them without touching wallet code.

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -226,6 +226,7 @@ import {
     ScheduledSession,
     FeeInfo,
 } from "./providers/ark";
+import { CachingArkProvider } from "./providers/cachingArk";
 import {
     DelegateProvider,
     DelegatorProvider,
@@ -604,6 +605,7 @@ export {
     ElectrumOnchainProvider,
     WsElectrumChainSource,
     RestArkProvider,
+    CachingArkProvider,
     DigestMismatchError,
     FetchError,
     RestIndexerProvider,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -189,6 +189,7 @@ import {
     ScheduledSession,
     FeeInfo,
 } from "./providers/ark";
+import { CachingArkProvider } from "./providers/cachingArk";
 import {
     DelegateProvider,
     DelegatorProvider,
@@ -470,6 +471,7 @@ export {
     ElectrumOnchainProvider,
     WsElectrumChainSource,
     RestArkProvider,
+    CachingArkProvider,
     DigestMismatchError,
     FetchError,
     RestIndexerProvider,

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -293,14 +293,18 @@ export class RestArkProvider implements ArkProvider {
      * stale. Empty until the first {@link getInfo}.
      */
     private _digest = "";
+    private _hasServerInfo = false;
+    private _suppressNextGetInfoChangeEmit = false;
 
     private _serverInfoListeners = new Set<(info: ArkInfo) => void>();
 
     /**
-     * Subscribe to server-info changes. Fired when a request is rejected with
-     * `DIGEST_MISMATCH` and fresh info is re-fetched, so consumers (the wallet)
-     * can re-derive signer-dependent state mid-session without polling. Returns
-     * an unsubscribe function.
+     * Subscribe to server-info changes, so consumers (the wallet) can re-derive
+     * signer-dependent state mid-session without polling. Returns an unsubscribe
+     * function. Fired on both paths that can observe a rotated operator config:
+     *
+     *  - a request rejected with `DIGEST_MISMATCH`, after fresh info is re-fetched;
+     *  - a routine {@link getInfo} refresh that comes back with a changed digest.
      */
     onServerInfoChanged(listener: (info: ArkInfo) => void): () => void {
         this._serverInfoListeners.add(listener);
@@ -388,7 +392,13 @@ export class RestArkProvider implements ArkProvider {
         // NOT silently retry — the in-flight request was built against the old config,
         // so the caller must rebuild and retry it under the refreshed server info.
         this._digest = "";
-        const info = await this.getInfo();
+        this._suppressNextGetInfoChangeEmit = true;
+        let info: ArkInfo;
+        try {
+            info = await this.getInfo();
+        } finally {
+            this._suppressNextGetInfoChangeEmit = false;
+        }
         this.emitServerInfoChanged(info);
         throw new DigestMismatchError(
             "Arkade server reported a configuration digest mismatch; server info was " +
@@ -458,7 +468,32 @@ export class RestArkProvider implements ArkProvider {
             vtxoMaxAmount: BigInt(fromServer.vtxoMaxAmount ?? -1),
             vtxoMinAmount: BigInt(fromServer.vtxoMinAmount ?? 0),
         };
+        const previousDigest = this._digest;
+        const hadServerInfo = this._hasServerInfo;
         this._digest = info.digest;
+        this._hasServerInfo = true;
+        // Refresh-path rotation detection, mirroring NArk's CachingClientTransport
+        // (`ServerInfoChangedReason.TtlExpiry`). `getInfo` is not digest-gated, so a
+        // routine refresh — a caller's direct call, or a CachingArkProvider TTL
+        // expiry — silently adopts a rotated config and re-arms `X-Digest`. Without
+        // this emit, arkd then accepts the request the mismatch guard would have
+        // rejected, and the wallet is left on stale signer-derived state with its
+        // only rotation trigger disarmed. Assign the digest first so a listener's
+        // own requests already carry the new one.
+        //
+        // First populate is not a change, even when its digest is non-empty.
+        // Conversely, a previously observed empty digest is still a real previous
+        // value: old/no-digest operators can rotate to a digest-bearing config.
+        // The DIGEST_MISMATCH path clears `_digest` before refetching and emits
+        // explicitly, so suppress only that one internal refresh to avoid a double
+        // event while preserving later refresh detection if the refetch fails.
+        if (
+            hadServerInfo &&
+            previousDigest !== info.digest &&
+            !this._suppressNextGetInfoChangeEmit
+        ) {
+            this.emitServerInfoChanged(info);
+        }
         return info;
     }
 

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -370,14 +370,18 @@ export class RestArkProvider implements ArkProvider {
      * stale. Empty until the first {@link getInfo}.
      */
     private _digest = "";
+    private _hasServerInfo = false;
+    private _suppressNextGetInfoChangeEmit = false;
 
     private _serverInfoListeners = new Set<(info: ArkInfo) => void>();
 
     /**
-     * Subscribe to server-info changes. Fired when a request is rejected with
-     * `DIGEST_MISMATCH` and fresh info is re-fetched, so consumers (the wallet)
-     * can re-derive signer-dependent state mid-session without polling. Returns
-     * an unsubscribe function.
+     * Subscribe to server-info changes, so consumers (the wallet) can re-derive
+     * signer-dependent state mid-session without polling. Returns an unsubscribe
+     * function. Fired on both paths that can observe a rotated operator config:
+     *
+     *  - a request rejected with `DIGEST_MISMATCH`, after fresh info is re-fetched;
+     *  - a routine {@link getInfo} refresh that comes back with a changed digest.
      */
     onServerInfoChanged(listener: (info: ArkInfo) => void): () => void {
         this._serverInfoListeners.add(listener);
@@ -465,7 +469,13 @@ export class RestArkProvider implements ArkProvider {
         // NOT silently retry — the in-flight request was built against the old config,
         // so the caller must rebuild and retry it under the refreshed server info.
         this._digest = "";
-        const info = await this.getInfo();
+        this._suppressNextGetInfoChangeEmit = true;
+        let info: ArkInfo;
+        try {
+            info = await this.getInfo();
+        } finally {
+            this._suppressNextGetInfoChangeEmit = false;
+        }
         this.emitServerInfoChanged(info);
         throw new DigestMismatchError(
             "Arkade server reported a configuration digest mismatch; server info was " +
@@ -539,7 +549,32 @@ export class RestArkProvider implements ArkProvider {
             vtxoMaxAmount: BigInt(fromServer.vtxoMaxAmount ?? -1),
             vtxoMinAmount: BigInt(fromServer.vtxoMinAmount ?? 0),
         };
+        const previousDigest = this._digest;
+        const hadServerInfo = this._hasServerInfo;
         this._digest = info.digest;
+        this._hasServerInfo = true;
+        // Refresh-path rotation detection, mirroring NArk's CachingClientTransport
+        // (`ServerInfoChangedReason.TtlExpiry`). `getInfo` is not digest-gated, so a
+        // routine refresh — a caller's direct call, or a CachingArkProvider TTL
+        // expiry — silently adopts a rotated config and re-arms `X-Digest`. Without
+        // this emit, arkd then accepts the request the mismatch guard would have
+        // rejected, and the wallet is left on stale signer-derived state with its
+        // only rotation trigger disarmed. Assign the digest first so a listener's
+        // own requests already carry the new one.
+        //
+        // First populate is not a change, even when its digest is non-empty.
+        // Conversely, a previously observed empty digest is still a real previous
+        // value: old/no-digest operators can rotate to a digest-bearing config.
+        // The DIGEST_MISMATCH path clears `_digest` before refetching and emits
+        // explicitly, so suppress only that one internal refresh to avoid a double
+        // event while preserving later refresh detection if the refetch fails.
+        if (
+            hadServerInfo &&
+            previousDigest !== info.digest &&
+            !this._suppressNextGetInfoChangeEmit
+        ) {
+            this.emitServerInfoChanged(info);
+        }
         return info;
     }
 

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -365,9 +365,8 @@ export class RestArkProvider implements ArkProvider {
     }
 
     /**
-     * Last server-info digest seen (from {@link getInfo}). Sent as `X-Digest`
-     * on outgoing requests so arkd can reject a client whose cached info is
-     * stale. Empty until the first {@link getInfo}.
+     * Last server-info digest seen from {@link getInfo}. Sent as `X-Digest`
+     * so arkd can reject stale client configuration.
      */
     private _digest = "";
     private _hasServerInfo = false;
@@ -376,12 +375,9 @@ export class RestArkProvider implements ArkProvider {
     private _serverInfoListeners = new Set<(info: ArkInfo) => void>();
 
     /**
-     * Subscribe to server-info changes, so consumers (the wallet) can re-derive
-     * signer-dependent state mid-session without polling. Returns an unsubscribe
-     * function. Fired on both paths that can observe a rotated operator config:
-     *
-     *  - a request rejected with `DIGEST_MISMATCH`, after fresh info is re-fetched;
-     *  - a routine {@link getInfo} refresh that comes back with a changed digest.
+     * Subscribe to server-info changes. Fired after a stale-info
+     * `DIGEST_MISMATCH` refresh or when {@link getInfo} observes a changed digest.
+     * Returns an unsubscribe function.
      */
     onServerInfoChanged(listener: (info: ArkInfo) => void): () => void {
         this._serverInfoListeners.add(listener);
@@ -553,21 +549,9 @@ export class RestArkProvider implements ArkProvider {
         const hadServerInfo = this._hasServerInfo;
         this._digest = info.digest;
         this._hasServerInfo = true;
-        // Refresh-path rotation detection, mirroring NArk's CachingClientTransport
-        // (`ServerInfoChangedReason.TtlExpiry`). `getInfo` is not digest-gated, so a
-        // routine refresh — a caller's direct call, or a CachingArkProvider TTL
-        // expiry — silently adopts a rotated config and re-arms `X-Digest`. Without
-        // this emit, arkd then accepts the request the mismatch guard would have
-        // rejected, and the wallet is left on stale signer-derived state with its
-        // only rotation trigger disarmed. Assign the digest first so a listener's
-        // own requests already carry the new one.
-        //
-        // First populate is not a change, even when its digest is non-empty.
-        // Conversely, a previously observed empty digest is still a real previous
-        // value: old/no-digest operators can rotate to a digest-bearing config.
-        // The DIGEST_MISMATCH path clears `_digest` before refetching and emits
-        // explicitly, so suppress only that one internal refresh to avoid a double
-        // event while preserving later refresh detection if the refetch fails.
+        // A refresh can observe server-info changes before any digest-gated
+        // request fails. `_hasServerInfo` makes an empty previous digest count
+        // as a real value; `DIGEST_MISMATCH` emits separately after its refetch.
         if (
             hadServerInfo &&
             previousDigest !== info.digest &&

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -288,9 +288,8 @@ export class RestArkProvider implements ArkProvider {
     constructor(public serverUrl: string = DEFAULT_ARKADE_SERVER_URL) {}
 
     /**
-     * Last server-info digest seen (from {@link getInfo}). Sent as `X-Digest`
-     * on outgoing requests so arkd can reject a client whose cached info is
-     * stale. Empty until the first {@link getInfo}.
+     * Last server-info digest seen from {@link getInfo}. Sent as `X-Digest`
+     * so arkd can reject stale client configuration.
      */
     private _digest = "";
     private _hasServerInfo = false;
@@ -299,12 +298,9 @@ export class RestArkProvider implements ArkProvider {
     private _serverInfoListeners = new Set<(info: ArkInfo) => void>();
 
     /**
-     * Subscribe to server-info changes, so consumers (the wallet) can re-derive
-     * signer-dependent state mid-session without polling. Returns an unsubscribe
-     * function. Fired on both paths that can observe a rotated operator config:
-     *
-     *  - a request rejected with `DIGEST_MISMATCH`, after fresh info is re-fetched;
-     *  - a routine {@link getInfo} refresh that comes back with a changed digest.
+     * Subscribe to server-info changes. Fired after a stale-info
+     * `DIGEST_MISMATCH` refresh or when {@link getInfo} observes a changed digest.
+     * Returns an unsubscribe function.
      */
     onServerInfoChanged(listener: (info: ArkInfo) => void): () => void {
         this._serverInfoListeners.add(listener);
@@ -472,21 +468,9 @@ export class RestArkProvider implements ArkProvider {
         const hadServerInfo = this._hasServerInfo;
         this._digest = info.digest;
         this._hasServerInfo = true;
-        // Refresh-path rotation detection, mirroring NArk's CachingClientTransport
-        // (`ServerInfoChangedReason.TtlExpiry`). `getInfo` is not digest-gated, so a
-        // routine refresh — a caller's direct call, or a CachingArkProvider TTL
-        // expiry — silently adopts a rotated config and re-arms `X-Digest`. Without
-        // this emit, arkd then accepts the request the mismatch guard would have
-        // rejected, and the wallet is left on stale signer-derived state with its
-        // only rotation trigger disarmed. Assign the digest first so a listener's
-        // own requests already carry the new one.
-        //
-        // First populate is not a change, even when its digest is non-empty.
-        // Conversely, a previously observed empty digest is still a real previous
-        // value: old/no-digest operators can rotate to a digest-bearing config.
-        // The DIGEST_MISMATCH path clears `_digest` before refetching and emits
-        // explicitly, so suppress only that one internal refresh to avoid a double
-        // event while preserving later refresh detection if the refetch fails.
+        // A refresh can observe server-info changes before any digest-gated
+        // request fails. `_hasServerInfo` makes an empty previous digest count
+        // as a real value; `DIGEST_MISMATCH` emits separately after its refetch.
         if (
             hadServerInfo &&
             previousDigest !== info.digest &&

--- a/packages/ts-sdk/src/providers/cachingArk.ts
+++ b/packages/ts-sdk/src/providers/cachingArk.ts
@@ -1,0 +1,107 @@
+import { TreeNonces, TreePartialSigs } from "../tree/signingSession";
+import { Intent } from "../intent";
+import {
+    ArkInfo,
+    ArkProvider,
+    PendingTx,
+    SettlementEvent,
+    SignedIntent,
+    TxNotification,
+} from "./ark";
+
+const DEFAULT_TTL_MS = 60_000;
+
+type ServerInfoEventSource = Partial<{
+    onServerInfoChanged(listener: (info: ArkInfo) => void): () => void;
+}>;
+
+/**
+ * Decorates an {@link ArkProvider}, caching {@link ArkProvider.getInfo} for
+ * `ttlMs` (default 60s). Every other method passes straight through. The
+ * cache is refreshed instantly on signer rotation via the inner provider's
+ * `onServerInfoChanged`, if it has one — mirrors NArk's
+ * `CachingClientTransport` (dotnet-sdk).
+ */
+export class CachingArkProvider implements ArkProvider {
+    private cached?: ArkInfo;
+    private expiresAt = 0;
+    private inflight?: Promise<ArkInfo>;
+
+    constructor(
+        private readonly inner: ArkProvider,
+        private readonly ttlMs: number = DEFAULT_TTL_MS,
+    ) {
+        (inner as ServerInfoEventSource).onServerInfoChanged?.((info) => {
+            this.cached = info;
+            this.expiresAt = Date.now() + this.ttlMs;
+        });
+    }
+
+    async getInfo(): Promise<ArkInfo> {
+        if (this.cached && Date.now() < this.expiresAt) return this.cached;
+        if (!this.inflight) {
+            this.inflight = this.inner
+                .getInfo()
+                .then((info) => {
+                    this.cached = info;
+                    this.expiresAt = Date.now() + this.ttlMs;
+                    return info;
+                })
+                .finally(() => {
+                    this.inflight = undefined;
+                });
+        }
+        return this.inflight;
+    }
+
+    submitTx(signedArkTx: string, checkpointTxs: string[]) {
+        return this.inner.submitTx(signedArkTx, checkpointTxs);
+    }
+
+    finalizeTx(arkTxid: string, finalCheckpointTxs: string[]) {
+        return this.inner.finalizeTx(arkTxid, finalCheckpointTxs);
+    }
+
+    registerIntent(intent: SignedIntent<Intent.RegisterMessage>) {
+        return this.inner.registerIntent(intent);
+    }
+
+    deleteIntent(intent: SignedIntent<Intent.DeleteMessage>) {
+        return this.inner.deleteIntent(intent);
+    }
+
+    confirmRegistration(intentId: string) {
+        return this.inner.confirmRegistration(intentId);
+    }
+
+    submitTreeNonces(batchId: string, pubkey: string, nonces: TreeNonces) {
+        return this.inner.submitTreeNonces(batchId, pubkey, nonces);
+    }
+
+    submitTreeSignatures(batchId: string, pubkey: string, signatures: TreePartialSigs) {
+        return this.inner.submitTreeSignatures(batchId, pubkey, signatures);
+    }
+
+    submitSignedForfeitTxs(signedForfeitTxs: string[], signedCommitmentTx?: string) {
+        return this.inner.submitSignedForfeitTxs(signedForfeitTxs, signedCommitmentTx);
+    }
+
+    getEventStream(signal: AbortSignal, topics: string[]): AsyncIterableIterator<SettlementEvent> {
+        return this.inner.getEventStream(signal, topics);
+    }
+
+    getTransactionsStream(signal: AbortSignal): AsyncIterableIterator<{
+        commitmentTx?: TxNotification;
+        arkTx?: TxNotification;
+    }> {
+        return this.inner.getTransactionsStream(signal);
+    }
+
+    getPendingTxs(intent: SignedIntent<Intent.GetPendingTxMessage>): Promise<PendingTx[]> {
+        return this.inner.getPendingTxs(intent);
+    }
+
+    onServerInfoChanged(listener: (info: ArkInfo) => void): () => void {
+        return (this.inner as ServerInfoEventSource).onServerInfoChanged?.(listener) ?? (() => {});
+    }
+}

--- a/packages/ts-sdk/src/providers/cachingArk.ts
+++ b/packages/ts-sdk/src/providers/cachingArk.ts
@@ -6,7 +6,7 @@ import {
     PendingTx,
     SettlementEvent,
     SignedIntent,
-    TxNotification,
+    TxNotificationEvent,
 } from "./ark";
 
 const DEFAULT_TTL_MS = 60_000;
@@ -18,6 +18,8 @@ type ServerInfoEventSource = Partial<{
 /**
  * Decorates an {@link ArkProvider}, caching {@link ArkProvider.getInfo} for
  * `ttlMs` (default 60s). Other provider methods pass through.
+ * Expired-cache refresh failures propagate; persisted wallet boot fallback
+ * lives in `arkInfoSnapshot`.
  */
 export class CachingArkProvider implements ArkProvider {
     private cached?: ArkInfo;
@@ -92,10 +94,7 @@ export class CachingArkProvider implements ArkProvider {
         return this.inner.getEventStream(signal, topics);
     }
 
-    getTransactionsStream(signal: AbortSignal): AsyncIterableIterator<{
-        commitmentTx?: TxNotification;
-        arkTx?: TxNotification;
-    }> {
+    getTransactionsStream(signal: AbortSignal): AsyncIterableIterator<TxNotificationEvent> {
         return this.inner.getTransactionsStream(signal);
     }
 

--- a/packages/ts-sdk/src/providers/cachingArk.ts
+++ b/packages/ts-sdk/src/providers/cachingArk.ts
@@ -25,15 +25,25 @@ export class CachingArkProvider implements ArkProvider {
     private cached?: ArkInfo;
     private expiresAt = 0;
     private inflight?: Promise<ArkInfo>;
+    /** Bumped on every event-driven cache write; see {@link getInfo}. */
+    private generation = 0;
+    private readonly unsubscribe: () => void;
 
     constructor(
         private readonly inner: ArkProvider,
         private readonly ttlMs: number = DEFAULT_TTL_MS,
     ) {
-        (inner as ServerInfoEventSource).onServerInfoChanged?.((info) => {
-            this.cached = info;
-            this.expiresAt = Date.now() + this.ttlMs;
-        });
+        this.unsubscribe =
+            (inner as ServerInfoEventSource).onServerInfoChanged?.((info) => {
+                this.cached = info;
+                this.expiresAt = Date.now() + this.ttlMs;
+                this.generation++;
+            }) ?? (() => {});
+    }
+
+    /** Releases the inner provider's server-info subscription. */
+    dispose(): void {
+        this.unsubscribe();
     }
 
     get serverUrl(): string | undefined {
@@ -44,9 +54,15 @@ export class CachingArkProvider implements ArkProvider {
     async getInfo(): Promise<ArkInfo> {
         if (this.cached && Date.now() < this.expiresAt) return this.cached;
         if (!this.inflight) {
+            // A rotation event can land while this request is in flight, making
+            // its result the older of the two. Writing it back would serve the
+            // superseded signer for a full TTL, so a bumped generation discards
+            // the response in favour of what the event already cached.
+            const generation = this.generation;
             this.inflight = this.inner
                 .getInfo()
                 .then((info) => {
+                    if (this.generation !== generation) return this.cached ?? info;
                     this.cached = info;
                     this.expiresAt = Date.now() + this.ttlMs;
                     return info;

--- a/packages/ts-sdk/src/providers/cachingArk.ts
+++ b/packages/ts-sdk/src/providers/cachingArk.ts
@@ -21,6 +21,13 @@ type ServerInfoEventSource = Partial<{
  * cache is refreshed instantly on signer rotation via the inner provider's
  * `onServerInfoChanged`, if it has one — mirrors NArk's
  * `CachingClientTransport` (dotnet-sdk).
+ *
+ * Rotation *detection* is the inner provider's job on both paths, including the
+ * one this decorator introduces: `RestArkProvider.getInfo` emits when a refresh
+ * returns a changed digest, so a rotation first observed by a TTL-expiry
+ * refetch still reaches subscribers. A custom inner provider without
+ * `onServerInfoChanged` caches fine but cannot report rotations — the same
+ * limitation it has undecorated.
  */
 export class CachingArkProvider implements ArkProvider {
     private cached?: ArkInfo;
@@ -35,6 +42,18 @@ export class CachingArkProvider implements ArkProvider {
             this.cached = info;
             this.expiresAt = Date.now() + this.ttlMs;
         });
+    }
+
+    /**
+     * The inner provider's server URL, when it exposes one. `ArkProvider` does
+     * not declare a URL accessor, so consumers read it structurally — wallet
+     * setup does, via `extractArkProviderUrl`, to derive the indexer URL when
+     * `indexerUrl` is not configured. Without this delegation, decorating a
+     * provider would make `Wallet.create` throw for want of an indexer URL.
+     */
+    get serverUrl(): string | undefined {
+        const url = (this.inner as { serverUrl?: unknown }).serverUrl;
+        return typeof url === "string" ? url : undefined;
     }
 
     async getInfo(): Promise<ArkInfo> {

--- a/packages/ts-sdk/src/providers/cachingArk.ts
+++ b/packages/ts-sdk/src/providers/cachingArk.ts
@@ -17,17 +17,7 @@ type ServerInfoEventSource = Partial<{
 
 /**
  * Decorates an {@link ArkProvider}, caching {@link ArkProvider.getInfo} for
- * `ttlMs` (default 60s). Every other method passes straight through. The
- * cache is refreshed instantly on signer rotation via the inner provider's
- * `onServerInfoChanged`, if it has one — mirrors NArk's
- * `CachingClientTransport` (dotnet-sdk).
- *
- * Rotation *detection* is the inner provider's job on both paths, including the
- * one this decorator introduces: `RestArkProvider.getInfo` emits when a refresh
- * returns a changed digest, so a rotation first observed by a TTL-expiry
- * refetch still reaches subscribers. A custom inner provider without
- * `onServerInfoChanged` caches fine but cannot report rotations — the same
- * limitation it has undecorated.
+ * `ttlMs` (default 60s). Other provider methods pass through.
  */
 export class CachingArkProvider implements ArkProvider {
     private cached?: ArkInfo;
@@ -44,13 +34,6 @@ export class CachingArkProvider implements ArkProvider {
         });
     }
 
-    /**
-     * The inner provider's server URL, when it exposes one. `ArkProvider` does
-     * not declare a URL accessor, so consumers read it structurally — wallet
-     * setup does, via `extractArkProviderUrl`, to derive the indexer URL when
-     * `indexerUrl` is not configured. Without this delegation, decorating a
-     * provider would make `Wallet.create` throw for want of an indexer URL.
-     */
     get serverUrl(): string | undefined {
         const url = (this.inner as { serverUrl?: unknown }).serverUrl;
         return typeof url === "string" ? url : undefined;

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -1,7 +1,6 @@
 import { hex } from "@scure/base";
-import { Wallet, type ProviderConnectionState } from "../wallet";
+import { Wallet, extractArkProviderUrl, type ProviderConnectionState } from "../wallet";
 import type { Activity, ActivityRegistry } from "../activity";
-import { RestArkProvider } from "../../providers/ark";
 import type {
     IWallet,
     IAssetManager,
@@ -173,11 +172,7 @@ export class ExpoWallet implements IWallet, HDWalletCapable, HDAllocationCapable
         // Persist wallet params so the background handler can rehydrate
         // without a network call. Only works with AsyncStorageTaskQueue.
         if ("persistConfig" in taskQueue) {
-            const arkServerUrl =
-                config.arkServerUrl ||
-                (wallet.arkProvider instanceof RestArkProvider
-                    ? wallet.arkProvider.serverUrl
-                    : undefined);
+            const arkServerUrl = config.arkServerUrl || extractArkProviderUrl(wallet.arkProvider);
 
             if (arkServerUrl) {
                 const timelock = wallet.offchainTapscript.options.csvTimelock;

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -1,7 +1,6 @@
 import { hex } from "@scure/base";
-import { Wallet, type ProviderConnectionState } from "../wallet";
+import { Wallet, extractArkProviderUrl, type ProviderConnectionState } from "../wallet";
 import type { Activity, ActivityRegistry } from "../activity";
-import { RestArkProvider } from "../../providers/ark";
 import type {
     IWallet,
     IAssetManager,
@@ -171,11 +170,7 @@ export class ExpoWallet implements IWallet {
         // Persist wallet params so the background handler can rehydrate
         // without a network call. Only works with AsyncStorageTaskQueue.
         if ("persistConfig" in taskQueue) {
-            const arkServerUrl =
-                config.arkServerUrl ||
-                (wallet.arkProvider instanceof RestArkProvider
-                    ? wallet.arkProvider.serverUrl
-                    : undefined);
+            const arkServerUrl = config.arkServerUrl || extractArkProviderUrl(wallet.arkProvider);
 
             if (arkServerUrl) {
                 const timelock = wallet.offchainTapscript.options.csvTimelock;

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -168,11 +168,8 @@ function intentProofJobs(coins: ReadonlyArray<{ tapTree: Bytes }>): InputSigning
     return [{ index: 0, lookupScript: coinJobs[0].lookupScript }, ...coinJobs];
 }
 
-// Built-in ArkProvider implementations (Rest/Expo) expose `serverUrl`,
-// but the interface itself does not declare a URL accessor — so this is a
-// structural read that returns undefined for custom implementations.
-// Structural, not `instanceof`: a decorator such as `CachingArkProvider` is not
-// a `RestArkProvider` but does forward `serverUrl`.
+// Built-in and decorated ArkProvider implementations may expose `serverUrl`.
+// The interface does not require it, so custom providers can return undefined.
 export function extractArkProviderUrl(provider: ArkProvider): string | undefined {
     const serverUrl = (provider as { serverUrl?: unknown }).serverUrl;
     return typeof serverUrl === "string" && serverUrl.length > 0 ? serverUrl : undefined;

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -208,11 +208,8 @@ function asSendParams(args: [SendParams] | [Recipient, ...Recipient[]]): SendPar
     return { recipients: args as [Recipient, ...Recipient[]] };
 }
 
-// Built-in ArkProvider implementations (Rest/Expo) expose `serverUrl`,
-// but the interface itself does not declare a URL accessor — so this is a
-// structural read that returns undefined for custom implementations.
-// Structural, not `instanceof`: a decorator such as `CachingArkProvider` is not
-// a `RestArkProvider` but does forward `serverUrl`.
+// Built-in and decorated ArkProvider implementations may expose `serverUrl`.
+// The interface does not require it, so custom providers can return undefined.
 export function extractArkProviderUrl(provider: ArkProvider): string | undefined {
     const serverUrl = (provider as { serverUrl?: unknown }).serverUrl;
     return typeof serverUrl === "string" && serverUrl.length > 0 ? serverUrl : undefined;

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -171,7 +171,9 @@ function intentProofJobs(coins: ReadonlyArray<{ tapTree: Bytes }>): InputSigning
 // Built-in ArkProvider implementations (Rest/Expo) expose `serverUrl`,
 // but the interface itself does not declare a URL accessor — so this is a
 // structural read that returns undefined for custom implementations.
-function extractArkProviderUrl(provider: ArkProvider): string | undefined {
+// Structural, not `instanceof`: a decorator such as `CachingArkProvider` is not
+// a `RestArkProvider` but does forward `serverUrl`.
+export function extractArkProviderUrl(provider: ArkProvider): string | undefined {
     const serverUrl = (provider as { serverUrl?: unknown }).serverUrl;
     return typeof serverUrl === "string" && serverUrl.length > 0 ? serverUrl : undefined;
 }

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -211,7 +211,9 @@ function asSendParams(args: [SendParams] | [Recipient, ...Recipient[]]): SendPar
 // Built-in ArkProvider implementations (Rest/Expo) expose `serverUrl`,
 // but the interface itself does not declare a URL accessor — so this is a
 // structural read that returns undefined for custom implementations.
-function extractArkProviderUrl(provider: ArkProvider): string | undefined {
+// Structural, not `instanceof`: a decorator such as `CachingArkProvider` is not
+// a `RestArkProvider` but does forward `serverUrl`.
+export function extractArkProviderUrl(provider: ArkProvider): string | undefined {
     const serverUrl = (provider as { serverUrl?: unknown }).serverUrl;
     return typeof serverUrl === "string" && serverUrl.length > 0 ? serverUrl : undefined;
 }

--- a/packages/ts-sdk/test/arkProviderDigest.test.ts
+++ b/packages/ts-sdk/test/arkProviderDigest.test.ts
@@ -3,7 +3,6 @@ import { RestArkProvider, DigestMismatchError } from "../src/providers/ark";
 
 const SIGNER = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 
-/** A 200 /v1/info response advertising the given digest (and optionally signer). */
 function okInfo(digest: string, signerPubkey: string = SIGNER) {
     return { ok: true, json: async () => ({ signerPubkey, digest }) };
 }
@@ -87,11 +86,6 @@ describe("RestArkProvider server-info digest negotiation", () => {
         expect(digestOf(provider)).toBe("dX");
     });
 
-    // `getInfo` is not digest-gated, so a plain refresh (a direct caller, or a
-    // CachingArkProvider TTL expiry) adopts a rotated config and re-arms
-    // `X-Digest` — arkd then accepts what the mismatch guard would have rejected.
-    // Without this emit the wallet keeps deriving against the old signer with its
-    // only rotation trigger already disarmed. Mirrors NArk's TtlExpiry reason.
     it("getInfo emits onServerInfoChanged when a refresh returns a changed digest", async () => {
         const ROTATED = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
         const provider = new RestArkProvider("http://ark.test");
@@ -106,7 +100,6 @@ describe("RestArkProvider server-info digest negotiation", () => {
         const seen: { signerPubkey: string; digest: string }[] = [];
         provider.onServerInfoChanged((info) => seen.push(info));
 
-        // The operator rotated its signer between refreshes.
         digest = "d2";
         signer = ROTATED;
         await provider.getInfo();
@@ -114,8 +107,6 @@ describe("RestArkProvider server-info digest negotiation", () => {
         expect(seen).toHaveLength(1);
         expect(seen[0].signerPubkey).toBe(ROTATED);
         expect(seen[0].digest).toBe("d2");
-        // The new digest is in place before listeners run, so a listener's own
-        // authed requests already carry it.
         expect(digestOf(provider)).toBe("d2");
     });
 

--- a/packages/ts-sdk/test/arkProviderDigest.test.ts
+++ b/packages/ts-sdk/test/arkProviderDigest.test.ts
@@ -3,9 +3,9 @@ import { RestArkProvider, DigestMismatchError } from "../src/providers/ark";
 
 const SIGNER = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 
-/** A 200 /v1/info response advertising the given digest. */
-function okInfo(digest: string) {
-    return { ok: true, json: async () => ({ signerPubkey: SIGNER, digest }) };
+/** A 200 /v1/info response advertising the given digest (and optionally signer). */
+function okInfo(digest: string, signerPubkey: string = SIGNER) {
+    return { ok: true, json: async () => ({ signerPubkey, digest }) };
 }
 
 /** A rejected non-/info response whose body carries the given marker. */
@@ -85,6 +85,78 @@ describe("RestArkProvider server-info digest negotiation", () => {
         await provider.getInfo();
 
         expect(digestOf(provider)).toBe("dX");
+    });
+
+    // `getInfo` is not digest-gated, so a plain refresh (a direct caller, or a
+    // CachingArkProvider TTL expiry) adopts a rotated config and re-arms
+    // `X-Digest` — arkd then accepts what the mismatch guard would have rejected.
+    // Without this emit the wallet keeps deriving against the old signer with its
+    // only rotation trigger already disarmed. Mirrors NArk's TtlExpiry reason.
+    it("getInfo emits onServerInfoChanged when a refresh returns a changed digest", async () => {
+        const ROTATED = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+        const provider = new RestArkProvider("http://ark.test");
+        let digest = "d1";
+        let signer = SIGNER;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => okInfo(digest, signer)),
+        );
+        await provider.getInfo();
+
+        const seen: { signerPubkey: string; digest: string }[] = [];
+        provider.onServerInfoChanged((info) => seen.push(info));
+
+        // The operator rotated its signer between refreshes.
+        digest = "d2";
+        signer = ROTATED;
+        await provider.getInfo();
+
+        expect(seen).toHaveLength(1);
+        expect(seen[0].signerPubkey).toBe(ROTATED);
+        expect(seen[0].digest).toBe("d2");
+        // The new digest is in place before listeners run, so a listener's own
+        // authed requests already carry it.
+        expect(digestOf(provider)).toBe("d2");
+    });
+
+    it("getInfo emits when a previously empty digest changes", async () => {
+        const ROTATED = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+        const provider = new RestArkProvider("http://ark.test");
+        let digest = "";
+        let signer = SIGNER;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => okInfo(digest, signer)),
+        );
+
+        const seen: { signerPubkey: string; digest: string }[] = [];
+        provider.onServerInfoChanged((info) => seen.push(info));
+
+        await provider.getInfo();
+        expect(seen).toHaveLength(0);
+
+        digest = "d1";
+        signer = ROTATED;
+        await provider.getInfo();
+
+        expect(seen).toHaveLength(1);
+        expect(seen[0].signerPubkey).toBe(ROTATED);
+        expect(seen[0].digest).toBe("d1");
+    });
+
+    it("getInfo does not emit on first populate or on an unchanged digest", async () => {
+        const provider = new RestArkProvider("http://ark.test");
+        const seen: unknown[] = [];
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => okInfo("d1")),
+        );
+        provider.onServerInfoChanged((info) => seen.push(info));
+
+        await provider.getInfo();
+        await provider.getInfo();
+
+        expect(seen).toHaveLength(0);
     });
 
     it("on DIGEST_MISMATCH refreshes + emits onServerInfoChanged + throws (no silent retry)", async () => {

--- a/packages/ts-sdk/test/cachingArkProvider.test.ts
+++ b/packages/ts-sdk/test/cachingArkProvider.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { CachingArkProvider } from "../src/providers/cachingArk";
+import { ArkInfo, ArkProvider } from "../src/providers/ark";
+
+function fakeInfo(digest: string): ArkInfo {
+    return {
+        boardingExitDelay: 0n,
+        checkpointTapscript: "",
+        deprecatedSigners: [],
+        digest,
+        dust: 0n,
+        fees: { intentFee: {} as never, txFeeRate: "" },
+        forfeitAddress: "",
+        forfeitPubkey: "",
+        network: "regtest",
+        serviceStatus: {},
+        sessionDuration: 0n,
+        signerPubkey: "signer",
+        unilateralExitDelay: 0n,
+        utxoMaxAmount: -1n,
+        utxoMinAmount: 0n,
+        version: "1.0",
+        vtxoMaxAmount: -1n,
+        vtxoMinAmount: 0n,
+    };
+}
+
+/** Minimal ArkProvider stub exposing only what CachingArkProvider touches. */
+function fakeInner(getInfo: () => Promise<ArkInfo>) {
+    const listeners = new Set<(info: ArkInfo) => void>();
+    return {
+        getInfo,
+        onServerInfoChanged: (listener: (info: ArkInfo) => void) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        },
+        emit: (info: ArkInfo) => listeners.forEach((l) => l(info)),
+    };
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("CachingArkProvider", () => {
+    it("serves getInfo from cache within the TTL", async () => {
+        const getInfo = vi.fn().mockResolvedValue(fakeInfo("d1"));
+        const provider = new CachingArkProvider(
+            fakeInner(getInfo) as unknown as ArkProvider,
+            60_000,
+        );
+
+        await provider.getInfo();
+        await provider.getInfo();
+
+        expect(getInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it("refetches once the TTL expires", async () => {
+        vi.useFakeTimers();
+        const getInfo = vi.fn().mockResolvedValue(fakeInfo("d1"));
+        const provider = new CachingArkProvider(
+            fakeInner(getInfo) as unknown as ArkProvider,
+            60_000,
+        );
+
+        await provider.getInfo();
+        vi.advanceTimersByTime(60_001);
+        await provider.getInfo();
+
+        expect(getInfo).toHaveBeenCalledTimes(2);
+    });
+
+    it("dedupes concurrent misses into a single inner call", async () => {
+        let resolveInner!: (info: ArkInfo) => void;
+        const getInfo = vi.fn().mockReturnValue(
+            new Promise<ArkInfo>((resolve) => {
+                resolveInner = resolve;
+            }),
+        );
+        const provider = new CachingArkProvider(
+            fakeInner(getInfo) as unknown as ArkProvider,
+            60_000,
+        );
+
+        const a = provider.getInfo();
+        const b = provider.getInfo();
+        resolveInner(fakeInfo("d1"));
+        await Promise.all([a, b]);
+
+        expect(getInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes the cache instantly when the inner provider reports a signer rotation", async () => {
+        const getInfo = vi.fn().mockResolvedValue(fakeInfo("d1"));
+        const inner = fakeInner(getInfo);
+        const provider = new CachingArkProvider(inner as unknown as ArkProvider, 60_000);
+
+        await provider.getInfo();
+        inner.emit(fakeInfo("d2"));
+        const info = await provider.getInfo();
+
+        expect(info.digest).toBe("d2");
+        expect(getInfo).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/ts-sdk/test/cachingArkProvider.test.ts
+++ b/packages/ts-sdk/test/cachingArkProvider.test.ts
@@ -108,6 +108,68 @@ describe("CachingArkProvider", () => {
         expect(getInfo).toHaveBeenCalledTimes(1);
     });
 
+    it("keeps an event-cached rotation over an older in-flight fetch result", async () => {
+        let resolveInner!: (info: ArkInfo) => void;
+        const getInfo = vi.fn().mockReturnValue(
+            new Promise<ArkInfo>((resolve) => {
+                resolveInner = resolve;
+            }),
+        );
+        const inner = fakeInner(getInfo);
+        const provider = new CachingArkProvider(inner as unknown as ArkProvider, 60_000);
+
+        const pending = provider.getInfo();
+        inner.emit(fakeInfo("d2"));
+        resolveInner(fakeInfo("d1"));
+
+        expect((await pending).digest).toBe("d2");
+        expect((await provider.getInfo()).digest).toBe("d2");
+        expect(getInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not extend the TTL of an event-cached rotation with the older fetch's clock", async () => {
+        vi.useFakeTimers();
+        let resolveInner!: (info: ArkInfo) => void;
+        const getInfo = vi.fn().mockReturnValueOnce(
+            new Promise<ArkInfo>((resolve) => {
+                resolveInner = resolve;
+            }),
+        );
+        const inner = fakeInner(getInfo);
+        const provider = new CachingArkProvider(inner as unknown as ArkProvider, 60_000);
+
+        const pending = provider.getInfo();
+        inner.emit(fakeInfo("d2"));
+        vi.advanceTimersByTime(30_000);
+        resolveInner(fakeInfo("d1"));
+        await pending;
+
+        getInfo.mockResolvedValue(fakeInfo("d3"));
+        vi.advanceTimersByTime(30_001);
+
+        expect((await provider.getInfo()).digest).toBe("d3");
+    });
+
+    it("stops caching rotation events once disposed", async () => {
+        const getInfo = vi.fn().mockResolvedValue(fakeInfo("d1"));
+        const inner = fakeInner(getInfo);
+        const provider = new CachingArkProvider(inner as unknown as ArkProvider, 60_000);
+
+        await provider.getInfo();
+        provider.dispose();
+        inner.emit(fakeInfo("d2"));
+
+        expect((await provider.getInfo()).digest).toBe("d1");
+    });
+
+    it("disposes cleanly when the inner provider emits no server-info events", () => {
+        const provider = new CachingArkProvider({
+            getInfo: async () => fakeInfo("d1"),
+        } as unknown as ArkProvider);
+
+        expect(() => provider.dispose()).not.toThrow();
+    });
+
     it("surfaces a rotation first observed by a TTL-expiry refetch", async () => {
         vi.useFakeTimers();
         let digest = "d1";

--- a/packages/ts-sdk/test/cachingArkProvider.test.ts
+++ b/packages/ts-sdk/test/cachingArkProvider.test.ts
@@ -29,7 +29,6 @@ function fakeInfo(digest: string): ArkInfo {
     };
 }
 
-/** Minimal ArkProvider stub exposing only what CachingArkProvider touches. */
 function fakeInner(getInfo: () => Promise<ArkInfo>) {
     const listeners = new Set<(info: ArkInfo) => void>();
     return {
@@ -109,10 +108,6 @@ describe("CachingArkProvider", () => {
         expect(getInfo).toHaveBeenCalledTimes(1);
     });
 
-    // The TTL refetch is a path no undecorated caller had: it observes a rotation
-    // with no request rejection to trigger DIGEST_MISMATCH, and re-arms `X-Digest`
-    // so no later request will trigger it either. Detection lives in the inner
-    // provider's getInfo; assert it survives the decorator end to end.
     it("surfaces a rotation first observed by a TTL-expiry refetch", async () => {
         vi.useFakeTimers();
         let digest = "d1";
@@ -127,8 +122,6 @@ describe("CachingArkProvider", () => {
         const seen: ArkInfo[] = [];
         provider.onServerInfoChanged((info) => seen.push(info));
 
-        // The operator rotates while the cache is warm; nothing observes it until
-        // the TTL lapses.
         digest = "d2";
         signerPubkey = ROTATED;
         vi.advanceTimersByTime(60_001);
@@ -137,12 +130,9 @@ describe("CachingArkProvider", () => {
         expect(seen).toHaveLength(1);
         expect(seen[0].signerPubkey).toBe(ROTATED);
         expect(info.signerPubkey).toBe(ROTATED);
-        // The listener fired against the same refreshed info the cache now holds.
         expect((await provider.getInfo()).digest).toBe("d2");
     });
 
-    // Wallet setup derives the indexer URL from the arkProvider when `indexerUrl`
-    // is not configured, and throws when it cannot. Decoration must not hide it.
     it("forwards the inner provider's serverUrl to wallet setup's structural read", () => {
         const provider = new CachingArkProvider(new RestArkProvider("http://ark.test"));
 

--- a/packages/ts-sdk/test/cachingArkProvider.test.ts
+++ b/packages/ts-sdk/test/cachingArkProvider.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { CachingArkProvider } from "../src/providers/cachingArk";
-import { ArkInfo, ArkProvider } from "../src/providers/ark";
+import { ArkInfo, ArkProvider, RestArkProvider } from "../src/providers/ark";
+import { extractArkProviderUrl } from "../src/wallet/wallet";
+
+const SIGNER = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const ROTATED = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
 
 function fakeInfo(digest: string): ArkInfo {
     return {
@@ -40,6 +44,7 @@ function fakeInner(getInfo: () => Promise<ArkInfo>) {
 
 afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
 });
 
 describe("CachingArkProvider", () => {
@@ -102,5 +107,55 @@ describe("CachingArkProvider", () => {
 
         expect(info.digest).toBe("d2");
         expect(getInfo).toHaveBeenCalledTimes(1);
+    });
+
+    // The TTL refetch is a path no undecorated caller had: it observes a rotation
+    // with no request rejection to trigger DIGEST_MISMATCH, and re-arms `X-Digest`
+    // so no later request will trigger it either. Detection lives in the inner
+    // provider's getInfo; assert it survives the decorator end to end.
+    it("surfaces a rotation first observed by a TTL-expiry refetch", async () => {
+        vi.useFakeTimers();
+        let digest = "d1";
+        let signerPubkey = SIGNER;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => ({ ok: true, json: async () => ({ signerPubkey, digest }) })),
+        );
+        const provider = new CachingArkProvider(new RestArkProvider("http://ark.test"), 60_000);
+        await provider.getInfo();
+
+        const seen: ArkInfo[] = [];
+        provider.onServerInfoChanged((info) => seen.push(info));
+
+        // The operator rotates while the cache is warm; nothing observes it until
+        // the TTL lapses.
+        digest = "d2";
+        signerPubkey = ROTATED;
+        vi.advanceTimersByTime(60_001);
+        const info = await provider.getInfo();
+
+        expect(seen).toHaveLength(1);
+        expect(seen[0].signerPubkey).toBe(ROTATED);
+        expect(info.signerPubkey).toBe(ROTATED);
+        // The listener fired against the same refreshed info the cache now holds.
+        expect((await provider.getInfo()).digest).toBe("d2");
+    });
+
+    // Wallet setup derives the indexer URL from the arkProvider when `indexerUrl`
+    // is not configured, and throws when it cannot. Decoration must not hide it.
+    it("forwards the inner provider's serverUrl to wallet setup's structural read", () => {
+        const provider = new CachingArkProvider(new RestArkProvider("http://ark.test"));
+
+        expect(provider.serverUrl).toBe("http://ark.test");
+        expect(extractArkProviderUrl(provider)).toBe("http://ark.test");
+    });
+
+    it("reports no serverUrl when the inner provider has none", () => {
+        const provider = new CachingArkProvider(
+            fakeInner(async () => fakeInfo("d1")) as unknown as ArkProvider,
+        );
+
+        expect(provider.serverUrl).toBeUndefined();
+        expect(extractArkProviderUrl(provider)).toBeUndefined();
     });
 });


### PR DESCRIPTION
Adds opt-in caching for ArkProvider.getInfo() and documents usage. Checks: pnpm -r lint, pnpm -r test:unit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable caching for Ark server information with expiration and concurrent request deduplication.
  * Added automatic cache refresh when server signer information changes.
  * Exposed the caching provider through the TypeScript SDK.
  * Improved wallet support for decorated providers and persisted server connections.

* **Bug Fixes**
  * Prevented duplicate server information change notifications and improved digest change detection.

* **Documentation**
  * Added guidance for caching, expiration, wallet integration, and server URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->