### PR TITLE
docs(swap): finish user/solver in the rfq, watch and onchain layers

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -87,7 +87,7 @@ funds an offer should keep cancelling within reach.
 5. **`watch`** — `watchOfferSwaps` drives swap status from the wallet's own contract events, so a
    fill shows up without re-running a scan. Registration is what makes it possible: only a
    registered covenant is watched. See "Live status" below.
-6. **`rfq`** — the maker / intent-submitter side of quoted swaps: RFQ negotiation over HTTP or a
+6. **`rfq`** — the user side of quoted swaps: RFQ negotiation over HTTP or a
    relay, then non-interactive filling (see below). All four reference-solver corridors:
    `arkade:BTC -> lightning:BTC` and `arkade:BTC -> onchain:BTC` (send), `lightning:BTC ->
    arkade:BTC` and `onchain:BTC -> arkade:BTC` (receive), plus `arkade:BTC|asset ->
@@ -294,7 +294,7 @@ other, and every request times out appearing to blame the solver.
 
 ## Onchain corridor: `arkade:BTC -> onchain:BTC` (and back)
 
-The off-board direction is implemented end to end on the maker side. The maker generates `P`
+The off-board direction is implemented end to end on the user side. The user generates `P`
 itself — `sha256(P)` is the wire `payment_hash`, and the script commitment is
 `ripemd160(sha256(P))` in BOTH contracts, so one preimage unlocks the Arkade leaf and the L1 leaf.
 The Arkade lockup is byte-identical to the lightning-send program (`htlcSendProgram` is an alias —
@@ -336,7 +336,7 @@ await addAssetSwap(repository, {
 });
 await wallet.send({ address: swap.address, amount: swap.fundAmount });
 
-// Unlike lightning-send the maker must STAY CLAIM-CAPABLE: watch for the fill
+// Unlike lightning-send the user must STAY CLAIM-CAPABLE: watch for the fill
 // and claim before the HTLC's refund leaf opens. chain is YOUR ChainSource.
 const utxo = await awaitOnchainFill(chain, swap.htlc, minConfirmations);
 await claimOnchainFill(chain, {
@@ -353,12 +353,12 @@ await claimOnchainFill(chain, {
 (`solver_pubkey`, `refund_locktime`, `htlc_pubkey`, `htlc_locktime`, `min_confirmations`) and
 refuses on any mismatch — `lockup_address` and `htlc_address` are compare-only. `assertFundable`
 adds three onchain gates, run immediately before funding: `timelock_order` (the L1 locktime plus a
-2 h reorg margin must fall before the Arkade refund, so the maker's escape hatch opens LAST),
+2 h reorg margin must fall before the Arkade refund, so the user's escape hatch opens LAST),
 `claim_window_too_short`, and `confirmations_out_of_range`. `claimOnchainFill` refuses to
 broadcast — publishing `P` — with less than 90 minutes before the refund leaf opens: past that
 point the safe move is to let the swap die and take the Arkade covenant refund rather than race
 the solver's refund with `P` exposed. If the solver never fills, there is nothing to do: the
-covenant refund pays the maker's address after `refund_locktime`, pushable by anyone.
+covenant refund pays the user's address after `refund_locktime`, pushable by anyone.
 
 Crash recovery is record-driven, not chain-driven: `classifyOnchainHtlc` re-derives the HTLC's
 state (unfunded / awaiting confirmations / claimable / refundable / claimed-with-P / swept) from

--- a/packages/swap/src/claimPacket.ts
+++ b/packages/swap/src/claimPacket.ts
@@ -1,5 +1,5 @@
 /**
- * ClaimPacket sealing: P encrypted to covclaimd so the maker can go offline
+ * ClaimPacket sealing: P encrypted to covclaimd so the user can go offline
  * after funding — the solver carries the packet blindly and cannot decrypt it.
  *
  * Scheme (per the covclaimd wire protocol):

--- a/packages/swap/src/coverage.ts
+++ b/packages/swap/src/coverage.ts
@@ -2,13 +2,13 @@
  * Coverage: whether an offer's script is in the wallet's watched set.
  *
  * Both edges live here because they are one decision seen from two sides.
- * `createOffer` promotes a script the moment it hands the maker an address to
+ * `createOffer` promotes a script the moment it hands the user an address to
  * fund ({@link promoteOfferContract}); the watcher and the restore consumer
  * retire it once nothing at that script holds funds any more
  * ({@link retireSettledOfferContracts}). Identical offers derive one script, so
  * those two can name the same row — and a demotion that lands after a promotion
  * recreates exactly the failure the promotion exists to prevent: an address the
- * maker was told to fund, out of the subscription, the poll and every sync.
+ * user was told to fund, out of the subscription, the poll and every sync.
  *
  * Two things keep them apart:
  *
@@ -17,7 +17,7 @@
  *   than left to interleave inside the manager.
  * - **The issuance mark.** A swap record is keyed by its funding txid, so an
  *   offer that has been created but not yet funded has no record at all — it is
- *   invisible to a liveness check over records, for as long as the maker takes
+ *   invisible to a liveness check over records, for as long as the user takes
  *   to send. {@link promoteOfferContract} therefore records the issuance
  *   itself, and a script with an address still waiting for its deposit is never
  *   retired.
@@ -34,7 +34,7 @@ import type { AssetSwap, AssetSwapStatus } from "./store";
 /**
  * Statuses after which the covenant no longer holds funds, so its contract can
  * leave the watched set. NOT `recoverable`: a swept deposit is still the
- * maker's money at that script, and unwatching it is how it goes missing.
+ * user's money at that script, and unwatching it is how it goes missing.
  */
 export const RETIRABLE: readonly AssetSwapStatus[] = ["fulfilled", "cancelled"];
 
@@ -118,7 +118,7 @@ export async function promoteOfferContract(
  *
  * `retained`, not deleted: the row is what keeps the deposit's VTXOs
  * annotatable and its history readable, while `retained` is what drops it from
- * the subscription, the failsafe poll and every sync. A maker who has made
+ * the subscription, the failsafe poll and every sync. A user who has made
  * hundreds of offers otherwise re-subscribes to hundreds of dead scripts on
  * every wallet start.
  *

--- a/packages/swap/src/nostr.ts
+++ b/packages/swap/src/nostr.ts
@@ -5,7 +5,7 @@
  * `rfq.ts` ships two other transports: `httpTransport`, and `relayTransport`
  * which speaks the dev broker's `{op:"sub"|"event"}` framing. Neither is what a
  * deployed solver listens on. This is, and it satisfies the same
- * {@link RfqTransport} interface, so everything above the transport — the maker
+ * {@link RfqTransport} interface, so everything above the transport — the user
  * flow, quote verification, the store — is identical whichever one it is handed.
  *
  * ## Why this is a separate entry point

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -281,8 +281,8 @@ export const OFFER_CONTRACT_KIND = "asset-swap-offer";
  *
  * `metadata.genericallySpendable: false` is what keeps the deposit out of
  * generic coin selection. The covenant's `cancel` leaf is an untimelocked
- * 2-of-2 of maker and server, so an offer VTXO is *always* cryptographically
- * spendable by the maker's own wallet; nothing in the program artifact says
+ * 2-of-2 of user and server, so an offer VTXO is *always* cryptographically
+ * spendable by the user's own wallet; nothing in the program artifact says
  * "escrow". Without the marker, `send`, `settle` or — with no user action at
  * all — background renewal would forfeit a live offer into an ordinary payment
  * and silently destroy it. The SDK's gate defaults closed, so the value is
@@ -292,7 +292,7 @@ export const OFFER_CONTRACT_KIND = "asset-swap-offer";
  * offers share one script, and `createContract` is first-writer-wins, so
  * re-offering a script that a settlement retired would leave the row `retained`
  * — funded, but out of the subscription, the poll and every sync. The invariant
- * this states is the one the corridor needs: an offer address handed to a maker
+ * this states is the one the corridor needs: an offer address handed to a user
  * is a watched address, and {@link promoteOfferContract} is what keeps a
  * settlement racing this call from taking it back.
  */
@@ -312,7 +312,7 @@ async function registerOfferContract(
         identity: wallet.identity,
         // without this the row's `address` would be derived against the SDK's
         // default network while its script is right — a row that disagrees with
-        // the address the maker is about to fund
+        // the address the user is about to fund
         network: getNetwork(network),
         contractManager,
     });
@@ -330,7 +330,7 @@ async function registerOfferContract(
     await promoteOfferContract(contractManager, hex.encode(expectedPkScript));
 }
 
-// ── Maker operations ─────────────────────────────────────────────────────────
+// ── User operations ─────────────────────────────────────────────────────────
 
 /**
  * Build a new offer for `wallet` (the user). Fund `address` with the side
@@ -358,7 +358,7 @@ export async function createOffer(
     wallet: IWallet,
     arkServerUrl: string,
     /** Covenant co-signer (emulator) x-only key — the SOLVER's deployment,
-     * not the maker's. This library does NOT fetch or verify it: clients
+     * not the user's. This library does NOT fetch or verify it: clients
      * have no network path to the emulator, only the solver and covclaimd
      * do. The caller must obtain this out-of-band, before calling this
      * function, from the solver's signed registry/corridor card (its
@@ -459,7 +459,7 @@ export async function createOffer(
  *
  * Marking the deposit as escrow (see {@link registerOfferContract}) does not
  * close this path: the gate's subject is *implicit* coin selection, and cancel
- * names its input outpoint explicitly. The maker keeps the only spend route
+ * names its input outpoint explicitly. The user keeps the only spend route
  * that was ever theirs to take.
  *
  * Identical offers derive the same address, so `fundingTxid` selects the exact
@@ -472,7 +472,7 @@ export async function createOffer(
  *
  * **When the matching swap record is present, this records its own outcome,
  * and that is what makes the live watcher cheap.** `cancel` is a 2-of-2 of
- * maker and server, so a cancel can only be the maker's own act: on a
+ * user and server, so a cancel can only be the user's own act: on a
  * successful submit this *is* the authoritative answer, and writing it here
  * means `watchOfferSwaps` has nothing left to decide for our own cancels — it
  * sees a terminal record and leaves it alone. The status moves to `cancelling`

--- a/packages/swap/src/onchainHtlc.ts
+++ b/packages/swap/src/onchainHtlc.ts
@@ -6,8 +6,8 @@
  *
  * | direction                             | claimKey            | refundKey          |
  * |---------------------------------------|---------------------|--------------------|
- * | arkade->onchain (solver funds L1)     | maker's payout key  | solver's htlc key  |
- * | onchain->arkade (maker funds L1)      | solver's htlc key   | maker's refund key |
+ * | arkade->onchain (solver funds L1)     | user's payout key   | solver's htlc key  |
+ * | onchain->arkade (user funds L1)       | solver's htlc key   | user's refund key  |
  *
  * The hash-lock commitment is HASH160-style — `ripemd160(sha256(P))` — the
  * same construction the lightning-send program uses, so ONE preimage unlocks
@@ -43,7 +43,7 @@ export const ONCHAIN_SECONDS_PER_BLOCK = 600;
  *
  * 330, not 546: Bitcoin Core's dust threshold is a function of the OUTPUT
  * type, and 546 is the P2PKH figure. Both payout scripts on this corridor are
- * taproot — the claim pays the maker's Arkade-side L1 address and the refund
+ * taproot — the claim pays the user's Arkade-side L1 address and the refund
  * pays the trader's — for which the threshold is 330 (the same number
  * `FALLBACK_WALLET_DUST_AMOUNT` already uses in the core SDK). Holding the
  * P2PKH number here rejects payouts between 330 and 546 that the network
@@ -64,7 +64,7 @@ export const ONCHAIN_DUST_SATS = BigInt(330);
 
 // ── Preimage utilities ───────────────────────────────────────────────────────
 
-/** 32 random bytes. The maker generates P for BOTH onchain directions. */
+/** 32 random bytes. The user generates P for BOTH onchain directions. */
 export const newPreimage = (): Uint8Array => crypto.getRandomValues(new Uint8Array(32));
 
 /** `sha256(P)`, hex — the wire `payment_hash`, same convention as BOLT11. */

--- a/packages/swap/src/restore.ts
+++ b/packages/swap/src/restore.ts
@@ -112,7 +112,7 @@ export type SpendKind = "cancelled" | "fulfilled" | "indeterminate";
  * Classify a spend by the covenant leaf it took.
  *
  * The covenant's whole vocabulary is two leaves: `cancel` returns the deposit
- * to the maker, `fulfill` is the solver paying for it. A submitted ark tx keeps
+ * to the user, `fulfill` is the solver paying for it. A submitted ark tx keeps
  * each input's `tapLeafScript`, so the spend *states* which one it used — this
  * reads an answer rather than inferring one.
  *
@@ -129,7 +129,7 @@ export type SpendKind = "cancelled" | "fulfilled" | "indeterminate";
  * moved. That works only while the deposit is invisible to the wallet. Once the
  * covenant is a registered contract the deposit joins the wallet's own coins,
  * every wallet-level asset figure becomes a *net* delta, and an asset offer's
- * cancel — asset out of the covenant, same asset back to the maker — nets to
+ * cancel — asset out of the covenant, same asset back to the user — nets to
  * zero and reads exactly like its fill. Leaves do not have that failure mode,
  * and they also survive batching: a solver filling several offers in one tx
  * gives each input its own leaf.

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -1,36 +1,40 @@
 /**
- * RFQ v1 — the maker / intent-submitter side of quoted swaps.
+ * RFQ v1 — the user side of quoted swaps.
  *
  * RFQ is the negotiation layer only. After the quote, **filling is
- * non-interactive maker-taker** for every corridor this module serves — the
- * MAKER is this side (the trader posting and funding the intent), the TAKER
- * is the solver that fills it:
+ * non-interactive** for every corridor this module serves: the user funds,
+ * and the solver fills by observing that funding rather than by being told.
+ * (Roles are *user* and *solver* throughout — see the README's Roles section
+ * for why this package does not name the participants maker and taker.)
  *
  * - `arkade:BTC -> lightning:BTC` / `arkade:BTC -> onchain:BTC` (send) — the
- *   trader funds its own locally derived VHTLC contract ({@link
+ *   user funds its own locally derived VHTLC contract ({@link
  *   lightningSendVtxoScript}) and the onchain leg claims its L1 HTLC with `P`;
  *   the solver fills by observing the funding on-chain. A failed swap refunds
- *   to the trader's address — by the trader's own `sender` key on every
- *   interactive path, or, if the trader's own key is ever lost, by the server
- *   and solver together via the `nonInteractiveRefund` leaf (no trader
+ *   to the user's address — by the user's own `sender` key on every
+ *   interactive path, or, if the user's own key is ever lost, by the server
+ *   and solver together via the `nonInteractiveRefund` leaf (no user
  *   signature, no timelock), which the emulator co-signs under a covenant
- *   provably paying only the trader's pre-committed address.
+ *   provably paying only the user's pre-committed address.
  * - `lightning:BTC -> arkade:BTC` / `onchain:BTC -> arkade:BTC` (receive) —
- *   the trader generates `P`, pays the solver's hold invoice or funds the L1
+ *   the user generates `P`, pays the solver's hold invoice or funds the L1
  *   HTLC, and may go offline; the solver funds the Arkade lockup pinned to
- *   the trader's payout ({@link receiveVtxoScript}, roles inverted), and the
- *   claim — the trader's own collaborative spend, or covclaimd's — reveals
- *   `P` publicly, which is what settles the trader's side.
- * - `arkade:BTC|asset -> arkade:BTC|asset` — the trader accepts the quote by
+ *   the user's payout ({@link receiveVtxoScript}, roles inverted), and the
+ *   claim — the user's own collaborative spend, or covclaimd's — reveals
+ *   `P` publicly, which is what settles the user's side.
+ * - `arkade:BTC|asset -> arkade:BTC|asset` — the user accepts the quote by
  *   creating and funding an Intents **offer** (`createOffer`) bound to the
  *   quoted terms; the offer covenant lets any filler deliver, so the solver
- *   fills without further interaction, or the trader cancels cooperatively.
+ *   fills without further interaction, or the user cancels cooperatively.
  *
  * There is deliberately NO accept message anywhere: acceptance is funding.
+ * Every corridor then ends the same way — a fill, or the value back: a
+ * timelocked refund on the HTLC corridors, a cooperative cancel on the
+ * Arkade-only one.
  *
- * Trust model, identical to the offer side: from a quote the trader uses only
+ * Trust model, identical to the offer side: from a quote the user uses only
  * the binding fields — `solver_pubkey`, `refund_locktime`, `valid_until`, the
- * amounts. Every other contract parameter is the trader's own data (its
+ * amounts. Every other contract parameter is the user's own data (its
  * invoice, its Ark server connection, its refund address) or obtained
  * out-of-band from a source it independently trusts — the emulator's x-only
  * key, from the solver's signed registry/corridor card, since clients have no
@@ -269,7 +273,7 @@ export const verifyLockupAddress = (quote: RfqQuote, derivedAddress: string): st
     return derivedAddress;
 };
 
-/** The maker's gates, checked immediately before funding — never at quote
+/** The user's gates, checked immediately before funding — never at quote
  * time. Throws with a stable `reason` property. `invoiceExpiresAt` applies to
  * BOLT11 profiles only; `onchain` adds the L1-HTLC gates (§ guardrails of the
  * onchain spec) and is required for the onchain pairs. */
@@ -319,8 +323,8 @@ export const assertFundable = (input: {
             fail("claim_window_too_short", "L1 HTLC locktime leaves no safe claim window");
         }
         if (direction === "send") {
-            // The solver claims Arkade with P AFTER the maker's L1 claim; the
-            // maker's Arkade refund must therefore open LAST, with reorg margin.
+            // The solver claims Arkade with P AFTER the user's L1 claim; the
+            // user's Arkade refund must therefore open LAST, with reorg margin.
             if (
                 input.quote.refund_locktime === undefined ||
                 htlcLocktime + ONCHAIN_ORDER_MARGIN_SECONDS > input.quote.refund_locktime
@@ -506,7 +510,7 @@ export const relayTransport = (
     };
 };
 
-// ── Lightning send: derivation + the maker flow ──────────────────────────────
+// ── Lightning send: derivation + the user flow ──────────────────────────────
 
 /** BIP68 sequence granularity; the delay derivation rounds up to it. */
 const SEQUENCE_GRANULARITY_SECONDS = 512;
@@ -637,11 +641,11 @@ export interface InvoiceFacts {
 }
 
 /**
- * The lightning-send maker flow, mirroring `createOffer`'s shape: quote →
+ * The lightning-send user flow, mirroring `createOffer`'s shape: quote →
  * derive locally → verify → gate. Pure of funding on purpose — it returns the
  * address and amount, and the caller funds with its own wallet
  * (`wallet.send({ address, amount })`) before `quote.valid_until`, after
- * which the maker may go OFFLINE: filling is non-interactive. Success reveals
+ * which the user may go OFFLINE: filling is non-interactive. Success reveals
  * the preimage in the solver's claim witness (also served via status as
  * `settled`); failure refunds to `refundAddress`.
  *
@@ -808,23 +812,23 @@ export const offerTermsFromQuote = (
 
 /** The Arkade lockup for an onchain send uses the SAME {@link
  * lightningSendVtxoScript} the Lightning leg does — only the SOURCE of the
- * payment hash differs (maker-generated P instead of a BOLT11). One function,
+ * payment hash differs (user-generated P instead of a BOLT11). One function,
  * one golden test. */
 
 const l1NetworkFromArk = (network: string): OnchainNetwork =>
     network === "bitcoin" ? "bitcoin" : network === "regtest" ? "regtest" : "testnet";
 
 /** The rfq_request for `arkade:BTC->onchain:BTC`. Exact-out means "this much
- * lands in the L1 HTLC". `senderPubkey` is the maker's own key for the
+ * lands in the L1 HTLC". `senderPubkey` is the user's own key for the
  * VHTLC's sender-side leaves — same role as in {@link lightningSendRequest}.
  * On the wire it's `client_refund_pubkey`, same as there. */
 export const onchainSendRequest = (input: {
     rfqId: string;
-    /** `sha256(P)`, hex — maker-chosen; see {@link paymentHashOf}. */
+    /** `sha256(P)`, hex — user-chosen; see {@link paymentHashOf}. */
     paymentHash: string;
-    /** Maker's x-only L1 key for the HTLC's claim leaf. */
+    /** User's x-only L1 key for the HTLC's claim leaf. */
     payoutPubkey: Uint8Array;
-    /** Maker's arkade address — where the covenant refund must pay. */
+    /** User's arkade address — where the covenant refund must pay. */
     refundAddress: string;
     senderPubkey: Uint8Array;
     amount: number;
@@ -877,9 +881,9 @@ export const lightningReceiveRequest = (input: {
     },
 });
 
-/** The rfq_request for `onchain:BTC->arkade:BTC`. The maker funds the L1 HTLC
+/** The rfq_request for `onchain:BTC->arkade:BTC`. The user funds the L1 HTLC
  * (holding its refund role) and receives Arkade; P travels sealed to
- * covclaimd (see `sealClaimPacket`) so the maker can go offline after
+ * covclaimd (see `sealClaimPacket`) so the user can go offline after
  * funding. `payoutPubkey` is the trader's own x-only Arkade key — the
  * covenant's `receiver` role, same as the Lightning receive leg's. */
 export const onchainReceiveRequest = (input: {
@@ -913,7 +917,7 @@ export const onchainReceiveRequest = (input: {
 
 /**
  * The pure core of {@link requestOnchainSend}: derive BOTH contracts locally
- * from the quote's binding fields plus the maker's own data, and refuse on any
+ * from the quote's binding fields plus the user's own data, and refuse on any
  * mismatch. Binding: `solver_pubkey`, `refund_locktime`, `htlc_pubkey`,
  * `htlc_locktime`, `min_confirmations`; `lockup_address` and `htlc_address`
  * are compare-only.
@@ -928,7 +932,7 @@ export function deriveOnchainSend(input: {
     hrp: string;
     l1Network: OnchainNetwork;
     refundAddress: string;
-    /** The maker's own key for the VHTLC's sender-side leaves — same role as
+    /** The user's own key for the VHTLC's sender-side leaves — same role as
      * in {@link requestLightningSend}. */
     senderPubkey: Uint8Array;
 }): {
@@ -997,7 +1001,7 @@ export function deriveOnchainSend(input: {
 }
 
 /**
- * The `arkade:BTC->onchain:BTC` maker flow, mirroring `requestLightningSend`:
+ * The `arkade:BTC->onchain:BTC` user flow, mirroring `requestLightningSend`:
  * quote → derive BOTH contracts locally → verify → gate. Pure of funding —
  * the caller funds `address` with its own wallet before `quote.valid_until`.
  *
@@ -1013,7 +1017,7 @@ export function deriveOnchainSend(input: {
  *   re-derive from the seed; otherwise it carries the raw secrets, and losing
  *   them forfeits the L1 claim and every interactive refund path — leaving
  *   recovery dependent on the solver via `nonInteractiveRefund`.
- * - **Stay claim-capable.** Unlike lightning-send the maker cannot go fully
+ * - **Stay claim-capable.** Unlike lightning-send the user cannot go fully
  *   offline: it must claim the L1 HTLC (`awaitOnchainFill` →
  *   `claimOnchainFill`) before `htlc.refundLocktime`. Missing that window
  *   forfeits the fill and falls back to the Arkade covenant refund.
@@ -1028,7 +1032,7 @@ export async function requestOnchainSend(
     params: {
         amount: number;
         amountSide: "from" | "to";
-        /** Maker's x-only L1 key that will claim the HTLC. */
+        /** User's x-only L1 key that will claim the HTLC. */
         payoutPubkey: Uint8Array;
         /** Optional caller-owned P. Persist it with the returned secrets before funding. */
         preimage?: Uint8Array;
@@ -1037,7 +1041,7 @@ export async function requestOnchainSend(
 ): Promise<{
     rfqId: string;
     quote: RfqQuote;
-    /** The maker's OWN arkade lockup derivation — the only address to fund. */
+    /** The user's OWN arkade lockup derivation — the only address to fund. */
     address: string;
     fundAmount: number;
     swapPkScript: Uint8Array;
@@ -1272,7 +1276,7 @@ export function deriveLightningReceive(input: {
 }
 
 /**
- * The `lightning:BTC->arkade:BTC` maker flow: quote → derive the covenant
+ * The `lightning:BTC->arkade:BTC` user flow: quote → derive the covenant
  * locally → verify → gate. Returns the solver's hold invoice to PAY — the
  * payment itself is the trader's own Lightning wallet's job, exactly as
  * funding is the caller's job on the send corridors. Once the paid HTLC is
@@ -1467,7 +1471,7 @@ export function deriveOnchainReceive(input: {
 }
 
 /**
- * The `onchain:BTC->arkade:BTC` maker flow: quote → derive BOTH contracts
+ * The `onchain:BTC->arkade:BTC` user flow: quote → derive BOTH contracts
  * locally → verify → gate. Returns the L1 HTLC to fund (`htlc.address`, for
  * `fundAmount`) — the funding transaction itself is the trader's own L1
  * wallet's job, exactly as on the send corridors. After `min_confirmations`

--- a/packages/swap/src/store.ts
+++ b/packages/swap/src/store.ts
@@ -72,7 +72,7 @@ export interface AssetSwap {
      * created on a wallet that can allocate.
      */
     signingDescriptor?: string;
-    /** P, hex, when the maker supplied a preimage that is not seed-derived. */
+    /** P, hex, when the user supplied a preimage that is not seed-derived. */
     preimageHex?: string;
     /**
      * Complete stored-arm secrets for wallets that cannot derive. Versioned

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -1,16 +1,16 @@
 /**
  * Live offer status, driven by the wallet's own contract events.
  *
- * Before this, nothing told a maker their offer had been filled: the deposit's
+ * Before this, nothing told a user their offer had been filled: the deposit's
  * fate was only visible by re-running {@link restoreAssetSwaps}, a scan over
  * sent transactions. Now that `createOffer` registers the covenant with the
  * contract manager, the wallet is already watching that script and already
- * emits `vtxo_spent` for it — so the maker's own wallet knows, and this module
+ * emits `vtxo_spent` for it — so the user's own wallet knows, and this module
  * turns that knowledge into a status.
  *
  * **Detection and classification are separate problems, answered separately.**
  * The event says a deposit was spent; it does not say by whom. The covenant's
- * `cancel` leaf is a 2-of-2 of the maker and the server, so *only the maker can
+ * `cancel` leaf is a 2-of-2 of the user and the server, so *only the user can
  * cancel* — which makes the cheapest classifier an exact one: a spend whose
  * txid is the one `cancelOffer` recorded is a cancel, and anything else that
  * spends an offer deposit is a fill. The fallback, for a cancel this device did
@@ -131,7 +131,7 @@ export async function watchOfferSwaps({
     };
 
     const classify = async (swap: AssetSwap, vtxo: ContractVtxo, spentTxid: string) => {
-        // the exact answer: only the maker can cancel, and cancelOffer records
+        // the exact answer: only the user can cancel, and cancelOffer records
         // the txid it submitted
         if (swap.spentTxid === spentTxid && swap.status === "cancelling") return "cancelled";
         try {


### PR DESCRIPTION
Finishes the rename #710/#711 started, on the layers that landed after it. Companion to arkade-os/docs#133, which settled the same vocabulary in the published docs.

## The inconsistency

This branch already carries #715's framing — the README's *Request for quote* and *Funding, then fill or cancel* sections are here, and the Roles section asserts that `maker` and `taker` "name contract positions, not product roles". But the layers added after the rename — `rfq`, `watch`, `coverage`, `onchainHtlc`, `nostr`, `claimPacket`, `restore`, `store` — use `maker` as a role word about 50 times. The README claims one convention; the modules underneath it use the other.

The `rfq` module header carried the strongest version:

> After the quote, **filling is non-interactive maker-taker** for every corridor this module serves — the MAKER is this side (the trader posting and funding the intent), the TAKER is the solver that fills it

Filling being non-interactive is the real content and it survives — the user funds, the solver fills by observing that funding rather than by being told — it just no longer needs the two words the rest of the documentation avoids. The header now also names the outcome pair every corridor shares: a fill, or the value back, by timelocked refund on the HTLC corridors and cooperative cancel on the Arkade-only one.

## Scope

Comments and markdown only. **Not touched:** the `maker*` script fields (`makerWP`, `makerPkScript`, `makerPublicKey`), the two doc comments that annotate those fields, the Roles section explaining why they read that way, and `market maker` where it names a synonym for solver. The `.program.json` bytes are untouched, so no derived swap address changes.

## What I checked in the code while I was in here

You asked me to spot anything wrong in the implementation. I read the safety-critical paths rather than only the prose, and **found nothing to fix** — recording what I verified so it isn't re-derived later:

- **Compare-only discipline holds on all four corridors.** `verifyLockupAddress` is called on every one (`rfq.ts` 760, 975, 1270, 1445), and it compares the caller's own derivation against `profile.lockup_address` rather than adopting the quoted value.
- **Gates run on all four**, immediately before funding (761, 1112, 1363, 1558) rather than at quote time.
- **The timelock-ordering invariant is right, and correctly one-sided.** `assertFundable` applies the `timelock_order` gate only on `direction: "send"`, where the user's Arkade refund must open last. On the receive corridors the generic `refund_locktime` headroom check carries the mirrored meaning — ≥ 90 min before the *solver's* refund opens, which is the deadline the user must claim inside. `MIN_HEADROOM_SECONDS = 90 min` is justified against BIP-113 median-time-past lag in the comment, matching the reference solver's `MIN_CLAIM_WINDOW`.
- **Amount handling is exactly right**, including the trap: `requestLightningSend` funds `quote.from_amount`, asserts `to_amount` equals the invoice verbatim, and rejects `from_amount < to_amount` as "a negative spread is not a quote". Funding `to_amount` would underfund by exactly the fee — this is the client-side mirror of the bug class lightning-swap-service#48 fixes on the solver side.
- **The preimage never reaches the solver.** Only `payment_hash` appears in outbound payloads; `P` travels sealed to covclaimd via `sealClaimPacket` on both receive corridors (1335, 1527).
- **`nostr-tools` is correctly an optional peer dependency** with a `./nostr` subpath export, so HTTP-only consumers don't pull it into their module graph.

## Verification

`pnpm -C packages/swap test`: **341 passed, 22 files**, unchanged from the pre-change baseline on this branch. Prettier clean.

Note for anyone reproducing: `packages/ts-sdk` must be rebuilt after switching to this branch or the swap suite fails wholesale on stale `dist` — 80 failures that have nothing to do with the code.

---

**Branch name:** this should have gone on `claude/marketing-material-accuracy-3qpd6v`, but that branch still holds #715's pre-squash history, so re-pointing it at `feat/arkade-swap` needed a force-push I don't have permission for. Pushed to a suffixed branch instead; say the word if you'd rather it sat on the original name.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQX8TB8Apaue2b6akiiorP)_