### PR TITLE
feat(swap): drive the lightning-receive leg from the swap manager

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -412,7 +412,11 @@ hash-verified preimage spend rather than by the txid we submitted, so a claim th
 still counts; `claimed` is a local belief and not terminal; and **`refunded` is a loss**, the solver
 having taken back a lockup we failed to claim. A lockup funded below `expectedAmount` is reported
 `needs_counterparty` and never claimed, which is non-terminal — a solver that tops it up before
-the window shuts makes it claimable again.
+the window shuts makes it claimable again, and a lockup funded piecemeal moves `claimed` →
+`claimable` → `claimed` again, so `onSwapUpdate` states say what to do next rather than track
+progress in one direction. A `refunded` outcome from `waitForSwapCompletion` reports no `txid` even
+when a claim was submitted and recorded: the chain never took it, and the record still carries
+`claimArkTxid` for anyone diagnosing the loss.
 
 **There is no client-side refund on this leg, and that is the whole answer to "what if I cannot
 claim in time".** Every non-claim leaf of the covenant is the solver's, so `refundArkade` is never

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -401,6 +401,31 @@ before finalizing. Until covclaimd's
 reference vectors are cross-checked, the `sealClaimPacket` test vector is pinned from this
 implementation and marked provisional (`TODO(claim-packet-vectors)`).
 
+`RfqSwapManager` drives the lightning-receive leg too, as `kind: "lightning_receive"` records
+carrying `expectedAmount` and wired to a `claimLockup` callback (`pushClaim`, with `expectedAmount`
+and `partiallyClaimed` passed through — the manager's value check decides *when* to act, the inner
+one decides whether `P` is published). Nothing is asked of the solver: the reference solver's
+`rfq_status_request` consults neither receive store, so a status poll answers `unknown` for every
+one of these swaps and chain observation is the only workable design. States mean what they do on
+the send legs with the roles swapped — `settled` is *our own* claim landing, matched by a
+hash-verified preimage spend rather than by the txid we submitted, so a claim that lands without us
+still counts; `claimed` is a local belief and not terminal; and **`refunded` is a loss**, the solver
+having taken back a lockup we failed to claim. A lockup funded below `expectedAmount` is reported
+`needs_counterparty` and never claimed, which is non-terminal — a solver that tops it up before
+the window shuts makes it claimable again.
+
+**There is no client-side refund on this leg, and that is the whole answer to "what if I cannot
+claim in time".** Every non-claim leaf of the covenant is the solver's, so `refundArkade` is never
+called for a receive record and no amount of waiting produces one. The deadline is the quote's
+`refund_locktime`: the manager claims right up to it and stops there, because publishing `P` into
+the solver's live refund window risks losing the race and giving away the preimage anyway. Wall
+clock with no margin is already conservative — the solver's leaf is a CLTV maturing against
+median-time-past, which trails, so the real window runs past that instant rather than ending before
+it. Past it the outcome is not symmetric with a send: the solver reclaims the lockup, the held
+Lightning HTLC lapses, and **the payer is refunded** — the trader loses the incoming payment, not
+funds it was holding. Which is why staying online to claim is an obligation and not a preference:
+covclaimd cannot claim this covenant today, so the claim packet's offline path does not yet run.
+
 ## RFQ secrets are derived, not stored
 
 The two secrets an RFQ swap needs — the VHTLC `sender` key and, for an onchain send, the preimage —
@@ -525,3 +550,9 @@ scanned? })` — the server key is required because a spend is classified by reb
   sender key — generate, persist, see `requestLightningSend`) and `receiverPkScript` (the solver's
   claim destination, from `profile.receiver_pk_script`). Callers that built the lockup directly
   must supply both; callers going through `requestLightningSend` are unaffected.
+- **`RfqSwapManagerCallbacks` gained a required `claimLockup`**, and `RfqSwap` a third member,
+  `LightningReceiveSwap`. Required rather than optional for the same reason `claimOnchain` is: a
+  receive swap monitored with nothing wired to claim it expires quietly, and a compile error is the
+  right way to learn a corridor was added. A caller with only send swaps can satisfy it with a stub
+  that throws. `RfqSwapActionName` gains `"claimLockup"`, so an exhaustive `switch` over it needs a
+  new arm.

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -182,6 +182,7 @@ export {
     isRfqSwapTerminal,
     nextOnchainAction,
     type ArkadeRefundResult,
+    type LightningReceiveSwap,
     type LightningSendSwap,
     type OnchainSendAction,
     type OnchainSendSwap,

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -1,14 +1,16 @@
 /**
- * Driving a set of funded RFQ swaps to their end, so a caller does not have to
+ * Driving a set of live RFQ swaps to their end, so a caller does not have to
  * know which function to call when.
  *
- * The corridor is complete as building blocks: `requestLightningSend` /
+ * The corridors are complete as building blocks: `requestLightningSend` /
  * `requestOnchainSend` quote and gate funding, `awaitOnchainFill` /
  * `claimOnchainFill` take the L1 fill, `refundIfUnresolved` /
- * `pushRefundWithoutReceiver` take the lockup back. What is missing is the
- * thing that calls them at the right moment for more than one swap at a time,
- * remembers where each one got to, and tells the caller when something
- * happened. That is this module.
+ * `pushRefundWithoutReceiver` take the lockup back, and on
+ * `lightning:BTC->arkade:BTC` `requestLightningReceive` gates the invoice while
+ * `claimReceiveLockup` / `pushClaim` take the solver-funded lockup. What is
+ * missing is the thing that calls them at the right moment for more than one
+ * swap at a time, remembers where each one got to, and tells the caller when
+ * something happened. That is this module.
  *
  * The shape is deliberately the one `packages/boltz-swap`'s `SwapManager`
  * arrived at — monitor a set, act automatically through injected callbacks,
@@ -31,6 +33,16 @@
  *   half of this argument — see `RFQ_RESOLVED_STATES`, which lets "the
  *   on-chain VTXO lookup be the authority on whether anything is actually
  *   there"; this finishes the thought for the outcome as well as the balance.
+ *
+ *   **On the receive leg the same read means the mirror image.** The trader is
+ *   the covenant's `receiver`, so the hash-verified spend is the trader's OWN
+ *   claim rather than the counterparty's, and the other leaves belong to the
+ *   SOLVER — a spend that reveals no matching preimage is the solver taking its
+ *   money back, which is a LOSS and not a return. `settled` and `refunded` keep
+ *   their names and swap their meanings; see {@link RfqSwapState}. The
+ *   chain-only posture is not merely preferable there but required: the
+ *   reference solver's `rfq_status_request` consults neither receive store, so
+ *   a status poll answers `unknown` for every one of these swaps.
  *
  * - **The onchain corridor's claim is on a consensus deadline, not on the
  *   solver's word.** See {@link nextOnchainAction}: a naive "poll status,
@@ -76,9 +88,11 @@ import {
 } from "./onchainHtlc";
 import {
     REFUND_MTP_LAG_SECONDS,
+    findLockupVtxos,
     readLockupFate,
     type LockupFate,
     type LockupSpendIndexer,
+    type LockupVtxo,
 } from "./refund";
 import { registerLockupContract } from "./lockupContract";
 import { RefundNotLocallyPossibleError } from "./secrets";
@@ -88,35 +102,69 @@ import { RefundNotLocallyPossibleError } from "./secrets";
 /**
  * Where a monitored swap stands.
  *
- * `claimable` and `claimed` are onchain-send only — the lightning leg has no
- * trader-side claim, the solver claims the lockup itself.
+ * `claimable` and `claimed` are the states of a swap the TRADER has something
+ * to claim on: the L1 fill on an onchain send, and the solver-funded lockup on
+ * a receive. Only `lightning_send` has neither — there the solver claims the
+ * lockup, and the trader's only move is the refund.
  */
 export type RfqSwapState =
-    /** Funded; nothing actionable yet. */
+    /** Live; nothing actionable yet. On a receive leg this covers the whole
+     * stretch before the solver funds anything. */
     | "pending"
-    /** onchain-send: the L1 fill is confirmed and the claim window is open. */
+    /** There is something for the trader to take, and the window to take it is
+     * open: the confirmed L1 fill on an onchain send, or a lockup funded for at
+     * least `expectedAmount` on a receive. */
     | "claimable"
-    /** onchain-send: our L1 claim is broadcast — the trader has the coins. */
+    /**
+     * The trader's claim has been made — its L1 broadcast on an onchain send,
+     * its Arkade submission on a receive.
+     *
+     * **On a receive this is a local belief and not a chain fact**, which is
+     * why it is not terminal: `settled` is the chain's answer, and `refunded`
+     * is still reachable from here if the claim never lands and the solver
+     * takes the lockup back.
+     */
     | "claimed"
     /**
-     * This wallet cannot push the swap's Arkade refund itself — no secrets on
-     * the record, a descriptor from another seed, or nothing wired to act. The
-     * lockup comes back only if the counterparty claims it, or if the wallet
-     * that can sign it is restored. {@link RfqSwapCommon.blockedReason} says
-     * which.
+     * This wallet will not act, and only the counterparty can change that.
+     *
+     * On a send leg: the Arkade refund cannot be pushed from here — no secrets
+     * on the record, a descriptor from another seed, or nothing wired to act —
+     * so the lockup comes back only if the counterparty claims it or the wallet
+     * that can sign it is restored. On a receive leg: the trader holds no
+     * refund at all, so this is a lockup that cannot be claimed — funded for
+     * less than the swap agreed (publishing `P` for it is the whole attack
+     * `LockupAmountMismatchError` exists to refuse), or one whose claim window
+     * shut unclaimed. {@link RfqSwapCommon.blockedReason} says which.
      *
      * **Not terminal, and not a dead end.** The money is still at the lockup,
-     * so a solver claim is still observable and still ends the swap `settled`;
-     * and the refusal is re-checked every pass, so restoring the right wallet
-     * (or wiring the callbacks) returns the swap to `pending` and resumes the
-     * normal drive. For an onchain-send swap it says nothing about the L1
-     * half, which keeps being driven and claimed.
+     * so the counterparty's move is still observable and still ends the swap;
+     * and the refusal is re-checked every pass, so restoring the right wallet,
+     * wiring the callbacks, or the solver topping the lockup up returns the
+     * swap to `pending` and resumes the normal drive. For an onchain-send swap
+     * it says nothing about the L1 half, which keeps being driven and claimed.
      */
     | "needs_counterparty"
-    /** Terminal: the lockup was spent by a hash-verified claim — the
-     * counterparty completed its side. Read off chain, never reported. */
+    /**
+     * Terminal: the lockup was spent by a hash-verified claim. Read off chain,
+     * never reported.
+     *
+     * On a send leg that claim is the counterparty's, and it is proof the
+     * counterparty completed its side. On a receive leg it is the TRADER's own
+     * — matched by the hash and not by our txid, so a claim that lands without
+     * us still counts (see {@link RfqSwapManager}).
+     */
     | "settled"
-    /** Terminal: the lockup came back, by the solver's hand or the trader's. */
+    /**
+     * Terminal: the lockup was spent by something other than a claim.
+     *
+     * On a send leg that is the money coming back, by the solver's hand or the
+     * trader's. **On a receive leg it is a LOSS**: the lockup was the solver's
+     * money, every non-claim leaf is the solver's, and a swap that ends here
+     * ended with the trader's incoming payment never arriving. It is also where
+     * a receive swap ends when its window closes with nothing left to observe —
+     * see {@link RfqSwapManager}.
+     */
     | "refunded"
     /** Terminal: an action failed and its window closed. */
     | "failed";
@@ -135,12 +183,12 @@ export const isRfqSwapTerminal = (state: RfqSwapState): boolean =>
  * seconds.
  *
  * Both fields are things the caller already holds. `script` is the very object
- * `pushRefundWithoutReceiver` takes, so a caller wired for refunds has it in
- * hand; `address` is `requestLightningSend` / `requestOnchainSend`'s own return
- * value. The address is taken rather than re-derived on purpose — the row's
- * address must be the one the trader actually funded, and a local re-derivation
- * would silently use the SDK's default network, which is the exact bug
- * `registerOfferContract` guards against.
+ * `pushRefundWithoutReceiver` and `pushClaim` take, so a caller wired to act has
+ * it in hand; `address` is the request entrypoint's own return value. The
+ * address is taken rather than re-derived on purpose — the row's address must be
+ * the one that was actually funded, and a local re-derivation would silently use
+ * the SDK's default network, which is the exact bug `registerOfferContract`
+ * guards against.
  */
 export interface RfqSwapLockup {
     /** The covenant. Its `pkScript` MUST equal the record's `lockupPkScript`. */
@@ -153,10 +201,10 @@ interface RfqSwapCommon {
     /** The negotiation id — this record's identity. */
     rfqId: string;
     state: RfqSwapState;
-    /** The Arkade lockup's scriptPubKey — `swapPkScript` from
-     * `requestLightningSend` / `requestOnchainSend`. This is what the manager
-     * watches to decide the swap: it is the only handle on the covenant whose
-     * spend witness says whether the swap settled or came back. */
+    /** The Arkade lockup's scriptPubKey — `swapPkScript` from any of the four
+     * request entrypoints. This is what the manager watches to decide the swap:
+     * it is the only handle on the covenant whose spend witness says whether
+     * the swap settled or came back. */
     lockupPkScript: Uint8Array;
     /** The covenant behind {@link lockupPkScript}, when the caller wants the
      * lockup registered with a contract manager. Optional: without it the
@@ -168,7 +216,15 @@ interface RfqSwapCommon {
      * settlement provable rather than reported. For an onchain send this is
      * the SAME hash the L1 `htlc` carries: one `P` unlocks both legs. */
     paymentHash: string;
-    /** `refund_locktime` from the quote, unix seconds. Gates the Arkade refund. */
+    /**
+     * `refund_locktime` from the quote, unix seconds.
+     *
+     * Whose deadline it is inverts with the direction, and so does what to do
+     * about it. On a send leg it is the TRADER's: the lockup is the trader's
+     * money and this gates the refund that takes it back, so it is a moment to
+     * act AFTER. On a receive leg it is the SOLVER's: the trader has no refund
+     * leaf at all, and this is the moment to have claimed BEFORE.
+     */
     refundLocktime: number;
     createdAt: number;
     updatedAt: number;
@@ -204,16 +260,65 @@ export interface OnchainSendSwap extends RfqSwapCommon {
 }
 
 /**
+ * `lightning:BTC->arkade:BTC`. The inverted leg: the SOLVER funds the lockup
+ * and the TRADER claims it, and that claim is what publishes `P` and lets the
+ * solver settle the payer's held Lightning HTLC.
+ *
+ * Two consequences shape how this record is driven, both of them absent from
+ * the send legs:
+ *
+ * - **There is no trader-side refund.** Every non-claim leaf of this covenant
+ *   is the solver's, so the manager never calls
+ *   {@link RfqSwapManagerCallbacks.refundArkade} for one of these. A swap that
+ *   is not claimed is simply lost — the solver reclaims at
+ *   {@link RfqSwapCommon.refundLocktime} and the payer is refunded when the
+ *   held HTLC lapses.
+ * - **The claim is the whole swap, and it is on a deadline.** The trader must
+ *   be online for it: covclaimd cannot claim this covenant today, so the claim
+ *   packet's offline path does not run.
+ */
+export interface LightningReceiveSwap extends RfqSwapCommon {
+    kind: "lightning_receive";
+    /**
+     * What the lockup must carry — the quote's `to_amount`, captured at REQUEST
+     * time and persisted with the record.
+     *
+     * **Not re-derivable, and not optional.** Captured at claim time it would
+     * be whatever the solver funded, which is the dust-funding attack rather
+     * than a check on it. A record that reaches the manager without a finite
+     * value here is reported `needs_counterparty` and never claimed: a
+     * comparison against `undefined` or `NaN` is false, so an unusable
+     * comparand does not fail the value gate, it deletes it.
+     */
+    expectedAmount: number;
+    /** Our Arkade claim's txid, once submitted. Set from the callback's return
+     * and never from a chain read — the chain's answer is `settled`. */
+    claimArkTxid?: string;
+}
+
+/**
  * A monitored swap.
  *
  * This is a live record, not a serialization format: `lockupPkScript` and
  * `htlc` hold derived `Uint8Array`s, and
  * {@link RfqSwapManagerCallbacks.saveSwap} is where a caller projects it into
  * whatever it stores. Rebuild it on restart the way it was made —
- * `lightningSendVtxoScript` / `onchainHtlcScript` over the quote's binding
- * fields — and hand the result to {@link RfqSwapManager.start}.
+ * `lightningSendVtxoScript` / `receiveVtxoScript` / `onchainHtlcScript` over
+ * the quote's binding fields — and hand the result to
+ * {@link RfqSwapManager.start}.
+ *
+ * **`onchain:BTC->arkade:BTC` is deliberately not a member yet.** Its Arkade
+ * half is the same solver-funded lockup as {@link LightningReceiveSwap}'s, but
+ * it also has an L1 half the trader funds and must take back itself
+ * (`buildHtlcRefund` at the HTLC's own `htlc_locktime`), which is a second
+ * deadline, a second observation seam and a second action callback. Adding the
+ * lockup half alone would produce a manager that silently lets that L1 refund
+ * window pass — the one failure mode {@link RfqSwapManager} refuses elsewhere
+ * by name (see `driveOnchain`'s missing-`ChainSource` check). Until the L1
+ * refund is driven too, that corridor is better served by the request and claim
+ * functions directly than by a monitor that covers half of it.
  */
-export type RfqSwap = LightningSendSwap | OnchainSendSwap;
+export type RfqSwap = LightningSendSwap | OnchainSendSwap | LightningReceiveSwap;
 
 // ── The onchain state machine ───────────────────────────────────────────────
 
@@ -299,15 +404,45 @@ export type ArkadeRefundResult = { arkTxid: string; amount: number } | null;
 export interface RfqSwapManagerCallbacks {
     /** Build and broadcast the L1 claim. See `claimOnchainFill`. */
     claimOnchain: (swap: OnchainSendSwap, utxo: ChainUtxo) => Promise<{ txid: string }>;
+    /**
+     * Claim the solver-funded lockup on a receive leg, revealing `P`. Wire it
+     * to `pushClaim` — the outputs are supplied, so `findLockupVtxos` has
+     * already been called and `claimReceiveLockup`'s wait would only sit on a
+     * lockup the manager has just seen.
+     *
+     * **Pass `expectedAmount` and `partiallyClaimed` straight through.** The
+     * manager checks the funded value before calling this, but that check
+     * decides WHEN to act; `pushClaim`'s decides whether `P` is published, and
+     * it is the one that runs with nothing between it and the signature. Two
+     * checks, one of which is load-bearing — do not drop the inner one because
+     * the outer one exists.
+     *
+     * Required rather than optional, like {@link claimOnchain}: a receive swap
+     * monitored with nothing wired to claim it is a swap that quietly expires,
+     * and a compile error is the right way to learn that.
+     */
+    claimLockup: (
+        swap: LightningReceiveSwap,
+        vtxos: readonly LockupVtxo[],
+        options: {
+            /** A claim of ours is already out, so `P` is public and the value
+             * gate has nothing left to protect — pass this to `pushClaim` so a
+             * funding that arrived piecemeal can still be swept. */
+            partiallyClaimed: boolean;
+        },
+    ) => Promise<{ arkTxid: string; amount: number }>;
     /** Push `refundWithoutReceiver` for every output at the lockup. See
-     * `pushRefundWithoutReceiver`; return `null` for an empty lockup. */
+     * `pushRefundWithoutReceiver`; return `null` for an empty lockup. Never
+     * called for a {@link LightningReceiveSwap} — that leg's refund leaf is the
+     * solver's. */
     refundArkade: (swap: RfqSwap) => Promise<ArkadeRefundResult>;
     /**
      * Whether a local refund is possible at all — the record's secrets, against
      * this wallet. Called every pass, including *before* the refund window
      * opens, so a swap nobody can refund says so while the solver can still
      * act, instead of at the deadline; and so restoring the right wallet lifts
-     * the state again.
+     * the state again. Never called for a receive swap: there is no local
+     * refund there to probe for.
      *
      * Optional: omit to answer "yes" and learn at push time, from
      * {@link RefundNotLocallyPossibleError}. Local by contract — no network
@@ -319,7 +454,7 @@ export interface RfqSwapManagerCallbacks {
 }
 
 /** The actions the manager executes on a caller's behalf. */
-export type RfqSwapActionName = "claimOnchain" | "refundArkade";
+export type RfqSwapActionName = "claimOnchain" | "claimLockup" | "refundArkade";
 
 export interface RfqSwapManagerEvents {
     onSwapUpdate?: (swap: RfqSwap, previous: RfqSwapState) => void;
@@ -408,7 +543,7 @@ const notify = <T extends (...args: never[]) => void>(
 // ── The manager ──────────────────────────────────────────────────────────────
 
 /**
- * Watches a set of funded RFQ swaps and drives each to its end.
+ * Watches a set of live RFQ swaps and drives each to its end.
  *
  * One pass per swap, in this order, every
  * {@link RfqSwapManagerConfig.pollIntervalMs} — and additionally the moment a
@@ -419,18 +554,41 @@ const notify = <T extends (...args: never[]) => void>(
  *    registered yet. Best-effort; never blocks the steps below.
  * 1. **Ask the chain what became of the lockup** — {@link readLockupFate}. A
  *    spend whose witness HASHES to the quote's `payment_hash` ends the swap
- *    `settled`; a lockup fully spent by anything else ends it `refunded`,
- *    because every other leaf pays the trader's own committed address or needs
- *    the trader's own signature. Anything the indexer could not answer is
- *    `unknown`, which is NOT an answer: the pass carries on to steps 2 and 3,
- *    whose deadlines an indexer outage has no bearing on.
- * 2. **Drive the L1 half**, onchain-send only — see {@link nextOnchainAction}.
- * 3. **Take the lockup back**, once `refundLocktime` has passed and step 1 has
- *    not ended the swap. This runs for onchain-send too, including after a
- *    successful claim: the trader's lockup is still funded and still theirs to
- *    recover if the solver never comes for it. When no local refund is possible
- *    at all — no secrets, another wallet's descriptor, nothing wired — the swap
- *    reports `needs_counterparty` instead of retrying a push that cannot work.
+ *    `settled`; a lockup fully spent by anything else ends it `refunded`.
+ *    Anything the indexer could not answer is `unknown`, which is NOT an
+ *    answer: the pass carries on to the steps below, whose deadlines an indexer
+ *    outage has no bearing on.
+ * 2. **Drive the trader's claim.** On an onchain send that is the L1 fill — see
+ *    {@link nextOnchainAction}. On a receive it is the lockup itself, and it
+ *    ends the pass: that leg has no step 3.
+ * 3. **Take the lockup back**, send legs only, once `refundLocktime` has passed
+ *    and step 1 has not ended the swap. This runs for onchain-send too,
+ *    including after a successful claim: the trader's lockup is still funded and
+ *    still theirs to recover if the solver never comes for it. When no local
+ *    refund is possible at all — no secrets, another wallet's descriptor,
+ *    nothing wired — the swap reports `needs_counterparty` instead of retrying
+ *    a push that cannot work.
+ *
+ * **What step 1 proves depends on the direction.** On a send leg every non-claim
+ * leaf pays the trader's own committed address or needs the trader's own
+ * signature, so "spent, but not by a hash-verified claim" means the money came
+ * back. On a receive leg those leaves are the SOLVER's and the claim leaf is the
+ * trader's, so the same two readings mean the opposite things — `settled` is the
+ * trader's own claim landing, `refunded` is the solver taking back a lockup the
+ * trader failed to claim. The read is identical; only the state docs differ.
+ *
+ * Two things about the receive arm that are easy to get wrong, and are asserted
+ * in the tests rather than left to be inferred:
+ *
+ * - **A claim is matched by its preimage, never by our txid.** The covenant's
+ *   `nonInteractiveClaim` leaf is pinned to the trader's own payout script, so a
+ *   claim that lands without us — covclaimd, the day it works — still pays the
+ *   trader and is still `settled`. Matching on the txid we submitted would turn
+ *   that success into an anomaly.
+ * - **`LockupFate.fate === "claimed"` maps to the state `settled`, never to the
+ *   state `claimed`.** The two words live one layer apart: the fate is the
+ *   chain's, the state is ours, and the state `claimed` means only that we
+ *   submitted something.
  */
 export class RfqSwapManager {
     private readonly deps: RfqSwapManagerDeps;
@@ -465,6 +623,38 @@ export class RfqSwapManager {
      * sign may well have been restored.
      */
     private readonly refundRefused = new Set<string>();
+    /**
+     * The last error a receive swap's claim callback threw, by rfqId.
+     *
+     * Kept only to tell two terminal outcomes apart once the claim window
+     * shuts: a swap whose claim was attempted and kept failing ends `failed`
+     * with that reason, while one that simply never became claimable ends
+     * `refunded`. Without it a broken claim callback would resolve a caller's
+     * {@link waitForSwapCompletion} as an ordinary unwind.
+     *
+     * Process-local, like {@link refundRefused}: after a restart the same swap
+     * ends `refunded` instead, which costs the caller a reason and nothing else
+     * — every throw was already reported through `onSwapFailed` as it happened.
+     */
+    private readonly lastClaimError = new Map<string, string>();
+    /**
+     * The lockup outpoints a receive swap's claim callback has already been
+     * handed, by rfqId.
+     *
+     * What this exists to prevent: a claim SUCCEEDS, and for the next few
+     * passes the indexer still lists those outputs as unspent. Without a
+     * record of what was already claimed, every one of those passes would
+     * re-submit the same spend, fail against the server, and report a swap
+     * that in fact worked as failing. With one, a re-claim happens only when
+     * an outpoint appears that was never claimed — a lockup funded piecemeal,
+     * which is legitimate and which `partiallyClaimed` exists for.
+     *
+     * Process-local: after a restart a swap with a live claim tries once more.
+     * That is the recovery case rather than the spam one — a claim that never
+     * landed leaves its outputs unspent, and one that did leaves a single
+     * rejection.
+     */
+    private readonly claimedOutpoints = new Map<string, Set<string>>();
     /** Live `onContractEvent` subscription, held so `stop()` can drop it. */
     private unsubscribeContracts: (() => void) | null = null;
     /** Terminal records, kept so a late {@link waitForSwapCompletion} still
@@ -652,10 +842,14 @@ export class RfqSwapManager {
      * the trader has the coins it swapped for, and what remains is the manager
      * watching the Arkade lockup close. That holds however the record is
      * labelled afterwards, `needs_counterparty` included. Lightning-send has no
-     * such split and resolves at `settled`/`refunded`.
+     * such split and resolves at `settled`/`refunded`, and so does lightning
+     * receive — see {@link isPayoutDecided} for why its own claim txid does not
+     * decide it.
      *
-     * Rejects only on `failed`. `refunded` resolves: a refund is an outcome the
-     * caller asked this manager to drive, not an exception.
+     * Rejects only on `failed`. `refunded` resolves: on a send leg a refund is
+     * an outcome the caller asked this manager to drive, not an exception. On a
+     * receive leg it is the swap being lost, which is still an answer and not
+     * an error — read `state`, do not infer success from resolution.
      */
     async waitForSwapCompletion(rfqId: string): Promise<RfqSwapOutcome> {
         const swap = this.monitored.get(rfqId) ?? this.finished.get(rfqId);
@@ -687,6 +881,8 @@ export class RfqSwapManager {
         if (swap) this.byLockupScript.delete(hex.encode(swap.lockupPkScript));
         this.monitored.delete(rfqId);
         this.refundRefused.delete(rfqId);
+        this.lastClaimError.delete(rfqId);
+        this.claimedOutpoints.delete(rfqId);
     }
 
     /**
@@ -890,7 +1086,16 @@ export class RfqSwapManager {
             return;
         }
 
-        // 2. The L1 half. Skipped once claimed — there is nothing further to
+        // 2. The trader's claim.
+        //
+        //    The receive leg ends the pass here rather than falling through:
+        //    step 3 would push `refundWithoutReceiver` on a leaf that belongs
+        //    to the solver, so the best case is a wasted callback every pass
+        //    and the worst is a caller who wired it generically watching that
+        //    push fail forever against a key this wallet does not hold.
+        if (swap.kind === "lightning_receive") return this.driveReceiveClaim(swap);
+
+        //    The L1 half. Skipped once claimed — there is nothing further to
         //    learn from chain, and the record already carries the txid.
         if (swap.kind === "onchain_send" && swap.state !== "claimed") {
             if ((await this.driveOnchain(swap)) === "handled") return;
@@ -898,6 +1103,160 @@ export class RfqSwapManager {
 
         // 3. The Arkade lockup.
         await this.driveArkadeRefund(swap);
+    }
+
+    /**
+     * The receive leg's whole state machine: claim the solver-funded lockup
+     * while the window is open, and recognise the shapes in which it can be
+     * lost.
+     *
+     * **The window closes at `refundLocktime`, on wall clock, with no margin.**
+     * Both halves of that are deliberate. It closes there because publishing
+     * `P` into the solver's live refund window risks losing the race and
+     * handing over the preimage anyway — the hazard `ONCHAIN_CLAIM_MARGIN_SECONDS`
+     * guards on the L1 side. It takes no margin because the two situations are
+     * not alike: that one budgets for confirmation depth, while this claim is an
+     * offchain spend that lands in seconds. Wall clock is already the
+     * conservative reading — the solver's leaf is a CLTV, which matures against
+     * median-time-past, and MTP trails wall clock — so the real window extends
+     * PAST this deadline rather than ending before it. Every second of margin
+     * subtracted here is a second of live claim window given away for nothing.
+     *
+     * **The trader has no move after it.** Nothing here can take the lockup
+     * back, so once the window shuts the swap is the solver's to resolve and
+     * this manager's job is to watch it happen and then stop.
+     */
+    private async driveReceiveClaim(swap: LightningReceiveSwap): Promise<void> {
+        const now = this.config.now();
+
+        if (now < swap.refundLocktime) {
+            let vtxos: readonly LockupVtxo[];
+            try {
+                vtxos = await findLockupVtxos(this.deps.indexer, swap.lockupPkScript);
+            } catch (error) {
+                // Transient by assumption, as in step 1 — but REPORTED, unlike
+                // step 1's. There the failure is absorbed because the pass
+                // carries on to deadlines an indexer outage cannot move; here
+                // this read is the entire pass, so swallowing it would leave a
+                // receive swap silently doing nothing until its window shut.
+                this.emitFailed(swap, error);
+                return;
+            }
+            return this.claimIfFunded(swap, vtxos);
+        }
+
+        // Past the window and still unresolved. Keep watching for a while: the
+        // solver's own CLTV matures against median-time-past, so its reclaim
+        // lands somewhere in the couple of hours after `refundLocktime` — and
+        // when it does, step 1 sees it and ends the swap on chain evidence
+        // rather than on this deadline.
+        if (now < swap.refundLocktime + REFUND_MTP_LAG_SECONDS) {
+            // A submitted claim keeps its label: `claimed` is still the truest
+            // thing the record knows, and replacing it with a refusal would
+            // un-say it. Only a swap that never got one is reported blocked.
+            if (swap.claimArkTxid) return;
+            return this.block(
+                swap,
+                "the claim window closed with the lockup unclaimed — only the solver can act now",
+            );
+        }
+
+        // The deadline. This is the receive leg's counterpart to the send
+        // leg's "settle for less than proof": a lockup the solver funded is
+        // long since reclaimed, one it never funded will never be, and either
+        // way there is nothing further to observe and no move left to make.
+        // Ending the wait at all costs the distinction between them.
+        const failure = this.lastClaimError.get(swap.rfqId);
+        if (failure && !swap.claimArkTxid) {
+            // The one shape that is not an ordinary unwind: this wallet had a
+            // claimable lockup and could not take it. `failed` rather than
+            // `refunded` so an awaiting caller is told, instead of reading a
+            // broken claim callback as a swap that simply did not happen.
+            return this.fail(swap, new Error(failure));
+        }
+        this.setState(swap, "refunded");
+    }
+
+    /**
+     * Claim what the solver funded, once it is enough.
+     *
+     * The value gate here decides WHEN to act. `pushClaim`'s decides whether
+     * `P` is published, and runs with nothing between it and the signature —
+     * the check that matters is the inner one, and this is not a reason to
+     * relax it.
+     */
+    private async claimIfFunded(
+        swap: LightningReceiveSwap,
+        vtxos: readonly LockupVtxo[],
+    ): Promise<void> {
+        if (vtxos.length === 0) return this.unblock(swap);
+
+        // A claim of ours is already out, so `P` is public: the value gate has
+        // nothing left to protect, and holding the remainder back over it would
+        // strand the trader's own money.
+        const partiallyClaimed = swap.claimArkTxid !== undefined;
+        if (partiallyClaimed && !this.hasUnclaimedOutpoint(swap.rfqId, vtxos)) {
+            // Everything here has already been through the callback. The
+            // indexer simply has not caught up with the spend yet, and
+            // re-submitting it would fail against the server and report a
+            // working swap as broken.
+            return;
+        }
+
+        if (!partiallyClaimed) {
+            if (!Number.isFinite(swap.expectedAmount)) {
+                // `locked < undefined` and `locked < NaN` are both false, so an
+                // unusable comparand does not fail the gate below — it deletes
+                // it, and `P` goes out for whatever the solver funded. Refused
+                // rather than defaulted, and re-checked every pass so a fixed
+                // record resumes.
+                return this.block(
+                    swap,
+                    `expectedAmount is not a finite number (${String(swap.expectedAmount)}), so the funded value cannot be checked — refusing to publish the preimage`,
+                );
+            }
+            // Swept outputs count toward the sum on purpose: they are still the
+            // agreed money sitting at the script, and treating them as missing
+            // would report a fully funded lockup as underfunded. What cannot be
+            // done with them is spend them offchain, and `pushClaim` is where
+            // that is refused — by name, with the outpoints to recover — rather
+            // than here, where it would be indistinguishable from dust funding.
+            const locked = vtxos.reduce((sum, vtxo) => sum + vtxo.value, 0);
+            if (!Number.isFinite(locked) || locked < swap.expectedAmount) {
+                // Not terminal: a solver that tops the lockup up before the
+                // window shuts makes this claimable, and the next pass takes it.
+                return this.block(
+                    swap,
+                    `lockup holds ${locked} sats, below the agreed ${swap.expectedAmount} — refusing to publish the preimage`,
+                );
+            }
+        }
+
+        this.setState(swap, "claimable");
+        // With auto-actions off the manager watches and reports only, which is
+        // the documented way to claim by hand off `claimable`.
+        if (!this.config.enableAutoActions || !this.callbacks) return;
+
+        try {
+            const { arkTxid } = await this.callbacks.claimLockup(swap, vtxos, { partiallyClaimed });
+            this.lastClaimError.delete(swap.rfqId);
+            // Recorded only on success: a claim that threw must be retried, and
+            // these outputs are still there to retry with.
+            this.rememberClaimed(swap.rfqId, vtxos);
+            swap.claimArkTxid = arkTxid;
+            // Touched explicitly: on a re-claim the state is already `claimed`,
+            // so `setState` is a no-op and the new txid would go unpersisted.
+            this.touch(swap);
+            this.setState(swap, "claimed");
+            this.emitAction(swap, "claimLockup");
+        } catch (error) {
+            // The window is still open — `driveReceiveClaim` only reaches here
+            // while it is — so the next pass retries. Recorded so that, if the
+            // window shuts having never succeeded, the swap can end `failed`
+            // with a reason rather than looking like a quiet expiry.
+            this.lastClaimError.set(swap.rfqId, errorMessage(error));
+            this.emitFailed(swap, error);
+        }
     }
 
     /** `handled` ends the pass; `continue` falls through to the refund gate. */
@@ -1083,6 +1442,20 @@ export class RfqSwapManager {
         }
     }
 
+    /** Whether any of these outputs has never been handed to the claim
+     * callback — the only reason to claim a lockup a second time. */
+    private hasUnclaimedOutpoint(rfqId: string, vtxos: readonly LockupVtxo[]): boolean {
+        const claimed = this.claimedOutpoints.get(rfqId);
+        if (!claimed) return true;
+        return vtxos.some((vtxo) => !claimed.has(outpointKey(vtxo)));
+    }
+
+    private rememberClaimed(rfqId: string, vtxos: readonly LockupVtxo[]): void {
+        const claimed = this.claimedOutpoints.get(rfqId) ?? new Set<string>();
+        for (const vtxo of vtxos) claimed.add(outpointKey(vtxo));
+        this.claimedOutpoints.set(rfqId, claimed);
+    }
+
     /**
      * L1 progress, which past the refund window must not overwrite a refusal.
      * The two halves are independent — a claimed fill says nothing about
@@ -1119,13 +1492,13 @@ export class RfqSwapManager {
         this.setState(swap, "needs_counterparty");
     }
 
-    /** The way back out, taken as soon as a refund becomes possible again.
-     * Back to what the record can prove, not to `pending` unconditionally: an
-     * onchain-send swap that already claimed its fill has a txid for it, and
-     * reporting that swap as `pending` would un-say something true. */
+    /** The way back out, taken as soon as the swap becomes actionable again.
+     * Back to what the record can prove, not to `pending` unconditionally: a
+     * swap that already made its claim has a txid for it, and reporting that
+     * swap as `pending` would un-say something true. */
     private unblock(swap: RfqSwap): void {
         if (swap.state !== "needs_counterparty") return;
-        this.setState(swap, swap.kind === "onchain_send" && swap.claimTxid ? "claimed" : "pending");
+        this.setState(swap, traderClaimTxid(swap) ? "claimed" : "pending");
     }
 
     private touch(swap: RfqSwap): void {
@@ -1217,18 +1590,37 @@ export class RfqSwapManager {
     }
 }
 
-/** What {@link RfqSwapManager.waitForSwapCompletion} reports. `txid` is the L1
- * claim for a claimed onchain send and the ark txid for a refund the trader
- * pushed; a solver-side settlement or refund carries none. */
+/** What {@link RfqSwapManager.waitForSwapCompletion} reports. `txid` is the
+ * trader's own claim — L1 for a claimed onchain send, Arkade for a claimed
+ * receive — or the ark txid for a refund the trader pushed; a solver-side
+ * settlement or refund carries none. */
 export interface RfqSwapOutcome {
     state: RfqSwapState;
     txid?: string;
 }
 
+/** The trader's own claim on this swap, whichever leg it belongs to. */
+const traderClaimTxid = (swap: RfqSwap): string | undefined => {
+    switch (swap.kind) {
+        case "onchain_send":
+            return swap.claimTxid;
+        case "lightning_receive":
+            return swap.claimArkTxid;
+        default:
+            return undefined;
+    }
+};
+
 // The txid, not the label — same reason `driveOnchain` guards on it. The label
 // moves on: a claimed onchain send whose Arkade half is refused past the window
 // reads `needs_counterparty`, and keying on `claimed` would hang a waiter on a
 // payout that already happened and that the record can prove.
+//
+// A receive swap is deliberately NOT decided by its claim txid, though it has
+// one. An L1 broadcast is a chain fact the trader holds coins from; an Arkade
+// submission is a submission, and `claimed -> refunded` is a legal transition
+// from it. Resolving a waiter there would report a payout that can still be
+// lost — so this leg waits for `settled`, which is the chain's answer.
 const isPayoutDecided = (swap: RfqSwap): boolean =>
     swap.state === "settled" ||
     swap.state === "refunded" ||
@@ -1236,8 +1628,10 @@ const isPayoutDecided = (swap: RfqSwap): boolean =>
 
 const outcomeOf = (swap: RfqSwap): RfqSwapOutcome => ({
     state: swap.state,
-    txid: swap.kind === "onchain_send" && swap.claimTxid ? swap.claimTxid : swap.refundArkTxid,
+    txid: traderClaimTxid(swap) ?? swap.refundArkTxid,
 });
 
 const errorMessage = (error: unknown): string =>
     error instanceof Error ? error.message : String(error);
+
+const outpointKey = (vtxo: LockupVtxo): string => `${vtxo.txid}:${vtxo.vout}`;

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -457,6 +457,11 @@ export interface RfqSwapManagerCallbacks {
 export type RfqSwapActionName = "claimOnchain" | "claimLockup" | "refundArkade";
 
 export interface RfqSwapManagerEvents {
+    /** Every state change, including ones that read as going backwards.
+     * `claimed -> claimable` is legal and expected on a receive swap the solver
+     * funds piecemeal: a lockup topped up after a claim is a new claimable
+     * event, and the label says so before the sweep goes out. Treat these
+     * states as a description of what to do next, not as a progress bar. */
     onSwapUpdate?: (swap: RfqSwap, previous: RfqSwapState) => void;
     /** Fired once, when a swap leaves monitoring `settled` or `refunded`.
      * A swap that ends `failed` reports through `onSwapFailed` instead — the
@@ -1232,10 +1237,23 @@ export class RfqSwapManager {
             }
         }
 
+        if (!this.callbacks) {
+            // Checked BEFORE the label, unlike the auto-actions case below: a
+            // wallet with nothing wired cannot claim by hand off `claimable`
+            // either, so reporting the lockup as claimable would name an action
+            // nobody here can take, and the swap would sit at it until the
+            // window shut. Reported the way `driveArkadeRefund` reports the
+            // same wiring gap, and lifted the moment `setCallbacks` runs.
+            return this.block(
+                swap,
+                "no callbacks are wired, so this wallet cannot claim the lockup",
+            );
+        }
+
         this.setState(swap, "claimable");
         // With auto-actions off the manager watches and reports only, which is
         // the documented way to claim by hand off `claimable`.
-        if (!this.config.enableAutoActions || !this.callbacks) return;
+        if (!this.config.enableAutoActions) return;
 
         try {
             const { arkTxid } = await this.callbacks.claimLockup(swap, vtxos, { partiallyClaimed });
@@ -1244,8 +1262,13 @@ export class RfqSwapManager {
             // these outputs are still there to retry with.
             this.rememberClaimed(swap.rfqId, vtxos);
             swap.claimArkTxid = arkTxid;
-            // Touched explicitly: on a re-claim the state is already `claimed`,
-            // so `setState` is a no-op and the new txid would go unpersisted.
+            // Touched independently of the label below, which today does the
+            // persisting on its own — a re-claim comes back through
+            // `claimable`, so `claimed` is a real transition either way. What
+            // this covers is the txid outliving that coupling: a crash between
+            // here and `setState`, and any later change that stops the label
+            // from moving on a re-claim, both leave a submitted claim recorded
+            // rather than a swap whose preimage is public and whose txid is not.
             this.touch(swap);
             this.setState(swap, "claimed");
             this.emitAction(swap, "claimLockup");
@@ -1593,7 +1616,10 @@ export class RfqSwapManager {
 /** What {@link RfqSwapManager.waitForSwapCompletion} reports. `txid` is the
  * trader's own claim — L1 for a claimed onchain send, Arkade for a claimed
  * receive — or the ark txid for a refund the trader pushed; a solver-side
- * settlement or refund carries none. */
+ * settlement or refund carries none, and a receive swap that ended `refunded`
+ * carries none either, however far its claim got (see {@link outcomeOf}). So
+ * a `txid` here always names something that happened, and `state` remains the
+ * only thing to read for whether the swap paid out. */
 export interface RfqSwapOutcome {
     state: RfqSwapState;
     txid?: string;
@@ -1626,10 +1652,18 @@ const isPayoutDecided = (swap: RfqSwap): boolean =>
     swap.state === "refunded" ||
     (swap.kind === "onchain_send" && swap.claimTxid !== undefined);
 
-const outcomeOf = (swap: RfqSwap): RfqSwapOutcome => ({
-    state: swap.state,
-    txid: traderClaimTxid(swap) ?? swap.refundArkTxid,
-});
+const outcomeOf = (swap: RfqSwap): RfqSwapOutcome => {
+    // A receive swap that ended `refunded` was lost: the solver took the lockup
+    // back, so a `claimArkTxid` on it names a submission the chain never took.
+    // Reporting it would put a claim txid on the one outcome where the trader
+    // has nothing — the single combination in which `txid` present would not
+    // mean an action that landed. The record still carries it for diagnosis.
+    const lostReceive = swap.kind === "lightning_receive" && swap.state === "refunded";
+    return {
+        state: swap.state,
+        txid: lostReceive ? swap.refundArkTxid : (traderClaimTxid(swap) ?? swap.refundArkTxid),
+    };
+};
 
 const errorMessage = (error: unknown): string =>
     error instanceof Error ? error.message : String(error);

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -24,7 +24,7 @@ import {
     type CreateContractParams,
 } from "@arkade-os/sdk";
 
-import { lightningSendVtxoScript } from "../src/rfq";
+import { lightningSendVtxoScript, receiveVtxoScript } from "../src/rfq";
 import {
     ONCHAIN_CLAIM_MARGIN_SECONDS,
     ONCHAIN_ORDER_MARGIN_SECONDS,
@@ -39,6 +39,7 @@ import {
     LockupNeedsRecoveryError,
     REFUND_MTP_LAG_SECONDS,
     type LockupSpendIndexer,
+    type LockupVtxo,
 } from "../src/refund";
 import { SWAP_LOCKUP_CONTRACT_TYPE } from "../src/lockupContract";
 import { RefundNotLocallyPossibleError } from "../src/secrets";
@@ -47,6 +48,7 @@ import {
     isRfqSwapTerminal,
     nextOnchainAction,
     type ArkadeRefundResult,
+    type LightningReceiveSwap,
     type LightningSendSwap,
     type OnchainSendSwap,
     type RfqSwap,
@@ -96,9 +98,31 @@ const LOCKUP = lightningSendVtxoScript({
     receiverPkScript: p2tr(key(1)),
 });
 
+/**
+ * The receive corridor's lockup: the SAME covenant with the roles inverted —
+ * the solver is `sender` and funds it, the trader is `receiver` and claims it.
+ * Built through the production builder, so what the receive tests below drive
+ * is the real tree and not the send tree wearing a different label. In
+ * particular `refundWithoutReceiver` on THIS script is the solver's leaf, which
+ * is what makes a spend through it a loss rather than a return.
+ */
+const RECEIVE_LOCKUP = receiveVtxoScript({
+    solverPubkey: key(1),
+    refundLocktime: REFUND_LOCKTIME,
+    serverPubkey: key(3),
+    paymentHash: PAYMENT_HASH,
+    claimDelay: 4096,
+    emulatorPubkey: key(9),
+    solverRefundPkScript: p2tr(key(1)),
+    payoutPubkey: key(13),
+    payoutPkScript: PAYOUT,
+});
+
 /** The lockup's funding outpoint — what a spend of it has to reference. */
 const LOCKUP_OUTPOINT = { txid: "99".repeat(32), vout: 0 };
 const LOCKUP_VALUE = 100_000;
+/** The txid our own receive claim comes back with. */
+const CLAIM_ARK_TXID = "ac".repeat(32);
 
 const UNROLL = CSVMultisigTapscript.encode({
     timelock: { type: "blocks", value: BigInt(144) },
@@ -124,10 +148,14 @@ const spendOfLockup = (
         leaf?: "claim" | "refundWithoutReceiver";
         conditionWitness?: Uint8Array[];
         finalWitness?: Uint8Array[];
+        /** Which covenant was spent — the send lockup unless a receive test
+         * says otherwise. */
+        script?: typeof LOCKUP;
     } = {},
 ): { txid: string; psbt: string } => {
+    const script = over.script ?? LOCKUP;
     const leaf =
-        over.leaf === "refundWithoutReceiver" ? LOCKUP.refundWithoutReceiver() : LOCKUP.claim();
+        over.leaf === "refundWithoutReceiver" ? script.refundWithoutReceiver() : script.claim();
     const { checkpoints } = buildOffchainTx(
         [
             {
@@ -135,7 +163,7 @@ const spendOfLockup = (
                 vout: LOCKUP_OUTPOINT.vout,
                 value: LOCKUP_VALUE,
                 tapLeafScript: leaf,
-                tapTree: LOCKUP.encode(),
+                tapTree: script.encode(),
             },
         ],
         [{ script: PAYOUT, amount: BigInt(LOCKUP_VALUE) }],
@@ -182,21 +210,44 @@ const spentUnnamed = (over: Partial<FakeVtxo> = {}): FakeVtxo => ({
  * tests can assert on what was asked, not only on what was concluded. */
 type FakeIndexer = LockupSpendIndexer & { vtxoCalls: number; txLookups: string[][] };
 
+/**
+ * A funded output as `findLockupVtxos` reads one — the receive leg's view of
+ * the same script. Separate from {@link FakeVtxo} because the two reads are
+ * genuinely different queries: the fate read asks for everything at the script
+ * and cares about `spentBy`, while this one asks the spendable and recoverable
+ * filters separately and is the only read whose `value` is summed.
+ */
+interface FakeFunded {
+    txid: string;
+    vout: number;
+    value: number;
+    recoverable?: boolean;
+}
+
 const fakeIndexer = (
     state: {
         vtxos?: FakeVtxo[];
         /** Only the txids present here are resolvable — a `spentBy` with no
          * entry models the indexer returning fewer txs than were asked for. */
         txs?: { txid: string; psbt: string }[];
+        /** What sits at the lockup, for the filtered reads. */
+        funded?: FakeFunded[];
         fail?: boolean;
     } = {},
 ): FakeIndexer => {
     const indexer = {
         vtxoCalls: 0,
         txLookups: [] as string[][],
-        async getVtxos() {
+        async getVtxos(filter?: { spendableOnly?: boolean; recoverableOnly?: boolean }) {
             indexer.vtxoCalls += 1;
             if (state.fail) throw new Error("indexer unreachable");
+            // The filters are honoured rather than ignored: `findLockupVtxos`
+            // makes both calls and merges them, so a fake that answered the
+            // same set twice would report every output as spendable AND
+            // recoverable and hide the dedup entirely.
+            const funded = state.funded ?? [];
+            if (filter?.spendableOnly) return { vtxos: funded.filter((v) => !v.recoverable) };
+            if (filter?.recoverableOnly) return { vtxos: funded.filter((v) => v.recoverable) };
             return { vtxos: state.vtxos ?? [] };
         },
         async getVirtualTxs(txids: string[]) {
@@ -266,9 +317,25 @@ const onchainSwap = (over: Partial<OnchainSendSwap> = {}): OnchainSendSwap => ({
     ...over,
 });
 
+/** The receive leg's record. `expectedAmount` is what the lockup must carry;
+ * every value test below moves it or the funding against each other. */
+const receiveSwap = (over: Partial<LightningReceiveSwap> = {}): LightningReceiveSwap => ({
+    kind: "lightning_receive",
+    rfqId: RFQ_ID,
+    state: "pending",
+    lockupPkScript: RECEIVE_LOCKUP.pkScript,
+    paymentHash: PAYMENT_HASH,
+    refundLocktime: REFUND_LOCKTIME,
+    expectedAmount: LOCKUP_VALUE,
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+});
+
 interface Spies {
     callbacks: RfqSwapManagerCallbacks;
     claims: { rfqId: string; utxo: ChainUtxo }[];
+    lockupClaims: { vtxos: readonly LockupVtxo[]; partiallyClaimed: boolean }[];
     refunds: string[];
     saved: RfqSwapState[];
     actions: RfqSwapActionName[];
@@ -277,15 +344,18 @@ interface Spies {
 const spies = (
     over: {
         claim?: () => Promise<{ txid: string }>;
+        claimLockup?: () => Promise<{ arkTxid: string; amount: number }>;
         refund?: () => Promise<ArkadeRefundResult>;
         probe?: () => Promise<{ ok: true } | { ok: false; reason: string }>;
     } = {},
 ): Spies => {
     const claims: { rfqId: string; utxo: ChainUtxo }[] = [];
+    const lockupClaims: { vtxos: readonly LockupVtxo[]; partiallyClaimed: boolean }[] = [];
     const refunds: string[] = [];
     const saved: RfqSwapState[] = [];
     return {
         claims,
+        lockupClaims,
         refunds,
         saved,
         actions: [],
@@ -293,6 +363,12 @@ const spies = (
             async claimOnchain(swap, utxo) {
                 claims.push({ rfqId: swap.rfqId, utxo });
                 return over.claim ? over.claim() : { txid: "dd".repeat(32) };
+            },
+            async claimLockup(_swap, vtxos, options) {
+                lockupClaims.push({ vtxos, partiallyClaimed: options.partiallyClaimed });
+                return over.claimLockup
+                    ? over.claimLockup()
+                    : { arkTxid: CLAIM_ARK_TXID, amount: LOCKUP_VALUE };
             },
             async refundArkade(swap) {
                 refunds.push(swap.rfqId);
@@ -953,6 +1029,405 @@ describe("RfqSwapManager — the lightning-send leg", () => {
 
         expect(swap.state).toBe("refunded");
         expect(swap.refundArkTxid).toBeUndefined();
+    });
+});
+
+/**
+ * The receive leg, where both halves of every other corridor are inverted: the
+ * SOLVER funds the lockup and the TRADER claims it.
+ *
+ * So the tests here are about the two things that inversion changes. First,
+ * what the manager is willing to publish `P` for — deriving the script proves
+ * nothing on this leg, because the script was never the lie, and a claim of a
+ * dust-funded lockup hands the solver a full Lightning settlement for nothing.
+ * Second, what the states mean: `refunded` is a LOSS here, `claimed` is our own
+ * belief rather than a chain fact, and there is no trader-side refund to fall
+ * back on when the window shuts.
+ */
+describe("RfqSwapManager — the lightning-receive leg", () => {
+    /** One pass over a receive swap. The manager is never started here, so
+     * `addSwap` does not poll on its own — same as every other block. */
+    const pass = async (m: RfqSwapManager, swap: LightningReceiveSwap): Promise<void> => {
+        await m.addSwap(swap);
+        await m.poll();
+    };
+
+    /** A lockup funded with one output, unspent — so the fate read says `open`
+     * and the pass carries on to the claim. */
+    const fundedIndexer = (value = LOCKUP_VALUE, over: Partial<FakeFunded> = {}) =>
+        fakeIndexer({
+            vtxos: unspent(),
+            funded: [{ ...LOCKUP_OUTPOINT, value, ...over }],
+        });
+
+    /** Comfortably inside the claim window. */
+    const BEFORE_DEADLINE = REFUND_LOCKTIME - 3600;
+
+    it("claims a lockup funded for the agreed amount", async () => {
+        const s = spies();
+        const swap = receiveSwap();
+        const m = manager({ indexer: fundedIndexer(), now: BEFORE_DEADLINE, spies: s });
+        await pass(m, swap);
+
+        expect(s.lockupClaims).toHaveLength(1);
+        expect(s.lockupClaims[0].partiallyClaimed).toBe(false);
+        expect(s.lockupClaims[0].vtxos).toEqual([
+            { ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE, recoverable: false },
+        ]);
+        expect(swap.state).toBe("claimed");
+        expect(swap.claimArkTxid).toBe(CLAIM_ARK_TXID);
+        expect(s.actions).toEqual(["claimLockup"]);
+        // and it is not over: `claimed` is what we did, not what the chain says
+        expect(await m.hasSwap(RFQ_ID)).toBe(true);
+    });
+
+    it("overfunding is fine; the gate is a floor", async () => {
+        const s = spies();
+        const swap = receiveSwap();
+        const m = manager({
+            indexer: fundedIndexer(LOCKUP_VALUE + 1),
+            now: BEFORE_DEADLINE,
+            spies: s,
+        });
+        await pass(m, swap);
+
+        expect(swap.state).toBe("claimed");
+    });
+
+    it("sums funding split across outputs rather than reading the first", async () => {
+        const s = spies();
+        const swap = receiveSwap();
+        const m = manager({
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                funded: [
+                    { ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE - 1 },
+                    { ...LOCKUP_OUTPOINT, vout: 1, value: 1 },
+                ],
+            }),
+            now: BEFORE_DEADLINE,
+            spies: s,
+        });
+        await pass(m, swap);
+
+        expect(swap.state).toBe("claimed");
+        expect(s.lockupClaims[0].vtxos).toHaveLength(2);
+    });
+
+    it("refuses to publish the preimage for a dust-funded lockup", async () => {
+        // THE attack this leg has and no other: the solver funds the correctly
+        // derived script with dust. Claiming makes `P` public, which is what
+        // lets the solver settle the payer's held HTLC in full.
+        const s = spies();
+        const swap = receiveSwap();
+        const m = manager({ indexer: fundedIndexer(330), now: BEFORE_DEADLINE, spies: s });
+        await pass(m, swap);
+
+        expect(s.lockupClaims).toHaveLength(0);
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/330 sats, below the agreed 100000/);
+        // not terminal: the solver can still make this right
+        expect(await m.hasSwap(RFQ_ID)).toBe(true);
+    });
+
+    it("refuses a record whose expectedAmount cannot be compared against", async () => {
+        // The same class as the invoice gate's non-finite guards: `locked <
+        // undefined` and `locked < NaN` are both false, so an unusable
+        // comparand does not FAIL the value gate, it deletes it — and the claim
+        // proceeds for whatever was funded.
+        for (const expectedAmount of [Number.NaN, undefined as unknown as number]) {
+            const s = spies();
+            const swap = receiveSwap({ expectedAmount });
+            const m = manager({ indexer: fundedIndexer(1), now: BEFORE_DEADLINE, spies: s });
+            await pass(m, swap);
+
+            expect(s.lockupClaims).toHaveLength(0);
+            expect(swap.state).toBe("needs_counterparty");
+            expect(swap.blockedReason).toMatch(/not a finite number/);
+        }
+    });
+
+    it("claims as soon as the solver tops a short lockup up", async () => {
+        const s = spies();
+        const swap = receiveSwap();
+        let value = LOCKUP_VALUE - 1;
+        const m = manager({
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                // read fresh every pass, so the top-up is visible
+                get funded() {
+                    return [{ ...LOCKUP_OUTPOINT, value }];
+                },
+            }),
+            now: BEFORE_DEADLINE,
+            spies: s,
+        });
+        await pass(m, swap);
+        expect(swap.state).toBe("needs_counterparty");
+
+        value = LOCKUP_VALUE;
+        await m.poll();
+
+        expect(swap.state).toBe("claimed");
+        expect(s.lockupClaims).toHaveLength(1);
+        // the refusal's reason does not outlive the refusal
+        expect(swap.blockedReason).toBeUndefined();
+    });
+
+    it("never pushes an Arkade refund, before or after the deadline", async () => {
+        // Every non-claim leaf of this covenant is the SOLVER's. A generic
+        // caller that wired `refundArkade` for its send swaps must not see it
+        // called with a receive one.
+        for (const now of [BEFORE_DEADLINE, REFUND_LOCKTIME + 1, REFUND_LOCKTIME + 100_000]) {
+            let probes = 0;
+            const s = spies({
+                probe: async () => {
+                    probes += 1;
+                    return { ok: true };
+                },
+            });
+            const swap = receiveSwap();
+            const m = manager({ indexer: fundedIndexer(), now, spies: s });
+            await pass(m, swap);
+
+            expect(s.refunds).toHaveLength(0);
+            // not even asked whether one is possible — there is nothing to ask
+            expect(probes).toBe(0);
+        }
+    });
+
+    it("stops claiming at refundLocktime, and claims right up to it", async () => {
+        // No margin, deliberately: the claim is an offchain spend that lands in
+        // seconds, and the solver's CLTV matures against median-time-past, so
+        // the real window runs PAST this deadline rather than ending before it.
+        const claimed = spies();
+        const open = receiveSwap();
+        const before = manager({
+            indexer: fundedIndexer(),
+            now: REFUND_LOCKTIME - 1,
+            spies: claimed,
+        });
+        await pass(before, open);
+        expect(open.state).toBe("claimed");
+
+        const s = spies();
+        const shut = receiveSwap();
+        const after = manager({ indexer: fundedIndexer(), now: REFUND_LOCKTIME, spies: s });
+        await pass(after, shut);
+
+        expect(s.lockupClaims).toHaveLength(0);
+        expect(shut.state).toBe("needs_counterparty");
+        expect(shut.blockedReason).toMatch(/claim window closed/);
+    });
+
+    it("keeps a submitted claim's label once the window shuts", async () => {
+        // `claimed` is still the truest thing the record knows; replacing it
+        // with a refusal would un-say it.
+        const s = spies();
+        const swap = receiveSwap({ state: "claimed", claimArkTxid: CLAIM_ARK_TXID });
+        const m = manager({ indexer: fundedIndexer(), now: REFUND_LOCKTIME + 1, spies: s });
+        await pass(m, swap);
+
+        expect(swap.state).toBe("claimed");
+        expect(swap.blockedReason).toBeUndefined();
+    });
+
+    it("settles on a hash-verified spend made by a txid that is not ours", async () => {
+        // `nonInteractiveClaim` is pinned to the trader's own payout script, so
+        // a claim that lands without us still pays us. Matching on the txid we
+        // submitted would turn that success into an anomaly the day covclaimd
+        // starts working.
+        const spend = spendOfLockup({ script: RECEIVE_LOCKUP, conditionWitness: [PREIMAGE] });
+        expect(spend.txid).not.toBe(CLAIM_ARK_TXID);
+
+        const s = spies();
+        const swap = receiveSwap({ state: "claimed", claimArkTxid: CLAIM_ARK_TXID });
+        const m = manager({
+            indexer: fakeIndexer({ vtxos: spentBy(spend.txid), txs: [spend] }),
+            now: BEFORE_DEADLINE,
+            spies: s,
+        });
+        await pass(m, swap);
+
+        // and the name collision one layer apart: fate `claimed` is state
+        // `settled`, never state `claimed`
+        expect(swap.state).toBe("settled");
+        expect(await m.hasSwap(RFQ_ID)).toBe(false);
+    });
+
+    it("a claim that never lands ends refunded when the solver takes the lockup back", async () => {
+        // The transition the state doc has to make legal: `claimed` is not
+        // terminal, so it must not retire the swap.
+        const s = spies();
+        const swap = receiveSwap({ state: "claimed", claimArkTxid: CLAIM_ARK_TXID });
+        const solverRefund = spendOfLockup({
+            script: RECEIVE_LOCKUP,
+            leaf: "refundWithoutReceiver",
+        });
+        const m = manager({
+            indexer: fakeIndexer({ vtxos: spentBy(solverRefund.txid), txs: [solverRefund] }),
+            now: BEFORE_DEADLINE,
+            spies: s,
+        });
+        await pass(m, swap);
+
+        expect(swap.state).toBe("refunded");
+        expect(isRfqSwapTerminal(swap.state)).toBe(true);
+    });
+
+    it("sweeps a lockup topped up after a claim, skipping the value gate", async () => {
+        // Once `P` is public the value gate protects nothing, and holding the
+        // remainder back over it would strand the trader's own money — note the
+        // funding here is far below `expectedAmount` and is claimed anyway.
+        const s = spies();
+        const swap = receiveSwap({ state: "claimed", claimArkTxid: CLAIM_ARK_TXID });
+        const m = manager({ indexer: fundedIndexer(1), now: BEFORE_DEADLINE, spies: s });
+        await pass(m, swap);
+
+        expect(s.lockupClaims).toHaveLength(1);
+        expect(s.lockupClaims[0].partiallyClaimed).toBe(true);
+        expect(swap.state).toBe("claimed");
+    });
+
+    it("does not re-claim the same outputs while the indexer catches up", async () => {
+        // The spend is submitted and finalized, but the outputs keep reading as
+        // unspent for a few passes. Re-submitting them would fail against the
+        // server every time and report a swap that worked as one that is
+        // failing — so the second pass claims nothing, and the third claims
+        // only because a NEW output showed up.
+        const s = spies();
+        const swap = receiveSwap();
+        const funded = [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }];
+        const m = manager({
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                get funded() {
+                    return funded;
+                },
+            }),
+            now: BEFORE_DEADLINE,
+            spies: s,
+        });
+        await pass(m, swap);
+        expect(s.lockupClaims).toHaveLength(1);
+
+        await m.poll();
+        expect(s.lockupClaims).toHaveLength(1);
+        expect(swap.state).toBe("claimed");
+
+        funded.push({ ...LOCKUP_OUTPOINT, vout: 1, value: 500 });
+        await m.poll();
+
+        expect(s.lockupClaims).toHaveLength(2);
+        expect(s.lockupClaims[1].partiallyClaimed).toBe(true);
+        expect(s.lockupClaims[1].vtxos).toHaveLength(2);
+    });
+
+    it("ends refunded once the solver's reclaim window has passed unobserved", async () => {
+        const s = spies();
+        const swap = receiveSwap();
+        const m = manager({
+            indexer: fakeIndexer({ vtxos: [] }),
+            now: REFUND_LOCKTIME + REFUND_MTP_LAG_SECONDS,
+            spies: s,
+        });
+        await pass(m, swap);
+
+        expect(swap.state).toBe("refunded");
+        expect(await m.hasSwap(RFQ_ID)).toBe(false);
+        // resolution, not rejection — but the caller has to read the state
+        await expect(m.waitForSwapCompletion(RFQ_ID)).resolves.toEqual({
+            state: "refunded",
+            txid: undefined,
+        });
+    });
+
+    it("ends failed, with the reason, when the claim kept throwing until the window shut", async () => {
+        // The one shape that is not an ordinary unwind: a claimable lockup this
+        // wallet could not take. Reported as `refunded` it would read to an
+        // awaiting caller as a swap that simply did not happen.
+        let now = BEFORE_DEADLINE;
+        const s = spies({
+            claimLockup: async () => {
+                throw new Error("ark server unreachable");
+            },
+        });
+        const swap = receiveSwap();
+        const m = manager({ indexer: fundedIndexer(), now: () => now, spies: s });
+        await pass(m, swap);
+        expect(swap.state).toBe("claimable"); // retried, not given up on
+        expect(s.lockupClaims).toHaveLength(1);
+
+        await m.poll();
+        expect(s.lockupClaims).toHaveLength(2);
+
+        now = REFUND_LOCKTIME + REFUND_MTP_LAG_SECONDS;
+        await m.poll();
+
+        expect(swap.state).toBe("failed");
+        expect(swap.failure).toMatch(/ark server unreachable/);
+        await expect(m.waitForSwapCompletion(RFQ_ID)).rejects.toThrow(/ark server unreachable/);
+    });
+
+    it("reports without acting when auto-actions are off", async () => {
+        const s = spies();
+        const swap = receiveSwap();
+        const m = manager({
+            indexer: fundedIndexer(),
+            now: BEFORE_DEADLINE,
+            spies: s,
+            enableAutoActions: false,
+        });
+        await pass(m, swap);
+
+        expect(s.lockupClaims).toHaveLength(0);
+        expect(swap.state).toBe("claimable");
+    });
+
+    it("leaves the swap running when the lockup read fails", async () => {
+        const s = spies();
+        const swap = receiveSwap();
+        const failures: string[] = [];
+        const m = manager({ indexer: fakeIndexer({ fail: true }), now: BEFORE_DEADLINE, spies: s });
+        m.onSwapFailed((_s, error) => failures.push(error.message));
+        await pass(m, swap);
+
+        expect(swap.state).toBe("pending");
+        expect(failures).toEqual(["indexer unreachable"]);
+        expect(await m.hasSwap(RFQ_ID)).toBe(true);
+    });
+
+    it("does not resolve a waiter on the local claim, only on the chain's answer", async () => {
+        // An L1 broadcast is a chain fact the trader holds coins from; an
+        // Arkade submission is a submission, and `claimed -> refunded` is
+        // reachable from it.
+        const s = spies();
+        const swap = receiveSwap();
+        const spend = spendOfLockup({ script: RECEIVE_LOCKUP, conditionWitness: [PREIMAGE] });
+        const state = { vtxos: unspent(), funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }] };
+        const indexer = fakeIndexer({
+            get vtxos() {
+                return state.vtxos;
+            },
+            get funded() {
+                return state.funded;
+            },
+            txs: [spend],
+        });
+        const m = manager({ indexer, now: BEFORE_DEADLINE, spies: s });
+        await pass(m, swap);
+        expect(swap.state).toBe("claimed");
+
+        let settled: unknown = null;
+        const waiting = m.waitForSwapCompletion(RFQ_ID).then((outcome) => (settled = outcome));
+        await Promise.resolve();
+        expect(settled).toBeNull();
+
+        state.vtxos = spentBy(spend.txid);
+        await m.poll();
+        await waiting;
+
+        expect(settled).toEqual({ state: "settled", txid: CLAIM_ARK_TXID });
     });
 });
 

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -1114,6 +1114,34 @@ describe("RfqSwapManager — the lightning-receive leg", () => {
         expect(s.lockupClaims[0].vtxos).toHaveLength(2);
     });
 
+    it("counts a swept output toward the funded value", async () => {
+        // A recoverable output is the agreed money still sitting at the script,
+        // so it makes the difference between the gate reading this lockup as
+        // fully funded and reading it as one satoshi short. What cannot be done
+        // with it is spend it offchain, and `pushClaim` refuses that by name —
+        // which is why it is handed to the callback rather than dropped here.
+        const s = spies();
+        const swap = receiveSwap();
+        const m = manager({
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                funded: [
+                    { ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE - 1 },
+                    { ...LOCKUP_OUTPOINT, vout: 1, value: 1, recoverable: true },
+                ],
+            }),
+            now: BEFORE_DEADLINE,
+            spies: s,
+        });
+        await pass(m, swap);
+
+        expect(swap.state).toBe("claimed");
+        expect(s.lockupClaims[0].vtxos).toEqual([
+            { ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE - 1, recoverable: false },
+            { ...LOCKUP_OUTPOINT, vout: 1, value: 1, recoverable: true },
+        ]);
+    });
+
     it("refuses to publish the preimage for a dust-funded lockup", async () => {
         // THE attack this leg has and no other: the solver funds the correctly
         // derived script with dust. Claiming makes `P` public, which is what
@@ -1273,6 +1301,81 @@ describe("RfqSwapManager — the lightning-receive leg", () => {
 
         expect(swap.state).toBe("refunded");
         expect(isRfqSwapTerminal(swap.state)).toBe(true);
+    });
+
+    it("reports a lost receive without the txid of the claim that lost it", async () => {
+        // The one combination where a `txid` on the outcome would name an
+        // action that did not happen: the claim was submitted, the chain never
+        // took it, and the solver reclaimed the lockup. The record keeps
+        // `claimArkTxid` for diagnosis; the outcome does not carry it.
+        const s = spies();
+        const swap = receiveSwap({ state: "claimed", claimArkTxid: CLAIM_ARK_TXID });
+        const solverRefund = spendOfLockup({
+            script: RECEIVE_LOCKUP,
+            leaf: "refundWithoutReceiver",
+        });
+        const m = manager({
+            indexer: fakeIndexer({ vtxos: spentBy(solverRefund.txid), txs: [solverRefund] }),
+            now: BEFORE_DEADLINE,
+            spies: s,
+        });
+        await m.addSwap(swap);
+        const waiting = m.waitForSwapCompletion(RFQ_ID);
+        await m.poll();
+
+        expect(swap.claimArkTxid).toBe(CLAIM_ARK_TXID);
+        await expect(waiting).resolves.toEqual({ state: "refunded", txid: undefined });
+    });
+
+    it("reports nothing wired to claim, instead of a lockup nobody here can take", async () => {
+        // `claimable` would name an action this wallet cannot perform by hand
+        // either, and the swap would sit at it until the window shut.
+        const swap = receiveSwap();
+        const m = new RfqSwapManager({ indexer: fundedIndexer() }, { now: () => BEFORE_DEADLINE });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/no callbacks are wired/);
+    });
+
+    it("ends refunded, not failed, when only a re-claim was the thing that threw", async () => {
+        // Both `claimArkTxid` and a claim error are set when the window shuts.
+        // A claim went out, so this is an ordinary loss rather than a wallet
+        // that could not act — `failed` is reserved for the latter.
+        let now = BEFORE_DEADLINE;
+        let fail = false;
+        const s = spies({
+            claimLockup: async () => {
+                if (fail) throw new Error("ark server unreachable");
+                return { arkTxid: CLAIM_ARK_TXID, amount: LOCKUP_VALUE };
+            },
+        });
+        const swap = receiveSwap();
+        const funded = [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }];
+        const m = manager({
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                get funded() {
+                    return funded;
+                },
+            }),
+            now: () => now,
+            spies: s,
+        });
+        await pass(m, swap);
+        expect(swap.claimArkTxid).toBe(CLAIM_ARK_TXID);
+
+        fail = true;
+        funded.push({ ...LOCKUP_OUTPOINT, vout: 1, value: 500 });
+        await m.poll();
+        expect(s.lockupClaims).toHaveLength(2);
+
+        now = REFUND_LOCKTIME + REFUND_MTP_LAG_SECONDS;
+        await m.poll();
+
+        expect(swap.state).toBe("refunded");
+        expect(swap.failure).toBeUndefined();
     });
 
     it("sweeps a lockup topped up after a claim, skipping the value gate", async () => {


### PR DESCRIPTION
Closes the last client-side gap in `lightning:BTC -> arkade:BTC` before the e2e: `RfqSwapManager` had no arm for the corridor, so a caller wanting the swap driven had to hand-roll the loop against `findLockupVtxos` / `pushClaim` / `readLockupFate` — and get the state meanings right, which the manager's own doc comments were actively wrong about.

## The inversion, and what it changes

Every other corridor has the trader funding a covenant and the counterparty claiming it. Here the **solver funds and the trader claims**, and two consequences shape the whole arm:

- **There is no trader-side refund.** Every non-claim leaf of this covenant is the solver's, so `refundArkade` is never called for one of these records and `canRefundArkade` is never even asked. A receive swap ends the pass at step 2 rather than falling through to the refund gate.
- **The claim is the whole swap, and it is on a deadline.** `refund_locktime` is the *solver's*, so it is the moment to have claimed BEFORE, not a gate to act after.

## States

| state | set by | terminal |
|---|---|---|
| `pending` | nothing funded yet | no |
| `claimable` | lockup funded and covering `expectedAmount` | no |
| `claimed` | our claim submitted — **local belief, no chain fact** | no |
| `settled` | `readLockupFate` → hash-verified preimage spend | yes |
| `refunded` | the solver took the lockup back, or the window closed with nothing left to observe. **A loss** | yes |
| `failed` | the claim callback kept throwing until the window shut | yes |

Two things the mapping makes explicit, both asserted rather than left to be inferred: **`LockupFate.fate === "claimed"` maps to state `settled`, never state `claimed`** — the words live one layer apart — and **a claim is matched by its preimage, never by our txid**, so a claim landing without us (covclaimd, the day it works) is still a success rather than an anomaly.

The two stale `RfqSwapState` comments D7 names are corrected: `claimable`/`claimed` are not onchain-send only, and `refunded` is not neutral here.

## The claim window closes at `refund_locktime`, with no margin

Both halves deliberate. It closes there because publishing `P` into the solver's live refund window risks losing the race *and* handing over the preimage — the hazard `ONCHAIN_CLAIM_MARGIN_SECONDS` guards on L1. It takes **no** margin because that constant budgets 90 minutes for confirmation depth, while this claim is an offchain spend that lands in seconds; and the solver's leaf is a CLTV maturing against median-time-past, which trails wall clock, so the real window runs *past* this instant. Every second of margin here is live claim window given away for nothing.

Past it the manager watches for the solver's reclaim, and at `refund_locktime + REFUND_MTP_LAG_SECONDS` ends the swap — the same "settle for less than proof" concession `driveArkadeRefund` already makes, since `open`/`unknown` are never answers and an unfunded receive swap would otherwise be watched forever.

## Two guards worth reading closely

- **The value gate is duplicated on purpose.** The manager's `Σ value >= expectedAmount` decides *when* to act; `pushClaim`'s decides whether `P` is published, and runs with nothing between it and the signature. The inner one is the load-bearing one. A non-finite `expectedAmount` on a persisted record is refused as `needs_counterparty` rather than defaulted — the same deleted-gate class as #716/#717 (`locked < NaN` is false, so an unusable comparand doesn't fail the gate, it removes it), at the third site where it bites.
- **Re-claims are bounded by claimed outpoints, not by the txid.** A successful claim leaves its outputs reading unspent for a few passes, so re-claiming on `claimArkTxid` alone would re-submit every pass and report a working swap as failing. The manager re-claims only when an outpoint appears that was never handed to the callback — which is exactly the piecemeal-funding case `partiallyClaimed` exists for.

## Scope

**`onchain:BTC -> arkade:BTC` is deliberately not included.** Its Arkade half is the same solver-funded lockup, but it also has an L1 half the trader funds and must take back itself (`buildHtlcRefund` at `htlc_locktime`) — a second deadline, seam and callback. Shipping the lockup half alone would produce a manager that silently lets that L1 refund window pass, which is the failure `driveOnchain`'s missing-`ChainSource` check refuses by name elsewhere. Recorded in the `RfqSwap` union's doc; its own PR, and not a blocker for #712.

**Breaking on this branch:** `RfqSwapManagerCallbacks.claimLockup` is required, like `claimOnchain` — a receive swap monitored with nothing wired to claim it expires quietly, and a compile error is the right way to learn a corridor was added. `RfqSwapActionName` gains `"claimLockup"`. Both noted in the README's migration list.

## Tests

18 new in `test/swapManager.test.ts` (96 in the file, 387 in the package, all green; `tsc` and prettier clean), driven against a real role-inverted covenant built through `receiveVtxoScript` rather than the send tree relabelled — so `refundWithoutReceiver` in these fixtures really is the solver's leaf. The security-relevant ones: dust funding refused with nothing claimed, a non-finite `expectedAmount` refused, the boundary at `refund_locktime` in both directions, a hash-verified spend by a txid that is not ours still settling, and `claimed` → `refunded` when a claim never lands.

Part of #712 (plan PR 5). Only the regtest e2e remains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Lightning receive swaps, including expected amounts, claim tracking, partial claims, retries, and settlement confirmation.
  * Added claim-lockup actions and callbacks for trader-funded lockup claims.
  * Added state handling for underfunded, partially claimed, failed, settled, and refunded receive swaps.
* **Documentation**
  * Documented the Lightning receive flow, solver refunds, settlement behavior, and breaking API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->