### PR TITLE
fix(swap): address review findings on derived RFQ secrets

### DIFF
--- a/packages/boltz-swap/src/arkade-swaps.ts
+++ b/packages/boltz-swap/src/arkade-swaps.ts
@@ -3808,7 +3808,21 @@ export class ArkadeSwaps {
         const keys = new Map<string, SwapOwnerKey>([[identityKey, { publicKey: identityKey }]]);
         if (!isHDWalletCapable(this.wallet)) return [...keys.values()];
 
-        for (const signingDescriptor of await this.wallet.getUsedSigningDescriptors()) {
+        // Behind a service worker this is a bus round-trip, which a restarted
+        // or not-yet-initialized worker fails. Losing the descriptor keys costs
+        // the HD-bound swaps; failing here costs the restore its every swap.
+        let usedDescriptors: string[] = [];
+        try {
+            usedDescriptors = await this.wallet.getUsedSigningDescriptors();
+        } catch (error) {
+            logger.warn(
+                "Could not read used signing descriptors; using the identity key only",
+                error,
+            );
+            return [...keys.values()];
+        }
+
+        for (const signingDescriptor of usedDescriptors) {
             try {
                 const publicKey = hex.encode(
                     deriveDescriptorLeafCompressedPubKey(signingDescriptor),

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -366,17 +366,19 @@ scanned? })` — the server key is required because a spend is classified by reb
   indistinguishable from a fill. Leaves have no such failure mode.
 - **A spend that cannot be classified is no longer restored as `fulfilled`.** It leaves the funding
   txid unanswered so a later scan decides it. Records are never written on a guess.
-- **`AssetSwapRepository.version` is now `2`.** The `AssetSwap` schema gained the secret-bearing
-  `signingDescriptor?` / `fallbackSecrets?` fields, and `preimageHex` narrowed from "the claim
-  preimage P" to "caller-supplied P only". A field-mapped backend written against v1 must add the
-  new columns — silently dropping `fallbackSecrets` on write loses the stored arm's claim and
-  refund keys. Records written by the previous shape (bare `preimageHex`, no descriptor, no
-  fallback) make `rfqSecretsOfRecord` throw a descriptive error rather than return `undefined`:
-  their preimage is live but their sender key was never persisted, so migrate the preimage by
-  reading it directly off the record.
-- **`addAssetSwap` throws on a failed write; `updateAssetSwap` stays best-effort.** The add path
-  gates funding (nothing irreversible may happen until the record is durable), while updates
-  record transitions that follow an irreversible action and must not fail the caller after it.
+- **`AssetSwap` gained the secret-bearing `signingDescriptor?` / `fallbackSecrets?` fields**, and
+  `preimageHex` narrowed from "the claim preimage P" to "caller-supplied P only". The repository
+  version stays `1` — the package is unreleased, so there is no stored record to migrate — but a
+  field-mapped backend must persist the record whole: silently dropping `fallbackSecrets` on write
+  loses the stored arm's claim and refund keys.
+- **A write that gates something irreversible throws; one that follows it does not.**
+  `addAssetSwap` and `updateAssetSwap` throw on a failed read or write — nothing irreversible may
+  happen until the record is durable, which is why `cancelOffer` writes its `cancelling` marker
+  before broadcasting. `updateAssetSwapBestEffort` is the other half: it records transitions that
+  follow an irreversible action (a broadcast claim, a spent lockup), so it cannot fail the caller,
+  and returns `{ swaps, persisted }` instead. `watchOfferSwaps` uses it and fires `onUpdate` only
+  when `persisted` is true — the callback is documented as following a persisted change, and a
+  consumer caching from it must not run ahead of the store.
 - **`lightningSendProgram` and `htlcSendProgram` are gone** along with the program-artifact layer
   they compiled. Derive scripts through `lightningSendVtxoScript` / `onchainHtlcScript`.
 - **`lightningSendVtxoScript` takes two new required fields**: `senderPubkey` (the trader's VHTLC

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -297,9 +297,14 @@ const swap = await requestOnchainSend(/* … */);
 swap.secrets; // { derivable: true, signingDescriptor } — persist it, it holds no secret
 await saveSwap({ ...record, ...rfqSecretsToRecord(swap.secrets) });
 
-// Later, from the seed plus that descriptor:
-const preimage = await preimageForRfqSecrets(wallet, rfqSecretsOfRecord(record)!);
-const sender = await senderIdentityForRfqSecrets(wallet, rfqSecretsOfRecord(record)!);
+// Later, from the seed plus that descriptor. Guard the lookup: offer-corridor
+// records (and records that lost their secrets fields) carry no secrets at
+// all, and a `!` here would crash the whole recovery loop on the first one.
+const secrets = rfqSecretsOfRecord(record);
+if (secrets) {
+    const preimage = await preimageForRfqSecrets(wallet, secrets);
+    const sender = await senderIdentityForRfqSecrets(wallet, secrets);
+}
 ```
 
 `derivable: false` is the fallback for wallets that cannot allocate (static / `auto` / custom
@@ -322,6 +327,14 @@ preimage for both corridors.
 
 **Not covered:** seed-only discovery after the swap repository is wiped. An unspent L1 HTLC reveals
 too little public quote data to rediscover, so the record remains required.
+
+**Gap-limit interaction:** every swap request — including one whose quote is refused — consumes one
+index from the wallet's receive stream, and a swap index never becomes a funded receive contract,
+so it looks *unused* to a seed-only `restore()` gap scan. Many consecutive swap allocations between
+two funded receive indices can therefore exceed the scan's `gapLimit` (default 20) and stop it
+before later-funded addresses are found. Keep the swap repository in backups (restore then adopts
+each record's descriptor via `adoptSwapDescriptor`), or raise `gapLimit` on seed-only restores
+after heavy swap use.
 
 ## Breaking changes on this branch (pre-release migration notes)
 
@@ -353,6 +366,17 @@ scanned? })` — the server key is required because a spend is classified by reb
   indistinguishable from a fill. Leaves have no such failure mode.
 - **A spend that cannot be classified is no longer restored as `fulfilled`.** It leaves the funding
   txid unanswered so a later scan decides it. Records are never written on a guess.
+- **`AssetSwapRepository.version` is now `2`.** The `AssetSwap` schema gained the secret-bearing
+  `signingDescriptor?` / `fallbackSecrets?` fields, and `preimageHex` narrowed from "the claim
+  preimage P" to "caller-supplied P only". A field-mapped backend written against v1 must add the
+  new columns — silently dropping `fallbackSecrets` on write loses the stored arm's claim and
+  refund keys. Records written by the previous shape (bare `preimageHex`, no descriptor, no
+  fallback) make `rfqSecretsOfRecord` throw a descriptive error rather than return `undefined`:
+  their preimage is live but their sender key was never persisted, so migrate the preimage by
+  reading it directly off the record.
+- **`addAssetSwap` throws on a failed write; `updateAssetSwap` stays best-effort.** The add path
+  gates funding (nothing irreversible may happen until the record is durable), while updates
+  record transitions that follow an irreversible action and must not fail the caller after it.
 - **`lightningSendProgram` and `htlcSendProgram` are gone** along with the program-artifact layer
   they compiled. Derive scripts through `lightningSendVtxoScript` / `onchainHtlcScript`.
 - **`lightningSendVtxoScript` takes two new required fields**: `senderPubkey` (the trader's VHTLC

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -20,8 +20,10 @@ export {
 export {
     BTC_ASSET_ID,
     getAssetSwaps,
+    getAssetSwapsOrThrow,
     addAssetSwap,
     updateAssetSwap,
+    updateAssetSwapBestEffort,
     type AssetSwap,
     type AssetSwapFallbackSecrets,
     type AssetSwapStatus,

--- a/packages/swap/src/indexedDbRepository.ts
+++ b/packages/swap/src/indexedDbRepository.ts
@@ -34,10 +34,20 @@ const request = <T>(req: IDBRequest<T>): Promise<T> =>
         req.onerror = () => reject(req.error);
     });
 
+/** A write is durable at *commit*, not at request success — quota pressure and
+ * storage eviction abort a transaction whose every request already succeeded.
+ * Reads may resolve on the request; writes must await this. */
+const txDone = (tx: IDBTransaction): Promise<void> =>
+    new Promise((resolve, reject) => {
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.onabort = () => reject(tx.error);
+    });
+
 /** Browser backend over the SDK's shared IndexedDB manager — the same
  * infrastructure the wallet already uses for its Boltz swap repository. */
 export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 2 as const;
+    readonly version = 1 as const;
     // the promise, not the resolved database: openDatabase bumps a refcount on
     // every call including cache hits, while dispose closes once, so two
     // concurrent first calls would strand the refcount above zero and leak the
@@ -56,33 +66,46 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
         ));
     }
 
-    private async store(name: string, mode: IDBTransactionMode): Promise<IDBObjectStore> {
-        return (await this.ensureDb()).transaction([name], mode).objectStore(name);
+    private async readStore(name: string): Promise<IDBObjectStore> {
+        return (await this.ensureDb()).transaction([name], "readonly").objectStore(name);
+    }
+
+    /** Every write in one place, so none of them can forget to await the
+     * commit. Requests need no individual await: a failed one aborts the
+     * transaction, which `txDone` reports. */
+    private async write(name: string, apply: (store: IDBObjectStore) => void): Promise<void> {
+        const tx = (await this.ensureDb()).transaction([name], "readwrite");
+        const done = txDone(tx);
+        apply(tx.objectStore(name));
+        await done;
     }
 
     async saveSwap(swap: AssetSwap): Promise<void> {
-        await request((await this.store(STORE_SWAPS, "readwrite")).put(swap));
+        await this.write(STORE_SWAPS, (store) => {
+            store.put(swap);
+        });
     }
 
     async getAllSwaps(): Promise<AssetSwap[]> {
-        return request((await this.store(STORE_SWAPS, "readonly")).getAll());
+        return request((await this.readStore(STORE_SWAPS)).getAll());
     }
 
     async getScannedTxids(): Promise<Set<string>> {
-        const keys = await request((await this.store(STORE_SCANNED, "readonly")).getAllKeys());
+        const keys = await request((await this.readStore(STORE_SCANNED)).getAllKeys());
         return new Set(keys as string[]);
     }
 
     async markTxidsScanned(txids: Iterable<string>): Promise<void> {
-        const store = await this.store(STORE_SCANNED, "readwrite");
-        await Promise.all([...txids].map((txid) => request(store.put(txid, txid))));
+        await this.write(STORE_SCANNED, (store) => {
+            for (const txid of txids) store.put(txid, txid);
+        });
     }
 
     async getCachedMarkets(
         network: string,
         registry: string,
     ): Promise<MarketsCacheEntry | undefined> {
-        const store = await this.store(STORE_MARKETS, "readonly");
+        const store = await this.readStore(STORE_MARKETS);
         return request(store.get(marketsCacheKey(network, registry)));
     }
 
@@ -91,8 +114,9 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
         registry: string,
         entry: MarketsCacheEntry,
     ): Promise<void> {
-        const store = await this.store(STORE_MARKETS, "readwrite");
-        await request(store.put(entry, marketsCacheKey(network, registry)));
+        await this.write(STORE_MARKETS, (store) => {
+            store.put(entry, marketsCacheKey(network, registry));
+        });
     }
 
     /** All stores in one transaction: clearing swaps but keeping scanned txids
@@ -101,11 +125,7 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
     async clear(): Promise<void> {
         const stores = STORES.map(([name]) => name);
         const tx = (await this.ensureDb()).transaction(stores, "readwrite");
-        const done = new Promise<void>((resolve, reject) => {
-            tx.oncomplete = () => resolve();
-            tx.onerror = () => reject(tx.error);
-            tx.onabort = () => reject(tx.error);
-        });
+        const done = txDone(tx);
         for (const name of stores) tx.objectStore(name).clear();
         await done;
     }

--- a/packages/swap/src/indexedDbRepository.ts
+++ b/packages/swap/src/indexedDbRepository.ts
@@ -37,7 +37,7 @@ const request = <T>(req: IDBRequest<T>): Promise<T> =>
 /** Browser backend over the SDK's shared IndexedDB manager — the same
  * infrastructure the wallet already uses for its Boltz swap repository. */
 export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
     // the promise, not the resolved database: openDatabase bumps a refcount on
     // every call including cache hits, while dispose closes once, so two
     // concurrent first calls would strand the refcount above zero and leak the

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -31,7 +31,7 @@ import {
 import wantAssetProgram from "./swap-want-asset.program.json";
 import wantBtcProgram from "./swap-want-btc.program.json";
 import type { AssetSwapRepository } from "./repository";
-import { getAssetSwaps, updateAssetSwap } from "./store";
+import { getAssetSwapsOrThrow, updateAssetSwap, updateAssetSwapBestEffort } from "./store";
 
 // json imports widen "type": "pubkey" to string; parseArtifact validates at runtime
 type Artifact = Parameters<typeof arkade.parseArtifact>[0];
@@ -537,14 +537,21 @@ export async function cancelOffer(
         });
     }
     const swapId = fundingTxid ?? vtxo.txid;
-    const hasLocalRecord = (await getAssetSwaps(repository)).some((s) => s.id === swapId);
+    // Strict read: a failed one must not read as "no local record here" and
+    // send us past the marker into the broadcast.
+    const hasLocalRecord = (await getAssetSwapsOrThrow(repository)).some((s) => s.id === swapId);
     // The in-flight marker is useful only when there is a local record to
     // update; a different or empty repository intentionally leaves the cancel
-    // for event/restore classification.
+    // for event/restore classification. It gates the broadcast, so it throws:
+    // the marker is what keeps a crash here from leaving a swap that still
+    // looks pending.
     if (hasLocalRecord) await updateAssetSwap(repository, swapId, { status: "cancelling" });
     const { txid } = await cancel.send();
     if (hasLocalRecord) {
-        await updateAssetSwap(repository, swapId, {
+        // Past the point of no return: the cancel is broadcast, so a lost write
+        // must not fail the caller. The watcher classifies by covenant leaf and
+        // the restore scan re-derives the outcome.
+        await updateAssetSwapBestEffort(repository, swapId, {
             status: "cancelled",
             spentTxid: txid,
         });

--- a/packages/swap/src/repository.ts
+++ b/packages/swap/src/repository.ts
@@ -30,13 +30,11 @@ export const marketsCacheKey = (network: string, registry: string) =>
  * subset queries.
  */
 export interface AssetSwapRepository extends AsyncDisposable {
-    /** v2: `AssetSwap` gained `signingDescriptor` and `fallbackSecrets`
-     * (secret-bearing — a field-mapped backend that drops them loses the
-     * stored arm's claim and refund keys), and `preimageHex` narrowed from
-     * "the claim preimage P" to "caller-supplied P only". */
-    readonly version: 2;
+    readonly version: 1;
 
-    /** Insert or replace a swap by id. */
+    /** Insert or replace a swap by id. Store the record whole: `fallbackSecrets`
+     * is secret-bearing, and a field-mapped backend that drops it loses the
+     * stored arm's claim and refund keys. */
     saveSwap(swap: AssetSwap): Promise<void>;
     /** All stored swaps, in no particular order — `getAssetSwaps` is the
      * canonical newest-first read. */
@@ -54,7 +52,7 @@ export interface AssetSwapRepository extends AsyncDisposable {
 }
 
 export class InMemoryAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 2 as const;
+    readonly version = 1 as const;
     private readonly swaps = new Map<string, AssetSwap>();
     private readonly scanned = new Set<string>();
     private readonly markets = new Map<string, MarketsCacheEntry>();

--- a/packages/swap/src/repository.ts
+++ b/packages/swap/src/repository.ts
@@ -30,7 +30,11 @@ export const marketsCacheKey = (network: string, registry: string) =>
  * subset queries.
  */
 export interface AssetSwapRepository extends AsyncDisposable {
-    readonly version: 1;
+    /** v2: `AssetSwap` gained `signingDescriptor` and `fallbackSecrets`
+     * (secret-bearing — a field-mapped backend that drops them loses the
+     * stored arm's claim and refund keys), and `preimageHex` narrowed from
+     * "the claim preimage P" to "caller-supplied P only". */
+    readonly version: 2;
 
     /** Insert or replace a swap by id. */
     saveSwap(swap: AssetSwap): Promise<void>;
@@ -50,7 +54,7 @@ export interface AssetSwapRepository extends AsyncDisposable {
 }
 
 export class InMemoryAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
     private readonly swaps = new Map<string, AssetSwap>();
     private readonly scanned = new Set<string>();
     private readonly markets = new Map<string, MarketsCacheEntry>();

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -959,6 +959,12 @@ export async function requestOnchainSend(
     secrets: SwapSecrets;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
+    // Before anything irreversible (HD allocation, quote, funding): the L1
+    // claim leaf pins OP_SIZE 32, so any other length funds an unclaimable
+    // HTLC, and restore rejects the record outright (`decodeHex32`).
+    if (params.preimage && params.preimage.length !== 32) {
+        throw new Error(`preimage must be 32 bytes, got ${params.preimage.length}`);
+    }
     const derivedSecrets = await deriveSwapSecrets(wallet);
     const secrets = derivedSecrets
         ? params.preimage

--- a/packages/swap/src/secrets.ts
+++ b/packages/swap/src/secrets.ts
@@ -177,20 +177,10 @@ export function rfqSecretsOfRecord(record: {
                 : {}),
         };
     }
+    // Total on purpose: consumers call this while iterating swap history, where
+    // a throw on one record would abort the whole loop.
     const fallback = record.fallbackSecrets;
-    if (!fallback) {
-        if (record.preimageHex) {
-            // Pre-derived-secrets record shape: P stored bare, sender key not
-            // persisted at all. Refuse loudly rather than return `undefined` —
-            // silence here reads as "no secrets" and loses a live preimage.
-            throw new Error(
-                "legacy swap record: preimageHex is set but neither signingDescriptor " +
-                    "nor fallbackSecrets is; read the preimage directly off the record " +
-                    "(its sender key was never persisted)",
-            );
-        }
-        return undefined;
-    }
+    if (!fallback) return undefined;
     if (fallback.version !== 1 || fallback.type !== "stored") {
         throw new Error("unsupported RFQ fallback secrets record");
     }
@@ -224,16 +214,30 @@ export async function adoptSwapDescriptor(
     await wallet.advanceSigningDescriptorWatermark(signingDescriptor);
 }
 
-/** The VHTLC `sender` identity — the signer for every interactive refund. */
+/**
+ * The VHTLC `sender` identity — the signer for every interactive refund.
+ *
+ * The capability probe is not the check that matters: `signerForDescriptor`
+ * falls back to the plain wallet identity for a descriptor it cannot derive —
+ * a different seed, a static wallet — and that identity signs happily with the
+ * wrong key, which surfaces only as a solver rejection or a dead claim script.
+ * So the check is on what comes back: only a descriptor-bound signer carries
+ * `signSchnorrDeterministic`.
+ */
 export async function senderIdentityForRfqSecrets(
     wallet: IWallet,
     secrets: SwapSecrets,
 ): Promise<Identity> {
     if (!secrets.derivable) return SingleKey.fromPrivateKey(secrets.senderPrivateKey);
-    if (!isHDWalletCapable(wallet)) {
-        throw new Error("swap was created on an HD wallet; this wallet cannot derive its key");
+    const signer = isHDWalletCapable(wallet)
+        ? await wallet.signerForDescriptor(secrets.signingDescriptor)
+        : undefined;
+    if (!signer || !isDeterministicSigner(signer)) {
+        throw new Error(
+            `this wallet cannot derive ${secrets.signingDescriptor}; the swap was created on another wallet`,
+        );
     }
-    return wallet.signerForDescriptor(secrets.signingDescriptor);
+    return signer;
 }
 
 /** The `sender` x-only pubkey, the only half the request flow needs. */

--- a/packages/swap/src/secrets.ts
+++ b/packages/swap/src/secrets.ts
@@ -98,6 +98,12 @@ export type SwapSecrets = DerivedSwapSecrets | StoredSwapSecrets;
  * descriptor until the wallet rotates, and two swaps sharing a descriptor
  * derive the *identical* preimage, so one solver learning its own preimage
  * would learn the other swap's.
+ *
+ * Cost of allocating: the index is consumed even when the quote is later
+ * refused, and a swap index never turns into a funded receive contract, so a
+ * long run of swaps widens the "unused" gap a seed-only `restore()` scan sees
+ * (see the README's gap-limit note). Restores that keep the swap repository
+ * are unaffected — `adoptSwapDescriptor` re-claims each record's index.
  */
 export async function deriveSwapSecrets(wallet: IWallet): Promise<DerivedSwapSecrets | undefined> {
     if (!isHDAllocationCapable(wallet)) return undefined;
@@ -113,6 +119,10 @@ export async function deriveSwapSecrets(wallet: IWallet): Promise<DerivedSwapSec
 export function randomSwapSecrets(
     opts: { preimage?: boolean | Uint8Array } = {},
 ): StoredSwapSecrets {
+    if (opts.preimage instanceof Uint8Array && opts.preimage.length !== 32) {
+        // The HTLC claim leaf pins OP_SIZE 32: any other length is unclaimable.
+        throw new Error(`preimage must be 32 bytes, got ${opts.preimage.length}`);
+    }
     const preimage =
         opts.preimage instanceof Uint8Array
             ? opts.preimage
@@ -168,7 +178,19 @@ export function rfqSecretsOfRecord(record: {
         };
     }
     const fallback = record.fallbackSecrets;
-    if (!fallback) return undefined;
+    if (!fallback) {
+        if (record.preimageHex) {
+            // Pre-derived-secrets record shape: P stored bare, sender key not
+            // persisted at all. Refuse loudly rather than return `undefined` —
+            // silence here reads as "no secrets" and loses a live preimage.
+            throw new Error(
+                "legacy swap record: preimageHex is set but neither signingDescriptor " +
+                    "nor fallbackSecrets is; read the preimage directly off the record " +
+                    "(its sender key was never persisted)",
+            );
+        }
+        return undefined;
+    }
     if (fallback.version !== 1 || fallback.type !== "stored") {
         throw new Error("unsupported RFQ fallback secrets record");
     }
@@ -269,5 +291,15 @@ export async function preimageForRfqSecrets(
             `wallet cannot sign deterministically for ${secrets.signingDescriptor}; its preimage is not derivable`,
         );
     }
-    return derivePreimage(signer);
+    try {
+        return await derivePreimage(signer);
+    } catch (cause) {
+        // The structural guard above cannot see call-time refusals:
+        // `DescriptorIdentity` always exposes `signSchnorrDeterministic` and
+        // only throws when its base cannot actually sign deterministically.
+        throw new Error(
+            `wallet cannot sign deterministically for ${secrets.signingDescriptor}; its preimage is not derivable`,
+            { cause },
+        );
+    }
 }

--- a/packages/swap/src/store.ts
+++ b/packages/swap/src/store.ts
@@ -111,9 +111,9 @@ export const getAssetSwaps = async (repository: AssetSwapRepository): Promise<As
     }
 };
 
-// Surface persistence failures: onchain sends must prove the pre-funding
-// record write landed before the caller broadcasts the lockup.
-const saveSwapSafely = async (repository: AssetSwapRepository, swap: AssetSwap): Promise<void> => {
+// Surface persistence failures on ADD only: onchain sends must prove the
+// pre-funding record write landed before the caller broadcasts the lockup.
+const saveSwapOrThrow = async (repository: AssetSwapRepository, swap: AssetSwap): Promise<void> => {
     try {
         await repository.saveSwap(swap);
     } catch (error) {
@@ -122,14 +122,16 @@ const saveSwapSafely = async (repository: AssetSwapRepository, swap: AssetSwap):
     }
 };
 
-/** Add a swap; no-op if the id is already stored. Returns the updated list. */
+/** Add a swap; no-op if the id is already stored. Returns the updated list.
+ * THROWS on a failed write — nothing irreversible may happen until this record
+ * is durable, so the caller must not fund on a failure. */
 export const addAssetSwap = async (
     repository: AssetSwapRepository,
     swap: AssetSwap,
 ): Promise<AssetSwap[]> => {
     const swaps = await getAssetSwaps(repository);
     if (swaps.some((s) => s.id === swap.id)) return swaps;
-    await saveSwapSafely(repository, swap);
+    await saveSwapOrThrow(repository, swap);
     // the list is already newest-first, so place the one new record rather than
     // re-sorting the whole history around it
     const at = swaps.findIndex((s) => byNewest(swap, s) <= 0);
@@ -138,7 +140,12 @@ export const addAssetSwap = async (
     return merged;
 };
 
-/** Merge changes into a swap by id. Returns the updated list. */
+/** Merge changes into a swap by id. Returns the updated list.
+ * Best-effort on the write, unlike {@link addAssetSwap}: updates record status
+ * transitions that follow an irreversible action (a broadcast claim, a spent
+ * lockup), so failing the caller here would report as failed a swap whose
+ * funds already moved. A stale status is recoverable — crash recovery
+ * re-derives the true state from the chain (`classifyOnchainHtlc`). */
 export const updateAssetSwap = async (
     repository: AssetSwapRepository,
     id: string,
@@ -150,6 +157,12 @@ export const updateAssetSwap = async (
         s.id === id ? { ...s, ...changes } : s,
     );
     const updated = swaps.find((s) => s.id === id);
-    if (updated) await saveSwapSafely(repository, updated);
+    if (updated) {
+        try {
+            await repository.saveSwap(updated);
+        } catch (error) {
+            console.warn(`[swap] failed to persist update for swap ${id}`, error);
+        }
+    }
     return swaps;
 };

--- a/packages/swap/src/store.ts
+++ b/packages/swap/src/store.ts
@@ -92,27 +92,35 @@ const byNewest = (a: AssetSwap, b: AssetSwap): number => b.createdAt - a.created
 
 /** All swaps, newest-first. Insertion order is not chronological — the restore
  * scan rebuilds records in tx-scan order — so sort at read to keep
- * newest-first canonical for every consumer. A broken backend reads as no
- * swaps rather than crashing the caller. */
+ * newest-first canonical for every consumer. */
+export const getAssetSwapsOrThrow = async (
+    repository: AssetSwapRepository,
+): Promise<AssetSwap[]> => {
+    return (await repository.getAllSwaps())
+        .filter(
+            (s) =>
+                s &&
+                typeof s.id === "string" &&
+                // offer swaps carry the TLV; onchain-corridor swaps carry
+                // the payment hash instead — either marks a valid record
+                (typeof s.offerHex === "string" || typeof s.paymentHash === "string"),
+        )
+        .sort(byNewest);
+};
+
+/** The consumer read: a broken backend reads as no swaps rather than crashing
+ * a history view. Mutations must use {@link getAssetSwapsOrThrow} instead —
+ * swallowing the read there would let "the backend is gone" masquerade as "no
+ * such swap" and skip the write silently. */
 export const getAssetSwaps = async (repository: AssetSwapRepository): Promise<AssetSwap[]> => {
     try {
-        return (await repository.getAllSwaps())
-            .filter(
-                (s) =>
-                    s &&
-                    typeof s.id === "string" &&
-                    // offer swaps carry the TLV; onchain-corridor swaps carry
-                    // the payment hash instead — either marks a valid record
-                    (typeof s.offerHex === "string" || typeof s.paymentHash === "string"),
-            )
-            .sort(byNewest);
+        return await getAssetSwapsOrThrow(repository);
     } catch {
         return [];
     }
 };
 
-// Surface persistence failures on ADD only: onchain sends must prove the
-// pre-funding record write landed before the caller broadcasts the lockup.
+// Surface persistence failures: the caller decides what a lost write means.
 const saveSwapOrThrow = async (repository: AssetSwapRepository, swap: AssetSwap): Promise<void> => {
     try {
         await repository.saveSwap(swap);
@@ -129,7 +137,7 @@ export const addAssetSwap = async (
     repository: AssetSwapRepository,
     swap: AssetSwap,
 ): Promise<AssetSwap[]> => {
-    const swaps = await getAssetSwaps(repository);
+    const swaps = await getAssetSwapsOrThrow(repository);
     if (swaps.some((s) => s.id === swap.id)) return swaps;
     await saveSwapOrThrow(repository, swap);
     // the list is already newest-first, so place the one new record rather than
@@ -141,11 +149,9 @@ export const addAssetSwap = async (
 };
 
 /** Merge changes into a swap by id. Returns the updated list.
- * Best-effort on the write, unlike {@link addAssetSwap}: updates record status
- * transitions that follow an irreversible action (a broadcast claim, a spent
- * lockup), so failing the caller here would report as failed a swap whose
- * funds already moved. A stale status is recoverable — crash recovery
- * re-derives the true state from the chain (`classifyOnchainHtlc`). */
+ * THROWS on a failed read or write, like {@link addAssetSwap} — use this for a
+ * write that gates something irreversible. Transitions written *after* the
+ * irreversible act belong on {@link updateAssetSwapBestEffort}. */
 export const updateAssetSwap = async (
     repository: AssetSwapRepository,
     id: string,
@@ -153,16 +159,38 @@ export const updateAssetSwap = async (
     // record stored under the old key and report one swap twice
     changes: Partial<Omit<AssetSwap, "id">>,
 ): Promise<AssetSwap[]> => {
-    const swaps = (await getAssetSwaps(repository)).map((s) =>
+    const swaps = (await getAssetSwapsOrThrow(repository)).map((s) =>
         s.id === id ? { ...s, ...changes } : s,
     );
     const updated = swaps.find((s) => s.id === id);
-    if (updated) {
-        try {
-            await repository.saveSwap(updated);
-        } catch (error) {
-            console.warn(`[swap] failed to persist update for swap ${id}`, error);
-        }
-    }
+    if (updated) await saveSwapOrThrow(repository, updated);
     return swaps;
+};
+
+/**
+ * {@link updateAssetSwap} for transitions that follow an irreversible action (a
+ * broadcast claim, a spent lockup): failing the caller there would report as
+ * failed a swap whose funds already moved, and a stale status is recoverable —
+ * crash recovery re-derives the true state from the chain
+ * (`classifyOnchainHtlc`).
+ *
+ * `persisted` is the part that must not be hidden: a caller that notifies on a
+ * change, or treats one as terminal, has to know the store did not agree.
+ */
+export const updateAssetSwapBestEffort = async (
+    repository: AssetSwapRepository,
+    id: string,
+    changes: Partial<Omit<AssetSwap, "id">>,
+): Promise<{ swaps: AssetSwap[]; persisted: boolean }> => {
+    try {
+        return { swaps: await updateAssetSwap(repository, id, changes), persisted: true };
+    } catch (error) {
+        console.warn(`[swap] failed to persist update for swap ${id}`, error);
+        // the read may be what failed, so report the merge over what we can
+        // still see rather than claiming an empty history
+        const swaps = (await getAssetSwaps(repository)).map((s) =>
+            s.id === id ? { ...s, ...changes } : s,
+        );
+        return { swaps, persisted: false };
+    }
 };

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -40,7 +40,12 @@ import {
 import { decodeOffer, OFFER_CONTRACT_KIND } from "./offer";
 import type { AssetSwapRepository } from "./repository";
 import { classifyDepositSpend, spendTxidsOf, type RestoreIndexer, type SpendKind } from "./restore";
-import { getAssetSwaps, updateAssetSwap, type AssetSwap, type AssetSwapStatus } from "./store";
+import {
+    getAssetSwaps,
+    updateAssetSwapBestEffort,
+    type AssetSwap,
+    type AssetSwapStatus,
+} from "./store";
 
 /** Statuses a spend cannot move: the swap is already resolved. */
 const TERMINAL: readonly AssetSwapStatus[] = ["fulfilled", "cancelled", "recoverable"];
@@ -110,7 +115,7 @@ export async function watchOfferSwaps({
     const serverPubkey = ArkAddress.decode(await wallet.getAddress()).serverPubKey;
     const indexer: RestoreIndexer = new RestIndexerProvider(arkServerUrl);
 
-    // events arrive independently but updateAssetSwap is read-modify-write over
+    // events arrive independently but the update is read-modify-write over
     // the whole list, so two concurrent handlers would lose one of the writes
     let queue: Promise<void> = Promise.resolve();
     const enqueue = (task: () => Promise<void>): void => {
@@ -160,8 +165,11 @@ export async function watchOfferSwaps({
             const changes = spendUpdate(swap, { txid: spentTxid, kind, at: event.timestamp });
             if (!changes) continue;
 
-            await updateAssetSwap(repository, swap.id, changes);
-            onUpdate?.({ ...swap, ...changes });
+            // notify only on a write that landed: `onUpdate` is documented as
+            // firing after the change is persisted, and a consumer that caches
+            // from it would otherwise run ahead of the store
+            const { persisted } = await updateAssetSwapBestEffort(repository, swap.id, changes);
+            if (persisted) onUpdate?.({ ...swap, ...changes });
         }
     };
 

--- a/packages/swap/test/cancel.test.ts
+++ b/packages/swap/test/cancel.test.ts
@@ -3,6 +3,7 @@ import { hex } from "@scure/base";
 import { ArkAddress, asset, type IWallet } from "@arkade-os/sdk";
 import { cancelOffer, encodeOffer, offerVtxoScript, type Offer } from "../src/offer";
 import { InMemoryAssetSwapRepository } from "../src/repository";
+import { addAssetSwap } from "../src/store";
 
 // cancelOffer's guards fire before any signing: mock only the network seam
 // (Arkade.connect for the current server key, ArkadeContract for the vtxo
@@ -13,6 +14,7 @@ const state = vi.hoisted(() => ({
     serverKey: new Uint8Array(0) as Uint8Array,
     utxos: [] as { txid: string; vout: number; value: number }[],
     connectOptions: undefined as { contractManager?: unknown } | undefined,
+    sends: 0,
 }));
 
 vi.mock("@arkade-os/sdk", async (importOriginal) => {
@@ -29,6 +31,20 @@ vi.mock("@arkade-os/sdk", async (importOriginal) => {
             },
             ArkadeContract: class {
                 getUtxos = async () => state.utxos;
+                functions = {
+                    cancel: () => {
+                        const chain = {
+                            from: () => chain,
+                            to: () => chain,
+                            withAsset: () => chain,
+                            send: async () => {
+                                state.sends += 1;
+                                return { txid: "cc".repeat(32) };
+                            },
+                        };
+                        return chain;
+                    },
+                };
             },
         },
     };
@@ -94,6 +110,44 @@ describe("cancelOffer guards", () => {
                 repository: new InMemoryAssetSwapRepository(),
             }),
         ).rejects.toThrow("pass fundingTxid");
+    });
+
+    it("does not broadcast when the in-flight marker cannot be written", async () => {
+        // The `cancelling` marker is what keeps a crash between submit and
+        // record from leaving a swap that still looks pending. It is written
+        // before `send()`, so a lost write must stop the broadcast, not warn
+        // past it.
+        state.serverKey = fundedServerKey;
+        state.utxos = [{ txid: "a".repeat(64), vout: 0, value: 10_000 }];
+        state.sends = 0;
+
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, {
+            id: "a".repeat(64),
+            fromAsset: "btc",
+            toAsset: "aa".repeat(32) + "0000",
+            fromAmount: "10000",
+            toAmount: "50000",
+            swapAddress: fundedAddress,
+            swapPkScript: hex.encode(script.pkScript),
+            offerHex,
+            fundingTxid: "a".repeat(64),
+            status: "pending",
+            createdAt: 1_700_000_000_000,
+        });
+        vi.spyOn(repository, "saveSwap").mockRejectedValue(new Error("quota exceeded"));
+        // this is the one test that gets past vtxo selection, so the maker
+        // address has to decode
+        const funded = { ...wallet, getAddress: async () => fundedAddress } as unknown as IWallet;
+
+        await expect(
+            cancelOffer(funded, "http://ark", offerHex, {
+                repository,
+                fundingTxid: "a".repeat(64),
+            }),
+        ).rejects.toThrow(/quota exceeded/);
+        expect(state.sends).toBe(0);
+        vi.restoreAllMocks();
     });
 
     // without this the contract takes the direct-indexer fallback and a

--- a/packages/swap/test/secrets.test.ts
+++ b/packages/swap/test/secrets.test.ts
@@ -12,6 +12,7 @@ import {
     InMemoryWalletRepository,
     MnemonicIdentity,
     SingleKey,
+    strictSigningDescriptorIndex,
     type IWallet,
 } from "@arkade-os/sdk";
 
@@ -61,7 +62,7 @@ const hdWallet = async (repository = new InMemoryWalletRepository()) => {
                 return out;
             },
             async advanceSigningDescriptorWatermark(descriptor: string) {
-                await provider.advanceLastIndexUsed(Number(descriptor.match(/\/(\d+)\)\s*$/)![1]));
+                await provider.advanceLastIndexUsed(strictSigningDescriptorIndex(descriptor)!);
             },
             async signerForDescriptor(descriptor: string) {
                 return new DescriptorIdentity({ descriptor, signer: provider, base: identity });
@@ -202,6 +203,14 @@ describe("the fallback arm", () => {
         expect(randomSwapSecrets({ preimage: true }).preimage).toHaveLength(32);
     });
 
+    it("rejects a supplied preimage that is not 32 bytes", () => {
+        // The HTLC claim leaf pins OP_SIZE 32: any other length funds an
+        // unclaimable swap, so it must be refused before money moves.
+        expect(() => randomSwapSecrets({ preimage: new Uint8Array(20) })).toThrow(
+            /preimage must be 32 bytes/,
+        );
+    });
+
     it("resolves its signer and preimage from the stored bytes", async () => {
         const wallet = staticWallet();
         const secrets = randomSwapSecrets({ preimage: true });
@@ -266,8 +275,17 @@ describe("restore", () => {
         );
     });
 
-    it("has nothing to reconstruct for a record with no descriptor", () => {
-        expect(rfqSecretsOfRecord({ preimageHex: "cd".repeat(32) })).toBeUndefined();
+    it("has nothing to reconstruct for a record with no secrets fields", () => {
+        expect(rfqSecretsOfRecord({})).toBeUndefined();
+    });
+
+    it("refuses loudly on a legacy record holding only a bare preimage", () => {
+        // Pre-derived-secrets shape: P at the top level, sender key never
+        // persisted. `undefined` here would read as "no secrets" and silently
+        // lose a live preimage.
+        expect(() => rfqSecretsOfRecord({ preimageHex: "cd".repeat(32) })).toThrow(
+            /legacy swap record/,
+        );
     });
 
     it("claims a restored index so the next swap cannot reuse it", async () => {
@@ -316,4 +334,4 @@ describe("nothing secret reaches the record", () => {
     });
 });
 
-const indexOf = (descriptor: string): number => Number(descriptor.match(/\/(\d+)\)\s*$/)![1]);
+const indexOf = (descriptor: string): number => strictSigningDescriptorIndex(descriptor)!;

--- a/packages/swap/test/secrets.test.ts
+++ b/packages/swap/test/secrets.test.ts
@@ -155,6 +155,34 @@ describe("derivation", () => {
             hex.encode(await preimageForRfqSecrets(wallet, secrets)),
         );
     });
+
+    it("refuses a wallet that answers with its own identity for a foreign descriptor", async () => {
+        // Both `Wallet.signerForDescriptor` and the service-worker one fall
+        // back to the wallet identity for a descriptor they cannot derive — a
+        // different seed, a wiped HD state. That identity signs happily with
+        // the wrong key, so the refusal has to come from checking what came
+        // back, not from asking the wallet whether it is HD-capable.
+        const { wallet } = await hdWallet();
+        const secrets = (await deriveSwapSecrets(wallet))!;
+        const foreign = {
+            ...wallet,
+            signerForDescriptor: async () => wallet.identity,
+        } as unknown as IWallet;
+
+        await expect(senderIdentityForRfqSecrets(foreign, secrets)).rejects.toThrow(
+            /cannot derive .*; the swap was created on another wallet/,
+        );
+        await expect(preimageForRfqSecrets(foreign, secrets)).rejects.toThrow(/cannot derive/);
+    });
+
+    it("refuses a wallet with no HD surface at all for a derivable record", async () => {
+        const { wallet } = await hdWallet();
+        const secrets = (await deriveSwapSecrets(wallet))!;
+
+        await expect(senderIdentityForRfqSecrets(staticWallet(), secrets)).rejects.toThrow(
+            /cannot derive/,
+        );
+    });
 });
 
 describe("cross-SDK vectors", () => {
@@ -279,13 +307,11 @@ describe("restore", () => {
         expect(rfqSecretsOfRecord({})).toBeUndefined();
     });
 
-    it("refuses loudly on a legacy record holding only a bare preimage", () => {
-        // Pre-derived-secrets shape: P at the top level, sender key never
-        // persisted. `undefined` here would read as "no secrets" and silently
-        // lose a live preimage.
-        expect(() => rfqSecretsOfRecord({ preimageHex: "cd".repeat(32) })).toThrow(
-            /legacy swap record/,
-        );
+    it("stays total for a record with no arm, so a history loop cannot abort", () => {
+        // A bare preimage names no arm: neither descriptor nor stored sender
+        // key. Callers iterate history with this, so it reports "nothing to
+        // reconstruct" rather than throwing on one record and losing the rest.
+        expect(rfqSecretsOfRecord({ preimageHex: "cd".repeat(32) })).toBeUndefined();
     });
 
     it("claims a restored index so the next swap cannot reuse it", async () => {

--- a/packages/swap/test/store.test.ts
+++ b/packages/swap/test/store.test.ts
@@ -65,9 +65,9 @@ describe("asset swap store", () => {
         expect((await getAssetSwaps(repository)).map((s) => s.id)).toEqual(["a"]);
     });
 
-    it("reports failed add and update writes", async () => {
+    it("reports failed add writes and keeps update writes best-effort", async () => {
         const broken = (existing: AssetSwap[] = []): AssetSwapRepository => ({
-            version: 1,
+            version: 2,
             saveSwap: async () => {
                 throw new Error("quota exceeded");
             },
@@ -80,17 +80,20 @@ describe("asset swap store", () => {
             [Symbol.asyncDispose]: async () => {},
         });
 
+        // add gates funding: a lost pre-funding record must fail the caller
         await expect(addAssetSwap(broken(), swap("a"))).rejects.toThrow(
             /failed to save swap a: quota exceeded/,
         );
+        // update records post-broadcast transitions: it must never throw after
+        // the irreversible action it describes
         await expect(
             updateAssetSwap(broken([swap("a")]), "a", { status: "cancelled" }),
-        ).rejects.toThrow(/failed to save swap a: quota exceeded/);
+        ).resolves.toMatchObject([{ id: "a", status: "cancelled" }]);
     });
 
     it("treats read failures as an empty swap list", async () => {
         const broken: AssetSwapRepository = {
-            version: 1,
+            version: 2,
             saveSwap: async () => {},
             getAllSwaps: async () => {
                 throw new Error("backend gone");

--- a/packages/swap/test/store.test.ts
+++ b/packages/swap/test/store.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { addAssetSwap, getAssetSwaps, updateAssetSwap, AssetSwap } from "../src/store";
+import {
+    addAssetSwap,
+    getAssetSwaps,
+    updateAssetSwap,
+    updateAssetSwapBestEffort,
+    AssetSwap,
+} from "../src/store";
 import { AssetSwapRepository, InMemoryAssetSwapRepository } from "../src/repository";
 
 const swap = (id: string): AssetSwap => ({
@@ -67,7 +73,7 @@ describe("asset swap store", () => {
 
     it("reports failed add writes and keeps update writes best-effort", async () => {
         const broken = (existing: AssetSwap[] = []): AssetSwapRepository => ({
-            version: 2,
+            version: 1,
             saveSwap: async () => {
                 throw new Error("quota exceeded");
             },
@@ -84,16 +90,24 @@ describe("asset swap store", () => {
         await expect(addAssetSwap(broken(), swap("a"))).rejects.toThrow(
             /failed to save swap a: quota exceeded/,
         );
-        // update records post-broadcast transitions: it must never throw after
-        // the irreversible action it describes
+        // so does a gating update — cancelOffer's `cancelling` marker is
+        // written before the broadcast it is there to explain
         await expect(
             updateAssetSwap(broken([swap("a")]), "a", { status: "cancelled" }),
-        ).resolves.toMatchObject([{ id: "a", status: "cancelled" }]);
+        ).rejects.toThrow(/failed to save swap a: quota exceeded/);
+        // the best-effort variant records what follows an irreversible action:
+        // it must never throw after it, but must report the lost write
+        await expect(
+            updateAssetSwapBestEffort(broken([swap("a")]), "a", { status: "cancelled" }),
+        ).resolves.toMatchObject({
+            persisted: false,
+            swaps: [{ id: "a", status: "cancelled" }],
+        });
     });
 
-    it("treats read failures as an empty swap list", async () => {
+    it("reads a failed read as empty history, but never writes on one", async () => {
         const broken: AssetSwapRepository = {
-            version: 2,
+            version: 1,
             saveSwap: async () => {},
             getAllSwaps: async () => {
                 throw new Error("backend gone");
@@ -105,7 +119,16 @@ describe("asset swap store", () => {
             clear: async () => {},
             [Symbol.asyncDispose]: async () => {},
         };
+        // a history view degrades to empty rather than crashing
         await expect(getAssetSwaps(broken)).resolves.toEqual([]);
-        await expect(updateAssetSwap(broken, "a", { status: "cancelled" })).resolves.toEqual([]);
+        // but a mutation must not read "backend gone" as "no such swap" and
+        // report success having written nothing
+        await expect(updateAssetSwap(broken, "a", { status: "cancelled" })).rejects.toThrow(
+            /backend gone/,
+        );
+        await expect(addAssetSwap(broken, swap("a"))).rejects.toThrow(/backend gone/);
+        await expect(
+            updateAssetSwapBestEffort(broken, "a", { status: "cancelled" }),
+        ).resolves.toMatchObject({ persisted: false });
     });
 });

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -266,6 +266,39 @@ describe("watchOfferSwaps", () => {
         );
     });
 
+    it("does not notify a change the store refused", async () => {
+        // `onUpdate` is documented as following a persisted change. Firing it
+        // on a lost write puts a consumer that caches from it ahead of the
+        // store, and marks a swap terminal that reads `pending` after reload.
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(repository, "saveSwap").mockRejectedValue(new Error("quota exceeded"));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit }) => {
+                const updates: AssetSwap[] = [];
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                    onUpdate: (swap) => updates.push(swap),
+                });
+
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(updates).toEqual([]);
+                expect(warn).toHaveBeenCalled();
+            },
+        );
+        vi.restoreAllMocks();
+    });
+
     it("stops delivering after stop()", async () => {
         const offer = makeOffer();
         const fill = spendPsbt(offer, "fulfill");

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -676,6 +676,11 @@ export class ContractManager implements IContractManager {
     /** A fire-and-forget drain failed, so the band is behind the watermark and
      * owes a retry. @see requestLookAheadDrain */
     private lookAheadRefillOwed = false;
+    /** Set by {@link dispose}, cleared by a re-`initialize`. A drain is a
+     * fire-and-forget async loop that outlives the synchronous `dispose()`,
+     * so it re-checks this at every await boundary instead of running on
+     * against a torn-down watcher. */
+    private disposed = false;
 
     private constructor(config: ContractManagerConfig) {
         this.config = config;
@@ -763,6 +768,9 @@ export class ContractManager implements IContractManager {
         if (this.initialized) {
             return;
         }
+        // Re-arm after a dispose(): this instance is being brought back up, so
+        // the look-ahead is allowed to drain again.
+        this.disposed = false;
 
         // Register persisted contracts with the watcher BEFORE the first
         // sync. `addContract` seeds `lastKnownVtxos` from the repo without
@@ -873,7 +881,7 @@ export class ContractManager implements IContractManager {
      * recursing.
      */
     private scheduleLookAheadDrain(): Promise<void> {
-        if (!this.config.lookAhead) return Promise.resolve();
+        if (!this.config.lookAhead || this.disposed) return Promise.resolve();
         if (this.lookAheadDrain) {
             this.lookAheadDirty = true;
             return this.lookAheadDrain;
@@ -882,7 +890,7 @@ export class ContractManager implements IContractManager {
             do {
                 this.lookAheadDirty = false;
                 await this.ensureLookAhead();
-            } while (this.lookAheadDirty);
+            } while (this.lookAheadDirty && !this.disposed);
             this.lookAheadRefillOwed = false;
         })().finally(() => {
             this.lookAheadDrain = undefined;
@@ -902,7 +910,7 @@ export class ContractManager implements IContractManager {
      * so the next contract event retries it. @see handleContractEvent
      */
     private requestLookAheadDrain(): void {
-        if (!this.config.lookAhead) return;
+        if (!this.config.lookAhead || this.disposed) return;
         if (this.lookAheadDrain) {
             this.lookAheadDirty = true;
             return;
@@ -931,9 +939,10 @@ export class ContractManager implements IContractManager {
      */
     private async ensureLookAhead(): Promise<void> {
         const lookAhead = this.config.lookAhead;
-        if (!lookAhead) return;
+        if (!lookAhead || this.disposed) return;
 
         const watermark = await lookAhead.currentWatermark();
+        if (this.disposed) return;
         // A fresh wallet (watermark -1) yields [0, size - 1].
         const from = Math.max(0, watermark - lookAhead.size);
         const to = watermark + lookAhead.size;
@@ -971,6 +980,10 @@ export class ContractManager implements IContractManager {
             const persistedScripts = new Set(persisted.map((c) => c.script));
 
             for (const [script, { index, params }] of band) {
+                // Re-checked per entry: dispose() may land between two
+                // registrations, and everything below re-populates state it
+                // just tore down.
+                if (this.disposed) return;
                 // A persisted row is watched through the repository path; it is
                 // declassified rather than tracked as speculative.
                 if (persistedScripts.has(script)) {
@@ -1018,6 +1031,9 @@ export class ContractManager implements IContractManager {
      * exist. Targeted + explicitly windowed, so the global cursor stays put.
      */
     private async runLookAheadCatchUp(): Promise<void> {
+        // `syncContracts` writes VTXO rows, so a disposed manager must not
+        // reach it — the repositories now belong to whatever replaced it.
+        if (this.disposed) return;
         const pending = [...this.lookAheadEntries.values()].filter((e) => e.catchUpPending);
         if (pending.length === 0) return;
         try {
@@ -2172,6 +2188,14 @@ export class ContractManager implements IContractManager {
      * Implements the disposable pattern for cleanup.
      */
     dispose(): void {
+        // Close the look-ahead first, before the watcher goes away. A drain
+        // started by getNextSigningDescriptor / advanceSigningDescriptorWatermark
+        // is fire-and-forget, so one can still be parked on an await here; the
+        // flag is what stops it from calling addContract or persisting
+        // catch-up VTXOs on the far side of this teardown.
+        this.disposed = true;
+        const pendingDrain = this.lookAheadDrain;
+
         // Stop watching
         this.stopWatcherFn?.();
         this.stopWatcherFn = undefined;
@@ -2181,6 +2205,16 @@ export class ContractManager implements IContractManager {
 
         // Speculative entries are pure derivation; a fresh manager rebuilds them.
         this.lookAheadEntries.clear();
+        // dispose() is synchronous and cannot await the drain, so sweep again
+        // once it unwinds: the iteration it was already inside can register
+        // one last entry after the clear above.
+        if (pendingDrain) {
+            void pendingDrain
+                .catch(() => {})
+                .then(() => {
+                    if (this.disposed) this.lookAheadEntries.clear();
+                });
+        }
 
         // Mark as uninitialized
         this.initialized = false;

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -673,6 +673,9 @@ export class ContractManager implements IContractManager {
     private lookAheadDrain?: Promise<void>;
     /** A refill was requested while a drain was running. */
     private lookAheadDirty = false;
+    /** A fire-and-forget drain failed, so the band is behind the watermark and
+     * owes a retry. @see requestLookAheadDrain */
+    private lookAheadRefillOwed = false;
 
     private constructor(config: ContractManagerConfig) {
         this.config = config;
@@ -880,6 +883,7 @@ export class ContractManager implements IContractManager {
                 this.lookAheadDirty = false;
                 await this.ensureLookAhead();
             } while (this.lookAheadDirty);
+            this.lookAheadRefillOwed = false;
         })().finally(() => {
             this.lookAheadDrain = undefined;
         });
@@ -889,7 +893,13 @@ export class ContractManager implements IContractManager {
 
     /**
      * Request a drain without awaiting it. Used from inside a sync (promotion),
-     * where awaiting the drain that the sync itself is part of would deadlock.
+     * and after an allocation the drain must not be able to fail — the
+     * watermark already moved, and a retry would burn another index.
+     *
+     * A failure here is not terminal: it leaves the watch band behind the
+     * watermark, so funded indices inside it would go unregistered and the
+     * balance would under-report for the rest of the session. Record the debt
+     * so the next contract event retries it. @see handleContractEvent
      */
     private requestLookAheadDrain(): void {
         if (!this.config.lookAhead) return;
@@ -898,6 +908,7 @@ export class ContractManager implements IContractManager {
             return;
         }
         void this.scheduleLookAheadDrain().catch((err) => {
+            this.lookAheadRefillOwed = true;
             console.error("ContractManager: look-ahead refill failed", err);
         });
     }
@@ -1824,6 +1835,10 @@ export class ContractManager implements IContractManager {
         // the startWatching callback's `.catch`, or diagnostics would keep
         // reporting online after a real degradation. Terminal failures still
         // propagate. The event is forwarded to subscribers either way.
+        // A drain that failed after an allocation left the band short; any
+        // event proves the transport is back, so pay the debt here rather than
+        // waiting for the next allocation or a restart.
+        if (this.lookAheadRefillOwed) this.requestLookAheadDrain();
         try {
             switch (event.type) {
                 // Delta-sync only the changed virtual outputs for this contract.

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -846,14 +846,20 @@ export class ContractManager implements IContractManager {
     /** @see IContractManager.getNextSigningDescriptor */
     async getNextSigningDescriptor(): Promise<string | undefined> {
         const descriptor = await this.config.lookAhead?.allocate?.();
-        if (descriptor !== undefined) await this.scheduleLookAheadDrain();
+        // The allocation is already committed (the watermark moved), so the
+        // band slide must not fail this call: a drain failure would surface an
+        // indexer error for a descriptor the caller can use — and a retry
+        // would burn another index. Fire-and-forget, like promotion does.
+        if (descriptor !== undefined) this.requestLookAheadDrain();
         return descriptor;
     }
 
     /** @see IContractManager.advanceSigningDescriptorWatermark */
     async advanceSigningDescriptorWatermark(index: number): Promise<void> {
         await this.advanceLookAheadWatermark(index);
-        await this.scheduleLookAheadDrain();
+        // Same rule as getNextSigningDescriptor: the watermark is committed,
+        // the band slide is best-effort.
+        this.requestLookAheadDrain();
     }
 
     /**

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -104,6 +104,10 @@ export {
 } from "./wallet";
 import { Batch } from "./wallet/batch";
 import {
+    signingDescriptorIndex,
+    strictSigningDescriptorIndex,
+} from "./wallet/walletReceiveRotator";
+import {
     Wallet,
     ReadonlyWallet,
     MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD,
@@ -490,6 +494,8 @@ export {
     isHDDeterministicSignCapable,
     isHDWalletCapable,
     isHDAllocationCapable,
+    signingDescriptorIndex,
+    strictSigningDescriptorIndex,
     deriveDescriptorLeafCompressedPubKey,
     OnchainWallet,
     Ramps,

--- a/packages/ts-sdk/src/wallet/hdDescriptorProvider.ts
+++ b/packages/ts-sdk/src/wallet/hdDescriptorProvider.ts
@@ -36,6 +36,12 @@ interface HDWalletSettings {
 const HD_SETTINGS_KEY = "hd";
 
 /**
+ * First hardened BIP32 index (2^31). Non-hardened child indices — the only
+ * kind an xpub-based account template can derive — must stay below it.
+ */
+const HARDENED_INDEX_OFFSET = 0x80000000;
+
+/**
  * HD-wallet {@link DescriptorProvider} that allocates a fresh signing
  * descriptor on every call. The provider holds no notion of "current" — it
  * is a pure rotating allocator. The question of "which descriptor is the
@@ -130,13 +136,16 @@ export class HDDescriptorProvider implements DescriptorProvider, ReceiveRotatorF
      * `getNextSigningDescriptor()` skips indices discovered by a restore
      * scan. Never rewinds: a lower or equal `index` is a no-op.
      *
-     * An invalid `index` (non-integer / negative) is ignored (no-op):
-     * persisting it would corrupt `lastIndexUsed` and make the next
-     * `parseSettings()` throw, mirroring the validation parseSettings
-     * already enforces.
+     * An invalid `index` (non-integer / negative / past the BIP32
+     * non-hardened ceiling) is ignored (no-op): persisting it would corrupt
+     * `lastIndexUsed` and make the next `parseSettings()` throw, mirroring
+     * the validation parseSettings already enforces. The upper bound matters
+     * because the damage outlives the call — `materializeDescriptorAt` cannot
+     * derive at or above 2^31, so a watermark parked there would fail every
+     * subsequent allocation for the life of the repo.
      */
     async advanceLastIndexUsed(index: number): Promise<void> {
-        if (!Number.isInteger(index) || index < 0) return;
+        if (!Number.isInteger(index) || index < 0 || index >= HARDENED_INDEX_OFFSET) return;
         await this.mutate((settings) => {
             if (settings.lastIndexUsed === undefined || index > settings.lastIndexUsed) {
                 settings.lastIndexUsed = index;

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -47,6 +47,7 @@ import {
     type ProviderConnectionState,
 } from "../wallet";
 import { computeOffchainBalance } from "../balance";
+import { isHDAllocationCapable, isHDWalletCapable } from "../hdWalletCapable";
 import { gatedContracts } from "../../contracts/spendability";
 import type {
     DeprecatedSignerMigrationReport,
@@ -367,6 +368,43 @@ export type RequestRefreshOutpoints = RequestEnvelope & {
 };
 export type ResponseRefreshOutpoints = ResponseEnvelope & {
     type: "REFRESH_OUTPOINTS_SUCCESS";
+};
+
+// HD signing-descriptor surface. Descriptor allocation and the watermark are
+// owned by the worker-side Wallet (single writer); the page proxies both as
+// plain strings — unlike scanContracts there is no callback to cross the
+// structured-clone boundary.
+export type RequestGetCurrentSigningDescriptor = RequestEnvelope & {
+    type: "GET_CURRENT_SIGNING_DESCRIPTOR";
+};
+export type ResponseGetCurrentSigningDescriptor = ResponseEnvelope & {
+    type: "CURRENT_SIGNING_DESCRIPTOR";
+    payload: { descriptor?: string };
+};
+
+export type RequestGetNextSigningDescriptor = RequestEnvelope & {
+    type: "GET_NEXT_SIGNING_DESCRIPTOR";
+};
+export type ResponseGetNextSigningDescriptor = ResponseEnvelope & {
+    type: "NEXT_SIGNING_DESCRIPTOR";
+    payload: { descriptor?: string };
+};
+
+export type RequestGetUsedSigningDescriptors = RequestEnvelope & {
+    type: "GET_USED_SIGNING_DESCRIPTORS";
+    payload?: { lookAhead?: number };
+};
+export type ResponseGetUsedSigningDescriptors = ResponseEnvelope & {
+    type: "USED_SIGNING_DESCRIPTORS";
+    payload: { descriptors: string[] };
+};
+
+export type RequestAdvanceSigningDescriptorWatermark = RequestEnvelope & {
+    type: "ADVANCE_SIGNING_DESCRIPTOR_WATERMARK";
+    payload: { descriptor: string };
+};
+export type ResponseAdvanceSigningDescriptorWatermark = ResponseEnvelope & {
+    type: "SIGNING_DESCRIPTOR_WATERMARK_ADVANCED";
 };
 
 export type RequestGetAllSpendingPaths = RequestEnvelope & {
@@ -735,6 +773,10 @@ export type WalletUpdaterRequest =
     | RequestIsContractManagerWatching
     | RequestRefreshVtxos
     | RequestRefreshOutpoints
+    | RequestGetCurrentSigningDescriptor
+    | RequestGetNextSigningDescriptor
+    | RequestGetUsedSigningDescriptors
+    | RequestAdvanceSigningDescriptorWatermark
     | RequestSend
     | RequestGetAssetDetails
     | RequestIssue
@@ -783,6 +825,10 @@ export type WalletUpdaterResponse = ResponseEnvelope &
         | ResponseIsContractManagerWatching
         | ResponseRefreshVtxos
         | ResponseRefreshOutpoints
+        | ResponseGetCurrentSigningDescriptor
+        | ResponseGetNextSigningDescriptor
+        | ResponseGetUsedSigningDescriptors
+        | ResponseAdvanceSigningDescriptorWatermark
         | ResponseContractEvent
         | ResponseSend
         | ResponseGetAssetDetails
@@ -1161,6 +1207,61 @@ export class WalletMessageHandler
                     return this.tagged({
                         id,
                         type: "REFRESH_OUTPOINTS_SUCCESS",
+                    });
+                }
+                // The HD probes below answer like a static wallet (undefined /
+                // empty) rather than erroring when the worker wallet is
+                // readonly or non-HD: the page-side structural guards
+                // (isHDWalletCapable / isHDAllocationCapable) cannot see
+                // across the message bus, so "no HD state" must be a value.
+                case "GET_CURRENT_SIGNING_DESCRIPTOR": {
+                    const wallet = this.wallet;
+                    const descriptor = isHDWalletCapable(wallet)
+                        ? await wallet.getCurrentSigningDescriptor()
+                        : undefined;
+                    return this.tagged({
+                        id,
+                        type: "CURRENT_SIGNING_DESCRIPTOR",
+                        payload: { descriptor },
+                    });
+                }
+                case "GET_NEXT_SIGNING_DESCRIPTOR": {
+                    const wallet = this.wallet;
+                    const descriptor = isHDAllocationCapable(wallet)
+                        ? await wallet.getNextSigningDescriptor()
+                        : undefined;
+                    return this.tagged({
+                        id,
+                        type: "NEXT_SIGNING_DESCRIPTOR",
+                        payload: { descriptor },
+                    });
+                }
+                case "GET_USED_SIGNING_DESCRIPTORS": {
+                    const wallet = this.wallet;
+                    const descriptors = isHDWalletCapable(wallet)
+                        ? await wallet.getUsedSigningDescriptors(
+                              (message as RequestGetUsedSigningDescriptors).payload,
+                          )
+                        : [];
+                    return this.tagged({
+                        id,
+                        type: "USED_SIGNING_DESCRIPTORS",
+                        payload: { descriptors },
+                    });
+                }
+                case "ADVANCE_SIGNING_DESCRIPTOR_WATERMARK": {
+                    const wallet = this.wallet;
+                    if (isHDAllocationCapable(wallet)) {
+                        // Throws on a foreign or index-less descriptor — that
+                        // propagates to the page as an error response.
+                        await wallet.advanceSigningDescriptorWatermark(
+                            (message as RequestAdvanceSigningDescriptorWatermark).payload
+                                .descriptor,
+                        );
+                    }
+                    return this.tagged({
+                        id,
+                        type: "SIGNING_DESCRIPTOR_WATERMARK_ADVANCED",
                     });
                 }
                 case "SEND": {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1209,11 +1209,20 @@ export class WalletMessageHandler
                         type: "REFRESH_OUTPOINTS_SUCCESS",
                     });
                 }
-                // The HD probes below answer like a static wallet (undefined /
-                // empty) rather than erroring when the worker wallet is
+                // The HD *probes* below answer like a static wallet (undefined
+                // / empty) rather than erroring when the worker wallet is
                 // readonly or non-HD: the page-side structural guards
                 // (isHDWalletCapable / isHDAllocationCapable) cannot see
                 // across the message bus, so "no HD state" must be a value.
+                //
+                // The two *allocating* cases split that condition. A wallet
+                // that is present but cannot allocate is a fact about the
+                // wallet, and still answers as a static one. No signing wallet
+                // at all — a readonly-initialized worker, or one past clear() /
+                // stop() — is an initialization error like every other mutating
+                // case here: answering "allocated" or "advanced" there would
+                // let the same index be issued twice, and two swaps sharing a
+                // descriptor derive the same preimage.
                 case "GET_CURRENT_SIGNING_DESCRIPTOR": {
                     const wallet = this.wallet;
                     const descriptor = isHDWalletCapable(wallet)
@@ -1227,6 +1236,7 @@ export class WalletMessageHandler
                 }
                 case "GET_NEXT_SIGNING_DESCRIPTOR": {
                     const wallet = this.wallet;
+                    if (!wallet) throw new WalletNotInitializedError();
                     const descriptor = isHDAllocationCapable(wallet)
                         ? await wallet.getNextSigningDescriptor()
                         : undefined;
@@ -1251,6 +1261,7 @@ export class WalletMessageHandler
                 }
                 case "ADVANCE_SIGNING_DESCRIPTOR_WATERMARK": {
                     const wallet = this.wallet;
+                    if (!wallet) throw new WalletNotInitializedError();
                     if (isHDAllocationCapable(wallet)) {
                         // Throws on a foreign or index-less descriptor — that
                         // propagates to the page as an error response.

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -1495,11 +1495,20 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
 
             advanceSigningDescriptorWatermark(): Promise<void> {
                 // The manager interface takes a raw index, which the wallet
-                // message protocol does not carry. Use the wallet-level
-                // `ServiceWorkerWallet.advanceSigningDescriptorWatermark`
-                // (descriptor-based) instead; page-side manager proxies do
-                // not mutate the worker-owned HD watermark.
-                return Promise.resolve();
+                // message protocol does not carry — so this cannot move the
+                // worker-owned watermark. It must not resolve: its sibling
+                // `getNextSigningDescriptor` really does allocate, and a caller
+                // that pairs the two would reserve nothing while believing an
+                // index was claimed, letting the next allocation reissue it.
+                return Promise.reject(
+                    new Error(
+                        "advanceSigningDescriptorWatermark is not available on the " +
+                            "service-worker contract-manager proxy: the manager API is " +
+                            "index-based and the worker message protocol carries " +
+                            "descriptors. Use ServiceWorkerWallet." +
+                            "advanceSigningDescriptorWatermark(descriptor) instead.",
+                    ),
+                );
             },
 
             async isWatching(): Promise<boolean> {

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -21,13 +21,17 @@ import { SettlementEvent } from "../../providers/ark";
 import { createDefaultActivityRegistry, buildActivities, type Activity } from "../activity";
 import { hex } from "@scure/base";
 import {
+    DescriptorIdentity,
     Identity,
     ReadonlyIdentity,
+    isHDCapableIdentity,
     type SerializedIdentity,
     type LegacySerializedIdentity,
     serializeReadonlyIdentity,
     serializeSigningIdentity,
 } from "../../identity";
+import { HDDescriptorProvider } from "../hdDescriptorProvider";
+import type { HDWalletCapable, HDAllocationCapable } from "../hdWalletCapable";
 import { WalletRepository } from "../../repositories/walletRepository";
 import { ContractRepository } from "../../repositories/contractRepository";
 import { setupServiceWorker } from "../../worker/browser/utils";
@@ -118,6 +122,13 @@ import {
     deserializeMigrationReport,
     deserializeDeprecatedSignerReport,
     RequestRestoreWallet,
+    RequestGetCurrentSigningDescriptor,
+    ResponseGetCurrentSigningDescriptor,
+    RequestGetNextSigningDescriptor,
+    ResponseGetNextSigningDescriptor,
+    RequestGetUsedSigningDescriptors,
+    ResponseGetUsedSigningDescriptors,
+    RequestAdvanceSigningDescriptorWatermark,
     DEFAULT_MESSAGE_TAG,
     deserializeAggregateError,
     isSerializedAggregateError,
@@ -184,6 +195,12 @@ export const DEFAULT_MESSAGE_TIMEOUTS: Readonly<Record<RequestType, number>> = {
     GET_CONTRACT_SYNC_STATE: 10_000,
     GET_DELEGATE_INFO: 10_000,
     IS_CONTRACT_MANAGER_WATCHING: 10_000,
+    GET_CURRENT_SIGNING_DESCRIPTOR: 10_000,
+    // Allocation is a local repository write plus a fire-and-forget band
+    // slide — no indexer round trip on the request path.
+    GET_NEXT_SIGNING_DESCRIPTOR: 10_000,
+    GET_USED_SIGNING_DESCRIPTORS: 20_000,
+    ADVANCE_SIGNING_DESCRIPTOR_WATERMARK: 10_000,
 
     // Medium reads — may involve indexer queries
     GET_VTXOS: 20_000,
@@ -1463,14 +1480,24 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
                 return Promise.resolve();
             },
 
-            getNextSigningDescriptor(): Promise<string | undefined> {
-                // Descriptor allocation is owned by the worker-side Wallet; the
-                // callback cannot cross the postMessage boundary.
-                return Promise.resolve(undefined);
+            async getNextSigningDescriptor(): Promise<string | undefined> {
+                // Descriptor allocation is owned by the worker-side Wallet;
+                // proxy it as a plain string so the worker stays the single
+                // writer of the HD watermark.
+                const message: RequestGetNextSigningDescriptor = {
+                    type: "GET_NEXT_SIGNING_DESCRIPTOR",
+                    id: getRandomId(),
+                    tag: messageTag,
+                };
+                const response = await sendContractMessage(message);
+                return (response as ResponseGetNextSigningDescriptor).payload.descriptor;
             },
 
             advanceSigningDescriptorWatermark(): Promise<void> {
-                // See getNextSigningDescriptor(): page-side manager proxies do
+                // The manager interface takes a raw index, which the wallet
+                // message protocol does not carry. Use the wallet-level
+                // `ServiceWorkerWallet.advanceSigningDescriptorWatermark`
+                // (descriptor-based) instead; page-side manager proxies do
                 // not mutate the worker-owned HD watermark.
                 return Promise.resolve();
             },
@@ -1503,7 +1530,10 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
     }
 }
 
-export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements IWallet {
+export class ServiceWorkerWallet
+    extends ServiceWorkerReadonlyWallet
+    implements IWallet, HDWalletCapable, HDAllocationCapable
+{
     public readonly walletRepository: WalletRepository;
     public readonly contractRepository: ContractRepository;
     public readonly identity: Identity;
@@ -1676,6 +1706,90 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
             ...options,
             serviceWorker,
         });
+    }
+
+    // ── HD signing-descriptor surface ({@link HDWalletCapable} +
+    // {@link HDAllocationCapable}), so descriptor-deriving plugins (RFQ swaps)
+    // keep their no-secrets-at-rest arm behind the service worker. Allocation
+    // and the watermark stay worker-owned (single writer over the shared
+    // repository) and cross the bus as plain strings; signing never crosses
+    // it — the page holds the identity and descriptor derivation is pure.
+
+    /** @see HDWalletCapable.getCurrentSigningDescriptor */
+    async getCurrentSigningDescriptor(): Promise<string | undefined> {
+        const message: RequestGetCurrentSigningDescriptor = {
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "GET_CURRENT_SIGNING_DESCRIPTOR",
+        };
+        try {
+            const response = await this.sendMessage(message);
+            return (response as ResponseGetCurrentSigningDescriptor).payload.descriptor;
+        } catch (error) {
+            throw new Error(`Failed to get current signing descriptor: ${error}`);
+        }
+    }
+
+    /** @see HDAllocationCapable.getNextSigningDescriptor */
+    async getNextSigningDescriptor(): Promise<string | undefined> {
+        const message: RequestGetNextSigningDescriptor = {
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "GET_NEXT_SIGNING_DESCRIPTOR",
+        };
+        try {
+            const response = await this.sendMessage(message);
+            return (response as ResponseGetNextSigningDescriptor).payload.descriptor;
+        } catch (error) {
+            throw new Error(`Failed to allocate next signing descriptor: ${error}`);
+        }
+    }
+
+    /** @see HDWalletCapable.getUsedSigningDescriptors */
+    async getUsedSigningDescriptors(opts?: { lookAhead?: number }): Promise<string[]> {
+        const message: RequestGetUsedSigningDescriptors = {
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "GET_USED_SIGNING_DESCRIPTORS",
+            ...(opts ? { payload: opts } : {}),
+        };
+        try {
+            const response = await this.sendMessage(message);
+            return (response as ResponseGetUsedSigningDescriptors).payload.descriptors;
+        } catch (error) {
+            throw new Error(`Failed to get used signing descriptors: ${error}`);
+        }
+    }
+
+    /** @see HDAllocationCapable.advanceSigningDescriptorWatermark */
+    async advanceSigningDescriptorWatermark(descriptor: string): Promise<void> {
+        const message: RequestAdvanceSigningDescriptorWatermark = {
+            id: getRandomId(),
+            tag: this.messageTag,
+            type: "ADVANCE_SIGNING_DESCRIPTOR_WATERMARK",
+            payload: { descriptor },
+        };
+        try {
+            await this.sendMessage(message);
+        } catch (error) {
+            throw new Error(`Failed to advance signing-descriptor watermark: ${error}`);
+        }
+    }
+
+    /**
+     * @see HDWalletCapable.signerForDescriptor
+     *
+     * Runs page-side: an Identity cannot cross the message bus, and it does
+     * not need to — the page owns the signing identity, and derivation reads
+     * no allocation state. Mirrors {@link Wallet.signerForDescriptor}'s
+     * fallback: the wallet identity itself for a non-HD identity or a foreign
+     * descriptor.
+     */
+    async signerForDescriptor(descriptor: string): Promise<Identity> {
+        if (!isHDCapableIdentity(this.identity)) return this.identity;
+        const provider = await HDDescriptorProvider.create(this.identity, this.walletRepository);
+        if (!provider.isOurs(descriptor)) return this.identity;
+        return new DescriptorIdentity({ descriptor, signer: provider, base: this.identity });
     }
 
     async sendBitcoin(params: SendBitcoinParams): Promise<string> {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -150,7 +150,11 @@ import { BoardingContractHandler } from "../contracts/handlers/boarding";
 import { timelockToSequence } from "../utils/timelock";
 import { clearSyncCursor, updateWalletState } from "../utils/syncCursors";
 import { validateVtxosForScript, saveVtxosForContract } from "../contracts/vtxoOwnership";
-import { WalletReceiveRotator, signingDescriptorIndex } from "./walletReceiveRotator";
+import {
+    WalletReceiveRotator,
+    signingDescriptorIndex,
+    strictSigningDescriptorIndex,
+} from "./walletReceiveRotator";
 import { HDDescriptorProvider } from "./hdDescriptorProvider";
 import { DescriptorProvider } from "../identity/descriptorProvider";
 import { DescriptorIdentity } from "../identity/descriptorIdentity";
@@ -2543,9 +2547,8 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         // it cannot parse, and 0 is a legitimate index, so a bare or
         // malformed descriptor would move the watermark nowhere while
         // reporting success.
-        const match = descriptor.match(/\/(\d+)\)\s*$/);
-        const index = match ? Number(match[1]) : NaN;
-        if (!Number.isInteger(index) || index < 0) {
+        const index = strictSigningDescriptorIndex(descriptor);
+        if (index === undefined) {
             throw new Error(`descriptor has no trailing child index: ${descriptor}`);
         }
         await (await this.getContractManager()).advanceSigningDescriptorWatermark(index);

--- a/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
+++ b/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
@@ -129,6 +129,9 @@ function hasPeekableDescriptor(
 // dependency cycle.
 export { WALLET_RECEIVE_SOURCE } from "../contracts/metadata";
 
+// captures the trailing child index N from "...xpub.../0/N)"
+const TRAILING_CHILD_INDEX = /\/(\d+)\)\s*$/;
+
 /**
  * Parse the trailing HD child index from a materialized signing
  * descriptor (`tr(...xpub.../0/<index>)`). Returns 0 when the
@@ -138,11 +141,20 @@ export { WALLET_RECEIVE_SOURCE } from "../contracts/metadata";
  */
 export function signingDescriptorIndex(descriptor: unknown): number {
     if (typeof descriptor !== "string") return 0;
-    // captures the trailing child index N from "...xpub.../0/N)"
-    const m = descriptor.match(/\/(\d+)\)\s*$/);
-    if (!m) return 0;
+    return strictSigningDescriptorIndex(descriptor) ?? 0;
+}
+
+/**
+ * Strict sibling of {@link signingDescriptorIndex}: `undefined` instead of
+ * the 0 fallback, for callers that must tell "no parseable index" apart from
+ * index 0 — a watermark move mapped to 0 would move nothing while reporting
+ * success.
+ */
+export function strictSigningDescriptorIndex(descriptor: string): number | undefined {
+    const m = descriptor.match(TRAILING_CHILD_INDEX);
+    if (!m) return undefined;
     const n = Number(m[1]);
-    return Number.isInteger(n) && n >= 0 ? n : 0;
+    return Number.isInteger(n) && n >= 0 ? n : undefined;
 }
 
 /**

--- a/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
+++ b/packages/ts-sdk/src/wallet/walletReceiveRotator.ts
@@ -154,7 +154,11 @@ export function strictSigningDescriptorIndex(descriptor: string): number | undef
     const m = descriptor.match(TRAILING_CHILD_INDEX);
     if (!m) return undefined;
     const n = Number(m[1]);
-    return Number.isInteger(n) && n >= 0 ? n : undefined;
+    // `isSafeInteger`, not `isInteger`: past 2^53 the parse stops being
+    // faithful (".../0/9007199254740993" reads back as ...992), so a caller
+    // would advance a watermark to an index the descriptor never named.
+    // Unparseable is the honest answer — callers already reject it.
+    return Number.isSafeInteger(n) && n >= 0 ? n : undefined;
 }
 
 /**

--- a/packages/ts-sdk/test/hdWalletCapable.test.ts
+++ b/packages/ts-sdk/test/hdWalletCapable.test.ts
@@ -182,6 +182,26 @@ describe("HDWalletCapable", () => {
             await wallet.dispose();
         });
 
+        it("ignores an index past the BIP32 non-hardened ceiling", async () => {
+            // Nothing can derive at or above 2^31, so persisting such a
+            // watermark would brick the repo: every later allocation would
+            // fail to materialize, permanently. Reached through the
+            // contract-manager API, which takes a raw index and has no
+            // `isOurs` gate in front of it.
+            const wallet = await makeWallet({ hd: true });
+            const provider: HDDescriptorProvider = (wallet as any)._descriptorProvider;
+            await provider.advanceLastIndexUsed(4);
+
+            for (const bad of [0x80000000, Number.MAX_SAFE_INTEGER, 1e20]) {
+                await provider.advanceLastIndexUsed(bad);
+                expect(await provider.getLastIndexUsed()).toBe(4);
+            }
+            expect(await wallet.getNextSigningDescriptor()).toBe(
+                provider.materializeDescriptorAt(5),
+            );
+            await wallet.dispose();
+        });
+
         it("refuses a descriptor from another seed", async () => {
             const wallet = await makeWallet({ hd: true });
             await expect(wallet.advanceSigningDescriptorWatermark("tr(deadbeef)")).rejects.toThrow(

--- a/packages/ts-sdk/test/lookAhead.test.ts
+++ b/packages/ts-sdk/test/lookAhead.test.ts
@@ -194,6 +194,74 @@ describe("HD look-ahead band composition", () => {
             manager.dispose();
         }
     });
+
+    /**
+     * Regression: a watermark move fires its band slide fire-and-forget, so the
+     * drain outlives the synchronous `dispose()`. It used to resume on the far
+     * side of teardown and register speculative entries with a stopped watcher,
+     * then sync their full history and persist the hits — writing to
+     * repositories the disposed manager no longer owns.
+     */
+    it("registers nothing when dispose() lands mid-drain", async () => {
+        const provider = await makeHdProviderForTest();
+        // Fund the whole band the post-dispose drain would cover, so a drain
+        // that survives disposal leaves an unmistakable trace: a catch-up
+        // fetch and promoted repository rows.
+        const watermark = 5;
+        const funded = new Set(
+            [3, 4, 5, 6, 7].map((i) =>
+                defaultScriptHex(provider.materializeDescriptorAt(i), SERVER_A, TL_A),
+            ),
+        );
+        const indexer = makeMockIndexer(funded);
+        const contractRepository = new InMemoryContractRepository();
+
+        let current = -1;
+        let release: (() => void) | undefined;
+        const manager = await ContractManager.create({
+            indexerProvider: indexer,
+            contractRepository,
+            walletRepository: new InMemoryWalletRepository(),
+            watcherConfig: { failsafePollIntervalMs: 100_000, reconnectDelayMs: 100_000 },
+            lookAhead: {
+                size,
+                currentWatermark: async () => {
+                    // Park every drain after the boot one, so the test can
+                    // dispose with a drain provably in flight.
+                    if (current >= 0 && !release) {
+                        await new Promise<void>((resolve) => {
+                            release = resolve;
+                        });
+                    }
+                    return current;
+                },
+                materialize: (index) => provider.materializeDescriptorAt(index),
+                candidateDeps: () => ({
+                    network: { hrp: "tark" },
+                    serverPubKey: SERVER_A,
+                    csvTimelocks: [TL_A],
+                }),
+                advanceWatermark: async (index) => {
+                    current = index;
+                },
+            },
+        });
+
+        // The boot band was [0, 1] and none of it is funded.
+        expect(await contractRepository.getContracts({})).toEqual([]);
+        const fetchesBeforeDispose = indexer.getVtxosCalls.length;
+
+        await manager.advanceSigningDescriptorWatermark(watermark);
+        expect(release).toBeDefined();
+
+        manager.dispose();
+        release!();
+        // Let the drain unwind as far as it is going to get.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(indexer.getVtxosCalls).toHaveLength(fetchesBeforeDispose);
+        expect(await contractRepository.getContracts({})).toEqual([]);
+    });
 });
 
 describe("Wallet HD look-ahead", () => {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { hex } from "@scure/base";
-import { signingDescriptorIndex } from "../src/wallet/walletReceiveRotator";
+import {
+    signingDescriptorIndex,
+    strictSigningDescriptorIndex,
+} from "../src/wallet/walletReceiveRotator";
 import { mnemonicToSeedSync } from "@scure/bip39";
 import { HDKey, networks, scriptExpressions } from "@bitcoinerlab/descriptors-scure";
 import { deriveDescriptorLeafPubKey } from "../src/identity/descriptor";
@@ -1220,6 +1223,32 @@ describe("signingDescriptorIndex", () => {
     it("returns 0 when absent/unparseable", () => {
         expect(signingDescriptorIndex(undefined)).toBe(0);
         expect(signingDescriptorIndex("tr(deadbeef)")).toBe(0);
+    });
+});
+
+describe("strictSigningDescriptorIndex", () => {
+    const at = (index: string) => `tr([aa/86'/0'/0']xpub6.../0/${index})`;
+
+    it("parses index 0 as 0, not as the absent case", () => {
+        expect(strictSigningDescriptorIndex(at("0"))).toBe(0);
+    });
+
+    it("returns undefined when there is no concrete trailing index", () => {
+        expect(strictSigningDescriptorIndex(at("*"))).toBeUndefined();
+        expect(strictSigningDescriptorIndex("tr(deadbeef)")).toBeUndefined();
+    });
+
+    it("holds at the largest exactly-representable index", () => {
+        expect(strictSigningDescriptorIndex(at("9007199254740991"))).toBe(Number.MAX_SAFE_INTEGER);
+    });
+
+    it("refuses an index past 2^53, where the parse stops being faithful", () => {
+        // `Number("9007199254740993")` is 9007199254740992 — a different
+        // index than the descriptor names. Reporting that would advance a
+        // watermark to a descriptor nobody ever issued, so the strict parse
+        // reports "no index" and lets the caller reject.
+        expect(strictSigningDescriptorIndex(at("9007199254740993"))).toBeUndefined();
+        expect(strictSigningDescriptorIndex(at("99999999999999999999"))).toBeUndefined();
     });
 });
 

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -69,6 +69,75 @@ describe("WalletMessageHandler handleMessage", () => {
         expect(response.error?.message).toBe("Wallet handler not initialized");
     });
 
+    describe("HD signing-descriptor allocation", () => {
+        const descriptor = "tr(deadbeef/86'/1'/0'/0/7)";
+
+        // A readonly-initialized worker, or one past clear()/stop(), has a
+        // readonlyWallet and no signing wallet. Answering "advanced" there lets
+        // the same index be issued twice, and two swaps bound to one descriptor
+        // derive the same preimage.
+        it.each([
+            ["ADVANCE_SIGNING_DESCRIPTOR_WATERMARK", { descriptor }],
+            ["GET_NEXT_SIGNING_DESCRIPTOR", undefined],
+        ])("errors on %s when there is no signing wallet", async (type, payload) => {
+            (updater as any).readonlyWallet = {};
+            (updater as any).wallet = undefined;
+
+            const response = await updater.handleMessage({
+                ...baseMessage(),
+                type,
+                ...(payload ? { payload } : {}),
+            } as any);
+
+            expect(response.error).toBeInstanceOf(Error);
+            expect(response.error?.name).toBe("WalletNotInitializedError");
+        });
+
+        // A wallet that is present but cannot allocate is a fact about the
+        // wallet, not a missing one: it still answers like a static wallet,
+        // because the page-side structural guards cannot see across the bus.
+        it("still answers like a static wallet for a non-HD signing wallet", async () => {
+            (updater as any).readonlyWallet = {};
+            (updater as any).wallet = {};
+
+            await expect(
+                updater.handleMessage({
+                    ...baseMessage(),
+                    type: "ADVANCE_SIGNING_DESCRIPTOR_WATERMARK",
+                    payload: { descriptor },
+                } as any),
+            ).resolves.toMatchObject({ type: "SIGNING_DESCRIPTOR_WATERMARK_ADVANCED" });
+
+            await expect(
+                updater.handleMessage({
+                    ...baseMessage(),
+                    type: "GET_NEXT_SIGNING_DESCRIPTOR",
+                } as any),
+            ).resolves.toMatchObject({
+                type: "NEXT_SIGNING_DESCRIPTOR",
+                payload: { descriptor: undefined },
+            });
+        });
+
+        it("advances the watermark on an allocating wallet", async () => {
+            const advance = vi.fn().mockResolvedValue(undefined);
+            (updater as any).readonlyWallet = {};
+            (updater as any).wallet = {
+                getNextSigningDescriptor: vi.fn().mockResolvedValue(descriptor),
+                advanceSigningDescriptorWatermark: advance,
+            };
+
+            await expect(
+                updater.handleMessage({
+                    ...baseMessage(),
+                    type: "ADVANCE_SIGNING_DESCRIPTOR_WATERMARK",
+                    payload: { descriptor },
+                } as any),
+            ).resolves.toMatchObject({ type: "SIGNING_DESCRIPTOR_WATERMARK_ADVANCED" });
+            expect(advance).toHaveBeenCalledWith(descriptor);
+        });
+    });
+
     it("handles SETTLE messages", async () => {
         (updater as any).readonlyWallet = {};
         (updater as any).wallet = {};


### PR DESCRIPTION
- Reject non-32-byte preimages up front (requestOnchainSend, randomSwapSecrets): the L1 claim leaf pins OP_SIZE 32, so any other length funds an unclaimable HTLC.
- Proxy HD allocation/watermark over the service-worker message bus (4 new message types) and run signerForDescriptor page-side, so HD-seeded service-worker wallets take the derived-secrets arm.
- Fire-and-forget the look-ahead drain after watermark commits so an indexer hiccup can't fail a swap whose index was already consumed.
- Bump AssetSwapRepository version to 2; addAssetSwap keeps throwing (gates funding) while updateAssetSwap is best-effort with a warning.
- Throw loudly on legacy bare-preimageHex records instead of silently reading them as secretless.
- Wrap call-time deterministic-signing refusals with a purposeful error; dedupe the trailing-index regex into strictSigningDescriptorIndex (exported).
- Document the HD-index-burn / gap-limit tradeoff in the README and on deriveSwapSecrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HD wallet support for retrieving, tracking, and advancing signing descriptors, including service-worker wallets.
  * Exposed signing-descriptor utilities through the SDK.
* **Bug Fixes**
  * Invalid preimages are now rejected unless exactly 32 bytes.
  * Improved recovery handling for missing or incomplete swap secrets.
  * Descriptor refill operations no longer delay allocation completion.
  * Update persistence failures are handled without rejecting completed operations.
* **Documentation**
  * Added migration guidance for repository version 2, secret fields, legacy preimages, and descriptor gap limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->