### PR TITLE
feat(swap): client-side claim for the receive corridors

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -308,7 +308,9 @@ senderPrivateKeyHex, preimageHex? }`.
 BOTH contracts locally (the role-inverted VHTLC, and the L1 HTLC for the onchain leg) → verify
 against the quote's compare-only addresses → gate. `requestLightningReceive` returns the solver's
 hold invoice to pay; `requestOnchainReceive` returns the L1 HTLC to fund — the payment/broadcast
-itself is the trader's own wallet's job, exactly as on the send corridors. Until covclaimd's
+itself is the trader's own wallet's job, exactly as on the send corridors. The trader-side
+completion lands in `claim.ts`: `claimReceiveLockup` waits for the solver's funding and pushes the
+collaborative claim with the swap's own `P` and receiver key (covclaimd optional). Until covclaimd's
 reference vectors are cross-checked, the `sealClaimPacket` test vector is pinned from this
 implementation and marked provisional (`TODO(claim-packet-vectors)`).
 

--- a/packages/swap/src/claim.ts
+++ b/packages/swap/src/claim.ts
@@ -1,0 +1,227 @@
+/**
+ * The receive corridors' completion: the trader claims the solver-funded
+ * lockup with its own preimage.
+ *
+ * On `lightning:BTC->arkade:BTC` and `onchain:BTC->arkade:BTC` the solver
+ * funds the Arkade lockup and the trader is the covenant's `receiver` — it
+ * generated `P`, and the collaborative claim leaf (`preimage-condition +
+ * receiver + Arkade server`) is spendable by the trader the moment the
+ * lockup lands, with no covclaimd in the loop. This module is that spend:
+ * `pushRefundWithoutReceiver`'s mirror, with two differences worth stating:
+ *
+ * - The claim leaf carries a **preimage condition**, so the preimage rides
+ *   the PSBT's `ConditionWitness` field — attached AFTER signing, on the ark
+ *   transaction and every checkpoint (the condition is not part of the
+ *   signed payload; attaching it first invalidates the signature the server
+ *   then rejects as `INVALID_SIGNATURE`).
+ * - The leaf is NOT covenant-pinned, so one aggregate output pays the whole
+ *   balance wherever the trader says — the `nonInteractiveClaim` pin is the
+ *   offline path's, not this one's. The destination is therefore a required
+ *   parameter, and the honest default is the swap's own payout address.
+ *
+ * covclaimd stays useful (it claims for an offline trader via
+ * `nonInteractiveClaim`), but with the receiver key derivable from the swap's
+ * `secrets` (`senderIdentityForRfqSecrets`), a trader that is online never
+ * depends on it.
+ */
+import { base64, hex } from "@scure/base";
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+    CSVMultisigTapscript,
+    ConditionWitness,
+    type Identity,
+    Transaction,
+    type VHTLC,
+    assertSubmittedArkTxid,
+    buildOffchainTx,
+    matchServerCheckpoints,
+    setArkPsbtField,
+} from "@arkade-os/sdk";
+
+import {
+    LockupNeedsRecoveryError,
+    findLockupVtxos,
+    type LockupVtxo,
+    type RefundArkProvider,
+    type RefundIndexer,
+} from "./refund";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** The Ark surface the claim push needs — the same seam the refund push uses. */
+export type ClaimArkProvider = RefundArkProvider;
+
+/**
+ * A signer that reveals a preimage when spending a condition leaf.
+ *
+ * The ordering encoded here is the whole point: the condition witness is NOT
+ * part of what is signed, so attaching it before signing leaves a signature
+ * over a PSBT that no longer matches once the field is present. Decorate per
+ * claim, never wallet-wide.
+ */
+const claimIdentity = (identity: Identity, preimage: Uint8Array): Identity => ({
+    ...identity,
+    sign: async (tx: Transaction, inputIndexes?: number[]): Promise<Transaction> => {
+        // Clone-and-round-trip so the caller's transaction is never mutated
+        // and the signed result is a fresh object we can add a field to.
+        const signed = Transaction.fromPSBT(
+            (await identity.sign(tx.clone(), inputIndexes)).toPSBT(),
+        );
+        const indexes = inputIndexes ?? Array.from({ length: signed.inputsLength }, (_, i) => i);
+        for (const index of indexes) {
+            setArkPsbtField(signed, index, ConditionWitness, [preimage]);
+        }
+        return signed;
+    },
+});
+
+/**
+ * Build, sign, and push the collaborative claim of a receive-corridor lockup:
+ * move every funded output at the lockup to the trader's own destination,
+ * revealing `P` in the witness — which is also what settles the trader's side
+ * of the swap (the solver reads `P` off the public claim).
+ *
+ * The preimage is checked against the script's committed hash BEFORE anything
+ * is signed: a wrong value can never open the leaf, and catching it here
+ * beats learning it from the server's rejection.
+ *
+ * Swept outputs are refused, not attempted, exactly as in
+ * {@link pushRefundWithoutReceiver} — one aggregate transaction means a
+ * single non-live input would take the live ones down with it.
+ */
+export async function pushClaim(
+    ark: ClaimArkProvider,
+    input: {
+        /** The receive-direction covenant (see `receiveVtxoScript`). */
+        script: InstanceType<typeof VHTLC.ScriptV2>;
+        /** The trader's `receiver` signer. Build it from the swap's `secrets`
+         * with `senderIdentityForRfqSecrets` — on an HD wallet that resolves
+         * from the seed, with no stored key bytes anywhere. */
+        receiver: Identity;
+        /** `P`, 32 bytes — the trader generated it at request time. */
+        preimage: Uint8Array;
+        vtxos: readonly LockupVtxo[];
+        /** Where the claimed sats land — the swap's payout address, decoded. */
+        destinationPkScript: Uint8Array;
+    },
+): Promise<{ arkTxid: string; amount: number }> {
+    if (input.vtxos.length === 0) throw new Error("nothing to claim: no funded outputs");
+
+    const swept = input.vtxos.filter((vtxo) => vtxo.recoverable);
+    if (swept.length > 0) {
+        throw new LockupNeedsRecoveryError(
+            swept.map((vtxo) => `${vtxo.txid}:${vtxo.vout}`),
+            input.script.options.refundLocktime,
+        );
+    }
+
+    const committed = input.script.options.preimageHash;
+    if (hex.encode(ripemd160(sha256(input.preimage))) !== hex.encode(committed)) {
+        throw new Error("preimage does not match the covenant's payment hash");
+    }
+
+    const info = await ark.getInfo();
+    let serverUnrollScript: CSVMultisigTapscript.Type;
+    try {
+        serverUnrollScript = CSVMultisigTapscript.decode(hex.decode(info.checkpointTapscript));
+    } catch {
+        throw new Error("invalid checkpointTapscript from the Arkade server");
+    }
+
+    const leaf = input.script.claim();
+    const tapTree = input.script.encode();
+    const amount = input.vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
+    const signer = claimIdentity(input.receiver, input.preimage);
+
+    const { arkTx, checkpoints } = buildOffchainTx(
+        input.vtxos.map((vtxo) => ({
+            txid: vtxo.txid,
+            vout: vtxo.vout,
+            value: vtxo.value,
+            tapLeafScript: leaf,
+            tapTree,
+        })),
+        // One aggregate output: unlike the covenant refund, this leaf inspects
+        // nothing about the output set.
+        [{ script: input.destinationPkScript, amount: BigInt(amount) }],
+        serverUnrollScript,
+    );
+
+    // No index list: every input spends the same claim leaf, so all are
+    // signed — and the claim identity attaches `P` after signing.
+    const signedArkTx = await signer.sign(arkTx);
+    const submitted = await ark.submitTx(
+        base64.encode(signedArkTx.toPSBT()),
+        checkpoints.map((c) => base64.encode(c.toPSBT())),
+    );
+    assertSubmittedArkTxid(submitted, signedArkTx, "claim");
+
+    // Only checkpoints we built ourselves get signed — the server's response
+    // is matched against the local set first — and the preimage rides the
+    // checkpoint signatures exactly as it rides the ark transaction's.
+    const matched = matchServerCheckpoints(submitted.signedCheckpointTxs, checkpoints, "claim");
+    const finalCheckpoints = await Promise.all(
+        matched.map(async ({ server }) => base64.encode((await signer.sign(server, [0])).toPSBT())),
+    );
+
+    await ark.finalizeTx(submitted.arkTxid, finalCheckpoints);
+    return { arkTxid: submitted.arkTxid, amount };
+}
+
+/**
+ * Wait for the solver-funded lockup to appear at the covenant script.
+ *
+ * Same conventions as `awaitRfqResolution`: a `pollMs` interval, an optional
+ * unix-seconds `deadline`, and a thrown error carrying a stable `reason` when
+ * the deadline passes.
+ */
+export async function awaitLockupFunding(
+    indexer: RefundIndexer,
+    swapPkScript: Uint8Array,
+    options: { pollMs?: number; deadline?: number } = {},
+): Promise<readonly LockupVtxo[]> {
+    const pollMs = options.pollMs ?? 5_000;
+    for (;;) {
+        const vtxos = await findLockupVtxos(indexer, swapPkScript);
+        if (vtxos.length > 0) return vtxos;
+        if (options.deadline !== undefined && Date.now() / 1000 >= options.deadline) {
+            const error = new Error("the lockup never appeared at the covenant script") as Error & {
+                reason: string;
+            };
+            error.reason = "lockup_timeout";
+            throw error;
+        }
+        await sleep(pollMs);
+    }
+}
+
+/**
+ * The one-call composition: wait for the solver's funding, then push the
+ * claim. The polling deadline gates the WAIT only — once the lockup is
+ * funded, the claim itself is gated by nothing but the solver's own refund
+ * deadline (`refund_locktime` from the quote), which is the number the
+ * caller's deadline should be measured against.
+ */
+export async function claimReceiveLockup(
+    indexer: RefundIndexer,
+    ark: ClaimArkProvider,
+    input: Parameters<typeof pushClaim>[1] & {
+        /** The covenant's scriptPubKey, from the request flow's `swapPkScript`. */
+        swapPkScript: Uint8Array;
+        pollMs?: number;
+        deadline?: number;
+    },
+): Promise<{ arkTxid: string; amount: number }> {
+    const vtxos = await awaitLockupFunding(indexer, input.swapPkScript, {
+        pollMs: input.pollMs,
+        deadline: input.deadline,
+    });
+    return pushClaim(ark, {
+        script: input.script,
+        receiver: input.receiver,
+        preimage: input.preimage,
+        vtxos,
+        destinationPkScript: input.destinationPkScript,
+    });
+}

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -119,6 +119,7 @@ export {
     requestOnchainSend,
 } from "./rfq";
 export { sealClaimPacket, type ClaimPacketInput, type SealedClaimPacket } from "./claimPacket";
+export { awaitLockupFunding, claimReceiveLockup, pushClaim, type ClaimArkProvider } from "./claim";
 export {
     RFQ_PREIMAGE_TAG,
     adoptSwapDescriptor,

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -1277,8 +1277,9 @@ export function deriveLightningReceive(input: {
  * payment itself is the trader's own Lightning wallet's job, exactly as
  * funding is the caller's job on the send corridors. Once the paid HTLC is
  * held, the solver funds the lockup; the trader claims it with `P` (its own,
- * generated here) — itself via the collaborative claim leaf, or via covclaimd
- * if it is offline.
+ * generated here) — itself via the collaborative claim leaf
+ * ({@link claimReceiveLockup} in `claim.ts`), or via covclaimd if it is
+ * offline.
  *
  * The same obligations as {@link requestOnchainSend}: persist `secrets`
  * BEFORE paying — the preimage and the payout key re-derive from it (or, on a

--- a/packages/swap/test/claim.test.ts
+++ b/packages/swap/test/claim.test.ts
@@ -1,0 +1,241 @@
+/**
+ * The receive-corridor claim: the trader spends the solver-funded lockup with
+ * its own preimage and receiver key.
+ *
+ * The assertions that matter: the spend really uses the `claim` leaf (not
+ * some other leaf that happens to be spendable), the preimage is attached
+ * AFTER signing on both the ark transaction and every checkpoint (the order
+ * the server enforces), and a preimage that does not open the script is
+ * caught before anything is signed.
+ */
+import { describe, expect, it } from "vitest";
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+    CSVMultisigTapscript,
+    ConditionWitness,
+    SingleKey,
+    Transaction,
+    getArkPsbtFields,
+} from "@arkade-os/sdk";
+
+import { receiveVtxoScript } from "../src/rfq";
+import {
+    awaitLockupFunding,
+    claimReceiveLockup,
+    pushClaim,
+    type ClaimArkProvider,
+} from "../src/claim";
+import { LockupNeedsRecoveryError, type LockupVtxo, type RefundIndexer } from "../src/refund";
+
+const priv = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+const key = (fill: number): Uint8Array => schnorr.getPublicKey(priv(fill));
+const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+
+const PREIMAGE = new Uint8Array(32).fill(7);
+const REFUND_LOCKTIME = 1_800_000_000;
+/** The trader's receiver key as the signer the claim path takes. */
+const RECEIVER = SingleKey.fromPrivateKey(priv(13));
+const DESTINATION_PK_SCRIPT = p2tr(key(21));
+
+/** The same role-inverted participant set rfqReceive.test.ts pins against the
+ * reference solver: solver = key(1) (VHTLC sender), trader = key(13)
+ * (receiver), server = key(3), emulator = key(9). */
+const swapScript = () =>
+    receiveVtxoScript({
+        solverPubkey: key(1),
+        refundLocktime: REFUND_LOCKTIME,
+        serverPubkey: key(3),
+        paymentHash: hex.encode(sha256(PREIMAGE)),
+        claimDelay: 4096,
+        emulatorPubkey: key(9),
+        solverRefundPkScript: p2tr(key(8)),
+        payoutPubkey: key(13),
+        payoutPkScript: p2tr(key(5)),
+    });
+
+const CHECKPOINT_TAPSCRIPT = hex.encode(
+    CSVMultisigTapscript.encode({
+        timelock: { type: "blocks", value: BigInt(144) },
+        pubkeys: [key(3)],
+    }).script,
+);
+
+const VTXOS: LockupVtxo[] = [
+    { txid: "11".repeat(32), vout: 0, value: 60_000, recoverable: false },
+    { txid: "22".repeat(32), vout: 1, value: 40_000, recoverable: false },
+];
+
+/** A scripted arkd, same contract as refund.test.ts's. */
+type FakeArk = ClaimArkProvider & {
+    submitted: { arkTx: string; checkpoints: string[] }[];
+    finalized: { arkTxid: string; checkpoints: string[] }[];
+};
+
+const fakeArk = (over: { checkpointsFor?: (submitted: string[]) => string[] } = {}): FakeArk => {
+    const submitted: { arkTx: string; checkpoints: string[] }[] = [];
+    const finalized: { arkTxid: string; checkpoints: string[] }[] = [];
+    return {
+        submitted,
+        finalized,
+        getInfo: async () => ({ checkpointTapscript: CHECKPOINT_TAPSCRIPT }),
+        submitTx: async (arkTx: string, checkpoints: string[]) => {
+            submitted.push({ arkTx, checkpoints });
+            return {
+                arkTxid: Transaction.fromPSBT(base64.decode(arkTx)).id,
+                finalArkTx: arkTx,
+                signedCheckpointTxs: over.checkpointsFor
+                    ? over.checkpointsFor(checkpoints)
+                    : checkpoints,
+            };
+        },
+        finalizeTx: async (arkTxid: string, checkpoints: string[]) => {
+            finalized.push({ arkTxid, checkpoints });
+        },
+    } as unknown as FakeArk;
+};
+
+/** The leaf script the ark tx's single input actually spends. */
+const spentLeafOf = (psbt: string): string => {
+    const tx = Transaction.fromPSBT(base64.decode(psbt));
+    const leaf = tx.getInput(0).tapLeafScript![0][1];
+    return hex.encode(leaf.subarray(0, -1));
+};
+
+describe("pushClaim", () => {
+    it("spends the claim leaf, signed by the trader's receiver key, preimage attached", async () => {
+        const script = swapScript();
+        const ark = fakeArk();
+        const result = await pushClaim(ark, {
+            script,
+            receiver: RECEIVER,
+            preimage: PREIMAGE,
+            vtxos: VTXOS,
+            destinationPkScript: DESTINATION_PK_SCRIPT,
+        });
+
+        expect(ark.submitted).toHaveLength(1);
+        // The exact leaf bytes, control block stripped — the claim leaf and no
+        // other.
+        expect(spentLeafOf(ark.submitted[0]!.arkTx)).toBe(script.claimScript);
+        // One aggregate output to the trader's destination, for the full amount.
+        const arkTx = Transaction.fromPSBT(base64.decode(ark.submitted[0]!.arkTx));
+        expect(arkTx.outputsLength).toBeGreaterThan(0);
+        expect(hex.encode(arkTx.getOutput(0)!.script!)).toBe(hex.encode(DESTINATION_PK_SCRIPT));
+        expect(arkTx.getOutput(0)!.amount).toBe(BigInt(100_000));
+        expect(result.amount).toBe(100_000);
+        // The preimage rides the condition-witness field on the ark
+        // transaction, attached after signing…
+        const conditionFields = getArkPsbtFields(arkTx, 0, ConditionWitness);
+        expect(conditionFields).toHaveLength(1);
+        expect(hex.encode(conditionFields[0]![0]!)).toBe(hex.encode(PREIMAGE));
+        // …and finalize got the checkpoints back signed.
+        expect(ark.finalized).toHaveLength(1);
+        expect(ark.finalized[0]!.arkTxid).toBe(result.arkTxid);
+    });
+
+    it("attaches the preimage only after signing — the server's INVALID_SIGNATURE ordering", async () => {
+        // A signer that records whether the ConditionWitness field was already
+        // present AT SIGN TIME: it must not be, or the signature covers a
+        // different payload than the one submitted.
+        const script = swapScript();
+        let fieldPresentAtSignTime = false;
+        const probe = {
+            ...RECEIVER,
+            sign: async (tx: InstanceType<typeof Transaction>, inputIndexes?: number[]) => {
+                const indexes =
+                    inputIndexes ?? Array.from({ length: tx.inputsLength }, (_, i) => i);
+                for (const index of indexes) {
+                    fieldPresentAtSignTime ||=
+                        getArkPsbtFields(tx, index, ConditionWitness).length > 0;
+                }
+                return RECEIVER.sign(tx, inputIndexes);
+            },
+        };
+        await pushClaim(fakeArk(), {
+            script,
+            receiver: probe,
+            preimage: PREIMAGE,
+            vtxos: VTXOS,
+            destinationPkScript: DESTINATION_PK_SCRIPT,
+        });
+        expect(fieldPresentAtSignTime).toBe(false);
+    });
+
+    it("refuses a preimage that cannot open the script, before signing anything", async () => {
+        const ark = fakeArk();
+        await expect(
+            pushClaim(ark, {
+                script: swapScript(),
+                receiver: RECEIVER,
+                preimage: new Uint8Array(32).fill(8),
+                vtxos: VTXOS,
+                destinationPkScript: DESTINATION_PK_SCRIPT,
+            }),
+        ).rejects.toThrow(/does not match/);
+        expect(ark.submitted).toHaveLength(0);
+    });
+
+    it("refuses a swept output rather than submitting a spend that cannot succeed", async () => {
+        await expect(
+            pushClaim(fakeArk(), {
+                script: swapScript(),
+                receiver: RECEIVER,
+                preimage: PREIMAGE,
+                vtxos: [{ txid: "33".repeat(32), vout: 0, value: 5_000, recoverable: true }],
+                destinationPkScript: DESTINATION_PK_SCRIPT,
+            }),
+        ).rejects.toThrow(LockupNeedsRecoveryError);
+    });
+
+    it("throws on nothing to claim", async () => {
+        await expect(
+            pushClaim(fakeArk(), {
+                script: swapScript(),
+                receiver: RECEIVER,
+                preimage: PREIMAGE,
+                vtxos: [],
+                destinationPkScript: DESTINATION_PK_SCRIPT,
+            }),
+        ).rejects.toThrow(/nothing to claim/);
+    });
+});
+
+describe("awaitLockupFunding + claimReceiveLockup", () => {
+    const indexerOver = (rounds: LockupVtxo[][]): RefundIndexer => {
+        let calls = 0;
+        return {
+            getVtxos: async (opts?: { spendableOnly?: boolean; recoverableOnly?: boolean }) => {
+                // The real findLockupVtxos asks both filters; only the
+                // spendable answer carries the live lockup.
+                if (opts?.recoverableOnly) return { vtxos: [] };
+                return { vtxos: rounds[Math.min(calls++, rounds.length - 1)]! };
+            },
+        } as unknown as RefundIndexer;
+    };
+
+    it("waits for the lockup, then claims it in one call", async () => {
+        const indexer = indexerOver([[], VTXOS]);
+        const ark = fakeArk();
+        const result = await claimReceiveLockup(indexer, ark, {
+            script: swapScript(),
+            receiver: RECEIVER,
+            preimage: PREIMAGE,
+            swapPkScript: swapScript().pkScript,
+            destinationPkScript: DESTINATION_PK_SCRIPT,
+            pollMs: 1,
+        });
+        expect(ark.submitted).toHaveLength(1);
+        expect(result.amount).toBe(100_000);
+    });
+
+    it("times out with a stable reason when the lockup never lands", async () => {
+        await expect(
+            awaitLockupFunding(indexerOver([[]]), swapScript().pkScript, {
+                pollMs: 1,
+                deadline: Math.floor(Date.now() / 1000) - 1,
+            }),
+        ).rejects.toThrow(expect.objectContaining({ reason: "lockup_timeout" }));
+    });
+});


### PR DESCRIPTION
Stacked on #713 — this is the receive-side completion that PR's flows stop short of. Base will retarget automatically once #713 merges.

`requestLightningReceive` / `requestOnchainReceive` end at funding instructions; what happens next — the trader claiming the solver-funded lockup — wasn't in the package. On the receive corridors the trader generated `P` and holds the covenant's `receiver` key, so it never needed covclaimd in the first place: it can spend the collaborative claim leaf (`preimage + receiver + server`) the moment the lockup lands.

New `src/claim.ts` does that, mirroring `pushRefundWithoutReceiver`'s submission flow with the two differences the claim leaf forces:

- The leaf carries a preimage condition, so `P` rides the PSBT's `ConditionWitness` field, attached **after** signing on the ark transaction and every checkpoint — the condition isn't part of the signed payload, and attaching it first is exactly what the server rejects as `INVALID_SIGNATURE`. (This is the same rule the reference solver's `claimSwapScript` encodes; the test pins it with a signer that probes for the field at sign time.)
- The leaf isn't covenant-pinned, so one aggregate output pays the whole balance to the trader's own destination (the `nonInteractiveClaim` pin is covclaimd's offline path, not this one's).

Guards in the same posture as the refund builder: the preimage is checked against the covenant's committed hash before anything is signed, swept (recoverable) outputs are refused rather than attempted, and `assertSubmittedArkTxid` + `matchServerCheckpoints` harden the two-phase submit. `awaitLockupFunding` waits for the solver's funding to appear, and `claimReceiveLockup` composes the two into the one call an integrator actually wants.

Tests cover the exact leaf bytes spent, the sign-then-attach ordering on ark tx and checkpoints, the wrong-preimage early refusal, swept-output refusal, the empty-lockup error, and the await/compose path. Package suite 294 → 301 passing, `tsc --noEmit`, prettier clean.
