### PR TITLE
docs(swap): pin the maker/taker roles against the RFQ naming collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ TypeScript packages for the Arkade Bitcoin wallet ecosystem — on-chain/off-cha
 |---------|-------------|
 | [`@arkade-os/sdk`](packages/ts-sdk/) | Bitcoin wallet SDK with Taproot and Ark protocol support |
 | [`@arkade-os/boltz-swap`](packages/boltz-swap/) | Lightning and chain swaps using Boltz |
-| [`@arkade-os/swap`](packages/swap/) | Maker-side Arkade Intents atomic swaps: market discovery, offers, restore |
+| [`@arkade-os/swap`](packages/swap/) | Offer-maker side Arkade Intents atomic swaps: market discovery, offers, restore |
 | [Regtest stack](regtest/) | Shared regtest environment ([arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest) submodule) |
 
 ## Prerequisites

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -1,11 +1,28 @@
 # @arkade-os/swap
 
-Maker-side [Arkade Intents](https://arkade.money) atomic swaps: discover markets, quote and
+Offer-maker side [Arkade Intents](https://arkade.money) atomic swaps: discover markets, quote and
 validate, create offers, track them, cancel them, and rebuild the whole record set from chain after
 a wallet restore. Framework-free TypeScript over `@arkade-os/sdk`: the core API and
 `InMemoryAssetSwapRepository` use no DOM and no Node-specific APIs, so they run in Node, the
 browser, and React Native alike. `IndexedDbAssetSwapRepository` is the one exception — it needs a
 platform-provided or polyfilled IndexedDB.
+
+## Roles: maker and taker
+
+Arkade Intents names its roles after the **offer**, not the quote:
+
+- **maker** — creates the offer and funds the swap address. That is the consumer of this package:
+  it prices a swap against the registry's markets, deposits one side, and waits.
+- **taker** — the solver that fills the offer, delivering `wantAmount` to the maker's script over
+  the covenant's `fulfill` path. Same sense the solver registry and
+  [`@arkade-os/solver-discovery`](https://www.npmjs.com/package/@arkade-os/solver-discovery) use.
+
+**This inverts generic RFQ vocabulary, so watch out for the collision.** In RFQ systems the side
+that *requests* a quote is conventionally the taker and the side that *answers* with a price is the
+maker — which makes "maker-side" elsewhere mean the liquidity provider, the exact opposite of what
+it means here. This package is the quote-requesting side, and it is called the **maker** side for
+that reason; nothing in it is an "RFQ taker layer". Throughout this package — its docs, its types,
+its comments — `taker` always means the solver that fills, never the party asking for a price.
 
 ## The four layers
 

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -2,7 +2,7 @@
     "name": "@arkade-os/swap",
     "version": "0.0.1",
     "type": "module",
-    "description": "Arkade Intents maker-side atomic swaps: discover markets, quote, create/track/cancel offers, restore from chain.",
+    "description": "Arkade Intents offer-maker side atomic swaps: discover markets, quote, create/track/cancel offers, restore from chain.",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/swap/src/markets.ts
+++ b/packages/swap/src/markets.ts
@@ -1,3 +1,13 @@
+/**
+ * Quoting: solver discovery and the pricing guardrails around a plan.
+ *
+ * This is the maker's quote-requesting side — the layer that asks what a swap
+ * would cost before `offer` commits to it. Generic RFQ vocabulary calls the
+ * quote-requesting role the *taker*; Arkade Intents names roles after the
+ * offer, so here that role is the **maker**, and `taker` (in this package and
+ * in the solver registry) always means the solver that fills. Nothing in this
+ * file is a "taker layer" in the RFQ sense — see the README's Roles section.
+ */
 import {
     bestMarket,
     discover,

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -1,6 +1,12 @@
 /**
  * Arkade Intents — an atomic-swap covenant on Arkade.
  *
+ * Roles follow the offer, not the quote: the **maker** creates and funds the
+ * offer (this package's consumer), the **taker** is the solver that fills it
+ * through `fulfill`. Generic RFQ vocabulary inverts that — there the
+ * quote-requesting side is the "taker" — so read every `taker` here, and in
+ * the solver registry, as the filling solver.
+ *
  * The contracts are the two JSON files, one per WANT side:
  *   swap-want-asset.program.json  the fill must deliver an asset
  *   swap-want-btc.program.json    the fill must deliver sats


### PR DESCRIPTION
Arkade Intents names its roles after the offer: the maker creates and funds
it, the taker is the solver that fills. Generic RFQ vocabulary inverts both
words — there the quote-requesting side is the taker and the side answering
with a price is the maker — so "maker-side" reads as "liquidity-provider
side" to anyone arriving from RFQ-land, and a maker-side quoting component
invites being called an "RFQ taker layer".

Nothing was named that here, but nothing said so either. State the two senses
once in the swap README and point the two layers where the ambiguity actually
lands at it: offer.ts (which owns fulfill/cancel and every taker mention) and
markets.ts (the quote-requesting layer itself). Qualify the package blurb as
"offer-maker side" so the npm description and the monorepo table carry the
distinction where no Roles section follows them.

Docs only — no behavior, API, or type changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X34oLJathWZym3zdSKbepU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the package supports the offer-maker side of Arkade Intents atomic swaps.
  * Documented market discovery, quote requests, offers, and restoration capabilities.
  * Added definitions for “maker” and “taker” roles, including how they differ from conventional RFQ terminology.
  * Improved terminology consistency across package documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->