### PR TITLE
fix(wallet): drop refused inputs from recovery instead of failing the batch

### DIFF
--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -399,6 +399,22 @@ export interface IContractManager extends Disposable {
     ): Promise<void>;
 
     /**
+     * Which of `vtxos` their owning handler refuses right now, keyed by outpoint
+     * (`txid:vout`) and valued with the handler's own explanation.
+     *
+     * The predicate form of {@link assertSpendableNow}, for callers that must
+     * DROP a refused input rather than fail the batch holding it. Keyed per
+     * outpoint, not per script: a relative (CSV) timelock is measured from each
+     * coin's own confirmation, so two coins on one contract can disagree.
+     *
+     * Optional for the same reason {@link assertSpendableNow} is.
+     */
+    unspendableNowReasons?(
+        vtxos: readonly AssertSpendableInput[],
+        walletPubKey?: () => Promise<string | undefined>,
+    ): Promise<Map<string, string>>;
+
+    /**
      * Update mutable contract fields.
      *
      * `script` and `createdAt` are immutable.
@@ -1673,7 +1689,24 @@ export class ContractManager implements IContractManager {
         vtxos: readonly AssertSpendableInput[],
         walletPubKey?: () => Promise<string | undefined>,
     ): Promise<void> {
-        if (vtxos.length === 0) return;
+        const refused = await this.unspendableNowReasons(vtxos, walletPubKey);
+        if (refused.size === 0) return;
+        // The single-input case rethrows verbatim: the handler's message names
+        // the maturity and what to wait for, and that text is the deliverable.
+        if (refused.size === 1) throw new Error([...refused.values()][0]);
+        throw new Error(
+            `refusing to spend ${refused.size} vtxo(s) that cannot be spent yet: ` +
+                [...refused].map(([outpoint, why]) => `${outpoint}: ${why}`).join("; "),
+        );
+    }
+
+    /** @inheritdoc */
+    async unspendableNowReasons(
+        vtxos: readonly AssertSpendableInput[],
+        walletPubKey?: () => Promise<string | undefined>,
+    ): Promise<Map<string, string>> {
+        const refused = new Map<string, string>();
+        if (vtxos.length === 0) return refused;
         const contracts = await this.config.contractRepository.getContracts({
             script: Array.from(new Set(vtxos.map((vtxo) => vtxo.script))),
         });
@@ -1691,7 +1724,7 @@ export class ContractManager implements IContractManager {
                 contractHandlers.get(contract.type)?.assertSpendableNow !== undefined
             );
         });
-        if (asking.length === 0) return;
+        if (asking.length === 0) return refused;
 
         const tip = await this.currentChainTip();
         const walletKey = await walletPubKey?.();
@@ -1720,16 +1753,24 @@ export class ContractManager implements IContractManager {
                 // really is one.
                 vtxo: isVirtualCoin(vtxo) && "status" in vtxo ? vtxo : undefined,
             };
-            // Awaited even though every shipped handler answers synchronously:
-            // the signature permits a promise, and an un-awaited one would drop
-            // its rejection on the floor — a refusal that never reaches the
-            // caller is worse than no guard, because it reads as approval.
-            await handler.assertSpendableNow(
-                handler.createScript(contract.params),
-                contract,
-                context,
-            );
+            try {
+                // Awaited even though every shipped handler answers
+                // synchronously: the signature permits a promise, and an
+                // un-awaited one would land outside this catch — recorded as no
+                // refusal, which reads as approval.
+                await handler.assertSpendableNow(
+                    handler.createScript(contract.params),
+                    contract,
+                    context,
+                );
+            } catch (err) {
+                refused.set(
+                    `${vtxo.txid}:${vtxo.vout}`,
+                    err instanceof Error ? err.message : String(err),
+                );
+            }
         }
+        return refused;
     }
 
     // Field-by-field, so every filter a caller can express reaches the

--- a/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlc.ts
@@ -269,21 +269,19 @@ export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Sc
      * `refundWithoutReceiver` — `CLTV[sender, server]`, the sender's OWN
      * refund, which the server rejects until `refundLocktime` matures. The
      * reasons are that an escrowed lockup must not count toward the
-     * `available` balance bucket (`computeOffchainBalance` credits `available`
-     * only where this gate is open), and that generic RENEWAL must not
-     * silently execute a refund the caller never asked for —
-     * `runPeriodicSettle` selects through `getSpendableVtxos`, which this gate
-     * filters, and it runs unprompted whenever a wallet is built without an
-     * explicit `settlementConfig`.
+     * `available` balance bucket, and that generic RENEWAL must not silently
+     * execute a refund the caller never asked for — `runPeriodicSettle` selects
+     * through `getSpendableVtxos`, which this gate filters, and it runs
+     * unprompted whenever a wallet is built without an explicit
+     * `settlementConfig`.
      *
-     * **Inseparable from {@link deriveTapscripts}.** Until that method existed
-     * a `vhtlc` row's VTXOs could not be annotated at all, so they never
-     * reached this gate and the answer here was unobservable — the previous
-     * `true` and the missing derivation were safe only by cancelling out.
-     * Deriving the leaf without closing the gate would hand generic renewal an
-     * escrow it had never been offered before. (The earlier `true` was
-     * justified as preserving selection of in-flight swaps; no such selection
-     * was ever reachable, for that same annotation reason.)
+     * **Inseparable from {@link deriveTapscripts}.** Deriving the leaf without
+     * closing the gate hands generic renewal an escrow it had never been
+     * offered before; before that method existed the answer here was
+     * unobservable, so the two only ever made sense together.
+     *
+     * Recovery is filtered on {@link assertSpendableNow}, not on this: the gate
+     * is permanent, and applying it there would strand a matured lockup.
      */
     isGenericallySpendable: () => false,
 
@@ -312,7 +310,12 @@ export const VHTLCContractHandler: ContractHandler<VHTLCContractParams, VHTLC.Sc
      * on this leaf is only valid once `refundLocktime` has matured, so a
      * recovery round that sweeps this VTXO early is rejected by the server.
      * Nothing in this handler can enforce that, because the annotation is
-     * derived per contract and knows no clock.
+     * derived per contract and knows no clock; `recoverVtxos` filters on
+     * {@link assertSpendableNow} for it.
+     *
+     * **Role-blind.** A receiver's row gets the same leaf, which names keys that
+     * wallet does not hold, so it is satisfiable only by the wallet holding the
+     * lockup's `sender` key and fails at intent registration for anyone else.
      */
     deriveTapscripts(script: VHTLC.Script): DerivedContractTapscripts {
         const leaf = script.refundWithoutReceiver();

--- a/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
@@ -386,10 +386,12 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
      * complete, or race a claim already in flight. The `vhtlc` handler now
      * answers the same, for the same reason.
      *
-     * Recovery is unaffected: the gate guards only GENERIC selection, and every
-     * way out of a lockup names its outpoints explicitly — `settle({ inputs })`,
-     * or `@arkade-os/swap`'s `pushRefundWithoutReceiver`, which builds the
-     * refund itself from `findLockupVtxos`' outpoints.
+     * The gate covers `available` and renewal. Recovery is generic and names
+     * nothing, so it is not covered here: `recoverVtxos` filters on
+     * {@link assertSpendableNow} instead, which drops a lockup only while its
+     * refund path is shut rather than forever. The explicit routes out —
+     * `settle({ inputs })`, or `@arkade-os/swap`'s `pushRefundWithoutReceiver`
+     * over `findLockupVtxos`' outpoints — are unaffected either way.
      */
     isGenericallySpendable: () => false,
 
@@ -422,7 +424,12 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
      * round that sweeps this VTXO early is rejected by the server. That is the
      * same constraint `packages/boltz-swap` encodes as "pre-CLTV recoverable →
      * skipped"; nothing in this handler can enforce it, because the annotation
-     * is derived per contract and knows no clock.
+     * is derived per contract and knows no clock. `recoverVtxos` filters on
+     * {@link assertSpendableNow} for it.
+     *
+     * **Role-blind.** A receiver's row gets the same leaf, which names keys that
+     * wallet does not hold, so it is satisfiable only by the wallet holding the
+     * lockup's `sender` key and fails at intent registration for anyone else.
      */
     deriveTapscripts(script: VHTLC.ScriptV2): DerivedContractTapscripts {
         const leaf = script.refundWithoutReceiver();

--- a/packages/ts-sdk/src/contracts/index.ts
+++ b/packages/ts-sdk/src/contracts/index.ts
@@ -20,6 +20,7 @@ export {
     gatedContracts,
     gateExclusion,
     outpointExclusion,
+    outpointReasons,
     logExcludedVtxos,
     UnannotatableInputError,
 } from "./spendability";

--- a/packages/ts-sdk/src/contracts/spendability.ts
+++ b/packages/ts-sdk/src/contracts/spendability.ts
@@ -55,6 +55,21 @@ export function outpointExclusion(outpoints: ReadonlySet<string>, reason: string
 }
 
 /**
+ * Outpoints excluded for individually-named reasons — a per-input timelock,
+ * where one shared reason would be wrong because the inputs differ.
+ *
+ * Unlike {@link gateExclusion}, the reasons are the handlers' own sentences and
+ * are not rephrased to follow the outpoint: that text is what tells the reader
+ * when to retry, and a paraphrase here would be a second spelling to keep in
+ * step with it.
+ *
+ * @see outpointExclusion for the shared-reason form.
+ */
+export function outpointReasons(reasons: ReadonlyMap<string, string>): VtxoExclusion {
+    return (vtxo) => reasons.get(`${vtxo.txid}:${vtxo.vout}`);
+}
+
+/**
  * Report VTXOs an exclusion dropped — the only field-diagnosable signal for why
  * a coin is missing from a spend, or why an explicitly named one will fail.
  * Debug level, one line per VTXO per reason.

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -439,6 +439,7 @@ import {
     gatedContracts,
     gateExclusion,
     outpointExclusion,
+    outpointReasons,
     logExcludedVtxos,
     UnannotatableInputError,
 } from "./contracts/spendability";
@@ -716,6 +717,7 @@ export {
     gatedContracts,
     gateExclusion,
     outpointExclusion,
+    outpointReasons,
     logExcludedVtxos,
     UnannotatableInputError,
     encodeArkContract,

--- a/packages/ts-sdk/src/wallet/balance.ts
+++ b/packages/ts-sdk/src/wallet/balance.ts
@@ -75,7 +75,10 @@ export function computeOffchainBalance(
         // Pending recovery is tested first, and before expiry: such funds cannot
         // be renewed until they recover, so once their batch expiry passes
         // `canRecoverOnchain` would otherwise report them as renewable-right-now.
-        // The branches are exclusive, so `total` counts each VTXO once.
+        // The branches are exclusive, so `total` counts each VTXO once — which is
+        // also why the gate is applied to `available` alone and not here: a gated
+        // coin dropping out of `recoverable` would meet `canSpendOffchain`, be
+        // false there too, and land in no bucket at all.
         if (isPendingRecovery(vtxo)) {
             pendingRecovery += vtxo.value;
             continue;

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -338,7 +338,13 @@ export interface WalletBalance {
      * intent. Equals `settled + preconfirmed` when nothing is intent-locked.
      */
     available: number;
-    /** Recoverable balance from subdust or expired (swept) virtual outputs. */
+    /**
+     * Recoverable balance from subdust or expired (swept) virtual outputs —
+     * recoverable in principle, so a lockup whose contract refuses a spend right
+     * now is still counted and `total` does not lose it.
+     * `VtxoManager.getRecoverableBalance()` answers the narrower question of
+     * what a batch would hand back today, and excludes it.
+     */
     recoverable: number;
 
     /**

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -1309,7 +1309,15 @@ export class ServiceWorkerReadonlyWallet implements IReadonlyWallet {
              */
             async assertAnnotatable(): Promise<void> {},
 
-            /** Same reasoning as {@link assertAnnotatable}: the worker checks it. */
+            /**
+             * Same reasoning as {@link assertAnnotatable}: the worker checks it.
+             *
+             * `unspendableNowReasons` is deliberately absent rather than stubbed
+             * alongside it. A stub returning an empty map reads as "nothing
+             * refused", and a filter acting on that silently drops its decision;
+             * absent, the optional call is skipped. Recovery — the only caller —
+             * runs inside the worker against the real manager anyway.
+             */
             async assertSpendableNow(): Promise<void> {},
 
             async annotateVtxos(vtxos: VirtualCoin[]): Promise<NormalizedExtendedVirtualCoin[]> {

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -1251,9 +1251,19 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // Neither message may reuse "No recoverable VTXOs found": the coins
             // were found and declined, and the handler's text says when to retry.
             if (vtxosToRecover.length === 0) {
+                // Every reason, not the first: lockups at different maturities
+                // become recoverable at different times, and naming one of them
+                // dates the whole wallet by the wrong clock. Same shape as
+                // `IContractManager.assertSpendableNow`'s multi-input refusal.
+                const why =
+                    refused.size === 1
+                        ? [...refused.values()][0]
+                        : [...refused]
+                              .map(([outpoint, reason]) => `${outpoint}: ${reason}`)
+                              .join("; ");
                 throw new Error(
                     `All ${held} recoverable VTXO(s) are held by a contract that refuses a ` +
-                        `spend right now: ${[...refused.values()][0]}`,
+                        `spend right now: ${why}`,
                 );
             }
             ({ vtxosToRecover } = getRecoverableWithSubdust(vtxosToRecover, dustAmount, now));

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -43,6 +43,7 @@ import type { OnchainProvider } from "../providers/onchain";
 import type { Network } from "../networks";
 import type { DefaultVtxo } from "../script/default";
 import { getDustAmount } from "./utils";
+import { logExcludedVtxos, outpointReasons } from "../contracts/spendability";
 
 /**
  * Outpoints (`txid:vout`) of VTXOs that are NOT cooperatively spendable because
@@ -1161,6 +1162,31 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     // ========== Recovery Methods ==========
 
     /**
+     * Outpoints recovery must not name yet, with the reason each was refused.
+     * Empty when the manager offers no opinion — an embedder's may not implement
+     * the predicate, and every contract type but VHTLC never answers.
+     *
+     * Reaches only a lockup whose `sender` is this wallet's own key: role
+     * resolution matches that key against the contract's params, so a
+     * descriptor-derived sender (every RFQ lockup) is not matched and such a row
+     * still fails its batch at submit.
+     *
+     * The key stays a thunk so an ordinary recovery never touches the identity,
+     * and the full coins are passed rather than bare outpoints because only they
+     * carry the confirmation a relative timelock is measured from.
+     */
+    private async unspendableNow(
+        vtxos: readonly NormalizedExtendedVirtualCoin[],
+    ): Promise<Map<string, string>> {
+        const contractManager = await this.wallet.getContractManager();
+        return (
+            (await contractManager.unspendableNowReasons?.(vtxos, async () =>
+                hex.encode(await this.wallet.identity.xOnlyPublicKey()),
+            )) ?? new Map()
+        );
+    }
+
+    /**
      * Recover swept/expired virtual outputs by settling them back to the wallet's Arkade address.
      *
      * This method:
@@ -1171,6 +1197,11 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      *
      * Note: Settled virtual outputs with long expiry are NOT recovered to avoid locking liquidity unnecessarily.
      * Only preconfirmed subdust is recovered to consolidate small amounts.
+     *
+     * Inputs whose contract refuses a spend right now — an immature VHTLC refund
+     * path — are skipped rather than failing the batch that holds them, and
+     * {@link getRecoverableBalance} skips the same set. See
+     * {@link unspendableNow} for which rows that reaches.
      *
      * @param eventCallback - Optional callback to receive settlement events
      * @returns Settlement transaction ID
@@ -1205,6 +1236,33 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         if (vtxosToRecover.length === 0) {
             throw new Error("No recoverable VTXOs found");
+        }
+
+        // Before pricing: the cap below fills slots highest-value-first, so a
+        // refused input filtered after it would occupy a slot and then vanish,
+        // under-filling the settlement.
+        const refused = await this.unspendableNow(vtxosToRecover);
+        if (refused.size > 0) {
+            logExcludedVtxos("recoverVtxos", vtxosToRecover, [outpointReasons(refused)]);
+            const held = vtxosToRecover.length;
+            vtxosToRecover = vtxosToRecover.filter(
+                (vtxo) => !refused.has(`${vtxo.txid}:${vtxo.vout}`),
+            );
+            // Neither message may reuse "No recoverable VTXOs found": the coins
+            // were found and declined, and the handler's text says when to retry.
+            if (vtxosToRecover.length === 0) {
+                throw new Error(
+                    `All ${held} recoverable VTXO(s) are held by a contract that refuses a ` +
+                        `spend right now: ${[...refused.values()][0]}`,
+                );
+            }
+            ({ vtxosToRecover } = getRecoverableWithSubdust(vtxosToRecover, dustAmount, now));
+            if (vtxosToRecover.length === 0) {
+                throw new Error(
+                    `Excluding ${refused.size} VTXO(s) not yet spendable, the remaining ` +
+                        `recoverable amount is below the dust threshold ${dustAmount}`,
+                );
+            }
         }
 
         // Cap the recovery batch to stay under both the server's intent-size
@@ -1331,6 +1389,11 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * The batch size caps are not applied here: they defer the overflow to the
      * next cycle rather than reducing what is recoverable.
      *
+     * Inputs a contract refuses right now are excluded, so this and
+     * {@link recoverVtxos} answer over the same set. `Balance.recoverable` still
+     * counts them: that field reports what the wallet owns, this one what a
+     * batch would hand back today.
+     *
      * @returns Object containing recoverable amounts and subdust information
      *
      * @example
@@ -1358,12 +1421,31 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         });
 
         const dustAmount = getDustAmount(this.wallet);
+        const now = await fetchTimeHeight(this.wallet);
 
-        const { vtxosToRecover, includesSubdust } = getRecoverableWithSubdust(
+        let { vtxosToRecover, includesSubdust } = getRecoverableWithSubdust(
             allVtxos,
             dustAmount,
-            await fetchTimeHeight(this.wallet),
+            now,
         );
+
+        // Excluded outright rather than reported in a field of their own: this
+        // answers what a recovery batch would hand back, and `Balance.recoverable`
+        // keeps counting the funds, so nothing disappears. Mirrors `recoverVtxos`
+        // so the preview and the sweep agree by construction — and it is the only
+        // channel through which a caller sees a partial drop.
+        const refused = await this.unspendableNow(vtxosToRecover);
+        if (refused.size > 0) {
+            logExcludedVtxos("getRecoverableBalance", vtxosToRecover, [outpointReasons(refused)]);
+            const remaining = vtxosToRecover.filter(
+                (vtxo) => !refused.has(`${vtxo.txid}:${vtxo.vout}`),
+            );
+            ({ vtxosToRecover, includesSubdust } = getRecoverableWithSubdust(
+                remaining,
+                dustAmount,
+                now,
+            ));
+        }
 
         // Priced the same way `recoverVtxos` prices what it settles. This exists
         // to tell a user what recovery would hand back, so it has to answer net

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -530,6 +530,47 @@ describe("VHTLCV2ContractHandler", () => {
             expect(seen!.vtxo).toBeUndefined();
         });
 
+        const reasonsThrough = async (
+            tip: number | undefined,
+            walletPubKey = SENDER,
+            vouts = [0],
+        ) => {
+            const manager = await managerFor(tip === undefined ? undefined : at(tip));
+            const contract = contractOf(fullParams());
+            await manager.createContract(contract);
+            return manager.unspendableNowReasons!(
+                vouts.map((vout) => ({ txid: "a".repeat(64), vout, script: contract.script })),
+                async () => walletPubKey,
+            );
+        };
+
+        it("reports the refusal against the outpoint instead of throwing", async () => {
+            const refused = await reasonsThrough(799_999);
+            expect([...refused.keys()]).toEqual([`${"a".repeat(64)}:0`]);
+            expect(refused.get(`${"a".repeat(64)}:0`)).toMatch(/cannot be spent yet/);
+        });
+
+        it("reports every refused input, not just the first", async () => {
+            const refused = await reasonsThrough(799_999, SENDER, [0, 1]);
+            expect(refused.size).toBe(2);
+        });
+
+        it("reports nothing once mature, and nothing without a tip", async () => {
+            expect(await reasonsThrough(800_000)).toEqual(new Map());
+            expect(await reasonsThrough(undefined)).toEqual(new Map());
+        });
+
+        it("reports nothing for the receiver, whose claim it cannot judge", async () => {
+            expect(await reasonsThrough(799_999, RECEIVER)).toEqual(new Map());
+        });
+
+        it("reports nothing for a key the covenant does not name", async () => {
+            // The silent no-op the recovery filter risks: role resolution matches
+            // the wallet's own key, so a lockup committing a derived sender is
+            // never refused — the bound `unspendableNow` documents.
+            expect(await reasonsThrough(799_999, SERVER)).toEqual(new Map());
+        });
+
         it("never reads a tip when no contract has an opinion", async () => {
             let reads = 0;
             const manager = await managerFor(async () => {

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -571,6 +571,40 @@ describe("VHTLCV2ContractHandler", () => {
             expect(await reasonsThrough(799_999, SERVER)).toEqual(new Map());
         });
 
+        /**
+         * The v1 population is what #702 exposed to recovery, and dispatch is
+         * by `contract.type` — so a `vhtlc` row reaching the same answer is the
+         * half the v2 cases above cannot show.
+         */
+        it("reaches a v1 row through the same dispatch", async () => {
+            const manager = await managerFor(at(799_999));
+            const params = {
+                sender: SENDER,
+                receiver: RECEIVER,
+                server: SERVER,
+                hash: HASH,
+                refundLocktime: "800000",
+                claimDelay: "10",
+                refundDelay: "12",
+                refundNoReceiverDelay: "14",
+            };
+            const script = hex.encode(VHTLCContractHandler.createScript(params).pkScript);
+            await manager.createContract({
+                type: "vhtlc",
+                params,
+                script,
+                address: "address",
+            } as never);
+            const vtxo = { txid: "d".repeat(64), vout: 0, script };
+
+            const refused = await manager.unspendableNowReasons!([vtxo], async () => SENDER);
+
+            expect(refused.get(`${"d".repeat(64)}:0`)).toMatch(/refund path opens at block 800000/);
+            expect(await manager.unspendableNowReasons!([vtxo], async () => RECEIVER)).toEqual(
+                new Map(),
+            );
+        });
+
         it("never reads a tip when no contract has an opinion", async () => {
             let reads = 0;
             const manager = await managerFor(async () => {

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -7,6 +7,7 @@ import {
     InMemoryContractRepository,
     InMemoryWalletRepository,
     isContractGenericallySpendable,
+    outpointReasons,
     UnannotatableInputError,
     ProviderUnavailableError,
     ReadonlyWallet,
@@ -457,6 +458,19 @@ describe("spending sites consume the accessor", () => {
             }),
         ).rejects.toThrow();
         expect(wallet.getSpendableVtxos).toHaveBeenCalled();
+    });
+});
+
+describe("outpointReasons", () => {
+    const reasons = outpointReasons(new Map([["a:0", "not yet"]]));
+
+    it("returns the reason recorded for that outpoint", () => {
+        expect(reasons({ txid: "a", vout: 0 })).toBe("not yet");
+    });
+
+    it("returns undefined for anything else", () => {
+        expect(reasons({ txid: "a", vout: 1 })).toBeUndefined();
+        expect(reasons({ txid: "b", vout: 0 })).toBeUndefined();
     });
 });
 

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -437,6 +437,116 @@ describe("VtxoManager - Recovery", () => {
             expect((wallet.settle as any).mock.calls).toHaveLength(0);
         });
 
+        describe("inputs a contract refuses right now", () => {
+            // `unspendableNowReasons` is absent from every other mock in this
+            // file, so the optional call is skipped and nothing is filtered —
+            // which is what keeps the rest of these tests untouched.
+            const withRefusals = (
+                vtxos: ExtendedVirtualCoin[],
+                refused: Map<string, string>,
+                arkAddress = "arkade1myaddress",
+            ) => {
+                const wallet = createMockWallet(vtxos, arkAddress, {
+                    contractManager: {
+                        onContractEvent: vi.fn().mockReturnValue(() => {}),
+                        refreshOutpoints: vi.fn().mockResolvedValue(undefined),
+                        unspendableNowReasons: vi.fn().mockResolvedValue(refused),
+                    } as any,
+                });
+                (wallet as any).identity = {
+                    xOnlyPublicKey: vi.fn().mockResolvedValue(new Uint8Array(32).fill(7)),
+                };
+                return wallet;
+            };
+
+            it("drops the refused outpoint and settles the rest", async () => {
+                const immature = createMockVtxo(5000, "swept", false);
+                const ordinary = createMockVtxo(3000, "swept", false);
+                const wallet = withRefusals(
+                    [immature, ordinary],
+                    new Map([
+                        [`${immature.txid}:0`, "vhtlc … cannot be spent yet: opens at block 9"],
+                    ]),
+                );
+
+                const txid = await new VtxoManager(wallet).recoverVtxos();
+
+                expect(txid).toBe("mock-txid");
+                const settleArgs = (wallet.settle as any).mock.calls[0][0];
+                expect(settleArgs.inputs).toEqual([ordinary]);
+                expect(settleArgs.outputs[0].amount).toBe(3000n);
+            });
+
+            it("recovers a lockup no longer refused", async () => {
+                const matured = createMockVtxo(5000, "swept", false);
+                const wallet = withRefusals([matured], new Map());
+
+                await new VtxoManager(wallet).recoverVtxos();
+
+                expect((wallet.settle as any).mock.calls[0][0].inputs).toEqual([matured]);
+            });
+
+            it("throws with the handler's own reason when every input is refused", async () => {
+                const immature = createMockVtxo(5000, "swept", false);
+                const wallet = withRefusals(
+                    [immature],
+                    new Map([[`${immature.txid}:0`, "its refund path opens at block 800000"]]),
+                );
+
+                await expect(new VtxoManager(wallet).recoverVtxos()).rejects.toThrow(
+                    /refuses a spend right now: its refund path opens at block 800000/,
+                );
+                expect((wallet.settle as any).mock.calls).toHaveLength(0);
+            });
+
+            it("throws distinctly when what survives is below dust", async () => {
+                const immature = createMockVtxo(5000, "swept", false);
+                const crumb = createMockVtxo(18, "swept", false);
+                const wallet = withRefusals(
+                    [immature, crumb],
+                    new Map([[`${immature.txid}:0`, "not yet"]]),
+                );
+
+                await expect(new VtxoManager(wallet).recoverVtxos()).rejects.toThrow(
+                    /Excluding 1 VTXO\(s\) not yet spendable, the remaining recoverable amount is below the dust threshold 1000/,
+                );
+            });
+
+            it("reports the drop", async () => {
+                const immature = createMockVtxo(5000, "swept", false);
+                const ordinary = createMockVtxo(3000, "swept", false);
+                const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+                const wallet = withRefusals(
+                    [immature, ordinary],
+                    new Map([[`${immature.txid}:0`, "not yet"]]),
+                );
+
+                await new VtxoManager(wallet).recoverVtxos();
+
+                expect(debug).toHaveBeenCalledWith(
+                    `[spendability] recoverVtxos: ${immature.txid}:0 not yet`,
+                );
+                debug.mockRestore();
+            });
+
+            it("agrees with getRecoverableBalance on the same set", async () => {
+                const immature = createMockVtxo(5000, "swept", false);
+                const ordinary = createMockVtxo(3000, "swept", false);
+                const refused = new Map([[`${immature.txid}:0`, "not yet"]]);
+
+                const swept = await new VtxoManager(
+                    withRefusals([immature, ordinary], refused),
+                ).recoverVtxos();
+                const preview = await new VtxoManager(
+                    withRefusals([immature, ordinary], refused),
+                ).getRecoverableBalance();
+
+                expect(swept).toBe("mock-txid");
+                expect(preview.recoverable).toBe(3000n);
+                expect(preview.vtxoCount).toBe(1);
+            });
+        });
+
         it("should include subdust when combined value exceeds dust threshold", async () => {
             const vtxos = [
                 createMockVtxo(5000, "swept", false),

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -499,6 +499,22 @@ describe("VtxoManager - Recovery", () => {
                 expect((wallet.settle as any).mock.calls).toHaveLength(0);
             });
 
+            it("names every refusal when they differ, not just the first", async () => {
+                const early = createMockVtxo(5000, "swept", false);
+                const late = createMockVtxo(4000, "swept", false);
+                const wallet = withRefusals(
+                    [early, late],
+                    new Map([
+                        [`${early.txid}:0`, "opens at block 800000"],
+                        [`${late.txid}:0`, "opens at block 900000"],
+                    ]),
+                );
+
+                await expect(new VtxoManager(wallet).recoverVtxos()).rejects.toThrow(
+                    `${early.txid}:0: opens at block 800000; ${late.txid}:0: opens at block 900000`,
+                );
+            });
+
             it("throws distinctly when what survives is below dust", async () => {
                 const immature = createMockVtxo(5000, "swept", false);
                 const crumb = createMockVtxo(18, "swept", false);


### PR DESCRIPTION
## The bug

`recoverVtxos` and `getRecoverableBalance` read the ungated `getVtxos({ withRecoverable: true })` and feed it straight into `settle({ inputs })` — the crossing that read's own JSDoc warns against. Since #702 made `vhtlc` v1 VTXOs persist, an immature lockup joins the recovery batch and fails it **wholesale**, taking unrelated funds with it, and `recoverVtxos` takes no input filter to exclude it. #704 turned that into a local throw naming the timelock; the batch still fails.

The gate is the wrong predicate here: it is permanent, so filtering recovery on it would strand *matured* lockups forever. This filters on `assertSpendableNow`, which reopens once the refund path does.

## What lands

**`unspendableNowReasons`** — the predicate form of `assertSpendableNow`, keyed by outpoint (a relative timelock is measured per coin, so two VTXOs on one contract can disagree). The assert becomes a wrapper: single-input refusals rethrow the handler's text verbatim, multi-input ones now name them all, matching `assertAnnotatable`. Optional on `IContractManager`, and deliberately absent from the service-worker proxy — an empty map there reads as "nothing refused", and recovery runs inside the worker anyway.

**`outpointReasons`** — per-input reasons through `logExcludedVtxos`; `outpointExclusion`'s single shared reason cannot express them.

**Recovery selection** — both entry points partition before pricing (the cap fills slots highest-value-first, so filtering after it would under-fill the settlement) and answer over the same surviving set. Two new throws, neither reusing `"No recoverable VTXOs found"`: the coins were found and declined. `getRecoverableBalance` excludes the refused amount outright — it answers what a batch would hand back today, while `Balance.recoverable` keeps counting the funds, so nothing leaves `total`.

## Scope — read before assuming this covers your lockup

Role resolution matches the contract's `sender` against **the wallet's own x-only key**. So this reaches boltz submarine swaps (`ourXOnlyPublicKey`), which is the v1 population #702 exposed — and **not** RFQ lockups, which commit a freshly derived key per swap. Those still fail their batch at submit. `assertSpendableNow`'s settle pre-flight has had the same bound since #704; this PR documents it rather than widening it, because resolving derived senders means a used-descriptor scan, which draft #727 is already building plugin-side for the neighbouring question.

Also unchanged: a receiver-role row. The predicate is silent for the receiver by design (its claim turns on a preimage the check cannot see), so the role-blind annotation stays an open follow-up.

## Tests

+13 unit tests. Against a real `ContractManager` over in-memory repositories: refusal reported against the outpoint, every refused input reported (not just the first), silent once mature, silent with no tip, silent for the receiver, and silent for a key the covenant does not name — the last pins the scope above so widening it fails loudly. Against `VtxoManager`: the refused outpoint is dropped while the coin beside it settles, a matured lockup is still recovered, both new throws, the debug line, and `recoverVtxos`/`getRecoverableBalance` agreeing on one fixture.

Existing recovery tests are untouched: their mock managers omit the optional method, so nothing is filtered.

## Verification

`pnpm run test:unit` green — ts-sdk 2499 passed + 1 skipped (159 files, up 13 from the 2486 baseline on `f3fb7ca7`), swap 391, boltz-swap 614. `pnpm run lint` and `tsc --noEmit` clean across all three packages. e2e not run.

Plan: `plans/pr-702-followup.md`.