### PR TITLE
feat(swap): track a funded RFQ swap to resolution, refund it if the solver never does

### DIFF
--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -95,3 +95,16 @@ export {
     requestOnchainSend,
 } from "./rfq";
 export { sealClaimPacket, type ClaimPacketInput, type SealedClaimPacket } from "./claimPacket";
+export {
+    REFUND_MTP_LAG_SECONDS,
+    RFQ_RESOLVED_STATES,
+    awaitRfqResolution,
+    findLockupVtxos,
+    isRfqTerminal,
+    pushRefundWithoutReceiver,
+    refundIfUnresolved,
+    type LockupVtxo,
+    type RefundArkProvider,
+    type RefundIndexer,
+    type RefundOutcome,
+} from "./refund";

--- a/packages/swap/src/refund.ts
+++ b/packages/swap/src/refund.ts
@@ -1,0 +1,358 @@
+/**
+ * Tracking a funded RFQ swap to its end, and taking the lockup back when the
+ * solver never resolves it.
+ *
+ * The corridor's operate side is complete (`requestLightningSend` /
+ * `requestOnchainSend` quote, derive every leaf locally, and gate funding) and
+ * so is the L1 claim side (`awaitOnchainFill` / `claimOnchainFill`). What was
+ * missing is the other end of a swap that goes wrong: the trader has funded a
+ * VHTLC the solver never claimed, and nothing in this package would build the
+ * spend that gets those sats back.
+ *
+ * **There is no "please refund me" message in this protocol.** `RfqTransport`
+ * carries `requestQuote`, `status`, and `close` — nothing else — so "ask the
+ * solver first" cannot mean sending a new request type. What it means here is
+ * to WATCH: a solver that decides a swap failed resolves it on its own, either
+ * by co-signing the collaborative `refund` leaf or by pushing its own
+ * `nonInteractiveRefund` escape hatch (server + solver + emulator, no timelock
+ * — the reference solver's `refund-now`). Either way the money comes back to
+ * the trader's pre-committed address and the RFQ reports `refunded`. So the
+ * ask is `status()`, and the fallback is the trader doing it itself once the
+ * quote's `refund_locktime` matures. See {@link refundIfUnresolved}.
+ *
+ * Which leaf the fallback uses, and why it is the only sensible one:
+ *
+ * | leaf                              | needs                        | timelock |
+ * |-----------------------------------|------------------------------|----------|
+ * | `refund`                          | trader + solver + server     | none     |
+ * | `refundWithoutReceiver`           | trader + server              | CLTV     |
+ * | `unilateralRefund`                | trader + solver              | CSV      |
+ * | `unilateralRefundWithoutReceiver` | trader alone                 | CSV, longest |
+ *
+ * `refund` needs the solver's live signature, which is exactly what a trader
+ * stuck in this situation does not have and has no way to request. The two CSV
+ * leaves need no server, but a relative timelock only starts counting once the
+ * VTXO is onchain — spending them means unrolling the commitment and checkpoint
+ * transactions first (a real unilateral exit) and then waiting out a delay
+ * strictly longer than the others. `refundWithoutReceiver` is the one that
+ * needs neither the solver nor an exit: the trader's own `sender` key plus the
+ * Arkade server, gated on the CLTV the quote already told the trader about.
+ * That is what this module builds.
+ */
+import { base64, hex } from "@scure/base";
+import {
+    CSVMultisigTapscript,
+    RestArkProvider,
+    RestIndexerProvider,
+    SingleKey,
+    VHTLC,
+    assertSubmittedArkTxid,
+    buildOffchainTx,
+    matchServerCheckpoints,
+} from "@arkade-os/sdk";
+
+import { RFQ_TERMINAL_STATES, type RfqStatus, type RfqTransport } from "./rfq";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** True for the states after which the solver will report nothing further. */
+export const isRfqTerminal = (state: string): boolean =>
+    (RFQ_TERMINAL_STATES as readonly string[]).includes(state);
+
+/**
+ * The terminal states that mean the swap is OVER and the lockup is already
+ * gone — the solver either claimed it (`settled`, revealing the preimage) or
+ * returned it (`refunded`). A trader seeing one of these has nothing left to
+ * do.
+ *
+ * Deliberately narrower than {@link RFQ_TERMINAL_STATES}: `refused`, `expired`
+ * and `stuck` are terminal for the NEGOTIATION but say nothing about whether
+ * the trader's sats are still sitting at the lockup. A trader that funded just
+ * as the quote expired, or whose solver wedged mid-payment, is exactly the
+ * trader who needs the refund most — so those states must not short-circuit
+ * it. {@link refundIfUnresolved} treats them as "keep going", and lets the
+ * on-chain VTXO lookup be the authority on whether anything is actually there.
+ */
+export const RFQ_RESOLVED_STATES = ["settled", "refunded"] as const;
+
+const isResolved = (state: string): boolean =>
+    (RFQ_RESOLVED_STATES as readonly string[]).includes(state);
+
+/**
+ * Poll a swap's status until it reaches a terminal state.
+ *
+ * Same shape and conventions as {@link awaitOnchainFill}: a `pollMs` interval,
+ * an optional unix-seconds `deadline`, and a thrown error carrying a stable
+ * `reason` when that deadline passes.
+ *
+ * A `null` status (the solver has no record of this `rfq_id`) is treated as
+ * "not yet", not as an answer — a status route can legitimately 404 for a
+ * moment after a quote is issued. The deadline is what bounds that wait.
+ *
+ * Transport errors are NOT swallowed; a failing `status()` call rejects this
+ * function. Callers polling across a long refund window should expect to
+ * restart it after a network blip — nothing is lost by doing so, since the
+ * refund path this feeds is gated on an absolute timelock that does not
+ * expire.
+ */
+export async function awaitRfqResolution(
+    transport: RfqTransport,
+    rfqId: string,
+    options: { pollMs?: number; deadline?: number } = {},
+): Promise<RfqStatus> {
+    const pollMs = options.pollMs ?? 5_000;
+    for (;;) {
+        const status = await transport.status(rfqId);
+        if (status && isRfqTerminal(status.state)) return status;
+        if (options.deadline !== undefined && Date.now() / 1000 >= options.deadline) {
+            const error = new Error(
+                `rfq ${rfqId} did not reach a terminal state before the deadline`,
+            ) as Error & { reason: string };
+            error.reason = "status_timeout";
+            throw error;
+        }
+        await sleep(pollMs);
+    }
+}
+
+// ── The refundWithoutReceiver push ───────────────────────────────────────────
+
+/** The Ark surface the refund push needs — narrower than a full provider, and
+ * satisfied by {@link RestArkProvider}. Same seam style as `RestoreIndexer`. */
+export type RefundArkProvider = Pick<RestArkProvider, "getInfo" | "submitTx" | "finalizeTx">;
+
+/** The indexer surface the lockup lookup needs. */
+export type RefundIndexer = Pick<RestIndexerProvider, "getVtxos">;
+
+/** A spendable virtual output sitting at the swap lockup. */
+export interface LockupVtxo {
+    txid: string;
+    vout: number;
+    value: number;
+}
+
+/**
+ * Every spendable output at the lockup script.
+ *
+ * All of them, not the first: a trader may fund a lockup in more than one
+ * send, and refunding only `vtxos[0]` returns part of the money and strands
+ * the rest at a script whose other refund paths are all longer.
+ *
+ * This read — not the RFQ's reported state — is the authority on whether
+ * there is anything left to refund.
+ */
+export async function findLockupVtxos(
+    indexer: RefundIndexer,
+    swapPkScript: Uint8Array,
+): Promise<LockupVtxo[]> {
+    const { vtxos } = await indexer.getVtxos({
+        scripts: [hex.encode(swapPkScript)],
+        spendableOnly: true,
+    });
+    return (vtxos ?? []).map((vtxo) => ({
+        txid: vtxo.txid,
+        vout: vtxo.vout,
+        value: Number(vtxo.value),
+    }));
+}
+
+/**
+ * Build, sign, and push the `refundWithoutReceiver` spend: return every funded
+ * output at the lockup to the trader's refund address.
+ *
+ * The leaf is `CLTV(refundLocktime) + <sender> + <server>` — the trader's own
+ * VHTLC `sender` key and the Arkade server, and NOBODY else. In particular the
+ * emulator is not involved: it co-signs only the two covenant leaves
+ * (`nonInteractiveClaim` / `nonInteractiveRefund`), which is why the solver's
+ * own escape hatch has to go through it and this one does not. So unlike that
+ * push, this transaction is submitted SIGNED, and the only counterparty is the
+ * Arkade server doing what it does for any collaborative spend.
+ *
+ * One aggregate output, not one per input — again unlike the solver's covenant
+ * refund, which needs index-aligned outputs because its ArkadeScript inspects
+ * the output at the current input's index. This leaf carries no covenant, so a
+ * single output paying the whole balance is both valid and cheaper.
+ *
+ * `refundPkScript` defaults to the destination the contract itself commits to
+ * (`nonInteractiveRefund`'s `senderPkScript`, i.e. the address the trader gave
+ * at quote time), so the ordinary call cannot send the refund somewhere the
+ * trader did not intend. It is overridable because this leaf, having no
+ * covenant, genuinely does permit any destination.
+ *
+ * **Consensus, not wall clock, decides when this is spendable.** A seconds
+ * locktime matures against median-time-past, which trails real time by roughly
+ * an hour, so a push issued the moment `refundLocktime` passes can be rejected
+ * until enough blocks land. That is expected, not a failure — see
+ * {@link refundIfUnresolved}, which retries.
+ */
+export async function pushRefundWithoutReceiver(
+    ark: RefundArkProvider,
+    input: {
+        script: InstanceType<typeof VHTLC.ScriptV2>;
+        /** The `sender` private key from `requestLightningSend`/`requestOnchainSend`. */
+        senderPrivateKey: Uint8Array;
+        vtxos: readonly LockupVtxo[];
+        /** Defaults to the contract's own committed refund destination. */
+        refundPkScript?: Uint8Array;
+    },
+): Promise<{ arkTxid: string; amount: number }> {
+    if (input.vtxos.length === 0) throw new Error("nothing to refund: no funded outputs");
+
+    const refundPkScript =
+        input.refundPkScript ?? input.script.options.nonInteractiveRefund?.senderPkScript;
+    if (!refundPkScript) {
+        throw new Error(
+            "no refund destination: the contract carries no nonInteractiveRefund leaf, so pass refundPkScript explicitly",
+        );
+    }
+
+    const info = await ark.getInfo();
+    let serverUnrollScript: CSVMultisigTapscript.Type;
+    try {
+        serverUnrollScript = CSVMultisigTapscript.decode(hex.decode(info.checkpointTapscript));
+    } catch {
+        throw new Error("invalid checkpointTapscript from the Arkade server");
+    }
+
+    const leaf = input.script.refundWithoutReceiver();
+    const tapTree = input.script.encode();
+    const amount = input.vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
+
+    // buildOffchainTx reads the CLTV out of this leaf and sets the ark tx's
+    // nLockTime and input sequence itself, on the checkpoints too — nothing
+    // here has to restate `refundLocktime`.
+    const { arkTx, checkpoints } = buildOffchainTx(
+        input.vtxos.map((vtxo) => ({
+            txid: vtxo.txid,
+            vout: vtxo.vout,
+            value: vtxo.value,
+            tapLeafScript: leaf,
+            tapTree,
+        })),
+        [{ script: refundPkScript, amount: BigInt(amount) }],
+        serverUnrollScript,
+    );
+
+    const signer = SingleKey.fromPrivateKey(input.senderPrivateKey);
+    // No index list: every input spends the same leaf, so all are signed.
+    const signedArkTx = await signer.sign(arkTx);
+    const submitted = await ark.submitTx(
+        base64.encode(signedArkTx.toPSBT()),
+        checkpoints.map((c) => base64.encode(c.toPSBT())),
+    );
+    assertSubmittedArkTxid(submitted, signedArkTx, "refundWithoutReceiver");
+
+    // Only checkpoints we built ourselves get signed: the server's response is
+    // matched against the local set first, so a substituted checkpoint is
+    // rejected rather than blind-signed with the sender key.
+    const matched = matchServerCheckpoints(
+        submitted.signedCheckpointTxs,
+        checkpoints,
+        "refundWithoutReceiver",
+    );
+    const finalCheckpoints = await Promise.all(
+        matched.map(async ({ server }) => base64.encode((await signer.sign(server, [0])).toPSBT())),
+    );
+
+    await ark.finalizeTx(submitted.arkTxid, finalCheckpoints);
+    return { arkTxid: submitted.arkTxid, amount };
+}
+
+// ── Ask first, then fall back ────────────────────────────────────────────────
+
+/**
+ * How long past `refundLocktime` to keep retrying the push before giving up
+ * and surfacing the server's refusal.
+ *
+ * Two hours because the CLTV matures against median-time-past (BIP-113), which
+ * lags wall clock by about an hour, plus room for a slow block. This is the
+ * mirror of `MIN_HEADROOM_SECONDS`, which refuses to FUND without 90 minutes
+ * of the same margin.
+ */
+export const REFUND_MTP_LAG_SECONDS = 2 * 60 * 60;
+
+export type RefundOutcome =
+    /** The solver resolved it — claimed (`settled`) or returned it (`refunded`). */
+    | { outcome: "resolved"; status: RfqStatus }
+    /** The trader took it back via `refundWithoutReceiver`. */
+    | { outcome: "refunded"; arkTxid: string; amount: number; status: RfqStatus | null }
+    /** The refund window opened but the lockup holds nothing to return. */
+    | { outcome: "nothing_to_refund"; status: RfqStatus | null };
+
+/**
+ * Ask first, then fall back: watch the swap for the solver to resolve it, and
+ * if `refundLocktime` matures without that happening, take the lockup back
+ * with `refundWithoutReceiver`.
+ *
+ * This is the whole trader-side failure story in one call. It polls `status()`
+ * — the only "asking" this protocol has (see the module doc) — and returns as
+ * soon as the solver reports `settled` or `refunded`. Otherwise, once the
+ * quote's `refund_locktime` passes, it looks up what is actually at the lockup
+ * and pushes the refund.
+ *
+ * Two behaviours worth knowing:
+ *
+ * - **A dead negotiation is not a reason to stop.** `refused`, `expired` and
+ *   `stuck` are terminal states, but a trader can be holding a funded lockup in
+ *   every one of them, so they do not end the wait — only `settled`/`refunded`
+ *   do (see {@link RFQ_RESOLVED_STATES}). What ends it otherwise is the
+ *   timelock.
+ * - **The first push after the deadline may legitimately fail.** Median-time-
+ *   past trails wall clock, so the server can still consider the leaf locked
+ *   for a while after `refundLocktime` passes in real time. Failures are
+ *   retried at the poll interval until `attemptDeadline`, after which the last
+ *   error is rethrown rather than swallowed.
+ *
+ * Safe to call late, and safe to call again: a caller recovering from a crash
+ * well past the deadline skips straight to the push, and a lockup that is
+ * already empty comes back as `nothing_to_refund` instead of an error.
+ */
+export async function refundIfUnresolved(
+    transport: RfqTransport,
+    ark: RefundArkProvider,
+    indexer: RefundIndexer,
+    input: {
+        rfqId: string;
+        script: InstanceType<typeof VHTLC.ScriptV2>;
+        senderPrivateKey: Uint8Array;
+        /** `refund_locktime` from the quote, unix seconds. */
+        refundLocktime: number;
+        /** Defaults to the contract's own committed refund destination. */
+        refundPkScript?: Uint8Array;
+        pollMs?: number;
+        /** Stop retrying the push at this unix time, rethrowing the last
+         * error. Defaults to `refundLocktime + REFUND_MTP_LAG_SECONDS`. */
+        attemptDeadline?: number;
+        /** Injected for tests; defaults to wall clock, in unix seconds. */
+        now?: () => number;
+    },
+): Promise<RefundOutcome> {
+    const pollMs = input.pollMs ?? 5_000;
+    const now = input.now ?? (() => Math.floor(Date.now() / 1000));
+    const attemptDeadline = input.attemptDeadline ?? input.refundLocktime + REFUND_MTP_LAG_SECONDS;
+
+    for (;;) {
+        const status = await transport.status(input.rfqId);
+        if (status && isResolved(status.state)) return { outcome: "resolved", status };
+
+        if (now() >= input.refundLocktime) {
+            const vtxos = await findLockupVtxos(indexer, input.script.pkScript);
+            if (vtxos.length === 0) return { outcome: "nothing_to_refund", status };
+            try {
+                const pushed = await pushRefundWithoutReceiver(ark, {
+                    script: input.script,
+                    senderPrivateKey: input.senderPrivateKey,
+                    vtxos,
+                    refundPkScript: input.refundPkScript,
+                });
+                return { outcome: "refunded", status, ...pushed };
+            } catch (error) {
+                // Expected while median-time-past has not caught up; give up
+                // only once the window closes, and surface the real reason.
+                if (now() >= attemptDeadline) throw error;
+            }
+        }
+
+        await sleep(pollMs);
+    }
+}

--- a/packages/swap/test/refund.test.ts
+++ b/packages/swap/test/refund.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Tracking a funded swap and taking the lockup back.
+ *
+ * The tests that matter most assert the two things a refund can silently get
+ * wrong and only discover on chain: that the spend really uses the
+ * `refundWithoutReceiver` leaf (carrying the CLTV that makes it valid), and
+ * that a dead-but-funded swap is still refunded rather than reported done.
+ */
+import { describe, expect, it } from "vitest";
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { CSVMultisigTapscript, Transaction } from "@arkade-os/sdk";
+
+import { lightningSendVtxoScript, type RfqStatus, type RfqTransport } from "../src/rfq";
+import {
+    RFQ_RESOLVED_STATES,
+    awaitRfqResolution,
+    findLockupVtxos,
+    isRfqTerminal,
+    pushRefundWithoutReceiver,
+    refundIfUnresolved,
+    type LockupVtxo,
+    type RefundArkProvider,
+    type RefundIndexer,
+} from "../src/refund";
+
+const priv = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+const key = (fill: number): Uint8Array => schnorr.getPublicKey(priv(fill));
+const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+
+const RFQ_ID = "a1".repeat(32);
+const REFUND_LOCKTIME = 1_800_000_000;
+const SENDER_PRIVATE_KEY = priv(13);
+const REFUND_PK_SCRIPT = p2tr(key(5));
+
+/** The same golden participant set rfq.test.ts pins the script bytes against. */
+const swapScript = () =>
+    lightningSendVtxoScript({
+        solverPubkey: key(1),
+        serverPubkey: key(3),
+        paymentHash: hex.encode(sha256(new Uint8Array(32).fill(7))),
+        refundLocktime: REFUND_LOCKTIME,
+        claimDelay: 4096,
+        emulatorPubkey: key(9),
+        refundPkScript: REFUND_PK_SCRIPT,
+        senderPubkey: key(13),
+        receiverPkScript: p2tr(key(1)),
+    });
+
+const CHECKPOINT_TAPSCRIPT = hex.encode(
+    CSVMultisigTapscript.encode({
+        timelock: { type: "blocks", value: BigInt(144) },
+        pubkeys: [key(3)],
+    }).script,
+);
+
+const VTXOS: LockupVtxo[] = [
+    { txid: "11".repeat(32), vout: 0, value: 60_000 },
+    { txid: "22".repeat(32), vout: 1, value: 40_000 },
+];
+
+/** A scripted arkd: echoes back the checkpoints it was handed (as a real one
+ * does, plus its own signature) and reports the ark txid it was submitted.
+ * Typed against the production contract so a change to RefundArkProvider
+ * breaks the fake at compile time. */
+type FakeArk = RefundArkProvider & {
+    submitted: { arkTx: string; checkpoints: string[] }[];
+    finalized: { arkTxid: string; checkpoints: string[] }[];
+};
+
+const fakeArk = (
+    over: {
+        checkpointTapscript?: string;
+        checkpointsFor?: (submitted: string[]) => string[];
+        failSubmit?: () => Error | undefined;
+    } = {},
+): FakeArk => {
+    const submitted: { arkTx: string; checkpoints: string[] }[] = [];
+    const finalized: { arkTxid: string; checkpoints: string[] }[] = [];
+    return {
+        submitted,
+        finalized,
+        getInfo: async () => ({
+            checkpointTapscript: over.checkpointTapscript ?? CHECKPOINT_TAPSCRIPT,
+        }),
+        submitTx: async (arkTx: string, checkpoints: string[]) => {
+            const failure = over.failSubmit?.();
+            if (failure) throw failure;
+            submitted.push({ arkTx, checkpoints });
+            return {
+                arkTxid: Transaction.fromPSBT(base64.decode(arkTx)).id,
+                finalArkTx: arkTx,
+                signedCheckpointTxs: over.checkpointsFor
+                    ? over.checkpointsFor(checkpoints)
+                    : checkpoints,
+            };
+        },
+        finalizeTx: async (arkTxid: string, checkpoints: string[]) => {
+            finalized.push({ arkTxid, checkpoints });
+        },
+    } as unknown as FakeArk;
+};
+
+const fakeIndexer = (vtxos: LockupVtxo[]): RefundIndexer & { scripts: string[][] } => {
+    const scripts: string[][] = [];
+    return {
+        scripts,
+        getVtxos: async (opts?: { scripts?: string[] }) => {
+            scripts.push(opts?.scripts ?? []);
+            return { vtxos };
+        },
+    } as unknown as RefundIndexer & { scripts: string[][] };
+};
+
+const statusOf = (state: string): RfqStatus => ({
+    v: 1,
+    type: "rfq_status",
+    rfq_id: RFQ_ID,
+    state,
+    updated_at: 1,
+    profile: {},
+});
+
+/** A transport that serves a scripted sequence of statuses, repeating the last. */
+const fakeTransport = (states: (string | null)[]): RfqTransport & { calls: number } => {
+    const transport = {
+        calls: 0,
+        async requestQuote() {
+            throw new Error("not used");
+        },
+        async status() {
+            const state = states[Math.min(transport.calls, states.length - 1)];
+            transport.calls += 1;
+            return state === null ? null : statusOf(state);
+        },
+        async close() {},
+    };
+    return transport as unknown as RfqTransport & { calls: number };
+};
+
+/** The leaf script the ark tx's single input actually spends. */
+const spentLeafOf = (psbt: string): string => {
+    const tx = Transaction.fromPSBT(base64.decode(psbt));
+    const leaf = tx.getInput(0).tapLeafScript![0][1];
+    return hex.encode(leaf.subarray(0, -1));
+};
+
+describe("pushRefundWithoutReceiver", () => {
+    it("spends the refundWithoutReceiver leaf, signed by the trader's own sender key", async () => {
+        const script = swapScript();
+        const ark = fakeArk();
+        await pushRefundWithoutReceiver(ark, {
+            script,
+            senderPrivateKey: SENDER_PRIVATE_KEY,
+            vtxos: VTXOS,
+        });
+
+        expect(ark.submitted).toHaveLength(1);
+        // Not `refund` (needs the solver) and not a unilateral leaf (needs an
+        // exit): the CLTV leaf is the only one a stranded trader can drive.
+        expect(spentLeafOf(ark.submitted[0].arkTx)).toBe(script.refundWithoutReceiverScript);
+
+        // SingleKey.sign() swallows "No inputs signed", so an unsigned tx would
+        // otherwise sail through to submitTx and be rejected only server-side.
+        const tx = Transaction.fromPSBT(base64.decode(ark.submitted[0].arkTx));
+        for (let i = 0; i < tx.inputsLength; i++) {
+            expect(tx.getInput(i).tapScriptSig?.length).toBeGreaterThan(0);
+        }
+    });
+
+    it("carries the CLTV locktime and an nLockTime-enabling sequence", async () => {
+        const ark = fakeArk();
+        await pushRefundWithoutReceiver(ark, {
+            script: swapScript(),
+            senderPrivateKey: SENDER_PRIVATE_KEY,
+            vtxos: VTXOS,
+        });
+
+        // Without both of these the spend is simply not consensus-valid — and
+        // nothing in this package restates the locktime, so this is the check
+        // that the CLTV leaf (not a timelock-free one) was handed to the builder.
+        const tx = Transaction.fromPSBT(base64.decode(ark.submitted[0].arkTx));
+        expect(tx.lockTime).toBe(REFUND_LOCKTIME);
+        expect(tx.getInput(0).sequence).toBeLessThan(0xffffffff);
+    });
+
+    it("returns every funded output to the contract's own committed destination", async () => {
+        const ark = fakeArk();
+        const result = await pushRefundWithoutReceiver(ark, {
+            script: swapScript(),
+            senderPrivateKey: SENDER_PRIVATE_KEY,
+            vtxos: VTXOS,
+        });
+
+        // Both deposits, aggregated: refunding vtxos[0] alone would strand the
+        // rest at a script whose other refund paths are all longer.
+        expect(result.amount).toBe(100_000);
+        const tx = Transaction.fromPSBT(base64.decode(ark.submitted[0].arkTx));
+        expect(tx.inputsLength).toBe(2);
+        expect(hex.encode(tx.getOutput(0).script!)).toBe(hex.encode(REFUND_PK_SCRIPT));
+        expect(tx.getOutput(0).amount).toBe(BigInt(100_000));
+        expect(ark.finalized).toHaveLength(1);
+        expect(ark.finalized[0].arkTxid).toBe(result.arkTxid);
+    });
+
+    it("honours an explicit destination override", async () => {
+        const ark = fakeArk();
+        const elsewhere = p2tr(key(21));
+        await pushRefundWithoutReceiver(ark, {
+            script: swapScript(),
+            senderPrivateKey: SENDER_PRIVATE_KEY,
+            vtxos: VTXOS,
+            refundPkScript: elsewhere,
+        });
+        const tx = Transaction.fromPSBT(base64.decode(ark.submitted[0].arkTx));
+        expect(hex.encode(tx.getOutput(0).script!)).toBe(hex.encode(elsewhere));
+    });
+
+    it("refuses an empty lockup instead of pushing an inputless transaction", async () => {
+        await expect(
+            pushRefundWithoutReceiver(fakeArk(), {
+                script: swapScript(),
+                senderPrivateKey: SENDER_PRIVATE_KEY,
+                vtxos: [],
+            }),
+        ).rejects.toThrow(/nothing to refund/);
+    });
+
+    it("refuses to sign a checkpoint the server substituted", async () => {
+        // The substitute is a REAL checkpoint for a different deposit at the
+        // same script — so the sender key can sign it perfectly well, and only
+        // matching it against the locally built set catches the swap. (A
+        // malformed stand-in would prove nothing: signing would fail anyway.)
+        const capture = fakeArk();
+        await pushRefundWithoutReceiver(capture, {
+            script: swapScript(),
+            senderPrivateKey: SENDER_PRIVATE_KEY,
+            vtxos: [{ txid: "33".repeat(32), vout: 0, value: 7_000 }],
+        });
+        const foreignCheckpoint = capture.submitted[0].checkpoints[0];
+
+        const ark = fakeArk({ checkpointsFor: () => [foreignCheckpoint] });
+        await expect(
+            pushRefundWithoutReceiver(ark, {
+                script: swapScript(),
+                senderPrivateKey: SENDER_PRIVATE_KEY,
+                vtxos: [VTXOS[0]],
+            }),
+        ).rejects.toThrow(/does not match any submitted checkpoint/);
+        expect(ark.finalized).toHaveLength(0);
+    });
+
+    it("reports a malformed checkpointTapscript rather than failing deep in the builder", async () => {
+        await expect(
+            pushRefundWithoutReceiver(fakeArk({ checkpointTapscript: "00" }), {
+                script: swapScript(),
+                senderPrivateKey: SENDER_PRIVATE_KEY,
+                vtxos: VTXOS,
+            }),
+        ).rejects.toThrow(/checkpointTapscript/);
+    });
+});
+
+describe("findLockupVtxos", () => {
+    it("asks for the lockup script and returns every spendable output", async () => {
+        const script = swapScript();
+        const indexer = fakeIndexer(VTXOS);
+        expect(await findLockupVtxos(indexer, script.pkScript)).toHaveLength(2);
+        expect(indexer.scripts[0]).toEqual([hex.encode(script.pkScript)]);
+    });
+});
+
+describe("awaitRfqResolution", () => {
+    it("resolves once the swap reaches a terminal state", async () => {
+        const transport = fakeTransport([null, "quoted", "settled"]);
+        const status = await awaitRfqResolution(transport, RFQ_ID, { pollMs: 1 });
+        expect(status.state).toBe("settled");
+    });
+
+    it("times out with the status_timeout reason", async () => {
+        await expect(
+            awaitRfqResolution(fakeTransport(["quoted"]), RFQ_ID, { pollMs: 1, deadline: 1 }),
+        ).rejects.toMatchObject({ reason: "status_timeout" });
+    });
+
+    it("agrees with the exported terminal-state vocabulary", () => {
+        expect(isRfqTerminal("settled")).toBe(true);
+        expect(isRfqTerminal("refunded")).toBe(true);
+        expect(isRfqTerminal("quoted")).toBe(false);
+        // resolved is a strict subset of terminal
+        for (const state of RFQ_RESOLVED_STATES) expect(isRfqTerminal(state)).toBe(true);
+    });
+});
+
+describe("refundIfUnresolved", () => {
+    const baseInput = () => ({
+        rfqId: RFQ_ID,
+        script: swapScript(),
+        senderPrivateKey: SENDER_PRIVATE_KEY,
+        refundLocktime: REFUND_LOCKTIME,
+        pollMs: 1,
+    });
+
+    it("stops without refunding when the solver resolved it", async () => {
+        for (const state of RFQ_RESOLVED_STATES) {
+            const ark = fakeArk();
+            const result = await refundIfUnresolved(
+                fakeTransport([state]),
+                ark,
+                fakeIndexer(VTXOS),
+                { ...baseInput(), now: () => REFUND_LOCKTIME + 1 },
+            );
+            expect(result.outcome).toBe("resolved");
+            // even though the deadline had passed and the lockup looked funded
+            expect(ark.submitted).toHaveLength(0);
+        }
+    });
+
+    it("still refunds a swap whose negotiation died — refused, expired or stuck", async () => {
+        // These are terminal states, but a trader can be holding a funded
+        // lockup in every one of them; treating "terminal" as "done" would
+        // walk away from the money.
+        for (const state of ["refused", "expired", "stuck"]) {
+            const ark = fakeArk();
+            const result = await refundIfUnresolved(
+                fakeTransport([state]),
+                ark,
+                fakeIndexer(VTXOS),
+                { ...baseInput(), now: () => REFUND_LOCKTIME + 1 },
+            );
+            expect(result.outcome).toBe("refunded");
+            expect(ark.submitted).toHaveLength(1);
+        }
+    });
+
+    it("waits while the refund window is shut, then pushes once it opens", async () => {
+        const ark = fakeArk();
+        let clock = REFUND_LOCKTIME - 3;
+        const result = await refundIfUnresolved(
+            fakeTransport(["quoted"]),
+            ark,
+            fakeIndexer(VTXOS),
+            { ...baseInput(), now: () => clock++ },
+        );
+        expect(result.outcome).toBe("refunded");
+        if (result.outcome === "refunded") expect(result.amount).toBe(100_000);
+        expect(ark.submitted).toHaveLength(1);
+    });
+
+    it("retries a push refused while median-time-past lags, then succeeds", async () => {
+        let attempts = 0;
+        const ark = fakeArk({
+            failSubmit: () => (++attempts <= 2 ? new Error("FORFEIT_CLOSURE_LOCKED") : undefined),
+        });
+        const result = await refundIfUnresolved(
+            fakeTransport(["quoted"]),
+            ark,
+            fakeIndexer(VTXOS),
+            { ...baseInput(), now: () => REFUND_LOCKTIME + 1 },
+        );
+        expect(result.outcome).toBe("refunded");
+        expect(attempts).toBe(3);
+    });
+
+    it("rethrows the server's refusal once the attempt window closes", async () => {
+        const ark = fakeArk({ failSubmit: () => new Error("FORFEIT_CLOSURE_LOCKED") });
+        await expect(
+            refundIfUnresolved(fakeTransport(["quoted"]), ark, fakeIndexer(VTXOS), {
+                ...baseInput(),
+                now: () => REFUND_LOCKTIME + 1,
+                attemptDeadline: REFUND_LOCKTIME,
+            }),
+        ).rejects.toThrow(/FORFEIT_CLOSURE_LOCKED/);
+    });
+
+    it("reports an empty lockup instead of failing", async () => {
+        const ark = fakeArk();
+        const result = await refundIfUnresolved(fakeTransport(["stuck"]), ark, fakeIndexer([]), {
+            ...baseInput(),
+            now: () => REFUND_LOCKTIME + 1,
+        });
+        expect(result.outcome).toBe("nothing_to_refund");
+        expect(ark.submitted).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Stacked on `feat/arkade-swap` (picks up cleanly on top of the #683 merge).

## What was missing

`packages/swap` already had both ends of a swap that *works*. It can quote (`requestLightningSend` / `requestOnchainSend`), it derives every VHTLC leaf locally, it gates funding on headroom, and it runs the onchain corridor's whole L1 claim side (`awaitOnchainFill` / `claimOnchainFill`). What it had nothing for is a swap that simply fails: a trader who funded a lockup the solver never claimed had no way, *in this library*, to build the spend that gets the sats back. Every refund-side leaf was derived correctly and never once spent.

This adds the other end: watch a funded swap to its resolution, and if the solver never resolves it, take the lockup back.

## Why "ask first" is `status()` polling, not a new message

There is no "please refund me" in this protocol. `RfqTransport` carries `requestQuote`, `status`, and `close` — that's the entire surface — so "ask the solver first" cannot mean sending a new request type without a protocol extension.

What it *can* mean is watching. A solver that decides a swap has failed resolves it on its own initiative, either by co-signing the collaborative `refund` leaf or by pushing its own `nonInteractiveRefund` escape hatch; either way the money returns to the trader's pre-committed address and the RFQ reports `refunded`. So the ask is `status()`, and the fallback is the trader acting alone once the quote's `refund_locktime` matures. `refundIfUnresolved()` is that whole sequence; `awaitRfqResolution()` is the status poller on its own, shaped like the existing `awaitOnchainFill` (a `pollMs` interval, an optional deadline, a stable `reason` on timeout).

## Why `refundWithoutReceiver`, and not any of the other three

| leaf | needs | timelock |
|---|---|---|
| `refund` | trader + solver + server | none |
| `refundWithoutReceiver` | trader + server | CLTV |
| `unilateralRefund` | trader + solver | CSV |
| `unilateralRefundWithoutReceiver` | trader alone | CSV, longest |

`refund` needs the solver's live signature — precisely the thing a stranded trader does not have and, per the above, has no way to request. The two CSV leaves need no server, but a *relative* timelock only starts counting once the VTXO is onchain, so spending them means performing a real unilateral exit first and then waiting out a delay strictly longer than the others.

`refundWithoutReceiver` is the one that needs neither the solver nor an exit. Worth stating explicitly because an early reading of this got it wrong: **this leaf does not involve the emulator.** It is `CLTVMultisigTapscript` with `pubkeys: [sender, server]` (`packages/ts-sdk/src/script/vhtlc.ts:108-111`) — the trader's own key plus the Arkade server, nobody else. The emulator co-signs only the two *covenant* leaves (`nonInteractiveClaim` / `nonInteractiveRefund`), which is exactly why the solver's escape hatch has to route through it and this one does not. So unlike that push, this transaction goes to `arkd` signed, like any ordinary collaborative spend.

## Terminal is not the same as resolved

The distinction that's easiest to get backwards, and it's load-bearing enough to have its own exported constant. `RFQ_TERMINAL_STATES` includes `refused`, `expired`, and `stuck` — those end the *negotiation*, but they say nothing whatsoever about whether the trader's sats are still sitting at the lockup. A trader who funded just as the quote expired, or whose solver wedged mid-payment, is exactly the trader who needs the refund most.

So `RFQ_RESOLVED_STATES` is deliberately narrower: only `settled` (solver claimed it, revealing the preimage) and `refunded` (solver returned it) mean the lockup is actually gone. Those stop the wait; the dead-negotiation states do not. What ends it otherwise is the timelock — and the on-chain VTXO lookup, not the RFQ's self-reported state, is the authority on whether there is anything left to refund.

## Two smaller decisions

**The first push after the deadline can legitimately be refused, and that isn't a failure.** A seconds-denominated locktime matures against median-time-past (BIP-113), which trails wall clock by roughly an hour. So a push issued the moment `refund_locktime` passes in real time can be rejected until enough blocks land. Failures are retried at the poll interval until `attemptDeadline` (default `refundLocktime + REFUND_MTP_LAG_SECONDS`, two hours) and only then rethrown with the server's real reason. This is the mirror of the existing `MIN_HEADROOM_SECONDS`, which refuses to *fund* without the same margin.

**Every funded output goes back in one transaction, not `vtxos[0]`.** A trader may fund a lockup across more than one send, and a partial refund strands the remainder at a script whose every other path is longer. The destination defaults to the address the contract itself commits to (`nonInteractiveRefund`'s `senderPkScript`, i.e. what the trader gave at quote time), so the ordinary call cannot pay somewhere the trader never named; it stays overridable because this leaf, carrying no covenant, genuinely does permit any destination. Server-returned checkpoints are matched against the locally built set before the sender key signs anything, so a substituted checkpoint is rejected rather than blind-signed.

## Explicitly out of scope

**`refundCollaborative`.** Not buildable today — there is no wire mechanism to request the solver's signature. It would need a protocol extension, not just a client-side function.

**The fully-unilateral leaf (`unilateralRefundWithoutReceiver`).** This is a real, separate, and considerably larger piece of work rather than something quietly skipped. It needs a genuine unilateral exit ahead of it. `Unroll` does exist (`packages/ts-sdk/src/wallet/unroll.ts`), but it lives in the wallet layer and depends on onchain broadcast (1C1P packages) and block-confirmation waiting that `packages/swap` deliberately does not wire in. And even with that, unrolling only gets the VTXO onchain — the actual CSV-leaf spend afterward is still unwritten. Worth flagging as a known gap in trust-minimisation: today's fallback still needs the Arkade server to be cooperative.

## One uncertainty worth carrying

The refund pays a **single aggregate output** rather than one output per input. The reasoning is that `refundWithoutReceiver` carries no covenant, unlike the solver's `refundSwapScript`, whose ArkadeScript inspects the output at the current input's index and therefore forces index-aligned outputs. With no such constraint here, one output paying the whole balance should be both valid and cheaper.

That is reasoned from the script source, **not verified against a live `arkd`** — no regtest was run building this. If a multi-VTXO lockup is ever exercised for real, this is the assumption I'd expect to be wrong first, and the one worth checking.

## Test plan

`packages/swap/test/refund.test.ts` — **17 tests, all passing**, covering the leaf and signer used, the CLTV locktime and nLockTime-enabling sequence, aggregate-output behaviour, the committed-destination default and its override, empty-lockup and malformed-`checkpointTapscript` rejection, checkpoint-substitution rejection, the terminal-vs-resolved split, the MTP retry-then-succeed path, and the rethrow once the attempt window closes.

These are genuine revert-verified regression guards, not coverage padding: each was checked by mutating the implementation to confirm the test actually fails. That pass caught one weak assertion among them, which was tightened rather than left in.

Full gate on this branch, against a baseline captured on the base commit (`5327fe19`):

| step | baseline | this branch |
|---|---|---|
| `pnpm lint` (3 pkgs) | pass | pass |
| typecheck ts-sdk / boltz-swap / swap | pass | pass |
| `pnpm build` | pass | pass |
| `smoke:dist` + `npm pack` shape (3 pkgs) | pass | pass |
| ts-sdk unit | 2319 passed, 1 skipped (153 files) | unchanged |
| swap unit | 116 passed (10 files) | **133 passed (11 files)** |
| boltz-swap unit | 609 passed (23 files) | unchanged |

**0 failing at baseline, 0 failing now; +17 tests, no regressions.** Integration/regtest E2E was not run locally.
