### PR TITLE
feat(sdk): reuse the core offchain-tx primitive for the receive claim

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -327,7 +327,10 @@ refuses, with `LockupAmountMismatchError`, to publish `P` for a lockup funded be
 `pkScript` is not enough on this leg, since a solver that funds the correctly derived script with
 dust still settles the payer's HTLC in full once `P` is out. The gate sums every live output and
 runs before signing — `P` reaches the Ark server at submit — and is skipped only for a lockup we
-have already partially claimed (`partiallyClaimed`), where `P` is public anyway. Until covclaimd's
+have already partially claimed (`partiallyClaimed`), where `P` is public anyway. The push itself is
+core's `signAndSubmitOffchainTx` plus `claimWithPreimageIdentity`, with `verifyServerSignatures`
+on: the server's countersignature is checked per input, against the leaf the local build spends,
+before finalizing. Until covclaimd's
 reference vectors are cross-checked, the `sealClaimPacket` test vector is pinned from this
 implementation and marked provisional (`TODO(claim-packet-vectors)`).
 

--- a/packages/swap/src/claim.ts
+++ b/packages/swap/src/claim.ts
@@ -11,9 +11,10 @@
  *
  * - The claim leaf carries a **preimage condition**, so the preimage rides
  *   the PSBT's `ConditionWitness` field — attached AFTER signing, on the ark
- *   transaction and every checkpoint (the condition is not part of the
- *   signed payload; attaching it first invalidates the signature the server
- *   then rejects as `INVALID_SIGNATURE`).
+ *   transaction and every checkpoint (`claimWithPreimageIdentity` in core owns
+ *   that ordering; the condition is not part of the signed payload, and
+ *   attaching it first invalidates the signature the server then rejects as
+ *   `INVALID_SIGNATURE`).
  * - The leaf is NOT covenant-pinned, so one aggregate output pays the whole
  *   balance wherever the trader says — the `nonInteractiveClaim` pin is the
  *   offline path's, not this one's. The destination is therefore a required
@@ -24,19 +25,15 @@
  * `secrets` (`senderIdentityForRfqSecrets`), a trader that is online never
  * depends on it.
  */
-import { base64, hex } from "@scure/base";
+import { hex } from "@scure/base";
 import { ripemd160 } from "@noble/hashes/legacy.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import {
     CSVMultisigTapscript,
-    ConditionWitness,
     type Identity,
-    Transaction,
     type VHTLC,
-    assertSubmittedArkTxid,
-    buildOffchainTx,
-    matchServerCheckpoints,
-    setArkPsbtField,
+    claimWithPreimageIdentity,
+    signAndSubmitOffchainTx,
 } from "@arkade-os/sdk";
 
 import {
@@ -98,30 +95,6 @@ const assertFiniteAmount = (value: number, reason: string, label: string): void 
 };
 
 /**
- * A signer that reveals a preimage when spending a condition leaf.
- *
- * The ordering encoded here is the whole point: the condition witness is NOT
- * part of what is signed, so attaching it before signing leaves a signature
- * over a PSBT that no longer matches once the field is present. Decorate per
- * claim, never wallet-wide.
- */
-const claimIdentity = (identity: Identity, preimage: Uint8Array): Identity => ({
-    ...identity,
-    sign: async (tx: Transaction, inputIndexes?: number[]): Promise<Transaction> => {
-        // Clone-and-round-trip so the caller's transaction is never mutated
-        // and the signed result is a fresh object we can add a field to.
-        const signed = Transaction.fromPSBT(
-            (await identity.sign(tx.clone(), inputIndexes)).toPSBT(),
-        );
-        const indexes = inputIndexes ?? Array.from({ length: signed.inputsLength }, (_, i) => i);
-        for (const index of indexes) {
-            setArkPsbtField(signed, index, ConditionWitness, [preimage]);
-        }
-        return signed;
-    },
-});
-
-/**
  * Build, sign, and push the collaborative claim of a receive-corridor lockup:
  * move every funded output at the lockup to the trader's own destination,
  * revealing `P` in the witness — which is also what settles the trader's side
@@ -141,6 +114,11 @@ const claimIdentity = (identity: Identity, preimage: Uint8Array): Identity => ({
  * single non-live input would take the live ones down with it. That refusal
  * comes first, which is what leaves the value gate a plain sum over live
  * outputs.
+ *
+ * The server's countersignature is verified before finalizing, per input and
+ * against that input's own leaf. It does not protect `P` — that reached the
+ * server at submit — but it turns "reported claimed, nothing landed, the
+ * solver refunds hours later" into an immediate failure.
  */
 export async function pushClaim(
     ark: ClaimArkProvider,
@@ -208,10 +186,15 @@ export async function pushClaim(
 
     const leaf = input.script.claim();
     const tapTree = input.script.encode();
-    const signer = claimIdentity(input.receiver, input.preimage);
 
-    const { arkTx, checkpoints } = buildOffchainTx(
-        input.vtxos.map((vtxo) => ({
+    // The core primitive owns build → sign → submit → match → finalize; this
+    // module supplies only what is swap-specific: the claim leaf, the preimage
+    // signer, and the server key to check the response against — the covenant
+    // already carries it, so it is not a caller obligation.
+    const arkTxid = await signAndSubmitOffchainTx({
+        identity: claimWithPreimageIdentity(input.receiver, input.preimage),
+        provider: ark,
+        inputs: input.vtxos.map((vtxo) => ({
             txid: vtxo.txid,
             vout: vtxo.vout,
             value: vtxo.value,
@@ -220,29 +203,11 @@ export async function pushClaim(
         })),
         // One aggregate output: unlike the covenant refund, this leaf inspects
         // nothing about the output set.
-        [{ script: input.destinationPkScript, amount: BigInt(locked) }],
+        outputs: [{ script: input.destinationPkScript, amount: BigInt(locked) }],
         serverUnrollScript,
-    );
-
-    // No index list: every input spends the same claim leaf, so all are
-    // signed — and the claim identity attaches `P` after signing.
-    const signedArkTx = await signer.sign(arkTx);
-    const submitted = await ark.submitTx(
-        base64.encode(signedArkTx.toPSBT()),
-        checkpoints.map((c) => base64.encode(c.toPSBT())),
-    );
-    assertSubmittedArkTxid(submitted, signedArkTx, "claim");
-
-    // Only checkpoints we built ourselves get signed — the server's response
-    // is matched against the local set first — and the preimage rides the
-    // checkpoint signatures exactly as it rides the ark transaction's.
-    const matched = matchServerCheckpoints(submitted.signedCheckpointTxs, checkpoints, "claim");
-    const finalCheckpoints = await Promise.all(
-        matched.map(async ({ server }) => base64.encode((await signer.sign(server, [0])).toPSBT())),
-    );
-
-    await ark.finalizeTx(submitted.arkTxid, finalCheckpoints);
-    return { arkTxid: submitted.arkTxid, amount: locked };
+        verifyServerSignatures: { serverPubkey: input.script.options.server },
+    });
+    return { arkTxid, amount: locked };
 }
 
 /**

--- a/packages/swap/test/claim.test.ts
+++ b/packages/swap/test/claim.test.ts
@@ -76,21 +76,39 @@ type FakeArk = ClaimArkProvider & {
     finalized: { arkTxid: string; checkpoints: string[] }[];
 };
 
-const fakeArk = (over: { checkpointsFor?: (submitted: string[]) => string[] } = {}): FakeArk => {
+/** The Ark server's own key — key(3) in the covenant above. */
+const SERVER_SIGNER = SingleKey.fromPrivateKey(priv(3));
+
+const serverCosign = async (psbt: string): Promise<string> =>
+    base64.encode((await SERVER_SIGNER.sign(Transaction.fromPSBT(base64.decode(psbt)))).toPSBT());
+
+/** A scripted arkd that countersigns like the real one — `pushClaim` verifies
+ * those signatures before finalizing, so a mute fake would prove nothing. */
+const fakeArk = (
+    over: {
+        checkpointsFor?: (submitted: string[]) => string[];
+        /** Answer without countersigning, as a server that never signed. */
+        cosign?: boolean;
+        finalArkTx?: (signed: string) => string | undefined;
+    } = {},
+): FakeArk => {
     const submitted: { arkTx: string; checkpoints: string[] }[] = [];
     const finalized: { arkTxid: string; checkpoints: string[] }[] = [];
+    const cosign = over.cosign ?? true;
     return {
         submitted,
         finalized,
         getInfo: async () => ({ checkpointTapscript: CHECKPOINT_TAPSCRIPT }),
         submitTx: async (arkTx: string, checkpoints: string[]) => {
             submitted.push({ arkTx, checkpoints });
+            const answered = over.checkpointsFor ? over.checkpointsFor(checkpoints) : checkpoints;
+            const finalArkTx = cosign ? await serverCosign(arkTx) : arkTx;
             return {
                 arkTxid: Transaction.fromPSBT(base64.decode(arkTx)).id,
-                finalArkTx: arkTx,
-                signedCheckpointTxs: over.checkpointsFor
-                    ? over.checkpointsFor(checkpoints)
-                    : checkpoints,
+                finalArkTx: over.finalArkTx ? over.finalArkTx(finalArkTx) : finalArkTx,
+                signedCheckpointTxs: cosign
+                    ? await Promise.all(answered.map(serverCosign))
+                    : answered,
             };
         },
         finalizeTx: async (arkTxid: string, checkpoints: string[]) => {
@@ -313,6 +331,38 @@ describe("pushClaim", () => {
                 expectedAmount: EXPECTED_AMOUNT,
             }),
         ).rejects.toThrow(LockupNeedsRecoveryError);
+    });
+
+    // Not a guard on `P` — that reached the server at submit — but on being
+    // told the claim landed when nothing was co-signed.
+    it("refuses to finalize a claim the server did not co-sign", async () => {
+        const ark = fakeArk({ cosign: false });
+        await expect(
+            pushClaim(ark, {
+                script: swapScript(),
+                receiver: RECEIVER,
+                preimage: PREIMAGE,
+                vtxos: VTXOS,
+                destinationPkScript: DESTINATION_PK_SCRIPT,
+                expectedAmount: EXPECTED_AMOUNT,
+            }),
+        ).rejects.toThrow(/not signed by the server/);
+        expect(ark.finalized).toHaveLength(0);
+    });
+
+    it("fails closed when the server returns no final ark tx to check", async () => {
+        const ark = fakeArk({ finalArkTx: () => undefined });
+        await expect(
+            pushClaim(ark, {
+                script: swapScript(),
+                receiver: RECEIVER,
+                preimage: PREIMAGE,
+                vtxos: VTXOS,
+                destinationPkScript: DESTINATION_PK_SCRIPT,
+                expectedAmount: EXPECTED_AMOUNT,
+            }),
+        ).rejects.toThrow(/no final ark tx to verify/);
+        expect(ark.finalized).toHaveLength(0);
     });
 
     it("throws on nothing to claim", async () => {

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -219,8 +219,11 @@ import {
     assertSubmittedArkTxid,
     matchServerCheckpoints,
     verifyTapscriptSignatures,
+    claimWithPreimageIdentity,
+    signAndSubmitOffchainTx,
     ArkTxInput,
     OffchainTx,
+    VerifyServerSignatures,
     combineTapscriptSigs,
     isValidArkAddress,
 } from "./utils/arkTransaction";
@@ -584,6 +587,8 @@ export {
     assertSubmittedArkTxid,
     matchServerCheckpoints,
     verifyTapscriptSignatures,
+    claimWithPreimageIdentity,
+    signAndSubmitOffchainTx,
     waitForIncomingFunds,
     hasBoardingTxExpired,
     combineTapscriptSigs,
@@ -758,6 +763,7 @@ export type {
     TapscriptType,
     ArkTxInput,
     OffchainTx,
+    VerifyServerSignatures,
     TapLeaves,
     IncomingFunds,
 

--- a/packages/ts-sdk/src/utils/arkTransaction.ts
+++ b/packages/ts-sdk/src/utils/arkTransaction.ts
@@ -13,7 +13,7 @@ import {
 } from "../script/base";
 import { P2A } from "./anchor";
 import { CSVMultisigTapscript } from "../script/tapscript";
-import { setArkPsbtField, VtxoTaprootTree } from "./unknownFields";
+import { ConditionWitness, setArkPsbtField, VtxoTaprootTree } from "./unknownFields";
 import { Transaction } from "./transaction";
 import { ArkAddress } from "../script/address";
 import { Extension } from "../extension";
@@ -526,6 +526,61 @@ export function assertSubmittedArkTxid(
 }
 
 /**
+ * Opt-in proof that the server co-signed what it handed back.
+ *
+ * Be precise about what this buys, because it is less than it sounds like. It
+ * does NOT protect a preimage or any other condition value: those reach the
+ * server at `submitTx`, before any of this runs. What it buys is a loud,
+ * immediate failure instead of a caller reporting success, watching nothing
+ * confirm, and learning the truth when the counterparty's refund lands.
+ */
+export interface VerifyServerSignatures {
+    /** The Ark server's key; x-only or compressed, both accepted. */
+    serverPubkey: Uint8Array;
+}
+
+/**
+ * Verify the server's signature on one input of `serverTx` against the leaf
+ * the LOCAL transaction spends at that index.
+ *
+ * Two things this ordering buys. The expected leaf is read from `localTx`, so a
+ * response carrying some other leaf is a mismatch rather than a self-consistent
+ * pass — taking the leaf from the server's own copy would ask the counterparty
+ * what it should have signed. And it is per-input, so a transaction mixing
+ * leaves, or spending several contracts at once, is checked honestly instead of
+ * against one assumed-shared leaf.
+ */
+function assertServerSignedLeaf(
+    serverTx: Transaction,
+    localTx: Transaction,
+    inputIndex: number,
+    serverPubkeyHex: string,
+    context: string,
+): void {
+    const leaf = localTx.getInput(inputIndex).tapLeafScript?.[0];
+    if (!leaf) {
+        throw new Error(
+            `${context}: input ${inputIndex} carries no spend leaf to verify the server signature against`,
+        );
+    }
+    try {
+        verifyTapscriptSignatures(
+            serverTx,
+            inputIndex,
+            [serverPubkeyHex],
+            undefined,
+            undefined,
+            tapLeafHash(scriptFromTapLeafScript(leaf)),
+        );
+    } catch (error) {
+        throw new ServerResponseMismatchError(
+            `${context}: input ${inputIndex} is not signed by the server on the leaf being spent ` +
+                `(${error instanceof Error ? error.message : String(error)})`,
+        );
+    }
+}
+
+/**
  * Assert every checkpoint in `checkpoints` is the one this wallet would build
  * for one of `inputs`, by rebuilding it from local VTXO data.
  *
@@ -589,6 +644,10 @@ export function assertCheckpointsMatchInputs(
  * machinery. Optional {@link hooks} let the wallet mark/clear its pending-tx
  * recovery flag around the network round-trip; a stateless caller omits them.
  *
+ * `options.verifyServerSignatures` is off by default, so every existing caller
+ * is unchanged; see {@link VerifyServerSignatures} for what it does and does
+ * not prove.
+ *
  * @returns The Ark transaction id and the server-signed checkpoint PSBTs
  * (the raw server response, for the wallet's bookkeeping).
  */
@@ -597,6 +656,7 @@ export async function submitOffchainTx(
     offchainTx: OffchainTx,
     signer: OffchainTxSigner,
     hooks?: { beforeSubmit?: () => Promise<void>; afterFinalize?: () => Promise<void> },
+    options?: { verifyServerSignatures?: VerifyServerSignatures },
 ): Promise<{ arkTxid: string; signedCheckpointTxs: string[] }> {
     const { arkTx: signedArkTx, userSignedCheckpoints } = await signer.signArkTx(
         offchainTx.arkTx,
@@ -630,6 +690,43 @@ export async function submitOffchainTx(
     // each must be one we built: nothing below signs a checkpoint that has not
     // been matched to a local one.
     const matched = matchServerCheckpoints(signedCheckpointTxs, offchainTx.checkpoints, "submitTx");
+
+    const verify = options?.verifyServerSignatures;
+    if (verify) {
+        // Fail closed: `finalArkTx` is optional in the wire type and
+        // `assertSubmittedArkTxid` skips it when absent, but a check that was
+        // asked for and cannot be run is a failed check, not a passed one.
+        if (response.finalArkTx === undefined) {
+            throw new ServerResponseMismatchError(
+                "submitTx: server returned no final ark tx to verify its signatures against",
+            );
+        }
+        const finalArkTx = Transaction.fromPSBT(base64.decode(response.finalArkTx));
+        const serverPubkeyHex = hex.encode(
+            verify.serverPubkey.length === 33
+                ? verify.serverPubkey.subarray(1)
+                : verify.serverPubkey,
+        );
+        for (let i = 0; i < offchainTx.arkTx.inputsLength; i++) {
+            assertServerSignedLeaf(
+                finalArkTx,
+                offchainTx.arkTx,
+                i,
+                serverPubkeyHex,
+                "submitTx ark tx",
+            );
+        }
+        // Each checkpoint carries exactly one input, the VTXO being spent.
+        matched.forEach(({ server, local }, index) =>
+            assertServerSignedLeaf(
+                server,
+                local,
+                0,
+                serverPubkeyHex,
+                `submitTx checkpoint ${index}`,
+            ),
+        );
+    }
 
     let finalCheckpoints: string[];
     if (userSignedCheckpoints) {
@@ -675,6 +772,8 @@ export async function signAndSubmitOffchainTx(params: {
     inputs: ArkTxInput[];
     outputs: TransactionOutput[];
     serverUnrollScript: CSVMultisigTapscript.Type;
+    /** Forwarded to {@link submitOffchainTx}; omitted, nothing is checked. */
+    verifyServerSignatures?: VerifyServerSignatures;
 }): Promise<string> {
     const offchainTx = buildOffchainTx(params.inputs, params.outputs, params.serverUnrollScript);
     // Single key: every input is signed by the same identity (all indexes), and
@@ -684,6 +783,41 @@ export async function signAndSubmitOffchainTx(params: {
         signArkTx: async (arkTx) => ({ arkTx: await params.identity.sign(arkTx) }),
         signCheckpoint: (checkpoint) => params.identity.sign(checkpoint),
     };
-    const { arkTxid } = await submitOffchainTx(params.provider, offchainTx, signer);
+    const { arkTxid } = await submitOffchainTx(params.provider, offchainTx, signer, undefined, {
+        verifyServerSignatures: params.verifyServerSignatures,
+    });
     return arkTxid;
+}
+
+/**
+ * Decorate a signer so it reveals `preimage` on every input it signs.
+ *
+ * The ordering encoded here is the whole point: the condition witness is NOT
+ * part of what is signed, so attaching it before signing leaves a signature
+ * over a PSBT that no longer matches once the field is present — which the
+ * server rejects as `INVALID_SIGNATURE`. Decorate per spend, never wallet-wide.
+ *
+ * For any condition-leaf spend (VHTLC claims on both swap directions); the
+ * generic signature keeps the decorated identity's own type, so the result is
+ * still whatever was passed in.
+ */
+export function claimWithPreimageIdentity<
+    T extends { sign(tx: Transaction, inputIndexes?: number[]): Promise<Transaction> },
+>(identity: T, preimage: Uint8Array): T {
+    return {
+        ...identity,
+        sign: async (tx: Transaction, inputIndexes?: number[]): Promise<Transaction> => {
+            // Clone-and-round-trip so the caller's transaction is never mutated
+            // and the signed result is a fresh object we can add a field to.
+            const signed = Transaction.fromPSBT(
+                (await identity.sign(tx.clone(), inputIndexes)).toPSBT(),
+            );
+            const indexes =
+                inputIndexes ?? Array.from({ length: signed.inputsLength }, (_, i) => i);
+            for (const index of indexes) {
+                setArkPsbtField(signed, index, ConditionWitness, [preimage]);
+            }
+            return signed;
+        },
+    };
 }

--- a/packages/ts-sdk/test/serverSignatureVerification.test.ts
+++ b/packages/ts-sdk/test/serverSignatureVerification.test.ts
@@ -1,0 +1,137 @@
+/**
+ * `submitOffchainTx`'s opt-in server-signature check, driven through
+ * `signAndSubmitOffchainTx` with real keys and real signatures.
+ *
+ * What it proves and what it does not: the server co-signed THIS transaction,
+ * on the leaf we are spending. It says nothing about condition values (a
+ * preimage has already reached the server by then) — it turns a silent
+ * "submitted, never landed" into an immediate failure.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { Transaction } from "../src/utils/transaction";
+import { SingleKey } from "../src/identity/singleKey";
+import { VtxoScript } from "../src/script/base";
+import { CSVMultisigTapscript, MultisigTapscript } from "../src/script/tapscript";
+import { signAndSubmitOffchainTx, type ArkTxInput } from "../src/utils/arkTransaction";
+
+const priv = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+const key = (fill: number): Uint8Array => schnorr.getPublicKey(priv(fill));
+
+const USER = SingleKey.fromPrivateKey(priv(11));
+const SERVER = SingleKey.fromPrivateKey(priv(3));
+const SERVER_PUBKEY = key(3);
+const P2TR = Uint8Array.from([0x51, 0x20, ...key(21)]);
+
+/** Two collaborative leaves the server is on: the spend uses the first, and
+ * the second is what a leaf-substituting server would sign instead. */
+const spendLeaf = MultisigTapscript.encode({ pubkeys: [key(11), SERVER_PUBKEY] }).script;
+const otherLeaf = MultisigTapscript.encode({ pubkeys: [key(12), SERVER_PUBKEY] }).script;
+const vtxoScript = new VtxoScript([spendLeaf, otherLeaf]);
+
+const SERVER_UNROLL = CSVMultisigTapscript.encode({
+    timelock: { type: "blocks", value: 144n },
+    pubkeys: [SERVER_PUBKEY],
+});
+
+const inputs = (): ArkTxInput[] => [
+    {
+        txid: "11".repeat(32),
+        vout: 0,
+        value: 10_000,
+        tapLeafScript: vtxoScript.findLeaf(hex.encode(spendLeaf)),
+        tapTree: vtxoScript.encode(),
+    },
+];
+
+const cosign = async (psbt: string): Promise<string> =>
+    base64.encode((await SERVER.sign(Transaction.fromPSBT(base64.decode(psbt)))).toPSBT());
+
+/** Sign the checkpoint after swapping its spend leaf for the other one: same
+ * txid (PSBT fields are not committed to), signature over the wrong leaf. */
+const cosignOtherLeaf = async (psbt: string): Promise<string> => {
+    const tx = Transaction.fromPSBT(base64.decode(psbt));
+    tx.updateInput(0, { tapLeafScript: [vtxoScript.findLeaf(hex.encode(otherLeaf))] });
+    return base64.encode((await SERVER.sign(tx)).toPSBT());
+};
+
+const provider = (
+    over: {
+        cosignArkTx?: (psbt: string) => Promise<string>;
+        cosignCheckpoint?: (psbt: string) => Promise<string>;
+        dropFinalArkTx?: boolean;
+    } = {},
+) => ({
+    submitTx: vi.fn(async (arkTx: string, checkpoints: string[]) => ({
+        arkTxid: Transaction.fromPSBT(base64.decode(arkTx)).id,
+        finalArkTx: over.dropFinalArkTx ? undefined : await (over.cosignArkTx ?? cosign)(arkTx),
+        signedCheckpointTxs: await Promise.all(checkpoints.map(over.cosignCheckpoint ?? cosign)),
+    })),
+    finalizeTx: vi.fn(async () => {}),
+});
+
+const submit = (
+    p: ReturnType<typeof provider>,
+    verifyServerSignatures?: { serverPubkey: Uint8Array },
+) =>
+    signAndSubmitOffchainTx({
+        identity: USER,
+        provider: p,
+        inputs: inputs(),
+        outputs: [{ script: P2TR, amount: 9_000n }],
+        serverUnrollScript: SERVER_UNROLL,
+        verifyServerSignatures,
+    });
+
+describe("signAndSubmitOffchainTx server-signature verification", () => {
+    it("finalizes when the server signed the ark tx and every checkpoint", async () => {
+        const p = provider();
+        const arkTxid = await submit(p, { serverPubkey: SERVER_PUBKEY });
+        expect(p.finalizeTx).toHaveBeenCalledTimes(1);
+        const submittedArkTx = p.submitTx.mock.calls[0][0];
+        expect(arkTxid).toBe(Transaction.fromPSBT(base64.decode(submittedArkTx)).id);
+    });
+
+    it("accepts a compressed server key, not only an x-only one", async () => {
+        const p = provider();
+        await submit(p, { serverPubkey: Uint8Array.from([0x02, ...SERVER_PUBKEY]) });
+        expect(p.finalizeTx).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a response the server never signed, before finalizing", async () => {
+        const p = provider({ cosignArkTx: async (psbt) => psbt });
+        await expect(submit(p, { serverPubkey: SERVER_PUBKEY })).rejects.toThrow(
+            /ark tx: input 0 is not signed by the server/,
+        );
+        expect(p.finalizeTx).not.toHaveBeenCalled();
+    });
+
+    // Same txid, signature over another leaf of the same contract: the expected
+    // leaf comes from the LOCAL build, so the substitution has nothing to hide
+    // behind.
+    it("rejects a checkpoint signed on a leaf other than the one being spent", async () => {
+        const p = provider({ cosignCheckpoint: cosignOtherLeaf });
+        await expect(submit(p, { serverPubkey: SERVER_PUBKEY })).rejects.toThrow(
+            /checkpoint 0: input 0 is not signed by the server on the leaf being spent/,
+        );
+        expect(p.finalizeTx).not.toHaveBeenCalled();
+    });
+
+    it("fails closed when the response carries no final ark tx — but only when asked to verify", async () => {
+        await expect(
+            submit(provider({ dropFinalArkTx: true }), { serverPubkey: SERVER_PUBKEY }),
+        ).rejects.toThrow(/no final ark tx to verify/);
+
+        // The same response with verification omitted is the pre-existing path.
+        const p = provider({ dropFinalArkTx: true });
+        await submit(p);
+        expect(p.finalizeTx).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves an unsigned-by-the-server response untouched when verification is omitted", async () => {
+        const p = provider({ cosignArkTx: async (psbt) => psbt, cosignCheckpoint: async (c) => c });
+        await submit(p);
+        expect(p.finalizeTx).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
PR 3 of the issue #712 receive stack (`plans/issue-712-arkade-swap-receive.md`). Stacked on #717; retarget as the stack merges.

`claim.ts` hand-rolled build → sign → submit → match → finalize because the core primitive that already does it was never exported.

`packages/ts-sdk`:
- export `signAndSubmitOffchainTx`
- add `claimWithPreimageIdentity(identity, preimage)` — the condition-witness-after-signing decorator, generic so it returns the identity type it was given
- opt-in `verifyServerSignatures: { serverPubkey }` on `submitOffchainTx`, forwarded by `signAndSubmitOffchainTx`. Checked before `finalizeTx`, per input, and — unlike the boltz version this generalizes — against the leaf the **local** build spends rather than one assumed-shared leaf read off the server's own copy. A checkpoint signed on another leaf of the same contract keeps its txid, so `matchServerCheckpoints` accepts it; only the local-leaf comparison catches it. Fails closed when `finalArkTx` is absent and verification was requested. Compressed or x-only server key both accepted.
- Default-off: omitting the option leaves every existing caller, including the wallet send path, bit-identical.

`packages/swap`: `pushClaim` now calls the primitive with `claimWithPreimageIdentity` and `verifyServerSignatures`, taking the server key off the covenant it already holds (`script.options.server`) rather than adding a parameter. The value gate from #717 stays exactly where it was, before signing.

What the check buys, precisely: it does **not** protect `P`, which reaches the server at submit, and it does not stand between us and a false terminal state. It converts "report `claimed`, watch nothing land, learn the truth when the solver's refund fires hours later" into an immediate failure.

`boltz-swap` is untouched — it is in production and this buys its users nothing on its own; folding its duplicate onto the export is a separate follow-up.