### PR TITLE
fix(vhtlc): give the v1 handler its annotation leaf and close its escrow gate

### DIFF
--- a/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
@@ -1,7 +1,14 @@
 import { hex } from "@scure/base";
 import { VHTLC } from "../../script/vhtlc";
 import { RelativeTimelock } from "../../script/tapscript";
-import { Contract, ContractHandler, PathContext, PathSelection } from "../types";
+import {
+    Contract,
+    ContractHandler,
+    DerivedContractTapscripts,
+    PathContext,
+    PathSelection,
+    TapscriptDeriving,
+} from "../types";
 import { isCltvSatisfied, isCsvSpendable, resolveRole } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 
@@ -34,7 +41,8 @@ export interface VHTLCContractParams {
  * - unilateralRefund: Sender + Receiver after CSV delay
  * - unilateralRefundWithoutReceiver: Sender after CSV delay
  */
-export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Script> = {
+export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Script> &
+    TapscriptDeriving<VHTLC.Script> = {
     type: "vhtlc",
 
     createScript(params: Record<string, string>): VHTLC.Script {
@@ -242,10 +250,67 @@ export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Sc
     },
 
     /**
-     * Today's behaviour verbatim: a VHTLC row is spendable unconditionally.
-     * Narrowing it to the claim/refund economics (as NArk's
-     * `VHTLCContractTransformer.CanTransform` does) would stop in-flight swaps
-     * from being selected — a real behaviour change, deliberately deferred.
+     * Never. A live VHTLC is escrow: the counterparty's claim leaf is armed,
+     * and generic selection — send, settle, renewal, offboard — would move the
+     * lockup out from under a swap the counterparty is still entitled to
+     * complete, or race a claim already in flight.
+     *
+     * Two narrow reasons, and neither is "spending this would destroy the
+     * VTXO". It would not: the leaf {@link deriveTapscripts} stamps is
+     * `refundWithoutReceiver` — `CLTV[sender, server]`, the sender's OWN
+     * refund, which the server rejects until `refundLocktime` matures. The
+     * reasons are that an escrowed lockup must not count toward the
+     * `available` balance bucket (`computeOffchainBalance` credits `available`
+     * only where this gate is open), and that generic RENEWAL must not
+     * silently execute a refund the caller never asked for —
+     * `runPeriodicSettle` selects through `getSpendableVtxos`, which this gate
+     * filters, and it runs unprompted whenever a wallet is built without an
+     * explicit `settlementConfig`.
+     *
+     * **Inseparable from {@link deriveTapscripts}.** Until that method existed
+     * a `vhtlc` row's VTXOs could not be annotated at all, so they never
+     * reached this gate and the answer here was unobservable — the previous
+     * `true` and the missing derivation were safe only by cancelling out.
+     * Deriving the leaf without closing the gate would hand generic renewal an
+     * escrow it had never been offered before. (The earlier `true` was
+     * justified as preserving selection of in-flight swaps; no such selection
+     * was ever reachable, for that same annotation reason.)
      */
-    isGenericallySpendable: () => true,
+    isGenericallySpendable: () => false,
+
+    /**
+     * The annotation leaf stamped onto every VTXO locked to this contract.
+     *
+     * **Without this the contract is unusable, not merely unoptimized.**
+     * `deriveContractTapscripts` falls back to `script.forfeit()` for any
+     * handler that does not implement {@link TapscriptDeriving}, and no VHTLC
+     * script version has a `forfeit()` — `VtxoScript` does not define one and
+     * `VHTLC.BaseScript` does not add one. The fallback therefore threw
+     * `legacy.forfeit is not a function`, `annotatableIn` caught it, and
+     * `fetchContractVtxosBulk` dropped this contract's VTXOs before they were
+     * persisted. The row existed and was watched while its balance stayed
+     * permanently invisible, and `getSyncState()` reported `degraded` forever.
+     *
+     * `refundWithoutReceiver` is the leaf, for both roles the annotation
+     * serves, because it is the only collaborative path this wallet can
+     * actually satisfy as the sender — the same conclusion `selectPath`
+     * reaches, kept in step with it deliberately. The claim leaves belong to
+     * the receiver and need a preimage the sender does not have; `refund` and
+     * `unilateralRefund` both need the counterparty's signature, which this
+     * protocol has no message to ask for. V1 has no covenant leaves at all.
+     *
+     * **It carries a CLTV, and callers must respect it.** A settlement built
+     * on this leaf is only valid once `refundLocktime` has matured, so a
+     * recovery round that sweeps this VTXO early is rejected by the server.
+     * Nothing in this handler can enforce that, because the annotation is
+     * derived per contract and knows no clock.
+     */
+    deriveTapscripts(script: VHTLC.Script): DerivedContractTapscripts {
+        const leaf = script.refundWithoutReceiver();
+        return {
+            forfeitTapLeafScript: leaf,
+            intentTapLeafScript: leaf,
+            tapTree: script.encode(),
+        };
+    },
 };

--- a/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
@@ -375,10 +375,8 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
      * Never. A live VHTLC is escrow: the counterparty's claim leaf is armed,
      * and generic selection — send, settle, RENEWAL, offboard — would move the
      * lockup out from under a swap the counterparty is still entitled to
-     * complete, or race a claim already in flight. `vhtlc` answers `true` only
-     * because that was its behaviour before the gate existed and narrowing it
-     * would have changed in-flight swaps; a type with no deployed rows inherits
-     * no such obligation.
+     * complete, or race a claim already in flight. The `vhtlc` handler now
+     * answers the same, for the same reason.
      *
      * Recovery is unaffected: the gate guards only GENERIC selection, and every
      * way out of a lockup names its outpoints explicitly — `settle({ inputs })`,
@@ -399,8 +397,9 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
      * `fetchContractVtxosBulk` drops this contract's VTXOs before they are
      * persisted. The row would exist and be watched while its balance stayed
      * permanently invisible, and `getSyncState()` would report `degraded`
-     * forever. (The `vhtlc` handler has the same gap; nothing registers V1 rows
-     * through `ContractManager` today, so it has never been hit.)
+     * forever. (The `vhtlc` handler had the same gap and now closes it the same
+     * way; nothing registers V1 rows through `ContractManager` in this repo, so
+     * it was never hit here.)
      *
      * `refundWithoutReceiver` is the leaf, for both roles the annotation
      * serves, because it is the only collaborative path this wallet can

--- a/packages/ts-sdk/test/contracts/vhtlc-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlc-handler.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The `vhtlc` (V1) handler's two contract-manager-facing properties:
+ * `deriveTapscripts` and `isGenericallySpendable`.
+ *
+ * These two are a pair, and the pairing is the point. Before either existed a
+ * `vhtlc` row was safe only by cancellation: `deriveContractTapscripts` falls
+ * back to `script.forfeit()`, no VHTLC script defines one, so annotation threw
+ * and the row's VTXOs were dropped before they could be persisted. They were
+ * invisible, not protected — and the `isGenericallySpendable: true` sitting
+ * next to that was unobservable rather than correct. Deriving the annotation
+ * leaf without also closing the gate would have made a V1 escrow visible AND
+ * selectable by unprompted renewal in one change.
+ *
+ * @see vhtlcV2-handler.test.ts for the same properties on ScriptV2, and for
+ * the parity pins that keep the two handlers from drifting apart.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { hex } from "@scure/base";
+
+import {
+    ContractManager,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    VHTLC,
+    gatedContracts,
+    isContractGenericallySpendable,
+    scriptFromTapLeafScript,
+    type Contract,
+} from "../../src";
+import { VHTLCContractHandler } from "../../src/contracts/handlers/vhtlc";
+import { deriveContractTapscripts } from "../../src/wallet/utils";
+import { createMockIndexerProvider, createMockVtxo } from "./helpers";
+
+const SENDER = "0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4";
+const RECEIVER = "1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b";
+const SERVER = "aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88";
+/** HASH160 output — VHTLC validates this at exactly 20 bytes. */
+const HASH = "4d487dd3753a89bc9fe98401d1196523058251fc";
+
+/** V1 takes the same eight mandatory fields as V2, minus the covenant leaves. */
+const params = (over: Record<string, string> = {}): Record<string, string> => ({
+    sender: SENDER,
+    receiver: RECEIVER,
+    server: SERVER,
+    hash: HASH,
+    refundLocktime: "800000",
+    claimDelay: "10",
+    refundDelay: "12",
+    refundNoReceiverDelay: "14",
+    ...over,
+});
+
+const contractOf = (p: Record<string, string>): Contract => ({
+    type: "vhtlc",
+    params: p,
+    script: hex.encode(VHTLCContractHandler.createScript(p).pkScript),
+    address: "ark1lockup",
+    state: "active",
+    createdAt: Date.now(),
+});
+
+const leafHex = (leaf: unknown): string => hex.encode(scriptFromTapLeafScript(leaf as never));
+
+describe("VHTLCContractHandler (v1)", () => {
+    it("inherits a working refundWithoutReceiver() from VHTLC.BaseScript", () => {
+        const script = VHTLCContractHandler.createScript(params());
+        expect(script).toBeInstanceOf(VHTLC.Script);
+        // The leaf the annotation depends on must resolve in V1's own tree,
+        // not merely be declared on the shared base class.
+        expect(leafHex(script.refundWithoutReceiver())).toBe(script.refundWithoutReceiverScript);
+    });
+
+    it("derives annotation tapscripts rather than falling back to a forfeit() it lacks", () => {
+        const p = params();
+        const script = VHTLCContractHandler.createScript(p);
+
+        // The pipeline entry point, not just the handler method: this is the
+        // call `annotateVtxos` makes, and the one that used to throw
+        // `legacy.forfeit is not a function`.
+        const derived = deriveContractTapscripts(contractOf(p));
+        expect(leafHex(derived.intentTapLeafScript)).toBe(script.refundWithoutReceiverScript);
+        expect(leafHex(derived.forfeitTapLeafScript)).toBe(script.refundWithoutReceiverScript);
+        expect(hex.encode(derived.tapTree)).toBe(hex.encode(script.encode()));
+    });
+
+    it("is never generically spendable — a live lockup is escrow", () => {
+        const contract = contractOf(params());
+        expect(VHTLCContractHandler.isGenericallySpendable?.(contract)).toBe(false);
+        expect(isContractGenericallySpendable(contract)).toBe(false);
+    });
+
+    /**
+     * The whole point of the pairing, in one assertion: the VTXOs of a
+     * registered V1 lockup now survive the sync (so the balance is no longer
+     * permanently invisible) AND are withheld from generic selection (so an
+     * unprompted renewal cannot sweep the escrow that just became visible).
+     */
+    it("syncs a registered lockup's vtxos but withholds them from generic selection", async () => {
+        const p = params();
+        const script = hex.encode(VHTLCContractHandler.createScript(p).pkScript);
+        const indexer = createMockIndexerProvider();
+        (indexer.getVtxos as ReturnType<typeof vi.fn>).mockResolvedValue({
+            vtxos: [createMockVtxo({ script, value: 5000 })],
+            page: undefined,
+        });
+
+        const manager = await ContractManager.create({
+            indexerProvider: indexer,
+            contractRepository: new InMemoryContractRepository(),
+            walletRepository: new InMemoryWalletRepository(),
+        });
+        const contract = await manager.createContract({
+            type: "vhtlc",
+            params: p,
+            script,
+            address: "ark1lockup",
+        });
+
+        const [entry] = await manager.getContractsWithVtxos({ script });
+        expect(entry.vtxos).toHaveLength(1);
+        expect(entry.vtxos[0].value).toBe(5000);
+        expect(leafHex(entry.vtxos[0].intentTapLeafScript)).toBe(
+            VHTLCContractHandler.createScript(p).refundWithoutReceiverScript,
+        );
+        // Visible, and not degraded...
+        expect(manager.getSyncState().mode).toBe("online");
+        // ...but closed to generic spending. `getSpendableVtxos` drops exactly
+        // the scripts this map holds, which is what keeps `runPeriodicSettle`
+        // from selecting the lockup.
+        expect(gatedContracts([contract]).get(script)).toBe("vhtlc");
+
+        manager.dispose();
+    });
+});

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -177,6 +177,64 @@ describe("VHTLCV2ContractHandler", () => {
         expect(v2).not.toBe(v1);
     });
 
+    /**
+     * The two handlers must answer the contract-manager-facing questions the
+     * same way, because the reasons are the same for both: a VHTLC of either
+     * version is escrow, and neither script version has a `forfeit()` for
+     * `deriveContractTapscripts` to fall back to.
+     *
+     * Pinned as a pair because they are easy to change one at a time, and one
+     * at a time is exactly what is unsafe. V1 shipped for a while answering
+     * `true` to the gate while deriving no annotation leaf at all — a
+     * combination that was only safe because the missing derivation kept its
+     * VTXOs out of the snapshot, so the open gate was never reached.
+     */
+    it("agrees with the vhtlc handler on annotation and on the spending gate", () => {
+        const shared = {
+            sender: SENDER,
+            receiver: RECEIVER,
+            server: SERVER,
+            hash: HASH,
+            refundLocktime: "800000",
+            claimDelay: "10",
+            refundDelay: "12",
+            refundNoReceiverDelay: "14",
+        };
+        const v1Script = VHTLCContractHandler.createScript(shared);
+        const v2Script = VHTLCV2ContractHandler.createScript(shared);
+        const v1Contract: Contract = {
+            type: "vhtlc",
+            params: shared,
+            script: hex.encode(v1Script.pkScript),
+            address: "address",
+            state: "active",
+            createdAt: Date.now(),
+        };
+        const v2Contract = contractOf(shared);
+
+        // Both closed to generic selection, and closed rather than merely equal.
+        expect(VHTLCContractHandler.isGenericallySpendable?.(v1Contract)).toBe(
+            VHTLCV2ContractHandler.isGenericallySpendable?.(v2Contract),
+        );
+        expect(isContractGenericallySpendable(v1Contract)).toBe(false);
+        expect(isContractGenericallySpendable(v2Contract)).toBe(false);
+
+        // Both annotate off their own refundWithoutReceiver leaf, through the
+        // shared entry point rather than the handler method.
+        for (const [contract, script] of [
+            [v1Contract, v1Script],
+            [v2Contract, v2Script],
+        ] as const) {
+            const derived = deriveContractTapscripts(contract);
+            expect(leafHex({ leaf: derived.intentTapLeafScript })).toBe(
+                script.refundWithoutReceiverScript,
+            );
+            expect(leafHex({ leaf: derived.forfeitTapLeafScript })).toBe(
+                script.refundWithoutReceiverScript,
+            );
+        }
+    });
+
     it("derives annotation tapscripts rather than falling back to a forfeit() it lacks", () => {
         const params = fullParams();
         const contract = contractOf(params);

--- a/packages/ts-sdk/test/e2e/unilateralExit.test.ts
+++ b/packages/ts-sdk/test/e2e/unilateralExit.test.ts
@@ -253,11 +253,11 @@ describe("unilateral exit packages", () => {
             });
 
             // register the contract (with the preimage) in bob's repository.
-            // NOTE: registration goes straight to the repository — the
-            // ContractManager annotation path (`deriveContractTapscripts`)
-            // still assumes forfeit-style scripts and cannot annotate VHTLCs.
-            // The exit flow's explicit-outpoint path is designed to work
-            // without wallet-side VTXO tracking.
+            // NOTE: registration goes straight to the repository, so this
+            // exercises the exit flow's explicit-outpoint path without any
+            // wallet-side VTXO tracking. It never goes through
+            // `ContractManager`, and so is untouched by the `vhtlc` handler's
+            // generic-spending gate, which filters generic selection only.
             await bob.wallet.contractRepository.saveContract({
                 type: "vhtlc",
                 params: {

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -170,8 +170,25 @@ describe("ContractHandler.isGenericallySpendable", () => {
         expect(DefaultContractHandler.isGenericallySpendable?.(row)).toBe(true);
         expect(DelegateContractHandler.isGenericallySpendable?.(row)).toBe(true);
         expect(BoardingContractHandler.isGenericallySpendable?.(row)).toBe(true);
-        // Today's behaviour verbatim — Phase 0 changes nothing for VHTLC.
-        expect(VHTLCContractHandler.isGenericallySpendable?.(row)).toBe(true);
+    });
+
+    /**
+     * This assertion used to read `true`, pinned as "today's behaviour
+     * verbatim" and deferred on the grounds that narrowing it would stop
+     * in-flight swaps from being selected.
+     *
+     * That premise did not hold. The `vhtlc` handler had no `deriveTapscripts`
+     * and no VHTLC script defines `forfeit()`, so `deriveContractTapscripts`
+     * threw for every `vhtlc` row, `annotatableIn` dropped its VTXOs, and they
+     * never reached this gate — there was no selection to preserve. The
+     * handler now derives its annotation leaf, so those VTXOs DO arrive here,
+     * and a VHTLC is escrow rather than wallet-owned money: it must not be
+     * credited to `available`, nor swept by an unprompted renewal.
+     */
+    it("answers false for vhtlc — escrow, not wallet-owned money", () => {
+        const row = contract("s", "vhtlc");
+        expect(VHTLCContractHandler.isGenericallySpendable?.(row)).toBe(false);
+        expect(isContractGenericallySpendable(row)).toBe(false);
     });
 
     it("makes arkade opt-in, never opt-out", () => {


### PR DESCRIPTION
Brings the `vhtlc` (v1) contract handler in line with `vhtlc-v2`, by giving it the two contract-manager-facing members v2 already has: `deriveTapscripts` and `isGenericallySpendable`.

## Why v1 needs this at all

A `vhtlc` row can't currently be used through `ContractManager`. `deriveContractTapscripts` falls back to `script.forfeit()` for any handler that doesn't implement `TapscriptDeriving`, and no VHTLC script version defines one — it's absent from both `VtxoScript` and `VHTLC.BaseScript`. So annotation throws `legacy.forfeit is not a function` for every v1 row. `annotatableIn` turns that into a per-contract failure, `fetchContractVtxosBulk` drops the row's VTXOs before they're persisted, and `assertAnnotatable` refuses even an explicit `settle({ inputs })` that names them. The contract row exists and stays watched while its balance is permanently invisible, and `getSyncState()` reports `degraded` forever.

Nothing in this repo registers a v1 row — the swap corridor registers `vhtlc-v2` — so this has never bitten us here. But the handler is registered by default, exported from the public API, and the README and `Wallet.getContractManager`'s JSDoc both document `createContract({ type: 'vhtlc', ... })` as the way to track a Lightning swap. Anyone following those docs hits the broken path.

## Why both changes are in one commit

They're currently safe only because they cancel out, and either one alone breaks that.

Without `deriveTapscripts`, a v1 lockup's VTXOs never reach the snapshot — they're invisible, not protected. The `isGenericallySpendable: () => true` sitting next to that says "generic settlement may take this," but nothing ever arrives for it to say that about. Adding the derivation on its own would make v1 escrow visible *and* selectable by renewal in the same change, and renewal is self-driving: `runPeriodicSettle` selects through `getSpendableVtxos` and runs unprompted whenever a wallet is built without an explicit `settlementConfig`.

## Why the gate closes — the narrow version

Worth being precise here, because there's a nearby argument that doesn't hold. Spending a covenant VTXO through `refundWithoutReceiver` is **not** destroying it: that leaf is `CLTV[sender, server]`, the sender's own refund, and the server enforces the timelock, so an early sweep is simply rejected. That isn't the reason.

The reasons are narrower:

- an escrowed lockup shouldn't count toward the `available` balance bucket (`computeOffchainBalance` credits `available` only where this gate is open), and
- generic **renewal** shouldn't silently execute a refund the caller never asked for.

Recovery is unaffected either way — the gate guards only generic selection, and every deliberate way out of a lockup names its outpoints explicitly.

The old comment justified `true` as preserving selection of in-flight swaps. That premise doesn't hold: no v1 row's VTXOs could ever be selected, because none could be annotated.

## The test that pinned the old behaviour

`test/spendability-gate.test.ts` asserted the old `true` as "today's behaviour verbatim — Phase 0 changes nothing for VHTLC". That assertion is now false. It's updated rather than deleted: it moves out of the "answers true for every built-in wallet-owned type" case — which a VHTLC isn't, it's escrow — into its own case that records why the original premise didn't hold.

Two comments on the `vhtlc-v2` handler that described the old v1 behaviour are corrected in the same commit, since this change makes them false.

## Test plan

New in `test/contracts/vhtlc-handler.test.ts`:

- `VHTLC.Script` inherits a working `refundWithoutReceiver()` — the derived leaf equals `script.refundWithoutReceiverScript`, mirroring how v2's tests check it
- v1 derives annotation tapscripts through `deriveContractTapscripts` (the call `annotateVtxos` makes) rather than the `forfeit()` fallback
- v1 is never generically spendable
- end-to-end through `ContractManager`: a registered v1 lockup's VTXOs now survive the sync **and** are withheld from generic selection

Added to `test/contracts/vhtlcV2-handler.test.ts`: a parity test pinning that the two handlers now agree on both properties, alongside the existing rung-for-rung `selectPath` pin. v2's own tests are unchanged and still pass.

Revert-verified each half separately:

- drop `deriveTapscripts`, keep the gate closed → 3 failures, all `legacy.forfeit is not a function`, with the runtime log `cannot annotate contract 'vhtlc' at 5120be4a…; skipping its vtxos`
- restore `isGenericallySpendable: () => true`, keep the derivation → 4 failures across all three test files, each naming the gate

Unit gate, baselined on `origin/feat/arkade-swap` at 540f82e8 (after #701 merged):

| package | baseline | after |
| --- | --- | --- |
| ts-sdk | 156 files, 2427 passed, 1 skipped | 157 files, 2433 passed, 1 skipped |
| swap | 17 files, 261 passed | 17 files, 261 passed |
| boltz-swap | 23 files, 614 passed | 23 files, 614 passed |

Zero failing before, zero after; the +6 are the new tests. Lint, all three typechecks and the build pass in both runs. Integration/e2e suites were not run locally — they need the regtest stack, so CI covers those.
