### PR TITLE
feat(swap): make lockup registration retryable on its own

### DIFF
--- a/packages/swap/src/lockupContract.ts
+++ b/packages/swap/src/lockupContract.ts
@@ -27,17 +27,28 @@ export type LockupContractWriter = Pick<IContractManager, "createContract">;
  *
  * Deliberately NOT a {@link SwapRefusal} or an {@link AddressMismatch}: those
  * say "the quote is bad, never fund it", while this says "the quote is fine and
- * your own store failed". A caller that retries the same quote after fixing its
- * storage is doing the right thing; one that retries past a refusal is not.
+ * your own store failed".
+ *
+ * The throw is the safe point: nothing is funded, and on the receive legs the
+ * invoice never left the function, so the abandoned quote is inert and simply
+ * retrying the request is the recovery. `script` travels beside `address` so a
+ * caller that still holds the swap — `RfqSwapManager`'s `ensureRegistered`, or
+ * one resuming from its own record — can retry `registerLockupContract` alone
+ * instead of re-quoting. It is NOT enough to resume a request that threw here:
+ * that caller never received the invoice or `secrets`.
  */
 export class LockupRegistrationFailed extends Error {
     /** The lockup address that was never registered — never fund it: nothing
      * is watching it. */
     readonly address: string;
-    constructor(address: string, cause: unknown) {
+    /** The covenant the row would have been written from — the other half of
+     * `registerLockupContract`, so the write is retryable without a quote. */
+    readonly script: InstanceType<typeof VHTLC.ScriptV2>;
+    constructor(script: InstanceType<typeof VHTLC.ScriptV2>, address: string, cause: unknown) {
         super(`failed to register the lockup contract for ${address}`, { cause });
         this.name = "LockupRegistrationFailed";
         this.address = address;
+        this.script = script;
     }
 }
 
@@ -71,6 +82,6 @@ export async function registerLockupContract(
             metadata: { genericallySpendable: false, kind: SWAP_LOCKUP_CONTRACT_KIND },
         });
     } catch (error) {
-        throw new LockupRegistrationFailed(address, error);
+        throw new LockupRegistrationFailed(script, address, error);
     }
 }

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -1446,15 +1446,26 @@ export function deriveLightningReceive(input: {
  * ({@link claimReceiveLockup} in `claim.ts`), or via covclaimd if it is
  * offline.
  *
- * The same obligations as {@link requestOnchainSend}: persist `secrets`
- * BEFORE paying — the preimage and the payout key re-derive from it (or, on a
- * non-HD wallet, are carried by it).
+ * Three obligations, all of them before the invoice is handed to a payer:
+ *
+ * 1. Persist `secrets` and `expectedAmount`. The preimage and the payout key
+ *    re-derive from `secrets` (or, on a non-HD wallet, are carried by it), and
+ *    without `expectedAmount` the claim has nothing to compare the funded
+ *    value against.
+ * 2. Stay online. covclaimd cannot claim this covenant today, so the offline
+ *    path the claim packet exists for does not run yet: an unclaimed lockup is
+ *    reclaimed by the solver at `refund_locktime` and the payer refunded.
+ * 3. On {@link LockupRegistrationFailed}, call this function again once the
+ *    store is working. The failed attempt is inert — it returned no invoice,
+ *    so nothing can be paid into the lockup nobody is watching — and the new
+ *    call derives its own preimage and `rfq_id`. Re-registering `error.script`
+ *    does NOT resume it: the invoice and `secrets` were never handed back.
  *
  * The invoice is the solver's, so it is verified here against the trader's own
  * `H` and the quote ({@link verifyReceiveInvoice}) before it is returned —
- * nothing publishable comes back from a failed check. Pay before
- * `invoiceExpiresAt`: the hold-invoice window is minutes, not the quote's
- * `valid_until`.
+ * nothing publishable comes back from a failed check, registration included.
+ * Pay before `invoiceExpiresAt`: the hold-invoice window is minutes, not the
+ * quote's `valid_until`.
  */
 export async function requestLightningReceive(
     wallet: IWallet,

--- a/packages/swap/test/rfqReceive.test.ts
+++ b/packages/swap/test/rfqReceive.test.ts
@@ -57,6 +57,7 @@ import {
     type RfqQuote,
     type RfqTransport,
 } from "../src/rfq";
+import { LockupRegistrationFailed } from "../src/lockupContract";
 import { onchainHtlcScript, paymentHashOf } from "../src/onchainHtlc";
 import { preimageForRfqSecrets } from "../src/secrets";
 
@@ -609,10 +610,14 @@ const lightningReceiveFlow = async (
         invoice?: Partial<InvoiceFacts>;
         decode?: (bolt11: string) => InvoiceFacts;
         maxPayAmount?: number;
+        register?: () => Promise<unknown>;
+        /** Reuse a wallet across flows, to observe what a second call
+         * allocates. Carries its own writer, so `register` does not apply. */
+        wallet?: IWallet;
     } = {},
 ) => {
-    const createContract = vi.fn(async () => ({}));
-    const wallet = await hdWallet(createContract);
+    const createContract = vi.fn(over.register ?? (async () => ({})));
+    const wallet = over.wallet ?? (await hdWallet(createContract));
     const seen: { paymentHash?: string; payoutPubkey?: string; claimPacket?: unknown } = {};
     const transport: RfqTransport = {
         async requestQuote(payload) {
@@ -726,6 +731,36 @@ describe("requestLightningReceive on an HD wallet", () => {
 
         const allowed = await lightningReceiveFlow({ maxPayAmount: 5_000 });
         expect((await allowed.run()).payAmount).toBe(5_000);
+    });
+
+    it("carries the covenant beside the address when registration fails", async () => {
+        const flow = await lightningReceiveFlow({
+            register: async () => {
+                throw new Error("repository unavailable");
+            },
+        });
+        const error = (await flow.run().catch((e: unknown) => e)) as LockupRegistrationFailed;
+
+        expect(error).toBeInstanceOf(LockupRegistrationFailed);
+        expect(error.cause).toMatchObject({ message: "repository unavailable" });
+        // Both halves of `registerLockupContract`'s call travel together, so a
+        // holder of the record can retry the write without a quote.
+        expect(error.script.address("tark", SERVER).encode()).toBe(error.address);
+        // The invoice must be unreachable, not merely discouraged: a payer who
+        // pays into an unwatched lockup loses the payment.
+        expect(error).not.toHaveProperty("invoice");
+        expect(error.message).not.toContain("lnbcrt");
+    });
+
+    it("derives a fresh payment hash per call, so starting over cannot reuse H", async () => {
+        const wallet = await hdWallet();
+        const first = await lightningReceiveFlow({ wallet });
+        await first.run();
+        const second = await lightningReceiveFlow({ wallet });
+        await second.run();
+
+        expect(first.seen.paymentHash).toBeDefined();
+        expect(second.seen.paymentHash).not.toBe(first.seen.paymentHash);
     });
 });
 


### PR DESCRIPTION
Stacked on #719.

`LockupRegistrationFailed` gains `readonly script` beside `address`, so a caller can retry `registerLockupContract(contracts, script, address)` without re-quoting. Additive; applies to all four corridors.

On the receive legs retrying the request cannot work: it re-quotes, and the solver refuses a second live quote on the same payment hash. The error's class comment and `requestLightningReceive`'s doc comment now state the layered recovery — retry registration, else start over with a fresh preimage and `rfq_id`, and never publish the abandoned invoice, since nothing watches that lockup.

`requestLightningReceive`'s doc also carries the other two obligations: persist `secrets` and `expectedAmount` before publishing the invoice, and stay online to claim (covclaimd cannot claim this covenant today).

Tests: registration failure surfaces both `address` and the covenant that derives it, and returns no invoice; two successive `requestLightningReceive` calls on one wallet derive different payment hashes.

PR 4 of the plan for #712.