### PR TITLE
feat(service-worker): forward the timelock floor overrides to the worker wallet

### DIFF
--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -414,6 +414,17 @@ interface ServiceWorkerWalletOptions {
      */
     lookAheadWindow?: number;
     /**
+     * Timelock floors forwarded to the worker wallet. Lowering either below its
+     * per-network default relaxes a fund-safety bound; intended for local
+     * testing and for fast public test networks (mutinynet) whose arkd runs
+     * below the mainnet-grade floors.
+     *
+     * @see WalletConfig.minBatchExpirySeconds
+     */
+    minBatchExpirySeconds?: bigint;
+    /** @see WalletConfig.minCheckpointExitDelaySeconds */
+    minCheckpointExitDelaySeconds?: bigint;
+    /**
      * Per-request timeout overrides for wallet-updater messages.
      * @see DEFAULT_MESSAGE_TIMEOUTS
      */
@@ -460,6 +471,8 @@ type MessageBusInitConfig = {
     walletMode?: ServiceWorkerWalletMode;
     watcherConfig?: Partial<Omit<ContractWatcherConfig, "indexerProvider">>;
     lookAheadWindow?: number;
+    minBatchExpirySeconds?: bigint;
+    minCheckpointExitDelaySeconds?: bigint;
     messageTimeouts?: Record<string, number>;
 };
 
@@ -1553,6 +1566,8 @@ export class ServiceWorkerWallet extends ServiceWorkerReadonlyWallet implements 
             walletMode: options.walletMode,
             watcherConfig: options.watcherConfig,
             lookAheadWindow: options.lookAheadWindow,
+            minBatchExpirySeconds: options.minBatchExpirySeconds,
+            minCheckpointExitDelaySeconds: options.minCheckpointExitDelaySeconds,
             messageTimeouts,
         };
 

--- a/packages/ts-sdk/src/worker/messageBus.ts
+++ b/packages/ts-sdk/src/worker/messageBus.ts
@@ -149,6 +149,10 @@ type Initialize = {
         watcherConfig?: Partial<Omit<ContractWatcherConfig, "indexerProvider">>;
         /** @see WalletConfig.lookAheadWindow */
         lookAheadWindow?: number;
+        /** @see WalletConfig.minBatchExpirySeconds */
+        minBatchExpirySeconds?: bigint;
+        /** @see WalletConfig.minCheckpointExitDelaySeconds */
+        minCheckpointExitDelaySeconds?: bigint;
         /**
          * Page-supplied per-operation timeout map. Keys are message types
          * (e.g. "SETTLE"). Overrides constructor-supplied
@@ -416,6 +420,8 @@ export class MessageBus {
                 walletMode: config.walletMode,
                 watcherConfig: config.watcherConfig,
                 lookAheadWindow: config.lookAheadWindow,
+                minBatchExpirySeconds: config.minBatchExpirySeconds,
+                minCheckpointExitDelaySeconds: config.minCheckpointExitDelaySeconds,
             });
             return { wallet, arkProvider, readonlyWallet: wallet };
         }

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -1487,6 +1487,46 @@ describe("INITIALIZE_MESSAGE_BUS wire shape emitted by create()", () => {
         expect(getInitializeMessage(serviceWorker).config.walletMode).toBe("hd");
     });
 
+    // Structured clone carries the bigints through postMessage untouched, so the
+    // worker hands `Wallet.create` the same floors the page asked for.
+    it("ServiceWorkerWallet.create forwards the timelock floor overrides to the worker init config", async () => {
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+        });
+        const { serviceWorker } = await setup(identity);
+
+        await ServiceWorkerWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            minBatchExpirySeconds: 3_600n,
+            minCheckpointExitDelaySeconds: 2_048n,
+            storage: storage(),
+        });
+
+        const { config } = getInitializeMessage(serviceWorker);
+        expect(config.minBatchExpirySeconds).toBe(3_600n);
+        expect(config.minCheckpointExitDelaySeconds).toBe(2_048n);
+    });
+
+    it("ServiceWorkerWallet.create omits the timelock floor overrides when unset", async () => {
+        const identity = MnemonicIdentity.fromMnemonic(TEST_MNEMONIC, {
+            isMainnet: true,
+        });
+        const { serviceWorker } = await setup(identity);
+
+        await ServiceWorkerWallet.create({
+            serviceWorker: serviceWorker as any,
+            arkServerUrl: "https://ark.test",
+            identity,
+            storage: storage(),
+        });
+
+        const { config } = getInitializeMessage(serviceWorker);
+        expect(config.minBatchExpirySeconds).toBeUndefined();
+        expect(config.minCheckpointExitDelaySeconds).toBeUndefined();
+    });
+
     it("ServiceWorkerReadonlyWallet.create uses the default Arkade server URL when omitted", async () => {
         const signing = SingleKey.fromHex(TEST_PRIVATE_KEY_HEX);
         const identity = await signing.toReadonly();


### PR DESCRIPTION
## Problem

`Wallet.create` accepts `minBatchExpirySeconds` and `minCheckpointExitDelaySeconds` to relax the per-network timelock floors, but neither crossed the service-worker boundary — so consumers going through `ServiceWorkerWallet.setup()`/`create()` had no way to set them.

This blocks mutinynet outright. Its arkd advertises a 4096s checkpoint exit delay, and `defaultCheckpointExitDelayPolicy` keys off `network.bech32`, where `networks.mutinynet` is structurally identical to `networks.testnet` — so mutinynet inherits the 86400s mainnet-grade floor and `Wallet.create` rejects the server's `checkpointTapscript` during connection:

```
checkpoint exit delay rejected: 4096 seconds is below the 86400s floor
```

`minBatchExpirySeconds` has the same 86400s floor and the same plumbing gap. It is validated on `BatchStartedEvent` rather than at setup, so it doesn't block connecting — it would surface on the first settle instead. Both are forwarded here so the second wall isn't hit right after clearing the first.

## Change

Carries both fields on the existing `INITIALIZE_MESSAGE_BUS` envelope: `ServiceWorkerWalletOptions` → `MessageBusInitConfig` → `Initialize["config"]` → `Wallet.create`. Additive; no behavior change for callers that don't set them.

Notes:

- The transport is a bare `serviceWorker.postMessage`, no JSON layer, so structured clone moves the bigints across untouched. Covered by the forwarding test.
- Signing path only. `ReadonlyWallet` validates neither bound, and `buildServices`' readonly branch doesn't accept the options.
- `buildInitConfig()`'s rebuild branch is deliberately left alone: it reconstructs the envelope from denormalized fields that are never actually assigned, so it always throws before reaching them, and `create()` always populates `initConfig` anyway. Adding fields there would be dead code.

## Deliberately not done

Giving mutinynet its own default floor in `defaultCheckpointExitDelayPolicy` was considered and rejected. That function takes a `Network` struct, in which mutinynet, testnet and signet are byte-identical — reaching it would mean threading `NetworkName`, which comes from server-supplied `info.network`, making the relaxed floor operator-selectable. That is exactly what the module's design note warns against. An explicit caller-side override keeps the choice on the client.

## Test plan

- Full `pre-commit` hook (`pnpm lint && pnpm test:unit`) passes on this branch: ts-sdk 154 files, swap 6, boltz-swap 23, no type errors.
- `packages/ts-sdk`: 2349 tests pass; `tsc --noEmit` clean.
- Two new cases in `test/serviceWorker/wallet.test.ts` covering forwarding and the omitted-when-unset default.
