### PR TITLE
feat(swap): gate the receive claim on the funded lockup value

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -321,7 +321,13 @@ window that can run out is the hold invoice's, and the claim window is measured 
 which is the deadline to show a payer, not `valid_until`. The optional `maxPayAmount` caps `from_amount`
 (`price_too_high`). The trader-side
 completion lands in `claim.ts`: `claimReceiveLockup` waits for the solver's funding and pushes the
-collaborative claim with the swap's own `P` and receiver key (covclaimd optional). Until covclaimd's
+collaborative claim with the swap's own `P` and receiver key (covclaimd optional). Both request
+flows return `expectedAmount` (the quote's `to_amount`) — persist it: `pushClaim` requires it and
+refuses, with `LockupAmountMismatchError`, to publish `P` for a lockup funded below it. Matching the
+`pkScript` is not enough on this leg, since a solver that funds the correctly derived script with
+dust still settles the payer's HTLC in full once `P` is out. The gate sums every live output and
+runs before signing — `P` reaches the Ark server at submit — and is skipped only for a lockup we
+have already partially claimed (`partiallyClaimed`), where `P` is public anyway. Until covclaimd's
 reference vectors are cross-checked, the `sealClaimPacket` test vector is pinned from this
 implementation and marked provisional (`TODO(claim-packet-vectors)`).
 

--- a/packages/swap/src/claim.ts
+++ b/packages/swap/src/claim.ts
@@ -62,6 +62,8 @@ export type ClaimArkProvider = RefundArkProvider;
  * HTLC in full.
  */
 export class LockupAmountMismatchError extends Error {
+    readonly name = "LockupAmountMismatchError";
+    readonly reason = "amount_mismatch";
     readonly expectedAmount: number;
     readonly lockedAmount: number;
     constructor(expectedAmount: number, lockedAmount: number) {
@@ -69,11 +71,31 @@ export class LockupAmountMismatchError extends Error {
             `lockup holds ${lockedAmount} sats, below the agreed ${expectedAmount} — ` +
                 "refusing to publish the preimage",
         );
-        this.name = "LockupAmountMismatchError";
         this.expectedAmount = expectedAmount;
         this.lockedAmount = lockedAmount;
     }
 }
+
+/**
+ * Refuse an amount the gate below cannot compare against — `rfq.ts`'s
+ * `assertFinite` rule, at the one threshold that lives outside that module.
+ *
+ * `NaN` and `undefined` both fail EVERY comparison, so neither one fails the
+ * value gate: they delete it, and `P` goes out for a dust lockup. Both are
+ * reachable despite the static types — `expectedAmount` arrives from the
+ * caller's persisted record, and the values are `Number()`d off the indexer's
+ * JSON. Unlike `assertFinite`, absence is refused here too: the field is
+ * required, so `undefined` means the record predates it, which is exactly the
+ * case that must not proceed.
+ */
+const assertFiniteAmount = (value: number, reason: string, label: string): void => {
+    if (Number.isFinite(value)) return;
+    const error = new Error(`${label} is not a finite number (${String(value)})`) as Error & {
+        reason: string;
+    };
+    error.reason = reason;
+    throw error;
+};
 
 /**
  * A signer that reveals a preimage when spending a condition leaf.
@@ -159,8 +181,16 @@ export async function pushClaim(
     // first-output check would miss the dust exactly as a first-output claim
     // would leave sats behind.
     const locked = input.vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
-    if (!input.partiallyClaimed && locked < input.expectedAmount) {
-        throw new LockupAmountMismatchError(input.expectedAmount, locked);
+    assertFiniteAmount(locked, "lockup_malformed", "the lockup's summed value");
+    // Ahead of the comparison, never inside it — and only on the path that
+    // compares: once `P` is public, refusing a partial claim over a record
+    // that predates `expectedAmount` would strand the remainder to protect
+    // nothing.
+    if (!input.partiallyClaimed) {
+        assertFiniteAmount(input.expectedAmount, "invalid_gate_input", "expectedAmount");
+        if (locked < input.expectedAmount) {
+            throw new LockupAmountMismatchError(input.expectedAmount, locked);
+        }
     }
 
     const committed = input.script.options.preimageHash;

--- a/packages/swap/src/claim.ts
+++ b/packages/swap/src/claim.ts
@@ -53,6 +53,29 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 export type ClaimArkProvider = RefundArkProvider;
 
 /**
+ * The lockup is funded for less than the swap agreed.
+ *
+ * The attack this names: the solver funds the correctly derived script with
+ * dust. Deriving the script locally — what protects every other corridor —
+ * proves nothing here, because the script was never the lie. Claiming anyway
+ * publishes `P`, which is what lets the solver settle the payer's Lightning
+ * HTLC in full.
+ */
+export class LockupAmountMismatchError extends Error {
+    readonly expectedAmount: number;
+    readonly lockedAmount: number;
+    constructor(expectedAmount: number, lockedAmount: number) {
+        super(
+            `lockup holds ${lockedAmount} sats, below the agreed ${expectedAmount} — ` +
+                "refusing to publish the preimage",
+        );
+        this.name = "LockupAmountMismatchError";
+        this.expectedAmount = expectedAmount;
+        this.lockedAmount = lockedAmount;
+    }
+}
+
+/**
  * A signer that reveals a preimage when spending a condition leaf.
  *
  * The ordering encoded here is the whole point: the condition witness is NOT
@@ -86,9 +109,16 @@ const claimIdentity = (identity: Identity, preimage: Uint8Array): Identity => ({
  * is signed: a wrong value can never open the leaf, and catching it here
  * beats learning it from the server's rejection.
  *
+ * So is the funded VALUE, against `expectedAmount` — and for the same reason,
+ * only more sharply: disclosure happens at SUBMIT, since `P` rides the PSBT to
+ * the Ark server. A check that waits for the transaction to land has already
+ * leaked the secret.
+ *
  * Swept outputs are refused, not attempted, exactly as in
  * {@link pushRefundWithoutReceiver} — one aggregate transaction means a
- * single non-live input would take the live ones down with it.
+ * single non-live input would take the live ones down with it. That refusal
+ * comes first, which is what leaves the value gate a plain sum over live
+ * outputs.
  */
 export async function pushClaim(
     ark: ClaimArkProvider,
@@ -104,6 +134,15 @@ export async function pushClaim(
         vtxos: readonly LockupVtxo[];
         /** Where the claimed sats land — the swap's payout address, decoded. */
         destinationPkScript: Uint8Array;
+        /** What the lockup must carry: the quote's `to_amount`, captured at
+         * REQUEST time and persisted with the record. Required rather than
+         * optional, so the guard cannot be skipped by the records that need
+         * it most. */
+        expectedAmount: number;
+        /** Set when this lockup already carries a claim of ours: `P` is public
+         * by then, so the value gate protects nothing and would only strand
+         * the remainder. */
+        partiallyClaimed?: boolean;
     },
 ): Promise<{ arkTxid: string; amount: number }> {
     if (input.vtxos.length === 0) throw new Error("nothing to claim: no funded outputs");
@@ -114,6 +153,14 @@ export async function pushClaim(
             swept.map((vtxo) => `${vtxo.txid}:${vtxo.vout}`),
             input.script.options.refundLocktime,
         );
+    }
+
+    // Summed across every live output: funding in several is legitimate, and a
+    // first-output check would miss the dust exactly as a first-output claim
+    // would leave sats behind.
+    const locked = input.vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
+    if (!input.partiallyClaimed && locked < input.expectedAmount) {
+        throw new LockupAmountMismatchError(input.expectedAmount, locked);
     }
 
     const committed = input.script.options.preimageHash;
@@ -131,7 +178,6 @@ export async function pushClaim(
 
     const leaf = input.script.claim();
     const tapTree = input.script.encode();
-    const amount = input.vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
     const signer = claimIdentity(input.receiver, input.preimage);
 
     const { arkTx, checkpoints } = buildOffchainTx(
@@ -144,7 +190,7 @@ export async function pushClaim(
         })),
         // One aggregate output: unlike the covenant refund, this leaf inspects
         // nothing about the output set.
-        [{ script: input.destinationPkScript, amount: BigInt(amount) }],
+        [{ script: input.destinationPkScript, amount: BigInt(locked) }],
         serverUnrollScript,
     );
 
@@ -166,7 +212,7 @@ export async function pushClaim(
     );
 
     await ark.finalizeTx(submitted.arkTxid, finalCheckpoints);
-    return { arkTxid: submitted.arkTxid, amount };
+    return { arkTxid: submitted.arkTxid, amount: locked };
 }
 
 /**
@@ -202,6 +248,12 @@ export async function awaitLockupFunding(
  * funded, the claim itself is gated by nothing but the solver's own refund
  * deadline (`refund_locktime` from the quote), which is the number the
  * caller's deadline should be measured against.
+ *
+ * The wait returns on the first output seen, so a funding the indexer
+ * surfaces piecemeal reaches {@link pushClaim}'s value gate short and throws
+ * {@link LockupAmountMismatchError}. Nothing was signed, so retrying once the
+ * rest lands is safe — and that is also the answer to a genuinely underfunded
+ * lockup, which never gets past the gate at all.
  */
 export async function claimReceiveLockup(
     indexer: RefundIndexer,
@@ -223,5 +275,7 @@ export async function claimReceiveLockup(
         preimage: input.preimage,
         vtxos,
         destinationPkScript: input.destinationPkScript,
+        expectedAmount: input.expectedAmount,
+        partiallyClaimed: input.partiallyClaimed,
     });
 }

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -123,7 +123,13 @@ export {
     requestOnchainSend,
 } from "./rfq";
 export { sealClaimPacket, type ClaimPacketInput, type SealedClaimPacket } from "./claimPacket";
-export { awaitLockupFunding, claimReceiveLockup, pushClaim, type ClaimArkProvider } from "./claim";
+export {
+    LockupAmountMismatchError,
+    awaitLockupFunding,
+    claimReceiveLockup,
+    pushClaim,
+    type ClaimArkProvider,
+} from "./claim";
 export {
     RFQ_PREIMAGE_TAG,
     RefundNotLocallyPossibleError,

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -1485,6 +1485,10 @@ export async function requestLightningReceive(
     invoice: string;
     /** What the trader pays: the quote's `from_amount`. */
     payAmount: number;
+    /** What the solver's lockup must carry: the quote's `to_amount`. Persist
+     * it with the record — `pushClaim` refuses to publish `P` for less, and
+     * captured at claim time instead it would be whatever the solver funded. */
+    expectedAmount: number;
     /** Last moment the invoice can be paid, unix seconds: `min(invoice
      * expiry, valid_until)`. Absolute on purpose — a countdown returned from
      * here is stale before the caller reads it; derive one at display time. */
@@ -1563,6 +1567,7 @@ export async function requestLightningReceive(
         quote,
         invoice: derived.invoice,
         payAmount: quote.from_amount,
+        expectedAmount: quote.to_amount,
         invoiceExpiresAt: payDeadline,
         address: derived.address,
         swapPkScript: derived.swapPkScript,
@@ -1692,6 +1697,9 @@ export async function requestOnchainReceive(
     address: string;
     /** What the trader's L1 funding must carry: the quote's `from_amount`. */
     fundAmount: number;
+    /** What the solver's lockup must carry: the quote's `to_amount`. Persist
+     * it with the record — see {@link requestLightningReceive}. */
+    expectedAmount: number;
     swapPkScript: Uint8Array;
     script: InstanceType<typeof VHTLC.ScriptV2>;
     /** The EXPECTED L1 contract, derived locally — fund only this address. */
@@ -1767,6 +1775,7 @@ export async function requestOnchainReceive(
         quote,
         address: derived.address,
         fundAmount: quote.from_amount,
+        expectedAmount: quote.to_amount,
         swapPkScript: derived.swapPkScript,
         script: derived.script,
         htlc: derived.htlc,

--- a/packages/swap/test/claim.test.ts
+++ b/packages/swap/test/claim.test.ts
@@ -22,6 +22,7 @@ import {
 
 import { receiveVtxoScript } from "../src/rfq";
 import {
+    LockupAmountMismatchError,
     awaitLockupFunding,
     claimReceiveLockup,
     pushClaim,
@@ -66,6 +67,8 @@ const VTXOS: LockupVtxo[] = [
     { txid: "11".repeat(32), vout: 0, value: 60_000, recoverable: false },
     { txid: "22".repeat(32), vout: 1, value: 40_000, recoverable: false },
 ];
+/** The quote's `to_amount`, captured at request time. */
+const EXPECTED_AMOUNT = 100_000;
 
 /** A scripted arkd, same contract as refund.test.ts's. */
 type FakeArk = ClaimArkProvider & {
@@ -113,6 +116,7 @@ describe("pushClaim", () => {
             preimage: PREIMAGE,
             vtxos: VTXOS,
             destinationPkScript: DESTINATION_PK_SCRIPT,
+            expectedAmount: EXPECTED_AMOUNT,
         });
 
         expect(ark.submitted).toHaveLength(1);
@@ -159,6 +163,7 @@ describe("pushClaim", () => {
             preimage: PREIMAGE,
             vtxos: VTXOS,
             destinationPkScript: DESTINATION_PK_SCRIPT,
+            expectedAmount: EXPECTED_AMOUNT,
         });
         expect(fieldPresentAtSignTime).toBe(false);
     });
@@ -172,6 +177,7 @@ describe("pushClaim", () => {
                 preimage: new Uint8Array(32).fill(8),
                 vtxos: VTXOS,
                 destinationPkScript: DESTINATION_PK_SCRIPT,
+                expectedAmount: EXPECTED_AMOUNT,
             }),
         ).rejects.toThrow(/does not match/);
         expect(ark.submitted).toHaveLength(0);
@@ -185,6 +191,78 @@ describe("pushClaim", () => {
                 preimage: PREIMAGE,
                 vtxos: [{ txid: "33".repeat(32), vout: 0, value: 5_000, recoverable: true }],
                 destinationPkScript: DESTINATION_PK_SCRIPT,
+                expectedAmount: EXPECTED_AMOUNT,
+            }),
+        ).rejects.toThrow(LockupNeedsRecoveryError);
+    });
+
+    // The dust-funding attack: the script is the one we derived ourselves, so
+    // only the value says anything is wrong. Claiming anyway publishes `P` and
+    // lets the solver settle the payer's HTLC in full.
+    it("refuses a lockup funded below the agreed amount, with nothing signed or submitted", async () => {
+        const ark = fakeArk();
+        await expect(
+            pushClaim(ark, {
+                script: swapScript(),
+                receiver: RECEIVER,
+                preimage: PREIMAGE,
+                vtxos: [{ txid: "44".repeat(32), vout: 0, value: 330, recoverable: false }],
+                destinationPkScript: DESTINATION_PK_SCRIPT,
+                expectedAmount: EXPECTED_AMOUNT,
+            }),
+        ).rejects.toThrow(LockupAmountMismatchError);
+        // `P` reaches the Ark server at submit, so this is the whole guarantee.
+        expect(ark.submitted).toHaveLength(0);
+    });
+
+    it("sums across outputs and tolerates overfunding", async () => {
+        // VTXOS is 60_000 + 40_000: neither output covers the amount alone.
+        const split = fakeArk();
+        await pushClaim(split, {
+            script: swapScript(),
+            receiver: RECEIVER,
+            preimage: PREIMAGE,
+            vtxos: VTXOS,
+            destinationPkScript: DESTINATION_PK_SCRIPT,
+            expectedAmount: EXPECTED_AMOUNT,
+        });
+        expect(split.submitted).toHaveLength(1);
+
+        const over = fakeArk();
+        const result = await pushClaim(over, {
+            script: swapScript(),
+            receiver: RECEIVER,
+            preimage: PREIMAGE,
+            vtxos: VTXOS,
+            destinationPkScript: DESTINATION_PK_SCRIPT,
+            expectedAmount: EXPECTED_AMOUNT - 1,
+        });
+        expect(result.amount).toBe(100_000);
+    });
+
+    it("claims the remainder of a partially-claimed lockup regardless of the amount", async () => {
+        const ark = fakeArk();
+        const result = await pushClaim(ark, {
+            script: swapScript(),
+            receiver: RECEIVER,
+            preimage: PREIMAGE,
+            vtxos: [{ txid: "55".repeat(32), vout: 0, value: 1_000, recoverable: false }],
+            destinationPkScript: DESTINATION_PK_SCRIPT,
+            expectedAmount: EXPECTED_AMOUNT,
+            partiallyClaimed: true,
+        });
+        expect(result.amount).toBe(1_000);
+    });
+
+    it("refuses a swept output before the amount is even considered", async () => {
+        await expect(
+            pushClaim(fakeArk(), {
+                script: swapScript(),
+                receiver: RECEIVER,
+                preimage: PREIMAGE,
+                vtxos: [{ txid: "33".repeat(32), vout: 0, value: 330, recoverable: true }],
+                destinationPkScript: DESTINATION_PK_SCRIPT,
+                expectedAmount: EXPECTED_AMOUNT,
             }),
         ).rejects.toThrow(LockupNeedsRecoveryError);
     });
@@ -197,6 +275,7 @@ describe("pushClaim", () => {
                 preimage: PREIMAGE,
                 vtxos: [],
                 destinationPkScript: DESTINATION_PK_SCRIPT,
+                expectedAmount: EXPECTED_AMOUNT,
             }),
         ).rejects.toThrow(/nothing to claim/);
     });
@@ -224,6 +303,7 @@ describe("awaitLockupFunding + claimReceiveLockup", () => {
             preimage: PREIMAGE,
             swapPkScript: swapScript().pkScript,
             destinationPkScript: DESTINATION_PK_SCRIPT,
+            expectedAmount: EXPECTED_AMOUNT,
             pollMs: 1,
         });
         expect(ark.submitted).toHaveLength(1);

--- a/packages/swap/test/claim.test.ts
+++ b/packages/swap/test/claim.test.ts
@@ -215,6 +215,41 @@ describe("pushClaim", () => {
         expect(ark.submitted).toHaveLength(0);
     });
 
+    // NaN and undefined fail every comparison, so an unchecked one does not
+    // fail the gate — it deletes it, and the dust claim above goes through.
+    it.each([
+        ["NaN", Number.NaN],
+        ["missing from an older record", undefined as unknown as number],
+    ])("refuses an expectedAmount that is %s instead of comparing against it", async (_, bad) => {
+        const ark = fakeArk();
+        await expect(
+            pushClaim(ark, {
+                script: swapScript(),
+                receiver: RECEIVER,
+                preimage: PREIMAGE,
+                vtxos: [{ txid: "44".repeat(32), vout: 0, value: 330, recoverable: false }],
+                destinationPkScript: DESTINATION_PK_SCRIPT,
+                expectedAmount: bad,
+            }),
+        ).rejects.toMatchObject({ reason: "invalid_gate_input" });
+        expect(ark.submitted).toHaveLength(0);
+    });
+
+    it("refuses a lockup whose indexed value is not a number", async () => {
+        const ark = fakeArk();
+        await expect(
+            pushClaim(ark, {
+                script: swapScript(),
+                receiver: RECEIVER,
+                preimage: PREIMAGE,
+                vtxos: [{ txid: "44".repeat(32), vout: 0, value: Number.NaN, recoverable: false }],
+                destinationPkScript: DESTINATION_PK_SCRIPT,
+                expectedAmount: EXPECTED_AMOUNT,
+            }),
+        ).rejects.toMatchObject({ reason: "lockup_malformed" });
+        expect(ark.submitted).toHaveLength(0);
+    });
+
     it("sums across outputs and tolerates overfunding", async () => {
         // VTXOS is 60_000 + 40_000: neither output covers the amount alone.
         const split = fakeArk();
@@ -252,6 +287,19 @@ describe("pushClaim", () => {
             partiallyClaimed: true,
         });
         expect(result.amount).toBe(1_000);
+
+        // Including one whose record predates the field: `P` is already
+        // public, so refusing here would strand the remainder for nothing.
+        const older = await pushClaim(fakeArk(), {
+            script: swapScript(),
+            receiver: RECEIVER,
+            preimage: PREIMAGE,
+            vtxos: [{ txid: "55".repeat(32), vout: 0, value: 1_000, recoverable: false }],
+            destinationPkScript: DESTINATION_PK_SCRIPT,
+            expectedAmount: undefined as unknown as number,
+            partiallyClaimed: true,
+        });
+        expect(older.amount).toBe(1_000);
     });
 
     it("refuses a swept output before the amount is even considered", async () => {

--- a/packages/swap/test/rfqReceive.test.ts
+++ b/packages/swap/test/rfqReceive.test.ts
@@ -620,7 +620,7 @@ const lightningReceiveFlow = async (
             seen.paymentHash = profile.payment_hash as string;
             seen.payoutPubkey = profile.payout_pubkey as string;
             seen.claimPacket = profile.claim_packet;
-            return receiveQuote(payload, { from: 5_000, to: 5_000, ...over.quote });
+            return receiveQuote(payload, { from: 5_000, to: 4_950, ...over.quote });
         },
         async status() {
             return null;
@@ -658,6 +658,8 @@ describe("requestLightningReceive on an HD wallet", () => {
 
         expect(result.secrets.derivable).toBe(true);
         expect(result.payAmount).toBe(5_000);
+        // What the claim gate compares against is the side that LANDS.
+        expect(result.expectedAmount).toBe(4_950);
         expect(result.invoice).toBe("lnbcrt49u1p...");
         // Absolute, so this pins exactly rather than tolerating drift between
         // module load (NOW) and the clock requestLightningReceive captures.
@@ -796,6 +798,7 @@ describe("requestOnchainReceive on an HD wallet", () => {
         );
 
         expect(result.fundAmount).toBe(100_000);
+        expect(result.expectedAmount).toBe(99_000);
         expect(result.htlc.address).toMatch(/^bcrt1p/);
         const preimage = await preimageForRfqSecrets(wallet, result.secrets);
         expect(seen.paymentHash).toBe(paymentHashOf(preimage));


### PR DESCRIPTION
PR 2 of the issue #712 receive stack (`plans/issue-712-arkade-swap-receive.md`). Stacked on #716 — retarget to `feat/arkade-swap` when that merges.

Deriving the lockup script locally is what protects every other corridor, and it protects nothing here: the solver can fund the correctly derived script with dust, and the claim publishes `P` regardless, which is what lets it settle the payer's Lightning HTLC in full.

- `pushClaim` takes a **required** `expectedAmount` and refuses with `LockupAmountMismatchError` (carrying expected/locked) when the live outputs sum below it. Required rather than optional so the records that most need the guard cannot skip it.
- Summed across every live output — funding in several is legitimate; `>=`, so overfunding passes. The existing swept-output refusal still runs first, which is what leaves this a plain sum over live outputs.
- The gate runs **before signing**: `P` rides the PSBT to the Ark server at submit, so a check that waits for the transaction to land has already leaked the secret.
- Skipped only when `partiallyClaimed` is set — this lockup already carries a claim of ours, so `P` is public and blocking the remainder would only strand our own money.
- `requestLightningReceive` / `requestOnchainReceive` return `expectedAmount = quote.to_amount`, documented must-persist: captured at claim time instead, the comparand would be whatever the solver funded.

Together with #716 this closes the value chain — `invoice.amountSats === from_amount` (what the payer is asked for), `to_amount === requestedAmount` (already shipped as `assertQuotedAmount`), `Σ funded >= to_amount` (here).