### PR TITLE
fix(swap): stop fetching the emulator pubkey live; take it from the caller

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -50,11 +50,11 @@ the rest:
 
 ```ts
 // BTC -> asset
-const o = await createOffer(wallet, ARK, EMU, { wantAmount: 1000n, wantAsset });
+const o = await createOffer(wallet, ARK, EMULATOR_PUBKEY, { wantAmount: 1000n, wantAsset });
 await wallet.send({ address: o.address, amount: 1000, extensions: [o.extension] });
 
 // asset -> BTC (the sats are the VTXO carrier for the asset)
-const o = await createOffer(wallet, ARK, EMU, { wantAmount: 1000n, offerAsset });
+const o = await createOffer(wallet, ARK, EMULATOR_PUBKEY, { wantAmount: 1000n, offerAsset });
 await wallet.send({
     address: o.address,
     amount: 500,
@@ -62,6 +62,11 @@ await wallet.send({
     extensions: [o.extension],
 });
 ```
+
+`EMULATOR_PUBKEY` is the covenant co-signer's x-only key — the solver's deployment, not yours.
+`createOffer` does not fetch or verify it: clients have no network path to the emulator, only the
+solver and covclaimd do. Obtain it out of band, before calling `createOffer`, from the solver's
+signed registry/corridor card and check it against whatever value you independently trust.
 
 ### What `createOffer` gives you back
 
@@ -135,7 +140,7 @@ import { httpTransport, requestLightningSend } from "@arkade-os/swap";
 const swap = await requestLightningSend(
     wallet,
     arkServerUrl,
-    emulatorUrl,
+    emulatorPubkey,
     httpTransport(solverUrl),
     {
         invoice: { raw: bolt11, paymentHash, amountSats, expiresAt },
@@ -148,10 +153,13 @@ await wallet.send({ address: swap.address, amount: BigInt(swap.fundAmount) });
 The trust model is the offer side's, applied to quotes: only `solver_pubkey`,
 `refund_locktime`, `valid_until` and the amounts are used from a quote; every other contract
 parameter is the trader's own data, and anything address-shaped from the solver is compare-only
-(`AddressMismatch` means refuse-to-fund). Refusals carry a closed reason set (`SwapRefusal`);
-unknown reasons are a generic decline. The `swap-lightning-send.program.json` bytes are frozen
-the same way the offer programs are — a golden test pins the compiled leaves and scriptPubKey to
-the reference solver's exact script.
+(`AddressMismatch` means refuse-to-fund). `emulatorPubkey` is neither: it is not fetched or
+verified by this library at all — clients have no network path to the emulator, only the solver
+and covclaimd do — so it must arrive already obtained out of band, from the solver's signed
+registry/corridor card, and already checked against whatever value you independently trust.
+Refusals carry a closed reason set (`SwapRefusal`); unknown reasons are a generic decline. The
+`swap-lightning-send.program.json` bytes are frozen the same way the offer programs are — a
+golden test pins the compiled leaves and scriptPubKey to the reference solver's exact script.
 
 Transports are symmetric-outbound: `httpTransport` (POST `/v1/swap`, GET `/v1/rfq/<rfq_id>`) and
 `relayTransport` (the dev broker framing; the production target is Nostr — a directed kind with
@@ -177,11 +185,13 @@ import {
     claimOnchainFill,
 } from "@arkade-os/swap";
 
-const swap = await requestOnchainSend(wallet, arkServerUrl, emulatorUrl, httpTransport(solverUrl), {
-    amount: 100_000,
-    amountSide: "to",
-    payoutPubkey,
-});
+const swap = await requestOnchainSend(
+    wallet,
+    arkServerUrl,
+    emulatorPubkey,
+    httpTransport(solverUrl),
+    { amount: 100_000, amountSide: "to", payoutPubkey },
+);
 // PERSIST swap.preimage (with the record) BEFORE funding — it is the only
 // thing that can claim the L1 fill, across restarts included.
 await wallet.send({ address: swap.address, amount: BigInt(swap.fundAmount) });

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -341,8 +341,9 @@ export async function createOffer(
      * not the maker's. This library does NOT fetch or verify it: clients
      * have no network path to the emulator, only the solver and covclaimd
      * do. The caller must obtain this out-of-band, before calling this
-     * function, from the solver's signed registry/corridor card
-     * (`SolverCard.emulator_pubkey`) or an equivalent source it
+     * function, from the solver's signed registry/corridor card (its
+     * `emulator_pubkey`, added in arkade-os/solver-registry#18) or an
+     * equivalent source it
      * independently trusts, and is responsible for having checked it
      * against that trusted value itself. */
     emulatorPubkey: Uint8Array,

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -21,7 +21,6 @@ import {
     ArkAddress,
     RestArkProvider,
     RestIndexerProvider,
-    RestEmulatorProvider,
     arkade,
     asset,
     getNetwork,
@@ -318,11 +317,11 @@ async function registerOfferContract(
  * you deposit, embedding the returned extension, and the solver does the rest:
  *
  *   // BTC -> asset
- *   const o = await createOffer(wallet, ARK, EMU, { wantAmount: 1000n, wantAsset })
+ *   const o = await createOffer(wallet, ARK, EMULATOR_PUBKEY, { wantAmount: 1000n, wantAsset })
  *   await wallet.send({ address: o.address, amount: 1000, extensions: [o.extension] })
  *
  *   // asset -> BTC (the sats are the VTXO carrier for the asset)
- *   const o = await createOffer(wallet, ARK, EMU, { wantAmount: 1000n, offerAsset })
+ *   const o = await createOffer(wallet, ARK, EMULATOR_PUBKEY, { wantAmount: 1000n, offerAsset })
  *   await wallet.send({ address: o.address, amount: 500,
  *                       assets: [{ assetId, amount: 1000n }],
  *                       extensions: [o.extension] })
@@ -338,7 +337,15 @@ async function registerOfferContract(
 export async function createOffer(
     wallet: IWallet,
     arkServerUrl: string,
-    emulatorUrl: string,
+    /** Covenant co-signer (emulator) x-only key — the SOLVER's deployment,
+     * not the maker's. This library does NOT fetch or verify it: clients
+     * have no network path to the emulator, only the solver and covclaimd
+     * do. The caller must obtain this out-of-band, before calling this
+     * function, from the solver's signed registry/corridor card
+     * (`SolverCard.emulator_pubkey`) or an equivalent source it
+     * independently trusts, and is responsible for having checked it
+     * against that trusted value itself. */
+    emulatorPubkey: Uint8Array,
     params: { wantAmount: bigint; wantAsset?: asset.AssetId; offerAsset?: asset.AssetId },
 ): Promise<{
     /** The encoded offer, hex. **Persist this** — it is the only input
@@ -359,16 +366,18 @@ export async function createOffer(
     if (Boolean(params.wantAsset) === Boolean(params.offerAsset)) {
         throw new Error("set exactly one of wantAsset (BTC->asset) or offerAsset (asset->BTC)");
     }
-    const [info, emulatorInfo, makerAddress, makerPublicKey] = await Promise.all([
+    const [info, makerAddress, makerPublicKey] = await Promise.all([
         new RestArkProvider(arkServerUrl).getInfo(),
-        new RestEmulatorProvider(emulatorUrl).getInfo(),
         wallet.getAddress(),
         wallet.identity.xOnlyPublicKey(),
     ]);
-    // both keys arrive compressed (33B) today; drop the prefix by length so an
-    // already-x-only key is passed through rather than shortened to 31 bytes
+    // the ark signer key arrives compressed (33B) today; drop the prefix by
+    // length so an already-x-only key is passed through rather than
+    // shortened to 31 bytes — same normalization applied to the
+    // caller-supplied emulator key below, in case its source hands back
+    // either width
     const serverPubKey = xOnly(hex.decode(info.signerPubkey), "ark signer key");
-    const emuKey = xOnly(hex.decode(emulatorInfo.signerPubkey), "emulator signer key");
+    const emuKey = xOnly(emulatorPubkey, "emulator pubkey");
 
     // the script derives from every field but the script itself, so build the
     // binding first and complete the offer with it — an Offer value never

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -26,9 +26,12 @@
  * Trust model, identical to the offer side: from a quote the trader uses only
  * the binding fields — `solver_pubkey`, `refund_locktime`, `valid_until`, the
  * amounts. Every other contract parameter is the trader's own data (its
- * invoice, its Ark server connection, its emulator endpoint, its refund
- * address). Anything address-shaped the solver sends is compare-only:
- * a mismatch means refuse-to-fund, never "use theirs".
+ * invoice, its Ark server connection, its refund address) or obtained
+ * out-of-band from a source it independently trusts — the emulator's x-only
+ * key, from the solver's signed registry/corridor card, since clients have no
+ * network path to the emulator itself; only the solver and covclaimd do.
+ * Anything address-shaped the solver sends is compare-only: a mismatch means
+ * refuse-to-fund, never "use theirs".
  *
  * Transport is symmetric-outbound: the reference framing below speaks the dev
  * broker (`{op:"sub"|"event"}` over WebSocket) or plain HTTP; the production
@@ -41,7 +44,6 @@ import { schnorr } from "@noble/curves/secp256k1.js";
 import {
     ArkAddress,
     RestArkProvider,
-    RestEmulatorProvider,
     VHTLC,
     asset,
     getNetwork,
@@ -563,7 +565,10 @@ export function lightningSendVtxoScript(params: {
      * {@link unilateralRefundDelay} and {@link unilateralRefundWithoutReceiverDelay}
      * derive from this same value — one rounding, shared across all three tiers. */
     claimDelay: number;
-    /** Emulator x-only key — the trader's OWN endpoint. */
+    /** Emulator x-only key — the SOLVER's deployment, not the trader's own.
+     * Not fetched here or anywhere in this package; see {@link
+     * requestLightningSend}'s `emulatorPubkey` parameter for where it comes
+     * from and why. */
     emulatorPubkey: Uint8Array;
     /** Where a refund must pay: the trader's P2TR pkScript (34 bytes). Also
      * `nonInteractiveRefund`'s covenant destination. */
@@ -640,7 +645,17 @@ export interface InvoiceFacts {
 export async function requestLightningSend(
     wallet: IWallet,
     arkServerUrl: string,
-    emulatorUrl: string,
+    /** Covenant co-signer (emulator) x-only key — the SOLVER's deployment,
+     * not the trader's. This library does NOT fetch or verify it: clients
+     * have no network path to the emulator, only the solver and covclaimd
+     * do. The caller must obtain this out-of-band, before calling this
+     * function, from the solver's signed registry/corridor card
+     * (`SolverCard.emulator_pubkey`) or an equivalent source it
+     * independently trusts, and is responsible for having checked it against
+     * that trusted value itself — the same never-trust-only-compare rule as
+     * {@link verifyLockupAddress}, just applied by the caller instead of
+     * here, because there is nothing in this module to derive it against. */
+    emulatorPubkey: Uint8Array,
     transport: RfqTransport,
     params: { invoice: InvoiceFacts; rfqId?: string },
 ): Promise<{
@@ -663,9 +678,8 @@ export async function requestLightningSend(
     const rfqId = params.rfqId ?? newRfqId();
     const senderPrivateKey = schnorr.utils.randomSecretKey();
     const senderPubkey = schnorr.getPublicKey(senderPrivateKey);
-    const [info, emulatorInfo, refundAddress] = await Promise.all([
+    const [info, refundAddress] = await Promise.all([
         new RestArkProvider(arkServerUrl).getInfo(),
-        new RestEmulatorProvider(emulatorUrl).getInfo(),
         wallet.getAddress(),
     ]);
 
@@ -687,7 +701,7 @@ export async function requestLightningSend(
         serverPubkey,
         paymentHash: params.invoice.paymentHash,
         claimDelay: unilateralClaimDelay(Number(info.unilateralExitDelay)),
-        emulatorPubkey: xOnly(hex.decode(emulatorInfo.signerPubkey), "emulator signer key"),
+        emulatorPubkey: xOnly(emulatorPubkey, "emulator pubkey"),
         senderPubkey,
         receiverPkScript: solverHex(receiverPkScriptHex, "profile.receiver_pk_script"),
         refundPkScript: ArkAddress.decode(refundAddress).pkScript,
@@ -905,7 +919,9 @@ export function deriveOnchainSend(input: {
 export async function requestOnchainSend(
     wallet: IWallet,
     arkServerUrl: string,
-    emulatorUrl: string,
+    /** Covenant co-signer (emulator) x-only key — same parameter, same
+     * caller obligation, as {@link requestLightningSend}'s. */
+    emulatorPubkey: Uint8Array,
     transport: RfqTransport,
     params: {
         amount: number;
@@ -937,9 +953,8 @@ export async function requestOnchainSend(
     const paymentHash = paymentHashOf(preimage);
     const senderPrivateKey = schnorr.utils.randomSecretKey();
     const senderPubkey = schnorr.getPublicKey(senderPrivateKey);
-    const [info, emulatorInfo, refundAddress] = await Promise.all([
+    const [info, refundAddress] = await Promise.all([
         new RestArkProvider(arkServerUrl).getInfo(),
-        new RestEmulatorProvider(emulatorUrl).getInfo(),
         wallet.getAddress(),
     ]);
 
@@ -960,7 +975,7 @@ export async function requestOnchainSend(
         paymentHash,
         payoutPubkey: params.payoutPubkey,
         serverPubkey: xOnly(hex.decode(info.signerPubkey), "ark signer key"),
-        emulatorPubkey: xOnly(hex.decode(emulatorInfo.signerPubkey), "emulator signer key"),
+        emulatorPubkey: xOnly(emulatorPubkey, "emulator pubkey"),
         claimDelay: unilateralClaimDelay(Number(info.unilateralExitDelay)),
         hrp: getNetwork(info.network as NetworkName).hrp,
         l1Network: l1NetworkFromArk(info.network),

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -649,8 +649,9 @@ export async function requestLightningSend(
      * not the trader's. This library does NOT fetch or verify it: clients
      * have no network path to the emulator, only the solver and covclaimd
      * do. The caller must obtain this out-of-band, before calling this
-     * function, from the solver's signed registry/corridor card
-     * (`SolverCard.emulator_pubkey`) or an equivalent source it
+     * function, from the solver's signed registry/corridor card (its
+     * `emulator_pubkey`, added in arkade-os/solver-registry#18) or an
+     * equivalent source it
      * independently trusts, and is responsible for having checked it against
      * that trusted value itself — the same never-trust-only-compare rule as
      * {@link verifyLockupAddress}, just applied by the caller instead of

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -35,8 +35,19 @@ const DEPOSIT_SATS = 10_000;
 const WANT_AMOUNT = BigInt(1_000);
 
 /** Drop the prefix of a 33-byte compressed key; pass an x-only key through —
- * same rule as offer.ts/rfq.ts, kept local so this suite stays self-contained. */
-const xOnly = (key: Uint8Array): Uint8Array => (key.length === 32 ? key : key.slice(1));
+ * same rule as offer.ts/rfq.ts, kept local so this suite stays self-contained.
+ *
+ * Validates rather than blindly slicing, matching those two: a laxer helper
+ * here would silently accept a wrong-width key — an uncompressed 65-byte one,
+ * say — from the emulator's own `getInfo()` in the setup path below, and this
+ * suite would then run against a key production would have rejected outright. */
+const xOnly = (key: Uint8Array): Uint8Array => {
+    if (key.length === 32) return key;
+    if (key.length !== 33 || (key[0] !== 0x02 && key[0] !== 0x03)) {
+        throw new Error("not a compressed or x-only public key");
+    }
+    return key.slice(1);
+};
 
 const execCommand = (command: string): string => {
     const result = execSync(command, { encoding: "utf8" })
@@ -91,8 +102,9 @@ beforeAll(async () => {
     // createOffer no longer fetches the emulator's key itself — clients have
     // no network path to the emulator, only the solver and covclaimd do — so
     // this stands in for the one-time, out-of-band read of the solver's
-    // registry card (SolverCard.emulator_pubkey) a real integration would do
-    // before ever calling createOffer.
+    // registry card (its `emulator_pubkey` field, added in
+    // arkade-os/solver-registry#18) a real integration would do before ever
+    // calling createOffer.
     const emulatorInfo = await new RestEmulatorProvider(EMULATOR_URL).getInfo();
     emulatorPubkey = xOnly(hex.decode(emulatorInfo.signerPubkey));
 }, 120_000);

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -17,6 +17,7 @@ import {
     EsploraProvider,
     InMemoryContractRepository,
     InMemoryWalletRepository,
+    RestEmulatorProvider,
     RestIndexerProvider,
     SingleKey,
     Wallet,
@@ -32,6 +33,10 @@ const arkdExec = "docker exec -t arkd";
 const FAUCET_SATS = 30_000;
 const DEPOSIT_SATS = 10_000;
 const WANT_AMOUNT = BigInt(1_000);
+
+/** Drop the prefix of a 33-byte compressed key; pass an x-only key through —
+ * same rule as offer.ts/rfq.ts, kept local so this suite stays self-contained. */
+const xOnly = (key: Uint8Array): Uint8Array => (key.length === 32 ? key : key.slice(1));
 
 const execCommand = (command: string): string => {
     const result = execSync(command, { encoding: "utf8" })
@@ -58,6 +63,7 @@ const waitFor = async (
 
 const indexer = new RestIndexerProvider(ARK_URL);
 let wallet: Wallet;
+let emulatorPubkey: Uint8Array;
 
 beforeAll(async () => {
     wallet = await Wallet.create({
@@ -81,6 +87,14 @@ beforeAll(async () => {
     const address = await wallet.getAddress();
     execCommand(`${arkdExec} ark send --to ${address} --amount ${FAUCET_SATS} --password secret`);
     await waitFor(async () => (await wallet.getVtxos()).length > 0);
+
+    // createOffer no longer fetches the emulator's key itself — clients have
+    // no network path to the emulator, only the solver and covclaimd do — so
+    // this stands in for the one-time, out-of-band read of the solver's
+    // registry card (SolverCard.emulator_pubkey) a real integration would do
+    // before ever calling createOffer.
+    const emulatorInfo = await new RestEmulatorProvider(EMULATOR_URL).getInfo();
+    emulatorPubkey = xOnly(hex.decode(emulatorInfo.signerPubkey));
 }, 120_000);
 
 describe("maker-side swap loop (regtest)", () => {
@@ -95,7 +109,7 @@ describe("maker-side swap loop (regtest)", () => {
     const history: Tx[] = [];
 
     it("derives, funds, and restores a pending offer from chain data alone", async () => {
-        offer = await createOffer(wallet, ARK_URL, EMULATOR_URL, {
+        offer = await createOffer(wallet, ARK_URL, emulatorPubkey, {
             wantAmount: WANT_AMOUNT,
             wantAsset,
         });

--- a/packages/swap/test/emulatorTrustBoundary.test.ts
+++ b/packages/swap/test/emulatorTrustBoundary.test.ts
@@ -261,6 +261,22 @@ describe("requestOnchainSend never touches the emulator", () => {
         expect(result.address.startsWith("tark1")).toBe(true);
         expect(result.htlc.address).toBeTruthy();
     });
+
+    it("refuses to fund when the caller's emulatorPubkey does not match what the covenant was quoted with", async () => {
+        // The onchain path derives its Arkade lockup through the same
+        // `verifyLockupAddress` check the lightning one does, so the parameter
+        // has to be load-bearing here too — without this, a dead
+        // `emulatorPubkey` on this entrypoint would pass the success case above
+        // and only be caught by whoever funded a lockup they cannot spend.
+        await expect(
+            requestOnchainSend(wallet, "http://ark", EMULATOR_PUBKEY, onchainTransport(key(29)), {
+                amount: 100_000,
+                amountSide: "to",
+                payoutPubkey: PAYOUT_PUBKEY,
+                preimage: PREIMAGE,
+            }),
+        ).rejects.toThrow(AddressMismatch);
+    });
 });
 
 describe("createOffer never touches the emulator", () => {

--- a/packages/swap/test/emulatorTrustBoundary.test.ts
+++ b/packages/swap/test/emulatorTrustBoundary.test.ts
@@ -1,0 +1,275 @@
+/**
+ * The three maker-flow entrypoints that need the emulator's key —
+ * `requestLightningSend`, `requestOnchainSend` (rfq.ts) and `createOffer`
+ * (offer.ts) — must never reach the emulator over the network: per policy,
+ * clients have no network path to it, only the solver and covclaimd do. The
+ * emulator's x-only key is instead a caller-supplied parameter, sourced out
+ * of band from the solver's signed registry/corridor card.
+ *
+ * This file makes `RestEmulatorProvider`'s constructor throw, so if any of
+ * these three ever regain a live emulator fetch, the test fails loudly
+ * instead of a mock silently absorbing it — and it confirms the supplied key
+ * actually reaches the covenant, not just that nothing crashes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { ArkAddress, asset, type IWallet } from "@arkade-os/sdk";
+
+// cancel.test.ts's pattern: spread the real module, override only the
+// network seam these functions must never touch (RestEmulatorProvider) plus
+// the one they legitimately still call (RestArkProvider), stubbed.
+const state = vi.hoisted(() => ({
+    arkInfo: { signerPubkey: "", unilateralExitDelay: 4096, network: "regtest" },
+}));
+
+vi.mock("@arkade-os/sdk", async (importOriginal) => {
+    const mod = await importOriginal<typeof import("@arkade-os/sdk")>();
+    // the factory is hoisted above this file's imports, so re-import inside it
+    const { hex: hexCodec } = await import("@scure/base");
+    return {
+        ...mod,
+        RestArkProvider: class {
+            async getInfo() {
+                // `createOffer` registers the covenant with the contract
+                // manager, and `Arkade.connect` decodes this — derived from
+                // whatever signer key the test set, so the two cannot drift.
+                return {
+                    ...state.arkInfo,
+                    checkpointTapscript: hexCodec.encode(
+                        mod.CSVMultisigTapscript.encode({
+                            timelock: { type: "blocks", value: 10n },
+                            pubkeys: [hexCodec.decode(state.arkInfo.signerPubkey)],
+                        }).script,
+                    ),
+                };
+            }
+        },
+        RestIndexerProvider: class {
+            async getVtxos() {
+                return { vtxos: [] };
+            }
+        },
+        RestEmulatorProvider: class {
+            constructor() {
+                throw new Error(
+                    "RestEmulatorProvider must never be constructed by a maker-flow " +
+                        "entrypoint — the emulator pubkey is caller-supplied now, never " +
+                        "fetched live by this package",
+                );
+            }
+        },
+    };
+});
+
+import {
+    AddressMismatch,
+    LIGHTNING_SEND_PAIR,
+    ONCHAIN_SEND_PAIR,
+    lightningSendVtxoScript,
+    requestLightningSend,
+    requestOnchainSend,
+    type RfqQuote,
+    type RfqTransport,
+} from "../src/rfq";
+import { onchainHtlcScript, paymentHashOf } from "../src/onchainHtlc";
+import { createOffer, decodeOffer } from "../src/offer";
+
+const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
+const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+
+const SERVER = key(3);
+const SOLVER = key(1);
+const RECEIVER_PK_SCRIPT = p2tr(key(1));
+const EMULATOR_PUBKEY = key(9);
+const PREIMAGE = new Uint8Array(32).fill(7);
+const PAYMENT_HASH = paymentHashOf(PREIMAGE);
+const REFUND_ADDRESS = new ArkAddress(SERVER, key(21), "tark").encode();
+
+state.arkInfo.signerPubkey = hex.encode(SERVER);
+
+const NOW = Math.floor(Date.now() / 1000);
+const VALID_UNTIL = NOW + 3600;
+// Days out, comfortably past every headroom / claim-window / timelock-order
+// gate (all bounded in hours) — the fixture never needs tuning against those
+// margins.
+const REFUND_LOCKTIME = NOW + 60 * 24 * 3600;
+const HTLC_LOCKTIME = NOW + 30 * 24 * 3600;
+
+const wallet = {
+    identity: { xOnlyPublicKey: async () => key(20) },
+    getAddress: async () => REFUND_ADDRESS,
+    // `createOffer` registers the funded covenant with the contract manager
+    // before handing back an address (see `registerOfferContract`), so the
+    // fake has to serve one. Only the offer test reaches this; the two
+    // request* paths never call it.
+    getContractManager: async () => ({
+        createContract: async (params: Record<string, unknown>) => ({
+            ...params,
+            state: "active",
+            createdAt: 0,
+        }),
+    }),
+} as unknown as IWallet;
+
+/** A `requestQuote` stub playing the solver: reads the sender key the
+ * caller generated internally (there is no way to inject it) off the
+ * request's own `client_refund_pubkey`, and quotes a `lockup_address` built
+ * with `forEmulatorPubkey` — standing in for "whatever emulator key the
+ * solver's covenant actually used". */
+const lightningTransport = (forEmulatorPubkey: Uint8Array): RfqTransport => ({
+    async requestQuote(payload) {
+        const profile = (payload as { profile: Record<string, unknown> }).profile;
+        const senderPubkey = hex.decode(profile.client_refund_pubkey as string);
+        const script = lightningSendVtxoScript({
+            solverPubkey: SOLVER,
+            refundLocktime: REFUND_LOCKTIME,
+            serverPubkey: SERVER,
+            paymentHash: PAYMENT_HASH,
+            claimDelay: 4096,
+            emulatorPubkey: forEmulatorPubkey,
+            senderPubkey,
+            receiverPkScript: RECEIVER_PK_SCRIPT,
+            refundPkScript: ArkAddress.decode(REFUND_ADDRESS).pkScript,
+        });
+        return {
+            v: 1,
+            type: "rfq_quote",
+            rfq_id: payload.rfq_id as string,
+            pair: LIGHTNING_SEND_PAIR,
+            from_amount: 1000,
+            to_amount: 1000,
+            solver_pubkey: hex.encode(SOLVER),
+            valid_until: VALID_UNTIL,
+            refund_locktime: REFUND_LOCKTIME,
+            profile: {
+                receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
+                lockup_address: script.address("tark", SERVER).encode(),
+            },
+        } satisfies RfqQuote;
+    },
+    async status() {
+        return null;
+    },
+    async close() {},
+});
+
+describe("requestLightningSend never touches the emulator", () => {
+    it("funds using the caller-supplied emulatorPubkey, without constructing RestEmulatorProvider", async () => {
+        const result = await requestLightningSend(
+            wallet,
+            "http://ark",
+            EMULATOR_PUBKEY,
+            lightningTransport(EMULATOR_PUBKEY),
+            {
+                invoice: {
+                    raw: "lnbc1...",
+                    paymentHash: PAYMENT_HASH,
+                    amountSats: 1000,
+                    expiresAt: NOW + 7200,
+                },
+            },
+        );
+        expect(result.address.startsWith("tark1")).toBe(true);
+    });
+
+    it("refuses to fund when the caller's emulatorPubkey does not match what the covenant was quoted with", async () => {
+        // the transport quotes a lockup built with a DIFFERENT emulator key
+        // than the caller passes in — proving emulatorPubkey is load-bearing
+        // in the derivation, not a dead parameter
+        await expect(
+            requestLightningSend(
+                wallet,
+                "http://ark",
+                EMULATOR_PUBKEY,
+                lightningTransport(key(29)),
+                {
+                    invoice: {
+                        raw: "lnbc1...",
+                        paymentHash: PAYMENT_HASH,
+                        amountSats: 1000,
+                        expiresAt: NOW + 7200,
+                    },
+                },
+            ),
+        ).rejects.toThrow(AddressMismatch);
+    });
+});
+
+describe("requestOnchainSend never touches the emulator", () => {
+    const PAYOUT_PUBKEY = key(15);
+    const HTLC_PUBKEY = key(11);
+
+    const onchainTransport = (forEmulatorPubkey: Uint8Array): RfqTransport => ({
+        async requestQuote(payload) {
+            const profile = (payload as { profile: Record<string, unknown> }).profile;
+            const senderPubkey = hex.decode(profile.client_refund_pubkey as string);
+            const lockupScript = lightningSendVtxoScript({
+                solverPubkey: SOLVER,
+                refundLocktime: REFUND_LOCKTIME,
+                serverPubkey: SERVER,
+                paymentHash: PAYMENT_HASH,
+                claimDelay: 4096,
+                emulatorPubkey: forEmulatorPubkey,
+                senderPubkey,
+                receiverPkScript: RECEIVER_PK_SCRIPT,
+                refundPkScript: ArkAddress.decode(REFUND_ADDRESS).pkScript,
+            });
+            const htlc = onchainHtlcScript(
+                {
+                    paymentHash: PAYMENT_HASH,
+                    claimKey: PAYOUT_PUBKEY,
+                    refundKey: HTLC_PUBKEY,
+                    refundLocktime: HTLC_LOCKTIME,
+                },
+                "regtest",
+            );
+            return {
+                v: 1,
+                type: "rfq_quote",
+                rfq_id: payload.rfq_id as string,
+                pair: ONCHAIN_SEND_PAIR,
+                from_amount: 100_000,
+                to_amount: 99_000,
+                solver_pubkey: hex.encode(SOLVER),
+                valid_until: VALID_UNTIL,
+                refund_locktime: REFUND_LOCKTIME,
+                profile: {
+                    lockup_address: lockupScript.address("tark", SERVER).encode(),
+                    htlc_pubkey: hex.encode(HTLC_PUBKEY),
+                    htlc_locktime: HTLC_LOCKTIME,
+                    htlc_address: htlc.address,
+                    min_confirmations: 2,
+                    receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
+                },
+            } satisfies RfqQuote;
+        },
+        async status() {
+            return null;
+        },
+        async close() {},
+    });
+
+    it("funds using the caller-supplied emulatorPubkey, without constructing RestEmulatorProvider", async () => {
+        const result = await requestOnchainSend(
+            wallet,
+            "http://ark",
+            EMULATOR_PUBKEY,
+            onchainTransport(EMULATOR_PUBKEY),
+            { amount: 100_000, amountSide: "to", payoutPubkey: PAYOUT_PUBKEY, preimage: PREIMAGE },
+        );
+        expect(result.address.startsWith("tark1")).toBe(true);
+        expect(result.htlc.address).toBeTruthy();
+    });
+});
+
+describe("createOffer never touches the emulator", () => {
+    it("embeds the caller-supplied emulatorPubkey, without constructing RestEmulatorProvider", async () => {
+        const wantAsset = asset.AssetId.fromString("aa".repeat(32) + "0000");
+        const offer = await createOffer(wallet, "http://ark", EMULATOR_PUBKEY, {
+            wantAmount: 1000n,
+            wantAsset,
+        });
+        expect(decodeOffer(hex.decode(offer.offerHex)).emulatorPubkey).toEqual(EMULATOR_PUBKEY);
+    });
+});

--- a/packages/swap/test/register.test.ts
+++ b/packages/swap/test/register.test.ts
@@ -70,9 +70,16 @@ const wallet = {
     getContractManager: async () => contractManager,
 } as unknown as IWallet;
 
+// Caller-supplied now, not fetched: `createOffer` takes the emulator's x-only
+// key rather than a URL, because a client has no network path to the emulator.
+// Same value the RestEmulatorProvider stub above used to hand back, so this
+// file's expectations are unchanged.
+const emulatorPubkey = hex.decode(
+    "466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
+);
 const testAsset = asset.AssetId.fromString("aa".repeat(32) + "0000");
 const create = () =>
-    createOffer(wallet, "http://ark", "http://emu", {
+    createOffer(wallet, "http://ark", emulatorPubkey, {
         wantAmount: BigInt(50_000),
         wantAsset: testAsset,
     });


### PR DESCRIPTION
## Summary

New policy: **clients do not have network access to the emulator co-signer service — only the solver and covclaimd do.** `packages/swap` violated this in three places, each constructing a `RestEmulatorProvider` directly to fetch the emulator's pubkey before deriving a covenant locally:

- `requestLightningSend` (`rfq.ts`)
- `requestOnchainSend` (`rfq.ts`)
- `createOffer` (`offer.ts`)

The emulator's pubkey is a fact about the **solver's** deployment, not something the client should fetch live. The solver now publishes it on its signed registry/corridor card (`SolverCard.emulator_pubkey`); a real integration fetches and verifies that card once, out of band, before ever calling these functions.

## Changes

- All three functions drop their `emulatorUrl: string` parameter and instead take `emulatorPubkey: Uint8Array` (x-only), documented as caller-supplied: this library does not fetch or verify it, and the caller is responsible for having obtained it from the solver's registry card and checked it against whatever it independently trusts — the same trust posture as every other non-binding quote field in this package (mirrors `verifyLockupAddress`'s doc comment and the module's existing "compare-only, derive locally" framing).
- `RestEmulatorProvider` is no longer imported by `offer.ts` or `rfq.ts`.
- No new `verifyEmulatorPubkey`-style helper was added — it would just be an equality check on two byte arrays; the caller compares the two values itself.
- Updated the stale "its emulator endpoint" trust-model comment in `rfq.ts` and the `lightningSendVtxoScript`/`createOffer` doc comments that assumed a trader-owned emulator endpoint.
- Updated `README.md`'s three call-site examples (`createOffer` x2, `requestLightningSend`, `requestOnchainSend`) and added a short explanation of where `emulatorPubkey` must come from.
- `test/e2e/swap.test.ts`: the regtest e2e suite now fetches the emulator's key once via `RestEmulatorProvider` in its own setup (standing in for the out-of-band registry-card read a real integration would do) and passes it into `createOffer`, instead of `createOffer` fetching it.
- Added `test/emulatorTrustBoundary.test.ts`: makes `RestEmulatorProvider`'s constructor throw and proves all three functions (a) never construct it, and (b) genuinely thread the caller-supplied `emulatorPubkey` into the derived covenant (a mismatched key is rejected via `AddressMismatch`, same as every other compare-only quote field). Verified this test actually catches a regression by temporarily reintroducing a `RestEmulatorProvider` construction and confirming it fails loudly, before reverting.

Checked `offer.ts`'s `Offer.emulatorPubkey` field (`OfferContractBinding`-equivalent) separately — it was already a plain caller-supplied field with no live fetch, so it's untouched. Checked `packages/boltz-swap` — no `RestEmulatorProvider`/`emulatorUrl` references there at all. Checked `index.ts` — it never re-exported `RestEmulatorProvider` or any emulator-related type, so nothing there needed changing either.

## Test plan

- [x] `pnpm --filter @arkade-os/swap typecheck` — clean, 0 errors (before and after)
- [x] `pnpm --filter @arkade-os/swap lint` — clean
- [x] `pnpm --filter @arkade-os/swap test:unit` — 137 passed (133 baseline + 4 new), 12 files, 0 failures
- [x] Monorepo-wide `pnpm lint` and `pnpm -r typecheck` — clean across `ts-sdk`, `swap`, `boltz-swap`
- [x] Monorepo-wide `pnpm test:unit` — 0 failures (`ts-sdk` 2319 passed/1 pre-existing skip, `swap` 137 passed, `boltz-swap` 609 passed)
- [x] `test/e2e/swap.test.ts` updated for the new `createOffer` signature and typechecked (via a temporary all-inclusive tsconfig, since `test/` is normally excluded from the package's typecheck) — not executed, since it needs a live docker/regtest stack unavailable in this environment