### PR TITLE
swap: client-unilateral refund leaf, matching the reference solver

### DIFF
--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -53,6 +53,7 @@ export {
     requestLightningSend,
     rfqPair,
     unilateralClaimDelay,
+    unilateralRefundWithoutReceiverDelay,
     verifyLockupAddress,
     type InvoiceFacts,
     type RelaySocket,

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -33,6 +33,7 @@
  */
 import { hex } from "@scure/base";
 import { ripemd160 } from "@noble/hashes/legacy.js";
+import { schnorr } from "@noble/curves/secp256k1.js";
 import {
     ArkAddress,
     RestArkProvider,
@@ -173,18 +174,27 @@ export interface RfqStatus {
 }
 
 /** The rfq_request for the lightning send profile. A BOLT11 profile is always
- * exact-out: the invoice fixes the amount, so none is restated here. */
+ * exact-out: the invoice fixes the amount, so none is restated here.
+ * `clientRefundPubkey` is the trader's own key for the covenant's
+ * client-unilateral refund leaf (see {@link lightningSendVtxoScript}) —
+ * required, never sent anywhere else, never trusted by the solver as
+ * anything but a pubkey to bind into the script. */
 export const lightningSendRequest = (input: {
     rfqId: string;
     invoice: string;
     refundAddress: string;
+    clientRefundPubkey: Uint8Array;
 }): Record<string, unknown> => ({
     v: 1,
     type: "rfq_request",
     rfq_id: input.rfqId,
     pair: LIGHTNING_SEND_PAIR,
     amount_side: "to",
-    profile: { invoice: input.invoice, refund_address: input.refundAddress },
+    profile: {
+        invoice: input.invoice,
+        refund_address: input.refundAddress,
+        client_refund_pubkey: hex.encode(input.clientRefundPubkey),
+    },
 });
 
 /** The rfq_request for an arkade↔arkade swap. Exactly one side may name an
@@ -502,6 +512,15 @@ export const unilateralClaimDelay = (serverExitDelaySeconds: number): number => 
     );
 };
 
+/** The client-unilateral refund leaf's CSV delay: one 512s tier past the
+ * solver's own unilateral-claim delay, preserving the mandatory
+ * `claim < ... < refundWithoutReceiver` ordering the reference solver's own
+ * three-tier ladder uses (it reserves the middle tier for a server-cooperative,
+ * emulator-free path this SDK does not build). Takes the already-rounded
+ * `claimDelay`, not the raw server exit delay — one rounding, shared. */
+export const unilateralRefundWithoutReceiverDelay = (claimDelay: number): number =>
+    claimDelay + 2 * SEQUENCE_GRANULARITY_SECONDS;
+
 /** Compile the lightning-send contract from the quote's binding fields plus
  * the trader's own data. `paymentHash` is the BOLT11 payment hash
  * (`sha256(P)`, hex); the script's HASH160 commitment is derived from it here,
@@ -521,6 +540,14 @@ export function lightningSendVtxoScript(params: {
     emulatorPubkey: Uint8Array;
     /** Where a refund must pay: the trader's P2TR pkScript (34 bytes). */
     refundPkScript: Uint8Array;
+    /** The trader's own key for the client-unilateral refund leaf — needs
+     * neither the Ark server nor the emulator once its own CSV matures.
+     * Required: every RFQ-family request this module builds now carries
+     * `client_refund_pubkey`, so there is no three-leaf shape to fall back to. */
+    clientRefundPubkey: Uint8Array;
+    /** From {@link unilateralRefundWithoutReceiverDelay} over the SAME
+     * `claimDelay` passed above — one rounding, shared between both leaves. */
+    clientRefundDelay: number;
 }): InstanceType<typeof arkade.ArkadeProgramScript> {
     return new arkade.ArkadeProgramScript(
         lightningSendProgram,
@@ -533,6 +560,8 @@ export function lightningSendVtxoScript(params: {
             // the covenant commits to the x-only key; the 0x5120 prefix is
             // re-added by the introspection opcode reading the output script
             refundKey: params.refundPkScript.subarray(2),
+            client: params.clientRefundPubkey,
+            clientRefundDelay: BigInt(params.clientRefundDelay),
         },
         { serverKey: params.serverPubkey, emulatorKey: params.emulatorPubkey },
     );
@@ -561,6 +590,12 @@ export interface InvoiceFacts {
  *
  * Throws {@link SwapRefusal} (closed reason), {@link AddressMismatch} (never
  * fund), or a gate error with a stable `reason`.
+ *
+ * Generates a fresh client-unilateral refund key per call and returns it as
+ * `clientRefundPubkey`/`clientRefundPrivateKey`. THIS FUNCTION DOES NOT
+ * PERSIST IT: a caller that discards the return value has traded away its
+ * only recourse if the Ark server and the emulator are ever both
+ * unavailable, without knowing it.
  */
 export async function requestLightningSend(
     wallet: IWallet,
@@ -579,8 +614,14 @@ export async function requestLightningSend(
     swapPkScript: Uint8Array;
     /** Where a failed swap provably refunds. */
     refundAddress: string;
+    /** The client-unilateral refund leaf's key — PERSIST BOTH before going
+     * offline, or this swap's only non-cooperative recourse is lost. */
+    clientRefundPubkey: Uint8Array;
+    clientRefundPrivateKey: Uint8Array;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
+    const clientRefundPrivateKey = schnorr.utils.randomSecretKey();
+    const clientRefundPubkey = schnorr.getPublicKey(clientRefundPrivateKey);
     const [info, emulatorInfo, refundAddress] = await Promise.all([
         new RestArkProvider(arkServerUrl).getInfo(),
         new RestEmulatorProvider(emulatorUrl).getInfo(),
@@ -588,21 +629,29 @@ export async function requestLightningSend(
     ]);
 
     const quote = await transport.requestQuote(
-        lightningSendRequest({ rfqId, invoice: params.invoice.raw, refundAddress }),
+        lightningSendRequest({
+            rfqId,
+            invoice: params.invoice.raw,
+            refundAddress,
+            clientRefundPubkey,
+        }),
     );
     if (quote.refund_locktime === undefined) {
         throw new Error("lightning-send quote is missing refund_locktime");
     }
 
     const serverPubkey = xOnly(hex.decode(info.signerPubkey), "ark signer key");
+    const claimDelay = unilateralClaimDelay(Number(info.unilateralExitDelay));
     const script = lightningSendVtxoScript({
         solverPubkey: xOnly(hex.decode(quote.solver_pubkey), "solver key"),
         refundLocktime: quote.refund_locktime,
         serverPubkey,
         paymentHash: params.invoice.paymentHash,
-        claimDelay: unilateralClaimDelay(Number(info.unilateralExitDelay)),
+        claimDelay,
         emulatorPubkey: xOnly(hex.decode(emulatorInfo.signerPubkey), "emulator signer key"),
         refundPkScript: ArkAddress.decode(refundAddress).pkScript,
+        clientRefundPubkey,
+        clientRefundDelay: unilateralRefundWithoutReceiverDelay(claimDelay),
     });
     const address = script
         .address(getNetwork(info.network as NetworkName).hrp, serverPubkey)
@@ -621,6 +670,8 @@ export async function requestLightningSend(
         fundAmount: params.invoice.amountSats,
         swapPkScript: script.pkScript,
         refundAddress,
+        clientRefundPubkey,
+        clientRefundPrivateKey,
     };
 }
 
@@ -664,6 +715,9 @@ export const onchainSendRequest = (input: {
     payoutPubkey: Uint8Array;
     /** Maker's arkade address — where the covenant refund must pay. */
     refundAddress: string;
+    /** Maker's own key for the covenant's client-unilateral refund leaf —
+     * same role as in {@link lightningSendRequest}. */
+    clientRefundPubkey: Uint8Array;
     amount: number;
     amountSide: "from" | "to";
 }): Record<string, unknown> => ({
@@ -677,6 +731,7 @@ export const onchainSendRequest = (input: {
         payment_hash: input.paymentHash,
         payout_pubkey: hex.encode(input.payoutPubkey),
         refund_address: input.refundAddress,
+        client_refund_pubkey: hex.encode(input.clientRefundPubkey),
     },
 });
 
@@ -727,6 +782,10 @@ export function deriveOnchainSend(input: {
     hrp: string;
     l1Network: OnchainNetwork;
     refundAddress: string;
+    /** The maker's own key for the covenant's client-unilateral refund leaf —
+     * same role as in {@link requestLightningSend}. */
+    clientRefundPubkey: Uint8Array;
+    clientRefundDelay: number;
 }): {
     address: string;
     swapPkScript: Uint8Array;
@@ -759,6 +818,8 @@ export function deriveOnchainSend(input: {
         claimDelay: input.claimDelay,
         emulatorPubkey: input.emulatorPubkey,
         refundPkScript: ArkAddress.decode(input.refundAddress).pkScript,
+        clientRefundPubkey: input.clientRefundPubkey,
+        clientRefundDelay: input.clientRefundDelay,
     });
     const address = script.address(input.hrp, input.serverPubkey).encode();
     verifyLockupAddress(quote, address);
@@ -796,6 +857,11 @@ export function deriveOnchainSend(input: {
  *   offline: it must claim the L1 HTLC (`awaitOnchainFill` →
  *   `claimOnchainFill`) before `htlc.refundLocktime`. Missing that window
  *   forfeits the fill and falls back to the Arkade covenant refund.
+ *
+ * Generates a fresh client-unilateral refund key per call and returns it —
+ * same obligation as {@link requestLightningSend}: persist both halves
+ * before funding, or this swap's only non-cooperative Arkade-side recourse
+ * is lost.
  */
 export async function requestOnchainSend(
     wallet: IWallet,
@@ -822,10 +888,16 @@ export async function requestOnchainSend(
     refundAddress: string;
     /** The EXPECTED L1 fill, derived locally — watch and claim against this. */
     htlc: OnchainHtlc;
+    /** The Arkade covenant's client-unilateral refund leaf key — PERSIST
+     * BOTH before funding, same obligation as `preimage`. */
+    clientRefundPubkey: Uint8Array;
+    clientRefundPrivateKey: Uint8Array;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
     const preimage = params.preimage ?? newPreimage();
     const paymentHash = paymentHashOf(preimage);
+    const clientRefundPrivateKey = schnorr.utils.randomSecretKey();
+    const clientRefundPubkey = schnorr.getPublicKey(clientRefundPrivateKey);
     const [info, emulatorInfo, refundAddress] = await Promise.all([
         new RestArkProvider(arkServerUrl).getInfo(),
         new RestEmulatorProvider(emulatorUrl).getInfo(),
@@ -838,21 +910,25 @@ export async function requestOnchainSend(
             paymentHash,
             payoutPubkey: params.payoutPubkey,
             refundAddress,
+            clientRefundPubkey,
             amount: params.amount,
             amountSide: params.amountSide,
         }),
     );
 
+    const claimDelay = unilateralClaimDelay(Number(info.unilateralExitDelay));
     const derived = deriveOnchainSend({
         quote,
         paymentHash,
         payoutPubkey: params.payoutPubkey,
         serverPubkey: xOnly(hex.decode(info.signerPubkey), "ark signer key"),
         emulatorPubkey: xOnly(hex.decode(emulatorInfo.signerPubkey), "emulator signer key"),
-        claimDelay: unilateralClaimDelay(Number(info.unilateralExitDelay)),
+        claimDelay,
         hrp: getNetwork(info.network as NetworkName).hrp,
         l1Network: l1NetworkFromArk(info.network),
         refundAddress,
+        clientRefundPubkey,
+        clientRefundDelay: unilateralRefundWithoutReceiverDelay(claimDelay),
     });
     assertFundable({
         quote,
@@ -873,5 +949,7 @@ export async function requestOnchainSend(
         swapPkScript: derived.swapPkScript,
         refundAddress,
         htlc: derived.htlc,
+        clientRefundPubkey,
+        clientRefundPrivateKey,
     };
 }

--- a/packages/swap/src/swap-lightning-send.program.json
+++ b/packages/swap/src/swap-lightning-send.program.json
@@ -7,7 +7,9 @@
     { "name": "preimageHash", "type": "hash" },
     { "name": "refundLocktime", "type": "int" },
     { "name": "claimDelay", "type": "int" },
-    { "name": "refundKey", "type": "pubkey" }
+    { "name": "refundKey", "type": "pubkey" },
+    { "name": "client", "type": "pubkey" },
+    { "name": "clientRefundDelay", "type": "int" }
   ],
   "functions": {
     "claim": {
@@ -39,6 +41,12 @@
         "signers": ["$receiver"],
         "asm": ["HASH160", "$preimageHash", "EQUAL"],
         "csv": { "type": "seconds", "value": "$claimDelay" }
+      }
+    },
+    "refundUnilateral": {
+      "tapscript": {
+        "signers": ["$client"],
+        "csv": { "type": "seconds", "value": "$clientRefundDelay" }
       }
     }
   }

--- a/packages/swap/test/onchainRfq.test.ts
+++ b/packages/swap/test/onchainRfq.test.ts
@@ -24,6 +24,7 @@ import {
     lightningSendVtxoScript,
     onchainReceiveRequest,
     onchainSendRequest,
+    unilateralRefundWithoutReceiverDelay,
     type RfqQuote,
 } from "../src/rfq";
 import { onchainHtlcScript, paymentHashOf } from "../src/onchainHtlc";
@@ -59,6 +60,7 @@ describe("request builders", () => {
                 paymentHash: PAYMENT_HASH,
                 payoutPubkey: key(5),
                 refundAddress: "ark1q...",
+                clientRefundPubkey: key(13),
                 amount: 100_000,
                 amountSide: "to",
             }),
@@ -73,6 +75,7 @@ describe("request builders", () => {
                 payment_hash: PAYMENT_HASH,
                 payout_pubkey: hex.encode(key(5)),
                 refund_address: "ark1q...",
+                client_refund_pubkey: hex.encode(key(13)),
             },
         });
     });
@@ -162,16 +165,21 @@ describe("assertFundable — onchain gates", () => {
 
 describe("deriveOnchainSend", () => {
     // The maker's own view of its stack: server key(3), emulator key(9),
-    // claim delay 4096 — and a real, decodable arkade refund address.
+    // client-unilateral-refund key(13), claim delay 4096 — and a real,
+    // decodable arkade refund address.
     const SERVER = key(3);
+    const CLAIM_DELAY = 4096;
+    const CLIENT_REFUND_DELAY = unilateralRefundWithoutReceiverDelay(CLAIM_DELAY);
     const REFUND_ADDRESS = lightningSendVtxoScript({
         solverPubkey: key(1),
         refundLocktime: REFUND_LOCKTIME,
         serverPubkey: SERVER,
         paymentHash: PAYMENT_HASH,
-        claimDelay: 4096,
+        claimDelay: CLAIM_DELAY,
         emulatorPubkey: key(9),
         refundPkScript: Uint8Array.from([0x51, 0x20, ...key(5)]),
+        clientRefundPubkey: key(13),
+        clientRefundDelay: CLIENT_REFUND_DELAY,
     })
         .address("ark", SERVER)
         .encode();
@@ -181,10 +189,12 @@ describe("deriveOnchainSend", () => {
         payoutPubkey: key(5),
         serverPubkey: SERVER,
         emulatorPubkey: key(9),
-        claimDelay: 4096,
+        claimDelay: CLAIM_DELAY,
         hrp: "ark",
         l1Network: "regtest" as const,
         refundAddress: REFUND_ADDRESS,
+        clientRefundPubkey: key(13),
+        clientRefundDelay: CLIENT_REFUND_DELAY,
     });
 
     /** A quote whose compare-only fields MATCH the maker's own derivations. */
@@ -195,9 +205,11 @@ describe("deriveOnchainSend", () => {
             refundLocktime: REFUND_LOCKTIME,
             serverPubkey: SERVER,
             paymentHash: PAYMENT_HASH,
-            claimDelay: 4096,
+            claimDelay: CLAIM_DELAY,
             emulatorPubkey: key(9),
             refundPkScript: ArkAddress.decode(REFUND_ADDRESS).pkScript,
+            clientRefundPubkey: key(13),
+            clientRefundDelay: CLIENT_REFUND_DELAY,
         });
         const htlc = onchainHtlcScript(
             {

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -26,6 +26,7 @@ import {
     offerTermsFromQuote,
     relayTransport,
     unilateralClaimDelay,
+    unilateralRefundWithoutReceiverDelay,
     verifyLockupAddress,
     type RelaySocket,
     type RfqQuote,
@@ -54,11 +55,14 @@ const quoteFixture = (over: Partial<RfqQuote> = {}): RfqQuote => ({
 describe("lightningSendVtxoScript", () => {
     // The reference solver's fixture, and its exact output bytes: receiver =
     // key(1), server = key(3), emulator = key(9), refund destination =
-    // p2tr(key(5)), preimage hash = ripemd160(sha256(0x07 * 32)), locktime
-    // 1_800_000_000, CSV 4096s.
+    // p2tr(key(5)), client-unilateral-refund key = key(13), preimage hash =
+    // ripemd160(sha256(0x07 * 32)), locktime 1_800_000_000, CSV 4096s /
+    // 5120s (claimDelay + 2*512, per unilateralRefundWithoutReceiverDelay).
     const PREIMAGE = new Uint8Array(32).fill(7);
     const PAYMENT_HASH = hex.encode(sha256(PREIMAGE));
     const REFUND_PK_SCRIPT = Uint8Array.from([0x51, 0x20, ...key(5)]);
+    const CLAIM_DELAY = 4096;
+    const CLIENT_REFUND_DELAY = unilateralRefundWithoutReceiverDelay(CLAIM_DELAY);
 
     const script = () =>
         lightningSendVtxoScript({
@@ -66,18 +70,20 @@ describe("lightningSendVtxoScript", () => {
             serverPubkey: key(3),
             paymentHash: PAYMENT_HASH,
             refundLocktime: 1_800_000_000,
-            claimDelay: 4096,
+            claimDelay: CLAIM_DELAY,
             emulatorPubkey: key(9),
             refundPkScript: REFUND_PK_SCRIPT,
+            clientRefundPubkey: key(13),
+            clientRefundDelay: CLIENT_REFUND_DELAY,
         });
 
     it("is byte-identical to the reference solver's script — golden scriptPubKey", () => {
         expect(hex.encode(script().pkScript)).toBe(
-            "5120599796afd33a8cf329579236d24b8d2d3952cac697c7253009e3c21653a350cd",
+            "5120f0efbb911dfde790f956c8414b0ca13150d94851685350f82a43c25b2bdab9d9",
         );
     });
 
-    it("compiles the three leaves the solver quotes, leaf for leaf", () => {
+    it("compiles the four leaves the solver quotes, leaf for leaf", () => {
         const compiled = script();
         const leaf = (name: string) => hex.encode(compiled.functionByName(name)!.leafScript);
         const hash160 = hex.encode(ripemd160(sha256(PREIMAGE)));
@@ -91,6 +97,10 @@ describe("lightningSendVtxoScript", () => {
         expect(leaf("unilateralClaim")).toBe(
             `a914${hash160}876903080040b275${"20"}${hex.encode(key(1))}ac`,
         );
+        // client alone, CSV(5120s), no server/emulator key anywhere in the leaf.
+        expect(leaf("refundUnilateral")).not.toContain(hex.encode(key(3)));
+        expect(leaf("refundUnilateral")).not.toContain(hex.encode(key(9)));
+        expect(leaf("refundUnilateral").endsWith(`20${hex.encode(key(13))}ac`)).toBe(true);
     });
 
     it("derives the HASH160 commitment from the payment hash — the trader never sees P", () => {
@@ -100,9 +110,26 @@ describe("lightningSendVtxoScript", () => {
             serverPubkey: key(3),
             paymentHash: hex.encode(sha256(new Uint8Array(32).fill(8))),
             refundLocktime: 1_800_000_000,
-            claimDelay: 4096,
+            claimDelay: CLAIM_DELAY,
             emulatorPubkey: key(9),
             refundPkScript: REFUND_PK_SCRIPT,
+            clientRefundPubkey: key(13),
+            clientRefundDelay: CLIENT_REFUND_DELAY,
+        });
+        expect(hex.encode(other.pkScript)).not.toBe(hex.encode(script().pkScript));
+    });
+
+    it("produces a different address than a client key alone would change", () => {
+        const other = lightningSendVtxoScript({
+            solverPubkey: key(1),
+            serverPubkey: key(3),
+            paymentHash: PAYMENT_HASH,
+            refundLocktime: 1_800_000_000,
+            claimDelay: CLAIM_DELAY,
+            emulatorPubkey: key(9),
+            refundPkScript: REFUND_PK_SCRIPT,
+            clientRefundPubkey: key(14),
+            clientRefundDelay: CLIENT_REFUND_DELAY,
         });
         expect(hex.encode(other.pkScript)).not.toBe(hex.encode(script().pkScript));
     });
@@ -123,14 +150,23 @@ describe("unilateralClaimDelay", () => {
 describe("requests", () => {
     it("builds the lightning-send request exact-out with the invoice in the profile", () => {
         expect(
-            lightningSendRequest({ rfqId: RFQ_ID, invoice: "lnbc...", refundAddress: "ark1q..." }),
+            lightningSendRequest({
+                rfqId: RFQ_ID,
+                invoice: "lnbc...",
+                refundAddress: "ark1q...",
+                clientRefundPubkey: key(13),
+            }),
         ).toEqual({
             v: 1,
             type: "rfq_request",
             rfq_id: RFQ_ID,
             pair: "arkade:BTC->lightning:BTC",
             amount_side: "to",
-            profile: { invoice: "lnbc...", refund_address: "ark1q..." },
+            profile: {
+                invoice: "lnbc...",
+                refund_address: "ark1q...",
+                client_refund_pubkey: hex.encode(key(13)),
+            },
         });
     });
 
@@ -183,7 +219,12 @@ describe("httpTransport", () => {
             fetchImpl: async () => jsonResponse(201, quoteFixture()),
         });
         const quote = await transport.requestQuote(
-            lightningSendRequest({ rfqId: RFQ_ID, invoice: "ln", refundAddress: "a" }),
+            lightningSendRequest({
+                rfqId: RFQ_ID,
+                invoice: "ln",
+                refundAddress: "a",
+                clientRefundPubkey: key(13),
+            }),
         );
         expect(quote.to_amount).toBe(2100);
     });
@@ -200,7 +241,12 @@ describe("httpTransport", () => {
         });
         await expect(
             transport.requestQuote(
-                lightningSendRequest({ rfqId: RFQ_ID, invoice: "ln", refundAddress: "a" }),
+                lightningSendRequest({
+                    rfqId: RFQ_ID,
+                    invoice: "ln",
+                    refundAddress: "a",
+                    clientRefundPubkey: key(13),
+                }),
             ),
         ).rejects.toMatchObject({ name: "SwapRefusal", reason: "exposure_cap" });
     });
@@ -271,7 +317,12 @@ describe("relayTransport", () => {
             rfq_id: request.rfq_id,
         }));
         const quote = await transport.requestQuote(
-            lightningSendRequest({ rfqId: newRfqId(), invoice: "ln", refundAddress: "a" }),
+            lightningSendRequest({
+                rfqId: newRfqId(),
+                invoice: "ln",
+                refundAddress: "a",
+                clientRefundPubkey: key(13),
+            }),
         );
         expect(quote.type).toBe("rfq_quote");
         await transport.close();
@@ -292,7 +343,12 @@ describe("relayTransport", () => {
         );
         await expect(
             transport.requestQuote(
-                lightningSendRequest({ rfqId: newRfqId(), invoice: "ln", refundAddress: "a" }),
+                lightningSendRequest({
+                    rfqId: newRfqId(),
+                    invoice: "ln",
+                    refundAddress: "a",
+                    clientRefundPubkey: key(13),
+                }),
             ),
         ).rejects.toThrow(SwapRefusal);
         expect((await transport.status(newRfqId()))?.state).toBe("quoted");


### PR DESCRIPTION
## Summary

The reference solver (`arkade-os/lightning-swap-service`, see [PR #8](https://github.com/arkade-os/lightning-swap-service/pull/8)) now ships a fourth leaf on the shared lightning-send/onchain-send covenant: `refundUnilateral` — the maker's own key behind a CSV delay, needing neither the Ark server nor the emulator once it matures. This closes the maker's only non-cooperative recourse gap: previously the sole refund path needed both the Ark server *and* the external emulator to co-sign.

`@arkade-os/swap` derived only the three-leaf shape, so a trader using it would compute a different `lockup_address` than the solver quotes and refuse to fund every swap once the solver starts serving four-leaf quotes. This PR closes that gap.

- New leaf in `swap-lightning-send.program.json` (shared by both the lightning-send and onchain-send corridors — one program, confirmed unchanged by the existing "aliases the Arkade lockup" golden test).
- `lightningSendVtxoScript`/`deriveOnchainSend` take `clientRefundPubkey` + `clientRefundDelay` (required — every RFQ-family request this package builds needs the leaf; there's no legacy shape to fall back to).
- `lightningSendRequest`/`onchainSendRequest` carry `client_refund_pubkey`.
- New `unilateralRefundWithoutReceiverDelay(claimDelay)`, one 512s tier past `unilateralClaimDelay`, matching the solver's own three-tier delay ladder.
- `requestLightningSend`/`requestOnchainSend` generate the key per call and now return it (`clientRefundPubkey`/`clientRefundPrivateKey`) — they were generating it internally with no way for a caller to retrieve it, which would have silently discarded the maker's only non-cooperative recourse. Same bug, same fix, as the equivalent function on the solver side.

Golden `scriptPubKey` re-pinned after adding the leaf. Verified byte-identical against the solver's own `CovenantSwapScript` for the same inputs via a throwaway cross-repo script (not part of either test suite) — two independent implementations, same output.

Based on `feat/arkade-swap` (not `master`), matching #667/#681 — this is where the RFQ/onchain client code lives; `@arkade-os/swap` hasn't been published yet, so there are no live consumers to break.

## Test plan
- [x] `pnpm --filter @arkade-os/swap typecheck/lint/build` — clean
- [x] `pnpm --filter @arkade-os/swap test:unit` — 116/116 passing
- [x] Full monorepo pre-commit hook (`pnpm -r lint && pnpm -r test:unit`) — passing
- [x] Cross-repo byte-identical check against the reference solver's `CovenantSwapScript`