### PR TITLE
fix: attribute lockup spends before skipping the claim amount guard

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -393,8 +393,10 @@ export class ArkadeSwaps {
     private async updatePendingChainSwap(
         swap: BoltzChainSwap,
         delta: Partial<BoltzChainSwap>,
+        { skipIfDropped = false }: { skipIfDropped?: boolean } = {},
     ): Promise<void> {
         let stored: BoltzChainSwap | undefined;
+        let read = false;
         try {
             stored = (
                 await this.swapRepository.getAllSwaps<BoltzChainSwap>({
@@ -402,9 +404,14 @@ export class ArkadeSwaps {
                     type: "chain",
                 })
             )?.[0];
+            read = true;
         } catch (error) {
             logger.warn(`Failed to re-read swap ${swap.id} before saving:`, error);
         }
+        // A record absent from a read that succeeded was dropped by a concurrent
+        // `removeSwap`; re-saving it would resurrect it. Only status refreshes
+        // opt in — a claim or refund delta is an outcome that has to land.
+        if (skipIfDropped && read && !stored) return;
         await this.savePendingChainSwap({ ...(stored ?? swap), ...delta });
     }
 
@@ -657,7 +664,7 @@ export class ArkadeSwaps {
         // a split lockup the indexer surfaces piecemeal is not misread. The
         // last raw response is kept so the post-retry branch can distinguish
         // "not found" from "already spent" for diagnostics.
-        const expected = pendingSwap.response.onchainAmount;
+        const expected = await this.expectedReverseClaimAmount(pendingSwap);
         let unspentVtxos: VirtualCoin[] = [];
         let rawVtxos: VirtualCoin[] = [];
         let partiallyClaimed = false;
@@ -667,16 +674,21 @@ export class ArkadeSwaps {
             });
             rawVtxos = result.vtxos;
             unspentVtxos = result.vtxos.filter((vtxo) => !hasTerminalSpend(vtxo));
-            partiallyClaimed = await this.lockupClaimedByUs(
-                rawVtxos.filter(hasTerminalSpend),
-                undefined,
-                vhtlcTimeouts.refund,
-            );
             const total = unspentVtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
-            if (
-                unspentVtxos.length > 0 &&
-                (typeof expected !== "number" || partiallyClaimed || total >= expected)
-            ) {
+            // Attribution costs an indexer round-trip, so only pay for it when
+            // the amount alone does not settle the question.
+            const covered = typeof expected !== "number" || total >= expected;
+            partiallyClaimed = covered
+                ? false
+                : // No `toAddress`: a reverse swap has no stored destination, and
+                  // the claim below pays `wallet.getAddress()`, which
+                  // `spentIntoOurWallet` queries anyway.
+                  await this.lockupClaimedByUs(
+                      rawVtxos.filter(hasTerminalSpend),
+                      undefined,
+                      vhtlcTimeouts.refund,
+                  );
+            if (unspentVtxos.length > 0 && (covered || partiallyClaimed)) {
                 break;
             }
             if (attempt < CLAIM_VTXO_RETRY_ATTEMPTS) {
@@ -2433,6 +2445,28 @@ export class ArkadeSwaps {
     }
 
     /**
+     * The agreed claim amount for a reverse swap. Same reason to prefer the
+     * stored record as {@link ArkadeSwaps.expectedClaimAmount}: the caller's
+     * copy can be a snapshot taken before the record was last written.
+     */
+    private async expectedReverseClaimAmount(
+        pendingSwap: BoltzReverseSwap,
+    ): Promise<number | undefined> {
+        let stored: BoltzReverseSwap | undefined;
+        try {
+            stored = (
+                await this.swapRepository.getAllSwaps<BoltzReverseSwap>({
+                    id: pendingSwap.id,
+                    type: "reverse",
+                })
+            )?.[0];
+        } catch (error) {
+            logger.warn(`Failed to re-read swap ${pendingSwap.id} for its claim amount:`, error);
+        }
+        return stored?.response?.onchainAmount ?? pendingSwap.response.onchainAmount;
+    }
+
+    /**
      * Claim sats on ARK chain by claiming the VHTLC.
      * Refactored to use claimVHTLCIdentity + claimVHTLCwithOffchainTx utilities.
      * @param pendingSwap - The pending chain swap.
@@ -2465,17 +2499,18 @@ export class ArkadeSwaps {
                 scripts: [hex.encode(vhtlcScript.pkScript)],
             });
             spendable = vtxos.filter((vtxo) => !hasTerminalSpend(vtxo));
-            partiallyClaimed = await this.lockupClaimedByUs(
-                vtxos.filter(hasTerminalSpend),
-                pendingSwap.toAddress,
-                pendingSwap.response.claimDetails.timeouts?.refund,
-            );
             const total = spendable.reduce((sum, vtxo) => sum + vtxo.value, 0);
-            if (
-                spendable.length > 0 &&
-                (expected === undefined || partiallyClaimed || total >= expected)
-            )
-                break;
+            // Attribution costs an indexer round-trip, so only pay for it when
+            // the amount alone does not settle the question.
+            const covered = expected === undefined || total >= expected;
+            partiallyClaimed = covered
+                ? false
+                : await this.lockupClaimedByUs(
+                      vtxos.filter(hasTerminalSpend),
+                      pendingSwap.toAddress,
+                      pendingSwap.response.claimDetails.timeouts?.refund,
+                  );
+            if (spendable.length > 0 && (covered || partiallyClaimed)) break;
             if (attempt < CLAIM_VTXO_RETRY_ATTEMPTS) {
                 await new Promise((resolve) => setTimeout(resolve, CLAIM_VTXO_RETRY_DELAY_MS));
             }
@@ -2644,6 +2679,13 @@ export class ArkadeSwaps {
      * carries the batch-settled VTXOs a mid-run claim leaves behind, which
      * `spentIntoOurWallet` cannot attribute — so a claim interrupted before
      * its refund locktime stays re-runnable.
+     *
+     * Known limitation: past that locktime a batch-settled claim of our own is
+     * indistinguishable from a counterparty refund, so this returns false and
+     * the guard stays armed on a remainder we are in fact entitled to sweep.
+     * Fail-safe by design — the other way round disarms the guard for the party
+     * it exists to defend against. Callers get the warning below to tell the
+     * two apart.
      */
     private async lockupClaimedByUs(
         spent: VirtualCoin[],
@@ -2652,7 +2694,13 @@ export class ArkadeSwaps {
     ): Promise<boolean> {
         if (spent.length === 0) return false;
         if (await this.spentIntoOurWallet(toAddress, spent)) return true;
-        return !(await this.refundLocktimeReached(refundLocktime));
+        if (!(await this.refundLocktimeReached(refundLocktime))) return true;
+        logger.warn(
+            `Lockup carries ${spent.length} spend(s) that cannot be attributed past the ` +
+                `refund locktime — either a counterparty refund, or our own batch-settled ` +
+                `claim resumed too late. The lockup amount check stays armed either way.`,
+        );
+        return false;
     }
 
     /**
@@ -2715,7 +2763,10 @@ export class ArkadeSwaps {
     private async refundLocktimeReached(locktime: number | undefined): Promise<boolean> {
         if (locktime === undefined) return true;
         const { height } = await this.chainTipSnapshotFor([locktime]);
-        if (isBlockHeightLocktime(locktime) && height === undefined) return true;
+        if (isBlockHeightLocktime(locktime) && height === undefined) {
+            if (!this.onchainProvider) this.warnMissingOnchainProviderOnce(locktime);
+            return true;
+        }
         return isRefundLocktimeReached(locktime, height);
     }
 
@@ -3705,7 +3756,9 @@ export class ArkadeSwaps {
             if (isChainFinalStatus(swap.status)) continue;
             promises.push(
                 this.getSwapStatus(swap.id)
-                    .then(({ status }) => this.updatePendingChainSwap(swap, { status }))
+                    .then(({ status }) =>
+                        this.updatePendingChainSwap(swap, { status }, { skipIfDropped: true }),
+                    )
                     .catch((error) => {
                         logger.error(`Failed to refresh swap status for ${swap.id}:`, error);
                     }),

--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -384,6 +384,30 @@ export class ArkadeSwaps {
         await this.swapRepository.saveSwap(swap);
     }
 
+    /**
+     * Apply a delta to the stored record rather than to the caller's copy,
+     * which may predate a field written since it was taken —
+     * `acceptedQuoteAmount` in particular. Falls back to the copy when the
+     * record has since been dropped.
+     */
+    private async updatePendingChainSwap(
+        swap: BoltzChainSwap,
+        delta: Partial<BoltzChainSwap>,
+    ): Promise<void> {
+        let stored: BoltzChainSwap | undefined;
+        try {
+            stored = (
+                await this.swapRepository.getAllSwaps<BoltzChainSwap>({
+                    id: swap.id,
+                    type: "chain",
+                })
+            )?.[0];
+        } catch (error) {
+            logger.warn(`Failed to re-read swap ${swap.id} before saving:`, error);
+        }
+        await this.savePendingChainSwap({ ...(stored ?? swap), ...delta });
+    }
+
     private async getPendingReverseSwapsFromStorage(): Promise<BoltzReverseSwap[]> {
         return this.swapRepository.getAllSwaps<BoltzReverseSwap>({
             type: "reverse",
@@ -636,18 +660,22 @@ export class ArkadeSwaps {
         const expected = pendingSwap.response.onchainAmount;
         let unspentVtxos: VirtualCoin[] = [];
         let rawVtxos: VirtualCoin[] = [];
+        let partiallyClaimed = false;
         for (let attempt = 1; attempt <= CLAIM_VTXO_RETRY_ATTEMPTS; attempt++) {
             const result = await this.indexerProvider.getVtxos({
                 scripts: [hex.encode(vhtlcScript.pkScript)],
             });
             rawVtxos = result.vtxos;
             unspentVtxos = result.vtxos.filter((vtxo) => !hasTerminalSpend(vtxo));
+            partiallyClaimed = await this.lockupClaimedByUs(
+                rawVtxos.filter(hasTerminalSpend),
+                undefined,
+                vhtlcTimeouts.refund,
+            );
             const total = unspentVtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
             if (
                 unspentVtxos.length > 0 &&
-                (typeof expected !== "number" ||
-                    rawVtxos.some(hasTerminalSpend) ||
-                    total >= expected)
+                (typeof expected !== "number" || partiallyClaimed || total >= expected)
             ) {
                 break;
             }
@@ -666,15 +694,15 @@ export class ArkadeSwaps {
         // Claiming publishes the preimage, which is what lets the counterparty
         // settle the Lightning side in full, so the locked total must cover the
         // agreed amount before the first claim. Once part of the lockup is
-        // spent an earlier claim has already disclosed it, and the remainder is
-        // swept unconditionally.
+        // claimed by us the preimage is already out, and the remainder is swept
+        // unconditionally.
         const total = unspentVtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
         if (typeof expected !== "number") {
             logger.warn(
                 `Swap ${pendingSwap.id}: no agreed claim amount on record — ` +
                     `skipping the lockup amount check`,
             );
-        } else if (!rawVtxos.some(hasTerminalSpend) && total < expected) {
+        } else if (!partiallyClaimed && total < expected) {
             throw new LockupAmountMismatchError({
                 swapId: pendingSwap.id,
                 expectedAmount: expected,
@@ -2160,10 +2188,11 @@ export class ArkadeSwaps {
             refundViaBoltz: this.swapProvider.refundChainSwap.bind(this.swapProvider),
         });
 
-        // update the pending swap on storage
+        // update the pending swap on storage; the mutation keeps the caller's
+        // copy — the SwapManager's monitored one — in step with the record
         const finalStatus = await this.getSwapStatus(pendingSwap.id);
         pendingSwap.status = finalStatus.status;
-        await this.savePendingChainSwap(pendingSwap);
+        await this.updatePendingChainSwap(pendingSwap, { status: finalStatus.status });
 
         return outcome;
     }
@@ -2436,7 +2465,11 @@ export class ArkadeSwaps {
                 scripts: [hex.encode(vhtlcScript.pkScript)],
             });
             spendable = vtxos.filter((vtxo) => !hasTerminalSpend(vtxo));
-            partiallyClaimed = vtxos.some(hasTerminalSpend);
+            partiallyClaimed = await this.lockupClaimedByUs(
+                vtxos.filter(hasTerminalSpend),
+                pendingSwap.toAddress,
+                pendingSwap.response.claimDetails.timeouts?.refund,
+            );
             const total = spendable.reduce((sum, vtxo) => sum + vtxo.value, 0);
             if (
                 spendable.length > 0 &&
@@ -2454,7 +2487,7 @@ export class ArkadeSwaps {
 
         // Same guard as `claimVHTLC`: the claim witness discloses the preimage,
         // so the lockup must cover the agreed amount before the first claim,
-        // and a partly spent lockup is swept unconditionally.
+        // and a lockup we already claimed part of is swept unconditionally.
         const total = spendable.reduce((sum, vtxo) => sum + vtxo.value, 0);
         if (expected === undefined) {
             logger.warn(
@@ -2515,8 +2548,7 @@ export class ArkadeSwaps {
 
         // update the pending swap on storage
         const finalStatus = await this.getSwapStatus(pendingSwap.id);
-        await this.savePendingChainSwap({
-            ...pendingSwap,
+        await this.updatePendingChainSwap(pendingSwap, {
             status: finalStatus.status,
             claimTxid: txid!,
         });
@@ -2579,13 +2611,14 @@ export class ArkadeSwaps {
             scripts: [hex.encode(vhtlcScript.pkScript)],
         });
         const spent = vtxos.filter((vtxo) => vtxo.isSpent);
+        const refundLocktime = pendingSwap.response.claimDetails.timeouts?.refund;
         if (vtxos.length > 0 && spent.length === vtxos.length) {
             // `isSpent` says nothing about who spent it, so pin the spender:
             // either the spending transaction paid us, or it ran while the
             // sender's refund leaves were still locked, when no spend path
             // exists that does not carry our signature.
-            if (await this.spentIntoOurWallet(pendingSwap, spent)) return;
-            if (!(await this.claimSideRefundReached(pendingSwap))) return;
+            if (await this.spentIntoOurWallet(pendingSwap.toAddress, spent)) return;
+            if (!(await this.refundLocktimeReached(refundLocktime))) return;
         }
 
         throw new CooperativeSignRefusedError({
@@ -2601,6 +2634,28 @@ export class ArkadeSwaps {
     }
 
     /**
+     * Whether the spends already seen at a lockup are our own claim, the only
+     * spend that discloses the preimage. A counterparty CLTV refund also
+     * empties the lockup, and must not disarm the amount guard.
+     *
+     * Same two tests as {@link ArkadeSwaps.assertClaimSideClaimed}: the spend
+     * paid us, or it ran while the sender's refund leaf was still locked, when
+     * no spend path exists that does not carry our signature. The second one
+     * carries the batch-settled VTXOs a mid-run claim leaves behind, which
+     * `spentIntoOurWallet` cannot attribute — so a claim interrupted before
+     * its refund locktime stays re-runnable.
+     */
+    private async lockupClaimedByUs(
+        spent: VirtualCoin[],
+        toAddress: string | undefined,
+        refundLocktime: number | undefined,
+    ): Promise<boolean> {
+        if (spent.length === 0) return false;
+        if (await this.spentIntoOurWallet(toAddress, spent)) return true;
+        return !(await this.refundLocktimeReached(refundLocktime));
+    }
+
+    /**
      * Whether every ark tx that spent the given VTXOs paid our scripts at
      * least the value it took from the lockup — the spend made us whole. A
      * bare paid-us check would accept a post-locktime refund carrying a dust
@@ -2612,7 +2667,7 @@ export class ArkadeSwaps {
      * counterparty, not a colluding operator.
      */
     private async spentIntoOurWallet(
-        pendingSwap: BoltzChainSwap,
+        toAddress: string | undefined,
         spent: VirtualCoin[],
     ): Promise<boolean> {
         if (spent.some((vtxo) => !vtxo.arkTxId)) return false;
@@ -2626,7 +2681,7 @@ export class ArkadeSwaps {
         // The claim pays `wallet.getAddress()` as of claim time; `toAddress` is
         // what the caller asked for. Under HD rotation neither alone covers
         // every claim, so query both.
-        const scripts = [pendingSwap.toAddress, await this.wallet.getAddress()]
+        const scripts = [toAddress, await this.wallet.getAddress()]
             .filter((address): address is string => Boolean(address))
             .flatMap((address) => {
                 try {
@@ -2653,13 +2708,11 @@ export class ArkadeSwaps {
     }
 
     /**
-     * Whether the claim-side refund locktime has been reached, i.e. the sender
-     * can spend the lockup without us. Unknown counts as reached: a
-     * block-height locktime with no chain tip cannot establish the window is
-     * still shut.
+     * Whether a lockup's refund locktime has been reached, i.e. the sender can
+     * spend it without us. Unknown counts as reached: a block-height locktime
+     * with no chain tip cannot establish the window is still shut.
      */
-    private async claimSideRefundReached(pendingSwap: BoltzChainSwap): Promise<boolean> {
-        const locktime = pendingSwap.response.claimDetails.timeouts?.refund;
+    private async refundLocktimeReached(locktime: number | undefined): Promise<boolean> {
         if (locktime === undefined) return true;
         const { height } = await this.chainTipSnapshotFor([locktime]);
         if (isBlockHeightLocktime(locktime) && height === undefined) return true;
@@ -3652,7 +3705,7 @@ export class ArkadeSwaps {
             if (isChainFinalStatus(swap.status)) continue;
             promises.push(
                 this.getSwapStatus(swap.id)
-                    .then(({ status }) => this.savePendingChainSwap({ ...swap, status }))
+                    .then(({ status }) => this.updatePendingChainSwap(swap, { status }))
                     .catch((error) => {
                         logger.error(`Failed to refresh swap status for ${swap.id}:`, error);
                     }),

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -412,6 +412,11 @@ describe("ArkadeSwaps", () => {
         },
     };
 
+    /** Derived, so a fixture change cannot silently flip a locktime assertion. */
+    const chainRefundLocktime = createBtcArkChainSwapResponse.claimDetails.timeouts!.refund;
+    /** Exceeds CLAIM_VTXO_RETRY_ATTEMPTS × CLAIM_VTXO_RETRY_DELAY_MS. */
+    const CLAIM_RETRY_WINDOW_MS = 5_000;
+
     const mockArkBtcChainSwap: BoltzChainSwap = {
         id: mock.id,
         type: "chain",
@@ -1667,6 +1672,53 @@ describe("ArkadeSwaps", () => {
                 );
             });
 
+            // The re-read that keeps a status refresh off the caller's stale
+            // copy also sees a concurrent `removeSwap`; writing anyway would
+            // bring the record back.
+            it("does not resurrect a chain swap dropped while its status was in flight", async () => {
+                const pendingSwap: BoltzChainSwap = {
+                    ...mockArkBtcChainSwap,
+                    status: "swap.created",
+                };
+                // the poll's own listing carries the swap; the per-swap re-read
+                // finds it gone
+                mockSwapRepository.getAllSwaps.mockImplementation(async (filter: any) =>
+                    filter?.type === "chain" && !filter.id ? [pendingSwap] : [],
+                );
+                vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                    status: "transaction.claimed",
+                });
+
+                await swaps.refreshSwapsStatus();
+
+                expect(mockSwapRepository.saveSwap).not.toHaveBeenCalled();
+            });
+
+            it("writes the refreshed chain status onto the stored record", async () => {
+                const pendingSwap: BoltzChainSwap = {
+                    ...mockArkBtcChainSwap,
+                    status: "swap.created",
+                };
+                mockSwapRepository.getAllSwaps.mockImplementation(async (filter: any) =>
+                    filter?.type === "chain"
+                        ? [{ ...pendingSwap, acceptedQuoteAmount: 12345 }]
+                        : [],
+                );
+                vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
+                    status: "transaction.claimed",
+                });
+
+                await swaps.refreshSwapsStatus();
+
+                expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        id: pendingSwap.id,
+                        status: "transaction.claimed",
+                        acceptedQuoteAmount: 12345,
+                    }),
+                );
+            });
+
             it("should not fetch the preimage for swaps that have not settled", async () => {
                 // arrange
                 const pendingSwap: BoltzSubmarineSwap = {
@@ -2911,7 +2963,9 @@ describe("ArkadeSwaps", () => {
                 it("treats a VTXO consumed by a batch round as already claimed", async () => {
                     const settled = chainVtxo(35000, { settledBy: "b".repeat(64) });
                     const remainder = chainVtxo(15000);
-                    const { pendingSwap } = arrange([settled, remainder], [], { chainTip: 10 });
+                    const { pendingSwap } = arrange([settled, remainder], [], {
+                        chainTip: chainRefundLocktime - 1,
+                    });
 
                     await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
                         txid: "a".repeat(64),
@@ -2951,12 +3005,63 @@ describe("ArkadeSwaps", () => {
                         const { pendingSwap, joinBatchSpy } = arrange(
                             [chainVtxo(35000, { isSpent: true, arkTxId }), chainVtxo(15000)],
                             [],
-                            { received: [], chainTip: 100 },
+                            { received: [], chainTip: chainRefundLocktime + 1 },
                         );
 
                         const promise = swaps.claimArk(pendingSwap);
                         promise.catch(() => {});
-                        await vi.advanceTimersByTimeAsync(1000);
+                        await vi.advanceTimersByTimeAsync(CLAIM_RETRY_WINDOW_MS);
+
+                        await expect(promise).rejects.toThrow(/below the agreed/);
+                        expect(vi.mocked(claimVHTLCwithOffchainTx)).not.toHaveBeenCalled();
+                        expect(joinBatchSpy).not.toHaveBeenCalled();
+                    } finally {
+                        vi.useRealTimers();
+                    }
+                });
+
+                // Without a chain tip a block-height locktime reads as reached,
+                // which disarms the attribution silently — so it must warn.
+                it("warns when attribution needs a chain tip and no provider is configured", async () => {
+                    vi.useFakeTimers();
+                    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+                    try {
+                        const { pendingSwap } = arrange(
+                            [chainVtxo(35000, { settledBy: "b".repeat(64) }), chainVtxo(15000)],
+                            [],
+                            { chainTip: undefined },
+                        );
+
+                        const promise = swaps.claimArk(pendingSwap);
+                        promise.catch(() => {});
+                        await vi.advanceTimersByTimeAsync(CLAIM_RETRY_WINDOW_MS);
+
+                        await expect(promise).rejects.toThrow(/below the agreed/);
+                        expect(warnSpy).toHaveBeenCalledWith(
+                            expect.stringMatching(/no .*OnchainProvider is configured/s),
+                        );
+                    } finally {
+                        vi.useRealTimers();
+                    }
+                });
+
+                // The other side of `treats a VTXO consumed by a batch round as
+                // already claimed`: past the locktime that settlement is no
+                // longer attributable, so the guard re-arms and the remainder
+                // is stranded. Fail-safe, and pinned here so the trade-off
+                // cannot change silently.
+                it("leaves a batch-settled remainder stranded past the refund locktime", async () => {
+                    vi.useFakeTimers();
+                    try {
+                        const { pendingSwap, joinBatchSpy } = arrange(
+                            [chainVtxo(35000, { settledBy: "b".repeat(64) }), chainVtxo(15000)],
+                            [],
+                            { chainTip: chainRefundLocktime + 1 },
+                        );
+
+                        const promise = swaps.claimArk(pendingSwap);
+                        promise.catch(() => {});
+                        await vi.advanceTimersByTimeAsync(CLAIM_RETRY_WINDOW_MS);
 
                         await expect(promise).rejects.toThrow(/below the agreed/);
                         expect(vi.mocked(claimVHTLCwithOffchainTx)).not.toHaveBeenCalled();
@@ -5901,7 +6006,15 @@ describe("ArkadeSwaps", () => {
             );
         };
 
-        const buildPendingSwap = (onchainAmount: number | undefined = 50000): BoltzReverseSwap => ({
+        /**
+         * The fixture's refund locktime is a timestamp already in the past, so
+         * `refundLocktime` overrides it for the cases that need the sender's
+         * refund window still shut.
+         */
+        const buildPendingSwap = (
+            onchainAmount: number | undefined = 50000,
+            refundLocktime = createReverseSwapResponse.timeoutBlockHeights!.refund,
+        ): BoltzReverseSwap => ({
             id: mock.id,
             type: "reverse",
             createdAt: Date.now(),
@@ -5911,6 +6024,10 @@ describe("ArkadeSwaps", () => {
                 ...createReverseSwapResponse,
                 lockupAddress: mockVHTLC.vhtlcAddress,
                 onchainAmount,
+                timeoutBlockHeights: {
+                    ...createReverseSwapResponse.timeoutBlockHeights!,
+                    refund: refundLocktime,
+                },
             },
             status: "swap.created",
         });
@@ -5989,14 +6106,15 @@ describe("ArkadeSwaps", () => {
             expect((offchainSpy.mock.calls[0][3] as any)[0].txid).toBe(txidB);
         });
 
-        it("ignores spent VTXOs but still claims the unspent ones", async () => {
+        // The spend is unattributable, so it does not disarm the guard — the
+        // unspent remainder covering the agreed amount on its own is what
+        // carries this, not the presence of a spend.
+        it("claims the unspent VTXOs when they cover the agreed amount on their own", async () => {
             const vtxos = [
                 { ...recoverableVtxo(txidA, 0), isSpent: true },
                 recoverableVtxo(txidB, 1),
             ];
-            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
-                vtxos: vtxos as any,
-            });
+            mockLockupVtxos(vtxos, []);
             const joinBatchSpy = vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
 
             await expect(swaps.claimVHTLC(buildPendingSwap())).resolves.toBeUndefined();
@@ -6154,11 +6272,54 @@ describe("ArkadeSwaps", () => {
 
                 const promise = swaps.claimVHTLC(buildPendingSwap(100000));
                 promise.catch(() => {});
-                await vi.advanceTimersByTimeAsync(1000);
+                await vi.advanceTimersByTimeAsync(CLAIM_RETRY_WINDOW_MS);
 
                 await expect(promise).rejects.toThrow(/below the agreed/);
                 expect(joinBatchSpy).not.toHaveBeenCalled();
                 expect(claimVHTLCwithOffchainTx).not.toHaveBeenCalled();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        // The locktime arm of the attribution, which only this path's
+        // batch-settled VTXOs (no `arkTxId` to attribute) depend on.
+        it("claims the remainder when a batch settled part of the lockup before the refund window opened", async () => {
+            const vtxos = [
+                { ...recoverableVtxo(txidA, 0), settledBy: hex.encode(randomBytes(32)) },
+                recoverableVtxo(txidB, 1),
+            ];
+            mockLockupVtxos(vtxos, []);
+            const joinBatchSpy = vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
+
+            const future = Math.floor(Date.now() / 1000) + 3600;
+            await expect(
+                swaps.claimVHTLC(buildPendingSwap(100000, future)),
+            ).resolves.toBeUndefined();
+            expect(joinBatchSpy).toHaveBeenCalledTimes(1);
+            expect((joinBatchSpy.mock.calls[0][1] as any).txid).toBe(txidB);
+        });
+
+        // Same lockup as above once the window has opened: no longer
+        // attributable, so the guard re-arms and the remainder is stranded.
+        it("leaves a batch-settled remainder stranded past the refund locktime", async () => {
+            vi.useFakeTimers();
+            try {
+                const vtxos = [
+                    { ...recoverableVtxo(txidA, 0), settledBy: hex.encode(randomBytes(32)) },
+                    recoverableVtxo(txidB, 1),
+                ];
+                mockLockupVtxos(vtxos, []);
+                const joinBatchSpy = vi
+                    .spyOn(swaps as any, "joinBatch")
+                    .mockResolvedValue(undefined);
+
+                const promise = swaps.claimVHTLC(buildPendingSwap(100000));
+                promise.catch(() => {});
+                await vi.advanceTimersByTimeAsync(CLAIM_RETRY_WINDOW_MS);
+
+                await expect(promise).rejects.toThrow(/below the agreed/);
+                expect(joinBatchSpy).not.toHaveBeenCalled();
             } finally {
                 vi.useRealTimers();
             }

--- a/packages/boltz-swap/test/arkade-swaps.test.ts
+++ b/packages/boltz-swap/test/arkade-swaps.test.ts
@@ -2741,9 +2741,15 @@ describe("ArkadeSwaps", () => {
             describe("lockup amount and multi-VTXO claim", () => {
                 const chainVtxo = (
                     value: number,
-                    opts: { swept?: boolean; isSpent?: boolean; settledBy?: string } = {},
+                    opts: {
+                        swept?: boolean;
+                        isSpent?: boolean;
+                        settledBy?: string;
+                        arkTxId?: string;
+                    } = {},
                 ) => ({
                     ...(opts.settledBy ? { settledBy: opts.settledBy } : {}),
+                    ...(opts.arkTxId ? { arkTxId: opts.arkTxId } : {}),
                     txid: hex.encode(randomBytes(32)),
                     vout: 0,
                     value,
@@ -2756,7 +2762,17 @@ describe("ArkadeSwaps", () => {
                     createdAt: new Date(),
                 });
 
-                const arrange = (vtxos: any[], stored: BoltzChainSwap[] = []) => {
+                /** A VTXO at our address crediting `arkTxId`'s output to us. */
+                const receivedVtxo = (value: number, arkTxId: string) => ({
+                    ...chainVtxo(value),
+                    txid: arkTxId,
+                });
+
+                const arrange = (
+                    vtxos: any[],
+                    stored: BoltzChainSwap[] = [],
+                    opts: { received?: any[]; chainTip?: number } = {},
+                ) => {
                     const pendingSwap: BoltzChainSwap = {
                         ...mockBtcArkChainSwap,
                         preimage: hex.encode(mockPreimage),
@@ -2766,7 +2782,21 @@ describe("ArkadeSwaps", () => {
                     vi.spyOn(swaps, "createVHTLCScript").mockReturnValue(mockBtcArkVHTLC);
                     vi.mocked(wallet.getAddress).mockResolvedValue(mock.address.ark);
                     mockSwapRepository.getAllSwaps.mockResolvedValue(stored);
-                    vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({ vtxos } as any);
+                    // Attributing a spend queries our own scripts, so answer by
+                    // script rather than returning the lockup set to everyone.
+                    const lockupScript = hex.encode(mockBtcArkVHTLC.vhtlcScript.pkScript);
+                    vi.spyOn(indexerProvider, "getVtxos").mockImplementation(
+                        async (request: any) =>
+                            ({
+                                vtxos: request?.scripts?.includes(lockupScript)
+                                    ? vtxos
+                                    : (opts.received ?? []),
+                            }) as any,
+                    );
+                    (swaps as any).onchainProvider =
+                        opts.chainTip === undefined
+                            ? null
+                            : { getChainTip: async () => ({ height: opts.chainTip }) };
                     vi.spyOn(swapProvider, "getSwapStatus").mockResolvedValue({
                         status: "transaction.claimed",
                     } as any);
@@ -2875,11 +2905,13 @@ describe("ArkadeSwaps", () => {
                 });
 
                 // Counting a batch-consumed VTXO as spendable would inflate the
-                // total past the agreed amount and re-feed a spent input.
+                // total past the agreed amount and re-feed a spent input. A
+                // batch settlement names a shared commitment tx and attributes
+                // to nobody, so the still-shut refund window carries it.
                 it("treats a VTXO consumed by a batch round as already claimed", async () => {
                     const settled = chainVtxo(35000, { settledBy: "b".repeat(64) });
                     const remainder = chainVtxo(15000);
-                    const { pendingSwap } = arrange([settled, remainder]);
+                    const { pendingSwap } = arrange([settled, remainder], [], { chainTip: 10 });
 
                     await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
                         txid: "a".repeat(64),
@@ -2892,11 +2924,13 @@ describe("ArkadeSwaps", () => {
                     expect((offchainSpy.mock.calls[0][4] as any).amount).toBe(15000n);
                 });
 
-                it("claims the remainder when part of the lockup is already spent", async () => {
-                    const { pendingSwap } = arrange([
-                        chainVtxo(35000, { isSpent: true }),
-                        chainVtxo(15000),
-                    ]);
+                it("claims the remainder when our own claim already took part of the lockup", async () => {
+                    const arkTxId = "d".repeat(64);
+                    const { pendingSwap } = arrange(
+                        [chainVtxo(35000, { isSpent: true, arkTxId }), chainVtxo(15000)],
+                        [],
+                        { received: [receivedVtxo(35000, arkTxId)] },
+                    );
 
                     await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
                         txid: "a".repeat(64),
@@ -2906,6 +2940,30 @@ describe("ArkadeSwaps", () => {
                     expect(offchainSpy).toHaveBeenCalledOnce();
                     expect((offchainSpy.mock.calls[0][3] as any[]).length).toBe(1);
                     expect((offchainSpy.mock.calls[0][4] as any).amount).toBe(15000n);
+                });
+
+                // A CLTV refund empties the lockup without publishing the
+                // preimage, so the guard must stay armed.
+                it("does not claim a remainder left by a counterparty refund", async () => {
+                    vi.useFakeTimers();
+                    try {
+                        const arkTxId = "d".repeat(64);
+                        const { pendingSwap, joinBatchSpy } = arrange(
+                            [chainVtxo(35000, { isSpent: true, arkTxId }), chainVtxo(15000)],
+                            [],
+                            { received: [], chainTip: 100 },
+                        );
+
+                        const promise = swaps.claimArk(pendingSwap);
+                        promise.catch(() => {});
+                        await vi.advanceTimersByTimeAsync(1000);
+
+                        await expect(promise).rejects.toThrow(/below the agreed/);
+                        expect(vi.mocked(claimVHTLCwithOffchainTx)).not.toHaveBeenCalled();
+                        expect(joinBatchSpy).not.toHaveBeenCalled();
+                    } finally {
+                        vi.useRealTimers();
+                    }
                 });
 
                 it("claims against the latest accepted renegotiation amount", async () => {
@@ -2925,6 +2983,31 @@ describe("ArkadeSwaps", () => {
                     expect(
                         (vi.mocked(claimVHTLCwithOffchainTx).mock.calls[0][4] as any).amount,
                     ).toBe(BigInt(renegotiated));
+                });
+
+                // The caller's copy predates the renegotiation; saving it back
+                // verbatim would drop the field the guard reads next time.
+                it("saves onto the stored record, not the caller's copy", async () => {
+                    const renegotiated = mock.amount - 10000;
+                    const base: BoltzChainSwap = {
+                        ...mockBtcArkChainSwap,
+                        preimage: hex.encode(mockPreimage),
+                    };
+                    const { pendingSwap } = arrange(
+                        [chainVtxo(renegotiated)],
+                        [{ ...base, acceptedQuoteAmount: renegotiated }],
+                    );
+
+                    await expect(swaps.claimArk(pendingSwap)).resolves.toEqual({
+                        txid: "a".repeat(64),
+                    });
+                    expect(pendingSwap.acceptedQuoteAmount).toBeUndefined();
+                    expect(mockSwapRepository.saveSwap).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            claimTxid: "a".repeat(64),
+                            acceptedQuoteAmount: renegotiated,
+                        }),
+                    );
                 });
             });
         });
@@ -5804,6 +5887,20 @@ describe("ArkadeSwaps", () => {
             },
         };
 
+        /**
+         * Attributing a spend queries our own scripts, so answer by script
+         * rather than returning the lockup set to everyone.
+         */
+        const mockLockupVtxos = (vtxos: any[], received: any[] = []) => {
+            const lockupScript = hex.encode(mockVHTLC.vhtlcScript.pkScript);
+            vi.spyOn(indexerProvider, "getVtxos").mockImplementation(
+                async (request: any) =>
+                    ({
+                        vtxos: request?.scripts?.includes(lockupScript) ? vtxos : received,
+                    }) as any,
+            );
+        };
+
         const buildPendingSwap = (onchainAmount: number | undefined = 50000): BoltzReverseSwap => ({
             id: mock.id,
             type: "reverse",
@@ -6024,21 +6121,47 @@ describe("ArkadeSwaps", () => {
             }
         });
 
-        it("claims the remainder when part of the lockup is already spent", async () => {
+        it("claims the remainder when our own claim already took part of the lockup", async () => {
+            const arkTxId = hex.encode(randomBytes(32));
             const vtxos = [
-                { ...recoverableVtxo(txidA, 0), isSpent: true },
+                { ...recoverableVtxo(txidA, 0), isSpent: true, arkTxId },
                 recoverableVtxo(txidB, 1),
             ];
-            vi.spyOn(indexerProvider, "getVtxos").mockResolvedValue({
-                vtxos: vtxos as any,
-            });
+            mockLockupVtxos(vtxos, [{ ...recoverableVtxo(arkTxId, 0), value: 50000 }]);
             const joinBatchSpy = vi.spyOn(swaps as any, "joinBatch").mockResolvedValue(undefined);
 
             // the remaining 50k does not cover the 100k confirmed amount, but
-            // an earlier claim already spent part of the lockup
+            // our own earlier claim already spent part of the lockup
             await expect(swaps.claimVHTLC(buildPendingSwap(100000))).resolves.toBeUndefined();
             expect(joinBatchSpy).toHaveBeenCalledTimes(1);
             expect((joinBatchSpy.mock.calls[0][1] as any).txid).toBe(txidB);
+        });
+
+        // A CLTV refund empties the lockup without publishing the preimage, so
+        // the guard must stay armed.
+        it("does not claim a remainder left by a counterparty refund", async () => {
+            vi.useFakeTimers();
+            try {
+                const arkTxId = hex.encode(randomBytes(32));
+                const vtxos = [
+                    { ...recoverableVtxo(txidA, 0), isSpent: true, arkTxId },
+                    recoverableVtxo(txidB, 1),
+                ];
+                mockLockupVtxos(vtxos, []);
+                const joinBatchSpy = vi
+                    .spyOn(swaps as any, "joinBatch")
+                    .mockResolvedValue(undefined);
+
+                const promise = swaps.claimVHTLC(buildPendingSwap(100000));
+                promise.catch(() => {});
+                await vi.advanceTimersByTimeAsync(1000);
+
+                await expect(promise).rejects.toThrow(/below the agreed/);
+                expect(joinBatchSpy).not.toHaveBeenCalled();
+                expect(claimVHTLCwithOffchainTx).not.toHaveBeenCalled();
+            } finally {
+                vi.useRealTimers();
+            }
         });
 
         it("warns and still claims when no confirmed amount is on record", async () => {


### PR DESCRIPTION
Follow-ups to #673, on the two claim paths that partition a VTXO set.

- `claimArk` and `claimVHTLC` skip the lockup amount check only when the spends already at the lockup are attributable to our own claim, not on any spend at the script
- attribution reuses the pair `assertClaimSideClaimed` already applies: the spending tx paid our scripts at least what it took, or it ran before the sender's refund locktime. The second arm carries batch settlements, which name a shared commitment tx and attribute to nobody, so a claim run interrupted after `joinBatch` stays re-runnable
- `spentIntoOurWallet` and `claimSideRefundReached` now take the address and the locktime rather than a chain swap, so both claim paths can call them
- `claimArk`, `refundArk` and the chain status poll apply their delta to the stored record instead of writing back the caller's copy, which can predate `acceptedQuoteAmount`

Unit: boltz-swap 603 passed (+3), ts-sdk 2277 passed/1 skipped unchanged. Both new guards verified to fail with their `src` change reverted. Lint and build clean.