### PR TITLE
fix(wallet): name the override that lowers a rejected timelock floor

### DIFF
--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -325,6 +325,8 @@ import {
     resolveCheckpointExitDelayPolicy,
     DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
     REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    MUTINYNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    SIGNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
 } from "./wallet/checkpointExitDelay";
 import type { CheckpointExitDelayPolicy } from "./wallet/checkpointExitDelay";
 import { buildForfeitTx } from "./forfeit";
@@ -652,6 +654,8 @@ export {
     resolveCheckpointExitDelayPolicy,
     DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
     REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    MUTINYNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    SIGNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
     type CheckpointExitDelayPolicy,
     buildForfeitTx,
     isRecoverable,

--- a/packages/ts-sdk/src/networks.ts
+++ b/packages/ts-sdk/src/networks.ts
@@ -8,6 +8,17 @@ export interface Network {
     pubKeyHash: number;
     scriptHash: number;
     wif: number;
+    /**
+     * Canonical name this network was resolved from, when known.
+     *
+     * `bech32` cannot separate the tb-family — testnet, signet and mutinynet
+     * share every field above — so anything that has to tell them apart (a
+     * per-network timelock floor, for one) has no other handle. Optional
+     * because a hand-built `Network` carries no name: consumers must read a
+     * missing one as "unknown" and fall back to their strictest branch rather
+     * than guess at one.
+     */
+    name?: NetworkName;
 }
 export const getNetwork = (network: NetworkName): Network => {
     const found = networks[network];
@@ -18,10 +29,10 @@ export const getNetwork = (network: NetworkName): Network => {
 };
 
 export const networks = {
-    bitcoin: withArkPrefix(NETWORK, "ark"),
-    testnet: withArkPrefix(TEST_NETWORK, "tark"),
-    signet: withArkPrefix(TEST_NETWORK, "tark"),
-    mutinynet: withArkPrefix(TEST_NETWORK, "tark"),
+    bitcoin: withArkPrefix(NETWORK, "ark", "bitcoin"),
+    testnet: withArkPrefix(TEST_NETWORK, "tark", "testnet"),
+    signet: withArkPrefix(TEST_NETWORK, "tark", "signet"),
+    mutinynet: withArkPrefix(TEST_NETWORK, "tark", "mutinynet"),
     regtest: withArkPrefix(
         {
             ...TEST_NETWORK,
@@ -30,13 +41,19 @@ export const networks = {
             scriptHash: 0xc4,
         },
         "tark",
+        "regtest",
     ),
 };
 
-function withArkPrefix(network: Omit<Network, "hrp">, prefix: string): Network {
+function withArkPrefix(
+    network: Omit<Network, "hrp" | "name">,
+    prefix: string,
+    name: NetworkName,
+): Network {
     return {
         ...network,
         hrp: prefix,
+        name,
     };
 }
 

--- a/packages/ts-sdk/src/wallet/batchExpiry.ts
+++ b/packages/ts-sdk/src/wallet/batchExpiry.ts
@@ -68,5 +68,5 @@ export function assertValidBatchExpiry(
         );
     }
 
-    return assertTimelockWithinFloor(batchExpiry, policy, "batch expiry");
+    return assertTimelockWithinFloor(batchExpiry, policy, "batch expiry", "minBatchExpirySeconds");
 }

--- a/packages/ts-sdk/src/wallet/checkpointExitDelay.ts
+++ b/packages/ts-sdk/src/wallet/checkpointExitDelay.ts
@@ -1,6 +1,6 @@
 import { hex } from "@scure/base";
 import { Bytes, equalBytes } from "@scure/btc-signer/utils.js";
-import type { Network } from "../networks";
+import type { Network, NetworkName } from "../networks";
 import { CSVMultisigTapscript } from "../script/tapscript";
 import { ServerResponseMismatchError } from "../providers/errors";
 import { assertTimelockInPolicy, isRegtest } from "./timelockPolicy";
@@ -17,6 +17,42 @@ export const DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS = 86_400n;
  * 1-block attack.
  */
 export const REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS = 1_200n;
+
+/**
+ * Wall-clock floor for the checkpoint exit delay on mutinynet.
+ *
+ * The hosted mutinynet Arkade Service advertises exactly this: its
+ * `checkpointTapscript` decodes to a 4096s (8 * 512) CSV, sized for a chain
+ * that mines ~30s blocks. {@link DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS}
+ * rejects it, which left mutinynet unusable until the caller went and found
+ * `minCheckpointExitDelaySeconds` and then this number.
+ */
+export const MUTINYNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS = 4_096n;
+
+/**
+ * Wall-clock floor for the checkpoint exit delay on signet.
+ *
+ * The hosted signet Arkade Service advertises 86016s (168 * 512): a 24h
+ * setting rounded down to BIP-68's 512s granularity, since 86400 is not a
+ * multiple of 512 and so cannot be encoded in a seconds-typed timelock at all.
+ * That lands 384s under {@link DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS} and
+ * is rejected by it, so signet needs its own floor for the same reason
+ * mutinynet does.
+ */
+export const SIGNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS = 86_016n;
+
+/**
+ * Floors for the networks whose hosted Arkade Service advertises a delay below
+ * {@link DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS}.
+ *
+ * Each entry is that operator's own advertised value, so the default accepts
+ * exactly what it serves and nothing lower. Deliberately not a blanket
+ * relaxation: `bitcoin` and `testnet` are absent and keep the generic floor.
+ */
+const HOSTED_MIN_CHECKPOINT_EXIT_DELAY_SECONDS: Partial<Record<NetworkName, bigint>> = {
+    signet: SIGNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    mutinynet: MUTINYNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+};
 
 /** Bounds applied to a server-supplied `ArkInfo.checkpointTapscript`. */
 export type CheckpointExitDelayPolicy = {
@@ -47,9 +83,21 @@ export type CheckpointExitDelayPolicy = {
  * selected by the operator.
  */
 export function defaultCheckpointExitDelayPolicy(network: Network): CheckpointExitDelayPolicy {
-    return isRegtest(network)
-        ? { minSeconds: REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS, requireSeconds: false }
-        : { minSeconds: DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS, requireSeconds: true };
+    if (isRegtest(network)) {
+        return { minSeconds: REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS, requireSeconds: false };
+    }
+    // A `Network` assembled by hand carries no name and falls through to the
+    // generic floor: an unrecognized network must not pick up a relaxed one.
+    const hosted = network.name
+        ? HOSTED_MIN_CHECKPOINT_EXIT_DELAY_SECONDS[network.name]
+        : undefined;
+    // Only `minSeconds` moves for the hosted networks. Each advertises a
+    // seconds-typed delay, so `requireSeconds` stays on and the block-typed
+    // branch remains regtest-only.
+    return {
+        minSeconds: hosted ?? DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+        requireSeconds: true,
+    };
 }
 
 /** Resolve a policy for `network`, applying any caller overrides on top. */

--- a/packages/ts-sdk/src/wallet/checkpointExitDelay.ts
+++ b/packages/ts-sdk/src/wallet/checkpointExitDelay.ts
@@ -111,7 +111,12 @@ export function assertValidServerUnrollScript(
     // Use the type the script itself encodes (BIP-68 disable flag) rather than
     // re-deriving it from the magnitude: a block-typed checkpoint delay above
     // 511 blocks is legal and would otherwise be misread as seconds.
-    assertTimelockInPolicy(script.params.timelock, policy, "checkpoint exit delay");
+    assertTimelockInPolicy(
+        script.params.timelock,
+        policy,
+        "checkpoint exit delay",
+        "minCheckpointExitDelaySeconds",
+    );
 
     return script;
 }

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -116,8 +116,10 @@ export interface BaseWalletConfig {
     /**
      * Minimum accepted checkpoint exit delay decoded from `ArkInfo.checkpointTapscript`,
      * as wall-clock seconds. Defaults per network — see
-     * `defaultCheckpointExitDelayPolicy`. Lowering it below the default relaxes a
-     * fund-safety bound; intended for local testing.
+     * `defaultCheckpointExitDelayPolicy`, which already carries the value the
+     * hosted signet and mutinynet Arkade Services advertise, so neither needs
+     * this set. Lowering it below the default relaxes a fund-safety bound;
+     * intended for local testing.
      */
     minCheckpointExitDelaySeconds?: bigint;
     /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -416,8 +416,9 @@ interface ServiceWorkerWalletOptions {
     /**
      * Timelock floors forwarded to the worker wallet. Lowering either below its
      * per-network default relaxes a fund-safety bound; intended for local
-     * testing and for fast public test networks (mutinynet) whose arkd runs
-     * below the mainnet-grade floors.
+     * testing. The fast public test networks whose arkd runs below the
+     * mainnet-grade checkpoint floor (signet, mutinynet) are defaulted to their
+     * own advertised value, so neither needs these set.
      *
      * @see WalletConfig.minBatchExpirySeconds
      */

--- a/packages/ts-sdk/src/wallet/timelockPolicy.ts
+++ b/packages/ts-sdk/src/wallet/timelockPolicy.ts
@@ -46,7 +46,9 @@ export const toSeconds = (t: RelativeTimelock): bigint =>
  * `label` names the value in thrown messages (e.g. `"batch expiry"`,
  * `"checkpoint exit delay"`) and `overrideOption` names the wallet-config
  * option that lowers this particular floor (e.g. `"minBatchExpirySeconds"`), so
- * callers share this one implementation without losing message specificity.
+ * callers share this one implementation without losing message specificity. A
+ * floor rejection quotes the value that would accept the timelock alongside the
+ * option name, so acting on the message needs nothing the message did not say.
  *
  * @throws {ServerResponseMismatchError} if the timelock is out of policy.
  */
@@ -69,8 +71,8 @@ export function assertTimelockInPolicy(
     if (seconds < policy.minSeconds) {
         throw new ServerResponseMismatchError(
             `${label} rejected: ${timelock.value} ${timelock.type} is below the ` +
-                `${policy.minSeconds}s floor; pass ${overrideOption} to Wallet.create ` +
-                `to lower it`,
+                `${policy.minSeconds}s floor; pass ${overrideOption}: ${seconds}n to ` +
+                `Wallet.create to lower it`,
         );
     }
 

--- a/packages/ts-sdk/src/wallet/timelockPolicy.ts
+++ b/packages/ts-sdk/src/wallet/timelockPolicy.ts
@@ -44,8 +44,9 @@ export const toSeconds = (t: RelativeTimelock): bigint =>
  * Check an already-typed server-supplied relative timelock against `policy`.
  *
  * `label` names the value in thrown messages (e.g. `"batch expiry"`,
- * `"checkpoint exit delay"`) so callers share this one implementation without
- * losing message specificity.
+ * `"checkpoint exit delay"`) and `overrideOption` names the wallet-config
+ * option that lowers this particular floor (e.g. `"minBatchExpirySeconds"`), so
+ * callers share this one implementation without losing message specificity.
  *
  * @throws {ServerResponseMismatchError} if the timelock is out of policy.
  */
@@ -53,8 +54,12 @@ export function assertTimelockInPolicy(
     timelock: RelativeTimelock,
     policy: TimelockFloorPolicy,
     label: string,
+    overrideOption: string,
 ): RelativeTimelock {
     if (policy.requireSeconds && timelock.type === "blocks") {
+        // No override named here on purpose: `requireSeconds` is not settable
+        // through the wallet config, so only the floor half of this policy is
+        // something a caller can act on.
         throw new ServerResponseMismatchError(
             `${label} rejected: block-typed timelocks are not accepted (got ${timelock.value})`,
         );
@@ -64,7 +69,8 @@ export function assertTimelockInPolicy(
     if (seconds < policy.minSeconds) {
         throw new ServerResponseMismatchError(
             `${label} rejected: ${timelock.value} ${timelock.type} is below the ` +
-                `${policy.minSeconds}s floor`,
+                `${policy.minSeconds}s floor; pass ${overrideOption} to Wallet.create ` +
+                `to lower it`,
         );
     }
 
@@ -81,6 +87,7 @@ export function assertTimelockWithinFloor(
     value: bigint,
     policy: TimelockFloorPolicy,
     label: string,
+    overrideOption: string,
 ): RelativeTimelock {
-    return assertTimelockInPolicy(toTimelock(value), policy, label);
+    return assertTimelockInPolicy(toTimelock(value), policy, label, overrideOption);
 }

--- a/packages/ts-sdk/test/batch-expiry-validation.test.ts
+++ b/packages/ts-sdk/test/batch-expiry-validation.test.ts
@@ -104,6 +104,15 @@ describe("assertValidBatchExpiry", () => {
         ).toThrow(/below the 86400s floor/);
     });
 
+    it("names its own override, not the checkpoint one", () => {
+        // This floor is reached at settle rather than at connect, so it is the
+        // one most likely to be met by someone who has already cleared the
+        // checkpoint floor and is reaching for the knob that moved that.
+        expect(() =>
+            assertValidBatchExpiry(512n, defaultBatchExpiryPolicy(networks.bitcoin)),
+        ).toThrow(/minBatchExpirySeconds/);
+    });
+
     it("still applies the floor when the value equals the advertised vtxoTreeExpiry", () => {
         expect(() =>
             assertValidBatchExpiry(512n, {

--- a/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
+++ b/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
@@ -195,4 +195,17 @@ describe("assertValidServerUnrollScript", () => {
             ),
         ).toThrow(/below the 86400s floor/);
     });
+
+    it("names the override that would accept the delay", () => {
+        // The floor is a client-side policy, so a rejection is actionable — but
+        // only if the message says which knob moves it. 4096s is what the hosted
+        // mutinynet operator advertises, and mutinynet is structurally identical
+        // to testnet here, so this is the rejection consumers actually meet.
+        expect(() =>
+            assertValidServerUnrollScript(
+                encodeCheckpointTapscript(4096n),
+                defaultCheckpointExitDelayPolicy(networks.bitcoin),
+            ),
+        ).toThrow(/minCheckpointExitDelaySeconds/);
+    });
 });

--- a/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
+++ b/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
@@ -263,13 +263,25 @@ describe("hosted networks that advertise below the generic floor", () => {
         );
     });
 
+    // Each network's floor is exactly the delay its own fixture decodes to, so
+    // asserting the decoded value against the constant pins the two together:
+    // a constant moved in either direction stops matching the wire bytes.
+    const ADVERTISED_SECONDS = {
+        bitcoin: 605_184n,
+        signet: SIGNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+        mutinynet: MUTINYNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    } as const;
+
     for (const network of ["bitcoin", "signet", "mutinynet"] as const) {
         it(`accepts what the hosted ${network} service serves, with no override`, () => {
             const result = assertValidServerUnrollScript(
                 ADVERTISED[network],
                 defaultCheckpointExitDelayPolicy(networks[network]),
             );
-            expect(result.params.timelock.type).toBe("seconds");
+            expect(result.params.timelock).toEqual({
+                value: ADVERTISED_SECONDS[network],
+                type: "seconds",
+            });
         });
     }
 

--- a/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
+++ b/packages/ts-sdk/test/checkpoint-exit-delay-validation.test.ts
@@ -7,6 +7,8 @@ import {
     resolveCheckpointExitDelayPolicy,
     DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
     REGTEST_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    MUTINYNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+    SIGNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
 } from "../src/wallet/checkpointExitDelay";
 import { ServerResponseMismatchError } from "../src/providers/errors";
 import { networks } from "../src/networks";
@@ -207,5 +209,90 @@ describe("assertValidServerUnrollScript", () => {
                 defaultCheckpointExitDelayPolicy(networks.bitcoin),
             ),
         ).toThrow(/minCheckpointExitDelaySeconds/);
+    });
+
+    it("quotes the value that would accept it, not just the option name", () => {
+        // Naming the option still leaves the reader to derive what to set it to.
+        // The rejected delay is exactly that value, so the message carries it
+        // and nothing has to be worked out from the rest of the sentence.
+        expect(() =>
+            assertValidServerUnrollScript(
+                encodeCheckpointTapscript(4096n),
+                defaultCheckpointExitDelayPolicy(networks.bitcoin),
+            ),
+        ).toThrow(/minCheckpointExitDelaySeconds: 4096n/);
+    });
+});
+
+describe("hosted networks that advertise below the generic floor", () => {
+    // Verbatim `ArkInfo.checkpointTapscript` as served by each hosted Arkade
+    // Service. Held as raw wire strings rather than re-encoded from the
+    // constants, so a constant that drifts from what the operator actually
+    // serves fails here instead of passing against itself.
+    const ADVERTISED = {
+        bitcoin: "039e0440b27520b43a8363118c084a04d4f6a50ebfa58e81957f8cceceb2aee0ab64c9fd2d9977ac",
+        signet: "03a80040b275202697695adaf0635333d6240739de02feb3f6852e180c596b69a77536aadb7123ac",
+        mutinynet:
+            "03080040b27520dfcaec558c7e78cf3e38b898ba8a43cfb5727266bae32c5c5b3aeb32c558aa0bac",
+    } as const;
+
+    it("defaults mutinynet to the delay its operator advertises", () => {
+        expect(MUTINYNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS).toBe(4_096n);
+        expect(defaultCheckpointExitDelayPolicy(networks.mutinynet)).toEqual({
+            minSeconds: MUTINYNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+            requireSeconds: true,
+        });
+    });
+
+    it("defaults signet to the delay its operator advertises", () => {
+        // 168 * 512: a 24h setting rounded down to BIP-68's 512s granularity,
+        // which is the only reason it misses the 86400s floor — by 384s.
+        expect(SIGNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS).toBe(86_016n);
+        expect(defaultCheckpointExitDelayPolicy(networks.signet)).toEqual({
+            minSeconds: SIGNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+            requireSeconds: true,
+        });
+    });
+
+    it("leaves bitcoin and testnet on the generic floor", () => {
+        expect(defaultCheckpointExitDelayPolicy(networks.bitcoin).minSeconds).toBe(
+            DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+        );
+        expect(defaultCheckpointExitDelayPolicy(networks.testnet).minSeconds).toBe(
+            DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+        );
+    });
+
+    for (const network of ["bitcoin", "signet", "mutinynet"] as const) {
+        it(`accepts what the hosted ${network} service serves, with no override`, () => {
+            const result = assertValidServerUnrollScript(
+                ADVERTISED[network],
+                defaultCheckpointExitDelayPolicy(networks[network]),
+            );
+            expect(result.params.timelock.type).toBe("seconds");
+        });
+    }
+
+    it("does not spill the relaxed floors onto testnet", () => {
+        // testnet shares every other `Network` field with signet and mutinynet,
+        // so a default keyed on anything but the name would relax it too.
+        for (const tapscript of [ADVERTISED.signet, ADVERTISED.mutinynet]) {
+            expect(() =>
+                assertValidServerUnrollScript(
+                    tapscript,
+                    defaultCheckpointExitDelayPolicy(networks.testnet),
+                ),
+            ).toThrow(/below the 86400s floor/);
+        }
+    });
+
+    it("keeps the generic floor for a Network that carries no name", () => {
+        // Fail closed: a hand-built network has no name to match on and must not
+        // inherit a relaxed floor just because it looks like the tb-family.
+        const { name, ...unnamed } = networks.mutinynet;
+        expect(name).toBe("mutinynet");
+        expect(defaultCheckpointExitDelayPolicy(unnamed).minSeconds).toBe(
+            DEFAULT_MIN_CHECKPOINT_EXIT_DELAY_SECONDS,
+        );
     });
 });


### PR DESCRIPTION
Connecting a service to the hosted mutinynet operator fails with:

```
checkpoint exit delay rejected: 4096 seconds is below the 86400s floor
```

which is accurate and not actionable. The floor is a client-side policy and `minCheckpointExitDelaySeconds` exists precisely to move it, but the message mentions neither. Finding the option means decoding the shipped bundle or stumbling on #706 in another repo — I did the first before the second.

`batch expiry` has the same gap and a worse landing spot. It is validated on `BatchStartedEvent` rather than at setup, so it surfaces at the first settle, well after the connection has been working, when the checkpoint knob is the obvious wrong thing to reach for. Naming each override separately is what keeps someone from trying that.

Both messages come from `assertTimelockInPolicy`, which already takes a `label` so the two call sites can share one implementation without losing specificity. This adds `overrideOption` on the same footing, and quotes the value that would accept the timelock, since naming the option still leaves the number to be derived:

```
checkpoint exit delay rejected: 4096 seconds is below the 86400s floor; pass minCheckpointExitDelaySeconds: 4096n to Wallet.create to lower it
```

The block-typed branch deliberately gets no hint. `requireSeconds` is not settable through the wallet config, so there is nothing actionable to name there, and pointing at an option that would not help seemed worse than saying nothing — there is a comment to that effect, since otherwise it reads as an oversight.

`overrideOption` is required rather than optional. `timelockPolicy.ts` is not exported from the package index and has exactly two callers, so nothing downstream breaks, and requiring it means a third floor cannot be added without deciding what a caller does about it. Happy to make it optional, or to fold the name into `TimelockFloorPolicy` instead, if you would rather keep the helper loose.

Existing assertions on `/below the 86400s floor/` are unanchored, so they still pass with the clause appended.

## A better message is still a message every mutinynet integrator has to act on

So the floors now default to what the hosted operators actually advertise. Two of the three are below the generic floor and reject at `Wallet.create` before anything else happens:

| network | advertised checkpoint delay | vs. the 86400s floor |
|---|---|---|
| bitcoin (`arkade.computer`) | 605184s | clears it |
| signet (`signet.arkade.sh`) | 86016s | 384s short — rejected |
| mutinynet (`mutinynet.arkade.sh`) | 4096s | rejected |

Read from each `/v1/info` and decoded with the SDK's own `CSVMultisigTapscript.decode`. The raw `checkpointTapscript` strings are in the test as fixtures rather than re-encoded from the constants, so a constant that drifts from what the operator serves fails there instead of passing against itself.

signet's number is the one worth pausing on. BIP-68 seconds have 512s granularity and 86400 is not a multiple of 512, so a 24h setting can only encode as 86016 (168\*512) or 86528 (169\*512). arkd rounds down, and the floor rejects the result — meaning the floor is unreachable for anyone configuring exactly the 24h it was written to match. I have left the floor alone here; that seemed like a separate decision from making the shipped networks work.

`defaultCheckpointExitDelayPolicy` now returns each of those two networks' own advertised delay as its floor: the default accepts exactly what the operator serves and nothing lower. Scoped per network, so bitcoin and testnet keep 86400 and nothing global moves. Only `minSeconds` moves — both advertise seconds-typed delays, so `requireSeconds` stays on and the block-typed branch stays regtest-only.

Signet is scope this PR did not start with. It is the same defect measured the same way, and leaving it out means the next person meets it one network over — but it is one constant and one table entry to drop if it should be split into its own change.

Batch expiry needs no equivalent, which is worth recording so it is not re-litigated: five sampled mutinynet commitment txs all report an `expiresAt - endedAt` of 7775744s (~90 days), about 90x above its floor.

## `Network` could not tell these networks apart

Keying a default on the network needs the network's name, and `Network` did not carry it — testnet, signet and mutinynet are the same object down to every field (`tb` / `tark`). `resolveNetworkName` in `wallet/exit/estimate.ts` already documents the gap from the other side ("the tb-family defaults to `testnet`, so pass this explicitly on signet/mutinynet"); it could now read `network.name`, but I left it alone as out of scope for this.

So `Network` gains an optional `name`, populated by the `networks` table. Optional rather than required, on two grounds: it stays additive for anyone constructing a `Network` themselves, and a `Network` that arrives without one falls through to the generic floor rather than to a relaxed one. Fail-closed was the point — an unrecognized network must not inherit somebody else's relaxation.

## Test plan

- `pnpm lint`, `pnpm run typecheck` (all three packages) and `pnpm run build` — all exit 0.
- `pnpm test:unit` — exit 0: ts-sdk 154 files / 2360 passed + 1 skipped, swap 6 / 67, boltz-swap 23 / 614. Unchanged from this branch's baseline (2351 / 67 / 614) except the 9 added ts-sdk cases.
- Negative controls, to check the added cases actually bite: dropping the per-network default and the value in the message fails 5 of them; lowering `MUTINYNET_MIN_CHECKPOINT_EXIT_DELAY_SECONDS` to 2048 fails 2 more. Both restored, all pass.
- The live `checkpointTapscript` from each hosted service, run through the built `dist` via the public `assertValidServerUnrollScript`: mutinynet and signet accepted with zero configuration, and the same mutinynet script still rejected under `networks.testnet`.
- Not run locally: `pnpm run test:integration` (needs the Docker regtest stack) and `pnpm -C packages/ts-sdk smoke:dist` (creates a symlink, which needs privileges this machine does not have). Both are green in CI — all six integration groups and the dist smoke test included.
