### PR TITLE
fix(checkpoint): bound the server-supplied checkpoint exit delay before committing to it

### DIFF
--- a/packages/boltz-swap/src/utils/vhtlc.ts
+++ b/packages/boltz-swap/src/utils/vhtlc.ts
@@ -3,6 +3,8 @@ import {
     ArkProvider,
     ArkTxInput,
     assertSubmittedArkTxid,
+    assertValidServerUnrollScript,
+    resolveCheckpointExitDelayPolicy,
     Batch,
     buildOffchainTx,
     getSequence,
@@ -10,13 +12,13 @@ import {
     matchServerCheckpoints,
     Intent,
     getNetwork,
+    Network,
     networks,
     NetworkName,
     Recipient,
     VHTLC,
     VtxoScript,
     VtxoTaprootTree,
-    CSVMultisigTapscript,
     combineTapscriptSigs,
     Transaction,
     scriptFromTapLeafScript,
@@ -148,6 +150,28 @@ export const candidateServerPubkeys = (arkInfo: ArkInfo): string[] => {
     return candidates;
 };
 
+/** Resolve `ArkInfo.network` (e.g. `"bitcoin"`, `"regtest"`) to a {@link Network}. */
+const resolveArkNetwork = (networkName: string): Network =>
+    networkName in networks ? networks[networkName as keyof typeof networks] : networks.bitcoin;
+
+/**
+ * Decode and validate `arkInfo.checkpointTapscript` for building checkpoint
+ * outputs. These free functions have no persistent wallet state to pin a
+ * forfeit pubkey against across calls, so — mirroring how
+ * `createVHTLCBatchHandler` already treats `vtxoTreeExpiry` — this checks
+ * self-consistency against this same response's own `forfeitPubkey`; the
+ * exit-delay floor is the primary defense against a malicious operator.
+ */
+const assertValidVHTLCServerUnrollScript = (
+    arkInfo: Pick<ArkInfo, "checkpointTapscript" | "forfeitPubkey" | "network">,
+) =>
+    assertValidServerUnrollScript(
+        arkInfo.checkpointTapscript,
+        resolveCheckpointExitDelayPolicy(resolveArkNetwork(arkInfo.network), {
+            advertisedForfeitPubkey: normalizeToXOnlyKey(arkInfo.forfeitPubkey, "forfeit"),
+        }),
+    );
+
 /**
  * Joins a batch to spend the vtxo via commitment transaction
  * @param identity - The identity to use for signing the forfeit transaction.
@@ -213,8 +237,7 @@ export const joinBatch = async (
         proof: base64.encode(signedRegisterIntent.toPSBT()),
     });
 
-    const btcNetwork =
-        network in networks ? networks[network as keyof typeof networks] : networks.bitcoin;
+    const btcNetwork = resolveArkNetwork(network);
     const decodedAddress = Address(btcNetwork).decode(forfeitAddress);
 
     try {
@@ -273,8 +296,7 @@ export const claimVHTLCwithOffchainTx = async (
     arkProvider: ArkProvider,
 ): Promise<string> => {
     // create the server unroll script for checkpoint transactions
-    const rawCheckpointTapscript = hex.decode(arkInfo.checkpointTapscript);
-    const serverUnrollScript = CSVMultisigTapscript.decode(rawCheckpointTapscript);
+    const serverUnrollScript = assertValidVHTLCServerUnrollScript(arkInfo);
 
     // create the offchain transaction to claim the VHTLC
     const { arkTx, checkpoints } = buildOffchainTx(inputs, [output], serverUnrollScript);
@@ -353,8 +375,7 @@ export const refundWithoutReceiverVHTLCwithOffchainTx = async (
     arkProvider: ArkProvider,
 ): Promise<string> => {
     // create the server unroll script for checkpoint transactions
-    const rawCheckpointTapscript = hex.decode(arkInfo.checkpointTapscript);
-    const serverUnrollScript = CSVMultisigTapscript.decode(rawCheckpointTapscript);
+    const serverUnrollScript = assertValidVHTLCServerUnrollScript(arkInfo);
 
     // create the offchain transaction to refund the VHTLC
     const { arkTx, checkpoints } = buildOffchainTx([input], [output], serverUnrollScript);
@@ -436,8 +457,7 @@ export const refundVHTLCwithOffchainTx = async (
     }>,
 ): Promise<void> => {
     // create the server unroll script for checkpoint transactions
-    const rawCheckpointTapscript = hex.decode(arkInfo.checkpointTapscript);
-    const serverUnrollScript = CSVMultisigTapscript.decode(rawCheckpointTapscript);
+    const serverUnrollScript = assertValidVHTLCServerUnrollScript(arkInfo);
 
     // create the virtual transaction to claim the VHTLC
     const { arkTx: unsignedRefundTx, checkpoints: checkpointPtxs } = buildOffchainTx(

--- a/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
+++ b/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
@@ -245,7 +245,7 @@ describe("claimVHTLCwithOffchainTx checkpoint exit delay validation [P720-2]", (
                 { ...arkInfo, checkpointTapscript: wrongPubkeyCheckpoint },
                 arkProvider,
             ),
-        ).rejects.toThrow(/do not match the advertised forfeitPubkey/);
+        ).rejects.toThrow(/does not match the advertised forfeitPubkey/);
         expect(arkProvider.submitTx).not.toHaveBeenCalled();
     });
 });

--- a/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
+++ b/packages/boltz-swap/test/vhtlc-claim-checkpoint.test.ts
@@ -62,6 +62,8 @@ async function fixture() {
     const output = { script: P2TR, amount: BigInt(VALUE) };
     const arkInfo = {
         checkpointTapscript: hex.encode((await unrollScript(serverKey)).script),
+        forfeitPubkey: hex.encode(server),
+        network: "regtest",
     } as ArkInfo;
 
     return { vhtlcScript, server, input, output, arkInfo };
@@ -200,5 +202,50 @@ describe("claimVHTLCwithOffchainTx checkpoint reconciliation", () => {
             ),
         ).rejects.toThrow(/does not match any submitted checkpoint/);
         expect(arkProvider.finalizeTx).not.toHaveBeenCalled();
+    });
+});
+
+describe("claimVHTLCwithOffchainTx checkpoint exit delay validation [P720-2]", () => {
+    it("rejects a sub-floor checkpointTapscript before submitting anything", async () => {
+        const { vhtlcScript, server, input, output, arkInfo } = await fixture();
+        const arkProvider = arkProviderStub(serverSigned);
+        const oneBlockCheckpoint = hex.encode(
+            CSVMultisigTapscript.encode({
+                timelock: { type: "blocks", value: 1n },
+                pubkeys: [server],
+            }).script,
+        );
+
+        await expect(
+            claimVHTLCwithOffchainTx(
+                ourKey,
+                vhtlcScript,
+                server,
+                [input],
+                output,
+                { ...arkInfo, checkpointTapscript: oneBlockCheckpoint },
+                arkProvider,
+            ),
+        ).rejects.toThrow(/checkpoint exit delay rejected/);
+        expect(arkProvider.submitTx).not.toHaveBeenCalled();
+    });
+
+    it("rejects a checkpointTapscript pinned to a pubkey other than forfeitPubkey", async () => {
+        const { vhtlcScript, server, input, output, arkInfo } = await fixture();
+        const arkProvider = arkProviderStub(serverSigned);
+        const wrongPubkeyCheckpoint = hex.encode((await unrollScript(foreignKey)).script);
+
+        await expect(
+            claimVHTLCwithOffchainTx(
+                ourKey,
+                vhtlcScript,
+                server,
+                [input],
+                output,
+                { ...arkInfo, checkpointTapscript: wrongPubkeyCheckpoint },
+                arkProvider,
+            ),
+        ).rejects.toThrow(/do not match the advertised forfeitPubkey/);
+        expect(arkProvider.submitTx).not.toHaveBeenCalled();
     });
 });

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -319,6 +319,14 @@ import {
     REGTEST_MIN_BATCH_EXPIRY_SECONDS,
 } from "./wallet/batchExpiry";
 import type { BatchExpiryPolicy } from "./wallet/batchExpiry";
+import {
+    assertValidServerUnrollScript,
+    defaultCheckpointExitDelayPolicy,
+    resolveCheckpointExitDelayPolicy,
+    DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+} from "./wallet/checkpointExitDelay";
+import type { CheckpointExitDelayPolicy } from "./wallet/checkpointExitDelay";
 import { buildForfeitTx } from "./forfeit";
 import { IndexedDBWalletRepository } from "./repositories/indexedDB/walletRepository";
 import { IndexedDBContractRepository } from "./repositories/indexedDB/contractRepository";
@@ -639,6 +647,12 @@ export {
     DEFAULT_MIN_BATCH_EXPIRY_SECONDS,
     REGTEST_MIN_BATCH_EXPIRY_SECONDS,
     type BatchExpiryPolicy,
+    assertValidServerUnrollScript,
+    defaultCheckpointExitDelayPolicy,
+    resolveCheckpointExitDelayPolicy,
+    DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    type CheckpointExitDelayPolicy,
     buildForfeitTx,
     isRecoverable,
     isSpendable,

--- a/packages/ts-sdk/src/wallet/batchExpiry.ts
+++ b/packages/ts-sdk/src/wallet/batchExpiry.ts
@@ -1,13 +1,7 @@
 import type { Network } from "../networks";
 import type { RelativeTimelock } from "../script/tapscript";
 import { ServerResponseMismatchError } from "../providers/errors";
-
-/**
- * Nominal seconds per block, used only to compare a block-typed timelock
- * against a wall-clock floor. Coarse by design: under the default policies
- * block-typed values are only accepted on regtest.
- */
-const NOMINAL_BLOCK_SECONDS = 600n;
+import { assertTimelockWithinFloor, isRegtest } from "./timelockPolicy";
 
 /** Wall-clock floor for `batchExpiry` outside regtest. */
 export const DEFAULT_MIN_BATCH_EXPIRY_SECONDS = 86_400n;
@@ -27,8 +21,6 @@ export type BatchExpiryPolicy = {
     /** When advertised by the operator, `batchExpiry` must equal it exactly. */
     advertisedVtxoTreeExpiry?: bigint;
 };
-
-const isRegtest = (network: Network): boolean => network.bech32 === "bcrt";
 
 /**
  * Default policy for a network.
@@ -51,15 +43,6 @@ export function resolveBatchExpiryPolicy(
     return { ...defaultBatchExpiryPolicy(network), ...overrides };
 }
 
-/** BIP-68 reads values >= 512 as seconds, below as blocks. */
-const toTimelock = (value: bigint): RelativeTimelock => ({
-    value,
-    type: value >= 512n ? "seconds" : "blocks",
-});
-
-const toSeconds = (t: RelativeTimelock): bigint =>
-    t.type === "seconds" ? t.value : t.value * NOMINAL_BLOCK_SECONDS;
-
 /**
  * Check a server-supplied batch expiry against `policy` and return the timelock
  * to commit to.
@@ -75,30 +58,15 @@ export function assertValidBatchExpiry(
     batchExpiry: bigint,
     policy: BatchExpiryPolicy,
 ): RelativeTimelock {
-    const timelock = toTimelock(batchExpiry);
-
-    if (policy.advertisedVtxoTreeExpiry !== undefined) {
-        if (batchExpiry !== policy.advertisedVtxoTreeExpiry) {
-            throw new ServerResponseMismatchError(
-                `batch expiry rejected: ${batchExpiry} does not match the advertised ` +
-                    `vtxoTreeExpiry ${policy.advertisedVtxoTreeExpiry}`,
-            );
-        }
-    }
-
-    if (policy.requireSeconds && timelock.type === "blocks") {
+    if (
+        policy.advertisedVtxoTreeExpiry !== undefined &&
+        batchExpiry !== policy.advertisedVtxoTreeExpiry
+    ) {
         throw new ServerResponseMismatchError(
-            `batch expiry rejected: block-typed timelocks are not accepted (got ${batchExpiry})`,
+            `batch expiry rejected: ${batchExpiry} does not match the advertised ` +
+                `vtxoTreeExpiry ${policy.advertisedVtxoTreeExpiry}`,
         );
     }
 
-    const seconds = toSeconds(timelock);
-    if (seconds < policy.minSeconds) {
-        throw new ServerResponseMismatchError(
-            `batch expiry rejected: ${timelock.value} ${timelock.type} is below the ` +
-                `${policy.minSeconds}s floor`,
-        );
-    }
-
-    return timelock;
+    return assertTimelockWithinFloor(batchExpiry, policy, "batch expiry");
 }

--- a/packages/ts-sdk/src/wallet/checkpointExitDelay.ts
+++ b/packages/ts-sdk/src/wallet/checkpointExitDelay.ts
@@ -3,7 +3,7 @@ import { Bytes, equalBytes } from "@scure/btc-signer/utils.js";
 import type { Network } from "../networks";
 import { CSVMultisigTapscript } from "../script/tapscript";
 import { ServerResponseMismatchError } from "../providers/errors";
-import { assertTimelockWithinFloor, isRegtest } from "./timelockPolicy";
+import { assertTimelockInPolicy, isRegtest } from "./timelockPolicy";
 
 /** Wall-clock floor for the checkpoint exit delay outside regtest. Matches arkd's own default. */
 export const DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS = 86_400n;
@@ -89,18 +89,29 @@ export function assertValidServerUnrollScript(
 
     if (policy.advertisedForfeitPubkey !== undefined) {
         const { pubkeys } = script.params;
-        const matches =
-            pubkeys.length === 1 && equalBytes(pubkeys[0], policy.advertisedForfeitPubkey);
-        if (!matches) {
+        // arkd encodes exactly one key here, so anything else is a mismatch —
+        // reported separately from a wrong single key so the two are
+        // distinguishable when debugging a rejected server.
+        if (pubkeys.length !== 1) {
             throw new ServerResponseMismatchError(
-                `checkpoint exit delay rejected: checkpointTapscript pubkeys ` +
-                    `[${pubkeys.map(hex.encode).join(", ")}] do not match the advertised ` +
-                    `forfeitPubkey ${hex.encode(policy.advertisedForfeitPubkey)}`,
+                `checkpoint exit delay rejected: checkpointTapscript must commit to exactly ` +
+                    `one pubkey, got ${pubkeys.length} ` +
+                    `[${pubkeys.map(hex.encode).join(", ")}]`,
+            );
+        }
+        if (!equalBytes(pubkeys[0], policy.advertisedForfeitPubkey)) {
+            throw new ServerResponseMismatchError(
+                `checkpoint exit delay rejected: checkpointTapscript pubkey ` +
+                    `${hex.encode(pubkeys[0])} does not match the advertised forfeitPubkey ` +
+                    `${hex.encode(policy.advertisedForfeitPubkey)}`,
             );
         }
     }
 
-    assertTimelockWithinFloor(script.params.timelock.value, policy, "checkpoint exit delay");
+    // Use the type the script itself encodes (BIP-68 disable flag) rather than
+    // re-deriving it from the magnitude: a block-typed checkpoint delay above
+    // 511 blocks is legal and would otherwise be misread as seconds.
+    assertTimelockInPolicy(script.params.timelock, policy, "checkpoint exit delay");
 
     return script;
 }

--- a/packages/ts-sdk/src/wallet/checkpointExitDelay.ts
+++ b/packages/ts-sdk/src/wallet/checkpointExitDelay.ts
@@ -1,0 +1,106 @@
+import { hex } from "@scure/base";
+import { Bytes, equalBytes } from "@scure/btc-signer/utils.js";
+import type { Network } from "../networks";
+import { CSVMultisigTapscript } from "../script/tapscript";
+import { ServerResponseMismatchError } from "../providers/errors";
+import { assertTimelockWithinFloor, isRegtest } from "./timelockPolicy";
+
+/** Wall-clock floor for the checkpoint exit delay outside regtest. Matches arkd's own default. */
+export const DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS = 86_400n;
+
+/**
+ * Wall-clock floor for the checkpoint exit delay on regtest (~2 blocks nominal).
+ *
+ * Deliberately lower than {@link REGTEST_MIN_BATCH_EXPIRY_SECONDS "../wallet/batchExpiry"} — this
+ * repo's own regtest envs run `ARKD_CHECKPOINT_EXIT_DELAY` as low as 5 blocks
+ * (`packages/boltz-swap/.env.regtest`), so the floor must clear that while still rejecting a
+ * 1-block attack.
+ */
+export const REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS = 1_200n;
+
+/** Bounds applied to a server-supplied `ArkInfo.checkpointTapscript`. */
+export type CheckpointExitDelayPolicy = {
+    /** Minimum wall-clock delay in seconds, after normalization. */
+    minSeconds: bigint;
+    /**
+     * Reject block-typed timelocks. Mirrors arkd, which allows a block-typed
+     * checkpoint exit delay only on regtest.
+     */
+    requireSeconds: boolean;
+    /**
+     * When set, the script's embedded pubkey must equal this x-only key.
+     *
+     * arkd always builds the checkpoint tapscript from its own `forfeitPubkey`
+     * (`internal/core/application/service.go`), so this should be the
+     * `forfeitPubkey` the caller already trusts — pinned wallet state where one
+     * exists, otherwise the same `ArkInfo` response's own `forfeitPubkey` field
+     * as a self-consistency check.
+     */
+    advertisedForfeitPubkey?: Bytes;
+};
+
+/**
+ * Default policy for a network.
+ *
+ * Derive it from the locally held {@link Network} — pinned at wallet setup —
+ * rather than from server data, so the permissive regtest branch can't be
+ * selected by the operator.
+ */
+export function defaultCheckpointExitDelayPolicy(network: Network): CheckpointExitDelayPolicy {
+    return isRegtest(network)
+        ? { minSeconds: REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS, requireSeconds: false }
+        : { minSeconds: DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS, requireSeconds: true };
+}
+
+/** Resolve a policy for `network`, applying any caller overrides on top. */
+export function resolveCheckpointExitDelayPolicy(
+    network: Network,
+    overrides?: Partial<CheckpointExitDelayPolicy>,
+): CheckpointExitDelayPolicy {
+    return { ...defaultCheckpointExitDelayPolicy(network), ...overrides };
+}
+
+/**
+ * Decode and validate a server-supplied `checkpointTapscript` against `policy`.
+ *
+ * Every offchain send/claim builds its checkpoint outputs' server-claim leaf
+ * straight from this script — undecodable, sub-floor or wrong-pubkey values
+ * let the operator sweep an in-flight checkpoint before it settles. This is
+ * the sole gate: callers must use the returned script rather than decoding
+ * their own copy.
+ *
+ * @throws {ServerResponseMismatchError} if the script fails to decode, its
+ *   timelock is out of policy, or its pubkey does not match
+ *   `policy.advertisedForfeitPubkey` (when set).
+ */
+export function assertValidServerUnrollScript(
+    checkpointTapscript: string,
+    policy: CheckpointExitDelayPolicy,
+): CSVMultisigTapscript.Type {
+    let script: CSVMultisigTapscript.Type;
+    try {
+        script = CSVMultisigTapscript.decode(hex.decode(checkpointTapscript));
+    } catch (e) {
+        throw new ServerResponseMismatchError(
+            `checkpoint exit delay rejected: invalid checkpointTapscript from server ` +
+                `(${e instanceof Error ? e.message : String(e)})`,
+        );
+    }
+
+    if (policy.advertisedForfeitPubkey !== undefined) {
+        const { pubkeys } = script.params;
+        const matches =
+            pubkeys.length === 1 && equalBytes(pubkeys[0], policy.advertisedForfeitPubkey);
+        if (!matches) {
+            throw new ServerResponseMismatchError(
+                `checkpoint exit delay rejected: checkpointTapscript pubkeys ` +
+                    `[${pubkeys.map(hex.encode).join(", ")}] do not match the advertised ` +
+                    `forfeitPubkey ${hex.encode(policy.advertisedForfeitPubkey)}`,
+            );
+        }
+    }
+
+    assertTimelockWithinFloor(script.params.timelock.value, policy, "checkpoint exit delay");
+
+    return script;
+}

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -114,6 +114,13 @@ export interface BaseWalletConfig {
      */
     minBatchExpirySeconds?: bigint;
     /**
+     * Minimum accepted checkpoint exit delay decoded from `ArkInfo.checkpointTapscript`,
+     * as wall-clock seconds. Defaults per network — see
+     * `defaultCheckpointExitDelayPolicy`. Lowering it below the default relaxes a
+     * fund-safety bound; intended for local testing.
+     */
+    minCheckpointExitDelaySeconds?: bigint;
+    /**
      * Repository-backed storage configuration overrides.
      * Defaults to IndexedDB if unset.
      */

--- a/packages/ts-sdk/src/wallet/timelockPolicy.ts
+++ b/packages/ts-sdk/src/wallet/timelockPolicy.ts
@@ -1,0 +1,65 @@
+import type { Network } from "../networks";
+import type { RelativeTimelock } from "../script/tapscript";
+import { ServerResponseMismatchError } from "../providers/errors";
+
+export const isRegtest = (network: Network): boolean => network.bech32 === "bcrt";
+
+/**
+ * Nominal seconds per block, used only to compare a block-typed timelock
+ * against a wall-clock floor. Coarse by design: under the default policies
+ * block-typed values are only accepted on regtest.
+ */
+export const NOMINAL_BLOCK_SECONDS = 600n;
+
+/** Floor + type bounds shared by every server-controlled relative timelock. */
+export type TimelockFloorPolicy = {
+    /** Minimum wall-clock delay in seconds, after normalization. */
+    minSeconds: bigint;
+    /**
+     * Reject block-typed timelocks. Mirrors arkd, which allows block-typed
+     * relative locktimes only on regtest.
+     */
+    requireSeconds: boolean;
+};
+
+/** BIP-68 reads values >= 512 as seconds, below as blocks. */
+export const toTimelock = (value: bigint): RelativeTimelock => ({
+    value,
+    type: value >= 512n ? "seconds" : "blocks",
+});
+
+export const toSeconds = (t: RelativeTimelock): bigint =>
+    t.type === "seconds" ? t.value : t.value * NOMINAL_BLOCK_SECONDS;
+
+/**
+ * Check a server-supplied relative-timelock value against `policy`.
+ *
+ * `label` names the value in thrown messages (e.g. `"batch expiry"`,
+ * `"checkpoint exit delay"`) so callers share this one implementation without
+ * losing message specificity.
+ *
+ * @throws {ServerResponseMismatchError} if the value is out of policy.
+ */
+export function assertTimelockWithinFloor(
+    value: bigint,
+    policy: TimelockFloorPolicy,
+    label: string,
+): RelativeTimelock {
+    const timelock = toTimelock(value);
+
+    if (policy.requireSeconds && timelock.type === "blocks") {
+        throw new ServerResponseMismatchError(
+            `${label} rejected: block-typed timelocks are not accepted (got ${value})`,
+        );
+    }
+
+    const seconds = toSeconds(timelock);
+    if (seconds < policy.minSeconds) {
+        throw new ServerResponseMismatchError(
+            `${label} rejected: ${timelock.value} ${timelock.type} is below the ` +
+                `${policy.minSeconds}s floor`,
+        );
+    }
+
+    return timelock;
+}

--- a/packages/ts-sdk/src/wallet/timelockPolicy.ts
+++ b/packages/ts-sdk/src/wallet/timelockPolicy.ts
@@ -22,7 +22,16 @@ export type TimelockFloorPolicy = {
     requireSeconds: boolean;
 };
 
-/** BIP-68 reads values >= 512 as seconds, below as blocks. */
+/**
+ * Type a bare wire value the way the protocol does: >= 512 is seconds, below is
+ * blocks.
+ *
+ * Only for values that arrive without a type of their own (e.g. a
+ * `BatchStartedEvent.batchExpiry` integer). A timelock decoded from a script
+ * carries its own BIP-68 disable-flag-derived type — pass that straight to
+ * {@link assertTimelockInPolicy} instead, since a block-typed value there can
+ * legitimately exceed 512 and re-deriving would misread it as seconds.
+ */
 export const toTimelock = (value: bigint): RelativeTimelock => ({
     value,
     type: value >= 512n ? "seconds" : "blocks",
@@ -32,24 +41,22 @@ export const toSeconds = (t: RelativeTimelock): bigint =>
     t.type === "seconds" ? t.value : t.value * NOMINAL_BLOCK_SECONDS;
 
 /**
- * Check a server-supplied relative-timelock value against `policy`.
+ * Check an already-typed server-supplied relative timelock against `policy`.
  *
  * `label` names the value in thrown messages (e.g. `"batch expiry"`,
  * `"checkpoint exit delay"`) so callers share this one implementation without
  * losing message specificity.
  *
- * @throws {ServerResponseMismatchError} if the value is out of policy.
+ * @throws {ServerResponseMismatchError} if the timelock is out of policy.
  */
-export function assertTimelockWithinFloor(
-    value: bigint,
+export function assertTimelockInPolicy(
+    timelock: RelativeTimelock,
     policy: TimelockFloorPolicy,
     label: string,
 ): RelativeTimelock {
-    const timelock = toTimelock(value);
-
     if (policy.requireSeconds && timelock.type === "blocks") {
         throw new ServerResponseMismatchError(
-            `${label} rejected: block-typed timelocks are not accepted (got ${value})`,
+            `${label} rejected: block-typed timelocks are not accepted (got ${timelock.value})`,
         );
     }
 
@@ -62,4 +69,18 @@ export function assertTimelockWithinFloor(
     }
 
     return timelock;
+}
+
+/**
+ * Type a bare server-supplied timelock value with {@link toTimelock}, then
+ * check it against `policy`.
+ *
+ * @throws {ServerResponseMismatchError} if the value is out of policy.
+ */
+export function assertTimelockWithinFloor(
+    value: bigint,
+    policy: TimelockFloorPolicy,
+    label: string,
+): RelativeTimelock {
+    return assertTimelockInPolicy(toTimelock(value), policy, label);
 }

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -75,6 +75,11 @@ import { signerSetFromInfo, toXOnlySignerHex } from "./signerRotation";
 import { assertValidBatchExpiry, resolveBatchExpiryPolicy } from "./batchExpiry";
 import type { BatchExpiryPolicy } from "./batchExpiry";
 import {
+    assertValidServerUnrollScript,
+    resolveCheckpointExitDelayPolicy,
+} from "./checkpointExitDelay";
+import type { CheckpointExitDelayPolicy } from "./checkpointExitDelay";
+import {
     assertCheckpointsMatchInputs,
     buildOffchainTx,
     hasBoardingTxExpired,
@@ -2409,20 +2414,20 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
     async rotateServerSigner(newServerPubKey: Bytes, checkpointTapscript: string): Promise<void> {
         const xonly = toXOnlyPubKey(newServerPubKey);
 
-        // Decode the new epoch's checkpoint script FIRST, before any
-        // persistence. The checkpoint script is server-controlled state the
+        // Decode and validate the new epoch's checkpoint script FIRST, before
+        // any persistence. The checkpoint script is server-controlled state the
         // send path builds its checkpoint outputs from; a missing/empty/
-        // undecodable value (the provider defaults it to "" when the server
-        // omits it) fails the rotation up front — mirroring `Wallet.create` —
-        // so a bad rotation is side-effect-free and the wallet keeps operating
-        // against its previous consistent epoch (old key + tapscripts + unroll
-        // script).
-        let newServerUnrollScript: CSVMultisigTapscript.Type;
-        try {
-            newServerUnrollScript = CSVMultisigTapscript.decode(hex.decode(checkpointTapscript));
-        } catch (e) {
-            throw new Error("Invalid checkpointTapscript from server");
-        }
+        // undecodable/sub-floor/wrong-pubkey value (the provider defaults it to
+        // "" when the server omits it) fails the rotation up front — mirroring
+        // `Wallet.create` — so a bad rotation is side-effect-free and the
+        // wallet keeps operating against its previous consistent epoch (old
+        // key + tapscripts + unroll script). The forfeit pubkey does not
+        // rotate, so it is pinned against `this.forfeitPubkey` here rather
+        // than trusted from the same response the script came from.
+        const newServerUnrollScript = assertValidServerUnrollScript(
+            checkpointTapscript,
+            resolveCheckpointExitDelayPolicy(this.network, this.checkpointExitDelayPolicy),
+        );
 
         // Fast-path idempotency. The authoritative re-check happens inside
         // `_doRotateServerSigner` after the serialization barrier, so two
@@ -2790,6 +2795,8 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         lookAheadWindow?: number,
         /** Overrides for the `batchExpiry` bounds; defaults derive from `network`. */
         protected readonly batchExpiryPolicy?: Partial<BatchExpiryPolicy>,
+        /** Overrides for the checkpoint exit delay bounds; defaults derive from `network`. */
+        protected readonly checkpointExitDelayPolicy?: Partial<CheckpointExitDelayPolicy>,
     ) {
         super(
             identity,
@@ -2973,21 +2980,29 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
 
         const setup = await ReadonlyWallet.setupWalletConfig(config, pubkey);
 
-        // Compute Wallet-specific forfeit and unroll scripts
-        // the serverUnrollScript is the one used to create output scripts of the checkpoint transactions
-        let serverUnrollScript: CSVMultisigTapscript.Type;
-        try {
-            const raw = hex.decode(setup.info.checkpointTapscript);
-            serverUnrollScript = CSVMultisigTapscript.decode(raw);
-        } catch (e) {
-            throw new Error("Invalid checkpointTapscript from server");
-        }
-
         // parse the server forfeit address
         // server is expecting funds to be sent to this address
         const forfeitPubkey = hex.decode(setup.info.forfeitPubkey).slice(1);
         const forfeitAddress = Address(setup.network).decode(setup.info.forfeitAddress);
         const forfeitOutputScript = OutScript.encode(forfeitAddress);
+
+        // Compute Wallet-specific unroll script — the serverUnrollScript is
+        // used to create output scripts of the checkpoint transactions. No
+        // prior pin exists at first contact, so this checks self-consistency
+        // against this same response's forfeitPubkey (catches malformed
+        // responses) and relies on the exit-delay floor as the real defense
+        // against a malicious operator (mirrors the `arkServerPublicKey` TOFU
+        // caveat, and #686's own batch-expiry floor-first defense).
+        const checkpointExitDelayOverrides: Partial<CheckpointExitDelayPolicy> = {
+            advertisedForfeitPubkey: forfeitPubkey,
+            ...(config.minCheckpointExitDelaySeconds !== undefined
+                ? { minSeconds: config.minCheckpointExitDelaySeconds }
+                : {}),
+        };
+        const serverUnrollScript = assertValidServerUnrollScript(
+            setup.info.checkpointTapscript,
+            resolveCheckpointExitDelayPolicy(setup.network, checkpointExitDelayOverrides),
+        );
 
         // HD wiring (boot path) — resolved via the descriptor provider.
         // The rotator (when present) is handed to the constructor as
@@ -3027,6 +3042,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                     ? { minSeconds: config.minBatchExpirySeconds }
                     : {}),
             },
+            checkpointExitDelayOverrides,
         );
         wallet._serverInfoSource = setup.serverInfoSource;
         // The response cleared construction validation — network/signer in
@@ -4514,8 +4530,9 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
 
         if (spendable.length > 0) {
             const info = await this.arkProvider.getInfo();
-            const serverUnrollScript = CSVMultisigTapscript.decode(
-                hex.decode(info.checkpointTapscript),
+            const serverUnrollScript = assertValidServerUnrollScript(
+                info.checkpointTapscript,
+                resolveCheckpointExitDelayPolicy(this.network, this.checkpointExitDelayPolicy),
             );
 
             // One tx per VTXO: a stale or rejected input then dents only its own

--- a/packages/ts-sdk/test/ark-info-snapshot.test.ts
+++ b/packages/ts-sdk/test/ark-info-snapshot.test.ts
@@ -429,7 +429,7 @@ describe("wallet boot: cache fallback derives identical construction metadata", 
                 onchainProvider: {} as OnchainProvider,
                 storage: { walletRepository, contractRepository },
             }),
-        ).rejects.toThrow(/do not match the advertised forfeitPubkey/);
+        ).rejects.toThrow(/does not match the advertised forfeitPubkey/);
         expect(await loadArkInfoSnapshot(walletRepository)).toBeNull();
     });
 });

--- a/packages/ts-sdk/test/ark-info-snapshot.test.ts
+++ b/packages/ts-sdk/test/ark-info-snapshot.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+import { CSVMultisigTapscript } from "../src/script/tapscript";
 import {
     Wallet,
     ReadonlyWallet,
@@ -34,7 +36,7 @@ function makeArkInfo(overrides: Partial<ArkInfo> = {}): ArkInfo {
     return {
         boardingExitDelay: 144n,
         checkpointTapscript:
-            "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+            "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
         deprecatedSigners: [{ cutoffDate: 1_700_000_000n, pubkey: "02" + "ab".repeat(32) }],
         digest: "digest-abc",
         dust: 1000n,
@@ -374,6 +376,60 @@ describe("wallet boot: cache fallback derives identical construction metadata", 
                 storage: { walletRepository, contractRepository },
             }),
         ).rejects.toThrow(/checkpointTapscript/);
+        expect(await loadArkInfoSnapshot(walletRepository)).toBeNull();
+    });
+
+    it("full Wallet.create rejects a sub-floor checkpoint exit delay [P720-2] and does not cache", async () => {
+        const walletRepository = new InMemoryWalletRepository();
+        const contractRepository = new InMemoryContractRepository();
+        // Well-formed, decodable, and pinned to the advertised forfeitPubkey —
+        // only the timelock (1 block) is out of policy.
+        const oneBlockCheckpoint = hex.encode(
+            CSVMultisigTapscript.encode({
+                timelock: { type: "blocks", value: 1 },
+                pubkeys: [hex.decode(serverKeyHex).slice(1)],
+            }).script,
+        );
+        await expect(
+            Wallet.create({
+                identity: SingleKey.fromHex(privKeyHex),
+                arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: async () => makeArkInfo({ checkpointTapscript: oneBlockCheckpoint }),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider: indexerStub(),
+                onchainProvider: {} as OnchainProvider,
+                storage: { walletRepository, contractRepository },
+            }),
+        ).rejects.toThrow(/checkpoint exit delay rejected/);
+        expect(await loadArkInfoSnapshot(walletRepository)).toBeNull();
+    });
+
+    it("full Wallet.create rejects a checkpoint script pinned to the wrong pubkey [P720-2] and does not cache", async () => {
+        const walletRepository = new InMemoryWalletRepository();
+        const contractRepository = new InMemoryContractRepository();
+        // Well-formed and in-policy timelock, but the embedded pubkey does not
+        // match the response's own forfeitPubkey — a malformed/malicious
+        // response, caught even at first-contact self-consistency.
+        const wrongPubkeyCheckpoint = hex.encode(
+            CSVMultisigTapscript.encode({
+                timelock: { type: "seconds", value: 604_672 },
+                pubkeys: [new Uint8Array(32).fill(0xab)],
+            }).script,
+        );
+        await expect(
+            Wallet.create({
+                identity: SingleKey.fromHex(privKeyHex),
+                arkServerUrl: "http://localhost:7070",
+                arkProvider: {
+                    getInfo: async () =>
+                        makeArkInfo({ checkpointTapscript: wrongPubkeyCheckpoint }),
+                } as Partial<ArkProvider> as ArkProvider,
+                indexerProvider: indexerStub(),
+                onchainProvider: {} as OnchainProvider,
+                storage: { walletRepository, contractRepository },
+            }),
+        ).rejects.toThrow(/do not match the advertised forfeitPubkey/);
         expect(await loadArkInfoSnapshot(walletRepository)).toBeNull();
     });
 });

--- a/packages/ts-sdk/test/arkadeCashClaim.test.ts
+++ b/packages/ts-sdk/test/arkadeCashClaim.test.ts
@@ -19,7 +19,7 @@ import type { VirtualCoin } from "../src/wallet";
 
 const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 const CHECKPOINT_TAPSCRIPT =
-    "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac";
+    "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac";
 
 const info = {
     signerPubkey: SERVER_PUBKEY_HEX,

--- a/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
+++ b/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+
+import {
+    assertValidServerUnrollScript,
+    defaultCheckpointExitDelayPolicy,
+    resolveCheckpointExitDelayPolicy,
+    DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+} from "../src/wallet/checkpointExitDelay";
+import { ServerResponseMismatchError } from "../src/providers/errors";
+import { networks } from "../src/networks";
+import { CSVMultisigTapscript } from "../src/script/tapscript";
+
+const FORFEIT_XONLY = "11".repeat(32);
+const OTHER_XONLY = "22".repeat(32);
+
+function encodeCheckpointTapscript(value: bigint, pubkeyXOnlyHex: string = FORFEIT_XONLY): string {
+    const timelock = { value, type: value >= 512n ? ("seconds" as const) : ("blocks" as const) };
+    return hex.encode(
+        CSVMultisigTapscript.encode({
+            timelock,
+            pubkeys: [hex.decode(pubkeyXOnlyHex)],
+        }).script,
+    );
+}
+
+describe("defaultCheckpointExitDelayPolicy", () => {
+    it("requires seconds off regtest", () => {
+        expect(defaultCheckpointExitDelayPolicy(networks.bitcoin)).toEqual({
+            minSeconds: DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+            requireSeconds: true,
+        });
+        expect(defaultCheckpointExitDelayPolicy(networks.testnet).requireSeconds).toBe(true);
+        expect(defaultCheckpointExitDelayPolicy(networks.signet).requireSeconds).toBe(true);
+        expect(defaultCheckpointExitDelayPolicy(networks.mutinynet).requireSeconds).toBe(true);
+    });
+
+    it("allows blocks on regtest with a lower floor", () => {
+        expect(defaultCheckpointExitDelayPolicy(networks.regtest)).toEqual({
+            minSeconds: REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+            requireSeconds: false,
+        });
+    });
+
+    it("applies overrides on top of the network default", () => {
+        expect(resolveCheckpointExitDelayPolicy(networks.bitcoin, { minSeconds: 0n })).toEqual({
+            minSeconds: 0n,
+            requireSeconds: true,
+        });
+    });
+});
+
+describe("assertValidServerUnrollScript", () => {
+    const cases: Array<[bigint, keyof typeof networks, "accept" | "reject", string]> = [
+        [1n, "bitcoin", "reject", "1-block sweep"],
+        [511n, "bitcoin", "reject", "max block-typed value"],
+        [512n, "bitcoin", "reject", "8.5 minutes"],
+        [86_016n, "bitcoin", "reject", "512*168, just under 24h"],
+        [86_528n, "bitcoin", "accept", "512*169, just over 24h"],
+        [604_672n, "bitcoin", "accept", "arkd default, ~7 days"],
+        [1n, "regtest", "reject", "1-block sweep on regtest"],
+        // ARKD_CHECKPOINT_EXIT_DELAY defaults used across this repo's regtest
+        // envs: 5 (packages/boltz-swap/.env.regtest) and 20
+        // (packages/ts-sdk/.env.regtest, packages/swap/.env.regtest) — both
+        // must clear the regtest floor.
+        [5n, "regtest", "accept", "boltz-swap regtest env value"],
+        [20n, "regtest", "accept", "ts-sdk/swap regtest env value"],
+    ];
+
+    for (const [value, network, expected, label] of cases) {
+        it(`${expected}s ${value} on ${network} (${label})`, () => {
+            const checkpointTapscript = encodeCheckpointTapscript(value);
+            const run = () =>
+                assertValidServerUnrollScript(
+                    checkpointTapscript,
+                    defaultCheckpointExitDelayPolicy(networks[network]),
+                );
+            if (expected === "accept") {
+                const result = run();
+                expect(result.params.timelock).toEqual({
+                    value,
+                    type: value >= 512n ? "seconds" : "blocks",
+                });
+            } else {
+                expect(run).toThrow(ServerResponseMismatchError);
+            }
+        });
+    }
+
+    it("rejects an undecodable script", () => {
+        expect(() =>
+            assertValidServerUnrollScript("zz", defaultCheckpointExitDelayPolicy(networks.bitcoin)),
+        ).toThrow(ServerResponseMismatchError);
+        expect(() =>
+            assertValidServerUnrollScript("zz", defaultCheckpointExitDelayPolicy(networks.bitcoin)),
+        ).toThrow(/invalid checkpointTapscript from server/);
+    });
+
+    it("rejects an empty script", () => {
+        expect(() =>
+            assertValidServerUnrollScript("", defaultCheckpointExitDelayPolicy(networks.bitcoin)),
+        ).toThrow(ServerResponseMismatchError);
+    });
+
+    it("rejects a pubkey that does not match the advertised forfeitPubkey", () => {
+        const checkpointTapscript = encodeCheckpointTapscript(604_672n, OTHER_XONLY);
+        expect(() =>
+            assertValidServerUnrollScript(
+                checkpointTapscript,
+                resolveCheckpointExitDelayPolicy(networks.bitcoin, {
+                    advertisedForfeitPubkey: hex.decode(FORFEIT_XONLY),
+                }),
+            ),
+        ).toThrow(/do not match the advertised forfeitPubkey/);
+    });
+
+    it("accepts a pubkey equal to the advertised forfeitPubkey", () => {
+        const checkpointTapscript = encodeCheckpointTapscript(604_672n, FORFEIT_XONLY);
+        const result = assertValidServerUnrollScript(
+            checkpointTapscript,
+            resolveCheckpointExitDelayPolicy(networks.bitcoin, {
+                advertisedForfeitPubkey: hex.decode(FORFEIT_XONLY),
+            }),
+        );
+        expect(hex.encode(result.params.pubkeys[0])).toBe(FORFEIT_XONLY);
+    });
+
+    it("skips the pubkey check when nothing is advertised", () => {
+        const checkpointTapscript = encodeCheckpointTapscript(604_672n, OTHER_XONLY);
+        expect(() =>
+            assertValidServerUnrollScript(
+                checkpointTapscript,
+                defaultCheckpointExitDelayPolicy(networks.bitcoin),
+            ),
+        ).not.toThrow();
+    });
+
+    it("still applies the floor when no pubkey is advertised", () => {
+        const checkpointTapscript = encodeCheckpointTapscript(512n);
+        expect(() =>
+            assertValidServerUnrollScript(
+                checkpointTapscript,
+                defaultCheckpointExitDelayPolicy(networks.bitcoin),
+            ),
+        ).toThrow(/below the 86400s floor/);
+    });
+});

--- a/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
+++ b/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
@@ -112,7 +112,7 @@ describe("assertValidServerUnrollScript", () => {
                     advertisedForfeitPubkey: hex.decode(FORFEIT_XONLY),
                 }),
             ),
-        ).toThrow(/do not match the advertised forfeitPubkey/);
+        ).toThrow(/does not match the advertised forfeitPubkey/);
     });
 
     it("accepts a pubkey equal to the advertised forfeitPubkey", () => {
@@ -134,6 +134,56 @@ describe("assertValidServerUnrollScript", () => {
                 defaultCheckpointExitDelayPolicy(networks.bitcoin),
             ),
         ).not.toThrow();
+    });
+
+    it("reports a multi-pubkey script distinctly from a wrong single pubkey", () => {
+        const checkpointTapscript = hex.encode(
+            CSVMultisigTapscript.encode({
+                timelock: { value: 604_672n, type: "seconds" },
+                pubkeys: [hex.decode(FORFEIT_XONLY), hex.decode(OTHER_XONLY)],
+            }).script,
+        );
+        expect(() =>
+            assertValidServerUnrollScript(
+                checkpointTapscript,
+                resolveCheckpointExitDelayPolicy(networks.bitcoin, {
+                    advertisedForfeitPubkey: hex.decode(FORFEIT_XONLY),
+                }),
+            ),
+        ).toThrow(/must commit to exactly one pubkey, got 2/);
+    });
+
+    // A block-typed timelock above 511 is legal BIP-68 (the type comes from the
+    // disable flag, not the magnitude). Re-deriving the type from the value
+    // would read it as seconds, letting it slip past `requireSeconds` and
+    // mis-scale it against the floor.
+    describe("block-typed timelocks above the 512 seconds boundary", () => {
+        const blocks = (value: number) =>
+            hex.encode(
+                CSVMultisigTapscript.encode({
+                    timelock: { value, type: "blocks" },
+                    pubkeys: [hex.decode(FORFEIT_XONLY)],
+                }).script,
+            );
+
+        it("rejects them as block-typed on mainnet, even below the floor in nominal seconds", () => {
+            expect(() =>
+                assertValidServerUnrollScript(
+                    blocks(1_000),
+                    resolveCheckpointExitDelayPolicy(networks.bitcoin, { minSeconds: 600n }),
+                ),
+            ).toThrow(/block-typed timelocks are not accepted \(got 1000\)/);
+        });
+
+        it("scales them by nominal block time on regtest instead of reading them as seconds", () => {
+            // 600 blocks is ~100h of nominal wall clock, far above the regtest
+            // floor — but only 600 if misread as seconds.
+            const result = assertValidServerUnrollScript(
+                blocks(600),
+                defaultCheckpointExitDelayPolicy(networks.regtest),
+            );
+            expect(result.params.timelock).toEqual({ value: 600n, type: "blocks" });
+        });
     });
 
     it("still applies the floor when no pubkey is advertised", () => {

--- a/packages/ts-sdk/test/hdWalletCapable.test.ts
+++ b/packages/ts-sdk/test/hdWalletCapable.test.ts
@@ -26,7 +26,7 @@ const mockArkInfo = {
     dust: BigInt(1000),
     forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
     checkpointTapscript:
-        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
 };
 
 const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));

--- a/packages/ts-sdk/test/helpers/restoreWallet.ts
+++ b/packages/ts-sdk/test/helpers/restoreWallet.ts
@@ -40,7 +40,7 @@ export const mockArkInfo = {
     dust: BigInt(1000),
     forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
     checkpointTapscript:
-        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
 };
 
 /**

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -123,7 +123,7 @@ describe("Wallet recipient address binding", () => {
         dust: BigInt(1000),
         forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
         checkpointTapscript:
-            "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+            "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
     };
 
     beforeEach(() => {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -1700,7 +1700,7 @@ describe("Wallet.restore", () => {
                     dust: 1000,
                     forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
                     checkpointTapscript:
-                        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                        "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
                     deprecatedSigners,
                 });
             if (url.includes("subscribe") || url.includes("subscriptions"))

--- a/packages/ts-sdk/test/serverSignerRotation.test.ts
+++ b/packages/ts-sdk/test/serverSignerRotation.test.ts
@@ -94,10 +94,17 @@ describe("Wallet.rotateServerSigner (mid-session server-signer rotation)", () =>
         try {
             const before = hex.encode(wallet.serverUnrollScript.script);
             // A distinct, valid checkpoint script for the new server epoch.
+            // The pubkey stays pinned to the wallet's forfeitPubkey — arkd
+            // never rotates the checkpoint script's pubkey independently of
+            // it, and `assertValidServerUnrollScript` pins against it — only
+            // the timelock varies, which is still a real re-source (the
+            // operator can legitimately change the checkpoint exit delay).
             const newCheckpoint = hex.encode(
                 CSVMultisigTapscript.encode({
-                    timelock: { type: "blocks", value: 200 },
-                    pubkeys: [hex.decode(NEW_SERVER)],
+                    // BIP-68 seconds granularity is 512s; 512*200 = 102400 (~28.4h,
+                    // above the 24h floor and distinct from mockArkInfo's 604672).
+                    timelock: { type: "seconds", value: 512 * 200 },
+                    pubkeys: [wallet.forfeitPubkey],
                 }).script,
             );
             expect(newCheckpoint).not.toBe(before);
@@ -122,7 +129,7 @@ describe("Wallet.rotateServerSigner (mid-session server-signer rotation)", () =>
             const beforeRows = (await contractRepository.getContracts({})).length;
 
             await expect(wallet.rotateServerSigner(hex.decode(NEW_SERVER), "")).rejects.toThrow(
-                "Invalid checkpointTapscript from server",
+                "invalid checkpointTapscript from server",
             );
 
             // The wallet stays on its previous consistent epoch: key, both

--- a/packages/ts-sdk/test/serverSignerRotation.test.ts
+++ b/packages/ts-sdk/test/serverSignerRotation.test.ts
@@ -144,6 +144,64 @@ describe("Wallet.rotateServerSigner (mid-session server-signer rotation)", () =>
         }
     });
 
+    it("rejects a checkpointTapscript pinned to a foreign pubkey without any side effect", async () => {
+        const { wallet, contractRepository } = await makeStaticWalletForTest();
+        try {
+            const beforeKey = hex.encode(wallet.arkServerPublicKey);
+            const beforeUnroll = hex.encode(wallet.serverUnrollScript.script);
+            const beforeRows = (await contractRepository.getContracts({})).length;
+
+            // Well-formed and in-policy on the timelock, but the embedded key
+            // is the rotating signer rather than the wallet's pinned
+            // forfeitPubkey — arkd never rotates the two independently, so a
+            // server that does is claiming a sweep path the wallet never
+            // agreed to.
+            const foreignCheckpoint = hex.encode(
+                CSVMultisigTapscript.encode({
+                    timelock: { type: "seconds", value: 512 * 200 },
+                    pubkeys: [hex.decode(NEW_SERVER)],
+                }).script,
+            );
+
+            await expect(
+                wallet.rotateServerSigner(hex.decode(NEW_SERVER), foreignCheckpoint),
+            ).rejects.toThrow(/does not match the advertised forfeitPubkey/);
+
+            expect(hex.encode(wallet.arkServerPublicKey)).toBe(beforeKey);
+            expect(hex.encode(wallet.serverUnrollScript.script)).toBe(beforeUnroll);
+            expect((await contractRepository.getContracts({})).length).toBe(beforeRows);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
+    it("rejects a sub-floor checkpoint exit delay without any side effect", async () => {
+        const { wallet, contractRepository } = await makeStaticWalletForTest();
+        try {
+            const beforeKey = hex.encode(wallet.arkServerPublicKey);
+            const beforeUnroll = hex.encode(wallet.serverUnrollScript.script);
+            const beforeRows = (await contractRepository.getContracts({})).length;
+
+            // The [P720-2] attack shape: a 1-block sweep path for the new epoch.
+            const sweepableCheckpoint = hex.encode(
+                CSVMultisigTapscript.encode({
+                    timelock: { type: "blocks", value: 1 },
+                    pubkeys: [wallet.forfeitPubkey],
+                }).script,
+            );
+
+            await expect(
+                wallet.rotateServerSigner(hex.decode(NEW_SERVER), sweepableCheckpoint),
+            ).rejects.toThrow(/checkpoint exit delay rejected/);
+
+            expect(hex.encode(wallet.arkServerPublicKey)).toBe(beforeKey);
+            expect(hex.encode(wallet.serverUnrollScript.script)).toBe(beforeUnroll);
+            expect((await contractRepository.getContracts({})).length).toBe(beforeRows);
+        } finally {
+            await wallet.dispose();
+        }
+    });
+
     it("dispose() drains an in-flight onServerInfoChanged handler before teardown", async () => {
         const { wallet } = await makeStaticWalletForTest();
 

--- a/packages/ts-sdk/test/wallet-offline-reads.test.ts
+++ b/packages/ts-sdk/test/wallet-offline-reads.test.ts
@@ -17,7 +17,7 @@ const privKeyHex = "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207
 const arkInfo = (): ArkInfo => ({
     boardingExitDelay: 144n,
     checkpointTapscript:
-        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
     deprecatedSigners: [],
     digest: "d",
     dust: 1000n,

--- a/packages/ts-sdk/test/wallet-virtualtx-inert.test.ts
+++ b/packages/ts-sdk/test/wallet-virtualtx-inert.test.ts
@@ -13,7 +13,7 @@ import type { VirtualTxRepository } from "../src/repositories/virtualTxRepositor
 
 const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 const CHECKPOINT_TAPSCRIPT =
-    "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac";
+    "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac";
 
 const info = {
     signerPubkey: SERVER_PUBKEY_HEX,

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -148,7 +148,7 @@ describe("Wallet", () => {
                             network: "mutinynet",
                             forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
                             checkpointTapscript:
-                                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                                "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
                         }),
                 })
                 .mockResolvedValueOnce({
@@ -510,7 +510,7 @@ describe("Wallet", () => {
             dust: BigInt(1000),
             forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
             checkpointTapscript:
-                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
             fees: {
                 intentFee: {
                     onchainInput: "200.0",
@@ -569,7 +569,7 @@ describe("Wallet", () => {
             dust: BigInt(1000),
             forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
             checkpointTapscript:
-                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
         };
 
         beforeEach(() => {
@@ -712,7 +712,7 @@ describe("Wallet", () => {
             dust: BigInt(1000),
             forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
             checkpointTapscript:
-                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
         };
         const mockBatchExpiry = 1767225600000;
 
@@ -941,7 +941,7 @@ describe("Wallet", () => {
             dust: BigInt(1000),
             forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
             checkpointTapscript:
-                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
         };
 
         function createMockVtxo(script: string): VirtualCoin {
@@ -1030,7 +1030,7 @@ describe("Wallet", () => {
             dust: BigInt(1000),
             forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
             checkpointTapscript:
-                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
         };
 
         it("opens exactly one getSubscription stream after notifyIncomingFunds", async () => {
@@ -1105,7 +1105,7 @@ describe("Wallet", () => {
             dust: BigInt(1000),
             forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
             checkpointTapscript:
-                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
         };
 
         function createMockVtxo(script: string, txid: string): VirtualCoin {
@@ -1262,7 +1262,7 @@ describe("Wallet", () => {
                     ? "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
                     : "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
             checkpointTapscript:
-                "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+                "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
         });
 
         function sequence(value: bigint, type: "blocks" | "seconds") {
@@ -1552,7 +1552,7 @@ describe("ReadonlyWallet", () => {
         dust: BigInt(1000),
         forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
         checkpointTapscript:
-            "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+            "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
     };
 
     beforeEach(() => {

--- a/packages/ts-sdk/test/wallet/boarding-contract.test.ts
+++ b/packages/ts-sdk/test/wallet/boarding-contract.test.ts
@@ -16,7 +16,7 @@ import { hex } from "@scure/base";
 // test/helpers/restoreWallet.ts harness so Wallet.create() parses cleanly.
 const SERVER_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 const CHECKPOINT_TAPSCRIPT =
-    "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac";
+    "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac";
 
 // boardingExitDelay is a seconds-type relative timelock and must be a multiple
 // of 512 (BIP68 seconds granularity; bip68.encode throws otherwise). 604672 =

--- a/packages/ts-sdk/test/wallet/unsignableBoardingInput.test.ts
+++ b/packages/ts-sdk/test/wallet/unsignableBoardingInput.test.ts
@@ -22,7 +22,7 @@ const mockArkInfo = {
     dust: BigInt(1000),
     forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
     checkpointTapscript:
-        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
 };
 
 const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));

--- a/packages/ts-sdk/test/walletBoardingRotation.test.ts
+++ b/packages/ts-sdk/test/walletBoardingRotation.test.ts
@@ -38,7 +38,7 @@ const mockArkInfo = {
     dust: BigInt(1000),
     forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
     checkpointTapscript:
-        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
 };
 
 const { mockFetch } = vi.hoisted(() => ({

--- a/packages/ts-sdk/test/walletBoardingTxs.test.ts
+++ b/packages/ts-sdk/test/walletBoardingTxs.test.ts
@@ -26,7 +26,7 @@ const mockArkInfo = {
     dust: BigInt(1000),
     forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
     checkpointTapscript:
-        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
 };
 
 const FUNDING_TXID = "aa".repeat(32);

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -43,7 +43,7 @@ const mockArkInfo = {
     dust: BigInt(1000),
     forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
     checkpointTapscript:
-        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+        "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
 };
 
 // Mock fetch


### PR DESCRIPTION
## Summary

Stacked on #686 (`fix/batch-expiry-validation`) — fixes the follow-up that PR's own description flagged as not-yet-covered: *"the same bounding for the checkpoint unroll script... the validator is shaped for that reuse."* This is `[P720-2]` from the security review: the checkpoint sweep script is entirely server-defined, same unbounded-server-timelock class as the batch sweep expiry Critical (`[P720-1]`, fixed by #686).

- Every offchain send/claim builds a checkpoint output whose server-claim leaf comes from `ArkInfo.checkpointTapscript`, checked only for decodability — no floor on the timelock, no check on the embedded pubkey. A malicious operator can ship a 1-block checkpoint script and sweep an in-flight checkpoint before it settles into a batch, stranding the recipient's vtxo.
- `assertValidServerUnrollScript` (new, `wallet/checkpointExitDelay.ts`) decodes and validates: a wall-clock floor (24h default — matches arkd's own `defaultCheckpointExitDelay`; ~2 blocks on regtest, tuned to clear this repo's own regtest envs, which range from 5 to 20 blocks across packages), seconds-typed required off regtest (mirrors arkd), and the embedded pubkey pinned to the forfeit key (arkd always builds this script from its own `forfeitPubkey`).
- The floor/type-check core is shared with `batchExpiry.ts` via a new `timelockPolicy.ts` extraction — no change to `batchExpiry.ts`'s existing public API.
- Wired into all **six** commit-time decode sites (the finding's "setup and rotation" undersold it):
  - `wallet.ts`: `Wallet.create()`, `rotateServerSigner()`, and the arkadeCash sweep path — pinned against the wallet's own `forfeitPubkey` at rotation/sweep (a value trusted before the current response, same asymmetry the existing server-signer rotation/deprecation flow relies on); self-consistency against the same response's `forfeitPubkey` at first-contact construction (same TOFU limitation as pinning `arkServerPublicKey` itself — the timelock floor is the real defense there).
  - `boltz-swap/src/utils/vhtlc.ts`: all three VHTLC claim/refund functions — self-consistency only, since these are stateless free functions with no persistent wallet state to pin against (same trust model #686 already used for the VHTLC batch handler's `vtxoTreeExpiry` check).
  - `checkpointUnrollCandidates()` (read-only recovery-matching helper) is untouched — gating it would break recovery of legitimately pre-existing checkpoints built before this fix ships.

## Test plan

- [x] New `test/checkpoint-exit-delay-validation.test.ts` (ts-sdk): policy defaults, boundary table (1 block / just-under-floor / just-over-floor / mainnet default, on both mainnet and regtest, including this repo's actual `ARKD_CHECKPOINT_EXIT_DELAY` env values), pubkey-mismatch rejection, decode-failure rejection.
- [x] New `Wallet.create()` rejection tests in `ark-info-snapshot.test.ts` (sub-floor timelock, wrong pubkey) asserting no snapshot is cached on rejection.
- [x] New rejection tests in boltz-swap's `vhtlc-claim-checkpoint.test.ts` covering `claimVHTLCwithOffchainTx`.
- [x] Fixed ~150 existing tests broken by the new validation (a shared hardcoded `checkpointTapscript` fixture across ~13 files no longer satisfied the floor/pubkey checks) and two `serverSignerRotation.test.ts` tests whose premises collided with the new pubkey pin.
- [x] `pnpm run build && pnpm run lint` clean.
- [x] `pnpm run test:unit` — 100% pass across all three packages (2319 ts-sdk, 614 boltz-swap, plus `swap`).
- [x] Regtest/e2e not run locally (no live regtest node in this environment).