### PR TITLE
feat(swap): take the sender key from the wallet, and persist RFQ swaps

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -517,10 +517,17 @@ scanned? })` — the server key is required because a spend is classified by reb
 - **A spend that cannot be classified is no longer restored as `fulfilled`.** It leaves the funding
   txid unanswered so a later scan decides it. Records are never written on a guess.
 - **`AssetSwap` gained the secret-bearing `signingDescriptor?` / `fallbackSecrets?` fields**, and
-  `preimageHex` narrowed from "the claim preimage P" to "caller-supplied P only". The repository
-  version stays `1` — the package is unreleased, so there is no stored record to migrate — but a
-  field-mapped backend must persist the record whole: silently dropping `fallbackSecrets` on write
-  loses the stored arm's claim and refund keys.
+  `preimageHex` narrowed from "the claim preimage P" to "caller-supplied P only". A field-mapped
+  backend must persist the record whole: silently dropping `fallbackSecrets` on write loses the
+  stored arm's claim and refund keys.
+- **The repository interface is at version `2`.** It gained `saveRfqSwap` / `getAllRfqSwaps` /
+  `removeRfqSwap` for monitored RFQ swaps, and the IndexedDB backend a matching `rfqSwaps` object
+  store at `DB_VERSION` 2. The bump is deliberate: an implementor must acknowledge the new methods
+  rather than silently satisfy an older shape. Existing databases upgrade in place — the new store
+  is added, the three original ones are untouched — so there is nothing to migrate by hand. Store
+  RFQ records whole for the same reason as above: every field is either a covenant tree parameter
+  or manager state, and dropping one leaves a record whose covenant `rebuildRfqSwap` cannot
+  reproduce.
 - **A write that gates something irreversible throws; one that follows it does not.**
   `addAssetSwap` and `updateAssetSwap` throw on a failed read or write — nothing irreversible may
   happen until the record is durable, which is why `cancelOffer` writes its `cancelling` marker

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -35,6 +35,15 @@ export {
 } from "./repository";
 export { IndexedDbAssetSwapRepository } from "./indexedDbRepository";
 export {
+    RFQ_SWAP_RETENTION_SECONDS,
+    createRfqSwapRecord,
+    rebuildRfqSwap,
+    shouldRetainRfqSwap,
+    updateRfqSwapRecord,
+    type RfqSwapOrigin,
+    type RfqSwapRecord,
+} from "./rfqRecord";
+export {
     restoreAssetSwaps,
     classifySpend,
     classifyDepositSpend,
@@ -137,6 +146,7 @@ export {
     buildPreimageMessage,
     derivePreimage,
     deriveSwapSecrets,
+    isBaselineSwapSecrets,
     isDeterministicSigner,
     preimageForRfqSecrets,
     randomSwapSecrets,
@@ -145,6 +155,7 @@ export {
     senderIdentityForRfqSecrets,
     senderIdentityForSwapRecord,
     senderPubkeyForRfqSecrets,
+    type BaselineSwapSecrets,
     type DerivedSwapSecrets,
     type DeterministicSigner,
     type RefundBlockedReason,

--- a/packages/swap/src/indexedDbRepository.ts
+++ b/packages/swap/src/indexedDbRepository.ts
@@ -1,14 +1,16 @@
 import { closeDatabase, openDatabase } from "@arkade-os/sdk";
 import { marketsCacheKey, type AssetSwapRepository, type MarketsCacheEntry } from "./repository";
 import type { AssetSwap } from "./store";
+import type { RfqSwapRecord } from "./rfqRecord";
 
 const DEFAULT_DB_NAME = "arkade-intents";
 /** Bump when adding an object store or index. `initDatabase` only runs inside
  * `onupgradeneeded`, which fires on a version *increase* — its contains-guard
  * cannot backfill a store into a database already open at this version, so a
  * new store added without a bump is simply missing for existing users. */
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE_SWAPS = "swaps";
+const STORE_RFQ_SWAPS = "rfqSwaps";
 const STORE_SCANNED = "scannedTxids";
 const STORE_MARKETS = "markets";
 
@@ -18,6 +20,9 @@ const STORE_MARKETS = "markets";
  * the txid / cache key is supplied at put time. */
 const STORES: readonly [name: string, options?: IDBObjectStoreParameters][] = [
     [STORE_SWAPS, { keyPath: "id" }],
+    // v2. Separate from `swaps` rather than sharing it: the two record types
+    // have different keys and no consumer wants them interleaved.
+    [STORE_RFQ_SWAPS, { keyPath: "rfqId" }],
     [STORE_SCANNED],
     [STORE_MARKETS],
 ];
@@ -47,7 +52,7 @@ const txDone = (tx: IDBTransaction): Promise<void> =>
 /** Browser backend over the SDK's shared IndexedDB manager — the same
  * infrastructure the wallet already uses for its Boltz swap repository. */
 export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
     // the promise, not the resolved database: openDatabase bumps a refcount on
     // every call including cache hits, while dispose closes once, so two
     // concurrent first calls would strand the refcount above zero and leak the
@@ -88,6 +93,22 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
 
     async getAllSwaps(): Promise<AssetSwap[]> {
         return request((await this.readStore(STORE_SWAPS)).getAll());
+    }
+
+    async saveRfqSwap(record: RfqSwapRecord): Promise<void> {
+        await this.write(STORE_RFQ_SWAPS, (store) => {
+            store.put(record);
+        });
+    }
+
+    async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {
+        return request((await this.readStore(STORE_RFQ_SWAPS)).getAll());
+    }
+
+    async removeRfqSwap(rfqId: string): Promise<void> {
+        await this.write(STORE_RFQ_SWAPS, (store) => {
+            store.delete(rfqId);
+        });
     }
 
     async getScannedTxids(): Promise<Set<string>> {

--- a/packages/swap/src/repository.ts
+++ b/packages/swap/src/repository.ts
@@ -1,5 +1,6 @@
 import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
 import type { AssetSwap } from "./store";
+import type { RfqSwapRecord } from "./rfqRecord";
 
 /** A registry discovery result held for reuse. Refetchable — unlike a swap
  * record, losing it costs one network round trip — but it must survive a cold
@@ -30,7 +31,7 @@ export const marketsCacheKey = (network: string, registry: string) =>
  * subset queries.
  */
 export interface AssetSwapRepository extends AsyncDisposable {
-    readonly version: 1;
+    readonly version: 2;
 
     /** Insert or replace a swap by id. Store the record whole: `fallbackSecrets`
      * is secret-bearing, and a field-mapped backend that drops it loses the
@@ -39,6 +40,20 @@ export interface AssetSwapRepository extends AsyncDisposable {
     /** All stored swaps, in no particular order — `getAssetSwaps` is the
      * canonical newest-first read. */
     getAllSwaps(): Promise<AssetSwap[]>;
+
+    /**
+     * Insert or replace a monitored RFQ swap by `rfqId`.
+     *
+     * Store the record WHOLE. Every field is a covenant tree parameter or the
+     * manager's own state, and a field-mapped backend that drops one round-trips
+     * a record whose covenant `rebuildRfqSwap` cannot reproduce — which surfaces
+     * as a refund that cannot be signed, long after the write.
+     */
+    saveRfqSwap(record: RfqSwapRecord): Promise<void>;
+    /** Every stored RFQ swap record, in no particular order. */
+    getAllRfqSwaps(): Promise<RfqSwapRecord[]>;
+    /** Drop one, once it is past retention — see `shouldRetainRfqSwap`. */
+    removeRfqSwap(rfqId: string): Promise<void>;
 
     /** Sent txids already checked for offer packets (see restore.ts). */
     getScannedTxids(): Promise<Set<string>>;
@@ -52,8 +67,9 @@ export interface AssetSwapRepository extends AsyncDisposable {
 }
 
 export class InMemoryAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
     private readonly swaps = new Map<string, AssetSwap>();
+    private readonly rfqSwaps = new Map<string, RfqSwapRecord>();
     private readonly scanned = new Set<string>();
     private readonly markets = new Map<string, MarketsCacheEntry>();
 
@@ -63,6 +79,18 @@ export class InMemoryAssetSwapRepository implements AssetSwapRepository {
 
     async getAllSwaps(): Promise<AssetSwap[]> {
         return [...this.swaps.values()];
+    }
+
+    async saveRfqSwap(record: RfqSwapRecord): Promise<void> {
+        this.rfqSwaps.set(record.rfqId, record);
+    }
+
+    async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {
+        return [...this.rfqSwaps.values()];
+    }
+
+    async removeRfqSwap(rfqId: string): Promise<void> {
+        this.rfqSwaps.delete(rfqId);
     }
 
     async getScannedTxids(): Promise<Set<string>> {
@@ -90,6 +118,7 @@ export class InMemoryAssetSwapRepository implements AssetSwapRepository {
 
     async clear(): Promise<void> {
         this.swaps.clear();
+        this.rfqSwaps.clear();
         this.scanned.clear();
         this.markets.clear();
     }

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -1111,9 +1111,13 @@ export async function requestOnchainSend(
     // `preimage: true` asks for one either way: derived on the allocated arm,
     // generated per swap on the baseline arm, and a caller's own passed through.
     const secrets = await deriveSwapSecrets(wallet, { preimage: params.preimage ?? true });
-    if (params.preimage) {
+    // Both arms that CARRY a preimage hold one nothing can re-derive: a
+    // caller's own, and the baseline arm's generated one. The allocated arm
+    // carries none — its preimage is a function of the descriptor and the seed,
+    // so there is nothing to lose by not persisting it.
+    if (secrets.preimage) {
         console.warn(
-            "[swap] this swap's preimage was supplied by the caller and MUST be persisted with the signing descriptor before funding",
+            "[swap] this swap's preimage is not derivable and MUST be persisted with the swap record before funding",
         );
     }
     const preimage = await preimageForRfqSecrets(wallet, secrets);

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -78,7 +78,6 @@ export {
 import {
     deriveSwapSecrets,
     preimageForRfqSecrets,
-    randomSwapSecrets,
     senderPubkeyForRfqSecrets,
     type SwapSecrets,
 } from "./secrets";
@@ -738,12 +737,8 @@ export async function requestLightningSend(
     secrets: SwapSecrets;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
-    const secrets = (await deriveSwapSecrets(wallet)) ?? randomSwapSecrets();
-    if (!secrets.derivable) {
-        console.warn(
-            "[swap] wallet cannot allocate an HD descriptor: the sender key is random and MUST be persisted before funding",
-        );
-    }
+    // No preimage on this corridor: a lightning send's P belongs to the payee.
+    const secrets = await deriveSwapSecrets(wallet);
     const senderPubkey = await senderPubkeyForRfqSecrets(wallet, secrets);
     const [info, refundAddress] = await Promise.all([
         new RestArkProvider(arkServerUrl).getInfo(),
@@ -1095,19 +1090,10 @@ export async function requestOnchainSend(
     if (params.preimage && params.preimage.length !== 32) {
         throw new Error(`preimage must be 32 bytes, got ${params.preimage.length}`);
     }
-    const derivedSecrets = await deriveSwapSecrets(wallet);
-    const secrets = derivedSecrets
-        ? params.preimage
-            ? { ...derivedSecrets, preimage: params.preimage }
-            : derivedSecrets
-        : randomSwapSecrets({ preimage: params.preimage ?? true });
-    if (!secrets.derivable) {
-        console.warn(
-            params.preimage
-                ? "[swap] this swap's sender key is random; the supplied preimage and sender key MUST be persisted before funding"
-                : "[swap] this swap's preimage and sender key are random and MUST be persisted before funding",
-        );
-    } else if (params.preimage) {
+    // `preimage: true` asks for one either way: derived on the allocated arm,
+    // generated per swap on the baseline arm, and a caller's own passed through.
+    const secrets = await deriveSwapSecrets(wallet, { preimage: params.preimage ?? true });
+    if (params.preimage) {
         console.warn(
             "[swap] this swap's preimage was supplied by the caller and MUST be persisted with the signing descriptor before funding",
         );
@@ -1515,12 +1501,7 @@ export async function requestLightningReceive(
     secrets: SwapSecrets;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
-    const secrets = (await deriveSwapSecrets(wallet)) ?? randomSwapSecrets({ preimage: true });
-    if (!secrets.derivable) {
-        console.warn(
-            "[swap] this swap's preimage and payout key are random and MUST be persisted before paying",
-        );
-    }
+    const secrets = await deriveSwapSecrets(wallet, { preimage: true });
     const preimage = await preimageForRfqSecrets(wallet, secrets);
     const paymentHash = paymentHashOf(preimage);
     const payoutPubkey = await senderPubkeyForRfqSecrets(wallet, secrets);
@@ -1723,12 +1704,7 @@ export async function requestOnchainReceive(
     secrets: SwapSecrets;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
-    const secrets = (await deriveSwapSecrets(wallet)) ?? randomSwapSecrets({ preimage: true });
-    if (!secrets.derivable) {
-        console.warn(
-            "[swap] this swap's preimage and payout key are random and MUST be persisted before funding",
-        );
-    }
+    const secrets = await deriveSwapSecrets(wallet, { preimage: true });
     const preimage = await preimageForRfqSecrets(wallet, secrets);
     const paymentHash = paymentHashOf(preimage);
     const payoutPubkey = await senderPubkeyForRfqSecrets(wallet, secrets);

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -735,6 +735,20 @@ export async function requestLightningSend(
     /** How the `sender` key is recovered later. Persist it with the record —
      * on the derivable arm it holds nothing secret. */
     secrets: SwapSecrets;
+    /**
+     * Every input the covenant was built from, as it was AT REQUEST TIME.
+     *
+     * Returned so a consumer can persist the swap without re-deriving any of
+     * it. Half of these are not on the quote — `serverPubkey` and `claimDelay`
+     * come from this wallet's own `getInfo()`, `emulatorPubkey` from a
+     * per-network pin, `refundPkScript` from decoding an address — so a
+     * consumer rebuilding them itself would need a second round trip and a copy
+     * of this function's logic, which would then drift.
+     *
+     * All public. Feed straight into `RfqSwapOrigin`; see `rfqRecord.ts` for
+     * why every one of them must be stored rather than re-read later.
+     */
+    treeParams: Parameters<typeof lightningSendVtxoScript>[0];
 }> {
     const rfqId = params.rfqId ?? newRfqId();
     // No preimage on this corridor: a lightning send's P belongs to the payee.
@@ -772,7 +786,9 @@ export async function requestLightningSend(
 
     const serverPubkey = xOnly(hex.decode(info.signerPubkey), "ark signer key");
     const network = getNetwork(info.network as NetworkName);
-    const script = lightningSendVtxoScript({
+    // Named rather than inlined so the exact inputs the covenant was built from
+    // can be returned to the caller — see `treeParams` on the return type.
+    const treeParams = {
         solverPubkey: xOnly(hex.decode(quote.solver_pubkey), "solver key"),
         refundLocktime: quote.refund_locktime,
         serverPubkey,
@@ -785,7 +801,8 @@ export async function requestLightningSend(
         senderPubkey,
         receiverPkScript: solverHex(receiverPkScriptHex, "profile.receiver_pk_script"),
         refundPkScript: ArkAddress.decode(refundAddress).pkScript,
-    });
+    };
+    const script = lightningSendVtxoScript(treeParams);
     const address = script.address(network.hrp, serverPubkey).encode();
     verifyLockupAddress(quote, address);
     assertFundable({
@@ -811,6 +828,7 @@ export async function requestLightningSend(
         refundAddress,
         senderPubkey,
         secrets,
+        treeParams,
     };
 }
 
@@ -1391,6 +1409,9 @@ export function deriveLightningReceive(input: {
     /** The solver's hold invoice on `H` — what the trader pays to arm the swap. */
     invoice: string;
     refundLocktime: number;
+    /** Every input the covenant was built from — see the same field on
+     * `requestLightningSend`'s result for why a consumer needs them. */
+    treeParams: Parameters<typeof receiveVtxoScript>[0];
 } {
     const { quote } = input;
     const profile = quote.profile ?? {};
@@ -1405,7 +1426,9 @@ export function deriveLightningReceive(input: {
         throw new Error("lightning-receive quote is missing a binding field");
     }
 
-    const script = receiveVtxoScript({
+    // Named rather than inlined so the exact inputs can be handed back — see
+    // `treeParams` on the return type.
+    const treeParams = {
         solverPubkey: xOnly(hex.decode(quote.solver_pubkey), "solver key"),
         refundLocktime,
         serverPubkey: input.serverPubkey,
@@ -1415,10 +1438,11 @@ export function deriveLightningReceive(input: {
         solverRefundPkScript: solverHex(solverRefundPkScriptHex, "profile.solver_refund_pk_script"),
         payoutPubkey: input.payoutPubkey,
         payoutPkScript: ArkAddress.decode(input.payoutAddress).pkScript,
-    });
+    };
+    const script = receiveVtxoScript(treeParams);
     const address = script.address(input.hrp, input.serverPubkey).encode();
     verifyLockupAddress(quote, address);
-    return { address, swapPkScript: script.pkScript, script, invoice, refundLocktime };
+    return { address, swapPkScript: script.pkScript, script, invoice, refundLocktime, treeParams };
 }
 
 /**
@@ -1499,6 +1523,9 @@ export async function requestLightningReceive(
     /** How the preimage and the payout key are recovered later. Persist it
      * with the record BEFORE paying the invoice. */
     secrets: SwapSecrets;
+    /** Every input the covenant was built from — see the same field on
+     * `requestLightningSend`'s result. */
+    treeParams: Parameters<typeof receiveVtxoScript>[0];
 }> {
     const rfqId = params.rfqId ?? newRfqId();
     const secrets = await deriveSwapSecrets(wallet, { preimage: true });
@@ -1570,6 +1597,7 @@ export async function requestLightningReceive(
         payoutAddress,
         payoutPubkey,
         secrets,
+        treeParams: derived.treeParams,
     };
 }
 

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -155,9 +155,28 @@ export function createRfqSwapRecord(origin: RfqSwapOrigin, swap: RfqSwap): RfqSw
     return { ...origin, ...managerState(swap) };
 }
 
-/** Every later write. The origin half is carried through untouched. */
+/**
+ * Every later write. The origin half is carried through untouched.
+ *
+ * The mutable half is REPLACED, not merged. `managerState` omits a key the live
+ * swap no longer carries, so spreading it over the old record could only ever
+ * set these fields, never clear them — and the manager clears them on purpose:
+ * it `delete`s `blockedReason` when a swap leaves `needs_counterparty`
+ * (`swapManager.ts`), precisely because "a stale `blockedReason` reads as a live
+ * refusal". Merging would persist a refusal for a swap that had recovered, and
+ * a reload would show it.
+ */
 export function updateRfqSwapRecord(record: RfqSwapRecord, swap: RfqSwap): RfqSwapRecord {
-    return { ...record, ...managerState(swap) };
+    // Dropped by name so adding a field to the mutable half is a compile error
+    // here rather than a value that silently survives forever.
+    const {
+        refundArkTxid: _refundArkTxid,
+        claimArkTxid: _claimArkTxid,
+        failure: _failure,
+        blockedReason: _blockedReason,
+        ...origin
+    } = record;
+    return { ...origin, ...managerState(swap) };
 }
 
 /** Names the missing field rather than letting `hex.decode(undefined)` throw

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -1,0 +1,243 @@
+/**
+ * The serializable projection of a monitored RFQ swap.
+ *
+ * {@link RfqSwap} is a live record, not a storage format: it holds derived
+ * `Uint8Array`s and a `VHTLC.ScriptV2` class instance, and IndexedDB's
+ * structured clone strips prototypes — a naive `store.put(swap)` round-trips a
+ * script object with no methods. So a consumer stores THIS and rebuilds the
+ * live record at boot.
+ *
+ * Two halves, because {@link RfqSwapManagerCallbacks.saveSwap} only ever sees
+ * an `RfqSwap` and that type carries none of the covenant's tree parameters:
+ *
+ * - {@link RfqSwapOrigin} — the immutable request-time facts, taken from the
+ *   entry point's own return value. Written once, by
+ *   {@link createRfqSwapRecord}.
+ * - the manager's mutable state, merged in by {@link updateRfqSwapRecord} on
+ *   every pass that changed something.
+ *
+ * **Every tree parameter is stored, including the ones that look re-readable
+ * from the live wallet.** `serverPubkey` and `claimDelay` are the trader's own
+ * *at request time*; a wallet later pointed at a different Arkade Service, or
+ * one whose server rotated its key, would rebuild a different covenant and lose
+ * the lockup. `emulatorPubkey` is resolved from a per-network pin the SDK can
+ * change between releases, for the same reason. Storing them all makes
+ * {@link rebuildRfqSwap} a pure function of the record — no wallet, no network,
+ * no ambient defaults — which is what lets a test prove a dropped field is a
+ * failure rather than a silent wrong address.
+ *
+ * **No record written here carries a private key.** The preimage is the only
+ * permitted secret at rest (see `secrets.ts`'s baseline arm);
+ * `fallbackSecrets` is read-only legacy so swaps persisted by earlier versions
+ * stay refundable.
+ */
+import { hex } from "@scure/base";
+import { lightningSendVtxoScript, receiveVtxoScript } from "./rfq";
+import type { AssetSwapFallbackSecrets } from "./store";
+import {
+    isRfqSwapTerminal,
+    type LightningReceiveSwap,
+    type LightningSendSwap,
+    type RfqSwap,
+    type RfqSwapState,
+} from "./swapManager";
+
+/**
+ * How long a retired swap's record is kept.
+ *
+ * Terminal records are history, not garbage: the covenant's spender is a
+ * transaction the wallet never signed, so its own history cannot reconstruct
+ * them. Kept for a month, then dropped so a hot wallet's store stays bounded.
+ */
+export const RFQ_SWAP_RETENTION_SECONDS = 30 * 24 * 60 * 60;
+
+/** The immutable request-time half. Hex for everything binary, so the record is
+ * plain JSON and survives any structured-clone backend unchanged. */
+export interface RfqSwapOrigin {
+    kind: "lightning_send" | "lightning_receive";
+
+    // ── Tree parameters shared by both legs ──────────────────────────────────
+    /** The solver's x-only key, from the quote. */
+    solverPubkey: string;
+    /** The covenant co-signer, from the SDK's per-network pin or an override. */
+    emulatorPubkey: string;
+    /** The Arkade Service's x-only key, as it was AT REQUEST TIME. */
+    serverPubkey: string;
+    /** `sha256(P)`, hex. */
+    paymentHash: string;
+    refundLocktime: number;
+    /** `unilateralClaimDelay` over the server info held at request time. */
+    claimDelay: number;
+
+    // ── Send-leg tree parameters ─────────────────────────────────────────────
+    /** VHTLC's `sender` — the trader's own key on this leg. */
+    senderPubkey?: string;
+    /** Where the refund leaf must pay. */
+    refundPkScript?: string;
+    /** The solver's claim destination, from `profile.receiver_pk_script`. */
+    receiverPkScript?: string;
+
+    // ── Receive-leg tree parameters ──────────────────────────────────────────
+    /** VHTLC's `receiver` — the trader's own key on this leg. */
+    payoutPubkey?: string;
+    /** `nonInteractiveClaim`'s pinned destination. */
+    payoutPkScript?: string;
+    /** From `profile.solver_refund_pk_script` — the one tree parameter nothing
+     * else on the wire determines. */
+    solverRefundPkScript?: string;
+    /** Where the claim pays; kept for display and for rebuilding the claim. */
+    payoutAddress?: string;
+    /**
+     * What the lockup must carry before the claim will publish `P`.
+     *
+     * Receive only, and **not re-derivable**: read at claim time it would be
+     * whatever the solver funded, which is the dust-funding attack rather than
+     * a check on it.
+     */
+    expectedAmount?: number;
+
+    // ── Secrets projection (see `rfqSecretsToRecord`) ────────────────────────
+    /** Public. Present on the HD-allocated arm. */
+    signingDescriptor?: string;
+    /** Present on the baseline arm: the covenant is bound to the wallet's own
+     * identity key. An explicit marker, not the absence of a descriptor. */
+    senderKey?: "baseline";
+    /** The only secret this record may hold. */
+    preimageHex?: string;
+    /** Public, and unwritten today — the slot a per-swap derivation index lands
+     * in (ts-sdk#737), so that change is a schema no-op. */
+    preimageIndex?: number;
+    /** Read-only legacy from records written before the baseline arm existed. */
+    fallbackSecrets?: AssetSwapFallbackSecrets;
+
+    // ── Lockup and display ───────────────────────────────────────────────────
+    /** The Arkade address that was actually funded. Taken, never re-derived:
+     * a local re-derivation would silently use the SDK's default network. */
+    lockupAddress: string;
+    /** Consumer display metadata. {@link rebuildRfqSwap} ignores it —
+     * `RfqSwapCommon` carries no amount of its own. */
+    amount?: number;
+}
+
+/** The stored record: the origin plus the manager's mutable state. */
+export interface RfqSwapRecord extends RfqSwapOrigin {
+    rfqId: string;
+    state: RfqSwapState;
+    createdAt: number;
+    updatedAt: number;
+    refundArkTxid?: string;
+    claimArkTxid?: string;
+    failure?: string;
+    blockedReason?: string;
+}
+
+/** The manager's mutable half, projected off a live record. */
+const managerState = (swap: RfqSwap) => ({
+    rfqId: swap.rfqId,
+    state: swap.state,
+    createdAt: swap.createdAt,
+    updatedAt: swap.updatedAt,
+    ...(swap.refundArkTxid ? { refundArkTxid: swap.refundArkTxid } : {}),
+    ...(swap.kind === "lightning_receive" && swap.claimArkTxid
+        ? { claimArkTxid: swap.claimArkTxid }
+        : {}),
+    ...(swap.failure ? { failure: swap.failure } : {}),
+    ...(swap.blockedReason ? { blockedReason: swap.blockedReason } : {}),
+});
+
+/** First write, at the moment the caller hands the swap to the manager. */
+export function createRfqSwapRecord(origin: RfqSwapOrigin, swap: RfqSwap): RfqSwapRecord {
+    return { ...origin, ...managerState(swap) };
+}
+
+/** Every later write. The origin half is carried through untouched. */
+export function updateRfqSwapRecord(record: RfqSwapRecord, swap: RfqSwap): RfqSwapRecord {
+    return { ...record, ...managerState(swap) };
+}
+
+/** Names the missing field rather than letting `hex.decode(undefined)` throw
+ * something that does not say which parameter was lost. */
+function required<T>(value: T | undefined, name: string): T {
+    if (value === undefined) {
+        throw new Error(`rfq swap record is missing ${name}; its covenant cannot be rebuilt`);
+    }
+    return value;
+}
+
+const bytes = (value: string | undefined, name: string): Uint8Array =>
+    hex.decode(required(value, name));
+
+/**
+ * Rebuild the live record. Pure: everything it needs is on the record.
+ *
+ * Hand the result to {@link RfqSwapManager.start}. The covenant is rebuilt the
+ * way it was made — the same builder over the same binding fields — so the
+ * `lockupPkScript` it produces is the one the funded lockup is keyed by.
+ */
+export function rebuildRfqSwap(record: RfqSwapRecord): RfqSwap {
+    const script =
+        record.kind === "lightning_send"
+            ? lightningSendVtxoScript({
+                  solverPubkey: bytes(record.solverPubkey, "solverPubkey"),
+                  refundLocktime: record.refundLocktime,
+                  serverPubkey: bytes(record.serverPubkey, "serverPubkey"),
+                  paymentHash: record.paymentHash,
+                  claimDelay: record.claimDelay,
+                  emulatorPubkey: bytes(record.emulatorPubkey, "emulatorPubkey"),
+                  refundPkScript: bytes(record.refundPkScript, "refundPkScript"),
+                  senderPubkey: bytes(record.senderPubkey, "senderPubkey"),
+                  receiverPkScript: bytes(record.receiverPkScript, "receiverPkScript"),
+              })
+            : receiveVtxoScript({
+                  solverPubkey: bytes(record.solverPubkey, "solverPubkey"),
+                  refundLocktime: record.refundLocktime,
+                  serverPubkey: bytes(record.serverPubkey, "serverPubkey"),
+                  paymentHash: record.paymentHash,
+                  claimDelay: record.claimDelay,
+                  emulatorPubkey: bytes(record.emulatorPubkey, "emulatorPubkey"),
+                  solverRefundPkScript: bytes(record.solverRefundPkScript, "solverRefundPkScript"),
+                  payoutPubkey: bytes(record.payoutPubkey, "payoutPubkey"),
+                  payoutPkScript: bytes(record.payoutPkScript, "payoutPkScript"),
+              });
+
+    const common = {
+        rfqId: record.rfqId,
+        state: record.state,
+        lockupPkScript: script.pkScript,
+        lockup: { script, address: record.lockupAddress },
+        paymentHash: record.paymentHash,
+        refundLocktime: record.refundLocktime,
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+        ...(record.refundArkTxid ? { refundArkTxid: record.refundArkTxid } : {}),
+        ...(record.failure ? { failure: record.failure } : {}),
+        ...(record.blockedReason ? { blockedReason: record.blockedReason } : {}),
+    };
+
+    if (record.kind === "lightning_send") {
+        return { ...common, kind: "lightning_send" } satisfies LightningSendSwap;
+    }
+    return {
+        ...common,
+        kind: "lightning_receive",
+        // Required, not defaulted: the manager reports `needs_counterparty`
+        // rather than claiming when this is not a finite number, and a
+        // comparison against `undefined` would delete the value gate instead of
+        // failing it.
+        expectedAmount: required(record.expectedAmount, "expectedAmount"),
+        ...(record.claimArkTxid ? { claimArkTxid: record.claimArkTxid } : {}),
+    } satisfies LightningReceiveSwap;
+}
+
+/**
+ * Whether a retired swap's record should be kept.
+ *
+ * `needs_counterparty` is deliberately not terminal and is never dropped: the
+ * money is still at the lockup, the counterparty's move is still what ends the
+ * swap, and the refusal is re-checked every pass — restoring the right wallet
+ * returns it to `pending`.
+ */
+export function shouldRetainRfqSwap(record: RfqSwapRecord, now: number): boolean {
+    if (!isRfqSwapTerminal(record.state)) return true;
+    return now - record.updatedAt < RFQ_SWAP_RETENTION_SECONDS;
+}

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -43,11 +43,16 @@ import {
 } from "./swapManager";
 
 /**
- * How long a retired swap's record is kept.
+ * How long a retired swap's record is kept, in SECONDS.
  *
  * Terminal records are history, not garbage: the covenant's spender is a
  * transaction the wallet never signed, so its own history cannot reconstruct
  * them. Kept for a month, then dropped so a hot wallet's store stays bounded.
+ *
+ * Seconds, not milliseconds, because that is the unit `RfqSwap.updatedAt`
+ * carries — the manager stamps it from `RfqSwapManagerConfig.now`, which is
+ * "wall clock, in unix seconds". Comparing it against `Date.now()` would drop
+ * every terminal record after ~43 minutes.
  */
 export const RFQ_SWAP_RETENTION_SECONDS = 30 * 24 * 60 * 60;
 
@@ -236,6 +241,12 @@ export function rebuildRfqSwap(record: RfqSwapRecord): RfqSwap {
  * money is still at the lockup, the counterparty's move is still what ends the
  * swap, and the refusal is re-checked every pass — restoring the right wallet
  * returns it to `pending`.
+ *
+ * @param now Current time in **unix seconds** — the same unit as
+ * `RfqSwap.updatedAt`, which the manager stamps from
+ * `RfqSwapManagerConfig.now`. Pass `Math.floor(Date.now() / 1000)`, never
+ * `Date.now()`: milliseconds against a seconds window would retire every
+ * terminal record after ~43 minutes.
  */
 export function shouldRetainRfqSwap(record: RfqSwapRecord, now: number): boolean {
     if (!isRfqSwapTerminal(record.state)) return true;

--- a/packages/swap/src/secrets.ts
+++ b/packages/swap/src/secrets.ts
@@ -134,9 +134,16 @@ export interface StoredSwapSecrets {
  */
 export type SwapSecrets = DerivedSwapSecrets | BaselineSwapSecrets | StoredSwapSecrets;
 
-/** Narrow the two `derivable: true` arms apart. */
+/**
+ * Narrow the two `derivable: true` arms apart.
+ *
+ * Checks the VALUE, not the property's presence. `"baseline" in secrets` would
+ * accept `{ baseline: false }` — which the types forbid but a deserialized
+ * record does not, and misclassifying there would sign with the wallet's own
+ * key for a swap whose covenant was never bound to it.
+ */
 export const isBaselineSwapSecrets = (secrets: SwapSecrets): secrets is BaselineSwapSecrets =>
-    secrets.derivable && "baseline" in secrets;
+    secrets.derivable && (secrets as BaselineSwapSecrets).baseline === true;
 
 /**
  * The secrets for one swap. Never mints a signing key.

--- a/packages/swap/src/secrets.ts
+++ b/packages/swap/src/secrets.ts
@@ -7,9 +7,16 @@
  * copied profile or a device backup yields nothing spendable and a wallet with
  * the seed can re-derive everything.
  *
- * Wallets that cannot allocate (static / `auto` / custom signers) get the
- * fallback arm instead, which carries real secrets the caller must store. That
- * arm is built by the caller, never in here: a restore probing for a derived
+ * Wallets that cannot allocate (static / `auto` / custom signers) bind the
+ * covenant to their OWN identity key instead — the baseline arm, modelled on
+ * boltz-swap's `swapSigner`. **No signing key is ever minted here.** The one
+ * secret that arm persists is the preimage, and only because the baseline key
+ * repeats across swaps: deriving at the pinned index would hand every swap the
+ * same P, and one solver learning its own would learn the next swap's.
+ *
+ * The older fallback arm, which minted a key and stored it as plaintext hex, is
+ * read-only legacy so swaps persisted by earlier versions stay refundable. It
+ * is still built by the caller, never in here: a restore probing for a derived
  * preimage must be able to come back empty rather than be handed a fresh
  * random one that will never match the chain.
  */
@@ -76,7 +83,43 @@ export interface DerivedSwapSecrets {
     preimage?: Uint8Array;
 }
 
-/** The wallet could not allocate. These are real secrets — persist them. */
+/**
+ * The wallet's own identity key, bound deliberately at creation.
+ *
+ * What a wallet that cannot allocate a descriptor gets. Modelled on
+ * boltz-swap's `swapSigner`, which falls back to `this.wallet.identity` rather
+ * than minting a key: a wallet without HD state still HAS a key, and the
+ * covenant can simply be bound to it.
+ *
+ * Nothing signing-related is at rest — the wallet already holds this key, so a
+ * record carries only the fact that this arm was used.
+ *
+ * One thing it does NOT inherit from the derived arm: the baseline key is the
+ * same for every swap, so the pinned-index preimage derivation would repeat
+ * itself. {@link deriveSwapSecrets} generates {@link preimage} per swap
+ * instead, and it is the only secret this arm persists.
+ *
+ * The privacy cost is real and accepted, as it is in boltz-swap: every swap on
+ * such a wallet shares one sender pubkey and is linkable by it. A minted key
+ * gave a fresh one per swap, at the price of a plaintext private key on disk.
+ */
+export interface BaselineSwapSecrets {
+    derivable: true;
+    /** Discriminates this arm from {@link DerivedSwapSecrets}. */
+    baseline: true;
+    /** Per-swap, because the key repeats. Absent when none was asked for — a
+     * lightning send's preimage belongs to the payee. */
+    preimage?: Uint8Array;
+}
+
+/**
+ * The wallet could not allocate. These are real secrets — persist them.
+ *
+ * **Legacy: read, never written.** {@link deriveSwapSecrets} returns
+ * {@link BaselineSwapSecrets} where it used to fall through to
+ * {@link randomSwapSecrets}. Kept so swaps persisted by earlier versions stay
+ * refundable.
+ */
 export interface StoredSwapSecrets {
     derivable: false;
     senderPrivateKey: Uint8Array;
@@ -89,27 +132,61 @@ export interface StoredSwapSecrets {
  * type-level fact: a consumer written against {@link DerivedSwapSecrets} alone
  * fails to compile when handed the stored arm.
  */
-export type SwapSecrets = DerivedSwapSecrets | StoredSwapSecrets;
+export type SwapSecrets = DerivedSwapSecrets | BaselineSwapSecrets | StoredSwapSecrets;
+
+/** Narrow the two `derivable: true` arms apart. */
+export const isBaselineSwapSecrets = (secrets: SwapSecrets): secrets is BaselineSwapSecrets =>
+    secrets.derivable && "baseline" in secrets;
 
 /**
- * Allocate a descriptor for one swap, or `undefined` when the wallet cannot.
+ * The secrets for one swap. Never mints a signing key.
  *
- * Allocates — never peeks. `getCurrentSigningDescriptor` returns the same
- * descriptor until the wallet rotates, and two swaps sharing a descriptor
- * derive the *identical* preimage, so one solver learning its own preimage
- * would learn the other swap's.
+ * Two arms, decided by whether the wallet can allocate a descriptor:
+ *
+ * - **Allocated** ({@link DerivedSwapSecrets}). Allocates — never peeks.
+ *   `getCurrentSigningDescriptor` returns the same descriptor until the wallet
+ *   rotates, and two swaps sharing a descriptor derive the *identical*
+ *   preimage, so one solver learning its own preimage would learn the other
+ *   swap's. A fresh descriptor per swap is exactly what lets
+ *   {@link derivePreimage} pin its message index.
+ * - **Baseline** ({@link BaselineSwapSecrets}). The wallet's own identity key,
+ *   as boltz-swap's `swapSigner` does. Because that key repeats, `opts.preimage`
+ *   is honoured by GENERATING one per swap rather than deriving it — deriving
+ *   would hand every swap the same P.
  *
  * Cost of allocating: the index is consumed even when the quote is later
  * refused, and a swap index never turns into a funded receive contract, so a
  * long run of swaps widens the "unused" gap a seed-only `restore()` scan sees
  * (see the README's gap-limit note). Restores that keep the swap repository
  * are unaffected — `adoptSwapDescriptor` re-claims each record's index.
+ *
+ * `undefined` is no longer returned: every wallet has one arm or the other.
  */
-export async function deriveSwapSecrets(wallet: IWallet): Promise<DerivedSwapSecrets | undefined> {
-    if (!isHDAllocationCapable(wallet)) return undefined;
-    const signingDescriptor = await wallet.getNextSigningDescriptor();
-    if (!signingDescriptor) return undefined;
-    return { derivable: true, signingDescriptor };
+export async function deriveSwapSecrets(
+    wallet: IWallet,
+    opts: { preimage?: boolean | Uint8Array } = {},
+): Promise<DerivedSwapSecrets | BaselineSwapSecrets> {
+    const supplied = opts.preimage instanceof Uint8Array ? opts.preimage : undefined;
+    if (supplied && supplied.length !== 32) {
+        // The HTLC claim leaf pins OP_SIZE 32: any other length is unclaimable.
+        throw new Error(`preimage must be 32 bytes, got ${supplied.length}`);
+    }
+
+    const signingDescriptor = isHDAllocationCapable(wallet)
+        ? await wallet.getNextSigningDescriptor()
+        : undefined;
+
+    if (signingDescriptor) {
+        // Fresh per swap, so the preimage derives; only a caller-supplied one
+        // is carried explicitly.
+        return { derivable: true, signingDescriptor, ...(supplied ? { preimage: supplied } : {}) };
+    }
+
+    return {
+        derivable: true,
+        baseline: true,
+        ...(supplied ? { preimage: supplied } : opts.preimage ? { preimage: randomBytes(32) } : {}),
+    };
 }
 
 /**
@@ -144,9 +221,20 @@ export function randomSwapSecrets(
  */
 export function rfqSecretsToRecord(secrets: SwapSecrets): {
     signingDescriptor?: string;
+    senderKey?: "baseline";
     preimageHex?: string;
     fallbackSecrets?: AssetSwapFallbackSecrets;
 } {
+    if (isBaselineSwapSecrets(secrets)) {
+        // An explicit marker, not the ABSENCE of a descriptor: a record with
+        // neither descriptor nor marker is one whose arm was never recorded,
+        // and `rfqSecretsOfRecord` must be able to refuse it rather than
+        // guessing that the baseline key was meant.
+        return {
+            senderKey: "baseline",
+            ...(secrets.preimage ? { preimageHex: hex.encode(secrets.preimage) } : {}),
+        };
+    }
     if (secrets.derivable) {
         return {
             signingDescriptor: secrets.signingDescriptor,
@@ -165,9 +253,19 @@ export function rfqSecretsToRecord(secrets: SwapSecrets): {
 
 export function rfqSecretsOfRecord(record: {
     signingDescriptor?: string;
+    senderKey?: "baseline";
     preimageHex?: string;
     fallbackSecrets?: AssetSwapFallbackSecrets;
 }): SwapSecrets | undefined {
+    if (record.senderKey === "baseline") {
+        return {
+            derivable: true,
+            baseline: true,
+            ...(record.preimageHex
+                ? { preimage: decodeHex32(record.preimageHex, "preimageHex") }
+                : {}),
+        };
+    }
     if (record.signingDescriptor) {
         return {
             derivable: true,
@@ -260,6 +358,11 @@ export async function senderIdentityForRfqSecrets(
     secrets: SwapSecrets,
 ): Promise<Identity> {
     if (!secrets.derivable) return SingleKey.fromPrivateKey(secrets.senderPrivateKey);
+    // The baseline arm is the one case where the plain wallet identity is the
+    // RIGHT key rather than a silent substitution: the covenant was bound to it
+    // at creation. The guard below exists for the opposite case — a descriptor
+    // this wallet cannot derive — and must not swallow this one.
+    if (isBaselineSwapSecrets(secrets)) return wallet.identity;
     const signer = isHDWalletCapable(wallet)
         ? await wallet.signerForDescriptor(secrets.signingDescriptor)
         : undefined;
@@ -368,6 +471,13 @@ export async function preimageForRfqSecrets(
         return secrets.preimage;
     }
     if (secrets.preimage) return secrets.preimage;
+    if (isBaselineSwapSecrets(secrets)) {
+        // Never derived on this arm: the baseline key repeats, so a derivation
+        // would return the same P for every swap. One was generated at request
+        // time or this swap never had one (a lightning send, whose P is the
+        // payee's).
+        throw new Error("this swap carries no stored preimage");
+    }
     const signer = await senderIdentityForRfqSecrets(wallet, secrets);
     if (!isDeterministicSigner(signer)) {
         // Loud: a preimage from a random-aux signature is unrecoverable, and

--- a/packages/swap/test/repository.test.ts
+++ b/packages/swap/test/repository.test.ts
@@ -1,8 +1,28 @@
 import "fake-indexeddb/auto";
 import { describe, expect, it } from "vitest";
 import type { AssetSwap } from "../src/store";
+import type { RfqSwapRecord } from "../src/rfqRecord";
 import { AssetSwapRepository, InMemoryAssetSwapRepository } from "../src/repository";
 import { IndexedDbAssetSwapRepository } from "../src/indexedDbRepository";
+
+const rfqRecord = (rfqId: string): RfqSwapRecord => ({
+    rfqId,
+    kind: "lightning_send",
+    state: "pending",
+    solverPubkey: "a1".repeat(32),
+    emulatorPubkey: "b2".repeat(32),
+    serverPubkey: "c3".repeat(32),
+    paymentHash: "d4".repeat(32),
+    refundLocktime: 1_900_000_000,
+    claimDelay: 4096,
+    senderPubkey: "a7".repeat(32),
+    refundPkScript: "5120" + "e5".repeat(32),
+    receiverPkScript: "5120" + "f6".repeat(32),
+    signingDescriptor: `tr(${"a7".repeat(32)})`,
+    lockupAddress: "tark1qlockup",
+    createdAt: 1,
+    updatedAt: 1,
+});
 
 const swap = (id: string, createdAt = 1): AssetSwap => ({
     id,
@@ -51,5 +71,107 @@ describe.each(backends)("AssetSwapRepository (%s)", (_, create) => {
         await repository.clear();
         expect(await repository.getAllSwaps()).toEqual([]);
         expect(await repository.getScannedTxids()).toEqual(new Set());
+    });
+
+    it("upserts rfq swaps by rfqId and returns them all", async () => {
+        await using repository = create();
+        await repository.saveRfqSwap(rfqRecord("r1"));
+        await repository.saveRfqSwap(rfqRecord("r2"));
+        await repository.saveRfqSwap({ ...rfqRecord("r1"), state: "settled" });
+        const records = await repository.getAllRfqSwaps();
+        expect(records).toHaveLength(2);
+        expect(records.find((r) => r.rfqId === "r1")?.state).toBe("settled");
+    });
+
+    it("stores the record whole, so the rebuild's tree parameters survive", async () => {
+        // A field-mapped backend that dropped one of these would round-trip a
+        // record whose covenant cannot be rebuilt — and nothing would say so
+        // until a refund was due.
+        await using repository = create();
+        const record = rfqRecord("r1");
+        await repository.saveRfqSwap(record);
+        const [restored] = await repository.getAllRfqSwaps();
+        expect(restored).toEqual(record);
+    });
+
+    it("removes an rfq swap by id and leaves the others", async () => {
+        await using repository = create();
+        await repository.saveRfqSwap(rfqRecord("r1"));
+        await repository.saveRfqSwap(rfqRecord("r2"));
+        await repository.removeRfqSwap("r1");
+        expect((await repository.getAllRfqSwaps()).map((r) => r.rfqId)).toEqual(["r2"]);
+    });
+
+    it("keeps rfq swaps and asset swaps in separate stores", async () => {
+        await using repository = create();
+        await repository.saveSwap(swap("a"));
+        await repository.saveRfqSwap(rfqRecord("a"));
+        // same key, different kind of record: neither may shadow the other
+        expect(await repository.getAllSwaps()).toHaveLength(1);
+        expect(await repository.getAllRfqSwaps()).toHaveLength(1);
+        expect((await repository.getAllSwaps())[0].id).toBe("a");
+        expect((await repository.getAllRfqSwaps())[0].rfqId).toBe("a");
+    });
+
+    it("clears rfq swaps along with everything else", async () => {
+        // A partial wipe is what the clear-all transaction exists to prevent.
+        await using repository = create();
+        await repository.saveRfqSwap(rfqRecord("r1"));
+        await repository.saveSwap(swap("a"));
+        await repository.markTxidsScanned(["t1"]);
+        await repository.clear();
+        expect(await repository.getAllRfqSwaps()).toEqual([]);
+        expect(await repository.getAllSwaps()).toEqual([]);
+        expect(await repository.getScannedTxids()).toEqual(new Set());
+    });
+});
+
+/**
+ * The riskiest claim in this change: the version bump runs against databases
+ * that already hold real swaps. `initDatabase`'s contains-guard makes adding a
+ * store idempotent, but only `onupgradeneeded` runs it, and that fires on a
+ * version *increase* — so the bump is what makes the new store exist at all for
+ * an existing user, and the existing stores must come through untouched.
+ */
+describe("IndexedDB v1 -> v2 migration", () => {
+    it("adds the rfqSwaps store while keeping swaps, scan state and markets", async () => {
+        const dbName = `migrate-${Math.random()}`;
+        const markets = { markets: [], fetchedAt: 42 };
+
+        // Seed a v1-shaped database: the three original stores, version 1.
+        await new Promise<void>((resolve, reject) => {
+            const open = indexedDB.open(dbName, 1);
+            open.onupgradeneeded = () => {
+                const db = open.result;
+                db.createObjectStore("swaps", { keyPath: "id" });
+                db.createObjectStore("scannedTxids");
+                db.createObjectStore("markets");
+            };
+            open.onsuccess = () => {
+                const db = open.result;
+                const tx = db.transaction(["swaps", "scannedTxids", "markets"], "readwrite");
+                tx.objectStore("swaps").put(swap("legacy"));
+                tx.objectStore("scannedTxids").put("t1", "t1");
+                tx.objectStore("markets").put(markets, "arkade-intents-markets-regtest-http://r");
+                tx.oncomplete = () => {
+                    db.close();
+                    resolve();
+                };
+                tx.onerror = () => reject(tx.error);
+            };
+            open.onerror = () => reject(open.error);
+        });
+
+        // Open at v2 through the repository: onupgradeneeded must add only the
+        // new store and leave the existing three alone.
+        await using repository = new IndexedDbAssetSwapRepository(dbName);
+        expect((await repository.getAllSwaps()).map((s) => s.id)).toEqual(["legacy"]);
+        expect(await repository.getScannedTxids()).toEqual(new Set(["t1"]));
+        expect(await repository.getCachedMarkets("regtest", "http://r")).toEqual(markets);
+        expect(await repository.getAllRfqSwaps()).toEqual([]);
+
+        // and the new store is usable immediately, not only after a reopen
+        await repository.saveRfqSwap(rfqRecord("r1"));
+        expect(await repository.getAllRfqSwaps()).toHaveLength(1);
     });
 });

--- a/packages/swap/test/rfqDerivedSecrets.test.ts
+++ b/packages/swap/test/rfqDerivedSecrets.test.ts
@@ -264,6 +264,47 @@ describe("requestLightningSend and the corridor spread", () => {
         ).rejects.toThrow(/below the invoice amount/);
     });
 });
+/**
+ * The loop a persisting consumer depends on: what the entry point hands back
+ * must rebuild the very covenant it just funded. Without it a consumer would
+ * re-fetch `getInfo()` and re-derive the tree itself, and any drift between the
+ * two derivations is a lockup nobody can spend.
+ */
+describe("treeParams round-trips to the funded script", () => {
+    it.each([
+        ["hd", async () => await hdWallet()],
+        ["static", async () => staticWallet()],
+    ] as const)("on a %s wallet", async (_kind, makeWallet) => {
+        const result = await requestLightningSend(
+            await makeWallet(),
+            "http://ark",
+            lightningTransport(),
+            { invoice: INVOICE, emulatorPubkey: EMULATOR_PUBKEY_HEX },
+        );
+
+        const rebuilt = lightningSendVtxoScript(result.treeParams);
+        expect(hex.encode(rebuilt.pkScript)).toBe(hex.encode(result.swapPkScript));
+        expect(hex.encode(rebuilt.pkScript)).toBe(hex.encode(result.script.pkScript));
+    });
+
+    it("carries the inputs no quote and no second round trip could supply", async () => {
+        const result = await requestLightningSend(
+            staticWallet(),
+            "http://ark",
+            lightningTransport(),
+            { invoice: INVOICE, emulatorPubkey: EMULATOR_PUBKEY_HEX },
+        );
+        // serverPubkey and claimDelay come from this wallet's own getInfo(),
+        // emulatorPubkey from a per-network pin, refundPkScript from decoding an
+        // address. None of them is on the quote.
+        expect(result.treeParams.serverPubkey).toHaveLength(32);
+        expect(result.treeParams.emulatorPubkey).toHaveLength(32);
+        expect(result.treeParams.claimDelay % 512).toBe(0);
+        expect(result.treeParams.refundPkScript.length).toBeGreaterThan(0);
+        expect(result.treeParams.paymentHash).toBe(INVOICE.paymentHash);
+    });
+});
+
 describe("requestLightningSend on an HD wallet", () => {
     it("returns a descriptor and no key material", async () => {
         const wallet = await hdWallet();

--- a/packages/swap/test/rfqDerivedSecrets.test.ts
+++ b/packages/swap/test/rfqDerivedSecrets.test.ts
@@ -353,7 +353,13 @@ describe("requestOnchainSend on an HD wallet", () => {
         }
     });
 
-    it("warns and returns raw fallback secrets when allocation is unavailable", async () => {
+    /**
+     * Was "warns and returns raw fallback secrets when allocation is
+     * unavailable". That arm is gone: a wallet that cannot allocate now binds
+     * the covenant to its OWN identity rather than to a minted key, so there is
+     * no raw private key to return and nothing to warn about.
+     */
+    it("binds to the wallet's own key when allocation is unavailable, minting nothing", async () => {
         const wallet = staticWallet();
         const preimage = new Uint8Array(32).fill(8);
         const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -366,13 +372,17 @@ describe("requestOnchainSend on an HD wallet", () => {
                 preimage,
             });
 
-            expect(result.secrets.derivable).toBe(false);
-            if (result.secrets.derivable) throw new Error("expected stored secrets");
-            expect(result.secrets.senderPrivateKey).toBeInstanceOf(Uint8Array);
+            expect(result.secrets.derivable).toBe(true);
+            expect(result.secrets).not.toHaveProperty("senderPrivateKey");
+            // the covenant's sender IS the wallet's identity
+            expect(hex.encode(result.senderPubkey)).toBe(
+                hex.encode(await wallet.identity.xOnlyPublicKey()),
+            );
+            // a caller-supplied preimage still rides through untouched
             expect(result.secrets.preimage).toEqual(preimage);
             expect(await preimageForRfqSecrets(wallet, result.secrets)).toEqual(preimage);
-            expect(warn).toHaveBeenCalledWith(expect.stringContaining("sender key is random"));
-            expect(warn.mock.calls.join("\n")).not.toContain("preimage and sender key are random");
+            // nothing to warn about any more: no random key was created
+            expect(warn.mock.calls.join("\n")).not.toContain("random");
         } finally {
             warn.mockRestore();
         }

--- a/packages/swap/test/rfqDerivedSecrets.test.ts
+++ b/packages/swap/test/rfqDerivedSecrets.test.ts
@@ -45,7 +45,7 @@ import {
     type RfqTransport,
 } from "../src/rfq";
 import { onchainHtlcScript, paymentHashOf } from "../src/onchainHtlc";
-import { preimageForRfqSecrets } from "../src/secrets";
+import { isBaselineSwapSecrets, preimageForRfqSecrets } from "../src/secrets";
 
 const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
 const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
@@ -386,9 +386,18 @@ describe("requestOnchainSend on an HD wallet", () => {
             expect(result.secrets.preimage).toEqual(preimage);
             expect(await preimageForRfqSecrets(wallet, result.secrets)).toEqual(preimage);
 
+            // Narrowed, not asserted: only the allocated arm carries a
+            // descriptor, and an HD wallet must be on that arm here.
+            if (isBaselineSwapSecrets(result.secrets)) {
+                throw new Error("expected the allocated arm on an HD wallet");
+            }
             const signer = await wallet.signerForDescriptor!(result.secrets.signingDescriptor);
             expect(hex.encode(result.senderPubkey)).toBe(hex.encode(await signer.xOnlyPublicKey()));
-            expect(warn).toHaveBeenCalledWith(expect.stringContaining("supplied by the caller"));
+            // The warning now names the property that matters — the preimage is
+            // not derivable — rather than how it got here. It covers the
+            // baseline arm's generated preimage too, which has the same
+            // persistence obligation and used to be silent.
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining("not derivable"));
         } finally {
             warn.mockRestore();
         }
@@ -422,8 +431,10 @@ describe("requestOnchainSend on an HD wallet", () => {
             // a caller-supplied preimage still rides through untouched
             expect(result.secrets.preimage).toEqual(preimage);
             expect(await preimageForRfqSecrets(wallet, result.secrets)).toEqual(preimage);
-            // nothing to warn about any more: no random key was created
+            // no random KEY was created, so nothing warns about one; the
+            // generated preimage does warn, because it must be persisted
             expect(warn.mock.calls.join("\n")).not.toContain("random");
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining("not derivable"));
         } finally {
             warn.mockRestore();
         }

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -1,0 +1,234 @@
+/**
+ * The projection exists because `RfqSwap` is a live record, not a storage
+ * format: it holds derived `Uint8Array`s and a `VHTLC.ScriptV2` class instance,
+ * and IndexedDB's structured clone strips prototypes.
+ *
+ * The property worth testing is that the rebuild is a PURE function of the
+ * record — no wallet, no network, no ambient defaults. That is what makes a
+ * dropped tree parameter a test failure instead of a covenant nobody can spend.
+ */
+import { describe, expect, it } from "vitest";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import {
+    RFQ_SWAP_RETENTION_SECONDS,
+    createRfqSwapRecord,
+    rebuildRfqSwap,
+    shouldRetainRfqSwap,
+    updateRfqSwapRecord,
+    type RfqSwapOrigin,
+    type RfqSwapRecord,
+} from "../src/rfqRecord";
+import type { LightningReceiveSwap, LightningSendSwap, RfqSwapState } from "../src/swapManager";
+
+const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
+const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+
+const REFUND_LOCKTIME = 1_900_000_000;
+// BIP68 encodes second-based relative timelocks in 512s units, and the refund
+// tiers stack +512 / +1024 on top, so every value here must be a multiple of
+// 512 — the same 4096 the rest of the suite uses.
+const CLAIM_DELAY = 4096;
+const PAYMENT_HASH = "d4".repeat(32);
+
+const sendOrigin: RfqSwapOrigin = {
+    kind: "lightning_send",
+    solverPubkey: hex.encode(key(1)),
+    emulatorPubkey: hex.encode(key(9)),
+    serverPubkey: hex.encode(key(3)),
+    paymentHash: PAYMENT_HASH,
+    refundLocktime: REFUND_LOCKTIME,
+    claimDelay: CLAIM_DELAY,
+    senderPubkey: hex.encode(key(7)),
+    refundPkScript: hex.encode(p2tr(key(21))),
+    receiverPkScript: hex.encode(p2tr(key(1))),
+    signingDescriptor: `tr(${hex.encode(key(7))})`,
+    lockupAddress: "tark1qsendlockup",
+    amount: 25_000,
+};
+
+const receiveOrigin: RfqSwapOrigin = {
+    kind: "lightning_receive",
+    solverPubkey: hex.encode(key(1)),
+    emulatorPubkey: hex.encode(key(9)),
+    serverPubkey: hex.encode(key(3)),
+    paymentHash: PAYMENT_HASH,
+    refundLocktime: REFUND_LOCKTIME,
+    claimDelay: CLAIM_DELAY,
+    payoutPubkey: hex.encode(key(15)),
+    payoutPkScript: hex.encode(p2tr(key(15))),
+    solverRefundPkScript: hex.encode(p2tr(key(2))),
+    payoutAddress: "tark1qpayout",
+    expectedAmount: 20_000,
+    senderKey: "baseline",
+    preimageHex: "ee".repeat(32),
+    lockupAddress: "tark1qreceivelockup",
+    amount: 20_400,
+};
+
+const swapOf = (
+    origin: RfqSwapOrigin,
+    state: RfqSwapState = "pending",
+): LightningSendSwap | LightningReceiveSwap => {
+    const common = {
+        rfqId: "rfq-1",
+        state,
+        lockupPkScript: p2tr(key(11)),
+        paymentHash: origin.paymentHash,
+        refundLocktime: origin.refundLocktime,
+        createdAt: 1_000,
+        updatedAt: 1_000,
+    };
+    return origin.kind === "lightning_send"
+        ? ({ ...common, kind: "lightning_send" } as LightningSendSwap)
+        : ({
+              ...common,
+              kind: "lightning_receive",
+              expectedAmount: origin.expectedAmount!,
+          } as LightningReceiveSwap);
+};
+
+describe("rebuildRfqSwap", () => {
+    it.each([
+        ["lightning_send", sendOrigin],
+        ["lightning_receive", receiveOrigin],
+    ] as const)("rebuilds %s with no wallet and no network", (kind, origin) => {
+        const record = createRfqSwapRecord(origin, swapOf(origin));
+        const rebuilt = rebuildRfqSwap(record);
+
+        expect(rebuilt.kind).toBe(kind);
+        expect(rebuilt.rfqId).toBe("rfq-1");
+        // the covenant itself, not a copy of the stored bytes
+        expect(rebuilt.lockup?.script).toBeDefined();
+        expect(hex.encode(rebuilt.lockupPkScript)).toBe(
+            hex.encode(rebuilt.lockup!.script.pkScript),
+        );
+        expect(rebuilt.lockup?.address).toBe(origin.lockupAddress);
+    });
+
+    it("is deterministic — the same record rebuilds the same covenant", () => {
+        const record = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin));
+        expect(hex.encode(rebuildRfqSwap(record).lockupPkScript)).toBe(
+            hex.encode(rebuildRfqSwap(record).lockupPkScript),
+        );
+    });
+
+    it("changes the covenant when any tree parameter changes", () => {
+        // The guard against a projection that silently drops a field: if a
+        // parameter did not reach the script, mutating it would be a no-op.
+        const base = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin));
+        const baseline = hex.encode(rebuildRfqSwap(base).lockupPkScript);
+
+        const mutations: Partial<RfqSwapRecord>[] = [
+            { solverPubkey: hex.encode(key(2)) },
+            { emulatorPubkey: hex.encode(key(8)) },
+            { serverPubkey: hex.encode(key(4)) },
+            { paymentHash: "aa".repeat(32) },
+            { refundLocktime: REFUND_LOCKTIME + 1 },
+            // one granularity step, so the mutated value stays encodable
+            { claimDelay: CLAIM_DELAY + 512 },
+            { senderPubkey: hex.encode(key(6)) },
+            { refundPkScript: hex.encode(p2tr(key(22))) },
+            { receiverPkScript: hex.encode(p2tr(key(5))) },
+        ];
+        for (const mutation of mutations) {
+            const changed = hex.encode(rebuildRfqSwap({ ...base, ...mutation }).lockupPkScript);
+            expect(
+                changed,
+                `mutating ${Object.keys(mutation)[0]} did not reach the script`,
+            ).not.toBe(baseline);
+        }
+    });
+
+    it("carries the receive leg's expectedAmount, which is not re-derivable", () => {
+        const record = createRfqSwapRecord(receiveOrigin, swapOf(receiveOrigin));
+        const rebuilt = rebuildRfqSwap(record) as LightningReceiveSwap;
+        expect(rebuilt.expectedAmount).toBe(20_000);
+    });
+
+    it("refuses a record missing a tree parameter rather than rebuilding a wrong covenant", () => {
+        const record = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin));
+        expect(() => rebuildRfqSwap({ ...record, senderPubkey: undefined })).toThrow(
+            /senderPubkey/,
+        );
+    });
+});
+
+describe("the record never carries a private key", () => {
+    it.each([
+        ["lightning_send", sendOrigin],
+        ["lightning_receive", receiveOrigin],
+    ] as const)("%s", (_kind, origin) => {
+        const record = createRfqSwapRecord(origin, swapOf(origin));
+        expect(record.fallbackSecrets).toBeUndefined();
+        expect(JSON.stringify(record)).not.toContain("senderPrivateKey");
+    });
+
+    it("keeps the baseline marker so a restored record knows which key it meant", () => {
+        const record = createRfqSwapRecord(receiveOrigin, swapOf(receiveOrigin));
+        expect(record.senderKey).toBe("baseline");
+        expect(record.signingDescriptor).toBeUndefined();
+    });
+});
+
+describe("updateRfqSwapRecord", () => {
+    it("merges manager state without disturbing the origin", () => {
+        const record = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin));
+        const moved = updateRfqSwapRecord(record, {
+            ...swapOf(sendOrigin, "refunded"),
+            updatedAt: 2_000,
+            refundArkTxid: "ff".repeat(32),
+        } as LightningSendSwap);
+
+        expect(moved.state).toBe("refunded");
+        expect(moved.refundArkTxid).toBe("ff".repeat(32));
+        expect(moved.updatedAt).toBe(2_000);
+        // the immutable half is untouched
+        expect(moved.solverPubkey).toBe(sendOrigin.solverPubkey);
+        expect(moved.claimDelay).toBe(CLAIM_DELAY);
+        expect(moved.lockupAddress).toBe(sendOrigin.lockupAddress);
+        expect(moved.signingDescriptor).toBe(sendOrigin.signingDescriptor);
+    });
+
+    it("keeps a rebuilt covenant identical across a state change", () => {
+        const record = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin));
+        const moved = updateRfqSwapRecord(record, swapOf(sendOrigin, "settled"));
+        expect(hex.encode(rebuildRfqSwap(moved).lockupPkScript)).toBe(
+            hex.encode(rebuildRfqSwap(record).lockupPkScript),
+        );
+    });
+});
+
+describe("shouldRetainRfqSwap", () => {
+    const at = (state: RfqSwapState, updatedAt: number): RfqSwapRecord =>
+        updateRfqSwapRecord(createRfqSwapRecord(sendOrigin, swapOf(sendOrigin)), {
+            ...swapOf(sendOrigin, state),
+            updatedAt,
+        } as LightningSendSwap);
+
+    it("retains a live swap however old", () => {
+        expect(shouldRetainRfqSwap(at("pending", 0), 10 * RFQ_SWAP_RETENTION_SECONDS)).toBe(true);
+    });
+
+    it("never drops needs_counterparty — the money is still at the lockup", () => {
+        // Not terminal, and not a dead end: the counterparty's move still ends
+        // the swap, and the refusal is re-checked every pass.
+        expect(
+            shouldRetainRfqSwap(at("needs_counterparty", 0), 10 * RFQ_SWAP_RETENTION_SECONDS),
+        ).toBe(true);
+    });
+
+    it.each(["settled", "refunded", "failed"] as const)("retains %s for 30 days", (state) => {
+        expect(shouldRetainRfqSwap(at(state, 0), RFQ_SWAP_RETENTION_SECONDS - 1)).toBe(true);
+    });
+
+    it.each(["settled", "refunded", "failed"] as const)("drops %s past 30 days", (state) => {
+        expect(shouldRetainRfqSwap(at(state, 0), RFQ_SWAP_RETENTION_SECONDS + 1)).toBe(false);
+    });
+
+    it("measures the window from updatedAt, not createdAt", () => {
+        // A swap created long ago but settled a moment ago is fresh history.
+        const record = at("settled", 10 * RFQ_SWAP_RETENTION_SECONDS);
+        expect(shouldRetainRfqSwap(record, 10 * RFQ_SWAP_RETENTION_SECONDS + 1)).toBe(true);
+    });
+});

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -190,6 +190,28 @@ describe("updateRfqSwapRecord", () => {
         expect(moved.signingDescriptor).toBe(sendOrigin.signingDescriptor);
     });
 
+    it("clears a field the swap no longer carries, not just sets new ones", () => {
+        // The manager `delete`s `blockedReason` when a swap leaves
+        // `needs_counterparty` — restoring the right wallet lifts the refusal.
+        // A merged update would persist it, and a reload would then show a live
+        // refusal for a swap that had recovered.
+        const blocked = updateRfqSwapRecord(createRfqSwapRecord(sendOrigin, swapOf(sendOrigin)), {
+            ...swapOf(sendOrigin, "needs_counterparty"),
+            blockedReason: "no secrets on this wallet",
+            failure: "an earlier push failed",
+        } as LightningSendSwap);
+        expect(blocked.blockedReason).toBe("no secrets on this wallet");
+        expect(blocked.failure).toBe("an earlier push failed");
+
+        // recovered: the manager passes a swap carrying neither field
+        const recovered = updateRfqSwapRecord(blocked, swapOf(sendOrigin, "pending"));
+        expect(recovered.blockedReason).toBeUndefined();
+        expect(recovered.failure).toBeUndefined();
+        // and the origin half is still intact
+        expect(recovered.solverPubkey).toBe(sendOrigin.solverPubkey);
+        expect(recovered.lockupAddress).toBe(sendOrigin.lockupAddress);
+    });
+
     it("keeps a rebuilt covenant identical across a state change", () => {
         const record = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin));
         const moved = updateRfqSwapRecord(record, swapOf(sendOrigin, "settled"));

--- a/packages/swap/test/rfqRegister.test.ts
+++ b/packages/swap/test/rfqRegister.test.ts
@@ -38,6 +38,7 @@ import {
     ProviderUnavailableError,
     ReadonlySingleKey,
     ReadonlyWallet,
+    SingleKey,
     VHTLCV2ContractHandler,
     type ArkProvider,
     type ExtendedVirtualCoin,
@@ -182,6 +183,9 @@ const recordingWallet = (
 ): { wallet: IWallet; created: Record<string, unknown>[] } => {
     const created: Record<string, unknown>[] = [];
     const wallet = {
+        // This stub cannot allocate a descriptor, so the swap takes the baseline
+        // arm and its sender key IS this identity. Required, not decoration.
+        identity: SingleKey.fromRandomBytes(),
         getAddress: async () => REFUND_ADDRESS,
         getContractManager: async () => ({
             createContract: async (params: Record<string, unknown>) => {
@@ -251,7 +255,13 @@ describe.each([
                 .filter((value): value is Uint8Array => value !== undefined)
                 .map((value) => hex.encode(value)),
         ];
-        expect(forbidden.length).toBeGreaterThan(1);
+        // Asserted directly rather than inferred from the list being long: the
+        // baseline arm mints no key, so on a lightning send — whose preimage is
+        // the payee's — `rfqId` is the only per-swap value that exists to look
+        // for, and a length guard would fail for the right reason at the wrong
+        // place.
+        expect(secrets.senderPrivateKey).toBeUndefined();
+        expect(forbidden.length).toBeGreaterThanOrEqual(1);
         for (const value of forbidden) expect(serialized).not.toContain(value);
     });
 

--- a/packages/swap/test/secrets.test.ts
+++ b/packages/swap/test/secrets.test.ts
@@ -135,7 +135,10 @@ describe("derivation", () => {
         const preimages: string[] = [];
 
         for (let i = 0; i < 4; i++) {
-            const secrets = (await deriveSwapSecrets(wallet))!;
+            const secrets = await deriveSwapSecrets(wallet);
+            // An HD wallet must take the allocated arm; if it fell through to
+            // the baseline one, this whole test's premise is gone.
+            if (isBaselineSwapSecrets(secrets)) throw new Error("expected the allocated arm");
             descriptors.push(secrets.signingDescriptor);
             pubkeys.push(hex.encode(await senderPubkeyForRfqSecrets(wallet, secrets)));
             preimages.push(hex.encode(await preimageForRfqSecrets(wallet, secrets)));
@@ -453,7 +456,11 @@ describe("the baseline arm", () => {
     it("keeps allocating a fresh descriptor when the wallet can", async () => {
         // The HD path must not regress into the baseline arm.
         const { wallet } = await hdWallet();
-        const secrets = (await deriveSwapSecrets(wallet, { preimage: true }))!;
+        const secrets = await deriveSwapSecrets(wallet, { preimage: true });
+        // Narrow before reading `signingDescriptor`: only the allocated arm has
+        // one, and this test exists to prove the HD path did not fall through
+        // to the baseline arm.
+        if (isBaselineSwapSecrets(secrets)) throw new Error("expected the allocated arm");
         expect(secrets.signingDescriptor).toBeDefined();
         // derived, not generated: nothing secret at rest on this arm
         expect(secrets.preimage).toBeUndefined();

--- a/packages/swap/test/secrets.test.ts
+++ b/packages/swap/test/secrets.test.ts
@@ -23,6 +23,7 @@ import {
     buildPreimageMessage,
     derivePreimage,
     deriveSwapSecrets,
+    isBaselineSwapSecrets,
     isDeterministicSigner,
     preimageForRfqSecrets,
     randomSwapSecrets,
@@ -31,6 +32,7 @@ import {
     senderIdentityForRfqSecrets,
     senderIdentityForSwapRecord,
     senderPubkeyForRfqSecrets,
+    type SwapSecrets,
 } from "../src/secrets";
 import { paymentHashOf } from "../src/onchainHtlc";
 
@@ -432,6 +434,20 @@ describe("the baseline arm", () => {
         expect(hex.encode(await signer.xOnlyPublicKey())).toBe(
             hex.encode(await wallet.identity.xOnlyPublicKey()),
         );
+    });
+
+    it("does not classify a falsy `baseline` as the baseline arm", async () => {
+        // A deserialized record could carry `baseline: false`; the types forbid
+        // it but the store does not. Treating that as the baseline arm would
+        // sign with the wallet's own key for a covenant never bound to it.
+        const impostor = {
+            derivable: true,
+            baseline: false,
+            signingDescriptor: `tr(${"a7".repeat(32)})`,
+        } as unknown as SwapSecrets;
+        expect(isBaselineSwapSecrets(impostor)).toBe(false);
+        // and the genuine arm still narrows
+        expect(isBaselineSwapSecrets((await deriveSwapSecrets(staticWallet()))!)).toBe(true);
     });
 
     it("keeps allocating a fresh descriptor when the wallet can", async () => {

--- a/packages/swap/test/secrets.test.ts
+++ b/packages/swap/test/secrets.test.ts
@@ -297,8 +297,13 @@ describe("cross-SDK vectors", () => {
 });
 
 describe("the fallback arm", () => {
-    it("is what a wallet with no HD state gets", async () => {
-        expect(await deriveSwapSecrets(staticWallet())).toBeUndefined();
+    it("is no longer what a wallet with no HD state gets — it gets the baseline arm", async () => {
+        // Was `undefined`, which sent every entry point into `randomSwapSecrets()`
+        // and a minted private key persisted as plaintext hex. A wallet that
+        // cannot allocate still HAS a key; see "the baseline arm" below.
+        const secrets = await deriveSwapSecrets(staticWallet());
+        expect(secrets).toBeDefined();
+        expect(secrets).not.toHaveProperty("senderPrivateKey");
     });
 
     it("carries the secrets, and a preimage only when asked", () => {
@@ -358,6 +363,84 @@ describe("the fallback arm", () => {
         expect(hex.encode(await senderPubkeyForRfqSecrets(wallet, restored))).toBe(
             hex.encode(await senderPubkeyForRfqSecrets(wallet, secrets)),
         );
+    });
+});
+
+/**
+ * The arm a wallet that cannot allocate a descriptor gets.
+ *
+ * Modelled on boltz-swap's `swapSigner`, which falls back to
+ * `this.wallet.identity` rather than minting: a wallet without HD state still
+ * holds a key, and the covenant can simply be bound to it. The difference from
+ * boltz-swap is the preimage — the baseline key is the SAME every swap, so the
+ * pinned-index derivation would repeat it, and it is generated per swap instead.
+ */
+describe("the baseline arm", () => {
+    it("binds to the wallet's own identity and mints nothing", async () => {
+        const wallet = staticWallet();
+        const secrets = (await deriveSwapSecrets(wallet))!;
+
+        expect(secrets.derivable).toBe(true);
+        expect(secrets).not.toHaveProperty("senderPrivateKey");
+        expect(hex.encode(await senderPubkeyForRfqSecrets(wallet, secrets))).toBe(
+            hex.encode(await wallet.identity.xOnlyPublicKey()),
+        );
+    });
+
+    it("gives each swap its own preimage, because the key repeats", async () => {
+        // The whole reason this arm cannot reuse the derived path: two swaps on
+        // one baseline key would derive the IDENTICAL preimage at the pinned
+        // index, and one solver learning its own would learn the other's.
+        const wallet = staticWallet();
+        const first = (await deriveSwapSecrets(wallet, { preimage: true }))!;
+        const second = (await deriveSwapSecrets(wallet, { preimage: true }))!;
+
+        expect(first.preimage).toHaveLength(32);
+        expect(hex.encode(second.preimage!)).not.toBe(hex.encode(first.preimage!));
+    });
+
+    it("carries no preimage when none was asked for", async () => {
+        // A lightning send's preimage belongs to the payee.
+        expect((await deriveSwapSecrets(staticWallet()))!.preimage).toBeUndefined();
+    });
+
+    it("round-trips through a record without persisting a private key", async () => {
+        const wallet = staticWallet();
+        const secrets = (await deriveSwapSecrets(wallet, { preimage: true }))!;
+        const record = rfqSecretsToRecord(secrets);
+
+        expect(record.fallbackSecrets).toBeUndefined();
+        expect(JSON.stringify(record)).not.toContain("senderPrivateKey");
+
+        const restored = rfqSecretsOfRecord(record)!;
+        expect(hex.encode(await preimageForRfqSecrets(wallet, restored))).toBe(
+            hex.encode(secrets.preimage!),
+        );
+        expect(hex.encode(await senderPubkeyForRfqSecrets(wallet, restored))).toBe(
+            hex.encode(await senderPubkeyForRfqSecrets(wallet, secrets)),
+        );
+    });
+
+    it("resolves the refund signer to the wallet's identity, not a refusal", async () => {
+        // `senderIdentityForRfqSecrets` refuses a DESCRIPTOR this wallet cannot
+        // derive, because signing that with the baseline key would produce a
+        // dead script. The baseline arm is the opposite case: the covenant was
+        // deliberately bound to this key, so returning it is correct.
+        const wallet = staticWallet();
+        const secrets = (await deriveSwapSecrets(wallet))!;
+        const signer = await senderIdentityForRfqSecrets(wallet, secrets);
+        expect(hex.encode(await signer.xOnlyPublicKey())).toBe(
+            hex.encode(await wallet.identity.xOnlyPublicKey()),
+        );
+    });
+
+    it("keeps allocating a fresh descriptor when the wallet can", async () => {
+        // The HD path must not regress into the baseline arm.
+        const { wallet } = await hdWallet();
+        const secrets = (await deriveSwapSecrets(wallet, { preimage: true }))!;
+        expect(secrets.signingDescriptor).toBeDefined();
+        // derived, not generated: nothing secret at rest on this arm
+        expect(secrets.preimage).toBeUndefined();
     });
 });
 

--- a/packages/swap/test/store.test.ts
+++ b/packages/swap/test/store.test.ts
@@ -73,11 +73,16 @@ describe("asset swap store", () => {
 
     it("reports failed add writes and keeps update writes best-effort", async () => {
         const broken = (existing: AssetSwap[] = []): AssetSwapRepository => ({
-            version: 1,
+            version: 2,
             saveSwap: async () => {
                 throw new Error("quota exceeded");
             },
             getAllSwaps: async () => existing,
+            // Unused by this test's subject, but part of the v2 contract: a
+            // stub missing them is not an AssetSwapRepository.
+            saveRfqSwap: async () => {},
+            getAllRfqSwaps: async () => [],
+            removeRfqSwap: async () => {},
             getScannedTxids: async () => new Set(),
             markTxidsScanned: async () => {},
             getCachedMarkets: async () => undefined,


### PR DESCRIPTION
## Summary

Two changes that have to travel together: the swap package stops minting signing
keys, and RFQ swaps become persistable. A record schema that *can* hold a private
key would only move the problem into a new store, so the schema is only honest
about "no private key" because the first change exists.

### Keys — no more minted signing keys

A wallet that cannot allocate an HD descriptor fell through to
`randomSwapSecrets()`: a signing key created outside any wallet key management,
held in package memory, and persisted as plaintext `senderPrivateKeyHex` on the
swap record. For a static wallet that was the *default* path, not an edge case.

It now takes a new **baseline arm**, following `boltz-swap`'s `swapSigner`
(`arkade-swaps.ts:3792-3797`), which falls back to `this.wallet.identity` rather
than minting. The wallet already has a key; the covenant is simply bound to it.

The preimage could not follow the same route, and this is the subtle part.
`derivePreimage` pins its message index at `0` (`secrets.ts:355-359`), which
`secrets.ts:64-68` documents as safe *only* because each swap allocates a fresh
descriptor. The baseline key repeats, so deriving would hand every swap the
identical `P` — and one solver learning its own would hold the next swap's before
it existed. The baseline arm therefore **generates a preimage per swap**, and
that preimage is the only secret it stores.

Notably this needed **no change to core `wallet.ts`**: a static wallet's
`getNextSigningDescriptor()` already returns `undefined`, and the baseline arm
takes it from there. The diff is confined to `packages/swap`.

### Persistence

`AssetSwapRepository` gains three `RfqSwapRecord` methods and a `rfqSwaps` object
store (`DB_VERSION` 1 → 2). One storage seam, as `repository.ts` already intends.

`RfqSwap` is a live record, not a storage format — it holds derived
`Uint8Array`s and a `VHTLC.ScriptV2` class instance, and IndexedDB's structured
clone strips prototypes. So consumers store a projection and rebuild at boot.

**Every tree parameter is stored, including the ones that look re-readable from
the live wallet.** `serverPubkey` and `claimDelay` are the trader's own *at
request time*; a wallet later pointed at a different Arkade Service, or one whose
server rotated its key, would rebuild a different covenant and lose the lockup.
`emulatorPubkey` now resolves from a per-network pin the SDK can change between
releases, for the same reason. That makes `rebuildRfqSwap` a pure function of the
record — no wallet, no network, no ambient defaults.

## Trade-off worth reviewing

**Every swap on a non-allocating wallet now shares one sender pubkey and is
linkable by it.** A minted key gave a fresh one per swap, at the price of a
plaintext private key on disk. `boltz-swap` accepted the same trade; it is stated
in `BaselineSwapSecrets`'s docstring rather than left implicit.

## Relationship to #737

This implements the core of #737 via boltz-swap's pattern. Deliberately left on
that issue: `signerForDescriptor`'s fail-loud contract,
`SingleKey.signSchnorrDeterministic`, the per-swap derivation index, and the
`isHDWalletCapable` probe removal. `RfqSwapRecord` carries an unwritten
`preimageIndex?: number` so the index change lands as a schema no-op.

Legacy `fallbackSecrets` records stay readable so swaps persisted by earlier
versions remain refundable; nothing produces them any more.

## Test plan

Baseline on `feat/arkade-swap` @ `a3fc6e06` was **391/391**; this branch is
**428/428**, +37 tests and no regressions. `typecheck`, `lint` and `build` clean,
with the new exports verified present in the built `dist/index.d.ts`.

Tests worth looking at specifically:

- **Mutation test over the projection** — perturbs each of the nine tree
  parameters in turn and fails if any one does not change the rebuilt
  `lockupPkScript`. This is what makes "I stored everything" mechanically
  checked rather than asserted.
- **Two receive swaps on one static wallet get different preimages** — the guard
  against the pinned-index reuse described above.
- **No new record carries a private key**, on both legs.
- **v1 → v2 migration** — seeds a genuine v1-shaped database, opens it through
  the repository at v2, and asserts swaps, scanned txids and the markets cache
  all survive while the new store is usable immediately.

## Not verified

The migration is proven against `fake-indexeddb`, not a real browser upgrade
path. Nothing here has been exercised against a live solver.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RFQ swap records can now be saved, restored, updated, listed, and removed across sessions.
  * In-progress and completed swaps retain the information needed to resume accurately.
  * Added support for baseline wallet-bound secrets and optional per-swap preimages.
  * Swap operations now expose the parameters needed to reliably reconstruct funded scripts.

* **Bug Fixes**
  * Improved secret handling by avoiding unnecessary private-key storage and preserving compatibility with existing records.
  * Existing swap data remains available after storage upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->