### PR TITLE
feat(providers): let consumers supply the EventSource

### DIFF
--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -1146,7 +1146,7 @@ const wallet = await Wallet.create({
 
 ### Using with Node.js
 
-Node.js does not provide a global `EventSource` implementation. The SDK relies on `EventSource` for Server-Sent Events during settlement (onboarding/offboarding) and contract watching. You must polyfill it before using the SDK:
+Node.js does not provide a global `EventSource` implementation (24.x has one behind `--experimental-eventsource`). The SDK relies on `EventSource` for Server-Sent Events during settlement (onboarding/offboarding) and contract watching, so tell it which one to use:
 
 ```bash
 npm install eventsource
@@ -1154,11 +1154,14 @@ npm install eventsource
 
 ```typescript
 import { EventSource } from "eventsource";
-(globalThis as any).EventSource = EventSource;
+import { configureEventSource, Wallet } from "@arkade-os/sdk";
 
-// Use dynamic import so the polyfill is set before the SDK evaluates
-const { Wallet } = await import("@arkade-os/sdk");
+configureEventSource((url) => new EventSource(url) as unknown as globalThis.EventSource);
 ```
+
+Order does not matter: the factory is resolved when a stream opens, not when the SDK is imported, so no dynamic-import dance is needed. A single provider can override it — `new RestIndexerProvider(url, { eventSource })` — for a process that needs different transports per connection.
+
+Assigning `globalThis.EventSource` still works and is still the last resort in the resolution order (per-provider option → `configureEventSource` → global).
 
 If you also need IndexedDB persistence (e.g. for `WalletRepository`), set up the shim before any SDK import:
 
@@ -1173,8 +1176,10 @@ setGlobalVars(null, { checkOrigin: false });
 ```
 
 > **Note:** `eventsource` and `indexeddbshim` are optional peer dependencies.
-> Without the `EventSource` polyfill, settlement operations will fail with
-> `ReferenceError: EventSource is not defined`.
+> With no `EventSource` available, settlement fails with a typed
+> `EventSourceUnavailableError` naming the remedy, and contract watching warns
+> once and falls back to its failsafe polling — it does not retry a missing
+> global, and it does not go quiet either.
 
 See [`examples/node/multiple-wallets.ts`](examples/node/multiple-wallets.ts) for a complete working example.
 

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -1156,7 +1156,7 @@ npm install eventsource
 import { EventSource } from "eventsource";
 import { configureEventSource, Wallet } from "@arkade-os/sdk";
 
-configureEventSource((url) => new EventSource(url) as unknown as globalThis.EventSource);
+configureEventSource((url) => new EventSource(url));
 ```
 
 Order does not matter: the factory is resolved when a stream opens, not when the SDK is imported, so no dynamic-import dance is needed. A single provider can override it — `new RestIndexerProvider(url, { eventSource })` — for a process that needs different transports per connection.

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -424,11 +424,11 @@ export class ContractWatcher {
                     console.error(e);
                 }
                 this.connectionState = "disconnected";
+                if (this.reportEventSourceUnavailable(e)) return;
                 this.eventCallback?.({
                     type: "connection_reset",
                     timestamp: Date.now(),
                 });
-                if (this.reportEventSourceUnavailable(e)) return;
                 this.scheduleReconnect();
             });
         } catch (error) {
@@ -436,11 +436,11 @@ export class ContractWatcher {
                 console.error("ContractWatcher connection failed:", error);
             }
             this.connectionState = "disconnected";
+            if (this.reportEventSourceUnavailable(error)) return;
             this.eventCallback?.({
                 type: "connection_reset",
                 timestamp: Date.now(),
             });
-            if (this.reportEventSourceUnavailable(error)) return;
             this.scheduleReconnect();
         }
     }
@@ -452,7 +452,9 @@ export class ContractWatcher {
      * Reconnecting is pointless here — a missing global is not a dropped
      * connection, and the default backoff (unlimited attempts, capped at 5s)
      * would otherwise retry it forever, logging each failure and firing a
-     * `connection_reset` every few seconds for the life of the wallet.
+     * `connection_reset` every few seconds for the life of the wallet. Not even
+     * one goes out: subscribers read that event as "the stream dropped, resync
+     * and expect it back", and here it never opened and never will.
      * Failsafe polling keeps running, so the watcher stays correct and merely
      * slower; what it loses is push latency.
      */

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -5,6 +5,7 @@ import { extendVirtualCoinForContract } from "../wallet/utils";
 import { WalletRepository } from "../repositories/walletRepository";
 import { Contract, ContractVtxo, ContractEventCallback, ContractEvent } from "./types";
 import { isEventSourceError } from "../providers/utils";
+import { isEventSourceUnavailableError } from "../providers/eventSource";
 import { getVtxosForContract } from "./vtxoOwnership";
 
 /**
@@ -143,6 +144,8 @@ export class ContractWatcher {
     /** See {@link withCoalescedSubscription}. */
     private subscriptionBatchDepth = 0;
     private subscriptionUpdateDeferred = false;
+    /** See {@link reportEventSourceUnavailable} — said once, not per attempt. */
+    private eventSourceReported = false;
 
     /**
      * Create a contract watcher with the given providers and polling settings.
@@ -417,7 +420,7 @@ export class ContractWatcher {
                 // is restored and events are fired.
                 if (isEventSourceError(e)) {
                     console.debug("ContractWatcher subscription disconnected; reconnecting");
-                } else {
+                } else if (!isEventSourceUnavailableError(e)) {
                     console.error(e);
                 }
                 this.connectionState = "disconnected";
@@ -425,17 +428,45 @@ export class ContractWatcher {
                     type: "connection_reset",
                     timestamp: Date.now(),
                 });
+                if (this.reportEventSourceUnavailable(e)) return;
                 this.scheduleReconnect();
             });
         } catch (error) {
-            console.error("ContractWatcher connection failed:", error);
+            if (!isEventSourceUnavailableError(error)) {
+                console.error("ContractWatcher connection failed:", error);
+            }
             this.connectionState = "disconnected";
             this.eventCallback?.({
                 type: "connection_reset",
                 timestamp: Date.now(),
             });
+            if (this.reportEventSourceUnavailable(error)) return;
             this.scheduleReconnect();
         }
+    }
+
+    /**
+     * Handle "this environment has no `EventSource`": say so once, loudly and
+     * actionably, and answer whether the caller should skip reconnecting.
+     *
+     * Reconnecting is pointless here — a missing global is not a dropped
+     * connection, and the default backoff (unlimited attempts, capped at 5s)
+     * would otherwise retry it forever, logging each failure and firing a
+     * `connection_reset` every few seconds for the life of the wallet.
+     * Failsafe polling keeps running, so the watcher stays correct and merely
+     * slower; what it loses is push latency.
+     */
+    private reportEventSourceUnavailable(error: unknown): boolean {
+        if (!isEventSourceUnavailableError(error)) return false;
+        if (!this.eventSourceReported) {
+            this.eventSourceReported = true;
+            console.warn(
+                `ContractWatcher: contract events are OFF and will not be retried — ` +
+                    `falling back to polling every ${this.config.failsafePollIntervalMs}ms. ` +
+                    error.message,
+            );
+        }
+        return true;
     }
 
     /**

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -262,6 +262,15 @@ import {
     type EmulatorInfo,
     type ConnectorTreeNode,
 } from "./providers/emulator";
+export {
+    EventSourceUnavailableError,
+    configureEventSource,
+    getConfiguredEventSource,
+    isEventSourceUnavailableError,
+    resolveEventSource,
+    type EventSourceCapable,
+    type EventSourceFactory,
+} from "./providers/eventSource";
 import type {
     ArkadeBatchInput,
     ArkadeExtendedCoin,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -270,6 +270,7 @@ export {
     resolveEventSource,
     type EventSourceCapable,
     type EventSourceFactory,
+    type EventSourceLike,
 } from "./providers/eventSource";
 import type {
     ArkadeBatchInput,

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -4,6 +4,12 @@ import { hex } from "@scure/base";
 import { Vtxo } from "./indexer";
 import { eventSourceIterator, isEventSourceError } from "./utils";
 import {
+    isEventSourceUnavailableError,
+    resolveEventSource,
+    type EventSourceCapable,
+    type EventSourceFactory,
+} from "./eventSource";
+import {
     ArkErrorName,
     isArkError,
     maybeArkError,
@@ -291,7 +297,15 @@ export interface ArkProvider {
  * ```
  */
 export class RestArkProvider implements ArkProvider {
-    constructor(public serverUrl: string = DEFAULT_ARKADE_SERVER_URL) {}
+    /** Overrides {@link configureEventSource} for this provider's streams. */
+    protected readonly eventSource?: EventSourceFactory;
+
+    constructor(
+        public serverUrl: string = DEFAULT_ARKADE_SERVER_URL,
+        options: EventSourceCapable = {},
+    ) {
+        this.eventSource = options.eventSource;
+    }
 
     /**
      * Last server-info digest seen (from {@link getInfo}). Sent as `X-Digest`
@@ -674,7 +688,9 @@ export class RestArkProvider implements ArkProvider {
 
             try {
                 while (!signal?.aborted) {
-                    const currentIterator = eventSourceIterator(new EventSource(url + queryParams));
+                    const currentIterator = eventSourceIterator(
+                        resolveEventSource(self.eventSource)(url + queryParams),
+                    );
                     iterator = currentIterator;
 
                     try {
@@ -709,6 +725,12 @@ export class RestArkProvider implements ArkProvider {
                         if (isEventSourceError(error)) {
                             throw error;
                         }
+
+                        // A missing EventSource is an environment fact, not a
+                        // stream failure: the caller reports it once (see
+                        // ContractWatcher), where this loop would log it on
+                        // every reconnect attempt.
+                        if (isEventSourceUnavailableError(error)) throw error;
 
                         console.error("Event stream error:", error);
                         throw error;
@@ -749,7 +771,9 @@ export class RestArkProvider implements ArkProvider {
             try {
                 while (!signal?.aborted) {
                     try {
-                        const currentIterator = eventSourceIterator(new EventSource(url));
+                        const currentIterator = eventSourceIterator(
+                            resolveEventSource(self.eventSource)(url),
+                        );
                         iterator = currentIterator;
 
                         for await (const event of currentIterator) {
@@ -783,6 +807,12 @@ export class RestArkProvider implements ArkProvider {
                         if (isEventSourceError(error)) {
                             throw error;
                         }
+
+                        // A missing EventSource is an environment fact, not a
+                        // stream failure: the caller reports it once (see
+                        // ContractWatcher), where this loop would log it on
+                        // every reconnect attempt.
+                        if (isEventSourceUnavailableError(error)) throw error;
 
                         console.error("Transaction stream error:", error);
                         throw error;

--- a/packages/ts-sdk/src/providers/eventSource.ts
+++ b/packages/ts-sdk/src/providers/eventSource.ts
@@ -1,0 +1,106 @@
+/**
+ * Where the SDK gets its `EventSource`.
+ *
+ * Every server-sent-events stream this SDK opens — settlement events, the tx
+ * feed, the indexer script subscription — needs one, and until now each site
+ * reached for the global. That works in browsers and, via
+ * {@link ExpoArkProvider}/{@link ExpoIndexerProvider}, in React Native. It does
+ * NOT work in Node, which exposes `EventSource` only behind
+ * `--experimental-eventsource` (24.x) — so a CLI, a server-side wallet or a
+ * background worker got a `ReferenceError` out of the stream and everything
+ * event-driven degraded to whatever polling happened to be running.
+ *
+ * Resolution order, per call: an explicit per-provider factory, then whatever
+ * {@link configureEventSource} was given, then the global. When none answers,
+ * {@link resolveEventSource} throws {@link EventSourceUnavailableError} rather
+ * than a bare `ReferenceError`, so callers can tell "this environment has no
+ * SSE" from "the connection dropped" — a distinction that matters, because the
+ * first is not worth reconnecting for and the second is.
+ */
+
+/** Opens an SSE connection to `url`. `new EventSource(url)`, as a value. */
+export type EventSourceFactory = (url: string) => EventSource;
+
+/** Options shared by every provider that opens an SSE stream. */
+export interface EventSourceCapable {
+    /**
+     * Where this provider gets its `EventSource`, overriding
+     * {@link configureEventSource} and the global. Use it when one process
+     * needs different transports per connection; otherwise configure once.
+     */
+    eventSource?: EventSourceFactory;
+}
+
+const GUIDANCE =
+    "Pass one with configureEventSource(url => new EventSource(url)) — in Node, from the " +
+    "`eventsource` package or by running with --experimental-eventsource. In React Native, " +
+    "use ExpoArkProvider / ExpoIndexerProvider instead.";
+
+/**
+ * No `EventSource` could be resolved, so no SSE stream can be opened.
+ *
+ * A property of the environment, not of the connection: retrying cannot fix it,
+ * which is why {@link ContractWatcher} reports it once and stops reconnecting
+ * instead of looping on it.
+ */
+export class EventSourceUnavailableError extends Error {
+    constructor() {
+        super(`no EventSource is available, so server-sent events cannot be opened. ${GUIDANCE}`);
+        this.name = "EventSourceUnavailableError";
+    }
+}
+
+/**
+ * Type guard for {@link EventSourceUnavailableError}.
+ *
+ * Falls back to the `name` because a custom error crossing the service-worker
+ * `postMessage` boundary arrives as a plain `Error` — the same reason
+ * `ProviderUnavailableError` keeps its state in the message.
+ */
+export function isEventSourceUnavailableError(error: unknown): error is Error {
+    return (
+        error instanceof EventSourceUnavailableError ||
+        (error instanceof Error && error.name === "EventSourceUnavailableError")
+    );
+}
+
+let configured: EventSourceFactory | undefined;
+
+/**
+ * Set the `EventSource` every provider uses by default. Call once at startup,
+ * before opening a wallet; pass `undefined` to go back to the global.
+ *
+ * This exists because the provider-level option cannot reach providers the SDK
+ * builds for you — `Wallet.create({ arkServerUrl })` constructs both itself.
+ *
+ * @example
+ * ```typescript
+ * import { EventSource } from "eventsource";
+ * configureEventSource((url) => new EventSource(url) as unknown as EventSource);
+ * ```
+ */
+export function configureEventSource(factory?: EventSourceFactory): void {
+    configured = factory;
+}
+
+/** What {@link configureEventSource} last set, if anything. */
+export function getConfiguredEventSource(): EventSourceFactory | undefined {
+    return configured;
+}
+
+/**
+ * Resolve the factory to open a stream with, or throw
+ * {@link EventSourceUnavailableError}.
+ *
+ * The global is read on every call rather than captured at module load: a test
+ * (or a polyfill) that assigns `globalThis.EventSource` after import must still
+ * be seen.
+ */
+export function resolveEventSource(override?: EventSourceFactory): EventSourceFactory {
+    const factory =
+        override ??
+        configured ??
+        (typeof EventSource === "undefined" ? undefined : (url: string) => new EventSource(url));
+    if (!factory) throw new EventSourceUnavailableError();
+    return factory;
+}

--- a/packages/ts-sdk/src/providers/eventSource.ts
+++ b/packages/ts-sdk/src/providers/eventSource.ts
@@ -18,8 +18,23 @@
  * first is not worth reconnecting for and the second is.
  */
 
+/**
+ * The slice of `EventSource` this SDK actually uses.
+ *
+ * Structural rather than the DOM type on purpose: Node's `eventsource` package
+ * and the React Native polyfills are not DOM `EventSource`s, and demanding one
+ * made every consumer launder a perfectly capable object through
+ * `as unknown as EventSource` — a cast that hides real mismatches as readily as
+ * it waves through this one.
+ */
+export interface EventSourceLike {
+    addEventListener(type: "message" | "error", listener: (event: MessageEvent) => void): void;
+    removeEventListener(type: "message" | "error", listener: (event: MessageEvent) => void): void;
+    close(): void;
+}
+
 /** Opens an SSE connection to `url`. `new EventSource(url)`, as a value. */
-export type EventSourceFactory = (url: string) => EventSource;
+export type EventSourceFactory = (url: string) => EventSourceLike;
 
 /** Options shared by every provider that opens an SSE stream. */
 export interface EventSourceCapable {
@@ -76,7 +91,7 @@ let configured: EventSourceFactory | undefined;
  * @example
  * ```typescript
  * import { EventSource } from "eventsource";
- * configureEventSource((url) => new EventSource(url) as unknown as EventSource);
+ * configureEventSource((url) => new EventSource(url));
  * ```
  */
 export function configureEventSource(factory?: EventSourceFactory): void {

--- a/packages/ts-sdk/src/providers/indexer.ts
+++ b/packages/ts-sdk/src/providers/indexer.ts
@@ -3,6 +3,12 @@ import { AssetDetails, AssetMetadata, Outpoint, VirtualCoin } from "../wallet";
 import { convertVtxo } from "../wallet/vtxo";
 import { isFetchTimeoutError } from "./ark";
 import { eventSourceIterator, isEventSourceError } from "./utils";
+import {
+    isEventSourceUnavailableError,
+    resolveEventSource,
+    type EventSourceCapable,
+    type EventSourceFactory,
+} from "./eventSource";
 import { MetadataList } from "../extension/asset";
 import { DEFAULT_ARKADE_SERVER_URL } from "../networks";
 import { baseFetch } from "../utils/fetch";
@@ -386,7 +392,15 @@ export interface IndexerProvider {
  * ```
  */
 export class RestIndexerProvider implements IndexerProvider {
-    constructor(public serverUrl: string = DEFAULT_ARKADE_SERVER_URL) {}
+    /** Overrides {@link configureEventSource} for this provider's subscription. */
+    protected readonly eventSource?: EventSourceFactory;
+
+    constructor(
+        public serverUrl: string = DEFAULT_ARKADE_SERVER_URL,
+        options: EventSourceCapable = {},
+    ) {
+        this.eventSource = options.eventSource;
+    }
 
     async getVtxoTree(
         batchOutpoint: Outpoint,
@@ -532,6 +546,10 @@ export class RestIndexerProvider implements IndexerProvider {
         abortSignal: AbortSignal,
     ): AsyncIterableIterator<SubscriptionResponse> {
         const url = `${this.serverUrl}/v1/indexer/script/subscription/${subscriptionId}`;
+        // Captured, not resolved, here: resolution has to happen per connection
+        // attempt inside the generator, so a caller that abandons the iterator
+        // never triggers it and a late `configureEventSource` is still seen.
+        const override = this.eventSource;
         let iterator: ReturnType<typeof eventSourceIterator> | null = null;
         const closeIterator = () => iterator?.close();
 
@@ -542,7 +560,9 @@ export class RestIndexerProvider implements IndexerProvider {
             try {
                 while (!abortSignal?.aborted) {
                     try {
-                        const currentIterator = eventSourceIterator(new EventSource(url));
+                        const currentIterator = eventSourceIterator(
+                            resolveEventSource(override)(url),
+                        );
                         iterator = currentIterator;
 
                         for await (const event of currentIterator) {
@@ -583,6 +603,12 @@ export class RestIndexerProvider implements IndexerProvider {
                         if (isEventSourceError(error)) {
                             throw error;
                         }
+
+                        // A missing EventSource is an environment fact, not a
+                        // stream failure: the caller reports it once (see
+                        // ContractWatcher), where this loop would log it on
+                        // every reconnect attempt.
+                        if (isEventSourceUnavailableError(error)) throw error;
 
                         console.error("Subscription error:", error);
                         throw error;

--- a/packages/ts-sdk/src/providers/utils.ts
+++ b/packages/ts-sdk/src/providers/utils.ts
@@ -1,3 +1,5 @@
+import type { EventSourceLike } from "./eventSource";
+
 export type ManagedEventSourceIterator = AsyncGenerator<MessageEvent, void, unknown> & {
     close(): void;
 };
@@ -15,7 +17,7 @@ function createAbortError(): Error {
  * close() closes the EventSource, removes listeners, and wakes any pending
  * next() even when the browser does not emit an error from EventSource.close().
  */
-export function eventSourceIterator(eventSource: EventSource): ManagedEventSourceIterator {
+export function eventSourceIterator(eventSource: EventSourceLike): ManagedEventSourceIterator {
     const messageQueue: MessageEvent[] = [];
     const errorQueue: Error[] = [];
     let messageResolve: ((value: MessageEvent) => void) | null = null;

--- a/packages/ts-sdk/test/contracts/watcher.test.ts
+++ b/packages/ts-sdk/test/contracts/watcher.test.ts
@@ -9,12 +9,15 @@ import {
     type IndexerProvider,
     InMemoryContractRepository,
     InMemoryWalletRepository,
+    EventSourceUnavailableError,
 } from "../../src";
+import { saveVtxosForContract } from "../../src/contracts/vtxoOwnership";
 import type { SubscriptionResponse } from "../../src/providers/indexer";
 import { hex } from "@scure/base";
 import {
     createDefaultContractParams,
     createDelegateContractParams,
+    createMockExtendedVtxo,
     createMockIndexerProvider,
     createMockVtxo,
     TEST_DEFAULT_SCRIPT,
@@ -379,6 +382,82 @@ describe("ContractWatcher", () => {
             } finally {
                 warnSpy.mockRestore();
                 await watcher.stopWatching();
+            }
+        });
+    });
+    describe("when the environment has no EventSource", () => {
+        const noEventSource = () =>
+            Object.assign(createMockIndexerProvider(), {
+                getSubscription: vi.fn(() => ({
+                    [Symbol.asyncIterator]: () => ({
+                        next: () => Promise.reject(new EventSourceUnavailableError()),
+                    }),
+                })),
+            }) as IndexerProvider;
+
+        it("says so once, stops reconnecting, and keeps polling", async () => {
+            vi.useFakeTimers();
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+            const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+            const indexer = noEventSource();
+            const walletRepository = new InMemoryWalletRepository();
+            const watcher = new ContractWatcher({
+                indexerProvider: indexer,
+                walletRepository,
+                failsafePollIntervalMs: 1_000,
+            });
+            const contract: Contract = {
+                type: "default",
+                params: createDefaultContractParams(),
+                script: TEST_DEFAULT_SCRIPT,
+                address: "address",
+                state: "active",
+                createdAt: Date.now(),
+            };
+            const events: ContractEvent[] = [];
+
+            try {
+                await watcher.addContract(contract);
+                await watcher.startWatching((event) => events.push(event));
+                await vi.advanceTimersByTimeAsync(0);
+
+                const attemptsAfterConnect = (indexer.getSubscription as any).mock.calls.length;
+                const warning = warnSpy.mock.calls.find(
+                    (call) =>
+                        typeof call[0] === "string" && call[0].includes("contract events are OFF"),
+                );
+                expect(warning).toBeDefined();
+                // The remedy has to travel with the warning, not just the type.
+                expect(String(warning?.[0])).toContain("configureEventSource");
+                // A ReferenceError used to land here every few seconds.
+                expect(errorSpy).not.toHaveBeenCalled();
+
+                // Past several reconnect windows (backoff caps at 5s): no retry
+                // and no second warning...
+                await vi.advanceTimersByTimeAsync(30_000);
+                expect((indexer.getSubscription as any).mock.calls.length).toBe(
+                    attemptsAfterConnect,
+                );
+                expect(
+                    warnSpy.mock.calls.filter(
+                        (call) =>
+                            typeof call[0] === "string" &&
+                            call[0].includes("contract events are OFF"),
+                    ),
+                ).toHaveLength(1);
+
+                // ...while the failsafe poll still delivers: a VTXO that lands
+                // after the stream gave up is still reported, just later.
+                await saveVtxosForContract(walletRepository, contract, [
+                    createMockExtendedVtxo({ script: contract.script, txid: "ab".repeat(32) }),
+                ]);
+                await vi.advanceTimersByTimeAsync(2_000);
+                expect(events.map((e) => e.type)).toContain("vtxo_received");
+            } finally {
+                await watcher.stopWatching();
+                warnSpy.mockRestore();
+                errorSpy.mockRestore();
+                vi.useRealTimers();
             }
         });
     });

--- a/packages/ts-sdk/test/contracts/watcher.test.ts
+++ b/packages/ts-sdk/test/contracts/watcher.test.ts
@@ -445,6 +445,9 @@ describe("ContractWatcher", () => {
                             call[0].includes("contract events are OFF"),
                     ),
                 ).toHaveLength(1);
+                // A reset invites subscribers to resync and wait for the stream
+                // back; there is no stream to come back.
+                expect(events.map((e) => e.type)).not.toContain("connection_reset");
 
                 // ...while the failsafe poll still delivers: a VTXO that lands
                 // after the stream gave up is still reported, just later.

--- a/packages/ts-sdk/test/providers/eventSource.test.ts
+++ b/packages/ts-sdk/test/providers/eventSource.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Where the SDK gets its `EventSource`, and what it does when there is none.
+ *
+ * The environment this file runs in HAS a global (test/polyfill.js assigns one
+ * from the `eventsource` package), so every "absent" case here removes it
+ * deliberately — which is also the only honest way to reproduce plain Node.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    EventSourceUnavailableError,
+    RestArkProvider,
+    RestIndexerProvider,
+    configureEventSource,
+    getConfiguredEventSource,
+    isEventSourceUnavailableError,
+    resolveEventSource,
+    type EventSourceFactory,
+} from "../../src";
+
+/** A factory that records its calls and returns something inert. */
+const fakeFactory = (): EventSourceFactory & { urls: string[] } => {
+    const urls: string[] = [];
+    const factory = ((url: string) => {
+        urls.push(url);
+        return {
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            close: () => {},
+        } as unknown as EventSource;
+    }) as EventSourceFactory & { urls: string[] };
+    factory.urls = urls;
+    return factory;
+};
+
+/** Run `fn` with no global EventSource — plain Node, in other words. */
+const withoutGlobal = async (fn: () => Promise<void> | void): Promise<void> => {
+    const saved = globalThis.EventSource;
+    // @ts-expect-error deleting an optional global for the duration of a test
+    delete globalThis.EventSource;
+    try {
+        await fn();
+    } finally {
+        globalThis.EventSource = saved;
+    }
+};
+
+afterEach(() => configureEventSource(undefined));
+
+describe("resolveEventSource", () => {
+    it("prefers the explicit override over everything else", () => {
+        const configured = fakeFactory();
+        const override = fakeFactory();
+        configureEventSource(configured);
+
+        resolveEventSource(override)("http://a");
+        expect(override.urls).toEqual(["http://a"]);
+        expect(configured.urls).toEqual([]);
+    });
+
+    it("prefers the configured factory over the global", async () => {
+        const configured = fakeFactory();
+        configureEventSource(configured);
+        expect(getConfiguredEventSource()).toBe(configured);
+
+        resolveEventSource()("http://b");
+        expect(configured.urls).toEqual(["http://b"]);
+    });
+
+    it("falls back to the global, read at call time not import time", () => {
+        // The SDK is imported long before a polyfill assigns the global, so a
+        // factory captured at module load would never see one.
+        const source = resolveEventSource();
+        expect(typeof source).toBe("function");
+    });
+
+    it("throws a typed, actionable error when nothing answers", async () => {
+        await withoutGlobal(() => {
+            expect(() => resolveEventSource()).toThrow(EventSourceUnavailableError);
+            try {
+                resolveEventSource();
+            } catch (error) {
+                // The message is the whole remedy: it has to name both routes.
+                expect((error as Error).message).toContain("configureEventSource");
+                expect((error as Error).message).toContain("--experimental-eventsource");
+            }
+        });
+    });
+
+    it("goes back to the global when configured with undefined", async () => {
+        configureEventSource(fakeFactory());
+        configureEventSource(undefined);
+        expect(getConfiguredEventSource()).toBeUndefined();
+        expect(typeof resolveEventSource()).toBe("function");
+    });
+});
+
+describe("isEventSourceUnavailableError", () => {
+    it("recognizes the error", () => {
+        expect(isEventSourceUnavailableError(new EventSourceUnavailableError())).toBe(true);
+        expect(isEventSourceUnavailableError(new Error("boom"))).toBe(false);
+        expect(isEventSourceUnavailableError(undefined)).toBe(false);
+    });
+
+    it("still recognizes it after a structured-clone round trip", () => {
+        // A custom Error crossing the service-worker boundary arrives as a
+        // plain Error carrying the name — `instanceof` alone would miss it.
+        const clone = new Error(new EventSourceUnavailableError().message);
+        clone.name = "EventSourceUnavailableError";
+        expect(isEventSourceUnavailableError(clone)).toBe(true);
+    });
+});
+
+describe("providers take a factory", () => {
+    it("RestIndexerProvider opens its subscription with the injected one", async () => {
+        const factory = fakeFactory();
+        const provider = new RestIndexerProvider("http://ark", { eventSource: factory });
+
+        const iterator = provider.getSubscription("sub-1", new AbortController().signal);
+        // The connection is opened on the first pull, not at call time.
+        expect(factory.urls).toEqual([]);
+        const pending = iterator.next();
+        await Promise.resolve();
+        expect(factory.urls).toEqual(["http://ark/v1/indexer/script/subscription/sub-1"]);
+
+        await iterator.return?.(undefined);
+        await pending.catch(() => {});
+    });
+
+    it("RestArkProvider opens its event stream with the injected one", async () => {
+        const factory = fakeFactory();
+        const provider = new RestArkProvider("http://ark", { eventSource: factory });
+
+        const iterator = provider.getEventStream(new AbortController().signal, []);
+        const pending = iterator.next();
+        await Promise.resolve();
+        expect(factory.urls).toEqual(["http://ark/v1/batch/events"]);
+
+        await iterator.return?.(undefined);
+        await pending.catch(() => {});
+    });
+
+    it("fails the stream with the typed error when there is nothing to open it with", async () => {
+        await withoutGlobal(async () => {
+            const provider = new RestIndexerProvider("http://ark");
+            const iterator = provider.getSubscription("sub-1", new AbortController().signal);
+            await expect(iterator.next()).rejects.toThrow(EventSourceUnavailableError);
+        });
+    });
+
+    it("keeps resolving lazily, so a factory configured after construction still applies", async () => {
+        await withoutGlobal(async () => {
+            const provider = new RestIndexerProvider("http://ark");
+            const factory = fakeFactory();
+            configureEventSource(factory);
+
+            const iterator = provider.getSubscription("sub-2", new AbortController().signal);
+            const pending = iterator.next();
+            await Promise.resolve();
+            expect(factory.urls).toEqual(["http://ark/v1/indexer/script/subscription/sub-2"]);
+
+            await iterator.return?.(undefined);
+            await pending.catch(() => {});
+        });
+    });
+});
+
+describe("the default resolution path is unchanged", () => {
+    it("uses the global when nothing is configured", () => {
+        const spy = vi.spyOn(globalThis, "EventSource" as never);
+        expect(spy).toBeDefined();
+        expect(getConfiguredEventSource()).toBeUndefined();
+        expect(typeof resolveEventSource()).toBe("function");
+    });
+});

--- a/packages/ts-sdk/test/providers/eventSource.test.ts
+++ b/packages/ts-sdk/test/providers/eventSource.test.ts
@@ -26,7 +26,7 @@ const fakeFactory = (): EventSourceFactory & { urls: string[] } => {
             addEventListener: () => {},
             removeEventListener: () => {},
             close: () => {},
-        } as unknown as EventSource;
+        };
     }) as EventSourceFactory & { urls: string[] };
     factory.urls = urls;
     return factory;
@@ -66,11 +66,28 @@ describe("resolveEventSource", () => {
         expect(configured.urls).toEqual(["http://b"]);
     });
 
-    it("falls back to the global, read at call time not import time", () => {
+    it("falls back to the global, read at call time not import time", async () => {
         // The SDK is imported long before a polyfill assigns the global, so a
-        // factory captured at module load would never see one.
-        const source = resolveEventSource();
-        expect(typeof source).toBe("function");
+        // factory captured at module load would never see one. Resolving with
+        // the global gone and then installing a different one — both after this
+        // module was imported — is what tells the two apart.
+        await withoutGlobal(() => {
+            expect(() => resolveEventSource()).toThrow(EventSourceUnavailableError);
+
+            const opened: string[] = [];
+            class LateGlobal {
+                constructor(url: string) {
+                    opened.push(url);
+                }
+                addEventListener() {}
+                removeEventListener() {}
+                close() {}
+            }
+            globalThis.EventSource = LateGlobal as unknown as typeof EventSource;
+
+            resolveEventSource()("http://late");
+            expect(opened).toEqual(["http://late"]);
+        });
     });
 
     it("throws a typed, actionable error when nothing answers", async () => {


### PR DESCRIPTION
Item 8 of `plans/arkade-swap-contract-manager-integration-leftover.md`. Independent of #694 / #695 / #697 — different files entirely.

## The problem, and it is worse than "silent"

Every SSE stream the SDK opens — settlement events, the tx feed, the indexer script subscription — reached for the global `EventSource`. Node exposes one only behind `--experimental-eventsource` (24.x), so a CLI, a server-side wallet or a background worker got a `ReferenceError` out of the stream.

The item recorded this as a silent degradation. It is not. `listenLoop`'s `ReferenceError` is not an `EventSourceError`, so `ContractWatcher` logged it, fired `connection_reset`, and called `scheduleReconnect` — with `maxReconnectAttempts: 0` (unlimited) and backoff capped at 5s. A Node consumer therefore got a permanent reconnect loop, an error line every ≤5s, and a `connection_reset` every few seconds for the life of the wallet — which `RfqSwapManager` answers by re-polling every monitored swap.

Both packages had already worked around the missing global twice, differently, in test-only scope: `ts-sdk/test/polyfill.js` assigns `globalThis.EventSource` from the `eventsource` package, and `swap/vitest.config.ts` passes the Node flag. Each approximates "inject an EventSource"; this makes that a supported thing to do.

## What changed

- **`src/providers/eventSource.ts`** — `EventSourceFactory`, `configureEventSource(factory)`, `resolveEventSource(override?)`, and a typed `EventSourceUnavailableError` whose message names both remedies. Resolution per call: explicit per-provider option → configured factory → `globalThis.EventSource`. The global is read at call time, never captured at module load, so a polyfill assigned after import still wins — which is what lets the README drop its dynamic-import dance.
- **Both injection routes, because neither covers the surface alone.** `RestArkProvider` / `RestIndexerProvider` take `{ eventSource }` for callers that construct providers; the module-level default is the only thing that reaches the providers `Wallet.create({ arkServerUrl })` builds for you (`wallet.ts:897`/`921`).
- All three sites resolve through it — `getEventStream`, `getTransactionsStream`, `getSubscription` — and each rethrows `EventSourceUnavailableError` **without** logging, so the owner reports it once instead of the loop reporting it per attempt.
- **`ContractWatcher`** recognizes the error: one `console.warn` naming the failsafe interval and the fix, and **no reconnect** — a missing global is not a dropped connection. Failsafe polling keeps running, so the watcher stays correct and loses only push latency. Settlement still throws, since it genuinely cannot work without SSE.
- **README** — the Node section now leads with `configureEventSource`; assigning `globalThis.EventSource` stays documented as the last resort in the order.

Nothing changes for browsers, Expo/React Native, or any consumer that already polyfills: with a global present, resolution returns exactly what the call sites used before.

## Tests

`test/providers/eventSource.test.ts` (12): precedence across all three sources, the global read lazily, the typed error and its guidance text, both providers opening with an injected factory, a factory configured *after* provider construction still applying, and the `name`-based guard for an error that crossed the service-worker boundary as a plain `Error`.

`test/contracts/watcher.test.ts` (+1): with an indexer whose subscription is unavailable, exactly one warning carrying the remedy, no `console.error`, no further `getSubscription` attempts across 30s of reconnect windows, and — the part that matters — a VTXO landing *after* the stream gave up is still reported, by the failsafe poll.

Suite: 2385 → 2398, exactly the +13 added (measured against a stashed baseline, so nothing was silently dropped). Lint clean.

**Regtest**, on a freshly reset stack: `test/e2e/ark.test.ts` 24/24 and `test/e2e/indexer.test.ts` green — the two files that lean hardest on the changed sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable EventSource support for SDK providers, including per-provider and global options.
  * Exported EventSource configuration utilities and availability errors.
  * Added documented EventSource resolution behavior for Node.js and other environments.

* **Bug Fixes**
  * Contract watching now issues a single warning and continues with polling when EventSource is unavailable.
  * Settlement and subscription flows now report unavailable EventSource environments clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->