### PR TITLE
fix(vtxo-manager): price the intent fee in renewVtxos and recoverVtxos

### DIFF
--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -306,6 +306,73 @@ export function capSettlementBatch<T extends { value: number }>(
     return batch;
 }
 
+/**
+ * Price a settlement's VTXO inputs against the operator's intent-fee policy,
+ * dropping any input that cannot pay for itself.
+ *
+ * An intent's fee IS `sum(inputs) - sum(outputs)`, so a single-output settlement
+ * asking for the gross input sum offers exactly zero and the server rejects the
+ * whole intent with `INTENT_INSUFFICIENT_FEE` wherever the operator prices
+ * offchain inputs at all. `subtotal` is what the inputs are worth once each has
+ * paid its own way; the caller still owes {@link deductOffchainOutputFee} on top.
+ *
+ * An input whose fee meets or exceeds its value is skipped rather than settled —
+ * it would take more out of the output than it puts in. Callers filter with this
+ * BEFORE {@link capSettlementBatch} so an uneconomic input cannot occupy a slot
+ * that a viable one behind it could have used.
+ */
+function priceSettlementInputs<T extends NormalizedExtendedVirtualCoin>(
+    vtxos: T[],
+    estimator: Estimator,
+): { payable: T[]; subtotal: bigint } {
+    const payable: T[] = [];
+    let subtotal = 0n;
+    for (const vtxo of vtxos) {
+        const inputFee = estimator.evalOffchainInput(toOffchainInputFeeParams(vtxo));
+        if (inputFee.satoshis >= vtxo.value) {
+            continue;
+        }
+        payable.push(vtxo);
+        subtotal += BigInt(vtxo.value - inputFee.satoshis);
+    }
+    return { payable, subtotal };
+}
+
+/**
+ * Take the operator's offchain output fee off a settlement's single output.
+ *
+ * The fee is evaluated on `subtotal` — the amount before this deduction — rather
+ * than on the amount finally committed, matching what
+ * {@link VtxoManager.runPeriodicSettle} and the no-argument `Wallet.settle()`
+ * branch already do. Under a percentage rate `r` that implies a fee of
+ * `r * subtotal` where the server asks only `r * subtotal * (1 - r)`, i.e. an
+ * over-payment of `r^2 * subtotal`. Deliberate: paying over is always accepted,
+ * whereas solving the fixed point exactly to recover those satoshis risks
+ * landing one under the minimum — which is the rejection this pricing exists to
+ * avoid.
+ *
+ * Can return a value below dust, or below zero, when a flat output fee outweighs
+ * the inputs; every caller checks the result against the dust threshold.
+ */
+function deductOffchainOutputFee(
+    subtotal: bigint,
+    estimator: Estimator,
+    arkAddress: string,
+): bigint {
+    // Mirror the estimator's own early return rather than reaching it through
+    // `ArkAddress.decode`: with no output program the script is never read, and
+    // an operator that doesn't price outputs shouldn't make a decodable address
+    // a precondition for renewing or recovering.
+    if (!estimator.config.offchainOutput) {
+        return subtotal;
+    }
+    const outputFee = estimator.evalOffchainOutput({
+        amount: subtotal,
+        script: hex.encode(ArkAddress.decode(arkAddress).pkScript),
+    });
+    return subtotal - BigInt(outputFee.satoshis);
+}
+
 /** Default renewal threshold in seconds (3 days). */
 export const DEFAULT_THRESHOLD_SECONDS = 259_200;
 
@@ -1106,7 +1173,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         // Filter recoverable virtual outputs and handle subdust logic
         const now = await fetchTimeHeight(this.wallet);
-        let { vtxosToRecover, totalAmount } = getRecoverableWithSubdust(allVtxos, dustAmount, now);
+        let { vtxosToRecover } = getRecoverableWithSubdust(allVtxos, dustAmount, now);
 
         if (vtxosToRecover.length === 0) {
             throw new Error("No recoverable VTXOs found");
@@ -1124,21 +1191,32 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // overflow is recovered next cycle.
         const info = await this.getInfoProvider()?.getInfo();
         const vtxoMaxAmount = info?.vtxoMaxAmount ?? -1n;
-        const capped = capSettlementBatch(byValueDescending(vtxosToRecover), vtxoMaxAmount);
+
+        // Price the batch before capping so a VTXO that cannot pay its own intent
+        // fee is dropped here rather than occupying a slot in the capped batch
+        // ahead of one that can. Subdust inputs survive this whenever they are
+        // still worth more than their own fee, which is what keeps consolidating
+        // them possible. `info` is undefined only when no ark provider is wired,
+        // which prices as zero and leaves the gross behaviour untouched.
+        const estimator = new Estimator(info?.fees.intentFee ?? {});
+        const payable = priceSettlementInputs(vtxosToRecover, estimator).payable;
+        const capped = capSettlementBatch(byValueDescending(payable), vtxoMaxAmount);
         if (capped.length < vtxosToRecover.length) {
             const recoverableCount = vtxosToRecover.length;
-            ({ vtxosToRecover, totalAmount } = getRecoverableWithSubdust(capped, dustAmount, now));
+            ({ vtxosToRecover } = getRecoverableWithSubdust(capped, dustAmount, now));
             if (vtxosToRecover.length === 0) {
                 // Recoverable VTXOs exist, but the highest-value subset that
-                // fits in one settlement stays below dust, so submitting it
-                // would be rejected and the next cycle would pick the same
-                // prefix. Distinct from the "none recoverable" case above so
-                // operators can tell a stuck-but-funded wallet from an empty
-                // one. Recovery resumes once the prefix accumulates dust.
+                // fits in one settlement — and can pay its own intent fee —
+                // stays below dust, so submitting it would be rejected and the
+                // next cycle would pick the same prefix. Distinct from the "none
+                // recoverable" case above so operators can tell a stuck-but-funded
+                // wallet from an empty one. Recovery resumes once the prefix
+                // accumulates dust.
                 throw new Error(
                     `Capped recovery batch (highest-value subset of ${recoverableCount} ` +
                         `recoverable VTXOs within the ${MAX_VTXOS_PER_SETTLEMENT}-input and ` +
-                        `${vtxoMaxAmount}-sat limits) is below the dust threshold ${dustAmount}`,
+                        `${vtxoMaxAmount}-sat limits, net of intent fees) is below the ` +
+                        `dust threshold ${dustAmount}`,
                 );
             }
         }
@@ -1154,7 +1232,28 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             await this.rotateForRecoverableInputs(vtxosToRecover, info);
         }
 
+        // Read AFTER any rotation above, so the output fee is priced against the
+        // script the recovered VTXO actually lands on.
         const arkAddress = await this.wallet.getAddress();
+
+        // The fee an intent offers IS `sum(inputs) - sum(outputs)`, so the output
+        // has to come back short by what the operator's programs price. Asking
+        // for the gross recoverable sum offers zero and the server rejects with
+        // INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
+        const { subtotal } = priceSettlementInputs(vtxosToRecover, estimator);
+        const totalAmount = deductOffchainOutputFee(subtotal, estimator, arkAddress);
+
+        // getRecoverableWithSubdust judges subdust inclusion on gross value, but
+        // the fees come off after that decision, so a batch that cleared dust
+        // gross can still land under it here. The server would reject such an
+        // output; say so instead, and let the next cycle retry once the
+        // recoverable set is worth more.
+        if (totalAmount < dustAmount) {
+            throw new Error(
+                `Recoverable amount ${totalAmount} net of intent fees is below ` +
+                    `dust threshold ${dustAmount}`,
+            );
+        }
 
         // Settle all recoverable virtual outputs back to the wallet
         return this.wallet.settle(
@@ -1394,6 +1493,23 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // renewed on the next cycle.
             const info = await this.getInfoProvider()?.getInfo();
             const vtxoMaxAmount = info?.vtxoMaxAmount ?? -1n;
+
+            // Price the candidates before capping so a VTXO that cannot pay its
+            // own intent fee is dropped here rather than occupying a slot in the
+            // capped batch ahead of one that can. `info` is undefined only when no
+            // ark provider is wired, which prices as zero and leaves the gross
+            // behaviour untouched.
+            const estimator = new Estimator(info?.fees.intentFee ?? {});
+            vtxos = priceSettlementInputs(vtxos, estimator).payable;
+            if (vtxos.length === 0) {
+                // Worded to match the benign cases the vtxo_received subscription
+                // already swallows: nothing is wrong, there is just nothing worth
+                // renewing at this fee policy.
+                throw new Error(
+                    "No VTXOs available to renew: every expiring VTXO is worth less than its own intent fee",
+                );
+            }
+
             const capped = capSettlementBatch(byExpiryAscending(vtxos, now), vtxoMaxAmount);
             if (vtxoMaxAmount >= 0n) {
                 // A VTXO whose value alone exceeds the per-output ceiling can
@@ -1424,17 +1540,8 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 }
             }
 
-            const totalAmount = vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
-
             // Get dust amount from wallet
             const dustAmount = getDustAmount(this.wallet);
-
-            // Check if total amount is above dust threshold
-            if (BigInt(totalAmount) < dustAmount) {
-                throw new Error(
-                    `Total amount ${totalAmount} is below dust threshold ${dustAmount}`,
-                );
-            }
 
             // Renewal includes recoverable VTXOs (getExpiringVtxos pulls them
             // in). If any carries a now-deprecated signer and the wallet's own
@@ -1448,7 +1555,25 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 await this.rotateForRecoverableInputs(vtxos, info);
             }
 
+            // Read AFTER any rotation above, so the output fee is priced against
+            // the script the renewed VTXO actually lands on.
             const arkAddress = await this.wallet.getAddress();
+
+            // The fee an intent offers IS `sum(inputs) - sum(outputs)`, so the
+            // output has to come back short by what the operator's programs
+            // price. Asking for the gross sum offers zero and the server rejects
+            // with INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
+            const { subtotal } = priceSettlementInputs(vtxos, estimator);
+            const totalAmount = deductOffchainOutputFee(subtotal, estimator, arkAddress);
+
+            // Dust is judged on the NET output, not the gross input sum: the fees
+            // come off after selection, so a batch that clears dust gross can
+            // land under it here.
+            if (totalAmount < dustAmount) {
+                throw new Error(
+                    `Total amount ${totalAmount} is below dust threshold ${dustAmount}`,
+                );
+            }
 
             const txid = await this.wallet.settle(
                 {
@@ -1456,7 +1581,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                     outputs: [
                         {
                             address: arkAddress,
-                            amount: BigInt(totalAmount),
+                            amount: totalAmount,
                         },
                     ],
                 },

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -1320,6 +1320,17 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      *
      * Useful for displaying to users before they decide to recover funds.
      *
+     * Both amounts are net of the operator's intent fees, so `recoverable` is
+     * what {@link recoverVtxos} would actually hand back rather than the gross
+     * sum of the inputs. `subdust` is net of the per-input fees only — the
+     * output fee is charged on the batch as a whole and is not attributed per
+     * coin — so it reports what the subdust coins are worth once each has paid
+     * its own way, and is not strictly a slice of `recoverable`. It can exceed
+     * `recoverable` where a flat output fee meets a wholly subdust wallet.
+     *
+     * The batch size caps are not applied here: they defer the overflow to the
+     * next cycle rather than reducing what is recoverable.
+     *
      * @returns Object containing recoverable amounts and subdust information
      *
      * @example
@@ -1378,12 +1389,20 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         // Subdust is CLASSIFIED on gross value — that is what makes a coin
         // subdust, and what `getRecoverableWithSubdust` judged inclusion on — but
-        // REPORTED net, so it stays a component of `recoverable` above rather
-        // than a figure on a different basis. Summing it gross lets `subdust`
-        // exceed `recoverable` whenever the recoverable set is entirely subdust,
-        // which is exactly the wallet this field exists to describe. Totalled
-        // through `subtotalOf` so an unpriced input throws instead of silently
-        // contributing zero.
+        // REPORTED net of the per-input fees, so it is on the same footing as
+        // `recoverable` rather than a figure on a different basis. Summing it
+        // gross overstated it under every non-zero input-fee policy.
+        //
+        // Net of the INPUT fees only, though: the output fee comes off the whole
+        // batch at once and does not decompose per coin, so it is not attributed
+        // here. `subdust <= recoverable` therefore holds whenever no output fee
+        // is configured or the non-subdust coins cover it, but NOT in general —
+        // a flat output fee against an all-subdust wallet still leaves `subdust`
+        // the larger of the two. Read this as "what the subdust coins are worth
+        // once each has paid its own way", not as a slice of `recoverable`.
+        //
+        // Totalled through `subtotalOf` so an unpriced input throws instead of
+        // silently contributing zero.
         const subdustAmount = subtotalOf(
             payable.filter((v) => BigInt(v.value) < dustAmount),
             net,

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -1229,6 +1229,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         const estimator = new Estimator(info?.fees.intentFee ?? {});
         const { payable, net } = priceSettlementInputs(vtxosToRecover, estimator);
         const capped = capSettlementBatch(byValueDescending(payable), vtxoMaxAmount);
+        // Compared against the pre-pricing count deliberately: this fires when
+        // EITHER filter narrowed the batch, fee pricing or a size cap, since both
+        // mean the subdust decision above was made over a set we are no longer
+        // settling and has to be re-run. Not just the cap, despite the name.
         if (capped.length < vtxosToRecover.length) {
             const recoverableCount = vtxosToRecover.length;
             // Two different things can narrow the batch, and an operator
@@ -1372,10 +1376,18 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // than settling it, so report nothing recoverable instead of a negative.
         const recoverable = priced > 0n ? priced : 0n;
 
-        // Calculate subdust amount separately for reporting
-        const subdustAmount = payable
-            .filter((v) => BigInt(v.value) < dustAmount)
-            .reduce((sum, v) => sum + BigInt(v.value), 0n);
+        // Subdust is CLASSIFIED on gross value — that is what makes a coin
+        // subdust, and what `getRecoverableWithSubdust` judged inclusion on — but
+        // REPORTED net, so it stays a component of `recoverable` above rather
+        // than a figure on a different basis. Summing it gross lets `subdust`
+        // exceed `recoverable` whenever the recoverable set is entirely subdust,
+        // which is exactly the wallet this field exists to describe. Totalled
+        // through `subtotalOf` so an unpriced input throws instead of silently
+        // contributing zero.
+        const subdustAmount = subtotalOf(
+            payable.filter((v) => BigInt(v.value) < dustAmount),
+            net,
+        );
 
         return {
             recoverable,

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -320,22 +320,50 @@ export function capSettlementBatch<T extends { value: number }>(
  * it would take more out of the output than it puts in. Callers filter with this
  * BEFORE {@link capSettlementBatch} so an uneconomic input cannot occupy a slot
  * that a viable one behind it could have used.
+ *
+ * Each survivor's net is returned alongside it so a caller that then narrows the
+ * batch can total the survivors through {@link subtotalOf} without pricing
+ * anything twice.
  */
 function priceSettlementInputs<T extends NormalizedExtendedVirtualCoin>(
     vtxos: T[],
     estimator: Estimator,
-): { payable: T[]; subtotal: bigint } {
+): { payable: T[]; net: ReadonlyMap<string, bigint> } {
     const payable: T[] = [];
-    let subtotal = 0n;
+    const net = new Map<string, bigint>();
     for (const vtxo of vtxos) {
         const inputFee = estimator.evalOffchainInput(toOffchainInputFeeParams(vtxo));
         if (inputFee.satoshis >= vtxo.value) {
             continue;
         }
         payable.push(vtxo);
-        subtotal += BigInt(vtxo.value - inputFee.satoshis);
+        net.set(`${vtxo.txid}:${vtxo.vout}`, BigInt(vtxo.value - inputFee.satoshis));
     }
-    return { payable, subtotal };
+    return { payable, net };
+}
+
+/**
+ * Total what a settlement's inputs are worth once each has paid its own intent
+ * fee, from the nets {@link priceSettlementInputs} already computed.
+ *
+ * `vtxos` must come from that call's `payable` — a batch cap may have narrowed
+ * it, nothing else may. An input with no priced net throws rather than counting
+ * as zero: silently dropping one understates the output, which offers the server
+ * MORE fee than asked and quietly overpays out of the user's own funds.
+ */
+function subtotalOf(
+    vtxos: readonly { txid: string; vout: number }[],
+    net: ReadonlyMap<string, bigint>,
+): bigint {
+    let subtotal = 0n;
+    for (const vtxo of vtxos) {
+        const priced = net.get(`${vtxo.txid}:${vtxo.vout}`);
+        if (priced === undefined) {
+            throw new Error(`Unpriced settlement input ${vtxo.txid}:${vtxo.vout}`);
+        }
+        subtotal += priced;
+    }
+    return subtotal;
 }
 
 /**
@@ -1199,19 +1227,29 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // them possible. `info` is undefined only when no ark provider is wired,
         // which prices as zero and leaves the gross behaviour untouched.
         const estimator = new Estimator(info?.fees.intentFee ?? {});
-        const payable = priceSettlementInputs(vtxosToRecover, estimator).payable;
+        const { payable, net } = priceSettlementInputs(vtxosToRecover, estimator);
         const capped = capSettlementBatch(byValueDescending(payable), vtxoMaxAmount);
         if (capped.length < vtxosToRecover.length) {
             const recoverableCount = vtxosToRecover.length;
+            // Two different things can narrow the batch, and an operator
+            // debugging a stuck wallet needs to know which one did: a size cap
+            // defers the overflow to the next cycle, whereas fee filtering means
+            // the coins cost more to move than they are worth and no later cycle
+            // will change that on its own.
+            const cappedAway = capped.length < payable.length;
             ({ vtxosToRecover } = getRecoverableWithSubdust(capped, dustAmount, now));
             if (vtxosToRecover.length === 0) {
-                // Recoverable VTXOs exist, but the highest-value subset that
-                // fits in one settlement — and can pay its own intent fee —
-                // stays below dust, so submitting it would be rejected and the
-                // next cycle would pick the same prefix. Distinct from the "none
-                // recoverable" case above so operators can tell a stuck-but-funded
-                // wallet from an empty one. Recovery resumes once the prefix
-                // accumulates dust.
+                // Recoverable VTXOs exist, but what survives stays below dust, so
+                // submitting it would be rejected and the next cycle would pick
+                // the same prefix. Distinct from the "none recoverable" case
+                // above so operators can tell a stuck-but-funded wallet from an
+                // empty one.
+                if (!cappedAway) {
+                    throw new Error(
+                        `All ${recoverableCount} recoverable VTXOs that can pay their own ` +
+                            `intent fee total less than the dust threshold ${dustAmount}`,
+                    );
+                }
                 throw new Error(
                     `Capped recovery batch (highest-value subset of ${recoverableCount} ` +
                         `recoverable VTXOs within the ${MAX_VTXOS_PER_SETTLEMENT}-input and ` +
@@ -1240,8 +1278,11 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // has to come back short by what the operator's programs price. Asking
         // for the gross recoverable sum offers zero and the server rejects with
         // INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
-        const { subtotal } = priceSettlementInputs(vtxosToRecover, estimator);
-        const totalAmount = deductOffchainOutputFee(subtotal, estimator, arkAddress);
+        const totalAmount = deductOffchainOutputFee(
+            subtotalOf(vtxosToRecover, net),
+            estimator,
+            arkAddress,
+        );
 
         // getRecoverableWithSubdust judges subdust inclusion on gross value, but
         // the fees come off after that decision, so a batch that cleared dust
@@ -1303,22 +1344,44 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         const dustAmount = getDustAmount(this.wallet);
 
-        const { vtxosToRecover, includesSubdust, totalAmount } = getRecoverableWithSubdust(
+        const { vtxosToRecover, includesSubdust } = getRecoverableWithSubdust(
             allVtxos,
             dustAmount,
             await fetchTimeHeight(this.wallet),
         );
 
+        // Priced the same way `recoverVtxos` prices what it settles. This exists
+        // to tell a user what recovery would hand back, so it has to answer net
+        // of the operator's intent fees — reporting the gross sum would promise
+        // more than the sweep delivers under any non-zero fee policy, and the two
+        // are reachable from the same worker call.
+        //
+        // Not applied here: the batch caps. They defer the overflow to the next
+        // cycle rather than reducing what is recoverable, and matching them would
+        // mean re-running the subdust decision over a capped subset. That gap
+        // predates the fee pricing and is left alone.
+        const info = await this.getInfoProvider()?.getInfo();
+        const estimator = new Estimator(info?.fees.intentFee ?? {});
+        const { payable, net } = priceSettlementInputs(vtxosToRecover, estimator);
+        const priced = deductOffchainOutputFee(
+            subtotalOf(payable, net),
+            estimator,
+            await this.wallet.getAddress(),
+        );
+        // A flat output fee can outweigh the inputs; recovery refuses that rather
+        // than settling it, so report nothing recoverable instead of a negative.
+        const recoverable = priced > 0n ? priced : 0n;
+
         // Calculate subdust amount separately for reporting
-        const subdustAmount = vtxosToRecover
+        const subdustAmount = payable
             .filter((v) => BigInt(v.value) < dustAmount)
             .reduce((sum, v) => sum + BigInt(v.value), 0n);
 
         return {
-            recoverable: totalAmount,
+            recoverable,
             subdust: subdustAmount,
             includesSubdust,
-            vtxoCount: vtxosToRecover.length,
+            vtxoCount: payable.length,
         };
     }
 
@@ -1500,7 +1563,8 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // ark provider is wired, which prices as zero and leaves the gross
             // behaviour untouched.
             const estimator = new Estimator(info?.fees.intentFee ?? {});
-            vtxos = priceSettlementInputs(vtxos, estimator).payable;
+            const { payable, net } = priceSettlementInputs(vtxos, estimator);
+            vtxos = payable;
             if (vtxos.length === 0) {
                 // Worded to match the benign cases the vtxo_received subscription
                 // already swallows: nothing is wrong, there is just nothing worth
@@ -1563,8 +1627,11 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // output has to come back short by what the operator's programs
             // price. Asking for the gross sum offers zero and the server rejects
             // with INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
-            const { subtotal } = priceSettlementInputs(vtxos, estimator);
-            const totalAmount = deductOffchainOutputFee(subtotal, estimator, arkAddress);
+            const totalAmount = deductOffchainOutputFee(
+                subtotalOf(vtxos, net),
+                estimator,
+                arkAddress,
+            );
 
             // Dust is judged on the NET output, not the gross input sum: the fees
             // come off after selection, so a batch that clears dust gross can

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -3798,6 +3798,39 @@ describe("VtxoManager - intent fee pricing", () => {
             expect(balance.vtxoCount).toBe(2);
         });
 
+        /**
+         * `subdust` reports part of what `recoverable` reports, so pricing one
+         * and not the other leaves them on different bases. A wallet whose whole
+         * recoverable set is subdust makes that visible: the two have to agree,
+         * and a gross `subdust` would exceed the net `recoverable`.
+         */
+        it("reports subdust net of fees, so it cannot exceed the recoverable total", async () => {
+            // Both are subdust against the 1000 threshold but total 1100, so
+            // getRecoverableWithSubdust folds them in.
+            const wallet = createMockWallet([swept(600), swept(500)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            // 600 less 6, and 500 less 5. Gross would report 1100.
+            expect(balance.subdust).toBe(1089n);
+            expect(balance.includesSubdust).toBe(true);
+            expect(balance.recoverable).toBe(1089n);
+            expect(balance.subdust).toBe(balance.recoverable);
+        });
+
+        it("prices only the subdust coins into subdust when the set is mixed", async () => {
+            const wallet = createMockWallet([swept(5000), swept(600), swept(500)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            // The two subdust coins net 594 and 495; the 5000 nets 4950 on top.
+            expect(balance.subdust).toBe(1089n);
+            expect(balance.recoverable).toBe(6039n);
+            expect(balance.subdust).toBeLessThan(balance.recoverable);
+        });
+
         it("omits from the preview a VTXO that cannot pay its own fee", async () => {
             const wallet = createMockWallet([swept(5000), swept(100)], ADDRESS, {
                 intentFee: { offchainInput: "250.0" },

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -3769,6 +3769,64 @@ describe("VtxoManager - intent fee pricing", () => {
         });
 
         /**
+         * The preview and the sweep are reachable from the same worker call, so a
+         * UI that previews with one and executes with the other must not show two
+         * different numbers. `getRecoverableBalance` prices exactly as
+         * `recoverVtxos` does.
+         */
+        it("previews the recoverable amount net of intent fees", async () => {
+            const fee: IntentFeeConfig = { offchainInput: "amount * 0.01" };
+            const previewWallet = createMockWallet([swept(5000), swept(3000)], ADDRESS, {
+                intentFee: fee,
+            });
+            const sweepWallet = createMockWallet([swept(5000), swept(3000)], ADDRESS, {
+                intentFee: fee,
+            });
+
+            const preview = await new VtxoManager(previewWallet).getRecoverableBalance();
+            await new VtxoManager(sweepWallet).recoverVtxos();
+
+            expect(preview.recoverable).toBe(7920n);
+            expect(preview.recoverable).toBe(settled(sweepWallet).outputs[0].amount);
+        });
+
+        it("leaves the preview gross when the operator charges nothing", async () => {
+            const wallet = createMockWallet([swept(5000), swept(3000)], ADDRESS);
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            expect(balance.recoverable).toBe(8000n);
+            expect(balance.vtxoCount).toBe(2);
+        });
+
+        it("omits from the preview a VTXO that cannot pay its own fee", async () => {
+            const wallet = createMockWallet([swept(5000), swept(100)], ADDRESS, {
+                intentFee: { offchainInput: "250.0" },
+            });
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            // The 100 costs 250 to move, so recovery drops it and so does this.
+            expect(balance.recoverable).toBe(4750n);
+            expect(balance.vtxoCount).toBe(1);
+        });
+
+        /**
+         * The capping block fires whenever the batch narrows, which fee filtering
+         * can now do on its own. An operator debugging a stuck wallet needs the
+         * cause: a size cap defers the rest to the next cycle, whereas fee
+         * filtering means no later cycle helps by itself.
+         */
+        it("names intent fees, not the size caps, when fees alone empty the batch", async () => {
+            const wallet = createMockWallet([swept(1500), swept(1200)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 1.0" },
+            });
+
+            await expect(new VtxoManager(wallet).recoverVtxos()).rejects.toThrow(
+                "All 2 recoverable VTXOs that can pay their own intent fee total less than " +
+                    "the dust threshold 1000",
+            );
+        });
+
+        /**
          * `getRecoverableWithSubdust` judges subdust inclusion on gross value, so
          * a batch can clear dust gross and land under it once the fees are off.
          * Recovery is an untimelocked all-or-nothing sweep, so this has to be a

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -12,6 +12,7 @@ import {
     SettlementConfig,
 } from "../src/wallet/vtxo-manager";
 import { IWallet, ExtendedCoin, ExtendedVirtualCoin } from "../src/wallet";
+import type { IntentFeeConfig } from "../src/arkfee";
 import { Wallet } from "../src/wallet/wallet";
 import { CSVMultisigTapscript } from "../src/script/tapscript";
 import { hex } from "@scure/base";
@@ -29,6 +30,12 @@ type MockWalletOptions = {
      * to `-1n` ("no limit") so existing recovery/renewal tests are unaffected.
      */
     vtxoMaxAmount?: bigint;
+    /**
+     * Operator intent-fee policy surfaced via `arkProvider.getInfo()`. CEL
+     * programs, exactly as arkd serves them. Defaults to `{}` — no program on
+     * any side, i.e. free — so existing recovery/renewal tests are unaffected.
+     */
+    intentFee?: IntentFeeConfig;
 };
 
 // Mock wallet implementation
@@ -62,7 +69,7 @@ const createMockWallet = (
         // non-sweep-capable and the boarding-poll paths are untouched.
         arkProvider: {
             getInfo: vi.fn().mockResolvedValue({
-                fees: { intentFee: {} },
+                fees: { intentFee: options.intentFee ?? {} },
                 vtxoMaxAmount: options.vtxoMaxAmount ?? -1n,
             }),
         },
@@ -3490,5 +3497,293 @@ describe("VtxoManager - VTXO_ALREADY_SPENT reconciliation", () => {
         } finally {
             await manager.dispose();
         }
+    });
+});
+
+/**
+ * Intent-fee pricing for the two `VtxoManager` entry points that build their own
+ * single-output settlement.
+ *
+ * An intent's fee IS `sum(inputs) - sum(outputs)`, so a settlement whose output
+ * equals the gross input sum offers exactly zero. Against an operator with any
+ * non-zero `intentFee` policy arkd rejects the intent outright —
+ * `INTENT_INSUFFICIENT_FEE (31): got 0 min expected N`, where the `got 0` is that
+ * zero literally — so renewal and recovery could never succeed. See
+ * arkade-os/ts-sdk#696.
+ *
+ * The CEL programs below are the shapes arkd actually serves: arkade-regtest ships
+ * `offchainInput: "amount * 0.01"` by default, alongside flat `"250.0"` programs
+ * on the onchain side of the same policy.
+ */
+describe("VtxoManager - intent fee pricing", () => {
+    /**
+     * A decodable ark address: the offchain output fee is priced against its
+     * pkScript, so a placeholder would fail inside `ArkAddress.decode` rather
+     * than inside the code under test.
+     */
+    const ADDRESS =
+        "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g";
+
+    /** Near enough to batch expiry that `renewVtxos` selects it. */
+    const expiring = (value: number, txid = `expiring-${value}`): ExtendedVirtualCoin => {
+        const now = Date.now();
+        return {
+            txid,
+            vout: 0,
+            value,
+            createdAt: new Date(now - 100_000),
+            virtualStatus: { state: "settled", batchExpiry: now + 5000 },
+            status: { confirmed: true },
+            isUnrolled: false,
+            isSpent: false,
+        } as any;
+    };
+
+    /** Swept by the server, so `recoverVtxos` sweeps it back. */
+    const swept = (value: number, txid = `swept-${value}`): ExtendedVirtualCoin =>
+        ({
+            txid,
+            vout: 0,
+            value,
+            virtualStatus: { state: "swept" },
+            isSwept: true,
+            isSpent: false,
+            status: { confirmed: true },
+            createdAt: new Date(),
+            isUnrolled: false,
+            forfeitTapLeafScript: [new Uint8Array(), new Uint8Array()],
+            intentTapLeafScript: [new Uint8Array(), new Uint8Array()],
+            tapTree: new Uint8Array(),
+        }) as any;
+
+    const settled = (wallet: IWallet) => (wallet.settle as any).mock.calls[0][0];
+
+    describe("renewVtxos", () => {
+        it("leaves the output at the gross sum when the operator charges nothing", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS);
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            expect(settled(wallet).outputs[0].amount).toBe(8000n);
+        });
+
+        it("pays a flat per-input fee out of the renewed output", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS, {
+                intentFee: { offchainInput: "250.0" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            // 8000 gross, less 250 for each of the two inputs.
+            expect(settled(wallet).outputs[0].amount).toBe(7500n);
+        });
+
+        it("pays a percentage per-input fee — the policy arkade-regtest ships", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            // 1% of each input: 5000 - 50 and 3000 - 30.
+            const amount = settled(wallet).outputs[0].amount;
+            expect(amount).toBe(7920n);
+            // What arkd measures as the offered fee, and what used to be zero.
+            expect(8000n - amount).toBe(80n);
+        });
+
+        it("prices the output fee too, not just the inputs", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS, {
+                intentFee: { offchainOutput: "250.0" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            expect(settled(wallet).outputs[0].amount).toBe(7750n);
+        });
+
+        /**
+         * A percentage on BOTH sides is the shape where our arithmetic and the
+         * server's genuinely disagree, so the direction of the disagreement is
+         * pinned deliberately rather than discovered in production.
+         *
+         * The output fee is a function of the output, but the output is what we
+         * are solving for, so `deductOffchainOutputFee` charges `r` of the
+         * pre-deduction subtotal while the server charges `r` of the amount it
+         * actually receives. The gap is `r^2 * subtotal`, and it falls on the
+         * safe side: the intent implies MORE fee than the minimum, so it is
+         * never rejected for underpaying.
+         */
+        it("over-pays rather than under-pays when both sides are a percentage", async () => {
+            const wallet = createMockWallet([expiring(1_000_000)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01", offchainOutput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            // 1_000_000 less 1% in = 990_000 subtotal, less 1% of that subtotal.
+            const amount = settled(wallet).outputs[0].amount;
+            expect(amount).toBe(980_100n);
+
+            // What the server checks: `inputs - outputs` against its own programs
+            // evaluated on the amount finally committed.
+            const impliedFee = 1_000_000n - amount;
+            const serverMinimum = 10_000n + 9_801n;
+            expect(impliedFee).toBe(19_900n);
+            expect(impliedFee).toBeGreaterThan(serverMinimum);
+            // Exactly r^2 * subtotal = 0.0001 * 990_000.
+            expect(impliedFee - serverMinimum).toBe(99n);
+        });
+
+        it("drops a VTXO whose own fee meets its value instead of settling it", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(1500)], ADDRESS, {
+                intentFee: { offchainInput: "2000.0" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            // Renewing the 1500 would cost 2000, destroying value outright.
+            const args = settled(wallet);
+            expect(args.inputs.map((v: ExtendedVirtualCoin) => v.txid)).toEqual(["expiring-5000"]);
+            expect(args.outputs[0].amount).toBe(3000n);
+        });
+
+        /**
+         * Worded so the `vtxo_received` subscription still classifies it as
+         * benign rather than logging it as a failure — nothing is wrong, there
+         * is just nothing worth renewing at this fee policy.
+         */
+        it("refuses when every expiring VTXO is below its own fee", async () => {
+            const wallet = createMockWallet([expiring(1500)], ADDRESS, {
+                intentFee: { offchainInput: "2000.0" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await expect(manager.renewVtxos()).rejects.toThrow("No VTXOs available to renew");
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+
+        /**
+         * The gross sum clears dust and the net does not. Settling that would
+         * just be rejected by the server, so the fees have to come off before
+         * the check rather than after it.
+         */
+        it("checks dust against the net output, not the gross input sum", async () => {
+            const wallet = createMockWallet([expiring(1200)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.5" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await expect(manager.renewVtxos()).rejects.toThrow(
+                "Total amount 600 is below dust threshold 1000",
+            );
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("recoverVtxos", () => {
+        it("leaves the output at the gross sum when the operator charges nothing", async () => {
+            const wallet = createMockWallet([swept(5000), swept(3000)], ADDRESS);
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            expect(settled(wallet).outputs[0].amount).toBe(8000n);
+        });
+
+        it("pays the operator's intent fee on recovery too", async () => {
+            const wallet = createMockWallet([swept(5000), swept(3000)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            expect(settled(wallet).outputs[0].amount).toBe(7920n);
+        });
+
+        it("prices the recovery output fee as well as the inputs", async () => {
+            const wallet = createMockWallet([swept(5000), swept(3000)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01", offchainOutput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            // 7920 subtotal, less 1% of it (79.2, rounded up to 80).
+            expect(settled(wallet).outputs[0].amount).toBe(7840n);
+        });
+
+        /**
+         * Consolidating subdust is the whole reason recovery pulls it in, so a
+         * percentage fee — which every subdust coin here can still afford — must
+         * not quietly drop it.
+         */
+        it("still consolidates subdust that can pay its own fee", async () => {
+            const vtxos = [
+                swept(5000, "regular-a"),
+                swept(3000, "regular-b"),
+                swept(100, "subdust-a"),
+                swept(100, "subdust-b"),
+                swept(100, "subdust-c"),
+            ];
+            const wallet = createMockWallet(vtxos, ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            const args = settled(wallet);
+            expect(args.inputs).toHaveLength(5);
+            // 4950 + 2970 + three subdust coins netting 99 each.
+            expect(args.outputs[0].amount).toBe(8217n);
+        });
+
+        it("drops subdust a flat fee has made uneconomic, and recovers the rest", async () => {
+            const vtxos = [
+                swept(5000, "regular-a"),
+                swept(3000, "regular-b"),
+                swept(100, "subdust-a"),
+                swept(100, "subdust-b"),
+            ];
+            const wallet = createMockWallet(vtxos, ADDRESS, {
+                intentFee: { offchainInput: "250.0" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            const args = settled(wallet);
+            expect(args.inputs.map((v: ExtendedVirtualCoin) => v.txid)).toEqual([
+                "regular-a",
+                "regular-b",
+            ]);
+            expect(args.outputs[0].amount).toBe(7500n);
+        });
+
+        /**
+         * `getRecoverableWithSubdust` judges subdust inclusion on gross value, so
+         * a batch can clear dust gross and land under it once the fees are off.
+         * Recovery is an untimelocked all-or-nothing sweep, so this has to be a
+         * loud refusal rather than an output the server silently rejects.
+         */
+        it("refuses a recovery the fee has driven under dust", async () => {
+            const wallet = createMockWallet([swept(1200)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.5" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await expect(manager.recoverVtxos()).rejects.toThrow(
+                "Recoverable amount 600 net of intent fees is below dust threshold 1000",
+            );
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -3831,6 +3831,27 @@ describe("VtxoManager - intent fee pricing", () => {
             expect(balance.subdust).toBeLessThan(balance.recoverable);
         });
 
+        /**
+         * `subdust` nets off the per-input fees but not the output fee, which is
+         * charged on the batch as a whole and does not decompose per coin. So it
+         * is not strictly a slice of `recoverable`, and a flat output fee against
+         * a wholly subdust wallet leaves it the larger of the two. Pinned rather
+         * than clamped: clamping would invent a number that answers to nothing,
+         * and the honest reading is "what the subdust coins are worth once each
+         * has paid its own way".
+         */
+        it("does not attribute the batch-level output fee to subdust", async () => {
+            const wallet = createMockWallet([swept(600), swept(500)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01", offchainOutput: "200.0" },
+            });
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            // Inputs net 594 + 495 = 1089; the flat 200 comes off the batch.
+            expect(balance.subdust).toBe(1089n);
+            expect(balance.recoverable).toBe(889n);
+            expect(balance.subdust).toBeGreaterThan(balance.recoverable);
+        });
+
         it("omits from the preview a VTXO that cannot pay its own fee", async () => {
             const wallet = createMockWallet([swept(5000), swept(100)], ADDRESS, {
                 intentFee: { offchainInput: "250.0" },


### PR DESCRIPTION
`IVtxoManager.renewVtxos()` and `recoverVtxos()` both build their settlement output as the gross sum of the inputs they selected, so the fee the intent implies — `sum(inputs) - sum(outputs)` — is always exactly zero. Against an operator with a non-zero `intentFee` policy the server rejects the intent outright and the call can never succeed. Fixes #696.

The arithmetic already existed a few hundred lines down in the same file. `runPeriodicSettle` prices every input and the output through `Estimator`, and its comment names this exact failure ("Without this, settle sends `outputAmount = sum(inputs)` and the server rejects with INTENT_INSUFFICIENT_FEE whenever the operator charges non-zero intent fees"). The no-argument `Wallet.settle()` branch does the same. Only these two entry points were left gross, and neither takes a fee argument, so a caller can't correct it from outside.

Both now price their inputs and output through two small shared helpers, `priceSettlementInputs` and `deductOffchainOutputFee`. Three things came along with that, because the fee deduction is what creates them:

An input whose own fee meets or exceeds its value is dropped — settling it takes more out of the output than it puts in. That filter runs *before* `capSettlementBatch` rather than after, so an uneconomic input can't occupy a slot a viable one behind it could have used; that's the hazard the comment in `runPeriodicSettle` already warns about ("skipping uneconomic inputs and continuing past the cap avoids an uneconomic prefix permanently starving valid VTXOs behind it"). `capSettlementBatch` itself is untouched, and its documented gross-value bound stays correct — the post-fee output is strictly smaller, so a batch that fits on gross still fits.

Dust is now judged on the net output rather than the gross input sum. `recoverVtxos` had no dust check at all, and `getRecoverableWithSubdust` decides subdust inclusion on gross value, so a batch could clear dust gross and land under it once the fees came off. Subdust still consolidates normally whenever each coin is worth more than its own fee, which is the case under any percentage policy.

The renewal throws keep the wording the `vtxo_received` subscription already classifies as benign, so a pass with nothing worth renewing stays quiet instead of turning into a reported failure.

One choice worth flagging. `deductOffchainOutputFee` evaluates the output fee on the pre-deduction subtotal, not on the amount finally committed — matching what the two working paths already do. Under a percentage output rate `r` that implies `r * subtotal` where the server asks only `r * subtotal * (1 - r)`, so it over-pays by `r^2 * subtotal` (99 sats on a 990,000-sat subtotal at 1%). Solving the fixed point would recover those satoshis, but the failure mode of getting it wrong is landing a satoshi *under* the minimum, which is the rejection this whole change exists to prevent — so I kept the conservative form and pinned the exact magnitude in a test rather than leaving it incidental. Happy to switch to an exact solve if you'd rather, though I'd suggest doing it to all four call sites at once.

I deliberately did not touch the `vtxoMaxAmount` ceiling checks. `_settleImpl` tests the projected post-output-fee amount while `runPeriodicSettle` and `capSettlementBatch` test the pre-fee running total; the latter two are conservative rather than wrong (they under-batch, never over-batch, so they can't cause a rejection), and tightening them makes settlements larger, which is the riskier direction. It's a real inconsistency and worth a follow-up, but not inside a fee fix — credit to `arkana-ai-bot` for spotting that `_settleImpl`'s version is the more correct one.

One note on scope, stated carefully because it's easy to overstate. Neither method applies a per-contract spendability gate: both select from `getVtxos({ withRecoverable: true })`, and `getExpiringAndRecoverableVtxos` pulls `canRecoverOnchain` coins into renewal explicitly, so an escrow output past its batch expiry is a candidate for renewal as well as recovery. On `master` today that is latent rather than live, at least for VHTLC: `VHTLCContractHandler` exposes only `createScript`, so `deriveContractTapscripts` (`wallet/utils.ts:83`) falls through to its `legacy.forfeit()` branch, and `VHTLC.Script` — which extends `VtxoScript` — implements no `forfeit`. Annotation throws, nothing in that chain catches it, and those VTXOs never reach the snapshot selection reads. The exposure arrives with the work that fixes annotation by adding `deriveTapscripts` for covenant handlers, which makes those VTXOs visible and selectable in the same change. So this PR neither creates nor closes that hazard; it's out of scope here and worth its own issue. Recovery's all-or-nothing sweep having no CLTV awareness is a separate matter and holds regardless.

Verified against a live arkade-regtest stack (arkd v0.9.15, `offchainInput: "amount * 0.01"`). Submitting the gross-output intent that `master` builds reproduces the bug exactly:

```
INTENT_INSUFFICIENT_FEE (31): got 0 min expected 990
```

and `renewVtxos()` on this branch is accepted, taking a 99,000-sat VTXO to 98,010 — a fee of exactly 990, the server's minimum to the satoshi. Incidentally, arkd's own `ark redeem-notes` CLI fails the same way on that stack, which is why the e2e `beforeEachFaucet` helper can't fund against a fee-charging operator; I funded through onchain boarding instead.

Eighteen unit tests cover zero fee (unchanged behaviour), flat and percentage input fees, flat and percentage output fees, both percentages together with the over-payment pinned exactly, an input whose fee exceeds its value, dust against the net, the subdust paths on recovery, and the preview agreeing with the sweep. Reverting the source while keeping the tests fails 12 of the original 14 — the two that still pass are precisely the zero-fee "unchanged behaviour" cases — and reverting the preview to the gross sum fails its two. Gate before and after: `lint`, all three `typecheck`s and `build` clean; ts-sdk unit went 2326 passed / 1 skipped to 2344 passed / 1 skipped (+18, no pre-existing test changed), `swap` 67 and `boltz-swap` 614 both unmoved.

Three things landed from @arkana-ai-bot's review. `getRecoverableBalance` still answered with the gross sum while `recoverVtxos` settles that minus fees, and both are reachable from the same service-worker call — so a UI previewing with one and executing with the other showed two different numbers under any non-zero policy. It now prices exactly as the sweep does, including `vtxoCount`. The batch caps are still not applied to the preview: they defer overflow to the next cycle rather than reducing what is recoverable, and matching them would mean re-running the subdust decision over a capped subset. That gap predates the fee pricing and is noted where it lives rather than fixed here. Worth naming the shape, because it is the same rule the covenant-spendability work applies elsewhere — a preview exists to say what the operation would do, so it has to agree with it; fees and spendability are two dimensions of one idea.

`priceSettlementInputs` was also being called twice per entry point, once to filter and once for the subtotal after capping, where the second call could never drop anything and just re-ran the fee evaluation to re-sum values it already had. It now returns each survivor's net and `subtotalOf` totals whichever survived, throwing on an input it has no net for rather than counting it as zero — silently skipping one understates the output, which overpays the operator out of the user's own funds. And the capping block's error named the size caps even when fee filtering alone emptied the batch with no cap binding; those want different responses from an operator, so they are now two messages.

Two more went on after that, and how they were found is the interesting part. I backported this fix to `feat/arkade-swap` as #701, because that is the branch the team works on and the one downstream pins, and asking @arkana-ai-bot to review the backport turned up a defect in *this* PR that its own review pass had not caught. Worth stating plainly: it took a second reviewer pass, on a second PR, to find a bug in the first one.

The defect is that this PR priced `recoverable` net while leaving `getRecoverableBalance`'s companion `subdust` field summing gross `value`. That puts the two on different bases, and for a wallet whose recoverable set is entirely subdust — precisely the wallet the field exists to describe — `subdust` could come back larger than `recoverable`. Note this is a defect the fee pricing *introduced*: before it, both fields were gross and therefore consistent. Subdust is still classified on gross value, which is what makes a coin subdust and what `getRecoverableWithSubdust` judged inclusion on, but it is now reported net. I totalled it through the existing `subtotalOf` rather than a `net.get(...) ?? 0n` lookup: a `?? 0n` fallback silently understates `subdust` if an unpriced input ever reaches it, and `subtotalOf` already throws on exactly that case for the same reason this PR gives elsewhere — on a money path an input silently counting as zero is the failure mode worth preventing. Everything in `payable` is priced by construction, so the throw is unreachable today; it is there so it stays unreachable, and the reasoning is in the commit message so it does not get "simplified" back.

That fix then needed its own claim narrowed, which is the part most likely to be got wrong later. My first comment called `subdust` a component of `recoverable`. It is not, quite: `subdust` is net of the per-input fees but **not** of the output fee, because that one is charged on the batch as a whole and does not decompose per coin. So `subdust <= recoverable` holds when no output fee is configured or the non-subdust coins cover it, but not in general. @arkana-ai-bot supplied a counter-example and I reproduced it rather than reasoning about it: two coins at 600 and 500 with a 1% input fee and a flat 200 output fee gives `subdust` 1089 against `recoverable` 889. Rather than clamp — which would invent a number that answers to nothing and would still mislead on mixed sets, where the non-subdust coins absorb the output fee — the public TSDoc now says what the field actually is, and a test pins the case so a future refactor cannot quietly break it in the other direction. A documented invariant with no test is one refactor away from being wrong.

Gate after those two commits, against a baseline recorded on this branch's previous head: `lint`, `build` and all three `typecheck`s clean; ts-sdk unit 2344 → 2347 passed / 1 skipped across the same 154 files, with no pre-existing test moved; `swap` 67 and `boltz-swap` 614 unmoved. Reverting the subdust pricing while keeping the tests fails all three new ones with `expected 1100n to be 1089n`, and leaves the thirteen pre-existing subdust tests passing, since those run at zero fee where gross and net coincide.

One note on what was actually reviewed, since a green check does not always mean a review happened. On this PR both are real: @arkana-ai-bot's passes caught the defects above, and CodeRabbit did post a review here. On #701 it did not — its check passes carrying *"Review skipped: reviews are disabled for this base branch"*, which renders identically to a completed review in the checks list. So the backport has had one reviewer, not two, and that is worth knowing before reading its green ticks as agreement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet recovery and renewal calculations to account for settlement and output fees.
  * Automatically excludes uneconomic transaction outputs and prevents settlements that would fall below the minimum dust threshold.
  * Recovery balance reporting now reflects the net recoverable value after fees.
  * Recovery can handle fee-affordable amounts below the standard dust threshold.
  * Renewal clearly reports when no eligible outputs remain after fees.
  * Fee-aware previews now match final transaction amounts.
  * Zero-fee behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



