### PR TITLE
fix(swap): mechanical fixes from the Arkana review of #684

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -68,12 +68,12 @@ await wallet.send({
 `createOffer` is pure derivation — it broadcasts nothing. The offer only becomes real when the
 deposit lands at `address`.
 
-| Field          | What it is                                                                                                                                    |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Field          | What it is                                                                                                                                                  |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `address`      | The swap address to fund with your deposit. Identical offers derive an identical address, so the **funding txid**, not the address, identifies one deposit. |
-| `extension`    | Pass straight to `wallet.send`'s `extensions`. It carries the offer inside the funding tx so the solver can discover the offer from the txid alone. |
-| `offerHex`     | The encoded offer. **Persist this** — it is the only input `cancelOffer` needs to rebuild the covenant.                                        |
-| `swapPkScript` | The covenant's scriptPubKey: the key an indexer watches to spot the deposit and its later spend.                                               |
+| `extension`    | Pass straight to `wallet.send`'s `extensions`. It carries the offer inside the funding tx so the solver can discover the offer from the txid alone.         |
+| `offerHex`     | The encoded offer. **Persist this** — it is the only input `cancelOffer` needs to rebuild the covenant.                                                     |
+| `swapPkScript` | The covenant's scriptPubKey: the key an indexer watches to spot the deposit and its later spend.                                                            |
 
 The minimum a maker must keep to stay in control of a swap is `offerHex` plus the funding txid.
 Everything else — status, amounts, timestamps — `restoreAssetSwaps` rebuilds from chain, and the
@@ -97,7 +97,7 @@ The two ways out of the covenant are deliberately asymmetric:
 - **`cancel`** is a **2-of-2 of the maker and the server**. Cancelling is cooperative, not a
   unilateral withdrawal.
 
-So cancel *races* a fill rather than pre-empting it. If the solver fills in the same moment,
+So cancel _races_ a fill rather than pre-empting it. If the solver fills in the same moment,
 `cancelOffer` throws `no spendable VTXO at the swap address` — that means the swap **completed**,
 not that anything went wrong. Re-read the swap's state before treating it as an error;
 `restoreAssetSwaps` tells the two spends apart afterwards and marks the record `fulfilled` rather
@@ -132,10 +132,15 @@ message anywhere: **acceptance is funding**.
 import { httpTransport, requestLightningSend } from "@arkade-os/swap";
 
 // invoice facts from YOUR OWN decoder — the module takes facts, not a decoder
-const swap = await requestLightningSend(wallet, arkServerUrl, emulatorUrl,
-    httpTransport(solverUrl), {
+const swap = await requestLightningSend(
+    wallet,
+    arkServerUrl,
+    emulatorUrl,
+    httpTransport(solverUrl),
+    {
         invoice: { raw: bolt11, paymentHash, amountSats, expiresAt },
-    });
+    },
+);
 // quote verified against the LOCAL derivation and gated; now fund and go offline:
 await wallet.send({ address: swap.address, amount: BigInt(swap.fundAmount) });
 ```
@@ -165,10 +170,18 @@ internal key (no key-path spend, ever): claim = `HASH160 <h160> EQUALVERIFY <cla
 refund = `<locktime> CLTV DROP <refundKey> CHECKSIG`.
 
 ```ts
-import { httpTransport, requestOnchainSend, awaitOnchainFill, claimOnchainFill } from "@arkade-os/swap";
+import {
+    httpTransport,
+    requestOnchainSend,
+    awaitOnchainFill,
+    claimOnchainFill,
+} from "@arkade-os/swap";
 
-const swap = await requestOnchainSend(wallet, arkServerUrl, emulatorUrl,
-    httpTransport(solverUrl), { amount: 100_000, amountSide: "to", payoutPubkey });
+const swap = await requestOnchainSend(wallet, arkServerUrl, emulatorUrl, httpTransport(solverUrl), {
+    amount: 100_000,
+    amountSide: "to",
+    payoutPubkey,
+});
 // PERSIST swap.preimage (with the record) BEFORE funding — it is the only
 // thing that can claim the L1 fill, across restarts included.
 await wallet.send({ address: swap.address, amount: BigInt(swap.fundAmount) });
@@ -176,8 +189,14 @@ await wallet.send({ address: swap.address, amount: BigInt(swap.fundAmount) });
 // Unlike lightning-send the maker must STAY CLAIM-CAPABLE: watch for the fill
 // and claim before the HTLC's refund leaf opens. chain is YOUR ChainSource.
 const utxo = await awaitOnchainFill(chain, swap.htlc, minConfirmations);
-await claimOnchainFill(chain, { htlc: swap.htlc, utxo, preimage: swap.preimage,
-    payoutPkScript, feeRateSatVb, sign });
+await claimOnchainFill(chain, {
+    htlc: swap.htlc,
+    utxo,
+    preimage: swap.preimage,
+    payoutPkScript,
+    feeRateSatVb,
+    sign,
+});
 ```
 
 `requestOnchainSend` derives BOTH contracts locally from the quote's binding fields
@@ -206,3 +225,21 @@ requires the SDK's non-interactive-claim API — not merged upstream yet (`arkad
 the one-call on-board flow lands when it is. Until covclaimd's reference vectors are
 cross-checked, the `sealClaimPacket` test vector is pinned from this implementation and marked
 provisional (`TODO(claim-packet-vectors)`).
+
+## Breaking changes on this branch (pre-release migration notes)
+
+The package is pre-release; these notes replace a changelog for consumers tracking the branch.
+
+- **Every derived address changed, in both corridors.** The lightning-send lockup moved from the
+  3-leaf program-artifact VHTLC to the 8-leaf `VHTLC.ScriptV2` (non-interactive claim and refund
+  leaves), and the L1 HTLC's claim leaf gained a `SIZE 32 EQUALVERIFY` preimage-length guard. Both
+  are pinned by golden tests (`test/rfq.test.ts`, `test/onchainHtlc.test.ts`). **Deployment must be
+  coordinated:** trader and solver derive the lockup independently and compare (`lockup_address` /
+  `htlc_address` are compare-only), so a version mismatch does not lose funds — it refuses every
+  quote at `verifyLockupAddress`. Upgrade both sides before expecting fills.
+- **`lightningSendProgram` and `htlcSendProgram` are gone** along with the program-artifact layer
+  they compiled. Derive scripts through `lightningSendVtxoScript` / `onchainHtlcScript`.
+- **`lightningSendVtxoScript` takes two new required fields**: `senderPubkey` (the trader's VHTLC
+  sender key — generate, persist, see `requestLightningSend`) and `receiverPkScript` (the solver's
+  claim destination, from `profile.receiver_pk_script`). Callers that built the lockup directly
+  must supply both; callers going through `requestLightningSend` are unaffected.

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -77,6 +77,17 @@ const xOnly = (key: Uint8Array, label: string): Uint8Array => {
     return key.slice(1);
 };
 
+/** Decode a solver-supplied hex field, turning a malformed value (odd length,
+ * non-hex chars) into a solver-blaming diagnostic instead of a bare
+ * `@scure/base` internal error. */
+const solverHex = (value: string, field: string): Uint8Array => {
+    try {
+        return hex.decode(value);
+    } catch {
+        throw new Error(`solver sent malformed hex for ${field}`);
+    }
+};
+
 // ── Pairs ────────────────────────────────────────────────────────────────────
 
 /** Legs are `<corridor>:<asset>`; a pair is directional, `from->to`. Arkade
@@ -496,9 +507,12 @@ export const unilateralClaimDelay = (serverExitDelaySeconds: number): number => 
             `server exit delay must be at least ${SEQUENCE_GRANULARITY_SECONDS}s of seconds, got ${serverExitDelaySeconds}`,
         );
     }
-    if (serverExitDelaySeconds > 0xffff * SEQUENCE_GRANULARITY_SECONDS) {
+    // two granularity steps below BIP68's ceiling, not at it: the refund tiers
+    // add one and two steps on top of this value, and every tier must encode
+    if (serverExitDelaySeconds > (0xffff - 2) * SEQUENCE_GRANULARITY_SECONDS) {
         throw new Error(
-            `server exit delay ${serverExitDelaySeconds}s exceeds what BIP68 can encode`,
+            `server exit delay ${serverExitDelaySeconds}s exceeds what BIP68 can encode ` +
+                `once the two refund tiers are stacked above it`,
         );
     }
     return (
@@ -675,7 +689,7 @@ export async function requestLightningSend(
         claimDelay: unilateralClaimDelay(Number(info.unilateralExitDelay)),
         emulatorPubkey: xOnly(hex.decode(emulatorInfo.signerPubkey), "emulator signer key"),
         senderPubkey,
-        receiverPkScript: hex.decode(receiverPkScriptHex),
+        receiverPkScript: solverHex(receiverPkScriptHex, "profile.receiver_pk_script"),
         refundPkScript: ArkAddress.decode(refundAddress).pkScript,
     });
     const address = script
@@ -844,7 +858,7 @@ export function deriveOnchainSend(input: {
         claimDelay: input.claimDelay,
         emulatorPubkey: input.emulatorPubkey,
         senderPubkey: input.senderPubkey,
-        receiverPkScript: hex.decode(receiverPkScriptHex),
+        receiverPkScript: solverHex(receiverPkScriptHex, "profile.receiver_pk_script"),
         refundPkScript: ArkAddress.decode(input.refundAddress).pkScript,
     });
     const address = script.address(input.hrp, input.serverPubkey).encode();

--- a/packages/swap/test/onchainHtlc.test.ts
+++ b/packages/swap/test/onchainHtlc.test.ts
@@ -1,7 +1,10 @@
 /**
  * The L1 side of the onchain corridor. The golden test pins the taproot HTLC
  * byte-for-byte — like the program-artifact goldens, any drift here changes
- * addresses on BOTH sides of a swap. The builder tests verify real BIP-341
+ * addresses on BOTH sides of a swap and needs coordinated trader/solver
+ * deployment (see "Breaking changes" in the README; a mismatch refuses quotes
+ * at the compare-only address check, it does not lose funds).
+ * The builder tests verify real BIP-341
  * script-path spends end to end: recomputed sighash, valid schnorr signature,
  * preimage recoverable from the witness.
  */

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -26,6 +26,8 @@ import {
     offerTermsFromQuote,
     relayTransport,
     unilateralClaimDelay,
+    unilateralRefundDelay,
+    unilateralRefundWithoutReceiverDelay,
     verifyLockupAddress,
     type RelaySocket,
     type RfqQuote,
@@ -57,6 +59,10 @@ const quoteFixture = (over: Partial<RfqQuote> = {}): RfqQuote => ({
 });
 
 describe("lightningSendVtxoScript", () => {
+    // Any change to these pinned bytes changes every lockup address and needs
+    // coordinated trader/solver deployment — see "Breaking changes" in the
+    // README. A version mismatch refuses quotes (verifyLockupAddress), it does
+    // not lose funds.
     // The reference solver's fixture, and its exact output bytes: sender =
     // key(13) (the trader's own VHTLC-sender key), receiver = key(1)
     // (solver), server = key(3), emulator = key(9), refund destination =
@@ -210,6 +216,37 @@ describe("unilateralClaimDelay", () => {
 
     it("rejects a value that is a block count, not seconds", () => {
         expect(() => unilateralClaimDelay(144)).toThrow(/512/);
+    });
+
+    it("keeps all three tiers BIP68-encodable at the maximum server delay", () => {
+        // the cap sits two 512s steps below BIP68's 0xffff * 512 ceiling so
+        // the refund tiers stacked above claimDelay stay encodable too
+        const max = (0xffff - 2) * 512;
+        const claim = unilateralClaimDelay(max);
+        expect(claim).toBe(max);
+        expect(unilateralRefundDelay(claim)).toBe((0xffff - 1) * 512);
+        expect(unilateralRefundWithoutReceiverDelay(claim)).toBe(0xffff * 512);
+        // the proof that matters: the full contract compiles, so every CSV
+        // leaf's sequence encoded — this threw from inside the tapscript
+        // encoder before the cap accounted for the stacked tiers
+        expect(() =>
+            lightningSendVtxoScript({
+                solverPubkey: key(1),
+                serverPubkey: key(3),
+                paymentHash: "da".repeat(32),
+                refundLocktime: 1_800_000_000,
+                claimDelay: claim,
+                emulatorPubkey: key(9),
+                senderPubkey: key(13),
+                receiverPkScript: p2tr(key(1)),
+                refundPkScript: p2tr(key(5)),
+            }),
+        ).not.toThrow();
+    });
+
+    it("rejects a server delay whose refund tiers would overflow BIP68", () => {
+        expect(() => unilateralClaimDelay((0xffff - 2) * 512 + 1)).toThrow(/BIP68/);
+        expect(() => unilateralClaimDelay(0xffff * 512)).toThrow(/BIP68/);
     });
 });
 

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -434,6 +434,18 @@ function isP2trPkScript(pkScript: Bytes): boolean {
  * input". Shared by {@link VHTLC.Options.nonInteractiveClaim} and {@link
  * VHTLC.Options.nonInteractiveRefund} — only the destination and the tier it
  * gates differ.
+ *
+ * `PUSHCURRENTINPUTINDEX` as the output index is not an assumption about how
+ * the Ark round pairs inputs with outputs — the covenant imposes the pairing
+ * on the spender. Whatever index a spending tx places this input at, the
+ * output at that same index must pay the destination at least the input's
+ * value, or the ArkadeScript fails and the server never co-signs. A tx with no
+ * output at that index fails the same way: the leaf is unsatisfiable, not
+ * fooled. Index alignment is therefore a *liveness* obligation on whoever
+ * assembles the spend (the solver, for both leaves — this SDK never builds
+ * them; its own aggregate refund uses the interactive leaf precisely because
+ * it lacks this per-index constraint, see `refund.ts`), never a safety
+ * assumption.
  */
 function enforcePayTo(destinationPkScript: Bytes): Bytes {
     // validateOptions already checked this for both current call sites — kept


### PR DESCRIPTION
Addresses the mechanical subset of arkana-ai-bot's review on #684. Those findings target code that a rebase moved into `feat/arkade-swap`, so they land here rather than widening #684's diff.

## What's fixed

- **N1 (blocking) — BIP68 overflow in the refund tiers.** `unilateralClaimDelay` capped at BIP68's exact ceiling (`0xffff × 512s`), but `unilateralRefundDelay` and `unilateralRefundWithoutReceiverDelay` stack one and two 512s steps on top, so a near-maximal server exit delay derived sequences BIP68 cannot encode — failing deep inside `CSVMultisigTapscript.encode`. The cap now sits two steps below the ceiling, with unit tests at the new maximum (all three tiers encode; the full eight-leaf contract compiles) and just past it (clear diagnostic).
- **#4 — `hex.decode` guards.** Both `profile.receiver_pk_script` decode sites now go through a helper that converts malformed hex into a solver-blaming diagnostic instead of a bare `@scure/base` internal error.
- **#6 — `PUSHCURRENTINPUTINDEX` invariant.** Documented on `enforcePayTo`: the pairing is not an assumption about round assembly — the covenant imposes it on the spender. Whatever index the input sits at, the output at that index must pay the destination at least the input value, or the ArkadeScript fails and the server never co-signs; a missing output at that index makes the leaf unsatisfiable, not fooled. Index alignment is a liveness obligation on the solver (the only party that builds these spends — the SDK's own refund uses the interactive leaf for exactly this reason, see `refund.ts`), never a safety assumption.
- **#7 / #8 / #1 — migration and deployment notes.** CHANGELOG.md is managed externally, so the notes live in `packages/swap/README.md` (pre-release "Breaking changes" section): the removed `lightningSendProgram`/`htlcSendProgram` exports, `lightningSendVtxoScript`'s two new required fields, and the coordinated-deployment requirement for the address change in both corridors (a version mismatch refuses quotes at the compare-only address check; it does not lose funds). Both golden tests now cross-reference the section.

## Deliberately not here

- **#3 (`senderPrivateKey` persistence)** is a design decision, not a patch — it gates Phase 3b of the contract-manager integration plan (RFQ secret persistence) and will be resolved there.
- **N2 (duplicate `getInfo`)** and the `cancelOffer` network comment were addressed on #684 directly (`59e66fca`); fully eliminating the second `getInfo` needs `Arkade.connect` to accept pre-resolved info, a core API change out of scope here.