### PR TITLE
feat(arkade): pin the emulator co-signer key per network

### DIFF
--- a/packages/ts-sdk/src/arkade/contract.ts
+++ b/packages/ts-sdk/src/arkade/contract.ts
@@ -69,7 +69,7 @@ import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import { equalBytes } from "@scure/btc-signer/utils.js";
 
 import type { Network } from "../networks";
-import { DEFAULT_NETWORK } from "../networks";
+import { DEFAULT_NETWORK, resolveEmulatorPubkey } from "../networks";
 import type { ArkProvider } from "../providers/ark";
 import type { EmulatorProvider } from "../providers/emulator";
 import type { IndexerProvider } from "../providers/indexer";
@@ -237,6 +237,18 @@ export interface ArkadeConnectOptions {
     /** Network for address derivation; defaults to the SDK default. */
     network?: Network;
     /**
+     * Co-sign with this emulator key (33-byte compressed hex) instead of the
+     * one pinned for `network`.
+     *
+     * Needed when a network's emulator key has rotated ahead of this SDK, for a
+     * self-hosted emulator, or on a network with no pinned key at all (signet,
+     * testnet, a hand-built `Network` — those throw without it). Setting it
+     * means trusting that operator as co-signer in place of the network's.
+     *
+     * @see resolveEmulatorPubkey
+     */
+    emulatorPubkey?: string;
+    /**
      * The wallet's contract manager. When set, contracts created from this
      * client can {@link ArkadeContract.register} themselves into the standard
      * contract pipeline (persistence, watching, events), and
@@ -258,7 +270,16 @@ export class Arkade {
     readonly emulator: EmulatorProvider | undefined;
     readonly network: Network;
     readonly serverKey: Uint8Array;
-    /** The co-signer's x-only key, present only when an emulator is configured. */
+    /**
+     * The co-signer key covenants are built against (33-byte compressed),
+     * present only when an emulator is configured.
+     *
+     * Resolved from the network — or from `emulatorPubkey` — never from the
+     * emulator's own report. When a claim is refused because the co-signer
+     * disagrees, compare `hex.encode(arkade.emulatorKey)` against the
+     * `signerPubkey` your emulator serves on `/v1/info`: if they differ, the
+     * network rotated and this SDK's pin is stale.
+     */
     readonly emulatorKey: Uint8Array | undefined;
     readonly checkpoint: CSVMultisigTapscript.Type;
     readonly indexer?: Pick<IndexerProvider, "getVtxos">;
@@ -297,12 +318,20 @@ export class Arkade {
         const info = await opts.arkade.getInfo();
         const serverKey = hex.decode(info.signerPubkey).slice(1);
         const checkpoint = CSVMultisigTapscript.decode(hex.decode(info.checkpointTapscript));
+        const network = opts.network ?? DEFAULT_NETWORK;
 
         // The emulator is optional — only covenant contracts need it.
+        //
+        // The key comes from the network, NOT from the emulator's own /v1/info:
+        // asking the co-signer to name itself lets whatever is answering that
+        // URL pick the key its covenants commit to. The tradeoff is that a
+        // rotated network key is invisible here until the pinned constant ships
+        // — `emulatorPubkey` is the escape hatch for that window. `emulatorKey`
+        // below is public so an operator debugging a refused claim can diff
+        // what was pinned against what their emulator reports.
         let emulatorKey: Uint8Array | undefined;
         if (opts.emulator) {
-            const eInfo = await opts.emulator.getInfo();
-            emulatorKey = hex.decode(eInfo.signerPubkey);
+            emulatorKey = hex.decode(resolveEmulatorPubkey(network, opts.emulatorPubkey));
         }
 
         // Resolve the user key up-front so contract instantiation stays synchronous
@@ -316,7 +345,7 @@ export class Arkade {
         return new Arkade({
             arkProvider: opts.arkade,
             emulator: opts.emulator,
-            network: opts.network ?? DEFAULT_NETWORK,
+            network,
             serverKey,
             emulatorKey,
             checkpoint,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -237,7 +237,17 @@ import { Intent } from "./intent";
 import { BIP322 } from "./bip322";
 import { ArkNote } from "./arknote";
 import { ArkadeCash } from "./arkadeCash";
-import { getNetwork, networks, Network, NetworkName } from "./networks";
+import {
+    getNetwork,
+    networks,
+    Network,
+    NetworkName,
+    defaultEmulatorPubkey,
+    resolveEmulatorPubkey,
+    BITCOIN_EMULATOR_PUBKEY,
+    MUTINYNET_EMULATOR_PUBKEY,
+    REGTEST_EMULATOR_PUBKEY,
+} from "./networks";
 import {
     RestIndexerProvider,
     IndexerProvider,
@@ -580,6 +590,11 @@ export {
     // Network
     getNetwork,
     networks,
+    defaultEmulatorPubkey,
+    resolveEmulatorPubkey,
+    BITCOIN_EMULATOR_PUBKEY,
+    MUTINYNET_EMULATOR_PUBKEY,
+    REGTEST_EMULATOR_PUBKEY,
 
     // DB
     closeDatabase,

--- a/packages/ts-sdk/src/networks.ts
+++ b/packages/ts-sdk/src/networks.ts
@@ -124,13 +124,32 @@ const EMULATOR_PUBKEYS: Partial<Record<NetworkName, string>> = {
  *   returning an empty string just moves the same failure somewhere harder to
  *   read. A hand-assembled `Network` carries no `name` and lands here too,
  *   matching how the per-network timelock floors treat an unnamed network.
+ *
+ *   Deliberately NOT falling back to whatever key the emulator reports about
+ *   itself: that is the self-report this pin exists to stop trusting, and doing
+ *   it only on unpinned networks would make the guarantee depend on
+ *   `network.name` with no signal to the caller that it had lapsed. The
+ *   unnamed case is the sharp one — a hand-built `Network` can carry
+ *   bitcoin-equivalent parameters, so a silent fallback would drop to
+ *   "trust the endpoint" on exactly the input that looks most like mainnet.
+ *   Callers who mean it pass {@link resolveEmulatorPubkey}'s override, which
+ *   the thrown message names.
  */
 export function defaultEmulatorPubkey(network: Network): string {
     const pinned = network.name ? EMULATOR_PUBKEYS[network.name] : undefined;
     if (!pinned) {
+        // Name the remedy, not just the refusal. Whoever hits this usually has
+        // a working emulator in front of them, so a bare "not pinned" reads as
+        // the SDK being broken rather than as one argument being missing.
+        const cause = network.name
+            ? `no emulator is deployed for ${network.name}`
+            : `this Network carries no name, so it cannot be matched ` +
+              `(build it with getNetwork(...) rather than by hand)`;
         throw new Error(
-            `No emulator pubkey is pinned for network ${network.name ?? "<unnamed>"}. ` +
-                `Pinned networks: ${Object.keys(EMULATOR_PUBKEYS).join(", ")}.`,
+            `No emulator co-signer key is pinned for this network: ${cause}; ` +
+                `pass emulatorPubkey: "<33-byte compressed hex>" to Arkade.connect to ` +
+                `co-sign with your own emulator instead. Pinned networks: ` +
+                `${Object.keys(EMULATOR_PUBKEYS).join(", ")}`,
         );
     }
     return pinned;
@@ -139,8 +158,20 @@ export function defaultEmulatorPubkey(network: Network): string {
 /**
  * Resolve the co-signer key for `network`, letting a caller substitute its own.
  *
- * The override exists for the deployment running an emulator that is not the
- * one pinned above — a private stack, or a network ahead of this constant.
+ * The override is the escape hatch for three situations, and the first is the
+ * one that matters operationally:
+ *
+ * 1. **A network rotated its emulator key and this SDK has not shipped the new
+ *    constant yet.** Since `Arkade.connect` no longer asks the service which
+ *    key it signs with, a rotation is invisible here until the constant is
+ *    updated — covenants keep building against the retired key and fail only
+ *    when a claim is attempted. Passing the new key restores service without
+ *    waiting for a release, so a rotation is a config change rather than an
+ *    outage.
+ * 2. A private or self-hosted emulator, including on a network with no pinned
+ *    key at all (signet, testnet, a hand-built `Network`).
+ * 3. Tests and local stacks.
+ *
  * Supplying it means co-signing with a different service: every covenant built
  * from the returned key can be completed by whoever holds it and by no one
  * else, so it is a statement that you trust that operator in place of the

--- a/packages/ts-sdk/src/networks.ts
+++ b/packages/ts-sdk/src/networks.ts
@@ -60,3 +60,102 @@ function withArkPrefix(
 export const DEFAULT_ARKADE_SERVER_URL = "https://arkade.computer" as const;
 export const DEFAULT_NETWORK = networks.bitcoin;
 export const DEFAULT_NETWORK_NAME = "bitcoin" as const satisfies NetworkName;
+
+/**
+ * 33-byte compressed secp256k1 point, lowercase hex.
+ *
+ * Compressed rather than the 32-byte x-only form, for two reasons that are not
+ * about the covenant leaf. The leaf itself is indifferent:
+ * `computeArkadeScriptPublicKey` truncates by length and `lift_x`es, so a
+ * compressed key and its x-only tail tweak to the same point — even for an
+ * odd-Y (`03`) key like mutinynet's.
+ *
+ * What decides it is that compressed is the lossless form and the one actually
+ * on the wire. The emulator's `/v1/info` returns `signerPubkey` compressed and
+ * `Arkade.connect` keeps all 33 bytes of it (unlike the Arkade server key on
+ * the line above, which it slices), so a value pinned here in compressed form
+ * is byte-identical to what a live fetch yields and can substitute for it
+ * directly. Going the other way is a one-way door: x-only can always be
+ * recovered by dropping the prefix, but the parity bit cannot be recovered
+ * from x-only. Consumers that need 32 bytes — the Arkade Intents offer TLV,
+ * for one — already normalize at their own boundary.
+ */
+const COMPRESSED_PUBKEY = /^0[23][0-9a-f]{64}$/;
+
+/** Covenant co-signer ("emulator") for the mainnet Arkade deployment. */
+export const BITCOIN_EMULATOR_PUBKEY =
+    "0239c196415da47b26456a101daaa12ba9e445bfe153197f1e2b750bf40e52092e" as const;
+
+/** Covenant co-signer ("emulator") for the hosted mutinynet Arkade deployment. */
+export const MUTINYNET_EMULATOR_PUBKEY =
+    "03f823b9b2febc81f4af967e77aed2f541cbd3397c6d8f5a72e32eb7b471af889a" as const;
+
+/** Covenant co-signer ("emulator") shipped with the `arkade-regtest` stack. */
+export const REGTEST_EMULATOR_PUBKEY =
+    "02999413c46fa10ada5cbc4bcc79a1d09160c2ba3cfc812705d7a13e5e545fb2a9" as const;
+
+/**
+ * The covenant co-signer each network's Arkade deployment runs.
+ *
+ * This is a property of the NETWORK, not of whoever happens to be talking to
+ * it: every participant building a covenant contract on one network co-signs
+ * with the same key, so carrying a per-deployment copy of it can only ever
+ * introduce disagreement — two peers on one network advertising two keys is a
+ * misconfiguration nothing downstream is positioned to catch.
+ *
+ * `testnet` and `signet` are absent because no emulator is deployed for them;
+ * they resolve to a throw rather than to a neighbouring network's key.
+ */
+const EMULATOR_PUBKEYS: Partial<Record<NetworkName, string>> = {
+    bitcoin: BITCOIN_EMULATOR_PUBKEY,
+    mutinynet: MUTINYNET_EMULATOR_PUBKEY,
+    regtest: REGTEST_EMULATOR_PUBKEY,
+};
+
+/**
+ * The pinned co-signer key for `network`, as 33-byte compressed lowercase hex.
+ *
+ * @throws if the network carries no name, or names one with no deployed
+ *   emulator. Fail closed on both counts: the return value ends up in a
+ *   covenant leaf that decides who can move the funds, so there is no
+ *   defensible fallback. Guessing a neighbour's key (the tb-family share every
+ *   other field on {@link Network}) would build a leaf co-signed by a service
+ *   that will never sign for it — funds locked to a key nobody holds — and
+ *   returning an empty string just moves the same failure somewhere harder to
+ *   read. A hand-assembled `Network` carries no `name` and lands here too,
+ *   matching how the per-network timelock floors treat an unnamed network.
+ */
+export function defaultEmulatorPubkey(network: Network): string {
+    const pinned = network.name ? EMULATOR_PUBKEYS[network.name] : undefined;
+    if (!pinned) {
+        throw new Error(
+            `No emulator pubkey is pinned for network ${network.name ?? "<unnamed>"}. ` +
+                `Pinned networks: ${Object.keys(EMULATOR_PUBKEYS).join(", ")}.`,
+        );
+    }
+    return pinned;
+}
+
+/**
+ * Resolve the co-signer key for `network`, letting a caller substitute its own.
+ *
+ * The override exists for the deployment running an emulator that is not the
+ * one pinned above — a private stack, or a network ahead of this constant.
+ * Supplying it means co-signing with a different service: every covenant built
+ * from the returned key can be completed by whoever holds it and by no one
+ * else, so it is a statement that you trust that operator in place of the
+ * network's. Prefer {@link defaultEmulatorPubkey} unless that is deliberate.
+ *
+ * A malformed override throws rather than being passed through — a typo here
+ * would otherwise surface as an unspendable contract long after the fact.
+ */
+export function resolveEmulatorPubkey(network: Network, override?: string): string {
+    if (override === undefined) return defaultEmulatorPubkey(network);
+    if (!COMPRESSED_PUBKEY.test(override)) {
+        throw new Error(
+            `Emulator pubkey override must be 33-byte compressed secp256k1 hex ` +
+                `(66 lowercase chars, 02/03 prefix), got ${JSON.stringify(override)}.`,
+        );
+    }
+    return override;
+}

--- a/packages/ts-sdk/test/arkade-contract.test.ts
+++ b/packages/ts-sdk/test/arkade-contract.test.ts
@@ -126,6 +126,11 @@ describe("arkade.Arkade / ArkadeContract", () => {
             emulator,
             indexer,
             network: networks.regtest,
+            // connect() takes the co-signer key from the network, not from the
+            // emulator's own getInfo, so this fixture key has to come in as the
+            // override or the tree below would be built against regtest's
+            // pinned key instead. "02"-prefixed like the server key above.
+            emulatorPubkey: "02" + hex.encode(emulatorKey),
         });
         return { ark, captured };
     }

--- a/packages/ts-sdk/test/arkade-swap.test.ts
+++ b/packages/ts-sdk/test/arkade-swap.test.ts
@@ -111,6 +111,10 @@ describe("non-interactive swap (multi-path contract)", () => {
             emulator,
             indexer,
             network: networks.regtest,
+            // connect() takes the co-signer key from the network, not from the
+            // emulator's own getInfo, so the fixture key comes in as the
+            // override. "02"-prefixed like the server key above.
+            emulatorPubkey: "02" + hex.encode(emulatorKey),
         });
         return ark.contract(swapProgram(), args);
     }

--- a/packages/ts-sdk/test/contracts/arkade-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/arkade-handler.test.ts
@@ -151,6 +151,10 @@ async function connectArkade(contractManager?: any) {
         identity,
         network: networks.regtest,
         contractManager,
+        // connect() takes the co-signer key from the network, not from the
+        // emulator's own getInfo, so handlerKeys()'s EMULATOR_KEY has to come
+        // in as the override for the two to derive the same script.
+        emulatorPubkey: "02" + hex.encode(EMULATOR_KEY),
     });
 }
 

--- a/packages/ts-sdk/test/emulator-pubkey.test.ts
+++ b/packages/ts-sdk/test/emulator-pubkey.test.ts
@@ -10,6 +10,51 @@ import {
     REGTEST_EMULATOR_PUBKEY,
     type Network,
 } from "../src/networks";
+import { arkade, CSVMultisigTapscript } from "../src";
+
+const SERVER_XONLY = "11".repeat(32);
+
+/**
+ * Minimal providers for `Arkade.connect`. The emulator counts its `getInfo`
+ * calls so a test can assert connect never asks it who it is.
+ */
+function stubProviders(emulatorSignerPubkey: string) {
+    let emulatorInfoCalls = 0;
+    const checkpointTapscript = hex.encode(
+        CSVMultisigTapscript.encode({
+            timelock: { type: "blocks", value: 10n },
+            pubkeys: [hex.decode(SERVER_XONLY)],
+        }).script,
+    );
+    const arkProvider = {
+        async getInfo() {
+            return { signerPubkey: "02" + SERVER_XONLY, checkpointTapscript } as any;
+        },
+        async submitTx() {
+            throw new Error("not used");
+        },
+        async finalizeTx() {},
+    } as any;
+    const emulator = {
+        async getInfo() {
+            emulatorInfoCalls++;
+            return { signerPubkey: emulatorSignerPubkey };
+        },
+        async submitTx() {
+            throw new Error("not used");
+        },
+        async submitIntent() {
+            throw new Error("not used");
+        },
+        async submitFinalization() {
+            throw new Error("not used");
+        },
+        async submitOnchainTx() {
+            throw new Error("not used");
+        },
+    } as any;
+    return { arkProvider, emulator, emulatorInfoCalls: () => emulatorInfoCalls };
+}
 
 describe("defaultEmulatorPubkey", () => {
     it("returns the pinned key for each network that has a deployed emulator", () => {
@@ -57,19 +102,26 @@ describe("defaultEmulatorPubkey", () => {
     it("throws for a network with no deployed emulator rather than guessing a neighbour's", () => {
         // testnet/signet share every other field with mutinynet, so falling
         // back by shape would hand back mutinynet's co-signer.
-        expect(() => defaultEmulatorPubkey(networks.testnet)).toThrow(/no emulator pubkey/i);
-        expect(() => defaultEmulatorPubkey(networks.signet)).toThrow(/no emulator pubkey/i);
+        expect(() => defaultEmulatorPubkey(networks.testnet)).toThrow(/no emulator is deployed/i);
+        expect(() => defaultEmulatorPubkey(networks.signet)).toThrow(/no emulator is deployed/i);
     });
 
     it("throws for a hand-assembled Network carrying no name", () => {
         const unnamed: Network = { ...networks.bitcoin, name: undefined };
-        expect(() => defaultEmulatorPubkey(unnamed)).toThrow(/<unnamed>/);
+        expect(() => defaultEmulatorPubkey(unnamed)).toThrow(/carries no name/);
+        // Points at the supported way to build one, not just at the failure.
+        expect(() => defaultEmulatorPubkey(unnamed)).toThrow(/getNetwork/);
     });
 
-    it("names the pinned networks in the failure so the message is actionable", () => {
-        expect(() => defaultEmulatorPubkey(networks.testnet)).toThrow(
-            /bitcoin, mutinynet, regtest/,
-        );
+    it("names the override as the remedy, not just the refusal", () => {
+        // Whoever hits this usually has a working emulator in front of them,
+        // so the message has to say which argument revives it — same register
+        // as the timelock-floor rejections naming minCheckpointExitDelaySeconds.
+        for (const network of [networks.testnet, networks.signet]) {
+            expect(() => defaultEmulatorPubkey(network)).toThrow(/emulatorPubkey/);
+            expect(() => defaultEmulatorPubkey(network)).toThrow(/Arkade\.connect/);
+            expect(() => defaultEmulatorPubkey(network)).toThrow(/bitcoin, mutinynet, regtest/);
+        }
     });
 });
 
@@ -114,5 +166,81 @@ describe("resolveEmulatorPubkey", () => {
 
     it("rejects an empty-string override rather than treating it as absent", () => {
         expect(() => resolveEmulatorPubkey(networks.regtest, "")).toThrow(/compressed/);
+    });
+});
+
+describe("Arkade.connect co-signer resolution", () => {
+    // A key the emulator claims for itself, distinct from every pinned value,
+    // standing in for a rogue or misconfigured endpoint.
+    const CLAIMED = "03" + "ab".repeat(32);
+
+    it("uses the network's pinned key and never asks the emulator who it is", async () => {
+        const { arkProvider, emulator, emulatorInfoCalls } = stubProviders(CLAIMED);
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            emulator,
+            network: networks.regtest,
+        });
+        expect(hex.encode(ark.emulatorKey!)).toBe(REGTEST_EMULATOR_PUBKEY);
+        // The whole point: the service's self-report is not consulted at all,
+        // so it cannot choose the key its covenants commit to.
+        expect(emulatorInfoCalls()).toBe(0);
+    });
+
+    it("ignores the emulator's claimed key when it differs from the pin", async () => {
+        const { arkProvider, emulator } = stubProviders(CLAIMED);
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            emulator,
+            network: networks.regtest,
+        });
+        expect(hex.encode(ark.emulatorKey!)).not.toBe(CLAIMED);
+    });
+
+    it("lets the override replace the pinned key", async () => {
+        const custom = "02" + "cd".repeat(32);
+        const { arkProvider, emulator } = stubProviders(CLAIMED);
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            emulator,
+            network: networks.regtest,
+            emulatorPubkey: custom,
+        });
+        expect(hex.encode(ark.emulatorKey!)).toBe(custom);
+        expect(hex.encode(ark.emulatorKey!)).not.toBe(REGTEST_EMULATOR_PUBKEY);
+    });
+
+    it("refuses an emulator on an unpinned network, naming the override", async () => {
+        const { arkProvider, emulator } = stubProviders(CLAIMED);
+        await expect(
+            arkade.Arkade.connect({
+                arkade: arkProvider,
+                emulator,
+                network: networks.signet,
+            }),
+        ).rejects.toThrow(/emulatorPubkey/);
+    });
+
+    it("connects on an unpinned network once the override is supplied", async () => {
+        const custom = "02" + "cd".repeat(32);
+        const { arkProvider, emulator } = stubProviders(CLAIMED);
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            emulator,
+            network: networks.signet,
+            emulatorPubkey: custom,
+        });
+        expect(hex.encode(ark.emulatorKey!)).toBe(custom);
+    });
+
+    it("still connects with no emulator on an unpinned network", async () => {
+        // Pure tapscript usage needs no co-signer, so the pin must not become a
+        // precondition for connecting at all.
+        const { arkProvider } = stubProviders(CLAIMED);
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            network: networks.signet,
+        });
+        expect(ark.emulatorKey).toBeUndefined();
     });
 });

--- a/packages/ts-sdk/test/emulator-pubkey.test.ts
+++ b/packages/ts-sdk/test/emulator-pubkey.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+
+import {
+    defaultEmulatorPubkey,
+    resolveEmulatorPubkey,
+    networks,
+    BITCOIN_EMULATOR_PUBKEY,
+    MUTINYNET_EMULATOR_PUBKEY,
+    REGTEST_EMULATOR_PUBKEY,
+    type Network,
+} from "../src/networks";
+
+describe("defaultEmulatorPubkey", () => {
+    it("returns the pinned key for each network that has a deployed emulator", () => {
+        expect(defaultEmulatorPubkey(networks.bitcoin)).toBe(BITCOIN_EMULATOR_PUBKEY);
+        expect(defaultEmulatorPubkey(networks.mutinynet)).toBe(MUTINYNET_EMULATOR_PUBKEY);
+        expect(defaultEmulatorPubkey(networks.regtest)).toBe(REGTEST_EMULATOR_PUBKEY);
+    });
+
+    it("pins the exact values the deployed emulators advertise", () => {
+        // Spelled out rather than compared against the constants they came
+        // from: this is the assertion that fails if someone edits the constant,
+        // which is the whole point of pinning a co-signer key.
+        expect(BITCOIN_EMULATOR_PUBKEY).toBe(
+            "0239c196415da47b26456a101daaa12ba9e445bfe153197f1e2b750bf40e52092e",
+        );
+        expect(MUTINYNET_EMULATOR_PUBKEY).toBe(
+            "03f823b9b2febc81f4af967e77aed2f541cbd3397c6d8f5a72e32eb7b471af889a",
+        );
+        expect(REGTEST_EMULATOR_PUBKEY).toBe(
+            "02999413c46fa10ada5cbc4bcc79a1d09160c2ba3cfc812705d7a13e5e545fb2a9",
+        );
+    });
+
+    it("pins them as 33-byte compressed points, not x-only", () => {
+        // Compressed is the lossless form and what `/v1/info` puts on the
+        // wire: `Arkade.connect` keeps all 33 bytes of the co-signer's
+        // signerPubkey (unlike the server key, which it slices), so these
+        // substitute for a live fetch byte-for-byte. The parity bit cannot be
+        // recovered once dropped, so pinning x-only would not be reversible.
+        for (const key of [
+            BITCOIN_EMULATOR_PUBKEY,
+            MUTINYNET_EMULATOR_PUBKEY,
+            REGTEST_EMULATOR_PUBKEY,
+        ]) {
+            expect(key).toMatch(/^0[23][0-9a-f]{64}$/);
+            expect(hex.decode(key)).toHaveLength(33);
+        }
+    });
+
+    it("gives each pinned network a distinct key", () => {
+        const keys = [BITCOIN_EMULATOR_PUBKEY, MUTINYNET_EMULATOR_PUBKEY, REGTEST_EMULATOR_PUBKEY];
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it("throws for a network with no deployed emulator rather than guessing a neighbour's", () => {
+        // testnet/signet share every other field with mutinynet, so falling
+        // back by shape would hand back mutinynet's co-signer.
+        expect(() => defaultEmulatorPubkey(networks.testnet)).toThrow(/no emulator pubkey/i);
+        expect(() => defaultEmulatorPubkey(networks.signet)).toThrow(/no emulator pubkey/i);
+    });
+
+    it("throws for a hand-assembled Network carrying no name", () => {
+        const unnamed: Network = { ...networks.bitcoin, name: undefined };
+        expect(() => defaultEmulatorPubkey(unnamed)).toThrow(/<unnamed>/);
+    });
+
+    it("names the pinned networks in the failure so the message is actionable", () => {
+        expect(() => defaultEmulatorPubkey(networks.testnet)).toThrow(
+            /bitcoin, mutinynet, regtest/,
+        );
+    });
+});
+
+describe("resolveEmulatorPubkey", () => {
+    it("falls through to the pinned key when no override is given", () => {
+        expect(resolveEmulatorPubkey(networks.regtest)).toBe(REGTEST_EMULATOR_PUBKEY);
+        expect(resolveEmulatorPubkey(networks.regtest, undefined)).toBe(REGTEST_EMULATOR_PUBKEY);
+    });
+
+    it("returns the override in place of the pinned key", () => {
+        const custom = "02" + "ab".repeat(32);
+        expect(resolveEmulatorPubkey(networks.regtest, custom)).toBe(custom);
+        expect(resolveEmulatorPubkey(networks.regtest, custom)).not.toBe(REGTEST_EMULATOR_PUBKEY);
+    });
+
+    it("lets an override supply a key for a network that has none pinned", () => {
+        const custom = "03" + "cd".repeat(32);
+        expect(() => defaultEmulatorPubkey(networks.signet)).toThrow();
+        expect(resolveEmulatorPubkey(networks.signet, custom)).toBe(custom);
+    });
+
+    it("rejects a malformed override instead of passing it through", () => {
+        // A typo that reaches a covenant leaf surfaces as an unspendable
+        // contract, so it has to fail at the seam instead.
+        expect(() => resolveEmulatorPubkey(networks.regtest, "not-hex")).toThrow(/compressed/);
+        // x-only: the encoding a caller is most likely to reach for by mistake.
+        expect(() => resolveEmulatorPubkey(networks.regtest, "ab".repeat(32))).toThrow(
+            /compressed/,
+        );
+        // Uncompressed (04-prefixed) and wrong-length are both out.
+        expect(() => resolveEmulatorPubkey(networks.regtest, "04" + "ab".repeat(64))).toThrow(
+            /compressed/,
+        );
+        expect(() => resolveEmulatorPubkey(networks.regtest, "02" + "ab".repeat(31))).toThrow(
+            /compressed/,
+        );
+        // Uppercase hex is not the lowercase form everything else here uses.
+        expect(() =>
+            resolveEmulatorPubkey(networks.regtest, ("02" + "ab".repeat(32)).toUpperCase()),
+        ).toThrow(/compressed/);
+    });
+
+    it("rejects an empty-string override rather than treating it as absent", () => {
+        expect(() => resolveEmulatorPubkey(networks.regtest, "")).toThrow(/compressed/);
+    });
+});


### PR DESCRIPTION
The emulator co-signer key is a property of the network, not of whoever you happen to be talking to. Until now `Arkade.connect` took it from a live `emulator.getInfo()` call, so the key that covenants are built against came from the same service being trusted to co-sign with it. Two solvers on one network could also end up advertising different keys, with nothing to catch the disagreement.

This pins it per network and drops the fetch. `resolveEmulatorPubkey(network, override?)` returns the key; `contract.ts` no longer calls `getInfo()` at all, since `signerPubkey` was its only field and connect was its only caller.

```
bitcoin    0239c196415da47b26456a101daaa12ba9e445bfe153197f1e2b750bf40e52092e
mutinynet  03f823b9b2febc81f4af967e77aed2f541cbd3397c6d8f5a72e32eb7b471af889a
regtest    02999413c46fa10ada5cbc4bcc79a1d09160c2ba3cfc812705d7a13e5e545fb2a9
```

Compressed rather than x-only, because that is lossless — x-only derives from it, parity does not derive back — and it is byte-identical to what `/v1/info` returns. Consumers needing 32 bytes already normalise at their own boundary.

The honest cost: networks with no pinned key now throw at connect where they previously worked off whatever the supplied emulator reported. That is testnet, signet, and any hand-built `Network` carrying no `name`. Anyone running their own emulator there passes `emulatorPubkey` to `Arkade.connect` and is on their way; the error names that remedy and lists the pinned networks rather than leaving someone to guess.

I considered falling back to the fetched key on unpinned networks and decided against it. A fallback makes the guarantee depend invisibly on whether `network.name` happens to be set — pinned on three networks, self-reported everywhere else, with nothing telling the caller which they got. The unnamed-`Network` case is the sharp one and it is already real in this repo: `test/contracts/handlers/boarding.test.ts` builds `{ bech32: "bcrt", hrp: "tark" } as any`. A hand-built network can carry bitcoin-equivalent parameters and no name, so a fallback would quietly degrade to "trust whatever answers that URL" on precisely the input that most resembles mainnet. It would also contradict `Network.name`'s own documentation, which tells consumers to read a missing name as unknown and take their strictest branch.

A key rotation is the other case worth naming: it is a config change, not an outage. Pass the new key as the override until a release ships the new constant. The resolver's doc leads with that. For debugging, `Arkade.emulatorKey` already exposes what was resolved, so an operator can diff it against their emulator's `/v1/info` — its doc claimed x-only for a field holding 33 compressed bytes, which is also fixed here.

Tests go 2372 to 2378, typecheck and prettier clean, and the commit hook's three packages pass. Four negative controls: restoring the fetch, ignoring the override, letting an unpinned network fall back, and dropping the override from the error message each fail the suite as intended. Three existing tests now pass their fixture's emulator key through the override rather than relying on the mock's `getInfo` — no assertion was relaxed, the tree-equality property is unchanged, only the key's delivery path moved.

Counterpart change: `arkade-os/lightning-swap-service` #66, merged, stops emitting `emulator_pubkey` on the solver card, and a matching removal in `arkade-os/solver-registry` is in flight. Together the key lives in one place instead of three.

Not verified here: I had no live emulator, so a real `Arkade.connect` producing a spendable covenant against the pinned key is untested — the regtest key is the cheapest way to check that. The mainnet value is the one constant never checked against a live service; it rests on the supplied table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network-specific emulator co-signer keys for Bitcoin, Mutinynet, and Regtest.
  * Added optional emulator public-key overrides when connecting.
  * Exported utilities and constants for resolving emulator public keys.
* **Bug Fixes**
  * Emulator connections no longer depend on keys reported by the emulator.
  * Added validation for malformed or unsupported emulator public keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->