### PR TITLE
fix(batch): bound the server-supplied batchExpiry before committing to the sweep leaf

### DIFF
--- a/packages/boltz-swap/src/batch.ts
+++ b/packages/boltz-swap/src/batch.ts
@@ -65,9 +65,13 @@ export function createVHTLCBatchHandler(
 
             // Bound the expiry before confirming, so a rejected round is never
             // confirmed to the operator.
+            const info = await arkProvider.getInfo();
             const timelock = assertValidBatchExpiry(
                 event.batchExpiry,
-                resolveBatchExpiryPolicy(network, batchExpiryPolicy),
+                resolveBatchExpiryPolicy(network, {
+                    advertisedVtxoTreeExpiry: info.vtxoTreeExpiry,
+                    ...batchExpiryPolicy,
+                }),
             );
 
             await arkProvider.confirmRegistration(intentId);

--- a/packages/boltz-swap/src/batch.ts
+++ b/packages/boltz-swap/src/batch.ts
@@ -19,6 +19,9 @@ import {
     buildForfeitTx,
     ArkTxInput,
     getSequence,
+    assertValidBatchExpiry,
+    resolveBatchExpiryPolicy,
+    type BatchExpiryPolicy,
 } from "@arkade-os/sdk";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { base64, hex } from "@scure/base";
@@ -37,6 +40,8 @@ export function createVHTLCBatchHandler(
     recipient?: Recipient,
     forfeitOutputScript?: Bytes, // undefined if recoverable
     connectorIndex: number = 0,
+    /** Overrides for the `batchExpiry` bounds; defaults derive from `network`. */
+    batchExpiryPolicy?: Partial<BatchExpiryPolicy>,
 ) {
     const utf8IntentId = new TextEncoder().encode(intentId);
     const intentIdHash = sha256(utf8IntentId);
@@ -47,28 +52,28 @@ export function createVHTLCBatchHandler(
 
     return {
         onBatchStarted: async (event: BatchStartedEvent): Promise<{ skip: boolean }> => {
-            let skip = true;
-
             // check if our intent ID hash matches any in the event
-            for (const idHash of event.intentIdHashes) {
-                if (idHash === intentIdHashStr) {
-                    if (!arkProvider) {
-                        throw new Error("Ark provider not configured");
-                    }
-                    await arkProvider.confirmRegistration(intentId);
-                    skip = false;
-                }
-            }
+            const skip = !event.intentIdHashes.includes(intentIdHashStr);
 
             if (skip) {
                 return { skip };
             }
 
+            if (!arkProvider) {
+                throw new Error("Ark provider not configured");
+            }
+
+            // Bound the expiry before confirming, so a rejected round is never
+            // confirmed to the operator.
+            const timelock = assertValidBatchExpiry(
+                event.batchExpiry,
+                resolveBatchExpiryPolicy(network, batchExpiryPolicy),
+            );
+
+            await arkProvider.confirmRegistration(intentId);
+
             const sweepTapscript = CSVMultisigTapscript.encode({
-                timelock: {
-                    value: event.batchExpiry,
-                    type: event.batchExpiry >= 512n ? "seconds" : "blocks",
-                },
+                timelock,
                 pubkeys: [sweepPublicKey],
             }).script;
 

--- a/packages/boltz-swap/test/batch.test.ts
+++ b/packages/boltz-swap/test/batch.test.ts
@@ -16,6 +16,7 @@ import {
     SingleKey,
     Transaction,
     networks,
+    ServerResponseMismatchError,
     validateVtxoTxGraph,
     type ArkProvider,
     type ArkTxInput,
@@ -239,5 +240,16 @@ describe("createVHTLCBatchHandler recipient validation", () => {
             ),
         ).rejects.toThrow(/offchain send output not found/);
         expect(arkProvider.submitTreeNonces).not.toHaveBeenCalled();
+    });
+});
+
+describe("createVHTLCBatchHandler batch expiry", () => {
+    it("rejects an out-of-policy expiry without confirming registration", async () => {
+        const { handler, arkProvider } = await makeHandler();
+
+        await expect(
+            handler.onBatchStarted({ ...batchStarted, batchExpiry: 1n } as BatchStartedEvent),
+        ).rejects.toThrow(ServerResponseMismatchError);
+        expect(arkProvider.confirmRegistration).not.toHaveBeenCalled();
     });
 });

--- a/packages/boltz-swap/test/batch.test.ts
+++ b/packages/boltz-swap/test/batch.test.ts
@@ -83,9 +83,10 @@ function makeSession(): SignerSession {
     } as unknown as SignerSession;
 }
 
-function makeArkProvider() {
+function makeArkProvider(info: { vtxoTreeExpiry?: bigint } = {}) {
     return {
         confirmRegistration: vi.fn(async () => {}),
+        getInfo: vi.fn(async () => info),
         submitTreeNonces: vi.fn(async () => {}),
         submitTreeSignatures: vi.fn(async () => {}),
         submitSignedForfeitTxs: vi.fn(async () => {}),
@@ -128,8 +129,12 @@ function treeSigningStarted(commitmentTx: string): TreeSigningStartedEvent {
     } as unknown as TreeSigningStartedEvent;
 }
 
-async function makeHandler(opts?: { recipient?: Recipient; recoverable?: boolean }) {
-    const arkProvider = makeArkProvider();
+async function makeHandler(opts?: {
+    recipient?: Recipient;
+    recoverable?: boolean;
+    vtxoTreeExpiry?: bigint;
+}) {
+    const arkProvider = makeArkProvider({ vtxoTreeExpiry: opts?.vtxoTreeExpiry });
     const handler = createVHTLCBatchHandler(
         INTENT_ID,
         await makeVhtlcInput(),
@@ -251,5 +256,21 @@ describe("createVHTLCBatchHandler batch expiry", () => {
             handler.onBatchStarted({ ...batchStarted, batchExpiry: 1n } as BatchStartedEvent),
         ).rejects.toThrow(ServerResponseMismatchError);
         expect(arkProvider.confirmRegistration).not.toHaveBeenCalled();
+    });
+
+    it("rejects an expiry that differs from the advertised vtxoTreeExpiry", async () => {
+        const { handler, arkProvider } = await makeHandler({ vtxoTreeExpiry: 180n });
+
+        await expect(handler.onBatchStarted(batchStarted)).rejects.toThrow(
+            /does not match the advertised vtxoTreeExpiry 180/,
+        );
+        expect(arkProvider.confirmRegistration).not.toHaveBeenCalled();
+    });
+
+    it("accepts an expiry equal to the advertised vtxoTreeExpiry", async () => {
+        const { handler, arkProvider } = await makeHandler({ vtxoTreeExpiry: 100n });
+
+        await expect(handler.onBatchStarted(batchStarted)).resolves.toEqual({ skip: false });
+        expect(arkProvider.confirmRegistration).toHaveBeenCalledWith(INTENT_ID);
     });
 });

--- a/packages/ts-sdk/src/arkade/batch.ts
+++ b/packages/ts-sdk/src/arkade/batch.ts
@@ -28,6 +28,8 @@ import type {
 
 import { VtxoScript } from "../script/base";
 import { CSVMultisigTapscript } from "../script/tapscript";
+import { assertValidBatchExpiry, resolveBatchExpiryPolicy } from "../wallet/batchExpiry";
+import type { BatchExpiryPolicy } from "../wallet/batchExpiry";
 import { Transaction } from "../utils/transaction";
 import { validateConnectorsTxGraph, validateVtxoTxGraph } from "../tree/validation";
 import {
@@ -84,6 +86,8 @@ export function createArkadeBatchHandler(
      * whatever the server proposes, on both paths.
      */
     recipients?: Recipient[],
+    /** Overrides for the `batchExpiry` bounds; defaults derive from `network`. */
+    batchExpiryPolicy?: Partial<BatchExpiryPolicy>,
 ): Batch.Handler {
     let batchId: string;
     let sweepTapTreeRoot: Uint8Array;
@@ -98,17 +102,25 @@ export function createArkadeBatchHandler(
             const intentIdHashStr = hex.encode(intentIdHash);
 
             if (!event.intentIdHashes.includes(intentIdHashStr)) return { skip: true };
+
+            const info = await arkProvider.getInfo();
+            // Bound the expiry before confirming, so a rejected round is never
+            // confirmed to the operator.
+            const timelock = assertValidBatchExpiry(
+                event.batchExpiry,
+                resolveBatchExpiryPolicy(network, {
+                    advertisedVtxoTreeExpiry: info.vtxoTreeExpiry,
+                    ...batchExpiryPolicy,
+                }),
+            );
+
             await arkProvider.confirmRegistration(intentId);
 
             batchId = event.id;
 
             const sweepTapscript = CSVMultisigTapscript.encode({
-                timelock: {
-                    value: event.batchExpiry,
-                    // BIP-65: values >= 512 are interpreted as seconds, below as blocks
-                    type: event.batchExpiry >= 512n ? "seconds" : "blocks",
-                },
-                pubkeys: [hex.decode((await arkProvider.getInfo()).forfeitPubkey).subarray(1)],
+                timelock,
+                pubkeys: [hex.decode(info.forfeitPubkey).subarray(1)],
             }).script;
 
             sweepTapTreeRoot = tapLeafHash(sweepTapscript);

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -311,6 +311,14 @@ import {
     validateBatchRecipients,
     assertFinalCommitmentMatchesValidated,
 } from "./wallet/validation";
+import {
+    assertValidBatchExpiry,
+    defaultBatchExpiryPolicy,
+    resolveBatchExpiryPolicy,
+    DEFAULT_MIN_BATCH_EXPIRY_SECONDS,
+    REGTEST_MIN_BATCH_EXPIRY_SECONDS,
+} from "./wallet/batchExpiry";
+import type { BatchExpiryPolicy } from "./wallet/batchExpiry";
 import { buildForfeitTx } from "./forfeit";
 import { IndexedDBWalletRepository } from "./repositories/indexedDB/walletRepository";
 import { IndexedDBContractRepository } from "./repositories/indexedDB/contractRepository";
@@ -625,6 +633,12 @@ export {
     validateConnectorsTxGraph,
     validateBatchRecipients,
     assertFinalCommitmentMatchesValidated,
+    assertValidBatchExpiry,
+    defaultBatchExpiryPolicy,
+    resolveBatchExpiryPolicy,
+    DEFAULT_MIN_BATCH_EXPIRY_SECONDS,
+    REGTEST_MIN_BATCH_EXPIRY_SECONDS,
+    type BatchExpiryPolicy,
     buildForfeitTx,
     isRecoverable,
     isSpendable,

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -177,6 +177,12 @@ export interface ArkInfo {
     signerPubkey: string;
     unilateralExitDelay: bigint;
     /**
+     * Sweep delay the operator advertises for the shared batch output.
+     * `undefined` when not advertised — never coerce to `0n`, which would
+     * satisfy any floor comparison.
+     */
+    vtxoTreeExpiry?: bigint;
+    /**
      * Maximum boarding input amount.
      *
      * @remarks
@@ -452,6 +458,8 @@ export class RestArkProvider implements ArkProvider {
             sessionDuration: BigInt(fromServer.sessionDuration ?? 0),
             signerPubkey: fromServer.signerPubkey ?? "",
             unilateralExitDelay: BigInt(fromServer.unilateralExitDelay ?? 0),
+            vtxoTreeExpiry:
+                fromServer.vtxoTreeExpiry != null ? BigInt(fromServer.vtxoTreeExpiry) : undefined,
             utxoMaxAmount: BigInt(fromServer.utxoMaxAmount ?? -1),
             utxoMinAmount: BigInt(fromServer.utxoMinAmount ?? 0),
             version: fromServer.version ?? "",

--- a/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
+++ b/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
@@ -37,6 +37,8 @@ export type StoredArkInfoSnapshot = {
         forfeitPubkey: string;
         unilateralExitDelay: string;
         boardingExitDelay: string;
+        /** Absent on snapshots written before the operator advertised it. */
+        vtxoTreeExpiry?: string;
         sessionDuration: string;
         dust: string;
         fees: FeeInfo;
@@ -86,6 +88,7 @@ export function serializeArkInfoSnapshot(info: ArkInfo, savedAt: number): Stored
             forfeitPubkey: info.forfeitPubkey,
             unilateralExitDelay: info.unilateralExitDelay.toString(),
             boardingExitDelay: info.boardingExitDelay.toString(),
+            vtxoTreeExpiry: info.vtxoTreeExpiry?.toString(),
             sessionDuration: info.sessionDuration.toString(),
             dust: info.dust.toString(),
             fees: info.fees,
@@ -145,6 +148,7 @@ export function hydrateArkInfo(snapshot: StoredArkInfoSnapshot): ArkInfo {
         sessionDuration: BigInt(a.sessionDuration),
         signerPubkey: a.signerPubkey,
         unilateralExitDelay: BigInt(a.unilateralExitDelay),
+        vtxoTreeExpiry: a.vtxoTreeExpiry !== undefined ? BigInt(a.vtxoTreeExpiry) : undefined,
         utxoMaxAmount: BigInt(a.utxoMaxAmount),
         utxoMinAmount: BigInt(a.utxoMinAmount),
         version: a.version,
@@ -226,6 +230,9 @@ export function parseStoredArkInfoSnapshot(raw: unknown): StoredArkInfoSnapshot 
         "utxoMaxAmount",
     ]) {
         assertDecimalString(a[field], `arkInfo.${field}`);
+    }
+    if (a.vtxoTreeExpiry !== undefined) {
+        assertDecimalString(a.vtxoTreeExpiry, "arkInfo.vtxoTreeExpiry");
     }
     assertFeeInfo(a.fees, "arkInfo.fees");
 

--- a/packages/ts-sdk/src/wallet/batchExpiry.ts
+++ b/packages/ts-sdk/src/wallet/batchExpiry.ts
@@ -1,0 +1,104 @@
+import type { Network } from "../networks";
+import type { RelativeTimelock } from "../script/tapscript";
+import { ServerResponseMismatchError } from "../providers/errors";
+
+/**
+ * Nominal seconds per block, used only to compare a block-typed timelock
+ * against a wall-clock floor. Coarse by design: under the default policies
+ * block-typed values are only accepted on regtest.
+ */
+const NOMINAL_BLOCK_SECONDS = 600n;
+
+/** Wall-clock floor for `batchExpiry` outside regtest. */
+export const DEFAULT_MIN_BATCH_EXPIRY_SECONDS = 86_400n;
+
+/** Wall-clock floor for `batchExpiry` on regtest (~10 blocks). */
+export const REGTEST_MIN_BATCH_EXPIRY_SECONDS = 6_000n;
+
+/** Bounds applied to a server-supplied `BatchStartedEvent.batchExpiry`. */
+export type BatchExpiryPolicy = {
+    /** Minimum wall-clock delay in seconds, after normalization. */
+    minSeconds: bigint;
+    /**
+     * Reject block-typed timelocks. Mirrors arkd, which allows a block-typed
+     * vtxo tree expiry only on regtest.
+     */
+    requireSeconds: boolean;
+    /** When advertised by the operator, `batchExpiry` must equal it exactly. */
+    advertisedVtxoTreeExpiry?: bigint;
+};
+
+const isRegtest = (network: Network): boolean => network.bech32 === "bcrt";
+
+/**
+ * Default policy for a network.
+ *
+ * Derive it from the locally held {@link Network} — pinned at wallet setup —
+ * rather than from a per-round server field, so the permissive regtest branch
+ * can't be selected by the operator at event time.
+ */
+export function defaultBatchExpiryPolicy(network: Network): BatchExpiryPolicy {
+    return isRegtest(network)
+        ? { minSeconds: REGTEST_MIN_BATCH_EXPIRY_SECONDS, requireSeconds: false }
+        : { minSeconds: DEFAULT_MIN_BATCH_EXPIRY_SECONDS, requireSeconds: true };
+}
+
+/** Resolve a policy for `network`, applying any caller overrides on top. */
+export function resolveBatchExpiryPolicy(
+    network: Network,
+    overrides?: Partial<BatchExpiryPolicy>,
+): BatchExpiryPolicy {
+    return { ...defaultBatchExpiryPolicy(network), ...overrides };
+}
+
+/** BIP-68 reads values >= 512 as seconds, below as blocks. */
+const toTimelock = (value: bigint): RelativeTimelock => ({
+    value,
+    type: value >= 512n ? "seconds" : "blocks",
+});
+
+const toSeconds = (t: RelativeTimelock): bigint =>
+    t.type === "seconds" ? t.value : t.value * NOMINAL_BLOCK_SECONDS;
+
+/**
+ * Check a server-supplied batch expiry against `policy` and return the timelock
+ * to commit to.
+ *
+ * The sweep leaf of the shared batch output is derived from this value, so it
+ * is never reconstructible from anything else the server sends: validating the
+ * tree only proves it is consistent with whatever value was chosen. Callers
+ * must encode the returned timelock rather than re-deriving their own.
+ *
+ * @throws {ServerResponseMismatchError} if the value is out of policy.
+ */
+export function assertValidBatchExpiry(
+    batchExpiry: bigint,
+    policy: BatchExpiryPolicy,
+): RelativeTimelock {
+    const timelock = toTimelock(batchExpiry);
+
+    if (policy.advertisedVtxoTreeExpiry !== undefined) {
+        if (batchExpiry !== policy.advertisedVtxoTreeExpiry) {
+            throw new ServerResponseMismatchError(
+                `batch expiry rejected: ${batchExpiry} does not match the advertised ` +
+                    `vtxoTreeExpiry ${policy.advertisedVtxoTreeExpiry}`,
+            );
+        }
+    }
+
+    if (policy.requireSeconds && timelock.type === "blocks") {
+        throw new ServerResponseMismatchError(
+            `batch expiry rejected: block-typed timelocks are not accepted (got ${batchExpiry})`,
+        );
+    }
+
+    const seconds = toSeconds(timelock);
+    if (seconds < policy.minSeconds) {
+        throw new ServerResponseMismatchError(
+            `batch expiry rejected: ${timelock.value} ${timelock.type} is below the ` +
+                `${policy.minSeconds}s floor`,
+        );
+    }
+
+    return timelock;
+}

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -108,6 +108,12 @@ export interface BaseWalletConfig {
     /** Relative timelock applied to unilateral exit paths. */
     exitTimelock?: RelativeTimelock;
     /**
+     * Minimum accepted `BatchStartedEvent.batchExpiry`, as wall-clock seconds.
+     * Defaults per network — see `defaultBatchExpiryPolicy`. Lowering it below
+     * the default relaxes a fund-safety bound; intended for local testing.
+     */
+    minBatchExpirySeconds?: bigint;
+    /**
      * Repository-backed storage configuration overrides.
      * Defaults to IndexedDB if unset.
      */

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -72,6 +72,8 @@ import { createAssetPacket, selectCoinsWithAsset, selectedCoinsToAssetInputs } f
 import { VtxoScript } from "../script/base";
 import { CSVMultisigTapscript, RelativeTimelock } from "../script/tapscript";
 import { signerSetFromInfo, toXOnlySignerHex } from "./signerRotation";
+import { assertValidBatchExpiry, resolveBatchExpiryPolicy } from "./batchExpiry";
+import type { BatchExpiryPolicy } from "./batchExpiry";
 import {
     assertCheckpointsMatchInputs,
     buildOffchainTx,
@@ -2786,6 +2788,8 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         receiveRotator?: WalletReceiveRotator,
         descriptorProvider?: DescriptorProvider,
         lookAheadWindow?: number,
+        /** Overrides for the `batchExpiry` bounds; defaults derive from `network`. */
+        protected readonly batchExpiryPolicy?: Partial<BatchExpiryPolicy>,
     ) {
         super(
             identity,
@@ -3016,6 +3020,13 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
             boot?.rotator,
             boot?.provider,
             config.lookAheadWindow,
+            // Pinned at setup rather than refetched per round.
+            {
+                advertisedVtxoTreeExpiry: setup.info.vtxoTreeExpiry,
+                ...(config.minBatchExpirySeconds !== undefined
+                    ? { minSeconds: config.minBatchExpirySeconds }
+                    : {}),
+            },
         );
         wallet._serverInfoSource = setup.serverInfoSource;
         // The response cleared construction validation — network/signer in
@@ -3863,28 +3874,28 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                 const intentIdHash = sha256(utf8IntentId);
                 const intentIdHashStr = hex.encode(intentIdHash);
 
-                let skip = true;
-
                 // check if our intent ID hash matches any in the event
-                for (const idHash of event.intentIdHashes) {
-                    if (idHash === intentIdHashStr) {
-                        if (!this.arkProvider) {
-                            throw new Error("Arkade provider not configured");
-                        }
-                        await this.arkProvider.confirmRegistration(intentId);
-                        skip = false;
-                    }
-                }
+                const skip = !event.intentIdHashes.includes(intentIdHashStr);
 
                 if (skip) {
                     return { skip };
                 }
 
+                if (!this.arkProvider) {
+                    throw new Error("Arkade provider not configured");
+                }
+
+                // Bound the expiry before confirming, so a rejected round is
+                // never confirmed to the operator.
+                const timelock = assertValidBatchExpiry(
+                    event.batchExpiry,
+                    resolveBatchExpiryPolicy(this.network, this.batchExpiryPolicy),
+                );
+
+                await this.arkProvider.confirmRegistration(intentId);
+
                 const sweepTapscript = CSVMultisigTapscript.encode({
-                    timelock: {
-                        value: event.batchExpiry,
-                        type: event.batchExpiry >= 512n ? "seconds" : "blocks",
-                    },
+                    timelock,
                     pubkeys: [this.forfeitPubkey],
                 }).script;
 

--- a/packages/ts-sdk/test/ark-info-snapshot.test.ts
+++ b/packages/ts-sdk/test/ark-info-snapshot.test.ts
@@ -89,6 +89,26 @@ describe("serializeArkInfoSnapshot / hydrateArkInfo", () => {
         expect(hydrated.scheduledSession).toBeUndefined();
         expect(hydrated).toEqual({ ...info, serviceStatus: {} });
     });
+
+    it("round-trips vtxoTreeExpiry when advertised", () => {
+        const info = makeArkInfo({ vtxoTreeExpiry: 604_672n });
+        const snapshot = serializeArkInfoSnapshot(info, 1);
+        expect(snapshot.arkInfo.vtxoTreeExpiry).toBe("604672");
+        expect(hydrateArkInfo(snapshot).vtxoTreeExpiry).toBe(604_672n);
+    });
+
+    it("keeps vtxoTreeExpiry undefined when not advertised — never 0n", () => {
+        const snapshot = serializeArkInfoSnapshot(makeArkInfo(), 1);
+        expect(snapshot.arkInfo.vtxoTreeExpiry).toBeUndefined();
+        expect(hydrateArkInfo(snapshot).vtxoTreeExpiry).toBeUndefined();
+    });
+
+    it("accepts a v1 snapshot written before vtxoTreeExpiry existed", () => {
+        const raw = JSON.parse(JSON.stringify(serializeArkInfoSnapshot(makeArkInfo(), 1)));
+        delete raw.arkInfo.vtxoTreeExpiry;
+        expect(() => parseStoredArkInfoSnapshot(raw)).not.toThrow();
+        expect(hydrateArkInfo(parseStoredArkInfoSnapshot(raw)).vtxoTreeExpiry).toBeUndefined();
+    });
 });
 
 describe("parseStoredArkInfoSnapshot", () => {

--- a/packages/ts-sdk/test/batch-expiry-validation.test.ts
+++ b/packages/ts-sdk/test/batch-expiry-validation.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from "vitest";
+import { hex } from "@scure/base";
+import { sha256 } from "@scure/btc-signer/utils.js";
+
+import {
+    assertValidBatchExpiry,
+    defaultBatchExpiryPolicy,
+    resolveBatchExpiryPolicy,
+    DEFAULT_MIN_BATCH_EXPIRY_SECONDS,
+    REGTEST_MIN_BATCH_EXPIRY_SECONDS,
+} from "../src/wallet/batchExpiry";
+import { createArkadeBatchHandler } from "../src/arkade/batch";
+import { ServerResponseMismatchError } from "../src/providers/errors";
+import { networks } from "../src/networks";
+import type { SignerSession } from "../src/tree/signingSession";
+import type { ArkProvider, BatchStartedEvent } from "../src/providers/ark";
+import type { EmulatorProvider } from "../src/providers/emulator";
+import type { Identity } from "../src/identity";
+import type { Intent } from "../src/intent";
+
+const INTENT_ID = "intent-123";
+const SIGNER_XONLY = "11".repeat(32);
+
+describe("defaultBatchExpiryPolicy", () => {
+    it("requires seconds off regtest", () => {
+        expect(defaultBatchExpiryPolicy(networks.bitcoin)).toEqual({
+            minSeconds: DEFAULT_MIN_BATCH_EXPIRY_SECONDS,
+            requireSeconds: true,
+        });
+        expect(defaultBatchExpiryPolicy(networks.testnet).requireSeconds).toBe(true);
+        expect(defaultBatchExpiryPolicy(networks.signet).requireSeconds).toBe(true);
+        expect(defaultBatchExpiryPolicy(networks.mutinynet).requireSeconds).toBe(true);
+    });
+
+    it("allows blocks on regtest with a lower floor", () => {
+        expect(defaultBatchExpiryPolicy(networks.regtest)).toEqual({
+            minSeconds: REGTEST_MIN_BATCH_EXPIRY_SECONDS,
+            requireSeconds: false,
+        });
+    });
+
+    it("applies overrides on top of the network default", () => {
+        expect(resolveBatchExpiryPolicy(networks.bitcoin, { minSeconds: 0n })).toEqual({
+            minSeconds: 0n,
+            requireSeconds: true,
+        });
+    });
+});
+
+describe("assertValidBatchExpiry", () => {
+    const cases: Array<[bigint, keyof typeof networks, "accept" | "reject", string]> = [
+        [1n, "bitcoin", "reject", "1-block sweep"],
+        [511n, "bitcoin", "reject", "max block-typed value"],
+        [512n, "bitcoin", "reject", "8.5 minutes"],
+        [86_016n, "bitcoin", "reject", "512*168, just under 24h"],
+        [86_528n, "bitcoin", "accept", "512*169, just over 24h"],
+        [604_672n, "bitcoin", "accept", "arkd default, ~7 days"],
+        [1n, "regtest", "reject", "1-block sweep on regtest"],
+        [10n, "regtest", "accept", "at the regtest floor"],
+        [100n, "regtest", "accept", "unit-test fixture value"],
+        [180n, "regtest", "accept", "compose.ark.yml value"],
+    ];
+
+    for (const [value, network, expected, label] of cases) {
+        it(`${expected}s ${value} on ${network} (${label})`, () => {
+            const run = () =>
+                assertValidBatchExpiry(value, defaultBatchExpiryPolicy(networks[network]));
+            if (expected === "accept") {
+                expect(run()).toEqual({
+                    value,
+                    type: value >= 512n ? "seconds" : "blocks",
+                });
+            } else {
+                expect(run).toThrow(ServerResponseMismatchError);
+            }
+        });
+    }
+
+    it("rejects a value that differs from the advertised vtxoTreeExpiry", () => {
+        expect(() =>
+            assertValidBatchExpiry(86_528n, {
+                minSeconds: 0n,
+                requireSeconds: false,
+                advertisedVtxoTreeExpiry: 604_672n,
+            }),
+        ).toThrow(/does not match the advertised vtxoTreeExpiry 604672/);
+    });
+
+    it("accepts a value equal to the advertised vtxoTreeExpiry", () => {
+        expect(
+            assertValidBatchExpiry(604_672n, {
+                ...defaultBatchExpiryPolicy(networks.bitcoin),
+                advertisedVtxoTreeExpiry: 604_672n,
+            }),
+        ).toEqual({ value: 604_672n, type: "seconds" });
+    });
+
+    it("still applies the floor when nothing is advertised", () => {
+        expect(() =>
+            assertValidBatchExpiry(512n, {
+                ...defaultBatchExpiryPolicy(networks.bitcoin),
+                advertisedVtxoTreeExpiry: undefined,
+            }),
+        ).toThrow(/below the 86400s floor/);
+    });
+});
+
+describe("createArkadeBatchHandler batch expiry", () => {
+    function makeArkProvider() {
+        return {
+            confirmRegistration: vi.fn(async () => {}),
+            getInfo: vi.fn(async () => ({
+                forfeitPubkey: "02" + "22".repeat(32),
+            })),
+        } as unknown as ArkProvider;
+    }
+
+    function makeSession() {
+        return {
+            getPublicKey: vi.fn(async () => hex.decode("02" + SIGNER_XONLY)),
+            init: vi.fn(async () => {}),
+        } as unknown as SignerSession;
+    }
+
+    function makeHandler(
+        arkProvider: ArkProvider,
+        session: SignerSession,
+        network = networks.bitcoin,
+    ) {
+        return createArkadeBatchHandler(
+            INTENT_ID,
+            [],
+            {} as unknown as Identity,
+            "signed-proof",
+            {} as unknown as Intent.RegisterMessage,
+            session,
+            arkProvider,
+            {} as unknown as EmulatorProvider,
+            network,
+        );
+    }
+
+    const batchStarted = (batchExpiry: bigint) =>
+        ({
+            id: "batch-1",
+            intentIdHashes: [hex.encode(sha256(new TextEncoder().encode(INTENT_ID)))],
+            batchExpiry,
+        }) as unknown as BatchStartedEvent;
+
+    it("rejects an out-of-policy expiry without confirming or initializing signing", async () => {
+        const arkProvider = makeArkProvider();
+        const session = makeSession();
+
+        await expect(
+            makeHandler(arkProvider, session).onBatchStarted(batchStarted(1n)),
+        ).rejects.toThrow(ServerResponseMismatchError);
+
+        expect(arkProvider.confirmRegistration).not.toHaveBeenCalled();
+        expect(session.init).not.toHaveBeenCalled();
+    });
+
+    it("confirms and proceeds on an in-policy expiry", async () => {
+        const arkProvider = makeArkProvider();
+
+        await expect(
+            makeHandler(arkProvider, makeSession()).onBatchStarted(batchStarted(604_672n)),
+        ).resolves.toEqual({ skip: false });
+
+        expect(arkProvider.confirmRegistration).toHaveBeenCalledWith(INTENT_ID);
+    });
+
+    it("does not validate or confirm when the intent is not ours", async () => {
+        const arkProvider = makeArkProvider();
+
+        await expect(
+            makeHandler(arkProvider, makeSession()).onBatchStarted({
+                id: "batch-1",
+                intentIdHashes: ["ff".repeat(32)],
+                batchExpiry: 1n,
+            } as unknown as BatchStartedEvent),
+        ).resolves.toEqual({ skip: true });
+
+        expect(arkProvider.confirmRegistration).not.toHaveBeenCalled();
+    });
+});

--- a/packages/ts-sdk/test/batch-expiry-validation.test.ts
+++ b/packages/ts-sdk/test/batch-expiry-validation.test.ts
@@ -103,6 +103,24 @@ describe("assertValidBatchExpiry", () => {
             }),
         ).toThrow(/below the 86400s floor/);
     });
+
+    it("still applies the floor when the value equals the advertised vtxoTreeExpiry", () => {
+        expect(() =>
+            assertValidBatchExpiry(512n, {
+                ...defaultBatchExpiryPolicy(networks.bitcoin),
+                advertisedVtxoTreeExpiry: 512n,
+            }),
+        ).toThrow(/below the 86400s floor/);
+    });
+
+    it("still rejects a block-typed value equal to the advertised vtxoTreeExpiry", () => {
+        expect(() =>
+            assertValidBatchExpiry(144n, {
+                ...defaultBatchExpiryPolicy(networks.bitcoin),
+                advertisedVtxoTreeExpiry: 144n,
+            }),
+        ).toThrow(/block-typed timelocks are not accepted/);
+    });
 });
 
 describe("createArkadeBatchHandler batch expiry", () => {

--- a/packages/ts-sdk/test/e2e/non-interactive-delegate.test.ts
+++ b/packages/ts-sdk/test/e2e/non-interactive-delegate.test.ts
@@ -5,8 +5,10 @@ import { tapLeafHash } from "@scure/btc-signer/payment.js";
 import { sha256 } from "@scure/btc-signer/utils.js";
 import {
     arkade,
+    assertValidBatchExpiry,
     Batch,
     CSVMultisigTapscript,
+    resolveBatchExpiryPolicy,
     Intent,
     networks,
     PrevArkTxField,
@@ -259,15 +261,20 @@ function buildDelegateHandler(opts: {
             if (!event.intentIdHashes.includes(intentIdHash)) {
                 return { skip: true };
             }
+            const info = await arkProvider.getInfo();
+            const timelock = assertValidBatchExpiry(
+                event.batchExpiry,
+                resolveBatchExpiryPolicy(networks.regtest, {
+                    advertisedVtxoTreeExpiry: info.vtxoTreeExpiry,
+                }),
+            );
+
             await arkProvider.confirmRegistration(opts.intentId);
             batchId = event.id;
 
             const sweepTapscript = CSVMultisigTapscript.encode({
-                timelock: {
-                    value: event.batchExpiry,
-                    type: event.batchExpiry >= 512n ? "seconds" : "blocks",
-                },
-                pubkeys: [hex.decode((await arkProvider.getInfo()).forfeitPubkey).subarray(1)],
+                timelock,
+                pubkeys: [hex.decode(info.forfeitPubkey).subarray(1)],
             }).script;
             sweepTapLeaf = tapLeafHash(sweepTapscript);
 

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -527,7 +527,7 @@ describe("Wallet", () => {
                 json: () =>
                     Promise.resolve({
                         ...mockArkInfo,
-                        vtxoTreeExpiry: mockArkInfo.batchExpiry, // Server response uses vtxoTreeExpiry
+                        vtxoTreeExpiry: mockArkInfo.batchExpiry,
                     }),
             });
 


### PR DESCRIPTION
The sweep leaf of the shared batch output is derived from `BatchStartedEvent.batchExpiry`, so `validateVtxoTxGraph` can only prove the tree is consistent with whatever value the round supplied — the value itself never leaves the leaf hash, and there was no floor on it.

`assertValidBatchExpiry` (new, `wallet/batchExpiry.ts`) checks it against a per-network policy and returns the timelock to encode:

- seconds-typed required off regtest, mirroring arkd's own rule (`config.go`: block-typed vtxo tree expiry is regtest-only)
- a wall-clock floor — 24h by default, ~10 blocks on regtest, which legitimately runs block-typed expiries (`ARKD_VTXO_TREE_EXPIRY=180`)
- equality with `vtxoTreeExpiry` when the operator advertises it

It runs at `onBatchStarted` before `confirmRegistration`, so a rejected round is never confirmed and no signing state is initialized. Rejections are `ServerResponseMismatchError`, matching the existing terminal-mismatch taxonomy.

Wired into all three batch handlers — arkade, `Wallet`, and the boltz-swap VHTLC one, which carried the same unbounded copy — plus the hand-rolled e2e handler.

`ArkInfo.vtxoTreeExpiry` is parsed as optional (`undefined`, never `0n`, when unadvertised — arkd dropped it from `GetInfoResponse` in arkade-os/arkd#737) and carried through the info snapshot as an optional v1 field, so existing snapshots stay readable.

Configurable via `WalletConfig.minBatchExpirySeconds` and a policy override on the free-function handlers; the floor can be lowered but not disabled.

### Notes

- Follow-ups, not in this PR: re-adding `vtxo_tree_expiry` to arkd's `GetInfoResponse` (until then the equality check is inert), and the same bounding for the checkpoint unroll script and the unilateral/boarding exit delays — the validator is shaped for that reuse.
- `NArk` has the same unbounded derivation at `BatchSession.cs:53`; worth mirroring there.

### Testing

`test/batch-expiry-validation.test.ts` covers the policy defaults, a boundary table (1 / 511 / 512 / 86016 / 86528 / 604672 on mainnet; 1 / 10 / 100 / 180 on regtest), and asserts the handler neither confirms nor initializes signing on rejection. Snapshot round-trip cases cover advertised, unadvertised, and pre-existing v1 snapshots.

Full unit suite green: 2299 ts-sdk, 610 boltz-swap, 67 swap. Lint and build clean. Regtest/e2e not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable batch-expiry policies with network-specific defaults and minimum expiry settings.
  - Added validation for server-advertised expiries, including seconds- and block-based values.
  - Exposed Ark server VTXO tree expiry information through provider, wallet, and snapshot APIs.
  - Added wallet configuration for custom minimum batch-expiry durations.

- **Bug Fixes**
  - Invalid or mismatched expiries are rejected before registration confirmation or signing.
  - Preserved compatibility with older wallet snapshots lacking expiry information.

- **Tests**
  - Added coverage for expiry validation, policy overrides, snapshot handling, and batch processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->