### PR TITLE
fix: encode minimal script pushes

### DIFF
--- a/packages/ts-sdk/src/arkade/script.ts
+++ b/packages/ts-sdk/src/arkade/script.ts
@@ -56,18 +56,6 @@ export const ArkadeScript: P.CoderType<ArkadeScriptType> = P.wrap({
                 w.byte(v);
                 continue;
             } else if (typeof o === "number" || typeof o === "bigint") {
-                // Arkade VM enforces MINIMALDATA: values 0, 1..16 and -1 must
-                // use OP_0 / OP_1..OP_16 / OP_1NEGATE, not data pushes.
-                if (o === 0 || o === 0n) {
-                    w.byte(0x00);
-                    continue;
-                } else if (o >= 1 && o <= 16) {
-                    w.byte(OP.OP_1 - 1 + Number(o));
-                    continue;
-                } else if (o === -1 || o === -1n) {
-                    w.byte(OP["1NEGATE"]);
-                    continue;
-                }
                 // Encode numbers via BigNum (520-byte cap).
                 const big = typeof o === "number" ? BigInt(o) : o;
                 o = BigNum.encode(big);
@@ -75,7 +63,14 @@ export const ArkadeScript: P.CoderType<ArkadeScriptType> = P.wrap({
             if (!(o instanceof Uint8Array)) throw new Error(`Wrong Script OP=${o} (${typeof o})`);
             // Bytes (data push)
             const len = o.length;
-            if (len < OP.PUSHDATA1) w.byte(len);
+            // Arkade VM enforces MINIMALDATA for small script numbers.
+            if (len === 1 && o[0] >= 1 && o[0] <= 16) {
+                w.byte(OP.OP_1 - 1 + o[0]);
+                continue;
+            } else if (len === 1 && o[0] === 0x81) {
+                w.byte(OP["1NEGATE"]);
+                continue;
+            } else if (len < OP.PUSHDATA1) w.byte(len);
             else if (len <= 0xff) {
                 w.byte(OP.PUSHDATA1);
                 w.byte(len);

--- a/packages/ts-sdk/test/arkade.test.ts
+++ b/packages/ts-sdk/test/arkade.test.ts
@@ -559,10 +559,30 @@ describe("ASM number-token fidelity", () => {
     });
 });
 
-describe("MINIMALDATA number encoding", () => {
+describe("MINIMALDATA push encoding", () => {
+    it("encodes single-byte small integers with their dedicated opcodes", () => {
+        for (let value = 1; value <= 16; value++) {
+            expect(hex.encode(ArkadeScript.encode([Uint8Array.of(value)]))).toBe(
+                (OPCODE_VALUES[`OP_${value}`] as number).toString(16),
+            );
+        }
+        expect(hex.encode(ArkadeScript.encode([Uint8Array.of(0x81)]))).toBe("4f");
+    });
+
+    it("keeps other single-byte values as direct data pushes", () => {
+        expect(hex.encode(ArkadeScript.encode([Uint8Array.of(0)]))).toBe("0100");
+        expect(hex.encode(ArkadeScript.encode([Uint8Array.of(17)]))).toBe("0111");
+    });
+
     it("encodes -1 as OP_1NEGATE, not a data push", () => {
         expect(hex.encode(ArkadeScript.encode([-1]))).toBe("4f");
         expect(hex.encode(ArkadeScript.encode([-1n]))).toBe("4f");
+    });
+
+    it("keeps the emulator's 520-byte BigNum range", () => {
+        const encoded = ArkadeScript.encode([1n << 4158n]);
+        expect(encoded.slice(0, 3)).toEqual(Uint8Array.of(0x4d, 0x08, 0x02));
+        expect(encoded).toHaveLength(523);
     });
 
     it("decodes 0x4f back to the number -1", () => {


### PR DESCRIPTION
## Summary

- encode empty, single-byte integers 1–16, and -1 with their minimal opcodes
- route both `number` and `bigint` inputs through Arkade's 520-byte BigNum encoding
- add coverage for raw byte pushes, numeric pushes, and the emulator's large-integer range

## Why

The Arkade emulator enforces minimal data pushes. The SDK previously emitted length-prefixed pushes for raw one-byte values such as `01` and `81`, even though those values must use `OP_1`–`OP_16` or `OP_1NEGATE`. That caused otherwise valid scripts to be rejected during execution.

## Impact

Arkade scripts now serialize those stack values canonically while preserving distinct raw values such as `00`. Existing larger data pushes keep their current encoding.

## Validation

- `pnpm -C packages/ts-sdk vitest run test/arkade.test.ts`
- `pnpm run lint`
- TypeScript typecheck
- full SDK unit suite: 155 files, 2381 tests passed, 1 skipped
- `pnpm run build`
- monorepo lint and unit-test commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script encoding for numeric and bigint values using minimal representations.
  * Correctly encodes `-1` and values from `1` to `16` using their dedicated opcodes.
  * Ensures byte-array values use minimal opcode encoding where applicable.
* **Tests**
  * Expanded coverage for minimal data encoding, direct byte pushes, and large numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->