### PR TITLE
feat(swap): bring the Nostr RFQ transport into the package

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -218,11 +218,33 @@ Refusals carry a closed reason set (`SwapRefusal`); unknown reasons are a generi
 `swap-lightning-send.program.json` bytes are frozen the same way the offer programs are — a
 golden test pins the compiled leaves and scriptPubKey to the reference solver's exact script.
 
-Transports are symmetric-outbound: `httpTransport` (POST `/v1/swap`, GET `/v1/rfq/<rfq_id>`) and
-`relayTransport` (the dev broker framing; the production target is Nostr — a directed kind with
-NIP-44 content — which swaps only the transport function). Status by `rfq_id` reaches terminal
-states `settled / refused / expired / refunded / stuck`; receipts (the preimage) appear only in
+Transports are symmetric-outbound: `httpTransport` (POST `/v1/swap`, GET `/v1/rfq/<rfq_id>`),
+`relayTransport` (the dev broker framing), and `nostrRfqTransport` — the production one a
+deployed solver actually listens on. Status by `rfq_id` reaches terminal states
+`settled / refused / expired / refunded / stuck`; receipts (the preimage) appear only in
 `settled`, and the chain itself is always the fallback nobody can withhold.
+
+### The Nostr transport is a separate entry point
+
+```ts
+import { nostrRfqTransport } from "@arkade-os/swap/nostr";
+
+const transport = nostrRfqTransport({
+    relays: card.transports.nostr.relays,
+    solverPubkey: card.discovery_pubkey,
+});
+```
+
+`nostr-tools` is an **optional peer dependency**, so it is only required if you import this
+subpath — a consumer doing HTTP-only swaps never resolves it, and the package root pulls in
+nothing Nostr-related. The trade is that importing `@arkade-os/swap/nostr` without `nostr-tools`
+installed fails at resolution, which is the intended loud failure rather than a transport that
+silently degrades.
+
+Directed traffic rides kind `24859`, which is **ephemeral** (NIP-01's 20000–29999): a conforming
+relay does not retain it. This must match the solver's `NOSTR_KIND_DIRECTED` — the two sides
+subscribe by `kinds`, so a mismatch is not an error either can report. They simply never see each
+other, and every request times out appearing to blame the solver.
 
 ## Onchain corridor: `arkade:BTC -> onchain:BTC` (and back)
 

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -15,13 +15,23 @@
                 "types": "./dist/index.d.ts",
                 "default": "./dist/index.cjs"
             }
+        },
+        "./nostr": {
+            "import": {
+                "types": "./dist/nostr.d.ts",
+                "default": "./dist/nostr.js"
+            },
+            "require": {
+                "types": "./dist/nostr.d.ts",
+                "default": "./dist/nostr.cjs"
+            }
         }
     },
     "files": [
         "dist"
     ],
     "scripts": {
-        "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+        "build": "tsup src/index.ts src/nostr.ts --format esm,cjs --dts --clean",
         "typecheck": "tsc --noEmit",
         "format": "prettier --write src test",
         "lint": "prettier --check src test",
@@ -48,12 +58,21 @@
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1"
     },
+    "peerDependencies": {
+        "nostr-tools": "^2.12.0"
+    },
+    "peerDependenciesMeta": {
+        "nostr-tools": {
+            "optional": true
+        }
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org/"
     },
     "packageManager": "pnpm@10.25.0",
     "devDependencies": {
-        "fake-indexeddb": "6.2.5"
+        "fake-indexeddb": "6.2.5",
+        "nostr-tools": "^2.12.0"
     }
 }

--- a/packages/swap/src/nostr.ts
+++ b/packages/swap/src/nostr.ts
@@ -1,0 +1,265 @@
+/**
+ * The Nostr RFQ transport — the PRODUCTION one (docs/rfq-protocol.md § 3.1 in
+ * arkade-os/lightning-swap-service).
+ *
+ * `rfq.ts` ships two other transports: `httpTransport`, and `relayTransport`
+ * which speaks the dev broker's `{op:"sub"|"event"}` framing. Neither is what a
+ * deployed solver listens on. This is, and it satisfies the same
+ * {@link RfqTransport} interface, so everything above the transport — the maker
+ * flow, quote verification, the store — is identical whichever one it is handed.
+ *
+ * ## Why this is a separate entry point
+ *
+ * Imported as `@arkade-os/swap/nostr`, never from the package root, and
+ * `nostr-tools` is an OPTIONAL peer dependency. A consumer doing HTTP-only
+ * swaps should not pay for a Nostr library it never calls, and re-exporting
+ * this from `index.ts` would put `nostr-tools` in every consumer's module graph
+ * whether or not they resolve it. The subpath is what keeps that promise: the
+ * module is only loaded if it is imported.
+ *
+ * The consequence, stated plainly: importing this subpath without `nostr-tools`
+ * installed fails at resolution with a module-not-found. That is the intended
+ * failure — loud, at the import, naming the missing package — rather than a
+ * transport that silently degrades.
+ *
+ * A dynamic `await import()` inside the factory would also defer the cost, but
+ * it would make construction async. This transport opens its subscription
+ * eagerly, on purpose (see below), so an async factory would push a `await`
+ * into every caller for no benefit the subpath does not already give.
+ */
+import { SwapRefusal, type RfqQuote, type RfqStatus, type RfqTransport } from "./rfq";
+import {
+    finalizeEvent,
+    generateSecretKey,
+    getPublicKey,
+    nip44,
+    SimplePool,
+    type Event,
+} from "nostr-tools";
+
+/**
+ * Directed RFQ traffic. Provisional in the spec; kept in one place.
+ *
+ * MUST stay inside NIP-01's ephemeral range (20000–29999) and MUST match the
+ * solver's `NOSTR_KIND_DIRECTED`. The two sides subscribe by `kinds`, so a
+ * mismatch is not an error either can report — they simply never see each
+ * other, and every request times out blaming the solver.
+ *
+ * Ephemeral because a negotiation is worthless once it is over: a request
+ * nobody answered inside the timeout, and a quote past its `valid_until`, help
+ * no one, while a retained copy is a permanent record of who negotiated what
+ * with whom. The cost is no store-and-forward — a request sent while the solver
+ * is disconnected is dropped rather than queued — which the timeout and the
+ * caller's retry cover.
+ */
+export const RFQ_DIRECTED_KIND = 24859;
+
+/**
+ * Indicative solver advertisement — never binding; only a quote binds.
+ *
+ * Addressable (30000–39999) rather than ephemeral, deliberately: an ad is
+ * standing state a relay should keep the current version of, not a message in a
+ * negotiation. The two constants want OPPOSITE retention, and neither is a typo
+ * of the other.
+ */
+export const RFQ_AD_KIND = 38859;
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Every relay dropped the subscription, so no reply can arrive on it.
+ *
+ * Distinct from a timeout on purpose. Both look like "no answer", but they mean
+ * opposite things: a timeout says the solver did not respond, while this says
+ * we were never in a position to hear it. Without the distinction the transport
+ * waits out the full timeout and then blames the solver for a failure on our
+ * own side of the wire.
+ */
+export class RelayUnavailable extends Error {
+    readonly reasons: string[];
+
+    constructor(reasons: string[]) {
+        super(`lost every relay connection: ${reasons.join("; ") || "connection closed"}`);
+        this.name = "RelayUnavailable";
+        this.reasons = reasons;
+    }
+}
+
+/**
+ * Normalise whatever `subscribeMany`'s `onclose` hands back into readable text.
+ *
+ * nostr-tools changed this payload WITHIN its own 2.x line: earlier versions
+ * pass `string[]`, later ones `{ url, reason }[]`. Because nostr-tools is a
+ * PEER dependency here, the consumer picks the version anywhere inside
+ * `^2.12.0` — so the transport has to accept either shape rather than pin the
+ * range to whichever one it happened to be written against. Declaring a peer
+ * range and then only tolerating one point in it is a promise the package would
+ * not keep.
+ */
+const closeReasons = (raw: readonly unknown[]): string[] =>
+    raw.map((entry) => {
+        if (typeof entry === "string") return entry;
+        const { url, reason } = (entry ?? {}) as { url?: string; reason?: string };
+        return url ? `${url}: ${reason ?? "closed"}` : (reason ?? "closed");
+    });
+
+/**
+ * Discriminate a decrypted reply, mirroring the client's own rule: a refusal
+ * carries a closed-set reason and is thrown as `SwapRefusal`; anything that is
+ * not a quote for THIS negotiation is an error rather than a value.
+ *
+ * The `rfq_id` check is what stops a reply to one negotiation being accepted as
+ * the answer to another — on a shared relay the solver's events all arrive on
+ * the same subscription.
+ */
+const asQuote = (payload: unknown, rfqId: string): RfqQuote => {
+    const p = payload as { type?: string; reason?: string; rfq_id?: string } | null;
+    if (p?.type === "rfq_refusal") throw new SwapRefusal(p.reason ?? "unknown", p.rfq_id ?? rfqId);
+    if (p?.type !== "rfq_quote" || p.rfq_id !== rfqId) {
+        throw new Error(`unexpected reply: ${p?.type ?? "no payload"}`);
+    }
+    return payload as RfqQuote;
+};
+
+export interface NostrRfqOptions {
+    /** Relay URLs from the solver's card. The rendezvous, not solver endpoints. */
+    relays: string[];
+    /** The card's `discovery_pubkey`, x-only hex — who we address. */
+    solverPubkey: string;
+    /**
+     * Transport key. Defaults to a FRESH key per transport, deliberately: the
+     * negotiation should not be linkable to a long-term identity, and nothing in
+     * the protocol needs a stable client key — the quote binds to the covenant,
+     * not to who asked for it.
+     */
+    secretKey?: Uint8Array;
+    /** Injectable for tests; a caller may also share one pool across swaps. */
+    pool?: SimplePool;
+    timeoutMs?: number;
+}
+
+/**
+ * Build an `RfqTransport` speaking kind-24859 directed traffic.
+ *
+ * Sends are fire-and-forget publishes; replies arrive on a single long-lived
+ * subscription filtered to this transport key, so a reply that arrives before
+ * the publish promise settles is not missed.
+ */
+export const nostrRfqTransport = (options: NostrRfqOptions): RfqTransport => {
+    const relays = options.relays;
+    const solverPubkey = options.solverPubkey;
+    const secretKey = options.secretKey ?? generateSecretKey();
+    const pubkey = getPublicKey(secretKey);
+    const pool = options.pool ?? new SimplePool();
+    const ownsPool = !options.pool;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const conversationKey = nip44.v2.utils.getConversationKey(secretKey, solverPubkey);
+
+    // close() closes the subscription, which fires onclose; that is a deliberate
+    // teardown, not a lost relay, so it must not reject anything.
+    let closed = false;
+
+    /** Waiters keyed by rfq_id, settled by a reply or by the subscription dying. */
+    const waiters = new Map<
+        string,
+        { resolve: (payload: unknown) => void; reject: (error: Error) => void }
+    >();
+
+    // One subscription for the whole transport. Opened eagerly so a fast solver
+    // cannot answer into a subscription that does not exist yet.
+    const subscription = pool.subscribeMany(
+        relays,
+        { kinds: [RFQ_DIRECTED_KIND], "#p": [pubkey], authors: [solverPubkey] },
+        {
+            onevent(event: Event) {
+                let payload: unknown;
+                try {
+                    payload = JSON.parse(nip44.v2.decrypt(event.content, conversationKey));
+                } catch {
+                    return; // not for us, or malformed: silence, never a throw on the socket
+                }
+                const rfqId = (payload as { rfq_id?: string } | null)?.rfq_id;
+                if (!rfqId) return;
+                waiters.get(rfqId)?.resolve(payload);
+            },
+            // subscribeMany calls this once every relay has closed. Nothing will
+            // arrive after it, so failing now beats waiting out the timeout — and
+            // it names the real cause instead of implicating the solver.
+            onclose(reasons: readonly unknown[]) {
+                if (closed) return;
+                const error = new RelayUnavailable(closeReasons(reasons));
+                for (const waiter of waiters.values()) waiter.reject(error);
+                waiters.clear();
+            },
+        },
+    );
+
+    const send = async (payload: Record<string, unknown>): Promise<void> => {
+        const event = finalizeEvent(
+            {
+                kind: RFQ_DIRECTED_KIND,
+                created_at: Math.floor(Date.now() / 1000),
+                tags: [["p", solverPubkey]],
+                content: nip44.v2.encrypt(JSON.stringify(payload), conversationKey),
+            },
+            secretKey,
+        );
+        // Publishing to several relays: one accepting is enough, so a single
+        // rejecting relay must not fail the negotiation.
+        const results = await Promise.allSettled(pool.publish(relays, event));
+        if (!results.some((r) => r.status === "fulfilled")) {
+            throw new Error("no relay accepted the RFQ message");
+        }
+    };
+
+    /** Await the reply for one rfq_id, with a timeout and guaranteed cleanup. */
+    const awaitReply = (rfqId: string): Promise<unknown> =>
+        new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                waiters.delete(rfqId);
+                reject(new Error(`no solver reply within ${timeoutMs}ms`));
+            }, timeoutMs);
+            waiters.set(rfqId, {
+                resolve: (payload) => {
+                    clearTimeout(timer);
+                    waiters.delete(rfqId);
+                    resolve(payload);
+                },
+                reject: (error) => {
+                    clearTimeout(timer);
+                    waiters.delete(rfqId);
+                    reject(error);
+                },
+            });
+        });
+
+    return {
+        async requestQuote(payload) {
+            const rfqId = String(payload.rfq_id);
+            // Register the waiter BEFORE publishing: the reply can land while the
+            // publish promise is still settling.
+            const reply = awaitReply(rfqId);
+            await send(payload);
+            return asQuote(await reply, rfqId);
+        },
+
+        async status(rfqId) {
+            const reply = awaitReply(rfqId);
+            await send({ v: 1, type: "rfq_status_request", rfq_id: rfqId });
+            const payload = (await reply) as { type?: string } | null;
+            // A solver that has forgotten the negotiation answers nothing useful;
+            // null means "no status", matching the HTTP transport's 404.
+            if (payload?.type !== "rfq_status") return null;
+            return payload as RfqStatus;
+        },
+
+        async close() {
+            closed = true;
+            subscription.close();
+            waiters.clear();
+            // Only tear down a pool this transport created; a shared one belongs
+            // to the caller and may still be serving other swaps.
+            if (ownsPool) pool.close(relays);
+        },
+    };
+};

--- a/packages/swap/test/nostr.test.ts
+++ b/packages/swap/test/nostr.test.ts
@@ -1,0 +1,207 @@
+/**
+ * The Nostr RFQ transport, and the two properties that fail silently if broken.
+ *
+ * Ported from the wallet, where this transport lived before it moved into the
+ * package beside `httpTransport` and `relayTransport`.
+ */
+import { describe, it, expect } from "vitest";
+import { generateSecretKey, getPublicKey, nip44, type Event } from "nostr-tools";
+import { SwapRefusal } from "../src/rfq";
+import { RFQ_AD_KIND, RFQ_DIRECTED_KIND, RelayUnavailable, nostrRfqTransport } from "../src/nostr";
+
+/**
+ * A stand-in for SimplePool that behaves like a relay the solver is also on:
+ * it decrypts what the client publishes and lets the test answer as the solver.
+ */
+const fakePool = (solverSecret: Uint8Array) => {
+    let onevent: ((e: Event) => void) | undefined;
+    let onclose: ((reasons: unknown[]) => void) | undefined;
+    const published: unknown[] = [];
+    const seenFilters: unknown[] = [];
+    const pool = {
+        subscribeMany(
+            _relays: string[],
+            filter: unknown,
+            params: { onevent: (e: Event) => void; onclose?: (reasons: unknown[]) => void },
+        ) {
+            seenFilters.push(filter);
+            onevent = params.onevent;
+            onclose = params.onclose;
+            return { close: () => {} };
+        },
+        publish(_relays: string[], event: Event) {
+            const key = nip44.v2.utils.getConversationKey(solverSecret, event.pubkey);
+            published.push(JSON.parse(nip44.v2.decrypt(event.content, key)));
+            return [Promise.resolve("ok")];
+        },
+        close() {},
+    };
+    /** Answer as the solver, encrypted to the client that published last. */
+    const solverReplies = (clientPubkey: string, payload: unknown) => {
+        const key = nip44.v2.utils.getConversationKey(solverSecret, clientPubkey);
+        onevent?.({
+            kind: RFQ_DIRECTED_KIND,
+            pubkey: getPublicKey(solverSecret),
+            content: nip44.v2.encrypt(JSON.stringify(payload), key),
+            tags: [["p", clientPubkey]],
+            created_at: Math.floor(Date.now() / 1000),
+            id: "x",
+            sig: "y",
+        } as Event);
+    };
+    const dropEveryRelay = (reasons: unknown[]) => onclose?.(reasons);
+    return { pool, published, seenFilters, solverReplies, dropEveryRelay };
+};
+
+describe("RFQ kinds", () => {
+    /**
+     * The RANGE, not the digits.
+     *
+     * The exact numbers are provisional in the spec and may still move by
+     * agreement. The range may not: NIP-01 makes 20000-29999 ephemeral, and that
+     * is what stops a relay retaining a negotiation. Drifting back into a stored
+     * range breaks nothing an eye would catch — every other test here goes
+     * through the constant and would follow it anywhere — while quietly
+     * reinstating a permanent record of who negotiated what with whom.
+     */
+    it("keeps directed traffic inside the NIP-01 ephemeral range", () => {
+        expect(RFQ_DIRECTED_KIND).toBeGreaterThanOrEqual(20_000);
+        expect(RFQ_DIRECTED_KIND).toBeLessThan(30_000);
+    });
+
+    /**
+     * The ad is standing state rather than a message, so it belongs in the
+     * addressable range where a relay keeps the current version per solver.
+     * Asserted beside the one above so the contrast is on the record: these two
+     * kinds want OPPOSITE retention, and neither is a typo of the other.
+     */
+    it("keeps the solver ad addressable, not ephemeral", () => {
+        expect(RFQ_AD_KIND).toBeGreaterThanOrEqual(30_000);
+        expect(RFQ_AD_KIND).toBeLessThan(40_000);
+    });
+
+    it("subscribes on the directed kind, addressed to itself, from the solver", () => {
+        const solverSecret = generateSecretKey();
+        const { pool, seenFilters } = fakePool(solverSecret);
+        const secretKey = generateSecretKey();
+        nostrRfqTransport({
+            relays: ["wss://x"],
+            solverPubkey: getPublicKey(solverSecret),
+            secretKey,
+            pool: pool as never,
+        });
+        // All three matter: the kind is how a mismatch goes silent, `#p` is what
+        // keeps another client's negotiation out, and `authors` is what stops a
+        // stranger answering in the solver's place.
+        expect(seenFilters[0]).toEqual({
+            kinds: [RFQ_DIRECTED_KIND],
+            "#p": [getPublicKey(secretKey)],
+            authors: [getPublicKey(solverSecret)],
+        });
+    });
+});
+
+describe("nostrRfqTransport", () => {
+    const quote = (rfqId: string) => ({ v: 1, type: "rfq_quote", rfq_id: rfqId });
+
+    it("returns the solver's quote for the negotiation it asked about", async () => {
+        const solverSecret = generateSecretKey();
+        const { pool, solverReplies } = fakePool(solverSecret);
+        const secretKey = generateSecretKey();
+        const transport = nostrRfqTransport({
+            relays: ["wss://x"],
+            solverPubkey: getPublicKey(solverSecret),
+            secretKey,
+            pool: pool as never,
+        });
+
+        const pending = transport.requestQuote({ v: 1, type: "rfq_request", rfq_id: "abc" });
+        solverReplies(getPublicKey(secretKey), quote("abc"));
+        await expect(pending).resolves.toMatchObject({ rfq_id: "abc" });
+        await transport.close();
+    });
+
+    it("throws a SwapRefusal rather than a value when the solver refuses", async () => {
+        const solverSecret = generateSecretKey();
+        const { pool, solverReplies } = fakePool(solverSecret);
+        const secretKey = generateSecretKey();
+        const transport = nostrRfqTransport({
+            relays: ["wss://x"],
+            solverPubkey: getPublicKey(solverSecret),
+            secretKey,
+            pool: pool as never,
+        });
+
+        const pending = transport.requestQuote({ v: 1, type: "rfq_request", rfq_id: "abc" });
+        solverReplies(getPublicKey(secretKey), {
+            v: 1,
+            type: "rfq_refusal",
+            rfq_id: "abc",
+            reason: "unsupported_pair",
+        });
+        await expect(pending).rejects.toBeInstanceOf(SwapRefusal);
+        await transport.close();
+    });
+
+    it("ignores a reply for a different negotiation", async () => {
+        const solverSecret = generateSecretKey();
+        const { pool, solverReplies } = fakePool(solverSecret);
+        const secretKey = generateSecretKey();
+        const transport = nostrRfqTransport({
+            relays: ["wss://x"],
+            solverPubkey: getPublicKey(solverSecret),
+            secretKey,
+            pool: pool as never,
+            timeoutMs: 60,
+        });
+
+        const pending = transport.requestQuote({ v: 1, type: "rfq_request", rfq_id: "abc" });
+        // Answer for someone else's rfq_id: on a shared relay this arrives on the
+        // same subscription, and accepting it would answer the wrong negotiation.
+        solverReplies(getPublicKey(secretKey), quote("other"));
+        await expect(pending).rejects.toThrow(/no solver reply/);
+        await transport.close();
+    });
+
+    /**
+     * A dropped subscription and a silent solver look identical from here, and
+     * mean opposite things. Both shapes of `onclose` payload nostr-tools has
+     * used across its 2.x line are exercised, because the package declares a
+     * peer range spanning both and would otherwise only work against one.
+     */
+    it.each([
+        ["legacy string[]", ["relay closed"]],
+        ["current {url,reason}[]", [{ url: "wss://x", reason: "closed" }]],
+    ])("fails as RelayUnavailable when every relay drops (%s)", async (_name, reasons) => {
+        const solverSecret = generateSecretKey();
+        const { pool, dropEveryRelay } = fakePool(solverSecret);
+        const transport = nostrRfqTransport({
+            relays: ["wss://x"],
+            solverPubkey: getPublicKey(solverSecret),
+            secretKey: generateSecretKey(),
+            pool: pool as never,
+        });
+
+        const pending = transport.requestQuote({ v: 1, type: "rfq_request", rfq_id: "abc" });
+        dropEveryRelay(reasons);
+        await expect(pending).rejects.toBeInstanceOf(RelayUnavailable);
+        await transport.close();
+    });
+
+    it("times out rather than hanging when the solver never answers", async () => {
+        const solverSecret = generateSecretKey();
+        const { pool } = fakePool(solverSecret);
+        const transport = nostrRfqTransport({
+            relays: ["wss://x"],
+            solverPubkey: getPublicKey(solverSecret),
+            secretKey: generateSecretKey(),
+            pool: pool as never,
+            timeoutMs: 40,
+        });
+
+        await expect(
+            transport.requestQuote({ v: 1, type: "rfq_request", rfq_id: "abc" }),
+        ).rejects.toThrow(/no solver reply within 40ms/);
+        await transport.close();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       fake-indexeddb:
         specifier: 6.2.5
         version: 6.2.5
+      nostr-tools:
+        specifier: ^2.12.0
+        version: 2.24.1(typescript@5.9.2)
 
   packages/ts-sdk:
     dependencies:
@@ -1218,6 +1221,10 @@ packages:
     resolution: {integrity: sha512-oaTrAziGr3zDLFiMt/yLU3nZuRMawyWQB5X1a0I7s9eGy3JYzX9l8ZXXHyMd64nzbeVFZTewuUShwsZQdK6UCA==}
     engines: {node: '>=20.19.0'}
     hasBin: true
+
+  '@noble/ciphers@2.1.1':
+    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+    engines: {node: '>= 20.19.0'}
 
   '@noble/curves@2.0.1':
     resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
@@ -2923,6 +2930,17 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  nostr-tools@2.24.1:
+    resolution: {integrity: sha512-KdrKjC74n/rr6J3eCSfZj8dcbZFvolHYe4S22SefNZ5YWbhHiB0KL/mmJjEZ0u6B9mZK0YcQtl+WQ46KzwapeQ==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  nostr-wasm@0.1.0:
+    resolution: {integrity: sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==}
 
   npm-package-arg@11.0.3:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
@@ -5097,6 +5115,8 @@ snapshots:
 
   '@marcbachmann/cel-js@8.0.0': {}
 
+  '@noble/ciphers@2.1.1': {}
+
   '@noble/curves@2.0.1':
     dependencies:
       '@noble/hashes': 2.0.1
@@ -7109,6 +7129,20 @@ snapshots:
   node-releases@2.0.47: {}
 
   normalize-path@3.0.0: {}
+
+  nostr-tools@2.24.1(typescript@5.9.2):
+    dependencies:
+      '@noble/ciphers': 2.1.1
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+      '@scure/bip32': 2.0.1
+      '@scure/bip39': 2.0.1
+      nostr-wasm: 0.1.0
+    optionalDependencies:
+      typescript: 5.9.2
+
+  nostr-wasm@0.1.0: {}
 
   npm-package-arg@11.0.3:
     dependencies:


### PR DESCRIPTION
`rfq.ts` ships `httpTransport` and `relayTransport` (the dev broker framing), and says in two places that Nostr is the production target and *"replaces only this function"*:

```ts
// src/rfq.ts
 * the production target is Nostr (directed kind + NIP-44), which changes only
 * the transport functions here, nothing above them.
```

It was written in the wallet instead. So the package shipped the two transports nobody deploys, while the one a real solver listens on lived in a single app — and anyone else reaching a solver had to reimplement NIP-01 and NIP-44 for themselves.

This moves it in beside the other two, behaviour unchanged.

## `nostr-tools` does not become a hard dependency

It is an **optional peer**, and the transport is a separate entry point rather than a re-export from the root:

```ts
import { nostrRfqTransport } from "@arkade-os/swap/nostr";
```

A consumer doing HTTP-only swaps never resolves it. That is **verified against the built artifacts**, not asserted:

| artifact | `nostr-tools` references |
| --- | --- |
| `dist/index.js`, `dist/index.cjs` | **0** |
| `dist/index.d.ts`, `dist/index.d.cts` | **0** |
| `dist/nostr.js`, `dist/nostr.cjs` | 1 — external `import` / `require` |

The trade, stated plainly: importing the subpath without `nostr-tools` installed fails at resolution. That is the intended loud failure — at the import, naming the missing package — rather than a transport that silently degrades.

**Why a subpath and not a dynamic `await import()`:** both defer the cost, but the dynamic form makes construction async. This transport opens its subscription eagerly on purpose (so a fast solver cannot answer into a subscription that does not exist yet), so going async would push an `await` into every caller for nothing the subpath does not already give.

## One real behaviour change, forced by the peer range

`nostr-tools` altered the `subscribeMany` `onclose` payload **inside its own 2.x line** — `string[]` in earlier versions, `{ url, reason }[]` in later ones. It surfaced here as a dts build failure, because this worktree resolved 2.17.2 while the wallet pins `^2.12.0`.

Since the consumer now picks the version anywhere in `^2.12.0`, the handler normalises either shape rather than pinning to whichever it happened to be written against. Both shapes are exercised by tests. Declaring a peer range and only working at one point in it is a promise the package would not keep.

## Test plan

- `packages/swap` suite — **19 files / 288 tests / 0 failed** (9 new; no existing test or source file modified)
- `pnpm typecheck` — **0 errors**
- `pnpm build` — clean, emitting `dist/nostr.{js,cjs,d.ts,d.cts}`
- `pnpm lint` (prettier) — clean

Note for anyone reproducing locally: `@arkade-os/sdk` is a `workspace:*` dependency, so `pnpm --filter @arkade-os/sdk build` has to run first or typecheck and the dts build fail on unresolved module errors that have nothing to do with this change.

## Not in this PR

**The wallet keeps its copy for now.** It consumes this package as a vendored tarball (`arkade-os-swap-0.0.1-pr691-752ed57.tgz`), so it can only migrate to the subpath when it next re-vendors. Its copy stays byte-compatible in the meantime.

**The solver is deliberately untouched.** Its `src/relay/nostr.ts` is a `WireCodec` behind a separate `RelayConnection` — framing only, bidirectional, handling the broadcast kind and verifying signatures on every inbound event. That is a different abstraction from a maker-side request/reply transport, and the codec/connection split is the seam its own transport doc treats as the exit toward a future bus. Folding it onto this would trade that away, and would point a server at a maker-side client package.
