### PR TITLE
feat(swap): let the trader register its own claim packet, and prove the sealing

### DIFF
--- a/packages/swap/src/claimPacket.ts
+++ b/packages/swap/src/claimPacket.ts
@@ -8,9 +8,13 @@
  * - AES-256-GCM with the ephemeral pubkey as additional data;
  * - wire layout `ephPub(33) ‖ nonce(12) ‖ ciphertext`, base64.
  *
- * TODO(claim-packet-vectors): byte-exactness against covclaimd's reference
- * implementation is pinned here only by our own generated vectors — confirm
- * against covclaimd's before production use (see the package README).
+ * Byte-exactness against covclaimd is pinned by `test/e2e/covclaimd.test.ts`,
+ * which seals with this function and registers the result with a LIVE
+ * covclaimd. Acceptance is the assertion: covclaimd decrypts before it will
+ * register, so a wrong key dies at the AEAD tag with a 400 — and that negative
+ * case is asserted too, because otherwise acceptance would prove nothing. The
+ * unit vectors below remain as a fast self-consistency check; they were never
+ * evidence that covclaimd can open what this produces.
  */
 import { base64 } from "@scure/base";
 import { secp256k1 } from "@noble/curves/secp256k1.js";

--- a/packages/swap/src/covclaimd.ts
+++ b/packages/swap/src/covclaimd.ts
@@ -1,0 +1,93 @@
+/**
+ * covclaimd, from the TRADER's side.
+ *
+ * Lifted from `packages/boltz-swap/src/covclaimd-provider.ts` (arkade-os/ts-sdk#613)
+ * rather than written again: that implementation already had the shape this one
+ * wants — bytes rather than hex strings at the boundary, and the pubkeys cached
+ * so a swap does not re-fetch them per call. Only the docs below are new. If
+ * #613 lands, these two should become one module rather than two copies.
+ *
+ * WHY THE TRADER CALLS THIS AT ALL. `claimPacket.ts` seals `P` to covclaimd so
+ * a trader can go offline after funding, but until now the packet reached
+ * covclaimd only by being handed to the solver in the `rfq_request` — which
+ * made the trader's ability to go offline depend on the solver having wired a
+ * covclaimd, a dependency the trader can neither see nor verify. Its failure is
+ * silent in the worst way: a solver that accepts the packet and never forwards
+ * it is indistinguishable from one that forwarded it to a covclaimd that never
+ * claimed.
+ *
+ * `reveal` is a REGISTRATION, not a claim instruction: covclaimd stores the
+ * packet against the swap's script and claims when it sees the funding
+ * transaction. So a trader may register BEFORE the solver funds — which is
+ * exactly the window in which a trader who intends to go offline is still
+ * online.
+ *
+ * Registering here and the solver also revealing is belt and braces rather than
+ * a double spend: covclaimd keys registrations by pkScript, so the second
+ * replaces the first, and a claim already made leaves nothing to spend.
+ *
+ * KNOWN LIMITS, worth reading before relying on it. covclaimd's registry is in
+ * memory, capped, and expires — upstream at the time of writing: 10,000 entries
+ * and a 15-minute TTL. So a covclaimd restart drops every pending registration
+ * silently, and a swap funded more than the TTL after registering is not
+ * claimed. The durable fix is to carry the packet ON the lockup transaction so
+ * covclaimd rebuilds intent from the chain instead of from memory; that needs a
+ * covclaimd change and is tracked separately.
+ *
+ * None of this is load-bearing for correctness. The trader holds the covenant's
+ * `receiver` key and can always claim the lockup itself (`claim.ts`).
+ */
+import { hex, base64 } from "@scure/base";
+
+/** covclaimd's advertised keys. `covclaimdPubKey` is what `sealClaimPacket` seals to. */
+export type CovclaimdPubKeys = { covclaimdPubKey: Uint8Array; emulatorPubKey: Uint8Array };
+
+export class CovclaimdProvider {
+    private readonly baseUrl: string;
+    private readonly timeoutMs: number;
+    private cachedKeys?: CovclaimdPubKeys;
+
+    constructor(baseUrl: string, timeoutMs = 30_000) {
+        this.baseUrl = baseUrl.replace(/\/$/, "");
+        this.timeoutMs = timeoutMs;
+    }
+
+    async getPubKeys(): Promise<CovclaimdPubKeys> {
+        if (this.cachedKeys) return this.cachedKeys;
+        const res = await fetch(`${this.baseUrl}/v1/preimage/covclaimd-pubkey`, {
+            signal: AbortSignal.timeout(this.timeoutMs),
+        });
+        if (!res.ok) throw new Error(`covclaimd getPubKeys failed: ${res.status}`);
+        const body = (await res.json()) as { covclaimd_pub_key: string; emulator_pub_key: string };
+        this.cachedKeys = {
+            covclaimdPubKey: hex.decode(body.covclaimd_pub_key),
+            emulatorPubKey: hex.decode(body.emulator_pub_key),
+        };
+        return this.cachedKeys;
+    }
+
+    async reveal(args: {
+        swapAddress: string;
+        ciphertext: Uint8Array;
+        arkadeScript: Uint8Array;
+        taptree: Uint8Array;
+    }): Promise<void> {
+        const res = await fetch(`${this.baseUrl}/v1/reveal`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                swap_address: args.swapAddress,
+                packet: {
+                    ciphertext: base64.encode(args.ciphertext),
+                    arkade_script: base64.encode(args.arkadeScript),
+                },
+                taptree: hex.encode(args.taptree),
+            }),
+            signal: AbortSignal.timeout(this.timeoutMs),
+        });
+        if (!res.ok) {
+            const detail = await res.text().catch(() => "");
+            throw new Error(`covclaimd reveal failed: ${res.status} ${detail}`);
+        }
+    }
+}

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -120,6 +120,7 @@ export {
     requestOnchainSend,
 } from "./rfq";
 export { sealClaimPacket, type ClaimPacketInput, type SealedClaimPacket } from "./claimPacket";
+export { CovclaimdProvider, type CovclaimdPubKeys } from "./covclaimd";
 export { awaitLockupFunding, claimReceiveLockup, pushClaim, type ClaimArkProvider } from "./claim";
 export {
     RFQ_PREIMAGE_TAG,

--- a/packages/swap/test/e2e/covclaimd.test.ts
+++ b/packages/swap/test/e2e/covclaimd.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The trader's own covclaimd registration, against a LIVE covclaimd.
+ *
+ * This exists to close `claimPacket.ts`'s standing TODO. The sealing there was
+ * pinned only by vectors this package generated for itself, which proves the
+ * implementation is self-consistent and nothing about whether covclaimd can
+ * open what it produces. Those are very different claims, and only the second
+ * one matters: a packet covclaimd cannot decrypt fails at the moment a trader
+ * has gone offline trusting it, which is the worst possible time to find out.
+ *
+ * A 200 from `/v1/reveal` is the assertion. covclaimd decrypts the packet
+ * before it will register anything — a packet sealed to the wrong key dies at
+ * the AEAD tag with a 400, and a taptree that does not hash to `swap_address`
+ * is refused as well — so acceptance means the ECIES construction, the wire
+ * layout, the preimage-to-condition binding and the taptree derivation are all
+ * right together. Nothing here mocks covclaimd, because a mock would only
+ * re-assert this package's own understanding of the protocol.
+ *
+ * Needs a covclaimd (default `http://localhost:7271`, override with
+ * `COVCLAIMD_URL`) and an arkd (`ARK_SERVER_URL`) to read the real server key
+ * from. Skipped, loudly, when they are not reachable: this is an integration
+ * test and pretending otherwise would let the TODO silently reopen.
+ */
+import { describe, expect, it, beforeAll } from "vitest";
+import { hex, base64 } from "@scure/base";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { ArkAddress } from "@arkade-os/sdk";
+import { sealClaimPacket } from "../../src/claimPacket";
+import { CovclaimdProvider } from "../../src/covclaimd";
+import { receiveVtxoScript } from "../../src/rfq";
+
+const COVCLAIMD_URL = process.env.COVCLAIMD_URL ?? "http://localhost:7271";
+const ARK_SERVER_URL = process.env.ARK_SERVER_URL ?? "http://localhost:7070";
+
+const reachable = async (url: string): Promise<boolean> => {
+    try {
+        const response = await fetch(url, { signal: AbortSignal.timeout(3000) });
+        return response.ok;
+    } catch {
+        return false;
+    }
+};
+
+/** arkd's own signer key — the covenant's `server` role, which covclaimd matches its closure against. */
+const serverPubkey = async (): Promise<Uint8Array> => {
+    const response = await fetch(`${ARK_SERVER_URL.replace(/\/$/, "")}/v1/info`, {
+        signal: AbortSignal.timeout(5000),
+    });
+    const body = (await response.json()) as { signerPubkey?: string; signer_pubkey?: string };
+    const key = body.signerPubkey ?? body.signer_pubkey;
+    if (!key) throw new Error("arkd /v1/info reported no signer pubkey");
+    // arkd reports it compressed; the covenant wants x-only.
+    const bytes = hex.decode(key);
+    return bytes.length === 33 ? bytes.slice(1) : bytes;
+};
+
+describe("covclaimd registration, live", () => {
+    let up = false;
+
+    beforeAll(async () => {
+        up =
+            (await reachable(`${COVCLAIMD_URL}/v1/preimage/covclaimd-pubkey`)) &&
+            (await reachable(`${ARK_SERVER_URL}/v1/info`));
+        if (!up) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[covclaimd e2e] SKIPPED — need covclaimd at ${COVCLAIMD_URL} and arkd at ${ARK_SERVER_URL}`,
+            );
+        }
+    });
+
+    it("accepts a packet this package sealed, against a taptree it derived", async () => {
+        if (!up) return;
+
+        const covclaimd = new CovclaimdProvider(COVCLAIMD_URL);
+        const keys = await covclaimd.getPubKeys();
+        expect(keys.covclaimdPubKey).toHaveLength(33);
+        expect(keys.emulatorPubKey).toHaveLength(33);
+
+        // A swap that could exist: the trader is `receiver`, the solver `sender`,
+        // and `nonInteractiveClaim` is pinned to the trader's own payout script —
+        // the leaf covclaimd looks for and the destination it pays.
+        const preimage = crypto.getRandomValues(new Uint8Array(32));
+        const paymentHash = hex.encode(sha256(preimage));
+        const traderKey = schnorr.utils.randomSecretKey();
+        const traderPubkey = schnorr.getPublicKey(traderKey);
+        const solverKey = schnorr.utils.randomSecretKey();
+        const payoutAddress = new ArkAddress(keys.emulatorPubKey.slice(1), traderPubkey, "ark");
+        const payoutPkScript = payoutAddress.pkScript;
+
+        const script = receiveVtxoScript({
+            paymentHash,
+            serverPubkey: await serverPubkey(),
+            emulatorPubkey: keys.emulatorPubKey,
+            solverPubkey: schnorr.getPublicKey(solverKey),
+            solverRefundPkScript: payoutPkScript,
+            payoutPubkey: traderPubkey,
+            payoutPkScript,
+            refundLocktime: Math.floor(Date.now() / 1000) + 7200,
+            claimDelay: 1024,
+        });
+
+        const sealed = await sealClaimPacket({
+            preimage,
+            covclaimdPubkey: keys.covclaimdPubKey,
+        });
+
+        // THE ASSERTION. Not throwing means covclaimd decrypted a packet this
+        // package sealed, and matched it to a taptree this package derived.
+        await expect(
+            covclaimd.reveal({
+                swapAddress: script.address("ark", await serverPubkey()).encode(),
+                ciphertext: base64.decode(sealed.ciphertext),
+                arkadeScript: script.nonInteractiveClaimArkadeScript ?? new Uint8Array(),
+                taptree: script.encode(),
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    it("refuses a packet sealed to the wrong key, rather than registering it", async () => {
+        if (!up) return;
+
+        // The negative control the positive case needs to mean anything: if
+        // covclaimd accepted this too, a 200 above would say nothing about the
+        // sealing at all.
+        const covclaimd = new CovclaimdProvider(COVCLAIMD_URL);
+        const keys = await covclaimd.getPubKeys();
+        const preimage = crypto.getRandomValues(new Uint8Array(32));
+        const wrongKey = schnorr.utils.randomSecretKey();
+        const sealed = await sealClaimPacket({
+            preimage,
+            covclaimdPubkey: hex.decode(`02${hex.encode(schnorr.getPublicKey(wrongKey))}`),
+        });
+
+        const script = receiveVtxoScript({
+            paymentHash: hex.encode(sha256(preimage)),
+            serverPubkey: await serverPubkey(),
+            emulatorPubkey: keys.emulatorPubKey,
+            solverPubkey: schnorr.getPublicKey(schnorr.utils.randomSecretKey()),
+            solverRefundPkScript: new ArkAddress(
+                keys.emulatorPubKey.slice(1),
+                schnorr.getPublicKey(schnorr.utils.randomSecretKey()),
+                "ark",
+            ).pkScript,
+            payoutPubkey: schnorr.getPublicKey(schnorr.utils.randomSecretKey()),
+            payoutPkScript: new ArkAddress(
+                keys.emulatorPubKey.slice(1),
+                schnorr.getPublicKey(schnorr.utils.randomSecretKey()),
+                "ark",
+            ).pkScript,
+            refundLocktime: Math.floor(Date.now() / 1000) + 7200,
+            claimDelay: 1024,
+        });
+
+        await expect(
+            covclaimd.reveal({
+                swapAddress: script.address("ark", await serverPubkey()).encode(),
+                ciphertext: base64.decode(sealed.ciphertext),
+                arkadeScript: new Uint8Array(),
+                taptree: script.encode(),
+            }),
+        ).rejects.toThrow();
+    });
+});


### PR DESCRIPTION
`sealClaimPacket` seals `P` to covclaimd so a trader can go offline after funding — but the packet could only *reach* covclaimd by being handed to the solver in the `rfq_request`. So a trader's ability to go offline depended on the solver having wired a covclaimd, which the trader can neither see nor verify. The failure is silent in the worst way: a solver that accepts the packet and never forwards it is indistinguishable from one that forwarded it to a covclaimd that never claimed.

covclaimd's reveal endpoint is a **registration**, not a claim instruction — it stores the packet against the swap's script and claims when it sees the funding transaction. So a trader can register **before** the solver funds, which is exactly the window in which a trader who intends to go offline is still online.

Registering here *and* the solver revealing is belt and braces, not a double spend: covclaimd keys registrations by pkScript, so the second replaces the first, and a claim already made leaves nothing to spend.

## The provider is lifted, not rewritten

From `packages/boltz-swap/src/covclaimd-provider.ts` (#613), which already had the better shape — bytes at the boundary rather than hex strings, and the pubkeys cached so a swap doesn't refetch them. Only the docs are new.

**If #613 lands, these two copies should become one.** It currently lives in `boltz-swap` on an unmerged branch, which is why this is a copy rather than an import.

## The valuable half is the test

`claimPacket.ts` carried a standing TODO:

> byte-exactness against covclaimd's reference implementation is pinned here only by our own generated vectors — confirm against covclaimd's before production use

Self-consistency and "covclaimd can open this" are different claims, and only the second matters — a packet covclaimd cannot decrypt fails at the moment a trader has gone offline trusting it.

So the TODO is closed by a live test, not more vectors. Seal with this package, derive the taptree with this package, register with a **real covclaimd**, assert acceptance. covclaimd decrypts *before* it registers, so a 200 means the ECIES construction, the wire layout, the preimage-to-condition binding and the taptree derivation are all correct **together**.

The negative control is asserted alongside it, because acceptance proves nothing if a packet sealed to the wrong key is accepted too:

| case | result |
| --- | --- |
| sealed by this package, taptree derived by this package | **accepted** |
| sealed to the wrong key | **refused** |

Verified against live `covclaimd:v0.0.1-rc.3` + arkd. The test skips loudly (not silently) when neither is reachable — a silent skip would let the TODO reopen without anyone noticing.

## Known limit, documented rather than fixed

covclaimd's registry is in memory, capped at 10,000, expiring after 15 minutes. So a covclaimd **restart drops every pending registration silently**, and a swap funded more than the TTL after registering is never claimed.

The durable fix is to carry the packet **on the lockup transaction**, so covclaimd rebuilds intent from the chain rather than from memory. That needs a covclaimd change — `Match()` currently consults only the in-memory registry and `Filter()` is empty — and is tracked separately. This PR documents the limit in the module rather than pretending it isn't there.

None of this is load-bearing for correctness: the trader holds the covenant's `receiver` key and can always claim the lockup itself (`claim.ts`). covclaimd is the convenience for going offline.

## Test plan

- `test/e2e/covclaimd.test.ts` against a live stack — **2/2 pass**
- Package suite — **22 files / 341 tests**
- `pnpm typecheck` clean, `pnpm lint` clean