### PR TITLE
fix(vtxo-manager): route recovery through the gated VTXO accessor

### DIFF
--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -1095,8 +1095,14 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * ```
      */
     async recoverVtxos(eventCallback?: (event: SettlementEvent) => void): Promise<string> {
-        // Get all virtual outputs including recoverable ones
-        const allVtxos = await this.wallet.getVtxos({
+        // Recoverable virtual outputs, through the gated read. Recovery is
+        // generic spending: it re-mints everything it selects into one batch
+        // output, so a gated contract's VTXO would lose its script paths the
+        // same way it would in a renewal — and `canRecoverOnchain` covers
+        // `isSwept || isPastExpiry`, which is exactly where an unresolved
+        // escrow ends up. An owner who does mean to recover one names it
+        // through `settle({ inputs })`, which stays ungated on purpose.
+        const allVtxos = await this.wallet.getSpendableVtxos({
             withRecoverable: true,
             withUnrolled: false,
         });
@@ -1197,7 +1203,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         includesSubdust: boolean;
         vtxoCount: number;
     }> {
-        const allVtxos = await this.wallet.getVtxos({
+        // Gated to match `recoverVtxos`: this previews what recovery would
+        // sweep, so counting funds recovery will not touch would overstate it.
+        // Gated contracts still show through `getBalance`.
+        const allVtxos = await this.wallet.getSpendableVtxos({
             withRecoverable: true,
             withUnrolled: false,
         });

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -409,6 +409,9 @@ describe("spending sites consume the accessor", () => {
     const mockWallet = (raw: unknown[], spendable: unknown[]) => ({
         getVtxos: vi.fn().mockResolvedValue(raw),
         getSpendableVtxos: vi.fn().mockResolvedValue(spendable),
+        // Present so a site that wrongly selects a gated VTXO reaches settle and
+        // is caught there, rather than dying on a missing mock method.
+        settle: vi.fn().mockResolvedValue("mock-txid"),
         getAddress: vi.fn().mockResolvedValue("ark1address"),
         getDelegateManager: vi.fn().mockResolvedValue(undefined),
         getContractManager: vi.fn().mockResolvedValue({
@@ -440,6 +443,46 @@ describe("spending sites consume the accessor", () => {
             }),
         ).rejects.toThrow();
         expect(wallet.getSpendableVtxos).toHaveBeenCalled();
+    });
+
+    /** Swept, so `canRecoverOnchain` matches it and recovery would select it. */
+    const sweptEscrow = () =>
+        createMockExtendedVtxo({
+            txid: "ee".repeat(32),
+            vout: 0,
+            value: 10_000,
+            script: ESCROW_SCRIPT,
+            virtualStatus: { state: "swept" },
+            isSwept: true,
+        });
+
+    /**
+     * Recovery is generic spending too, and it was the last selection site still
+     * on the raw accessor. A swept escrow output is exactly what
+     * `canRecoverOnchain` matches, so it would have been swept into a batch
+     * settlement that re-mints it as a plain output and destroys the contract.
+     */
+    it("recovery does not see gated VTXOs", async () => {
+        const wallet = mockWallet([sweptEscrow()], []);
+        const manager = new VtxoManager(wallet as never);
+
+        await expect(manager.recoverVtxos()).rejects.toThrow("No recoverable VTXOs found");
+        expect(wallet.getSpendableVtxos).toHaveBeenCalled();
+        expect(wallet.getVtxos).not.toHaveBeenCalled();
+        // The one that matters: no settlement was ever built over the escrow.
+        expect(wallet.settle).not.toHaveBeenCalled();
+    });
+
+    it("the recoverable-balance preview does not count gated VTXOs", async () => {
+        const wallet = mockWallet([sweptEscrow()], []);
+        const manager = new VtxoManager(wallet as never);
+
+        await expect(manager.getRecoverableBalance()).resolves.toMatchObject({
+            recoverable: 0n,
+            vtxoCount: 0,
+        });
+        expect(wallet.getSpendableVtxos).toHaveBeenCalled();
+        expect(wallet.getVtxos).not.toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
`recoverVtxos()` and `getRecoverableBalance()` are the only two selection sites on this branch still reading the raw `getVtxos`. Every sibling was converted to the gated `getSpendableVtxos` — renewal (`vtxo-manager.ts:1270`), the no-arg settle sweep (`wallet.ts:3519`), and send (`wallet.ts:5015`). Recovery kept the original untouched comment, and the branch''s own "spending sites consume the accessor" test block covers renewal and offboard with recovery conspicuously absent.

That reads as an oversight rather than a decision, and it has teeth: a live covenant VTXO can be selected by recovery and spent into a batch settlement, destroying the covenant and every spend path depending on it — the counterparty''s claim leaf and the wallet''s own refund leaf alike.

The change is two call sites: `getVtxos` -> `getSpendableVtxos`.

## Revert-verification

With the source reverted and the tests kept:

```
x recovery does not see gated VTXOs
  -> promise resolved "''mock-txid''" instead of rejecting
x the recoverable-balance preview does not count gated VTXOs
  -> expected { recoverable: 10000n, ... } to match { recoverable: 0n, vtxoCount: 0 }
```

`recoverVtxos()` **succeeds** unfixed — it builds and submits a settlement spending the escrowed output. The first version of that test failed on a missing mock method, which was suggestive but indirect, so it now asserts against a `settle` spy: the failure is the settlement itself, not a proxy for it.

## Why `getSpendableVtxos` is safe here

It also drops `pendingRecovery`, and recovery exists to rescue those, so this needed checking rather than assuming. `selectPendingRecoveryOutpoints` adds only `!hasTerminalSpend(v) && !v.isSwept` — a **swept** VTXO is never in that set, so recovery''s main target is untouched. The narrow overlap (past-expiry, unswept, EXPIRED signer) cannot be cooperatively settled anyway.

## Gate

Baseline on pristine `feat/arkade-swap`: ts-sdk 2385 passed | 1 skipped, 156 files. After: **2387 passed | 1 skipped**, 156 files — +2, no pre-existing test changed. swap 217 and boltz-swap 614 green both sides. lint, all three typechecks and build exit 0.

## Not covered, and one open question

**No live proof.** This is verified by unit tests and the revert-check above; no funded covenant contract was constructed on a regtest stack. That is now possible on this branch (unlike `master`, where annotation throws before selection is reached) and is the obvious next step if wanted before merge.

**v1 `vhtlc` remains fully exposed.** It answers `isGenericallySpendable: () => true` and has no `deriveTapscripts`, so it is shielded today only by the annotation failure, not by any gate. Whoever ships v1 annotation needs to flip that answer in the same change — otherwise fixing annotation opens renewal *and* recovery to v1 covenants. That is the unfinished half of the "Phase 0 changes nothing for VHTLC" note.

**The question for the branch authors:** was leaving `recoverVtxos` ungated an oversight, or a deliberate carve-out so escrow can be recovered after a swap dies? The untouched comment and the missing test point at oversight. If it was deliberate, this PR removes that escape hatch and `settle({ inputs })` becomes the only way back — say so and it should be reshaped rather than merged.

Unrelated to #696 / #698, which change how the settlement output is priced, not which coins are selected.