### PR TITLE
feat(swap): retire settled offer contracts

### DIFF
--- a/packages/swap/src/coverage.ts
+++ b/packages/swap/src/coverage.ts
@@ -1,0 +1,170 @@
+/**
+ * Coverage: whether an offer's script is in the wallet's watched set.
+ *
+ * Both edges live here because they are one decision seen from two sides.
+ * `createOffer` promotes a script the moment it hands the maker an address to
+ * fund ({@link promoteOfferContract}); the watcher and the restore consumer
+ * retire it once nothing at that script holds funds any more
+ * ({@link retireSettledOfferContracts}). Identical offers derive one script, so
+ * those two can name the same row — and a demotion that lands after a promotion
+ * recreates exactly the failure the promotion exists to prevent: an address the
+ * maker was told to fund, out of the subscription, the poll and every sync.
+ *
+ * Two things keep them apart:
+ *
+ * - **Per-script serialization.** `setContractWatchState` is a read-modify-write
+ *   over the contract row, so promotion and demotion are ordered here rather
+ *   than left to interleave inside the manager.
+ * - **The issuance mark.** A swap record is keyed by its funding txid, so an
+ *   offer that has been created but not yet funded has no record at all — it is
+ *   invisible to a liveness check over records, for as long as the maker takes
+ *   to send. {@link promoteOfferContract} therefore records the issuance
+ *   itself, and a script with an address still waiting for its deposit is never
+ *   retired.
+ *
+ * The mark is per process: a second wallet context (another tab, a service
+ * worker) issuing an offer while this one retires the same script is not
+ * covered, and neither is an address issued before a restart and funded after
+ * it. Both leave a funded-but-unwatched row that the restore scan still finds —
+ * the same backstop every other best-effort step here relies on.
+ */
+import type { IContractManager } from "@arkade-os/sdk";
+import type { AssetSwap, AssetSwapStatus } from "./store";
+
+/**
+ * Statuses after which the covenant no longer holds funds, so its contract can
+ * leave the watched set. NOT `recoverable`: a swept deposit is still the
+ * maker's money at that script, and unwatching it is how it goes missing.
+ */
+export const RETIRABLE: readonly AssetSwapStatus[] = ["fulfilled", "cancelled"];
+
+/** The one contract-manager capability changing coverage needs. */
+export type OfferContractRetirer = Pick<IContractManager, "setContractWatchState">;
+
+/**
+ * Scripts whose address has been handed out, by the time it was handed out.
+ * Cleared by the first record that shows the deposit landed — from there the
+ * records answer liveness, and a mark left behind would pin the script watched
+ * for the life of the process.
+ */
+const issuedAt = new Map<string, number>();
+
+/**
+ * Per-script tail of in-flight coverage changes. A script is dropped from the
+ * map once its own chain settles, so this holds only what is running.
+ */
+const inFlight = new Map<string, Promise<void>>();
+
+/** Run `task` after every coverage change already queued for `script`. */
+async function serialize<T>(script: string, task: () => Promise<T>): Promise<T> {
+    const previous = inFlight.get(script) ?? Promise.resolve();
+    // `.then(task, task)`: a failed predecessor must not cancel its successors —
+    // the queue is for ordering, never for propagating outcomes
+    const result = previous.then(task, task);
+    const settled = result.then(
+        () => {},
+        () => {},
+    );
+    inFlight.set(script, settled);
+    void settled.then(() => {
+        if (inFlight.get(script) === settled) inFlight.delete(script);
+    });
+    return result;
+}
+
+/**
+ * Whether an address issued at `script` is still waiting for its deposit.
+ *
+ * A record at the script created since the issuance *is* that deposit landing:
+ * `createdAt` is the funding time (`restoreAssetSwaps` reads it off the funding
+ * transaction), so a record older than the mark belongs to an earlier offer and
+ * says nothing about this one.
+ */
+function addressOutstanding(swaps: AssetSwap[], script: string): boolean {
+    const issued = issuedAt.get(script);
+    if (issued === undefined) return false;
+    if (swaps.some((s) => s.swapPkScript === script && s.createdAt >= issued)) {
+        issuedAt.delete(script);
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Put `script` in the watched set and record that its address is outstanding.
+ *
+ * Unconditional, not conditional on a fresh contract row: identical offers share
+ * one script and `createContract` is first-writer-wins, so re-offering a script
+ * an earlier settlement retired would otherwise leave the row `retained`.
+ *
+ * Throws, unlike retiring: an address returned without coverage is the failure
+ * this exists to prevent, and nothing is at stake yet, so the caller can retry.
+ */
+export async function promoteOfferContract(
+    manager: OfferContractRetirer,
+    script: string,
+): Promise<void> {
+    await serialize(script, async () => {
+        await manager.setContractWatchState(script, "watched");
+        // after the write: a promotion that failed hands out no address, so
+        // there is nothing outstanding to protect
+        issuedAt.set(script, Date.now());
+    });
+}
+
+/**
+ * Drop `script` from the watched set unless something there still needs it.
+ * Identical offers share one script, so the check is per script, not per record.
+ *
+ * `retained`, not deleted: the row is what keeps the deposit's VTXOs
+ * annotatable and its history readable, while `retained` is what drops it from
+ * the subscription, the failsafe poll and every sync. A maker who has made
+ * hundreds of offers otherwise re-subscribes to hundreds of dead scripts on
+ * every wallet start.
+ *
+ * A `recoverable` record blocks its script for good — nothing moves a record
+ * off that status — so a script that once held a swept deposit stays watched
+ * for the life of the wallet. Accepted: the cost is polling, and the
+ * alternative (tracking when recovery completed) buys less than it costs.
+ *
+ * Best-effort, exactly as core's own demotion is: a failed retire costs
+ * polling, never correctness.
+ */
+export async function retireOfferContract(
+    manager: OfferContractRetirer,
+    swaps: AssetSwap[],
+    script: string,
+): Promise<void> {
+    // both reads happen inside the queue, so a promotion that arrives while an
+    // earlier retire was being decided is seen here rather than overwritten
+    await serialize(script, async () => {
+        // NOT `!TERMINAL.includes(...)`: `recoverable` is terminal for a spend
+        // and not retirable, so reading liveness off TERMINAL unwatches swept
+        // funds.
+        if (swaps.some((s) => s.swapPkScript === script && !RETIRABLE.includes(s.status))) return;
+        if (addressOutstanding(swaps, script)) return;
+        try {
+            await manager.setContractWatchState(script, "retained");
+        } catch (err) {
+            console.warn(`[swap] could not retire offer contract ${script}`, err);
+        }
+    });
+}
+
+/**
+ * Retire every offer script in `swaps` that no live record still holds — the
+ * batch form of what the watcher does per spend event, for a consumer that
+ * applies {@link restoreAssetSwaps} results without running the watcher.
+ *
+ * Takes the caller's full record list: liveness is a property of all records at
+ * a script, so a partial list would retire a script another record still holds.
+ */
+export async function retireSettledOfferContracts(
+    manager: OfferContractRetirer,
+    swaps: AssetSwap[],
+): Promise<void> {
+    const settled = new Set(
+        swaps.filter((s) => RETIRABLE.includes(s.status)).map((s) => s.swapPkScript),
+    );
+    for (const script of settled) await retireOfferContract(manager, swaps, script);
+}

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -45,7 +45,9 @@ export {
 } from "./restore";
 export {
     watchOfferSwaps,
+    retireSettledOfferContracts,
     spendUpdate,
+    type OfferContractRetirer,
     type OfferSwapWatcher,
     type WatchOfferSwapsParams,
 } from "./watch";

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -45,12 +45,11 @@ export {
 } from "./restore";
 export {
     watchOfferSwaps,
-    retireSettledOfferContracts,
     spendUpdate,
-    type OfferContractRetirer,
     type OfferSwapWatcher,
     type WatchOfferSwapsParams,
 } from "./watch";
+export { retireSettledOfferContracts, type OfferContractRetirer } from "./coverage";
 export {
     ARKADE_ASSET,
     ARKADE_BTC,

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -36,6 +36,7 @@ import {
 
 import wantAssetProgram from "./swap-want-asset.program.json";
 import wantBtcProgram from "./swap-want-btc.program.json";
+import { promoteOfferContract, retireOfferContract } from "./coverage";
 import type { AssetSwapRepository } from "./repository";
 import { getAssetSwapsOrThrow, updateAssetSwap, updateAssetSwapBestEffort } from "./store";
 
@@ -288,10 +289,11 @@ export const OFFER_CONTRACT_KIND = "asset-swap-offer";
  *
  * **The watch state is set unconditionally, not only on a fresh row.** Identical
  * offers share one script, and `createContract` is first-writer-wins, so
- * re-offering a script that `retireSettledOfferContracts` retired would
- * leave the row `retained` — funded, but out of the subscription, the poll and
- * every sync. The invariant this states is the one the corridor needs: an offer
- * address handed to a maker is a watched address.
+ * re-offering a script that a settlement retired would leave the row `retained`
+ * — funded, but out of the subscription, the poll and every sync. The invariant
+ * this states is the one the corridor needs: an offer address handed to a maker
+ * is a watched address, and {@link promoteOfferContract} is what keeps a
+ * settlement racing this call from taking it back.
  */
 async function registerOfferContract(
     wallet: IWallet,
@@ -324,10 +326,7 @@ async function registerOfferContract(
         label: OFFER_CONTRACT_LABEL,
         metadata: { genericallySpendable: false, kind: OFFER_CONTRACT_KIND },
     });
-    // Throws like the registration itself: an address returned without coverage
-    // is the failure both of these exist to prevent, and nothing is at stake
-    // yet, so the caller can retry.
-    await contractManager.setContractWatchState(hex.encode(expectedPkScript), "watched");
+    await promoteOfferContract(contractManager, hex.encode(expectedPkScript));
 }
 
 // ── Maker operations ─────────────────────────────────────────────────────────
@@ -499,6 +498,7 @@ export async function cancelOffer(
     const { repository, fundingTxid, swapAddress } = opts;
     const offer = decodeOffer(hex.decode(offerHex));
 
+    const contractManager = await wallet.getContractManager();
     const client = await arkade.Arkade.connect({
         arkade: new RestArkProvider(arkServerUrl),
         indexer: new RestIndexerProvider(arkServerUrl),
@@ -506,7 +506,7 @@ export async function cancelOffer(
         // registered offers resolve their VTXOs from the contract repository
         // instead of a direct indexer query; the indexer above stays as the
         // fallback for offers created before registration existed
-        contractManager: await wallet.getContractManager(),
+        contractManager,
         // no `network`, unlike registerOfferContract: the row lookup is by
         // script and the payout script comes from wallet.getAddress(), so the
         // client's network (which only shapes address derivation) is unused here
@@ -569,10 +569,20 @@ export async function cancelOffer(
         // Past the point of no return: the cancel is broadcast, so a lost write
         // must not fail the caller. The watcher classifies by covenant leaf and
         // the restore scan re-derives the outcome.
-        await updateAssetSwapBestEffort(repository, swapId, {
+        const { persisted, swaps } = await updateAssetSwapBestEffort(repository, swapId, {
             status: "cancelled",
             spentTxid: txid,
         });
+        // Retiring belongs here for the same reason the status does: recording
+        // its own outcome is what leaves the watcher nothing to do, and a
+        // watcher that sees a terminal record returns before it would retire
+        // (`spendUpdate`). Nothing else would ever drop this script.
+        //
+        // Only on a persisted write, as the watcher does: a record that still
+        // reads `pending` to the next restore scan must stay watched.
+        if (persisted) {
+            await retireOfferContract(contractManager, swaps, hex.encode(offer.swapPkScript));
+        }
     }
     return txid;
 }

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -285,6 +285,13 @@ export const OFFER_CONTRACT_KIND = "asset-swap-offer";
  * all — background renewal would forfeit a live offer into an ordinary payment
  * and silently destroy it. The SDK's gate defaults closed, so the value is
  * redundant; it is written anyway because this is the one site that knows why.
+ *
+ * **The watch state is set unconditionally, not only on a fresh row.** Identical
+ * offers share one script, and `createContract` is first-writer-wins, so
+ * re-offering a script that `retireSettledOfferContracts` retired would
+ * leave the row `retained` — funded, but out of the subscription, the poll and
+ * every sync. The invariant this states is the one the corridor needs: an offer
+ * address handed to a maker is a watched address.
  */
 async function registerOfferContract(
     wallet: IWallet,
@@ -295,6 +302,7 @@ async function registerOfferContract(
     expectedPkScript: Uint8Array,
 ): Promise<void> {
     const { program, args, keys } = swapProgramBinding(binding, serverPubkey);
+    const contractManager = await wallet.getContractManager();
     const client = await arkade.Arkade.connect({
         arkade: new RestArkProvider(arkServerUrl),
         indexer: new RestIndexerProvider(arkServerUrl),
@@ -303,7 +311,7 @@ async function registerOfferContract(
         // default network while its script is right — a row that disagrees with
         // the address the maker is about to fund
         network: getNetwork(network),
-        contractManager: await wallet.getContractManager(),
+        contractManager,
     });
     const contract = new arkade.ArkadeContract(client, program, args, keys);
     // the row is keyed by script: registering anything but the script being
@@ -316,6 +324,10 @@ async function registerOfferContract(
         label: OFFER_CONTRACT_LABEL,
         metadata: { genericallySpendable: false, kind: OFFER_CONTRACT_KIND },
     });
+    // Throws like the registration itself: an address returned without coverage
+    // is the failure both of these exist to prevent, and nothing is at stake
+    // yet, so the caller can retry.
+    await contractManager.setContractWatchState(hex.encode(expectedPkScript), "watched");
 }
 
 // ── Maker operations ─────────────────────────────────────────────────────────

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -28,8 +28,8 @@
  * - **Report funding.** `vtxo_received` needs no status: a funded offer is
  *   `pending`, which is what it already was.
  * - **Keep watching a script it has finished with.** A persisted terminal
- *   status retires the contract to `retained`, once no live record is left at
- *   that script ({@link retireSettledOfferContracts}).
+ *   status retires the contract to `retained`, once nothing at that script
+ *   still needs coverage ({@link retireOfferContract}).
  */
 import { base64, hex } from "@scure/base";
 import {
@@ -38,9 +38,9 @@ import {
     Transaction,
     type ContractEvent,
     type ContractVtxo,
-    type IContractManager,
     type IWallet,
 } from "@arkade-os/sdk";
+import { RETIRABLE, retireOfferContract } from "./coverage";
 import { decodeOffer, OFFER_CONTRACT_KIND } from "./offer";
 import type { AssetSwapRepository } from "./repository";
 import { classifyDepositSpend, spendTxidsOf, type RestoreIndexer, type SpendKind } from "./restore";
@@ -54,68 +54,6 @@ import {
 /** Statuses a spend cannot move: the swap is already resolved.
  * @see RETIRABLE — a different question, and not the same set. */
 const TERMINAL: readonly AssetSwapStatus[] = ["fulfilled", "cancelled", "recoverable"];
-
-/**
- * Statuses after which the covenant no longer holds funds, so its contract can
- * leave the watched set. NOT `recoverable`: a swept deposit is still the
- * maker's money at that script, and unwatching it is how it goes missing.
- */
-const RETIRABLE: readonly AssetSwapStatus[] = ["fulfilled", "cancelled"];
-
-/** The one contract-manager capability retiring needs. */
-export type OfferContractRetirer = Pick<IContractManager, "setContractWatchState">;
-
-/**
- * Drop `script` from the watched set unless another record there still holds
- * funds. Identical offers share one script, so the check is per script, not per
- * record.
- *
- * `retained`, not deleted: the row is what keeps the deposit's VTXOs
- * annotatable and its history readable, while `retained` is what drops it from
- * the subscription, the failsafe poll and every sync. A maker who has made
- * hundreds of offers otherwise re-subscribes to hundreds of dead scripts on
- * every wallet start.
- *
- * A `recoverable` record blocks its script for good — nothing moves a record
- * off that status — so a script that once held a swept deposit stays watched
- * for the life of the wallet. Accepted: the cost is polling, and the
- * alternative (tracking when recovery completed) buys less than it costs.
- *
- * Best-effort, exactly as core's own demotion is: a failed retire costs
- * polling, never correctness.
- */
-async function retireOfferContract(
-    manager: OfferContractRetirer,
-    swaps: AssetSwap[],
-    script: string,
-): Promise<void> {
-    // NOT `!TERMINAL.includes(...)`: `recoverable` is terminal for a spend and
-    // not retirable, so reading liveness off TERMINAL unwatches swept funds.
-    if (swaps.some((s) => s.swapPkScript === script && !RETIRABLE.includes(s.status))) return;
-    try {
-        await manager.setContractWatchState(script, "retained");
-    } catch (err) {
-        console.warn(`[swap] could not retire offer contract ${script}`, err);
-    }
-}
-
-/**
- * Retire every offer script in `swaps` that no live record still holds — the
- * batch form of what the watcher does per spend event, for a consumer that
- * applies {@link restoreAssetSwaps} results without running the watcher.
- *
- * Takes the caller's full record list: liveness is a property of all records at
- * a script, so a partial list would retire a script another record still holds.
- */
-export async function retireSettledOfferContracts(
-    manager: OfferContractRetirer,
-    swaps: AssetSwap[],
-): Promise<void> {
-    const settled = new Set(
-        swaps.filter((s) => RETIRABLE.includes(s.status)).map((s) => s.swapPkScript),
-    );
-    for (const script of settled) await retireOfferContract(manager, swaps, script);
-}
 
 /**
  * The record change a classified spend implies, or `undefined` when it implies

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -27,6 +27,9 @@
  *   reactivity, never an alternative sink.
  * - **Report funding.** `vtxo_received` needs no status: a funded offer is
  *   `pending`, which is what it already was.
+ * - **Keep watching a script it has finished with.** A persisted terminal
+ *   status retires the contract to `retained`, once no live record is left at
+ *   that script ({@link retireSettledOfferContracts}).
  */
 import { base64, hex } from "@scure/base";
 import {
@@ -35,6 +38,7 @@ import {
     Transaction,
     type ContractEvent,
     type ContractVtxo,
+    type IContractManager,
     type IWallet,
 } from "@arkade-os/sdk";
 import { decodeOffer, OFFER_CONTRACT_KIND } from "./offer";
@@ -47,8 +51,71 @@ import {
     type AssetSwapStatus,
 } from "./store";
 
-/** Statuses a spend cannot move: the swap is already resolved. */
+/** Statuses a spend cannot move: the swap is already resolved.
+ * @see RETIRABLE — a different question, and not the same set. */
 const TERMINAL: readonly AssetSwapStatus[] = ["fulfilled", "cancelled", "recoverable"];
+
+/**
+ * Statuses after which the covenant no longer holds funds, so its contract can
+ * leave the watched set. NOT `recoverable`: a swept deposit is still the
+ * maker's money at that script, and unwatching it is how it goes missing.
+ */
+const RETIRABLE: readonly AssetSwapStatus[] = ["fulfilled", "cancelled"];
+
+/** The one contract-manager capability retiring needs. */
+export type OfferContractRetirer = Pick<IContractManager, "setContractWatchState">;
+
+/**
+ * Drop `script` from the watched set unless another record there still holds
+ * funds. Identical offers share one script, so the check is per script, not per
+ * record.
+ *
+ * `retained`, not deleted: the row is what keeps the deposit's VTXOs
+ * annotatable and its history readable, while `retained` is what drops it from
+ * the subscription, the failsafe poll and every sync. A maker who has made
+ * hundreds of offers otherwise re-subscribes to hundreds of dead scripts on
+ * every wallet start.
+ *
+ * A `recoverable` record blocks its script for good — nothing moves a record
+ * off that status — so a script that once held a swept deposit stays watched
+ * for the life of the wallet. Accepted: the cost is polling, and the
+ * alternative (tracking when recovery completed) buys less than it costs.
+ *
+ * Best-effort, exactly as core's own demotion is: a failed retire costs
+ * polling, never correctness.
+ */
+async function retireOfferContract(
+    manager: OfferContractRetirer,
+    swaps: AssetSwap[],
+    script: string,
+): Promise<void> {
+    // NOT `!TERMINAL.includes(...)`: `recoverable` is terminal for a spend and
+    // not retirable, so reading liveness off TERMINAL unwatches swept funds.
+    if (swaps.some((s) => s.swapPkScript === script && !RETIRABLE.includes(s.status))) return;
+    try {
+        await manager.setContractWatchState(script, "retained");
+    } catch (err) {
+        console.warn(`[swap] could not retire offer contract ${script}`, err);
+    }
+}
+
+/**
+ * Retire every offer script in `swaps` that no live record still holds — the
+ * batch form of what the watcher does per spend event, for a consumer that
+ * applies {@link restoreAssetSwaps} results without running the watcher.
+ *
+ * Takes the caller's full record list: liveness is a property of all records at
+ * a script, so a partial list would retire a script another record still holds.
+ */
+export async function retireSettledOfferContracts(
+    manager: OfferContractRetirer,
+    swaps: AssetSwap[],
+): Promise<void> {
+    const settled = new Set(
+        swaps.filter((s) => RETIRABLE.includes(s.status)).map((s) => s.swapPkScript),
+    );
+    for (const script of settled) await retireOfferContract(manager, swaps, script);
+}
 
 /**
  * The record change a classified spend implies, or `undefined` when it implies
@@ -168,8 +235,20 @@ export async function watchOfferSwaps({
             // notify only on a write that landed: `onUpdate` is documented as
             // firing after the change is persisted, and a consumer that caches
             // from it would otherwise run ahead of the store
-            const { persisted } = await updateAssetSwapBestEffort(repository, swap.id, changes);
-            if (persisted) onUpdate?.({ ...swap, ...changes });
+            const { persisted, swaps } = await updateAssetSwapBestEffort(
+                repository,
+                swap.id,
+                changes,
+            );
+            // a lost write must not retire: the next restore scan still
+            // believes this deposit is live
+            if (!persisted) continue;
+            onUpdate?.({ ...swap, ...changes });
+            // `swaps` is the post-update view, so the liveness check sees this
+            // record's new status without a third read
+            if (changes.status && RETIRABLE.includes(changes.status)) {
+                await retireOfferContract(manager, swaps, event.contractScript);
+            }
         }
     };
 

--- a/packages/swap/test/cancel.test.ts
+++ b/packages/swap/test/cancel.test.ts
@@ -3,7 +3,7 @@ import { hex } from "@scure/base";
 import { ArkAddress, asset, type IWallet } from "@arkade-os/sdk";
 import { cancelOffer, encodeOffer, offerVtxoScript, type Offer } from "../src/offer";
 import { InMemoryAssetSwapRepository } from "../src/repository";
-import { addAssetSwap } from "../src/store";
+import { addAssetSwap, getAssetSwaps, type AssetSwap } from "../src/store";
 
 // cancelOffer's guards fire before any signing: mock only the network seam
 // (Arkade.connect for the current server key, ArkadeContract for the vtxo
@@ -69,12 +69,29 @@ const script = offerVtxoScript(binding, fundedServerKey);
 const offerHex = hex.encode(encodeOffer({ ...binding, swapPkScript: script.pkScript }));
 const fundedAddress = new ArkAddress(fundedServerKey, script.tweakedPublicKey, "tark").encode();
 
-const contractManager = { marker: "the wallet's manager" };
+const setContractWatchState = vi.fn(async (_script: string, _watch: string) => {});
+const contractManager = { marker: "the wallet's manager", setContractWatchState };
 const wallet = {
     identity: {},
     getAddress: async () => "unused-before-a-vtxo-is-selected",
     getContractManager: async () => contractManager,
 } as unknown as IWallet;
+
+/** The record a funded, cancellable deposit leaves in the caller's store. */
+const pendingSwap = (over: Partial<AssetSwap> = {}): AssetSwap => ({
+    id: "a".repeat(64),
+    fromAsset: "btc",
+    toAsset: "aa".repeat(32) + "0000",
+    fromAmount: "10000",
+    toAmount: "50000",
+    swapAddress: fundedAddress,
+    swapPkScript: hex.encode(script.pkScript),
+    offerHex,
+    fundingTxid: "a".repeat(64),
+    status: "pending",
+    createdAt: 1_700_000_000_000,
+    ...over,
+});
 
 describe("cancelOffer guards", () => {
     it("diagnoses a rotated server key instead of reporting a missing VTXO", async () => {
@@ -122,19 +139,7 @@ describe("cancelOffer guards", () => {
         state.sends = 0;
 
         const repository = new InMemoryAssetSwapRepository();
-        await addAssetSwap(repository, {
-            id: "a".repeat(64),
-            fromAsset: "btc",
-            toAsset: "aa".repeat(32) + "0000",
-            fromAmount: "10000",
-            toAmount: "50000",
-            swapAddress: fundedAddress,
-            swapPkScript: hex.encode(script.pkScript),
-            offerHex,
-            fundingTxid: "a".repeat(64),
-            status: "pending",
-            createdAt: 1_700_000_000_000,
-        });
+        await addAssetSwap(repository, pendingSwap());
         vi.spyOn(repository, "saveSwap").mockRejectedValue(new Error("quota exceeded"));
         // this is the one test that gets past vtxo selection, so the maker
         // address has to decode
@@ -162,5 +167,71 @@ describe("cancelOffer guards", () => {
             }),
         ).rejects.toThrow("no spendable VTXO");
         expect(state.connectOptions?.contractManager).toBe(contractManager);
+    });
+});
+
+// A cancel through the same repository never reaches the watcher's retire:
+// `cancelOffer` writes the terminal status itself, and a watcher that later
+// sees the spend finds a terminal record and returns before writing anything
+// (`spendUpdate`). This site is the only one that can drop the script.
+describe("cancelOffer coverage", () => {
+    const funded = { ...wallet, getAddress: async () => fundedAddress } as unknown as IWallet;
+    const cancellable = () => {
+        state.serverKey = fundedServerKey;
+        state.utxos = [{ txid: "a".repeat(64), vout: 0, value: 10_000 }];
+        setContractWatchState.mockClear();
+    };
+    const cancel = (repository: InMemoryAssetSwapRepository) =>
+        cancelOffer(funded, "http://ark", offerHex, { repository, fundingTxid: "a".repeat(64) });
+
+    it("retires the offer contract once the cancel is recorded", async () => {
+        cancellable();
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, pendingSwap());
+
+        await cancel(repository);
+
+        const [cancelled] = await getAssetSwaps(repository);
+        expect(cancelled.status).toBe("cancelled");
+        expect(setContractWatchState.mock.calls).toEqual([
+            [hex.encode(script.pkScript), "retained"],
+        ]);
+    });
+
+    it("keeps watching while another deposit at the same script is live", async () => {
+        // identical offers share one script: cancelling one deposit says
+        // nothing about the other's
+        cancellable();
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, pendingSwap());
+        await addAssetSwap(
+            repository,
+            pendingSwap({ id: "b".repeat(64), fundingTxid: "b".repeat(64) }),
+        );
+
+        await cancel(repository);
+
+        expect(setContractWatchState).not.toHaveBeenCalled();
+    });
+
+    it("does not retire a settlement the store refused", async () => {
+        // the record still reads `cancelling` to the next restore scan, which
+        // will resolve it — unwatching now would drop the script on a status
+        // nothing has persisted
+        cancellable();
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, pendingSwap());
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        // the in-flight marker still has to land: it gates the broadcast
+        const store = repository.saveSwap.bind(repository);
+        const saveSwap = vi.spyOn(repository, "saveSwap");
+        saveSwap.mockRejectedValue(new Error("quota exceeded"));
+        saveSwap.mockImplementationOnce(store);
+
+        await expect(cancel(repository)).resolves.toBe("cc".repeat(32));
+
+        expect(setContractWatchState).not.toHaveBeenCalled();
+        expect(warn).toHaveBeenCalled();
+        vi.restoreAllMocks();
     });
 });

--- a/packages/swap/test/coverage.test.ts
+++ b/packages/swap/test/coverage.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { promoteOfferContract, retireOfferContract } from "../src/coverage";
+import type { AssetSwap } from "../src/store";
+
+const SCRIPT = "51" + "aa".repeat(32);
+
+const manager = () => ({
+    setContractWatchState: vi.fn(async (_script: string, _watch: string) => {}),
+});
+
+const swap = (over: Partial<AssetSwap>): AssetSwap => ({
+    id: "aa".repeat(32),
+    fromAsset: "btc",
+    toAsset: "cc".repeat(34),
+    fromAmount: "10000",
+    toAmount: "50000",
+    swapAddress: "",
+    swapPkScript: SCRIPT,
+    offerHex: "00",
+    fundingTxid: "aa".repeat(32),
+    status: "fulfilled",
+    createdAt: 1_700_000_000_000,
+    ...over,
+});
+
+// The two sides of one row. `createOffer` promotes a script the moment it hands
+// out an address to fund; a settlement at that same script — identical offers
+// derive one — retires it. What must never happen is the demotion landing last.
+describe("offer contract coverage", () => {
+    it("does not retire a script whose address is still waiting for its deposit", async () => {
+        // the race the watcher would otherwise lose: it read its records, found
+        // them all settled, and only then does a new offer claim the script.
+        // The old swap's `createdAt` predates the issuance, so it is not this
+        // address's funding and says nothing about it.
+        const { setContractWatchState } = manager();
+        await promoteOfferContract({ setContractWatchState }, SCRIPT);
+        await retireOfferContract({ setContractWatchState }, [swap({})], SCRIPT);
+
+        expect(setContractWatchState.mock.calls).toEqual([[SCRIPT, "watched"]]);
+    });
+
+    it("retires once the issued address has been funded and settled", async () => {
+        // the mark answers one question — has this address been funded — and a
+        // record created since the issuance is that funding; from there the
+        // records are the liveness answer again
+        const { setContractWatchState } = manager();
+        await promoteOfferContract({ setContractWatchState }, SCRIPT);
+        const funded = [swap({ createdAt: Date.now() })];
+        await retireOfferContract({ setContractWatchState }, funded, SCRIPT);
+
+        expect(setContractWatchState.mock.calls).toEqual([
+            [SCRIPT, "watched"],
+            [SCRIPT, "retained"],
+        ]);
+    });
+
+    it("keeps a promotion that arrives mid-retire", async () => {
+        // `setContractWatchState` is a read-modify-write over the row, so the
+        // two are ordered here: a promotion that overlaps a demotion in flight
+        // must not end up underneath it
+        let release: () => void = () => {};
+        const blocked = new Promise<void>((resolve) => (release = resolve));
+        // the row as the manager would leave it: what lands, lands last, so a
+        // slow demotion left free to overlap wins over the promotion it raced
+        let row = "watched";
+        const setContractWatchState = async (_script: string, watch: string) => {
+            if (watch === "retained") await blocked;
+            row = watch;
+        };
+
+        const retire = retireOfferContract({ setContractWatchState }, [swap({})], SCRIPT);
+        // let the retire reach its write before the promotion is asked for
+        await Promise.resolve();
+        const promote = promoteOfferContract({ setContractWatchState }, SCRIPT);
+        release();
+        await Promise.all([retire, promote]);
+
+        expect(row).toBe("watched");
+    });
+});

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -351,6 +351,12 @@ describe("maker-side swap loop (regtest)", () => {
             const [resolved] = await getAssetSwaps(swapRepository);
             expect(resolved.spentTxid).toBeTruthy();
             expect(updates.map((u) => u.status)).toContain("cancelled");
+
+            // and the settled script leaves the watched set: no live record is
+            // left at it, so the row is kept for history and dropped from every
+            // background channel
+            const rows = await (await wallet.getContractManager()).getContracts();
+            expect(rows.find((c) => c.script === secondScript)?.watch).toBe("retained");
         } finally {
             watcher.stop();
         }

--- a/packages/swap/test/emulatorTrustBoundary.test.ts
+++ b/packages/swap/test/emulatorTrustBoundary.test.ts
@@ -109,6 +109,7 @@ const wallet = {
             state: "active",
             createdAt: 0,
         }),
+        setContractWatchState: async () => {},
     }),
 } as unknown as IWallet;
 

--- a/packages/swap/test/register.test.ts
+++ b/packages/swap/test/register.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { hex } from "@scure/base";
-import { asset, type IWallet } from "@arkade-os/sdk";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import {
+    asset,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    ProviderUnavailableError,
+    ReadonlySingleKey,
+    ReadonlyWallet,
+    type ArkProvider,
+    type IndexerProvider,
+    type IWallet,
+    type OnchainProvider,
+} from "@arkade-os/sdk";
 import { createOffer, OFFER_CONTRACT_KIND, OFFER_CONTRACT_LABEL } from "../src/offer";
 
 // the covenant derivation, Arkade.connect, ArkadeContract and register() are
@@ -13,6 +25,7 @@ const makerAddress =
 
 const state = vi.hoisted(() => ({
     created: [] as Record<string, unknown>[],
+    watched: [] as [string, string][],
     createContract: undefined as ((params: Record<string, unknown>) => unknown) | undefined,
 }));
 
@@ -62,6 +75,9 @@ const contractManager = {
         state.created.push(params);
         return { ...params, state: "active", createdAt: 0 };
     },
+    setContractWatchState: async (script: string, watch: string) => {
+        state.watched.push([script, watch]);
+    },
 };
 
 const wallet = {
@@ -78,8 +94,8 @@ const emulatorPubkey = hex.decode(
     "466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
 );
 const testAsset = asset.AssetId.fromString("aa".repeat(32) + "0000");
-const create = () =>
-    createOffer(wallet, "http://ark", emulatorPubkey, {
+const create = (maker: IWallet = wallet) =>
+    createOffer(maker, "http://ark", emulatorPubkey, {
         wantAmount: BigInt(50_000),
         wantAsset: testAsset,
     });
@@ -87,6 +103,7 @@ const create = () =>
 describe("offer contract registration", () => {
     beforeEach(() => {
         state.created = [];
+        state.watched = [];
         state.createContract = undefined;
     });
 
@@ -130,5 +147,85 @@ describe("offer contract registration", () => {
             throw new Error("repository unavailable");
         };
         await expect(create()).rejects.toThrow("repository unavailable");
+    });
+
+    it("states that the address it hands back is watched", async () => {
+        const offer = await create();
+        expect(state.watched).toEqual([[hex.encode(offer.swapPkScript), "watched"]]);
+    });
+});
+
+// ── Re-offering a retired script, against a real contract manager ────────────
+
+const SIGNER_PUBKEY = "02" + "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa";
+
+const arkInfo = () => ({
+    boardingExitDelay: 144n,
+    checkpointTapscript:
+        "5ab27520e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdbac",
+    deprecatedSigners: [],
+    digest: "d",
+    dust: 1000n,
+    fees: { intentFee: {}, txFeeRate: "0" },
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    forfeitPubkey: SIGNER_PUBKEY,
+    network: "regtest",
+    serviceStatus: {},
+    sessionDuration: 3600n,
+    signerPubkey: SIGNER_PUBKEY,
+    unilateralExitDelay: 4096n,
+    utxoMaxAmount: -1n,
+    utxoMinAmount: 0n,
+    version: "1",
+    vtxoMaxAmount: -1n,
+    vtxoMinAmount: 0n,
+});
+
+/** Offline: every indexer read fails retryably, so the row still persists. */
+const offlineIndexer = () =>
+    ({
+        getVtxos: async () => {
+            throw new ProviderUnavailableError("operator down");
+        },
+        subscribeForScripts: async () => "sub-1",
+        unsubscribeForScripts: async () => undefined,
+        getSubscription: async function* () {},
+    }) as Partial<IndexerProvider> as IndexerProvider;
+
+const realWallet = async () => {
+    const contractRepository = new InMemoryContractRepository();
+    const wallet = await ReadonlyWallet.create({
+        arkServerUrl: "http://localhost:7070",
+        arkProvider: { getInfo: async () => arkInfo() } as Partial<ArkProvider> as ArkProvider,
+        indexerProvider: offlineIndexer(),
+        onchainProvider: {
+            getCoins: async () => [],
+            getTransactions: async () => [],
+            getTxOutspends: async () => [],
+        } as Partial<OnchainProvider> as OnchainProvider,
+        storage: { walletRepository: new InMemoryWalletRepository(), contractRepository },
+        identity: ReadonlySingleKey.fromPublicKey(
+            hex.decode("02" + hex.encode(schnorr.getPublicKey(makerKey))),
+        ),
+    });
+    return { wallet: wallet as unknown as IWallet, contractRepository };
+};
+
+describe("an offer at a script an earlier offer retired", () => {
+    it("is watched again before the maker can fund it", async () => {
+        const { wallet, contractRepository } = await realWallet();
+        const offer = await create(wallet);
+        const script = hex.encode(offer.swapPkScript);
+        const manager = await wallet.getContractManager();
+        // the state a settled offer leaves behind
+        await manager.setContractWatchState(script, "retained");
+
+        // identical offers derive one script, and createContract is
+        // first-writer-wins: it never touches the existing row, so the
+        // promotion is the only thing that can restore coverage here
+        await create(wallet);
+
+        const row = (await contractRepository.getContracts()).find((c) => c.script === script);
+        expect(row?.watch).toBe("watched");
     });
 });

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -5,7 +5,7 @@ import { asset, ArkAddress, Transaction } from "@arkade-os/sdk";
 import { encodeOffer, offerVtxoScript, OFFER_CONTRACT_KIND, type Offer } from "../src/offer";
 import { InMemoryAssetSwapRepository } from "../src/repository";
 import { addAssetSwap, getAssetSwaps, type AssetSwap } from "../src/store";
-import { spendUpdate, watchOfferSwaps } from "../src/watch";
+import { retireSettledOfferContracts, spendUpdate, watchOfferSwaps } from "../src/watch";
 
 const ASSET_ID = "f1".repeat(34);
 
@@ -61,6 +61,7 @@ const makeWallet = (getVirtualTxs: (txids: string[]) => Promise<{ txs: string[] 
     const callbacks = new Set<(event: any) => void>();
     // a real ark address, so ArkAddress.decode recovers SERVER_KEY from it
     const address = new ArkAddress(SERVER_KEY, key("66"), "tark").encode();
+    const setContractWatchState = vi.fn(async (_script: string, _watch: string) => {});
     const wallet = {
         getAddress: async () => address,
         getContractManager: async () => ({
@@ -68,11 +69,13 @@ const makeWallet = (getVirtualTxs: (txids: string[]) => Promise<{ txs: string[] 
                 callbacks.add(cb);
                 return () => callbacks.delete(cb);
             },
+            setContractWatchState,
         }),
     } as any;
     return {
         wallet,
         getVirtualTxs,
+        setContractWatchState,
         emit: (event: any) => callbacks.forEach((cb) => cb(event)),
         listeners: () => callbacks.size,
     };
@@ -299,6 +302,150 @@ describe("watchOfferSwaps", () => {
         vi.restoreAllMocks();
     });
 
+    it("retires the contract when the fill leaves no live record at the script", async () => {
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(setContractWatchState).toHaveBeenCalledWith(
+                    hex.encode(offer.swapPkScript),
+                    "retained",
+                );
+            },
+        );
+    });
+
+    it("keeps watching while another deposit at the same script is still live", async () => {
+        // identical offers share one script and are told apart by their
+        // funding txid: retiring on one fill would unwatch the other's deposit
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+        await addAssetSwap(
+            repository,
+            swapFor(offer, { id: "ee".repeat(32), fundingTxid: "ee".repeat(32) }),
+        );
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(setContractWatchState).not.toHaveBeenCalled();
+            },
+        );
+    });
+
+    it("keeps watching when the sibling deposit was swept", async () => {
+        // `recoverable` is terminal for a spend but the funds are still the
+        // maker's at that script: reading liveness off TERMINAL unwatches them
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+        await addAssetSwap(
+            repository,
+            swapFor(offer, {
+                id: "ee".repeat(32),
+                fundingTxid: "ee".repeat(32),
+                status: "recoverable",
+            }),
+        );
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(setContractWatchState).not.toHaveBeenCalled();
+            },
+        );
+    });
+
+    it("does not retire a change the store refused", async () => {
+        // the record still reads `pending` to the next restore scan, so
+        // unwatching it here would strand a deposit the scan still tracks
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(repository, "saveSwap").mockRejectedValue(new Error("quota exceeded"));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(setContractWatchState).not.toHaveBeenCalled();
+            },
+        );
+        vi.restoreAllMocks();
+    });
+
+    it("keeps the status write when the retire fails", async () => {
+        // best-effort: a failed retire costs polling, never correctness
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, setContractWatchState }) => {
+                setContractWatchState.mockRejectedValue(new Error("repository unavailable"));
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "fulfilled" }]);
+                expect(warn).toHaveBeenCalled();
+            },
+        );
+        vi.restoreAllMocks();
+    });
+
     it("stops delivering after stop()", async () => {
         const offer = makeOffer();
         const fill = spendPsbt(offer, "fulfill");
@@ -321,5 +468,41 @@ describe("watchOfferSwaps", () => {
                 expect(await getAssetSwaps(repository)).toMatchObject([{ status: "pending" }]);
             },
         );
+    });
+});
+
+describe("retireSettledOfferContracts", () => {
+    // the batch path: a consumer that applies restore results without running
+    // the watcher retires with one call rather than a re-implementation
+    const btcOffer = makeOffer();
+    const assetOffer = makeOffer("want-btc");
+    const btcScript = hex.encode(btcOffer.swapPkScript);
+    const assetScript = hex.encode(assetOffer.swapPkScript);
+    const manager = () => ({
+        setContractWatchState: vi.fn(async (_script: string, _watch: string) => {}),
+    });
+
+    it("retires each settled script once and leaves the others watched", async () => {
+        const { setContractWatchState } = manager();
+        await retireSettledOfferContracts({ setContractWatchState }, [
+            swapFor(btcOffer, { status: "fulfilled" }),
+            swapFor(btcOffer, { id: "ee".repeat(32), status: "cancelled" }),
+            swapFor(assetOffer, { id: "ff".repeat(32), status: "pending" }),
+        ]);
+
+        expect(setContractWatchState.mock.calls).toEqual([[btcScript, "retained"]]);
+        expect(setContractWatchState).not.toHaveBeenCalledWith(assetScript, "retained");
+    });
+
+    it("never retires a script with a swept deposit at it", async () => {
+        const { setContractWatchState } = manager();
+        await retireSettledOfferContracts({ setContractWatchState }, [
+            swapFor(btcOffer, { status: "recoverable" }),
+            swapFor(assetOffer, { id: "ee".repeat(32), status: "recoverable" }),
+            swapFor(assetOffer, { id: "ff".repeat(32), status: "fulfilled" }),
+        ]);
+
+        // neither on its own account, nor as a sibling of a fill
+        expect(setContractWatchState).not.toHaveBeenCalled();
     });
 });

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -5,7 +5,8 @@ import { asset, ArkAddress, Transaction } from "@arkade-os/sdk";
 import { encodeOffer, offerVtxoScript, OFFER_CONTRACT_KIND, type Offer } from "../src/offer";
 import { InMemoryAssetSwapRepository } from "../src/repository";
 import { addAssetSwap, getAssetSwaps, type AssetSwap } from "../src/store";
-import { retireSettledOfferContracts, spendUpdate, watchOfferSwaps } from "../src/watch";
+import { retireSettledOfferContracts } from "../src/coverage";
+import { spendUpdate, watchOfferSwaps } from "../src/watch";
 
 const ASSET_ID = "f1".repeat(34);
 


### PR DESCRIPTION
First of the two PRs in `plans/arkade-swap-leftover-5-6.md` (item 5). Item 6 follows separately.

## What

A settled offer script leaves the watched set. On a persisted `fulfilled` /
`cancelled` write, the watcher sets the contract to `retained` — the row stays
for history, VTXO annotation and classification, while the script drops out of
the subscription, the failsafe poll and every sync. Same argument
`RfqSwapManager.retireContract` already won for lockups: a maker with hundreds
of past offers otherwise re-subscribes to hundreds of dead scripts on every
wallet start.

- `RETIRABLE = ["fulfilled", "cancelled"]`, beside the existing `TERMINAL`,
  which keeps `recoverable`. **`recoverable` is deliberately not retirable**: a
  swept deposit is still the maker's money at that script, and the liveness
  check reads `RETIRABLE` for the same reason — reading it off `TERMINAL` would
  make a swept sibling count as "not live" and unwatch the funds. A
  `recoverable` record therefore blocks its script for the life of the wallet;
  accepted, and noted in the code.
- Identical offers share one script, so the retire is keyed on no *other* live
  record being at it. It reuses the post-update list `updateAssetSwapBestEffort`
  already returns — no extra read — and is gated on `persisted`.
- Best-effort: a failed retire costs polling, never correctness.
- `retireSettledOfferContracts(manager, swaps)` is exported for consumers that
  apply `restoreAssetSwaps` results without running the watcher.

## The part that makes it safe rather than a funds-visibility bug

`registerOfferContract` now sets `watched` unconditionally after `register()`.
Identical offers derive an identical script and `createContract` is
first-writer-wins — it does not touch an existing row — so re-offering a script
this PR retired would hand the maker a `retained` address: funded, but never
subscribed, never persisted, never in balance. The invariant is now stated where
it belongs: an offer address handed to a maker is a watched address.

Core is untouched: `retained` stays a state a plugin asked for, so
re-registration does not silently undo it for the RFQ corridor, where
`ensureRegistered` re-registers retired lockups by design.

## Tests

`test/watch.test.ts`, `test/register.test.ts` (a real `ContractManager` over
in-memory repositories for the promotion, asserting the repository row), plus
the e2e assertion below. Both load-bearing cases were mutation-checked: swapping
the liveness predicate to `TERMINAL` and dropping the promotion each fail the
suite.

- `pnpm -r test:unit` — green (swap: 288).
- `pnpm run regtest:test:swap test/e2e/swap.test.ts` — 5 passed, including a new
  assertion that the cancelled script's row is `retained` after the watcher
  resolves it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Offer contracts are automatically added to active monitoring when registered.
  - Settled or cancelled offers are removed from active monitoring when no longer needed.
  - Contracts remain retained for history and are protected while related deposits remain active or recoverable.

- **Bug Fixes**
  - Monitoring state is preserved during concurrent offer updates.
  - Contract cleanup is skipped when status updates fail, preventing inconsistent records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->