### PR TITLE
docs(swap): name the roles user and solver, not maker and taker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ TypeScript packages for the Arkade Bitcoin wallet ecosystem — on-chain/off-cha
 |---------|-------------|
 | [`@arkade-os/sdk`](packages/ts-sdk/) | Bitcoin wallet SDK with Taproot and Ark protocol support |
 | [`@arkade-os/boltz-swap`](packages/boltz-swap/) | Lightning and chain swaps using Boltz |
-| [`@arkade-os/swap`](packages/swap/) | Offer-maker side Arkade Intents atomic swaps: market discovery, offers, restore |
+| [`@arkade-os/swap`](packages/swap/) | Client-side Arkade Intents asset swaps: market discovery, offers, restore |
 | [Regtest stack](regtest/) | Shared regtest environment ([arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest) submodule) |
 
 ## Prerequisites

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -1,34 +1,38 @@
 # @arkade-os/swap
 
-Offer-maker side [Arkade Intents](https://arkade.money) atomic swaps: discover markets, quote and
+Client-side [Arkade Intents](https://arkade.money) asset swaps: discover markets, quote and
 validate, create offers, track them, cancel them, and rebuild the whole record set from chain after
 a wallet restore. Framework-free TypeScript over `@arkade-os/sdk`: the core API and
 `InMemoryAssetSwapRepository` use no DOM and no Node-specific APIs, so they run in Node, the
 browser, and React Native alike. `IndexedDbAssetSwapRepository` is the one exception — it needs a
 platform-provided or polyfilled IndexedDB.
 
-## Roles: maker and taker
+## Roles
 
-Arkade Intents names its roles after the **offer**, not the quote:
+Arkade Intents names two participants:
 
-- **maker** — creates the offer and funds the swap address. That is the consumer of this package:
-  it prices a swap against the registry's markets, deposits one side, and waits.
-- **taker** — the solver that fills the offer, delivering `wantAmount` to the maker's script over
-  the covenant's `fulfill` path. Same sense the solver registry and
-  [`@arkade-os/solver-discovery`](https://www.npmjs.com/package/@arkade-os/solver-discovery) use.
+- **user** — states an intent and, through a wallet or application, approves and funds it. That is
+  the consumer of this package: it prices a swap against the registry's markets, funds the derived
+  contract, and tracks it to a fill or a cancellation.
+- **solver** — supplies inventory and pricing, and fills the funded contract by delivering
+  `wantAmount` to the user's script over the covenant's `fulfill` path. Some specifications and
+  repositories use *provider* or *market maker* as synonyms.
 
-**This inverts generic RFQ vocabulary, so watch out for the collision.** In RFQ systems the side
-that *requests* a quote is conventionally the taker and the side that *answers* with a price is the
-maker — which makes "maker-side" elsewhere mean the liquidity provider, the exact opposite of what
-it means here. This package is the quote-requesting side, and it is called the **maker** side for
-that reason; nothing in it is an "RFQ taker layer". Throughout this package — its docs, its types,
-its comments — `taker` always means the solver that fills, never the party asking for a price.
+**`maker` and `taker` in this package name contract positions, not product roles.** The covenant
+programs bind `makerWP`, and the `Offer` type carries `makerPkScript` and `makerPublicKey`; those
+identify the side that funds the swap and receives `wantAmount`. Read them as script field names.
+
+Arkade Intents documentation deliberately avoids maker and taker for the participants themselves.
+A resting maker order is firm once taken, and nothing here is: the user funds first, and if no
+solver fills, the deposit comes back through `cancelOffer` rather than through an executed trade.
+Naming the sides *user* and *solver* says who does what without borrowing a guarantee the contract
+does not make.
 
 ## The four layers
 
 1. **`offer`** — the swap covenant itself. Two program JSONs (want-BTC / want-asset), the
    `Offer` type, the TLV wire codec (`encodeOffer`/`decodeOffer`, `OFFER_PACKET_TYPE`), address
-   derivation (`offerVtxoScript`), and the maker operations `createOffer`/`cancelOffer`. Identical
+   derivation (`offerVtxoScript`), and the user-side operations `createOffer`/`cancelOffer`. Identical
    offers always derive identical swap addresses — the program JSONs are hashed into the address,
    so their bytes are frozen (guarded by a golden test).
 2. **`markets`** — solver discovery and pricing guardrails: `discoverMarkets` (1-hour cached

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -2,7 +2,7 @@
     "name": "@arkade-os/swap",
     "version": "0.0.1",
     "type": "module",
-    "description": "Arkade Intents offer-maker side atomic swaps: discover markets, quote, create/track/cancel offers, restore from chain.",
+    "description": "Client-side Arkade Intents asset swaps: discover markets, quote, create/track/cancel offers, restore from chain.",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/swap/src/markets.ts
+++ b/packages/swap/src/markets.ts
@@ -1,12 +1,11 @@
 /**
  * Quoting: solver discovery and the pricing guardrails around a plan.
  *
- * This is the maker's quote-requesting side — the layer that asks what a swap
- * would cost before `offer` commits to it. Generic RFQ vocabulary calls the
- * quote-requesting role the *taker*; Arkade Intents names roles after the
- * offer, so here that role is the **maker**, and `taker` (in this package and
- * in the solver registry) always means the solver that fills. Nothing in this
- * file is a "taker layer" in the RFQ sense — see the README's Roles section.
+ * The user side of a swap — the layer that works out what one would cost
+ * before `offer` commits to it. Prices come from the market's own feed, not
+ * from a solver quote over a relay, so nothing here is signed and no solver
+ * has reserved anything. See the README's Roles section for why this package
+ * says user and solver rather than maker and taker.
  */
 import {
     bestMarket,

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -1,11 +1,10 @@
 /**
  * Arkade Intents — an atomic-swap covenant on Arkade.
  *
- * Roles follow the offer, not the quote: the **maker** creates and funds the
- * offer (this package's consumer), the **taker** is the solver that fills it
- * through `fulfill`. Generic RFQ vocabulary inverts that — there the
- * quote-requesting side is the "taker" — so read every `taker` here, and in
- * the solver registry, as the filling solver.
+ * The user funds this contract; a solver fills it through `fulfill`. The
+ * `maker*` fields below (`makerWP`, `makerPkScript`, `makerPublicKey`) name
+ * the funding side's position in the script, not a product role — see the
+ * README's Roles section.
  *
  * The contracts are the two JSON files, one per WANT side:
  *   swap-want-asset.program.json  the fill must deliver an asset


### PR DESCRIPTION
Reverses the terminology #693 introduced. Same five files, docs only.

## Why

#693 pinned maker and taker as the Arkade Intents role vocabulary, on the premise that *"Arkade Intents names its roles after the offer, not the quote."* That premise no longer holds. Intents is a request-for-quote system on every route — the quote **is** the thing — so naming roles after the offer inverts the model rather than clarifying it.

The deeper problem is that the pair claims a guarantee the contract does not make. A resting maker order is firm once taken. Nothing here is: the user funds first, and if no solver fills, the deposit comes back through `cancelOffer` rather than through an executed trade. Calling the funding side the *maker* imports firmness that never existed, which is exactly the confusion #693 set out to prevent — just one level up.

Rather than explain a collision between two inverted senses, the docs now name the participants directly:

- **user** — states an intent and, through a wallet or application, approves and funds it. The consumer of this package.
- **solver** — supplies inventory and pricing, and fills the funded contract through the covenant's `fulfill` path.

This matches the Arkade Intents documentation, which drops maker/taker for participants for the same reason.

## What stays

`maker` still names **contract positions**, and every one of them is untouched: `makerWP` in the covenant programs, `makerPkScript` and `makerPublicKey` on the `Offer` type. The README now says so explicitly, so a reader meeting those fields knows they are script field names rather than a competing role vocabulary — the ambiguity #693 was right to worry about, resolved by scoping the words to the script instead of promoting them to the product.

## Scope

No behavior, API, or type changes. Every edit is inside a comment block, a README, or the package description:

| File | Change |
|---|---|
| `README.md` | Monorepo table blurb |
| `packages/swap/README.md` | Blurb, and the Roles section rewritten |
| `packages/swap/package.json` | `description` |
| `packages/swap/src/markets.ts` | File header comment |
| `packages/swap/src/offer.ts` | File header comment |

Verified mechanically: no non-comment line in either `.ts` file differs, and `package.json` still parses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyyk1wuSFmcVXYz2aLeJqx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the swap package supports client-side asset swaps and user-side quoting.
  * Updated terminology to distinguish users, solvers, and covenant contract positions.
  * Documented funding responsibilities, unsigned quotes, market-feed pricing, and offer operations more clearly.
  * Updated package descriptions across the README and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->