### PR TITLE
feat(swap): drive offer status from contract events, and stop watching finished contracts

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -7,7 +7,7 @@ a wallet restore. Framework-free TypeScript over `@arkade-os/sdk`: the core API 
 browser, and React Native alike. `IndexedDbAssetSwapRepository` is the one exception — it needs a
 platform-provided or polyfilled IndexedDB.
 
-## The five layers
+## The seven layers
 
 1. **`offer`** — the swap covenant itself. Two program JSONs (want-BTC / want-asset), the
    `Offer` type, the TLV wire codec (`encodeOffer`/`decodeOffer`, `OFFER_PACKET_TYPE`), address
@@ -25,11 +25,14 @@ platform-provided or polyfilled IndexedDB.
    offer packets and binding each funding vtxo to its spend. Incremental: answered txids are
    remembered in the repository (`getScannedTxids`/`markTxidsScanned`) so nothing is fetched
    twice.
-5. **`rfq`** — the maker / intent-submitter side of quoted swaps: RFQ negotiation over HTTP or a
+5. **`watch`** — `watchOfferSwaps` drives swap status from the wallet's own contract events, so a
+   fill shows up without re-running a scan. Registration is what makes it possible: only a
+   registered covenant is watched. See "Live status" below.
+6. **`rfq`** — the maker / intent-submitter side of quoted swaps: RFQ negotiation over HTTP or a
    relay, then non-interactive filling (see below). Covers `arkade:BTC|asset -> lightning:BTC`
    (implemented against the reference solver), `arkade:BTC|asset -> arkade:BTC|asset` (quote,
    then take by funding an offer from layer 1), and the onchain corridor below.
-6. **`onchainHtlc`** — the Bitcoin-L1 side of `arkade:BTC <-> onchain:BTC`: a NUMS-keyed taproot
+7. **`onchainHtlc`** — the Bitcoin-L1 side of `arkade:BTC <-> onchain:BTC`: a NUMS-keyed taproot
    HTLC as pure local derivation (golden-pinned), claim/refund spend builders with signing as a
    callback, the injected `ChainSource` seam (the package holds no L1 backend and no keys),
    preimage extraction from a spend's witness, and crash-recovery classification.
@@ -84,11 +87,41 @@ The minimum a maker must keep to stay in control of a swap is `offerHex` plus th
 Everything else — status, amounts, timestamps — `restoreAssetSwaps` rebuilds from chain, and the
 offer bytes themselves are recoverable from the funding tx if the record is lost.
 
+## Live status
+
+```ts
+const watcher = await watchOfferSwaps({ wallet, arkServerUrl: ARK, repository, onUpdate: render });
+// later
+watcher.stop();
+```
+
+Because `createOffer` registers the covenant, the wallet already watches that script and emits a
+spend event when the deposit moves — so a **fill** reaches the maker without re-running a scan,
+which is what `restoreAssetSwaps` alone could never do.
+
+How a spend is classified, cheapest answer first: a cancel this device made is already recorded by
+`cancelOffer`, so nothing needs deciding; anything else is read off the spending transaction's
+covenant leaf (`cancel` vs `fulfill`), which is exact and stays exact when one transaction fills
+several offers at once. A spend that cannot be classified — the indexer has not caught up, say —
+**leaves the record untouched** for the restore scan to decide later. Nothing is written on a
+guess: a stored swap is skipped by every later scan, so a guess here would be permanent.
+
+`onUpdate` is a notification for UI reactivity, not a second store; every write goes through the
+repository.
+
 ## Cancelling an offer no taker filled
 
 ```ts
-const txid = await cancelOffer(wallet, ARK, swap.offerHex, swap.fundingTxid, swap.swapAddress);
+const txid = await cancelOffer(wallet, ARK, swap.offerHex, {
+    repository,
+    fundingTxid: swap.fundingTxid,
+    swapAddress: swap.swapAddress,
+});
 ```
+
+The call records its own outcome — `cancelling` before submitting, `cancelled` plus the spend txid
+after — so a cancel needs no follow-up write from the caller, and the live watcher below finds a
+record already resolved rather than re-deriving it.
 
 **An unfilled offer never expires.** Neither program carries a timelock, so a deposit no taker
 picked up sits at the swap address indefinitely — nothing reclaims it for the maker, and there is
@@ -247,6 +280,17 @@ The package is pre-release; these notes replace a changelog for consumers tracki
   coordinated:** trader and solver derive the lockup independently and compare (`lockup_address` /
   `htlc_address` are compare-only), so a version mismatch does not lose funds — it refuses every
   quote at `verifyLockupAddress`. Upgrade both sides before expecting fills.
+- **`cancelOffer` and `restoreAssetSwaps` take an options object.** `cancelOffer(wallet, url,
+offerHex, { repository, fundingTxid?, swapAddress? })` — the repository is required because the
+  call now records its own outcome. `restoreAssetSwaps(indexer, txs, existingIds, { serverPubkey,
+scanned? })` — the server key is required because a spend is classified by rebuilding the
+  covenant and matching the leaf it took.
+- **`isCancelSpend` is gone**, replaced by `classifySpend`, and `Tx.assets` with it. The old test
+  read what a transaction moved, which a wallet reports as a _net_ delta: once the deposit is a
+  registered contract, an asset offer's cancel moves the asset out and back, nets to zero, and is
+  indistinguishable from a fill. Leaves have no such failure mode.
+- **A spend that cannot be classified is no longer restored as `fulfilled`.** It leaves the funding
+  txid unanswered so a later scan decides it. Records are never written on a guess.
 - **`lightningSendProgram` and `htlcSendProgram` are gone** along with the program-artifact layer
   they compiled. Derive scripts through `lightningSendVtxoScript` / `onchainHtlcScript`.
 - **`lightningSendVtxoScript` takes two new required fields**: `senderPubkey` (the trader's VHTLC

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -34,6 +34,8 @@ export { IndexedDbAssetSwapRepository } from "./indexedDbRepository";
 export {
     restoreAssetSwaps,
     classifySpend,
+    classifyDepositSpend,
+    spendTxidsOf,
     type RestoreIndexer,
     type SpendKind,
     type Tx,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -31,7 +31,19 @@ export {
     InMemoryAssetSwapRepository,
 } from "./repository";
 export { IndexedDbAssetSwapRepository } from "./indexedDbRepository";
-export { restoreAssetSwaps, isCancelSpend, type RestoreIndexer, type Tx } from "./restore";
+export {
+    restoreAssetSwaps,
+    classifySpend,
+    type RestoreIndexer,
+    type SpendKind,
+    type Tx,
+} from "./restore";
+export {
+    watchOfferSwaps,
+    spendUpdate,
+    type OfferSwapWatcher,
+    type WatchOfferSwapsParams,
+} from "./watch";
 export {
     ARKADE_ASSET,
     ARKADE_BTC,

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -31,7 +31,7 @@ import {
 import wantAssetProgram from "./swap-want-asset.program.json";
 import wantBtcProgram from "./swap-want-btc.program.json";
 import type { AssetSwapRepository } from "./repository";
-import { updateAssetSwap } from "./store";
+import { getAssetSwaps, updateAssetSwap } from "./store";
 
 // json imports widen "type": "pubkey" to string; parseArtifact validates at runtime
 type Artifact = Parameters<typeof arkade.parseArtifact>[0];
@@ -450,17 +450,23 @@ export async function createOffer(
  * it a rotated key is detected and reported rather than reading as a missing
  * VTXO.
  *
- * **This records its own outcome, and that is what makes the live watcher
- * cheap.** `cancel` is a 2-of-2 of maker and server, so a cancel can only be
- * the maker's own act: on a successful submit this *is* the authoritative
- * answer, and writing it here means `watchOfferSwaps` has nothing left to
- * decide for our own cancels — it sees a terminal record and leaves it alone.
- * The status moves to `cancelling` first so a crash between submit and record
- * leaves a marker rather than a swap that still looks pending.
+ * **When the matching swap record is present, this records its own outcome,
+ * and that is what makes the live watcher cheap.** `cancel` is a 2-of-2 of
+ * maker and server, so a cancel can only be the maker's own act: on a
+ * successful submit this *is* the authoritative answer, and writing it here
+ * means `watchOfferSwaps` has nothing left to decide for our own cancels — it
+ * sees a terminal record and leaves it alone. The status moves to `cancelling`
+ * first so a crash between submit and record leaves a marker rather than a
+ * swap that still looks pending.
  *
- * The txid is only knowable after `send()` returns, so a spend event that
- * arrives in that window finds a `cancelling` record and classifies the spend
- * by its covenant leaf instead — the same answer, one indexer read more.
+ * Passing a repository that does not contain the swap record is allowed: the
+ * cancel still submits and returns its txid, but no local status is written,
+ * so the watcher or restore scan must classify the spend later.
+ *
+ * When a local record exists, the txid is only knowable after `send()`
+ * returns, so a spend event that arrives in that window finds a `cancelling`
+ * record and classifies the spend by its covenant leaf instead — the same
+ * answer, one indexer read more.
  */
 export async function cancelOffer(
     wallet: IWallet,
@@ -530,13 +536,18 @@ export async function cancelOffer(
             outputs: [{ vout: 0, amount: BigInt(a.amount) }],
         });
     }
-    // the in-flight marker: written before submit so a crash in between leaves
-    // a swap that reads as cancelling rather than as untouched
-    await updateAssetSwap(repository, fundingTxid ?? vtxo.txid, { status: "cancelling" });
+    const swapId = fundingTxid ?? vtxo.txid;
+    const hasLocalRecord = (await getAssetSwaps(repository)).some((s) => s.id === swapId);
+    // The in-flight marker is useful only when there is a local record to
+    // update; a different or empty repository intentionally leaves the cancel
+    // for event/restore classification.
+    if (hasLocalRecord) await updateAssetSwap(repository, swapId, { status: "cancelling" });
     const { txid } = await cancel.send();
-    await updateAssetSwap(repository, fundingTxid ?? vtxo.txid, {
-        status: "cancelled",
-        spentTxid: txid,
-    });
+    if (hasLocalRecord) {
+        await updateAssetSwap(repository, swapId, {
+            status: "cancelled",
+            spentTxid: txid,
+        });
+    }
     return txid;
 }

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -30,6 +30,8 @@ import {
 
 import wantAssetProgram from "./swap-want-asset.program.json";
 import wantBtcProgram from "./swap-want-btc.program.json";
+import type { AssetSwapRepository } from "./repository";
+import { updateAssetSwap } from "./store";
 
 // json imports widen "type": "pubkey" to string; parseArtifact validates at runtime
 type Artifact = Parameters<typeof arkade.parseArtifact>[0];
@@ -433,7 +435,7 @@ export async function createOffer(
  * is filling in the same moment may be spent by `fulfill` first, in which case
  * this throws "no spendable VTXO at the swap address" — which means the swap
  * completed, not that anything failed. `restoreAssetSwaps` classifies the two
- * spends apart afterwards (see `isCancelSpend`).
+ * spends apart afterwards by the leaf each took (see `classifySpend`).
  *
  * Marking the deposit as escrow (see {@link registerOfferContract}) does not
  * close this path: the gate's subject is *implicit* coin selection, and cancel
@@ -447,14 +449,30 @@ export async function createOffer(
  * built with, so cancel keeps working across a server signer rotation; without
  * it a rotated key is detected and reported rather than reading as a missing
  * VTXO.
+ *
+ * **This records its own outcome, and that is what makes the live watcher
+ * cheap.** `cancel` is a 2-of-2 of maker and server, so a cancel can only be
+ * the maker's own act: on a successful submit this *is* the authoritative
+ * answer, and writing it here means `watchOfferSwaps` has nothing left to
+ * decide for our own cancels — it sees a terminal record and leaves it alone.
+ * The status moves to `cancelling` first so a crash between submit and record
+ * leaves a marker rather than a swap that still looks pending.
+ *
+ * The txid is only knowable after `send()` returns, so a spend event that
+ * arrives in that window finds a `cancelling` record and classifies the spend
+ * by its covenant leaf instead — the same answer, one indexer read more.
  */
 export async function cancelOffer(
     wallet: IWallet,
     arkServerUrl: string,
     offerHex: string,
-    fundingTxid?: string,
-    swapAddress?: string,
+    opts: {
+        repository: AssetSwapRepository;
+        fundingTxid?: string;
+        swapAddress?: string;
+    },
 ): Promise<string> {
+    const { repository, fundingTxid, swapAddress } = opts;
     const offer = decodeOffer(hex.decode(offerHex));
 
     const client = await arkade.Arkade.connect({
@@ -512,6 +530,13 @@ export async function cancelOffer(
             outputs: [{ vout: 0, amount: BigInt(a.amount) }],
         });
     }
+    // the in-flight marker: written before submit so a crash in between leaves
+    // a swap that reads as cancelling rather than as untouched
+    await updateAssetSwap(repository, fundingTxid ?? vtxo.txid, { status: "cancelling" });
     const { txid } = await cancel.send();
+    await updateAssetSwap(repository, fundingTxid ?? vtxo.txid, {
+        status: "cancelled",
+        spentTxid: txid,
+    });
     return txid;
 }

--- a/packages/swap/src/restore.ts
+++ b/packages/swap/src/restore.ts
@@ -160,6 +160,8 @@ export function classifySpend(
     for (let i = 0; i < spendTx.inputsLength; i++) {
         const input = spendTx.getInput(i);
         if (!input.txid || input.index !== deposit.vout) continue;
+        // @scure exposes input txids in display/BE order (`txid`, not the raw
+        // LE transaction hash), matching the indexer convention for vtxo txids.
         if (hex.encode(input.txid) !== deposit.txid) continue;
         for (const leaf of input.tapLeafScript ?? []) {
             const spent = hex.encode(scriptFromTapLeafScript(leaf));

--- a/packages/swap/src/restore.ts
+++ b/packages/swap/src/restore.ts
@@ -13,14 +13,26 @@
  * is ever fetched twice.
  */
 import { base64, hex } from "@scure/base";
-import { Extension, RestIndexerProvider, Transaction } from "@arkade-os/sdk";
-import { decodeOffer, Offer, OFFER_PACKET_TYPE } from "./offer";
+import {
+    Extension,
+    RestIndexerProvider,
+    Transaction,
+    scriptFromTapLeafScript,
+} from "@arkade-os/sdk";
+import { decodeOffer, Offer, OFFER_PACKET_TYPE, offerVtxoScript } from "./offer";
 import { BTC_ASSET_ID, type AssetSwap, type AssetSwapStatus } from "./store";
 
 // ponytail: fixed request size; tune only if histories outgrow it
 const TXS_PER_REQUEST = 50;
 
-/** The subset of a wallet transaction record the swap scan reads. */
+/**
+ * The subset of a wallet transaction record the swap scan reads.
+ *
+ * No `assets`: a spend is classified from the covenant leaf it took, read off
+ * the spending transaction itself (see {@link classifySpend}). A wallet
+ * record's asset field is a net delta — an asset offer's cancel moves the asset
+ * out and back, netting to nothing — so it cannot answer the question.
+ */
 export interface Tx {
     type: string;
     /** The virtual (ark) txid; the funding tx's identity. */
@@ -29,11 +41,47 @@ export interface Tx {
     roundTxid?: string;
     /** Unix seconds. */
     createdAt?: number;
-    assets?: { assetId: string; amount: bigint }[];
 }
 
 /** The indexer surface the restore scan needs — narrower than a full provider. */
 export type RestoreIndexer = Pick<RestIndexerProvider, "getVirtualTxs" | "getVtxos">;
+
+/**
+ * Fetch and parse virtual txs, keyed by the psbt's own unsigned txid rather
+ * than by response order. Chunks are independent requests and are issued
+ * concurrently; a chunk that fails or a txid that does not come back is simply
+ * absent from the result, which every caller reads as "unanswered, retry later"
+ * — the property that keeps a partial response from orphaning a txid forever.
+ */
+async function fetchParsedTxs(
+    indexer: RestoreIndexer,
+    txids: string[],
+): Promise<Map<string, Transaction>> {
+    const parsedByTxid = new Map<string, Transaction>();
+    if (txids.length === 0) return parsedByTxid;
+
+    const chunks: string[][] = [];
+    for (let i = 0; i < txids.length; i += TXS_PER_REQUEST) {
+        chunks.push(txids.slice(i, i + TXS_PER_REQUEST));
+    }
+    const chunkResults = await Promise.allSettled(
+        chunks.map(async (ids) => (await indexer.getVirtualTxs(ids)).txs),
+    );
+
+    for (const result of chunkResults) {
+        if (result.status !== "fulfilled") continue;
+        for (const psbt of result.value) {
+            try {
+                // the SDK's Transaction.fromPSBT already allows unknown fields/outputs
+                const parsed = Transaction.fromPSBT(base64.decode(psbt));
+                parsedByTxid.set(parsed.id, parsed);
+            } catch {
+                // unattributable blob: its txid stays unanswered and retries
+            }
+        }
+    }
+    return parsedByTxid;
+}
 
 /** The candidate txs a scan would fetch: sent virtual txs with no stored swap
  * record and no previous authoritative answer. Module-local: `restoreAssetSwaps`
@@ -52,16 +100,67 @@ const unscannedSwapCandidates = (
             !scanned.has(tx.redeemTxid),
     );
 
-/** The cancel spend returns the deposit: a BTC offer gets its sats back (no
- * want-asset delivered), an asset offer gets the asset back. */
-export function isCancelSpend(offer: Offer, spend: Tx): boolean {
-    // exactly one of the two is set (createOffer enforces it); the spend either
-    // delivered the want-asset (a fill) or returned the offer-asset (a cancel)
-    const assetId = (offer.wantAsset ?? offer.offerAsset!).toString();
-    const carriesAsset = Boolean(
-        spend.assets?.some((a) => a.assetId === assetId && a.amount > BigInt(0)),
-    );
-    return offer.wantAsset ? !carriesAsset : carriesAsset;
+/**
+ * What became of a deposit, as the spending transaction reports it.
+ *
+ * `indeterminate` is not a third outcome — it is the absence of one, and the
+ * caller decides whether to retry or accept a default.
+ */
+export type SpendKind = "cancelled" | "fulfilled" | "indeterminate";
+
+/**
+ * Classify a spend by the covenant leaf it took.
+ *
+ * The covenant's whole vocabulary is two leaves: `cancel` returns the deposit
+ * to the maker, `fulfill` is the solver paying for it. A submitted ark tx keeps
+ * each input's `tapLeafScript`, so the spend *states* which one it used — this
+ * reads an answer rather than inferring one.
+ *
+ * What it replaces, and why: the previous test asked what the transaction
+ * moved. That works only while the deposit is invisible to the wallet. Once the
+ * covenant is a registered contract the deposit joins the wallet's own coins,
+ * every wallet-level asset figure becomes a *net* delta, and an asset offer's
+ * cancel — asset out of the covenant, same asset back to the maker — nets to
+ * zero and reads exactly like its fill. Leaves do not have that failure mode,
+ * and they also survive batching: a solver filling several offers in one tx
+ * gives each input its own leaf.
+ *
+ * `serverPubkey` must be the key the covenant was *funded* against. If it has
+ * rotated since, the rebuilt script will not match the offer's own
+ * `swapPkScript` and this returns `indeterminate` rather than guessing —
+ * `cancelOffer` diagnoses the same mismatch the same way.
+ */
+export function classifySpend(
+    offer: Offer,
+    serverPubkey: Uint8Array,
+    spendTx: Transaction,
+    deposit: { txid: string; vout: number },
+): SpendKind {
+    let leaves: { cancel?: Uint8Array; fulfill?: Uint8Array };
+    try {
+        const script = offerVtxoScript(offer, serverPubkey);
+        if (hex.encode(script.pkScript) !== hex.encode(offer.swapPkScript)) return "indeterminate";
+        leaves = {
+            cancel: script.functionByName("cancel")?.leafScript,
+            fulfill: script.functionByName("fulfill")?.leafScript,
+        };
+    } catch {
+        return "indeterminate"; // an offer whose covenant will not compile is not classifiable
+    }
+
+    for (let i = 0; i < spendTx.inputsLength; i++) {
+        const input = spendTx.getInput(i);
+        if (!input.txid || input.index !== deposit.vout) continue;
+        if (hex.encode(input.txid) !== deposit.txid) continue;
+        for (const leaf of input.tapLeafScript ?? []) {
+            const spent = hex.encode(scriptFromTapLeafScript(leaf));
+            if (leaves.cancel && spent === hex.encode(leaves.cancel)) return "cancelled";
+            if (leaves.fulfill && spent === hex.encode(leaves.fulfill)) return "fulfilled";
+        }
+    }
+    // the deposit left the covenant by neither leaf (a batch forfeit, say), or
+    // the spend carries no tapleaf at all
+    return "indeterminate";
 }
 
 /**
@@ -70,77 +169,62 @@ export function isCancelSpend(offer: Offer, spend: Tx): boolean {
  * an authoritative answer (fetched fine, vtxo lookup fine) — the caller
  * persists those so they are never fetched again.
  *
- * ## Caller contract: cancelled swaps can be restored as `fulfilled`
+ * ## A spent deposit is classified or left alone — never guessed
  *
- * Whether a spent deposit was filled or cancelled is only decidable from the
- * spending tx, which this scan looks up in the `txs` you pass. When the
- * deposit reads as spent but its spender is not in `txs` yet (the wallet's own
- * history still syncing), the swap is restored as `fulfilled` — the likelier
- * reading, since a maker-initiated cancel normally has its tx locally.
+ * Whether a spent deposit was filled or cancelled is read from the spending
+ * transaction's covenant leaf ({@link classifySpend}), fetched from the same
+ * indexer as everything else rather than from the `txs` you pass. A spend that
+ * cannot be classified — not fetchable yet, or gone by neither leaf — leaves
+ * the funding txid unanswered, so nothing is persisted and a later scan decides
+ * it. Nothing sticky is written on a guess.
  *
- * That guess is **not** revisited: once you persist the record, its id lands
- * in `existingIds` and every later scan skips it. A swap the user cancelled
- * can therefore stay labelled `fulfilled` forever.
+ * That is a deliberate reversal: this used to restore an unclassifiable spend
+ * as `fulfilled`, which a persisted record then made permanent, because the
+ * spending tx came from the caller's possibly-lagging history. It no longer
+ * does, so the `existingIds` escape hatch is no longer a correction mechanism
+ * for a wrong label — it is only a skip list.
  *
- * A restore-only integration has no way to correct this, so callers should
- * also feed live spend events (the solver's SSE stream) into
- * `updateAssetSwap`, which is what closes the window in practice. If you
- * cannot, and a mislabel is worse for you than a re-scan, drop the affected
- * record from the repository: a swap that is no longer in `existingIds` is
- * scanned again and re-decided against a fuller `txs`.
+ * `serverPubkey` must be the server key the covenants were funded against; a
+ * key that has rotated since makes every affected swap unclassifiable rather
+ * than misclassified.
  */
 export async function restoreAssetSwaps(
     indexer: RestoreIndexer,
     txs: Tx[],
     existingIds: ReadonlySet<string>,
-    scanned: ReadonlySet<string> = new Set(),
+    opts: { serverPubkey: Uint8Array; scanned?: ReadonlySet<string> },
 ): Promise<{ restored: AssetSwap[]; scannedTxids: string[] }> {
+    const { serverPubkey, scanned = new Set<string>() } = opts;
     const candidates = unscannedSwapCandidates(txs, existingIds, scanned);
     if (candidates.length === 0) return { restored: [], scannedTxids: [] };
 
-    // fetch the raw txs and pick out the ones carrying an offer packet, binding
-    // by the PSBT's own unsigned txid rather than trusting response order; a
-    // failed chunk is simply not marked scanned and retries on a later scan.
-    // Chunks are independent requests, so fetch them all concurrently.
+    // fetch the raw txs and pick out the ones carrying an offer packet
     const byTxid = new Map(candidates.map((tx) => [tx.redeemTxid, tx]));
-    const chunks: string[][] = [];
-    for (let i = 0; i < candidates.length; i += TXS_PER_REQUEST) {
-        chunks.push(candidates.slice(i, i + TXS_PER_REQUEST).map((tx) => tx.redeemTxid));
-    }
-    const chunkResults = await Promise.allSettled(
-        chunks.map(async (txids) => (await indexer.getVirtualTxs(txids)).txs),
+    const parsedByTxid = await fetchParsedTxs(
+        indexer,
+        candidates.map((tx) => tx.redeemTxid),
     );
 
     const fetchedTxids: string[] = [];
     const found: { fundingTx: Tx; offer: Offer; offerHex: string }[] = [];
-    for (const result of chunkResults) {
-        if (result.status !== "fulfilled") continue;
-        for (const psbt of result.value) {
-            let parsed: Transaction;
-            try {
-                // the SDK's Transaction.fromPSBT already allows unknown fields/outputs
-                parsed = Transaction.fromPSBT(base64.decode(psbt));
-            } catch {
-                continue; // unattributable blob: its txid stays unscanned and retries
-            }
-            const fundingTx = byTxid.get(parsed.id);
-            if (!fundingTx) continue;
-            // only a txid whose psbt actually came back is answered — a chunk may
-            // return fewer than requested, and blanket-marking the request would
-            // orphan the missing ones forever (scans skip answered txids)
-            fetchedTxids.push(parsed.id);
-            try {
-                const packet = Extension.fromTx(parsed).getPacketByType(OFFER_PACKET_TYPE);
-                if (!packet) continue;
-                const payload = packet.serialize();
-                found.push({
-                    fundingTx,
-                    offer: decodeOffer(payload),
-                    offerHex: hex.encode(payload),
-                });
-            } catch {
-                // no extension, foreign packet or malformed offer: not a swap funding
-            }
+    for (const [txid, parsed] of parsedByTxid) {
+        const fundingTx = byTxid.get(txid);
+        if (!fundingTx) continue;
+        // only a txid whose psbt actually came back is answered — a chunk may
+        // return fewer than requested, and blanket-marking the request would
+        // orphan the missing ones forever (scans skip answered txids)
+        fetchedTxids.push(txid);
+        try {
+            const packet = Extension.fromTx(parsed).getPacketByType(OFFER_PACKET_TYPE);
+            if (!packet) continue;
+            const payload = packet.serialize();
+            found.push({
+                fundingTx,
+                offer: decodeOffer(payload),
+                offerHex: hex.encode(payload),
+            });
+        } catch {
+            // no extension, foreign packet or malformed offer: not a swap funding
         }
     }
     if (found.length === 0) return { restored: [], scannedTxids: fetchedTxids };
@@ -154,13 +238,28 @@ export async function restoreAssetSwaps(
     // lookups per restored swap instead of a scan over every returned vtxo
     const vtxoByScriptAndTxid = new Map(vtxos.map((v) => [`${v.script}:${v.txid}`, v]));
 
-    // one O(txs) pass so each restored swap's spend lookup below is O(1)
+    // one O(txs) pass so each restored swap's spend lookup below is O(1). The
+    // caller's records are consulted for the completion *time* only — the
+    // classification comes from the spending psbt fetched below
     const txByAnyId = new Map<string, Tx>();
     for (const tx of txs) {
         for (const id of [tx.boardingTxid, tx.redeemTxid, tx.roundTxid]) {
             if (id) txByAnyId.set(id, tx);
         }
     }
+
+    // every deposit that has been spent, so its spender can be fetched once for
+    // the whole batch rather than per swap
+    const spendTxids = new Set<string>();
+    for (const { fundingTx, offer } of found) {
+        const vtxo = vtxoByScriptAndTxid.get(
+            `${hex.encode(offer.swapPkScript)}:${fundingTx.redeemTxid}`,
+        );
+        if (vtxo?.virtualStatus.state !== "spent") continue;
+        const spentTxid = vtxo.arkTxId || vtxo.spentBy;
+        if (spentTxid) spendTxids.add(spentTxid);
+    }
+    const spendTxByTxid = await fetchParsedTxs(indexer, [...spendTxids]);
 
     const restored: AssetSwap[] = [];
     const unresolved = new Set<string>();
@@ -199,18 +298,25 @@ export async function restoreAssetSwaps(
         const fromAmount = depositAmount.toString();
 
         const state = vtxo.virtualStatus.state;
-        const spentTxid = state === "spent" ? (vtxo.arkTxId ?? vtxo.spentBy) : undefined;
-        const spendTx = spentTxid ? txByAnyId.get(spentTxid) : undefined;
-        // TODO(arkade-os/wallet#836): if state === 'spent' but spendTx hasn't synced
-        // locally yet, status defaults to 'fulfilled' — a genuinely cancelled swap
-        // could be permanently mislabeled, since a persisted swap is skipped by
-        // future scans (see existingIds in unscannedSwapCandidates). No safer
-        // default exists without local wallet-initiated-cancel tracking (the live
-        // SSE monitor in the wallet has the same gap).
+        const spentTxid = state === "spent" ? vtxo.arkTxId || vtxo.spentBy : undefined;
         let status: AssetSwapStatus = "pending";
         if (state === "swept") status = "recoverable";
-        else if (state === "spent")
-            status = spendTx && isCancelSpend(offer, spendTx) ? "cancelled" : "fulfilled";
+        else if (state === "spent") {
+            const spendTx = spentTxid ? spendTxByTxid.get(spentTxid) : undefined;
+            const kind = spendTx
+                ? classifySpend(offer, serverPubkey, spendTx, {
+                      txid: vtxo.txid,
+                      vout: vtxo.vout,
+                  })
+                : "indeterminate";
+            if (kind === "indeterminate") {
+                // the spender is not fetchable yet, or took neither covenant
+                // leaf: retry rather than persist a label that later scans skip
+                unresolved.add(fundingTx.redeemTxid);
+                continue;
+            }
+            status = kind;
+        }
 
         restored.push({
             id: fundingTx.redeemTxid,
@@ -229,8 +335,10 @@ export async function restoreAssetSwaps(
             spentTxid,
             status,
             createdAt: fundingTx.createdAt ? fundingTx.createdAt * 1000 : vtxo.createdAt.getTime(),
-            ...(status === "fulfilled" && spendTx?.createdAt
-                ? { completedAt: spendTx.createdAt * 1000 }
+            // the completion time is the caller's record of the spend, if it
+            // has one — the psbt that classified it carries no timestamp
+            ...(status === "fulfilled" && spentTxid && txByAnyId.get(spentTxid)?.createdAt
+                ? { completedAt: txByAnyId.get(spentTxid)!.createdAt! * 1000 }
                 : {}),
         });
     }

--- a/packages/swap/src/restore.ts
+++ b/packages/swap/src/restore.ts
@@ -116,6 +116,15 @@ export type SpendKind = "cancelled" | "fulfilled" | "indeterminate";
  * each input's `tapLeafScript`, so the spend *states* which one it used — this
  * reads an answer rather than inferring one.
  *
+ * **Hand it the transaction that actually spends the deposit outpoint, which is
+ * the checkpoint, not the ark tx.** A spend is two linked transactions: the
+ * checkpoint (`vtxo.spentBy`) takes the deposit outpoint and carries the
+ * covenant leaf, and the ark tx (`vtxo.arkTxId`) spends the checkpoint's output
+ * — carrying the same leaf, but over an outpoint that is not the deposit's. A
+ * caller that offers only the ark tx gets `indeterminate` for every real spend,
+ * which is exactly what the first version of this function did.
+ * {@link classifyDepositSpend} takes both and picks whichever answers.
+ *
  * What it replaces, and why: the previous test asked what the transaction
  * moved. That works only while the deposit is invisible to the wallet. Once the
  * covenant is a registered contract the deposit joins the wallet's own coins,
@@ -158,8 +167,37 @@ export function classifySpend(
             if (leaves.fulfill && spent === hex.encode(leaves.fulfill)) return "fulfilled";
         }
     }
-    // the deposit left the covenant by neither leaf (a batch forfeit, say), or
-    // the spend carries no tapleaf at all
+    // the deposit left the covenant by neither leaf (a batch forfeit, say), the
+    // spend carries no tapleaf, or this is the wrong half of the spend
+    return "indeterminate";
+}
+
+/**
+ * The txids that may hold a deposit's spend, in the order worth trying: the
+ * checkpoint first, since it is the one carrying the deposit outpoint.
+ */
+export const spendTxidsOf = (vtxo: { spentBy?: string; arkTxId?: string }): string[] =>
+    [vtxo.spentBy, vtxo.arkTxId].filter((id): id is string => Boolean(id));
+
+/**
+ * Classify a deposit's spend across both halves of it.
+ *
+ * A caller holds two txids for one spend — `spentBy` (the checkpoint, which
+ * takes the deposit outpoint) and `arkTxId` (the ark tx built on it) — and
+ * cannot tell from the outside which shape a given deployment produced: for a
+ * settlement they may be the same id. Try each and take the first definite
+ * answer, so the classification does not depend on that distinction.
+ */
+export function classifyDepositSpend(
+    offer: Offer,
+    serverPubkey: Uint8Array,
+    spendTxs: Iterable<Transaction>,
+    deposit: { txid: string; vout: number },
+): SpendKind {
+    for (const tx of spendTxs) {
+        const kind = classifySpend(offer, serverPubkey, tx, deposit);
+        if (kind !== "indeterminate") return kind;
+    }
     return "indeterminate";
 }
 
@@ -249,15 +287,15 @@ export async function restoreAssetSwaps(
     }
 
     // every deposit that has been spent, so its spender can be fetched once for
-    // the whole batch rather than per swap
+    // the whole batch rather than per swap. Both halves: the checkpoint carries
+    // the deposit outpoint, the ark tx is what the record and history name
     const spendTxids = new Set<string>();
     for (const { fundingTx, offer } of found) {
         const vtxo = vtxoByScriptAndTxid.get(
             `${hex.encode(offer.swapPkScript)}:${fundingTx.redeemTxid}`,
         );
         if (vtxo?.virtualStatus.state !== "spent") continue;
-        const spentTxid = vtxo.arkTxId || vtxo.spentBy;
-        if (spentTxid) spendTxids.add(spentTxid);
+        for (const txid of spendTxidsOf(vtxo)) spendTxids.add(txid);
     }
     const spendTxByTxid = await fetchParsedTxs(indexer, [...spendTxids]);
 
@@ -302,13 +340,13 @@ export async function restoreAssetSwaps(
         let status: AssetSwapStatus = "pending";
         if (state === "swept") status = "recoverable";
         else if (state === "spent") {
-            const spendTx = spentTxid ? spendTxByTxid.get(spentTxid) : undefined;
-            const kind = spendTx
-                ? classifySpend(offer, serverPubkey, spendTx, {
-                      txid: vtxo.txid,
-                      vout: vtxo.vout,
-                  })
-                : "indeterminate";
+            const spendTxs = spendTxidsOf(vtxo)
+                .map((id) => spendTxByTxid.get(id))
+                .filter((tx): tx is Transaction => tx !== undefined);
+            const kind = classifyDepositSpend(offer, serverPubkey, spendTxs, {
+                txid: vtxo.txid,
+                vout: vtxo.vout,
+            });
             if (kind === "indeterminate") {
                 // the spender is not fetchable yet, or took neither covenant
                 // leaf: retry rather than persist a label that later scans skip

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -324,7 +324,7 @@ export interface RfqSwapManagerConfig {
  * `ContractManager` (`await wallet.getContractManager()`). */
 export type SwapContractRegistry = Pick<
     IContractManager,
-    "createContract" | "onContractEvent" | "setContractState"
+    "createContract" | "onContractEvent" | "setContractWatchState"
 >;
 
 /** The contract type a swap lockup registers under. `@arkade-os/sdk`'s handler
@@ -748,17 +748,18 @@ export class RfqSwapManager {
         }
     }
 
-    /** Retire a finished swap's contract row. Retired, not deleted: the row is
-     * what keeps the lockup's own VTXOs annotatable and its history readable,
-     * and `inactive` already means "no longer a live destination". Best-effort
-     * — the swap is over either way. */
+    /** Stop watching a finished swap's lockup. Retained, not deleted: the row
+     * is what keeps the lockup's own VTXOs annotatable and its history
+     * readable, while `retained` is what drops it from the subscription and
+     * the poll — a settled swap that stayed watched would cost the wallet a
+     * script for its whole life. Best-effort — the swap is over either way. */
     private retireContract(swap: RfqSwap): void {
         // Only a swap that actually got a row: retiring one that was never
         // written would throw "not found" and report a failure on a swap that
         // had in fact just succeeded.
         if (!this.deps.contracts || !this.registered.get(swap.rfqId)) return;
         void this.deps.contracts
-            .setContractState(hex.encode(swap.lockupPkScript), "inactive")
+            .setContractWatchState(hex.encode(swap.lockupPkScript), "retained")
             .catch((error: unknown) => this.emitFailed(swap, error));
     }
 

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -1,0 +1,166 @@
+/**
+ * Live offer status, driven by the wallet's own contract events.
+ *
+ * Before this, nothing told a maker their offer had been filled: the deposit's
+ * fate was only visible by re-running {@link restoreAssetSwaps}, a scan over
+ * sent transactions. Now that `createOffer` registers the covenant with the
+ * contract manager, the wallet is already watching that script and already
+ * emits `vtxo_spent` for it — so the maker's own wallet knows, and this module
+ * turns that knowledge into a status.
+ *
+ * **Detection and classification are separate problems, answered separately.**
+ * The event says a deposit was spent; it does not say by whom. The covenant's
+ * `cancel` leaf is a 2-of-2 of the maker and the server, so *only the maker can
+ * cancel* — which makes the cheapest classifier an exact one: a spend whose
+ * txid is the one `cancelOffer` recorded is a cancel, and anything else that
+ * spends an offer deposit is a fill. The fallback, for a cancel this device did
+ * not make (another device, or a wiped store), reads the covenant leaf off the
+ * spending transaction ({@link classifySpend}).
+ *
+ * What this deliberately does not do:
+ *
+ * - **Guess.** A spend that cannot be classified leaves the record untouched,
+ *   for the restore scan to decide later. Writing a guess here is what made a
+ *   wrong label permanent before: a stored swap is skipped by every later scan.
+ * - **Own a second store.** Updates go through {@link AssetSwapRepository}, the
+ *   package's one storage seam. `onUpdate` is a notification for UI
+ *   reactivity, never an alternative sink.
+ * - **Report funding.** `vtxo_received` needs no status: a funded offer is
+ *   `pending`, which is what it already was.
+ */
+import { base64, hex } from "@scure/base";
+import {
+    ArkAddress,
+    RestIndexerProvider,
+    Transaction,
+    type ContractEvent,
+    type ContractVtxo,
+    type IWallet,
+} from "@arkade-os/sdk";
+import { decodeOffer, OFFER_CONTRACT_KIND } from "./offer";
+import type { AssetSwapRepository } from "./repository";
+import { classifySpend, type RestoreIndexer, type SpendKind } from "./restore";
+import { getAssetSwaps, updateAssetSwap, type AssetSwap, type AssetSwapStatus } from "./store";
+
+/** Statuses a spend cannot move: the swap is already resolved. */
+const TERMINAL: readonly AssetSwapStatus[] = ["fulfilled", "cancelled", "recoverable"];
+
+/**
+ * The record change a classified spend implies, or `undefined` when it implies
+ * none — an already-resolved swap, or a spend nobody could classify.
+ *
+ * Pure, so a consumer with its own store can apply the same transition without
+ * taking the watcher, and so re-delivery of an event is a no-op rather than a
+ * rewrite.
+ */
+export function spendUpdate(
+    swap: AssetSwap,
+    spend: { txid: string; kind: SpendKind; at?: number },
+): Partial<Omit<AssetSwap, "id">> | undefined {
+    if (TERMINAL.includes(swap.status)) return undefined;
+    if (spend.kind === "indeterminate") return undefined;
+
+    const status: AssetSwapStatus = spend.kind === "cancelled" ? "cancelled" : "fulfilled";
+    return {
+        status,
+        spentTxid: spend.txid,
+        // mirrors restore.ts: a completion time is a fill's, not a cancel's
+        ...(status === "fulfilled" && spend.at ? { completedAt: spend.at } : {}),
+    };
+}
+
+/** A running watcher. `idle()` exists because the writes are async: shutdown
+ * and tests both need to know when in-flight updates have settled. */
+export interface OfferSwapWatcher {
+    stop(): void;
+    idle(): Promise<void>;
+}
+
+export interface WatchOfferSwapsParams {
+    wallet: IWallet;
+    /** Same URL `createOffer`/`cancelOffer` take; used to read a spending tx
+     * when the exact classifier cannot answer. */
+    arkServerUrl: string;
+    repository: AssetSwapRepository;
+    /** Called after a change is persisted. A notification, not a store. */
+    onUpdate?: (swap: AssetSwap) => void;
+}
+
+/**
+ * Subscribe to the wallet's contract events and drive offer swap status.
+ *
+ * Registration ({@link createOffer}) is what makes this possible: only a
+ * registered covenant is watched, so only registered offers produce events.
+ * Offers funded before registration existed stay on the restore scan.
+ */
+export async function watchOfferSwaps({
+    wallet,
+    arkServerUrl,
+    repository,
+    onUpdate,
+}: WatchOfferSwapsParams): Promise<OfferSwapWatcher> {
+    const manager = await wallet.getContractManager();
+    // the covenant was compiled against this key; classifySpend rebuilds the
+    // script with it to recognise the leaf a spend took
+    const serverPubkey = ArkAddress.decode(await wallet.getAddress()).serverPubKey;
+    const indexer: RestoreIndexer = new RestIndexerProvider(arkServerUrl);
+
+    // events arrive independently but updateAssetSwap is read-modify-write over
+    // the whole list, so two concurrent handlers would lose one of the writes
+    let queue: Promise<void> = Promise.resolve();
+    const enqueue = (task: () => Promise<void>): void => {
+        queue = queue.then(task).catch(() => {
+            // a handler must never reject into the manager's dispatch loop; an
+            // unwritten record stays recoverable through the restore scan
+        });
+    };
+
+    const classify = async (swap: AssetSwap, vtxo: ContractVtxo, spentTxid: string) => {
+        // the exact answer: only the maker can cancel, and cancelOffer records
+        // the txid it submitted
+        if (swap.spentTxid === spentTxid && swap.status === "cancelling") return "cancelled";
+        try {
+            const { txs } = await indexer.getVirtualTxs([spentTxid]);
+            if (txs.length === 0) return "indeterminate";
+            const spendTx = Transaction.fromPSBT(base64.decode(txs[0]));
+            return classifySpend(decodeOffer(hex.decode(swap.offerHex)), serverPubkey, spendTx, {
+                txid: vtxo.txid,
+                vout: vtxo.vout,
+            });
+        } catch {
+            return "indeterminate" as const;
+        }
+    };
+
+    const handleSpend = async (event: Extract<ContractEvent, { type: "vtxo_spent" }>) => {
+        if (event.contract.metadata?.kind !== OFFER_CONTRACT_KIND) return;
+
+        for (const vtxo of event.vtxos) {
+            const spentTxid = vtxo.arkTxId || vtxo.spentBy;
+            if (!spentTxid) continue;
+            // identical offers share one script and are told apart by the
+            // deposit that funded them
+            const swap = (await getAssetSwaps(repository)).find(
+                (s) => s.fundingTxid === vtxo.txid && s.swapPkScript === event.contractScript,
+            );
+            if (!swap) continue;
+
+            const kind: SpendKind = await classify(swap, vtxo, spentTxid);
+            const changes = spendUpdate(swap, { txid: spentTxid, kind, at: event.timestamp });
+            if (!changes) continue;
+
+            await updateAssetSwap(repository, swap.id, changes);
+            onUpdate?.({ ...swap, ...changes });
+        }
+    };
+
+    const unsubscribe = manager.onContractEvent((event) => {
+        if (event.type !== "vtxo_spent") return;
+        enqueue(() => handleSpend(event));
+    });
+
+    return {
+        stop: unsubscribe,
+        idle: () => queue,
+    };
+}

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -39,7 +39,7 @@ import {
 } from "@arkade-os/sdk";
 import { decodeOffer, OFFER_CONTRACT_KIND } from "./offer";
 import type { AssetSwapRepository } from "./repository";
-import { classifySpend, type RestoreIndexer, type SpendKind } from "./restore";
+import { classifyDepositSpend, spendTxidsOf, type RestoreIndexer, type SpendKind } from "./restore";
 import { getAssetSwaps, updateAssetSwap, type AssetSwap, type AssetSwapStatus } from "./store";
 
 /** Statuses a spend cannot move: the swap is already resolved. */
@@ -120,13 +120,17 @@ export async function watchOfferSwaps({
         // the txid it submitted
         if (swap.spentTxid === spentTxid && swap.status === "cancelling") return "cancelled";
         try {
-            const { txs } = await indexer.getVirtualTxs([spentTxid]);
-            if (txs.length === 0) return "indeterminate";
-            const spendTx = Transaction.fromPSBT(base64.decode(txs[0]));
-            return classifySpend(decodeOffer(hex.decode(swap.offerHex)), serverPubkey, spendTx, {
-                txid: vtxo.txid,
-                vout: vtxo.vout,
-            });
+            // both halves of the spend: the checkpoint carries the deposit
+            // outpoint, the ark tx is the id the record and history name
+            const candidates = spendTxidsOf(vtxo);
+            if (candidates.length === 0) return "indeterminate";
+            const { txs } = await indexer.getVirtualTxs(candidates);
+            return classifyDepositSpend(
+                decodeOffer(hex.decode(swap.offerHex)),
+                serverPubkey,
+                txs.map((psbt) => Transaction.fromPSBT(base64.decode(psbt))),
+                { txid: vtxo.txid, vout: vtxo.vout },
+            );
         } catch {
             return "indeterminate" as const;
         }

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -92,6 +92,10 @@ export interface WatchOfferSwapsParams {
  * Registration ({@link createOffer}) is what makes this possible: only a
  * registered covenant is watched, so only registered offers produce events.
  * Offers funded before registration existed stay on the restore scan.
+ *
+ * This depends on the wallet's contract event transport. In Node, callers must
+ * provide an `EventSource` implementation or use a runtime where it is enabled;
+ * otherwise live updates do not arrive and restore remains the fallback.
  */
 export async function watchOfferSwaps({
     wallet,
@@ -100,8 +104,9 @@ export async function watchOfferSwaps({
     onUpdate,
 }: WatchOfferSwapsParams): Promise<OfferSwapWatcher> {
     const manager = await wallet.getContractManager();
-    // the covenant was compiled against this key; classifySpend rebuilds the
-    // script with it to recognise the leaf a spend took
+    // Current server key at watcher start. TODO: persist the funding-time key
+    // with swap records; a signer rotation during a long session makes leaf
+    // classification return indeterminate rather than guessing.
     const serverPubkey = ArkAddress.decode(await wallet.getAddress()).serverPubKey;
     const indexer: RestoreIndexer = new RestIndexerProvider(arkServerUrl);
 
@@ -142,8 +147,10 @@ export async function watchOfferSwaps({
         for (const vtxo of event.vtxos) {
             const spentTxid = vtxo.arkTxId || vtxo.spentBy;
             if (!spentTxid) continue;
-            // identical offers share one script and are told apart by the
-            // deposit that funded them
+            // Identical offers share one script and are told apart by the
+            // deposit that funded them. Repository v1 has no indexed lookup, so
+            // this is O(history) per spend event; add a query API if offer
+            // event volume makes this hot.
             const swap = (await getAssetSwaps(repository)).find(
                 (s) => s.fundingTxid === vtxo.txid && s.swapPkScript === event.contractScript,
             );

--- a/packages/swap/test/cancel.test.ts
+++ b/packages/swap/test/cancel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { hex } from "@scure/base";
 import { ArkAddress, asset, type IWallet } from "@arkade-os/sdk";
 import { cancelOffer, encodeOffer, offerVtxoScript, type Offer } from "../src/offer";
+import { InMemoryAssetSwapRepository } from "../src/repository";
 
 // cancelOffer's guards fire before any signing: mock only the network seam
 // (Arkade.connect for the current server key, ArkadeContract for the vtxo
@@ -62,9 +63,11 @@ const wallet = {
 describe("cancelOffer guards", () => {
     it("diagnoses a rotated server key instead of reporting a missing VTXO", async () => {
         state.serverKey = rotatedServerKey;
-        await expect(cancelOffer(wallet, "http://ark", offerHex)).rejects.toThrow(
-            "signing key has likely rotated",
-        );
+        await expect(
+            cancelOffer(wallet, "http://ark", offerHex, {
+                repository: new InMemoryAssetSwapRepository(),
+            }),
+        ).rejects.toThrow("signing key has likely rotated");
     });
 
     it("proceeds past a rotation when swapAddress pins the funded server key", async () => {
@@ -73,7 +76,10 @@ describe("cancelOffer guards", () => {
         state.serverKey = rotatedServerKey;
         state.utxos = [];
         await expect(
-            cancelOffer(wallet, "http://ark", offerHex, undefined, fundedAddress),
+            cancelOffer(wallet, "http://ark", offerHex, {
+                repository: new InMemoryAssetSwapRepository(),
+                swapAddress: fundedAddress,
+            }),
         ).rejects.toThrow("no spendable VTXO");
     });
 
@@ -83,9 +89,11 @@ describe("cancelOffer guards", () => {
             { txid: "a".repeat(64), vout: 0, value: 10_000 },
             { txid: "b".repeat(64), vout: 0, value: 10_000 },
         ];
-        await expect(cancelOffer(wallet, "http://ark", offerHex)).rejects.toThrow(
-            "pass fundingTxid",
-        );
+        await expect(
+            cancelOffer(wallet, "http://ark", offerHex, {
+                repository: new InMemoryAssetSwapRepository(),
+            }),
+        ).rejects.toThrow("pass fundingTxid");
     });
 
     // without this the contract takes the direct-indexer fallback and a
@@ -94,9 +102,11 @@ describe("cancelOffer guards", () => {
         state.serverKey = fundedServerKey;
         state.utxos = [];
         state.connectOptions = undefined;
-        await expect(cancelOffer(wallet, "http://ark", offerHex)).rejects.toThrow(
-            "no spendable VTXO",
-        );
+        await expect(
+            cancelOffer(wallet, "http://ark", offerHex, {
+                repository: new InMemoryAssetSwapRepository(),
+            }),
+        ).rejects.toThrow("no spendable VTXO");
         expect(state.connectOptions?.contractManager).toBe(contractManager);
     });
 });

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -24,11 +24,15 @@ import {
     Wallet,
 } from "@arkade-os/sdk";
 import {
+    addAssetSwap,
     cancelOffer,
     createOffer,
     decodeOffer,
+    getAssetSwaps,
     InMemoryAssetSwapRepository,
     restoreAssetSwaps,
+    watchOfferSwaps,
+    type AssetSwap,
     type Tx,
 } from "../../src";
 
@@ -275,4 +279,78 @@ describe("maker-side swap loop (regtest)", () => {
             return vtxos.some((v) => v.txid === cancelTxid && v.value === DEPOSIT_SATS);
         });
     }, 120_000);
+
+    it("drives status from the wallet's own spend event, with no restore call", async () => {
+        // Phase 3 end to end, and the half no unit test can reach: registration
+        // makes the covenant watched, the watcher's SSE delivers `vtxo_spent`,
+        // and the record resolves without anyone scanning history. A second
+        // offer, because the one above is already spent.
+        //
+        // The cancel is submitted against a DIFFERENT repository on purpose.
+        // `cancelOffer` records its own outcome, so cancelling into the watched
+        // store would resolve the record before the event arrived and this test
+        // could not tell the two apart. Cancelling elsewhere is also the case
+        // that actually exercises the classifier: another device's cancel, read
+        // back off the spending transaction's covenant leaf.
+        const elsewhere = new InMemoryAssetSwapRepository();
+        const swapRepository = new InMemoryAssetSwapRepository();
+        const updates: AssetSwap[] = [];
+        const watcher = await watchOfferSwaps({
+            wallet,
+            arkServerUrl: ARK_URL,
+            repository: swapRepository,
+            onUpdate: (swap) => updates.push(swap),
+        });
+
+        try {
+            const second = await createOffer(wallet, ARK_URL, emulatorPubkey, {
+                wantAmount: WANT_AMOUNT + BigInt(1),
+                wantAsset,
+            });
+            const secondFundingTxid = await wallet.send({
+                address: second.address,
+                amount: DEPOSIT_SATS,
+                extensions: [second.extension],
+            });
+            const secondScript = hex.encode(second.swapPkScript);
+            await waitFor(async () => {
+                const { vtxos } = await indexer.getVtxos({ scripts: [secondScript] });
+                return vtxos.some((v) => v.txid === secondFundingTxid);
+            });
+
+            // the record the watcher will resolve. `pending`, as createOffer
+            // leaves it — the watcher's job is to move it
+            await addAssetSwap(swapRepository, {
+                id: secondFundingTxid,
+                fromAsset: "btc",
+                toAsset: wantAsset.toString(),
+                fromAmount: String(DEPOSIT_SATS),
+                toAmount: (WANT_AMOUNT + BigInt(1)).toString(),
+                swapAddress: second.address,
+                swapPkScript: secondScript,
+                offerHex: second.offerHex,
+                fundingTxid: secondFundingTxid,
+                status: "pending",
+                createdAt: Date.now(),
+            });
+
+            await cancelOffer(wallet, ARK_URL, second.offerHex, {
+                repository: elsewhere,
+                fundingTxid: secondFundingTxid,
+                swapAddress: second.address,
+            });
+
+            // no restoreAssetSwaps anywhere in this test: the event carries it
+            await waitFor(async () => {
+                await watcher.idle();
+                const [swap] = await getAssetSwaps(swapRepository);
+                return swap?.status === "cancelled";
+            });
+            const [resolved] = await getAssetSwaps(swapRepository);
+            expect(resolved.spentTxid).toBeTruthy();
+            expect(updates.map((u) => u.status)).toContain("cancelled");
+        } finally {
+            watcher.stop();
+        }
+    }, 180_000);
 });

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -161,6 +161,8 @@ describe("maker-side swap loop (regtest)", () => {
             redeemTxid: fundingTxid,
             createdAt: Math.floor(Date.now() / 1000),
         });
+        // Pending deposits have no spend to classify; serverPubkey is required
+        // by the restore API but does not affect this assertion.
         const { restored, scannedTxids } = await restoreAssetSwaps(indexer, history, new Set(), {
             serverPubkey,
         });

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -13,6 +13,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { execSync } from "child_process";
 import { hex } from "@scure/base";
 import {
+    ArkAddress,
     asset,
     EsploraProvider,
     InMemoryContractRepository,
@@ -22,7 +23,14 @@ import {
     SingleKey,
     Wallet,
 } from "@arkade-os/sdk";
-import { cancelOffer, createOffer, decodeOffer, restoreAssetSwaps, type Tx } from "../../src";
+import {
+    cancelOffer,
+    createOffer,
+    decodeOffer,
+    InMemoryAssetSwapRepository,
+    restoreAssetSwaps,
+    type Tx,
+} from "../../src";
 
 const ARK_URL = "http://localhost:7070";
 const EMULATOR_URL = "http://localhost:7073";
@@ -73,8 +81,12 @@ const waitFor = async (
 };
 
 const indexer = new RestIndexerProvider(ARK_URL);
+const repository = new InMemoryAssetSwapRepository();
 let wallet: Wallet;
 let emulatorPubkey: Uint8Array;
+// the key the covenants are funded against — restore classifies each spend by
+// the covenant leaf it took, so it has to rebuild the same script
+let serverPubkey: Uint8Array;
 
 beforeAll(async () => {
     wallet = await Wallet.create({
@@ -107,6 +119,8 @@ beforeAll(async () => {
     // calling createOffer.
     const emulatorInfo = await new RestEmulatorProvider(EMULATOR_URL).getInfo();
     emulatorPubkey = xOnly(hex.decode(emulatorInfo.signerPubkey));
+
+    serverPubkey = ArkAddress.decode(await wallet.getAddress()).serverPubKey;
 }, 120_000);
 
 describe("maker-side swap loop (regtest)", () => {
@@ -143,7 +157,9 @@ describe("maker-side swap loop (regtest)", () => {
             redeemTxid: fundingTxid,
             createdAt: Math.floor(Date.now() / 1000),
         });
-        const { restored, scannedTxids } = await restoreAssetSwaps(indexer, history, new Set());
+        const { restored, scannedTxids } = await restoreAssetSwaps(indexer, history, new Set(), {
+            serverPubkey,
+        });
 
         expect(scannedTxids).toEqual([fundingTxid]);
         expect(restored).toHaveLength(1);
@@ -224,13 +240,11 @@ describe("maker-side swap loop (regtest)", () => {
         // outpoint, so the escrow marker must not close the one spend route the
         // maker actually owns. A future tightening that gates explicit inputs
         // would strand every offer deposit, and would fail here.
-        const cancelTxid = await cancelOffer(
-            wallet,
-            ARK_URL,
-            restoredOfferHex,
+        const cancelTxid = await cancelOffer(wallet, ARK_URL, restoredOfferHex, {
+            repository,
             fundingTxid,
-            offer.address,
-        );
+            swapAddress: offer.address,
+        });
         expect(cancelTxid).toBeTruthy();
 
         const script = hex.encode(offer.swapPkScript);
@@ -248,7 +262,7 @@ describe("maker-side swap loop (regtest)", () => {
             redeemTxid: cancelTxid,
             createdAt: Math.floor(Date.now() / 1000),
         });
-        const { restored } = await restoreAssetSwaps(indexer, history, new Set());
+        const { restored } = await restoreAssetSwaps(indexer, history, new Set(), { serverPubkey });
         expect(restored).toHaveLength(1);
         expect(restored[0]).toMatchObject({
             status: "cancelled",

--- a/packages/swap/test/restore.test.ts
+++ b/packages/swap/test/restore.test.ts
@@ -1,31 +1,67 @@
 import { describe, expect, it } from "vitest";
 import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
 import { asset, Extension, Transaction, UnknownPacket } from "@arkade-os/sdk";
-import { encodeOffer, Offer, OFFER_PACKET_TYPE } from "../src/offer";
-import { restoreAssetSwaps, type RestoreIndexer, type Tx } from "../src/restore";
+import { encodeOffer, offerVtxoScript, Offer, OFFER_PACKET_TYPE } from "../src/offer";
+import { classifySpend, restoreAssetSwaps, type RestoreIndexer, type Tx } from "../src/restore";
 
 const ASSET_ID = "f1".repeat(34);
 const OTHER_ASSET_ID = "a2".repeat(34);
-const SWAP_PK_SCRIPT = "5120" + "ab".repeat(32);
 
-const makeOffer = (side: "want-asset" | "want-btc", wantAmount: bigint): Offer => ({
-    swapPkScript: hex.decode(SWAP_PK_SCRIPT),
-    wantAmount,
-    ...(side === "want-asset"
-        ? { wantAsset: asset.AssetId.fromString(ASSET_ID) }
-        : { offerAsset: asset.AssetId.fromString(ASSET_ID) }),
-    makerPkScript: hex.decode("5120" + "cd".repeat(32)),
-    makerPublicKey: hex.decode("ef".repeat(32)),
-    emulatorPubkey: hex.decode("12".repeat(32)),
-});
+// real points: the covenant is compiled for every fixture, so the offer's
+// swapPkScript is the script the spends below are classified against
+const key = (seed: string) => schnorr.getPublicKey(hex.decode(seed.repeat(32)));
+const SERVER_KEY = key("11");
+const MAKER_KEY = key("22");
+const EMULATOR_KEY = key("33");
+// a real taproot output key: the spend psbts below pay it, and @scure rejects
+// a script whose key is not a point
+const MAKER_PK_SCRIPT = new Uint8Array([0x51, 0x20, ...key("55")]);
+
+const makeOffer = (side: "want-asset" | "want-btc", wantAmount: bigint): Offer => {
+    const binding: Omit<Offer, "swapPkScript"> = {
+        wantAmount,
+        ...(side === "want-asset"
+            ? { wantAsset: asset.AssetId.fromString(ASSET_ID) }
+            : { offerAsset: asset.AssetId.fromString(ASSET_ID) }),
+        makerPkScript: MAKER_PK_SCRIPT,
+        makerPublicKey: MAKER_KEY,
+        emulatorPubkey: EMULATOR_KEY,
+    };
+    return { ...binding, swapPkScript: offerVtxoScript(binding, SERVER_KEY).pkScript };
+};
+
+const scriptOf = (offer: Offer) => hex.encode(offer.swapPkScript);
 
 /** A funding PSBT: covenant output + the offer packet in the extension. */
-const fundingPsbt = (payload: Uint8Array): { psbt: string; txid: string } => {
+const fundingPsbt = (offer: Offer): { psbt: string; txid: string } => {
     const tx = new Transaction({ allowUnknownOutputs: true });
     tx.addInput({ txid: new Uint8Array(32), index: 0 });
-    tx.addOutput({ script: hex.decode(SWAP_PK_SCRIPT), amount: BigInt(10_000) });
+    tx.addOutput({ script: offer.swapPkScript, amount: BigInt(10_000) });
+    const payload = encodeOffer(offer);
     const ext = Extension.create([new UnknownPacket(OFFER_PACKET_TYPE, payload)]).txOut();
     tx.addOutput({ script: ext.script, amount: ext.amount });
+    return { psbt: base64.encode(tx.toPSBT()), txid: tx.id };
+};
+
+/**
+ * A spend of one or more deposits, each input carrying the covenant leaf it
+ * took. This is what the classifier reads: `cancel` returns the deposit,
+ * `fulfill` is the solver paying for it.
+ */
+const spendPsbt = (
+    spends: { offer: Offer; deposit: { txid: string; vout: number }; via: "cancel" | "fulfill" }[],
+): { psbt: string; txid: string } => {
+    const tx = new Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true });
+    for (const { offer, deposit, via } of spends) {
+        const leaf = offerVtxoScript(offer, SERVER_KEY).functionByName(via)!.tapLeafScript;
+        tx.addInput({
+            txid: hex.decode(deposit.txid),
+            index: deposit.vout,
+            tapLeafScript: [leaf],
+        });
+    }
+    tx.addOutput({ script: MAKER_PK_SCRIPT, amount: BigInt(9_000) });
     return { psbt: base64.encode(tx.toPSBT()), txid: tx.id };
 };
 
@@ -42,88 +78,177 @@ type FakeIndexer = RestoreIndexer & { calls: string[][] };
 
 // typed against the production contract so a change to RestoreIndexer breaks
 // these fakes at compile time instead of leaving them on a stale shape
-const makeIndexer = (psbts: string[], vtxos: any[]): FakeIndexer => {
+const makeIndexer = (psbts: { psbt: string; txid: string }[], vtxos: any[]): FakeIndexer => {
     const calls: string[][] = [];
+    const byTxid = new Map(psbts.map((p) => [p.txid, p.psbt]));
     return {
         calls,
         getVirtualTxs: async (txids: string[]) => {
             calls.push(txids);
-            return { txs: psbts };
+            return { txs: txids.map((id) => byTxid.get(id)).filter(Boolean) as string[] };
         },
         getVtxos: async () => ({ vtxos }),
     } as unknown as FakeIndexer;
 };
 
-const spentVtxo = (txid: string, spentBy: string) => ({
+const depositVtxo = (offer: Offer, txid: string, extra: Record<string, unknown> = {}) => ({
     txid,
-    script: SWAP_PK_SCRIPT,
+    vout: 0,
+    script: scriptOf(offer),
     value: 10_000,
     createdAt: new Date(1_700_000_000_000),
-    virtualStatus: { state: "spent" },
-    arkTxId: spentBy,
+    virtualStatus: { state: "settled" },
+    ...extra,
+});
+
+const spentVtxo = (offer: Offer, txid: string, spentBy: string, extra = {}) =>
+    depositVtxo(offer, txid, { virtualStatus: { state: "spent" }, arkTxId: spentBy, ...extra });
+
+const scan = (
+    indexer: RestoreIndexer,
+    txs: Tx[],
+    existingIds = new Set<string>(),
+    scanned?: Set<string>,
+) => restoreAssetSwaps(indexer, txs, existingIds, { serverPubkey: SERVER_KEY, scanned });
+
+describe("classifySpend", () => {
+    it("reads the leaf, not what the transaction moved", async () => {
+        // the case a net-delta reading gets wrong: an asset offer's cancel takes
+        // the asset out of the covenant and puts the same asset back, so every
+        // wallet-level asset figure nets to zero and looks exactly like a fill
+        const offer = makeOffer("want-btc", BigInt(21_000));
+        const deposit = { txid: "ab".repeat(32), vout: 0 };
+        const cancel = spendPsbt([{ offer, deposit, via: "cancel" }]);
+        const fill = spendPsbt([{ offer, deposit, via: "fulfill" }]);
+
+        const parse = (psbt: string) => Transaction.fromPSBT(base64.decode(psbt));
+        expect(classifySpend(offer, SERVER_KEY, parse(cancel.psbt), deposit)).toBe("cancelled");
+        expect(classifySpend(offer, SERVER_KEY, parse(fill.psbt), deposit)).toBe("fulfilled");
+    });
+
+    it("classifies each deposit by its own input when one tx spends several", async () => {
+        // a solver batching fills, or any tx touching two of a maker's offers:
+        // per-input leaves answer per deposit, where a transaction-level rollup
+        // would give both deposits the same answer
+        const cancelled = makeOffer("want-btc", BigInt(21_000));
+        const filled = makeOffer("want-btc", BigInt(22_000));
+        const a = { txid: "ab".repeat(32), vout: 0 };
+        const b = { txid: "cd".repeat(32), vout: 1 };
+        const { psbt } = spendPsbt([
+            { offer: cancelled, deposit: a, via: "cancel" },
+            { offer: filled, deposit: b, via: "fulfill" },
+        ]);
+        const parsed = Transaction.fromPSBT(base64.decode(psbt));
+
+        expect(classifySpend(cancelled, SERVER_KEY, parsed, a)).toBe("cancelled");
+        expect(classifySpend(filled, SERVER_KEY, parsed, b)).toBe("fulfilled");
+    });
+
+    it("is indeterminate for a wrong server key or a spend by neither leaf", async () => {
+        const offer = makeOffer("want-asset", BigInt(992));
+        const deposit = { txid: "ab".repeat(32), vout: 0 };
+        const { psbt } = spendPsbt([{ offer, deposit, via: "cancel" }]);
+        const parsed = Transaction.fromPSBT(base64.decode(psbt));
+
+        // a rotated server key rebuilds a different covenant: say so rather than
+        // classify against a script the deposit was never funded to
+        expect(classifySpend(offer, key("44"), parsed, deposit)).toBe("indeterminate");
+        // right tx, wrong outpoint — the deposit is not among its inputs
+        expect(classifySpend(offer, SERVER_KEY, parsed, { txid: "ef".repeat(32), vout: 0 })).toBe(
+            "indeterminate",
+        );
+    });
 });
 
 describe("restoreAssetSwaps", () => {
     it("rebuilds a fulfilled BTC->asset swap from the funding tx offer packet and its spend", async () => {
         const offer = makeOffer("want-asset", BigInt(992));
         const payload = encodeOffer(offer);
-        const { psbt, txid } = fundingPsbt(payload);
+        const funding = fundingPsbt(offer);
+        const fill = spendPsbt([
+            { offer, deposit: { txid: funding.txid, vout: 0 }, via: "fulfill" },
+        ]);
         const txs = [
-            walletTx(txid, "sent"),
-            walletTx("fill-txid", "received", {
-                createdAt: 1_700_000_100,
-                assets: [{ assetId: ASSET_ID, amount: BigInt(992) }] as any,
-            }),
+            walletTx(funding.txid, "sent"),
+            walletTx(fill.txid, "received", { createdAt: 1_700_000_100 }),
         ];
-        const indexer = makeIndexer([psbt], [spentVtxo(txid, "fill-txid")]);
+        const indexer = makeIndexer([funding, fill], [spentVtxo(offer, funding.txid, fill.txid)]);
 
-        const { restored } = await restoreAssetSwaps(indexer, txs, new Set());
+        const { restored } = await scan(indexer, txs);
 
         expect(restored).toHaveLength(1);
         expect(restored[0]).toMatchObject({
-            id: txid,
-            fundingTxid: txid,
+            id: funding.txid,
+            fundingTxid: funding.txid,
             fromAsset: "btc",
             toAsset: ASSET_ID,
             fromAmount: "10000",
             toAmount: "992",
-            swapPkScript: SWAP_PK_SCRIPT,
+            swapPkScript: scriptOf(offer),
             offerHex: hex.encode(payload),
             status: "fulfilled",
-            spentTxid: "fill-txid",
+            spentTxid: fill.txid,
             createdAt: 1_700_000_000_000,
             completedAt: 1_700_000_100_000,
         });
     });
 
-    it("marks a spend that returned no want-asset as cancelled", async () => {
+    it("marks a spend that took the cancel leaf as cancelled", async () => {
         const offer = makeOffer("want-asset", BigInt(992));
-        const { psbt, txid } = fundingPsbt(encodeOffer(offer));
-        // the spend credited sats back, no asset delivered: our cancel
-        const txs = [walletTx(txid, "sent"), walletTx("cancel-txid", "received")];
-        const indexer = makeIndexer([psbt], [spentVtxo(txid, "cancel-txid")]);
+        const funding = fundingPsbt(offer);
+        const cancel = spendPsbt([
+            { offer, deposit: { txid: funding.txid, vout: 0 }, via: "cancel" },
+        ]);
+        const txs = [walletTx(funding.txid, "sent"), walletTx(cancel.txid, "received")];
+        const indexer = makeIndexer(
+            [funding, cancel],
+            [spentVtxo(offer, funding.txid, cancel.txid)],
+        );
 
         const {
             restored: [restored],
-        } = await restoreAssetSwaps(indexer, txs, new Set());
+        } = await scan(indexer, txs);
 
-        expect(restored).toMatchObject({ status: "cancelled", spentTxid: "cancel-txid" });
+        expect(restored).toMatchObject({ status: "cancelled", spentTxid: cancel.txid });
         expect(restored.completedAt).toBeUndefined();
+    });
+
+    it("marks an asset->BTC cancel as cancelled, though it returns the deposit asset", async () => {
+        // the regression this classifier exists for: with the deposit registered
+        // as a contract, the asset leaves and returns within the wallet's own
+        // coins, so every net asset figure for this tx is zero — identical to a
+        // fill. The leaf is not.
+        const offer = makeOffer("want-btc", BigInt(21_000));
+        const funding = fundingPsbt(offer);
+        const cancel = spendPsbt([
+            { offer, deposit: { txid: funding.txid, vout: 0 }, via: "cancel" },
+        ]);
+        const vtxo = spentVtxo(offer, funding.txid, cancel.txid, {
+            assets: [{ assetId: ASSET_ID, amount: BigInt(500) }],
+        });
+        const indexer = makeIndexer([funding, cancel], [vtxo]);
+
+        const {
+            restored: [restored],
+        } = await scan(indexer, [walletTx(funding.txid, "sent")]);
+
+        expect(restored).toMatchObject({ status: "cancelled", fromAsset: ASSET_ID });
     });
 
     it("rebuilds an asset->BTC swap with the deposit amount from the covenant vtxo assets", async () => {
         const offer = makeOffer("want-btc", BigInt(21_000));
-        const { psbt, txid } = fundingPsbt(encodeOffer(offer));
-        const txs = [walletTx(txid, "sent"), walletTx("fill-txid", "received")];
-        const vtxo = {
-            ...spentVtxo(txid, "fill-txid"),
+        const funding = fundingPsbt(offer);
+        const fill = spendPsbt([
+            { offer, deposit: { txid: funding.txid, vout: 0 }, via: "fulfill" },
+        ]);
+        const vtxo = spentVtxo(offer, funding.txid, fill.txid, {
             assets: [{ assetId: ASSET_ID, amount: BigInt(500) }],
-        };
-        const indexer = makeIndexer([psbt], [vtxo]);
+        });
+        const indexer = makeIndexer([funding, fill], [vtxo]);
 
         const {
             restored: [restored],
-        } = await restoreAssetSwaps(indexer, txs, new Set());
+        } = await scan(indexer, [walletTx(funding.txid, "sent"), walletTx(fill.txid, "received")]);
 
         expect(restored).toMatchObject({
             fromAsset: ASSET_ID,
@@ -138,22 +263,18 @@ describe("restoreAssetSwaps", () => {
         // a want-asset offer whose funding vtxo carries a different asset: the
         // TLV names no deposit, so its identity comes from the vtxo's own rider
         const offer = makeOffer("want-asset", BigInt(992)); // wants ASSET_ID
-        const { psbt, txid } = fundingPsbt(encodeOffer(offer));
-        const txs = [
-            walletTx(txid, "sent"),
-            walletTx("fill-txid", "received", {
-                assets: [{ assetId: ASSET_ID, amount: BigInt(992) }] as any,
-            }),
-        ];
-        const vtxo = {
-            ...spentVtxo(txid, "fill-txid"),
+        const funding = fundingPsbt(offer);
+        const fill = spendPsbt([
+            { offer, deposit: { txid: funding.txid, vout: 0 }, via: "fulfill" },
+        ]);
+        const vtxo = spentVtxo(offer, funding.txid, fill.txid, {
             assets: [{ assetId: OTHER_ASSET_ID, amount: BigInt(500) }],
-        };
-        const indexer = makeIndexer([psbt], [vtxo]);
+        });
+        const indexer = makeIndexer([funding, fill], [vtxo]);
 
         const {
             restored: [restored],
-        } = await restoreAssetSwaps(indexer, txs, new Set());
+        } = await scan(indexer, [walletTx(funding.txid, "sent"), walletTx(fill.txid, "received")]);
 
         expect(restored).toMatchObject({
             fromAsset: OTHER_ASSET_ID,
@@ -164,82 +285,81 @@ describe("restoreAssetSwaps", () => {
         });
     });
 
-    it("marks an asset->BTC spend that returned the deposit asset as cancelled", async () => {
-        const offer = makeOffer("want-btc", BigInt(21_000));
-        const { psbt, txid } = fundingPsbt(encodeOffer(offer));
-        const txs = [
-            walletTx(txid, "sent"),
-            walletTx("cancel-txid", "received", {
-                assets: [{ assetId: ASSET_ID, amount: BigInt(500) }] as any,
-            }),
-        ];
-        const vtxo = {
-            ...spentVtxo(txid, "cancel-txid"),
-            assets: [{ assetId: ASSET_ID, amount: BigInt(500) }],
-        };
-        const indexer = makeIndexer([psbt], [vtxo]);
-
-        const {
-            restored: [restored],
-        } = await restoreAssetSwaps(indexer, txs, new Set());
-
-        expect(restored).toMatchObject({ status: "cancelled" });
-    });
-
     it("keeps an unspent deposit pending and a swept one recoverable", async () => {
         const offer = makeOffer("want-asset", BigInt(992));
-        const { psbt, txid } = fundingPsbt(encodeOffer(offer));
+        const funding = fundingPsbt(offer);
         for (const [state, status] of [
             ["settled", "pending"],
             ["swept", "recoverable"],
         ]) {
-            const vtxo = { ...spentVtxo(txid, ""), arkTxId: undefined, virtualStatus: { state } };
-            const indexer = makeIndexer([psbt], [vtxo]);
+            const vtxo = depositVtxo(offer, funding.txid, { virtualStatus: { state } });
+            const indexer = makeIndexer([funding], [vtxo]);
             const {
                 restored: [restored],
-            } = await restoreAssetSwaps(indexer, [walletTx(txid, "sent")], new Set());
+            } = await scan(indexer, [walletTx(funding.txid, "sent")]);
             expect(restored.status).toBe(status);
             expect(restored.spentTxid).toBeUndefined();
         }
     });
 
+    it("leaves a spend it cannot classify unscanned, rather than guessing", async () => {
+        // the spender is not fetchable yet. Persisting a guess here is what made
+        // a mislabel permanent: a stored swap is skipped by every later scan.
+        const offer = makeOffer("want-asset", BigInt(992));
+        const funding = fundingPsbt(offer);
+        const indexer = makeIndexer([funding], [spentVtxo(offer, funding.txid, "not-fetchable")]);
+
+        const result = await scan(indexer, [walletTx(funding.txid, "sent")]);
+
+        expect(result).toEqual({ restored: [], scannedTxids: [] });
+
+        // once the spender is fetchable the same candidate resolves
+        const cancel = spendPsbt([
+            { offer, deposit: { txid: funding.txid, vout: 0 }, via: "cancel" },
+        ]);
+        const later = makeIndexer([funding, cancel], [spentVtxo(offer, funding.txid, cancel.txid)]);
+        const retry = await scan(later, [walletTx(funding.txid, "sent")]);
+        expect(retry.restored).toMatchObject([{ status: "cancelled" }]);
+        expect(retry.scannedTxids).toEqual([funding.txid]);
+    });
+
     it("skips sent txs without an offer packet and already-known swaps", async () => {
         const offer = makeOffer("want-asset", BigInt(992));
-        const { psbt, txid } = fundingPsbt(encodeOffer(offer));
+        const funding = fundingPsbt(offer);
         const plainTx = new Transaction({ allowUnknownOutputs: true });
         plainTx.addInput({ txid: new Uint8Array(32), index: 1 });
-        plainTx.addOutput({ script: hex.decode(SWAP_PK_SCRIPT), amount: BigInt(500) });
-        const plain = base64.encode(plainTx.toPSBT());
+        plainTx.addOutput({ script: offer.swapPkScript, amount: BigInt(500) });
+        const plain = { psbt: base64.encode(plainTx.toPSBT()), txid: plainTx.id };
 
         // known id: never fetched, never restored
-        const known = await restoreAssetSwaps(
-            makeIndexer([psbt], []),
-            [walletTx(txid, "sent")],
-            new Set([txid]),
+        const known = await scan(
+            makeIndexer([funding], []),
+            [walletTx(funding.txid, "sent")],
+            new Set([funding.txid]),
         );
         expect(known).toEqual({ restored: [], scannedTxids: [] });
 
         // plain sends and received txs produce nothing
         const indexer = makeIndexer([plain], []);
-        const result = await restoreAssetSwaps(
-            indexer,
-            [walletTx(plainTx.id, "sent"), walletTx("other", "received")],
-            new Set(),
-        );
+        const result = await scan(indexer, [
+            walletTx(plainTx.id, "sent"),
+            walletTx("other", "received"),
+        ]);
         expect(result.restored).toEqual([]);
         expect(result.scannedTxids).toEqual([plainTx.id]);
         expect(indexer.calls).toEqual([[plainTx.id]]);
     });
 
     it("never re-fetches txids that already got an authoritative answer", async () => {
-        const { psbt, txid } = fundingPsbt(encodeOffer(makeOffer("want-asset", BigInt(992))));
-        const indexer = makeIndexer([psbt], []);
+        const offer = makeOffer("want-asset", BigInt(992));
+        const funding = fundingPsbt(offer);
+        const indexer = makeIndexer([funding], []);
 
-        const result = await restoreAssetSwaps(
+        const result = await scan(
             indexer,
-            [walletTx(txid, "sent")],
+            [walletTx(funding.txid, "sent")],
             new Set(),
-            new Set([txid]),
+            new Set([funding.txid]),
         );
 
         expect(result).toEqual({ restored: [], scannedTxids: [] });
@@ -250,10 +370,10 @@ describe("restoreAssetSwaps", () => {
         // a want-btc offer's TLV names the deposit asset; if the indexer hasn't
         // attached the rider yet, persisting now would burn a zero-amount record
         const offer = makeOffer("want-btc", BigInt(21_000));
-        const { psbt, txid } = fundingPsbt(encodeOffer(offer));
-        const indexer = makeIndexer([psbt], [spentVtxo(txid, "fill-txid")]); // vtxo without assets
+        const funding = fundingPsbt(offer);
+        const indexer = makeIndexer([funding], [spentVtxo(offer, funding.txid, "fill-txid")]);
 
-        const result = await restoreAssetSwaps(indexer, [walletTx(txid, "sent")], new Set());
+        const result = await scan(indexer, [walletTx(funding.txid, "sent")]);
 
         expect(result).toEqual({ restored: [], scannedTxids: [] });
     });
@@ -262,39 +382,41 @@ describe("restoreAssetSwaps", () => {
         // two candidates requested, the indexer answers for only one: the missing
         // txid must stay unscanned or its swap could never be restored
         const offer = makeOffer("want-asset", BigInt(992));
-        const { psbt, txid } = fundingPsbt(encodeOffer(offer));
-        const indexer = makeIndexer([psbt], [spentVtxo(txid, "fill-txid")]);
+        const funding = fundingPsbt(offer);
+        const fill = spendPsbt([
+            { offer, deposit: { txid: funding.txid, vout: 0 }, via: "fulfill" },
+        ]);
+        const indexer = makeIndexer([funding, fill], [spentVtxo(offer, funding.txid, fill.txid)]);
 
-        const result = await restoreAssetSwaps(
-            indexer,
-            [walletTx(txid, "sent"), walletTx("unanswered", "sent")],
-            new Set(),
-        );
+        const result = await scan(indexer, [
+            walletTx(funding.txid, "sent"),
+            walletTx("unanswered", "sent"),
+        ]);
 
         expect(result.restored).toHaveLength(1);
-        expect(result.scannedTxids).toEqual([txid]);
+        expect(result.scannedTxids).toEqual([funding.txid]);
     });
 
     it("leaves a txid unscanned while its funding vtxo is not yet indexed", async () => {
         // the offer packet is there but getVtxos lags behind the tx feed: marking
         // the txid scanned now would permanently orphan a still-pending swap
         const offer = makeOffer("want-asset", BigInt(992));
-        const { psbt, txid } = fundingPsbt(encodeOffer(offer));
-        const indexer = makeIndexer([psbt], []);
+        const funding = fundingPsbt(offer);
+        const indexer = makeIndexer([funding], []);
 
-        const result = await restoreAssetSwaps(indexer, [walletTx(txid, "sent")], new Set());
+        const result = await scan(indexer, [walletTx(funding.txid, "sent")]);
 
         expect(result).toEqual({ restored: [], scannedTxids: [] });
 
         // once the indexer catches up, the same candidate restores normally
-        const caughtUp = makeIndexer([psbt], [spentVtxo(txid, "fill-txid")]);
-        const retry = await restoreAssetSwaps(caughtUp, [walletTx(txid, "sent")], new Set());
+        const caughtUp = makeIndexer([funding], [depositVtxo(offer, funding.txid)]);
+        const retry = await scan(caughtUp, [walletTx(funding.txid, "sent")]);
         expect(retry.restored).toHaveLength(1);
-        expect(retry.scannedTxids).toEqual([txid]);
+        expect(retry.scannedTxids).toEqual([funding.txid]);
     });
 
     it("leaves a failed fetch unscanned so it retries on a later scan", async () => {
-        const { txid } = fundingPsbt(encodeOffer(makeOffer("want-asset", BigInt(992))));
+        const funding = fundingPsbt(makeOffer("want-asset", BigInt(992)));
         const indexer = {
             getVirtualTxs: async () => {
                 throw new Error("indexer down");
@@ -302,7 +424,7 @@ describe("restoreAssetSwaps", () => {
             getVtxos: async () => ({ vtxos: [] }),
         } as any;
 
-        const result = await restoreAssetSwaps(indexer, [walletTx(txid, "sent")], new Set());
+        const result = await scan(indexer, [walletTx(funding.txid, "sent")]);
 
         expect(result).toEqual({ restored: [], scannedTxids: [] });
     });
@@ -311,26 +433,27 @@ describe("restoreAssetSwaps", () => {
         // TXS_PER_REQUEST is 50, so 51 candidates split into two requests. If a
         // failed chunk let its txids be marked scanned, those swaps could never
         // be rebuilt — later scans skip answered txids.
-        const funded = Array.from({ length: 51 }, (_, i) =>
-            fundingPsbt(encodeOffer(makeOffer("want-asset", BigInt(1_000 + i)))),
+        const offers = Array.from({ length: 51 }, (_, i) =>
+            makeOffer("want-asset", BigInt(1_000 + i)),
         );
+        const funded = offers.map((offer) => ({ offer, ...fundingPsbt(offer) }));
         const firstChunk = funded.slice(0, 50);
         const lastTxid = funded[50].txid;
+        const byTxid = new Map(funded.map((f) => [f.txid, f.psbt]));
 
         const indexer = {
             getVirtualTxs: async (txids: string[]) => {
                 if (txids.includes(lastTxid)) throw new Error("indexer down for this chunk");
-                return { txs: firstChunk.map((f) => f.psbt) };
+                return { txs: txids.map((id) => byTxid.get(id)).filter(Boolean) as string[] };
             },
             getVtxos: async () => ({
-                vtxos: funded.map((f) => spentVtxo(f.txid, "fill-txid")),
+                vtxos: funded.map((f) => depositVtxo(f.offer, f.txid)),
             }),
         } as unknown as FakeIndexer;
 
-        const result = await restoreAssetSwaps(
+        const result = await scan(
             indexer,
             funded.map((f) => walletTx(f.txid, "sent")),
-            new Set(),
         );
 
         expect(result.restored).toHaveLength(50);

--- a/packages/swap/test/restore.test.ts
+++ b/packages/swap/test/restore.test.ts
@@ -3,7 +3,14 @@ import { base64, hex } from "@scure/base";
 import { schnorr } from "@noble/curves/secp256k1.js";
 import { asset, Extension, Transaction, UnknownPacket } from "@arkade-os/sdk";
 import { encodeOffer, offerVtxoScript, Offer, OFFER_PACKET_TYPE } from "../src/offer";
-import { classifySpend, restoreAssetSwaps, type RestoreIndexer, type Tx } from "../src/restore";
+import {
+    classifyDepositSpend,
+    classifySpend,
+    restoreAssetSwaps,
+    spendTxidsOf,
+    type RestoreIndexer,
+    type Tx,
+} from "../src/restore";
 
 const ASSET_ID = "f1".repeat(34);
 const OTHER_ASSET_ID = "a2".repeat(34);
@@ -142,6 +149,42 @@ describe("classifySpend", () => {
 
         expect(classifySpend(cancelled, SERVER_KEY, parsed, a)).toBe("cancelled");
         expect(classifySpend(filled, SERVER_KEY, parsed, b)).toBe("fulfilled");
+    });
+
+    it("classifies across both halves of a real spend, where only the checkpoint holds the outpoint", async () => {
+        // the shape regtest produces: `spentBy` is the checkpoint, which takes
+        // the deposit outpoint and carries the covenant leaf, and `arkTxId`
+        // spends the checkpoint's output — same leaf, different outpoint. A
+        // classifier handed only the ark tx answers `indeterminate` for every
+        // real spend, which is precisely the bug the e2e caught.
+        const offer = makeOffer("want-btc", BigInt(21_000));
+        const deposit = { txid: "ab".repeat(32), vout: 0 };
+        const checkpoint = spendPsbt([{ offer, deposit, via: "cancel" }]);
+        // the ark tx spends the checkpoint, not the deposit
+        const arkTx = spendPsbt([
+            { offer, deposit: { txid: checkpoint.txid, vout: 0 }, via: "cancel" },
+        ]);
+        const parse = (psbt: string) => Transaction.fromPSBT(base64.decode(psbt));
+
+        expect(classifySpend(offer, SERVER_KEY, parse(arkTx.psbt), deposit)).toBe("indeterminate");
+        expect(classifyDepositSpend(offer, SERVER_KEY, [parse(arkTx.psbt)], deposit)).toBe(
+            "indeterminate",
+        );
+        // given both, the checkpoint answers
+        expect(
+            classifyDepositSpend(
+                offer,
+                SERVER_KEY,
+                [parse(checkpoint.psbt), parse(arkTx.psbt)],
+                deposit,
+            ),
+        ).toBe("cancelled");
+    });
+
+    it("orders the candidate txids checkpoint-first", () => {
+        expect(spendTxidsOf({ spentBy: "ck", arkTxId: "ark" })).toEqual(["ck", "ark"]);
+        expect(spendTxidsOf({ arkTxId: "ark" })).toEqual(["ark"]);
+        expect(spendTxidsOf({})).toEqual([]);
     });
 
     it("is indeterminate for a wrong server key or a spend by neither leaf", async () => {

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -309,7 +309,13 @@ const spies = (
  * lifecycle is as much of the contract as the events themselves. */
 type FakeContracts = SwapContractRegistry & {
     created: CreateContractParams[];
-    retired: { script: string; state: string }[];
+    retired: { script: string; watch: string }[];
+    /**
+     * The scripts a real manager would still subscribe and poll — every
+     * written row minus the `retained` ones. Retirement is only worth
+     * anything if it moves this set.
+     */
+    watched: () => string[];
     /** Push an event to every live listener, the way the watcher would. */
     emit: (event: ContractEvent) => void;
     listenerCount: () => number;
@@ -318,10 +324,15 @@ type FakeContracts = SwapContractRegistry & {
 const fakeContracts = (over: { failCreate?: () => boolean } = {}): FakeContracts => {
     const listeners = new Set<(event: ContractEvent) => void>();
     const created: CreateContractParams[] = [];
-    const retired: { script: string; state: string }[] = [];
+    const retired: { script: string; watch: string }[] = [];
+    const rows = new Map<string, string>();
     return {
         created,
         retired,
+        watched: () =>
+            [...rows.entries()]
+                .filter(([, watch]) => watch !== "retained")
+                .map(([script]) => script),
         emit(event: ContractEvent) {
             for (const listener of [...listeners]) listener(event);
         },
@@ -329,20 +340,22 @@ const fakeContracts = (over: { failCreate?: () => boolean } = {}): FakeContracts
         async createContract(params: CreateContractParams) {
             if (over.failCreate?.()) throw new Error("contract repository unavailable");
             created.push(params);
+            rows.set(params.script, params.watch ?? "watched");
             return { ...params, state: "active", createdAt: 1 } as Contract;
         },
         onContractEvent(callback: (event: ContractEvent) => void) {
             listeners.add(callback);
             return () => listeners.delete(callback);
         },
-        async setContractState(script: string, state: string) {
+        async setContractWatchState(script: string, watch: string) {
             // A real ContractManager resolves the row first and throws
             // `Contract ${script} not found` when there is none — modelled
             // here, so a test cannot pass by retiring something never written.
-            if (!created.some((row) => row.script === script)) {
+            if (!rows.has(script)) {
                 throw new Error(`Contract ${script} not found`);
             }
-            retired.push({ script, state });
+            rows.set(script, watch);
+            retired.push({ script, watch });
         },
     } as unknown as FakeContracts;
 };
@@ -1390,7 +1403,7 @@ describe("RfqSwapManager — the lockup as a contract", () => {
         });
     });
 
-    it("retires the contract once the swap is over, and never deletes it", async () => {
+    it("stops watching the contract once the swap is over, and never deletes it", async () => {
         const s = spies();
         const contracts = fakeContracts();
         const m = manager({
@@ -1405,7 +1418,11 @@ describe("RfqSwapManager — the lockup as a contract", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(swap.state).toBe("settled");
-        expect(contracts.retired).toEqual([{ script: LOCKUP_SCRIPT_HEX, state: "inactive" }]);
+        expect(contracts.retired).toEqual([{ script: LOCKUP_SCRIPT_HEX, watch: "retained" }]);
+        // The row survives — it is what keeps the lockup's VTXOs annotatable —
+        // but it is out of every background channel.
+        expect(contracts.created.map((row) => row.script)).toEqual([LOCKUP_SCRIPT_HEX]);
+        expect(contracts.watched()).toEqual([]);
     });
 
     it("does not try to retire a row it never managed to write", async () => {
@@ -1449,6 +1466,7 @@ describe("RfqSwapManager — the lockup as a contract", () => {
 
         expect(contracts.created).toHaveLength(1);
         expect(contracts.retired).toEqual([]);
+        expect(contracts.watched()).toEqual([LOCKUP_SCRIPT_HEX]);
     });
 
     it("hands a needs-recovery refusal to the caller intact, and keeps retrying", async () => {

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi } from "vitest";
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { asset, ArkAddress, Transaction } from "@arkade-os/sdk";
+import { encodeOffer, offerVtxoScript, OFFER_CONTRACT_KIND, type Offer } from "../src/offer";
+import { InMemoryAssetSwapRepository } from "../src/repository";
+import { addAssetSwap, getAssetSwaps, type AssetSwap } from "../src/store";
+import { spendUpdate, watchOfferSwaps } from "../src/watch";
+
+const ASSET_ID = "f1".repeat(34);
+
+const key = (seed: string) => schnorr.getPublicKey(hex.decode(seed.repeat(32)));
+const SERVER_KEY = key("11");
+const MAKER_KEY = key("22");
+const EMULATOR_KEY = key("33");
+const MAKER_PK_SCRIPT = new Uint8Array([0x51, 0x20, ...key("55")]);
+const FUNDING_TXID = "ab".repeat(32);
+
+const makeOffer = (side: "want-asset" | "want-btc" = "want-asset"): Offer => {
+    const binding: Omit<Offer, "swapPkScript"> = {
+        wantAmount: BigInt(992),
+        ...(side === "want-asset"
+            ? { wantAsset: asset.AssetId.fromString(ASSET_ID) }
+            : { offerAsset: asset.AssetId.fromString(ASSET_ID) }),
+        makerPkScript: MAKER_PK_SCRIPT,
+        makerPublicKey: MAKER_KEY,
+        emulatorPubkey: EMULATOR_KEY,
+    };
+    return { ...binding, swapPkScript: offerVtxoScript(binding, SERVER_KEY).pkScript };
+};
+
+const swapFor = (offer: Offer, overrides: Partial<AssetSwap> = {}): AssetSwap => ({
+    id: FUNDING_TXID,
+    fromAsset: "btc",
+    toAsset: ASSET_ID,
+    fromAmount: "10000",
+    toAmount: "992",
+    swapAddress: "",
+    swapPkScript: hex.encode(offer.swapPkScript),
+    offerHex: hex.encode(encodeOffer(offer)),
+    fundingTxid: FUNDING_TXID,
+    status: "pending",
+    createdAt: 1_700_000_000_000,
+    ...overrides,
+});
+
+const spendPsbt = (offer: Offer, via: "cancel" | "fulfill", vout = 0) => {
+    const leaf = offerVtxoScript(offer, SERVER_KEY).functionByName(via)!.tapLeafScript;
+    const tx = new Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true });
+    tx.addInput({ txid: hex.decode(FUNDING_TXID), index: vout, tapLeafScript: [leaf] });
+    tx.addOutput({ script: MAKER_PK_SCRIPT, amount: BigInt(9_000) });
+    return { psbt: base64.encode(tx.toPSBT()), txid: tx.id };
+};
+
+/**
+ * A wallet stub exposing only what the watcher reads: the contract manager's
+ * event seam, and an address to recover the server key from. `emit` plays the
+ * manager's part.
+ */
+const makeWallet = (getVirtualTxs: (txids: string[]) => Promise<{ txs: string[] }>) => {
+    const callbacks = new Set<(event: any) => void>();
+    // a real ark address, so ArkAddress.decode recovers SERVER_KEY from it
+    const address = new ArkAddress(SERVER_KEY, key("66"), "tark").encode();
+    const wallet = {
+        getAddress: async () => address,
+        getContractManager: async () => ({
+            onContractEvent: (cb: (event: any) => void) => {
+                callbacks.add(cb);
+                return () => callbacks.delete(cb);
+            },
+        }),
+    } as any;
+    return {
+        wallet,
+        getVirtualTxs,
+        emit: (event: any) => callbacks.forEach((cb) => cb(event)),
+        listeners: () => callbacks.size,
+    };
+};
+
+const spentEvent = (offer: Offer, spentTxid: string, overrides: Record<string, unknown> = {}) => ({
+    type: "vtxo_spent",
+    contractScript: hex.encode(offer.swapPkScript),
+    contract: { metadata: { kind: OFFER_CONTRACT_KIND }, ...(overrides.contract as object) },
+    vtxos: [{ txid: FUNDING_TXID, vout: 0, arkTxId: spentTxid }],
+    timestamp: 1_700_000_100_000,
+    ...overrides,
+});
+
+// the watcher builds its own RestIndexerProvider from arkServerUrl; intercept
+// the one call it makes rather than reaching through the constructor
+const withIndexer = async (
+    fetcher: (txids: string[]) => Promise<{ txs: string[] }>,
+    run: (harness: ReturnType<typeof makeWallet>) => Promise<void>,
+) => {
+    const sdk = await import("@arkade-os/sdk");
+    const spy = vi
+        .spyOn(sdk.RestIndexerProvider.prototype, "getVirtualTxs")
+        .mockImplementation(fetcher as any);
+    try {
+        await run(makeWallet(fetcher));
+    } finally {
+        spy.mockRestore();
+    }
+};
+
+describe("spendUpdate", () => {
+    const offer = makeOffer();
+
+    it("resolves a classified spend and ignores one nobody could classify", () => {
+        const swap = swapFor(offer);
+        expect(spendUpdate(swap, { txid: "f".repeat(64), kind: "cancelled" })).toMatchObject({
+            status: "cancelled",
+            spentTxid: "f".repeat(64),
+        });
+        expect(
+            spendUpdate(swap, { txid: "f".repeat(64), kind: "fulfilled", at: 42 }),
+        ).toMatchObject({ status: "fulfilled", completedAt: 42 });
+        // no answer, no write: the restore scan decides it later
+        expect(spendUpdate(swap, { txid: "f".repeat(64), kind: "indeterminate" })).toBeUndefined();
+    });
+
+    it("leaves an already-resolved swap alone, so a re-delivered event is a no-op", () => {
+        for (const status of ["fulfilled", "cancelled", "recoverable"] as const) {
+            const resolved = swapFor(offer, { status, spentTxid: "aa".repeat(32) });
+            expect(
+                spendUpdate(resolved, { txid: "bb".repeat(32), kind: "fulfilled" }),
+            ).toBeUndefined();
+        }
+    });
+
+    it("records a completion time for a fill but not for a cancel", () => {
+        const swap = swapFor(offer);
+        expect(spendUpdate(swap, { txid: "f".repeat(64), kind: "cancelled", at: 42 })).not.toEqual(
+            expect.objectContaining({ completedAt: expect.anything() }),
+        );
+    });
+});
+
+describe("watchOfferSwaps", () => {
+    it("marks a swap fulfilled when a spend takes the fulfill leaf", async () => {
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit }) => {
+                const updates: AssetSwap[] = [];
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                    onUpdate: (swap) => updates.push(swap),
+                });
+
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([
+                    { status: "fulfilled", spentTxid: fill.txid, completedAt: 1_700_000_100_000 },
+                ]);
+                expect(updates).toMatchObject([{ status: "fulfilled" }]);
+            },
+        );
+    });
+
+    it("marks a cancel made elsewhere as cancelled, by its leaf", async () => {
+        // the multi-device case: this store never recorded the cancel, so the
+        // exact classifier has nothing to match and the leaf answers instead
+        const offer = makeOffer("want-btc");
+        const cancel = spendPsbt(offer, "cancel");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer, { fromAsset: ASSET_ID, toAsset: "btc" }));
+
+        await withIndexer(
+            async () => ({ txs: [cancel.psbt] }),
+            async ({ wallet, emit }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, cancel.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "cancelled" }]);
+            },
+        );
+    });
+
+    it("takes our own recorded cancel without reading the spending tx", async () => {
+        const offer = makeOffer();
+        const repository = new InMemoryAssetSwapRepository();
+        const cancelTxid = "cc".repeat(32);
+        await addAssetSwap(
+            repository,
+            swapFor(offer, { status: "cancelling", spentTxid: cancelTxid }),
+        );
+
+        const fetcher = vi.fn(async () => ({ txs: [] as string[] }));
+        await withIndexer(fetcher, async ({ wallet, emit }) => {
+            const watcher = await watchOfferSwaps({
+                wallet,
+                arkServerUrl: "http://ark",
+                repository,
+            });
+            emit(spentEvent(offer, cancelTxid));
+            await watcher.idle();
+            watcher.stop();
+
+            expect(await getAssetSwaps(repository)).toMatchObject([{ status: "cancelled" }]);
+            // the whole point of the record: no indexer round trip
+            expect(fetcher).not.toHaveBeenCalled();
+        });
+    });
+
+    it("writes nothing when the spending tx cannot be read", async () => {
+        // the indexer lags a freshly submitted ark tx. Persisting a guess here
+        // is what made a wrong label permanent — later scans skip stored swaps
+        const offer = makeOffer();
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [] }),
+            async ({ wallet, emit }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, "dd".repeat(32)));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "pending" }]);
+            },
+        );
+    });
+
+    it("ignores events for contracts that are not offer covenants", async () => {
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, fill.txid, { contract: { metadata: { kind: "other" } } }));
+                emit({ type: "vtxo_received", contractScript: "", vtxos: [], contract: {} });
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "pending" }]);
+            },
+        );
+    });
+
+    it("stops delivering after stop()", async () => {
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, listeners }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                watcher.stop();
+                expect(listeners()).toBe(0);
+
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "pending" }]);
+            },
+        );
+    });
+});

--- a/packages/swap/vitest.config.ts
+++ b/packages/swap/vitest.config.ts
@@ -1,4 +1,17 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import base from "../../config/vitest.base";
 
-export default mergeConfig(base, defineConfig({}));
+export default mergeConfig(
+    base,
+    defineConfig({
+        test: {
+            // `ContractWatcher` subscribes over SSE, and Node exposes
+            // `EventSource` only behind this flag (24.x). Without it every
+            // subscription fails with "EventSource is not defined", the manager
+            // emits no `vtxo_received`/`vtxo_spent`, and anything event-driven
+            // — `watchOfferSwaps`, `RfqSwapManager`'s contract subscription —
+            // silently degrades to whatever polling the test does itself.
+            poolOptions: { forks: { execArgv: ["--experimental-eventsource"] } },
+        },
+    }),
+);

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -1356,6 +1356,24 @@ Contract freshness behavior:
 - **Failsafe polling** every 20 seconds by default to catch missed events, configurable via `watcherConfig.failsafePollIntervalMs`
 - **Manual refresh** through `manager.refreshVtxos()`; pass `{ includeInactive: true }` to sweep every repository contract
 
+Which contracts get that coverage is `contract.watch`, and it is independent of
+`contract.state` (which only governs receive-address selection — a retired
+receive address stays watched, because it can still be paid):
+
+```typescript
+// Watch a one-shot destination only until it is funded; the manager
+// demotes it to `retained` itself once a VTXO lands.
+await manager.createContract({ ...params, watch: 'awaiting-funds' })
+
+// A finished contract — a settled swap lockup, say. The row stays for
+// history, annotation and restore; it just leaves the subscription and
+// the poll. Unlike `deleteContract`, nothing is lost.
+await manager.setContractWatchState(script, 'retained')
+```
+
+A row with no `watch` value is `watched`, so contracts written by earlier SDK
+versions keep the coverage they have today.
+
 ### Repository Pattern
 
 Most users don't need to touch repositories directly — `Wallet` reads through them and `ContractManager` owns VTXO/contract synchronization into them. They are documented here for advanced integrations (custom storage backends, offline-first apps, repository inspection).

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -1508,11 +1508,15 @@ export class ContractManager implements IContractManager {
         );
     }
 
+    // Field-by-field, so every filter a caller can express reaches the
+    // repository. A field missing here is not a narrower query — it is an
+    // unfiltered one.
     private buildContractsDbFilter(filter: GetContractsFilter): ContractFilter {
         return {
             script: filter.script,
             state: filter.state,
             type: filter.type,
+            watch: filter.watch,
         };
     }
 

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -8,6 +8,7 @@ import {
     ContractEvent,
     ContractEventCallback,
     ContractState,
+    ContractWatchState,
     ContractHandler,
     ContractWithVtxos,
     Discoverable,
@@ -19,6 +20,7 @@ import {
     ExtendedContractVtxo,
     hasCandidates,
     isDiscoverable,
+    watchStateOf,
 } from "./types";
 import { ContractWatcher, ContractWatcherConfig } from "./contractWatcher";
 import { contractHandlers } from "./handlers";
@@ -350,14 +352,31 @@ export interface IContractManager extends Disposable {
 
     /**
      * Convenience helper to update only the contract state. Note
-     * `inactive` does not stop watching; see {@link ContractState} and
-     * {@link deleteContract}.
+     * `inactive` governs receive-address selection and does not stop
+     * watching; see {@link ContractState} and
+     * {@link setContractWatchState}.
      */
     setContractState(script: string, state: ContractState): Promise<void>;
 
     /**
-     * Delete a contract by script and stop watching it. This — not
-     * retiring via {@link setContractState} — is the stop-watching path.
+     * Convenience helper to update only the contract's watch state.
+     *
+     * `retained` is how an owner says "this script is done": it leaves
+     * the subscription and the sweep, while the row — and so history,
+     * annotation and restore — is untouched. `awaiting-funds` asks for
+     * coverage only until the script is funded, after which the manager
+     * demotes it to `retained` itself.
+     *
+     * @see ContractWatchState
+     */
+    setContractWatchState(script: string, watch: ContractWatchState): Promise<void>;
+
+    /**
+     * Delete a contract by script, dropping both the row and the watch.
+     * Destructive: the row is what keeps the contract's VTXOs
+     * annotatable and its transactions readable in history, so to stop
+     * watching a finished contract use
+     * {@link setContractWatchState}(`"retained"`) instead.
      */
     deleteContract(script: string): Promise<void>;
 
@@ -1557,17 +1576,22 @@ export class ContractManager implements IContractManager {
 
     /**
      * Set a contract's state. Retiring (`inactive`) keeps it watched;
-     * see {@link ContractState}. To stop watching, use
-     * {@link deleteContract}.
+     * see {@link ContractState}. To stop watching while keeping the row,
+     * use {@link setContractWatchState}.
      */
     async setContractState(script: string, state: ContractState): Promise<void> {
         await this.updateContract(script, { state });
     }
 
+    /** @see IContractManager.setContractWatchState */
+    async setContractWatchState(script: string, watch: ContractWatchState): Promise<void> {
+        await this.updateContract(script, { watch });
+    }
+
     /**
-     * Delete a contract. Also removes it from the watcher — the only way
-     * to stop watching a contract (retiring it via
-     * {@link setContractState} does not).
+     * Delete a contract, dropping the row along with the watch. To stop
+     * watching a finished contract without losing its history, use
+     * {@link setContractWatchState}(`"retained"`).
      *
      * @param script - Contract script
      */
@@ -1856,7 +1880,40 @@ export class ContractManager implements IContractManager {
             await advanceSyncCursor(this.config.walletRepository, cutoff);
         }
 
+        await this.demoteFundedAwaitingContracts(contracts);
+
         return result;
+    }
+
+    /**
+     * Demote every `awaiting-funds` contract in `contracts` that has been
+     * funded — the automatic half of {@link ContractWatchState}.
+     *
+     * Runs after the sync has persisted, so the funding VTXO is saved
+     * while the contract is still watched, and reads the repository
+     * rather than this sync's delta: funds that landed while the app was
+     * closed are outside every later window, and a contract asked to
+     * watch until it is funded must still stop once it is.
+     *
+     * Best-effort. A demotion that fails costs coverage that is merely
+     * no longer needed, and must not fail the sync that carried it.
+     */
+    private async demoteFundedAwaitingContracts(contracts: Contract[]): Promise<void> {
+        const awaiting = contracts.filter((c) => watchStateOf(c) === "awaiting-funds");
+        if (awaiting.length === 0) return;
+
+        for (const contract of awaiting) {
+            try {
+                const vtxos = await getVtxosForContract(this.config.walletRepository, contract);
+                if (vtxos.length === 0) continue;
+                await this.setContractWatchState(contract.script, "retained");
+            } catch (err) {
+                console.warn(
+                    `[contracts] could not demote funded contract ${contract.script}`,
+                    err,
+                );
+            }
+        }
     }
 
     /**

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -3,7 +3,13 @@ import { VirtualCoin } from "../wallet";
 import { normalizeVtxo } from "../wallet/vtxo";
 import { extendVirtualCoinForContract } from "../wallet/utils";
 import { WalletRepository } from "../repositories/walletRepository";
-import { Contract, ContractVtxo, ContractEventCallback, ContractEvent } from "./types";
+import {
+    Contract,
+    ContractVtxo,
+    ContractEventCallback,
+    ContractEvent,
+    isWatchedContract,
+} from "./types";
 import { isEventSourceError } from "../providers/utils";
 import { getVtxosForContract } from "./vtxoOwnership";
 
@@ -161,7 +167,8 @@ export class ContractWatcher {
      * Add a contract to be watched.
      *
      * Once watching, every contract is subscribed and polled whatever
-     * its state.
+     * its {@link ContractState} — a `retained` one is held for reads
+     * only, and never enters a background channel.
      *
      * @see getWatchedContracts
      */
@@ -182,7 +189,7 @@ export class ContractWatcher {
 
         // If we're already watching, poll to seed virtual outputs and fold
         // this script into the subscription.
-        if (this.isWatching) {
+        if (this.isWatching && isWatchedContract(contract)) {
             await this.pollContracts([contract.script]);
             await this.tryUpdateSubscription();
         }
@@ -256,18 +263,25 @@ export class ContractWatcher {
     }
 
     /**
-     * Every registered contract, retired (`inactive`) ones included.
+     * Every registered contract except the `retained` ones, retired
+     * (`inactive`) receive addresses included.
      *
      * Feeds both the subscription and the indexer sweep scope, so
      * narrowing it drops a contract from every background channel at
-     * once. Nothing may be narrowed out: an Ark receive address can be
+     * once. `state` may never narrow it: an Ark receive address can be
      * paid again after the wallet has rotated past it, and a payment
      * that lands outside every background channel is invisible until
      * some foreground read happens to sweep it. Retirement therefore
      * governs receive-address selection, not coverage.
+     *
+     * {@link ContractWatchState} is the one thing that does narrow it,
+     * and only when an owner has explicitly said the script is done —
+     * a settled swap lockup, a funded one-shot destination. The row
+     * stays in {@link getAllContracts} so reads, annotation and history
+     * are unaffected.
      */
     getWatchedContracts(): Contract[] {
-        return this.getAllContracts();
+        return this.getAllContracts().filter(isWatchedContract);
     }
 
     /**

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -9,14 +9,63 @@ import type { OnchainProvider } from "../providers/onchain";
 import type { Network } from "../networks";
 
 /**
- * Contract lifecycle state. Both states stay monitored — the watcher
- * subscribes and sweeps every registered contract regardless
- * (see {@link ContractWatcher.getWatchedContracts}), because a retired
- * receive address can still be paid. `inactive` only demotes a contract
- * out of receive-address selection; it does **not** unsubscribe it.
- * Use {@link IContractManager.deleteContract} to stop watching.
+ * Contract lifecycle state. Neither state affects coverage: the watcher
+ * subscribes and sweeps a contract according to {@link Contract.watch}
+ * alone, because a retired receive address can still be paid. `inactive`
+ * only demotes a contract out of receive-address selection; it does
+ * **not** unsubscribe it. To stop watching but keep the row, set
+ * {@link ContractWatchState} to `retained`; to drop both, use
+ * {@link IContractManager.deleteContract}.
  */
 export type ContractState = "active" | "inactive";
+
+/**
+ * Whether a contract is covered by background monitoring — the
+ * subscription and the failsafe/indexer sweep
+ * ({@link ContractWatcher.getWatchedContracts}).
+ *
+ * Orthogonal to {@link ContractState}, which governs receive-address
+ * selection only. A contract can be the wallet's display address and
+ * watched, or terminal and retained; the two questions never answer each
+ * other.
+ *
+ * NArk calls this `ContractActivityState` (`Active` / `Inactive` /
+ * `AwaitingFundsBeforeDeactivate`). The concept is the same; the names
+ * differ because TS already spends `active`/`inactive` on
+ * {@link ContractState}, and a row reading `state: "active",
+ * activityState: "inactive"` would be unreadable.
+ */
+export type ContractWatchState =
+    /** Subscribed and polled. */
+    | "watched"
+    /**
+     * Watched until the first VTXO lands at the script, then
+     * automatically demoted to `retained` by the contract manager.
+     * For one-shot destinations — a refund address, a swap lockup —
+     * that only need coverage until they are funded.
+     */
+    | "awaiting-funds"
+    /**
+     * Kept for history, restore and classification, but absent from
+     * every background channel. The row still resolves in
+     * `getContracts`, still annotates its VTXOs, and still feeds
+     * transaction history; nothing subscribes or polls it.
+     */
+    | "retained";
+
+/**
+ * A contract's watch state, defaulting rows written before the field
+ * existed — including retired (`inactive`) receive addresses — to
+ * `watched`, which is the coverage they have today.
+ */
+export function watchStateOf(contract: Pick<Contract, "watch">): ContractWatchState {
+    return contract.watch ?? "watched";
+}
+
+/** Whether a contract belongs in the subscription and sweep scope. */
+export function isWatchedContract(contract: Pick<Contract, "watch">): boolean {
+    return watchStateOf(contract) !== "retained";
+}
 
 /**
  * Represents a contract that can receive and manage virtual outputs.
@@ -73,6 +122,12 @@ export interface Contract {
 
     /** Current state of the contract. */
     state: ContractState;
+
+    /**
+     * Background-monitoring scope. Absent means `watched`.
+     * @see ContractWatchState
+     */
+    watch?: ContractWatchState;
 
     /** Unix timestamp in milliseconds when this contract was created. */
     createdAt: number;

--- a/packages/ts-sdk/src/repositories/contractRepository.ts
+++ b/packages/ts-sdk/src/repositories/contractRepository.ts
@@ -1,4 +1,4 @@
-import { Contract, ContractState } from "../contracts/types";
+import { Contract, ContractState, ContractWatchState } from "../contracts/types";
 
 /**
  * Filter options for querying contracts.
@@ -10,10 +10,20 @@ export interface ContractFilter {
     state?: ContractState | ContractState[];
     /** Filter by contract type(s) */
     type?: string | string[];
+    /**
+     * Filter by watch state(s). Rows written before the field existed
+     * have no stored value and match `"watched"`.
+     * @see ContractWatchState
+     */
+    watch?: ContractWatchState | ContractWatchState[];
 }
 
 export interface ContractRepository extends AsyncDisposable {
-    readonly version: 1;
+    /**
+     * 2 — {@link Contract.watch}. An implementation must persist and
+     * round-trip it, and treat a row without one as `"watched"`.
+     */
+    readonly version: 2;
 
     /**
      * Clear all data from storage.

--- a/packages/ts-sdk/src/repositories/inMemory/contractRepository.ts
+++ b/packages/ts-sdk/src/repositories/inMemory/contractRepository.ts
@@ -1,12 +1,12 @@
 import { ContractFilter, ContractRepository } from "../contractRepository";
-import { Contract } from "../../contracts";
+import { Contract, watchStateOf } from "../../contracts";
 
 /**
  * In-memory implementation of ContractRepository.
  * Data is ephemeral and scoped to the instance.
  */
 export class InMemoryContractRepository implements ContractRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
     private readonly contractData = new Map<string, unknown>();
     private readonly collections = new Map<string, unknown[]>();
     private readonly contractsByScript = new Map<string, Contract>();
@@ -38,7 +38,8 @@ export class InMemoryContractRepository implements ContractRepository {
             if (
                 matches(contract.script, filter.script) &&
                 matches(contract.state, filter.state) &&
-                matches(contract.type, filter.type)
+                matches(contract.type, filter.type) &&
+                matches(watchStateOf(contract), filter.watch)
             ) {
                 results.push(contract);
             }

--- a/packages/ts-sdk/src/repositories/indexedDB/contractRepository.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/contractRepository.ts
@@ -1,5 +1,5 @@
 import { DB_VERSION, STORE_CONTRACTS } from "./db";
-import { Contract } from "../../contracts";
+import { Contract, watchStateOf } from "../../contracts";
 import { ContractFilter, ContractRepository } from "../contractRepository";
 import { closeDatabase, openDatabase } from "./manager";
 import { initDatabase } from "./schema";
@@ -11,7 +11,7 @@ import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
  * Data is stored as JSON strings in key/value stores.
  */
 export class IndexedDBContractRepository implements ContractRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
     private db: IDBDatabase | null = null;
 
     constructor(private readonly dbName: string = DEFAULT_DB_NAME) {}
@@ -180,6 +180,10 @@ export class IndexedDBContractRepository implements ContractRepository {
                 return false;
             if (filter.has("state") && !filter.get("state")?.includes(contract.state)) return false;
             if (filter.has("type") && !filter.get("type")?.includes(contract.type)) return false;
+            // Whole objects are stored, so a row written before the field
+            // existed simply has none — `watchStateOf` supplies the default.
+            if (filter.has("watch") && !filter.get("watch")?.includes(watchStateOf(contract)))
+                return false;
             return true;
         }) as Contract[];
     }
@@ -197,7 +201,9 @@ export class IndexedDBContractRepository implements ContractRepository {
     }
 }
 
-const FILTER_FIELDS = ["script", "state", "type"] as (keyof ContractFilter)[];
+// `watch` has no index — it is filtered in memory by `applyContractFilter`,
+// after whichever indexed field narrowed the read.
+const FILTER_FIELDS = ["script", "state", "type", "watch"] as (keyof ContractFilter)[];
 
 // Transform all filter fields into an array of values
 function normalizeFilter(filter: ContractFilter) {

--- a/packages/ts-sdk/src/repositories/migrations/contractRepositoryImpl.ts
+++ b/packages/ts-sdk/src/repositories/migrations/contractRepositoryImpl.ts
@@ -9,13 +9,16 @@ export const getCollectionStorageKey = (type: string) => `collection:${type}`;
  * @deprecated This is only to be used in migration from storage V1
  */
 export class ContractRepositoryImpl implements ContractRepository {
-    // Nominal: every contract-row method below throws. Legacy V1 storage
-    // predates the watch state entirely, so there is nothing to migrate.
-    readonly version = 2 as const;
     private storage: StorageAdapter;
 
     constructor(storage: StorageAdapter) {
         this.storage = storage;
+    }
+
+    get version(): 2 {
+        throw new TypeError(
+            "ContractRepositoryImpl is a migration shim and does not implement contract rows.",
+        );
     }
 
     async getContractData<T>(contractId: string, key: string): Promise<T | null> {

--- a/packages/ts-sdk/src/repositories/migrations/contractRepositoryImpl.ts
+++ b/packages/ts-sdk/src/repositories/migrations/contractRepositoryImpl.ts
@@ -9,7 +9,9 @@ export const getCollectionStorageKey = (type: string) => `collection:${type}`;
  * @deprecated This is only to be used in migration from storage V1
  */
 export class ContractRepositoryImpl implements ContractRepository {
-    readonly version = 1 as const;
+    // Nominal: every contract-row method below throws. Legacy V1 storage
+    // predates the watch state entirely, so there is nothing to migrate.
+    readonly version = 2 as const;
     private storage: StorageAdapter;
 
     constructor(storage: StorageAdapter) {

--- a/packages/ts-sdk/src/repositories/realm/contractRepository.ts
+++ b/packages/ts-sdk/src/repositories/realm/contractRepository.ts
@@ -1,4 +1,4 @@
-import { Contract, ContractState } from "../../contracts/types";
+import { Contract, ContractState, ContractWatchState } from "../../contracts/types";
 import { ContractFilter, ContractRepository } from "../contractRepository";
 import { RealmLike } from "./types";
 
@@ -12,7 +12,7 @@ import { RealmLike } from "./types";
  * The consumer owns the Realm lifecycle — `[Symbol.asyncDispose]` is a no-op.
  */
 export class RealmContractRepository implements ContractRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
 
     constructor(private readonly realm: RealmLike) {}
 
@@ -68,6 +68,7 @@ export class RealmContractRepository implements ContractRepository {
                 filter.type,
                 argIndex,
             );
+            argIndex = this.addWatchCondition(filterParts, filterArgs, filter.watch, argIndex);
 
             if (filterParts.length > 0) {
                 const query = filterParts.join(" AND ");
@@ -92,6 +93,7 @@ export class RealmContractRepository implements ContractRepository {
                     createdAt: contract.createdAt,
                     label: contract.label ?? null,
                     metadataJson: contract.metadata ? JSON.stringify(contract.metadata) : null,
+                    watch: contract.watch ?? null,
                 },
                 "modified",
             );
@@ -131,6 +133,28 @@ export class RealmContractRepository implements ContractRepository {
             return argIndex + 1;
         }
     }
+
+    /**
+     * Same as {@link addFilterCondition}, except a row predating the
+     * property stores null and must match `"watched"`.
+     */
+    private addWatchCondition(
+        parts: string[],
+        args: unknown[],
+        value: ContractWatchState | ContractWatchState[] | undefined,
+        argIndex: number,
+    ): number {
+        if (value === undefined) return argIndex;
+
+        const wanted = Array.isArray(value) ? value : [value];
+        if (wanted.length === 0) return argIndex;
+
+        const conditions = wanted.map((_, i) => `watch == $${argIndex + i}`);
+        if (wanted.includes("watched")) conditions.push("watch == null");
+        parts.push(`(${conditions.join(" OR ")})`);
+        args.push(...wanted);
+        return argIndex + wanted.length;
+    }
 }
 
 // ── Realm object → Domain converter ──────────────────────────────────────
@@ -151,6 +175,9 @@ function contractObjectToDomain(obj: any): Contract {
     }
     if (obj.metadataJson !== null && obj.metadataJson !== undefined) {
         contract.metadata = JSON.parse(obj.metadataJson);
+    }
+    if (obj.watch !== null && obj.watch !== undefined) {
+        contract.watch = obj.watch as ContractWatchState;
     }
 
     return contract;

--- a/packages/ts-sdk/src/repositories/realm/schemas.ts
+++ b/packages/ts-sdk/src/repositories/realm/schemas.ts
@@ -102,6 +102,7 @@ export const ArkContractSchema = {
         expiresAt: "int?",
         label: "string?",
         metadataJson: "string?",
+        watch: { type: "string", optional: true, indexed: true },
     },
 } as const;
 
@@ -205,15 +206,17 @@ export const ArkExperimentalRealmSchemas = [
  *   - v1: initial ArkVtxo/ArkUtxo/... schemas, `script` nullable.
  *   - v2: ArkVtxo.script becomes required; NULL values are backfilled from
  *     the owning Ark address during migration.
+ *   - v3: ArkContract.watch added (nullable). No data migration: a row
+ *     without one reads as `watched`, which is the coverage every
+ *     existing contract has today.
  *
  * The intent/virtualtx schemas ({@link ArkExperimentalRealmSchemas}) are NOT
- * counted here: they are experimental and inert, so the advertised version
- * stays at v2 and upgrading the SDK never triggers a Realm migration for a
- * consumer using the default {@link ArkRealmSchemas} set. `runArkRealmMigrations`
- * still carries the intent-schema migration steps (guarded per-schema) for
- * consumers who opt in and bump their own version.
+ * counted here: they are experimental and inert, so they never move the
+ * advertised version on their own. `runArkRealmMigrations` still carries the
+ * intent-schema migration steps (guarded per-schema) for consumers who opt in
+ * and bump their own version.
  */
-export const ARK_REALM_SCHEMA_VERSION = 2;
+export const ARK_REALM_SCHEMA_VERSION = 3;
 
 /**
  * Run every Arkade schema migration applicable to the open Realm.

--- a/packages/ts-sdk/src/repositories/sqlite/contractRepository.ts
+++ b/packages/ts-sdk/src/repositories/sqlite/contractRepository.ts
@@ -1,4 +1,4 @@
-import { Contract, ContractState } from "../../contracts/types";
+import { Contract, ContractState, ContractWatchState } from "../../contracts/types";
 import { ContractFilter, ContractRepository } from "../contractRepository";
 import { SQLExecutor } from "./types";
 
@@ -17,7 +17,7 @@ interface SQLiteContractRepositoryOptions {
  * The consumer owns the SQLExecutor lifecycle — `[Symbol.asyncDispose]` is a no-op.
  */
 export class SQLiteContractRepository implements ContractRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
     private initPromise: Promise<void> | null = null;
     private readonly prefix: string;
     private readonly table: string;
@@ -50,9 +50,15 @@ export class SQLiteContractRepository implements ContractRepository {
                 created_at INTEGER NOT NULL,
                 expires_at INTEGER,
                 label TEXT,
-                metadata_json TEXT
+                metadata_json TEXT,
+                watch TEXT
             )
         `);
+
+        // Nullable and added in place, so a table created before the
+        // column existed keeps every row and reads back as "watched" —
+        // the coverage those rows have today.
+        await this.addColumnIfMissing("watch", "TEXT");
 
         await this.db.run(
             `CREATE INDEX IF NOT EXISTS idx_${this.prefix}contracts_type ON ${this.table} (type)`,
@@ -60,6 +66,12 @@ export class SQLiteContractRepository implements ContractRepository {
         await this.db.run(
             `CREATE INDEX IF NOT EXISTS idx_${this.prefix}contracts_state ON ${this.table} (state)`,
         );
+    }
+
+    private async addColumnIfMissing(column: string, type: string): Promise<void> {
+        const columns = await this.db.all<{ name: string }>(`PRAGMA table_info(${this.table})`);
+        if (columns.some((c) => c.name === column)) return;
+        await this.db.run(`ALTER TABLE ${this.table} ADD COLUMN ${column} ${type}`);
     }
 
     async [Symbol.asyncDispose](): Promise<void> {
@@ -85,6 +97,7 @@ export class SQLiteContractRepository implements ContractRepository {
             this.addFilterCondition(conditions, params, "script", filter.script);
             this.addFilterCondition(conditions, params, "state", filter.state);
             this.addFilterCondition(conditions, params, "type", filter.type);
+            this.addWatchCondition(conditions, params, filter.watch);
         }
 
         let sql = `SELECT * FROM ${this.table}`;
@@ -101,9 +114,9 @@ export class SQLiteContractRepository implements ContractRepository {
         await this.db.run(
             `INSERT OR REPLACE INTO ${this.table}
                 (script, address, type, state, params_json,
-                 created_at, label, metadata_json)
+                 created_at, label, metadata_json, watch)
              VALUES (?, ?, ?, ?, ?,
-                     ?, ?, ?)`,
+                     ?, ?, ?, ?)`,
             [
                 contract.script,
                 contract.address,
@@ -113,6 +126,7 @@ export class SQLiteContractRepository implements ContractRepository {
                 contract.createdAt,
                 contract.label ?? null,
                 contract.metadata ? JSON.stringify(contract.metadata) : null,
+                contract.watch ?? null,
             ],
         );
     }
@@ -142,6 +156,26 @@ export class SQLiteContractRepository implements ContractRepository {
             params.push(value);
         }
     }
+
+    /**
+     * Same as {@link addFilterCondition}, except a row predating the
+     * column stores NULL and must match `"watched"`.
+     */
+    private addWatchCondition(
+        conditions: string[],
+        params: unknown[],
+        value?: ContractWatchState | ContractWatchState[],
+    ): void {
+        if (value === undefined) return;
+
+        const wanted = Array.isArray(value) ? value : [value];
+        if (wanted.length === 0) return;
+
+        const placeholders = wanted.map(() => "?").join(", ");
+        const clause = `watch IN (${placeholders})`;
+        conditions.push(wanted.includes("watched") ? `(${clause} OR watch IS NULL)` : clause);
+        params.push(...wanted);
+    }
 }
 
 // ── Row type ────────────────────────────────────────────────────────────
@@ -155,6 +189,7 @@ interface ContractRow {
     created_at: number;
     label: string | null;
     metadata_json: string | null;
+    watch: string | null;
 }
 
 // ── Row → Domain converter ──────────────────────────────────────────────
@@ -185,6 +220,9 @@ function contractRowToDomain(row: ContractRow): Contract {
     }
     if (row.metadata_json !== null) {
         contract.metadata = JSON.parse(row.metadata_json);
+    }
+    if (row.watch !== null && row.watch !== undefined) {
+        contract.watch = row.watch as ContractWatchState;
     }
 
     return contract;

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -138,7 +138,7 @@ import type {
     RefreshVtxosOptions,
     ScanResult,
 } from "../../contracts/contractManager";
-import type { ContractState } from "../../contracts/types";
+import type { ContractState, ContractWatchState } from "../../contracts/types";
 import type { IDelegateManager } from "../delegate";
 import type {
     IVtxoManager,
@@ -1325,6 +1325,21 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                     return;
                 } catch (e) {
                     throw new Error("Failed to update contract state");
+                }
+            },
+
+            async setContractWatchState(script: string, watch: ContractWatchState): Promise<void> {
+                const message: RequestUpdateContract = {
+                    type: "UPDATE_CONTRACT",
+                    id: getRandomId(),
+                    tag: messageTag,
+                    payload: { script, updates: { watch } },
+                };
+                try {
+                    await sendContractMessage(message);
+                    return;
+                } catch (e) {
+                    throw new Error("Failed to update contract watch state");
                 }
             },
 

--- a/packages/ts-sdk/src/worker/expo/processors/contractPollProcessor.ts
+++ b/packages/ts-sdk/src/worker/expo/processors/contractPollProcessor.ts
@@ -6,6 +6,7 @@ import {
     warnAndFilterVtxosForScript,
     saveVtxosForContract,
 } from "../../../contracts/vtxoOwnership";
+import { isWatchedContract } from "../../../contracts/types";
 
 export const CONTRACT_POLL_TASK_TYPE = "contract-poll";
 
@@ -14,7 +15,7 @@ export const CONTRACT_POLL_TASK_TYPE = "contract-poll";
  * persists the results to the wallet repository.
  *
  * Replicates the polling subset of @see ContractManager.initialize:
- * 1. Load all contracts from the contract repository.
+ * 1. Load every watched contract from the contract repository.
  * 2. Paginated fetch of every VTXO (including spent) from the indexer.
  * 3. Extend each VTXO with tapscript data.
  * 4. Save to the wallet repository.
@@ -34,7 +35,9 @@ export const contractPollProcessor: TaskProcessor = {
     ): Promise<Omit<TaskResult, "id" | "executedAt">> {
         const { contractRepository, walletRepository, indexerProvider, extendVtxo } = deps;
 
-        const contracts = await contractRepository.getContracts();
+        // Background channel, so it covers exactly what the watcher's
+        // subscription covers: `retained` rows are kept for reads only.
+        const contracts = (await contractRepository.getContracts()).filter(isWatchedContract);
         let contractsProcessed = 0;
         let vtxosSaved = 0;
 

--- a/packages/ts-sdk/test/contracts/manager.test.ts
+++ b/packages/ts-sdk/test/contracts/manager.test.ts
@@ -644,6 +644,127 @@ describe("ContractManager", () => {
         });
     });
 
+    describe("watch state", () => {
+        const newManager = (walletRepository = new InMemoryWalletRepository()) =>
+            ContractManager.create({
+                indexerProvider: mockIndexer,
+                contractRepository: new InMemoryContractRepository(),
+                walletRepository,
+                watcherConfig: { failsafePollIntervalMs: 1000, reconnectDelayMs: 500 },
+            });
+
+        it("drops a retained contract from the subscription and the sweep, keeping the row", async () => {
+            const mgr = await newManager();
+            try {
+                await mgr.createContract({
+                    type: "default",
+                    params: createDefaultContractParams(),
+                    script: TEST_DEFAULT_SCRIPT,
+                    address: "lockup-address",
+                });
+                (mockIndexer.subscribeForScripts as any).mockClear();
+
+                await mgr.setContractWatchState(TEST_DEFAULT_SCRIPT, "retained");
+
+                const subscribed = (mockIndexer.subscribeForScripts as any).mock.calls.flatMap(
+                    (c: any) => c[0],
+                );
+                expect(subscribed).not.toContain(TEST_DEFAULT_SCRIPT);
+
+                // The sweep is the other background channel, and it reads
+                // the same watched set.
+                (mockIndexer.getVtxos as any).mockClear();
+                (mockIndexer.getVtxos as any).mockResolvedValue({ vtxos: [] });
+                await mgr.refreshVtxos();
+                expect(collectRequestedScripts(mockIndexer).has(TEST_DEFAULT_SCRIPT)).toBe(false);
+
+                // Retained, not deleted: history, annotation and restore all
+                // read the row through here.
+                const [row] = await mgr.getContracts({ script: TEST_DEFAULT_SCRIPT });
+                expect(row?.watch).toBe("retained");
+                expect(await mgr.getContractsWithVtxos()).toHaveLength(1);
+            } finally {
+                await mgr.dispose();
+            }
+        });
+
+        it("watches an awaiting-funds contract until a vtxo lands, then demotes it", async () => {
+            const walletRepo = new InMemoryWalletRepository();
+            const mgr = await newManager(walletRepo);
+            try {
+                (mockIndexer.getVtxos as any).mockResolvedValue({ vtxos: [] });
+                await mgr.createContract({
+                    type: "default",
+                    params: createDefaultContractParams(),
+                    script: TEST_DEFAULT_SCRIPT,
+                    address: "awaiting-address",
+                    watch: "awaiting-funds",
+                });
+
+                // Unfunded: still watched, on both channels.
+                (mockIndexer.getVtxos as any).mockClear();
+                await mgr.refreshVtxos();
+                expect(collectRequestedScripts(mockIndexer).has(TEST_DEFAULT_SCRIPT)).toBe(true);
+                expect((await mgr.getContracts({ script: TEST_DEFAULT_SCRIPT }))[0]?.watch).toBe(
+                    "awaiting-funds",
+                );
+
+                // Funded — the sync that persists the vtxo is the one that
+                // demotes the contract.
+                const incoming = createMockContractVtxo(TEST_DEFAULT_SCRIPT, {
+                    txid: "cd".repeat(32),
+                });
+                (mockIndexer.getVtxos as any).mockClear();
+                (mockIndexer.getVtxos as any).mockResolvedValue({ vtxos: [incoming] });
+                await mgr.refreshVtxos();
+
+                expect(
+                    (await walletRepo.getVtxos("awaiting-address")).map((v) => v.txid),
+                ).toContain(incoming.txid);
+                expect((await mgr.getContracts({ script: TEST_DEFAULT_SCRIPT }))[0]?.watch).toBe(
+                    "retained",
+                );
+
+                (mockIndexer.getVtxos as any).mockClear();
+                (mockIndexer.getVtxos as any).mockResolvedValue({ vtxos: [] });
+                await mgr.refreshVtxos();
+                expect(collectRequestedScripts(mockIndexer).has(TEST_DEFAULT_SCRIPT)).toBe(false);
+            } finally {
+                await mgr.dispose();
+            }
+        });
+
+        it("re-registers a retained script without waking it up", async () => {
+            // `createContract` is idempotent and first-writer-wins, so a
+            // caller that registers the same lockup again must not silently
+            // put a finished contract back on the wire.
+            const mgr = await newManager();
+            try {
+                const params = {
+                    type: "default",
+                    params: createDefaultContractParams(),
+                    script: TEST_DEFAULT_SCRIPT,
+                    address: "lockup-address",
+                } as const;
+                await mgr.createContract(params);
+                await mgr.setContractWatchState(TEST_DEFAULT_SCRIPT, "retained");
+
+                (mockIndexer.subscribeForScripts as any).mockClear();
+                await mgr.createContract(params);
+
+                const subscribed = (mockIndexer.subscribeForScripts as any).mock.calls.flatMap(
+                    (c: any) => c[0],
+                );
+                expect(subscribed).not.toContain(TEST_DEFAULT_SCRIPT);
+                expect((await mgr.getContracts({ script: TEST_DEFAULT_SCRIPT }))[0]?.watch).toBe(
+                    "retained",
+                );
+            } finally {
+                await mgr.dispose();
+            }
+        });
+    });
+
     describe("annotateVtxos", () => {
         it("returns empty array for empty input", async () => {
             const extended = await manager.annotateVtxos([]);

--- a/packages/ts-sdk/test/contracts/manager.test.ts
+++ b/packages/ts-sdk/test/contracts/manager.test.ts
@@ -653,6 +653,39 @@ describe("ContractManager", () => {
                 watcherConfig: { failsafePollIntervalMs: 1000, reconnectDelayMs: 500 },
             });
 
+        it("filters by watch state through the manager, not just the repository", async () => {
+            // `getContracts` rebuilds the repository filter field by field, so
+            // a field it forgets is not a narrower query — it is an unfiltered
+            // one, and every caller silently gets every row.
+            const mgr = await newManager();
+            try {
+                await mgr.createContract({
+                    type: "default",
+                    params: createDefaultContractParams(),
+                    script: TEST_DEFAULT_SCRIPT,
+                    address: "address-1",
+                });
+                await mgr.createContract({
+                    type: "default",
+                    params: SECOND_DEFAULT_PARAMS,
+                    script: SECOND_DEFAULT_SCRIPT,
+                    address: "address-2",
+                    watch: "awaiting-funds",
+                });
+                await mgr.setContractWatchState(TEST_DEFAULT_SCRIPT, "retained");
+
+                expect(
+                    (await mgr.getContracts({ watch: "retained" })).map((c) => c.script),
+                ).toEqual([TEST_DEFAULT_SCRIPT]);
+                expect(
+                    (await mgr.getContracts({ watch: "awaiting-funds" })).map((c) => c.script),
+                ).toEqual([SECOND_DEFAULT_SCRIPT]);
+                expect(await mgr.getContracts({ watch: "watched" })).toHaveLength(0);
+            } finally {
+                await mgr.dispose();
+            }
+        });
+
         it("drops a retained contract from the subscription and the sweep, keeping the row", async () => {
             const mgr = await newManager();
             try {

--- a/packages/ts-sdk/test/contracts/watcher.test.ts
+++ b/packages/ts-sdk/test/contracts/watcher.test.ts
@@ -68,6 +68,45 @@ describe("ContractWatcher", () => {
         expect(mockIndexer.subscribeForScripts).toHaveBeenCalledWith([contract.script], undefined);
     });
 
+    it("should not subscribe retained contracts, but should keep them readable", async () => {
+        await watcher.startWatching(() => {});
+        (mockIndexer.subscribeForScripts as any).mockClear();
+
+        const contract: Contract = {
+            type: "default",
+            params: createDefaultContractParams(),
+            script: TEST_DEFAULT_SCRIPT,
+            address: "address",
+            state: "active",
+            watch: "retained",
+            createdAt: Date.now(),
+        };
+
+        await watcher.addContract(contract);
+
+        expect(mockIndexer.subscribeForScripts).not.toHaveBeenCalled();
+        expect(watcher.getWatchedContracts()).toEqual([]);
+        // The row is still held: reads, annotation and history go through it.
+        expect(watcher.getAllContracts().map((c) => c.script)).toEqual([TEST_DEFAULT_SCRIPT]);
+    });
+
+    it("should subscribe awaiting-funds contracts", async () => {
+        await watcher.startWatching(() => {});
+
+        const contract: Contract = {
+            type: "default",
+            params: createDefaultContractParams(),
+            script: TEST_DEFAULT_SCRIPT,
+            address: "address",
+            state: "active",
+            watch: "awaiting-funds",
+            createdAt: Date.now(),
+        };
+
+        await watcher.addContract(contract);
+        expect(mockIndexer.subscribeForScripts).toHaveBeenCalledWith([contract.script], undefined);
+    });
+
     it("should unsubscribe from scripts when stopped", async () => {
         await watcher.startWatching(() => {});
 

--- a/packages/ts-sdk/test/e2e/contractWatchState.test.ts
+++ b/packages/ts-sdk/test/e2e/contractWatchState.test.ts
@@ -1,0 +1,74 @@
+import { expect, describe, it, beforeEach } from "vitest";
+import { hex } from "@scure/base";
+import { DefaultContractHandler, SingleKey, networks } from "../../src";
+import { beforeEachFaucet, createTestArkWallet, faucetOffchain, waitFor } from "./utils";
+
+/**
+ * `awaiting-funds` against a live operator: a one-shot destination is covered
+ * by the background channels until it is paid, and demotes itself the moment
+ * the payment lands.
+ *
+ * Unit coverage in `test/contracts/manager.test.ts` drives the same transition
+ * through a mocked indexer. What only a real stack can show is that the
+ * demotion fires off genuine indexer data — the VTXO is persisted first, so the
+ * contract stops being watched only after it has stopped needing to be.
+ */
+describe("contract watch state", () => {
+    beforeEach(beforeEachFaucet, 20000);
+
+    it(
+        "demotes an awaiting-funds contract once its payment lands, keeping the vtxo",
+        { timeout: 120000 },
+        async () => {
+            const AMOUNT = 2000;
+            const alice = await createTestArkWallet();
+            const manager = await alice.wallet.getContractManager();
+
+            // A second `default` script the wallet owns nothing else at:
+            // the live row's serialized params verbatim, with a fresh key.
+            // Reusing them keeps the server pubkey and CSV exactly what this
+            // operator issues, so the address is payable by the faucet.
+            const [own] = await manager.getContracts({ type: "default" });
+            const other = SingleKey.fromRandomBytes();
+            const params = { ...own.params, pubKey: hex.encode(await other.xOnlyPublicKey()) };
+            const tapscript = DefaultContractHandler.createScript(params);
+            const script = hex.encode(tapscript.pkScript);
+            const address = tapscript
+                .address(networks.regtest.hrp, hex.decode(params.serverPubKey))
+                .encode();
+
+            await manager.createContract({
+                type: "default",
+                params,
+                script,
+                address,
+                watch: "awaiting-funds",
+            });
+
+            // Unfunded: watched, on every background channel.
+            expect((await manager.getContracts({ script }))[0].watch).toBe("awaiting-funds");
+            expect(
+                (await manager.getContracts({ watch: "watched" })).map((c) => c.script),
+            ).not.toContain(script);
+
+            faucetOffchain(address, AMOUNT);
+
+            // The subscription drives this on its own; the refresh is the
+            // failsafe, so the assertion does not depend on SSE delivery.
+            await waitFor(async () => {
+                await manager.refreshVtxos();
+                return (await manager.getContracts({ script }))[0]?.watch === "retained";
+            });
+
+            // Demoted only after the payment was persisted — coverage held
+            // exactly as long as it was needed.
+            const [withVtxos] = await manager.getContractsWithVtxos({ script });
+            expect(withVtxos.vtxos.map((v) => v.value)).toContain(AMOUNT);
+
+            // And the row is still there for history and restore.
+            expect((await manager.getContracts({ script }))[0].address).toBe(address);
+
+            await alice.wallet.dispose();
+        },
+    );
+});

--- a/packages/ts-sdk/test/realm-contract-repository.test.ts
+++ b/packages/ts-sdk/test/realm-contract-repository.test.ts
@@ -71,6 +71,13 @@ function createMockRealm() {
     }
 
     function evaluateCondition(obj: any, condition: string, args: any[]): boolean {
+        // `field == null` — how a nullable column (e.g. `watch` on rows
+        // written before it existed) is matched.
+        const nullMatch = condition.match(/(\w+)\s*==\s*null/);
+        if (nullMatch) {
+            const value = obj[nullMatch[1]];
+            return value === null || value === undefined;
+        }
         const match = condition.match(/(\w+)\s*==\s*\$(\d+)/);
         if (!match) return true; // skip unknown conditions
         const field = match[1];
@@ -168,8 +175,8 @@ describe("RealmContractRepository", () => {
 
     // ── version ────────────────────────────────────────────────────────
 
-    it("should have version 1", () => {
-        expect(repository.version).toBe(1);
+    it("should have version 2", () => {
+        expect(repository.version).toBe(2);
     });
 
     // ── Save and retrieve ──────────────────────────────────────────────
@@ -311,6 +318,36 @@ describe("RealmContractRepository", () => {
             });
             expect(filtered).toHaveLength(2);
             expect(filtered.map((c) => c.type).sort()).toEqual(["default", "vhtlc"]);
+        });
+    });
+
+    // ── Watch state ────────────────────────────────────────────────────
+
+    describe("watch state", () => {
+        it("round-trips the watch state", async () => {
+            await repository.saveContract(createMockContract({ script: "s1", watch: "retained" }));
+            await repository.saveContract(
+                createMockContract({ script: "s2", watch: "awaiting-funds" }),
+            );
+
+            expect((await repository.getContracts({ script: "s1" }))[0].watch).toBe("retained");
+            expect((await repository.getContracts({ script: "s2" }))[0].watch).toBe(
+                "awaiting-funds",
+            );
+        });
+
+        it("filters by watch state, counting rows without one as watched", async () => {
+            // A contract saved before the property existed — the shape
+            // every deployed row has.
+            await repository.saveContract(createMockContract({ script: "legacy" }));
+            await repository.saveContract(createMockContract({ script: "s1", watch: "watched" }));
+            await repository.saveContract(createMockContract({ script: "s2", watch: "retained" }));
+
+            const watched = await repository.getContracts({ watch: "watched" });
+            expect(watched.map((c) => c.script).sort()).toEqual(["legacy", "s1"]);
+
+            const retained = await repository.getContracts({ watch: "retained" });
+            expect(retained.map((c) => c.script)).toEqual(["s2"]);
         });
     });
 

--- a/packages/ts-sdk/test/realm-schema-version.test.ts
+++ b/packages/ts-sdk/test/realm-schema-version.test.ts
@@ -6,9 +6,10 @@ import {
 } from "../src/repositories/realm/schemas";
 
 describe("Realm schema version", () => {
-    it("advertises the inert v2 default set, excluding the intent/virtual-tx schemas", () => {
-        // Pinned at v2 so upgrading the SDK never migrates a consumer's Realm.
-        expect(ARK_REALM_SCHEMA_VERSION).toBe(2);
+    it("advertises the v3 default set, excluding the intent/virtual-tx schemas", () => {
+        // v3 adds the nullable ArkContract.watch; the intent/virtual-tx
+        // schemas stay out, so they never move this on their own.
+        expect(ARK_REALM_SCHEMA_VERSION).toBe(3);
         const names = ArkRealmSchemas.map((s) => s.name);
         expect(names).not.toContain("ArkIntent");
         expect(names).not.toContain("ArkVirtualTx");

--- a/packages/ts-sdk/test/sqlite-contract-repository.test.ts
+++ b/packages/ts-sdk/test/sqlite-contract-repository.test.ts
@@ -10,13 +10,25 @@ import type { Contract, ContractState } from "../src/contracts/types";
 
 interface TableDef {
     primaryKey: string[];
+    columns: string[];
     rows: Map<string, Record<string, unknown>>;
+}
+
+/**
+ * `in_or_null` is the nullable-column form the repository emits for
+ * `watch`: a row written before the column existed stores NULL and must
+ * still match `"watched"`.
+ */
+interface Condition {
+    column: string;
+    op: "eq" | "in" | "in_or_null";
+    paramCount: number;
 }
 
 function createMockSQLExecutor(): SQLExecutor {
     const tables = new Map<string, TableDef>();
 
-    function parseCreateTable(sql: string): { name: string; pk: string[] } {
+    function parseCreateTable(sql: string): { name: string; pk: string[]; columns: string[] } {
         const nameMatch = sql.match(/CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+(\w+)/i);
         if (!nameMatch) throw new Error(`Cannot parse CREATE TABLE: ${sql}`);
         const name = nameMatch[1];
@@ -28,7 +40,12 @@ function createMockSQLExecutor(): SQLExecutor {
             const colPkMatch = sql.match(/(\w+)\s+TEXT\s+PRIMARY\s+KEY/i);
             if (colPkMatch) pk = [colPkMatch[1]];
         }
-        return { name, pk };
+        const body = sql.slice(sql.indexOf("(") + 1, sql.lastIndexOf(")"));
+        const columns = body
+            .split(",")
+            .map((def) => def.trim().split(/\s+/)[0])
+            .filter((col) => /^\w+$/.test(col) && !/^PRIMARY$/i.test(col));
+        return { name, pk, columns };
     }
 
     function parseInsertOrReplace(sql: string): {
@@ -48,21 +65,13 @@ function createMockSQLExecutor(): SQLExecutor {
      */
     function parseSelect(sql: string): {
         table: string;
-        conditions: Array<{
-            column: string;
-            op: "eq" | "in";
-            paramCount: number;
-        }>;
+        conditions: Condition[];
     } {
         const tableMatch = sql.match(/SELECT\s+\*\s+FROM\s+(\w+)/i);
         if (!tableMatch) throw new Error(`Cannot parse SELECT: ${sql}`);
         const table = tableMatch[1];
 
-        const conditions: Array<{
-            column: string;
-            op: "eq" | "in";
-            paramCount: number;
-        }> = [];
+        const conditions: Condition[] = [];
 
         const whereMatch = sql.match(/WHERE\s+(.+)$/i);
         if (whereMatch) {
@@ -75,7 +84,9 @@ function createMockSQLExecutor(): SQLExecutor {
                     const placeholders = inMatch[2].split(",").map((s) => s.trim());
                     conditions.push({
                         column,
-                        op: "in",
+                        op: new RegExp(`${column}\\s+IS\\s+NULL`, "i").test(part)
+                            ? "in_or_null"
+                            : "in",
                         paramCount: placeholders.length,
                     });
                     continue;
@@ -96,21 +107,13 @@ function createMockSQLExecutor(): SQLExecutor {
 
     function parseDelete(sql: string): {
         table: string;
-        conditions: Array<{
-            column: string;
-            op: "eq" | "in";
-            paramCount: number;
-        }>;
+        conditions: Condition[];
     } {
         const match = sql.match(/DELETE\s+FROM\s+(\w+)/i);
         if (!match) throw new Error(`Cannot parse DELETE: ${sql}`);
         const table = match[1];
 
-        const conditions: Array<{
-            column: string;
-            op: "eq" | "in";
-            paramCount: number;
-        }> = [];
+        const conditions: Condition[] = [];
 
         const whereMatch = sql.match(/WHERE\s+(.+)$/i);
         if (whereMatch) {
@@ -139,11 +142,7 @@ function createMockSQLExecutor(): SQLExecutor {
 
     function matchesConditions(
         row: Record<string, unknown>,
-        conditions: Array<{
-            column: string;
-            op: "eq" | "in";
-            paramCount: number;
-        }>,
+        conditions: Condition[],
         params: unknown[],
     ): boolean {
         let paramIdx = 0;
@@ -152,9 +151,11 @@ function createMockSQLExecutor(): SQLExecutor {
                 if (row[cond.column] !== params[paramIdx]) return false;
                 paramIdx += 1;
             } else {
-                // in
                 const values = params.slice(paramIdx, paramIdx + cond.paramCount);
-                if (!values.includes(row[cond.column])) return false;
+                const value = row[cond.column];
+                const nullMatches =
+                    cond.op === "in_or_null" && (value === null || value === undefined);
+                if (!values.includes(value) && !nullMatches) return false;
                 paramIdx += cond.paramCount;
             }
         }
@@ -166,10 +167,18 @@ function createMockSQLExecutor(): SQLExecutor {
             const trimmed = sql.trim();
 
             if (/^CREATE\s+TABLE/i.test(trimmed)) {
-                const { name, pk } = parseCreateTable(trimmed);
+                const { name, pk, columns } = parseCreateTable(trimmed);
                 if (!tables.has(name)) {
-                    tables.set(name, { primaryKey: pk, rows: new Map() });
+                    tables.set(name, { primaryKey: pk, columns, rows: new Map() });
                 }
+                return;
+            }
+
+            if (/^ALTER\s+TABLE/i.test(trimmed)) {
+                const match = trimmed.match(/ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)/i);
+                if (!match) throw new Error(`Cannot parse ALTER TABLE: ${trimmed}`);
+                const t = getTable(match[1]);
+                if (!t.columns.includes(match[2])) t.columns.push(match[2]);
                 return;
             }
 
@@ -231,6 +240,13 @@ function createMockSQLExecutor(): SQLExecutor {
 
         async all<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> {
             const trimmed = sql.trim();
+
+            const pragma = trimmed.match(/^PRAGMA\s+table_info\((\w+)\)/i);
+            if (pragma) {
+                const t = tables.get(pragma[1]);
+                return (t?.columns ?? []).map((name) => ({ name })) as T[];
+            }
+
             const { table, conditions } = parseSelect(trimmed);
             const t = getTable(table);
 
@@ -285,8 +301,8 @@ describe("SQLiteContractRepository", () => {
 
     // ── version ────────────────────────────────────────────────────────
 
-    it("should have version 1", () => {
-        expect(repository.version).toBe(1);
+    it("should have version 2", () => {
+        expect(repository.version).toBe(2);
     });
 
     // ── Save and retrieve ──────────────────────────────────────────────
@@ -428,6 +444,72 @@ describe("SQLiteContractRepository", () => {
             });
             expect(filtered).toHaveLength(2);
             expect(filtered.map((c) => c.type).sort()).toEqual(["default", "vhtlc"]);
+        });
+    });
+
+    // ── Watch state ────────────────────────────────────────────────────
+
+    describe("watch state", () => {
+        it("round-trips the watch state", async () => {
+            await repository.saveContract(createMockContract({ script: "s1", watch: "retained" }));
+            await repository.saveContract(
+                createMockContract({ script: "s2", watch: "awaiting-funds" }),
+            );
+
+            const [retained] = await repository.getContracts({ script: "s1" });
+            expect(retained.watch).toBe("retained");
+            const [awaiting] = await repository.getContracts({ script: "s2" });
+            expect(awaiting.watch).toBe("awaiting-funds");
+        });
+
+        it("filters by watch state, counting rows without one as watched", async () => {
+            // A contract saved before the field existed — the shape every
+            // deployed row has.
+            await repository.saveContract(createMockContract({ script: "legacy" }));
+            await repository.saveContract(createMockContract({ script: "s1", watch: "watched" }));
+            await repository.saveContract(createMockContract({ script: "s2", watch: "retained" }));
+
+            const watched = await repository.getContracts({ watch: "watched" });
+            expect(watched.map((c) => c.script).sort()).toEqual(["legacy", "s1"]);
+
+            const retained = await repository.getContracts({ watch: "retained" });
+            expect(retained.map((c) => c.script)).toEqual(["s2"]);
+
+            const live = await repository.getContracts({ watch: ["watched", "awaiting-funds"] });
+            expect(live.map((c) => c.script).sort()).toEqual(["legacy", "s1"]);
+        });
+
+        it("adds the column to a table created before it existed", async () => {
+            const legacyDb = createMockSQLExecutor();
+            await legacyDb.run(`
+                CREATE TABLE IF NOT EXISTS ark_contracts (
+                    script TEXT PRIMARY KEY,
+                    address TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    params_json TEXT NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    expires_at INTEGER,
+                    label TEXT,
+                    metadata_json TEXT
+                )
+            `);
+            await legacyDb.run(
+                `INSERT OR REPLACE INTO ark_contracts
+                    (script, address, type, state, params_json, created_at, label, metadata_json)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+                ["legacy", "addr", "default", "active", "{}", 1, null, null],
+            );
+
+            const migrated = new SQLiteContractRepository(legacyDb);
+            const [row] = await migrated.getContracts({ script: "legacy" });
+            expect(row.watch).toBeUndefined();
+
+            // The pre-existing row keeps the coverage it has today...
+            expect(await migrated.getContracts({ watch: "watched" })).toHaveLength(1);
+            // ...and the column is now writable.
+            await migrated.saveContract(createMockContract({ script: "s1", watch: "retained" }));
+            expect((await migrated.getContracts({ script: "s1" }))[0].watch).toBe("retained");
         });
     });
 


### PR DESCRIPTION
Stacked on `feat/arkade-swap`. Continues the `@arkade-os/swap` ↔ contracts-subsystem integration:
Phase 3 (live offer status) and Phase 4b (a retained-but-unwatched contract state).

## Phase 3 — offer status from contract events

`swap/src/watch.ts` subscribes to the manager's spend events for registered offer covenants and
drives `AssetSwap.status` from them; `restoreAssetSwaps` degrades to the cold-start/backfill path it
was always meant to be.

Classification reads the **covenant leaf the spend took**, not the transaction's contents. The
rollup alternative is verifiably wrong once the covenant is registered: history computes a net
delta, so an asset→BTC offer's cancel (asset out and back, netting to zero) is indistinguishable
from its fill. Leaves are per input, so batching stops mattering too. An unclassifiable spend
writes **nothing** and is left for the backfill scan rather than persisted as a guess.

The regtest pass found a real bug: **a spend is two transactions, and only one holds the deposit
outpoint.** `vtxo.spentBy` is the *checkpoint*, which takes the deposit outpoint and carries the
leaf; `vtxo.arkTxId` is the ark tx spending the checkpoint's output. The first `classifySpend` was
handed only `arkTxId` and answered `indeterminate` for every real spend.

## Phase 4b — `Contract.watch`

`RfqSwapManager.retire()` called `setContractState(script, "inactive")` under a comment promising
retirement. It did not stop watching: `getWatchedContracts()` returned *every* registered contract,
and both the subscription and the failsafe poll are built from it. Every finished RFQ swap stayed
subscribed and polled for the life of the wallet.

New optional field, **separate** from `state`:

```ts
type ContractWatchState = "watched" | "awaiting-funds" | "retained"
```

- `retained` — kept for history, restore and classification; absent from every background channel.
- `awaiting-funds` — watched until the first VTXO lands, then demoted by the manager itself.
- Absent means `watched`, so every deployed row — including retired (`inactive`) receive addresses —
  keeps exactly the coverage it has today.

`state` is untouched and still means receive-address selection only. `deleteContract` stays
destructive; `inactive` was not redefined. Both were considered and rejected: deletion drops the row
that keeps VTXOs annotatable and history readable, and redefining `inactive` would silently drop
historical receive scripts from coverage.

Auto-demotion runs after a sync has persisted — the funding VTXO is saved while the contract is
still watched — and reads the repository rather than the sync's delta, so funds that arrived while
the app was closed still demote.

`ContractRepository.version` 1 → 2. That bump earned itself: SQLite and Realm map columns
explicitly and were silently dropping the new field. SQLite gained a nullable column plus an
idempotent `ALTER TABLE ADD COLUMN`; Realm gained a nullable property (`ARK_REALM_SCHEMA_VERSION`
2 → 3, no data migration). Legacy rows store NULL and match `"watched"`.

Naming diverges from NArk's `ContractActivityState` deliberately, recorded in the type doc: TS
already spends `active`/`inactive` on `ContractState`, so a row reading `state: "active",
activityState: "inactive"` would be unreadable.

## Testing

- **ts-sdk e2e: 22 files / 103 tests, zero failures** against the regtest stack.
- swap e2e: 5/5, including a cancel made on another store reaching the record through the watcher
  alone.
- New `test/e2e/contractWatchState.test.ts`: awaiting-funds → funded → retained against a live
  operator, asserting the VTXO is persisted *before* the demotion.
- Unit: ts-sdk 2396, swap 232, boltz-swap 614.

The new e2e caught a bug in the first Phase 4b commit: `getContracts` rebuilds the repository filter
field by field and had dropped `watch`, so the query came back **unfiltered** rather than narrowed —
fail-open, the same shape as the SQLite/Realm column mapping one layer up. Fixed in `6a4a70b6` and
pinned by a unit test that fails without it.

## Notes for reviewers

- **`../wallet` gains nothing until it migrates** off its vendored `lib/swap/*` copies — and once it
  switches to this package's `createOffer`, its `getTransactionHistory` → `restoreAssetSwaps` path
  **will mislabel asset→BTC cancels**, for the net-delta reason above. Registration is what changes
  the shape of history for those transactions.
- **Node consumers get no contract events without an EventSource.** `ContractWatcher` drives
  everything over SSE and Node exposes `EventSource` only behind `--experimental-eventsource`; the
  subscription throws once, is caught, and everything event-driven silently degrades. Not fixed
  here — filed as its own item, with a pluggable EventSource as the proposed answer.
- **No RFQ e2e exists anywhere** (driving a real RFQ swap needs a solver counterparty), so
  `retireContract`'s `retained` write is covered by unit tests plus the core transition's e2e, not
  end to end.
- ignore breaking changes for `packages/swap` because it hasn't been released yet
