### PR TITLE
feat(contracts): refuse an explicit settle of a VHTLC before its refund opens

### DIFF
--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -363,6 +363,30 @@ export interface IContractManager extends Disposable {
     ): Promise<void>;
 
     /**
+     * Throw when one of `vtxos` belongs to a contract that provably cannot be
+     * spent right now, asking each owning handler's
+     * {@link ContractHandler.assertSpendableNow}.
+     *
+     * The complement of {@link isContractGenericallySpendable}, which keeps
+     * escrow out of generic selection and leaves explicit-input APIs open on
+     * purpose. This does not close that door — it makes walking through it too
+     * early report itself locally, naming the timelock, instead of coming back
+     * as a protocol-level rejection after the round trip.
+     *
+     * Handlers answer only where they are certain, so contracts with no opinion
+     * (which is all of them but VHTLC today) pass through untouched and cost
+     * nothing — not even a chain-tip read.
+     *
+     * Optional so that adding it is not a breaking change for an embedder with
+     * its own `IContractManager`. An implementation that omits it simply offers
+     * no opinion, which is the same answer every non-VHTLC contract gives.
+     */
+    assertSpendableNow?(
+        vtxos: readonly { txid: string; vout: number; script: string }[],
+        walletPubKey?: () => Promise<string | undefined>,
+    ): Promise<void>;
+
+    /**
      * Update mutable contract fields.
      *
      * `script` and `createdAt` are immutable.
@@ -1592,6 +1616,40 @@ export class ContractManager implements IContractManager {
             `refusing to spend ${outpoints.length} vtxo(s) whose contract cannot be annotated ` +
                 `(${outpoints.join(", ")}): ${[...failures.values()].join("; ")}`,
         );
+    }
+
+    /** @inheritdoc */
+    async assertSpendableNow(
+        vtxos: readonly { txid: string; vout: number; script: string }[],
+        walletPubKey?: () => Promise<string | undefined>,
+    ): Promise<void> {
+        if (vtxos.length === 0) return;
+        const scripts = Array.from(new Set(vtxos.map((vtxo) => vtxo.script)));
+        const contracts = await this.config.contractRepository.getContracts({
+            script: scripts,
+        });
+        // Only if some handler actually asks. Contracts with no opinion — which
+        // is every type but VHTLC today — must cost nothing: no chain-tip read,
+        // and no identity access either. `walletPubKey` is a thunk for exactly
+        // that reason; resolving it eagerly made an ordinary settle depend on a
+        // key it never consults.
+        const asking = contracts.filter(
+            (contract) => contractHandlers.get(contract.type)?.assertSpendableNow !== undefined,
+        );
+        if (asking.length === 0) return;
+
+        const context: PathContext = {
+            collaborative: true,
+            currentTime: Date.now(),
+            blockHeight: await this.currentBlockHeight(),
+            walletPubKey: await walletPubKey?.(),
+        };
+        for (const contract of asking) {
+            const handler = contractHandlers.get(contract.type);
+            // Checked above; narrowing for the type system.
+            if (!handler?.assertSpendableNow) continue;
+            handler.assertSpendableNow(handler.createScript(contract.params), contract, context);
+        }
     }
 
     // Field-by-field, so every filter a caller can express reaches the

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -29,6 +29,7 @@ import { ExtendedVirtualCoin, Outpoint, VirtualCoin } from "../wallet";
 import {
     getAllNormalizedVtxos,
     getNormalizedVtxos,
+    isVirtualCoin,
     normalizeVtxo,
     type NormalizedExtendedVirtualCoin,
 } from "../wallet/vtxo";
@@ -171,6 +172,17 @@ const CHAIN_TIP_TTL_MS = 30_000;
  * Expiry is treated as "tip unknown", the same as a read that fails.
  */
 const CHAIN_TIP_TIMEOUT_MS = 5_000;
+
+/**
+ * An input for {@link IContractManager.assertSpendableNow}.
+ *
+ * The outpoint and script are what identify the owning contract. A full
+ * {@link VirtualCoin} is accepted and preferred: a relative (CSV) timelock is
+ * measured from this coin's own confirmation, so `status.block_height` /
+ * `status.block_time` are the only way to answer one. Pass the coin where you
+ * have it; the bare shape still answers every absolute (CLTV) question.
+ */
+export type AssertSpendableInput = { txid: string; vout: number; script: string };
 
 export type RefreshVtxosOptions = {
     /**
@@ -382,7 +394,7 @@ export interface IContractManager extends Disposable {
      * no opinion, which is the same answer every non-VHTLC contract gives.
      */
     assertSpendableNow?(
-        vtxos: readonly { txid: string; vout: number; script: string }[],
+        vtxos: readonly AssertSpendableInput[],
         walletPubKey?: () => Promise<string | undefined>,
     ): Promise<void>;
 
@@ -617,11 +629,16 @@ export interface ContractManagerConfig {
      * VTXO's confirmation height, and `status.block_height` is never populated
      * for a virtual coin, so it stays `false` regardless of the tip.
      *
+     * Both fields matter. `height` answers height-typed timelocks; `time` (the
+     * tip's timestamp, in SECONDS) is what seconds-typed ones should be judged
+     * against, because the machine's clock is an estimate of chain time and a
+     * drifting one reads the boundary wrong.
+     *
      * Resolve `undefined` rather than rejecting when the tip cannot be read:
      * the callers treat it as "unknown", which is the pre-existing behaviour,
      * and a path query is not worth failing over a provider hiccup.
      */
-    chainTip?: () => Promise<number | undefined>;
+    chainTip?: () => Promise<{ height: number; time: number } | undefined>;
 }
 
 /**
@@ -733,10 +750,10 @@ export class ContractManager implements IContractManager {
     private syncDegradedReason?: string;
     /** Epoch-ms of the last successful provider sync, if any. */
     private lastSyncedAt?: number;
-    /** Last chain tip read, with the epoch-ms it was read at. @see currentBlockHeight */
-    private chainTipCache?: { height: number; at: number };
+    /** Last chain tip read, with the epoch-ms it was read at. @see currentChainTip */
+    private chainTipCache?: { height: number; time: number; at: number };
     /** In-flight chain tip read, so concurrent cache misses share one. */
-    private chainTipInflight?: Promise<number | undefined>;
+    private chainTipInflight?: Promise<{ height: number; time: number } | undefined>;
     /** Speculative look-ahead scripts, keyed by script. @see LookAheadEntry */
     private lookAheadEntries: Map<string, LookAheadEntry> = new Map();
     /** In-flight look-ahead drain, if any. @see scheduleLookAheadDrain */
@@ -1620,34 +1637,49 @@ export class ContractManager implements IContractManager {
 
     /** @inheritdoc */
     async assertSpendableNow(
-        vtxos: readonly { txid: string; vout: number; script: string }[],
+        vtxos: readonly AssertSpendableInput[],
         walletPubKey?: () => Promise<string | undefined>,
     ): Promise<void> {
         if (vtxos.length === 0) return;
-        const scripts = Array.from(new Set(vtxos.map((vtxo) => vtxo.script)));
         const contracts = await this.config.contractRepository.getContracts({
-            script: scripts,
+            script: Array.from(new Set(vtxos.map((vtxo) => vtxo.script))),
         });
-        // Only if some handler actually asks. Contracts with no opinion — which
-        // is every type but VHTLC today — must cost nothing: no chain-tip read,
-        // and no identity access either. `walletPubKey` is a thunk for exactly
-        // that reason; resolving it eagerly made an ordinary settle depend on a
-        // key it never consults.
-        const asking = contracts.filter(
-            (contract) => contractHandlers.get(contract.type)?.assertSpendableNow !== undefined,
-        );
+        const byScript = new Map(contracts.map((contract) => [contract.script, contract]));
+
+        // Only the inputs whose handler actually asks. Contracts with no
+        // opinion — every type but VHTLC today — must cost nothing: no
+        // chain-tip read, and no identity access either. `walletPubKey` is a
+        // thunk for exactly that reason; resolving it eagerly made an ordinary
+        // settle depend on a key it never consults.
+        const asking = vtxos.filter((vtxo) => {
+            const contract = byScript.get(vtxo.script);
+            return (
+                contract !== undefined &&
+                contractHandlers.get(contract.type)?.assertSpendableNow !== undefined
+            );
+        });
         if (asking.length === 0) return;
 
-        const context: PathContext = {
-            collaborative: true,
-            currentTime: Date.now(),
-            blockHeight: await this.currentBlockHeight(),
-            walletPubKey: await walletPubKey?.(),
-        };
-        for (const contract of asking) {
+        const tip = await this.currentChainTip();
+        const walletKey = await walletPubKey?.();
+        // Per INPUT, not per contract. A relative (CSV) timelock is measured
+        // from the moment THIS coin confirmed, so two vtxos on one contract can
+        // disagree about whether the same leaf is open. A batch-wide context
+        // cannot express that, and a handler handed one would have to answer
+        // for the whole set or not at all.
+        for (const vtxo of asking) {
+            const contract = byScript.get(vtxo.script)!;
             const handler = contractHandlers.get(contract.type);
-            // Checked above; narrowing for the type system.
+            // Filtered for above; narrowing for the type system.
             if (!handler?.assertSpendableNow) continue;
+            const context: PathContext = {
+                collaborative: true,
+                currentTime: Date.now(),
+                blockHeight: tip?.height,
+                chainTime: tip?.time,
+                walletPubKey: walletKey,
+                vtxo: isVirtualCoin(vtxo) ? vtxo : undefined,
+            };
             // Awaited even though every shipped handler answers synchronously:
             // the signature permits a promise, and an un-awaited one would drop
             // its rejection on the floor — a refusal that never reaches the
@@ -1767,16 +1799,16 @@ export class ContractManager implements IContractManager {
      * reported unspendable slightly longer than it truly is, never spendable
      * before it is.
      */
-    private async currentBlockHeight(): Promise<number | undefined> {
+    private async currentChainTip(): Promise<{ height: number; time: number } | undefined> {
         const source = this.config.chainTip;
         if (!source) return undefined;
         if (this.chainTipCache && Date.now() - this.chainTipCache.at < CHAIN_TIP_TTL_MS) {
-            return this.chainTipCache.height;
+            return { height: this.chainTipCache.height, time: this.chainTipCache.time };
         }
         // Collapse concurrent misses onto one read. Without this, a pass that
         // resolves paths for many contracts fires a provider request per
         // contract on the tick the TTL lapses — every one of them racing to
-        // write the same height.
+        // write the same tip.
         if (!this.chainTipInflight) {
             // Cleared from out here rather than a `finally` inside the read: a
             // source that throws synchronously settles the read before the
@@ -1796,26 +1828,26 @@ export class ContractManager implements IContractManager {
      * a provider hiccup.
      */
     private async readChainTip(
-        source: () => Promise<number | undefined>,
-    ): Promise<number | undefined> {
+        source: () => Promise<{ height: number; time: number } | undefined>,
+    ): Promise<{ height: number; time: number } | undefined> {
         let timer: ReturnType<typeof setTimeout> | undefined;
         try {
-            const height = await Promise.race([
+            const tip = await Promise.race([
                 source(),
                 new Promise<undefined>((resolve) => {
                     timer = setTimeout(() => resolve(undefined), CHAIN_TIP_TIMEOUT_MS);
                 }),
             ]);
             // Stamped after the await, not before, so the TTL measures from
-            // when the height was actually true. A source answering
-            // `undefined` — or a read that timed out — is saying "no height
-            // available", which is not worth remembering: leaving the cache
-            // alone lets the next call ask again rather than serving an
-            // absence for the rest of the TTL.
-            if (height !== undefined) {
-                this.chainTipCache = { height, at: Date.now() };
+            // when the tip was actually true. A source answering `undefined` —
+            // or a read that timed out — is saying "no tip available", which
+            // is not worth remembering: leaving the cache alone lets the next
+            // call ask again rather than serving an absence for the rest of
+            // the TTL.
+            if (tip !== undefined) {
+                this.chainTipCache = { ...tip, at: Date.now() };
             }
-            return height;
+            return tip;
         } catch {
             return undefined;
         } finally {
@@ -1838,10 +1870,12 @@ export class ContractManager implements IContractManager {
         if (!handler) return [];
 
         const script = handler.createScript(contract.params);
+        const tip = await this.currentChainTip();
         const context: PathContext = {
             collaborative,
             currentTime: Date.now(),
-            blockHeight: await this.currentBlockHeight(),
+            blockHeight: tip?.height,
+            chainTime: tip?.time,
             walletPubKey,
             vtxo,
         };

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -1678,7 +1678,14 @@ export class ContractManager implements IContractManager {
                 blockHeight: tip?.height,
                 chainTime: tip?.time,
                 walletPubKey: walletKey,
-                vtxo: isVirtualCoin(vtxo) ? vtxo : undefined,
+                // `isVirtualCoin` alone is too weak here: it only asks for a
+                // string `script`, which every AssertSpendableInput has, so a
+                // bare outpoint would be published as a coin with no `status`.
+                // `isCsvSpendable` reads `vtxo.status.block_time` unguarded, so
+                // the next handler to answer a CSV question would meet a
+                // TypeError instead of a `false`. Carry the coin only when it
+                // really is one.
+                vtxo: isVirtualCoin(vtxo) && "status" in vtxo ? vtxo : undefined,
             };
             // Awaited even though every shipped handler answers synchronously:
             // the signature permits a promise, and an un-awaited one would drop

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -1648,7 +1648,15 @@ export class ContractManager implements IContractManager {
             const handler = contractHandlers.get(contract.type);
             // Checked above; narrowing for the type system.
             if (!handler?.assertSpendableNow) continue;
-            handler.assertSpendableNow(handler.createScript(contract.params), contract, context);
+            // Awaited even though every shipped handler answers synchronously:
+            // the signature permits a promise, and an un-awaited one would drop
+            // its rejection on the floor — a refusal that never reaches the
+            // caller is worse than no guard, because it reads as approval.
+            await handler.assertSpendableNow(
+                handler.createScript(contract.params),
+                contract,
+                context,
+            );
         }
     }
 

--- a/packages/ts-sdk/src/contracts/handlers/helpers.ts
+++ b/packages/ts-sdk/src/contracts/handlers/helpers.ts
@@ -129,12 +129,10 @@ const CLTV_HEIGHT_THRESHOLD = 500_000_000n;
  * Returns false if the relevant context field is missing.
  */
 export function isCltvSatisfied(context: PathContext, locktime: bigint): boolean {
-    if (locktime < CLTV_HEIGHT_THRESHOLD) {
-        if (context.blockHeight === undefined) return false;
-        return BigInt(context.blockHeight) >= locktime;
-    }
-    const currentTimeSec = BigInt(Math.floor(context.currentTime / 1000));
-    return currentTimeSec >= locktime;
+    // Deliberately the same clock `cltvMaturity` reads. Offering a path and
+    // refusing one are two answers to one question, and sourcing them from
+    // different clocks lets a wallet offer a leaf its own guard would reject.
+    return cltvMaturity(context, locktime) === "satisfied";
 }
 
 /**

--- a/packages/ts-sdk/src/contracts/handlers/helpers.ts
+++ b/packages/ts-sdk/src/contracts/handlers/helpers.ts
@@ -138,6 +138,88 @@ export function isCltvSatisfied(context: PathContext, locktime: bigint): boolean
 }
 
 /**
+ * How an absolute (CLTV) locktime stands against `context`, keeping "not yet"
+ * and "cannot tell" apart.
+ *
+ * {@link isCltvSatisfied} folds both into `false`, which is the right answer
+ * for OFFERING a path — an unknown maturity is not an invitation to spend. It
+ * is the wrong answer for REFUSING one: a height-typed locktime with no
+ * `blockHeight` in context is unreadable, not immature, and turning that into a
+ * refusal would reject spends that are perfectly valid. Anything that fails a
+ * caller rather than merely withholding an option must ask this instead.
+ *
+ * - `satisfied` — matured; the leaf behind it is spendable now.
+ * - `pending`   — definitively not matured yet, with a maturity to quote.
+ * - `unknown`   — height-typed with no chain tip supplied. Say nothing.
+ */
+export type CltvMaturity = "satisfied" | "pending" | "unknown";
+
+export function cltvMaturity(context: PathContext, locktime: bigint): CltvMaturity {
+    if (locktime < CLTV_HEIGHT_THRESHOLD) {
+        if (context.blockHeight === undefined) return "unknown";
+        return BigInt(context.blockHeight) >= locktime ? "satisfied" : "pending";
+    }
+    const currentTimeSec = BigInt(Math.floor(context.currentTime / 1000));
+    return currentTimeSec >= locktime ? "satisfied" : "pending";
+}
+
+/** Whether `locktime` is height-typed (BIP65), for phrasing a maturity. */
+export function isHeightLocktime(locktime: bigint): boolean {
+    return locktime < CLTV_HEIGHT_THRESHOLD;
+}
+
+/**
+ * The VHTLC spendability refusal, shared by the v1 and v2 handlers.
+ *
+ * Both versions gate the sender's only collaborative leaf —
+ * `refundWithoutReceiver` — on `refundLocktime`. Before it matures the sender
+ * has nothing collaborative to spend: `claim` belongs to the receiver and needs
+ * a preimage, and `refund` / `nonInteractiveRefund` need the receiver's
+ * signature, which is precisely what a refunding sender cannot get. So an
+ * explicit `settle({ inputs })` naming that lockup is refusable with certainty
+ * rather than guessed at.
+ *
+ * Lives here rather than in either handler because v1 and v2 differ only in
+ * which preimage fragment their claim leaves are built from; a rule applied to
+ * one and not the other is the realistic drift, and the same reasoning already
+ * keeps their path selection in step.
+ *
+ * Silent in every case that is not a certainty:
+ * - not collaborative — a unilateral spend answers to its CSV, not this
+ * - not the sender — the receiver's claim turns on a preimage this cannot see
+ * - maturity `unknown` — height-typed with no chain tip; unreadable, not immature
+ */
+export function assertVhtlcSpendableNow(contract: Contract, context: PathContext): void {
+    if (!context.collaborative) return;
+    if (resolveRole(contract, context) !== "sender") return;
+
+    const raw = contract.params?.refundLocktime;
+    if (raw === undefined) return;
+    let refundLocktime: bigint;
+    try {
+        refundLocktime = BigInt(raw);
+    } catch {
+        // Unparseable params are someone else's error to report, not ours to
+        // guess at — createScript already refuses them with a better message.
+        return;
+    }
+
+    if (cltvMaturity(context, refundLocktime) !== "pending") return;
+
+    const [matures, now] = isHeightLocktime(refundLocktime)
+        ? [`block ${refundLocktime}`, `${context.blockHeight}`]
+        : [
+              `${new Date(Number(refundLocktime) * 1000).toISOString()}`,
+              new Date(context.currentTime).toISOString(),
+          ];
+    throw new Error(
+        `vhtlc ${contract.script} cannot be spent yet: its refund path opens at ${matures}, ` +
+            `now ${now}. Until then the lockup is the receiver's to claim, and the server ` +
+            `rejects a spend of it. Retry after ${matures}, or claim it with the preimage.`,
+    );
+}
+
+/**
  * Check if a CSV timelock is currently satisfied for the given context/virtual output.
  */
 export function isCsvSpendable(context: PathContext, sequence?: number): boolean {

--- a/packages/ts-sdk/src/contracts/handlers/helpers.ts
+++ b/packages/ts-sdk/src/contracts/handlers/helpers.ts
@@ -159,8 +159,17 @@ export function cltvMaturity(context: PathContext, locktime: bigint): CltvMaturi
         if (context.blockHeight === undefined) return "unknown";
         return BigInt(context.blockHeight) >= locktime ? "satisfied" : "pending";
     }
-    const currentTimeSec = BigInt(Math.floor(context.currentTime / 1000));
-    return currentTimeSec >= locktime ? "satisfied" : "pending";
+    // Chain time where we have it. The wall-clock fallback is a decent estimate
+    // and a poor authority: the server matures this against median-time-past,
+    // which trails wall clock, so a drifting host reads the boundary wrong in
+    // whichever direction it drifted — including "not yet" for something the
+    // chain already accepts.
+    return nowSeconds(context) >= locktime ? "satisfied" : "pending";
+}
+
+/** Chain time if the context carries it, else the local clock. Seconds. */
+function nowSeconds(context: PathContext): bigint {
+    return BigInt(Math.floor(context.chainTime ?? context.currentTime / 1000));
 }
 
 /** Whether `locktime` is height-typed (BIP65), for phrasing a maturity. */
@@ -240,9 +249,12 @@ export function isCsvSpendable(context: PathContext, sequence?: number): boolean
     }
 
     if (timelock.type === "seconds") {
+        // The input's own confirmation time is the CSV's origin — a relative
+        // timelock is measured from when THIS coin confirmed, not from now.
+        // Absent, the age is unknowable and the answer is no.
         const blockTime = context.vtxo.status.block_time;
         if (blockTime === undefined) return false;
-        return context.currentTime / 1000 - blockTime >= Number(timelock.value);
+        return Number(nowSeconds(context)) - blockTime >= Number(timelock.value);
     }
 
     return false;

--- a/packages/ts-sdk/src/contracts/handlers/helpers.ts
+++ b/packages/ts-sdk/src/contracts/handlers/helpers.ts
@@ -212,10 +212,15 @@ export function assertVhtlcSpendableNow(contract: Contract, context: PathContext
               `${new Date(Number(refundLocktime) * 1000).toISOString()}`,
               new Date(context.currentTime).toISOString(),
           ];
+    // Addressed to the sender — the only role that reaches here. Do not offer
+    // them the preimage claim: that is the receiver's leaf and the receiver's
+    // secret, and suggesting it sends the reader looking for a key they will
+    // never hold.
     throw new Error(
         `vhtlc ${contract.script} cannot be spent yet: its refund path opens at ${matures}, ` +
             `now ${now}. Until then the lockup is the receiver's to claim, and the server ` +
-            `rejects a spend of it. Retry after ${matures}, or claim it with the preimage.`,
+            `rejects a spend of it. Retry after ${matures}, or wait for the receiver to ` +
+            `claim it with the preimage.`,
     );
 }
 

--- a/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
@@ -9,7 +9,7 @@ import {
     PathSelection,
     TapscriptDeriving,
 } from "../types";
-import { isCltvSatisfied, isCsvSpendable, resolveRole } from "./helpers";
+import { assertVhtlcSpendableNow, isCltvSatisfied, isCsvSpendable, resolveRole } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 
 /**
@@ -247,6 +247,15 @@ export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Sc
         }
 
         return paths;
+    },
+
+    /**
+     * Refuse an explicit spend of a lockup whose refund path has not opened.
+     * Shared with the v2 handler so the two cannot drift.
+     * @see assertVhtlcSpendableNow for why this is the one certain case.
+     */
+    assertSpendableNow(_script: VHTLC.Script, contract: Contract, context: PathContext): void {
+        assertVhtlcSpendableNow(contract, context);
     },
 
     /**

--- a/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
@@ -9,7 +9,7 @@ import {
     PathSelection,
     TapscriptDeriving,
 } from "../types";
-import { isCltvSatisfied, isCsvSpendable, resolveRole } from "./helpers";
+import { assertVhtlcSpendableNow, isCltvSatisfied, isCsvSpendable, resolveRole } from "./helpers";
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 
 /**
@@ -369,6 +369,14 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
         }
 
         return paths;
+    },
+
+    /**
+     * Refuse an explicit spend of a lockup whose refund path has not opened.
+     * @see assertVhtlcSpendableNow for why this is the one certain case.
+     */
+    assertSpendableNow(_script: VHTLC.ScriptV2, contract: Contract, context: PathContext): void {
+        assertVhtlcSpendableNow(contract, context);
     },
 
     /**

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -217,6 +217,18 @@ export interface PathContext {
      */
     role?: string;
 
+    /**
+     * Chain tip timestamp in SECONDS, when known.
+     *
+     * Timelocks mature against chain time, not the machine's clock, so any
+     * seconds-typed comparison should prefer this and fall back to
+     * {@link currentTime} only when it is absent. The two differ by more than
+     * pedantry: the server matures absolute locktimes against median-time-past,
+     * which trails wall clock, and a host whose clock drifts turns a local
+     * decision into a wrong one in whichever direction it drifted.
+     */
+    chainTime?: number;
+
     /** The specific virtual output being evaluated. */
     vtxo?: VirtualCoin;
 }

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -311,6 +311,31 @@ export interface ContractHandler<P = Record<string, unknown>, S extends VtxoScri
      * call its own `createScript(contract.params)`.
      */
     isGenericallySpendable?(contract: Contract): boolean;
+
+    /**
+     * Refuse a spend this contract definitively cannot make right now, with a
+     * reason the caller can act on. Called before anything is signed or
+     * submitted, for inputs the caller named explicitly.
+     *
+     * This is the counterpart to {@link isGenericallySpendable}, not a
+     * duplicate of it. That gate keeps escrow out of GENERIC selection and
+     * deliberately leaves explicit-input APIs open, because naming an outpoint
+     * is the intent it protects. Naming one too early is still a mistake
+     * though, and without this it is a mistake the server reports — as a
+     * protocol-level rejection, after the round trip, in terms that do not name
+     * the timelock that was not yet mature.
+     *
+     * **Throw only on a definite no.** Absent, silent, or unsure all mean "no
+     * opinion" and the spend proceeds. A handler must not refuse merely because
+     * it found no path: `getSpendablePaths` legitimately returns empty for
+     * spendable contracts — `arkade`'s skips every covenant leaf, so a program
+     * spendable only through its emulator-signed leaf reports nothing — and an
+     * unreadable timelock (height-typed with no chain tip) is unknown, not
+     * immature. @see cltvMaturity, which keeps those apart.
+     *
+     * @throws Error when the contract provably cannot be spent at `context`
+     */
+    assertSpendableNow?(script: S, contract: Contract, context: PathContext): void;
 }
 
 /**

--- a/packages/ts-sdk/src/contracts/types.ts
+++ b/packages/ts-sdk/src/contracts/types.ts
@@ -333,9 +333,14 @@ export interface ContractHandler<P = Record<string, unknown>, S extends VtxoScri
      * unreadable timelock (height-typed with no chain tip) is unknown, not
      * immature. @see cltvMaturity, which keeps those apart.
      *
+     * Returning a promise is allowed so a handler needing I/O is not forced to
+     * throw synchronously — callers await the result. Prefer synchronous where
+     * possible: this runs on the path between a caller's decision to spend and
+     * the spend itself.
+     *
      * @throws Error when the contract provably cannot be spent at `context`
      */
-    assertSpendableNow?(script: S, contract: Contract, context: PathContext): void;
+    assertSpendableNow?(script: S, contract: Contract, context: PathContext): void | Promise<void>;
 }
 
 /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -1279,6 +1279,9 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
              */
             async assertAnnotatable(): Promise<void> {},
 
+            /** Same reasoning as {@link assertAnnotatable}: the worker checks it. */
+            async assertSpendableNow(): Promise<void> {},
+
             async annotateVtxos(vtxos: VirtualCoin[]): Promise<NormalizedExtendedVirtualCoin[]> {
                 if (vtxos.length === 0) return [];
                 const message: RequestAnnotateVtxos = {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -3782,9 +3782,17 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         // a bad arknote should still report itself first — and before the
         // intent. Arknotes and boarding inputs carry no vtxo script, so they
         // are not the ones this can speak about.
-        await (
-            await this.getContractManager()
-        ).assertAnnotatable(params.inputs.filter(isVirtualCoin));
+        const settleInputVtxos = params.inputs.filter(isVirtualCoin);
+        await (await this.getContractManager()).assertAnnotatable(settleInputVtxos);
+        // And the timelock, for the same reason one line up: a lockup named
+        // before its refund path opens builds and registers fine here, and is
+        // refused by the server — after the round trip, in terms that do not
+        // say which timelock was not yet mature. Only handlers that are certain
+        // answer, so this is a no-op for ordinary coins.
+        const manager = await this.getContractManager();
+        await manager.assertSpendableNow?.(settleInputVtxos, async () =>
+            hex.encode(await this.identity.xOnlyPublicKey()),
+        );
 
         // Optimistically hide these inputs from concurrent getVtxos() callers
         // while the settlement is in flight. Set before safeRegisterIntent so

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -3783,14 +3783,14 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         // intent. Arknotes and boarding inputs carry no vtxo script, so they
         // are not the ones this can speak about.
         const settleInputVtxos = params.inputs.filter(isVirtualCoin);
-        await (await this.getContractManager()).assertAnnotatable(settleInputVtxos);
+        const contractManager = await this.getContractManager();
+        await contractManager.assertAnnotatable(settleInputVtxos);
         // And the timelock, for the same reason one line up: a lockup named
         // before its refund path opens builds and registers fine here, and is
         // refused by the server — after the round trip, in terms that do not
         // say which timelock was not yet mature. Only handlers that are certain
         // answer, so this is a no-op for ordinary coins.
-        const manager = await this.getContractManager();
-        await manager.assertSpendableNow?.(settleInputVtxos, async () =>
+        await contractManager.assertSpendableNow?.(settleInputVtxos, async () =>
             hex.encode(await this.identity.xOnlyPublicKey()),
         );
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2034,8 +2034,13 @@ export class ReadonlyWallet implements IReadonlyWallet {
             lookAhead: this.lookAheadConfig(),
             // Without this a PathContext carries no blockHeight, and every
             // height-typed CLTV reads as unsatisfied however mature it is.
+            // The tip's `time` matters just as much: it is what seconds-typed
+            // timelocks are judged against, in place of this host's clock.
             // @see ContractManagerConfig.chainTip
-            chainTip: async () => (await this.onchainProvider.getChainTip()).height,
+            chainTip: async () => {
+                const { height, time } = await this.onchainProvider.getChainTip();
+                return { height, time };
+            },
         });
 
         // Register the wallet's baseline always-active contracts: every

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -494,6 +494,42 @@ describe("VHTLCV2ContractHandler", () => {
             await expect(assertThrough(undefined)).resolves.toBeUndefined();
         });
 
+        /**
+         * A bare outpoint must not be published to handlers as a coin. It has
+         * no `status`, and `isCsvSpendable` reads `vtxo.status.block_time`
+         * unguarded — so a handler answering a CSV question would meet a
+         * TypeError rather than a `false`. Asserted through the real dispatch
+         * with a temporary handler, because the type system cannot say this:
+         * every AssertSpendableInput structurally satisfies `isVirtualCoin`.
+         */
+        it("does not hand a handler a coin that has no status", async () => {
+            const manager = await managerFor(at(799_999));
+            const contract = contractOf(fullParams());
+            await manager.createContract(contract);
+
+            const real = contractHandlers.get("vhtlc-v2")!;
+            let seen: PathContext | undefined;
+            contractHandlers.unregister("vhtlc-v2");
+            contractHandlers.register({
+                ...real,
+                assertSpendableNow: (_s: unknown, _c: unknown, ctx: PathContext) => {
+                    seen = ctx;
+                },
+            } as never);
+            try {
+                await manager.assertSpendableNow!(
+                    [{ txid: "c".repeat(64), vout: 0, script: contract.script }],
+                    async () => SENDER,
+                );
+            } finally {
+                contractHandlers.unregister("vhtlc-v2");
+                contractHandlers.register(real as never);
+            }
+
+            expect(seen).toBeDefined();
+            expect(seen!.vtxo).toBeUndefined();
+        });
+
         it("never reads a tip when no contract has an opinion", async () => {
             let reads = 0;
             const manager = await managerFor(async () => {

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -334,6 +334,34 @@ describe("VHTLCV2ContractHandler", () => {
             ).not.toThrow();
         });
 
+        /**
+         * A seconds-typed locktime must be judged against the chain, not the
+         * host. The server matures these against median-time-past, which trails
+         * wall clock, so a machine whose clock runs slow would otherwise refuse
+         * a spend the chain already accepts — the same false refusal the
+         * `unknown` state exists to prevent, arriving by a different door.
+         */
+        it("prefers chain time over the host clock for a seconds-typed locktime", () => {
+            const locktime = Math.floor(Date.now() / 1000) + 3600;
+            // Host clock says an hour short; the chain says matured.
+            expect(() =>
+                check(
+                    fullParams({ refundLocktime: String(locktime) }),
+                    contextAt({ chainTime: locktime + 1 }),
+                ),
+            ).not.toThrow();
+            // And the reverse: chain behind, host ahead — still refused.
+            expect(() =>
+                check(
+                    fullParams({ refundLocktime: String(locktime) }),
+                    contextAt({
+                        currentTime: (locktime + 3600) * 1000,
+                        chainTime: locktime - 1,
+                    }),
+                ),
+            ).toThrow(/cannot be spent yet/);
+        });
+
         it("says nothing about a unilateral spend, which answers to its CSV", () => {
             expect(() =>
                 check(fullParams(), contextAt({ collaborative: false, blockHeight: 799_999 })),
@@ -370,7 +398,16 @@ describe("VHTLCV2ContractHandler", () => {
     });
 
     describe("blockHeight reaches the handler through ContractManager", () => {
-        const managerFor = async (chainTip?: () => Promise<number | undefined>) =>
+        type Tip = { height: number; time: number } | undefined;
+        /** A tip at `height`; its time only matters to the seconds-typed cases. */
+        const at =
+            (height: number, time = 1_700_000_000): (() => Promise<Tip>) =>
+            async () => ({
+                height,
+                time,
+            });
+
+        const managerFor = async (chainTip?: () => Promise<Tip>) =>
             ContractManager.create({
                 indexerProvider: createMockIndexerProvider(),
                 contractRepository: new InMemoryContractRepository(),
@@ -378,9 +415,7 @@ describe("VHTLCV2ContractHandler", () => {
                 chainTip,
             });
 
-        const refundLeafOffered = async (
-            chainTip?: () => Promise<number | undefined>,
-        ): Promise<boolean> => {
+        const refundLeafOffered = async (chainTip?: () => Promise<Tip>): Promise<boolean> => {
             const manager = await managerFor(chainTip);
             const contract = contractOf(fullParams());
             await manager.createContract(contract);
@@ -398,11 +433,11 @@ describe("VHTLCV2ContractHandler", () => {
         });
 
         it("withholds it when the tip is below the locktime", async () => {
-            expect(await refundLeafOffered(async () => 799_999)).toBe(false);
+            expect(await refundLeafOffered(at(799_999))).toBe(false);
         });
 
         it("offers it once the tip reaches the locktime", async () => {
-            expect(await refundLeafOffered(async () => 800_000)).toBe(true);
+            expect(await refundLeafOffered(at(800_000))).toBe(true);
         });
 
         it("collapses concurrent cache misses onto a single tip read", async () => {
@@ -412,7 +447,7 @@ describe("VHTLCV2ContractHandler", () => {
                 // Resolve on a later turn, so all three callers are waiting on
                 // the same in-flight read rather than being served in sequence.
                 await Promise.resolve();
-                return 800_000;
+                return { height: 800_000, time: 1_700_000_000 };
             });
             const contract = contractOf(fullParams());
             await manager.createContract(contract);
@@ -440,7 +475,7 @@ describe("VHTLCV2ContractHandler", () => {
          * mode worth a test of its own.
          */
         const assertThrough = async (tip: number | undefined) => {
-            const manager = await managerFor(tip === undefined ? undefined : async () => tip);
+            const manager = await managerFor(tip === undefined ? undefined : at(tip));
             const contract = contractOf(fullParams());
             await manager.createContract(contract);
             const vtxo = { txid: "a".repeat(64), vout: 0, script: contract.script };
@@ -463,7 +498,7 @@ describe("VHTLCV2ContractHandler", () => {
             let reads = 0;
             const manager = await managerFor(async () => {
                 reads += 1;
-                return 800_000;
+                return { height: 800_000, time: 1_700_000_000 };
             });
             // A `default` row: its handler implements no assertSpendableNow, so
             // the whole check must short-circuit before touching the provider.
@@ -518,7 +553,7 @@ describe("VHTLCV2ContractHandler", () => {
             let reads = 0;
             const manager = await managerFor(() => {
                 reads += 1;
-                return new Promise<number>(() => {});
+                return new Promise<Tip>(() => {});
             });
             const contract = contractOf(fullParams());
             await manager.createContract(contract);
@@ -554,7 +589,7 @@ describe("VHTLCV2ContractHandler", () => {
             const manager = await managerFor(() => {
                 reads += 1;
                 if (reads === 1) throw new Error("provider not ready");
-                return Promise.resolve(800_000);
+                return at(800_000)();
             });
             const contract = contractOf(fullParams());
             await manager.createContract(contract);
@@ -576,7 +611,7 @@ describe("VHTLCV2ContractHandler", () => {
             let reads = 0;
             const manager = await managerFor(async () => {
                 reads += 1;
-                return 800_000;
+                return at(800_000)();
             });
             const contract = contractOf(fullParams());
             await manager.createContract(contract);

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -24,6 +24,7 @@ import {
     type Contract,
 } from "../../src";
 import { contractHandlers } from "../../src/contracts/handlers";
+import type { PathContext } from "../../src/contracts/types";
 import { VHTLCContractHandler } from "../../src/contracts/handlers/vhtlc";
 import { VHTLCV2ContractHandler } from "../../src/contracts/handlers/vhtlcV2";
 import { deriveContractTapscripts } from "../../src/wallet/utils";
@@ -270,6 +271,104 @@ describe("VHTLCV2ContractHandler", () => {
      * height, matured or not. This pins the wiring, not the arithmetic: same
      * contract, same maturity, the only variable is whether a tip is supplied.
      */
+    /**
+     * The settle pre-flight. `isGenericallySpendable: false` keeps a lockup out
+     * of generic selection and deliberately leaves `settle({ inputs })` open —
+     * naming an outpoint is the intent that gate protects. Naming one before
+     * the refund path opens is still a mistake, and without this it is one the
+     * server reports, after the round trip, without saying which timelock was
+     * short.
+     *
+     * The refusals are the easy half. The silences are the point: this must
+     * never convert a spend the server would have accepted into a local throw.
+     */
+    describe("assertSpendableNow", () => {
+        const contextAt = (over: Partial<PathContext> = {}): PathContext => ({
+            collaborative: true,
+            currentTime: Date.now(),
+            walletPubKey: SENDER,
+            ...over,
+        });
+
+        const check = (params: Record<string, string>, context: PathContext) =>
+            VHTLCV2ContractHandler.assertSpendableNow!(
+                VHTLCV2ContractHandler.createScript(params),
+                contractOf(params),
+                context,
+            );
+
+        it("refuses the sender's spend before the refund height, naming it", () => {
+            expect(() => check(fullParams(), contextAt({ blockHeight: 799_999 }))).toThrow(
+                /refund path opens at block 800000, now 799999/,
+            );
+        });
+
+        it("allows it once the height is reached", () => {
+            expect(() => check(fullParams(), contextAt({ blockHeight: 800_000 }))).not.toThrow();
+        });
+
+        it("refuses a seconds-typed locktime against the clock", () => {
+            const future = Math.floor(Date.now() / 1000) + 3600;
+            expect(() =>
+                check(fullParams({ refundLocktime: String(future) }), contextAt()),
+            ).toThrow(/cannot be spent yet/);
+        });
+
+        it("says nothing when the height is unknown — unreadable is not immature", () => {
+            // The false-refusal case this design exists to avoid: height-typed
+            // locktime, no chain tip. `isCltvSatisfied` reports false here, so
+            // anything refusing on that alone would reject a mature lockup.
+            expect(() => check(fullParams(), contextAt({ blockHeight: undefined }))).not.toThrow();
+        });
+
+        it("says nothing to the receiver, whose claim turns on a preimage", () => {
+            expect(() =>
+                check(fullParams(), contextAt({ walletPubKey: RECEIVER, blockHeight: 799_999 })),
+            ).not.toThrow();
+        });
+
+        it("says nothing to a wallet that is neither party", () => {
+            const stranger = "0".repeat(64);
+            expect(() =>
+                check(fullParams(), contextAt({ walletPubKey: stranger, blockHeight: 799_999 })),
+            ).not.toThrow();
+        });
+
+        it("says nothing about a unilateral spend, which answers to its CSV", () => {
+            expect(() =>
+                check(fullParams(), contextAt({ collaborative: false, blockHeight: 799_999 })),
+            ).not.toThrow();
+        });
+
+        it("is shared with the v1 handler, so the two cannot drift", () => {
+            const params = {
+                sender: SENDER,
+                receiver: RECEIVER,
+                server: SERVER,
+                hash: HASH,
+                refundLocktime: "800000",
+                claimDelay: "10",
+                refundDelay: "12",
+                refundNoReceiverDelay: "14",
+            };
+            const v1Contract: Contract = {
+                type: "vhtlc",
+                params,
+                script: hex.encode(VHTLCContractHandler.createScript(params).pkScript),
+                address: "address",
+                state: "active",
+                createdAt: Date.now(),
+            };
+            expect(() =>
+                VHTLCContractHandler.assertSpendableNow!(
+                    VHTLCContractHandler.createScript(params),
+                    v1Contract,
+                    contextAt({ blockHeight: 799_999 }),
+                ),
+            ).toThrow(/refund path opens at block 800000/);
+        });
+    });
+
     describe("blockHeight reaches the handler through ContractManager", () => {
         const managerFor = async (chainTip?: () => Promise<number | undefined>) =>
             ContractManager.create({
@@ -331,6 +430,63 @@ describe("VHTLCV2ContractHandler", () => {
             for (const paths of results) {
                 expect(paths.map(leafHex)).toContain(script.refundWithoutReceiverScript);
             }
+        });
+
+        /**
+         * The handler cases above prove the rule; these prove it is reachable.
+         * The settle pre-flight calls `assertSpendableNow?.()` optionally — an
+         * unimplemented manager is a valid "no opinion" — so a wiring break
+         * here would not fail loudly, it would go quiet. That is the failure
+         * mode worth a test of its own.
+         */
+        const assertThrough = async (tip: number | undefined) => {
+            const manager = await managerFor(tip === undefined ? undefined : async () => tip);
+            const contract = contractOf(fullParams());
+            await manager.createContract(contract);
+            const vtxo = { txid: "a".repeat(64), vout: 0, script: contract.script };
+            return manager.assertSpendableNow!([vtxo], async () => SENDER);
+        };
+
+        it("refuses an immature lockup through the manager, not just the handler", async () => {
+            await expect(assertThrough(799_999)).rejects.toThrow(/cannot be spent yet/);
+        });
+
+        it("allows it through the manager once mature", async () => {
+            await expect(assertThrough(800_000)).resolves.toBeUndefined();
+        });
+
+        it("stays silent when no tip is available", async () => {
+            await expect(assertThrough(undefined)).resolves.toBeUndefined();
+        });
+
+        it("never reads a tip when no contract has an opinion", async () => {
+            let reads = 0;
+            const manager = await managerFor(async () => {
+                reads += 1;
+                return 800_000;
+            });
+            // A `default` row: its handler implements no assertSpendableNow, so
+            // the whole check must short-circuit before touching the provider.
+            // Script derived, not invented — createContract refuses any row
+            // whose script disagrees with its params.
+            const defaultHandler = contractHandlers.get("default")!;
+            const params = {
+                pubKey: SENDER,
+                serverPubKey: SERVER,
+                csvTimelock: JSON.stringify({ type: "blocks", value: "144" }),
+            };
+            const script = hex.encode(defaultHandler.createScript(params).pkScript);
+            await manager.createContract({
+                type: "default",
+                params,
+                script,
+                address: "address",
+            } as never);
+            await manager.assertSpendableNow!(
+                [{ txid: "b".repeat(64), vout: 0, script }],
+                async () => SENDER,
+            );
+            expect(reads).toBe(0);
         });
 
         it("treats an unreadable tip as unknown rather than failing the query", async () => {


### PR DESCRIPTION
> Stacked on #703, which supplies the `blockHeight` this depends on. **Merge #703 first**, then retarget this to `feat/arkade-swap`. Its diff against `feat/arkade-swap` will look like both changes until then.

## The problem

`isGenericallySpendable: false` keeps a live VHTLC out of generic selection — send, settle, renewal, offboard — and deliberately leaves explicit-input APIs open, because naming an outpoint is the intent that gate exists to protect.

Naming one too early is still a mistake, and it was one only the server caught. `settle({ inputs: [vhtlcVtxo] })` before `refundLocktime` matures builds fine, registers an intent fine, and comes back as a protocol-level rejection after the round trip — in terms that never say which timelock was short, or when it opens. Raised in review on #702 as the asymmetry between generic renewal (blocked with a reason) and explicit early settle (not pre-checked at all).

## What changed

A new optional `ContractHandler.assertSpendableNow`, called from the settle pre-flight beside `assertAnnotatable` — the same "last check before anything leaves the wallet" position, for the same reason.

**Handlers answer, not the manager.** Only the handler knows what its leaves need. The manager just collects the ones with an opinion, builds one `PathContext` for the batch, and lets them speak.

**Not a generic "no spendable paths ⇒ refuse".** That rule looks obvious and is wrong: `arkade.ts`'s `pathsFor` does `if (fn.arkadeScript) continue`, skipping every covenant leaf, so an Arkade-program contract spendable only through its emulator-signed leaf reports an empty set while being perfectly spendable. A generic rule would refuse exactly those.

**It fires only where it is certain.** Silent for a unilateral spend (that answers to its CSV), for the receiver (whose claim turns on a preimage this cannot see), for a wallet that is neither party, and — the important one — when the locktime is height-typed and no chain tip is available. `isCltvSatisfied` folds "unknown" into `false`, which is right for *offering* a path and wrong for *refusing* one, so a new `cltvMaturity` helper keeps `pending` and `unknown` apart. Refusing on `unknown` would reject spends the server would have accepted.

**Chain time, not the host's clock.** Seconds-typed timelocks were compared against `Date.now()`. The server matures them against median-time-past, which trails wall clock, so a drifting host reads the boundary wrong in whichever direction it drifted — including refusing a spend the chain already accepts. The tip we already fetch carries its timestamp, so `chainTip` now returns `{height, time}`, `PathContext` carries `chainTime`, and both the CLTV and CSV seconds branches prefer it, falling back to the local clock only when it is absent.

**The context is per input, not per batch.** A relative (CSV) timelock is measured from the moment *its own* input confirmed, so two coins on one contract can disagree about whether the same leaf is open. The first cut built one batch-wide context with no `vtxo` on it at all, which made CSV unanswerable by construction. Each input now gets its own context carrying the coin, so `status.block_height` / `status.block_time` are there to read.

The rule itself lives in `helpers.ts` and is shared by the v1 and v2 handlers. Both gate the sender's only collaborative leaf on the same `refundLocktime`, and a rule applied to one and not the other is the realistic drift — the same reasoning already keeps their path selection in step.

## Compatibility

`assertSpendableNow` is optional on **both** `ContractHandler` and `IContractManager`, so this breaks no embedder with its own implementation of either — an omission simply means "no opinion", which is what every non-VHTLC contract answers anyway. The check also costs nothing when no contract in the batch has an opinion: it short-circuits before reading a chain tip, and before touching the wallet identity (the pubkey is passed as a thunk for exactly that reason — resolving it eagerly made an ordinary settle depend on a key it never consults, which broke four existing tests).

## Tests

16 new cases, including chain-time-beats-host-clock in both directions. The refusals are the easy half; the silences are the point, since the failure mode that matters is converting a valid spend into a local throw:

- refuses the sender before the refund height, quoting it and the current height
- allows it at the height, and refuses a seconds-typed locktime against the clock
- silent on unknown height, on the receiver, on a stranger, on a unilateral spend
- the v1 handler refuses identically, pinning the shared rule
- through the manager, not just the handler: refuses immature, allows mature, silent with no tip
- never reads a chain tip when no contract has an opinion

Revert-verified: breaking the manager's dispatch fails the manager-level case with `promise resolved "undefined" instead of rejecting`. That one matters because the call site is `assertSpendableNow?.()` — a wiring break would go quiet rather than loud.

## Verification

`pnpm test:unit` in `packages/ts-sdk`: **156 files, 2445 passed, 1 skipped, 0 failed**. `tsc --noEmit` clean. `packages/swap` and `boltz-swap` green via the pre-commit hook.

Four failures appeared mid-work and were mine, both times from the same root cause — the settle path reaching for things an ordinary settle does not need. Fixed by deferring the identity read behind a thunk and making the manager method optional, not by loosening the tests.

