### PR TITLE
chore: widen engines.node upper bound to allow Node 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "packageManager": "pnpm@10.25.0",
     "engines": {
-        "node": ">=24.15.0 <25",
+        "node": ">=24.15.0 <27",
         "pnpm": ">=10.25.0 <11"
     },
     "scripts": {

--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -134,7 +134,7 @@
         "registry": "https://registry.npmjs.org/"
     },
     "engines": {
-        "node": ">=22.12.0 <25"
+        "node": ">=22.12.0 <27"
     },
     "scripts": {
         "build": "tsup",


### PR DESCRIPTION
## Summary
- Widen `engines.node` in the root `package.json` and `packages/ts-sdk/package.json` from `<25` to `<27`, so installs on Node 26 aren't blocked.

## Context
- Node 26 shipped as Current on 2026-05-05 and enters Active LTS in October 2026.
- Node 25 (Current-only) already reached EOL on 2026-06-01, and technically falls back inside the widened range, but it's dead either way.
- CI (`.nvmrc`) still pins to Node 24.15.0, so this change only affects the published compatibility range for consumers — it does not add Node 26 to the test matrix.

## Test plan
- [x] `pnpm run lint` (via pre-commit hook)
- [x] `pnpm run test:unit` for both packages (via pre-commit hook, all passing)
- [x] Verified edited `package.json` files are valid JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Expanded supported Node.js versions for the project to include versions below 27.
  * Expanded supported Node.js versions for the TypeScript SDK to include versions below 27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->