### PR TITLE
feat(sdk): let sendBitcoin carry extension packets

### DIFF
--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -397,6 +397,29 @@ export interface SendBitcoinParams {
      * @see IReadonlyWallet.getSpendableVtxos
      */
     selectedVtxos?: ExtendedVirtualCoin[];
+
+    /**
+     * Extension packets to commit in the transaction's OP_RETURN, the same
+     * shape `Recipient.extensions` takes on {@link IWallet.send}.
+     *
+     * Here because the two send paths had drifted apart: `send` could carry an
+     * extension but not choose its inputs, and `sendBitcoin({ selectedVtxos })`
+     * could choose its inputs but not carry an extension — so a caller that
+     * needed both had to give one up. Giving up input selection is not a real
+     * option for anything spending contract-gated coins, which is what made
+     * this the missing half rather than a preference.
+     *
+     * The concrete case: a swap solver funding an HTLC lockup has to pick coins
+     * whose batch outlives the swap AND commit the claim packet that lets
+     * covclaimd claim on the receiver's behalf. Without this it had to route
+     * the packet out of band and hope, which is strictly worse — an out-of-band
+     * registration lives in someone's memory, while an on-chain one is
+     * recoverable by anyone reading the transaction.
+     */
+    extensions?: Array<{
+        type: number;
+        payload: Uint8Array;
+    }>;
 }
 
 /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -3471,10 +3471,26 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                     });
                 }
 
+                // `changeVout` is read BEFORE the extension output is appended,
+                // deliberately: it indexes the change, and appending after would
+                // make the extension the last output and silently retarget it.
+                const changeVout = selected.changeAmount > 0n ? outputs.length - 1 : 0;
+
+                if (params.extensions && params.extensions.length > 0) {
+                    outputs.push(
+                        Extension.create(
+                            params.extensions.map((ext) => ({
+                                type: () => ext.type,
+                                serialize: () => ext.payload,
+                            })),
+                        ).txOut(),
+                    );
+                }
+
                 return this._submitOffchainSpend(selected.inputs, outputs, {
                     sentAmount: params.amount,
                     changeAmount: selected.changeAmount,
-                    changeVout: selected.changeAmount > 0n ? outputs.length - 1 : 0,
+                    changeVout,
                     offchainTapscript,
                     serverPubKey,
                     serverUnrollScript,
@@ -3485,6 +3501,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         return this.send({
             address: params.address,
             amount: params.amount,
+            extensions: params.extensions,
         });
     }
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -3409,6 +3409,32 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         }
 
         if (params.selectedVtxos && params.selectedVtxos.length > 0) {
+            // REFUSE asset-bearing inputs on this path rather than spend them.
+            //
+            // This branch builds its own outputs and has never emitted an asset
+            // packet, so an asset carried in on a selected VTXO was already
+            // being dropped silently — the coin is spent, the assets are not
+            // re-declared, and nothing says so. That predates `extensions`, but
+            // combining the two makes it worse in a specific way: an extension
+            // output now EXISTS, so the transaction looks well-formed while
+            // still omitting the asset packet that had to be in it.
+            //
+            // Refusing converts a silent loss into a loud one. Not attempting
+            // to build the packet here is deliberate: `_sendImpl` derives asset
+            // routing from recipients and a change receiver that this path does
+            // not have, and inventing that mapping for a BTC-only helper is how
+            // asset accounting gets quietly wrong. Callers moving assets want
+            // `send()`, which does it properly.
+            const assetBearing = params.selectedVtxos.filter(
+                (v) => v.assets && v.assets.length > 0,
+            );
+            if (assetBearing.length > 0) {
+                throw new Error(
+                    `sendBitcoin({ selectedVtxos }) cannot spend asset-bearing VTXOs: ` +
+                        `${assetBearing.length} of ${params.selectedVtxos.length} carry assets. ` +
+                        `Use send() for asset-aware transfers.`,
+                );
+            }
             void this.logUngatedInputs("sendBitcoin({ selectedVtxos })", params.selectedVtxos);
             return this._withTxLock(async () => {
                 // Snapshot the active receive tapscript synchronously

--- a/packages/ts-sdk/test/sendbitcoin-extensions.test.ts
+++ b/packages/ts-sdk/test/sendbitcoin-extensions.test.ts
@@ -1,0 +1,181 @@
+/**
+ * `sendBitcoin({ selectedVtxos, extensions })` — the two properties that break
+ * silently.
+ *
+ * Both are ordering/omission bugs rather than logic bugs, which is why they get
+ * a test rather than a comment: neither throws, neither shows up in a type, and
+ * both produce a transaction that looks well-formed and is not.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { hex } from "@scure/base";
+import { Wallet, SingleKey } from "../src";
+import { ArkAddress } from "../src/script/address";
+
+const SERVER_KEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const SERVER_XONLY = hex.decode(SERVER_KEY_HEX).slice(1);
+
+const mockIdentity = SingleKey.fromHex(
+    "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2",
+);
+
+// Lifted verbatim from recipient-address-binding.test.ts: the delays must be
+// BIP68-representable (multiples of 512 seconds) or `Wallet.create` refuses,
+// which is not a thing worth rediscovering per test file.
+const mockArkInfo = {
+    signerPubkey: SERVER_KEY_HEX,
+    forfeitPubkey: SERVER_KEY_HEX,
+    batchExpiry: BigInt(144),
+    unilateralExitDelay: BigInt(144),
+    boardingExitDelay: BigInt(144),
+    roundInterval: BigInt(144),
+    network: "mutinynet",
+    dust: BigInt(1000),
+    forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    checkpointTapscript:
+        "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
+};
+
+const VTXO_KEY = new Uint8Array(32).fill(0xaa);
+
+const encodeAddr = (serverPubKey: Uint8Array, hrp: string): string =>
+    new ArkAddress(serverPubKey, VTXO_KEY, hrp).encode();
+
+let mockFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+    // URL-aware rather than a blanket resolve: the wallet's background VtxoManager
+    // queries the indexer during construction, and handing it `arkInfo` makes
+    // `Wallet.create` fail with "Invalid vtxos data received" — a failure about
+    // this mock rather than about anything under test.
+    mockFetch = vi.fn().mockImplementation((input: unknown) => {
+        const url = String(input);
+        const body = url.includes("/v1/info")
+            ? mockArkInfo
+            : { vtxos: [], txs: [], page: null, commitmentTxs: {}, chains: [] };
+        return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(body),
+            text: () => Promise.resolve(""),
+        });
+    });
+    vi.stubGlobal("fetch", mockFetch);
+});
+
+describe("sendBitcoin({ selectedVtxos, extensions })", () => {
+    /**
+     * The asset packet this branch never builds.
+     *
+     * `_sendImpl` emits `createAssetPacket(...)` alongside any custom packets;
+     * this branch builds its own outputs and emits neither. So an asset carried
+     * in on a selected VTXO was already being dropped silently — spent, not
+     * re-declared, nothing said. Adding `extensions` makes that worse in one
+     * specific way: an extension output now exists, so the transaction looks
+     * well-formed while still omitting the asset packet that had to be in it.
+     *
+     * Refusing is the fix. Building the packet here would mean inventing an
+     * asset-routing mapping (which assets follow the recipient, which the
+     * change) that a BTC-only helper has no basis to decide.
+     */
+    it("refuses asset-bearing selected VTXOs rather than dropping their assets", async () => {
+        const wallet = await Wallet.create({
+            identity: mockIdentity,
+            arkServerUrl: "http://localhost:7070",
+        });
+
+        await expect(
+            wallet.sendBitcoin({
+                address: encodeAddr(SERVER_XONLY, "tark"),
+                amount: 2000,
+                selectedVtxos: [
+                    { value: 100_000, assets: [{ assetId: "aa".repeat(34), amount: 5n }] },
+                ] as never,
+                extensions: [{ type: 0x04, payload: new Uint8Array([1, 2, 3]) }],
+            }),
+        ).rejects.toThrow(/cannot spend asset-bearing VTXOs/);
+    });
+
+    it("refuses them with no extensions either — the silent drop predates extensions", async () => {
+        const wallet = await Wallet.create({
+            identity: mockIdentity,
+            arkServerUrl: "http://localhost:7070",
+        });
+
+        await expect(
+            wallet.sendBitcoin({
+                address: encodeAddr(SERVER_XONLY, "tark"),
+                amount: 2000,
+                selectedVtxos: [
+                    { value: 100_000, assets: [{ assetId: "bb".repeat(34), amount: 1n }] },
+                ] as never,
+            }),
+        ).rejects.toThrow(/cannot spend asset-bearing VTXOs/);
+    });
+
+    /**
+     * `changeVout` indexes the change output as `outputs.length - 1`, so it has
+     * to be read BEFORE the extension output is appended. Get the order wrong
+     * and it points at the OP_RETURN instead — change metadata silently bound
+     * to an unspendable output, with nothing throwing.
+     *
+     * Asserted against the value handed to `_submitOffchainSpend`, because that
+     * is the only place the mistake would surface, and it would surface as a
+     * wrong number rather than an error.
+     */
+    it("keeps changeVout pointing at the change output, not the extension", async () => {
+        const wallet = await Wallet.create({
+            identity: mockIdentity,
+            arkServerUrl: "http://localhost:7070",
+        });
+
+        const submitted: Array<{ outputs: unknown[]; changeVout: number }> = [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (wallet as any)._submitOffchainSpend = async (
+            _inputs: unknown,
+            outputs: unknown[],
+            meta: { changeVout: number },
+        ) => {
+            submitted.push({ outputs, changeVout: meta.changeVout });
+            return "txid";
+        };
+
+        await wallet.sendBitcoin({
+            address: encodeAddr(SERVER_XONLY, "tark"),
+            amount: 2000,
+            // 100_000 in, 2_000 out => change, so outputs are [dest, change, ext]
+            selectedVtxos: [{ value: 100_000 }] as never,
+            extensions: [{ type: 0x04, payload: new Uint8Array([1, 2, 3, 4]) }],
+        });
+
+        expect(submitted).toHaveLength(1);
+        const call = submitted[0]!;
+        // Three outputs: destination, change, and the extension OP_RETURN.
+        expect(call.outputs).toHaveLength(3);
+        // The change is index 1. If the extension were appended before this was
+        // read, `outputs.length - 1` would have made it 2 — the OP_RETURN.
+        expect(call.changeVout).toBe(1);
+    });
+
+    it("emits no extension output when none is asked for", async () => {
+        const wallet = await Wallet.create({
+            identity: mockIdentity,
+            arkServerUrl: "http://localhost:7070",
+        });
+
+        const submitted: Array<{ outputs: unknown[] }> = [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (wallet as any)._submitOffchainSpend = async (_inputs: unknown, outputs: unknown[]) => {
+            submitted.push({ outputs });
+            return "txid";
+        };
+
+        await wallet.sendBitcoin({
+            address: encodeAddr(SERVER_XONLY, "tark"),
+            amount: 2000,
+            selectedVtxos: [{ value: 100_000 }] as never,
+        });
+
+        // Destination and change only — an empty or absent `extensions` must not
+        // add a stray OP_RETURN.
+        expect(submitted[0]!.outputs).toHaveLength(2);
+    });
+});


### PR DESCRIPTION
The two send paths had drifted into a false choice:

| API | choose inputs | commit an extension |
| --- | --- | --- |
| `send(Recipient)` | ❌ | ✅ `extensions?: [{type, payload}]` |
| `sendBitcoin({ selectedVtxos })` | ✅ | ❌ |

A caller needing both had to give one up — and giving up input selection isn't a real option for anything spending contract-gated coins. So this is a missing half rather than a preference.

## The case that surfaced it

A swap solver funding an HTLC lockup must do two things at once: pick coins whose batch outlives the swap (otherwise it funds a lockup the counterparty can't claim and the service may not renew), and commit the sealed claim packet that lets covclaimd claim on the receiver's behalf.

covclaimd already reads that packet **off the funding transaction** — `pkg/preimage/plugin.go` parses the extension, `packet.go` defines the format. But the solver couldn't put it there, so the packet had to travel out of band via covclaimd's HTTP registration instead. That path keeps registrations **in memory**, capped at 10,000, expiring after 15 minutes — so a covclaimd restart silently drops every pending claim.

An on-chain registration is recoverable by anyone reading the transaction. That's the difference this unlocks.

## The change

`extensions` — the same shape `Recipient` already accepts — threaded into both `sendBitcoin` paths: the `selectedVtxos` branch builds the OP_RETURN output the way the recipient path does, and the generic fallback forwards to `send`.

**One ordering detail worth review attention.** `changeVout` is now read *before* the extension output is appended. It indexes the change output as `outputs.length - 1`, so appending the extension first would have made it point at the OP_RETURN instead — silently retargeting change metadata. The reason is in the code so it doesn't get "tidied" back.

## Test plan

- `pnpm test:unit` — **158 files / 2480 tests, 0 failures**
- `pnpm typecheck` clean

No unit test is added here, and I'd rather say why than pad it: nothing in the suite currently covers `extensions` on *any* send path, so there's no pattern to extend, and a mocked `sendBitcoin` would mostly assert the mock. The real verification is the consumer — a solver funding a lockup with the packet committed, and covclaimd claiming from what it reads on chain. That runs on regtest as the next step in this chain, and proves this change end to end rather than in isolation.