### PR TITLE
chore: add repository field to published packages

### DIFF
--- a/packages/boltz-swap/package.json
+++ b/packages/boltz-swap/package.json
@@ -3,6 +3,11 @@
     "version": "0.3.63",
     "type": "module",
     "description": "A production-ready TypeScript package that brings Boltz submarine-swaps to Arkade.",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/arkade-os/ts-sdk.git",
+        "directory": "packages/boltz-swap"
+    },
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -3,6 +3,11 @@
     "version": "0.0.1",
     "type": "module",
     "description": "Arkade Intents offer-maker side atomic swaps: discover markets, quote, create/track/cancel offers, restore from chain.",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/arkade-os/ts-sdk.git",
+        "directory": "packages/swap"
+    },
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -2,6 +2,11 @@
     "name": "@arkade-os/sdk",
     "version": "0.4.58",
     "description": "TypeScript SDK for building Bitcoin wallets using the Arkade protocol",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/arkade-os/ts-sdk.git",
+        "directory": "packages/ts-sdk"
+    },
     "type": "module",
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",


### PR DESCRIPTION
Adds the missing `repository` field to `ts-sdk`, `boltz-swap`, and `swap` package.json files so npm metadata can be traced back to source.

Raised in https://github.com/arkade-os/wallet/pull/886#pullrequestreview-4883739727

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* Added repository metadata to multiple packages, including repository links and package locations.
* Improved package identification and repository navigation for package consumers.
* No user-facing functionality or API behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->