### PR TITLE
feat(contracts): gate generic spending on a per-contract predicate

### DIFF
--- a/packages/boltz-swap/src/expo/background.ts
+++ b/packages/boltz-swap/src/expo/background.ts
@@ -66,6 +66,7 @@ function createBackgroundWalletShim(args: {
         getBoardingAddress: async () => notImplemented("getBoardingAddress"),
         getBalance: async () => notImplemented("getBalance"),
         getVtxos: async () => notImplemented("getVtxos"),
+        getSpendableVtxos: async () => notImplemented("getSpendableVtxos"),
         getBoardingUtxos: async () => notImplemented("getBoardingUtxos"),
         getTransactionHistory: async () => notImplemented("getTransactionHistory"),
         getActivityHistory: async () => notImplemented("getActivityHistory"),

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -914,6 +914,7 @@ import {
   WalletMessageHandler,
   IndexedDBWalletRepository,
   IndexedDBContractRepository,
+  IndexedDBIntentRepository,
 } from '@arkade-os/sdk'
 
 const walletRepo = new IndexedDBWalletRepository()
@@ -922,6 +923,10 @@ const contractRepo = new IndexedDBContractRepository()
 const bus = new MessageBus(walletRepo, contractRepo, {
   messageHandlers: [new WalletMessageHandler()],
   tickIntervalMs: 10_000, // default 10s
+  // Optional, same opt-in as `storage.intentRepository` on a main-thread
+  // wallet. Omit it and the worker persists no settlement intent, reconciles
+  // none on restart, and counts intent-locked VTXOs as available.
+  intentRepository: new IndexedDBIntentRepository(),
 })
 
 bus.start()

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -30,7 +30,12 @@ import {
     normalizeVtxo,
     type NormalizedExtendedVirtualCoin,
 } from "../wallet/vtxo";
-import { extendVirtualCoinForContract, type ContractTapscriptCache } from "../wallet/utils";
+import {
+    deriveContractTapscripts,
+    extendVirtualCoinForContract,
+    type ContractTapscriptCache,
+} from "../wallet/utils";
+import { UnannotatableInputError } from "./spendability";
 import { ContractFilter, ContractRepository, IntentRepository } from "../repositories";
 import { reconcileIntents } from "../wallet/intentReconciliation";
 import {
@@ -84,28 +89,42 @@ function toWatchOnlyContract(params: CreateContractParams): Contract {
 }
 
 /**
- * The subset of `script → contract` whose VTXOs this runtime can annotate.
+ * Which of `vtxos`' contracts this runtime can annotate, with the tapscripts
+ * built along the way and a reason for each that it cannot.
  *
- * A persisted row can outlive its handler — a plugin type in a build that no
- * longer loads the plugin — and {@link ContractManager.annotateVtxos} throws
- * for one, having no tapscripts to annotate with. A bulk sync must drop those
- * VTXOs rather than let a single stale row fail the whole read: balance,
- * history and coin selection all go through it, and a contract with no handler
- * is not generically spendable anyway (see `isContractGenericallySpendable`).
- * Their already-persisted VTXOs stay in the repository, just unrefreshed.
+ * Two ways a persisted row stops being annotatable, both surviving restarts:
+ * its handler is not registered here (a plugin type in a build that no longer
+ * loads the plugin), or its handler rejects the stored params (a schema that
+ * gained a required field after the row was written). Either way
+ * {@link ContractManager.annotateVtxos} throws for it, and a bulk sync must
+ * drop just that contract's VTXOs rather than let one row fail the whole read —
+ * balance, history, coin selection and `initialize` all go through it.
+ *
+ * Only contracts present in this batch are examined, so nothing is built that
+ * annotation would not have built anyway, and the cache carries the work
+ * forward so it is built exactly once.
  */
-function annotatableScripts(scriptToContract: ReadonlyMap<string, Contract>): Set<string> {
-    const annotatable = new Set<string>();
-    for (const [script, contract] of scriptToContract) {
-        if (contractHandlers.get(contract.type)) {
-            annotatable.add(script);
-        } else {
-            console.debug(
-                `[contracts] no handler registered for type '${contract.type}': not syncing ${script}`,
+function annotatableIn(
+    scriptToContract: ReadonlyMap<string, Contract>,
+    vtxos: readonly { script: string }[],
+): { scripts: Set<string>; cache: ContractTapscriptCache; failures: Map<string, string> } {
+    const scripts = new Set<string>();
+    const cache: ContractTapscriptCache = new Map();
+    const failures = new Map<string, string>();
+    for (const script of new Set(vtxos.map((vtxo) => vtxo.script))) {
+        const contract = scriptToContract.get(script);
+        if (!contract) continue; // not ours; dropped by the caller's filter
+        try {
+            cache.set(script, deriveContractTapscripts(contract));
+            scripts.add(script);
+        } catch (err) {
+            failures.set(
+                script,
+                `'${contract.type}' at ${script}: ${err instanceof Error ? err.message : String(err)}`,
             );
         }
     }
-    return annotatable;
+    return { scripts, cache, failures };
 }
 
 /**
@@ -299,7 +318,25 @@ export interface IContractManager extends Disposable {
      * in wallet/handler code, and keeps the wallet from silently stamping the
      * default tapscript onto a non-default vtxo.
      */
-    annotateVtxos(vtxos: VirtualCoin[]): Promise<NormalizedExtendedVirtualCoin[]>;
+    annotateVtxos(
+        vtxos: VirtualCoin[],
+        tapscripts?: ContractTapscriptCache,
+    ): Promise<NormalizedExtendedVirtualCoin[]>;
+
+    /**
+     * Throw unless every one of `vtxos` still has an annotatable contract.
+     *
+     * Spending does not re-derive tapscripts — it uses the ones stored on the
+     * coin — so a contract that stopped being annotatable (handler no longer
+     * registered, or params its handler now rejects) still builds and submits a
+     * transaction fine, and only fails afterwards, in the bookkeeping that
+     * re-annotates the inputs. Calling this before submitting turns that into a
+     * refusal to spend, naming the contract, rather than a broadcast whose local
+     * state could not be recorded.
+     */
+    assertAnnotatable(
+        vtxos: readonly { txid: string; vout: number; script: string }[],
+    ): Promise<void>;
 
     /**
      * Update mutable contract fields.
@@ -641,8 +678,39 @@ export class ContractManager implements IContractManager {
     }
 
     private markSyncOnline(): void {
-        this.syncDegradedReason = undefined;
         this.lastSyncedAt = Date.now();
+        // An unannotatable contract outlives an otherwise-successful sync: the
+        // operator is reachable and every other contract is current, but this
+        // wallet still cannot read that one, and its VTXOs stopped being
+        // refreshed. Reporting it here is what keeps the skip from being
+        // silent — `getSyncState()` is the channel apps already watch.
+        this.syncDegradedReason = this.annotationDegradedReason();
+    }
+
+    /** Contracts a sync could not annotate, as `script → reason`. */
+    private annotationFailures = new Map<string, string>();
+
+    private annotationDegradedReason(): string | undefined {
+        if (this.annotationFailures.size === 0) return undefined;
+        return `cannot annotate ${this.annotationFailures.size} contract(s), their vtxos are not being synced — ${[...this.annotationFailures.values()].join("; ")}`;
+    }
+
+    /**
+     * Fold one batch's verdict in: what it annotated clears, what it could not
+     * sets. Merged rather than replaced because a batch can cover a subset of
+     * the wallet's contracts (a single-contract fetch, the pending-only
+     * reconcile), and those must not erase what a wider sync found. A row
+     * repaired by an upgrade clears itself on the next batch that includes it.
+     */
+    private recordAnnotationFailures(
+        annotated: ReadonlySet<string>,
+        failures: ReadonlyMap<string, string>,
+    ): void {
+        for (const script of annotated) this.annotationFailures.delete(script);
+        for (const [script, reason] of failures) {
+            this.annotationFailures.set(script, reason);
+            console.warn(`[contracts] cannot annotate contract ${reason}; skipping its vtxos`);
+        }
     }
 
     private markSyncDegraded(err: unknown): void {
@@ -1361,7 +1429,10 @@ export class ContractManager implements IContractManager {
         }));
     }
 
-    async annotateVtxos(vtxos: VirtualCoin[]): Promise<NormalizedExtendedVirtualCoin[]> {
+    async annotateVtxos(
+        vtxos: VirtualCoin[],
+        tapscripts?: ContractTapscriptCache,
+    ): Promise<NormalizedExtendedVirtualCoin[]> {
         if (vtxos.length === 0) return [];
 
         const scripts = Array.from(new Set(vtxos.map((v) => v.script)));
@@ -1378,11 +1449,43 @@ export class ContractManager implements IContractManager {
         // identical for every VTXO locked to the same contract. Memoize it per
         // contract to avoid rebuilding the taproot tree once per VTXO — the
         // dominant cost when annotating long spent/swept histories (see #521).
-        const tapscriptCache: ContractTapscriptCache = new Map();
+        // A caller that already built these (the sync, deciding what it could
+        // annotate at all) passes its cache so nothing is built twice.
+        const tapscriptCache: ContractTapscriptCache = tapscripts ?? new Map();
         // `vtxos` is caller-supplied, so normalize before annotating: the annotated coins flow on
         // into forfeit construction and repository writes.
         return vtxos.map((vtxo) =>
             extendVirtualCoinForContract(normalizeVtxo(vtxo), byScript, tapscriptCache),
+        );
+    }
+
+    /** @inheritdoc */
+    async assertAnnotatable(
+        vtxos: readonly { txid: string; vout: number; script: string }[],
+    ): Promise<void> {
+        if (vtxos.length === 0) return;
+        const contracts = await this.config.contractRepository.getContracts({
+            script: Array.from(new Set(vtxos.map((vtxo) => vtxo.script))),
+        });
+        const { scripts, failures } = annotatableIn(
+            new Map(contracts.map((contract) => [contract.script, contract])),
+            vtxos,
+        );
+        // A script with no contract row at all fails the same way, and with the
+        // same consequence, so it belongs in the same refusal.
+        const orphans = vtxos.filter(
+            (vtxo) => !scripts.has(vtxo.script) && !failures.has(vtxo.script),
+        );
+        for (const vtxo of orphans) {
+            failures.set(vtxo.script, `no contract registered for ${vtxo.script}`);
+        }
+        if (failures.size === 0) return;
+        const outpoints = vtxos
+            .filter((vtxo) => failures.has(vtxo.script))
+            .map((vtxo) => `${vtxo.txid}:${vtxo.vout}`);
+        throw new UnannotatableInputError(
+            `refusing to spend ${outpoints.length} vtxo(s) whose contract cannot be annotated ` +
+                `(${outpoints.join(", ")}): ${[...failures.values()].join("; ")}`,
         );
     }
 
@@ -1779,9 +1882,10 @@ export class ContractManager implements IContractManager {
 
         // Share the annotation path with external callers so the two entry
         // points can't drift.
-        const annotatable = annotatableScripts(scriptToContract);
+        const { scripts: annotatable, cache, failures } = annotatableIn(scriptToContract, vtxos);
+        this.recordAnnotationFailures(annotatable, failures);
         const owned = vtxos.filter((v) => annotatable.has(v.script));
-        const annotated = await this.annotateVtxos(owned);
+        const annotated = await this.annotateVtxos(owned, cache);
 
         const byContract = new Map<string, ExtendedContractVtxo[]>();
         // Resolved here rather than re-found in `contracts` below, so a
@@ -1923,9 +2027,10 @@ export class ContractManager implements IContractManager {
         // populated by the indexer, then share the annotation path with
         // external callers via annotateVtxos so the two entry points can't
         // drift.
-        const annotatable = annotatableScripts(scriptToContract);
+        const { scripts: annotatable, cache, failures } = annotatableIn(scriptToContract, vtxos);
+        this.recordAnnotationFailures(annotatable, failures);
         const owned = vtxos.filter((v) => annotatable.has(v.script));
-        const annotated = await this.annotateVtxos(owned);
+        const annotated = await this.annotateVtxos(owned, cache);
         for (const vtxo of annotated) {
             result.get(vtxo.script)!.push({
                 ...vtxo,

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -84,6 +84,31 @@ function toWatchOnlyContract(params: CreateContractParams): Contract {
 }
 
 /**
+ * The subset of `script → contract` whose VTXOs this runtime can annotate.
+ *
+ * A persisted row can outlive its handler — a plugin type in a build that no
+ * longer loads the plugin — and {@link ContractManager.annotateVtxos} throws
+ * for one, having no tapscripts to annotate with. A bulk sync must drop those
+ * VTXOs rather than let a single stale row fail the whole read: balance,
+ * history and coin selection all go through it, and a contract with no handler
+ * is not generically spendable anyway (see `isContractGenericallySpendable`).
+ * Their already-persisted VTXOs stay in the repository, just unrefreshed.
+ */
+function annotatableScripts(scriptToContract: ReadonlyMap<string, Contract>): Set<string> {
+    const annotatable = new Set<string>();
+    for (const [script, contract] of scriptToContract) {
+        if (contractHandlers.get(contract.type)) {
+            annotatable.add(script);
+        } else {
+            console.debug(
+                `[contracts] no handler registered for type '${contract.type}': not syncing ${script}`,
+            );
+        }
+    }
+    return annotatable;
+}
+
+/**
  * Hard upper bound on the HD index range probed by {@link scanContracts}.
  * Safety valve: a buggy or malicious `Discoverable` handler that returns a
  * hit at every index would otherwise keep the gap window open forever and
@@ -1754,7 +1779,8 @@ export class ContractManager implements IContractManager {
 
         // Share the annotation path with external callers so the two entry
         // points can't drift.
-        const owned = vtxos.filter((v) => scriptToContract.has(v.script));
+        const annotatable = annotatableScripts(scriptToContract);
+        const owned = vtxos.filter((v) => annotatable.has(v.script));
         const annotated = await this.annotateVtxos(owned);
 
         const byContract = new Map<string, ExtendedContractVtxo[]>();
@@ -1897,7 +1923,8 @@ export class ContractManager implements IContractManager {
         // populated by the indexer, then share the annotation path with
         // external callers via annotateVtxos so the two entry points can't
         // drift.
-        const owned = vtxos.filter((v) => scriptToContract.has(v.script));
+        const annotatable = annotatableScripts(scriptToContract);
+        const owned = vtxos.filter((v) => annotatable.has(v.script));
         const annotated = await this.annotateVtxos(owned);
         for (const vtxo of annotated) {
             result.get(vtxo.script)!.push({

--- a/packages/ts-sdk/src/contracts/handlers/arkade.ts
+++ b/packages/ts-sdk/src/contracts/handlers/arkade.ts
@@ -199,6 +199,19 @@ export const ArkadeContractHandler: ContractHandler<ArkadeContractParams, Arkade
     },
 
     /**
+     * Opt-in, never opt-out. A program artifact cannot say whether its funds are
+     * escrowed — an escrow's collaborative cancel leaf is indistinguishable from
+     * an ordinary spend — so the answer is read from the row the registering code
+     * wrote. Anything but an explicit `true` (absent, malformed, or a row written
+     * before this gate existed) is not generically spendable: `createContract` is
+     * first-writer-wins, so a fail-open marker would let one unmarked
+     * registration permanently open the gate for every contract sharing the script.
+     */
+    isGenericallySpendable(contract: Contract): boolean {
+        return contract.metadata?.genericallySpendable === true;
+    },
+
+    /**
      * Annotation tapscripts for VTXOs locked to this contract: prefer the
      * collaborative tapscript path (the multisig the Arkade Service co-signs,
      * mirroring `forfeit()` on the built-in script shapes); covenant-only

--- a/packages/ts-sdk/src/contracts/handlers/boarding.ts
+++ b/packages/ts-sdk/src/contracts/handlers/boarding.ts
@@ -106,6 +106,9 @@ export const BoardingContractHandler: ContractHandler<BoardingContractParams, De
         return DefaultContractHandler.getSpendablePaths(script, contract, context);
     },
 
+    /** Preserves today's settle/board behaviour. */
+    isGenericallySpendable: () => true,
+
     /**
      * Probe the on-chain UTXO set for a boarding output at this HD index.
      *

--- a/packages/ts-sdk/src/contracts/handlers/default.ts
+++ b/packages/ts-sdk/src/contracts/handlers/default.ts
@@ -81,6 +81,9 @@ export const DefaultContractHandler: ContractHandler<DefaultContractParams, Defa
         return forfeitExitSpendablePaths(script, contract, context);
     },
 
+    /** The wallet's own money. */
+    isGenericallySpendable: () => true,
+
     discoverAt: discoverAtViaRange(discoverDefaultRange),
 
     discoverRange: discoverDefaultRange,

--- a/packages/ts-sdk/src/contracts/handlers/delegate.ts
+++ b/packages/ts-sdk/src/contracts/handlers/delegate.ts
@@ -90,6 +90,9 @@ export const DelegateContractHandler: ContractHandler<DelegateContractParams, De
         return forfeitExitSpendablePaths(script, contract, context);
     },
 
+    /** The wallet's own money, delegated signing. */
+    isGenericallySpendable: () => true,
+
     discoverAt: discoverAtViaRange(discoverDelegateRange),
 
     discoverRange: discoverDelegateRange,

--- a/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
@@ -240,4 +240,12 @@ export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Sc
 
         return paths;
     },
+
+    /**
+     * Today's behaviour verbatim: a VHTLC row is spendable unconditionally.
+     * Narrowing it to the claim/refund economics (as NArk's
+     * `VHTLCContractTransformer.CanTransform` does) would stop in-flight swaps
+     * from being selected — a real behaviour change, deliberately deferred.
+     */
+    isGenericallySpendable: () => true,
 };

--- a/packages/ts-sdk/src/contracts/index.ts
+++ b/packages/ts-sdk/src/contracts/index.ts
@@ -19,6 +19,7 @@ export {
     gateExclusion,
     outpointExclusion,
     logExcludedVtxos,
+    UnannotatableInputError,
 } from "./spendability";
 export type { ExcludableVtxo, VtxoExclusion } from "./spendability";
 

--- a/packages/ts-sdk/src/contracts/index.ts
+++ b/packages/ts-sdk/src/contracts/index.ts
@@ -13,7 +13,14 @@ export { BoardingContractHandler } from "./handlers";
 export type { BoardingContractParams } from "./handlers";
 
 // Generic-spending gate
-export { isContractGenericallySpendable, gatedContracts, logGatedVtxos } from "./spendability";
+export {
+    isContractGenericallySpendable,
+    gatedContracts,
+    gateExclusion,
+    outpointExclusion,
+    logExcludedVtxos,
+} from "./spendability";
+export type { ExcludableVtxo, VtxoExclusion } from "./spendability";
 
 // arkcontract string codec
 export {

--- a/packages/ts-sdk/src/contracts/index.ts
+++ b/packages/ts-sdk/src/contracts/index.ts
@@ -12,6 +12,9 @@ export type { VHTLCContractParams } from "./handlers";
 export { BoardingContractHandler } from "./handlers";
 export type { BoardingContractParams } from "./handlers";
 
+// Generic-spending gate
+export { isContractGenericallySpendable, gatedContracts, logGatedVtxos } from "./spendability";
+
 // arkcontract string codec
 export {
     encodeArkContract,

--- a/packages/ts-sdk/src/contracts/spendability.ts
+++ b/packages/ts-sdk/src/contracts/spendability.ts
@@ -1,0 +1,46 @@
+import { contractHandlers } from "./handlers";
+import type { Contract } from "./types";
+
+/**
+ * Whether generic wallet spending may select this contract's VTXOs.
+ *
+ * Default closed: a type whose handler declares nothing — a custom type, a
+ * plugin type, a row whose handler is not registered in this context — is not
+ * spendable. Every shipped handler answers explicitly.
+ *
+ * @see ContractHandler.isGenericallySpendable
+ */
+export function isContractGenericallySpendable(contract: Contract): boolean {
+    return contractHandlers.get(contract.type)?.isGenericallySpendable?.(contract) === true;
+}
+
+/**
+ * The contracts generic spending must skip, as `script → type`. VTXOs are keyed
+ * to their contract by `script`, so membership answers the per-VTXO question too.
+ */
+export function gatedContracts(contracts: readonly Contract[]): Map<string, string> {
+    const gated = new Map<string, string>();
+    for (const contract of contracts) {
+        if (!isContractGenericallySpendable(contract)) gated.set(contract.script, contract.type);
+    }
+    return gated;
+}
+
+/**
+ * Report VTXOs the gate excluded — the only field-diagnosable signal that this
+ * is what dropped a coin from a spend. Debug level, one line per VTXO.
+ */
+export function logGatedVtxos(
+    source: string,
+    vtxos: readonly { txid: string; vout: number; script?: string }[],
+    gated: ReadonlyMap<string, string>,
+): void {
+    if (gated.size === 0) return;
+    for (const vtxo of vtxos) {
+        const type = vtxo.script === undefined ? undefined : gated.get(vtxo.script);
+        if (type === undefined) continue;
+        console.debug(
+            `[spendability] ${source}: ${vtxo.txid}:${vtxo.vout} at ${vtxo.script} (contract type '${type}') is not generically spendable`,
+        );
+    }
+}

--- a/packages/ts-sdk/src/contracts/spendability.ts
+++ b/packages/ts-sdk/src/contracts/spendability.ts
@@ -73,3 +73,17 @@ export function logExcludedVtxos(
         }
     }
 }
+
+/**
+ * Thrown when a spend names VTXOs whose contract can no longer be annotated —
+ * its handler is not registered here, its handler rejects the stored params, or
+ * it has no contract row at all.
+ *
+ * Raised before submission on purpose. Spending reads the tapscripts stored on
+ * each coin rather than re-deriving them, so such a spend would otherwise build
+ * and broadcast normally and only fail in the bookkeeping afterwards, leaving
+ * the transaction on the network and the local state behind it.
+ */
+export class UnannotatableInputError extends Error {
+    readonly name = "UnannotatableInputError";
+}

--- a/packages/ts-sdk/src/contracts/spendability.ts
+++ b/packages/ts-sdk/src/contracts/spendability.ts
@@ -26,21 +26,50 @@ export function gatedContracts(contracts: readonly Contract[]): Map<string, stri
     return gated;
 }
 
+/** The minimum a VTXO must carry to be matched against an exclusion set. */
+export type ExcludableVtxo = { txid: string; vout: number; script?: string };
+
 /**
- * Report VTXOs the gate excluded — the only field-diagnosable signal that this
- * is what dropped a coin from a spend. Debug level, one line per VTXO.
+ * Why generic spending skips a VTXO, or `undefined` when it does not — phrased
+ * to follow the outpoint in a log line.
+ *
+ * Generic spending applies three exclusions (the contract gate, pending
+ * recovery, intent locks) that key on different things — script, script,
+ * outpoint. Stating each as a reason-or-undefined lets all three report through
+ * one path, so no exclusion can drop a coin silently while another logs.
  */
-export function logGatedVtxos(
-    source: string,
-    vtxos: readonly { txid: string; vout: number; script?: string }[],
-    gated: ReadonlyMap<string, string>,
-): void {
-    if (gated.size === 0) return;
-    for (const vtxo of vtxos) {
+export type VtxoExclusion = (vtxo: ExcludableVtxo) => string | undefined;
+
+/** The contract gate as an exclusion, naming the type that closed it. */
+export function gateExclusion(gated: ReadonlyMap<string, string>): VtxoExclusion {
+    return (vtxo) => {
         const type = vtxo.script === undefined ? undefined : gated.get(vtxo.script);
-        if (type === undefined) continue;
-        console.debug(
-            `[spendability] ${source}: ${vtxo.txid}:${vtxo.vout} at ${vtxo.script} (contract type '${type}') is not generically spendable`,
-        );
+        if (type === undefined) return undefined;
+        return `at ${vtxo.script} (contract type '${type}') is not generically spendable`;
+    };
+}
+
+/** Outpoints excluded for a shared reason, e.g. an intent-lock set. */
+export function outpointExclusion(outpoints: ReadonlySet<string>, reason: string): VtxoExclusion {
+    return (vtxo) => (outpoints.has(`${vtxo.txid}:${vtxo.vout}`) ? reason : undefined);
+}
+
+/**
+ * Report VTXOs an exclusion dropped — the only field-diagnosable signal for why
+ * a coin is missing from a spend, or why an explicitly named one will fail.
+ * Debug level, one line per VTXO per reason.
+ */
+export function logExcludedVtxos(
+    source: string,
+    vtxos: readonly ExcludableVtxo[],
+    exclusions: readonly VtxoExclusion[],
+): void {
+    if (exclusions.length === 0) return;
+    for (const vtxo of vtxos) {
+        for (const exclusion of exclusions) {
+            const reason = exclusion(vtxo);
+            if (reason === undefined) continue;
+            console.debug(`[spendability] ${source}: ${vtxo.txid}:${vtxo.vout} ${reason}`);
+        }
     }
 }

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -240,6 +240,22 @@ export interface ContractHandler<P = Record<string, unknown>, S extends VtxoScri
      * Returns empty array if no paths are available.
      */
     getSpendablePaths(script: S, contract: Contract, context: PathContext): PathSelection[];
+
+    /**
+     * Whether this contract's VTXOs may be picked by *generic* wallet spending —
+     * send, settle, renewal, asset operations, offboard, `available` balance.
+     * Explicit-input APIs (`settle({ inputs })`, `sendBitcoin({ selectedVtxos })`,
+     * …) stay open regardless: naming an outpoint is the intent this gate protects.
+     *
+     * Pure, synchronous and offline — it runs inside the service worker, so no
+     * chain tip, no network, no live plugin object. Absent or `false` ⇒ NOT
+     * spendable: a type core cannot reason about must not leak by omission.
+     *
+     * No `script` parameter: deriving it costs a taproot tree per contract on a
+     * read path (#521) and no shipped handler needs it. A handler that does can
+     * call its own `createScript(contract.params)`.
+     */
+    isGenericallySpendable?(contract: Contract): boolean;
 }
 
 /**

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -401,8 +401,11 @@ import { hasCandidates, isDiscoverable } from "./contracts/types";
 import {
     isContractGenericallySpendable,
     gatedContracts,
-    logGatedVtxos,
+    gateExclusion,
+    outpointExclusion,
+    logExcludedVtxos,
 } from "./contracts/spendability";
+import type { ExcludableVtxo, VtxoExclusion } from "./contracts/spendability";
 import type {
     Contract,
     ContractVtxo,
@@ -655,7 +658,9 @@ export {
     ArkadeContractHandler,
     isContractGenericallySpendable,
     gatedContracts,
-    logGatedVtxos,
+    gateExclusion,
+    outpointExclusion,
+    logExcludedVtxos,
     encodeArkContract,
     decodeArkContract,
     contractFromArkContract,
@@ -859,6 +864,8 @@ export type {
     CreateContractParams,
     ContractWatcherConfig,
     ParsedArkContract,
+    ExcludableVtxo,
+    VtxoExclusion,
     DefaultContractParams,
     DelegateContractParams,
     VHTLCContractParams,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -398,6 +398,11 @@ import {
 } from "./contracts/arkcontract";
 import type { ParsedArkContract } from "./contracts/arkcontract";
 import { hasCandidates, isDiscoverable } from "./contracts/types";
+import {
+    isContractGenericallySpendable,
+    gatedContracts,
+    logGatedVtxos,
+} from "./contracts/spendability";
 import type {
     Contract,
     ContractVtxo,
@@ -648,6 +653,9 @@ export {
     VHTLCContractHandler,
     BoardingContractHandler,
     ArkadeContractHandler,
+    isContractGenericallySpendable,
+    gatedContracts,
+    logGatedVtxos,
     encodeArkContract,
     decodeArkContract,
     contractFromArkContract,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -404,6 +404,7 @@ import {
     gateExclusion,
     outpointExclusion,
     logExcludedVtxos,
+    UnannotatableInputError,
 } from "./contracts/spendability";
 import type { ExcludableVtxo, VtxoExclusion } from "./contracts/spendability";
 import type {
@@ -661,6 +662,7 @@ export {
     gateExclusion,
     outpointExclusion,
     logExcludedVtxos,
+    UnannotatableInputError,
     encodeArkContract,
     decodeArkContract,
     contractFromArkContract,

--- a/packages/ts-sdk/src/wallet/asset-manager.ts
+++ b/packages/ts-sdk/src/wallet/asset-manager.ts
@@ -66,7 +66,7 @@ export class AssetManager extends ReadonlyAssetManager implements IAssetManager 
 
         const metadata = castMetadata(params.metadata);
 
-        const virtualCoins = await this.wallet.getVtxos({
+        const virtualCoins = await this.wallet.getSpendableVtxos({
             withRecoverable: false,
         });
 
@@ -178,7 +178,7 @@ export class AssetManager extends ReadonlyAssetManager implements IAssetManager 
             throw new Error(`Asset ${params.assetId} is not reissuable`);
         }
 
-        const virtualCoins = await this.wallet.getVtxos({
+        const virtualCoins = await this.wallet.getSpendableVtxos({
             withRecoverable: false,
         });
 
@@ -309,7 +309,7 @@ export class AssetManager extends ReadonlyAssetManager implements IAssetManager 
             throw new Error(`Burn amount must be greater than 0, got ${params.amount}`);
         }
 
-        const virtualCoins = await this.wallet.getVtxos({
+        const virtualCoins = await this.wallet.getSpendableVtxos({
             withRecoverable: false,
         });
 

--- a/packages/ts-sdk/src/wallet/balance.ts
+++ b/packages/ts-sdk/src/wallet/balance.ts
@@ -1,0 +1,113 @@
+import type { Asset } from ".";
+import type { NormalizedExtendedVirtualCoin, TimeHeight } from "./vtxo";
+import { canRecoverOnchain, canSpendOffchain, hasTerminalSpend } from "./vtxo";
+
+/**
+ * The offchain half of {@link WalletBalance}, bucketed from one VTXO snapshot.
+ *
+ * @see computeOffchainBalance
+ */
+export interface OffchainBalance {
+    settled: number;
+    preconfirmed: number;
+    available: number;
+    recoverable: number;
+    pendingRecovery: number;
+    /** `settled + preconfirmed + recoverable + pendingRecovery` — the buckets are disjoint. */
+    total: number;
+    assets: Asset[];
+    availableAssets: Asset[];
+}
+
+/**
+ * Per-VTXO facts the bucketing rules need but cannot derive offline from the
+ * VTXO alone. Each caller supplies them from its own read strategy — the
+ * main-thread balance from a synced contract snapshot, the service worker from
+ * a pure repository read — so the *rules* stay shared while the *freshness*
+ * stays deliberately different.
+ */
+export interface BalanceCapabilities {
+    now: TimeHeight;
+    /** Past-cutoff deprecated-signer funds awaiting recovery. */
+    isPendingRecovery: (vtxo: NormalizedExtendedVirtualCoin) => boolean;
+    /** The generic-spending gate. @see isContractGenericallySpendable */
+    isGenericallySpendable: (vtxo: NormalizedExtendedVirtualCoin) => boolean;
+    /** Not committed to an in-flight (non-terminal) intent. */
+    isUnlocked: (vtxo: NormalizedExtendedVirtualCoin) => boolean;
+}
+
+/**
+ * Bucket a VTXO snapshot into the offchain balance.
+ *
+ * Owned vs spendable is the whole shape here. `settled`/`preconfirmed`/`total`
+ * and `assets` count everything the wallet owns — escrowed funds are still the
+ * user's funds. `available` and `availableAssets` count only what generic
+ * spending would actually pick, so nothing reported as available can be refused
+ * by `send`.
+ *
+ * Terminally spent VTXOs are skipped outright: neither capability predicate
+ * claims them, and they must not reach the asset rollup.
+ */
+export function computeOffchainBalance(
+    vtxos: readonly NormalizedExtendedVirtualCoin[],
+    caps: BalanceCapabilities,
+): OffchainBalance {
+    const { now, isPendingRecovery, isGenericallySpendable, isUnlocked } = caps;
+
+    let settled = 0;
+    let preconfirmed = 0;
+    let available = 0;
+    let recoverable = 0;
+    let pendingRecovery = 0;
+    const owned = new Map<string, bigint>();
+    const spendable = new Map<string, bigint>();
+
+    const addAssets = (into: Map<string, bigint>, vtxo: NormalizedExtendedVirtualCoin) => {
+        for (const asset of vtxo.assets ?? []) {
+            into.set(asset.assetId, (into.get(asset.assetId) ?? 0n) + asset.amount);
+        }
+    };
+
+    for (const vtxo of vtxos) {
+        if (hasTerminalSpend(vtxo)) continue;
+        addAssets(owned, vtxo);
+
+        // Pending recovery is tested first, and before expiry: such funds cannot
+        // be renewed until they recover, so once their batch expiry passes
+        // `canRecoverOnchain` would otherwise report them as renewable-right-now.
+        // The branches are exclusive, so `total` counts each VTXO once.
+        if (isPendingRecovery(vtxo)) {
+            pendingRecovery += vtxo.value;
+            continue;
+        }
+        if (canRecoverOnchain(vtxo, now)) {
+            recoverable += vtxo.value;
+            continue;
+        }
+        if (!canSpendOffchain(vtxo, now)) continue;
+
+        if (vtxo.isPreconfirmed) {
+            preconfirmed += vtxo.value;
+        } else {
+            settled += vtxo.value;
+        }
+        if (isGenericallySpendable(vtxo) && isUnlocked(vtxo)) {
+            available += vtxo.value;
+            addAssets(spendable, vtxo);
+        }
+    }
+
+    const toAssets = (from: Map<string, bigint>): Asset[] =>
+        Array.from(from.entries()).map(([assetId, amount]) => ({ assetId, amount }));
+
+    return {
+        settled,
+        preconfirmed,
+        available,
+        recoverable,
+        pendingRecovery,
+        total: settled + preconfirmed + recoverable + pendingRecovery,
+        assets: toAssets(owned),
+        availableAssets: toAssets(spendable),
+    };
+}

--- a/packages/ts-sdk/src/wallet/expo/wallet.ts
+++ b/packages/ts-sdk/src/wallet/expo/wallet.ts
@@ -308,6 +308,10 @@ export class ExpoWallet implements IWallet {
         return this.wallet.getVtxos(filter);
     }
 
+    getSpendableVtxos(filter?: GetVtxosFilter): Promise<NormalizedExtendedVirtualCoin[]> {
+        return this.wallet.getSpendableVtxos(filter);
+    }
+
     getBoardingUtxos(): Promise<ExtendedCoin[]> {
         return this.wallet.getBoardingUtxos();
     }

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -339,8 +339,16 @@ export interface WalletBalance {
     /** Total balance across offchain, recoverable, pending-recovery, and boarding funds. */
     total: number;
 
-    /** Asset balance entries (`assetId` & `amount`) */
+    /** Asset balance entries (`assetId` & `amount`) the wallet owns. */
     assets: Asset[];
+
+    /**
+     * The subset of {@link assets} generic spending will accept, i.e. the asset
+     * analogue of {@link available}. Assets have no owned/spendable split of
+     * their own, so `assets - availableAssets` is what is held but not
+     * selectable — escrowed, intent-locked or awaiting recovery.
+     */
+    availableAssets: Asset[];
 }
 
 /**
@@ -368,7 +376,13 @@ export interface SendBitcoinParams {
      */
     memo?: string;
 
-    /** Optional explicit virtual output selection used by `Wallet.sendBitcoin`. */
+    /**
+     * Optional explicit virtual output selection used by `Wallet.sendBitcoin`.
+     * Ungated, like `settle({ inputs })`: whatever is named here is spent, even
+     * if generic selection would skip it.
+     *
+     * @see IReadonlyWallet.getSpendableVtxos
+     */
     selectedVtxos?: ExtendedVirtualCoin[];
 }
 
@@ -976,6 +990,21 @@ export interface IReadonlyWallet {
      * @see GetVtxosFilter
      */
     getVtxos(filter?: GetVtxosFilter): Promise<NormalizedExtendedVirtualCoin[]>;
+
+    /**
+     * The subset of {@link getVtxos} that generic spending may select: the same
+     * filter, minus contracts the generic-spending gate closes, minus funds
+     * awaiting recovery under a past-cutoff signer, minus outpoints locked by an
+     * in-flight intent. Every implicit coin selection in the SDK reads this;
+     * `getVtxos` stays the raw reporting/recovery read.
+     *
+     * Both exclusion sets are derived from one contract snapshot, so they cannot
+     * disagree about which VTXOs exist.
+     *
+     * @param filter - Same flags, same defaults, as {@link getVtxos}
+     * @see GetVtxosFilter
+     */
+    getSpendableVtxos(filter?: GetVtxosFilter): Promise<NormalizedExtendedVirtualCoin[]>;
 
     /** @returns Onchain boarding inputs tracked by the wallet. */
     getBoardingUtxos(): Promise<ExtendedCoin[]>;

--- a/packages/ts-sdk/src/wallet/ramps.ts
+++ b/packages/ts-sdk/src/wallet/ramps.ts
@@ -194,7 +194,7 @@ export class Ramps {
      * @param eventCallback - Optional callback that receives settlement events
      * @returns The Arkade transaction id created by settlement
      * @throws Error if no virtual outputs remain after fee deduction or the destination address cannot be decoded
-     * @see IWallet.getVtxos
+     * @see IWallet.getSpendableVtxos
      * @see IWallet.settle
      * @example
      * ```typescript
@@ -209,7 +209,7 @@ export class Ramps {
         amount?: bigint,
         eventCallback?: (event: SettlementEvent) => void,
     ): ReturnType<IWallet["settle"]> {
-        const vtxos = await this.wallet.getVtxos({
+        const vtxos = await this.wallet.getSpendableVtxos({
             withRecoverable: true,
             withUnrolled: false,
         });

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -47,7 +47,7 @@ import {
     type ProviderConnectionState,
 } from "../wallet";
 import { computeOffchainBalance } from "../balance";
-import { gatedContracts, logGatedVtxos } from "../../contracts/spendability";
+import { gatedContracts } from "../../contracts/spendability";
 import type {
     DeprecatedSignerMigrationReport,
     DeprecatedSignerReport,
@@ -1381,19 +1381,19 @@ export class WalletMessageHandler
      * The worker's own balance. Same bucketing rules as `Wallet.getBalance` —
      * both call {@link computeOffchainBalance} — but deliberately a different
      * freshness: this reads the repository directly, with no indexer sync, so a
-     * polling UI never pays for a network round-trip.
+     * polling UI never pays for a network round-trip. That rules out
+     * `pendingRecoveryOutpoints()`, whose snapshot syncs; the same classification
+     * runs over this method's local snapshot instead.
      */
     private async handleGetBalance(): Promise<WalletBalance> {
-        const [boardingUtxos, allVtxos, pendingOutpoints, contracts] = await Promise.all([
+        const [boardingUtxos, { snapshot, vtxos: allVtxos }] = await Promise.all([
             this.getAllBoardingUtxos(),
-            this.getVtxosFromRepo(),
-            this.readonlyWallet
-                ? this.readonlyWallet.pendingRecoveryOutpoints()
-                : Promise.resolve(new Set<string>()),
-            this.readonlyWallet
-                ? this.readonlyWallet.getContractManager().then((m) => m.getContracts())
-                : Promise.resolve([]),
+            this.repoSnapshot(),
         ]);
+        // Both exclusion sets come off that one snapshot, so they answer about
+        // the same instant — and neither costs an indexer round-trip.
+        const pendingOutpoints =
+            this.readonlyWallet?.pendingRecoveryOutpointsIn(snapshot) ?? new Set<string>();
 
         // boarding
         let confirmed = 0;
@@ -1406,7 +1406,7 @@ export class WalletMessageHandler
             }
         }
 
-        const gated = gatedContracts(contracts);
+        const gated = gatedContracts(snapshot.map((_) => _.contract));
         const unlocked = new Set(
             (
                 await spendableVtxosExcludingLocked(allVtxos, this.readonlyWallet?.intentRepository)
@@ -1694,12 +1694,7 @@ export class WalletMessageHandler
         // authority itself to a third party, which for a gated (e.g. escrowed)
         // contract means giving away its cancel path. Legitimate deliberately,
         // bad by accident: report it. Diagnostics only, never fatal.
-        try {
-            const manager = await wallet.getContractManager();
-            logGatedVtxos("delegate", filtered, gatedContracts(await manager.getContracts()));
-        } catch {
-            // ignored
-        }
+        void wallet.logUngatedInputs("delegate", filtered);
 
         const result = await delegateManager.delegate(
             filtered,
@@ -1788,18 +1783,43 @@ export class WalletMessageHandler
      * addresses and the wallet's primary address, with deduplication.
      */
     private async getVtxosFromRepo(): Promise<NormalizedExtendedVirtualCoin[]> {
-        if (!this.walletRepository || !this.readonlyWallet) return [];
+        return (await this.repoSnapshot()).vtxos;
+    }
+
+    /**
+     * The worker's equivalent of `ReadonlyWallet.contractSnapshot`: contracts
+     * paired with the VTXOs the repository holds for them, plus the flat
+     * deduplicated list. Purely local — unlike the main-thread snapshot it never
+     * syncs against the indexer.
+     *
+     * One read of the contract rows serves both halves. Reading them twice
+     * (once for the VTXO buckets, once for the gate) races the contract
+     * manager's own writes: a contract registered between the two reads yields
+     * VTXOs with no matching row in the gate, and `gatedContracts` lists only
+     * what it knows is closed — so the coins of a just-registered escrowed
+     * contract would count as available until the next poll.
+     */
+    private async repoSnapshot(): Promise<{
+        // Not `ContractWithVtxos`: repository rows carry no `contractScript`,
+        // and the gate and signer classification only read `contract`/`vtxos`.
+        snapshot: { contract: Contract; vtxos: NormalizedExtendedVirtualCoin[] }[];
+        vtxos: NormalizedExtendedVirtualCoin[];
+    }> {
+        if (!this.walletRepository || !this.readonlyWallet) return { snapshot: [], vtxos: [] };
         const seen = new Set<string>();
         const allVtxos: NormalizedExtendedVirtualCoin[] = [];
 
         const addVtxos = (vtxos: NormalizedExtendedVirtualCoin[]) => {
+            const fresh: NormalizedExtendedVirtualCoin[] = [];
             for (const vtxo of vtxos) {
                 const key = `${vtxo.txid}:${vtxo.vout}`;
                 if (!seen.has(key)) {
                     seen.add(key);
                     allVtxos.push(vtxo);
+                    fresh.push(vtxo);
                 }
             }
+            return fresh;
         };
 
         // Aggregate virtual outputs from all contract addresses. Address
@@ -1808,8 +1828,12 @@ export class WalletMessageHandler
         // wrong-script row never wins the txid:vout race.
         const manager = await this.readonlyWallet.getContractManager();
         const contracts = await manager.getContracts();
+        const snapshot: { contract: Contract; vtxos: NormalizedExtendedVirtualCoin[] }[] = [];
         for (const contract of contracts) {
-            addVtxos(await getVtxosForContract(this.walletRepository, contract));
+            snapshot.push({
+                contract,
+                vtxos: addVtxos(await getVtxosForContract(this.walletRepository, contract)),
+            });
         }
 
         // Also check the wallet's primary address. Decode it to its script
@@ -1827,7 +1851,9 @@ export class WalletMessageHandler
             );
         }
         // Routed through the same helper as the contract buckets rather than reading the
-        // repository directly, so this bucket normalizes too.
+        // repository directly, so this bucket normalizes too. Anything left here
+        // is outside every contract row, so it carries no contract to judge it
+        // by — the wallet's own receive address, which is never gated.
         addVtxos(
             await getVtxosForContract(this.walletRepository, {
                 script: walletScript,
@@ -1835,7 +1861,7 @@ export class WalletMessageHandler
             }),
         );
 
-        return allVtxos;
+        return { snapshot, vtxos: allVtxos };
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1442,15 +1442,6 @@ export class WalletMessageHandler
         if (!this.readonlyWallet) return [];
         return this.readonlyWallet.getBoardingUtxos();
     }
-    /**
-     * Unspent vtxos from the repository. Ungated — {@link handleGetVtxos} mirrors
-     * `Wallet.getVtxos`, the raw reporting read.
-     */
-    private async getUnspentVtxosFromRepo() {
-        const vtxos = await this.getVtxosFromRepo();
-        return vtxos.filter((v) => !hasTerminalSpend(v));
-    }
-
     private async onWalletInitialized() {
         if (
             !this.readonlyWallet ||
@@ -1735,11 +1726,15 @@ export class WalletMessageHandler
         };
     }
 
+    /**
+     * Ungated repository read mirroring `Wallet.getVtxos`, the raw reporting read.
+     */
     private async handleGetVtxos(message: RequestGetVtxos) {
         if (!this.readonlyWallet) {
             throw new WalletNotInitializedError();
         }
-        const vtxos = await this.getUnspentVtxosFromRepo();
+        const allVtxos = await this.getVtxosFromRepo();
+        const vtxos = allVtxos.filter((v) => !hasTerminalSpend(v));
         const dustAmount = this.readonlyWallet.dustAmount;
         const includeRecoverable = message.payload.filter?.withRecoverable ?? false;
         const filteredVtxos = includeRecoverable
@@ -1757,7 +1752,13 @@ export class WalletMessageHandler
                   return true;
               });
 
-        return filteredVtxos;
+        // Unrolling terminally spends the virtual output, so unrolled coins never
+        // survive the unspent read above — append them on request, as `Wallet.getVtxos`
+        // does, otherwise `prepareUnrollTransaction` finds nothing behind the worker.
+        if (!message.payload.filter?.withUnrolled) {
+            return filteredVtxos;
+        }
+        return filteredVtxos.concat(allVtxos.filter((v) => hasTerminalSpend(v) && v.isUnrolled));
     }
 
     /** Tear down handler subscriptions, then delegate the full wipe to the wallet. */

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -36,13 +36,18 @@ import {
 } from "../index";
 import { DelegateInfo } from "../../providers/delegate";
 import {
-    canRecoverOnchain,
-    canSpendOffchain,
     fetchVtxoCreatedAtByTxid,
     hasTerminalSpend,
     type NormalizedExtendedVirtualCoin,
 } from "../vtxo";
-import { ReadonlyWallet, Wallet, type ProviderConnectionState } from "../wallet";
+import {
+    ReadonlyWallet,
+    spendableVtxosExcludingLocked,
+    Wallet,
+    type ProviderConnectionState,
+} from "../wallet";
+import { computeOffchainBalance } from "../balance";
+import { gatedContracts, logGatedVtxos } from "../../contracts/spendability";
 import type {
     DeprecatedSignerMigrationReport,
     DeprecatedSignerReport,
@@ -198,6 +203,15 @@ export type RequestGetVtxos = RequestEnvelope & {
 export type ResponseGetVtxos = ResponseEnvelope & {
     type: "VTXOS";
     payload: { vtxos: Awaited<ReturnType<IWallet["getVtxos"]>> };
+};
+
+export type RequestGetSpendableVtxos = RequestEnvelope & {
+    type: "GET_SPENDABLE_VTXOS";
+    payload: { filter?: GetVtxosFilter };
+};
+export type ResponseGetSpendableVtxos = ResponseEnvelope & {
+    type: "SPENDABLE_VTXOS";
+    payload: { vtxos: Awaited<ReturnType<IWallet["getSpendableVtxos"]>> };
 };
 
 export type RequestGetBoardingUtxos = RequestEnvelope & {
@@ -702,6 +716,7 @@ export type WalletUpdaterRequest =
     | RequestGetBoardingAddress
     | RequestGetBalance
     | RequestGetVtxos
+    | RequestGetSpendableVtxos
     | RequestGetBoardingUtxos
     | RequestGetTransactionHistory
     | RequestGetStatus
@@ -747,6 +762,7 @@ export type WalletUpdaterResponse = ResponseEnvelope &
         | ResponseGetBoardingAddress
         | ResponseGetBalance
         | ResponseGetVtxos
+        | ResponseGetSpendableVtxos
         | ResponseGetBoardingUtxos
         | ResponseGetTransactionHistory
         | ResponseGetStatus
@@ -969,6 +985,19 @@ export class WalletMessageHandler
                         type: "VTXOS",
                         payload: { vtxos },
                     };
+                }
+                case "GET_SPENDABLE_VTXOS": {
+                    if (!this.readonlyWallet) {
+                        throw new WalletNotInitializedError();
+                    }
+                    const vtxos = await this.readonlyWallet.getSpendableVtxos(
+                        message.payload.filter,
+                    );
+                    return this.tagged({
+                        id,
+                        type: "SPENDABLE_VTXOS",
+                        payload: { vtxos },
+                    });
                 }
                 case "GET_BOARDING_UTXOS": {
                     const utxos = await this.getAllBoardingUtxos();
@@ -1348,13 +1377,22 @@ export class WalletMessageHandler
         await this.onWalletInitialized();
     }
 
-    private async handleGetBalance() {
-        const [boardingUtxos, allVtxos, pendingOutpoints] = await Promise.all([
+    /**
+     * The worker's own balance. Same bucketing rules as `Wallet.getBalance` —
+     * both call {@link computeOffchainBalance} — but deliberately a different
+     * freshness: this reads the repository directly, with no indexer sync, so a
+     * polling UI never pays for a network round-trip.
+     */
+    private async handleGetBalance(): Promise<WalletBalance> {
+        const [boardingUtxos, allVtxos, pendingOutpoints, contracts] = await Promise.all([
             this.getAllBoardingUtxos(),
             this.getVtxosFromRepo(),
             this.readonlyWallet
                 ? this.readonlyWallet.pendingRecoveryOutpoints()
                 : Promise.resolve(new Set<string>()),
+            this.readonlyWallet
+                ? this.readonlyWallet.getContractManager().then((m) => m.getContracts())
+                : Promise.resolve([]),
         ]);
 
         // boarding
@@ -1368,54 +1406,21 @@ export class WalletMessageHandler
             }
         }
 
-        // offchain — bucketed from a single repo read, with the same capability reads
-        // Wallet.getBalance uses so the two agree. No chain tip: this is an offline-first read.
-        const now = { timestamp: new Date() };
-
-        let settled = 0;
-        let preconfirmed = 0;
-        let recoverable = 0;
-        let pendingRecovery = 0;
-        // Past-cutoff (EXPIRED) deprecated-signer funds not yet swept are NOT
-        // spendable — bucket them under pendingRecovery, out of settled/preconfirmed.
-        //
-        // Pending is tested first, and before expiry: such funds cannot be renewed until they
-        // recover, so once their batch expiry passes `canRecoverOnchain` would otherwise claim
-        // them and report them as renewable-right-now. The branches are exclusive, so
-        // `totalOffchain` below counts each VTXO once.
-        for (const vtxo of allVtxos) {
-            if (hasTerminalSpend(vtxo)) continue;
-            if (pendingOutpoints.has(`${vtxo.txid}:${vtxo.vout}`)) {
-                pendingRecovery += vtxo.value;
-            } else if (canRecoverOnchain(vtxo, now)) {
-                recoverable += vtxo.value;
-            } else if (canSpendOffchain(vtxo, now)) {
-                if (vtxo.isPreconfirmed) {
-                    preconfirmed += vtxo.value;
-                } else {
-                    settled += vtxo.value;
-                }
-            }
-        }
+        const gated = gatedContracts(contracts);
+        const unlocked = new Set(
+            (
+                await spendableVtxosExcludingLocked(allVtxos, this.readonlyWallet?.intentRepository)
+            ).map((vtxo) => `${vtxo.txid}:${vtxo.vout}`),
+        );
 
         const totalBoarding = confirmed + unconfirmed;
-        const totalOffchain = settled + preconfirmed + recoverable + pendingRecovery;
-
-        // aggregate asset balances from spendable virtual outputs
-        const assetBalances = new Map<string, bigint>();
-        for (const vtxo of allVtxos) {
-            if (hasTerminalSpend(vtxo)) continue;
-            if (vtxo.assets) {
-                for (const a of vtxo.assets) {
-                    const current = assetBalances.get(a.assetId) ?? 0n;
-                    assetBalances.set(a.assetId, current + a.amount);
-                }
-            }
-        }
-        const assets = Array.from(assetBalances.entries()).map(([assetId, amount]) => ({
-            assetId,
-            amount,
-        }));
+        // No chain tip: this is an offline-first read.
+        const offchain = computeOffchainBalance(allVtxos, {
+            now: { timestamp: new Date() },
+            isPendingRecovery: (vtxo) => pendingOutpoints.has(`${vtxo.txid}:${vtxo.vout}`),
+            isGenericallySpendable: (vtxo) => !gated.has(vtxo.script),
+            isUnlocked: (vtxo) => unlocked.has(`${vtxo.txid}:${vtxo.vout}`),
+        });
 
         return {
             boarding: {
@@ -1423,13 +1428,14 @@ export class WalletMessageHandler
                 unconfirmed,
                 total: totalBoarding,
             },
-            settled,
-            preconfirmed,
-            available: settled + preconfirmed,
-            recoverable,
-            pendingRecovery,
-            total: totalBoarding + totalOffchain,
-            assets,
+            settled: offchain.settled,
+            preconfirmed: offchain.preconfirmed,
+            available: offchain.available,
+            recoverable: offchain.recoverable,
+            pendingRecovery: offchain.pendingRecovery,
+            total: totalBoarding + offchain.total,
+            assets: offchain.assets,
+            availableAssets: offchain.availableAssets,
         };
     }
     private async getAllBoardingUtxos(): Promise<ExtendedCoin[]> {
@@ -1437,9 +1443,10 @@ export class WalletMessageHandler
         return this.readonlyWallet.getBoardingUtxos();
     }
     /**
-     * Get spendable vtxos from the repository
+     * Unspent vtxos from the repository. Ungated — {@link handleGetVtxos} mirrors
+     * `Wallet.getVtxos`, the raw reporting read.
      */
-    private async getSpendableVtxos() {
+    private async getUnspentVtxosFromRepo() {
         const vtxos = await this.getVtxosFromRepo();
         return vtxos.filter((v) => !hasTerminalSpend(v));
     }
@@ -1692,6 +1699,17 @@ export class WalletMessageHandler
             .filter((v) => outpointSet.has(`${v.txid}:${v.vout}`))
             .map((v) => ({ ...v, contractScript: v.script }));
 
+        // Explicit outpoints, so ungated — but delegation hands the spending
+        // authority itself to a third party, which for a gated (e.g. escrowed)
+        // contract means giving away its cancel path. Legitimate deliberately,
+        // bad by accident: report it. Diagnostics only, never fatal.
+        try {
+            const manager = await wallet.getContractManager();
+            logGatedVtxos("delegate", filtered, gatedContracts(await manager.getContracts()));
+        } catch {
+            // ignored
+        }
+
         const result = await delegateManager.delegate(
             filtered,
             destination,
@@ -1721,7 +1739,7 @@ export class WalletMessageHandler
         if (!this.readonlyWallet) {
             throw new WalletNotInitializedError();
         }
-        const vtxos = await this.getSpendableVtxos();
+        const vtxos = await this.getUnspentVtxosFromRepo();
         const dustAmount = this.readonlyWallet.dustAmount;
         const includeRecoverable = message.payload.filter?.withRecoverable ?? false;
         const filteredVtxos = includeRecoverable

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -1272,6 +1272,13 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 return syncState;
             },
 
+            /**
+             * The worker owns the spend paths this guards, so it runs the check
+             * on its own manager before submitting. Proxying it would only add a
+             * round-trip whose answer the worker already has.
+             */
+            async assertAnnotatable(): Promise<void> {},
+
             async annotateVtxos(vtxos: VirtualCoin[]): Promise<NormalizedExtendedVirtualCoin[]> {
                 if (vtxos.length === 0) return [];
                 const message: RequestAnnotateVtxos = {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -48,6 +48,7 @@ import {
     RequestGetSpendablePaths,
     RequestGetTransactionHistory,
     RequestGetVtxos,
+    RequestGetSpendableVtxos,
     RequestInitWallet,
     RequestIsContractManagerWatching,
     RequestRefreshVtxos,
@@ -70,6 +71,7 @@ import {
     ResponseGetSpendablePaths,
     ResponseGetTransactionHistory,
     ResponseGetVtxos,
+    ResponseGetSpendableVtxos,
     ResponseIsContractManagerWatching,
     ResponseReloadWallet,
     ResponseSendBitcoin,
@@ -185,6 +187,7 @@ export const DEFAULT_MESSAGE_TIMEOUTS: Readonly<Record<RequestType, number>> = {
 
     // Medium reads — may involve indexer queries
     GET_VTXOS: 20_000,
+    GET_SPENDABLE_VTXOS: 20_000,
     GET_BOARDING_UTXOS: 20_000,
     GET_TRANSACTION_HISTORY: 20_000,
     GET_CONTRACTS: 20_000,
@@ -245,6 +248,7 @@ const DEDUPABLE_REQUEST_TYPES: ReadonlySet<string> = new Set([
     "GET_EXPIRED_BOARDING_UTXOS",
     "GET_DEPRECATED_SIGNER_STATUS",
     "GET_VTXOS",
+    "GET_SPENDABLE_VTXOS",
     "GET_CONTRACTS",
     "GET_CONTRACTS_WITH_VTXOS",
     "ANNOTATE_VTXOS",
@@ -1107,6 +1111,33 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
             return (response as ResponseGetVtxos).payload.vtxos.map(normalizeVtxo);
         } catch (error) {
             throw new Error(`Failed to get vtxos: ${error}`);
+        }
+    }
+
+    /**
+     * The gate has to run *inside* the worker (no plugin object or contract row
+     * metadata exists on this side), so this is its own message rather than a
+     * post-filter over `GET_VTXOS`.
+     *
+     * A worker predating this message answers "Unknown message" and the call
+     * throws. That is deliberate: service workers activate asynchronously, so
+     * new page code runs against a stale worker for a window on every deploy,
+     * and falling back to `GET_VTXOS` there would silently spend ungated coins.
+     * Fail closed — loud and recoverable — rather than make the gate advisory.
+     */
+    async getSpendableVtxos(filter?: GetVtxosFilter): Promise<NormalizedExtendedVirtualCoin[]> {
+        const message: RequestGetSpendableVtxos = {
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "GET_SPENDABLE_VTXOS",
+            payload: { filter },
+        };
+
+        try {
+            const response = await this.sendMessage(message);
+            return (response as ResponseGetSpendableVtxos).payload.vtxos.map(normalizeVtxo);
+        } catch (error) {
+            throw new Error(`Failed to get spendable vtxos: ${error}`);
         }
     }
 

--- a/packages/ts-sdk/src/wallet/unroll.ts
+++ b/packages/ts-sdk/src/wallet/unroll.ts
@@ -288,6 +288,10 @@ export namespace Unroll {
 
 /**
  * Prepares the transaction that spends the CSV path to complete unrolling a VTXO.
+ *
+ * Caller-named txids, so the generic-spending gate does not apply — this spends
+ * already-unrolled onchain funds, not the offchain coin set.
+ *
  * @param wallet the wallet owning the VTXO(s)
  * @param vtxoTxIds the txids of the VTXO(s) to complete unroll
  * @param outputAddress the address to send the unrolled funds to

--- a/packages/ts-sdk/src/wallet/utils.ts
+++ b/packages/ts-sdk/src/wallet/utils.ts
@@ -80,7 +80,13 @@ export type ContractTapscripts = Pick<
  */
 export type ContractTapscriptCache = Map<string, ContractTapscripts>;
 
-function deriveContractTapscripts(contract: Contract): ContractTapscripts {
+/**
+ * Build a contract's annotation tapscripts, or throw. Exported so callers that
+ * must know *whether* a contract can still be annotated — the bulk sync, the
+ * pre-spend check — can ask without annotating a VTXO, and can keep the result
+ * in a {@link ContractTapscriptCache} so nothing is built twice.
+ */
+export function deriveContractTapscripts(contract: Contract): ContractTapscripts {
     const handler = contractHandlers.get(contract.type);
     if (!handler) {
         throw new Error(`No handler for contract type '${contract.type}'`);

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -1267,7 +1267,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             return [];
         }
 
-        const vtxos = await this.wallet.getVtxos({ withRecoverable: true });
+        const vtxos = await this.wallet.getSpendableVtxos({ withRecoverable: true });
 
         // Resolve threshold: method param > settlementConfig (seconds→ms) > renewalConfig > default
         let threshold: number;

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -1166,9 +1166,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
     async getSpendableVtxos(filter?: GetVtxosFilter): Promise<NormalizedExtendedVirtualCoin[]> {
         const snapshot = await this.contractSnapshot();
         const vtxos = filterSnapshotVtxos(snapshot, filter, this._pendingSpendOutpoints);
-        const gated = gatedContracts(snapshot.map((_) => _.contract));
+        const { gated, pendingRecovery } = this.spendabilityView(snapshot);
         logGatedVtxos("getSpendableVtxos", vtxos, gated);
-        const pendingRecovery = this.selectPendingRecovery(snapshot);
         const selectable = vtxos.filter(
             (vtxo) => !gated.has(vtxo.script) && !pendingRecovery.has(`${vtxo.txid}:${vtxo.vout}`),
         );
@@ -1208,13 +1207,26 @@ export class ReadonlyWallet implements IReadonlyWallet {
         return contractManager.getContractsWithVtxos();
     }
 
+    /**
+     * The two exclusion sets the gate is made of, derived from one snapshot so
+     * {@link getSpendableVtxos} and the balance answer about the same instant.
+     */
+    private spendabilityView(snapshot: readonly ContractWithVtxos[]): {
+        gated: ReturnType<typeof gatedContracts>;
+        pendingRecovery: ReadonlySet<string>;
+    } {
+        return {
+            gated: gatedContracts(snapshot.map((_) => _.contract)),
+            pendingRecovery: this.selectPendingRecovery(snapshot),
+        };
+    }
+
     /** The capability probes {@link computeOffchainBalance} needs, over one snapshot. */
     private async balanceCapabilities(
         snapshot: readonly ContractWithVtxos[],
         vtxos: readonly NormalizedExtendedVirtualCoin[],
     ): Promise<BalanceCapabilities> {
-        const pendingRecovery = this.selectPendingRecovery(snapshot);
-        const gated = gatedContracts(snapshot.map((_) => _.contract));
+        const { gated, pendingRecovery } = this.spendabilityView(snapshot);
         // Offline-first and fails open — see {@link spendableVtxosExcludingLocked}.
         const unlocked = new Set(
             (await spendableVtxosExcludingLocked([...vtxos], this.intentRepository)).map(

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -150,7 +150,9 @@ import { DescriptorIdentity } from "../identity/descriptorIdentity";
 import { HDWalletCapable } from "./hdWalletCapable";
 import { deriveDescriptorLeafPubKey } from "../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../contracts/metadata";
-import { CandidateDeps, DiscoveryDeps } from "../contracts/types";
+import { CandidateDeps, ContractWithVtxos, DiscoveryDeps } from "../contracts/types";
+import { gatedContracts, logGatedVtxos } from "../contracts/spendability";
+import { computeOffchainBalance, type BalanceCapabilities } from "./balance";
 import { InputSignerRouter, InputSigningJob } from "./inputSignerRouter";
 import {
     DescriptorSigningProviderMissingError,
@@ -332,6 +334,37 @@ function hasToReadonly(identity: unknown): identity is HasToReadonly {
 }
 
 export { DescriptorSigningProviderMissingError, MissingSigningDescriptorError };
+
+/**
+ * Apply {@link GetVtxosFilter} to a contract snapshot. Pure, so `getVtxos` and
+ * {@link IReadonlyWallet.getSpendableVtxos} share one definition of the filter
+ * instead of each re-reading (and possibly disagreeing on) the snapshot.
+ *
+ * No chain tip: the balance and send paths are offline-first reads, so
+ * height-encoded expiry reads as not expired here too.
+ */
+export function filterSnapshotVtxos(
+    snapshot: readonly ContractWithVtxos[],
+    filter: GetVtxosFilter | undefined,
+    pendingSpendOutpoints: ReadonlySet<string>,
+): NormalizedExtendedVirtualCoin[] {
+    const f = filter ?? { withRecoverable: true, withUnrolled: false };
+    const now = { timestamp: new Date() };
+    return snapshot
+        .flatMap((_) => _.vtxos)
+        .filter((vtxo) => {
+            if (pendingSpendOutpoints.has(`${vtxo.txid}:${vtxo.vout}`)) {
+                return false;
+            }
+            if (!hasTerminalSpend(vtxo)) {
+                if (!f.withRecoverable && canRecoverOnchain(vtxo, now)) {
+                    return false;
+                }
+                return true;
+            }
+            return !!(f.withUnrolled && vtxo.isUnrolled);
+        });
+}
 
 /**
  * Drop VTXOs whose outpoint is locked by a non-terminal intent. Returns the
@@ -1066,20 +1099,11 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * Return the wallet's combined onchain and offchain balances.
      */
     async getBalance(): Promise<WalletBalance> {
-        const [boardingUtxos, vtxos, pendingOutpoints] = await Promise.all([
+        const [boardingUtxos, snapshot] = await Promise.all([
             this.getBoardingUtxos(),
-            this.getVtxos(),
-            this.pendingRecoveryOutpoints(),
+            this.contractSnapshot(),
         ]);
-        const isPendingRecovery = (coin: ExtendedVirtualCoin) =>
-            pendingOutpoints.has(`${coin.txid}:${coin.vout}`);
-
-        // `settled`/`preconfirmed`/`total` and the asset rollup count every
-        // spendable VTXO, including those locked by a non-terminal intent (still
-        // the wallet's funds); only `available` subtracts the locked ones. The
-        // lock read is offline-first and fails open — see
-        // {@link spendableVtxosExcludingLocked}.
-        const unlockedVtxos = await spendableVtxosExcludingLocked(vtxos, this.intentRepository);
+        const vtxos = filterSnapshotVtxos(snapshot, undefined, this._pendingSpendOutpoints);
 
         // boarding
         let confirmed = 0;
@@ -1092,62 +1116,15 @@ export class ReadonlyWallet implements IReadonlyWallet {
             }
         }
 
-        // offchain
-        let recoverable = 0;
-        let pendingRecovery = 0;
-        // Buckets read the same capability the send path does, so nothing counted as available can
-        // be refused by `send`. No chain tip: balance is an offline-first read and must not gain a
-        // network dependency, so height-encoded expiry reads as not expired — as it does on the
-        // send path.
-        const now = { timestamp: new Date() };
-        // Funds under a past-cutoff (EXPIRED) deprecated signer that are not yet
-        // swept are NOT spendable — excluded from settled/preconfirmed/available
-        // and surfaced under `pendingRecovery` (they still count toward `total`).
-        const settled = vtxos
-            .filter(
-                (coin) =>
-                    canSpendOffchain(coin, now) && !coin.isPreconfirmed && !isPendingRecovery(coin),
-            )
-            .reduce((sum, coin) => sum + coin.value, 0);
-        const preconfirmed = vtxos
-            .filter(
-                (coin) =>
-                    canSpendOffchain(coin, now) && coin.isPreconfirmed && !isPendingRecovery(coin),
-            )
-            .reduce((sum, coin) => sum + coin.value, 0);
-        // Spendable-right-now subset: the same rule, but over VTXOs not
-        // currently locked by an in-flight intent.
-        const available = unlockedVtxos
-            .filter((coin) => canSpendOffchain(coin, now) && !isPendingRecovery(coin))
-            .reduce((sum, coin) => sum + coin.value, 0);
-        // `!isPendingRecovery` keeps the buckets disjoint, so `totalOffchain` counts each VTXO
-        // once: a pending-recovery VTXO past its batch expiry satisfies `canRecoverOnchain` too,
-        // and it belongs to `pendingRecovery` — it cannot be renewed until it recovers.
-        recoverable = vtxos
-            .filter((coin) => canRecoverOnchain(coin, now) && !isPendingRecovery(coin))
-            .reduce((sum, coin) => sum + coin.value, 0);
-        pendingRecovery = vtxos
-            .filter(isPendingRecovery)
-            .reduce((sum, coin) => sum + coin.value, 0);
-
+        // `settled`/`preconfirmed`/`total` and the `assets` rollup count every VTXO
+        // the wallet owns, including escrowed and intent-locked ones; `available`
+        // and `availableAssets` count only what generic spending would pick, so
+        // nothing reported as available can be refused by `send`.
         const totalBoarding = confirmed + unconfirmed;
-        const totalOffchain = settled + preconfirmed + recoverable + pendingRecovery;
-
-        // aggregate asset balances from spendable virtual outputs
-        const assetBalances = new Map<string, bigint>();
-        for (const vtxo of vtxos) {
-            if (hasTerminalSpend(vtxo)) continue;
-            if (vtxo.assets) {
-                for (const a of vtxo.assets) {
-                    const current = assetBalances.get(a.assetId) ?? 0n;
-                    assetBalances.set(a.assetId, current + a.amount);
-                }
-            }
-        }
-        const assets = Array.from(assetBalances.entries()).map(([assetId, amount]) => ({
-            assetId,
-            amount,
-        }));
+        const offchain = computeOffchainBalance(
+            vtxos,
+            await this.balanceCapabilities(snapshot, vtxos),
+        );
 
         return {
             boarding: {
@@ -1155,42 +1132,101 @@ export class ReadonlyWallet implements IReadonlyWallet {
                 unconfirmed,
                 total: totalBoarding,
             },
-            settled,
-            preconfirmed,
-            available,
-            recoverable,
-            pendingRecovery,
-            total: totalBoarding + totalOffchain,
-            assets,
+            settled: offchain.settled,
+            preconfirmed: offchain.preconfirmed,
+            available: offchain.available,
+            recoverable: offchain.recoverable,
+            pendingRecovery: offchain.pendingRecovery,
+            total: totalBoarding + offchain.total,
+            assets: offchain.assets,
+            availableAssets: offchain.availableAssets,
         };
     }
 
     /**
      * Return virtual outputs tracked by the wallet.
      *
+     * The raw reporting/recovery read: escrowed, locked and awaiting-recovery
+     * funds are all present. Coin selection must use
+     * {@link getSpendableVtxos} instead — feeding this straight into
+     * `settle({ inputs })` or `sendBitcoin({ selectedVtxos })` bypasses the
+     * generic-spending gate.
+     *
      * @param filter - Optional flags controlling whether recoverable or unrolled VTXOs are included
      */
     async getVtxos(filter?: GetVtxosFilter): Promise<NormalizedExtendedVirtualCoin[]> {
-        const f = filter ?? { withRecoverable: true, withUnrolled: false };
-        const contractManager = await this.getContractManager();
-        const vtxos = await contractManager.getContractsWithVtxos();
+        return filterSnapshotVtxos(
+            await this.contractSnapshot(),
+            filter,
+            this._pendingSpendOutpoints,
+        );
+    }
 
-        // No chain tip, for the same reason as `getBalance`, which this must agree with.
-        const now = { timestamp: new Date() };
-        return vtxos
-            .flatMap((_) => _.vtxos)
-            .filter((vtxo) => {
-                if (this._pendingSpendOutpoints.has(`${vtxo.txid}:${vtxo.vout}`)) {
-                    return false;
-                }
-                if (!hasTerminalSpend(vtxo)) {
-                    if (!f.withRecoverable && canRecoverOnchain(vtxo, now)) {
-                        return false;
-                    }
-                    return true;
-                }
-                return !!(f.withUnrolled && vtxo.isUnrolled);
-            });
+    /** @inheritdoc */
+    async getSpendableVtxos(filter?: GetVtxosFilter): Promise<NormalizedExtendedVirtualCoin[]> {
+        const snapshot = await this.contractSnapshot();
+        const vtxos = filterSnapshotVtxos(snapshot, filter, this._pendingSpendOutpoints);
+        const gated = gatedContracts(snapshot.map((_) => _.contract));
+        logGatedVtxos("getSpendableVtxos", vtxos, gated);
+        const pendingRecovery = this.selectPendingRecovery(snapshot);
+        const selectable = vtxos.filter(
+            (vtxo) => !gated.has(vtxo.script) && !pendingRecovery.has(`${vtxo.txid}:${vtxo.vout}`),
+        );
+        return spendableVtxosExcludingLocked(selectable, this.intentRepository);
+    }
+
+    /**
+     * Debug-log any explicit input the gate would have excluded. Explicit-input
+     * APIs stay ungated on purpose (naming an outpoint *is* the intent the gate
+     * protects, and it is how an escrowed deposit is recovered once generic
+     * selection stops covering it), so this only makes the crossing visible —
+     * notably `settle({ inputs: await wallet.getVtxos() })`, which launders the
+     * raw read into a spend. Never throws into a spend path.
+     */
+    protected async logUngatedInputs(
+        source: string,
+        inputs: readonly { txid: string; vout: number; script?: string }[],
+    ): Promise<void> {
+        try {
+            // Pure repository read: no sync, so this cannot slow or fail a spend.
+            const manager = await this.getContractManager();
+            logGatedVtxos(source, inputs, gatedContracts(await manager.getContracts()));
+        } catch {
+            // diagnostics only
+        }
+    }
+
+    /**
+     * One contract+VTXO read. `getContractsWithVtxos` opportunistically syncs
+     * against the indexer, so every caller that needs more than one view of the
+     * wallet's coins takes a single snapshot and derives them all from it —
+     * otherwise the gate and the pending-recovery set answer about two different
+     * points in time, and each read costs another sync.
+     */
+    protected async contractSnapshot(): Promise<ContractWithVtxos[]> {
+        const contractManager = await this.getContractManager();
+        return contractManager.getContractsWithVtxos();
+    }
+
+    /** The capability probes {@link computeOffchainBalance} needs, over one snapshot. */
+    private async balanceCapabilities(
+        snapshot: readonly ContractWithVtxos[],
+        vtxos: readonly NormalizedExtendedVirtualCoin[],
+    ): Promise<BalanceCapabilities> {
+        const pendingRecovery = this.selectPendingRecovery(snapshot);
+        const gated = gatedContracts(snapshot.map((_) => _.contract));
+        // Offline-first and fails open — see {@link spendableVtxosExcludingLocked}.
+        const unlocked = new Set(
+            (await spendableVtxosExcludingLocked([...vtxos], this.intentRepository)).map(
+                (vtxo) => `${vtxo.txid}:${vtxo.vout}`,
+            ),
+        );
+        return {
+            now: { timestamp: new Date() },
+            isPendingRecovery: (vtxo) => pendingRecovery.has(`${vtxo.txid}:${vtxo.vout}`),
+            isGenericallySpendable: (vtxo) => !gated.has(vtxo.script),
+            isUnlocked: (vtxo) => unlocked.has(`${vtxo.txid}:${vtxo.vout}`),
+        };
     }
 
     /**
@@ -1199,13 +1235,16 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * classifies the repo's contracts against the cached signer set (active +
      * {@link _deprecatedSigners}, cutoffs included). Empty fast-path when no
      * signer is deprecated. Consumed by {@link getBalance} (the `pendingRecovery`
-     * bucket) and the send coin-selection path so neither counts nor spends them.
+     * bucket) and by {@link getSpendableVtxos} so neither counts nor spends them.
      */
     async pendingRecoveryOutpoints(): Promise<Set<string>> {
         if (this._deprecatedSigners.size === 0) return new Set();
-        const contractManager = await this.getContractManager();
-        const contractsWithVtxos = await contractManager.getContractsWithVtxos();
-        return selectPendingRecoveryOutpoints(contractsWithVtxos, {
+        return this.selectPendingRecovery(await this.contractSnapshot());
+    }
+
+    private selectPendingRecovery(snapshot: readonly ContractWithVtxos[]): Set<string> {
+        if (this._deprecatedSigners.size === 0) return new Set();
+        return selectPendingRecoveryOutpoints(snapshot as ContractWithVtxos[], {
             active: toXOnlySignerHex(hex.encode(this.offchainTapscript.options.serverPubKey)),
             deprecated: this._deprecatedSigners,
         });
@@ -3151,6 +3190,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         }
 
         if (params.selectedVtxos && params.selectedVtxos.length > 0) {
+            void this.logUngatedInputs("sendBitcoin({ selectedVtxos })", params.selectedVtxos);
             return this._withTxLock(async () => {
                 // Snapshot the active receive tapscript synchronously
                 // before any `await` so the change output's pkScript and
@@ -3232,6 +3272,13 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
     /**
      * Settle boarding inputs and/or virtual outputs into a finalized mainnet transaction.
      *
+     * `params.inputs` is **ungated**: whatever the caller names is settled,
+     * including VTXOs generic selection would skip. That is what makes an
+     * escrowed or otherwise gated deposit recoverable by hand — but it also
+     * means `settle({ inputs: await wallet.getVtxos() })` silently bypasses the
+     * gate. Pass {@link getSpendableVtxos} instead when the intent is "settle
+     * whatever is spendable".
+     *
      * @param params - Optional settlement inputs and outputs. When omitted, the wallet settles all eligible funds.
      * @param eventCallback - Optional callback invoked for settlement stream events.
      * @returns The finalized Arkade transaction id
@@ -3258,6 +3305,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                     }
                 }
             }
+            void this.logUngatedInputs("settle({ inputs })", params.inputs as ExtendedCoin[]);
         }
 
         // Resolve the wallet's receive address once and reuse it for every read
@@ -3312,7 +3360,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                 amount += utxo.value - inputFee.satoshis;
             }
 
-            const vtxos = await this.getVtxos({ withRecoverable: true });
+            const vtxos = await this.getSpendableVtxos({ withRecoverable: true });
 
             // Cap the VTXOs per settlement to stay under the server's
             // intent-size limit (MAX_VTXOS_PER_SETTLEMENT inputs) and its
@@ -4793,15 +4841,12 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
             this.recipientAddressContext(serverPubKey),
         );
 
-        const allVirtualCoins = await this.getVtxos({
+        // Escrowed contracts, past-cutoff deprecated-signer funds (the operator
+        // will not co-sign them) and intent-locked outpoints are all excluded by
+        // the accessor, from one snapshot.
+        const virtualCoins = await this.getSpendableVtxos({
             withRecoverable: false,
         });
-        // Drop funds under a past-cutoff (EXPIRED) deprecated signer: the operator
-        // will not co-sign a spend of them, so selecting one would fail at submit.
-        const pendingRecovery = await this.pendingRecoveryOutpoints();
-        const virtualCoins = pendingRecovery.size
-            ? allVirtualCoins.filter((c) => !pendingRecovery.has(`${c.txid}:${c.vout}`))
-            : allVirtualCoins;
 
         // keep track of asset changes
         const assetChanges = new Map<string, bigint>();
@@ -5149,6 +5194,9 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
     /**
      * Build an offchain transaction from the given inputs and outputs,
      * sign it, submit to the Arkade provider, and finalize.
+     *
+     * Signs whatever it is handed, ungated — see {@link settle} for the trade.
+     *
      * @returns The Arkade transaction id and server-signed checkpoint PSBTs (for bookkeeping)
      */
     async buildAndSubmitOffchainTx(
@@ -5156,6 +5204,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         outputs: TransactionOutput[],
         serverUnrollScript: CSVMultisigTapscript.Type = this.serverUnrollScript,
     ): Promise<{ arkTxid: string; signedCheckpointTxs: string[] }> {
+        void this.logUngatedInputs("buildAndSubmitOffchainTx", inputs);
         const offchainTx = buildOffchainTx(
             inputs.map((input) => {
                 return {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -3693,6 +3693,17 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         // the hook's terminal repo write failed, which repo state can't tell us.
         let committedTxid: string | undefined;
 
+        // Last check before anything leaves the wallet, for the same reason as
+        // in `buildAndSubmitOffchainTx`: `updateDbAfterSettle` re-annotates
+        // these inputs, and by then the batch has already finalized. Placed
+        // after the cheap local validation above — an unspendable recipient or
+        // a bad arknote should still report itself first — and before the
+        // intent. Arknotes and boarding inputs carry no vtxo script, so they
+        // are not the ones this can speak about.
+        await (
+            await this.getContractManager()
+        ).assertAnnotatable(params.inputs.filter(isVirtualCoin));
+
         // Optimistically hide these inputs from concurrent getVtxos() callers
         // while the settlement is in flight. Set before safeRegisterIntent so
         // there's no window between intent registration and coin-visibility.
@@ -5334,6 +5345,10 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         serverUnrollScript: CSVMultisigTapscript.Type = this.serverUnrollScript,
     ): Promise<{ arkTxid: string; signedCheckpointTxs: string[] }> {
         void this.logUngatedInputs("buildAndSubmitOffchainTx", inputs);
+        // Before anything is signed or submitted: the tx would build fine from
+        // the tapscripts stored on each coin, and only `updateDbAfterOffchainTx`
+        // would fail — after the broadcast. @see IContractManager.assertAnnotatable
+        await (await this.getContractManager()).assertAnnotatable(inputs);
         const offchainTx = buildOffchainTx(
             inputs.map((input) => {
                 return {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -71,7 +71,7 @@ import {
 import { createAssetPacket, selectCoinsWithAsset, selectedCoinsToAssetInputs } from "./asset";
 import { VtxoScript } from "../script/base";
 import { CSVMultisigTapscript, RelativeTimelock } from "../script/tapscript";
-import { signerSetFromInfo, toXOnlySignerHex } from "./signerRotation";
+import { classifyAgainstSignerSet, signerSetFromInfo, toXOnlySignerHex } from "./signerRotation";
 import {
     assertCheckpointsMatchInputs,
     buildOffchainTx,
@@ -150,8 +150,14 @@ import { DescriptorIdentity } from "../identity/descriptorIdentity";
 import { HDWalletCapable } from "./hdWalletCapable";
 import { deriveDescriptorLeafPubKey } from "../identity/descriptor";
 import { WALLET_RECEIVE_SOURCE } from "../contracts/metadata";
-import { CandidateDeps, ContractWithVtxos, DiscoveryDeps } from "../contracts/types";
-import { gatedContracts, logGatedVtxos } from "../contracts/spendability";
+import { CandidateDeps, Contract, ContractWithVtxos, DiscoveryDeps } from "../contracts/types";
+import {
+    gateExclusion,
+    gatedContracts,
+    logExcludedVtxos,
+    outpointExclusion,
+    type VtxoExclusion,
+} from "../contracts/spendability";
 import { computeOffchainBalance, type BalanceCapabilities } from "./balance";
 import { InputSignerRouter, InputSigningJob } from "./inputSignerRouter";
 import {
@@ -364,6 +370,34 @@ export function filterSnapshotVtxos(
             }
             return !!(f.withUnrolled && vtxo.isUnrolled);
         });
+}
+
+/**
+ * Shared by the two places a past-cutoff signer excludes a VTXO: the
+ * outpoint-level `pendingRecovery` set and the script-level check
+ * {@link ReadonlyWallet.logUngatedInputs} can afford.
+ */
+const PENDING_RECOVERY_REASON =
+    "is past its operator signer's rotation cutoff — the operator will not co-sign it until it recovers";
+
+/**
+ * What signer classification needs of a snapshot: contract params and the coins
+ * under them. Structural rather than {@link ContractWithVtxos} so a repository-
+ * built snapshot — the worker's, whose VTXOs carry no `contractScript` — can be
+ * classified without allocating a parallel array to satisfy the nominal type.
+ */
+type PendingRecoverySnapshot = Parameters<typeof selectPendingRecoveryOutpoints>[0];
+
+/** The outpoints in `before` that `after` dropped. */
+function omittedOutpoints(
+    before: readonly { txid: string; vout: number }[],
+    after: readonly { txid: string; vout: number }[],
+): Set<string> {
+    if (before.length === after.length) return new Set();
+    const kept = new Set(after.map((vtxo) => `${vtxo.txid}:${vtxo.vout}`));
+    return new Set(
+        before.map((vtxo) => `${vtxo.txid}:${vtxo.vout}`).filter((outpoint) => !kept.has(outpoint)),
+    );
 }
 
 /**
@@ -1167,31 +1201,100 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const snapshot = await this.contractSnapshot();
         const vtxos = filterSnapshotVtxos(snapshot, filter, this._pendingSpendOutpoints);
         const { gated, pendingRecovery } = this.spendabilityView(snapshot);
-        logGatedVtxos("getSpendableVtxos", vtxos, gated);
         const selectable = vtxos.filter(
             (vtxo) => !gated.has(vtxo.script) && !pendingRecovery.has(`${vtxo.txid}:${vtxo.vout}`),
         );
-        return spendableVtxosExcludingLocked(selectable, this.intentRepository);
+        const unlocked = await spendableVtxosExcludingLocked(selectable, this.intentRepository);
+        logExcludedVtxos("getSpendableVtxos", vtxos, [
+            gateExclusion(gated),
+            outpointExclusion(pendingRecovery, PENDING_RECOVERY_REASON),
+            outpointExclusion(
+                omittedOutpoints(selectable, unlocked),
+                "is locked by an in-flight settlement intent",
+            ),
+        ]);
+        return unlocked;
     }
 
     /**
-     * Debug-log any explicit input the gate would have excluded. Explicit-input
-     * APIs stay ungated on purpose (naming an outpoint *is* the intent the gate
-     * protects, and it is how an escrowed deposit is recovered once generic
-     * selection stops covering it), so this only makes the crossing visible —
-     * notably `settle({ inputs: await wallet.getVtxos() })`, which launders the
-     * raw read into a spend. Never throws into a spend path.
+     * Debug-log any explicit input generic selection would have excluded, for
+     * each of the three reasons it excludes on. Explicit-input APIs stay ungated
+     * on purpose (naming an outpoint *is* the intent the gate protects, and it
+     * is how an escrowed deposit is recovered once generic selection stops
+     * covering it), so this only makes the crossing visible — notably
+     * `settle({ inputs: await wallet.getVtxos() })`, which launders the raw read
+     * into a spend. Never throws into a spend path.
+     *
+     * Public so the worker handler and plugins can report their own
+     * explicit-input crossings through the same three checks.
      */
-    protected async logUngatedInputs(
+    async logUngatedInputs(
         source: string,
         inputs: readonly { txid: string; vout: number; script?: string }[],
     ): Promise<void> {
         try {
-            // Pure repository read: no sync, so this cannot slow or fail a spend.
+            // Pure repository reads: no indexer sync, so this cannot slow or
+            // fail a spend. That rules out reusing `spendabilityView`, whose
+            // snapshot syncs; each exclusion is rebuilt from contract rows and
+            // the intent store instead.
             const manager = await this.getContractManager();
-            logGatedVtxos(source, inputs, gatedContracts(await manager.getContracts()));
+            const contracts = await manager.getContracts();
+            const locked = await this.lockedOutpoints();
+            logExcludedVtxos(source, inputs, [
+                gateExclusion(gatedContracts(contracts)),
+                this.expiredSignerExclusion(contracts),
+                outpointExclusion(locked, "is locked by an in-flight settlement intent"),
+            ]);
         } catch {
             // diagnostics only
+        }
+    }
+
+    /**
+     * Contracts whose operator signer is past its rotation cutoff, as an
+     * exclusion over scripts. The outpoint-level `pendingRecovery` set needs a
+     * synced VTXO snapshot to also drop already-swept coins; this answers the
+     * same question about a caller-supplied input without one, and a swept
+     * outpoint is unspendable regardless.
+     */
+    private expiredSignerExclusion(contracts: readonly Contract[]): VtxoExclusion {
+        if (this._deprecatedSigners.size === 0) return () => undefined;
+        const signerSet = {
+            active: toXOnlySignerHex(hex.encode(this.offchainTapscript.options.serverPubKey)),
+            deprecated: this._deprecatedSigners,
+        };
+        const expired = new Set(
+            contracts
+                .filter((contract) => {
+                    const serverPubKey = contract.params.serverPubKey;
+                    if (typeof serverPubKey !== "string") return false;
+                    try {
+                        return (
+                            classifyAgainstSignerSet(serverPubKey, signerSet).status === "EXPIRED"
+                        );
+                    } catch {
+                        // One malformed row must not suppress every other
+                        // input's diagnostics; `refreshDeprecatedSigners` skips
+                        // malformed keys the same way.
+                        return false;
+                    }
+                })
+                .map((contract) => contract.script),
+        );
+        return (vtxo) =>
+            vtxo.script !== undefined && expired.has(vtxo.script)
+                ? PENDING_RECOVERY_REASON
+                : undefined;
+    }
+
+    /** The intent store's lock set. Fails open, like every other read of it. */
+    private async lockedOutpoints(): Promise<Set<string>> {
+        if (!this.intentRepository) return new Set();
+        try {
+            const locked = await this.intentRepository.getLockedVtxoOutpoints();
+            return new Set(locked.map((o) => `${o.txid}:${o.vout}`));
+        } catch {
+            return new Set();
         }
     }
 
@@ -1248,15 +1351,29 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * {@link _deprecatedSigners}, cutoffs included). Empty fast-path when no
      * signer is deprecated. Consumed by {@link getBalance} (the `pendingRecovery`
      * bucket) and by {@link getSpendableVtxos} so neither counts nor spends them.
+     *
+     * Takes a fresh {@link contractSnapshot}, which syncs against the indexer.
+     * Callers that already hold a snapshot — or that must not sync at all, like
+     * the worker's balance read — pass it to
+     * {@link pendingRecoveryOutpointsIn} instead.
      */
     async pendingRecoveryOutpoints(): Promise<Set<string>> {
         if (this._deprecatedSigners.size === 0) return new Set();
         return this.selectPendingRecovery(await this.contractSnapshot());
     }
 
-    private selectPendingRecovery(snapshot: readonly ContractWithVtxos[]): Set<string> {
+    /**
+     * {@link pendingRecoveryOutpoints} over a snapshot the caller already has:
+     * pure classification against the cached signer set, no repository or
+     * network read of its own.
+     */
+    pendingRecoveryOutpointsIn(snapshot: PendingRecoverySnapshot): Set<string> {
+        return this.selectPendingRecovery(snapshot);
+    }
+
+    private selectPendingRecovery(snapshot: PendingRecoverySnapshot): Set<string> {
         if (this._deprecatedSigners.size === 0) return new Set();
-        return selectPendingRecoveryOutpoints(snapshot as ContractWithVtxos[], {
+        return selectPendingRecoveryOutpoints(snapshot, {
             active: toXOnlySignerHex(hex.encode(this.offchainTapscript.options.serverPubKey)),
             deprecated: this._deprecatedSigners,
         });

--- a/packages/ts-sdk/src/worker/browser/README.md
+++ b/packages/ts-sdk/src/worker/browser/README.md
@@ -35,7 +35,12 @@ scheduler.
    (calls `clients.claim()`).
 3. The client sends an `INITIALIZE_MESSAGE_BUS` message with wallet and Ark
    server configuration. The `MessageBus` builds services (wallet, provider)
-   and calls `start()` on each handler, then begins the tick loop.
+   and calls `start()` on each handler, then begins the tick loop. The wallet
+   is built with the repositories the bus was constructed with — the optional
+   `intentRepository` included, without which intent persistence,
+   reconciliation and intent-lock exclusion are no-ops in the worker exactly as
+   they are on the main thread. A custom `buildServices` owns `storage`
+   outright and must wire the repository itself.
 4. Subsequent client messages are routed by `tag` (the handler's `messageTag`)
    or broadcast to all handlers.
 5. Handlers can respond immediately (via `handleMessage`) or later (via `tick`).

--- a/packages/ts-sdk/src/worker/messageBus.ts
+++ b/packages/ts-sdk/src/worker/messageBus.ts
@@ -15,7 +15,7 @@ import {
 import { ReadonlyWallet, Wallet } from "../wallet/wallet";
 import type { SettlementConfig } from "../wallet/vtxo-manager";
 import type { ContractWatcherConfig } from "../contracts/contractWatcher";
-import { ContractRepository, WalletRepository } from "../repositories";
+import { ContractRepository, IntentRepository, WalletRepository } from "../repositories";
 import {
     MessageBusInitializingError,
     MessageBusNotInitializedError,
@@ -102,6 +102,16 @@ type Options = {
      * every (re-)init.
      */
     messageTimeoutOverrides?: Record<string, number>;
+    /**
+     * Optional intent-lifecycle repository, handed to the worker's wallet as
+     * `storage.intentRepository`. Same opt-in as a main-thread wallet: without
+     * it the worker persists no settlement intent, reconciles none on restart,
+     * and counts intent-locked VTXOs as available. Pass the same repository the
+     * main thread uses so both sides read one intent state.
+     *
+     * Ignored when `buildServices` is supplied — that override owns `storage`.
+     */
+    intentRepository?: IntentRepository;
     debug?: boolean;
     buildServices?: (config: Initialize["config"]) => Promise<{
         arkProvider: ArkProvider;
@@ -186,6 +196,7 @@ export class MessageBus {
         readonlyWallet: ReadonlyWallet;
     }>;
     private readonly boundOnMessage = this.onMessage.bind(this);
+    private readonly intentRepository?: IntentRepository;
 
     /** Create the service-worker message bus with repositories and handler configuration. */
     constructor(
@@ -196,10 +207,12 @@ export class MessageBus {
             tickIntervalMs = 10_000,
             messageTimeoutMs = 30_000,
             messageTimeoutOverrides = {},
+            intentRepository,
             debug = false,
             buildServices,
         }: Options,
     ) {
+        this.intentRepository = intentRepository;
         this.handlers = new Map(messageHandlers.map((u) => [u.messageTag, u]));
         this.tickIntervalMs = tickIntervalMs;
         this.messageTimeoutMs = messageTimeoutMs;
@@ -393,6 +406,7 @@ export class MessageBus {
         const storage = {
             walletRepository: this.walletRepository,
             contractRepository: this.contractRepository,
+            ...(this.intentRepository && { intentRepository: this.intentRepository }),
         };
         const delegateProvider = config.delegateUrl
             ? new RestDelegateProvider(config.delegateUrl)

--- a/packages/ts-sdk/test/deprecatedSignerMigration.test.ts
+++ b/packages/ts-sdk/test/deprecatedSignerMigration.test.ts
@@ -179,6 +179,7 @@ function createMigrationMockWallet(opts: MigrationMockOptions) {
         getAddress: vi.fn().mockResolvedValue(opts.address ?? ARK_ADDRESS),
         getDelegateManager: vi.fn().mockResolvedValue(undefined),
         getVtxos: vi.fn().mockResolvedValue([]),
+        getSpendableVtxos: vi.fn().mockResolvedValue([]),
         settle,
         sendSelectedVtxosToSelf,
         dustAmount: 1000n,
@@ -823,6 +824,7 @@ function createPollableWallet() {
         refreshDeprecatedSigners: vi.fn(),
         rotateServerSigner: vi.fn().mockResolvedValue(undefined),
         getVtxos: vi.fn().mockResolvedValue([]),
+        getSpendableVtxos: vi.fn().mockResolvedValue([]),
         getAddress: vi.fn().mockResolvedValue(ARK_ADDRESS),
         getDelegateManager: vi.fn().mockResolvedValue(undefined),
         getContractManager: vi.fn().mockResolvedValue({
@@ -946,6 +948,7 @@ function createRecoveryMockWallet(opts: RecoveryMockOptions) {
         refreshDeprecatedSigners: vi.fn(),
         rotateServerSigner,
         getVtxos,
+        getSpendableVtxos: getVtxos,
         getAddress,
         getDelegateManager: vi.fn().mockResolvedValue(undefined),
         getContractManager: vi.fn().mockResolvedValue({

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -208,6 +208,45 @@ describe("ServiceWorkerReadonlyWallet", () => {
         await expect(wallet.getBoardingUtxos()).resolves.toEqual(utxos);
     });
 
+    it("asks the worker for the gated set over its own message", async () => {
+        // The gate reads contract-row metadata, which exists only inside the
+        // worker — so this cannot be a main-thread filter over GET_VTXOS.
+        const vtxos = [{ txid: "tx", vout: 0, value: 1, virtualStatus: { state: "settled" } }];
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) =>
+            message.type === "GET_SPENDABLE_VTXOS"
+                ? {
+                      id: message.id,
+                      tag: messageTag,
+                      type: "SPENDABLE_VTXOS",
+                      payload: { vtxos },
+                  }
+                : null,
+        );
+
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createWallet(serviceWorker as any, messageTag);
+        await expect(wallet.getSpendableVtxos()).resolves.toMatchObject([{ txid: "tx" }]);
+    });
+
+    it("fails closed against a worker that predates the message", async () => {
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) =>
+            message.type === "GET_SPENDABLE_VTXOS"
+                ? { id: message.id, tag: messageTag, error: new Error("Unknown message") }
+                : null,
+        );
+
+        vi.stubGlobal("navigator", { serviceWorker: navigatorServiceWorker } as any);
+
+        const wallet = createWallet(serviceWorker as any, messageTag);
+        await expect(wallet.getSpendableVtxos()).rejects.toThrow("Unknown message");
+        // No GET_VTXOS fallback: degrading to the ungated read would make the
+        // gate advisory for the whole worker-activation window of every deploy.
+        expect(serviceWorker.postMessage).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: "GET_VTXOS" }),
+        );
+    });
+
     it("rejects when the response contains an error", async () => {
         const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness((message) => ({
             id: message.id,

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -70,6 +70,18 @@ const offlineIndexer = () =>
         getSubscription: async function* () {},
     }) as Partial<IndexerProvider> as IndexerProvider;
 
+// Online: answers every script query from a fixed set, so `getContractsWithVtxos`
+// actually syncs and annotates what comes back.
+const onlineIndexer = (vtxos: { script: string }[]) =>
+    ({
+        getVtxos: async (opts?: { scripts?: string[] }) => ({
+            vtxos: vtxos.filter((v) => opts?.scripts?.includes(v.script)),
+        }),
+        subscribeForScripts: async () => "sub-1",
+        unsubscribeForScripts: async () => undefined,
+        getSubscription: async function* () {},
+    }) as Partial<IndexerProvider> as IndexerProvider;
+
 const contract = (script: string, type: string, metadata?: Record<string, unknown>): Contract => ({
     type,
     params: type === "default" ? createDefaultContractParams() : {},
@@ -95,7 +107,11 @@ const vtxo = (script: string, value: number, assets?: { assetId: string; amount:
  * contract (escrow), a marked `arkade` contract, and a contract whose type has
  * no handler at all.
  */
-async function seededWallet(opts?: { intents?: InMemoryIntentRepository; signing?: boolean }) {
+async function seededWallet(opts?: {
+    intents?: InMemoryIntentRepository;
+    signing?: boolean;
+    indexerProvider?: IndexerProvider;
+}) {
     const walletRepository = new InMemoryWalletRepository();
     const contractRepository = new InMemoryContractRepository();
 
@@ -114,7 +130,7 @@ async function seededWallet(opts?: { intents?: InMemoryIntentRepository; signing
     const config = {
         arkServerUrl: "http://localhost:7070",
         arkProvider: { getInfo: async () => arkInfo() } as Partial<ArkProvider> as ArkProvider,
-        indexerProvider: offlineIndexer(),
+        indexerProvider: opts?.indexerProvider ?? offlineIndexer(),
         onchainProvider: {
             getCoins: async () => [],
             getTransactions: async () => [],
@@ -259,6 +275,27 @@ describe("getSpendableVtxos", () => {
         expect(scriptsOf(await wallet.getSpendableVtxos())).toEqual([MARKED_SCRIPT]);
         // Still reported as owned.
         expect(scriptsOf(await wallet.getVtxos())).toContain(defaultScript);
+    });
+
+    it("survives a stored contract whose handler this runtime never registered", async () => {
+        // A persisted plugin row outliving its handler is the case the gate is
+        // meant to close, so the read that applies the gate must reach it: the
+        // sync annotates whatever the indexer returns, and no handler means no
+        // tapscripts to annotate with.
+        const { wallet, defaultScript } = await seededWallet({
+            indexerProvider: onlineIndexer([vtxo(UNKNOWN_SCRIPT, 10_000)]),
+        });
+
+        expect(scriptsOf(await wallet.getSpendableVtxos())).toEqual(
+            [defaultScript, MARKED_SCRIPT].sort(),
+        );
+        await expect(wallet.getBalance()).resolves.toMatchObject({
+            total: 70_000,
+            available: 50_000,
+        });
+        // Its already-persisted funds stay owned and reported — only the
+        // refresh of them is skipped.
+        expect(scriptsOf(await wallet.getVtxos())).toContain(UNKNOWN_SCRIPT);
     });
 
     it("takes exactly one contract snapshot per call", async () => {

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+    ArkadeContractHandler,
+    BoardingContractHandler,
+    DefaultContractHandler,
+    DelegateContractHandler,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    isContractGenericallySpendable,
+    ProviderUnavailableError,
+    ReadonlyWallet,
+    VHTLCContractHandler,
+    Wallet,
+    type ArkProvider,
+    type Contract,
+    type IndexerProvider,
+    type OnchainProvider,
+} from "../src";
+import type { ArkInfo } from "../src/providers/ark";
+import { InMemoryIntentRepository } from "../src/repositories/inMemory/intentRepository";
+import { ReadonlySingleKey, SingleKey } from "../src/identity/singleKey";
+import { Ramps } from "../src/wallet/ramps";
+import { VtxoManager } from "../src/wallet/vtxo-manager";
+import {
+    createMockExtendedVtxo,
+    createDefaultContractParams,
+    TEST_DEFAULT_ARK_ADDRESS,
+} from "./contracts/helpers";
+
+const serverKeyHex = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const privKeyHex = "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2";
+
+const ESCROW_SCRIPT = "51200000000000000000000000000000000000000000000000000000000000000001";
+const MARKED_SCRIPT = "51200000000000000000000000000000000000000000000000000000000000000002";
+const UNKNOWN_SCRIPT = "51200000000000000000000000000000000000000000000000000000000000000003";
+const ASSET_ID = "aa".repeat(32);
+
+const arkInfo = (): ArkInfo => ({
+    boardingExitDelay: 144n,
+    checkpointTapscript:
+        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+    deprecatedSigners: [],
+    digest: "d",
+    dust: 1000n,
+    fees: { intentFee: {}, txFeeRate: "0" },
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    forfeitPubkey: serverKeyHex,
+    network: "mutinynet",
+    serviceStatus: {},
+    sessionDuration: 3600n,
+    signerPubkey: serverKeyHex,
+    unilateralExitDelay: 144n,
+    utxoMaxAmount: -1n,
+    utxoMinAmount: 0n,
+    version: "1",
+    vtxoMaxAmount: -1n,
+    vtxoMinAmount: 0n,
+});
+
+// Offline: every indexer read fails retryably, so `getContractsWithVtxos`
+// serves the seeded repository state instead of syncing it away.
+const offlineIndexer = () =>
+    ({
+        getVtxos: async () => {
+            throw new ProviderUnavailableError("operator down");
+        },
+        subscribeForScripts: async () => "sub-1",
+        unsubscribeForScripts: async () => undefined,
+        getSubscription: async function* () {},
+    }) as Partial<IndexerProvider> as IndexerProvider;
+
+const contract = (script: string, type: string, metadata?: Record<string, unknown>): Contract => ({
+    type,
+    params: type === "default" ? createDefaultContractParams() : {},
+    script,
+    address: `addr-${script.slice(-2)}`,
+    state: "active",
+    createdAt: 1,
+    ...(metadata ? { metadata } : {}),
+});
+
+const vtxo = (script: string, value: number, assets?: { assetId: string; amount: bigint }[]) =>
+    createMockExtendedVtxo({
+        txid: script.slice(-2).repeat(32),
+        vout: 0,
+        value,
+        script,
+        virtualStatus: { state: "settled" },
+        ...(assets ? { assets } : {}),
+    });
+
+/**
+ * A wallet holding four VTXOs: its own default one, an unmarked `arkade`
+ * contract (escrow), a marked `arkade` contract, and a contract whose type has
+ * no handler at all.
+ */
+async function seededWallet(opts?: { intents?: InMemoryIntentRepository; signing?: boolean }) {
+    const walletRepository = new InMemoryWalletRepository();
+    const contractRepository = new InMemoryContractRepository();
+
+    const rows = [
+        contract(ESCROW_SCRIPT, "arkade"),
+        contract(MARKED_SCRIPT, "arkade", { genericallySpendable: true }),
+        contract(UNKNOWN_SCRIPT, "not-a-registered-type"),
+    ];
+    for (const row of rows) {
+        await contractRepository.saveContract(row);
+        await walletRepository.saveVtxos(row.address, [
+            vtxo(row.script, 10_000, [{ assetId: ASSET_ID, amount: 5n }]),
+        ]);
+    }
+
+    const config = {
+        arkServerUrl: "http://localhost:7070",
+        arkProvider: { getInfo: async () => arkInfo() } as Partial<ArkProvider> as ArkProvider,
+        indexerProvider: offlineIndexer(),
+        onchainProvider: {
+            getCoins: async () => [],
+            getTransactions: async () => [],
+            getTxOutspends: async () => [],
+        } as Partial<OnchainProvider> as OnchainProvider,
+        storage: {
+            walletRepository,
+            contractRepository,
+            ...(opts?.intents ? { intentRepository: opts.intents } : {}),
+        },
+    };
+
+    const identity = SingleKey.fromHex(privKeyHex);
+    const wallet = opts?.signing
+        ? await Wallet.create({ ...config, identity })
+        : await ReadonlyWallet.create({
+              ...config,
+              identity: ReadonlySingleKey.fromPublicKey(await identity.compressedPublicKey()),
+          });
+
+    // The wallet's own receive contract, funded, as the control.
+    const defaultScript = wallet.defaultContractScript;
+    await walletRepository.saveVtxos(await wallet.getAddress(), [
+        vtxo(defaultScript, 40_000, [{ assetId: ASSET_ID, amount: 7n }]),
+    ]);
+
+    return { wallet, defaultScript, walletRepository, contractRepository };
+}
+
+const scriptsOf = (vtxos: { script: string }[]) => vtxos.map((v) => v.script).sort();
+
+describe("ContractHandler.isGenericallySpendable", () => {
+    it("answers true for every built-in wallet-owned type", () => {
+        const row = contract("s", "default");
+        expect(DefaultContractHandler.isGenericallySpendable?.(row)).toBe(true);
+        expect(DelegateContractHandler.isGenericallySpendable?.(row)).toBe(true);
+        expect(BoardingContractHandler.isGenericallySpendable?.(row)).toBe(true);
+        // Today's behaviour verbatim — Phase 0 changes nothing for VHTLC.
+        expect(VHTLCContractHandler.isGenericallySpendable?.(row)).toBe(true);
+    });
+
+    it("makes arkade opt-in, never opt-out", () => {
+        const answer = (metadata?: Record<string, unknown>) =>
+            ArkadeContractHandler.isGenericallySpendable?.(contract("s", "arkade", metadata));
+        expect(answer({ genericallySpendable: true })).toBe(true);
+        expect(answer()).toBe(false);
+        expect(answer({})).toBe(false);
+        // Malformed markers must not open the gate.
+        expect(answer({ genericallySpendable: "true" })).toBe(false);
+        expect(answer({ genericallySpendable: 1 })).toBe(false);
+    });
+
+    it("closes a type no handler declares (D1a)", () => {
+        expect(isContractGenericallySpendable(contract("s", "not-a-registered-type"))).toBe(false);
+    });
+});
+
+describe("getSpendableVtxos", () => {
+    it("drops gated contracts while getVtxos keeps them", async () => {
+        const { wallet, defaultScript } = await seededWallet();
+
+        expect(scriptsOf(await wallet.getVtxos())).toEqual(
+            [defaultScript, ESCROW_SCRIPT, MARKED_SCRIPT, UNKNOWN_SCRIPT].sort(),
+        );
+        expect(scriptsOf(await wallet.getSpendableVtxos())).toEqual(
+            [defaultScript, MARKED_SCRIPT].sort(),
+        );
+    });
+
+    it("passes its filter through unchanged", async () => {
+        const { wallet } = await seededWallet();
+        const spy = vi.spyOn(wallet, "getVtxos");
+        // Same filter, same result set modulo the gate: the accessor is
+        // gate(getVtxos(filter)), so a site's migration cannot change its filter.
+        for (const filter of [
+            undefined,
+            { withRecoverable: false },
+            { withRecoverable: true },
+            { withRecoverable: true, withUnrolled: false },
+        ]) {
+            const raw = await wallet.getVtxos(filter);
+            const gated = await wallet.getSpendableVtxos(filter);
+            expect(scriptsOf(gated)).toEqual(
+                scriptsOf(
+                    raw.filter((v) => v.script !== ESCROW_SCRIPT && v.script !== UNKNOWN_SCRIPT),
+                ),
+            );
+        }
+        spy.mockRestore();
+    });
+
+    it("excludes intent-locked outpoints", async () => {
+        const intents = new InMemoryIntentRepository();
+        const { wallet, defaultScript } = await seededWallet({ intents });
+        await intents.saveIntent({
+            intentTxId: "i",
+            createdAt: 1,
+            updatedAt: 1,
+            registerProof: "",
+            registerProofMessage: "",
+            deleteProof: "",
+            deleteProofMessage: "",
+            partialForfeits: [],
+            state: "batch_in_progress",
+            intentVtxos: [{ txid: defaultScript.slice(-2).repeat(32), vout: 0 }],
+        });
+
+        expect(scriptsOf(await wallet.getSpendableVtxos())).toEqual([MARKED_SCRIPT]);
+        // Still reported as owned.
+        expect(scriptsOf(await wallet.getVtxos())).toContain(defaultScript);
+    });
+
+    it("takes exactly one contract snapshot per call", async () => {
+        const { wallet } = await seededWallet();
+        const manager = await wallet.getContractManager();
+        const spy = vi.spyOn(manager, "getContractsWithVtxos");
+
+        await wallet.getSpendableVtxos();
+
+        // getContractsWithVtxos syncs against the indexer, so a second read
+        // would cost a round-trip AND evaluate the two exclusion sets against
+        // two different points in time.
+        expect(spy).toHaveBeenCalledTimes(1);
+        spy.mockRestore();
+    });
+});
+
+describe("getBalance", () => {
+    it("counts gated funds as owned but not as available (D1c)", async () => {
+        const { wallet } = await seededWallet();
+        const balance = await wallet.getBalance();
+
+        // 40k own + 10k escrow + 10k marked + 10k unknown-type
+        expect(balance.settled).toBe(70_000);
+        expect(balance.total).toBe(70_000);
+        // …minus the escrowed and the unknown-type contract.
+        expect(balance.available).toBe(50_000);
+    });
+
+    it("gives assets the same owned/spendable split (D1e)", async () => {
+        const { wallet } = await seededWallet();
+        const balance = await wallet.getBalance();
+
+        const amount = (assets: { assetId: string; amount: bigint }[]) =>
+            assets.find((a) => a.assetId === ASSET_ID)?.amount ?? 0n;
+
+        expect(amount(balance.assets)).toBe(22n); // 7 + 5 + 5 + 5
+        expect(amount(balance.availableAssets)).toBe(12n); // 7 + 5
+        // The escrowed asset amount, without a new balance bucket.
+        expect(amount(balance.assets) - amount(balance.availableAssets)).toBe(10n);
+    });
+});
+
+describe("gated reads stay ungated (D1b/D1d)", () => {
+    it("keeps escrowed funds in the recovery and history reads", async () => {
+        const { wallet } = await seededWallet();
+
+        expect(scriptsOf(await wallet.getVtxos({ withRecoverable: true }))).toContain(
+            ESCROW_SCRIPT,
+        );
+        const history = await wallet.getTransactionHistory();
+        expect(history.length).toBeGreaterThan(0);
+    });
+
+    it("settles a gated VTXO when it is named explicitly (D1d)", async () => {
+        // The escape hatch that keeps an escrowed deposit recoverable once
+        // generic selection — and with it background renewal — stops covering it.
+        const escrowed = vtxo(ESCROW_SCRIPT, 10_000);
+        const getSpendableVtxos = vi.fn();
+        const registerInputs = vi.fn().mockResolvedValue({
+            proof: "register-proof",
+            message: { type: "register" },
+        });
+
+        const thisArg: any = {
+            network: "mutinynet",
+            arkProvider: {
+                getEventStream: vi.fn().mockReturnValue({
+                    next: vi.fn().mockResolvedValue({ done: false, value: { type: "x" } }),
+                    return: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+                    [Symbol.asyncIterator]() {
+                        return this;
+                    },
+                }),
+                deleteIntent: vi.fn().mockResolvedValue(undefined),
+            },
+            getSpendableVtxos,
+            _addPendingSpends: vi.fn(),
+            _removePendingSpends: vi.fn(),
+            getAddress: vi.fn().mockResolvedValue(TEST_DEFAULT_ARK_ADDRESS),
+            makeRegisterIntentSignature: registerInputs,
+            makeDeleteIntentSignature: vi.fn().mockResolvedValue({
+                proof: "delete-proof",
+                message: { type: "delete", expire_at: 0 },
+            }),
+            logUngatedInputs: vi.fn().mockResolvedValue(undefined),
+            safeRegisterIntent: vi.fn().mockRejectedValue(new Error("stop-after-selection")),
+            persistIntentSnapshot: vi.fn(),
+        };
+
+        await expect(
+            (Wallet.prototype as any)._settleImpl.call(thisArg, {
+                inputs: [escrowed],
+                outputs: [],
+            }),
+        ).rejects.toThrow("stop-after-selection");
+
+        expect(registerInputs.mock.calls[0][0]).toEqual([escrowed]);
+        expect(getSpendableVtxos).not.toHaveBeenCalled();
+        expect(thisArg.logUngatedInputs).toHaveBeenCalledWith("settle({ inputs })", [escrowed]);
+    });
+});
+
+describe("spending sites consume the accessor", () => {
+    const mockWallet = (raw: unknown[], spendable: unknown[]) => ({
+        getVtxos: vi.fn().mockResolvedValue(raw),
+        getSpendableVtxos: vi.fn().mockResolvedValue(spendable),
+        getAddress: vi.fn().mockResolvedValue("ark1address"),
+        getDelegateManager: vi.fn().mockResolvedValue(undefined),
+        getContractManager: vi.fn().mockResolvedValue({
+            onContractEvent: vi.fn().mockReturnValue(() => {}),
+            refreshOutpoints: vi.fn().mockResolvedValue(undefined),
+        }),
+        dustAmount: 1000n,
+        arkProvider: { getInfo: vi.fn().mockResolvedValue(arkInfo()) },
+    });
+
+    it("renewal does not see gated VTXOs", async () => {
+        const escrowed = vtxo(ESCROW_SCRIPT, 10_000);
+        const wallet = mockWallet([escrowed], []);
+        const manager = new VtxoManager(wallet as never);
+
+        await expect(manager.getExpiringVtxos()).resolves.toEqual([]);
+        expect(wallet.getSpendableVtxos).toHaveBeenCalled();
+    });
+
+    it("offboard does not see gated VTXOs", async () => {
+        const escrowed = vtxo(ESCROW_SCRIPT, 10_000);
+        const wallet = mockWallet([escrowed], []);
+        const ramps = new Ramps(wallet as never);
+
+        await expect(
+            ramps.offboard("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080", {
+                intentFee: {},
+                txFeeRate: "1",
+            }),
+        ).rejects.toThrow();
+        expect(wallet.getSpendableVtxos).toHaveBeenCalled();
+    });
+});

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -13,6 +13,7 @@ import {
     Wallet,
     type ArkProvider,
     type Contract,
+    type GetVtxosFilter,
     type IndexerProvider,
     type OnchainProvider,
 } from "../src";
@@ -144,6 +145,7 @@ async function seededWallet(opts?: { intents?: InMemoryIntentRepository; signing
 }
 
 const scriptsOf = (vtxos: { script: string }[]) => vtxos.map((v) => v.script).sort();
+const txidsOf = (vtxos: { txid: string }[]) => vtxos.map((v) => v.txid).sort();
 
 describe("ContractHandler.isGenericallySpendable", () => {
     it("answers true for every built-in wallet-owned type", () => {
@@ -184,25 +186,58 @@ describe("getSpendableVtxos", () => {
     });
 
     it("passes its filter through unchanged", async () => {
-        const { wallet } = await seededWallet();
-        const spy = vi.spyOn(wallet, "getVtxos");
+        const { wallet, walletRepository, defaultScript } = await seededWallet();
+        // Two more of the wallet's own coins, each visible under exactly one
+        // filter flag, so an accessor that ignored the filter would show up.
+        const recoverableTxid = "e1".repeat(32);
+        const unrolledTxid = "e2".repeat(32);
+        await walletRepository.saveVtxos(await wallet.getAddress(), [
+            createMockExtendedVtxo({
+                txid: recoverableTxid,
+                vout: 0,
+                value: 10_000,
+                script: defaultScript,
+                isSwept: true,
+            }),
+            createMockExtendedVtxo({
+                txid: unrolledTxid,
+                vout: 0,
+                value: 10_000,
+                script: defaultScript,
+                isSpent: true,
+                isUnrolled: true,
+            }),
+        ]);
+
+        const ownTxid = defaultScript.slice(-2).repeat(32);
+        const markedTxid = MARKED_SCRIPT.slice(-2).repeat(32);
+        const cases: [GetVtxosFilter | undefined, string[]][] = [
+            // The default filter is { withRecoverable: true, withUnrolled: false }.
+            [undefined, [ownTxid, markedTxid, recoverableTxid]],
+            [{ withRecoverable: false }, [ownTxid, markedTxid]],
+            [{ withRecoverable: true }, [ownTxid, markedTxid, recoverableTxid]],
+            [
+                { withRecoverable: true, withUnrolled: false },
+                [ownTxid, markedTxid, recoverableTxid],
+            ],
+            [
+                { withRecoverable: true, withUnrolled: true },
+                [ownTxid, markedTxid, recoverableTxid, unrolledTxid],
+            ],
+        ];
+
         // Same filter, same result set modulo the gate: the accessor is
         // gate(getVtxos(filter)), so a site's migration cannot change its filter.
-        for (const filter of [
-            undefined,
-            { withRecoverable: false },
-            { withRecoverable: true },
-            { withRecoverable: true, withUnrolled: false },
-        ]) {
+        for (const [filter, expected] of cases) {
             const raw = await wallet.getVtxos(filter);
             const gated = await wallet.getSpendableVtxos(filter);
-            expect(scriptsOf(gated)).toEqual(
-                scriptsOf(
+            expect(txidsOf(gated)).toEqual(expected.sort());
+            expect(txidsOf(gated)).toEqual(
+                txidsOf(
                     raw.filter((v) => v.script !== ESCROW_SCRIPT && v.script !== UNKNOWN_SCRIPT),
                 ),
             );
         }
-        spy.mockRestore();
     });
 
     it("excludes intent-locked outpoints", async () => {

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -7,6 +7,7 @@ import {
     InMemoryContractRepository,
     InMemoryWalletRepository,
     isContractGenericallySpendable,
+    UnannotatableInputError,
     ProviderUnavailableError,
     ReadonlyWallet,
     VHTLCContractHandler,
@@ -382,6 +383,11 @@ describe("gated reads stay ungated (D1b/D1d)", () => {
                 message: { type: "delete", expire_at: 0 },
             }),
             logUngatedInputs: vi.fn().mockResolvedValue(undefined),
+            // Gated, but still annotatable — the pre-submission check must let
+            // the deliberate recovery spend through.
+            getContractManager: vi.fn().mockResolvedValue({
+                assertAnnotatable: vi.fn().mockResolvedValue(undefined),
+            }),
             safeRegisterIntent: vi.fn().mockRejectedValue(new Error("stop-after-selection")),
             persistIntentSnapshot: vi.fn(),
         };
@@ -506,5 +512,70 @@ describe("logUngatedInputs", () => {
             wallet.logUngatedInputs("buildAndSubmitOffchainTx", [vtxo(defaultScript, 10_000)]),
         );
         expect(lines).toEqual([]);
+    });
+});
+
+describe("a contract whose handler rejects its stored params", () => {
+    // The upgrade shape: `arkade` params written before `program` became
+    // required. The handler is registered and `createScript` throws.
+    const BROKEN_SCRIPT = "51200000000000000000000000000000000000000000000000000000000000000005";
+
+    const withBrokenContract = async () => {
+        const seeded = await seededWallet({
+            indexerProvider: onlineIndexer([vtxo(BROKEN_SCRIPT, 10_000)]),
+        });
+        await seeded.contractRepository.saveContract(contract(BROKEN_SCRIPT, "arkade"));
+        return seeded;
+    };
+
+    it("does not fail the reads of every other contract", async () => {
+        const { wallet, defaultScript } = await withBrokenContract();
+
+        await expect(wallet.getBalance()).resolves.toMatchObject({ available: 50_000 });
+        expect(scriptsOf(await wallet.getSpendableVtxos())).toEqual(
+            [defaultScript, MARKED_SCRIPT].sort(),
+        );
+    });
+
+    it("reports itself through the sync state instead of going quiet", async () => {
+        const { wallet } = await withBrokenContract();
+        await wallet.getBalance();
+
+        const state = wallet.getContractSyncState();
+        expect(state.mode).toBe("degraded");
+        expect(state.mode === "degraded" && state.reason).toContain(BROKEN_SCRIPT);
+        expect(state.mode === "degraded" && state.reason).toContain("not being synced");
+    });
+
+    it("refuses the spend before it is submitted, naming the contract", async () => {
+        const { wallet } = await withBrokenContract();
+        const manager = await wallet.getContractManager();
+
+        // Stored coins keep working tapscripts, so the spend would otherwise
+        // build and broadcast and only fail in the bookkeeping afterwards.
+        await expect(
+            manager.assertAnnotatable([{ txid: "ff".repeat(32), vout: 0, script: BROKEN_SCRIPT }]),
+        ).rejects.toThrow(UnannotatableInputError);
+        await expect(
+            manager.assertAnnotatable([{ txid: "ff".repeat(32), vout: 0, script: BROKEN_SCRIPT }]),
+        ).rejects.toThrow(/missing 'program'/);
+    });
+
+    it("lets a spendable contract through", async () => {
+        const { wallet, defaultScript } = await withBrokenContract();
+        const manager = await wallet.getContractManager();
+        await expect(
+            manager.assertAnnotatable([{ txid: "aa".repeat(32), vout: 0, script: defaultScript }]),
+        ).resolves.toBeUndefined();
+    });
+
+    it("refuses a vtxo with no contract row at all, for the same reason", async () => {
+        const { wallet } = await withBrokenContract();
+        const manager = await wallet.getContractManager();
+        await expect(
+            manager.assertAnnotatable([
+                { txid: "ab".repeat(32), vout: 0, script: "5120" + "cd".repeat(32) },
+            ]),
+        ).rejects.toThrow(/no contract registered/);
     });
 });

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -436,3 +436,75 @@ describe("spending sites consume the accessor", () => {
         expect(wallet.getSpendableVtxos).toHaveBeenCalled();
     });
 });
+
+describe("logUngatedInputs", () => {
+    // A real point: the contract manager builds a script from every stored row.
+    const DEPRECATED_KEY = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+    const EXPIRED_SCRIPT = "51200000000000000000000000000000000000000000000000000000000000000004";
+
+    /** Every debug line the call emitted, in order. */
+    const captureDebug = async (run: () => Promise<void>): Promise<string[]> => {
+        const lines: string[] = [];
+        const spy = vi.spyOn(console, "debug").mockImplementation((...args: unknown[]) => {
+            lines.push(args.join(" "));
+        });
+        await run();
+        spy.mockRestore();
+        return lines.filter((l) => l.startsWith("[spendability]"));
+    };
+
+    it("reports all three exclusions, not just the contract gate", async () => {
+        const intents = new InMemoryIntentRepository();
+        const { wallet, contractRepository, defaultScript } = await seededWallet({ intents });
+
+        // A contract on a deprecated signer whose cutoff has passed: the
+        // operator will not co-sign a spend of it.
+        await contractRepository.saveContract({
+            ...contract(EXPIRED_SCRIPT, "default"),
+            params: { ...createDefaultContractParams(), serverPubKey: DEPRECATED_KEY },
+        });
+        wallet.refreshDeprecatedSigners({
+            deprecatedSigners: [{ pubkey: DEPRECATED_KEY, cutoffDate: 1n }],
+        });
+
+        const lockedTxid = "e3".repeat(32);
+        await intents.saveIntent({
+            intentTxId: "i",
+            createdAt: 1,
+            updatedAt: 1,
+            registerProof: "",
+            registerProofMessage: "",
+            deleteProof: "",
+            deleteProofMessage: "",
+            partialForfeits: [],
+            state: "batch_in_progress",
+            intentVtxos: [{ txid: lockedTxid, vout: 0 }],
+        });
+
+        const inputs = [
+            vtxo(ESCROW_SCRIPT, 10_000),
+            vtxo(EXPIRED_SCRIPT, 10_000),
+            { ...vtxo(defaultScript, 10_000), txid: lockedTxid },
+            vtxo(MARKED_SCRIPT, 10_000),
+        ];
+
+        const lines = await captureDebug(() =>
+            wallet.logUngatedInputs("settle({ inputs })", inputs),
+        );
+
+        expect(lines).toHaveLength(3);
+        expect(lines[0]).toContain("is not generically spendable");
+        expect(lines[1]).toContain("rotation cutoff");
+        expect(lines[2]).toContain("in-flight settlement intent");
+        // The one input generic selection would have picked stays silent.
+        expect(lines.join("\n")).not.toContain(MARKED_SCRIPT.slice(-2).repeat(32));
+    });
+
+    it("says nothing about inputs generic selection would have picked", async () => {
+        const { wallet, defaultScript } = await seededWallet();
+        const lines = await captureDebug(() =>
+            wallet.logUngatedInputs("buildAndSubmitOffchainTx", [vtxo(defaultScript, 10_000)]),
+        );
+        expect(lines).toEqual([]);
+    });
+});

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -52,6 +52,7 @@ const createMockWallet = (
 
     return {
         getVtxos: vi.fn().mockResolvedValue(vtxos),
+        getSpendableVtxos: vi.fn().mockResolvedValue(vtxos),
         getAddress: vi.fn().mockResolvedValue(arkAddress),
         getDelegateManager: vi.fn().mockResolvedValue(options.delegateManager),
         getContractManager: vi.fn().mockResolvedValue(contractManager),
@@ -1714,6 +1715,7 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
 
         return {
             getVtxos: vi.fn().mockResolvedValue([]),
+            getSpendableVtxos: vi.fn().mockResolvedValue([]),
             getAddress: vi
                 .fn()
                 .mockResolvedValue(
@@ -1897,6 +1899,7 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
             // A minimal IWallet that lacks boardingTapscript/onchainProvider/network
             const minimalWallet = {
                 getVtxos: vi.fn().mockResolvedValue([]),
+                getSpendableVtxos: vi.fn().mockResolvedValue([]),
                 getAddress: vi
                     .fn()
                     .mockResolvedValue(
@@ -1945,6 +1948,7 @@ describe("VtxoManager - Boarding UTXO Sweep", () => {
 
             return {
                 getVtxos: vi.fn().mockResolvedValue([]),
+                getSpendableVtxos: vi.fn().mockResolvedValue([]),
                 getAddress: vi
                     .fn()
                     .mockResolvedValue(
@@ -2260,6 +2264,7 @@ describe("VtxoManager - Periodic settle cooldown", () => {
         };
         return {
             getVtxos: vi.fn().mockResolvedValue([]),
+            getSpendableVtxos: vi.fn().mockResolvedValue([]),
             getAddress: vi
                 .fn()
                 .mockResolvedValue(
@@ -2542,6 +2547,7 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
         };
         return {
             getVtxos: vi.fn().mockResolvedValue(vtxos),
+            getSpendableVtxos: vi.fn().mockResolvedValue(vtxos),
             getAddress: vi
                 .fn()
                 .mockResolvedValue(
@@ -2968,6 +2974,7 @@ describe("VtxoManager - Cross-instance poll guard", () => {
         };
         return {
             getVtxos: vi.fn().mockResolvedValue([]),
+            getSpendableVtxos: vi.fn().mockResolvedValue([]),
             getAddress: vi
                 .fn()
                 .mockResolvedValue(
@@ -3106,6 +3113,7 @@ describe("VtxoManager - VTXO_ALREADY_SPENT reconciliation", () => {
         return {
             wallet: {
                 getVtxos: vi.fn().mockResolvedValue(vtxos),
+                getSpendableVtxos: vi.fn().mockResolvedValue(vtxos),
                 getAddress: vi
                     .fn()
                     .mockResolvedValue(

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -1498,6 +1498,39 @@ describe("WalletMessageHandler repo-backed reads", () => {
         expect(vtxos[0].txid).toBe("aa".repeat(32));
     });
 
+    it("GET_VTXOS returns unrolled VTXOs only when asked", async () => {
+        setupHandler();
+        const settled = createMockExtendedVtxo({
+            txid: "aa".repeat(32),
+            value: 50000,
+            virtualStatus: { state: "settled" },
+        });
+        // Unrolling spends the virtual output, so nothing but the filter can surface it.
+        const unrolled = createMockExtendedVtxo({
+            txid: "bb".repeat(32),
+            value: 50000,
+            virtualStatus: { state: "settled" },
+            isSpent: true,
+            isUnrolled: true,
+        });
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [settled, unrolled]);
+
+        const get = async (filter: Record<string, boolean>) =>
+            (
+                (await updater.handleMessage({
+                    ...baseMessage(),
+                    type: "GET_VTXOS",
+                    payload: { filter },
+                } as any)) as any
+            ).payload.vtxos.map((v: any) => v.txid);
+
+        expect(await get({ withRecoverable: true })).toEqual(["aa".repeat(32)]);
+        expect(await get({ withRecoverable: true, withUnrolled: true })).toEqual([
+            "aa".repeat(32),
+            "bb".repeat(32),
+        ]);
+    });
+
     it("GET_BALANCE reads from repository, not indexer", async () => {
         setupHandler();
         const settled = createMockExtendedVtxo({

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -508,6 +508,7 @@ describe("WalletMessageHandler handleMessage", () => {
         };
         (updater as any).walletRepository = {
             getVtxos: vi.fn().mockResolvedValue([]),
+            getSpendableVtxos: vi.fn().mockResolvedValue([]),
         };
         // wallet is NOT set — readonly only
 
@@ -566,6 +567,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue(vtxos),
+            getSpendableVtxos: vi.fn().mockResolvedValue(vtxos),
             getDelegateManager: vi.fn().mockResolvedValue({
                 delegate: delegateSpy,
             }),
@@ -609,6 +611,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue(vtxos),
+            getSpendableVtxos: vi.fn().mockResolvedValue(vtxos),
             getDelegateManager: vi.fn().mockResolvedValue({
                 delegate: delegateSpy,
             }),
@@ -639,6 +642,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue(allVtxos),
+            getSpendableVtxos: vi.fn().mockResolvedValue(allVtxos),
             getDelegateManager: vi.fn().mockResolvedValue({ delegate: delegateSpy }),
         };
 
@@ -659,6 +663,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue([]),
+            getSpendableVtxos: vi.fn().mockResolvedValue([]),
             getDelegateManager: vi.fn().mockResolvedValue(undefined),
         };
 
@@ -1254,6 +1259,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).indexerProvider = {};
         (updater as any).walletRepository = {
             getVtxos: vi.fn().mockResolvedValue([]),
+            getSpendableVtxos: vi.fn().mockResolvedValue([]),
             saveVtxos: vi.fn().mockResolvedValue(undefined),
             getUtxos: vi.fn().mockResolvedValue([]),
             deleteUtxos: vi.fn().mockResolvedValue(undefined),
@@ -1290,6 +1296,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).indexerProvider = {};
         (updater as any).walletRepository = {
             getVtxos: vi.fn().mockResolvedValue([]),
+            getSpendableVtxos: vi.fn().mockResolvedValue([]),
             saveVtxos: vi.fn().mockResolvedValue(undefined),
             getUtxos: vi.fn().mockResolvedValue([]),
             deleteUtxos: vi.fn().mockResolvedValue(undefined),
@@ -1582,8 +1589,8 @@ describe("WalletMessageHandler repo-backed reads", () => {
 
     it("GET_VTXOS aggregates across contract addresses", async () => {
         const contracts = [
-            { address: "contract-1", script: "s1" },
-            { address: "contract-2", script: "s2" },
+            { address: "contract-1", script: "s1", type: "default" },
+            { address: "contract-2", script: "s2", type: "default" },
         ];
         setupHandler(contracts);
 
@@ -1614,8 +1621,8 @@ describe("WalletMessageHandler repo-backed reads", () => {
 
     it("GET_BALANCE accounts for VTXOs from all contracts", async () => {
         const contracts = [
-            { address: "contract-1", script: "s1" },
-            { address: "contract-2", script: "s2" },
+            { address: "contract-1", script: "s1", type: "default" },
+            { address: "contract-2", script: "s2", type: "default" },
         ];
         setupHandler(contracts);
 
@@ -1648,6 +1655,67 @@ describe("WalletMessageHandler repo-backed reads", () => {
                 available: 30000,
             },
         });
+    });
+
+    it("GET_BALANCE gates escrowed funds out of available but keeps them owned", async () => {
+        const contracts = [
+            { address: "contract-1", script: "s1", type: "default" },
+            // An unmarked arkade row: the escrow case the gate exists for.
+            { address: "contract-2", script: "s2", type: "arkade" },
+        ];
+        setupHandler(contracts);
+
+        await walletRepo.saveVtxos("contract-1", [
+            createMockExtendedVtxo({
+                txid: "aa".repeat(32),
+                value: 10000,
+                virtualStatus: { state: "settled" },
+                script: "s1",
+                assets: [{ assetId: "cc".repeat(32), amount: 3n }],
+            }),
+        ]);
+        await walletRepo.saveVtxos("contract-2", [
+            createMockExtendedVtxo({
+                txid: "bb".repeat(32),
+                value: 20000,
+                virtualStatus: { state: "settled" },
+                script: "s2",
+                assets: [{ assetId: "cc".repeat(32), amount: 4n }],
+            }),
+        ]);
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "GET_BALANCE",
+        } as any);
+
+        expect(response).toMatchObject({
+            type: "BALANCE",
+            payload: {
+                settled: 30000,
+                total: 30000,
+                available: 10000,
+                assets: [{ assetId: "cc".repeat(32), amount: 7n }],
+                availableAssets: [{ assetId: "cc".repeat(32), amount: 3n }],
+            },
+        });
+    });
+
+    it("GET_SPENDABLE_VTXOS delegates to the wallet's gated accessor", async () => {
+        setupHandler();
+        const vtxos = [createMockExtendedVtxo({ txid: "aa".repeat(32) })];
+        (updater as any).readonlyWallet.getSpendableVtxos = vi.fn().mockResolvedValue(vtxos);
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "GET_SPENDABLE_VTXOS",
+            payload: { filter: { withRecoverable: false } },
+        } as any);
+
+        expect((updater as any).readonlyWallet.getSpendableVtxos).toHaveBeenCalledWith({
+            withRecoverable: false,
+        });
+        expect(response).toMatchObject({ type: "SPENDABLE_VTXOS", payload: { vtxos } });
     });
 
     it("GET_VTXOS deduplicates across wallet and contract addresses", async () => {

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -568,6 +568,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue(vtxos),
             getSpendableVtxos: vi.fn().mockResolvedValue(vtxos),
+            logUngatedInputs: vi.fn().mockResolvedValue(undefined),
             getDelegateManager: vi.fn().mockResolvedValue({
                 delegate: delegateSpy,
             }),
@@ -586,6 +587,9 @@ describe("WalletMessageHandler handleMessage", () => {
         } as any);
 
         expect(delegateSpy).toHaveBeenCalledWith(vtxos, "dest-addr", undefined);
+        // Delegation hands spending authority away, so the crossing is reported
+        // through the wallet's shared check rather than a local one-reason copy.
+        expect((updater as any).wallet.logUngatedInputs).toHaveBeenCalledWith("delegate", vtxos);
         expect(response).toMatchObject({
             tag: updater.messageTag,
             type: "DELEGATE_SUCCESS",
@@ -612,6 +616,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue(vtxos),
             getSpendableVtxos: vi.fn().mockResolvedValue(vtxos),
+            logUngatedInputs: vi.fn().mockResolvedValue(undefined),
             getDelegateManager: vi.fn().mockResolvedValue({
                 delegate: delegateSpy,
             }),
@@ -643,6 +648,7 @@ describe("WalletMessageHandler handleMessage", () => {
         (updater as any).wallet = {
             getVtxos: vi.fn().mockResolvedValue(allVtxos),
             getSpendableVtxos: vi.fn().mockResolvedValue(allVtxos),
+            logUngatedInputs: vi.fn().mockResolvedValue(undefined),
             getDelegateManager: vi.fn().mockResolvedValue({ delegate: delegateSpy }),
         };
 
@@ -1427,6 +1433,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
             }),
             dustAmount: 546n,
             pendingRecoveryOutpoints: vi.fn().mockResolvedValue(new Set<string>()),
+            pendingRecoveryOutpointsIn: vi.fn().mockReturnValue(new Set<string>()),
             getContractManager: vi.fn().mockResolvedValue({
                 getContracts: vi.fn().mockResolvedValue(contracts),
                 onContractEvent: vi.fn().mockReturnValue(vi.fn()),
@@ -1576,9 +1583,9 @@ describe("WalletMessageHandler repo-backed reads", () => {
         await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [settled, pendingExpired]);
 
         // The wallet reports the past-cutoff (EXPIRED) VTXO as pending recovery.
-        (updater as any).readonlyWallet.pendingRecoveryOutpoints = vi
+        (updater as any).readonlyWallet.pendingRecoveryOutpointsIn = vi
             .fn()
-            .mockResolvedValue(new Set([`${pendingExpired.txid}:${pendingExpired.vout}`]));
+            .mockReturnValue(new Set([`${pendingExpired.txid}:${pendingExpired.vout}`]));
 
         const response = await updater.handleMessage({
             ...baseMessage(),
@@ -1596,6 +1603,61 @@ describe("WalletMessageHandler repo-backed reads", () => {
                 total: 170000,
             },
         });
+    });
+
+    it("GET_BALANCE derives the VTXOs and the gate from one read of the contract rows", async () => {
+        const gatedContract = {
+            type: "arkade",
+            params: {},
+            script: "5120" + "11".repeat(32),
+            address: "gated-address",
+            state: "active",
+            createdAt: 1,
+        };
+        setupHandler([gatedContract]);
+        await walletRepo.saveVtxos(gatedContract.address, [
+            createMockExtendedVtxo({
+                txid: "dd".repeat(32),
+                value: 30000,
+                script: gatedContract.script,
+                virtualStatus: { state: "settled" },
+            }),
+        ]);
+
+        const manager = await (updater as any).readonlyWallet.getContractManager();
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "GET_BALANCE",
+        } as any);
+
+        // Two reads race the contract manager's writes: a row landing between
+        // them yields VTXOs the gate has never seen, and `gatedContracts` lists
+        // only what it knows is closed — so they would count as available.
+        expect(manager.getContracts).toHaveBeenCalledTimes(1);
+        expect(response).toMatchObject({
+            type: "BALANCE",
+            payload: { settled: 30000, total: 30000, available: 0 },
+        });
+    });
+
+    it("GET_BALANCE derives pending recovery without the syncing accessor", async () => {
+        setupHandler();
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [
+            createMockExtendedVtxo({
+                txid: "aa".repeat(32),
+                value: 100000,
+                virtualStatus: { state: "settled" },
+            }),
+        ]);
+
+        await updater.handleMessage({ ...baseMessage(), type: "GET_BALANCE" } as any);
+
+        // `pendingRecoveryOutpoints()` takes a fresh contractSnapshot(), which
+        // syncs — the one thing this repo-backed read promises not to do.
+        const wallet = (updater as any).readonlyWallet;
+        expect(wallet.pendingRecoveryOutpoints).not.toHaveBeenCalled();
+        expect(wallet.pendingRecoveryOutpointsIn).toHaveBeenCalled();
+        expect(mockIndexer.getVtxos).not.toHaveBeenCalled();
     });
 
     it("GET_TRANSACTION_HISTORY reads from repository, not indexer", async () => {

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -2012,7 +2012,7 @@ describe("Wallet._settleImpl", () => {
             }).script,
         );
 
-        const makeVtxo = (value: number, i: number): ExtendedVirtualCoin =>
+        const makeVtxo = (value: number, i: number | string): ExtendedVirtualCoin =>
             ({
                 txid: `vtxo-${value}-${i}`,
                 vout: 0,
@@ -2046,6 +2046,9 @@ describe("Wallet._settleImpl", () => {
                 },
             }) as ExtendedCoin;
 
+        // A gated (e.g. escrowed) coin: reported by getVtxos, withheld by getSpendableVtxos.
+        const gatedVtxo = makeVtxo(1_000_000, "gated");
+
         // Build a `this` for _settleImpl that runs the auto-select branch and
         // short-circuits at makeRegisterIntentSignature, capturing the final
         // selected inputs (which is what gets registered with the server).
@@ -2074,7 +2077,10 @@ describe("Wallet._settleImpl", () => {
                 },
                 boardingTapscript: { exitScript: exitScriptHex },
                 getBoardingUtxos: vi.fn().mockResolvedValue(boardingUtxos),
-                getVtxos: vi.fn().mockResolvedValue(vtxos),
+                // The gate lives in getSpendableVtxos: the raw read carries a coin
+                // auto-selection must never reach for (and, at this value, would
+                // sort to the front of the batch if it did).
+                getVtxos: vi.fn().mockResolvedValue([...vtxos, gatedVtxo]),
                 getSpendableVtxos: vi.fn().mockResolvedValue(vtxos),
                 getAddress: vi.fn().mockResolvedValue(walletAddress),
                 identity: {
@@ -2094,6 +2100,18 @@ describe("Wallet._settleImpl", () => {
             };
             return { thisArg, sentinel, getCaptured: () => capturedInputs };
         };
+
+        it("auto-selects from the gated read", async () => {
+            const vtxos = [makeVtxo(5_000, 0), makeVtxo(7_000, 1)];
+            const { thisArg, sentinel, getCaptured } = buildThisArg(vtxos, {});
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            expect(getCaptured()!.map((v: any) => v.txid)).toEqual(["vtxo-7000-1", "vtxo-5000-0"]);
+            expect(thisArg.getSpendableVtxos).toHaveBeenCalled();
+        });
 
         it("caps the number of auto-selected VTXOs at MAX_VTXOS_PER_SETTLEMENT", async () => {
             const value = 5_000;

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -1856,6 +1856,9 @@ describe("Wallet._settleImpl", () => {
                 message: { type: "delete", expire_at: 0 },
             }),
             logUngatedInputs: vi.fn().mockResolvedValue(undefined),
+            getContractManager: vi.fn().mockResolvedValue({
+                assertAnnotatable: vi.fn().mockResolvedValue(undefined),
+            }),
             safeRegisterIntent,
             createBatchHandler,
             updateDbAfterSettle,
@@ -1928,6 +1931,9 @@ describe("Wallet._settleImpl", () => {
                 message: { type: "delete", expire_at: 0 },
             }),
             logUngatedInputs: vi.fn().mockResolvedValue(undefined),
+            getContractManager: vi.fn().mockResolvedValue({
+                assertAnnotatable: vi.fn().mockResolvedValue(undefined),
+            }),
             safeRegisterIntent: vi.fn(async () => {
                 callOrder.push("safeRegisterIntent");
                 throw registerError;
@@ -1984,6 +1990,9 @@ describe("Wallet._settleImpl", () => {
                 message: { type: "delete", expire_at: 0 },
             }),
             logUngatedInputs: vi.fn().mockResolvedValue(undefined),
+            getContractManager: vi.fn().mockResolvedValue({
+                assertAnnotatable: vi.fn().mockResolvedValue(undefined),
+            }),
             safeRegisterIntent: vi.fn().mockResolvedValue("intent-id"),
             createBatchHandler: vi.fn().mockReturnValue({} as Batch.Handler),
             updateDbAfterSettle: vi.fn().mockRejectedValue(new Error("db write failed")),

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -1855,6 +1855,7 @@ describe("Wallet._settleImpl", () => {
                 proof: "delete-proof",
                 message: { type: "delete", expire_at: 0 },
             }),
+            logUngatedInputs: vi.fn().mockResolvedValue(undefined),
             safeRegisterIntent,
             createBatchHandler,
             updateDbAfterSettle,
@@ -1926,6 +1927,7 @@ describe("Wallet._settleImpl", () => {
                 proof: "delete-proof",
                 message: { type: "delete", expire_at: 0 },
             }),
+            logUngatedInputs: vi.fn().mockResolvedValue(undefined),
             safeRegisterIntent: vi.fn(async () => {
                 callOrder.push("safeRegisterIntent");
                 throw registerError;
@@ -1981,6 +1983,7 @@ describe("Wallet._settleImpl", () => {
                 proof: "delete-proof",
                 message: { type: "delete", expire_at: 0 },
             }),
+            logUngatedInputs: vi.fn().mockResolvedValue(undefined),
             safeRegisterIntent: vi.fn().mockResolvedValue("intent-id"),
             createBatchHandler: vi.fn().mockReturnValue({} as Batch.Handler),
             updateDbAfterSettle: vi.fn().mockRejectedValue(new Error("db write failed")),
@@ -2072,6 +2075,7 @@ describe("Wallet._settleImpl", () => {
                 boardingTapscript: { exitScript: exitScriptHex },
                 getBoardingUtxos: vi.fn().mockResolvedValue(boardingUtxos),
                 getVtxos: vi.fn().mockResolvedValue(vtxos),
+                getSpendableVtxos: vi.fn().mockResolvedValue(vtxos),
                 getAddress: vi.fn().mockResolvedValue(walletAddress),
                 identity: {
                     signerSession: () => ({

--- a/packages/ts-sdk/test/worker/messageBus.test.ts
+++ b/packages/ts-sdk/test/worker/messageBus.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { InMemoryWalletRepository, InMemoryContractRepository } from "../../src";
+import {
+    InMemoryWalletRepository,
+    InMemoryContractRepository,
+    InMemoryIntentRepository,
+    Wallet,
+    type IntentRepository,
+} from "../../src";
 import {
     MessageBus,
     MessageHandler,
@@ -1173,5 +1179,39 @@ describe("MessageBus init serialization (Iteration 1)", () => {
         expect(new MessageBusNotInitializedError().message.includes(MESSAGE_BUS_INITIALIZING)).toBe(
             false,
         );
+    });
+});
+
+describe("MessageBus default buildServices", () => {
+    const config = {
+        wallet: { privateKey: "15".repeat(32) },
+        arkServer: { url: "https://ark.example.test" },
+    } as never;
+
+    const buildServices = async (intentRepository?: IntentRepository) => {
+        const bus = new MessageBus(
+            new InMemoryWalletRepository(),
+            new InMemoryContractRepository(),
+            { messageHandlers: [], ...(intentRepository ? { intentRepository } : {}) },
+        );
+        const create = vi
+            .spyOn(Wallet, "create")
+            .mockResolvedValue({ dispose: vi.fn() } as unknown as Wallet);
+        await (bus as any).buildServices(config);
+        const storage = create.mock.calls[0][0].storage;
+        create.mockRestore();
+        return storage;
+    };
+
+    it("hands the configured intentRepository to the worker's wallet", async () => {
+        // Without this the worker builds an intent-repo-less wallet: no
+        // persisted intents, no reconciliation on restart, and intent-locked
+        // VTXOs counted as available — silently unlike a main-thread wallet.
+        const intentRepository = new InMemoryIntentRepository();
+        expect(await buildServices(intentRepository)).toMatchObject({ intentRepository });
+    });
+
+    it("leaves it unset when none is configured", async () => {
+        expect(await buildServices()).not.toHaveProperty("intentRepository");
     });
 });


### PR DESCRIPTION
Phase 0 of `plans/arkade-swap-contract-manager-integration.md`. Core-only; no `packages/swap` changes.

A registered covenant whose collaborative leaf the wallet can sign is selectable by ordinary coin selection today — including by background renewal, which needs no user action. Escrow is not derivable from a program artifact, so spendability becomes a declared per-contract capability.

- `ContractHandler.isGenericallySpendable?(contract)` — absent means not spendable. `default`/`delegate`/`boarding`/`vhtlc` answer `true` (no behaviour change); `arkade` answers only for `metadata.genericallySpendable === true`.
- `IReadonlyWallet.getSpendableVtxos(filter?)` — required member, one snapshot composing the gate, pending recovery and intent locks. `send`, `settle`, renewal, the three asset operations and `offboard` route through it; `getVtxos`, `recoverVtxos` and history stay on the raw read.
- `available` and the new `WalletBalance.availableAssets` are gated; the totals and `assets` are not. Both threads share one bucketing function over their own read — the service worker keeps its sync-free repository read.
- Service worker gets `GET_SPENDABLE_VTXOS`; a page against a worker that predates it fails closed.

Declared behaviour changes: `settle`, renewal, the asset operations and `offboard` now also skip past-cutoff deprecated-signer VTXOs and intent-locked outpoints. Explicit-input APIs stay ungated by design (`settle({ inputs })` et al.), with a debug log when they cross the gate.

Deviation from the plan: the predicate takes only `contract`, not `(script, contract)` — deriving the script costs a taproot tree per contract on a read path (#521) and no shipped handler needs it.

Migration note: `docs/generic-spending-gate.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spendable VTXO retrieval with optional filtering across wallet interfaces and service-worker wallets.
  * Wallet balances now distinguish spendable, recoverable, pending, settled, and available asset amounts.
  * Added contract-based safeguards to exclude restricted funds from automatic spending and selection.
  * Asset issuance, renewal, settlement, and offboarding now use spendable funds where appropriate.
* **Behavior Updates**
  * Explicitly selected inputs remain supported, including inputs that are not generically spendable.
  * Added diagnostics for excluded or gated VTXOs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->