### PR TITLE
feat(swap): register offer covenants with the contract manager

### DIFF
--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -303,7 +303,7 @@ async function registerOfferContract(
     // funded would leave the real deposit unwatched and unmarked, which is the
     // failure this whole registration exists to prevent
     if (hex.encode(contract.pkScript) !== hex.encode(expectedPkScript)) {
-        throw new Error("registered covenant does not match the offer's swapPkScript");
+        throw new Error("derived covenant does not match the offer's swapPkScript");
     }
     await contract.register({
         label: OFFER_CONTRACT_LABEL,
@@ -455,6 +455,9 @@ export async function cancelOffer(
         // instead of a direct indexer query; the indexer above stays as the
         // fallback for offers created before registration existed
         contractManager: await wallet.getContractManager(),
+        // no `network`, unlike registerOfferContract: the row lookup is by
+        // script and the payout script comes from wallet.getAddress(), so the
+        // client's network (which only shapes address derivation) is unused here
     });
 
     // Rebuild the contract with the offer's own keys (not the client's) so the

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -253,6 +253,64 @@ export function decodeOffer(data: Uint8Array): Offer {
     };
 }
 
+// ── Contract registration ────────────────────────────────────────────────────
+
+/** Label for a registered offer covenant. A script-level string, deliberately
+ * not the swap id: identical offers share one address and `createContract` is
+ * first-writer-wins, so the second deposit would inherit the first's label. */
+export const OFFER_CONTRACT_LABEL = "Arkade swap offer";
+
+/** `metadata.kind` for a registered offer covenant — what this script *is*,
+ * which is the only kind of fact a shared script row can carry truthfully.
+ * Per-offer identity (swap id, `offerHex`, `fundingTxid`) stays in `AssetSwap`. */
+export const OFFER_CONTRACT_KIND = "asset-swap-offer";
+
+/**
+ * Register an offer's covenant as an `"arkade"` contract, so the deposit is
+ * watched, survives restarts and re-derives offline — and, critically, so the
+ * wallet knows the funds are escrowed.
+ *
+ * `metadata.genericallySpendable: false` is what keeps the deposit out of
+ * generic coin selection. The covenant's `cancel` leaf is an untimelocked
+ * 2-of-2 of maker and server, so an offer VTXO is *always* cryptographically
+ * spendable by the maker's own wallet; nothing in the program artifact says
+ * "escrow". Without the marker, `send`, `settle` or — with no user action at
+ * all — background renewal would forfeit a live offer into an ordinary payment
+ * and silently destroy it. The SDK's gate defaults closed, so the value is
+ * redundant; it is written anyway because this is the one site that knows why.
+ */
+async function registerOfferContract(
+    wallet: IWallet,
+    arkServerUrl: string,
+    network: NetworkName,
+    binding: Omit<Offer, "swapPkScript">,
+    serverPubkey: Uint8Array,
+    expectedPkScript: Uint8Array,
+): Promise<void> {
+    const { program, args, keys } = swapProgramBinding(binding, serverPubkey);
+    const client = await arkade.Arkade.connect({
+        arkade: new RestArkProvider(arkServerUrl),
+        indexer: new RestIndexerProvider(arkServerUrl),
+        identity: wallet.identity,
+        // without this the row's `address` would be derived against the SDK's
+        // default network while its script is right — a row that disagrees with
+        // the address the maker is about to fund
+        network: getNetwork(network),
+        contractManager: await wallet.getContractManager(),
+    });
+    const contract = new arkade.ArkadeContract(client, program, args, keys);
+    // the row is keyed by script: registering anything but the script being
+    // funded would leave the real deposit unwatched and unmarked, which is the
+    // failure this whole registration exists to prevent
+    if (hex.encode(contract.pkScript) !== hex.encode(expectedPkScript)) {
+        throw new Error("registered covenant does not match the offer's swapPkScript");
+    }
+    await contract.register({
+        label: OFFER_CONTRACT_LABEL,
+        metadata: { genericallySpendable: false, kind: OFFER_CONTRACT_KIND },
+    });
+}
+
 // ── Maker operations ─────────────────────────────────────────────────────────
 
 /**
@@ -268,6 +326,14 @@ export function decodeOffer(data: Uint8Array): Offer {
  *   await wallet.send({ address: o.address, amount: 500,
  *                       assets: [{ assetId, amount: 1000n }],
  *                       extensions: [o.extension] })
+ *
+ * Broadcasts nothing, but does write locally: the covenant is registered with
+ * the wallet's contract manager before the address is returned, so the deposit
+ * is watched from the moment it lands and is marked as escrow (see
+ * {@link registerOfferContract}). Registration deliberately happens *before*
+ * funding rather than after: nothing is at stake yet, so a failure can throw
+ * and be retried, where the same failure after `wallet.send` would leave a
+ * funded deposit unwatched with no way to notice.
  */
 export async function createOffer(
     wallet: IWallet,
@@ -318,6 +384,15 @@ export async function createOffer(
     const script = offerVtxoScript(binding, serverPubKey);
     const offer: Offer = { ...binding, swapPkScript: script.pkScript };
 
+    await registerOfferContract(
+        wallet,
+        arkServerUrl,
+        info.network as NetworkName,
+        binding,
+        serverPubKey,
+        script.pkScript,
+    );
+
     const payload = encodeOffer(offer);
     return {
         offerHex: hex.encode(payload),
@@ -350,6 +425,11 @@ export async function createOffer(
  * completed, not that anything failed. `restoreAssetSwaps` classifies the two
  * spends apart afterwards (see `isCancelSpend`).
  *
+ * Marking the deposit as escrow (see {@link registerOfferContract}) does not
+ * close this path: the gate's subject is *implicit* coin selection, and cancel
+ * names its input outpoint explicitly. The maker keeps the only spend route
+ * that was ever theirs to take.
+ *
  * Identical offers derive the same address, so `fundingTxid` selects the exact
  * deposit; without it the address must hold exactly one spendable VTXO — with
  * several, cancel refuses to guess and throws.
@@ -371,6 +451,10 @@ export async function cancelOffer(
         arkade: new RestArkProvider(arkServerUrl),
         indexer: new RestIndexerProvider(arkServerUrl),
         identity: wallet.identity,
+        // registered offers resolve their VTXOs from the contract repository
+        // instead of a direct indexer query; the indexer above stays as the
+        // fallback for offers created before registration existed
+        contractManager: await wallet.getContractManager(),
     });
 
     // Rebuild the contract with the offer's own keys (not the client's) so the

--- a/packages/swap/test/cancel.test.ts
+++ b/packages/swap/test/cancel.test.ts
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
     // returns the ArrayBufferLike flavor and must be assignable here
     serverKey: new Uint8Array(0) as Uint8Array,
     utxos: [] as { txid: string; vout: number; value: number }[],
+    connectOptions: undefined as { contractManager?: unknown } | undefined,
 }));
 
 vi.mock("@arkade-os/sdk", async (importOriginal) => {
@@ -19,7 +20,12 @@ vi.mock("@arkade-os/sdk", async (importOriginal) => {
         ...mod,
         arkade: {
             ...mod.arkade,
-            Arkade: { connect: async () => ({ serverKey: state.serverKey }) },
+            Arkade: {
+                connect: async (opts: { contractManager?: unknown }) => {
+                    state.connectOptions = opts;
+                    return { serverKey: state.serverKey };
+                },
+            },
             ArkadeContract: class {
                 getUtxos = async () => state.utxos;
             },
@@ -46,9 +52,11 @@ const script = offerVtxoScript(binding, fundedServerKey);
 const offerHex = hex.encode(encodeOffer({ ...binding, swapPkScript: script.pkScript }));
 const fundedAddress = new ArkAddress(fundedServerKey, script.tweakedPublicKey, "tark").encode();
 
+const contractManager = { marker: "the wallet's manager" };
 const wallet = {
     identity: {},
     getAddress: async () => "unused-before-a-vtxo-is-selected",
+    getContractManager: async () => contractManager,
 } as unknown as IWallet;
 
 describe("cancelOffer guards", () => {
@@ -78,5 +86,17 @@ describe("cancelOffer guards", () => {
         await expect(cancelOffer(wallet, "http://ark", offerHex)).rejects.toThrow(
             "pass fundingTxid",
         );
+    });
+
+    // without this the contract takes the direct-indexer fallback and a
+    // registered offer's repository-backed VTXOs are never consulted
+    it("hands the wallet's contract manager to the arkade client", async () => {
+        state.serverKey = fundedServerKey;
+        state.utxos = [];
+        state.connectOptions = undefined;
+        await expect(cancelOffer(wallet, "http://ark", offerHex)).rejects.toThrow(
+            "no spendable VTXO",
+        );
+        expect(state.connectOptions?.contractManager).toBe(contractManager);
     });
 });

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -140,9 +140,64 @@ describe("maker-side swap loop (regtest)", () => {
         expect(() => decodeOffer(hex.decode(restoredOfferHex))).not.toThrow();
     }, 120_000);
 
+    // The Phase 2 merge gate: everything below runs through the real
+    // createOffer -> register -> ContractManager path above, never a hand-built
+    // contract row, because a hand-marked fixture cannot catch a writer that
+    // omits or misspells the marker.
+    it("escrows the deposit: owned and watched, but not generically spendable", async () => {
+        const script = hex.encode(offer.swapPkScript);
+        const manager = await wallet.getContractManager();
+        const [row] = await manager.getContracts({ script });
+
+        expect(row).toBeDefined();
+        expect(row?.type).toBe("arkade");
+        expect(row?.metadata?.genericallySpendable).toBe(false);
+
+        // the funding tx also pays the maker's own change, so match the
+        // covenant script too — by txid alone this picks up the change output,
+        // which is ordinary wallet money and rightly stays spendable
+        const isDeposit = (v: { txid: string; script: string }) =>
+            v.txid === fundingTxid && v.script === script;
+        // the raw read keeps it — this is the maker's money, and filtering it
+        // here would make it unrecoverable and erase it from history
+        await waitFor(async () => (await wallet.getVtxos()).some(isDeposit));
+        // ...while the spendable read, the one every coin selection goes
+        // through, does not
+        expect((await wallet.getSpendableVtxos()).some(isDeposit)).toBe(false);
+
+        const balance = await wallet.getBalance();
+        expect(balance.settled + balance.preconfirmed).toBeGreaterThanOrEqual(DEPOSIT_SATS);
+        expect(balance.available).toBeLessThanOrEqual(FAUCET_SATS - DEPOSIT_SATS);
+    }, 120_000);
+
+    it("refuses to fund an unrelated payment out of the escrowed deposit", async () => {
+        // the §3 hazard as a behaviour test: without the marker, coin selection
+        // picks the offer deposit like any other UTXO, the server co-signs the
+        // covenant's untimelocked cancel leaf, and the offer silently ceases to
+        // exist. This send only succeeds if that happens.
+        // an amount the wallet can only reach by dipping into the deposit:
+        // under the totals (which count it, per D1c) but above what is left
+        // once it is excluded
+        const balance = await wallet.getBalance();
+        const needsTheDeposit =
+            balance.settled + balance.preconfirmed - Math.floor(DEPOSIT_SATS / 2);
+
+        await expect(
+            wallet.send({ address: await wallet.getAddress(), amount: needsTheDeposit }),
+        ).rejects.toThrow();
+
+        // and the deposit is still there to be cancelled below
+        const { vtxos } = await indexer.getVtxos({ scripts: [hex.encode(offer.swapPkScript)] });
+        expect(vtxos.find((v) => v.txid === fundingTxid)?.virtualStatus.state).not.toBe("spent");
+    }, 120_000);
+
     it("cancels the deposit cooperatively and restores it as cancelled", async () => {
         // cancel from the chain-recovered bytes, not the createOffer result:
-        // this is the restored-wallet path, plus the swapAddress pin
+        // this is the restored-wallet path, plus the swapAddress pin.
+        // It doubles as the escape-hatch assertion: cancel names its input
+        // outpoint, so the escrow marker must not close the one spend route the
+        // maker actually owns. A future tightening that gates explicit inputs
+        // would strand every offer deposit, and would fail here.
         const cancelTxid = await cancelOffer(
             wallet,
             ARK_URL,

--- a/packages/swap/test/register.test.ts
+++ b/packages/swap/test/register.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { hex } from "@scure/base";
+import { asset, type IWallet } from "@arkade-os/sdk";
+import { createOffer, OFFER_CONTRACT_KIND, OFFER_CONTRACT_LABEL } from "../src/offer";
+
+// the covenant derivation, Arkade.connect, ArkadeContract and register() are
+// all real here — only the network seam (the three Rest* providers) and the
+// contract manager are stubbed, so a writer that omits or misspells the escrow
+// marker fails this test rather than passing on a hand-built fixture
+const makerKey = hex.decode("3c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1");
+const makerAddress =
+    "tark1qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc65wq0wnmwgr4nglzx999xqx7xahllp4gfh6638wkrjt5tl3k7c8vy6frzj2";
+
+const state = vi.hoisted(() => ({
+    created: [] as Record<string, unknown>[],
+    createContract: undefined as ((params: Record<string, unknown>) => unknown) | undefined,
+}));
+
+vi.mock("@arkade-os/sdk", async (importOriginal) => {
+    const mod = await importOriginal<typeof import("@arkade-os/sdk")>();
+    // the factory is hoisted above this file's imports, so re-import inside it
+    const { hex } = await import("@scure/base");
+    const checkpointTapscript = hex.encode(
+        mod.CSVMultisigTapscript.encode({
+            timelock: { type: "blocks", value: 10n },
+            pubkeys: [
+                hex.decode("4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa"),
+            ],
+        }).script,
+    );
+    return {
+        ...mod,
+        RestArkProvider: class {
+            async getInfo() {
+                return {
+                    signerPubkey:
+                        "02" + "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+                    checkpointTapscript,
+                    network: "regtest",
+                };
+            }
+        },
+        RestIndexerProvider: class {
+            async getVtxos() {
+                return { vtxos: [] };
+            }
+        },
+        RestEmulatorProvider: class {
+            async getInfo() {
+                return {
+                    signerPubkey:
+                        "466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
+                };
+            }
+        },
+    };
+});
+
+const contractManager = {
+    createContract: async (params: Record<string, unknown>) => {
+        if (state.createContract) return state.createContract(params);
+        state.created.push(params);
+        return { ...params, state: "active", createdAt: 0 };
+    },
+};
+
+const wallet = {
+    identity: { xOnlyPublicKey: async () => makerKey },
+    getAddress: async () => makerAddress,
+    getContractManager: async () => contractManager,
+} as unknown as IWallet;
+
+const testAsset = asset.AssetId.fromString("aa".repeat(32) + "0000");
+const create = () =>
+    createOffer(wallet, "http://ark", "http://emu", {
+        wantAmount: BigInt(50_000),
+        wantAsset: testAsset,
+    });
+
+describe("offer contract registration", () => {
+    beforeEach(() => {
+        state.created = [];
+        state.createContract = undefined;
+    });
+
+    it("registers the funded covenant as an escrowed arkade contract", async () => {
+        const offer = await create();
+
+        expect(state.created).toHaveLength(1);
+        const row = state.created[0];
+        expect(row.type).toBe("arkade");
+        // the row must key on the script the maker is about to fund; a row at
+        // any other script leaves the real deposit unwatched and unmarked
+        expect(row.script).toBe(hex.encode(offer.swapPkScript));
+        // and carry the address the caller was handed — a row derived against
+        // the SDK's default network instead of the server's would disagree here
+        expect(row.address).toBe(offer.address);
+        expect(row.label).toBe(OFFER_CONTRACT_LABEL);
+        expect(row.metadata).toEqual({
+            genericallySpendable: false,
+            kind: OFFER_CONTRACT_KIND,
+        });
+    });
+
+    it("stores only script-level facts, so a shared row cannot go stale", async () => {
+        // identical offers derive one address and createContract is
+        // first-writer-wins, so the second deposit inherits the first row: any
+        // per-offer value written here would silently describe the wrong offer
+        const [a, b] = [await create(), await create()];
+        expect(b.swapPkScript).toEqual(a.swapPkScript);
+        expect(state.created[1]).toEqual(state.created[0]);
+
+        const serialized = JSON.stringify(state.created[0]);
+        for (const perOffer of [a.offerHex, "fundingTxid", "swapId"]) {
+            expect(serialized).not.toContain(perOffer);
+        }
+    });
+
+    it("fails the offer rather than returning an address it never registered", async () => {
+        // registration runs before funding precisely so this can throw: the
+        // same failure after wallet.send would strand an unwatched deposit
+        state.createContract = () => {
+            throw new Error("repository unavailable");
+        };
+        await expect(create()).rejects.toThrow("repository unavailable");
+    });
+});


### PR DESCRIPTION
Phases 1–2 of ContractManager integration, stacked on #683.

- `createOffer` registers the covenant as an `"arkade"` contract with `metadata.genericallySpendable: false`, so the deposit is watched and stays out of generic coin selection. The cancel leaf has no timelock, so an unmarked deposit is forfeitable by `send`/`settle`/background renewal.
- `cancelOffer` passes the contract manager to `Arkade.connect`, so a registered offer resolves its VTXOs from the repository.

Two deviations from the plan, both because `createOffer` derives and the consumer funds — there is no in-package funding site:

- registration happens before funding, matching NArk and boltz-swap (register on create);
- it throws rather than being best-effort: nothing is at stake pre-funding, whereas the same failure after `wallet.send` strands an unwatched deposit.

Fixed while writing it: without `network` on `Arkade.connect` the row's address derives against the SDK default (`ark1…` row for a `tark1…` deposit).

## Test plan

- [x] e2e merge gate through the real `createOffer`/registration path, no hand-built rows. Flipping the marker to `true` reproduces the hazard: the deposit enters `getSpendableVtxos()`, an unrelated `wallet.send` **succeeds**, and cancel then fails with "no spendable VTXO at the swap address".
- [x] every new assertion probed by reverting the fix and confirming failure
- [x] cancel still works with the deposit gated (explicit-input path stays open)
- [x] unit: swap 124, `@arkade-os/sdk` 2315, boltz-swap 609; lint clean

## Note to reviewers

The whole `packages/swap` package isn't released yet: exclude API breaking changes and version numbering from the analysis.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for non-interactive claim and refund paths in swap transactions.
  * Swap requests now securely bind sender keys and receiver payout destinations.
  * Offers are registered before funding, enabling reliable recovery and cancellation.
  * Escrowed deposits remain recoverable while being excluded from ordinary spendable balances.

* **Bug Fixes**
  * Improved cancellation handling when restoring offers.
  * Added validation to prevent mismatched swap scripts and invalid payout destinations.

* **Tests**
  * Expanded coverage for registration, recovery, cancellation, and end-to-end swap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->