### PR TITLE
feat(swap): derive RFQ swap secrets from the seed instead of storing them

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -18,9 +18,8 @@ platform-provided or polyfilled IndexedDB.
    registry fetch with stale-cache fallback), `findMarket`, `validatePlan` (balance, both-side
    limits, BTC-leg dust), `QUOTE_OPTIONS`, and `makeCachedFeedFetch` for rate-limited price feeds.
 3. **`store`** — the persisted `AssetSwap` records (`getAssetSwaps`/`addAssetSwap`/
-   `updateAssetSwap`), thin helpers over an `AssetSwapRepository`. Persistence failures never
-   throw: by the time a swap is stored its funding tx is broadcast, and everything stays
-   recoverable from chain.
+   `updateAssetSwap`), thin helpers over an `AssetSwapRepository`. Read failures degrade to an
+   empty list; write failures throw so pre-funding records can be retried before money is sent.
 4. **`restore`** — `restoreAssetSwaps` rebuilds lost records by scanning sent virtual txs for
    offer packets and binding each funding vtxo to its spend. Incremental: answered txids are
    remembered in the repository (`getScannedTxids`/`markTxidsScanned`) so nothing is fetched
@@ -178,12 +177,15 @@ internal key (no key-path spend, ever): claim = `HASH160 <h160> EQUALVERIFY <cla
 refund = `<locktime> CLTV DROP <refundKey> CHECKSIG`.
 
 ```ts
+import { hex } from "@scure/base";
 import {
     httpTransport,
     requestOnchainSend,
     awaitOnchainFill,
     claimOnchainFill,
+    addAssetSwap,
     preimageForRfqSecrets,
+    rfqSecretsToRecord,
 } from "@arkade-os/swap";
 
 const swap = await requestOnchainSend(
@@ -193,10 +195,19 @@ const swap = await requestOnchainSend(
     httpTransport(solverUrl),
     { amount: 100_000, amountSide: "to", payoutPubkey },
 );
-// PERSIST swap.secrets (with the record) BEFORE funding. On an HD wallet it
-// is just a public descriptor: the preimage and the sender key re-derive from
-// the seed. Otherwise it carries the raw secrets and losing them forfeits the
-// claim.
+// Persist the record, including secrets, BEFORE funding. This must succeed:
+// if addAssetSwap throws, do not call wallet.send.
+await addAssetSwap(repository, {
+    ...record,
+    id: swap.rfqId,
+    pair: "arkade:BTC->onchain:BTC",
+    paymentHash: swap.htlc.paymentHash,
+    swapAddress: swap.address,
+    swapPkScript: hex.encode(swap.swapPkScript),
+    htlcPkScriptHex: hex.encode(swap.htlc.pkScript),
+    htlcLocktime: swap.htlc.refundLocktime,
+    ...rfqSecretsToRecord(swap.secrets),
+});
 await wallet.send({ address: swap.address, amount: BigInt(swap.fundAmount) });
 
 // Unlike lightning-send the maker must STAY CLAIM-CAPABLE: watch for the fill
@@ -228,8 +239,10 @@ state (unfunded / awaiting confirmations / claimable / refundable / claimed-with
 `ChainSource` plus the stored outpoint — without the stored record a spent HTLC is
 indistinguishable from an unfunded one, which is why persisting before funding is mandatory. The
 `AssetSwap` record carries the onchain fields (`paymentHash`, `signingDescriptor`,
-`htlcPkScriptHex`, `htlcLocktime`, `l1Txid`) and the statuses `awaiting_fill / claimable / claimed
-/ refunded_l1`. `preimageHex` is fallback-only — see below.
+`preimageHex` for caller-supplied P, `fallbackSecrets`, `htlcPkScriptHex`, `htlcLocktime`,
+`l1Txid`) and the statuses `awaiting_fill / claimable / claimed / refunded_l1`.
+`fallbackSecrets` is versioned and discriminated: `{ version: 1, type: "stored",
+senderPrivateKeyHex, preimageHex? }`.
 
 **On-board (`onchain:BTC -> arkade:BTC`) is milestone 2 and partially gated.** The wire request
 (`onchainReceiveRequest`), the L1 HTLC (roles swapped: the solver claims, the maker refunds) and
@@ -249,7 +262,7 @@ which is public, so a copied browser profile or a device backup yields nothing s
 ```ts
 const swap = await requestOnchainSend(/* … */);
 swap.secrets; // { derivable: true, signingDescriptor } — persist it, it holds no secret
-await saveSwap({ ...record, signingDescriptor: swap.secrets.signingDescriptor });
+await saveSwap({ ...record, ...rfqSecretsToRecord(swap.secrets) });
 
 // Later, from the seed plus that descriptor:
 const preimage = await preimageForRfqSecrets(wallet, rfqSecretsOfRecord(record)!);
@@ -257,10 +270,11 @@ const sender = await senderIdentityForRfqSecrets(wallet, rfqSecretsOfRecord(reco
 ```
 
 `derivable: false` is the fallback for wallets that cannot allocate (static / `auto` / custom
-signers). It carries the raw `senderPrivateKey` and `preimage`, warns at generation, and the caller
-must persist them — `AssetSwap.preimageHex` exists for exactly that case and must stay empty on the
-derivable path. The discriminant is a type-level fact, so a consumer written against the derivable
-arm alone will not compile against the fallback.
+signers). It carries the raw `senderPrivateKey` and, for onchain sends, `preimage`;
+`rfqSecretsToRecord` stores them under `AssetSwap.fallbackSecrets` as a complete versioned
+record. The discriminant is a type-level fact, so a consumer written against the derivable arm
+alone will not compile against the fallback. A caller-supplied preimage on an HD wallet keeps
+`signingDescriptor` for the sender key and stores only `preimageHex` as secret material.
 
 Each swap **allocates** its own descriptor rather than peeking at the current one: two swaps sharing
 a descriptor derive the *identical* preimage, so one solver learning its own preimage would learn the
@@ -280,13 +294,14 @@ too little public quote data to rediscover, so the record remains required.
 
 The package is pre-release; these notes replace a changelog for consumers tracking the branch.
 
-- **`requestLightningSend` / `requestOnchainSend` return `secrets`, not raw key material.**
-  `senderPrivateKey` and `preimage` are gone from both return types; `secrets` replaces them and is
-  what the record persists. `pushRefundWithoutReceiver` / `refundIfUnresolved` take `sender: Identity`
-  instead of `senderPrivateKey: Uint8Array` — build it with `senderIdentityForRfqSecrets`.
-  `AssetSwap` gains `signingDescriptor?` and demotes `preimageHex?` to fallback-only. Landed while
-  the package is unpublished and consumer-free, which is the whole window for doing it: after a
-  consumer ships, the same change becomes a secret migration across every deployed wallet.
+- **`requestLightningSend` / `requestOnchainSend` return `secrets`, not top-level raw key material.**
+  `senderPrivateKey` is gone from both return types; caller-owned onchain preimages live inside
+  `secrets` and must be persisted with the record. `pushRefundWithoutReceiver` /
+  `refundIfUnresolved` take `sender: Identity` instead of `senderPrivateKey: Uint8Array` — build
+  it with `senderIdentityForRfqSecrets`. `AssetSwap` gains `signingDescriptor?`,
+  `preimageHex?`, and complete stored-arm `fallbackSecrets?`. Landed while the package is
+  unpublished and consumer-free, which is the whole window for doing it: after a consumer ships,
+  the same change becomes a secret migration across every deployed wallet.
 - **Every derived address changed, in both corridors.** The lightning-send lockup moved from the
   3-leaf program-artifact VHTLC to the 8-leaf `VHTLC.ScriptV2` (non-interactive claim and refund
   leaves), and the L1 HTLC's claim leaf gained a `SIZE 32 EQUALVERIFY` preimage-length guard. Both

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -183,6 +183,7 @@ import {
     requestOnchainSend,
     awaitOnchainFill,
     claimOnchainFill,
+    preimageForRfqSecrets,
 } from "@arkade-os/swap";
 
 const swap = await requestOnchainSend(
@@ -192,8 +193,10 @@ const swap = await requestOnchainSend(
     httpTransport(solverUrl),
     { amount: 100_000, amountSide: "to", payoutPubkey },
 );
-// PERSIST swap.preimage (with the record) BEFORE funding — it is the only
-// thing that can claim the L1 fill, across restarts included.
+// PERSIST swap.secrets (with the record) BEFORE funding. On an HD wallet it
+// is just a public descriptor: the preimage and the sender key re-derive from
+// the seed. Otherwise it carries the raw secrets and losing them forfeits the
+// claim.
 await wallet.send({ address: swap.address, amount: BigInt(swap.fundAmount) });
 
 // Unlike lightning-send the maker must STAY CLAIM-CAPABLE: watch for the fill
@@ -202,7 +205,7 @@ const utxo = await awaitOnchainFill(chain, swap.htlc, minConfirmations);
 await claimOnchainFill(chain, {
     htlc: swap.htlc,
     utxo,
-    preimage: swap.preimage,
+    preimage: await preimageForRfqSecrets(wallet, swap.secrets),
     payoutPkScript,
     feeRateSatVb,
     sign,
@@ -224,8 +227,9 @@ Crash recovery is record-driven, not chain-driven: `classifyOnchainHtlc` re-deri
 state (unfunded / awaiting confirmations / claimable / refundable / claimed-with-P / swept) from
 `ChainSource` plus the stored outpoint — without the stored record a spent HTLC is
 indistinguishable from an unfunded one, which is why persisting before funding is mandatory. The
-`AssetSwap` record carries the onchain fields (`paymentHash`, `preimageHex`, `htlcPkScriptHex`,
-`htlcLocktime`, `l1Txid`) and the statuses `awaiting_fill / claimable / claimed / refunded_l1`.
+`AssetSwap` record carries the onchain fields (`paymentHash`, `signingDescriptor`,
+`htlcPkScriptHex`, `htlcLocktime`, `l1Txid`) and the statuses `awaiting_fill / claimable / claimed
+/ refunded_l1`. `preimageHex` is fallback-only — see below.
 
 **On-board (`onchain:BTC -> arkade:BTC`) is milestone 2 and partially gated.** The wire request
 (`onchainReceiveRequest`), the L1 HTLC (roles swapped: the solver claims, the maker refunds) and
@@ -236,10 +240,53 @@ the one-call on-board flow lands when it is. Until covclaimd's reference vectors
 cross-checked, the `sealClaimPacket` test vector is pinned from this implementation and marked
 provisional (`TODO(claim-packet-vectors)`).
 
+## RFQ secrets are derived, not stored
+
+The two secrets an RFQ swap needs — the VHTLC `sender` key and, for an onchain send, the preimage —
+are functions of the wallet seed plus one HD-allocated descriptor. The record keeps the descriptor,
+which is public, so a copied browser profile or a device backup yields nothing spendable.
+
+```ts
+const swap = await requestOnchainSend(/* … */);
+swap.secrets; // { derivable: true, signingDescriptor } — persist it, it holds no secret
+await saveSwap({ ...record, signingDescriptor: swap.secrets.signingDescriptor });
+
+// Later, from the seed plus that descriptor:
+const preimage = await preimageForRfqSecrets(wallet, rfqSecretsOfRecord(record)!);
+const sender = await senderIdentityForRfqSecrets(wallet, rfqSecretsOfRecord(record)!);
+```
+
+`derivable: false` is the fallback for wallets that cannot allocate (static / `auto` / custom
+signers). It carries the raw `senderPrivateKey` and `preimage`, warns at generation, and the caller
+must persist them — `AssetSwap.preimageHex` exists for exactly that case and must stay empty on the
+derivable path. The discriminant is a type-level fact, so a consumer written against the derivable
+arm alone will not compile against the fallback.
+
+Each swap **allocates** its own descriptor rather than peeking at the current one: two swaps sharing
+a descriptor derive the *identical* preimage, so one solver learning its own preimage would learn the
+other swap's. On restore, `adoptSwapDescriptor` moves the wallet's watermark past a restored record's
+index so it cannot be handed out twice.
+
+The derivation is `sha256(signSchnorrDeterministic(sha256("Arkade-RFQ-Preimage-v1" ‖ xonly(32) ‖
+u32le(0))))`, mirroring NArk's Boltz scheme (`SwapsManagementService.cs:128-160`) with an
+RFQ-scoped tag. NArk has no RFQ corridor yet, so this tag defines the scheme rather than matching
+one; it is deliberately distinct from the Boltz tag so one wallet key cannot derive the same
+preimage for both corridors.
+
+**Not covered:** seed-only discovery after the swap repository is wiped. An unspent L1 HTLC reveals
+too little public quote data to rediscover, so the record remains required.
+
 ## Breaking changes on this branch (pre-release migration notes)
 
 The package is pre-release; these notes replace a changelog for consumers tracking the branch.
 
+- **`requestLightningSend` / `requestOnchainSend` return `secrets`, not raw key material.**
+  `senderPrivateKey` and `preimage` are gone from both return types; `secrets` replaces them and is
+  what the record persists. `pushRefundWithoutReceiver` / `refundIfUnresolved` take `sender: Identity`
+  instead of `senderPrivateKey: Uint8Array` — build it with `senderIdentityForRfqSecrets`.
+  `AssetSwap` gains `signingDescriptor?` and demotes `preimageHex?` to fallback-only. Landed while
+  the package is unpublished and consumer-free, which is the whole window for doing it: after a
+  consumer ships, the same change becomes a secret migration across every deployed wallet.
 - **Every derived address changed, in both corridors.** The lightning-send lockup moved from the
   3-leaf program-artifact VHTLC to the 8-leaf `VHTLC.ScriptV2` (non-interactive claim and refund
   leaves), and the L1 HTLC's claim leaf gained a `SIZE 32 EQUALVERIFY` preimage-length guard. Both

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -23,6 +23,7 @@ export {
     addAssetSwap,
     updateAssetSwap,
     type AssetSwap,
+    type AssetSwapFallbackSecrets,
     type AssetSwapStatus,
 } from "./store";
 export {
@@ -105,6 +106,7 @@ export {
     preimageForRfqSecrets,
     randomSwapSecrets,
     rfqSecretsOfRecord,
+    rfqSecretsToRecord,
     senderIdentityForRfqSecrets,
     senderPubkeyForRfqSecrets,
     type DerivedSwapSecrets,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -96,6 +96,23 @@ export {
 } from "./rfq";
 export { sealClaimPacket, type ClaimPacketInput, type SealedClaimPacket } from "./claimPacket";
 export {
+    RFQ_PREIMAGE_TAG,
+    adoptSwapDescriptor,
+    buildPreimageMessage,
+    derivePreimage,
+    deriveSwapSecrets,
+    isDeterministicSigner,
+    preimageForRfqSecrets,
+    randomSwapSecrets,
+    rfqSecretsOfRecord,
+    senderIdentityForRfqSecrets,
+    senderPubkeyForRfqSecrets,
+    type DerivedSwapSecrets,
+    type DeterministicSigner,
+    type StoredSwapSecrets,
+    type SwapSecrets,
+} from "./secrets";
+export {
     LockupNeedsRecoveryError,
     REFUND_MTP_LAG_SECONDS,
     RFQ_RESOLVED_STATES,

--- a/packages/swap/src/refund.ts
+++ b/packages/swap/src/refund.ts
@@ -44,9 +44,9 @@ import { sha256 } from "@noble/hashes/sha2.js";
 import {
     CSVMultisigTapscript,
     ConditionWitness,
+    type Identity,
     RestArkProvider,
     RestIndexerProvider,
-    SingleKey,
     Transaction,
     VHTLC,
     assertSubmittedArkTxid,
@@ -492,8 +492,10 @@ export async function pushRefundWithoutReceiver(
     ark: RefundArkProvider,
     input: {
         script: InstanceType<typeof VHTLC.ScriptV2>;
-        /** The `sender` private key from `requestLightningSend`/`requestOnchainSend`. */
-        senderPrivateKey: Uint8Array;
+        /** The `sender` signer. Build it from the swap's `secrets` with
+         * `senderIdentityForRfqSecrets` — on an HD wallet that resolves from
+         * the seed, with no stored key bytes anywhere. */
+        sender: Identity;
         vtxos: readonly LockupVtxo[];
         /** Defaults to the contract's own committed refund destination. */
         refundPkScript?: Uint8Array;
@@ -544,9 +546,8 @@ export async function pushRefundWithoutReceiver(
         serverUnrollScript,
     );
 
-    const signer = SingleKey.fromPrivateKey(input.senderPrivateKey);
     // No index list: every input spends the same leaf, so all are signed.
-    const signedArkTx = await signer.sign(arkTx);
+    const signedArkTx = await input.sender.sign(arkTx);
     const submitted = await ark.submitTx(
         base64.encode(signedArkTx.toPSBT()),
         checkpoints.map((c) => base64.encode(c.toPSBT())),
@@ -562,7 +563,9 @@ export async function pushRefundWithoutReceiver(
         "refundWithoutReceiver",
     );
     const finalCheckpoints = await Promise.all(
-        matched.map(async ({ server }) => base64.encode((await signer.sign(server, [0])).toPSBT())),
+        matched.map(async ({ server }) =>
+            base64.encode((await input.sender.sign(server, [0])).toPSBT()),
+        ),
     );
 
     await ark.finalizeTx(submitted.arkTxid, finalCheckpoints);
@@ -642,7 +645,8 @@ export async function refundIfUnresolved(
     input: {
         rfqId: string;
         script: InstanceType<typeof VHTLC.ScriptV2>;
-        senderPrivateKey: Uint8Array;
+        /** @see pushRefundWithoutReceiver */
+        sender: Identity;
         /** `refund_locktime` from the quote, unix seconds. */
         refundLocktime: number;
         /** Defaults to the contract's own committed refund destination. */
@@ -669,7 +673,7 @@ export async function refundIfUnresolved(
             try {
                 const pushed = await pushRefundWithoutReceiver(ark, {
                     script: input.script,
-                    senderPrivateKey: input.senderPrivateKey,
+                    sender: input.sender,
                     vtxos,
                     refundPkScript: input.refundPkScript,
                 });

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -40,7 +40,6 @@
  */
 import { hex } from "@scure/base";
 import { ripemd160 } from "@noble/hashes/legacy.js";
-import { schnorr } from "@noble/curves/secp256k1.js";
 import {
     ArkAddress,
     RestArkProvider,
@@ -939,6 +938,7 @@ export async function requestOnchainSend(
         amountSide: "from" | "to";
         /** Maker's x-only L1 key that will claim the HTLC. */
         payoutPubkey: Uint8Array;
+        /** Optional caller-owned P. Persist it with the returned secrets before funding. */
         preimage?: Uint8Array;
         rfqId?: string;
     },
@@ -959,18 +959,21 @@ export async function requestOnchainSend(
     secrets: SwapSecrets;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
-    // A caller-supplied preimage is its own to keep, so it forces the stored
-    // arm even on a wallet that could derive one.
-    const secrets = params.preimage
-        ? {
-              derivable: false as const,
-              senderPrivateKey: schnorr.utils.randomSecretKey(),
-              preimage: params.preimage,
-          }
-        : ((await deriveSwapSecrets(wallet)) ?? randomSwapSecrets({ preimage: true }));
+    const derivedSecrets = await deriveSwapSecrets(wallet);
+    const secrets = derivedSecrets
+        ? params.preimage
+            ? { ...derivedSecrets, preimage: params.preimage }
+            : derivedSecrets
+        : randomSwapSecrets({ preimage: params.preimage ?? true });
     if (!secrets.derivable) {
         console.warn(
-            "[swap] this swap's preimage and sender key are random and MUST be persisted before funding",
+            params.preimage
+                ? "[swap] this swap's sender key is random; the supplied preimage and sender key MUST be persisted before funding"
+                : "[swap] this swap's preimage and sender key are random and MUST be persisted before funding",
+        );
+    } else if (params.preimage) {
+        console.warn(
+            "[swap] this swap's preimage was supplied by the caller and MUST be persisted with the signing descriptor before funding",
         );
     }
     const preimage = await preimageForRfqSecrets(wallet, secrets);

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -56,7 +56,6 @@ import {
     ONCHAIN_CLAIM_MARGIN_SECONDS,
     ONCHAIN_ORDER_MARGIN_SECONDS,
     ONCHAIN_SECONDS_PER_BLOCK,
-    newPreimage,
     onchainHtlcScript,
     paymentHashOf,
     type OnchainHtlc,
@@ -68,6 +67,14 @@ export {
     ONCHAIN_CLAIM_MARGIN_SECONDS,
     ONCHAIN_ORDER_MARGIN_SECONDS,
 } from "./onchainHtlc";
+
+import {
+    deriveSwapSecrets,
+    preimageForRfqSecrets,
+    randomSwapSecrets,
+    senderPubkeyForRfqSecrets,
+    type SwapSecrets,
+} from "./secrets";
 
 /** Drop the prefix of a 33-byte compressed key; pass an x-only key through —
  * same rule as offer.ts, kept local so this module stays self-contained. */
@@ -633,14 +640,13 @@ export interface InvoiceFacts {
  * Throws {@link SwapRefusal} (closed reason), {@link AddressMismatch} (never
  * fund), or a gate error with a stable `reason`.
  *
- * Generates a fresh `sender` key per call and returns it as `senderPubkey`/
- * `senderPrivateKey`. THIS FUNCTION DOES NOT PERSIST IT: a caller that
- * discards the return value has traded away every interactive refund path.
- * `nonInteractiveRefund` can still recover the funds without it — but unlike
- * `refundWithoutReceiver`'s old CLTV-gated guarantee, it needs the SOLVER's
- * active cooperation (server + solver + emulator), not just infrastructure
- * uptime. If the solver is also gone or unwilling, losing this key is a
- * total loss, same as it would be without `nonInteractiveRefund` at all.
+ * Allocates a fresh `sender` key per call and returns it as `senderPubkey`
+ * plus `secrets`. On an HD wallet `secrets` holds only a public descriptor and
+ * nothing needs protecting; otherwise it holds the raw key and the caller MUST
+ * persist it, or every interactive refund path is gone. `nonInteractiveRefund`
+ * still recovers the funds without it — but it needs the SOLVER's active
+ * cooperation, not just infrastructure uptime, so losing the key with an
+ * unwilling solver is a total loss.
  */
 export async function requestLightningSend(
     wallet: IWallet,
@@ -670,15 +676,20 @@ export async function requestLightningSend(
     swapPkScript: Uint8Array;
     /** Where a failed swap refunds. */
     refundAddress: string;
-    /** The VHTLC `sender` key — PERSIST BOTH before going offline, or every
-     * interactive refund path (everything except `nonInteractiveRefund`) is
-     * lost. */
+    /** The VHTLC `sender` x-only key, bound into the covenant. Public. */
     senderPubkey: Uint8Array;
-    senderPrivateKey: Uint8Array;
+    /** How the `sender` key is recovered later. Persist it with the record —
+     * on the derivable arm it holds nothing secret. */
+    secrets: SwapSecrets;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
-    const senderPrivateKey = schnorr.utils.randomSecretKey();
-    const senderPubkey = schnorr.getPublicKey(senderPrivateKey);
+    const secrets = (await deriveSwapSecrets(wallet)) ?? randomSwapSecrets();
+    if (!secrets.derivable) {
+        console.warn(
+            "[swap] wallet cannot allocate an HD descriptor: the sender key is random and MUST be persisted before funding",
+        );
+    }
+    const senderPubkey = await senderPubkeyForRfqSecrets(wallet, secrets);
     const [info, refundAddress] = await Promise.all([
         new RestArkProvider(arkServerUrl).getInfo(),
         wallet.getAddress(),
@@ -725,7 +736,7 @@ export async function requestLightningSend(
         swapPkScript: script.pkScript,
         refundAddress,
         senderPubkey,
-        senderPrivateKey,
+        secrets,
     };
 }
 
@@ -905,13 +916,12 @@ export function deriveOnchainSend(input: {
  * quote → derive BOTH contracts locally → verify → gate. Pure of funding —
  * the caller funds `address` with its own wallet before `quote.valid_until`.
  *
- * Three obligations, all LOUD:
- * - **Persist `preimage` (with the record) BEFORE funding.** It is the only
- *   thing that can claim the L1 fill, across restarts included.
- * - **Persist `senderPubkey`/`senderPrivateKey`** — same obligation as {@link
- *   requestLightningSend}: discard it and every interactive refund path is
- *   gone, leaving recovery dependent on the solver's cooperation via
- *   `nonInteractiveRefund` rather than guaranteed outright.
+ * Two obligations, both LOUD:
+ * - **Persist `secrets` (with the record) BEFORE funding.** On an HD wallet it
+ *   is a public descriptor and both the preimage and the `sender` key
+ *   re-derive from the seed; otherwise it carries the raw secrets, and losing
+ *   them forfeits the L1 claim and every interactive refund path — leaving
+ *   recovery dependent on the solver via `nonInteractiveRefund`.
  * - **Stay claim-capable.** Unlike lightning-send the maker cannot go fully
  *   offline: it must claim the L1 HTLC (`awaitOnchainFill` →
  *   `claimOnchainFill`) before `htlc.refundLocktime`. Missing that window
@@ -935,8 +945,6 @@ export async function requestOnchainSend(
 ): Promise<{
     rfqId: string;
     quote: RfqQuote;
-    /** Caller MUST persist this before funding. */
-    preimage: Uint8Array;
     /** The maker's OWN arkade lockup derivation — the only address to fund. */
     address: string;
     fundAmount: number;
@@ -944,16 +952,30 @@ export async function requestOnchainSend(
     refundAddress: string;
     /** The EXPECTED L1 fill, derived locally — watch and claim against this. */
     htlc: OnchainHtlc;
-    /** The VHTLC `sender` key — PERSIST BOTH before funding, same obligation
-     * as `preimage`. */
+    /** The VHTLC `sender` x-only key, bound into the covenant. Public. */
     senderPubkey: Uint8Array;
-    senderPrivateKey: Uint8Array;
+    /** How the preimage and the `sender` key are recovered later. Persist it
+     * with the record BEFORE funding. */
+    secrets: SwapSecrets;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
-    const preimage = params.preimage ?? newPreimage();
+    // A caller-supplied preimage is its own to keep, so it forces the stored
+    // arm even on a wallet that could derive one.
+    const secrets = params.preimage
+        ? {
+              derivable: false as const,
+              senderPrivateKey: schnorr.utils.randomSecretKey(),
+              preimage: params.preimage,
+          }
+        : ((await deriveSwapSecrets(wallet)) ?? randomSwapSecrets({ preimage: true }));
+    if (!secrets.derivable) {
+        console.warn(
+            "[swap] this swap's preimage and sender key are random and MUST be persisted before funding",
+        );
+    }
+    const preimage = await preimageForRfqSecrets(wallet, secrets);
     const paymentHash = paymentHashOf(preimage);
-    const senderPrivateKey = schnorr.utils.randomSecretKey();
-    const senderPubkey = schnorr.getPublicKey(senderPrivateKey);
+    const senderPubkey = await senderPubkeyForRfqSecrets(wallet, secrets);
     const [info, refundAddress] = await Promise.all([
         new RestArkProvider(arkServerUrl).getInfo(),
         wallet.getAddress(),
@@ -996,13 +1018,12 @@ export async function requestOnchainSend(
     return {
         rfqId,
         quote,
-        preimage,
         address: derived.address,
         fundAmount: quote.from_amount,
         swapPkScript: derived.swapPkScript,
         refundAddress,
         htlc: derived.htlc,
         senderPubkey,
-        senderPrivateKey,
+        secrets,
     };
 }

--- a/packages/swap/src/secrets.ts
+++ b/packages/swap/src/secrets.ts
@@ -13,7 +13,9 @@
  * preimage must be able to come back empty rather than be handed a fresh
  * random one that will never match the chain.
  */
+import { hex } from "@scure/base";
 import { sha256 } from "@noble/hashes/sha2.js";
+import { randomBytes } from "@noble/hashes/utils.js";
 import { schnorr } from "@noble/curves/secp256k1.js";
 import {
     Identity,
@@ -23,6 +25,7 @@ import {
     isHDAllocationCapable,
     isHDWalletCapable,
 } from "@arkade-os/sdk";
+import type { AssetSwapFallbackSecrets } from "./store";
 
 /**
  * Domain separator for the preimage derivation.
@@ -69,6 +72,8 @@ export interface DerivedSwapSecrets {
     derivable: true;
     /** Public. Persist it on the swap record; it is what restore keys off. */
     signingDescriptor: string;
+    /** Onchain-send only, when the caller supplied P instead of deriving it. */
+    preimage?: Uint8Array;
 }
 
 /** The wallet could not allocate. These are real secrets — persist them. */
@@ -105,29 +110,83 @@ export async function deriveSwapSecrets(wallet: IWallet): Promise<DerivedSwapSec
  * The fallback arm. Separate from {@link deriveSwapSecrets} so nothing can
  * fabricate a preimage while probing for a derived one.
  */
-export function randomSwapSecrets(opts: { preimage?: boolean } = {}): StoredSwapSecrets {
+export function randomSwapSecrets(
+    opts: { preimage?: boolean | Uint8Array } = {},
+): StoredSwapSecrets {
+    const preimage =
+        opts.preimage instanceof Uint8Array
+            ? opts.preimage
+            : opts.preimage
+              ? randomBytes(32)
+              : undefined;
     return {
         derivable: false,
         senderPrivateKey: schnorr.utils.randomSecretKey(),
-        ...(opts.preimage ? { preimage: schnorr.utils.randomSecretKey() } : {}),
+        ...(preimage ? { preimage } : {}),
     };
 }
 
 /**
- * The secrets arm a persisted record describes, or `undefined` when the record
- * predates derivation (or was written by a wallet that could not derive).
- *
- * Only the derivable arm is reconstructible from a record: `AssetSwap`
- * deliberately has no field for a sender private key, so a stored-arm swap's
- * key lives in whatever encrypted store the consumer provides and must be
- * supplied from there.
+ * Serialize or restore the secrets arm a persisted record describes. Normal
+ * HD swaps store only `signingDescriptor`; caller-supplied preimages add
+ * `preimageHex`; fallback swaps use `fallbackSecrets` so both P and the
+ * sender identity survive a restart.
  */
+export function rfqSecretsToRecord(secrets: SwapSecrets): {
+    signingDescriptor?: string;
+    preimageHex?: string;
+    fallbackSecrets?: AssetSwapFallbackSecrets;
+} {
+    if (secrets.derivable) {
+        return {
+            signingDescriptor: secrets.signingDescriptor,
+            ...(secrets.preimage ? { preimageHex: hex.encode(secrets.preimage) } : {}),
+        };
+    }
+    return {
+        fallbackSecrets: {
+            version: 1,
+            type: "stored",
+            senderPrivateKeyHex: hex.encode(secrets.senderPrivateKey),
+            ...(secrets.preimage ? { preimageHex: hex.encode(secrets.preimage) } : {}),
+        },
+    };
+}
+
 export function rfqSecretsOfRecord(record: {
     signingDescriptor?: string;
     preimageHex?: string;
-}): DerivedSwapSecrets | undefined {
-    if (!record.signingDescriptor) return undefined;
-    return { derivable: true, signingDescriptor: record.signingDescriptor };
+    fallbackSecrets?: AssetSwapFallbackSecrets;
+}): SwapSecrets | undefined {
+    if (record.signingDescriptor) {
+        return {
+            derivable: true,
+            signingDescriptor: record.signingDescriptor,
+            ...(record.preimageHex
+                ? { preimage: decodeHex32(record.preimageHex, "preimageHex") }
+                : {}),
+        };
+    }
+    const fallback = record.fallbackSecrets;
+    if (!fallback) return undefined;
+    if (fallback.version !== 1 || fallback.type !== "stored") {
+        throw new Error("unsupported RFQ fallback secrets record");
+    }
+    return {
+        derivable: false,
+        senderPrivateKey: decodeHex32(fallback.senderPrivateKeyHex, "senderPrivateKeyHex"),
+        ...(fallback.preimageHex
+            ? { preimage: decodeHex32(fallback.preimageHex, "preimageHex") }
+            : {}),
+    };
+}
+
+function decodeHex32(value: string, label: string): Uint8Array {
+    const bytes = hex.decode(value);
+    if (bytes.length !== 32) {
+        throw new Error(label + " must be 32 bytes, got " + bytes.length);
+    }
+    return bytes;
 }
 
 /**
@@ -201,6 +260,7 @@ export async function preimageForRfqSecrets(
         if (!secrets.preimage) throw new Error("this swap carries no stored preimage");
         return secrets.preimage;
     }
+    if (secrets.preimage) return secrets.preimage;
     const signer = await senderIdentityForRfqSecrets(wallet, secrets);
     if (!isDeterministicSigner(signer)) {
         // Loud: a preimage from a random-aux signature is unrecoverable, and

--- a/packages/swap/src/secrets.ts
+++ b/packages/swap/src/secrets.ts
@@ -1,0 +1,213 @@
+/**
+ * RFQ swap secrets, derived from the wallet seed instead of stored.
+ *
+ * Both secrets an RFQ corridor needs — the VHTLC `sender` key and, for an
+ * onchain send, the preimage — become functions of one HD-allocated
+ * descriptor. The record keeps only that descriptor, which is public, so a
+ * copied profile or a device backup yields nothing spendable and a wallet with
+ * the seed can re-derive everything.
+ *
+ * Wallets that cannot allocate (static / `auto` / custom signers) get the
+ * fallback arm instead, which carries real secrets the caller must store. That
+ * arm is built by the caller, never in here: a restore probing for a derived
+ * preimage must be able to come back empty rather than be handed a fresh
+ * random one that will never match the chain.
+ */
+import { sha256 } from "@noble/hashes/sha2.js";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import {
+    Identity,
+    IWallet,
+    ReadonlyIdentity,
+    SingleKey,
+    isHDAllocationCapable,
+    isHDWalletCapable,
+} from "@arkade-os/sdk";
+
+/**
+ * Domain separator for the preimage derivation.
+ *
+ * NArk scopes its tag by protocol+provider (`Arkade-Boltz-Preimage-v1`,
+ * `SwapsManagementService.cs:128`) so any Arkade SDK reproduces the same
+ * preimage. NArk has no RFQ corridor yet, so this tag defines the scheme
+ * rather than mirroring one; it is deliberately distinct from the Boltz tag,
+ * or the same wallet key would derive one preimage for both corridors.
+ */
+export const RFQ_PREIMAGE_TAG = "Arkade-RFQ-Preimage-v1";
+
+/**
+ * `TAG ‖ xonly(32) ‖ u32le(index)` — the message that gets BIP-340 signed.
+ *
+ * Anchored on the canonical x-only key rather than the descriptor string:
+ * restore reconstructs a bare descriptor that serialises differently from the
+ * signing descriptor used at create time, and only the key agrees across both.
+ */
+export function buildPreimageMessage(xonly: Uint8Array, index: number): Uint8Array {
+    if (xonly.length !== 32) {
+        throw new Error(`x-only pubkey must be 32 bytes, got ${xonly.length}`);
+    }
+    if (!Number.isInteger(index) || index < 0 || index > 0xffffffff) {
+        throw new Error(`index must be a u32, got ${index}`);
+    }
+    const tag = new TextEncoder().encode(RFQ_PREIMAGE_TAG);
+    const message = new Uint8Array(tag.length + 32 + 4);
+    message.set(tag, 0);
+    message.set(xonly, tag.length);
+    new DataView(message.buffer).setUint32(tag.length + 32, index, true);
+    return message;
+}
+
+/**
+ * Every swap allocates its own descriptor, so the key alone separates two
+ * swaps and the message index stays pinned. Kept as a parameter of
+ * {@link buildPreimageMessage} for cross-SDK vectors.
+ */
+const PREIMAGE_INDEX = 0;
+
+/** No secrets at rest: everything re-derives from the seed plus this. */
+export interface DerivedSwapSecrets {
+    derivable: true;
+    /** Public. Persist it on the swap record; it is what restore keys off. */
+    signingDescriptor: string;
+}
+
+/** The wallet could not allocate. These are real secrets — persist them. */
+export interface StoredSwapSecrets {
+    derivable: false;
+    senderPrivateKey: Uint8Array;
+    /** Onchain-send only. A lightning send's preimage belongs to the payee. */
+    preimage?: Uint8Array;
+}
+
+/**
+ * Which arm a swap got. The discriminant makes the persistence obligation a
+ * type-level fact: a consumer written against {@link DerivedSwapSecrets} alone
+ * fails to compile when handed the stored arm.
+ */
+export type SwapSecrets = DerivedSwapSecrets | StoredSwapSecrets;
+
+/**
+ * Allocate a descriptor for one swap, or `undefined` when the wallet cannot.
+ *
+ * Allocates — never peeks. `getCurrentSigningDescriptor` returns the same
+ * descriptor until the wallet rotates, and two swaps sharing a descriptor
+ * derive the *identical* preimage, so one solver learning its own preimage
+ * would learn the other swap's.
+ */
+export async function deriveSwapSecrets(wallet: IWallet): Promise<DerivedSwapSecrets | undefined> {
+    if (!isHDAllocationCapable(wallet)) return undefined;
+    const signingDescriptor = await wallet.getNextSigningDescriptor();
+    if (!signingDescriptor) return undefined;
+    return { derivable: true, signingDescriptor };
+}
+
+/**
+ * The fallback arm. Separate from {@link deriveSwapSecrets} so nothing can
+ * fabricate a preimage while probing for a derived one.
+ */
+export function randomSwapSecrets(opts: { preimage?: boolean } = {}): StoredSwapSecrets {
+    return {
+        derivable: false,
+        senderPrivateKey: schnorr.utils.randomSecretKey(),
+        ...(opts.preimage ? { preimage: schnorr.utils.randomSecretKey() } : {}),
+    };
+}
+
+/**
+ * The secrets arm a persisted record describes, or `undefined` when the record
+ * predates derivation (or was written by a wallet that could not derive).
+ *
+ * Only the derivable arm is reconstructible from a record: `AssetSwap`
+ * deliberately has no field for a sender private key, so a stored-arm swap's
+ * key lives in whatever encrypted store the consumer provides and must be
+ * supplied from there.
+ */
+export function rfqSecretsOfRecord(record: {
+    signingDescriptor?: string;
+    preimageHex?: string;
+}): DerivedSwapSecrets | undefined {
+    if (!record.signingDescriptor) return undefined;
+    return { derivable: true, signingDescriptor: record.signingDescriptor };
+}
+
+/**
+ * Claim a restored swap's index so a later allocation cannot reissue it —
+ * which would derive that swap's preimage a second time, for a different swap.
+ * Monotonic; a no-op on a wallet that cannot allocate.
+ */
+export async function adoptSwapDescriptor(
+    wallet: IWallet,
+    signingDescriptor: string,
+): Promise<void> {
+    if (!isHDAllocationCapable(wallet)) return;
+    await wallet.advanceSigningDescriptorWatermark(signingDescriptor);
+}
+
+/** The VHTLC `sender` identity — the signer for every interactive refund. */
+export async function senderIdentityForRfqSecrets(
+    wallet: IWallet,
+    secrets: SwapSecrets,
+): Promise<Identity> {
+    if (!secrets.derivable) return SingleKey.fromPrivateKey(secrets.senderPrivateKey);
+    if (!isHDWalletCapable(wallet)) {
+        throw new Error("swap was created on an HD wallet; this wallet cannot derive its key");
+    }
+    return wallet.signerForDescriptor(secrets.signingDescriptor);
+}
+
+/** The `sender` x-only pubkey, the only half the request flow needs. */
+export async function senderPubkeyForRfqSecrets(
+    wallet: IWallet,
+    secrets: SwapSecrets,
+): Promise<Uint8Array> {
+    if (!secrets.derivable) return schnorr.getPublicKey(secrets.senderPrivateKey);
+    return (await senderIdentityForRfqSecrets(wallet, secrets)).xOnlyPublicKey();
+}
+
+/**
+ * An identity that signs with `aux_rand = 0`, which is what makes the
+ * derivation reproducible. `DescriptorIdentity` satisfies it and throws rather
+ * than degrading to a random-aux signer.
+ */
+export interface DeterministicSigner extends ReadonlyIdentity {
+    signSchnorrDeterministic(messageHash: Uint8Array): Promise<Uint8Array>;
+}
+
+export function isDeterministicSigner(value: unknown): value is DeterministicSigner {
+    if (typeof value !== "object" || value === null) return false;
+    const v = value as Record<string, unknown>;
+    return (
+        typeof v.signSchnorrDeterministic === "function" && typeof v.xOnlyPublicKey === "function"
+    );
+}
+
+/**
+ * `sha256(sign(sha256(msg)))`, with the signing key and the message key being
+ * the same identity — passing a key in separately is how this silently derives
+ * an unrecoverable preimage.
+ */
+export async function derivePreimage(signer: DeterministicSigner): Promise<Uint8Array> {
+    const xonly = await signer.xOnlyPublicKey();
+    const message = buildPreimageMessage(xonly, PREIMAGE_INDEX);
+    return sha256(await signer.signSchnorrDeterministic(sha256(message)));
+}
+
+/** The onchain-send preimage, re-derived or read back off the stored arm. */
+export async function preimageForRfqSecrets(
+    wallet: IWallet,
+    secrets: SwapSecrets,
+): Promise<Uint8Array> {
+    if (!secrets.derivable) {
+        if (!secrets.preimage) throw new Error("this swap carries no stored preimage");
+        return secrets.preimage;
+    }
+    const signer = await senderIdentityForRfqSecrets(wallet, secrets);
+    if (!isDeterministicSigner(signer)) {
+        // Loud: a preimage from a random-aux signature is unrecoverable, and
+        // the failure would otherwise only surface at claim time.
+        throw new Error(
+            `wallet cannot sign deterministically for ${secrets.signingDescriptor}; its preimage is not derivable`,
+        );
+    }
+    return derivePreimage(signer);
+}

--- a/packages/swap/src/store.ts
+++ b/packages/swap/src/store.ts
@@ -48,15 +48,24 @@ export interface AssetSwap {
     status: AssetSwapStatus;
     createdAt: number;
     completedAt?: number;
-    // ── Onchain-corridor fields (absent on offer swaps). Persist the record —
-    // preimage included — BEFORE funding: the preimage is what makes the swap
-    // claimable across restarts, and nothing on chain can recover it until the
-    // counterparty spends. ──
+    // ── Onchain-corridor fields (absent on offer swaps). Persist the record
+    // BEFORE funding: what claims the swap across restarts lives here, and
+    // nothing on chain recovers it until the counterparty spends. ──
     /** RFQ pair string, e.g. `arkade:BTC->onchain:BTC`. */
     pair?: string;
-    /** `sha256(P)`, hex. */
+    /** `sha256(P)`, hex. Public, and how a restore confirms a candidate
+     * derivation is the right one. */
     paymentHash?: string;
-    /** P, hex — cleared once the claim is spent if the caller wishes. */
+    /**
+     * The HD descriptor this swap's secrets derive from. Public — it is what
+     * lets the record carry no secrets at all. Present iff the swap was
+     * created on a wallet that can allocate.
+     */
+    signingDescriptor?: string;
+    /**
+     * P, hex. **Fallback only**, for wallets that cannot derive: an HD swap
+     * carries `signingDescriptor` instead and must not write this.
+     */
     preimageHex?: string;
     /** The L1 HTLC's pkScript, hex — the chain-watch key. */
     htlcPkScriptHex?: string;

--- a/packages/swap/src/store.ts
+++ b/packages/swap/src/store.ts
@@ -17,12 +17,22 @@ export type AssetSwapStatus =
  * restore layers share one spelling instead of re-typing the literal. */
 export const BTC_ASSET_ID = "btc";
 
+export interface AssetSwapFallbackSecretsV1 {
+    version: 1;
+    type: "stored";
+    senderPrivateKeyHex: string;
+    /** Onchain-send only. A lightning send's preimage belongs to the payee. */
+    preimageHex?: string;
+}
+
+export type AssetSwapFallbackSecrets = AssetSwapFallbackSecretsV1;
+
 // ponytail: records carry only chain-recoverable facts — no quote-time display
 // snapshot (tickers, fee bps, fiat value); add an optional snapshot field back
 // if a consumer must persist display metadata the restore scan cannot rebuild
 
 // ponytail: store policy (newest-first order, insert-if-absent, id-is-the-key,
-// write-failure tolerance) lives in these repository-first functions, so a
+// write-failure reporting) lives in these repository-first functions, so a
 // consumer calling repository.saveSwap directly bypasses all of it — saveSwap
 // is an upsert, so it will not even preserve insert-if-absent. Promote to an
 // AssetSwapStore class holding the repository privately if a second consumer
@@ -62,11 +72,14 @@ export interface AssetSwap {
      * created on a wallet that can allocate.
      */
     signingDescriptor?: string;
-    /**
-     * P, hex. **Fallback only**, for wallets that cannot derive: an HD swap
-     * carries `signingDescriptor` instead and must not write this.
-     */
+    /** P, hex, when the maker supplied a preimage that is not seed-derived. */
     preimageHex?: string;
+    /**
+     * Complete stored-arm secrets for wallets that cannot derive. Versioned
+     * and discriminated so restore can rebuild both the sender identity and,
+     * for onchain sends, P.
+     */
+    fallbackSecrets?: AssetSwapFallbackSecrets;
     /** The L1 HTLC's pkScript, hex — the chain-watch key. */
     htlcPkScriptHex?: string;
     htlcLocktime?: number;
@@ -98,13 +111,14 @@ export const getAssetSwaps = async (repository: AssetSwapRepository): Promise<As
     }
 };
 
-// persistence must never fail the caller: by the time a swap is stored the
-// funding tx is already broadcast, and the offer stays recoverable from it
+// Surface persistence failures: onchain sends must prove the pre-funding
+// record write landed before the caller broadcasts the lockup.
 const saveSwapSafely = async (repository: AssetSwapRepository, swap: AssetSwap): Promise<void> => {
     try {
         await repository.saveSwap(swap);
-    } catch {
-        // best effort: the record stays recoverable from chain (see restore.ts)
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        throw new Error(`failed to save swap ${swap.id}: ${reason}`);
     }
 };
 

--- a/packages/swap/test/onchainRfq.test.ts
+++ b/packages/swap/test/onchainRfq.test.ts
@@ -281,7 +281,12 @@ describe("store — onchain records", () => {
             createdAt: 1,
             pair: ONCHAIN_SEND_PAIR,
             paymentHash: PAYMENT_HASH,
-            preimageHex: hex.encode(PREIMAGE),
+            fallbackSecrets: {
+                version: 1,
+                type: "stored",
+                senderPrivateKeyHex: "11".repeat(32),
+                preimageHex: hex.encode(PREIMAGE),
+            },
             htlcPkScriptHex: "5120bb",
             htlcLocktime: HTLC_LOCKTIME,
         } as unknown as AssetSwap;

--- a/packages/swap/test/refund.test.ts
+++ b/packages/swap/test/refund.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 import { base64, hex } from "@scure/base";
 import { schnorr } from "@noble/curves/secp256k1.js";
 import { sha256 } from "@noble/hashes/sha2.js";
-import { CSVMultisigTapscript, Transaction } from "@arkade-os/sdk";
+import { CSVMultisigTapscript, SingleKey, Transaction } from "@arkade-os/sdk";
 
 import { lightningSendVtxoScript, type RfqStatus, type RfqTransport } from "../src/rfq";
 import {
@@ -33,6 +33,8 @@ const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, .
 const RFQ_ID = "a1".repeat(32);
 const REFUND_LOCKTIME = 1_800_000_000;
 const SENDER_PRIVATE_KEY = priv(13);
+/** The sender key as the signer the refund path now takes. */
+const SENDER = SingleKey.fromPrivateKey(SENDER_PRIVATE_KEY);
 const REFUND_PK_SCRIPT = p2tr(key(5));
 
 /** The same golden participant set rfq.test.ts pins the script bytes against. */
@@ -153,7 +155,7 @@ describe("pushRefundWithoutReceiver", () => {
         const ark = fakeArk();
         await pushRefundWithoutReceiver(ark, {
             script,
-            senderPrivateKey: SENDER_PRIVATE_KEY,
+            sender: SENDER,
             vtxos: VTXOS,
         });
 
@@ -174,7 +176,7 @@ describe("pushRefundWithoutReceiver", () => {
         const ark = fakeArk();
         await pushRefundWithoutReceiver(ark, {
             script: swapScript(),
-            senderPrivateKey: SENDER_PRIVATE_KEY,
+            sender: SENDER,
             vtxos: VTXOS,
         });
 
@@ -190,7 +192,7 @@ describe("pushRefundWithoutReceiver", () => {
         const ark = fakeArk();
         const result = await pushRefundWithoutReceiver(ark, {
             script: swapScript(),
-            senderPrivateKey: SENDER_PRIVATE_KEY,
+            sender: SENDER,
             vtxos: VTXOS,
         });
 
@@ -210,7 +212,7 @@ describe("pushRefundWithoutReceiver", () => {
         const elsewhere = p2tr(key(21));
         await pushRefundWithoutReceiver(ark, {
             script: swapScript(),
-            senderPrivateKey: SENDER_PRIVATE_KEY,
+            sender: SENDER,
             vtxos: VTXOS,
             refundPkScript: elsewhere,
         });
@@ -222,7 +224,7 @@ describe("pushRefundWithoutReceiver", () => {
         await expect(
             pushRefundWithoutReceiver(fakeArk(), {
                 script: swapScript(),
-                senderPrivateKey: SENDER_PRIVATE_KEY,
+                sender: SENDER,
                 vtxos: [],
             }),
         ).rejects.toThrow(/nothing to refund/);
@@ -245,7 +247,7 @@ describe("pushRefundWithoutReceiver", () => {
             await expect(
                 pushRefundWithoutReceiver(ark, {
                     script: swapScript(),
-                    senderPrivateKey: SENDER_PRIVATE_KEY,
+                    sender: SENDER,
                     vtxos: swept,
                 }),
             ).rejects.toThrow(LockupNeedsRecoveryError);
@@ -259,7 +261,7 @@ describe("pushRefundWithoutReceiver", () => {
             ];
             const error: unknown = await pushRefundWithoutReceiver(fakeArk(), {
                 script: swapScript(),
-                senderPrivateKey: SENDER_PRIVATE_KEY,
+                sender: SENDER,
                 vtxos: swept,
             }).then(
                 () => undefined,
@@ -289,7 +291,7 @@ describe("pushRefundWithoutReceiver", () => {
             await expect(
                 pushRefundWithoutReceiver(ark, {
                     script: swapScript(),
-                    senderPrivateKey: SENDER_PRIVATE_KEY,
+                    sender: SENDER,
                     vtxos: mixed,
                 }),
             ).rejects.toThrow(LockupNeedsRecoveryError);
@@ -301,7 +303,7 @@ describe("pushRefundWithoutReceiver", () => {
             const live: LockupVtxo[] = VTXOS.map((v) => ({ ...v, recoverable: false }));
             await pushRefundWithoutReceiver(ark, {
                 script: swapScript(),
-                senderPrivateKey: SENDER_PRIVATE_KEY,
+                sender: SENDER,
                 vtxos: live,
             });
             expect(ark.submitted).toHaveLength(1);
@@ -316,7 +318,7 @@ describe("pushRefundWithoutReceiver", () => {
         const capture = fakeArk();
         await pushRefundWithoutReceiver(capture, {
             script: swapScript(),
-            senderPrivateKey: SENDER_PRIVATE_KEY,
+            sender: SENDER,
             vtxos: [{ txid: "33".repeat(32), vout: 0, value: 7_000, recoverable: false }],
         });
         const foreignCheckpoint = capture.submitted[0].checkpoints[0];
@@ -325,7 +327,7 @@ describe("pushRefundWithoutReceiver", () => {
         await expect(
             pushRefundWithoutReceiver(ark, {
                 script: swapScript(),
-                senderPrivateKey: SENDER_PRIVATE_KEY,
+                sender: SENDER,
                 vtxos: [VTXOS[0]],
             }),
         ).rejects.toThrow(/does not match any submitted checkpoint/);
@@ -336,7 +338,7 @@ describe("pushRefundWithoutReceiver", () => {
         await expect(
             pushRefundWithoutReceiver(fakeArk({ checkpointTapscript: "00" }), {
                 script: swapScript(),
-                senderPrivateKey: SENDER_PRIVATE_KEY,
+                sender: SENDER,
                 vtxos: VTXOS,
             }),
         ).rejects.toThrow(/checkpointTapscript/);
@@ -423,7 +425,7 @@ describe("refundIfUnresolved", () => {
     const baseInput = () => ({
         rfqId: RFQ_ID,
         script: swapScript(),
-        senderPrivateKey: SENDER_PRIVATE_KEY,
+        sender: SENDER,
         refundLocktime: REFUND_LOCKTIME,
         pollMs: 1,
     });

--- a/packages/swap/test/rfqDerivedSecrets.test.ts
+++ b/packages/swap/test/rfqDerivedSecrets.test.ts
@@ -32,6 +32,7 @@ import {
     HDDescriptorProvider,
     InMemoryWalletRepository,
     MnemonicIdentity,
+    SingleKey,
     type IWallet,
 } from "@arkade-os/sdk";
 import {
@@ -81,6 +82,14 @@ const hdWallet = async (): Promise<IWallet> => {
             new DescriptorIdentity({ descriptor, signer: provider, base: identity }),
     } as unknown as IWallet;
 };
+
+const staticWallet = (): IWallet =>
+    ({
+        identity: SingleKey.fromHex(
+            "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2",
+        ),
+        getAddress: async () => REFUND_ADDRESS,
+    }) as unknown as IWallet;
 
 /** Quotes back whatever the maker derived, so the flow reaches its gates. */
 const lightningTransport = (): RfqTransport => ({
@@ -257,20 +266,54 @@ describe("requestOnchainSend on an HD wallet", () => {
         expect(second.paymentHash).not.toBe(first.paymentHash);
     });
 
-    it("falls back to the stored arm when the caller brings its own preimage", async () => {
+    it("keeps the HD sender key when the caller brings its own preimage", async () => {
         const wallet = await hdWallet();
         const preimage = new Uint8Array(32).fill(7);
-        const result = await requestOnchainSend(
-            wallet,
-            "http://ark",
-            EMULATOR_PUBKEY,
-            onchainTransport({}),
-            { amount: 100_000, amountSide: "to", payoutPubkey: PAYOUT_PUBKEY, preimage },
-        );
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            const result = await requestOnchainSend(
+                wallet,
+                "http://ark",
+                EMULATOR_PUBKEY,
+                onchainTransport({}),
+                { amount: 100_000, amountSide: "to", payoutPubkey: PAYOUT_PUBKEY, preimage },
+            );
 
-        // A preimage the caller owns cannot be re-derived, so the record has
-        // to keep it — saying `derivable` here would lose it silently.
-        expect(result.secrets.derivable).toBe(false);
-        expect(await preimageForRfqSecrets(wallet, result.secrets)).toEqual(preimage);
+            expect(result.secrets.derivable).toBe(true);
+            if (!result.secrets.derivable) throw new Error("expected derived secrets");
+            expect(result.secrets.preimage).toEqual(preimage);
+            expect(await preimageForRfqSecrets(wallet, result.secrets)).toEqual(preimage);
+
+            const signer = await wallet.signerForDescriptor!(result.secrets.signingDescriptor);
+            expect(hex.encode(result.senderPubkey)).toBe(hex.encode(await signer.xOnlyPublicKey()));
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining("supplied by the caller"));
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it("warns and returns raw fallback secrets when allocation is unavailable", async () => {
+        const wallet = staticWallet();
+        const preimage = new Uint8Array(32).fill(8);
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            const result = await requestOnchainSend(
+                wallet,
+                "http://ark",
+                EMULATOR_PUBKEY,
+                onchainTransport({}),
+                { amount: 100_000, amountSide: "to", payoutPubkey: PAYOUT_PUBKEY, preimage },
+            );
+
+            expect(result.secrets.derivable).toBe(false);
+            if (result.secrets.derivable) throw new Error("expected stored secrets");
+            expect(result.secrets.senderPrivateKey).toBeInstanceOf(Uint8Array);
+            expect(result.secrets.preimage).toEqual(preimage);
+            expect(await preimageForRfqSecrets(wallet, result.secrets)).toEqual(preimage);
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining("sender key is random"));
+            expect(warn.mock.calls.join("\n")).not.toContain("preimage and sender key are random");
+        } finally {
+            warn.mockRestore();
+        }
     });
 });

--- a/packages/swap/test/rfqDerivedSecrets.test.ts
+++ b/packages/swap/test/rfqDerivedSecrets.test.ts
@@ -1,0 +1,276 @@
+/**
+ * The wiring: what the two maker entrypoints hand back on an HD wallet.
+ *
+ * `secrets.test.ts` proves the derivation; this proves the request flow uses
+ * it — that the covenant is built from the allocated key, that the payment
+ * hash commits to the derived preimage, and that nothing secret leaves the
+ * function at all.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+
+const state = vi.hoisted(() => ({
+    arkInfo: { signerPubkey: "", unilateralExitDelay: 4096, network: "regtest" },
+}));
+
+vi.mock("@arkade-os/sdk", async (importOriginal) => {
+    const mod = await importOriginal<typeof import("@arkade-os/sdk")>();
+    return {
+        ...mod,
+        RestArkProvider: class {
+            async getInfo() {
+                return state.arkInfo;
+            }
+        },
+    };
+});
+
+import {
+    ArkAddress,
+    DescriptorIdentity,
+    HDDescriptorProvider,
+    InMemoryWalletRepository,
+    MnemonicIdentity,
+    type IWallet,
+} from "@arkade-os/sdk";
+import {
+    LIGHTNING_SEND_PAIR,
+    ONCHAIN_SEND_PAIR,
+    lightningSendVtxoScript,
+    requestLightningSend,
+    requestOnchainSend,
+    type RfqQuote,
+    type RfqTransport,
+} from "../src/rfq";
+import { onchainHtlcScript, paymentHashOf } from "../src/onchainHtlc";
+import { preimageForRfqSecrets } from "../src/secrets";
+
+const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
+const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+
+const MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const SERVER = key(3);
+const SOLVER = key(1);
+const RECEIVER_PK_SCRIPT = p2tr(key(1));
+const EMULATOR_PUBKEY = key(9);
+const PAYOUT_PUBKEY = key(15);
+const HTLC_PUBKEY = key(11);
+const REFUND_ADDRESS = new ArkAddress(SERVER, key(21), "tark").encode();
+
+state.arkInfo.signerPubkey = hex.encode(SERVER);
+
+const NOW = Math.floor(Date.now() / 1000);
+const VALID_UNTIL = NOW + 3600;
+const REFUND_LOCKTIME = NOW + 60 * 24 * 3600;
+const HTLC_LOCKTIME = NOW + 30 * 24 * 3600;
+
+/** A wallet backed by the real allocator and the real deterministic signer. */
+const hdWallet = async (): Promise<IWallet> => {
+    const identity = MnemonicIdentity.fromMnemonic(MNEMONIC, { isMainnet: false });
+    const provider = await HDDescriptorProvider.create(identity, new InMemoryWalletRepository());
+    return {
+        identity,
+        getAddress: async () => REFUND_ADDRESS,
+        getCurrentSigningDescriptor: () => provider.getCurrentSigningDescriptor(),
+        getNextSigningDescriptor: () => provider.getNextSigningDescriptor(),
+        getUsedSigningDescriptors: async () => [],
+        advanceSigningDescriptorWatermark: async () => {},
+        signerForDescriptor: async (descriptor: string) =>
+            new DescriptorIdentity({ descriptor, signer: provider, base: identity }),
+    } as unknown as IWallet;
+};
+
+/** Quotes back whatever the maker derived, so the flow reaches its gates. */
+const lightningTransport = (): RfqTransport => ({
+    async requestQuote(payload) {
+        const profile = (payload as { profile: Record<string, unknown> }).profile;
+        const script = lightningSendVtxoScript({
+            solverPubkey: SOLVER,
+            refundLocktime: REFUND_LOCKTIME,
+            serverPubkey: SERVER,
+            paymentHash: PAYMENT_HASH,
+            claimDelay: 4096,
+            emulatorPubkey: EMULATOR_PUBKEY,
+            senderPubkey: hex.decode(profile.client_refund_pubkey as string),
+            receiverPkScript: RECEIVER_PK_SCRIPT,
+            refundPkScript: ArkAddress.decode(REFUND_ADDRESS).pkScript,
+        });
+        return {
+            v: 1,
+            type: "rfq_quote",
+            rfq_id: payload.rfq_id as string,
+            pair: LIGHTNING_SEND_PAIR,
+            from_amount: 1000,
+            to_amount: 1000,
+            solver_pubkey: hex.encode(SOLVER),
+            valid_until: VALID_UNTIL,
+            refund_locktime: REFUND_LOCKTIME,
+            profile: {
+                receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
+                lockup_address: script.address("tark", SERVER).encode(),
+            },
+        } satisfies RfqQuote;
+    },
+    async status() {
+        return null;
+    },
+    async close() {},
+});
+
+const PAYMENT_HASH = "ab".repeat(32);
+const INVOICE = {
+    raw: "lnbcrt10u1p",
+    paymentHash: PAYMENT_HASH,
+    amountSats: 1000,
+    expiresAt: NOW + 7200,
+};
+
+/** Records the payment hash the maker sent, and quotes to match it. */
+const onchainTransport = (seen: { paymentHash?: string; senderPubkey?: string }): RfqTransport => ({
+    async requestQuote(payload) {
+        const profile = (payload as { profile: Record<string, unknown> }).profile;
+        seen.paymentHash = profile.payment_hash as string;
+        seen.senderPubkey = profile.client_refund_pubkey as string;
+        const lockup = lightningSendVtxoScript({
+            solverPubkey: SOLVER,
+            refundLocktime: REFUND_LOCKTIME,
+            serverPubkey: SERVER,
+            paymentHash: seen.paymentHash,
+            claimDelay: 4096,
+            emulatorPubkey: EMULATOR_PUBKEY,
+            senderPubkey: hex.decode(seen.senderPubkey),
+            receiverPkScript: RECEIVER_PK_SCRIPT,
+            refundPkScript: ArkAddress.decode(REFUND_ADDRESS).pkScript,
+        });
+        const htlc = onchainHtlcScript(
+            {
+                paymentHash: seen.paymentHash,
+                claimKey: PAYOUT_PUBKEY,
+                refundKey: HTLC_PUBKEY,
+                refundLocktime: HTLC_LOCKTIME,
+            },
+            "regtest",
+        );
+        return {
+            v: 1,
+            type: "rfq_quote",
+            rfq_id: payload.rfq_id as string,
+            pair: ONCHAIN_SEND_PAIR,
+            from_amount: 100_000,
+            to_amount: 99_000,
+            solver_pubkey: hex.encode(SOLVER),
+            valid_until: VALID_UNTIL,
+            refund_locktime: REFUND_LOCKTIME,
+            profile: {
+                lockup_address: lockup.address("tark", SERVER).encode(),
+                htlc_pubkey: hex.encode(HTLC_PUBKEY),
+                htlc_locktime: HTLC_LOCKTIME,
+                htlc_address: htlc.address,
+                min_confirmations: 2,
+                receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
+            },
+        } satisfies RfqQuote;
+    },
+    async status() {
+        return null;
+    },
+    async close() {},
+});
+
+describe("requestLightningSend on an HD wallet", () => {
+    it("returns a descriptor and no key material", async () => {
+        const wallet = await hdWallet();
+        const result = await requestLightningSend(
+            wallet,
+            "http://ark",
+            EMULATOR_PUBKEY,
+            lightningTransport(),
+            { invoice: INVOICE },
+        );
+
+        expect(result.secrets.derivable).toBe(true);
+        expect(result).not.toHaveProperty("senderPrivateKey");
+        // The covenant is bound to the allocated key, so the pubkey the solver
+        // was given has to be the descriptor's.
+        const signer = await (
+            wallet as never as {
+                signerForDescriptor: (
+                    d: string,
+                ) => Promise<{ xOnlyPublicKey: () => Promise<Uint8Array> }>;
+            }
+        ).signerForDescriptor((result.secrets as { signingDescriptor: string }).signingDescriptor);
+        expect(hex.encode(result.senderPubkey)).toBe(hex.encode(await signer.xOnlyPublicKey()));
+    });
+});
+
+describe("requestOnchainSend on an HD wallet", () => {
+    it("commits to the derived preimage and returns neither it nor the key", async () => {
+        const wallet = await hdWallet();
+        const seen: { paymentHash?: string; senderPubkey?: string } = {};
+        const result = await requestOnchainSend(
+            wallet,
+            "http://ark",
+            EMULATOR_PUBKEY,
+            onchainTransport(seen),
+            { amount: 100_000, amountSide: "to", payoutPubkey: PAYOUT_PUBKEY },
+        );
+
+        expect(result.secrets.derivable).toBe(true);
+        expect(result).not.toHaveProperty("preimage");
+        expect(result).not.toHaveProperty("senderPrivateKey");
+
+        // The quote was requested against sha256 of the derived preimage, and
+        // the preimage re-derives from the returned descriptor alone.
+        const preimage = await preimageForRfqSecrets(wallet, result.secrets);
+        expect(seen.paymentHash).toBe(paymentHashOf(preimage));
+        expect(seen.senderPubkey).toBe(hex.encode(result.senderPubkey));
+    });
+
+    it("gives a second swap on the same wallet a different key and preimage", async () => {
+        const wallet = await hdWallet();
+        const first: { paymentHash?: string; senderPubkey?: string } = {};
+        const second: { paymentHash?: string; senderPubkey?: string } = {};
+        const params = {
+            amount: 100_000,
+            amountSide: "to" as const,
+            payoutPubkey: PAYOUT_PUBKEY,
+        };
+
+        await requestOnchainSend(
+            wallet,
+            "http://ark",
+            EMULATOR_PUBKEY,
+            onchainTransport(first),
+            params,
+        );
+        await requestOnchainSend(
+            wallet,
+            "http://ark",
+            EMULATOR_PUBKEY,
+            onchainTransport(second),
+            params,
+        );
+
+        expect(second.senderPubkey).not.toBe(first.senderPubkey);
+        expect(second.paymentHash).not.toBe(first.paymentHash);
+    });
+
+    it("falls back to the stored arm when the caller brings its own preimage", async () => {
+        const wallet = await hdWallet();
+        const preimage = new Uint8Array(32).fill(7);
+        const result = await requestOnchainSend(
+            wallet,
+            "http://ark",
+            EMULATOR_PUBKEY,
+            onchainTransport({}),
+            { amount: 100_000, amountSide: "to", payoutPubkey: PAYOUT_PUBKEY, preimage },
+        );
+
+        // A preimage the caller owns cannot be re-derived, so the record has
+        // to keep it — saying `derivable` here would lose it silently.
+        expect(result.secrets.derivable).toBe(false);
+        expect(await preimageForRfqSecrets(wallet, result.secrets)).toEqual(preimage);
+    });
+});

--- a/packages/swap/test/secrets.test.ts
+++ b/packages/swap/test/secrets.test.ts
@@ -1,0 +1,280 @@
+/**
+ * The property the whole scheme rests on is that a preimage is a *function* of
+ * the seed and one allocated index — so it survives a restart with nothing
+ * stored, and two swaps never share one. Both are asserted directly here
+ * rather than inferred from `aux_rand`.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { hex } from "@scure/base";
+import {
+    DescriptorIdentity,
+    HDDescriptorProvider,
+    InMemoryWalletRepository,
+    MnemonicIdentity,
+    SingleKey,
+    type IWallet,
+} from "@arkade-os/sdk";
+
+import {
+    RFQ_PREIMAGE_TAG,
+    adoptSwapDescriptor,
+    buildPreimageMessage,
+    derivePreimage,
+    deriveSwapSecrets,
+    preimageForRfqSecrets,
+    randomSwapSecrets,
+    rfqSecretsOfRecord,
+    senderIdentityForRfqSecrets,
+    senderPubkeyForRfqSecrets,
+} from "../src/secrets";
+
+const MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+/** Set by `hdWallet()`; the vectors name indices the wallet has not allocated. */
+let descriptorAt: (index: number) => string;
+
+/**
+ * An HD-capable wallet built on the real allocator and the real deterministic
+ * signer — the two pieces the derivation depends on. Everything else an
+ * `IWallet` has is irrelevant here and left off.
+ */
+const hdWallet = async (repository = new InMemoryWalletRepository()) => {
+    const identity = MnemonicIdentity.fromMnemonic(MNEMONIC, { isMainnet: false });
+    const provider = await HDDescriptorProvider.create(identity, repository);
+    descriptorAt = (index: number) => provider.materializeDescriptorAt(index);
+    return {
+        repository,
+        wallet: {
+            identity,
+            getCurrentSigningDescriptor: () => provider.getCurrentSigningDescriptor(),
+            getNextSigningDescriptor: () => provider.getNextSigningDescriptor(),
+            async getUsedSigningDescriptors(opts?: { lookAhead?: number }) {
+                const last = await provider.getLastIndexUsed();
+                const out: string[] = [];
+                for (let i = 0; i <= (last ?? -1) + (opts?.lookAhead ?? 0); i++) {
+                    out.push(provider.materializeDescriptorAt(i));
+                }
+                return out;
+            },
+            async advanceSigningDescriptorWatermark(descriptor: string) {
+                await provider.advanceLastIndexUsed(Number(descriptor.match(/\/(\d+)\)\s*$/)![1]));
+            },
+            async signerForDescriptor(descriptor: string) {
+                return new DescriptorIdentity({ descriptor, signer: provider, base: identity });
+            },
+        } as unknown as IWallet,
+    };
+};
+
+/** A wallet with no HD state at all — the fallback corridor. */
+const staticWallet = () => ({ identity: SingleKey.fromRandomBytes() }) as unknown as IWallet;
+
+describe("buildPreimageMessage", () => {
+    it("lays out TAG ‖ xonly(32) ‖ u32le(index)", () => {
+        const xonly = new Uint8Array(32).fill(0xab);
+        const message = buildPreimageMessage(xonly, 1);
+        const tag = new TextEncoder().encode(RFQ_PREIMAGE_TAG);
+
+        expect(message).toHaveLength(tag.length + 36);
+        expect(message.slice(0, tag.length)).toEqual(tag);
+        expect(message.slice(tag.length, tag.length + 32)).toEqual(xonly);
+        // little-endian, so index 1 is 01 00 00 00
+        expect([...message.slice(tag.length + 32)]).toEqual([1, 0, 0, 0]);
+    });
+
+    it("is scoped away from the Boltz corridor", () => {
+        // Same key, same index: a shared tag would derive one preimage for
+        // both corridors.
+        expect(RFQ_PREIMAGE_TAG).toBe("Arkade-RFQ-Preimage-v1");
+        expect(RFQ_PREIMAGE_TAG).not.toBe("Arkade-Boltz-Preimage-v1");
+    });
+
+    it.each([
+        ["a short key", new Uint8Array(31), 0],
+        ["a long key", new Uint8Array(33), 0],
+    ])("rejects %s", (_label, xonly, index) => {
+        expect(() => buildPreimageMessage(xonly, index)).toThrow(/32 bytes/);
+    });
+
+    it.each([-1, 1.5, 0x1_0000_0000])("rejects index %s", (index) => {
+        expect(() => buildPreimageMessage(new Uint8Array(32), index)).toThrow(/u32/);
+    });
+});
+
+describe("derivation", () => {
+    it("derives the same preimage from the same seed and index, across instances", async () => {
+        // Two wallets built independently from one mnemonic, as a restart
+        // would produce.
+        const a = await hdWallet();
+        const secrets = (await deriveSwapSecrets(a.wallet))!;
+        const first = await preimageForRfqSecrets(a.wallet, secrets);
+
+        const b = await hdWallet();
+        const second = await preimageForRfqSecrets(b.wallet, secrets);
+
+        expect(hex.encode(second)).toBe(hex.encode(first));
+        expect(first).toHaveLength(32);
+    });
+
+    it("gives every swap its own descriptor, key and preimage", async () => {
+        // The regression test for peeking instead of allocating: a peek
+        // returns the same descriptor until the wallet rotates, and two swaps
+        // sharing a descriptor derive the IDENTICAL preimage.
+        const { wallet } = await hdWallet();
+        const descriptors: string[] = [];
+        const pubkeys: string[] = [];
+        const preimages: string[] = [];
+
+        for (let i = 0; i < 4; i++) {
+            const secrets = (await deriveSwapSecrets(wallet))!;
+            descriptors.push(secrets.signingDescriptor);
+            pubkeys.push(hex.encode(await senderPubkeyForRfqSecrets(wallet, secrets)));
+            preimages.push(hex.encode(await preimageForRfqSecrets(wallet, secrets)));
+        }
+
+        expect(new Set(descriptors).size).toBe(4);
+        expect(new Set(pubkeys).size).toBe(4);
+        expect(new Set(preimages).size).toBe(4);
+    });
+
+    it("signs with the same identity the message is built from", async () => {
+        const { wallet } = await hdWallet();
+        const secrets = (await deriveSwapSecrets(wallet))!;
+        const signer = await senderIdentityForRfqSecrets(wallet, secrets);
+
+        // Passing a different key in is the silent-failure mode: the result is
+        // a valid-looking preimage that nothing on chain will ever match.
+        expect(hex.encode(await derivePreimage(signer as never))).toBe(
+            hex.encode(await preimageForRfqSecrets(wallet, secrets)),
+        );
+    });
+});
+
+describe("cross-SDK vectors", () => {
+    // Generated from this implementation, because NArk has no RFQ corridor to
+    // pin against — these are what it should reproduce when it grows one.
+    // BIP-39 test mnemonic, testnet, `m/86'/1'/0'/0/i`.
+    it.each([
+        {
+            index: 0,
+            xonly: "55355ca83c973f1d97ce0e3843c85d78905af16b4dc531bc488e57212d230116",
+            preimage: "82e569a01f30760031a1f5bf119ae8ef9bd4fa916cf14bf27b7936f6a715c48e",
+        },
+        {
+            index: 1,
+            xonly: "3058679f6d60b87ef921d98a2a9a1f1e0779dae27bedbd1cdb2f147a07835ac9",
+            preimage: "5bfb00043a3cc0bae4992083db44a4af3bf255cc29d83180c16bd3d47f86b599",
+        },
+        {
+            index: 5,
+            xonly: "b46c5983819186bd7df9ca386c25d27e86c7293e953d765df34f954c6ece2ba6",
+            preimage: "6ae5a4570b8f57454d72f9b4f0a00518865df11dca5b595c8cc3e29a567b295c",
+        },
+    ])("index $index", async ({ index, xonly, preimage }) => {
+        const { wallet } = await hdWallet();
+        const signer = await wallet.signerForDescriptor!(descriptorAt(index));
+
+        expect(hex.encode(await signer.xOnlyPublicKey())).toBe(xonly);
+        expect(hex.encode(await derivePreimage(signer as never))).toBe(preimage);
+        // The message these hash from, spelled out for a reimplementation.
+        expect(hex.encode(buildPreimageMessage(hex.decode(xonly), 0))).toBe(
+            hex.encode(new TextEncoder().encode(RFQ_PREIMAGE_TAG)) + xonly + "00000000",
+        );
+    });
+});
+
+describe("the fallback arm", () => {
+    it("is what a wallet with no HD state gets", async () => {
+        expect(await deriveSwapSecrets(staticWallet())).toBeUndefined();
+    });
+
+    it("carries the secrets, and a preimage only when asked", () => {
+        expect(randomSwapSecrets()).toMatchObject({ derivable: false });
+        expect(randomSwapSecrets().preimage).toBeUndefined();
+        expect(randomSwapSecrets({ preimage: true }).preimage).toHaveLength(32);
+    });
+
+    it("resolves its signer and preimage from the stored bytes", async () => {
+        const wallet = staticWallet();
+        const secrets = randomSwapSecrets({ preimage: true });
+
+        expect(hex.encode(await preimageForRfqSecrets(wallet, secrets))).toBe(
+            hex.encode(secrets.preimage!),
+        );
+        const signer = await senderIdentityForRfqSecrets(wallet, secrets);
+        expect(hex.encode(await signer.xOnlyPublicKey())).toBe(
+            hex.encode(await senderPubkeyForRfqSecrets(wallet, secrets)),
+        );
+    });
+
+    it("refuses to invent a preimage it was never given", async () => {
+        await expect(preimageForRfqSecrets(staticWallet(), randomSwapSecrets())).rejects.toThrow(
+            /no stored preimage/,
+        );
+    });
+});
+
+describe("restore", () => {
+    it("re-derives from a record carrying nothing but the descriptor", async () => {
+        const a = await hdWallet();
+        const secrets = (await deriveSwapSecrets(a.wallet))!;
+        const record = {
+            paymentHash: "ab".repeat(32),
+            signingDescriptor: secrets.signingDescriptor,
+        };
+
+        // A fresh wallet on the same seed, holding only the public record.
+        const b = await hdWallet();
+        const restored = rfqSecretsOfRecord(record)!;
+        expect(restored.derivable).toBe(true);
+        expect(hex.encode(await preimageForRfqSecrets(b.wallet, restored))).toBe(
+            hex.encode(await preimageForRfqSecrets(a.wallet, secrets)),
+        );
+    });
+
+    it("has nothing to reconstruct for a record with no descriptor", () => {
+        expect(rfqSecretsOfRecord({ preimageHex: "cd".repeat(32) })).toBeUndefined();
+    });
+
+    it("claims a restored index so the next swap cannot reuse it", async () => {
+        // The restored record's index is ahead of this wallet's watermark —
+        // reallocating it would derive that swap's preimage for a new swap.
+        const source = await hdWallet();
+        let ahead = "";
+        for (let i = 0; i < 3; i++)
+            ahead = (await deriveSwapSecrets(source.wallet))!.signingDescriptor;
+
+        const fresh = await hdWallet();
+        await adoptSwapDescriptor(fresh.wallet, ahead);
+
+        const next = (await deriveSwapSecrets(fresh.wallet))!.signingDescriptor;
+        expect(next).not.toBe(ahead);
+        expect(indexOf(next)).toBeGreaterThan(indexOf(ahead));
+    });
+
+    it("is a no-op on a wallet that cannot allocate", async () => {
+        await expect(adoptSwapDescriptor(staticWallet(), "tr(deadbeef)")).resolves.toBeUndefined();
+    });
+});
+
+describe("nothing secret reaches the record", () => {
+    it("leaves a derivable swap's record free of 64-hex fields", async () => {
+        const { wallet } = await hdWallet();
+        const secrets = (await deriveSwapSecrets(wallet))!;
+
+        // What a consumer would persist for an HD swap.
+        const record = {
+            paymentHash: hex.encode(await preimageForRfqSecrets(wallet, secrets)).slice(0, 64),
+            signingDescriptor: secrets.signingDescriptor,
+        };
+
+        expect(Object.keys(secrets)).toEqual(["derivable", "signingDescriptor"]);
+        for (const [field, value] of Object.entries(record)) {
+            if (field === "paymentHash") continue; // public by construction
+            expect(value).not.toMatch(/^[0-9a-f]{64}$/i);
+        }
+    });
+});
+
+const indexOf = (descriptor: string): number => Number(descriptor.match(/\/(\d+)\)\s*$/)![1]);

--- a/packages/swap/test/secrets.test.ts
+++ b/packages/swap/test/secrets.test.ts
@@ -21,12 +21,15 @@ import {
     buildPreimageMessage,
     derivePreimage,
     deriveSwapSecrets,
+    isDeterministicSigner,
     preimageForRfqSecrets,
     randomSwapSecrets,
     rfqSecretsOfRecord,
+    rfqSecretsToRecord,
     senderIdentityForRfqSecrets,
     senderPubkeyForRfqSecrets,
 } from "../src/secrets";
+import { paymentHashOf } from "../src/onchainHtlc";
 
 const MNEMONIC =
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
@@ -145,7 +148,9 @@ describe("derivation", () => {
 
         // Passing a different key in is the silent-failure mode: the result is
         // a valid-looking preimage that nothing on chain will ever match.
-        expect(hex.encode(await derivePreimage(signer as never))).toBe(
+        expect(isDeterministicSigner(signer)).toBe(true);
+        if (!isDeterministicSigner(signer)) throw new Error("expected deterministic signer");
+        expect(hex.encode(await derivePreimage(signer))).toBe(
             hex.encode(await preimageForRfqSecrets(wallet, secrets)),
         );
     });
@@ -176,7 +181,9 @@ describe("cross-SDK vectors", () => {
         const signer = await wallet.signerForDescriptor!(descriptorAt(index));
 
         expect(hex.encode(await signer.xOnlyPublicKey())).toBe(xonly);
-        expect(hex.encode(await derivePreimage(signer as never))).toBe(preimage);
+        expect(isDeterministicSigner(signer)).toBe(true);
+        if (!isDeterministicSigner(signer)) throw new Error("expected deterministic signer");
+        expect(hex.encode(await derivePreimage(signer))).toBe(preimage);
         // The message these hash from, spelled out for a reimplementation.
         expect(hex.encode(buildPreimageMessage(hex.decode(xonly), 0))).toBe(
             hex.encode(new TextEncoder().encode(RFQ_PREIMAGE_TAG)) + xonly + "00000000",
@@ -211,6 +218,32 @@ describe("the fallback arm", () => {
     it("refuses to invent a preimage it was never given", async () => {
         await expect(preimageForRfqSecrets(staticWallet(), randomSwapSecrets())).rejects.toThrow(
             /no stored preimage/,
+        );
+    });
+
+    it("serializes enough fallback data to restore the sender identity", async () => {
+        const wallet = staticWallet();
+        const secrets = randomSwapSecrets({ preimage: true });
+        const record = rfqSecretsToRecord(secrets);
+
+        expect(record).toEqual({
+            fallbackSecrets: {
+                version: 1,
+                type: "stored",
+                senderPrivateKeyHex: hex.encode(secrets.senderPrivateKey),
+                preimageHex: hex.encode(secrets.preimage!),
+            },
+        });
+
+        const restored = rfqSecretsOfRecord(record)!;
+        expect(restored.derivable).toBe(false);
+        if (restored.derivable) throw new Error("expected stored secrets");
+        expect(hex.encode(restored.senderPrivateKey)).toBe(hex.encode(secrets.senderPrivateKey));
+        expect(hex.encode(await preimageForRfqSecrets(wallet, restored))).toBe(
+            hex.encode(secrets.preimage!),
+        );
+        expect(hex.encode(await senderPubkeyForRfqSecrets(wallet, restored))).toBe(
+            hex.encode(await senderPubkeyForRfqSecrets(wallet, secrets)),
         );
     });
 });
@@ -264,15 +297,21 @@ describe("nothing secret reaches the record", () => {
         const secrets = (await deriveSwapSecrets(wallet))!;
 
         // What a consumer would persist for an HD swap.
+        const preimage = await preimageForRfqSecrets(wallet, secrets);
         const record = {
-            paymentHash: hex.encode(await preimageForRfqSecrets(wallet, secrets)).slice(0, 64),
+            paymentHash: paymentHashOf(preimage),
             signingDescriptor: secrets.signingDescriptor,
         };
 
         expect(Object.keys(secrets)).toEqual(["derivable", "signingDescriptor"]);
+        expect(record.paymentHash).toMatch(/^[0-9a-f]{64}$/i);
+        expect(record.paymentHash).not.toBe(hex.encode(preimage));
+        expect(record.signingDescriptor).toBe(secrets.signingDescriptor);
         for (const [field, value] of Object.entries(record)) {
-            if (field === "paymentHash") continue; // public by construction
-            expect(value).not.toMatch(/^[0-9a-f]{64}$/i);
+            expect({ field, isHex64: /^[0-9a-f]{64}$/i.test(value) }).toEqual({
+                field,
+                isHex64: field === "paymentHash",
+            });
         }
     });
 });

--- a/packages/swap/test/store.test.ts
+++ b/packages/swap/test/store.test.ts
@@ -65,12 +65,33 @@ describe("asset swap store", () => {
         expect((await getAssetSwaps(repository)).map((s) => s.id)).toEqual(["a"]);
     });
 
-    it("never fails the caller when the backend cannot persist or read", async () => {
-        const broken: AssetSwapRepository = {
+    it("reports failed add and update writes", async () => {
+        const broken = (existing: AssetSwap[] = []): AssetSwapRepository => ({
             version: 1,
             saveSwap: async () => {
                 throw new Error("quota exceeded");
             },
+            getAllSwaps: async () => existing,
+            getScannedTxids: async () => new Set(),
+            markTxidsScanned: async () => {},
+            getCachedMarkets: async () => undefined,
+            saveCachedMarkets: async () => {},
+            clear: async () => {},
+            [Symbol.asyncDispose]: async () => {},
+        });
+
+        await expect(addAssetSwap(broken(), swap("a"))).rejects.toThrow(
+            /failed to save swap a: quota exceeded/,
+        );
+        await expect(
+            updateAssetSwap(broken([swap("a")]), "a", { status: "cancelled" }),
+        ).rejects.toThrow(/failed to save swap a: quota exceeded/);
+    });
+
+    it("treats read failures as an empty swap list", async () => {
+        const broken: AssetSwapRepository = {
+            version: 1,
+            saveSwap: async () => {},
             getAllSwaps: async () => {
                 throw new Error("backend gone");
             },
@@ -81,7 +102,6 @@ describe("asset swap store", () => {
             clear: async () => {},
             [Symbol.asyncDispose]: async () => {},
         };
-        await expect(addAssetSwap(broken, swap("a"))).resolves.toEqual([swap("a")]);
         await expect(getAssetSwaps(broken)).resolves.toEqual([]);
         await expect(updateAssetSwap(broken, "a", { status: "cancelled" })).resolves.toEqual([]);
     });

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -417,6 +417,19 @@ export interface IContractManager extends Disposable {
     refillLookAhead(): Promise<void>;
 
     /**
+     * Allocate the next signing descriptor through the manager-owned HD
+     * watermark path. Returns `undefined` when look-ahead/allocation is not
+     * configured.
+     */
+    getNextSigningDescriptor(): Promise<string | undefined>;
+
+    /**
+     * Advance the HD signing descriptor watermark to `index` and refill the
+     * watched look-ahead band. No-op when look-ahead/allocation is not configured.
+     */
+    advanceSigningDescriptorWatermark(index: number): Promise<void>;
+
+    /**
      * Explicit, gap-limit contract discovery used by `wallet.restore()`.
      *
      * Walks HD indices from 0, asking every registered `Discoverable`
@@ -536,6 +549,10 @@ export interface LookAheadConfig {
     size: number;
     /** Current allocation watermark (`lastIndexUsed ?? -1`). */
     currentWatermark(): Promise<number>;
+    /** Allocate the next signing descriptor, advancing the watermark. */
+    allocate?(): Promise<string | undefined>;
+    /** Advance the allocation watermark to a confirmed/restored index. */
+    advanceWatermark?(index: number): Promise<void>;
     /** Signing descriptor at an HD index. Pure derivation. */
     materialize(index: number): string;
     /**
@@ -544,7 +561,10 @@ export interface LookAheadConfig {
      * `rotateServerSigner` fans the new signer set.
      */
     candidateDeps(): CandidateDeps;
-    /** Fired after a speculative entry at `index` is promoted to a real row. */
+    /**
+     * Fired after a speculative entry at `index` is promoted to a real row.
+     * @deprecated Use `advanceWatermark`; kept for external LookAheadConfig users.
+     */
     onPromoted?(index: number): Promise<void>;
 }
 
@@ -804,6 +824,19 @@ export class ContractManager implements IContractManager {
         return this.scheduleLookAheadDrain();
     }
 
+    /** @see IContractManager.getNextSigningDescriptor */
+    async getNextSigningDescriptor(): Promise<string | undefined> {
+        const descriptor = await this.config.lookAhead?.allocate?.();
+        if (descriptor !== undefined) await this.scheduleLookAheadDrain();
+        return descriptor;
+    }
+
+    /** @see IContractManager.advanceSigningDescriptorWatermark */
+    async advanceSigningDescriptorWatermark(index: number): Promise<void> {
+        await this.advanceLookAheadWatermark(index);
+        await this.scheduleLookAheadDrain();
+    }
+
     /**
      * Serialized drain of the look-ahead band: concurrent callers join the
      * active drain and mark it dirty, an idle call starts a new one. Promotion
@@ -967,6 +1000,13 @@ export class ContractManager implements IContractManager {
         }
     }
 
+    private async advanceLookAheadWatermark(index: number): Promise<void> {
+        const lookAhead = this.config.lookAhead;
+        if (!lookAhead) return;
+        const advance = lookAhead.advanceWatermark ?? lookAhead.onPromoted;
+        await advance?.(index);
+    }
+
     /**
      * Promote every look-ahead entry funded by `vtxos` into a real repository
      * row, returning the persisted rows keyed by script.
@@ -994,7 +1034,7 @@ export class ContractManager implements IContractManager {
         for (const [script, entry] of hits) {
             // `upsertContract` declassifies the entry (D10).
             promoted.set(script, await this.persistAndWatchContract(entry.params));
-            await this.config.lookAhead?.onPromoted?.(entry.index);
+            await this.advanceLookAheadWatermark(entry.index);
         }
         // The watermark moved (or a gap closed): slide the band, but not from
         // inside the sync this promotion belongs to.

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -106,6 +106,7 @@ import { Batch } from "./wallet/batch";
 import {
     Wallet,
     ReadonlyWallet,
+    MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD,
     waitForIncomingFunds,
     IncomingFunds,
     selectVirtualCoins,
@@ -468,6 +469,7 @@ export {
     // Wallets
     Wallet,
     ReadonlyWallet,
+    MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD,
     SingleKey,
     ReadonlySingleKey,
     SeedIdentity,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -26,8 +26,8 @@ import type {
     DescriptorSigner,
     HDDeterministicSignCapable,
 } from "./identity";
-import { isHDWalletCapable } from "./wallet/hdWalletCapable";
-import type { HDWalletCapable } from "./wallet/hdWalletCapable";
+import { isHDWalletCapable, isHDAllocationCapable } from "./wallet/hdWalletCapable";
+import type { HDAllocationCapable, HDWalletCapable } from "./wallet/hdWalletCapable";
 import { ArkAddress } from "./script/address";
 import { VHTLC } from "./script/vhtlc";
 import { DefaultVtxo } from "./script/default";
@@ -477,6 +477,7 @@ export {
     DescriptorIdentity,
     isHDDeterministicSignCapable,
     isHDWalletCapable,
+    isHDAllocationCapable,
     deriveDescriptorLeafCompressedPubKey,
     OnchainWallet,
     Ramps,
@@ -751,6 +752,7 @@ export type {
     DescriptorSigner,
     HDDeterministicSignCapable,
     HDWalletCapable,
+    HDAllocationCapable,
     // Indexer types
     IndexerProvider,
     PageResponse,

--- a/packages/ts-sdk/src/wallet/hdWalletCapable.ts
+++ b/packages/ts-sdk/src/wallet/hdWalletCapable.ts
@@ -21,8 +21,12 @@ export interface HDWalletCapable {
      * Every descriptor the wallet may hold keys under, ascending by index:
      * the allocation watermark's band plus any descriptor persisted on a
      * contract. Empty for static wallets.
+     *
+     * `lookAhead` appends that many descriptors past the watermark without
+     * advancing it, for a restore that must probe indices no local state
+     * mentions yet.
      */
-    getUsedSigningDescriptors(): Promise<string[]>;
+    getUsedSigningDescriptors(opts?: { lookAhead?: number }): Promise<string[]>;
 
     /**
      * An {@link Identity} whose keys and signatures are those of `descriptor`.
@@ -40,5 +44,48 @@ export function isHDWalletCapable(value: unknown): value is HDWalletCapable {
         typeof v.getCurrentSigningDescriptor === "function" &&
         typeof v.getUsedSigningDescriptors === "function" &&
         typeof v.signerForDescriptor === "function"
+    );
+}
+
+/**
+ * Allocating a *fresh* index, which is strictly more than
+ * {@link HDWalletCapable}'s descriptor awareness.
+ *
+ * Deliberately a separate probe rather than three more methods on
+ * `HDWalletCapable`: widening that guard would silently demote every wallet
+ * implementing only its original surface — including one built by an older
+ * SDK — from HD-capable to static, which is exactly the breakage it documents
+ * itself as avoiding. Consumers that only read descriptors keep the narrow
+ * probe; anything deriving per-artifact secrets asks for this one.
+ */
+export interface HDAllocationCapable {
+    /**
+     * Allocate the next descriptor, advancing the watermark. `undefined` for
+     * static / `auto` wallets, which cannot allocate.
+     *
+     * Distinct from {@link HDWalletCapable.getCurrentSigningDescriptor}, which
+     * peeks: two artifacts bound to a peek share a key.
+     */
+    getNextSigningDescriptor(): Promise<string | undefined>;
+
+    /**
+     * Move the allocation watermark to `descriptor`'s index so later
+     * allocations cannot reissue it. Monotonic — a lower index is a no-op.
+     *
+     * Throws on a descriptor this wallet cannot derive, or one with no
+     * parseable trailing child index: silently mapping those to index 0 would
+     * move the watermark nowhere and let a restored artifact's index be handed
+     * out again.
+     */
+    advanceSigningDescriptorWatermark(descriptor: string): Promise<void>;
+}
+
+/** Structural type guard for {@link HDAllocationCapable}. */
+export function isHDAllocationCapable(value: unknown): value is HDAllocationCapable {
+    if (typeof value !== "object" || value === null) return false;
+    const v = value as Record<string, unknown>;
+    return (
+        typeof v.getNextSigningDescriptor === "function" &&
+        typeof v.advanceSigningDescriptorWatermark === "function"
     );
 }

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -1448,6 +1448,18 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 return Promise.resolve();
             },
 
+            getNextSigningDescriptor(): Promise<string | undefined> {
+                // Descriptor allocation is owned by the worker-side Wallet; the
+                // callback cannot cross the postMessage boundary.
+                return Promise.resolve(undefined);
+            },
+
+            advanceSigningDescriptorWatermark(): Promise<void> {
+                // See getNextSigningDescriptor(): page-side manager proxies do
+                // not mutate the worker-owned HD watermark.
+                return Promise.resolve();
+            },
+
             async isWatching(): Promise<boolean> {
                 const message: RequestIsContractManagerWatching = {
                     type: "IS_CONTRACT_MANAGER_WATCHING",

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2513,6 +2513,36 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
     }
 
     /**
+     * @see HDWalletCapable.getNextSigningDescriptor
+     */
+    async getNextSigningDescriptor(): Promise<string | undefined> {
+        const provider = this._descriptorProvider;
+        if (!(provider instanceof HDDescriptorProvider)) return undefined;
+        return provider.getNextSigningDescriptor();
+    }
+
+    /**
+     * @see HDWalletCapable.advanceSigningDescriptorWatermark
+     */
+    async advanceSigningDescriptorWatermark(descriptor: string): Promise<void> {
+        const provider = this._descriptorProvider;
+        if (!(provider instanceof HDDescriptorProvider)) return;
+        if (!provider.isOurs(descriptor)) {
+            throw new Error(`descriptor is not derivable from this wallet: ${descriptor}`);
+        }
+        // Strict on purpose: `signingDescriptorIndex` answers 0 for anything
+        // it cannot parse, and 0 is a legitimate index, so a bare or
+        // malformed descriptor would move the watermark nowhere while
+        // reporting success.
+        const match = descriptor.match(/\/(\d+)\)\s*$/);
+        const index = match ? Number(match[1]) : NaN;
+        if (!Number.isInteger(index) || index < 0) {
+            throw new Error(`descriptor has no trailing child index: ${descriptor}`);
+        }
+        await provider.advanceLastIndexUsed(index);
+    }
+
+    /**
      * @see HDWalletCapable.getUsedSigningDescriptors
      *
      * Union of the watermark band and the descriptors persisted on contracts:
@@ -2520,12 +2550,15 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
      * alone would miss indices allocated for something the wallet never
      * persisted (a swap, an externally issued invoice).
      */
-    async getUsedSigningDescriptors(): Promise<string[]> {
+    async getUsedSigningDescriptors(opts?: { lookAhead?: number }): Promise<string[]> {
         const provider = this._descriptorProvider;
         const descriptors = new Set<string>();
         if (provider instanceof HDDescriptorProvider) {
             const lastIndexUsed = await provider.getLastIndexUsed();
-            for (let i = 0; i <= (lastIndexUsed ?? -1); i++) {
+            const lookAhead = Math.max(0, Math.trunc(opts?.lookAhead ?? 0));
+            // Probing past the watermark must not move it: an index nothing
+            // has claimed yet stays available to the next allocation.
+            for (let i = 0; i <= (lastIndexUsed ?? -1) + lookAhead; i++) {
                 descriptors.add(provider.materializeDescriptorAt(i));
             }
         }

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -203,6 +203,13 @@ function extractArkProviderUrl(provider: ArkProvider): string | undefined {
  */
 export const DEFAULT_LOOK_AHEAD_WINDOW = 20;
 
+/**
+ * Maximum caller-requested HD descriptors materialized past the watermark by
+ * getUsedSigningDescriptors(). Bounds plugin/restore probes without changing
+ * the wallet's actual allocation watermark.
+ */
+export const MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD = 1_000;
+
 // Historical unilateral exit delay for mainnet (~7 days in seconds).
 // Kept so existing wallets can still discover and spend VTXOs sent to the
 // legacy address after arkd starts advertising a different delay.
@@ -2331,9 +2338,10 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         return {
             size: this._lookAheadWindow,
             currentWatermark: async () => (await provider.getLastIndexUsed()) ?? -1,
+            allocate: () => provider.getNextSigningDescriptor(),
+            advanceWatermark: (index) => provider.advanceLastIndexUsed(index),
             materialize: (index) => provider.materializeDescriptorAt(index),
             candidateDeps: () => this.receiveCandidateDeps(),
-            onPromoted: (index) => provider.advanceLastIndexUsed(index),
         };
     }
 
@@ -2461,7 +2469,9 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
             return this.getBoardingAddress();
         }
 
-        const descriptor = await provider.getNextSigningDescriptor();
+        const manager = await this.getContractManager();
+        const descriptor = await manager.getNextSigningDescriptor();
+        if (!descriptor) return this.getBoardingAddress();
         const pubKey = deriveDescriptorLeafPubKey(descriptor);
         const newBoarding = new DefaultVtxo.Script({
             ...this._boardingTapscript.options,
@@ -2469,7 +2479,6 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         });
         const csvTimelock = newBoarding.options.csvTimelock ?? DefaultVtxo.Script.DEFAULT_TIMELOCK;
 
-        const manager = await this.getContractManager();
         // Persist BEFORE swapping the visible tapscript: if registration
         // throws, the wallet keeps displaying the previous (registered)
         // boarding address — never an unwatched one (mirrors `rotate()`).
@@ -2518,7 +2527,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
     async getNextSigningDescriptor(): Promise<string | undefined> {
         const provider = this._descriptorProvider;
         if (!(provider instanceof HDDescriptorProvider)) return undefined;
-        return provider.getNextSigningDescriptor();
+        return (await this.getContractManager()).getNextSigningDescriptor();
     }
 
     /**
@@ -2539,7 +2548,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         if (!Number.isInteger(index) || index < 0) {
             throw new Error(`descriptor has no trailing child index: ${descriptor}`);
         }
-        await provider.advanceLastIndexUsed(index);
+        await (await this.getContractManager()).advanceSigningDescriptorWatermark(index);
     }
 
     /**
@@ -2555,7 +2564,16 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         const descriptors = new Set<string>();
         if (provider instanceof HDDescriptorProvider) {
             const lastIndexUsed = await provider.getLastIndexUsed();
-            const lookAhead = Math.max(0, Math.trunc(opts?.lookAhead ?? 0));
+            const requestedLookAhead = opts?.lookAhead ?? 0;
+            if (!Number.isFinite(requestedLookAhead)) {
+                throw new Error(
+                    `lookAhead must be a finite number (got ${String(requestedLookAhead)})`,
+                );
+            }
+            const lookAhead = Math.min(
+                MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD,
+                Math.max(0, Math.trunc(requestedLookAhead)),
+            );
             // Probing past the watermark must not move it: an index nothing
             // has claimed yet stays available to the next allocation.
             for (let i = 0; i <= (lastIndexUsed ?? -1) + lookAhead; i++) {
@@ -2921,7 +2939,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         // below would otherwise be handed an already-funded index as a fresh
         // receive address. See `ScanResult.highestConfirmedUsedIndex`.
         if (hd && result.highestConfirmedUsedIndex >= 0) {
-            await provider.advanceLastIndexUsed(result.highestConfirmedUsedIndex);
+            await manager.advanceSigningDescriptorWatermark(result.highestConfirmedUsedIndex);
         }
 
         // Leave the wallet watching ahead of the watermark the scan just moved.

--- a/packages/ts-sdk/test/hdWalletCapable.test.ts
+++ b/packages/ts-sdk/test/hdWalletCapable.test.ts
@@ -6,6 +6,7 @@ import {
     SingleKey,
     InMemoryWalletRepository,
     InMemoryContractRepository,
+    MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD,
     isHDWalletCapable,
     isHDAllocationCapable,
 } from "../src";
@@ -198,6 +199,31 @@ describe("HDWalletCapable", () => {
 
         expect(probed).toEqual([0, 1, 2].map((i) => provider.materializeDescriptorAt(i)));
         // An index nothing has claimed stays available to the next allocation.
+        expect(await provider.getLastIndexUsed()).toBe(0);
+        await wallet.dispose();
+    });
+
+    it("rejects non-finite look-ahead values", async () => {
+        const wallet = await makeWallet({ hd: true });
+
+        await expect(wallet.getUsedSigningDescriptors({ lookAhead: Infinity })).rejects.toThrow(
+            /finite number/,
+        );
+        await wallet.dispose();
+    });
+
+    it("caps excessive finite look-ahead before materializing descriptors", async () => {
+        const wallet = await makeWallet({ hd: true });
+        const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+
+        const probed = await wallet.getUsedSigningDescriptors({
+            lookAhead: MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD + 500,
+        });
+
+        expect(probed).toHaveLength(MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD + 1);
+        expect(probed.at(-1)).toBe(
+            provider.materializeDescriptorAt(MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD),
+        );
         expect(await provider.getLastIndexUsed()).toBe(0);
         await wallet.dispose();
     });

--- a/packages/ts-sdk/test/hdWalletCapable.test.ts
+++ b/packages/ts-sdk/test/hdWalletCapable.test.ts
@@ -7,6 +7,7 @@ import {
     InMemoryWalletRepository,
     InMemoryContractRepository,
     isHDWalletCapable,
+    isHDAllocationCapable,
 } from "../src";
 import { deriveDescriptorLeafCompressedPubKey } from "../src/identity/descriptor";
 import { HDDescriptorProvider } from "../src/wallet/hdDescriptorProvider";
@@ -98,6 +99,106 @@ describe("HDWalletCapable", () => {
         expect(await wallet.getUsedSigningDescriptors()).toEqual([
             provider.materializeDescriptorAt(0),
         ]);
+        await wallet.dispose();
+    });
+
+    it("keeps allocation a separate probe from descriptor awareness", async () => {
+        // Widening `isHDWalletCapable` instead would demote every wallet
+        // implementing only its original surface — an older SDK build, a
+        // hand-rolled double — from HD-capable to static, silently.
+        const readOnly = {
+            getCurrentSigningDescriptor: async () => undefined,
+            getUsedSigningDescriptors: async () => [],
+            signerForDescriptor: async () => undefined,
+        };
+        expect(isHDWalletCapable(readOnly)).toBe(true);
+        expect(isHDAllocationCapable(readOnly)).toBe(false);
+
+        const wallet = await makeWallet({ hd: true });
+        expect(isHDAllocationCapable(wallet)).toBe(true);
+        await wallet.dispose();
+    });
+
+    it("allocates a fresh descriptor per call, never repeating one", async () => {
+        // A peek would hand two artifacts the same key; anything deriving
+        // per-artifact secrets from it would derive them identically.
+        const wallet = await makeWallet({ hd: true });
+        const allocated = [
+            await wallet.getNextSigningDescriptor(),
+            await wallet.getNextSigningDescriptor(),
+            await wallet.getNextSigningDescriptor(),
+        ];
+        expect(new Set(allocated).size).toBe(3);
+        expect(await wallet.getCurrentSigningDescriptor()).toBe(allocated[2]);
+        await wallet.dispose();
+    });
+
+    it("cannot allocate on a static wallet", async () => {
+        const wallet = await makeWallet({ hd: false });
+        expect(await wallet.getNextSigningDescriptor()).toBeUndefined();
+        await wallet.dispose();
+    });
+
+    describe("advanceSigningDescriptorWatermark", () => {
+        it("skips a restored index so it cannot be allocated twice", async () => {
+            const wallet = await makeWallet({ hd: true });
+            const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+
+            await wallet.advanceSigningDescriptorWatermark(provider.materializeDescriptorAt(7));
+
+            expect(await wallet.getNextSigningDescriptor()).toBe(
+                provider.materializeDescriptorAt(8),
+            );
+            await wallet.dispose();
+        });
+
+        it("never rewinds", async () => {
+            const wallet = await makeWallet({ hd: true });
+            const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+            await provider.advanceLastIndexUsed(5);
+
+            await wallet.advanceSigningDescriptorWatermark(provider.materializeDescriptorAt(2));
+
+            expect(await wallet.getNextSigningDescriptor()).toBe(
+                provider.materializeDescriptorAt(6),
+            );
+            await wallet.dispose();
+        });
+
+        it("refuses a rangeable descriptor, which names no index at all", async () => {
+            // `.../0/*)` is ours but concrete-index-free. The lenient parse
+            // answers 0 for it, and 0 is a real index — so the watermark would
+            // stay put while the call reported success.
+            const wallet = await makeWallet({ hd: true });
+            const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+            const ranged = provider.materializeDescriptorAt(0).replace(/\/\d+\)$/, "/*)");
+            await provider.advanceLastIndexUsed(4);
+
+            await expect(wallet.advanceSigningDescriptorWatermark(ranged)).rejects.toThrow(
+                /no trailing child index/,
+            );
+            expect(await provider.getLastIndexUsed()).toBe(4);
+            await wallet.dispose();
+        });
+
+        it("refuses a descriptor from another seed", async () => {
+            const wallet = await makeWallet({ hd: true });
+            await expect(wallet.advanceSigningDescriptorWatermark("tr(deadbeef)")).rejects.toThrow(
+                /not derivable/,
+            );
+            await wallet.dispose();
+        });
+    });
+
+    it("appends look-ahead descriptors without moving the watermark", async () => {
+        const wallet = await makeWallet({ hd: true });
+        const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+
+        const probed = await wallet.getUsedSigningDescriptors({ lookAhead: 2 });
+
+        expect(probed).toEqual([0, 1, 2].map((i) => provider.materializeDescriptorAt(i)));
+        // An index nothing has claimed stays available to the next allocation.
+        expect(await provider.getLastIndexUsed()).toBe(0);
         await wallet.dispose();
     });
 


### PR DESCRIPTION
Stacked on `feat/arkade-swap`. Implements `plans/arkade-swap-secret-derivation.md` — the `KEY-001`
class, re-created in `@arkade-os/swap` after the Boltz instance was de-prioritised by retirement.

## What was wrong

Both RFQ entry points generated two long-lived secrets and told the caller to persist them:

| secret | spends |
| --- | --- |
| preimage (`AssetSwap.preimageHex`, plaintext hex) | the lockup's claim leaf — a solver learning it early claims without filling |
| `senderPrivateKey` (**no field existed at all**) | the lockup alone via `unilateralRefundWithoutReceiver`, once unrolled and the CSV elapses — no receiver, no server |

So the package *mandated* storage for a secret it gave no home to, and the cheap invention for the
first consumer was another plaintext string on the same record.

## What this does

Both secrets become functions of the wallet seed plus one HD-allocated descriptor:

```
descriptor = await wallet.getNextSigningDescriptor()
signer     = await wallet.signerForDescriptor(descriptor)
preimage   = sha256(signer.signSchnorrDeterministic(sha256(
               "Arkade-RFQ-Preimage-v1" ‖ xonly(32) ‖ u32le(0))))
```

The record keeps only `signingDescriptor`, which is public. A copied browser profile or a device
backup yields nothing spendable, and restore needs no secret store.

**Allocates, never peeks.** `getCurrentSigningDescriptor` returns the same descriptor until the
wallet rotates, and because the message pins `index = 0`, two swaps sharing a descriptor derive the
*identical* preimage — one solver learning its own preimage would learn another swap's. That is
worse than the status quo, so it has its own regression test.

**The fallback is typed, not silent.** Wallets that cannot allocate get
`{ derivable: false, senderPrivateKey, preimage? }` with a warning; the derivable arm returns no
secrets at all. A consumer written against one arm will not compile against the other. The util
never fabricates randomness internally — the caller constructs the fallback — so a future restore
can probe for a derived preimage and come back empty rather than be handed a fresh random one that
will never match the chain.

## The one divergence from the plan

Phase 1 said to add the new methods to `HDWalletCapable` and its guard. I did, and it broke 7
boltz-swap tests — which was the useful part: widening a *structural* guard silently demotes every
object implementing only the original surface (a hand-rolled double, or a `Wallet` built by an older
SDK) from HD-capable to static, which is precisely what that interface's doc says it exists to
avoid. Allocation ships as a separate `HDAllocationCapable` / `isHDAllocationCapable` probe;
consumers that only read descriptors keep the narrow one, and boltz-swap is untouched.
`getUsedSigningDescriptors` gained its optional `lookAhead` in place, which is backward-compatible
for implementors. Pinned by a test.

## Decisions taken (plan §9)

- **Tag** — NArk has no RFQ corridor (`grep -li rfq` over dotnet-sdk finds nothing), so there was
  nobody to agree with and this defines the scheme. `Arkade-RFQ-Preimage-v1`, deliberately distinct
  from `Arkade-Boltz-Preimage-v1` so one wallet key cannot derive the same preimage for both
  corridors. Vectors generated from this implementation are committed for NArk to pin when it grows
  one. **No dotnet-sdk issue opened** — left to raise on that side.
- **Retry** — allocate inside the request function, preserving today's behaviour (each call already
  made a fresh random key). A same-`rfqId` retry gets a new key and fails *closed*: `senderPubkey`
  travels as `client_refund_pubkey`, the solver binds it into the quoted address, and
  `verifyLockupAddress` throws `AddressMismatch` before anything is funded. Cost: one burnt HD index.
- **Fallback arm** — kept. Non-HD wallets are not refused.

## Breaking changes

Landed while the package is unpublished and consumer-free, which is the entire window: after a
consumer ships, the same change becomes a secret migration across every deployed wallet — exactly
where `KEY-001` sits on the Boltz side today.

- `requestLightningSend` / `requestOnchainSend` return `secrets` instead of `senderPrivateKey` /
  `preimage`.
- `pushRefundWithoutReceiver` / `refundIfUnresolved` take `sender: Identity` instead of
  `senderPrivateKey: Uint8Array` — build it with `senderIdentityForRfqSecrets`.
- `AssetSwap` gains `signingDescriptor?`; `preimageHex?` is demoted to fallback-only.

## Testing

- Unit: ts-sdk 2393, swap 243, boltz-swap 614 — all green.
- Regtest: swap e2e 4/4, ts-sdk `restore` + `lookAhead` e2e green (the two that exercise descriptor
  allocation).
- Determinism is asserted directly across two independently constructed wallets, not inferred from
  `aux_rand`; distinctness across N sequential swaps is the regression test for peek-instead-of-
  allocate; the restore path re-derives from a record carrying only the descriptor; and one test
  asserts a derivable swap's record carries no 64-hex field at all.

## Not covered

Seed-only discovery after the swap repository is wiped. An unspent L1 HTLC reveals too little public
quote data to rediscover, so the record stays required — deferred to the contracts/discovery
follow-up, which also needs `VHTLC.ScriptV2` row support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - RFQ swaps can now securely derive and restore secrets through supported HD wallets.
  - Swap records persist signing descriptors instead of exposing sensitive secret material.
  - Added HD wallet descriptor allocation, watermark management, and look-ahead support.
  - Added utilities for deriving swap identities, public keys, and preimages.

- **Breaking Changes**
  - RFQ request responses now return `secrets`; refund APIs accept signing identities.
  - Updated script and helper APIs require explicit sender and receiver details.

- **Bug Fixes**
  - Improved recovery metadata persistence and distinguished claimed swap statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->