### PR TITLE
fix(contracts): give PathContext the block height it declares

### DIFF
--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -161,6 +161,17 @@ const DEFAULT_SCAN_BATCH = 10;
  */
 const CHAIN_TIP_TTL_MS = 30_000;
 
+/**
+ * How long a chain tip read may take before a path query stops waiting on it.
+ *
+ * A path query answers from local state; the tip only enriches it. `fetch`
+ * carries no timeout of its own, and a connection that opens and then goes
+ * quiet neither resolves nor rejects — so without this one stalled read would
+ * hang every path query that joins it, for as long as the socket stays open.
+ * Expiry is treated as "tip unknown", the same as a read that fails.
+ */
+const CHAIN_TIP_TIMEOUT_MS = 5_000;
+
 export type RefreshVtxosOptions = {
     /**
      * Narrow the refresh to these scripts. A subset query, so the
@@ -1699,31 +1710,51 @@ export class ContractManager implements IContractManager {
         // Collapse concurrent misses onto one read. Without this, a pass that
         // resolves paths for many contracts fires a provider request per
         // contract on the tick the TTL lapses — every one of them racing to
-        // write the same height. Assignment happens before the first await
-        // inside, so a caller arriving later in the same tick joins this
-        // promise rather than starting its own.
-        this.chainTipInflight ??= (async () => {
-            try {
-                const height = await source();
-                // Stamped after the await, not before, so the TTL measures
-                // from when the height was actually true.
-                if (height !== undefined) {
-                    this.chainTipCache = { height, at: Date.now() };
-                }
-                // A source that answers `undefined` is saying "no height
-                // available", which is not a value worth remembering — leaving
-                // the cache alone lets the next call past the TTL ask again
-                // rather than serving an absence for 30 seconds.
-                return height;
-            } catch {
-                // Unknown, i.e. exactly the pre-existing behaviour. A tip that
-                // cannot be read must not turn a path query into a rejection.
-                return undefined;
-            } finally {
+        // write the same height.
+        if (!this.chainTipInflight) {
+            // Cleared from out here rather than a `finally` inside the read: a
+            // source that throws synchronously settles the read before the
+            // assignment below, and an inner `finally` would then clear the
+            // field before it was ever set — pinning it for good.
+            this.chainTipInflight = this.readChainTip(source).finally(() => {
                 this.chainTipInflight = undefined;
-            }
-        })();
+            });
+        }
         return this.chainTipInflight;
+    }
+
+    /**
+     * One chain tip read, bounded by {@link CHAIN_TIP_TIMEOUT_MS}. Never
+     * rejects: an unreadable tip is "unknown", which is what the callers did
+     * before a tip existed at all, and a path query is not worth failing over
+     * a provider hiccup.
+     */
+    private async readChainTip(
+        source: () => Promise<number | undefined>,
+    ): Promise<number | undefined> {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+            const height = await Promise.race([
+                source(),
+                new Promise<undefined>((resolve) => {
+                    timer = setTimeout(() => resolve(undefined), CHAIN_TIP_TIMEOUT_MS);
+                }),
+            ]);
+            // Stamped after the await, not before, so the TTL measures from
+            // when the height was actually true. A source answering
+            // `undefined` — or a read that timed out — is saying "no height
+            // available", which is not worth remembering: leaving the cache
+            // alone lets the next call ask again rather than serving an
+            // absence for the rest of the TTL.
+            if (height !== undefined) {
+                this.chainTipCache = { height, at: Date.now() };
+            }
+            return height;
+        } catch {
+            return undefined;
+        } finally {
+            clearTimeout(timer);
+        }
     }
 
     /**
@@ -1755,6 +1786,11 @@ export class ContractManager implements IContractManager {
     /**
      * Get every currently valid spending path for a contract.
      *
+     * No `blockHeight`: this enumerates paths "regardless of current
+     * spendability", so no handler evaluates a timelock here and the tip would
+     * be fetched only to be discarded — leaving a purely local answer waiting
+     * on the network for nothing.
+     *
      * @param options - Options for getting spending paths
      */
     async getAllSpendingPaths(options: GetAllSpendingPathsOptions): Promise<PathSelection[]> {
@@ -1770,7 +1806,6 @@ export class ContractManager implements IContractManager {
         const context: PathContext = {
             collaborative,
             currentTime: Date.now(),
-            blockHeight: await this.currentBlockHeight(),
             walletPubKey,
         };
 

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -150,6 +150,17 @@ const SCAN_MAX_INDEX = 10_000;
  */
 const DEFAULT_SCAN_BATCH = 10;
 
+/**
+ * How long a chain tip read stays usable for {@link PathContext.blockHeight}.
+ *
+ * Sized well under a block interval so the cached height is at most one block
+ * behind, and short enough that a caller resolving paths across many contracts
+ * pays a single provider round trip. Staleness is one-directional here: a
+ * height below the true tip can only withhold a height-gated path that has
+ * just matured, never offer one that has not.
+ */
+const CHAIN_TIP_TTL_MS = 30_000;
+
 export type RefreshVtxosOptions = {
     /**
      * Narrow the refresh to these scripts. A subset query, so the
@@ -556,6 +567,23 @@ export interface ContractManagerConfig {
      * {@link ContractManager.refillLookAhead}.
      */
     lookAhead?: LookAheadConfig;
+
+    /**
+     * Current chain tip height, for the `blockHeight` a {@link PathContext}
+     * carries. Absent, or resolving `undefined`, leaves `blockHeight` unset.
+     *
+     * Height-typed timelocks cannot be evaluated without it: `isCltvSatisfied`
+     * and `isCsvSpendable` both answer `false` outright when `blockHeight` is
+     * missing, so every height-gated path is reported unspendable no matter how
+     * mature it is. Nothing populated this before, which made that the only
+     * behaviour available. Seconds-typed timelocks read `currentTime` and are
+     * unaffected either way.
+     *
+     * Resolve `undefined` rather than rejecting when the tip cannot be read:
+     * the callers treat it as "unknown", which is the pre-existing behaviour,
+     * and a path query is not worth failing over a provider hiccup.
+     */
+    chainTip?: () => Promise<number | undefined>;
 }
 
 /**
@@ -667,6 +695,8 @@ export class ContractManager implements IContractManager {
     private syncDegradedReason?: string;
     /** Epoch-ms of the last successful provider sync, if any. */
     private lastSyncedAt?: number;
+    /** Last chain tip read, with the epoch-ms it was read at. @see currentBlockHeight */
+    private chainTipCache?: { height: number; at: number };
     /** Speculative look-ahead scripts, keyed by script. @see LookAheadEntry */
     private lookAheadEntries: Map<string, LookAheadEntry> = new Map();
     /** In-flight look-ahead drain, if any. @see scheduleLookAheadDrain */
@@ -1645,6 +1675,36 @@ export class ContractManager implements IContractManager {
     }
 
     /**
+     * Chain tip height for a {@link PathContext}, or `undefined` when there is
+     * no source configured or it cannot be read.
+     *
+     * Cached for {@link CHAIN_TIP_TTL_MS} so a caller resolving paths for many
+     * contracts does not pay a provider round trip each time. Blocks arrive
+     * ~10 minutes apart, so a cache this short can only ever be one block
+     * stale, and a stale-low height is the conservative direction: a path is
+     * reported unspendable slightly longer than it truly is, never spendable
+     * before it is.
+     */
+    private async currentBlockHeight(): Promise<number | undefined> {
+        const source = this.config.chainTip;
+        if (!source) return undefined;
+        const now = Date.now();
+        if (this.chainTipCache && now - this.chainTipCache.at < CHAIN_TIP_TTL_MS) {
+            return this.chainTipCache.height;
+        }
+        try {
+            const height = await source();
+            if (height === undefined) return undefined;
+            this.chainTipCache = { height, at: now };
+            return height;
+        } catch {
+            // Unknown, i.e. exactly the pre-existing behaviour. A tip that
+            // cannot be read must not turn a path query into a rejection.
+            return undefined;
+        }
+    }
+
+    /**
      * Get currently spendable paths for a contract.
      *
      * @param options - Options for getting spendable paths
@@ -1662,6 +1722,7 @@ export class ContractManager implements IContractManager {
         const context: PathContext = {
             collaborative,
             currentTime: Date.now(),
+            blockHeight: await this.currentBlockHeight(),
             walletPubKey,
             vtxo,
         };
@@ -1687,6 +1748,7 @@ export class ContractManager implements IContractManager {
         const context: PathContext = {
             collaborative,
             currentTime: Date.now(),
+            blockHeight: await this.currentBlockHeight(),
             walletPubKey,
         };
 

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -572,12 +572,15 @@ export interface ContractManagerConfig {
      * Current chain tip height, for the `blockHeight` a {@link PathContext}
      * carries. Absent, or resolving `undefined`, leaves `blockHeight` unset.
      *
-     * Height-typed timelocks cannot be evaluated without it: `isCltvSatisfied`
-     * and `isCsvSpendable` both answer `false` outright when `blockHeight` is
-     * missing, so every height-gated path is reported unspendable no matter how
-     * mature it is. Nothing populated this before, which made that the only
-     * behaviour available. Seconds-typed timelocks read `currentTime` and are
-     * unaffected either way.
+     * `isCltvSatisfied` answers `false` outright for a height-typed locktime
+     * when `blockHeight` is missing, so every such path was reported
+     * unspendable however mature it was. Nothing populated this before, which
+     * made that the only behaviour available. Seconds-typed locktimes read
+     * `currentTime` and are unaffected either way.
+     *
+     * Block-typed CSV is not fixed by this. `isCsvSpendable` also needs the
+     * VTXO's confirmation height, and `status.block_height` is never populated
+     * for a virtual coin, so it stays `false` regardless of the tip.
      *
      * Resolve `undefined` rather than rejecting when the tip cannot be read:
      * the callers treat it as "unknown", which is the pre-existing behaviour,

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -697,6 +697,8 @@ export class ContractManager implements IContractManager {
     private lastSyncedAt?: number;
     /** Last chain tip read, with the epoch-ms it was read at. @see currentBlockHeight */
     private chainTipCache?: { height: number; at: number };
+    /** In-flight chain tip read, so concurrent cache misses share one. */
+    private chainTipInflight?: Promise<number | undefined>;
     /** Speculative look-ahead scripts, keyed by script. @see LookAheadEntry */
     private lookAheadEntries: Map<string, LookAheadEntry> = new Map();
     /** In-flight look-ahead drain, if any. @see scheduleLookAheadDrain */
@@ -1688,20 +1690,37 @@ export class ContractManager implements IContractManager {
     private async currentBlockHeight(): Promise<number | undefined> {
         const source = this.config.chainTip;
         if (!source) return undefined;
-        const now = Date.now();
-        if (this.chainTipCache && now - this.chainTipCache.at < CHAIN_TIP_TTL_MS) {
+        if (this.chainTipCache && Date.now() - this.chainTipCache.at < CHAIN_TIP_TTL_MS) {
             return this.chainTipCache.height;
         }
-        try {
-            const height = await source();
-            if (height === undefined) return undefined;
-            this.chainTipCache = { height, at: now };
-            return height;
-        } catch {
-            // Unknown, i.e. exactly the pre-existing behaviour. A tip that
-            // cannot be read must not turn a path query into a rejection.
-            return undefined;
-        }
+        // Collapse concurrent misses onto one read. Without this, a pass that
+        // resolves paths for many contracts fires a provider request per
+        // contract on the tick the TTL lapses — every one of them racing to
+        // write the same height. Assignment happens before the first await
+        // inside, so a caller arriving later in the same tick joins this
+        // promise rather than starting its own.
+        this.chainTipInflight ??= (async () => {
+            try {
+                const height = await source();
+                // Stamped after the await, not before, so the TTL measures
+                // from when the height was actually true.
+                if (height !== undefined) {
+                    this.chainTipCache = { height, at: Date.now() };
+                }
+                // A source that answers `undefined` is saying "no height
+                // available", which is not a value worth remembering — leaving
+                // the cache alone lets the next call past the TTL ask again
+                // rather than serving an absence for 30 seconds.
+                return height;
+            } catch {
+                // Unknown, i.e. exactly the pre-existing behaviour. A tip that
+                // cannot be read must not turn a path query into a rejection.
+                return undefined;
+            } finally {
+                this.chainTipInflight = undefined;
+            }
+        })();
+        return this.chainTipInflight;
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2033,7 +2033,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             watcherConfig: this.watcherConfig,
             lookAhead: this.lookAheadConfig(),
             // Without this a PathContext carries no blockHeight, and every
-            // height-typed timelock reads as unsatisfied however mature it is.
+            // height-typed CLTV reads as unsatisfied however mature it is.
             // @see ContractManagerConfig.chainTip
             chainTip: async () => (await this.onchainProvider.getChainTip()).height,
         });

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2032,6 +2032,10 @@ export class ReadonlyWallet implements IReadonlyWallet {
             onVtxosSpent,
             watcherConfig: this.watcherConfig,
             lookAhead: this.lookAheadConfig(),
+            // Without this a PathContext carries no blockHeight, and every
+            // height-typed timelock reads as unsatisfied however mature it is.
+            // @see ContractManagerConfig.chainTip
+            chainTip: async () => (await this.onchainProvider.getChainTip()).height,
         });
 
         // Register the wallet's baseline always-active contracts: every

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -248,6 +248,33 @@ describe("VHTLCV2ContractHandler", () => {
             expect(await refundLeafOffered(async () => 800_000)).toBe(true);
         });
 
+        it("collapses concurrent cache misses onto a single tip read", async () => {
+            let reads = 0;
+            const manager = await managerFor(async () => {
+                reads += 1;
+                // Resolve on a later turn, so all three callers are waiting on
+                // the same in-flight read rather than being served in sequence.
+                await Promise.resolve();
+                return 800_000;
+            });
+            const contract = contractOf(fullParams());
+            await manager.createContract(contract);
+
+            const query = () =>
+                manager.getSpendablePaths({
+                    contractScript: contract.script,
+                    collaborative: true,
+                    walletPubKey: SENDER,
+                });
+            const results = await Promise.all([query(), query(), query()]);
+
+            expect(reads).toBe(1);
+            const script = VHTLCV2ContractHandler.createScript(contract.params);
+            for (const paths of results) {
+                expect(paths.map(leafHex)).toContain(script.refundWithoutReceiverScript);
+            }
+        });
+
         it("treats an unreadable tip as unknown rather than failing the query", async () => {
             const paths = await (async () => {
                 const manager = await managerFor(async () => {

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -292,6 +292,89 @@ describe("VHTLCV2ContractHandler", () => {
             const script = VHTLCV2ContractHandler.createScript(fullParams());
             expect(paths.map(leafHex)).not.toContain(script.refundWithoutReceiverScript);
         });
+
+        /**
+         * A rejection is the easy failure; a socket that opens and then goes
+         * quiet is the one `fetch` has no answer for. It never settles, so the
+         * `catch` above never runs — and since every later query joins the same
+         * in-flight read, one stalled tip would wedge path resolution for the
+         * manager's lifetime rather than for one call.
+         */
+        it("gives up on a stalled tip read, and lets the next query start a fresh one", async () => {
+            let reads = 0;
+            const manager = await managerFor(() => {
+                reads += 1;
+                return new Promise<number>(() => {});
+            });
+            const contract = contractOf(fullParams());
+            await manager.createContract(contract);
+            const script = VHTLCV2ContractHandler.createScript(contract.params);
+            const query = () =>
+                manager.getSpendablePaths({
+                    contractScript: contract.script,
+                    collaborative: true,
+                    walletPubKey: SENDER,
+                });
+
+            vi.useFakeTimers();
+            try {
+                const first = query();
+                // Well past any bound, so the test does not encode the exact one.
+                await vi.advanceTimersByTimeAsync(60_000);
+                expect((await first).map(leafHex)).not.toContain(
+                    script.refundWithoutReceiverScript,
+                );
+
+                const second = query();
+                await vi.advanceTimersByTimeAsync(60_000);
+                await second;
+                // Not still joined to the first, dead read.
+                expect(reads).toBe(2);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("does not wedge on a source that throws synchronously", async () => {
+            let reads = 0;
+            const manager = await managerFor(() => {
+                reads += 1;
+                if (reads === 1) throw new Error("provider not ready");
+                return Promise.resolve(800_000);
+            });
+            const contract = contractOf(fullParams());
+            await manager.createContract(contract);
+            const script = VHTLCV2ContractHandler.createScript(contract.params);
+            const query = () =>
+                manager.getSpendablePaths({
+                    contractScript: contract.script,
+                    collaborative: true,
+                    walletPubKey: SENDER,
+                });
+
+            expect((await query()).map(leafHex)).not.toContain(script.refundWithoutReceiverScript);
+            // The transient throw must not outlive itself: the provider has
+            // recovered, so the matured leaf comes back.
+            expect((await query()).map(leafHex)).toContain(script.refundWithoutReceiverScript);
+        });
+
+        it("does not read the tip for getAllSpendingPaths, which ignores timelocks", async () => {
+            let reads = 0;
+            const manager = await managerFor(async () => {
+                reads += 1;
+                return 800_000;
+            });
+            const contract = contractOf(fullParams());
+            await manager.createContract(contract);
+
+            await manager.getAllSpendingPaths({
+                contractScript: contract.script,
+                collaborative: true,
+                walletPubKey: SENDER,
+            });
+
+            expect(reads).toBe(0);
+        });
     });
 
     describe("path selection", () => {

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -200,6 +200,73 @@ describe("VHTLCV2ContractHandler", () => {
         expect(isContractGenericallySpendable(contract)).toBe(false);
     });
 
+    /**
+     * The handler's own CLTV check has always been right, and the tests below
+     * prove it by handing the context a `blockHeight` directly. What nothing
+     * proved is that anything ever PUTS one there.
+     *
+     * `refundLocktime` here is 800000 — under `CLTV_HEIGHT_THRESHOLD`, so
+     * height-typed — and `isCltvSatisfied` answers `false` outright when
+     * `blockHeight` is missing. No construction site populated it, so through
+     * the manager the sender's collaborative refund was unreachable at every
+     * height, matured or not. This pins the wiring, not the arithmetic: same
+     * contract, same maturity, the only variable is whether a tip is supplied.
+     */
+    describe("blockHeight reaches the handler through ContractManager", () => {
+        const managerFor = async (chainTip?: () => Promise<number | undefined>) =>
+            ContractManager.create({
+                indexerProvider: createMockIndexerProvider(),
+                contractRepository: new InMemoryContractRepository(),
+                walletRepository: new InMemoryWalletRepository(),
+                chainTip,
+            });
+
+        const refundLeafOffered = async (
+            chainTip?: () => Promise<number | undefined>,
+        ): Promise<boolean> => {
+            const manager = await managerFor(chainTip);
+            const contract = contractOf(fullParams());
+            await manager.createContract(contract);
+            const script = VHTLCV2ContractHandler.createScript(contract.params);
+            const paths = await manager.getSpendablePaths({
+                contractScript: contract.script,
+                collaborative: true,
+                walletPubKey: SENDER,
+            });
+            return paths.map(leafHex).includes(script.refundWithoutReceiverScript!);
+        };
+
+        it("withholds the matured refund leaf when no tip source is configured", async () => {
+            expect(await refundLeafOffered(undefined)).toBe(false);
+        });
+
+        it("withholds it when the tip is below the locktime", async () => {
+            expect(await refundLeafOffered(async () => 799_999)).toBe(false);
+        });
+
+        it("offers it once the tip reaches the locktime", async () => {
+            expect(await refundLeafOffered(async () => 800_000)).toBe(true);
+        });
+
+        it("treats an unreadable tip as unknown rather than failing the query", async () => {
+            const paths = await (async () => {
+                const manager = await managerFor(async () => {
+                    throw new Error("provider down");
+                });
+                const contract = contractOf(fullParams());
+                await manager.createContract(contract);
+                return manager.getSpendablePaths({
+                    contractScript: contract.script,
+                    collaborative: true,
+                    walletPubKey: SENDER,
+                });
+            })();
+            // Resolved, not rejected — and the height-gated leaf stays out.
+            const script = VHTLCV2ContractHandler.createScript(fullParams());
+            expect(paths.map(leafHex)).not.toContain(script.refundWithoutReceiverScript);
+        });
+    });
+
     describe("path selection", () => {
         it("gives the sender refundWithoutReceiver only once the CLTV is satisfied", () => {
             const contract = contractOf(fullParams());


### PR DESCRIPTION
## The problem

`PathContext` declares an optional `blockHeight`, and the timelock helpers treat its absence as a hard "no":

```ts
export function isCltvSatisfied(context: PathContext, locktime: bigint): boolean {
    if (locktime < CLTV_HEIGHT_THRESHOLD) {
        if (context.blockHeight === undefined) return false;   // <-- always, before this PR
        return BigInt(context.blockHeight) >= locktime;
    }
    ...
}
```

Nothing ever assigned it. `getSpendablePaths` and `getAllSpendingPaths` are the only two places a `PathContext` is built, and both wrote `{ collaborative, currentTime, walletPubKey, vtxo }`. So for a **height-typed** locktime the answer was `false` at every height, however mature.

The effect is under-reporting, not a wrong spend: a matured collaborative path simply never appears. It has been invisible because the affected paths are advisory today — nothing refuses based on them — and because seconds-typed locktimes read `currentTime` and were never affected.

**Scope: this fixes `isCltvSatisfied`, not `isCsvSpendable`.** The CSV helper has the same shape, but its block branch also needs the VTXO's own confirmation height, and `status.block_height` is never populated for a virtual coin — `convertVtxo` builds `status` as exactly `{ confirmed, isLeaf }`. So a block-typed CSV path stays unreported however mature, tip or no tip. Supplying that height is a separate change, on the VTXO side rather than here.

## What changed

`ContractManagerConfig` gains an optional `chainTip?: () => Promise<number | undefined>`, and both context construction sites fill `blockHeight` from it. `Wallet` supplies its onchain provider's tip.

Two deliberate choices:

- **Cached for 30s.** Resolving paths across many contracts otherwise costs a provider round trip each. Blocks are ~10 minutes apart, so the cached height is at most one block stale, and staleness is one-directional: a height below the true tip can withhold a path that just matured, never offer one that has not.
- **An unreadable tip resolves to `undefined`, not a rejection.** That is exactly the behaviour that exists today, so a provider hiccup degrades a path query rather than failing it. A source that answers `undefined` deliberately leaves the cache alone — an absence is not a value worth serving for the rest of the TTL.
- **Concurrent misses share one read.** `currentBlockHeight` is async, so several path queries awaited together on the tick the TTL lapses would each reach the provider before any wrote the cache. Identical heights and no correctness risk, but a pass resolving paths across many contracts fired a request per contract for a single value; they now join one in-flight promise. (Added in review.)

No handler changed — the arithmetic was already right. This only supplies the input it was written against.

## Compatibility

A `ContractManager` built without `chainTip` behaves exactly as before, which the first new test pins. That covers every existing embedder and the whole test suite, which is why nothing else moved.

## Tests

Five new cases in `vhtlcV2-handler.test.ts`, driving the manager rather than the handler — the existing handler tests already pass `blockHeight` in by hand, so they proved the arithmetic and could not have caught this. The fixture's `refundLocktime` is `800000`, i.e. height-typed, so it exercises the broken branch directly:

- no tip source configured → matured refund leaf withheld (the old behaviour, pinned)
- tip below the locktime → withheld
- tip at the locktime → offered
- tip source throws → query resolves, leaf stays out
- three concurrent queries on a cold cache → exactly one provider read

That last one was revert-verified: dropping the in-flight dedup fails it with `expected 3 to be 1`.

## Verification

`pnpm test:unit` in `packages/ts-sdk`: **156 files, 2432 passed, 1 skipped, 0 failed** (2427 + the 5 added). `tsc --noEmit` clean. `packages/swap` `test:unit` 17 files / 261 passed, and `boltz-swap` green via the pre-commit hook.

Note for anyone reproducing locally: the bare `pnpm test` includes `test/e2e`, which needs a live regtest and fails at setup without one (`INTENT_INSUFFICIENT_FEE ... got 0 min expected 2000` out of a child process). `test:unit` is the gate this change is measured against. `packages/swap` also needs `packages/ts-sdk` built first, or its tests fail resolving `@arkade-os/sdk`'s entry rather than on anything real.

## Follow-up, not in this PR

This is the prerequisite for a settle-time pre-flight guard that turns "explicit `settle({inputs})` on a VHTLC before its CLTV matures" from an opaque server-level rejection into a clear client error. That guard cannot be a generic "no spendable paths ⇒ refuse" rule: `arkade.ts`'s `pathsFor` skips every covenant leaf (`if (fn.arkadeScript) continue`), so an Arkade-program contract spendable only through its emulator-signed leaf reports an empty set while being perfectly spendable. The guard therefore has to be opt-in per handler.


