### PR TITLE
feat(swap): sweep refundable lockups from wallet state alone

### DIFF
--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -159,6 +159,7 @@ export {
     type RefundIndexer,
     type RefundOutcome,
 } from "./refund";
+export { sweepRefundableLockups, type LockupSweepReport } from "./lockupSweep";
 export {
     LockupRegistrationFailed,
     SWAP_LOCKUP_CONTRACT_KIND,

--- a/packages/swap/src/lockupSweep.ts
+++ b/packages/swap/src/lockupSweep.ts
@@ -1,0 +1,150 @@
+/**
+ * Sweep every refundable RFQ lockup from wallet state alone.
+ *
+ * `requestLightningSend` / `requestOnchainSend` register each lockup with the
+ * wallet's contract manager before handing back an address to fund
+ * (`lockupContract.ts`), and the row's params carry every script-level fact —
+ * including the committed `sender` key and `refundLocktime`. On an HD wallet
+ * the sender signer re-derives from the seed. Put together, a stalled send is
+ * recoverable with NOTHING persisted by the application: enumerate the rows,
+ * rebuild each covenant from its stored params, match its sender to a wallet
+ * descriptor, and push the `refundWithoutReceiver` leaf once the CLTV has
+ * matured.
+ *
+ * Two families fall out as `no-signer`, correctly: swaps made under
+ * `randomSwapSecrets()` (their sender key exists only in the swap record, not
+ * the seed) and receive-direction lockups (their `sender` is the solver — the
+ * trader's way out of a receive is the claim, never this refund).
+ *
+ * The wall clock is only an optimistic gate for `pending`: seconds-based
+ * locktimes mature against chain time, so a push right at the boundary can
+ * still be rejected server-side — rerun the sweep.
+ */
+import {
+    RestArkProvider,
+    RestIndexerProvider,
+    VHTLCV2ContractHandler,
+    isHDWalletCapable,
+    type Identity,
+    type IWallet,
+} from "@arkade-os/sdk";
+import { hex } from "@scure/base";
+
+import { SWAP_LOCKUP_CONTRACT_KIND, SWAP_LOCKUP_CONTRACT_TYPE } from "./lockupContract";
+import {
+    LockupNeedsRecoveryError,
+    findLockupVtxos,
+    pushRefundWithoutReceiver,
+    type RefundArkProvider,
+    type RefundIndexer,
+} from "./refund";
+
+export interface LockupSweepReport {
+    /** Refunds pushed this run, one aggregate transaction per lockup. */
+    refunded: { address: string; arkTxid: string; amount: number }[];
+    /** Funded lockups whose `refundLocktime` has not matured yet. */
+    pending: { address: string; refundLocktime: number }[];
+    /** Funded lockups holding swept outputs — run the wallet's VTXO recovery
+     * first, then sweep again. Outpoints are `txid:vout`. */
+    needsRecovery: { address: string; outpoints: string[] }[];
+    /** `no-signer`: no wallet descriptor derives the row's `sender` (a
+     * random-secrets swap, or a receive lockup whose sender is the solver).
+     * `empty`: nothing funded at the lockup — filled, refunded, or never
+     * funded. */
+    skipped: { address: string; reason: "no-signer" | "empty" }[];
+}
+
+/**
+ * Recover stalled sends using only what the SDK already persisted.
+ *
+ * Safe to run on every wallet start: a lockup whose swap completed holds no
+ * outputs and is skipped as `empty`, and a premature push never happens —
+ * immature lockups land in `pending`.
+ */
+export async function sweepRefundableLockups(
+    wallet: IWallet,
+    arkServerUrl: string,
+    opts: {
+        /** Descriptors probed past the allocation watermark, for restores
+         * whose local state predates some swaps. Passed through to
+         * `getUsedSigningDescriptors`. */
+        lookAhead?: number;
+        /** Unix seconds used for the maturity gate; defaults to wall clock. */
+        nowSeconds?: number;
+        /** Test seams; default to REST providers over `arkServerUrl`. */
+        ark?: RefundArkProvider;
+        indexer?: RefundIndexer;
+    } = {},
+): Promise<LockupSweepReport> {
+    const ark = opts.ark ?? new RestArkProvider(arkServerUrl);
+    const indexer = opts.indexer ?? new RestIndexerProvider(arkServerUrl);
+    const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000);
+
+    const manager = await wallet.getContractManager();
+    const rows = (await manager.getContracts()).filter(
+        (row) =>
+            row.type === SWAP_LOCKUP_CONTRACT_TYPE &&
+            row.metadata?.kind === SWAP_LOCKUP_CONTRACT_KIND,
+    );
+
+    // Every signer the wallet can re-derive, indexed by x-only pubkey, so each
+    // row's committed `sender` finds its signer without allocating anything.
+    const signers = new Map<string, Identity>();
+    if (isHDWalletCapable(wallet)) {
+        const descriptors = await wallet.getUsedSigningDescriptors(
+            opts.lookAhead === undefined ? undefined : { lookAhead: opts.lookAhead },
+        );
+        for (const descriptor of descriptors) {
+            const signer = await wallet.signerForDescriptor(descriptor);
+            signers.set(hex.encode(await signer.xOnlyPublicKey()), signer);
+        }
+    }
+
+    const report: LockupSweepReport = {
+        refunded: [],
+        pending: [],
+        needsRecovery: [],
+        skipped: [],
+    };
+
+    for (const row of rows) {
+        const script = VHTLCV2ContractHandler.createScript(row.params);
+        const signer = signers.get(hex.encode(script.options.sender));
+        if (!signer) {
+            report.skipped.push({ address: row.address, reason: "no-signer" });
+            continue;
+        }
+
+        const vtxos = await findLockupVtxos(indexer, script.pkScript);
+        if (vtxos.length === 0) {
+            report.skipped.push({ address: row.address, reason: "empty" });
+            continue;
+        }
+
+        const refundLocktime = Number(script.options.refundLocktime);
+        if (now < refundLocktime) {
+            report.pending.push({ address: row.address, refundLocktime });
+            continue;
+        }
+
+        try {
+            const { arkTxid, amount } = await pushRefundWithoutReceiver(ark, {
+                script,
+                sender: signer,
+                vtxos,
+            });
+            report.refunded.push({ address: row.address, arkTxid, amount });
+        } catch (error) {
+            if (error instanceof LockupNeedsRecoveryError) {
+                report.needsRecovery.push({
+                    address: row.address,
+                    outpoints: [...error.outpoints],
+                });
+                continue;
+            }
+            throw error;
+        }
+    }
+
+    return report;
+}

--- a/packages/swap/test/lockupSweep.test.ts
+++ b/packages/swap/test/lockupSweep.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The zero-persistence recovery loop: contract rows in, refunds out.
+ *
+ * What must hold: a matured, funded lockup whose sender the wallet can
+ * re-derive is refunded; an immature one is reported `pending`, not pushed; a
+ * foreign sender (random-secrets swap, receive lockup) is `no-signer`; an
+ * unfunded row is `empty`; swept outputs surface as `needsRecovery` instead
+ * of poisoning the aggregate push. All of it from the row's serialized
+ * params alone — the same write `registerLockupContract` makes.
+ */
+import { describe, expect, it } from "vitest";
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+    CSVMultisigTapscript,
+    SingleKey,
+    Transaction,
+    VHTLCV2ContractHandler,
+    type IWallet,
+} from "@arkade-os/sdk";
+
+import { lightningSendVtxoScript } from "../src/rfq";
+import {
+    SWAP_LOCKUP_CONTRACT_KIND,
+    SWAP_LOCKUP_CONTRACT_LABEL,
+    SWAP_LOCKUP_CONTRACT_TYPE,
+} from "../src/lockupContract";
+import { sweepRefundableLockups } from "../src/lockupSweep";
+import type { LockupVtxo, RefundArkProvider, RefundIndexer } from "../src/refund";
+
+const priv = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+const key = (fill: number): Uint8Array => schnorr.getPublicKey(priv(fill));
+const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+
+const REFUND_LOCKTIME = 1_800_000_000;
+const SENDER = SingleKey.fromPrivateKey(priv(13));
+const DESCRIPTOR = "tr(descriptor-for-sender)/0/7";
+
+const swapScript = (over: { senderPubkey?: Uint8Array; refundLocktime?: number } = {}) =>
+    lightningSendVtxoScript({
+        solverPubkey: key(1),
+        serverPubkey: key(3),
+        paymentHash: hex.encode(sha256(new Uint8Array(32).fill(7))),
+        refundLocktime: over.refundLocktime ?? REFUND_LOCKTIME,
+        claimDelay: 4096,
+        emulatorPubkey: key(9),
+        refundPkScript: p2tr(key(5)),
+        senderPubkey: over.senderPubkey ?? key(13),
+        receiverPkScript: p2tr(key(1)),
+    });
+
+const rowOf = (script: ReturnType<typeof swapScript>, address: string) => ({
+    type: SWAP_LOCKUP_CONTRACT_TYPE,
+    params: VHTLCV2ContractHandler.serializeParams(script.options),
+    script: hex.encode(script.pkScript),
+    address,
+    state: "active",
+    createdAt: 0,
+    label: SWAP_LOCKUP_CONTRACT_LABEL,
+    metadata: { genericallySpendable: false, kind: SWAP_LOCKUP_CONTRACT_KIND },
+});
+
+const CHECKPOINT_TAPSCRIPT = hex.encode(
+    CSVMultisigTapscript.encode({
+        timelock: { type: "blocks", value: BigInt(144) },
+        pubkeys: [key(3)],
+    }).script,
+);
+
+const fakeArk = (): RefundArkProvider & { submitted: string[] } => {
+    const submitted: string[] = [];
+    return {
+        submitted,
+        getInfo: async () => ({ checkpointTapscript: CHECKPOINT_TAPSCRIPT }),
+        submitTx: async (arkTx: string, checkpoints: string[]) => {
+            submitted.push(arkTx);
+            return {
+                arkTxid: Transaction.fromPSBT(base64.decode(arkTx)).id,
+                finalArkTx: arkTx,
+                signedCheckpointTxs: checkpoints,
+            };
+        },
+        finalizeTx: async () => {},
+    } as unknown as RefundArkProvider & { submitted: string[] };
+};
+
+/** Serves per-pkScript vtxo sets; anything unlisted is unfunded. */
+const fakeIndexer = (byScript: Record<string, LockupVtxo[]>): RefundIndexer =>
+    ({
+        getVtxos: async (opts?: { scripts?: string[]; recoverableOnly?: boolean }) => {
+            const vtxos = byScript[opts?.scripts?.[0] ?? ""] ?? [];
+            return {
+                vtxos: vtxos.filter(
+                    (v) => Boolean(v.recoverable) === Boolean(opts?.recoverableOnly),
+                ),
+            };
+        },
+    }) as unknown as RefundIndexer;
+
+const fakeWallet = (rows: ReturnType<typeof rowOf>[]): IWallet =>
+    ({
+        getContractManager: async () => ({ getContracts: async () => rows }),
+        // HDWalletCapable — the sweep must find the sender without allocating.
+        getCurrentSigningDescriptor: async () => DESCRIPTOR,
+        getUsedSigningDescriptors: async () => [DESCRIPTOR],
+        signerForDescriptor: async (descriptor: string) => {
+            if (descriptor !== DESCRIPTOR) throw new Error(`unknown descriptor ${descriptor}`);
+            return SENDER;
+        },
+    }) as unknown as IWallet;
+
+const funded: LockupVtxo[] = [
+    { txid: "11".repeat(32), vout: 0, value: 60_000, recoverable: false },
+];
+
+describe("sweepRefundableLockups", () => {
+    it("refunds a matured lockup rebuilt from its contract row alone", async () => {
+        const script = swapScript();
+        const ark = fakeArk();
+        const report = await sweepRefundableLockups(
+            fakeWallet([rowOf(script, "ark1matured")]),
+            "",
+            {
+                ark,
+                indexer: fakeIndexer({ [hex.encode(script.pkScript)]: funded }),
+                nowSeconds: REFUND_LOCKTIME + 1,
+            },
+        );
+        expect(report.refunded).toHaveLength(1);
+        expect(report.refunded[0].address).toBe("ark1matured");
+        expect(report.refunded[0].amount).toBe(60_000);
+        expect(ark.submitted).toHaveLength(1);
+        expect(report.pending).toEqual([]);
+        expect(report.skipped).toEqual([]);
+    });
+
+    it("reports an immature lockup as pending without pushing", async () => {
+        const script = swapScript();
+        const ark = fakeArk();
+        const report = await sweepRefundableLockups(fakeWallet([rowOf(script, "ark1early")]), "", {
+            ark,
+            indexer: fakeIndexer({ [hex.encode(script.pkScript)]: funded }),
+            nowSeconds: REFUND_LOCKTIME - 1,
+        });
+        expect(report.pending).toEqual([{ address: "ark1early", refundLocktime: REFUND_LOCKTIME }]);
+        expect(ark.submitted).toEqual([]);
+    });
+
+    it("skips foreign senders and unfunded rows for the right reasons", async () => {
+        const foreign = swapScript({ senderPubkey: key(42) }); // receive / random-secrets
+        const empty = swapScript();
+        const report = await sweepRefundableLockups(
+            fakeWallet([rowOf(foreign, "ark1foreign"), rowOf(empty, "ark1empty")]),
+            "",
+            { ark: fakeArk(), indexer: fakeIndexer({}), nowSeconds: REFUND_LOCKTIME + 1 },
+        );
+        expect(report.skipped).toEqual([
+            { address: "ark1foreign", reason: "no-signer" },
+            { address: "ark1empty", reason: "empty" },
+        ]);
+        expect(report.refunded).toEqual([]);
+    });
+
+    it("routes swept outputs to needsRecovery instead of pushing", async () => {
+        const script = swapScript();
+        const swept: LockupVtxo[] = [
+            { txid: "33".repeat(32), vout: 2, value: 10_000, recoverable: true },
+        ];
+        const report = await sweepRefundableLockups(fakeWallet([rowOf(script, "ark1swept")]), "", {
+            ark: fakeArk(),
+            indexer: fakeIndexer({ [hex.encode(script.pkScript)]: [...funded, ...swept] }),
+            nowSeconds: REFUND_LOCKTIME + 1,
+        });
+        expect(report.needsRecovery).toEqual([
+            { address: "ark1swept", outpoints: [`${"33".repeat(32)}:2`] },
+        ]);
+        expect(report.refunded).toEqual([]);
+    });
+
+    it("ignores contract rows that are not swap lockups", async () => {
+        const report = await sweepRefundableLockups(
+            fakeWallet([
+                { ...rowOf(swapScript(), "ark1other"), metadata: { kind: "something-else" } },
+            ]),
+            "",
+            { ark: fakeArk(), indexer: fakeIndexer({}), nowSeconds: REFUND_LOCKTIME + 1 },
+        );
+        expect(report.skipped).toEqual([]);
+        expect(report.refunded).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Closes the persistence loop the docs review surfaced: `requestLightningSend` / `requestOnchainSend` already register every lockup with the wallet's contract manager (`lockupContract.ts`), and the row's serialized params carry the committed `sender` key and `refundLocktime`. What was missing is the read side. **`sweepRefundableLockups(wallet, arkServerUrl)`** enumerates the `rfq-swap-lockup` rows, rebuilds each covenant with `VHTLCV2ContractHandler.createScript`, matches its `sender` to a wallet descriptor via `getUsedSigningDescriptors` + `signerForDescriptor` (never allocating), and pushes the `refundWithoutReceiver` leaf once the CLTV has matured.

Result: **a stalled send is recoverable with nothing persisted by the application** — safe to run on every wallet start.

## Behavior

- **`refunded`** — matured, funded, sender re-derivable: one aggregate `pushRefundWithoutReceiver` per lockup.
- **`pending`** — funded but `refundLocktime` not matured; never pushed early (wall-clock gate only; chain time is authoritative, so a boundary push is retried by rerunning).
- **`needsRecovery`** — swept outputs surface via `LockupNeedsRecoveryError` with their outpoints instead of poisoning the aggregate push.
- **`skipped`** — `no-signer` (random-secrets swaps, and receive lockups whose `sender` is the solver — a receive's way out is the claim, not this refund) or `empty` (filled, refunded, or never funded).

## Tests

`test/lockupSweep.test.ts` builds real covenants with `lightningSendVtxoScript`, serializes them through the handler exactly as `registerLockupContract` does, and drives the sweep through a fake manager/HD wallet/indexer/ark: refund pushed and finalized, pending not pushed, foreign-sender and empty rows skipped with the right reasons, swept outputs routed to `needsRecovery`, non-lockup rows ignored. Full swap suite: 23 files, 346 tests green; prettier clean.

## Relation to other work

- Complements #726 (absorb `emulatorPubkey`): both remove integrator-held state the SDK already owns.
- The docs (arkade-os/docs#134) already state that persistence is the SDK's job — snippets store nothing. Once this lands, the docs' refund section can add the sweep as the works-after-restart recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qyyk1wuSFmcVXYz2aLeJqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyyk1wuSFmcVXYz2aLeJqx)_