### PR TITLE
fix(vtxo-manager): price the intent fee in renewVtxos and recoverVtxos

### DIFF
--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -306,6 +306,73 @@ export function capSettlementBatch<T extends { value: number }>(
     return batch;
 }
 
+/**
+ * Price a settlement's VTXO inputs against the operator's intent-fee policy,
+ * dropping any input that cannot pay for itself.
+ *
+ * An intent's fee IS `sum(inputs) - sum(outputs)`, so a single-output settlement
+ * asking for the gross input sum offers exactly zero and the server rejects the
+ * whole intent with `INTENT_INSUFFICIENT_FEE` wherever the operator prices
+ * offchain inputs at all. `subtotal` is what the inputs are worth once each has
+ * paid its own way; the caller still owes {@link deductOffchainOutputFee} on top.
+ *
+ * An input whose fee meets or exceeds its value is skipped rather than settled —
+ * it would take more out of the output than it puts in. Callers filter with this
+ * BEFORE {@link capSettlementBatch} so an uneconomic input cannot occupy a slot
+ * that a viable one behind it could have used.
+ */
+function priceSettlementInputs<T extends NormalizedExtendedVirtualCoin>(
+    vtxos: T[],
+    estimator: Estimator,
+): { payable: T[]; subtotal: bigint } {
+    const payable: T[] = [];
+    let subtotal = 0n;
+    for (const vtxo of vtxos) {
+        const inputFee = estimator.evalOffchainInput(toOffchainInputFeeParams(vtxo));
+        if (inputFee.satoshis >= vtxo.value) {
+            continue;
+        }
+        payable.push(vtxo);
+        subtotal += BigInt(vtxo.value - inputFee.satoshis);
+    }
+    return { payable, subtotal };
+}
+
+/**
+ * Take the operator's offchain output fee off a settlement's single output.
+ *
+ * The fee is evaluated on `subtotal` — the amount before this deduction — rather
+ * than on the amount finally committed, matching what
+ * {@link VtxoManager.runPeriodicSettle} and the no-argument `Wallet.settle()`
+ * branch already do. Under a percentage rate `r` that implies a fee of
+ * `r * subtotal` where the server asks only `r * subtotal * (1 - r)`, i.e. an
+ * over-payment of `r^2 * subtotal`. Deliberate: paying over is always accepted,
+ * whereas solving the fixed point exactly to recover those satoshis risks
+ * landing one under the minimum — which is the rejection this pricing exists to
+ * avoid.
+ *
+ * Can return a value below dust, or below zero, when a flat output fee outweighs
+ * the inputs; every caller checks the result against the dust threshold.
+ */
+function deductOffchainOutputFee(
+    subtotal: bigint,
+    estimator: Estimator,
+    arkAddress: string,
+): bigint {
+    // Mirror the estimator's own early return rather than reaching it through
+    // `ArkAddress.decode`: with no output program the script is never read, and
+    // an operator that doesn't price outputs shouldn't make a decodable address
+    // a precondition for renewing or recovering.
+    if (!estimator.config.offchainOutput) {
+        return subtotal;
+    }
+    const outputFee = estimator.evalOffchainOutput({
+        amount: subtotal,
+        script: hex.encode(ArkAddress.decode(arkAddress).pkScript),
+    });
+    return subtotal - BigInt(outputFee.satoshis);
+}
+
 /** Default renewal threshold in seconds (3 days). */
 export const DEFAULT_THRESHOLD_SECONDS = 259_200;
 
@@ -1106,7 +1173,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         // Filter recoverable virtual outputs and handle subdust logic
         const now = await fetchTimeHeight(this.wallet);
-        let { vtxosToRecover, totalAmount } = getRecoverableWithSubdust(allVtxos, dustAmount, now);
+        let { vtxosToRecover } = getRecoverableWithSubdust(allVtxos, dustAmount, now);
 
         if (vtxosToRecover.length === 0) {
             throw new Error("No recoverable VTXOs found");
@@ -1124,21 +1191,32 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // overflow is recovered next cycle.
         const info = await this.getInfoProvider()?.getInfo();
         const vtxoMaxAmount = info?.vtxoMaxAmount ?? -1n;
-        const capped = capSettlementBatch(byValueDescending(vtxosToRecover), vtxoMaxAmount);
+
+        // Price the batch before capping so a VTXO that cannot pay its own intent
+        // fee is dropped here rather than occupying a slot in the capped batch
+        // ahead of one that can. Subdust inputs survive this whenever they are
+        // still worth more than their own fee, which is what keeps consolidating
+        // them possible. `info` is undefined only when no ark provider is wired,
+        // which prices as zero and leaves the gross behaviour untouched.
+        const estimator = new Estimator(info?.fees.intentFee ?? {});
+        const payable = priceSettlementInputs(vtxosToRecover, estimator).payable;
+        const capped = capSettlementBatch(byValueDescending(payable), vtxoMaxAmount);
         if (capped.length < vtxosToRecover.length) {
             const recoverableCount = vtxosToRecover.length;
-            ({ vtxosToRecover, totalAmount } = getRecoverableWithSubdust(capped, dustAmount, now));
+            ({ vtxosToRecover } = getRecoverableWithSubdust(capped, dustAmount, now));
             if (vtxosToRecover.length === 0) {
                 // Recoverable VTXOs exist, but the highest-value subset that
-                // fits in one settlement stays below dust, so submitting it
-                // would be rejected and the next cycle would pick the same
-                // prefix. Distinct from the "none recoverable" case above so
-                // operators can tell a stuck-but-funded wallet from an empty
-                // one. Recovery resumes once the prefix accumulates dust.
+                // fits in one settlement — and can pay its own intent fee —
+                // stays below dust, so submitting it would be rejected and the
+                // next cycle would pick the same prefix. Distinct from the "none
+                // recoverable" case above so operators can tell a stuck-but-funded
+                // wallet from an empty one. Recovery resumes once the prefix
+                // accumulates dust.
                 throw new Error(
                     `Capped recovery batch (highest-value subset of ${recoverableCount} ` +
                         `recoverable VTXOs within the ${MAX_VTXOS_PER_SETTLEMENT}-input and ` +
-                        `${vtxoMaxAmount}-sat limits) is below the dust threshold ${dustAmount}`,
+                        `${vtxoMaxAmount}-sat limits, net of intent fees) is below the ` +
+                        `dust threshold ${dustAmount}`,
                 );
             }
         }
@@ -1154,7 +1232,28 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             await this.rotateForRecoverableInputs(vtxosToRecover, info);
         }
 
+        // Read AFTER any rotation above, so the output fee is priced against the
+        // script the recovered VTXO actually lands on.
         const arkAddress = await this.wallet.getAddress();
+
+        // The fee an intent offers IS `sum(inputs) - sum(outputs)`, so the output
+        // has to come back short by what the operator's programs price. Asking
+        // for the gross recoverable sum offers zero and the server rejects with
+        // INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
+        const { subtotal } = priceSettlementInputs(vtxosToRecover, estimator);
+        const totalAmount = deductOffchainOutputFee(subtotal, estimator, arkAddress);
+
+        // getRecoverableWithSubdust judges subdust inclusion on gross value, but
+        // the fees come off after that decision, so a batch that cleared dust
+        // gross can still land under it here. The server would reject such an
+        // output; say so instead, and let the next cycle retry once the
+        // recoverable set is worth more.
+        if (totalAmount < dustAmount) {
+            throw new Error(
+                `Recoverable amount ${totalAmount} net of intent fees is below ` +
+                    `dust threshold ${dustAmount}`,
+            );
+        }
 
         // Settle all recoverable virtual outputs back to the wallet
         return this.wallet.settle(
@@ -1394,6 +1493,23 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // renewed on the next cycle.
             const info = await this.getInfoProvider()?.getInfo();
             const vtxoMaxAmount = info?.vtxoMaxAmount ?? -1n;
+
+            // Price the candidates before capping so a VTXO that cannot pay its
+            // own intent fee is dropped here rather than occupying a slot in the
+            // capped batch ahead of one that can. `info` is undefined only when no
+            // ark provider is wired, which prices as zero and leaves the gross
+            // behaviour untouched.
+            const estimator = new Estimator(info?.fees.intentFee ?? {});
+            vtxos = priceSettlementInputs(vtxos, estimator).payable;
+            if (vtxos.length === 0) {
+                // Worded to match the benign cases the vtxo_received subscription
+                // already swallows: nothing is wrong, there is just nothing worth
+                // renewing at this fee policy.
+                throw new Error(
+                    "No VTXOs available to renew: every expiring VTXO is worth less than its own intent fee",
+                );
+            }
+
             const capped = capSettlementBatch(byExpiryAscending(vtxos, now), vtxoMaxAmount);
             if (vtxoMaxAmount >= 0n) {
                 // A VTXO whose value alone exceeds the per-output ceiling can
@@ -1424,17 +1540,8 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 }
             }
 
-            const totalAmount = vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
-
             // Get dust amount from wallet
             const dustAmount = getDustAmount(this.wallet);
-
-            // Check if total amount is above dust threshold
-            if (BigInt(totalAmount) < dustAmount) {
-                throw new Error(
-                    `Total amount ${totalAmount} is below dust threshold ${dustAmount}`,
-                );
-            }
 
             // Renewal includes recoverable VTXOs (getExpiringVtxos pulls them
             // in). If any carries a now-deprecated signer and the wallet's own
@@ -1448,7 +1555,25 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 await this.rotateForRecoverableInputs(vtxos, info);
             }
 
+            // Read AFTER any rotation above, so the output fee is priced against
+            // the script the renewed VTXO actually lands on.
             const arkAddress = await this.wallet.getAddress();
+
+            // The fee an intent offers IS `sum(inputs) - sum(outputs)`, so the
+            // output has to come back short by what the operator's programs
+            // price. Asking for the gross sum offers zero and the server rejects
+            // with INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
+            const { subtotal } = priceSettlementInputs(vtxos, estimator);
+            const totalAmount = deductOffchainOutputFee(subtotal, estimator, arkAddress);
+
+            // Dust is judged on the NET output, not the gross input sum: the fees
+            // come off after selection, so a batch that clears dust gross can
+            // land under it here.
+            if (totalAmount < dustAmount) {
+                throw new Error(
+                    `Total amount ${totalAmount} is below dust threshold ${dustAmount}`,
+                );
+            }
 
             const txid = await this.wallet.settle(
                 {
@@ -1456,7 +1581,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                     outputs: [
                         {
                             address: arkAddress,
-                            amount: BigInt(totalAmount),
+                            amount: totalAmount,
                         },
                     ],
                 },

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -1320,6 +1320,17 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      *
      * Useful for displaying to users before they decide to recover funds.
      *
+     * Both amounts are net of the operator's intent fees, so `recoverable` is
+     * what {@link recoverVtxos} would actually hand back rather than the gross
+     * sum of the inputs. `subdust` is net of the per-input fees only — the
+     * output fee is charged on the batch as a whole and is not attributed per
+     * coin — so it reports what the subdust coins are worth once each has paid
+     * its own way, and is not strictly a slice of `recoverable`. It can exceed
+     * `recoverable` where a flat output fee meets a wholly subdust wallet.
+     *
+     * The batch size caps are not applied here: they defer the overflow to the
+     * next cycle rather than reducing what is recoverable.
+     *
      * @returns Object containing recoverable amounts and subdust information
      *
      * @example
@@ -1378,12 +1389,20 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         // Subdust is CLASSIFIED on gross value — that is what makes a coin
         // subdust, and what `getRecoverableWithSubdust` judged inclusion on — but
-        // REPORTED net, so it stays a component of `recoverable` above rather
-        // than a figure on a different basis. Summing it gross lets `subdust`
-        // exceed `recoverable` whenever the recoverable set is entirely subdust,
-        // which is exactly the wallet this field exists to describe. Totalled
-        // through `subtotalOf` so an unpriced input throws instead of silently
-        // contributing zero.
+        // REPORTED net of the per-input fees, so it is on the same footing as
+        // `recoverable` rather than a figure on a different basis. Summing it
+        // gross overstated it under every non-zero input-fee policy.
+        //
+        // Net of the INPUT fees only, though: the output fee comes off the whole
+        // batch at once and does not decompose per coin, so it is not attributed
+        // here. `subdust <= recoverable` therefore holds whenever no output fee
+        // is configured or the non-subdust coins cover it, but NOT in general —
+        // a flat output fee against an all-subdust wallet still leaves `subdust`
+        // the larger of the two. Read this as "what the subdust coins are worth
+        // once each has paid its own way", not as a slice of `recoverable`.
+        //
+        // Totalled through `subtotalOf` so an unpriced input throws instead of
+        // silently contributing zero.
         const subdustAmount = subtotalOf(
             payable.filter((v) => BigInt(v.value) < dustAmount),
             net,

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -1229,6 +1229,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         const estimator = new Estimator(info?.fees.intentFee ?? {});
         const { payable, net } = priceSettlementInputs(vtxosToRecover, estimator);
         const capped = capSettlementBatch(byValueDescending(payable), vtxoMaxAmount);
+        // Compared against the pre-pricing count deliberately: this fires when
+        // EITHER filter narrowed the batch, fee pricing or a size cap, since both
+        // mean the subdust decision above was made over a set we are no longer
+        // settling and has to be re-run. Not just the cap, despite the name.
         if (capped.length < vtxosToRecover.length) {
             const recoverableCount = vtxosToRecover.length;
             // Two different things can narrow the batch, and an operator
@@ -1372,10 +1376,18 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // than settling it, so report nothing recoverable instead of a negative.
         const recoverable = priced > 0n ? priced : 0n;
 
-        // Calculate subdust amount separately for reporting
-        const subdustAmount = payable
-            .filter((v) => BigInt(v.value) < dustAmount)
-            .reduce((sum, v) => sum + BigInt(v.value), 0n);
+        // Subdust is CLASSIFIED on gross value — that is what makes a coin
+        // subdust, and what `getRecoverableWithSubdust` judged inclusion on — but
+        // REPORTED net, so it stays a component of `recoverable` above rather
+        // than a figure on a different basis. Summing it gross lets `subdust`
+        // exceed `recoverable` whenever the recoverable set is entirely subdust,
+        // which is exactly the wallet this field exists to describe. Totalled
+        // through `subtotalOf` so an unpriced input throws instead of silently
+        // contributing zero.
+        const subdustAmount = subtotalOf(
+            payable.filter((v) => BigInt(v.value) < dustAmount),
+            net,
+        );
 
         return {
             recoverable,

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -320,22 +320,50 @@ export function capSettlementBatch<T extends { value: number }>(
  * it would take more out of the output than it puts in. Callers filter with this
  * BEFORE {@link capSettlementBatch} so an uneconomic input cannot occupy a slot
  * that a viable one behind it could have used.
+ *
+ * Each survivor's net is returned alongside it so a caller that then narrows the
+ * batch can total the survivors through {@link subtotalOf} without pricing
+ * anything twice.
  */
 function priceSettlementInputs<T extends NormalizedExtendedVirtualCoin>(
     vtxos: T[],
     estimator: Estimator,
-): { payable: T[]; subtotal: bigint } {
+): { payable: T[]; net: ReadonlyMap<string, bigint> } {
     const payable: T[] = [];
-    let subtotal = 0n;
+    const net = new Map<string, bigint>();
     for (const vtxo of vtxos) {
         const inputFee = estimator.evalOffchainInput(toOffchainInputFeeParams(vtxo));
         if (inputFee.satoshis >= vtxo.value) {
             continue;
         }
         payable.push(vtxo);
-        subtotal += BigInt(vtxo.value - inputFee.satoshis);
+        net.set(`${vtxo.txid}:${vtxo.vout}`, BigInt(vtxo.value - inputFee.satoshis));
     }
-    return { payable, subtotal };
+    return { payable, net };
+}
+
+/**
+ * Total what a settlement's inputs are worth once each has paid its own intent
+ * fee, from the nets {@link priceSettlementInputs} already computed.
+ *
+ * `vtxos` must come from that call's `payable` — a batch cap may have narrowed
+ * it, nothing else may. An input with no priced net throws rather than counting
+ * as zero: silently dropping one understates the output, which offers the server
+ * MORE fee than asked and quietly overpays out of the user's own funds.
+ */
+function subtotalOf(
+    vtxos: readonly { txid: string; vout: number }[],
+    net: ReadonlyMap<string, bigint>,
+): bigint {
+    let subtotal = 0n;
+    for (const vtxo of vtxos) {
+        const priced = net.get(`${vtxo.txid}:${vtxo.vout}`);
+        if (priced === undefined) {
+            throw new Error(`Unpriced settlement input ${vtxo.txid}:${vtxo.vout}`);
+        }
+        subtotal += priced;
+    }
+    return subtotal;
 }
 
 /**
@@ -1199,19 +1227,29 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // them possible. `info` is undefined only when no ark provider is wired,
         // which prices as zero and leaves the gross behaviour untouched.
         const estimator = new Estimator(info?.fees.intentFee ?? {});
-        const payable = priceSettlementInputs(vtxosToRecover, estimator).payable;
+        const { payable, net } = priceSettlementInputs(vtxosToRecover, estimator);
         const capped = capSettlementBatch(byValueDescending(payable), vtxoMaxAmount);
         if (capped.length < vtxosToRecover.length) {
             const recoverableCount = vtxosToRecover.length;
+            // Two different things can narrow the batch, and an operator
+            // debugging a stuck wallet needs to know which one did: a size cap
+            // defers the overflow to the next cycle, whereas fee filtering means
+            // the coins cost more to move than they are worth and no later cycle
+            // will change that on its own.
+            const cappedAway = capped.length < payable.length;
             ({ vtxosToRecover } = getRecoverableWithSubdust(capped, dustAmount, now));
             if (vtxosToRecover.length === 0) {
-                // Recoverable VTXOs exist, but the highest-value subset that
-                // fits in one settlement — and can pay its own intent fee —
-                // stays below dust, so submitting it would be rejected and the
-                // next cycle would pick the same prefix. Distinct from the "none
-                // recoverable" case above so operators can tell a stuck-but-funded
-                // wallet from an empty one. Recovery resumes once the prefix
-                // accumulates dust.
+                // Recoverable VTXOs exist, but what survives stays below dust, so
+                // submitting it would be rejected and the next cycle would pick
+                // the same prefix. Distinct from the "none recoverable" case
+                // above so operators can tell a stuck-but-funded wallet from an
+                // empty one.
+                if (!cappedAway) {
+                    throw new Error(
+                        `All ${recoverableCount} recoverable VTXOs that can pay their own ` +
+                            `intent fee total less than the dust threshold ${dustAmount}`,
+                    );
+                }
                 throw new Error(
                     `Capped recovery batch (highest-value subset of ${recoverableCount} ` +
                         `recoverable VTXOs within the ${MAX_VTXOS_PER_SETTLEMENT}-input and ` +
@@ -1240,8 +1278,11 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // has to come back short by what the operator's programs price. Asking
         // for the gross recoverable sum offers zero and the server rejects with
         // INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
-        const { subtotal } = priceSettlementInputs(vtxosToRecover, estimator);
-        const totalAmount = deductOffchainOutputFee(subtotal, estimator, arkAddress);
+        const totalAmount = deductOffchainOutputFee(
+            subtotalOf(vtxosToRecover, net),
+            estimator,
+            arkAddress,
+        );
 
         // getRecoverableWithSubdust judges subdust inclusion on gross value, but
         // the fees come off after that decision, so a batch that cleared dust
@@ -1303,22 +1344,44 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         const dustAmount = getDustAmount(this.wallet);
 
-        const { vtxosToRecover, includesSubdust, totalAmount } = getRecoverableWithSubdust(
+        const { vtxosToRecover, includesSubdust } = getRecoverableWithSubdust(
             allVtxos,
             dustAmount,
             await fetchTimeHeight(this.wallet),
         );
 
+        // Priced the same way `recoverVtxos` prices what it settles. This exists
+        // to tell a user what recovery would hand back, so it has to answer net
+        // of the operator's intent fees — reporting the gross sum would promise
+        // more than the sweep delivers under any non-zero fee policy, and the two
+        // are reachable from the same worker call.
+        //
+        // Not applied here: the batch caps. They defer the overflow to the next
+        // cycle rather than reducing what is recoverable, and matching them would
+        // mean re-running the subdust decision over a capped subset. That gap
+        // predates the fee pricing and is left alone.
+        const info = await this.getInfoProvider()?.getInfo();
+        const estimator = new Estimator(info?.fees.intentFee ?? {});
+        const { payable, net } = priceSettlementInputs(vtxosToRecover, estimator);
+        const priced = deductOffchainOutputFee(
+            subtotalOf(payable, net),
+            estimator,
+            await this.wallet.getAddress(),
+        );
+        // A flat output fee can outweigh the inputs; recovery refuses that rather
+        // than settling it, so report nothing recoverable instead of a negative.
+        const recoverable = priced > 0n ? priced : 0n;
+
         // Calculate subdust amount separately for reporting
-        const subdustAmount = vtxosToRecover
+        const subdustAmount = payable
             .filter((v) => BigInt(v.value) < dustAmount)
             .reduce((sum, v) => sum + BigInt(v.value), 0n);
 
         return {
-            recoverable: totalAmount,
+            recoverable,
             subdust: subdustAmount,
             includesSubdust,
-            vtxoCount: vtxosToRecover.length,
+            vtxoCount: payable.length,
         };
     }
 
@@ -1500,7 +1563,8 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // ark provider is wired, which prices as zero and leaves the gross
             // behaviour untouched.
             const estimator = new Estimator(info?.fees.intentFee ?? {});
-            vtxos = priceSettlementInputs(vtxos, estimator).payable;
+            const { payable, net } = priceSettlementInputs(vtxos, estimator);
+            vtxos = payable;
             if (vtxos.length === 0) {
                 // Worded to match the benign cases the vtxo_received subscription
                 // already swallows: nothing is wrong, there is just nothing worth
@@ -1563,8 +1627,11 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // output has to come back short by what the operator's programs
             // price. Asking for the gross sum offers zero and the server rejects
             // with INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
-            const { subtotal } = priceSettlementInputs(vtxos, estimator);
-            const totalAmount = deductOffchainOutputFee(subtotal, estimator, arkAddress);
+            const totalAmount = deductOffchainOutputFee(
+                subtotalOf(vtxos, net),
+                estimator,
+                arkAddress,
+            );
 
             // Dust is judged on the NET output, not the gross input sum: the fees
             // come off after selection, so a batch that clears dust gross can

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -3806,6 +3806,39 @@ describe("VtxoManager - intent fee pricing", () => {
             expect(balance.vtxoCount).toBe(2);
         });
 
+        /**
+         * `subdust` reports part of what `recoverable` reports, so pricing one
+         * and not the other leaves them on different bases. A wallet whose whole
+         * recoverable set is subdust makes that visible: the two have to agree,
+         * and a gross `subdust` would exceed the net `recoverable`.
+         */
+        it("reports subdust net of fees, so it cannot exceed the recoverable total", async () => {
+            // Both are subdust against the 1000 threshold but total 1100, so
+            // getRecoverableWithSubdust folds them in.
+            const wallet = createMockWallet([swept(600), swept(500)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            // 600 less 6, and 500 less 5. Gross would report 1100.
+            expect(balance.subdust).toBe(1089n);
+            expect(balance.includesSubdust).toBe(true);
+            expect(balance.recoverable).toBe(1089n);
+            expect(balance.subdust).toBe(balance.recoverable);
+        });
+
+        it("prices only the subdust coins into subdust when the set is mixed", async () => {
+            const wallet = createMockWallet([swept(5000), swept(600), swept(500)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            // The two subdust coins net 594 and 495; the 5000 nets 4950 on top.
+            expect(balance.subdust).toBe(1089n);
+            expect(balance.recoverable).toBe(6039n);
+            expect(balance.subdust).toBeLessThan(balance.recoverable);
+        });
+
         it("omits from the preview a VTXO that cannot pay its own fee", async () => {
             const wallet = createMockWallet([swept(5000), swept(100)], ADDRESS, {
                 intentFee: { offchainInput: "250.0" },

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -12,6 +12,7 @@ import {
     SettlementConfig,
 } from "../src/wallet/vtxo-manager";
 import { IWallet, ExtendedCoin, ExtendedVirtualCoin } from "../src/wallet";
+import type { IntentFeeConfig } from "../src/arkfee";
 import { Wallet } from "../src/wallet/wallet";
 import { CSVMultisigTapscript } from "../src/script/tapscript";
 import { hex } from "@scure/base";
@@ -29,6 +30,12 @@ type MockWalletOptions = {
      * to `-1n` ("no limit") so existing recovery/renewal tests are unaffected.
      */
     vtxoMaxAmount?: bigint;
+    /**
+     * Operator intent-fee policy surfaced via `arkProvider.getInfo()`. CEL
+     * programs, exactly as arkd serves them. Defaults to `{}` — no program on
+     * any side, i.e. free — so existing recovery/renewal tests are unaffected.
+     */
+    intentFee?: IntentFeeConfig;
 };
 
 // Mock wallet implementation
@@ -63,7 +70,7 @@ const createMockWallet = (
         // non-sweep-capable and the boarding-poll paths are untouched.
         arkProvider: {
             getInfo: vi.fn().mockResolvedValue({
-                fees: { intentFee: {} },
+                fees: { intentFee: options.intentFee ?? {} },
                 vtxoMaxAmount: options.vtxoMaxAmount ?? -1n,
             }),
         },
@@ -3498,5 +3505,293 @@ describe("VtxoManager - VTXO_ALREADY_SPENT reconciliation", () => {
         } finally {
             await manager.dispose();
         }
+    });
+});
+
+/**
+ * Intent-fee pricing for the two `VtxoManager` entry points that build their own
+ * single-output settlement.
+ *
+ * An intent's fee IS `sum(inputs) - sum(outputs)`, so a settlement whose output
+ * equals the gross input sum offers exactly zero. Against an operator with any
+ * non-zero `intentFee` policy arkd rejects the intent outright —
+ * `INTENT_INSUFFICIENT_FEE (31): got 0 min expected N`, where the `got 0` is that
+ * zero literally — so renewal and recovery could never succeed. See
+ * arkade-os/ts-sdk#696.
+ *
+ * The CEL programs below are the shapes arkd actually serves: arkade-regtest ships
+ * `offchainInput: "amount * 0.01"` by default, alongside flat `"250.0"` programs
+ * on the onchain side of the same policy.
+ */
+describe("VtxoManager - intent fee pricing", () => {
+    /**
+     * A decodable ark address: the offchain output fee is priced against its
+     * pkScript, so a placeholder would fail inside `ArkAddress.decode` rather
+     * than inside the code under test.
+     */
+    const ADDRESS =
+        "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g";
+
+    /** Near enough to batch expiry that `renewVtxos` selects it. */
+    const expiring = (value: number, txid = `expiring-${value}`): ExtendedVirtualCoin => {
+        const now = Date.now();
+        return {
+            txid,
+            vout: 0,
+            value,
+            createdAt: new Date(now - 100_000),
+            virtualStatus: { state: "settled", batchExpiry: now + 5000 },
+            status: { confirmed: true },
+            isUnrolled: false,
+            isSpent: false,
+        } as any;
+    };
+
+    /** Swept by the server, so `recoverVtxos` sweeps it back. */
+    const swept = (value: number, txid = `swept-${value}`): ExtendedVirtualCoin =>
+        ({
+            txid,
+            vout: 0,
+            value,
+            virtualStatus: { state: "swept" },
+            isSwept: true,
+            isSpent: false,
+            status: { confirmed: true },
+            createdAt: new Date(),
+            isUnrolled: false,
+            forfeitTapLeafScript: [new Uint8Array(), new Uint8Array()],
+            intentTapLeafScript: [new Uint8Array(), new Uint8Array()],
+            tapTree: new Uint8Array(),
+        }) as any;
+
+    const settled = (wallet: IWallet) => (wallet.settle as any).mock.calls[0][0];
+
+    describe("renewVtxos", () => {
+        it("leaves the output at the gross sum when the operator charges nothing", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS);
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            expect(settled(wallet).outputs[0].amount).toBe(8000n);
+        });
+
+        it("pays a flat per-input fee out of the renewed output", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS, {
+                intentFee: { offchainInput: "250.0" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            // 8000 gross, less 250 for each of the two inputs.
+            expect(settled(wallet).outputs[0].amount).toBe(7500n);
+        });
+
+        it("pays a percentage per-input fee — the policy arkade-regtest ships", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            // 1% of each input: 5000 - 50 and 3000 - 30.
+            const amount = settled(wallet).outputs[0].amount;
+            expect(amount).toBe(7920n);
+            // What arkd measures as the offered fee, and what used to be zero.
+            expect(8000n - amount).toBe(80n);
+        });
+
+        it("prices the output fee too, not just the inputs", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS, {
+                intentFee: { offchainOutput: "250.0" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            expect(settled(wallet).outputs[0].amount).toBe(7750n);
+        });
+
+        /**
+         * A percentage on BOTH sides is the shape where our arithmetic and the
+         * server's genuinely disagree, so the direction of the disagreement is
+         * pinned deliberately rather than discovered in production.
+         *
+         * The output fee is a function of the output, but the output is what we
+         * are solving for, so `deductOffchainOutputFee` charges `r` of the
+         * pre-deduction subtotal while the server charges `r` of the amount it
+         * actually receives. The gap is `r^2 * subtotal`, and it falls on the
+         * safe side: the intent implies MORE fee than the minimum, so it is
+         * never rejected for underpaying.
+         */
+        it("over-pays rather than under-pays when both sides are a percentage", async () => {
+            const wallet = createMockWallet([expiring(1_000_000)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01", offchainOutput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            // 1_000_000 less 1% in = 990_000 subtotal, less 1% of that subtotal.
+            const amount = settled(wallet).outputs[0].amount;
+            expect(amount).toBe(980_100n);
+
+            // What the server checks: `inputs - outputs` against its own programs
+            // evaluated on the amount finally committed.
+            const impliedFee = 1_000_000n - amount;
+            const serverMinimum = 10_000n + 9_801n;
+            expect(impliedFee).toBe(19_900n);
+            expect(impliedFee).toBeGreaterThan(serverMinimum);
+            // Exactly r^2 * subtotal = 0.0001 * 990_000.
+            expect(impliedFee - serverMinimum).toBe(99n);
+        });
+
+        it("drops a VTXO whose own fee meets its value instead of settling it", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(1500)], ADDRESS, {
+                intentFee: { offchainInput: "2000.0" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await manager.renewVtxos();
+
+            // Renewing the 1500 would cost 2000, destroying value outright.
+            const args = settled(wallet);
+            expect(args.inputs.map((v: ExtendedVirtualCoin) => v.txid)).toEqual(["expiring-5000"]);
+            expect(args.outputs[0].amount).toBe(3000n);
+        });
+
+        /**
+         * Worded so the `vtxo_received` subscription still classifies it as
+         * benign rather than logging it as a failure — nothing is wrong, there
+         * is just nothing worth renewing at this fee policy.
+         */
+        it("refuses when every expiring VTXO is below its own fee", async () => {
+            const wallet = createMockWallet([expiring(1500)], ADDRESS, {
+                intentFee: { offchainInput: "2000.0" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await expect(manager.renewVtxos()).rejects.toThrow("No VTXOs available to renew");
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+
+        /**
+         * The gross sum clears dust and the net does not. Settling that would
+         * just be rejected by the server, so the fees have to come off before
+         * the check rather than after it.
+         */
+        it("checks dust against the net output, not the gross input sum", async () => {
+            const wallet = createMockWallet([expiring(1200)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.5" },
+            });
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await expect(manager.renewVtxos()).rejects.toThrow(
+                "Total amount 600 is below dust threshold 1000",
+            );
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("recoverVtxos", () => {
+        it("leaves the output at the gross sum when the operator charges nothing", async () => {
+            const wallet = createMockWallet([swept(5000), swept(3000)], ADDRESS);
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            expect(settled(wallet).outputs[0].amount).toBe(8000n);
+        });
+
+        it("pays the operator's intent fee on recovery too", async () => {
+            const wallet = createMockWallet([swept(5000), swept(3000)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            expect(settled(wallet).outputs[0].amount).toBe(7920n);
+        });
+
+        it("prices the recovery output fee as well as the inputs", async () => {
+            const wallet = createMockWallet([swept(5000), swept(3000)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01", offchainOutput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            // 7920 subtotal, less 1% of it (79.2, rounded up to 80).
+            expect(settled(wallet).outputs[0].amount).toBe(7840n);
+        });
+
+        /**
+         * Consolidating subdust is the whole reason recovery pulls it in, so a
+         * percentage fee — which every subdust coin here can still afford — must
+         * not quietly drop it.
+         */
+        it("still consolidates subdust that can pay its own fee", async () => {
+            const vtxos = [
+                swept(5000, "regular-a"),
+                swept(3000, "regular-b"),
+                swept(100, "subdust-a"),
+                swept(100, "subdust-b"),
+                swept(100, "subdust-c"),
+            ];
+            const wallet = createMockWallet(vtxos, ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            const args = settled(wallet);
+            expect(args.inputs).toHaveLength(5);
+            // 4950 + 2970 + three subdust coins netting 99 each.
+            expect(args.outputs[0].amount).toBe(8217n);
+        });
+
+        it("drops subdust a flat fee has made uneconomic, and recovers the rest", async () => {
+            const vtxos = [
+                swept(5000, "regular-a"),
+                swept(3000, "regular-b"),
+                swept(100, "subdust-a"),
+                swept(100, "subdust-b"),
+            ];
+            const wallet = createMockWallet(vtxos, ADDRESS, {
+                intentFee: { offchainInput: "250.0" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            const args = settled(wallet);
+            expect(args.inputs.map((v: ExtendedVirtualCoin) => v.txid)).toEqual([
+                "regular-a",
+                "regular-b",
+            ]);
+            expect(args.outputs[0].amount).toBe(7500n);
+        });
+
+        /**
+         * `getRecoverableWithSubdust` judges subdust inclusion on gross value, so
+         * a batch can clear dust gross and land under it once the fees are off.
+         * Recovery is an untimelocked all-or-nothing sweep, so this has to be a
+         * loud refusal rather than an output the server silently rejects.
+         */
+        it("refuses a recovery the fee has driven under dust", async () => {
+            const wallet = createMockWallet([swept(1200)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.5" },
+            });
+            const manager = new VtxoManager(wallet);
+
+            await expect(manager.recoverVtxos()).rejects.toThrow(
+                "Recoverable amount 600 net of intent fees is below dust threshold 1000",
+            );
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -3839,6 +3839,27 @@ describe("VtxoManager - intent fee pricing", () => {
             expect(balance.subdust).toBeLessThan(balance.recoverable);
         });
 
+        /**
+         * `subdust` nets off the per-input fees but not the output fee, which is
+         * charged on the batch as a whole and does not decompose per coin. So it
+         * is not strictly a slice of `recoverable`, and a flat output fee against
+         * a wholly subdust wallet leaves it the larger of the two. Pinned rather
+         * than clamped: clamping would invent a number that answers to nothing,
+         * and the honest reading is "what the subdust coins are worth once each
+         * has paid its own way".
+         */
+        it("does not attribute the batch-level output fee to subdust", async () => {
+            const wallet = createMockWallet([swept(600), swept(500)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 0.01", offchainOutput: "200.0" },
+            });
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            // Inputs net 594 + 495 = 1089; the flat 200 comes off the batch.
+            expect(balance.subdust).toBe(1089n);
+            expect(balance.recoverable).toBe(889n);
+            expect(balance.subdust).toBeGreaterThan(balance.recoverable);
+        });
+
         it("omits from the preview a VTXO that cannot pay its own fee", async () => {
             const wallet = createMockWallet([swept(5000), swept(100)], ADDRESS, {
                 intentFee: { offchainInput: "250.0" },

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -3777,6 +3777,64 @@ describe("VtxoManager - intent fee pricing", () => {
         });
 
         /**
+         * The preview and the sweep are reachable from the same worker call, so a
+         * UI that previews with one and executes with the other must not show two
+         * different numbers. `getRecoverableBalance` prices exactly as
+         * `recoverVtxos` does.
+         */
+        it("previews the recoverable amount net of intent fees", async () => {
+            const fee: IntentFeeConfig = { offchainInput: "amount * 0.01" };
+            const previewWallet = createMockWallet([swept(5000), swept(3000)], ADDRESS, {
+                intentFee: fee,
+            });
+            const sweepWallet = createMockWallet([swept(5000), swept(3000)], ADDRESS, {
+                intentFee: fee,
+            });
+
+            const preview = await new VtxoManager(previewWallet).getRecoverableBalance();
+            await new VtxoManager(sweepWallet).recoverVtxos();
+
+            expect(preview.recoverable).toBe(7920n);
+            expect(preview.recoverable).toBe(settled(sweepWallet).outputs[0].amount);
+        });
+
+        it("leaves the preview gross when the operator charges nothing", async () => {
+            const wallet = createMockWallet([swept(5000), swept(3000)], ADDRESS);
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            expect(balance.recoverable).toBe(8000n);
+            expect(balance.vtxoCount).toBe(2);
+        });
+
+        it("omits from the preview a VTXO that cannot pay its own fee", async () => {
+            const wallet = createMockWallet([swept(5000), swept(100)], ADDRESS, {
+                intentFee: { offchainInput: "250.0" },
+            });
+            const balance = await new VtxoManager(wallet).getRecoverableBalance();
+
+            // The 100 costs 250 to move, so recovery drops it and so does this.
+            expect(balance.recoverable).toBe(4750n);
+            expect(balance.vtxoCount).toBe(1);
+        });
+
+        /**
+         * The capping block fires whenever the batch narrows, which fee filtering
+         * can now do on its own. An operator debugging a stuck wallet needs the
+         * cause: a size cap defers the rest to the next cycle, whereas fee
+         * filtering means no later cycle helps by itself.
+         */
+        it("names intent fees, not the size caps, when fees alone empty the batch", async () => {
+            const wallet = createMockWallet([swept(1500), swept(1200)], ADDRESS, {
+                intentFee: { offchainInput: "amount * 1.0" },
+            });
+
+            await expect(new VtxoManager(wallet).recoverVtxos()).rejects.toThrow(
+                "All 2 recoverable VTXOs that can pay their own intent fee total less than " +
+                    "the dust threshold 1000",
+            );
+        });
+
+        /**
          * `getRecoverableWithSubdust` judges subdust inclusion on gross value, so
          * a batch can clear dust gross and land under it once the fees are off.
          * Recovery is an untimelocked all-or-nothing sweep, so this has to be a


### PR DESCRIPTION
This is the `feat/arkade-swap` companion to #698, which carries the same fix onto `master`. Both target #696.

`IVtxoManager.renewVtxos()` and `recoverVtxos()` build their settlement output as the gross sum of the inputs they selected, so the fee the intent implies — `sum(inputs) - sum(outputs)` — is always exactly zero. Against an operator with a non-zero `intentFee` policy the server rejects the intent outright and neither call can ever succeed. The bug is present here in the same form it is on `master`: `packages/ts-sdk/src/wallet/vtxo-manager.ts` differs between the two branches by exactly one line, and it is not one of the lines that computes the amount.

I am opening this separately rather than waiting for #698 to merge because `feat/arkade-swap` is the branch the team works on day to day and the one downstream consumers pin, so a fix that only lands on `master` does not reach them for however long the two branches stay apart. #698 stays on `master` since that is where releases are cut.

The first two commits are #698's, unmodified. Both entry points now price their inputs and their output through two shared helpers, `priceSettlementInputs` and `deductOffchainOutputFee`, using the arithmetic that already existed a few hundred lines down the same file — `runPeriodicSettle` and the no-argument `Wallet.settle()` branch both do this, and `runPeriodicSettle`'s comment names this exact failure. Only these two entry points were left gross, and neither takes a fee argument, so a caller cannot correct it from outside. Three things come along with the deduction: an input whose own fee meets or exceeds its value is dropped (and dropped *before* `capSettlementBatch`, so it cannot occupy a slot a viable input behind it could have used); dust is judged on the net output rather than the gross input sum; and `getRecoverableBalance` prices identically to the sweep, so a UI that previews with one and executes with the other stops showing two different numbers. #698's description has the full derivation and I would rather not duplicate it here.

The one thing worth reading carefully on *this* branch is where the pricing lands relative to the gated selection accessor. `feat/arkade-swap` routes the renewal read through `getSpendableVtxos({ withRecoverable: true })` where `master` uses `getVtxos` — that is the single-line divergence, and it sits in `selectExpiringVtxos`. The pricing runs downstream of it: `renewVtxos` selects through the gate, revalidates, and only then prices whatever survived, which is the ordering you want, since pricing a coin the gate is going to reject is wasted work and the gate is the stricter filter. Recovery is unaffected — `recoverVtxos` and `getRecoverableBalance` both still read the ungated `getVtxos` on this branch exactly as they do on `master`, so the pricing lands in the identical place. Whether recovery *should* also be gated is a separate question that was raised and dropped in #700; nothing here changes that either way.

The last two commits came out of review and are **not** in #698, so they should be ported there too. `getRecoverableBalance` returns both a `recoverable` total and a `subdust` figure, and #698 priced the first net while leaving the second summing gross `value` — which puts them on different bases and, for a wallet whose recoverable set is entirely subdust, could report `subdust` larger than `recoverable`. Subdust is still *classified* on gross value, which is what makes a coin subdust and what `getRecoverableWithSubdust` judged inclusion on, but it is now *reported* net, totalled through the existing `subtotalOf` so an unpriced input throws rather than silently contributing zero.

That fix then needed its own claim narrowed, which is worth stating plainly because it is a real limit on the number: `subdust` is net of the per-input fees but *not* of the output fee, because that one is charged on the batch as a whole and does not decompose per coin. So `subdust <= recoverable` holds when no output fee is configured or the non-subdust coins cover it, but not in general — a flat output fee against a wholly subdust wallet still leaves `subdust` the larger. Rather than clamp it, which would invent a number that answers to nothing and would still mislead on mixed sets, the public TSDoc now says what the field actually is (what the subdust coins are worth once each has paid its own way) and a test pins the case. The same round moved a comment up to the recovery capping condition to say that it fires when *either* fee pricing or a size cap narrows the batch, since the comparison is against the pre-pricing count deliberately and reads as cap-only otherwise.

One tradeoff carried over from #698 and worth restating, because it costs the user satoshis. `deductOffchainOutputFee` evaluates the output fee on the pre-deduction subtotal rather than on the amount finally committed, matching what the two already-working paths do. Under a percentage output rate `r` that means paying `r * subtotal` where the server asks only `r * subtotal * (1 - r)`, an over-payment of `r² * subtotal` — 99 sats on a 990,000-sat subtotal at 1%. Solving the fixed point would recover those, but the failure mode of getting it wrong is landing a satoshi *under* the minimum, which is precisely the rejection this change exists to prevent, so I kept the conservative form and pinned the exact magnitude in a test rather than leaving it incidental. If you would rather have the exact solve, I would suggest doing it to all four call sites in one go instead of just these two.

One review suggestion I did not take: making the `getAddress()` call in `getRecoverableBalance` conditional on the operator actually pricing outputs. It is `this.arkAddress.encode()` — a local bech32m encode over an in-memory address, no I/O — and skipping it would mean testing `estimator.config.offchainOutput` at the call site, which duplicates `deductOffchainOutputFee`'s own early return and leaks its internals to every caller. The abstraction seems worth more than the encode.

On evidence, and I want to be precise about what I did and did not re-run. Both of #698's commits cherry-picked onto `feat/arkade-swap` with no conflicts, and the resulting `vtxo-manager.ts` differed from #698's head by exactly the `getSpendableVtxos` line above before the review commits went on top. Gate, measured on pristine `feat/arkade-swap` first and again after: `lint`, `build` and all three `typecheck`s clean on both sides; ts-sdk unit went 2396 passed / 1 skipped to 2417 passed / 1 skipped across the same 156 files, which is 18 new tests from #698 plus 3 from the review round, with no pre-existing test moved; `swap` held at 232 and `boltz-swap` at 614, both unmoved. Reverting the pricing to the gross output while keeping the tests fails 15 of those 18 — the three that still pass are exactly the zero-fee "unchanged behaviour" cases, one per entry point plus the preview — and the flagship failure reads `expected 8000n to be 7920n`, the gross sum offering a zero fee, which is the bug itself. Reverting just the subdust change fails its tests with `expected 1100n to be 1089n` while leaving all eleven pre-existing subdust tests passing, since those run at zero fee where gross and net coincide.

What I did not do is re-run the live regtest verification. #698 confirmed the fix against an arkade-regtest stack (arkd v0.9.15, `offchainInput: "amount * 0.01"`), reproducing `INTENT_INSUFFICIENT_FEE (31): got 0 min expected 990` on the gross intent and getting a 99,000-sat VTXO renewed to 98,010 — a fee of exactly 990, the server's minimum to the satoshi. The recovery path here is byte-identical to what was exercised there, so that result carries over. The renewal path is not quite: it reaches the same pricing code through `getSpendableVtxos` rather than `getVtxos`, so the selection read in front of the fix is one this branch covers by unit test rather than on a live fee-charging stack. This repo's own regtest integration jobs do run against this branch and pass, but their operator charges no intent fee, so they exercise the zero-fee no-op rather than the priced path.


Naming the limit of that squarely, because it is the thing most likely to be wrong and it becomes invisible once this is merged and the reasoning is gone: the unit tests mock `getSpendableVtxos` to return the same set as `getVtxos`. That is what lets them pass identically on both branches — but it also means they cannot detect a divergence between what the gate admits and what the pricing then sees. If the gated accessor ever returns a different set from the ungated one in a way that matters to fee pricing, nothing in this test suite would notice. What the backport proves is that the arithmetic is right and that it sits downstream of the gate; it does not prove the gate and the pricing agree on a real wallet.

One note on what was actually reviewed, since a green check does not always mean a review happened. @arkana-ai-bot's reviews on this PR are real, and are what caught the `subdust` defect and then the overstated invariant in my own first fix for it. CodeRabbit's check, by contrast, passes carrying *"Review skipped: reviews are disabled for this base branch"* — no review took place, and it renders identically to a completed one in the checks list. #698 did get a real CodeRabbit review, so the difference is this PR's base branch rather than anything about the change. Net effect: this PR has had one reviewer, not two.

