### PR TITLE
feat(swap): name the refund this wallet cannot make

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -381,7 +381,10 @@ The package is pre-release; these notes replace a changelog for consumers tracki
   `senderPrivateKey` is gone from both return types; caller-owned onchain preimages live inside
   `secrets` and must be persisted with the record. `pushRefundWithoutReceiver` /
   `refundIfUnresolved` take `sender: Identity` instead of `senderPrivateKey: Uint8Array` — build
-  it with `senderIdentityForRfqSecrets`. `AssetSwap` gains `signingDescriptor?`,
+  it from the record with `senderIdentityForSwapRecord`, which is what keeps a wallet that cannot
+  sign reporting `RefundNotLocallyPossibleError` rather than a `TypeError` at the push site;
+  `senderIdentityForRfqSecrets` is for callers that already hold resolved secrets. `AssetSwap`
+  gains `signingDescriptor?`,
   `preimageHex?`, and complete stored-arm `fallbackSecrets?`. Landed while the package is
   unpublished and consumer-free, which is the whole window for doing it: after a consumer ships,
   the same change becomes a secret migration across every deployed wallet.

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -328,9 +328,21 @@ await saveSwap({ ...record, ...rfqSecretsToRecord(swap.secrets) });
 const secrets = rfqSecretsOfRecord(record);
 if (secrets) {
     const preimage = await preimageForRfqSecrets(wallet, secrets);
-    const sender = await senderIdentityForRfqSecrets(wallet, secrets);
 }
+
+// For a refund, take the composition instead of the guard: it turns all three
+// ways a wallet can fail to produce the sender key — no secrets on the record,
+// an unreadable fallback arm, a descriptor from another seed — into one typed
+// `RefundNotLocallyPossibleError` carrying which. Wire `refundArkade` to this.
+const sender = await senderIdentityForSwapRecord(wallet, record);
 ```
+
+`RfqSwapManager` catches that error and reports `needs_counterparty` with a `blockedReason`,
+instead of retrying a push that cannot work until the refund window closes. The state is **not**
+terminal: the lockup stays funded and watched, a solver claim still ends the swap `settled`, and a
+`canRefundArkade` probe answering `ok` — after the right wallet is restored — returns it to
+`pending`. The manager reports the same state when nothing is wired to act (`enableAutoActions:
+false`, or no callbacks) and the window has passed.
 
 `derivable: false` is the fallback for wallets that cannot allocate (static / `auto` / custom
 signers). It carries the raw `senderPrivateKey` and, for onchain sends, `preimage`;

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -114,6 +114,7 @@ export {
 export { sealClaimPacket, type ClaimPacketInput, type SealedClaimPacket } from "./claimPacket";
 export {
     RFQ_PREIMAGE_TAG,
+    RefundNotLocallyPossibleError,
     adoptSwapDescriptor,
     buildPreimageMessage,
     derivePreimage,
@@ -124,9 +125,11 @@ export {
     rfqSecretsOfRecord,
     rfqSecretsToRecord,
     senderIdentityForRfqSecrets,
+    senderIdentityForSwapRecord,
     senderPubkeyForRfqSecrets,
     type DerivedSwapSecrets,
     type DeterministicSigner,
+    type RefundBlockedReason,
     type StoredSwapSecrets,
     type SwapSecrets,
 } from "./secrets";

--- a/packages/swap/src/secrets.ts
+++ b/packages/swap/src/secrets.ts
@@ -214,6 +214,36 @@ export async function adoptSwapDescriptor(
     await wallet.advanceSigningDescriptorWatermark(signingDescriptor);
 }
 
+/** Why a wallet cannot produce a swap's sender key. Different instructions to
+ * a user: restore the other wallet, or accept that this record never carried
+ * the secrets at all. */
+export type RefundBlockedReason =
+    /** The record names no arm: neither `signingDescriptor` nor `fallbackSecrets`. */
+    | "no-secrets"
+    /** It names an arm this version cannot read. */
+    | "unreadable-secrets"
+    /** The descriptor belongs to another seed, or this wallet is static. */
+    | "foreign-descriptor";
+
+/**
+ * The wallet cannot produce this swap's sender key, so no local refund is
+ * possible: not a failure to retry, a capability this wallet does not have.
+ *
+ * Thrown where the cause is discovered rather than translated at the edge, so
+ * a `refundArkade` wired through {@link senderIdentityForSwapRecord} reports it
+ * to `RfqSwapManager` unwrapped — which is what stops the manager grinding
+ * against a push that can never work for the whole refund window.
+ */
+export class RefundNotLocallyPossibleError extends Error {
+    override readonly name = "RefundNotLocallyPossibleError";
+    constructor(
+        readonly reason: RefundBlockedReason,
+        message: string,
+    ) {
+        super(message);
+    }
+}
+
 /**
  * The VHTLC `sender` identity — the signer for every interactive refund.
  *
@@ -233,11 +263,58 @@ export async function senderIdentityForRfqSecrets(
         ? await wallet.signerForDescriptor(secrets.signingDescriptor)
         : undefined;
     if (!signer || !isDeterministicSigner(signer)) {
-        throw new Error(
+        // Typed at the throw site, not in a translator: this is the function
+        // that discovers the cause. A faithful `Error` subclass, so callers
+        // matching on the message keep working.
+        throw new RefundNotLocallyPossibleError(
+            "foreign-descriptor",
             `this wallet cannot derive ${secrets.signingDescriptor}; the swap was created on another wallet`,
         );
     }
     return signer;
+}
+
+/**
+ * The VHTLC `sender` identity for a stored swap record, or a typed refusal.
+ *
+ * The record→identity composition {@link rfqSecretsOfRecord} deliberately does
+ * not do: it stays total so history iteration can call it, so *this* is where
+ * "no secrets on the record" becomes a refusal rather than an `undefined` the
+ * caller has to remember to check.
+ *
+ * **Wire `refundArkade` here, not to {@link senderIdentityForRfqSecrets}.**
+ * Only two of the three causes are throws; a caller one level down would skip
+ * the third silently and turn it into a `TypeError` at the push site, which
+ * `RfqSwapManager` then treats as retryable and grinds against for the whole
+ * refund window.
+ *
+ * Takes the record shape structurally, matching {@link rfqSecretsOfRecord}, so
+ * either record type can be passed.
+ */
+export async function senderIdentityForSwapRecord(
+    wallet: IWallet,
+    record: {
+        signingDescriptor?: string;
+        preimageHex?: string;
+        fallbackSecrets?: AssetSwapFallbackSecrets;
+    },
+): Promise<Identity> {
+    let secrets: SwapSecrets | undefined;
+    try {
+        secrets = rfqSecretsOfRecord(record);
+    } catch (error) {
+        throw new RefundNotLocallyPossibleError(
+            "unreadable-secrets",
+            error instanceof Error ? error.message : String(error),
+        );
+    }
+    if (!secrets) {
+        throw new RefundNotLocallyPossibleError(
+            "no-secrets",
+            "this swap record carries no signing descriptor and no fallback secrets",
+        );
+    }
+    return senderIdentityForRfqSecrets(wallet, secrets);
 }
 
 /** The `sender` x-only pubkey, the only half the request flow needs. */

--- a/packages/swap/src/secrets.ts
+++ b/packages/swap/src/secrets.ts
@@ -239,8 +239,9 @@ export class RefundNotLocallyPossibleError extends Error {
     constructor(
         readonly reason: RefundBlockedReason,
         message: string,
+        options?: { cause?: unknown },
     ) {
-        super(message);
+        super(message, options);
     }
 }
 
@@ -306,6 +307,9 @@ export async function senderIdentityForSwapRecord(
         throw new RefundNotLocallyPossibleError(
             "unreadable-secrets",
             error instanceof Error ? error.message : String(error),
+            // the record's own diagnosis, kept for a caller that wants more
+            // than the message
+            { cause: error },
         );
     }
     if (!secrets) {

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -947,6 +947,11 @@ export class RfqSwapManager {
         });
 
         if (action === "claim" && phase.phase === "claimable") {
+            // The txid, not the label, is what says the claim was made. Until
+            // `needs_counterparty` existed the `claimed` state carried both, and
+            // step 2 skipped this branch on it; a blocked swap keeps the txid
+            // while the label defers, and re-broadcasting would publish P twice.
+            if (swap.claimTxid) return "continue";
             this.setOnchainState(swap, "claimable");
             if (!this.config.enableAutoActions || !this.callbacks) return "handled";
             try {
@@ -1113,11 +1118,13 @@ export class RfqSwapManager {
         this.setState(swap, "needs_counterparty");
     }
 
-    /** The way back out, taken as soon as a refund becomes possible again. */
+    /** The way back out, taken as soon as a refund becomes possible again.
+     * Back to what the record can prove, not to `pending` unconditionally: an
+     * onchain-send swap that already claimed its fill has a txid for it, and
+     * reporting that swap as `pending` would un-say something true. */
     private unblock(swap: RfqSwap): void {
         if (swap.state !== "needs_counterparty") return;
-        delete swap.blockedReason;
-        this.setState(swap, "pending");
+        this.setState(swap, swap.kind === "onchain_send" && swap.claimTxid ? "claimed" : "pending");
     }
 
     private touch(swap: RfqSwap): void {
@@ -1128,6 +1135,10 @@ export class RfqSwapManager {
     private setState(swap: RfqSwap, state: RfqSwapState): void {
         if (swap.state === state) return;
         const previous = swap.state;
+        // Every exit from the refusal clears its reason, not just `unblock`'s:
+        // a swap the counterparty finally claimed leaves through `settled`, and
+        // a stale `blockedReason` there reads as a live refusal.
+        if (previous === "needs_counterparty") delete swap.blockedReason;
         swap.state = state;
         this.touch(swap);
         notify(this.swapUpdateListeners, (listener) => listener(swap, previous));

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -648,10 +648,11 @@ export class RfqSwapManager {
 
     /**
      * Resolve once this swap's PAYOUT is decided — which for onchain-send is
-     * the L1 claim, not the end of the record's life: at `claimed` the trader
-     * has the coins it swapped for, and what remains is the manager watching
-     * the Arkade lockup close. Lightning-send has no such split and resolves at
-     * `settled`/`refunded`.
+     * the L1 claim, not the end of the record's life: once `claimTxid` is set
+     * the trader has the coins it swapped for, and what remains is the manager
+     * watching the Arkade lockup close. That holds however the record is
+     * labelled afterwards, `needs_counterparty` included. Lightning-send has no
+     * such split and resolves at `settled`/`refunded`.
      *
      * Rejects only on `failed`. `refunded` resolves: a refund is an outcome the
      * caller asked this manager to drive, not an exception.
@@ -1224,17 +1225,18 @@ export interface RfqSwapOutcome {
     txid?: string;
 }
 
+// The txid, not the label — same reason `driveOnchain` guards on it. The label
+// moves on: a claimed onchain send whose Arkade half is refused past the window
+// reads `needs_counterparty`, and keying on `claimed` would hang a waiter on a
+// payout that already happened and that the record can prove.
 const isPayoutDecided = (swap: RfqSwap): boolean =>
     swap.state === "settled" ||
     swap.state === "refunded" ||
-    (swap.kind === "onchain_send" && swap.state === "claimed");
+    (swap.kind === "onchain_send" && swap.claimTxid !== undefined);
 
 const outcomeOf = (swap: RfqSwap): RfqSwapOutcome => ({
     state: swap.state,
-    txid:
-        swap.kind === "onchain_send" && swap.state === "claimed"
-            ? swap.claimTxid
-            : swap.refundArkTxid,
+    txid: swap.kind === "onchain_send" && swap.claimTxid ? swap.claimTxid : swap.refundArkTxid,
 });
 
 const errorMessage = (error: unknown): string =>

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -81,6 +81,7 @@ import {
     type LockupSpendIndexer,
 } from "./refund";
 import { registerLockupContract } from "./lockupContract";
+import { RefundNotLocallyPossibleError } from "./secrets";
 
 // ── Records ──────────────────────────────────────────────────────────────────
 
@@ -97,6 +98,21 @@ export type RfqSwapState =
     | "claimable"
     /** onchain-send: our L1 claim is broadcast — the trader has the coins. */
     | "claimed"
+    /**
+     * This wallet cannot push the swap's Arkade refund itself — no secrets on
+     * the record, a descriptor from another seed, or nothing wired to act. The
+     * lockup comes back only if the counterparty claims it, or if the wallet
+     * that can sign it is restored. {@link RfqSwapCommon.blockedReason} says
+     * which.
+     *
+     * **Not terminal, and not a dead end.** The money is still at the lockup,
+     * so a solver claim is still observable and still ends the swap `settled`;
+     * and the refusal is re-checked every pass, so restoring the right wallet
+     * (or wiring the callbacks) returns the swap to `pending` and resumes the
+     * normal drive. For an onchain-send swap it says nothing about the L1
+     * half, which keeps being driven and claimed.
+     */
+    | "needs_counterparty"
     /** Terminal: the lockup was spent by a hash-verified claim — the
      * counterparty completed its side. Read off chain, never reported. */
     | "settled"
@@ -105,7 +121,9 @@ export type RfqSwapState =
     /** Terminal: an action failed and its window closed. */
     | "failed";
 
-/** The states after which the manager stops monitoring a swap. */
+/** The states after which the manager stops monitoring a swap. Deliberately
+ * without `needs_counterparty`: retiring on it would unwatch a funded lockup
+ * whose claim is still the thing that ends the swap. */
 export const RFQ_SWAP_TERMINAL_STATES = ["settled", "refunded", "failed"] as const;
 
 export const isRfqSwapTerminal = (state: RfqSwapState): boolean =>
@@ -158,6 +176,9 @@ interface RfqSwapCommon {
     refundArkTxid?: string;
     /** Why `state` is `failed`. */
     failure?: string;
+    /** Why `state` is `needs_counterparty`. Distinct from {@link failure},
+     * which means an action was attempted and did not work. */
+    blockedReason?: string;
 }
 
 /** `arkade:BTC->lightning:BTC`. Nothing for the trader to claim: the solver
@@ -269,6 +290,11 @@ export type ArkadeRefundResult = { arkTxid: string; amount: number } | null;
  * and its own MTP retry loop, which would nest inside the manager's. Wire it
  * to `findLockupVtxos` + `pushRefundWithoutReceiver`, which is the atomic push
  * `refundIfUnresolved` itself calls.
+ *
+ * Resolve the sender key through `senderIdentityForSwapRecord`: it is
+ * what turns "this wallet cannot sign this swap" into
+ * {@link RefundNotLocallyPossibleError}, which the manager reports as
+ * `needs_counterparty` instead of retrying for the whole refund window.
  */
 export interface RfqSwapManagerCallbacks {
     /** Build and broadcast the L1 claim. See `claimOnchainFill`. */
@@ -276,6 +302,18 @@ export interface RfqSwapManagerCallbacks {
     /** Push `refundWithoutReceiver` for every output at the lockup. See
      * `pushRefundWithoutReceiver`; return `null` for an empty lockup. */
     refundArkade: (swap: RfqSwap) => Promise<ArkadeRefundResult>;
+    /**
+     * Whether a local refund is possible at all — the record's secrets, against
+     * this wallet. Called every pass, including *before* the refund window
+     * opens, so a swap nobody can refund says so while the solver can still
+     * act, instead of at the deadline; and so restoring the right wallet lifts
+     * the state again.
+     *
+     * Optional: omit to answer "yes" and learn at push time, from
+     * {@link RefundNotLocallyPossibleError}. Local by contract — no network
+     * call belongs here.
+     */
+    canRefundArkade?: (swap: RfqSwap) => Promise<{ ok: true } | { ok: false; reason: string }>;
     /** Persist the record. Called after any pass that changed it. */
     saveSwap: (swap: RfqSwap) => Promise<void>;
 }
@@ -390,7 +428,9 @@ const notify = <T extends (...args: never[]) => void>(
  * 3. **Take the lockup back**, once `refundLocktime` has passed and step 1 has
  *    not ended the swap. This runs for onchain-send too, including after a
  *    successful claim: the trader's lockup is still funded and still theirs to
- *    recover if the solver never comes for it.
+ *    recover if the solver never comes for it. When no local refund is possible
+ *    at all — no secrets, another wallet's descriptor, nothing wired — the swap
+ *    reports `needs_counterparty` instead of retrying a push that cannot work.
  */
 export class RfqSwapManager {
     private readonly deps: RfqSwapManagerDeps;
@@ -415,6 +455,16 @@ export class RfqSwapManager {
      * on a swap that in fact succeeded.
      */
     private readonly registered = new Map<string, boolean>();
+    /**
+     * Swaps whose `refundArkade` answered {@link RefundNotLocallyPossibleError}
+     * in this process. Membership stops the push from being re-issued every
+     * pass — it cannot start working on its own, and re-issuing it is the
+     * grind `needs_counterparty` exists to remove. Only
+     * {@link RfqSwapManagerCallbacks.canRefundArkade} clears it, so a caller
+     * with no probe learns again on the next start, when the wallet that can
+     * sign may well have been restored.
+     */
+    private readonly refundRefused = new Set<string>();
     /** Live `onContractEvent` subscription, held so `stop()` can drop it. */
     private unsubscribeContracts: (() => void) | null = null;
     /** Terminal records, kept so a late {@link waitForSwapCompletion} still
@@ -635,6 +685,7 @@ export class RfqSwapManager {
         const swap = this.monitored.get(rfqId);
         if (swap) this.byLockupScript.delete(hex.encode(swap.lockupPkScript));
         this.monitored.delete(rfqId);
+        this.refundRefused.delete(rfqId);
     }
 
     /**
@@ -896,12 +947,12 @@ export class RfqSwapManager {
         });
 
         if (action === "claim" && phase.phase === "claimable") {
-            this.setState(swap, "claimable");
+            this.setOnchainState(swap, "claimable");
             if (!this.config.enableAutoActions || !this.callbacks) return "handled";
             try {
                 const { txid } = await this.callbacks.claimOnchain(swap, phase.utxo);
                 swap.claimTxid = txid;
-                this.setState(swap, "claimed");
+                this.setOnchainState(swap, "claimed");
                 this.emitAction(swap, "claimOnchain");
             } catch (error) {
                 // The window is still open, so the next pass tries again; no
@@ -920,7 +971,7 @@ export class RfqSwapManager {
                 swap.claimTxid = phase.txid;
                 this.touch(swap);
             }
-            this.setState(swap, "claimed");
+            this.setOnchainState(swap, "claimed");
         }
 
         // Everything else — still waiting for the fill, the window closed
@@ -936,8 +987,44 @@ export class RfqSwapManager {
 
     private async driveArkadeRefund(swap: RfqSwap): Promise<void> {
         const now = this.config.now();
-        if (now < swap.refundLocktime) return;
-        if (!this.config.enableAutoActions || !this.callbacks) return;
+
+        // Ask first, and ask on every pass. Before the window opens this is
+        // what makes "nobody here can refund this" reportable while the solver
+        // can still act; after it, it is what lifts the state again when the
+        // wallet that can sign is restored.
+        const refusal = await this.probeRefusal(swap);
+        if (refusal) {
+            // Before the window, an onchain-send swap's live claim keeps the
+            // label — it is a different half with a different key, and it is
+            // the half the trader can still act on. After the window the
+            // refusal wins, which {@link setOnchainState} is the other side of.
+            const claiming = swap.state === "claimable" || swap.state === "claimed";
+            if (now < swap.refundLocktime && claiming) return;
+            return this.block(swap, refusal);
+        }
+        // A probe that answered is the only thing that can retract a refusal
+        // the push itself reported; without one there is nothing new to learn,
+        // and re-issuing a push that cannot work is the grind this state
+        // removes. Step 1 still ends the swap if the counterparty acts.
+        if (this.refundRefused.has(swap.rfqId)) {
+            if (!this.callbacks?.canRefundArkade) return;
+            this.refundRefused.delete(swap.rfqId);
+        }
+
+        if (now < swap.refundLocktime) return this.unblock(swap);
+
+        if (!this.config.enableAutoActions || !this.callbacks) {
+            // The loudest gap this state closes: with nothing wired to act, the
+            // swap would otherwise sit `pending` past its window forever —
+            // monitored, never acted on, never reported.
+            return this.block(
+                swap,
+                this.callbacks
+                    ? "automatic actions are disabled, so this wallet will not push the refund"
+                    : "no callbacks are wired, so this wallet cannot push the refund",
+            );
+        }
+        this.unblock(swap);
 
         try {
             const pushed = await this.callbacks.refundArkade(swap);
@@ -959,6 +1046,15 @@ export class RfqSwapManager {
             this.setState(swap, "refunded");
             this.emitAction(swap, "refundArkade");
         } catch (error) {
+            if (error instanceof RefundNotLocallyPossibleError) {
+                // Not a failure to retry: a capability this wallet does not
+                // have. Caught before the retry branch, so it costs one call
+                // rather than a pass-per-poll storm of `onSwapFailed` ending in
+                // `failed` — a label that would claim an action failed when the
+                // truth is that none was ever possible here.
+                this.refundRefused.add(swap.rfqId);
+                return this.block(swap, error.message);
+            }
             // Reported UNWRAPPED, so a caller can tell the failures apart with
             // `instanceof`. That matters most for `LockupNeedsRecoveryError`: a
             // swept lockup cannot be taken back by any offchain spend until it
@@ -979,6 +1075,49 @@ export class RfqSwapManager {
                 this.setState(swap, "failed");
             }
         }
+    }
+
+    /**
+     * L1 progress, which past the refund window must not overwrite a refusal.
+     * The two halves are independent — a claimed fill says nothing about
+     * whether this wallet can take the Arkade lockup back — and `claimed` is
+     * re-asserted from chain on every pass, so without this a blocked swap
+     * would flip between the two states forever. The claim itself always runs;
+     * only the label defers, and only once the refund is the live half.
+     */
+    private setOnchainState(swap: OnchainSendSwap, state: RfqSwapState): void {
+        if (swap.state === "needs_counterparty" && this.config.now() >= swap.refundLocktime) return;
+        this.setState(swap, state);
+    }
+
+    /** The probe's refusal reason, or `undefined` when a local refund is
+     * possible as far as anyone here can tell. A probe that throws is treated
+     * as a refusal: a capability check that cannot answer is not a yes. */
+    private async probeRefusal(swap: RfqSwap): Promise<string | undefined> {
+        const probe = this.callbacks?.canRefundArkade;
+        if (!probe) return undefined;
+        try {
+            const answer = await probe(swap);
+            return answer.ok ? undefined : answer.reason;
+        } catch (error) {
+            return errorMessage(error);
+        }
+    }
+
+    /** Report that no local refund will happen, without ending the swap. */
+    private block(swap: RfqSwap, reason: string): void {
+        if (swap.blockedReason !== reason) {
+            swap.blockedReason = reason;
+            this.touch(swap);
+        }
+        this.setState(swap, "needs_counterparty");
+    }
+
+    /** The way back out, taken as soon as a refund becomes possible again. */
+    private unblock(swap: RfqSwap): void {
+        if (swap.state !== "needs_counterparty") return;
+        delete swap.blockedReason;
+        this.setState(swap, "pending");
     }
 
     private touch(swap: RfqSwap): void {

--- a/packages/swap/test/secrets.test.ts
+++ b/packages/swap/test/secrets.test.ts
@@ -18,6 +18,7 @@ import {
 
 import {
     RFQ_PREIMAGE_TAG,
+    RefundNotLocallyPossibleError,
     adoptSwapDescriptor,
     buildPreimageMessage,
     derivePreimage,
@@ -28,6 +29,7 @@ import {
     rfqSecretsOfRecord,
     rfqSecretsToRecord,
     senderIdentityForRfqSecrets,
+    senderIdentityForSwapRecord,
     senderPubkeyForRfqSecrets,
 } from "../src/secrets";
 import { paymentHashOf } from "../src/onchainHtlc";
@@ -173,6 +175,12 @@ describe("derivation", () => {
             /cannot derive .*; the swap was created on another wallet/,
         );
         await expect(preimageForRfqSecrets(foreign, secrets)).rejects.toThrow(/cannot derive/);
+        // typed at the throw site — and a faithful subclass, so the message
+        // assertions above are unchanged
+        await expect(senderIdentityForRfqSecrets(foreign, secrets)).rejects.toMatchObject({
+            name: "RefundNotLocallyPossibleError",
+            reason: "foreign-descriptor",
+        });
     });
 
     it("refuses a wallet with no HD surface at all for a derivable record", async () => {
@@ -182,6 +190,74 @@ describe("derivation", () => {
         await expect(senderIdentityForRfqSecrets(staticWallet(), secrets)).rejects.toThrow(
             /cannot derive/,
         );
+        await expect(senderIdentityForRfqSecrets(staticWallet(), secrets)).rejects.toBeInstanceOf(
+            RefundNotLocallyPossibleError,
+        );
+    });
+});
+
+describe("senderIdentityForSwapRecord", () => {
+    // The composition `rfqSecretsOfRecord` deliberately does not do. Each cause
+    // reaches a consumer as one catchable type carrying WHICH one it was:
+    // "restore the other wallet" and "this record never had secrets" are
+    // different instructions to a user.
+    const refusal = async (promise: Promise<unknown>) =>
+        promise.catch((error: unknown) => error as RefundNotLocallyPossibleError);
+
+    it("refuses a record that names no arm", async () => {
+        // The cause that is a RETURN VALUE one level down, so a consumer wiring
+        // `senderIdentityForRfqSecrets` would skip it and hit a TypeError at
+        // the push site instead — which the manager would retry for hours.
+        const { wallet } = await hdWallet();
+        const error = await refusal(senderIdentityForSwapRecord(wallet, {}));
+
+        expect(error).toBeInstanceOf(RefundNotLocallyPossibleError);
+        expect(error.reason).toBe("no-secrets");
+        // and the totality it is built on is untouched
+        expect(rfqSecretsOfRecord({})).toBeUndefined();
+    });
+
+    it("refuses a fallback record this version cannot read", async () => {
+        const { wallet } = await hdWallet();
+        const error = await refusal(
+            senderIdentityForSwapRecord(wallet, {
+                fallbackSecrets: {
+                    version: 2,
+                    type: "stored",
+                    senderPrivateKeyHex: "11".repeat(32),
+                } as unknown as AssetSwapFallbackSecrets,
+            }),
+        );
+
+        expect(error).toBeInstanceOf(RefundNotLocallyPossibleError);
+        expect(error.reason).toBe("unreadable-secrets");
+        expect(error.message).toMatch(/unsupported RFQ fallback secrets record/);
+    });
+
+    it("refuses a descriptor from another seed", async () => {
+        const { wallet } = await hdWallet();
+        const record = rfqSecretsToRecord((await deriveSwapSecrets(wallet))!);
+        const error = await refusal(senderIdentityForSwapRecord(staticWallet(), record));
+
+        expect(error).toBeInstanceOf(RefundNotLocallyPossibleError);
+        expect(error.reason).toBe("foreign-descriptor");
+    });
+
+    it("hands back the signer for a record this wallet can derive", async () => {
+        const { wallet } = await hdWallet();
+        const secrets = (await deriveSwapSecrets(wallet))!;
+        const identity = await senderIdentityForSwapRecord(wallet, rfqSecretsToRecord(secrets));
+
+        expect(await identity.xOnlyPublicKey()).toEqual(
+            await senderPubkeyForRfqSecrets(wallet, secrets),
+        );
+    });
+
+    it("hands back the stored key for a fallback record, on any wallet", async () => {
+        const record = rfqSecretsToRecord(randomSwapSecrets({ preimage: true }));
+        const identity = await senderIdentityForSwapRecord(staticWallet(), record);
+
+        expect(await identity.xOnlyPublicKey()).toHaveLength(32);
     });
 });
 

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -41,6 +41,7 @@ import {
     type LockupSpendIndexer,
 } from "../src/refund";
 import { SWAP_LOCKUP_CONTRACT_TYPE } from "../src/lockupContract";
+import { RefundNotLocallyPossibleError } from "../src/secrets";
 import {
     RfqSwapManager,
     isRfqSwapTerminal,
@@ -277,6 +278,7 @@ const spies = (
     over: {
         claim?: () => Promise<{ txid: string }>;
         refund?: () => Promise<ArkadeRefundResult>;
+        probe?: () => Promise<{ ok: true } | { ok: false; reason: string }>;
     } = {},
 ): Spies => {
     const claims: { rfqId: string; utxo: ChainUtxo }[] = [];
@@ -299,6 +301,9 @@ const spies = (
             async saveSwap(swap) {
                 saved.push(swap.state);
             },
+            // optional on the interface: only wired when a test asks for it,
+            // so the unprobed configuration stays the default here too
+            ...(over.probe ? { canRefundArkade: over.probe } : {}),
         },
     };
 };
@@ -948,6 +953,188 @@ describe("RfqSwapManager — the lightning-send leg", () => {
 
         expect(swap.state).toBe("refunded");
         expect(swap.refundArkTxid).toBeUndefined();
+    });
+});
+
+/**
+ * A refund nobody here can push is not a failure and not an ending: the lockup
+ * is still funded, and the solver claiming it is still what resolves the swap.
+ * So the state has to be reported without retrying, without `onSwapFailed`,
+ * and — the item-5 interaction — without unwatching the contract.
+ */
+describe("RfqSwapManager — a refund this wallet cannot make", () => {
+    const cannotSign = () =>
+        new RefundNotLocallyPossibleError(
+            "foreign-descriptor",
+            "this wallet cannot derive tr(xpub…/0/7); the swap was created on another wallet",
+        );
+
+    it("reports it on the first pass, with a reason and no failure event", async () => {
+        const s = spies({
+            refund: async () => {
+                throw cannotSign();
+            },
+        });
+        const failures: string[] = [];
+        const swap = lightningSwap();
+        const m = manager({ now: REFUND_LOCKTIME + 1, spies: s });
+        m.onSwapFailed((_swap, error) => failures.push(error.message));
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/created on another wallet/);
+        // `failure` is for an action that was attempted and did not work
+        expect(swap.failure).toBeUndefined();
+        expect(failures).toEqual([]);
+    });
+
+    it("is not retried, and never becomes `failed`", async () => {
+        // The behaviour this whole state exists for: at the default cadence the
+        // retry branch would burn ~1440 passes against a push that cannot work,
+        // and end on a label claiming an action failed.
+        let now = REFUND_LOCKTIME + 1;
+        const s = spies({
+            refund: async () => {
+                throw cannotSign();
+            },
+        });
+        const swap = lightningSwap();
+        const m = manager({ now: () => now, spies: s });
+        await m.addSwap(swap);
+        await m.poll();
+        now = REFUND_LOCKTIME + REFUND_MTP_LAG_SECONDS + 1;
+        await m.poll();
+        await m.poll();
+
+        expect(s.refunds).toEqual([RFQ_ID]);
+        expect(swap.state).toBe("needs_counterparty");
+        // and it is still monitored: the swap has not ended
+        expect(await m.hasSwap(RFQ_ID)).toBe(true);
+    });
+
+    it("leaves an ordinary refusal on the retry path", async () => {
+        // The narrowness of the new branch. `LockupNeedsRecoveryError` is the
+        // case that must keep retrying: the caller can recover the lockup while
+        // the window is open, after which the next pass simply succeeds.
+        const s = spies({
+            refund: async () => {
+                throw new LockupNeedsRecoveryError(["aa".repeat(32) + ":0"], BigInt(0));
+            },
+        });
+        const swap = lightningSwap();
+        const m = manager({ now: REFUND_LOCKTIME + 1, spies: s });
+        await m.addSwap(swap);
+        await m.poll();
+        await m.poll();
+
+        expect(s.refunds).toEqual([RFQ_ID, RFQ_ID]);
+        expect(swap.state).toBe("pending");
+    });
+
+    it("reports a wallet with nothing wired to act, instead of sitting `pending`", async () => {
+        // The loudest gap, and the one that needs no key material to see: with
+        // `enableAutoActions` off the swap would otherwise stay `pending` past
+        // its window forever — monitored, never acted on, never reported.
+        const s = spies();
+        const swap = lightningSwap();
+        const m = manager({ now: REFUND_LOCKTIME + 1, spies: s, enableAutoActions: false });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(s.refunds).toEqual([]);
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/automatic actions are disabled/);
+    });
+
+    it("keeps the lockup watched", async () => {
+        // The item-5 interaction from the other side: the money is still at the
+        // lockup, so retiring its contract here would unwatch live funds and
+        // lose the solver claim that still ends this swap.
+        const s = spies({
+            refund: async () => {
+                throw cannotSign();
+            },
+        });
+        const contracts = fakeContracts();
+        const swap = lightningSwap({ lockup: LOCKUP_HANDLE });
+        const m = manager({ contracts, now: REFUND_LOCKTIME + 1, spies: s });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(contracts.retired).toEqual([]);
+        expect(contracts.watched()).toEqual([LOCKUP_SCRIPT_HEX]);
+    });
+
+    it("still ends `settled` when the counterparty claims the lockup", async () => {
+        const s = spies({
+            refund: async () => {
+                throw cannotSign();
+            },
+        });
+        const swap = lightningSwap();
+        let claimed = false;
+        const m = manager({
+            indexer: {
+                getVtxos: async () =>
+                    claimed
+                        ? fakeIndexer({ vtxos: spentBy(CLAIM_SPEND.txid) }).getVtxos()
+                        : fakeIndexer({ vtxos: unspent() }).getVtxos(),
+                getVirtualTxs: fakeIndexer({ txs: [CLAIM_SPEND] }).getVirtualTxs,
+            } as unknown as LockupSpendIndexer,
+            now: REFUND_LOCKTIME + 1,
+            spies: s,
+        });
+        await m.addSwap(swap);
+        await m.poll();
+        expect(swap.state).toBe("needs_counterparty");
+
+        claimed = true;
+        await m.poll();
+
+        expect(swap.state).toBe("settled");
+        expect(await m.hasSwap(RFQ_ID)).toBe(false);
+    });
+
+    it("says so before the window opens, when a probe is wired", async () => {
+        // Reportable while the solver can still act, rather than at the
+        // deadline — which is the whole reason the probe exists.
+        const s = spies({
+            probe: async () => ({ ok: false, reason: "the signing wallet is not this one" }),
+        });
+        const swap = lightningSwap();
+        const m = manager({ now: REFUND_LOCKTIME - 3600, spies: s });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toBe("the signing wallet is not this one");
+        expect(s.refunds).toEqual([]);
+    });
+
+    it("goes back to `pending` and refunds once the probe says yes", async () => {
+        // Not a dead end: restoring the wallet that can sign resumes the normal
+        // drive, which is why the probe re-runs on every pass.
+        let ok = false;
+        const s = spies({
+            probe: async () =>
+                ok ? { ok: true } : { ok: false, reason: "the signing wallet is not this one" },
+        });
+        const swap = lightningSwap();
+        const states: RfqSwapState[] = [];
+        const m = manager({ now: REFUND_LOCKTIME + 1, spies: s });
+        m.onSwapUpdate((updated) => states.push(updated.state));
+        await m.addSwap(swap);
+        await m.poll();
+        expect(swap.state).toBe("needs_counterparty");
+
+        ok = true;
+        await m.poll();
+
+        expect(states).toEqual(["needs_counterparty", "pending", "refunded"]);
+        expect(swap.blockedReason).toBeUndefined();
+        expect(s.refunds).toEqual([RFQ_ID]);
     });
 });
 

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -1299,6 +1299,20 @@ describe("RfqSwapManager — bookkeeping", () => {
         expect(await m.hasSwap(RFQ_ID)).toBe(true); // still watching the lockup
     });
 
+    it("resolves for a claimed onchain send the refund refusal has since relabelled", async () => {
+        // The shape a restart loads when the Arkade half was refused after the
+        // window: the L1 payout is done and the txid proves it, so the caller
+        // must not hang waiting for a label that will never come back.
+        const swap = onchainSwap({ state: "needs_counterparty", claimTxid: "dd".repeat(32) });
+        const m = manager({ now: REFUND_LOCKTIME + 1, spies: spies() });
+        await m.addSwap(swap);
+
+        await expect(m.waitForSwapCompletion(RFQ_ID)).resolves.toEqual({
+            state: "needs_counterparty",
+            txid: "dd".repeat(32),
+        });
+    });
+
     it("settles a waiter only once the record has been persisted", async () => {
         // A caller that awaits completion and then reads its own storage must
         // not find the record still saying `pending`.

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -1094,6 +1094,9 @@ describe("RfqSwapManager — a refund this wallet cannot make", () => {
         await m.poll();
 
         expect(swap.state).toBe("settled");
+        // and the refusal's reason goes with it: a settled swap carrying one
+        // reads as still blocked
+        expect(swap.blockedReason).toBeUndefined();
         expect(await m.hasSwap(RFQ_ID)).toBe(false);
     });
 
@@ -1111,6 +1114,77 @@ describe("RfqSwapManager — a refund this wallet cannot make", () => {
         expect(swap.state).toBe("needs_counterparty");
         expect(swap.blockedReason).toBe("the signing wallet is not this one");
         expect(s.refunds).toEqual([]);
+    });
+
+    it("keeps a claimed L1 fill across the refusal, and claims it only once", async () => {
+        // The two halves have different keys: being unable to take the Arkade
+        // lockup back says nothing about the fill the trader already has. The
+        // label defers while blocked — `claimed` is re-read from chain every
+        // pass and would otherwise flip — but `claimTxid` is what carries the
+        // fact, and it is what stops a second broadcast of P.
+        let ok = false;
+        let now = SAFE_NOW;
+        const s = spies({
+            probe: async () => (ok ? { ok: true } : { ok: false, reason: "not this wallet" }),
+        });
+        const swap = onchainSwap();
+        const states: RfqSwapState[] = [];
+        const m = manager({
+            chain: fakeChain({ utxos: [FILL], mtp: SAFE_NOW }),
+            now: () => now,
+            spies: s,
+        });
+        m.onSwapUpdate((updated) => states.push(updated.state));
+        await m.addSwap(swap);
+        await m.poll();
+        // pre-window, the live claim keeps the label
+        expect(swap.state).toBe("claimed");
+
+        now = REFUND_LOCKTIME + 1;
+        await m.poll();
+        await m.poll();
+        expect(swap.state).toBe("needs_counterparty");
+
+        ok = true;
+        await m.poll();
+
+        // back to `claimed`, not `pending` — and the resumed push then refunds
+        expect(states).toEqual([
+            "claimable",
+            "claimed",
+            "needs_counterparty",
+            "claimed",
+            "refunded",
+        ]);
+        expect(swap.claimTxid).toBe("dd".repeat(32));
+        expect(s.claims).toHaveLength(1);
+        expect(swap.blockedReason).toBeUndefined();
+    });
+
+    it("re-attempts a push-reported refusal only when the probe retracts it", async () => {
+        // Without a probe the push is not re-issued; with one, its `ok` is the
+        // single thing that clears the refusal and lets the push run again.
+        let ok = false;
+        const s = spies({
+            probe: async () => (ok ? { ok: true } : { ok: false, reason: "not this wallet" }),
+            refund: async () => {
+                if (!ok) throw cannotSign();
+                return { arkTxid: "ee".repeat(32), amount: 100_000 };
+            },
+        });
+        const swap = lightningSwap();
+        const m = manager({ now: REFUND_LOCKTIME + 1, spies: s });
+        await m.addSwap(swap);
+        // a refusing probe reports before the push is ever tried
+        await m.poll();
+        expect(s.refunds).toEqual([]);
+        expect(swap.state).toBe("needs_counterparty");
+
+        ok = true;
+        await m.poll();
+
+        expect(s.refunds).toEqual([RFQ_ID]);
+        expect(swap.state).toBe("refunded");
     });
 
     it("goes back to `pending` and refunds once the probe says yes", async () => {


### PR DESCRIPTION
Second of the two PRs in `plans/arkade-swap-leftover-5-6.md` (item 6). Independent of
#708 — different files, and its own retirement is `RfqSwapManager.retireContract`, which
is already on this base — so the two can merge in either order. Reviewing #708 first is
still the intended order: it establishes "a state with money behind it stays watched",
which this one has to not violate.

## What

`RfqSwapState` gains `needs_counterparty`, with `blockedReason` beside `failure` on the
record. A swap enters it when no local refund is possible at all:

- `refundArkade` throws the new `RefundNotLocallyPossibleError` — caught *before* the
  retry branch, so it costs one call instead of ~1440 passes of `onSwapFailed` ending in
  `failed`, a label that would claim an action failed when none was ever possible.
- Nothing is wired to act (`enableAutoActions: false`, or no callbacks) and the window
  has passed. This is the loudest gap and needs no key material to see: the swap used to
  sit `pending` forever — monitored, never acted on, never reported.
- The new optional `canRefundArkade` probe refuses. It runs every pass, including before
  the window opens, so a swap nobody can refund says so while the solver can still act.

**Not terminal, and not a dead end.** `RFQ_SWAP_TERMINAL_STATES` is unchanged, so the
lockup contract stays watched and a later solver claim still arrives as `settled`; the
probe answering `ok` returns the swap to `pending` and resumes the normal drive.

## Composing the three causes

The causes reached callers in three shapes — an `undefined` return, two plain throws —
across two functions, with nothing composing record → identity. Added
`senderIdentityForSwapRecord(wallet, record)`, which `refundArkade` should wire to:

- `no-secrets` (the `undefined`, which a lower-level wiring would skip — it becomes a
  `TypeError` at the push site, which the manager would then treat as retryable)
- `unreadable-secrets`
- `foreign-descriptor` — now thrown typed by `senderIdentityForRfqSecrets` itself, at the
  site that discovers it.

`rfqSecretsOfRecord` keeps its documented totality: it is called while iterating swap
history, where a throw on one record aborts the loop. Its `undefined`-return tests are
unmodified, and so are the two `rejects.toThrow(/…/)` message assertions the typed error
now satisfies as a subclass.

## Two interactions worth a look in review

- A refusal the *push* reported is not re-issued every pass (`refundRefused`) — it cannot
  start working on its own, and re-issuing it is the grind this state removes. Only the
  probe retracts it; without a probe the swap learns again on the next process start,
  when the wallet that can sign may have been restored.
- The L1 half is a different key: before the window an onchain-send swap's live claim
  keeps the label; after it the refusal wins, and `setOnchainState` stops the
  re-asserted-from-chain `claimed` from flipping a blocked swap every pass. The claim
  itself always runs.

## Tests

`test/swapManager.test.ts` (8 new, incl. the item-5 interaction asserted from this side:
`setContractWatchState` is never called for a blocked swap) and `test/secrets.test.ts`
(one per cause, asserting the error *and* its `reason`). Mutation-checked: adding
`needs_counterparty` to the terminal set, and removing the typed-error branch, each fail
4 tests.

- `pnpm -r test:unit` — green (swap: 292).
- No e2e: a filled RFQ swap needs a solver counterparty, which is the standing coverage
  gap for this corridor. The unit tests are the coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Swaps that cannot currently be refunded locally now show a `needs_counterparty` status with a clear blocking reason.
  - Refund capability is rechecked automatically, allowing swaps to return to normal processing when recovery becomes possible.
  - Monitoring and on-chain claim tracking continue while a refund is blocked.

- **Bug Fixes**
  - Prevented repeated failed refund attempts and misleading terminal failures when automatic refunds are unavailable.
  - Improved handling of missing, unreadable, or unsupported refund information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->