### PR TITLE
docs(swap): finish the role rename, and say where the price comes from

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -28,6 +28,10 @@ solver fills, the deposit comes back through `cancelOffer` rather than through a
 Naming the sides *user* and *solver* says who does what without borrowing a guarantee the contract
 does not make.
 
+This route does not negotiate over a relay. `quoteOffer` prices a swap from the market card's
+own price feed, so the terms you show are indicative: nothing is signed, and no solver has
+reserved inventory or promised a fill until one lands on the funded contract.
+
 ## The four layers
 
 1. **`offer`** — the swap covenant itself. Two program JSONs (want-BTC / want-asset), the
@@ -87,27 +91,27 @@ deposit lands at `address`.
 | `offerHex`     | The encoded offer. **Persist this** — it is the only input `cancelOffer` needs to rebuild the covenant.                                        |
 | `swapPkScript` | The covenant's scriptPubKey: the key an indexer watches to spot the deposit and its later spend.                                               |
 
-The minimum a maker must keep to stay in control of a swap is `offerHex` plus the funding txid.
+The minimum you must keep to stay in control of a swap is `offerHex` plus the funding txid.
 Everything else — status, amounts, timestamps — `restoreAssetSwaps` rebuilds from chain, and the
 offer bytes themselves are recoverable from the funding tx if the record is lost.
 
-## Cancelling an offer no taker filled
+## Cancelling an offer no solver filled
 
 ```ts
 const txid = await cancelOffer(wallet, ARK, swap.offerHex, swap.fundingTxid, swap.swapAddress);
 ```
 
-**An unfilled offer never expires.** Neither program carries a timelock, so a deposit no taker
-picked up sits at the swap address indefinitely — nothing reclaims it for the maker, and there is
-no "expired" state to wait for. Cancelling is the only way out, and the maker has to ask.
+**An unfilled offer never expires.** Neither program carries a timelock, so a deposit no solver
+picked up sits at the swap address indefinitely — nothing reclaims it for you, and there is no
+"expired" state to wait for. Cancelling is the only way out, and you have to ask.
 
 The two ways out of the covenant are deliberately asymmetric:
 
 - **`fulfill`** is signed by the **server alone**, but the covenant constrains it to pay output 0
-  to the maker's script for at least `wantAmount`. A taker cannot take the deposit without
+  to your payout script for at least `wantAmount`. A solver cannot take the deposit without
   delivering the other side.
-- **`cancel`** is a **2-of-2 of the maker and the server**. Cancelling is cooperative, not a
-  unilateral withdrawal.
+- **`cancel`** is a **2-of-2 of you and the server**. Cancelling is cooperative, not a unilateral
+  withdrawal.
 
 So cancel *races* a fill rather than pre-empting it. If the solver fills in the same moment,
 `cancelOffer` throws `no spendable VTXO at the swap address` — that means the swap **completed**,


### PR DESCRIPTION
Follow-up to #710, which I did not finish. README only.

## The rename was half-applied

#710 replaced the Roles section and both file headers, but left the README body using maker and taker as role words:

- a heading, *"Cancelling an offer no taker filled"*
- *"The minimum a **maker** must keep to stay in control of a swap"*
- *"a deposit no **taker** picked up… nothing reclaims it for the **maker**"*
- *"`cancel` is a 2-of-2 of the **maker** and the server"*

So the README asserted the words name contract positions while still using them for people, two sections apart. The body now says **you** and **solver**, and the Roles section stands as the one place explaining the covenant's `maker*` field names.

One judgement call: *"pay output 0 to the maker's script"* became *"to your payout script"*. That one genuinely refers to `makerWP`, but the sentence is describing behaviour rather than naming a field, so the role reading is the one that matters there.

## Where the price comes from

The README says the package can *"quote and validate"*, which reads like a solver quoted you — a fair assumption for anyone arriving from the RFQ corridors, and wrong here. Added one paragraph:

> This route does not negotiate over a relay. `quoteOffer` prices a swap from the market card's own price feed, so the terms you show are indicative: nothing is signed, and no solver has reserved inventory or promised a fill until one lands on the funded contract.

This is the distinction the Arkade Intents docs now lean on to explain why the intra-Arkade route behaves differently from Lightning and onchain.

## Scope

`packages/swap/README.md` only — 12 insertions, 8 deletions. No source, config, or exported API touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyyk1wuSFmcVXYz2aLeJqx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that quote terms are indicative and non-binding.
  * Documented that relay negotiation, solver reservation, and fill are not guaranteed before funding.
  * Updated offer and cancellation guidance with user/solver terminology.
  * Added clearer explanations of custody, fulfillment, and cancellation responsibilities.
  * Identified `offerHex` and the funding transaction ID as the minimum information needed to retain swap control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->