### PR TITLE
fix(swap): one teardown path per pool ownership in the Nostr transport

### DIFF
--- a/packages/swap/src/nostr.ts
+++ b/packages/swap/src/nostr.ts
@@ -255,11 +255,16 @@ export const nostrRfqTransport = (options: NostrRfqOptions): RfqTransport => {
 
         async close() {
             closed = true;
-            subscription.close();
             waiters.clear();
             // Only tear down a pool this transport created; a shared one belongs
-            // to the caller and may still be serving other swaps.
+            // to the caller and may still be serving other swaps. On an owned
+            // pool, `pool.close()` already ends every subscription on those
+            // relays — closing the subscription first as well sends a CLOSE
+            // frame on a socket the pool is about to close, and the browser
+            // logs "WebSocket is already in CLOSING or CLOSED state" on every
+            // negotiation. One teardown path each, per ownership.
             if (ownsPool) pool.close(relays);
+            else subscription.close();
         },
     };
 };

--- a/packages/swap/test/nostr.test.ts
+++ b/packages/swap/test/nostr.test.ts
@@ -4,8 +4,8 @@
  * Ported from the wallet, where this transport lived before it moved into the
  * package beside `httpTransport` and `relayTransport`.
  */
-import { describe, it, expect } from "vitest";
-import { generateSecretKey, getPublicKey, nip44, type Event } from "nostr-tools";
+import { describe, it, expect, vi } from "vitest";
+import { generateSecretKey, getPublicKey, nip44, SimplePool, type Event } from "nostr-tools";
 import { SwapRefusal } from "../src/rfq";
 import { RFQ_AD_KIND, RFQ_DIRECTED_KIND, RelayUnavailable, nostrRfqTransport } from "../src/nostr";
 
@@ -203,5 +203,35 @@ describe("nostrRfqTransport", () => {
             transport.requestQuote({ v: 1, type: "rfq_request", rfq_id: "abc" }),
         ).rejects.toThrow(/no solver reply within 40ms/);
         await transport.close();
+    });
+
+    /**
+     * Every other test injects a pool, so this is the only coverage of the
+     * owned-pool teardown. The two assertions are one property: `pool.close()`
+     * already ends every subscription on those relays, so closing the
+     * subscription as well sends a second CLOSE frame on a socket that is
+     * already closing — the double-close this transport exists to avoid.
+     */
+    it("tears an owned pool down through pool.close() alone", async () => {
+        const subscriptionClose = vi.fn();
+        const subscribeMany = vi
+            .spyOn(SimplePool.prototype, "subscribeMany")
+            .mockReturnValue({ close: subscriptionClose } as never);
+        const poolClose = vi.spyOn(SimplePool.prototype, "close").mockImplementation(() => {});
+        try {
+            const relays = ["wss://x", "wss://y"];
+            const transport = nostrRfqTransport({
+                relays,
+                solverPubkey: getPublicKey(generateSecretKey()),
+                secretKey: generateSecretKey(),
+                // no `pool`: the transport creates and therefore owns one
+            });
+            await transport.close();
+            expect(poolClose).toHaveBeenCalledWith(relays);
+            expect(subscriptionClose).not.toHaveBeenCalled();
+        } finally {
+            subscribeMany.mockRestore();
+            poolClose.mockRestore();
+        }
     });
 });


### PR DESCRIPTION
Every negotiation ends with the browser logging `WebSocket is already in CLOSING or CLOSED state`. Cause: `close()` ends the subscription and then closes the owned pool — and `pool.close()` ends every subscription on those relays again, so the second CLOSE frame lands on a socket that is already closing.

One teardown path per ownership now: an owned pool tears down through `pool.close()` alone; a shared pool (the caller's, possibly serving other swaps) keeps the subscription-only close.

Context: the wallet currently works around this at its call site, and the tempting wallet-side "fix" — dropping the `close()` call — would leak the owned pool and its socket on every negotiation. This removes the reason to touch that call site at all. Transport suite 9/9 green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyyk1wuSFmcVXYz2aLeJqx)_