### PR TITLE
Derive static wallets' preimage from a public per-swap salt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,10 +71,15 @@ keys and never branch on wallet *type* — they ask the wallet and use what come
   wallet is HD, or calls `randomSecretKey()` for a signing/refund/claim key, is a defect: the
   wallet's identity key is the fallback, never a minted one.
 - Per-artifact secrets (swap preimages) key off the **descriptor's shape**, not the wallet's type:
-  an HD child descriptor is unique per artifact and can derive secrets deterministically; a bare
-  `tr(pubkey)` repeats across artifacts, so derived-from-key secrets would collide and must be
-  stored per artifact instead (see `packages/ts-sdk/src/wallet/contractSecrets.ts` and
-  `swapSecretsToRecord` in `packages/swap/src/store.ts`).
+  an HD child descriptor is unique per artifact and derives secrets from the key alone; a bare
+  `tr(pubkey)` repeats across artifacts, so that derivation would collide and the uniqueness comes
+  from a public per-artifact **salt** stored with the artifact instead. Only a signer that cannot
+  sign deterministically at all falls back to a stored secret. See
+  `packages/ts-sdk/src/wallet/contractSecrets.ts`.
+- The ban is on **key material and on anything that signs** — not on public per-artifact values. A
+  package may mint and store public material such as a derivation salt: it is an input the wallet
+  needs back, not a capability, and knowing it grants nothing without the seed. Apply the same test
+  to anything new: could a reader of the repository spend with it?
 
 ## Local Scratch Files
 

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -436,34 +436,42 @@ descriptor, which is public, and `contractSigner(wallet, descriptor)` recovers t
 
 What each swap stores, and what is recoverable:
 
-| Wallet answers with | Spending key          | Preimage (when the leg needs one) | Secret at rest    |
-| ------------------- | --------------------- | --------------------------------- | ----------------- |
-| fresh HD descriptor | re-derives from seed  | derives deterministically         | none              |
-| static `tr(pubkey)` | the wallet's identity | random, stored on the record      | the preimage only |
+| Wallet answers with       | Spending key          | Preimage (when the leg needs one)     | Secret at rest    |
+| ------------------------- | --------------------- | ------------------------------------- | ----------------- |
+| fresh HD descriptor       | re-derives from seed  | derives deterministically             | none              |
+| static `tr(pubkey)`       | the wallet's identity | derives from a public per-swap salt   | none              |
+| a signer that cannot sign |                       |                                       |                   |
+| deterministically         | the wallet's identity | random, stored on the record          | the preimage only |
 
-The preimage split follows the **descriptor's shape**, not the wallet's type: an HD child
-descriptor is unique to its swap, so `sha256(sign_det(...))` is safe; a static descriptor is the
-same key for every swap, so a derived preimage would repeat across swaps — one solver learning its
-own preimage would learn every other swap's — and a per-swap random preimage is stored instead.
-`mustPersistPreimage` says which you got. A stored preimage is the one secret at rest in the
-design, and it is never a private key.
+The preimage split follows the **descriptor's shape**, not the wallet's type. An HD child
+descriptor is unique to its swap, so `sha256(sign_det(...))` over the key alone is safe. A static
+descriptor is the same key for every swap, so that derivation would repeat across swaps — one
+solver learning its own preimage would learn every other swap's — and the uniqueness has to come
+from the message instead: the SDK mints 32 random bytes per swap, signs a **salted** message, and
+stores the salt in the clear.
+
+**The salt is not a secret.** Knowing it yields nothing without the seed, which is the whole
+difference from the preimage it replaces: the record goes from carrying a per-swap _secret_ to a
+per-swap _public_ value, exactly what `signingDescriptor` already is. Recoverability is unchanged
+in shape — keep the record and the swap recovers from the seed.
+
+Only a signer that cannot sign deterministically at all — an external or extension signer — still
+gets a random stored preimage. `mustPersistPreimage` says which you got, and it is the only thing
+to branch on. A stored preimage remains the one secret at rest in the design, and it is never a
+private key.
 
 ```ts
 const swap = await requestOnchainSend(/* … */);
-// `swapSecretsToRecord` stores the public descriptor always, and `preimageHex`
-// only when the wallet said it cannot re-derive P.
+// `swapSecretsToRecord` stores the public descriptor always, then whichever of
+// `preimageSaltHex` (derivable) or `preimageHex` (not) the wallet produced.
 await saveSwap({ ...record, ...swapSecretsToRecord(swap.secrets) });
 
-// Later, from the seed plus that descriptor. Only ask for a preimage the
-// corridor gave us one for: a lightning send's P belongs to the payee, so
-// this throws on those records rather than inventing something the chain will
-// never match. `LIGHTNING_SEND_PAIR` is exported from this package.
-if (record.signingDescriptor && record.pair !== LIGHTNING_SEND_PAIR) {
-    const preimage = await contractPreimage(
-        wallet,
-        record.signingDescriptor,
-        record.preimageHex ? hex.decode(record.preimageHex) : undefined,
-    );
+// Later, from the seed plus the record's public fields. Only ask for a
+// preimage the corridor gave us one for: a lightning send's P belongs to the
+// payee, so this throws on those records rather than inventing something the
+// chain will never match. `LIGHTNING_SEND_PAIR` is exported from this package.
+if (record.pair !== LIGHTNING_SEND_PAIR) {
+    const preimage = await preimageForSwapRecord(wallet, record);
 }
 
 // For a refund, take the composition instead of the guard: it turns all three
@@ -481,21 +489,38 @@ terminal: the lockup stays funded and watched, a solver claim still ends the swa
 `pending`. The manager reports the same state when nothing is wired to act (`enableAutoActions:
 false`, or no callbacks) and the window has passed.
 
+`preimageForSwapRecord` is the read path to wire, not a hand-rolled `contractPreimage` call: it
+knows which of the record's fields are derivation inputs, and it verifies the result against
+`paymentHash`. A caller that forgets to pass the salt gets a _wrong_ preimage from a wallet that can
+derive, not an error — and that surfaces as an opaque script failure at claim time.
+
 A caller-supplied preimage keeps `signingDescriptor` for the sender key and stores only
 `preimageHex` as secret material.
 
 On an HD wallet each swap **allocates** its own descriptor rather than peeking at the current one:
 two swaps sharing a descriptor derive the _identical_ preimage, so one solver learning its own
-preimage would learn the other swap's. (Static wallets share their one descriptor by design — that
-is why their preimages are stored per swap, never derived.) On restore, `adoptContractDescriptor`
+preimage would learn the other swap's. (Static wallets share their one descriptor by design — the
+per-swap salt is what separates their preimages instead.) On restore, `adoptContractDescriptor`
 (from `@arkade-os/sdk`) moves the wallet's watermark past a restored record's index so it cannot be
 handed out twice; a static descriptor names no index and adopts as a no-op.
 
-The derivation is `sha256(signSchnorrDeterministic(sha256("Arkade-RFQ-Preimage-v1" ‖ xonly(32) ‖
-u32le(0))))`, mirroring NArk's Boltz scheme (`SwapsManagementService.cs:128-160`) with an
-RFQ-scoped tag. NArk has no RFQ corridor yet, so this tag defines the scheme rather than matching
-one; it is deliberately distinct from the Boltz tag so one wallet key cannot derive the same
-preimage for both corridors.
+Two derivations, picked by the descriptor's shape:
+
+```
+HD child      sha256(sign_det(sha256("Arkade-RFQ-Preimage-v1"             ‖ xonly(32) ‖ u32le(0))))
+static/salted sha256(sign_det(sha256("Arkade-Contract-Preimage-Salted-v1" ‖ xonly(32) ‖ salt(32))))
+```
+
+The first mirrors NArk's Boltz scheme (`SwapsManagementService.cs:128-160`) with an RFQ-scoped tag.
+NArk has no RFQ corridor yet, so this tag defines the scheme rather than matching one; it is
+deliberately distinct from the Boltz tag so one wallet key cannot derive the same preimage for both
+corridors.
+
+The salted tag is corridor-generic where the first is not, and that asymmetry is deliberate: the v1
+tags must be per-corridor because v1 pins its message index, leaving the tag as the only separation
+between two corridors reaching the same key. The salted form mints a fresh salt per swap, so no two
+swaps share a message within a corridor or across two — the salt carries the separation, and the tag
+names the layer rather than the corridor.
 
 **Not covered:** seed-only discovery after the swap repository is wiped. An unspent L1 HTLC reveals
 too little public quote data to rediscover, so the record remains required.
@@ -508,9 +533,38 @@ before later-funded addresses are found. Keep the swap repository in backups (re
 each record's descriptor via `adoptContractDescriptor`), or raise `gapLimit` on seed-only restores
 after heavy swap use.
 
+## Upgrading from 0.0.3
+
+0.0.1–0.0.3 are published. Under npm's 0.0.x rules `^0.0.3` resolves to exactly 0.0.3, so nothing
+auto-upgrades into the changes below — but a consumer that does upgrade meets them all in one jump,
+so they are written as one migration rather than per-release fragments.
+
+**Key provisioning moved into the SDK.** `packages/swap/src/secrets.ts` is gone. `deriveSwapSecrets`,
+`randomSwapSecrets`, `preimageForRfqSecrets`, `senderIdentityForRfqSecrets`, `rfqSecretsToRecord`,
+`rfqSecretsOfRecord`, `isPerSwapDescriptor`, `RFQ_PREIMAGE_TAG` and `SwapSecrets` no longer exist.
+Import `provisionRefundKey`, `provisionClaimSecret`, `contractSigner`, `contractPreimage`,
+`isPerArtifactDescriptor` and `ARKADE_SWAP_PREIMAGE_TAG` from `@arkade-os/sdk` instead;
+`swapSecretsToRecord` and `senderIdentityForSwapRecord` stay in this package. No consumer branches
+on wallet type any more, and no swap record can carry a private key.
+
+**`contractPreimage` takes an options object.** `contractPreimage(wallet, descriptor, stored?)`
+became `contractPreimage(wallet, descriptor, { stored?, salt? })`. Prefer `preimageForSwapRecord`,
+which reads both fields off the record and verifies against `paymentHash`.
+
+**Static wallets derive their preimage instead of storing it.** New records from such wallets carry
+`preimageSaltHex` and no `preimageHex`; `mustPersistPreimage` is now `false` for them, so the
+"persist the preimage" warning stops firing. Nothing at rest is secret unless the signer cannot sign
+deterministically at all.
+
+**`AssetSwap` gains `preimageSaltHex?`, and `AssetSwapRepository.version` is `2`.** External
+repository implementations must recompile — deliberately, because a field-mapped backend that drops
+`preimageSaltHex` leaves the swap unclaimable exactly as one dropping `preimageHex` does. Records
+written by 0.0.1–0.0.3 need no rewrite and no migration: the field is optional, older rows resolve
+through their stored `preimageHex` or their HD descriptor, and `DB_VERSION` is unchanged.
+
 ## Breaking changes on this branch (pre-release migration notes)
 
-The package is pre-release; these notes replace a changelog for consumers tracking the branch.
+Notes from before 0.0.1, kept for consumers who tracked the branch.
 
 - **`secrets.ts` is gone; key provisioning moved into `@arkade-os/sdk`.** This package no longer
   derives, mints, or names keys. It asks the SDK for what the leg needs — `provisionRefundKey(wallet)`

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -494,6 +494,13 @@ knows which of the record's fields are derivation inputs, and it verifies the re
 `paymentHash`. A caller that forgets to pass the salt gets a _wrong_ preimage from a wallet that can
 derive, not an error — and that surfaces as an opaque script failure at claim time.
 
+Every refusal is a `PreimageNotRecoverableError` carrying a `reason`: `no-secrets` (the record
+predates the descriptor), `malformed-record`, `not-derivable` (nothing to derive from, or a key this
+wallet does not hold), or `hash-mismatch` (derived, but wrong — a tampered salt or the wrong seed).
+Branch on `reason`, never on message text. It is deliberately **not**
+`RefundNotLocallyPossibleError`: that one means no local refund is possible and `RfqSwapManager`
+reports `needs_counterparty` for it, which is a different verdict from a claim-path read failing.
+
 A caller-supplied preimage keeps `signingDescriptor` for the sender key and stores only
 `preimageHex` as secret material.
 

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -25,8 +25,10 @@ export {
     updateAssetSwap,
     updateAssetSwapBestEffort,
     swapSecretsToRecord,
+    preimageForSwapRecord,
     type AssetSwap,
     type AssetSwapStatus,
+    type SwapSecretsProjection,
 } from "./store";
 export {
     type AssetSwapRepository,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -26,8 +26,10 @@ export {
     updateAssetSwapBestEffort,
     swapSecretsToRecord,
     preimageForSwapRecord,
+    PreimageNotRecoverableError,
     type AssetSwap,
     type AssetSwapStatus,
+    type PreimageBlockedReason,
     type SwapSecretsProjection,
 } from "./store";
 export {

--- a/packages/swap/src/indexedDbRepository.ts
+++ b/packages/swap/src/indexedDbRepository.ts
@@ -47,7 +47,7 @@ const txDone = (tx: IDBTransaction): Promise<void> =>
 /** Browser backend over the SDK's shared IndexedDB manager — the same
  * infrastructure the wallet already uses for its Boltz swap repository. */
 export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
     // the promise, not the resolved database: openDatabase bumps a refcount on
     // every call including cache hits, while dispose closes once, so two
     // concurrent first calls would strand the refcount above zero and leak the

--- a/packages/swap/src/repository.ts
+++ b/packages/swap/src/repository.ts
@@ -30,12 +30,13 @@ export const marketsCacheKey = (network: string, registry: string) =>
  * subset queries.
  */
 export interface AssetSwapRepository extends AsyncDisposable {
-    readonly version: 1;
+    readonly version: 2;
 
     /** Insert or replace a swap by id. Store the record whole: `preimageHex`
-     * is secret-bearing — the only claim secret of a swap whose descriptor is
-     * not per-swap — and a field-mapped backend that drops it leaves the swap
-     * unclaimable. */
+     * and `preimageSaltHex` both leave the swap unclaimable if a field-mapped
+     * backend drops them — the first is the only claim secret of a swap whose
+     * signer cannot derive, the second the public input every other static
+     * wallet's preimage derives from. */
     saveSwap(swap: AssetSwap): Promise<void>;
     /** All stored swaps, in no particular order — `getAssetSwaps` is the
      * canonical newest-first read. */
@@ -53,7 +54,7 @@ export interface AssetSwapRepository extends AsyncDisposable {
 }
 
 export class InMemoryAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 1 as const;
+    readonly version = 2 as const;
     private readonly swaps = new Map<string, AssetSwap>();
     private readonly scanned = new Set<string>();
     private readonly markets = new Map<string, MarketsCacheEntry>();

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -1080,8 +1080,9 @@ export async function requestOnchainSend(
     htlc: OnchainHtlc;
     /** The VHTLC `sender` x-only key, bound into the covenant. Public. */
     senderPubkey: Uint8Array;
-    /** How the preimage and the `sender` key are recovered later. Persist it
-     * with the record BEFORE funding. */
+    /** How the preimage and the `sender` key are recovered later — map it
+     * through `swapSecretsToRecord` and persist BEFORE funding. Public unless
+     * `mustPersistPreimage` says the wallet could not derive P. */
     secrets: ProvisionedClaimSecret;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
@@ -1492,8 +1493,9 @@ export async function requestLightningReceive(
     payoutAddress: string;
     /** The trader's covenant `receiver` key, bound into the tree. Public. */
     payoutPubkey: Uint8Array;
-    /** How the preimage and the payout key are recovered later. Persist it
-     * with the record BEFORE paying the invoice. */
+    /** How the preimage and the payout key are recovered later — map it
+     * through `swapSecretsToRecord` and persist BEFORE paying the invoice.
+     * Public unless `mustPersistPreimage` says the wallet could not derive P. */
     secrets: ProvisionedClaimSecret;
 }> {
     const rfqId = params.rfqId ?? newRfqId();
@@ -1703,6 +1705,9 @@ export async function requestOnchainReceive(
     htlc: OnchainHtlc;
     payoutAddress: string;
     payoutPubkey: Uint8Array;
+    /** How the preimage and the payout key are recovered later — map it
+     * through `swapSecretsToRecord` and persist BEFORE funding. Public unless
+     * `mustPersistPreimage` says the wallet could not derive P. */
     secrets: ProvisionedClaimSecret;
 }> {
     const rfqId = params.rfqId ?? newRfqId();

--- a/packages/swap/src/store.ts
+++ b/packages/swap/src/store.ts
@@ -1,5 +1,7 @@
 import { hex } from "@scure/base";
-import type { ProvisionedClaimSecret, ProvisionedKey } from "@arkade-os/sdk";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { contractPreimage } from "@arkade-os/sdk";
+import type { IWallet, ProvisionedClaimSecret, ProvisionedKey } from "@arkade-os/sdk";
 import type { AssetSwapRepository } from "./repository";
 
 export type AssetSwapStatus =
@@ -30,7 +32,41 @@ export const BTC_ASSET_ID = "btc";
 // AssetSwapStore class holding the repository privately if a second consumer
 // starts writing swaps, or the first invariant gets violated in practice.
 
-export interface AssetSwap {
+/**
+ * The record fields a wallet-provisioned secret becomes — what
+ * {@link swapSecretsToRecord} emits, and what every record type carrying swap
+ * secrets embeds.
+ *
+ * A named type rather than four fields restated per record: the mapper and the
+ * records it feeds must agree exactly, and a record that silently omits one of
+ * these round-trips a swap whose preimage cannot be re-derived. Embedding makes
+ * the omission a compile error instead.
+ *
+ * **Only `preimageHex` is secret.** `signingDescriptor` and `preimageSaltHex`
+ * are public derivation inputs — they must survive a field-mapped backend, but
+ * they leak nothing without the seed.
+ */
+export interface SwapSecretsProjection {
+    /**
+     * The wallet descriptor this swap's sender key comes from — a fresh HD
+     * child, or a static wallet's `tr(pubkey)`. Public — the signer
+     * re-derives from the wallet, so the record carries no key material.
+     */
+    signingDescriptor?: string;
+    /** P, hex, when it cannot be re-derived from the seed at all: the user
+     * supplied it, or the signer cannot sign deterministically. The swap's only
+     * claim secret when present. */
+    preimageHex?: string;
+    /**
+     * The salt P derives from, hex, on the salted arm — what a static wallet
+     * gets instead of storing P. **Public**, and unlike every other field here
+     * it is minted per swap: it is what stops one repeating key from handing
+     * every swap the same preimage.
+     */
+    preimageSaltHex?: string;
+}
+
+export interface AssetSwap extends SwapSecretsProjection {
     /** Funding txid — the swap's identity. */
     id: string;
     /** 'btc' or a 68-hex asset id. */
@@ -58,16 +94,6 @@ export interface AssetSwap {
     /** `sha256(P)`, hex. Public, and how a restore confirms a candidate
      * derivation is the right one. */
     paymentHash?: string;
-    /**
-     * The wallet descriptor this swap's sender key comes from — a fresh HD
-     * child, or a static wallet's `tr(pubkey)`. Public — the signer
-     * re-derives from the wallet, so the record carries no key material.
-     */
-    signingDescriptor?: string;
-    /** P, hex, when it cannot be re-derived from the seed: the user supplied
-     * it, or the descriptor is static (shared across swaps, so a derived
-     * preimage would collide). The swap's only claim secret when present. */
-    preimageHex?: string;
     /** The L1 HTLC's pkScript, hex — the chain-watch key. */
     htlcPkScriptHex?: string;
     htlcLocktime?: number;
@@ -187,14 +213,63 @@ export const updateAssetSwapBestEffort = async (
  * The record fields a wallet-provisioned secret becomes.
  *
  * `signingDescriptor` is public and always stored — it is what recovers the
- * signer. `preimageHex` is stored only when the wallet says it cannot
- * re-derive P, and is then the swap's only claim secret.
+ * signer. Then at most one of: `preimageHex`, when the wallet says it cannot
+ * re-derive P and it becomes the swap's only claim secret; or
+ * `preimageSaltHex`, the public input a derivable-but-repeating key needs.
  */
 export const swapSecretsToRecord = (
     secrets: ProvisionedKey | ProvisionedClaimSecret,
-): { signingDescriptor: string; preimageHex?: string } => ({
+): SwapSecretsProjection & { signingDescriptor: string } => ({
     signingDescriptor: secrets.descriptor,
     ...("mustPersistPreimage" in secrets && secrets.mustPersistPreimage
         ? { preimageHex: hex.encode(secrets.preimage) }
         : {}),
+    ...("preimageSalt" in secrets && secrets.preimageSalt
+        ? { preimageSaltHex: hex.encode(secrets.preimageSalt) }
+        : {}),
 });
+
+/** 32 bytes of hex, or a message naming the field that was wrong. */
+const decodeHex32 = (value: string, field: string): Uint8Array => {
+    const bytes = hex.decode(value);
+    if (bytes.length !== 32) {
+        throw new Error(`${field} must be 32 bytes, got ${bytes.length}`);
+    }
+    return bytes;
+};
+
+/**
+ * The preimage a swap record claims with — stored, or re-derived from the
+ * wallet.
+ *
+ * The record-shaped inverse of {@link swapSecretsToRecord}, and the one place
+ * that knows which of a record's fields `contractPreimage` needs. Wire claim
+ * paths here rather than composing it by hand: a caller that forgets to pass
+ * `preimageSaltHex` gets a *wrong* preimage from a wallet that can derive,
+ * not an error.
+ *
+ * Verifies the result against `paymentHash` when the record carries one. The
+ * salted arm has two inputs that can be wrong — the key and the salt — where
+ * the HD arm had one, and a wrong P otherwise surfaces as an opaque script
+ * failure at claim time, long after the mistake.
+ */
+export const preimageForSwapRecord = async (
+    wallet: IWallet,
+    record: SwapSecretsProjection & { paymentHash?: string },
+): Promise<Uint8Array> => {
+    if (!record.signingDescriptor) {
+        throw new Error("this swap record carries no signing descriptor");
+    }
+    const preimage = await contractPreimage(wallet, record.signingDescriptor, {
+        stored: record.preimageHex ? decodeHex32(record.preimageHex, "preimageHex") : undefined,
+        salt: record.preimageSaltHex
+            ? decodeHex32(record.preimageSaltHex, "preimageSaltHex")
+            : undefined,
+    });
+    if (record.paymentHash && hex.encode(sha256(preimage)) !== record.paymentHash) {
+        throw new Error(
+            "the derived preimage does not match this swap's payment hash: wrong wallet, or a tampered salt",
+        );
+    }
+    return preimage;
+};

--- a/packages/swap/src/store.ts
+++ b/packages/swap/src/store.ts
@@ -238,6 +238,46 @@ const decodeHex32 = (value: string, field: string): Uint8Array => {
     return bytes;
 };
 
+/** Why a wallet cannot produce a swap's preimage. */
+export type PreimageBlockedReason =
+    /** The record carries no `signingDescriptor`. */
+    | "no-secrets"
+    /** `preimageHex` or `preimageSaltHex` is present but not 32 bytes of hex. */
+    | "malformed-record"
+    /**
+     * Nothing to derive from: a descriptor that repeats across swaps, with
+     * neither a stored preimage nor a salt — or one this wallet holds no key
+     * for. Merged deliberately: `contractSigner` reports a key it does not
+     * hold as a plain `Error` for static wallets and a `ForeignDescriptorError`
+     * for HD ones, so splitting the two here would mean matching on message
+     * text, which is the thing this type exists to avoid. The `cause` carries
+     * whichever it was.
+     */
+    | "not-derivable"
+    /** Derived, but it does not hash to the record's `paymentHash`. */
+    | "hash-mismatch";
+
+/**
+ * The wallet cannot produce this swap's preimage, and which of the four ways
+ * is `reason`.
+ *
+ * Deliberately **not** {@link RefundNotLocallyPossibleError}: that one means
+ * "no local refund is possible", and `RfqSwapManager` acts on it by reporting
+ * `needs_counterparty`. A claim-path read failure is a different verdict, and
+ * borrowing the refund error would have the manager announce one for the
+ * other.
+ */
+export class PreimageNotRecoverableError extends Error {
+    override readonly name = "PreimageNotRecoverableError";
+    constructor(
+        readonly reason: PreimageBlockedReason,
+        message: string,
+        options?: { cause?: unknown },
+    ) {
+        super(message, options);
+    }
+}
+
 /**
  * The preimage a swap record claims with — stored, or re-derived from the
  * wallet.
@@ -252,22 +292,52 @@ const decodeHex32 = (value: string, field: string): Uint8Array => {
  * salted arm has two inputs that can be wrong — the key and the salt — where
  * the HD arm had one, and a wrong P otherwise surfaces as an opaque script
  * failure at claim time, long after the mistake.
+ *
+ * Every refusal is a {@link PreimageNotRecoverableError} carrying a `reason`,
+ * so a caller can tell "this record predates the descriptor" from "the salt is
+ * corrupt" without reading message text.
  */
 export const preimageForSwapRecord = async (
     wallet: IWallet,
     record: SwapSecretsProjection & { paymentHash?: string },
 ): Promise<Uint8Array> => {
     if (!record.signingDescriptor) {
-        throw new Error("this swap record carries no signing descriptor");
+        throw new PreimageNotRecoverableError(
+            "no-secrets",
+            "this swap record carries no signing descriptor",
+        );
     }
-    const preimage = await contractPreimage(wallet, record.signingDescriptor, {
-        stored: record.preimageHex ? decodeHex32(record.preimageHex, "preimageHex") : undefined,
-        salt: record.preimageSaltHex
+    // Decoding sits outside the derivation try: a malformed record is the
+    // caller's bug, not evidence the wallet cannot derive.
+    let stored: Uint8Array | undefined;
+    let salt: Uint8Array | undefined;
+    try {
+        stored = record.preimageHex ? decodeHex32(record.preimageHex, "preimageHex") : undefined;
+        salt = record.preimageSaltHex
             ? decodeHex32(record.preimageSaltHex, "preimageSaltHex")
-            : undefined,
-    });
+            : undefined;
+    } catch (cause) {
+        throw new PreimageNotRecoverableError(
+            "malformed-record",
+            `this swap record's secrets projection is unreadable: ${String(cause)}`,
+            { cause },
+        );
+    }
+
+    let preimage: Uint8Array;
+    try {
+        preimage = await contractPreimage(wallet, record.signingDescriptor, { stored, salt });
+    } catch (cause) {
+        throw new PreimageNotRecoverableError(
+            "not-derivable",
+            `this wallet cannot produce the preimage for ${record.signingDescriptor}`,
+            { cause },
+        );
+    }
+
     if (record.paymentHash && hex.encode(sha256(preimage)) !== record.paymentHash) {
-        throw new Error(
+        throw new PreimageNotRecoverableError(
+            "hash-mismatch",
             "the derived preimage does not match this swap's payment hash: wrong wallet, or a tampered salt",
         );
     }

--- a/packages/swap/src/store.ts
+++ b/packages/swap/src/store.ts
@@ -335,7 +335,11 @@ export const preimageForSwapRecord = async (
         );
     }
 
-    if (record.paymentHash && hex.encode(sha256(preimage)) !== record.paymentHash) {
+    // Case-folded: `hex.encode` always emits lowercase, but `hex.decode`
+    // accepts either, so a backend that normalises hex to uppercase round-trips
+    // the salt and the preimage fine and then fails only here — a spurious
+    // hash-mismatch on a preimage that is actually correct.
+    if (record.paymentHash && hex.encode(sha256(preimage)) !== record.paymentHash.toLowerCase()) {
         throw new PreimageNotRecoverableError(
             "hash-mismatch",
             "the derived preimage does not match this swap's payment hash: wrong wallet, or a tampered salt",

--- a/packages/swap/test/rfqDerivedSecrets.test.ts
+++ b/packages/swap/test/rfqDerivedSecrets.test.ts
@@ -46,6 +46,7 @@ import {
 } from "../src/rfq";
 import { onchainHtlcScript, paymentHashOf } from "../src/onchainHtlc";
 import { contractPreimage } from "@arkade-os/sdk";
+import { swapSecretsToRecord } from "../src/store";
 
 const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
 const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
@@ -300,11 +301,9 @@ describe("requestOnchainSend on an HD wallet", () => {
 
         // The quote was requested against sha256 of the derived preimage, and
         // the preimage re-derives from the returned descriptor alone.
-        const preimage = await contractPreimage(
-            wallet,
-            result.secrets.descriptor,
-            result.secrets.preimage,
-        );
+        const preimage = await contractPreimage(wallet, result.secrets.descriptor, {
+            stored: result.secrets.preimage,
+        });
         expect(seen.paymentHash).toBe(paymentHashOf(preimage));
         expect(seen.senderPubkey).toBe(hex.encode(result.senderPubkey));
     });
@@ -342,7 +341,9 @@ describe("requestOnchainSend on an HD wallet", () => {
 
             expect(result.secrets.preimage).toEqual(preimage);
             expect(
-                await contractPreimage(wallet, result.secrets.descriptor, result.secrets.preimage),
+                await contractPreimage(wallet, result.secrets.descriptor, {
+                    stored: result.secrets.preimage,
+                }),
             ).toEqual(preimage);
 
             const signer = await wallet.signerForDescriptor!(result.secrets.descriptor);
@@ -360,9 +361,9 @@ describe("requestOnchainSend on an HD wallet", () => {
     });
 
     it("binds a static wallet's swap to its identity key, never a minted one", async () => {
-        // The wallet that cannot allocate still provides ITS key. The one
-        // secret the record carries is the per-swap preimage — a static key
-        // deriving preimages would hand every swap the same one.
+        // The wallet that cannot allocate still provides ITS key. This case
+        // supplies its own preimage, so the record does carry one — see the
+        // next test for what a static wallet stores when it does not.
         const wallet = staticWallet();
         const preimage = new Uint8Array(32).fill(8);
         const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -383,7 +384,9 @@ describe("requestOnchainSend on an HD wallet", () => {
             );
             expect(result.secrets.preimage).toEqual(preimage);
             expect(
-                await contractPreimage(wallet, result.secrets.descriptor, result.secrets.preimage),
+                await contractPreimage(wallet, result.secrets.descriptor, {
+                    stored: result.secrets.preimage,
+                }),
             ).toEqual(preimage);
             expect(result.secrets.mustPersistPreimage).toBe(true);
             expect(warn).toHaveBeenCalledWith(
@@ -394,32 +397,74 @@ describe("requestOnchainSend on an HD wallet", () => {
         }
     });
 
-    it("mints a stored per-swap preimage for a static wallet when none is supplied", async () => {
+    it("derives a static wallet's preimage from a per-swap salt, storing nothing secret", async () => {
         const wallet = staticWallet();
         const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
         try {
-            const first = await requestOnchainSend(wallet, "http://ark", onchainTransport({}), {
-                emulatorPubkey: EMULATOR_PUBKEY_HEX,
-                amount: 100_000,
-                amountSide: "to",
-                payoutPubkey: PAYOUT_PUBKEY,
-            });
-            const second = await requestOnchainSend(wallet, "http://ark", onchainTransport({}), {
+            const send = () =>
+                requestOnchainSend(wallet, "http://ark", onchainTransport({}), {
+                    emulatorPubkey: EMULATOR_PUBKEY_HEX,
+                    amount: 100_000,
+                    amountSide: "to",
+                    payoutPubkey: PAYOUT_PUBKEY,
+                });
+            const first = await send();
+            const second = await send();
+
+            // Same key for both swaps — that is the static policy — but the
+            // salts, and therefore the preimages, must never repeat.
+            expect(second.secrets.descriptor).toBe(first.secrets.descriptor);
+            expect(first.secrets.preimageSalt).toHaveLength(32);
+            expect(hex.encode(second.secrets.preimageSalt!)).not.toBe(
+                hex.encode(first.secrets.preimageSalt!),
+            );
+            expect(hex.encode(second.secrets.preimage)).not.toBe(
+                hex.encode(first.secrets.preimage),
+            );
+
+            // Nothing to persist, and therefore no warning: the salt is public
+            // and the preimage re-derives from it.
+            for (const result of [first, second]) {
+                expect(result.secrets.mustPersistPreimage).toBe(false);
+                expect(swapSecretsToRecord(result.secrets).preimageHex).toBeUndefined();
+                expect(
+                    hex.encode(
+                        await contractPreimage(wallet, result.secrets.descriptor, {
+                            salt: result.secrets.preimageSalt,
+                        }),
+                    ),
+                ).toBe(hex.encode(result.secrets.preimage));
+            }
+            expect(warn).not.toHaveBeenCalledWith(
+                expect.stringContaining("cannot be re-derived from the seed"),
+            );
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it("writes only public fields on a derived-arm record, on either wallet", async () => {
+        // Backstop against a future change putting a secret back on disk. An
+        // allowlist rather than a hex pattern: `preimageSaltHex` is 64 hex too,
+        // and the difference between it and `preimageHex` is what they mean,
+        // not what they look like.
+        const send = (wallet: IWallet) =>
+            requestOnchainSend(wallet, "http://ark", onchainTransport({}), {
                 emulatorPubkey: EMULATOR_PUBKEY_HEX,
                 amount: 100_000,
                 amountSide: "to",
                 payoutPubkey: PAYOUT_PUBKEY,
             });
 
-            // Same key for both swaps — that is the static policy — but the
-            // stored preimages must never repeat.
-            expect(second.secrets.descriptor).toBe(first.secrets.descriptor);
-            expect(first.secrets.preimage).toHaveLength(32);
-            expect(hex.encode(second.secrets.preimage!)).not.toBe(
-                hex.encode(first.secrets.preimage!),
+        for (const wallet of [await hdWallet(), staticWallet()]) {
+            const record = swapSecretsToRecord((await send(wallet)).secrets);
+            expect(record.preimageHex).toBeUndefined();
+            expect(Object.keys(record).sort()).toEqual(
+                expect.arrayContaining(["signingDescriptor"]),
             );
-        } finally {
-            warn.mockRestore();
+            for (const field of Object.keys(record)) {
+                expect(["signingDescriptor", "preimageSaltHex"]).toContain(field);
+            }
         }
     });
 });

--- a/packages/swap/test/rfqReceive.test.ts
+++ b/packages/swap/test/rfqReceive.test.ts
@@ -672,11 +672,9 @@ describe("requestLightningReceive on an HD wallet", () => {
         expect(result.invoiceExpiresAt).toBe(INVOICE_EXPIRES_AT);
         // The quote was requested against sha256 of the derived preimage, and
         // the covenant's receiver key is the allocated one.
-        const preimage = await contractPreimage(
-            flow.wallet,
-            result.secrets.descriptor,
-            result.secrets.preimage,
-        );
+        const preimage = await contractPreimage(flow.wallet, result.secrets.descriptor, {
+            stored: result.secrets.preimage,
+        });
         expect(flow.seen.paymentHash).toBe(paymentHashOf(preimage));
         expect(flow.seen.payoutPubkey).toBe(hex.encode(result.payoutPubkey));
         // The wire carries the sealed packet string, never an object.
@@ -835,11 +833,9 @@ describe("requestOnchainReceive on an HD wallet", () => {
         expect(result.fundAmount).toBe(100_000);
         expect(result.expectedAmount).toBe(99_000);
         expect(result.htlc.address).toMatch(/^bcrt1p/);
-        const preimage = await contractPreimage(
-            wallet,
-            result.secrets.descriptor,
-            result.secrets.preimage,
-        );
+        const preimage = await contractPreimage(wallet, result.secrets.descriptor, {
+            stored: result.secrets.preimage,
+        });
         expect(seen.paymentHash).toBe(paymentHashOf(preimage));
     });
 });

--- a/packages/swap/test/swapSecretsRecord.test.ts
+++ b/packages/swap/test/swapSecretsRecord.test.ts
@@ -26,6 +26,21 @@ import {
 const staticWallet = (key = SingleKey.fromRandomBytes()) =>
     ({ identity: key }) as unknown as IWallet;
 
+/**
+ * A complete identity that cannot sign deterministically — an extension or
+ * remote signer, which is the only thing that still reaches the stored-preimage
+ * arm. A partial identity is refused by `contractSigner` before it gets there.
+ */
+const nonDerivingWallet = (key = SingleKey.fromRandomBytes()) =>
+    ({
+        identity: {
+            sign: (tx: unknown) => key.sign(tx as never),
+            signMessage: (m: Uint8Array) => key.signMessage(m),
+            signerSession: () => key.signerSession(),
+            xOnlyPublicKey: () => key.xOnlyPublicKey(),
+        },
+    }) as unknown as IWallet;
+
 /** What a consumer persists: the projection, plus the committed hash. */
 const recordOf = (secrets: ProvisionedClaimSecret) => ({
     ...swapSecretsToRecord(secrets),
@@ -70,6 +85,57 @@ describe("swapSecretsToRecord", () => {
             const record = swapSecretsToRecord(secrets);
             expect(Boolean(record.preimageHex) && Boolean(record.preimageSaltHex)).toBe(false);
         }
+    });
+});
+
+describe("projection completeness", () => {
+    // The compile-time tie in `SwapSecretsProjection` guarantees a mapper field
+    // is CARRIED by every record type. It cannot guarantee the reader CONSULTS
+    // it, because every field is optional — so a future derivation input that
+    // `swapSecretsToRecord` writes and `preimageForSwapRecord` ignores would
+    // compile happily and surface as a dead script at claim time.
+    //
+    // This is that missing half: every arm goes mapper → record → reader and
+    // must come back with the preimage it was provisioned with. `recordOf`
+    // carries `paymentHash`, so a wrong P trips the guard here too.
+    const arms: {
+        name: string;
+        carries: "preimageHex" | "preimageSaltHex";
+        walletFor: (key: SingleKey) => IWallet;
+        opts: { preimage?: Uint8Array };
+    }[] = [
+        {
+            name: "salted — a static wallet that can derive",
+            carries: "preimageSaltHex",
+            walletFor: (key) => staticWallet(key),
+            opts: {},
+        },
+        {
+            name: "stored — a signer that cannot derive",
+            carries: "preimageHex",
+            walletFor: (key) => nonDerivingWallet(key),
+            opts: {},
+        },
+        {
+            name: "stored — a caller-supplied preimage",
+            carries: "preimageHex",
+            walletFor: (key) => staticWallet(key),
+            opts: { preimage: new Uint8Array(32).fill(5) },
+        },
+    ];
+
+    it.each(arms)("$name round-trips through the record", async ({ carries, walletFor, opts }) => {
+        const wallet = walletFor(SingleKey.fromRandomBytes());
+        const secrets = await provisionClaimSecret(wallet, opts);
+        const record = recordOf(secrets);
+
+        // This case really is exercising the arm it names.
+        expect(record[carries]).toBeDefined();
+        // And the reader reproduces the provisioned preimage from the record
+        // alone — every field it needs survived the mapper.
+        expect(hex.encode(await preimageForSwapRecord(wallet, record))).toBe(
+            hex.encode(secrets.preimage),
+        );
     });
 });
 

--- a/packages/swap/test/swapSecretsRecord.test.ts
+++ b/packages/swap/test/swapSecretsRecord.test.ts
@@ -242,6 +242,36 @@ describe("preimageForSwapRecord", () => {
             ).toBe("not-derivable");
         });
 
+        it("accepts an uppercase payment hash", async () => {
+            // `hex.encode` emits lowercase but `hex.decode` accepts either, so
+            // a backend that normalises hex to uppercase round-trips the salt
+            // fine and would fail only here — a spurious mismatch on a correct
+            // preimage, which is the hardest kind to diagnose.
+            const key = SingleKey.fromRandomBytes();
+            const secrets = await provisionClaimSecret(staticWallet(key));
+            const record = recordOf(secrets);
+            record.paymentHash = record.paymentHash.toUpperCase();
+
+            expect(hex.encode(await preimageForSwapRecord(staticWallet(key), record))).toBe(
+                hex.encode(secrets.preimage),
+            );
+        });
+
+        it("catches the wrong wallet even with no payment hash to check", async () => {
+            // The key check in `contractSigner` fires before anything is
+            // derived, so the guard is a second line of defence, not the only
+            // one: a record with no `paymentHash` is still not claimable by a
+            // wallet that does not hold its descriptor's key.
+            const secrets = await provisionClaimSecret(staticWallet());
+            const record = swapSecretsToRecord(secrets);
+
+            expect(
+                await reasonOf(
+                    preimageForSwapRecord(staticWallet(SingleKey.fromRandomBytes()), record),
+                ),
+            ).toBe("not-derivable");
+        });
+
         it("stays quiet when the record carries no payment hash", async () => {
             const key = SingleKey.fromRandomBytes();
             const secrets = await provisionClaimSecret(staticWallet(key));

--- a/packages/swap/test/swapSecretsRecord.test.ts
+++ b/packages/swap/test/swapSecretsRecord.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The record↔secret round trip, and the read path that inverts it.
+ *
+ * The write side (`swapSecretsToRecord`) and the read side
+ * (`preimageForSwapRecord`) have to agree about which fields are derivation
+ * inputs. When they disagree the failure is silent — a wallet that CAN derive
+ * hands back a preimage the chain will never match — so the round trip is
+ * asserted end to end rather than field by field.
+ */
+import { describe, expect, it } from "vitest";
+import { hex } from "@scure/base";
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+    SingleKey,
+    provisionClaimSecret,
+    type IWallet,
+    type ProvisionedClaimSecret,
+} from "@arkade-os/sdk";
+import { preimageForSwapRecord, swapSecretsToRecord } from "../src/store";
+
+/** A wallet with no descriptor surface: its identity is its whole policy. */
+const staticWallet = (key = SingleKey.fromRandomBytes()) =>
+    ({ identity: key }) as unknown as IWallet;
+
+/** What a consumer persists: the projection, plus the committed hash. */
+const recordOf = (secrets: ProvisionedClaimSecret) => ({
+    ...swapSecretsToRecord(secrets),
+    paymentHash: hex.encode(secrets.paymentHash),
+});
+
+describe("swapSecretsToRecord", () => {
+    it("stores the salt in the clear and no preimage, on the salted arm", async () => {
+        const secrets = await provisionClaimSecret(staticWallet());
+        const record = swapSecretsToRecord(secrets);
+
+        expect(record.signingDescriptor).toBe(secrets.descriptor);
+        expect(record.preimageSaltHex).toBe(hex.encode(secrets.preimageSalt!));
+        expect(record.preimageHex).toBeUndefined();
+    });
+
+    it("stores the preimage and no salt when the wallet cannot derive", async () => {
+        const key = SingleKey.fromRandomBytes();
+        const identity = { xOnlyPublicKey: () => key.xOnlyPublicKey() };
+        const secrets = await provisionClaimSecret({ identity } as unknown as IWallet);
+        const record = swapSecretsToRecord(secrets);
+
+        expect(record.preimageHex).toBe(hex.encode(secrets.preimage));
+        expect(record.preimageSaltHex).toBeUndefined();
+    });
+
+    it("never writes both a preimage and a salt", async () => {
+        // They are alternatives, not a pair: a record carrying both invites a
+        // reader to pick the wrong one.
+        for (const secrets of [
+            await provisionClaimSecret(staticWallet()),
+            await provisionClaimSecret(staticWallet(), { preimage: new Uint8Array(32).fill(4) }),
+        ]) {
+            const record = swapSecretsToRecord(secrets);
+            expect(Boolean(record.preimageHex) && Boolean(record.preimageSaltHex)).toBe(false);
+        }
+    });
+});
+
+describe("preimageForSwapRecord", () => {
+    it("re-derives a static wallet's preimage from public record fields alone", async () => {
+        // The restore case: the repository survived, nothing secret is in it,
+        // and a wallet rebuilt from the seed reproduces P.
+        const key = SingleKey.fromRandomBytes();
+        const secrets = await provisionClaimSecret(staticWallet(key));
+        const record = recordOf(secrets);
+        expect(record.preimageHex).toBeUndefined();
+
+        const restored = staticWallet(SingleKey.fromHex(key.toHex()));
+        expect(hex.encode(await preimageForSwapRecord(restored, record))).toBe(
+            hex.encode(secrets.preimage),
+        );
+    });
+
+    it("returns a stored preimage whatever the wallet can do", async () => {
+        // Pinned as a literal rather than a record the current code produces:
+        // this is the back-compat line for rows written by 0.0.1–0.0.3, and it
+        // has to stay honest as the write path keeps moving.
+        const preimage = new Uint8Array(32).fill(7);
+        const key = SingleKey.fromRandomBytes();
+        const record = {
+            signingDescriptor: `tr(${hex.encode(await key.xOnlyPublicKey())})`,
+            preimageHex: hex.encode(preimage),
+            paymentHash: hex.encode(sha256(preimage)),
+        };
+
+        expect(hex.encode(await preimageForSwapRecord(staticWallet(key), record))).toBe(
+            hex.encode(preimage),
+        );
+    });
+
+    it("refuses a record with no signing descriptor", async () => {
+        await expect(preimageForSwapRecord(staticWallet(), {})).rejects.toThrow(
+            /no signing descriptor/,
+        );
+    });
+
+    it("refuses a salt that is not 32 bytes", async () => {
+        const key = SingleKey.fromRandomBytes();
+        await expect(
+            preimageForSwapRecord(staticWallet(key), {
+                signingDescriptor: `tr(${hex.encode(await key.xOnlyPublicKey())})`,
+                preimageSaltHex: "aabb",
+            }),
+        ).rejects.toThrow(/preimageSaltHex must be 32 bytes/);
+    });
+
+    describe("the payment-hash guard", () => {
+        it("catches a tampered salt", async () => {
+            // The right wallet, so the descriptor check passes and the guard
+            // is the only thing standing between a swapped salt and a claim
+            // attempt with a preimage the chain will never match.
+            const key = SingleKey.fromRandomBytes();
+            const secrets = await provisionClaimSecret(staticWallet(key));
+            const record = recordOf(secrets);
+            // Same length, different bytes: derives cleanly, matches nothing.
+            record.preimageSaltHex = "ab".repeat(32);
+
+            await expect(preimageForSwapRecord(staticWallet(key), record)).rejects.toThrow(
+                /does not match this swap's payment hash/,
+            );
+        });
+
+        it("catches the wrong wallet", async () => {
+            // The salted arm has two inputs that can be wrong where the HD arm
+            // had one. Without this the mistake surfaces as a dead script.
+            const secrets = await provisionClaimSecret(staticWallet());
+            const record = recordOf(secrets);
+
+            await expect(
+                preimageForSwapRecord(staticWallet(SingleKey.fromRandomBytes()), record),
+            ).rejects.toThrow(/holds no key for descriptor|does not match/);
+        });
+
+        it("stays quiet when the record carries no payment hash", async () => {
+            const key = SingleKey.fromRandomBytes();
+            const secrets = await provisionClaimSecret(staticWallet(key));
+            const record = swapSecretsToRecord(secrets);
+
+            await expect(
+                preimageForSwapRecord(staticWallet(SingleKey.fromHex(key.toHex())), record),
+            ).resolves.toHaveLength(32);
+        });
+    });
+});

--- a/packages/swap/test/swapSecretsRecord.test.ts
+++ b/packages/swap/test/swapSecretsRecord.test.ts
@@ -16,7 +16,11 @@ import {
     type IWallet,
     type ProvisionedClaimSecret,
 } from "@arkade-os/sdk";
-import { preimageForSwapRecord, swapSecretsToRecord } from "../src/store";
+import {
+    PreimageNotRecoverableError,
+    preimageForSwapRecord,
+    swapSecretsToRecord,
+} from "../src/store";
 
 /** A wallet with no descriptor surface: its identity is its whole policy. */
 const staticWallet = (key = SingleKey.fromRandomBytes()) =>
@@ -39,8 +43,16 @@ describe("swapSecretsToRecord", () => {
     });
 
     it("stores the preimage and no salt when the wallet cannot derive", async () => {
+        // A COMPLETE identity that simply cannot sign deterministically — an
+        // extension or remote signer. A partial one is refused outright by
+        // `contractSigner`, so it never reaches this arm.
         const key = SingleKey.fromRandomBytes();
-        const identity = { xOnlyPublicKey: () => key.xOnlyPublicKey() };
+        const identity = {
+            sign: (tx: unknown) => key.sign(tx as never),
+            signMessage: (m: Uint8Array) => key.signMessage(m),
+            signerSession: () => key.signerSession(),
+            xOnlyPublicKey: () => key.xOnlyPublicKey(),
+        };
         const secrets = await provisionClaimSecret({ identity } as unknown as IWallet);
         const record = swapSecretsToRecord(secrets);
 
@@ -93,20 +105,44 @@ describe("preimageForSwapRecord", () => {
         );
     });
 
+    /** The reason of the `PreimageNotRecoverableError` a call throws. */
+    const reasonOf = async (call: Promise<unknown>): Promise<string> => {
+        try {
+            await call;
+        } catch (error) {
+            expect(error).toBeInstanceOf(PreimageNotRecoverableError);
+            return (error as PreimageNotRecoverableError).reason;
+        }
+        throw new Error("expected the call to throw");
+    };
+
     it("refuses a record with no signing descriptor", async () => {
-        await expect(preimageForSwapRecord(staticWallet(), {})).rejects.toThrow(
-            /no signing descriptor/,
-        );
+        // Typed, so a caller can tell this from a corrupt salt without
+        // matching on message text.
+        expect(await reasonOf(preimageForSwapRecord(staticWallet(), {}))).toBe("no-secrets");
     });
 
     it("refuses a salt that is not 32 bytes", async () => {
         const key = SingleKey.fromRandomBytes();
-        await expect(
-            preimageForSwapRecord(staticWallet(key), {
-                signingDescriptor: `tr(${hex.encode(await key.xOnlyPublicKey())})`,
-                preimageSaltHex: "aabb",
-            }),
-        ).rejects.toThrow(/preimageSaltHex must be 32 bytes/);
+        expect(
+            await reasonOf(
+                preimageForSwapRecord(staticWallet(key), {
+                    signingDescriptor: `tr(${hex.encode(await key.xOnlyPublicKey())})`,
+                    preimageSaltHex: "aabb",
+                }),
+            ),
+        ).toBe("malformed-record");
+    });
+
+    it("refuses a static record carrying neither a preimage nor a salt", async () => {
+        const key = SingleKey.fromRandomBytes();
+        expect(
+            await reasonOf(
+                preimageForSwapRecord(staticWallet(key), {
+                    signingDescriptor: `tr(${hex.encode(await key.xOnlyPublicKey())})`,
+                }),
+            ),
+        ).toBe("not-derivable");
     });
 
     describe("the payment-hash guard", () => {
@@ -120,20 +156,24 @@ describe("preimageForSwapRecord", () => {
             // Same length, different bytes: derives cleanly, matches nothing.
             record.preimageSaltHex = "ab".repeat(32);
 
-            await expect(preimageForSwapRecord(staticWallet(key), record)).rejects.toThrow(
-                /does not match this swap's payment hash/,
+            expect(await reasonOf(preimageForSwapRecord(staticWallet(key), record))).toBe(
+                "hash-mismatch",
             );
         });
 
         it("catches the wrong wallet", async () => {
             // The salted arm has two inputs that can be wrong where the HD arm
             // had one. Without this the mistake surfaces as a dead script.
+            // Refused as `not-derivable` rather than `hash-mismatch`: the key
+            // check fires first, before anything is derived.
             const secrets = await provisionClaimSecret(staticWallet());
             const record = recordOf(secrets);
 
-            await expect(
-                preimageForSwapRecord(staticWallet(SingleKey.fromRandomBytes()), record),
-            ).rejects.toThrow(/holds no key for descriptor|does not match/);
+            expect(
+                await reasonOf(
+                    preimageForSwapRecord(staticWallet(SingleKey.fromRandomBytes()), record),
+                ),
+            ).toBe("not-derivable");
         });
 
         it("stays quiet when the record carries no payment hash", async () => {

--- a/packages/ts-sdk/src/identity/seedIdentity.ts
+++ b/packages/ts-sdk/src/identity/seedIdentity.ts
@@ -228,6 +228,20 @@ export class SeedIdentity implements HDCapableIdentity {
         return this.signMessageWithKey(this.derivedKey, message, signatureType);
     }
 
+    /**
+     * BIP-340 sign `messageHash` with this identity's own key, aux_rand = 0.
+     *
+     * The descriptor-less sibling of
+     * {@link signSchnorrDeterministicWithDescriptor}, for an `auto`-mode wallet
+     * whose bare `tr(pubkey)` resolves to the identity itself rather than to a
+     * {@link DescriptorIdentity}. Deliberately NOT routed through
+     * `signMessage`, whose schnorr branch draws a random aux_rand and would
+     * make the "deterministic" signature unreproducible.
+     */
+    async signSchnorrDeterministic(messageHash: Uint8Array): Promise<Uint8Array> {
+        return schnorr.signAsync(messageHash, this.derivedKey, new Uint8Array(32));
+    }
+
     signerSession(): SignerSession {
         return TreeSignerSession.random();
     }

--- a/packages/ts-sdk/src/identity/singleKey.ts
+++ b/packages/ts-sdk/src/identity/singleKey.ts
@@ -104,6 +104,19 @@ export class SingleKey implements Identity {
         return schnorr.signAsync(message, this.key);
     }
 
+    /**
+     * BIP-340 sign `messageHash` with aux_rand = 0, so the signature — and
+     * anything derived from it — is reproducible from the key alone.
+     *
+     * What lets a static wallet derive a swap preimage instead of storing one
+     * (see `wallet/contractSecrets.ts`). Deliberately NOT `signMessage`, whose
+     * schnorr branch draws a random aux_rand: a preimage derived from that is
+     * unrecoverable, and the loss would only surface at claim time.
+     */
+    async signSchnorrDeterministic(messageHash: Uint8Array): Promise<Uint8Array> {
+        return schnorr.signAsync(messageHash, this.key, new Uint8Array(32));
+    }
+
     async toReadonly(): Promise<ReadonlySingleKey> {
         return new ReadonlySingleKey(await this.compressedPublicKey());
     }

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -38,9 +38,11 @@ import {
     resolveDescriptorSigner,
 } from "./wallet/hdWalletCapable";
 import {
+    ARKADE_SALTED_PREIMAGE_TAG,
     ARKADE_SWAP_PREIMAGE_TAG,
     adoptContractDescriptor,
     buildPreimageMessage,
+    buildSaltedPreimageMessage,
     contractPreimage,
     contractSigner,
     isDeterministicSigner,
@@ -539,9 +541,11 @@ export {
     isHDAllocationCapable,
     ForeignDescriptorError,
     resolveDescriptorSigner,
+    ARKADE_SALTED_PREIMAGE_TAG,
     ARKADE_SWAP_PREIMAGE_TAG,
     adoptContractDescriptor,
     buildPreimageMessage,
+    buildSaltedPreimageMessage,
     contractPreimage,
     contractSigner,
     isDeterministicSigner,

--- a/packages/ts-sdk/src/wallet/contractSecrets.ts
+++ b/packages/ts-sdk/src/wallet/contractSecrets.ts
@@ -375,6 +375,14 @@ export async function contractPreimage(
  * derivation reproducible. `DescriptorIdentity` satisfies it, and throws
  * rather than degrading to a random-aux signer. */
 export interface DeterministicSigner extends ReadonlyIdentity {
+    /**
+     * Implementors wrapping a remote: throw only for a refusal that will
+     * repeat. {@link provisionClaimSecret} reads a transient throw — a network
+     * hiccup, an extension timeout — as "this signer cannot derive", and falls
+     * back to a stored random preimage for the artifact's whole life. That is
+     * claimable, but it persists a secret the seed would otherwise have
+     * replaced, and nothing surfaces the downgrade to the caller.
+     */
     signSchnorrDeterministic(messageHash: Uint8Array): Promise<Uint8Array>;
 }
 

--- a/packages/ts-sdk/src/wallet/contractSecrets.ts
+++ b/packages/ts-sdk/src/wallet/contractSecrets.ts
@@ -14,9 +14,17 @@
  * type. An HD child descriptor belongs to exactly one artifact, so its
  * preimage can be a deterministic signature over the key — recoverable from
  * the seed with nothing at rest. A bare `tr(pubkey)` repeats across artifacts,
- * so the same derivation would hand every artifact the identical preimage;
- * those get a random one, and `mustPersistPreimage` tells the caller it is now
- * the artifact's only claim secret.
+ * so the same derivation would hand every artifact the identical preimage.
+ * Those derive from a **salted** message instead: 32 public bytes minted per
+ * artifact and stored in the clear, which restore uniqueness without the key
+ * having to be unique. Only a signer that cannot sign deterministically at all
+ * still gets a random preimage, and `mustPersistPreimage` tells the caller it
+ * is then the artifact's only claim secret.
+ *
+ * Uniqueness therefore never rests on a claim about the descriptor. The shape
+ * test picks the arm; it is not load-bearing for collision safety, so a custom
+ * `DescriptorProvider` handing back one constant descriptor forever still gets
+ * a distinct preimage per artifact.
  */
 import { sha256 } from "@noble/hashes/sha2.js";
 import { randomBytes } from "@noble/hashes/utils.js";
@@ -46,6 +54,20 @@ import type { IWallet } from ".";
 export const ARKADE_SWAP_PREIMAGE_TAG = "Arkade-RFQ-Preimage-v1";
 
 /**
+ * Domain separator for the **salted** preimage derivation, used when the
+ * descriptor repeats across artifacts.
+ *
+ * Corridor-generic where {@link ARKADE_SWAP_PREIMAGE_TAG} is not, and that
+ * asymmetry is deliberate. The v1 tags must be per-corridor
+ * (`Arkade-RFQ-Preimage-v1` here, NArk's `Arkade-Boltz-Preimage-v1` there)
+ * because v1 pins its message index, so the tag is the only thing separating
+ * two corridors that reach the same key. v2 mints a salt per artifact, so no
+ * two artifacts share a message within a corridor, let alone across two — the
+ * salt carries the separation, and the tag names the layer it belongs to.
+ */
+export const ARKADE_SALTED_PREIMAGE_TAG = "Arkade-Contract-Preimage-Salted-v1";
+
+/**
  * `TAG ‖ xonly(32) ‖ u32le(index)` — the message that gets BIP-340 signed.
  *
  * Anchored on the canonical x-only key rather than the descriptor string: a
@@ -68,9 +90,32 @@ export function buildPreimageMessage(xonly: Uint8Array, index: number): Uint8Arr
 }
 
 /**
- * Deriving is only safe when the key belongs to one artifact, so the message
- * index stays pinned. Kept a parameter of {@link buildPreimageMessage} for
- * cross-SDK vectors.
+ * `TAG ‖ xonly(32) ‖ salt(32)` — the salted message that gets BIP-340 signed.
+ *
+ * The salt replaces v1's pinned index as the source of per-artifact
+ * uniqueness, which is what lets a key that repeats across artifacts still
+ * derive a distinct preimage for each. It is public: knowing it yields nothing
+ * without the seed.
+ */
+export function buildSaltedPreimageMessage(xonly: Uint8Array, salt: Uint8Array): Uint8Array {
+    if (xonly.length !== 32) {
+        throw new Error(`x-only pubkey must be 32 bytes, got ${xonly.length}`);
+    }
+    if (salt.length !== 32) {
+        throw new Error(`preimage salt must be 32 bytes, got ${salt.length}`);
+    }
+    const tag = new TextEncoder().encode(ARKADE_SALTED_PREIMAGE_TAG);
+    const message = new Uint8Array(tag.length + 32 + 32);
+    message.set(tag, 0);
+    message.set(xonly, tag.length);
+    message.set(salt, tag.length + 32);
+    return message;
+}
+
+/**
+ * Deriving unsalted is only safe when the key belongs to one artifact, so the
+ * message index stays pinned. Kept a parameter of
+ * {@link buildPreimageMessage} for cross-SDK vectors.
  */
 const PREIMAGE_INDEX = 0;
 
@@ -100,10 +145,21 @@ export interface ProvisionedClaimSecret extends ProvisionedKey {
     /** `sha256(preimage)` — what the contract commits to. */
     paymentHash: Uint8Array;
     /**
+     * The salt {@link preimage} was derived from, when it came from the salted
+     * arm. **Public** — the opposite of {@link preimage} above: persist it with
+     * the artifact in the clear, because without it a wallet holding the seed
+     * still cannot re-derive P.
+     *
+     * Absent on the other two arms: an HD child descriptor already names one
+     * artifact, and a stored preimage needs no derivation input.
+     */
+    preimageSalt?: Uint8Array;
+    /**
      * Persist `preimage` with the artifact: this wallet cannot re-derive it.
-     * True when the caller supplied P, or when the descriptor is shared across
-     * artifacts. When false the preimage re-derives from the seed and nothing
-     * secret needs to be stored.
+     * True when the caller supplied P, or when the signer cannot sign
+     * deterministically. When false the preimage re-derives from the seed —
+     * given {@link preimageSalt}, where there is one — and nothing secret
+     * needs to be stored.
      */
     mustPersistPreimage: boolean;
 }
@@ -149,6 +205,19 @@ export async function provisionRefundKey(wallet: IWallet): Promise<ProvisionedKe
  * Pass `opts.preimage` to bring your own 32-byte P; it comes back verbatim
  * with `mustPersistPreimage` set, since the wallet cannot re-derive what it
  * did not choose.
+ *
+ * Three arms, and which one a wallet lands in is the whole of this function:
+ *
+ * 1. **Caller-supplied P.** Returned unchanged, `mustPersistPreimage: true`.
+ * 2. **Per-artifact descriptor** (an HD child). Derives from the key alone at
+ *    the pinned index. Nothing at rest. Raises rather than falling through if
+ *    the signer cannot sign deterministically — an HD descriptor whose wallet
+ *    refuses is a broken wallet, not a fallback case.
+ * 3. **Anything else** — a static wallet's `tr(pubkey)`, or a constant
+ *    descriptor from a custom provider. Mints a public per-artifact salt and
+ *    derives from it, so a key that repeats still yields a distinct P. Only
+ *    this arm falls back to a stored random preimage, and only when the signer
+ *    refuses — which is discovered by deriving, never by probing.
  */
 export async function provisionClaimSecret(
     wallet: IWallet,
@@ -160,15 +229,39 @@ export async function provisionClaimSecret(
         throw new Error(`preimage must be 32 bytes, got ${opts.preimage.length}`);
     }
     const { descriptor, pubkey } = await provisionRefundKey(wallet);
-    const derivable = !opts.preimage && isPerArtifactDescriptor(descriptor);
-    const preimage =
-        opts.preimage ?? (derivable ? await derivePreimage(wallet, descriptor) : randomBytes(32));
+    const claim = async (): Promise<
+        Pick<ProvisionedClaimSecret, "preimage" | "preimageSalt" | "mustPersistPreimage">
+    > => {
+        if (opts.preimage) return { preimage: opts.preimage, mustPersistPreimage: true };
+        if (isPerArtifactDescriptor(descriptor)) {
+            return {
+                preimage: await derivePreimage(wallet, descriptor),
+                mustPersistPreimage: false,
+            };
+        }
+        const preimageSalt = randomBytes(32);
+        try {
+            return {
+                preimage: await derivePreimage(wallet, descriptor, preimageSalt),
+                preimageSalt,
+                mustPersistPreimage: false,
+            };
+        } catch {
+            // The probe IS the use: DescriptorIdentity exposes the method and
+            // only refuses at call time, so asking first would answer for a
+            // different question than the one that matters. Discard the salt —
+            // a record carrying one it cannot derive from is worse than none.
+            return { preimage: randomBytes(32), mustPersistPreimage: true };
+        }
+    };
+    const { preimage, preimageSalt, mustPersistPreimage } = await claim();
     return {
         descriptor,
         pubkey,
         preimage,
         paymentHash: sha256(preimage),
-        mustPersistPreimage: !derivable,
+        ...(preimageSalt ? { preimageSalt } : {}),
+        mustPersistPreimage,
     };
 }
 
@@ -233,33 +326,38 @@ export class WalletCannotSignError extends Error {
 }
 
 /**
- * The preimage for a provisioned descriptor: `stored` when the artifact kept
- * one, otherwise re-derived from the seed.
+ * The preimage for a provisioned descriptor: `opts.stored` when the artifact
+ * kept one, otherwise re-derived from the seed.
  *
- * Throws for a descriptor shared across artifacts and no stored preimage —
- * deriving there would hand two artifacts one preimage, and the caller was
- * told to persist it (`mustPersistPreimage`).
+ * Resolves in one precedence order, mirroring the arms
+ * {@link provisionClaimSecret} chose between:
+ *
+ * 1. `opts.stored` — a caller-supplied P, or one from a wallet that could not
+ *    derive. Whatever the wallet can do now, a stored P is the artifact's.
+ * 2. a per-artifact descriptor — derive at the pinned index.
+ * 3. `opts.salt` — derive from the salted message.
+ * 4. otherwise throw: a repeating descriptor with neither a stored preimage
+ *    nor a salt has nothing to derive from that would not collide.
  */
 export async function contractPreimage(
     wallet: IWallet,
     descriptor: string,
-    stored?: Uint8Array,
+    opts: { stored?: Uint8Array; salt?: Uint8Array } = {},
 ): Promise<Uint8Array> {
-    if (stored) {
+    if (opts.stored) {
         // The check the deleted record decoder used to make. A truncated
         // column or a partial write would otherwise restore silently and be
         // diagnosed only at claim time, with the timeout margin already spent.
-        if (stored.length !== 32) {
-            throw new Error(`stored preimage must be 32 bytes, got ${stored.length}`);
+        if (opts.stored.length !== 32) {
+            throw new Error(`stored preimage must be 32 bytes, got ${opts.stored.length}`);
         }
-        return stored;
+        return opts.stored;
     }
-    if (!isPerArtifactDescriptor(descriptor)) {
-        throw new Error(
-            `descriptor ${descriptor} names no single artifact, so its preimage cannot be derived; none was stored`,
-        );
-    }
-    return derivePreimage(wallet, descriptor);
+    if (isPerArtifactDescriptor(descriptor)) return derivePreimage(wallet, descriptor);
+    if (opts.salt) return derivePreimage(wallet, descriptor, opts.salt);
+    throw new Error(
+        `descriptor ${descriptor} names no single artifact, so its preimage cannot be derived; no salt and no stored preimage were given`,
+    );
 }
 
 /** An identity that signs with `aux_rand = 0`, which is what makes the
@@ -278,11 +376,16 @@ export function isDeterministicSigner(value: unknown): value is DeterministicSig
 }
 
 /**
- * `sha256(sign_det(sha256(TAG ‖ xonly ‖ index)))`, where the signing key and
- * the message key are the same identity — passing a key in separately is how
- * this silently derives an unrecoverable preimage.
+ * `sha256(sign_det(sha256(TAG ‖ xonly ‖ index)))`, or its salted variant when
+ * `salt` is given — where the signing key and the message key are the same
+ * identity. Passing a key in separately is how this silently derives an
+ * unrecoverable preimage.
  */
-async function derivePreimage(wallet: IWallet, descriptor: string): Promise<Uint8Array> {
+async function derivePreimage(
+    wallet: IWallet,
+    descriptor: string,
+    salt?: Uint8Array,
+): Promise<Uint8Array> {
     const signer = await contractSigner(wallet, descriptor);
     if (!isDeterministicSigner(signer)) {
         // Loud: a preimage from a random-aux signature is unrecoverable, and
@@ -291,7 +394,10 @@ async function derivePreimage(wallet: IWallet, descriptor: string): Promise<Uint
             `wallet cannot sign deterministically for ${descriptor}; its preimage is not derivable`,
         );
     }
-    const message = buildPreimageMessage(await signer.xOnlyPublicKey(), PREIMAGE_INDEX);
+    const xonly = await signer.xOnlyPublicKey();
+    const message = salt
+        ? buildSaltedPreimageMessage(xonly, salt)
+        : buildPreimageMessage(xonly, PREIMAGE_INDEX);
     try {
         return sha256(await signer.signSchnorrDeterministic(sha256(message)));
     } catch (cause) {

--- a/packages/ts-sdk/src/wallet/contractSecrets.ts
+++ b/packages/ts-sdk/src/wallet/contractSecrets.ts
@@ -246,7 +246,16 @@ export async function provisionClaimSecret(
                 preimageSalt,
                 mustPersistPreimage: false,
             };
-        } catch {
+        } catch (cause) {
+            // "Cannot sign deterministically" is the only refusal this arm may
+            // absorb. A wallet that does not hold the key, or holds it and
+            // cannot sign at all, must propagate: degrading those to a stored
+            // preimage would fund a leg nothing can spend and report success.
+            // `provisionRefundKey` resolved a signer moments ago, so reaching
+            // here means the signer changed under us.
+            if (cause instanceof ForeignDescriptorError || cause instanceof WalletCannotSignError) {
+                throw cause;
+            }
             // The probe IS the use: DescriptorIdentity exposes the method and
             // only refuses at call time, so asking first would answer for a
             // different question than the one that matters. Discard the salt —
@@ -345,9 +354,11 @@ export async function contractPreimage(
     opts: { stored?: Uint8Array; salt?: Uint8Array } = {},
 ): Promise<Uint8Array> {
     if (opts.stored) {
-        // The check the deleted record decoder used to make. A truncated
-        // column or a partial write would otherwise restore silently and be
-        // diagnosed only at claim time, with the timeout margin already spent.
+        // The check the deleted record decoder used to make, and the same
+        // OP_SIZE 32 rule provisioning enforces. An empty array is truthy, so
+        // a truncated column or a partial write would otherwise restore
+        // silently and be diagnosed only at claim time, with the timeout
+        // margin already spent.
         if (opts.stored.length !== 32) {
             throw new Error(`stored preimage must be 32 bytes, got ${opts.stored.length}`);
         }

--- a/packages/ts-sdk/test/contractSecrets.test.ts
+++ b/packages/ts-sdk/test/contractSecrets.test.ts
@@ -6,12 +6,14 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { hex } from "@scure/base";
+import { sha256 } from "@noble/hashes/sha2.js";
 import {
     DescriptorIdentity,
     HDDescriptorProvider,
     InMemoryWalletRepository,
     MnemonicIdentity,
     SingleKey,
+    deriveDescriptorLeafPubKey,
     strictSigningDescriptorIndex,
     type IWallet,
     resolveDescriptorSigner,
@@ -19,9 +21,11 @@ import {
     WalletCannotSignError,
 } from "../src";
 import {
+    ARKADE_SALTED_PREIMAGE_TAG,
     ARKADE_SWAP_PREIMAGE_TAG,
     adoptContractDescriptor,
     buildPreimageMessage,
+    buildSaltedPreimageMessage,
     contractPreimage,
     contractSigner,
     isDeterministicSigner,
@@ -95,6 +99,34 @@ describe("buildPreimageMessage", () => {
 
     it.each([-1, 1.5, 0x1_0000_0000])("rejects index %s", (index) => {
         expect(() => buildPreimageMessage(new Uint8Array(32), index)).toThrow(/u32/);
+    });
+});
+
+describe("buildSaltedPreimageMessage", () => {
+    it("lays out TAG ‖ xonly(32) ‖ salt(32)", () => {
+        const xonly = new Uint8Array(32).fill(0xab);
+        const salt = new Uint8Array(32).fill(0xcd);
+        const message = buildSaltedPreimageMessage(xonly, salt);
+        const tag = new TextEncoder().encode(ARKADE_SALTED_PREIMAGE_TAG);
+
+        expect(message).toHaveLength(tag.length + 64);
+        expect(hex.encode(message)).toBe(hex.encode(tag) + "ab".repeat(32) + "cd".repeat(32));
+    });
+
+    it("cannot collide with the pinned-index message for the same key", () => {
+        // Distinct tags are the whole separation between the two arms; a
+        // shared prefix would let one key derive one P through both.
+        const xonly = new Uint8Array(32).fill(0xab);
+        expect(ARKADE_SALTED_PREIMAGE_TAG).not.toBe(ARKADE_SWAP_PREIMAGE_TAG);
+        expect(hex.encode(buildSaltedPreimageMessage(xonly, new Uint8Array(32)))).not.toBe(
+            hex.encode(buildPreimageMessage(xonly, 0)),
+        );
+    });
+
+    it("rejects a salt or key that is not 32 bytes", () => {
+        const ok = new Uint8Array(32);
+        expect(() => buildSaltedPreimageMessage(new Uint8Array(20), ok)).toThrow(/32 bytes/);
+        expect(() => buildSaltedPreimageMessage(ok, new Uint8Array(31))).toThrow(/32 bytes/);
     });
 });
 
@@ -203,19 +235,133 @@ describe("provisionClaimSecret", () => {
 
     it("never repeats a preimage, on either kind of wallet", async () => {
         // HD: uniqueness comes from a fresh index. Static: the key repeats by
-        // design, so uniqueness has to come from the stored preimage instead —
-        // deriving there would hand two artifacts one P, and one counterparty
-        // learning its own would learn the other's.
+        // design, so uniqueness comes from a fresh salt instead. This is the
+        // regression test for the collision the salted arm exists to avoid —
+        // it fails if anyone reuses a constant salt.
         const { wallet: hd } = await hdWallet();
         const hdSecrets = [await provisionClaimSecret(hd), await provisionClaimSecret(hd)];
         expect(new Set(hdSecrets.map((s) => hex.encode(s.preimage))).size).toBe(2);
         expect(hdSecrets.every((s) => !s.mustPersistPreimage)).toBe(true);
+        expect(hdSecrets.every((s) => s.preimageSalt === undefined)).toBe(true);
 
         const stat = staticWallet();
-        const statSecrets = [await provisionClaimSecret(stat), await provisionClaimSecret(stat)];
-        expect(statSecrets[0].descriptor).toBe(statSecrets[1].descriptor);
-        expect(new Set(statSecrets.map((s) => hex.encode(s.preimage))).size).toBe(2);
-        expect(statSecrets.every((s) => s.mustPersistPreimage)).toBe(true);
+        const statSecrets = [
+            await provisionClaimSecret(stat),
+            await provisionClaimSecret(stat),
+            await provisionClaimSecret(stat),
+        ];
+        // One descriptor, three swaps, three different everything-else.
+        expect(new Set(statSecrets.map((s) => s.descriptor)).size).toBe(1);
+        expect(new Set(statSecrets.map((s) => hex.encode(s.preimageSalt!))).size).toBe(3);
+        expect(new Set(statSecrets.map((s) => hex.encode(s.preimage))).size).toBe(3);
+        expect(new Set(statSecrets.map((s) => hex.encode(s.paymentHash))).size).toBe(3);
+        // And nothing secret to store: the salt is public.
+        expect(statSecrets.every((s) => !s.mustPersistPreimage)).toBe(true);
+    });
+
+    it("derives a static wallet's preimage from the seed and the salt alone", async () => {
+        // The property the salted arm rests on: two independently constructed
+        // wallets on one key agree, given only the record's public fields.
+        const key = SingleKey.fromRandomBytes();
+        const first = { identity: key } as unknown as IWallet;
+        const secret = await provisionClaimSecret(first);
+        expect(secret.mustPersistPreimage).toBe(false);
+        expect(secret.preimageSalt).toHaveLength(32);
+
+        const second = {
+            identity: SingleKey.fromHex(key.toHex()),
+        } as unknown as IWallet;
+        const rederived = await contractPreimage(second, secret.descriptor, {
+            salt: secret.preimageSalt,
+        });
+        expect(hex.encode(rederived)).toBe(hex.encode(secret.preimage));
+    });
+
+    it("separates the salted arm from the pinned-index arm by tag", async () => {
+        // Same key, both derivations: distinct tags must keep them apart, or
+        // one corridor's preimage would be the other's.
+        const key = SingleKey.fromRandomBytes();
+        const secret = await provisionClaimSecret({ identity: key } as unknown as IWallet);
+        const xonly = await key.xOnlyPublicKey();
+
+        const asIfPinned = sha256(
+            await key.signSchnorrDeterministic(sha256(buildPreimageMessage(xonly, 0))),
+        );
+        expect(hex.encode(secret.preimage)).not.toBe(hex.encode(asIfPinned));
+    });
+
+    it("falls back to a stored preimage when the signer cannot derive", async () => {
+        // Both signers here are COMPLETE identities — `contractSigner` refuses
+        // a partial one outright (WalletCannotSignError), so the fallback arm
+        // is for a wallet that can spend the leg but cannot sign
+        // deterministically: an extension or remote signer.
+        //
+        // Two distinct refusals: one missing the method entirely, and one that
+        // exposes it and throws at call time (DescriptorIdentity's shape). The
+        // structural guard only sees the first, so both must land here.
+        const base = SingleKey.fromRandomBytes();
+        const signing = {
+            sign: (tx: unknown) => base.sign(tx as never),
+            signMessage: (m: Uint8Array) => base.signMessage(m),
+            signerSession: () => base.signerSession(),
+            xOnlyPublicKey: () => base.xOnlyPublicKey(),
+        };
+
+        for (const identity of [
+            signing,
+            {
+                ...signing,
+                signSchnorrDeterministic: async () => {
+                    throw new Error("this signer refuses");
+                },
+            },
+        ]) {
+            const secret = await provisionClaimSecret({ identity } as unknown as IWallet);
+            expect(secret.mustPersistPreimage).toBe(true);
+            expect(secret.preimage).toHaveLength(32);
+            // No salt: a record carrying one it cannot derive from is worse
+            // than none, because it reads as recoverable.
+            expect(secret.preimageSalt).toBeUndefined();
+        }
+    });
+
+    it("refuses a watch-only identity before it reaches the salted arm", async () => {
+        // The fallback must not paper over a wallet that cannot spend the leg
+        // at all: #738's check fires first, so such a wallet learns before it
+        // funds rather than at refund time.
+        const base = SingleKey.fromRandomBytes();
+        const watchOnly = { xOnlyPublicKey: () => base.xOnlyPublicKey() };
+
+        await expect(
+            provisionClaimSecret({ identity: watchOnly } as unknown as IWallet),
+        ).rejects.toThrow(/cannot sign with it/);
+    });
+
+    it("still raises loudly for an HD descriptor whose signer cannot derive", async () => {
+        // A per-artifact descriptor that cannot sign deterministically is a
+        // broken wallet, not a fallback case — the salted arm's tolerance must
+        // not leak into this one.
+        const { wallet } = await hdWallet();
+        const { descriptor } = await provisionRefundKey(wallet);
+        const identity = (wallet as unknown as { identity: Record<string, unknown> }).identity;
+        const broken = {
+            identity,
+            getCurrentSigningDescriptor: async () => undefined,
+            getNextSigningDescriptor: async () => descriptor,
+            getUsedSigningDescriptors: async () => [],
+            advanceSigningDescriptorWatermark: async () => {},
+            // A COMPLETE identity for the right key that simply cannot sign
+            // deterministically — otherwise `contractSigner` refuses it as
+            // watch-only first and this asserts the wrong refusal.
+            signerForDescriptor: async () => ({
+                sign: identity.sign,
+                signMessage: identity.signMessage,
+                signerSession: identity.signerSession,
+                xOnlyPublicKey: async () => deriveDescriptorLeafPubKey(descriptor),
+            }),
+        } as unknown as IWallet;
+
+        await expect(provisionClaimSecret(broken)).rejects.toThrow(/not derivable/);
     });
 
     it("takes a caller's preimage verbatim and marks it for storage", async () => {
@@ -291,7 +437,21 @@ describe("contractPreimage", () => {
         const { wallet } = await hdWallet();
         const { descriptor } = await provisionRefundKey(wallet);
         const stored = new Uint8Array(32).fill(3);
-        expect(await contractPreimage(wallet, descriptor, stored)).toEqual(stored);
+        expect(await contractPreimage(wallet, descriptor, { stored })).toEqual(stored);
+    });
+
+    it("prefers a stored preimage over a salt, on a static descriptor", async () => {
+        // Precedence, not a coin flip: a stored P is the artifact's, whatever
+        // the wallet could derive now.
+        const wallet = staticWallet();
+        const { descriptor } = await provisionRefundKey(wallet);
+        const stored = new Uint8Array(32).fill(9);
+        expect(
+            await contractPreimage(wallet, descriptor, {
+                stored,
+                salt: new Uint8Array(32).fill(1),
+            }),
+        ).toEqual(stored);
     });
 
     it("refuses a stored preimage that is not 32 bytes", async () => {
@@ -306,9 +466,9 @@ describe("contractPreimage", () => {
     });
 
     it("refuses to derive for a descriptor that carries none", async () => {
-        // Deriving off a shared key would hand two artifacts one preimage —
-        // without accusing the record of losing anything: a leg whose P
-        // belongs to the counterparty legitimately has none, and lands here.
+        // Deriving off a shared key with no salt would hand two artifacts one
+        // preimage — without accusing the record of losing anything: a leg
+        // whose P belongs to the counterparty legitimately has none.
         const wallet = staticWallet();
         const { descriptor } = await provisionRefundKey(wallet);
         await expect(contractPreimage(wallet, descriptor)).rejects.toThrow(
@@ -411,6 +571,41 @@ describe("cross-SDK vectors", () => {
         // The message these hash from, spelled out for a reimplementation.
         expect(hex.encode(buildPreimageMessage(hex.decode(xonly), 0))).toBe(
             hex.encode(new TextEncoder().encode(ARKADE_SWAP_PREIMAGE_TAG)) + xonly + "00000000",
+        );
+    });
+
+    // The salted arm. Keyed off a raw private key rather than the mnemonic,
+    // because this arm is what a wallet with no HD stream uses — a
+    // reimplementation needs no derivation path to reproduce it.
+    it.each([
+        {
+            privateKey: "0101010101010101010101010101010101010101010101010101010101010101",
+            xonly: "1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+            salt: "0000000000000000000000000000000000000000000000000000000000000000",
+            preimage: "b4d9da14ae18b0de26571983e689846d02f58ff19449104d05f3578b0081a828",
+        },
+        {
+            privateKey: "0202020202020202020202020202020202020202020202020202020202020202",
+            xonly: "4d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766",
+            salt: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            preimage: "7fc76ad065dbfa7cdba6905d04b1f37c93f970c03fb123b5612cec3a185dfad5",
+        },
+        {
+            privateKey: "4242424242424242424242424242424242424242424242424242424242424242",
+            xonly: "24653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c",
+            salt: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90",
+            preimage: "dbaf93e66f2149482c6be3b6ebeccb033d6ae7adb3a20547d411a0577d6f135d",
+        },
+    ])("salted, key $privateKey", async ({ privateKey, xonly, salt, preimage }) => {
+        const key = SingleKey.fromHex(privateKey);
+        const wallet = { identity: key } as unknown as IWallet;
+        expect(hex.encode(await key.xOnlyPublicKey())).toBe(xonly);
+
+        expect(
+            hex.encode(await contractPreimage(wallet, `tr(${xonly})`, { salt: hex.decode(salt) })),
+        ).toBe(preimage);
+        expect(hex.encode(buildSaltedPreimageMessage(hex.decode(xonly), hex.decode(salt)))).toBe(
+            hex.encode(new TextEncoder().encode(ARKADE_SALTED_PREIMAGE_TAG)) + xonly + salt,
         );
     });
 });

--- a/packages/ts-sdk/test/contractSecrets.test.ts
+++ b/packages/ts-sdk/test/contractSecrets.test.ts
@@ -325,6 +325,29 @@ describe("provisionClaimSecret", () => {
         }
     });
 
+    it("propagates a key refusal instead of degrading it to a stored preimage", async () => {
+        // The salted arm's fallback may absorb "cannot sign deterministically"
+        // and nothing else. A wallet that does not hold the key must not come
+        // back with a random preimage and a success — that funds a leg nothing
+        // can spend.
+        const base = SingleKey.fromRandomBytes();
+        const wallet = {
+            identity: base,
+            getCurrentSigningDescriptor: async () => undefined,
+            getNextSigningDescriptor: async () => undefined,
+            getUsedSigningDescriptors: async () => [],
+            advanceSigningDescriptorWatermark: async () => {},
+            // Resolves once for provisioning, then stops holding the key —
+            // the only way to reach the salted arm's catch with a key error.
+            signerForDescriptor: vi
+                .fn()
+                .mockResolvedValueOnce(base)
+                .mockRejectedValue(new ForeignDescriptorError("tr(deadbeef)")),
+        } as unknown as IWallet;
+
+        await expect(provisionClaimSecret(wallet)).rejects.toBeInstanceOf(ForeignDescriptorError);
+    });
+
     it("refuses a watch-only identity before it reaches the salted arm", async () => {
         // The fallback must not paper over a wallet that cannot spend the leg
         // at all: #738's check fires first, so such a wallet learns before it
@@ -455,14 +478,17 @@ describe("contractPreimage", () => {
     });
 
     it("refuses a stored preimage that is not 32 bytes", async () => {
-        // The check the deleted record decoder made. A truncated column or a
-        // partial write would otherwise restore silently and be caught only
-        // when the claim is built, with the timeout margin already spent.
-        const { wallet } = await hdWallet();
+        // The check the deleted record decoder made — a truncated column would
+        // otherwise restore silently and be caught only when the claim is
+        // built. The empty case is the one an explicit length test buys: a
+        // zero-length array is truthy, so it would be handed straight back.
+        const wallet = staticWallet();
         const { descriptor } = await provisionRefundKey(wallet);
-        await expect(
-            contractPreimage(wallet, descriptor, new Uint8Array(20).fill(3)),
-        ).rejects.toThrow(/stored preimage must be 32 bytes/);
+        for (const stored of [new Uint8Array(0), new Uint8Array(20).fill(3), new Uint8Array(31)]) {
+            await expect(contractPreimage(wallet, descriptor, { stored })).rejects.toThrow(
+                /stored preimage must be 32 bytes/,
+            );
+        }
     });
 
     it("refuses to derive for a descriptor that carries none", async () => {

--- a/packages/ts-sdk/test/e2e/vhtlc.test.ts
+++ b/packages/ts-sdk/test/e2e/vhtlc.test.ts
@@ -2,20 +2,25 @@ import { expect, describe, it, beforeEach } from "vitest";
 import * as bip68 from "bip68";
 import { base64, hex } from "@scure/base";
 import { hash160 } from "@scure/btc-signer/utils.js";
+import { sha256 } from "@noble/hashes/sha2.js";
 import {
     ArkError,
     ArkErrorName,
     buildOffchainTx,
     ConditionWitness,
+    contractPreimage,
     CSVMultisigTapscript,
     EsploraProvider,
     Identity,
     isArkError,
+    IWallet,
     networks,
     OnchainWallet,
+    provisionClaimSecret,
     RestArkProvider,
     RestIndexerProvider,
     setArkPsbtField,
+    SingleKey,
     Unroll,
     VHTLC,
     Transaction,
@@ -147,6 +152,176 @@ describe("vhtlc", () => {
 
         await arkProvider.finalizeTx(arkTxid, finalCheckpoints);
     });
+
+    it(
+        "should claim with a preimage re-derived from a static wallet's seed and salt",
+        { timeout: 60000 },
+        async () => {
+            // The property the salted arm exists for, proved against a real
+            // covenant: a static wallet stores NOTHING secret, and a restore
+            // holding only the record's public fields still claims.
+            //
+            // Two things only chain execution can settle. The record commits to
+            // `sha256(P)` while the covenant commits to `ripemd160(sha256(P))`,
+            // so a derived P has to satisfy a hash form the record never names;
+            // and the claim leaf pins OP_SIZE 32, which a 32-byte derivation
+            // output meets only by construction.
+            const alice = createTestIdentity();
+
+            // A static wallet: one key, no descriptor surface, its identity is
+            // its whole policy.
+            const key = SingleKey.fromRandomBytes();
+            const seedHex = key.toHex();
+            const secret = await provisionClaimSecret({ identity: key } as unknown as IWallet);
+
+            // Nothing secret is at rest, and the salt is what replaced it.
+            expect(secret.mustPersistPreimage).toBe(false);
+            expect(secret.preimageSalt).toHaveLength(32);
+
+            // What a consumer persists — every field public.
+            const record = {
+                signingDescriptor: secret.descriptor,
+                preimageSaltHex: hex.encode(secret.preimageSalt!),
+                paymentHash: hex.encode(secret.paymentHash),
+            };
+
+            const vhtlcScript = new VHTLC.Script({
+                // The corridor's hash form, not the record's.
+                preimageHash: hash160(secret.preimage),
+                sender: await alice.xOnlyPublicKey(),
+                // The leg we claim: the provisioned key receives it.
+                receiver: secret.pubkey,
+                server: X_ONLY_PUBLIC_KEY,
+                refundLocktime: BigInt(1000),
+                unilateralClaimDelay: { type: "blocks", value: 100n },
+                unilateralRefundDelay: { type: "blocks", value: 50n },
+                unilateralRefundWithoutReceiverDelay: { type: "blocks", value: 50n },
+            });
+
+            const address = vhtlcScript.address(networks.regtest.hrp, X_ONLY_PUBLIC_KEY).encode();
+            const fundAmount = 1000;
+            execCommand(
+                `${arkdExec} ark send --to ${address} --amount ${fundAmount} --password secret`,
+            );
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            // ── The restore. Everything but `record` and the seed is gone. ──
+            const restored = SingleKey.fromHex(seedHex);
+            const wallet = { identity: restored } as unknown as IWallet;
+            const preimage = await contractPreimage(wallet, record.signingDescriptor, {
+                salt: hex.decode(record.preimageSaltHex),
+            });
+
+            expect(hex.encode(preimage)).toBe(hex.encode(secret.preimage));
+            expect(hex.encode(sha256(preimage))).toBe(record.paymentHash);
+            // The seam: the derived P satisfies the hash the covenant pins.
+            expect(hex.encode(hash160(preimage))).toBe(
+                hex.encode(vhtlcScript.options.preimageHash),
+            );
+
+            const claimIdentity: Identity = {
+                sign: async (tx: Transaction, inputIndexes?: number[]) => {
+                    const cpy = tx.clone();
+                    setArkPsbtField(cpy, 0, ConditionWitness, [preimage]);
+                    return restored.sign(cpy, inputIndexes);
+                },
+                compressedPublicKey: () => restored.compressedPublicKey(),
+                xOnlyPublicKey: () => restored.xOnlyPublicKey(),
+                signerSession: () => restored.signerSession(),
+                signMessage: (message, signatureType) =>
+                    restored.signMessage(message, signatureType),
+            };
+
+            const arkProvider = new RestArkProvider("http://localhost:7070");
+            const indexerProvider = new RestIndexerProvider("http://localhost:7070");
+
+            const spendable = await indexerProvider.getVtxos({
+                scripts: [hex.encode(vhtlcScript.pkScript)],
+                spendableOnly: true,
+            });
+            expect(spendable.vtxos).toHaveLength(1);
+
+            const info = await arkProvider.getInfo();
+            const checkpointUnrollClosure = CSVMultisigTapscript.decode(
+                hex.decode(info.checkpointTapscript),
+            );
+
+            const { arkTx, checkpoints } = buildOffchainTx(
+                [
+                    {
+                        ...spendable.vtxos[0],
+                        tapLeafScript: vhtlcScript.claim(),
+                        tapTree: vhtlcScript.encode(),
+                    },
+                ],
+                [{ script: vhtlcScript.pkScript, amount: BigInt(fundAmount) }],
+                checkpointUnrollClosure,
+            );
+
+            const signedArkTx = await claimIdentity.sign(arkTx);
+            const { arkTxid, signedCheckpointTxs } = await arkProvider.submitTx(
+                base64.encode(signedArkTx.toPSBT()),
+                checkpoints.map((c) => base64.encode(c.toPSBT())),
+            );
+            expect(arkTxid).toBeDefined();
+
+            const finalCheckpoints = await Promise.all(
+                signedCheckpointTxs.map(async (c) => {
+                    const signed = await claimIdentity.sign(
+                        Transaction.fromPSBT(base64.decode(c)),
+                        [0],
+                    );
+                    return base64.encode(signed.toPSBT());
+                }),
+            );
+            // The server accepting this is the assertion: a covenant funded
+            // before the restore, unlocked by a preimage that existed nowhere
+            // in between.
+            await arkProvider.finalizeTx(arkTxid, finalCheckpoints);
+        },
+    );
+
+    it(
+        "should give two swaps on one static wallet unrelated covenants",
+        { timeout: 60000 },
+        async () => {
+            // The collision this design exists to avoid, at the address level:
+            // one key, two swaps, and nothing they share is claimable twice.
+            const alice = await createTestIdentity().xOnlyPublicKey();
+            const key = SingleKey.fromRandomBytes();
+            const wallet = { identity: key } as unknown as IWallet;
+
+            const scriptFor = async () => {
+                const secret = await provisionClaimSecret(wallet);
+                return {
+                    secret,
+                    address: new VHTLC.Script({
+                        preimageHash: hash160(secret.preimage),
+                        sender: alice,
+                        receiver: secret.pubkey,
+                        server: X_ONLY_PUBLIC_KEY,
+                        refundLocktime: BigInt(1000),
+                        unilateralClaimDelay: { type: "blocks", value: 100n },
+                        unilateralRefundDelay: { type: "blocks", value: 50n },
+                        unilateralRefundWithoutReceiverDelay: { type: "blocks", value: 50n },
+                    })
+                        .address(networks.regtest.hrp, X_ONLY_PUBLIC_KEY)
+                        .encode(),
+                };
+            };
+
+            const first = await scriptFor();
+            const second = await scriptFor();
+
+            // Same wallet key on both covenants — that is the static policy.
+            expect(hex.encode(second.secret.pubkey)).toBe(hex.encode(first.secret.pubkey));
+            expect(second.secret.descriptor).toBe(first.secret.descriptor);
+            // Everything derived from the salt differs, so one counterparty
+            // learning its own preimage learns nothing about the other.
+            expect(second.address).not.toBe(first.address);
+            expect(hex.encode(second.secret.preimage)).not.toBe(hex.encode(first.secret.preimage));
+        },
+    );
 
     it("should unilaterally claim", { timeout: 300_000 }, async () => {
         const alice = await createTestArkWallet();

--- a/packages/ts-sdk/test/seedIdentity.test.ts
+++ b/packages/ts-sdk/test/seedIdentity.test.ts
@@ -221,6 +221,49 @@ describe("SeedIdentity", () => {
             expect(defaulted.descriptor).toMatch(/\/86'\/0'\/0'\]/);
         });
     });
+
+    describe("signSchnorrDeterministic", () => {
+        const messageHash = new Uint8Array(32).fill(0x33);
+        const identityOf = () =>
+            SeedIdentity.fromSeed(mnemonicToSeedSync(TEST_MNEMONIC), { isMainnet: false });
+
+        it("is stable across calls and across instances on one seed", async () => {
+            // An `auto`-mode wallet resolves its bare descriptor to the
+            // identity itself, so this is what its swap preimage derives from.
+            const first = await identityOf().signSchnorrDeterministic(messageHash);
+            const second = await identityOf().signSchnorrDeterministic(messageHash);
+
+            expect(hex.encode(first)).toBe(hex.encode(second));
+            expect(
+                await schnorr.verifyAsync(first, messageHash, await identityOf().xOnlyPublicKey()),
+            ).toBe(true);
+        });
+
+        it("agrees with the descriptor sibling for the identity's own key", async () => {
+            // The two paths reach the same key by different routes; a
+            // construction drift between them would make a preimage derived
+            // through one unrecoverable through the other.
+            const identity = identityOf();
+            expect(hex.encode(await identity.signSchnorrDeterministic(messageHash))).toBe(
+                hex.encode(
+                    await identity.signSchnorrDeterministicWithDescriptor(
+                        identity.descriptor.replace("/*", "/0"),
+                        messageHash,
+                    ),
+                ),
+            );
+        });
+
+        it("does not draw a random aux_rand, unlike signMessage", async () => {
+            const identity = identityOf();
+            const a = await identity.signMessage(messageHash, "schnorr");
+            const b = await identity.signMessage(messageHash, "schnorr");
+            expect(hex.encode(a)).not.toBe(hex.encode(b));
+            expect(hex.encode(await identity.signSchnorrDeterministic(messageHash))).toBe(
+                hex.encode(await identity.signSchnorrDeterministic(messageHash)),
+            );
+        });
+    });
 });
 
 describe("MnemonicIdentity", () => {

--- a/packages/ts-sdk/test/serviceWorkerContractSecrets.test.ts
+++ b/packages/ts-sdk/test/serviceWorkerContractSecrets.test.ts
@@ -392,25 +392,28 @@ describe("contract secrets behind the service worker", () => {
         ).toBe(hex.encode(secret.preimage));
     });
 
-    it("falls back to the identity key on a static worker wallet and must persist the preimage", async () => {
-        // A bare `tr(pubkey)` repeats across artifacts, so deriving from it
-        // would hand two swaps one preimage. The caller is told to store it.
+    it("falls back to the identity key on a static worker wallet and salts the preimage", async () => {
+        // A bare `tr(pubkey)` repeats across artifacts, so deriving from the
+        // key alone would hand two swaps one preimage. A per-swap salt is
+        // where the uniqueness comes from instead, and it is public — so the
+        // worker arm stores nothing secret either.
         const { sw, identity } = await staticPair();
 
         const secret = await provisionClaimSecret(sw as unknown as IWallet);
 
         expect(secret.descriptor).toBe(await bareDescriptorFor(identity));
-        expect(secret.mustPersistPreimage).toBe(true);
+        expect(secret.mustPersistPreimage).toBe(false);
+        expect(secret.preimageSalt).toHaveLength(32);
+        // The salt is the derivation input: without it there is nothing to
+        // derive from that would not collide.
         await expect(contractPreimage(sw as unknown as IWallet, secret.descriptor)).rejects.toThrow(
             /names no single artifact/,
         );
         expect(
             hex.encode(
-                await contractPreimage(
-                    sw as unknown as IWallet,
-                    secret.descriptor,
-                    secret.preimage,
-                ),
+                await contractPreimage(sw as unknown as IWallet, secret.descriptor, {
+                    salt: secret.preimageSalt,
+                }),
             ),
         ).toBe(hex.encode(secret.preimage));
 
@@ -446,5 +449,21 @@ describe("contract secrets behind the service worker", () => {
         await expect(provisionRefundKey(sw as unknown as IWallet)).rejects.toBeInstanceOf(
             WalletCannotSignError,
         );
+    });
+
+    it("derives one preimage across the bus, page-side and worker-side", async () => {
+        // The whole point of resolving page-side: the two contexts must not
+        // answer differently for one descriptor, or a swap funded through one
+        // is unclaimable through the other.
+        const { sw, inner } = await staticPair();
+
+        const secret = await provisionClaimSecret(sw as unknown as IWallet);
+        expect(
+            hex.encode(
+                await contractPreimage(inner as unknown as IWallet, secret.descriptor, {
+                    salt: secret.preimageSalt,
+                }),
+            ),
+        ).toBe(hex.encode(secret.preimage));
     });
 });

--- a/packages/ts-sdk/test/singlekey.test.ts
+++ b/packages/ts-sdk/test/singlekey.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
 import { SingleKey, ReadonlySingleKey } from "../src/identity/singleKey";
 import { InMemoryStorageAdapter } from "../src/storage/inMemory";
 import { schnorr, verifyAsync } from "@noble/secp256k1";
+
+const zeroAux = new Uint8Array(32);
 
 describe("SingleKey", () => {
     it("should create random keys with fromRandomBytes", async () => {
@@ -149,6 +152,41 @@ describe("SingleKey", () => {
             const compressedPubKey = await key.compressedPublicKey();
             const readonlyCompressedPubKey = await readonlyKey.compressedPublicKey();
             expect(Array.from(compressedPubKey)).toEqual(Array.from(readonlyCompressedPubKey));
+        });
+    });
+
+    describe("signSchnorrDeterministic", () => {
+        const messageHash = new Uint8Array(32).fill(0x11);
+
+        it("returns the same signature every call", async () => {
+            // What a static wallet's swap preimage is derived from: a signature
+            // that moves would make the preimage unrecoverable.
+            const key = SingleKey.fromHex("11".repeat(32));
+            const first = await key.signSchnorrDeterministic(messageHash);
+            const second = await key.signSchnorrDeterministic(messageHash);
+
+            expect(Buffer.from(first).toString("hex")).toBe(Buffer.from(second).toString("hex"));
+            expect(await schnorr.verifyAsync(first, messageHash, await key.xOnlyPublicKey())).toBe(
+                true,
+            );
+        });
+
+        it("matches an aux_rand = 0 BIP-340 signature, not signMessage's", async () => {
+            // signMessage's schnorr branch draws a random aux_rand. Routing the
+            // deterministic path through it would still verify, so only this
+            // comparison catches the mistake.
+            const key = SingleKey.fromHex("22".repeat(32));
+            const deterministic = await key.signSchnorrDeterministic(messageHash);
+
+            expect(Buffer.from(deterministic).toString("hex")).toBe(
+                Buffer.from(
+                    await schnorr.signAsync(messageHash, hex.decode("22".repeat(32)), zeroAux),
+                ).toString("hex"),
+            );
+
+            const a = await key.signMessage(messageHash, "schnorr");
+            const b = await key.signMessage(messageHash, "schnorr");
+            expect(Buffer.from(a).toString("hex")).not.toBe(Buffer.from(b).toString("hex"));
         });
     });
 });


### PR DESCRIPTION
**Stacked on #738** — review that first; this branch contains its commits. Retarget to `master` when it merges.

Closes the remainder of #737. #737 §2 proposed both halves — the wallet provides the sender key, and the preimage becomes per-swap derivable. #738 shipped the first and dropped the second after its "reachable preimage collision" finding. This is the second half, designed so that finding does not apply.

## The problem

After #738 a static (`SingleKey`) wallet still stores its preimage in the clear:

| Wallet | Sender key | Preimage | Secret at rest |
|---|---|---|---|
| HD | fresh child descriptor | `sha256(sign_det(TAG ‖ xonly ‖ u32le(0)))` | none |
| static | identity key, via `tr(pubkey)` | **`randomBytes(32)` → `preimageHex`** | **P** |

The HD arm gets per-swap uniqueness from a fresh key, which is what lets it pin the message index. A static wallet has one key, so deriving at a pinned index would hand every swap the *identical* preimage — one counterparty learning its own would learn all of them.

## The change

Uniqueness comes from the message instead. A second, salted derivation, with the existing one left byte-identical:

```
v1 (HD, unchanged)  msg = "Arkade-RFQ-Preimage-v1"             ‖ xonly(32) ‖ u32le(0)
v2 (salted, new)    msg = "Arkade-Contract-Preimage-Salted-v1" ‖ xonly(32) ‖ salt(32)

P = sha256(signSchnorrDeterministic(sha256(msg)))
```

`salt` is 32 random bytes minted per swap and persisted **in the clear** as `preimageSaltHex`. Knowing it yields nothing without the seed — that is the whole difference from the `preimageHex` it replaces. The record goes from carrying a per-swap *secret* to a per-swap *public* value, which is exactly what `signingDescriptor` already is on the HD arm.

`SingleKey` and `SeedIdentity` gain `signSchnorrDeterministic` (aux_rand = 0). `DeterministicSigner` already existed in the SDK from #738, so no new interface.

**Why the #738 finding does not apply here.** That finding is about deriving from the descriptor: `isPerArtifactDescriptor` tests *shape*, not freshness, so a custom `DescriptorProvider` returning a constant HD-shaped descriptor would collide. Here uniqueness comes from a value minted per swap by the code that stores it, not from any claim about the descriptor. A constant descriptor — static, custom-provider, or otherwise — still yields distinct preimages. The shape test only picks the arm, and a wrong answer from it is no longer a collision.

**Three arms, and the probe is the use.** `provisionClaimSecret` resolves: caller-supplied P → per-artifact descriptor → salted. It does not ask `isDeterministicSigner` and then act on the answer — `DescriptorIdentity` always exposes the method and only refuses at call time. It mints the salt and *actually derives*; only if that throws does it fall back to a stored random P. The v1 HD arm still raises loudly, because an HD descriptor whose wallet cannot sign deterministically is a broken wallet, not a fallback case.

The three `mustPersistPreimage` warnings in `rfq.ts` stop firing for static wallets with no code change, which is the observable outcome.

## Corridor-generic tag

`Arkade-Contract-Preimage-Salted-v1`, where v1 is RFQ-scoped, and the asymmetry is deliberate. The v1 tags *must* be per-corridor (`Arkade-RFQ-Preimage-v1` here, NArk's `Arkade-Boltz-Preimage-v1` there) because v1 pins its index, leaving the tag as the only separation between two corridors reaching the same key. v2 mints a salt per swap, so no two swaps share a message within a corridor or across two — the salt carries the separation and the tag names the layer.

arkade-os/dotnet-sdk#185 is the same defect in NArk, on the Boltz corridor. If this argument holds, both SDKs converge on one salted tag and NArk adds no `Arkade-Boltz-Preimage-Salted-v1`. Nothing is pinned or stored yet, so the tag can still be renamed on agreement.

## Record and repository

`AssetSwap` gains `preimageSaltHex?`; `AssetSwapRepository.version` goes 1 → 2 so external implementors recompile — a field-mapped backend that drops the salt leaves the swap unclaimable, exactly as one dropping `preimageHex` does. `DB_VERSION` is unchanged: swaps are stored whole, so an added optional field needs no migration and no backfill. Nothing already written needs rewriting either — the field is optional, and any row carrying a stored `preimageHex` or an HD descriptor keeps resolving through precedence steps 1 and 2 forever.

Two additions worth looking at:

- **`SwapSecretsProjection`** — the mapper's output as a named type that `AssetSwap` embeds, rather than three fields restated per record type. It costs nothing now and makes a record that omits one a compile error later — which is what keeps #740's `RfqSwapOrigin` honest when it rebases, since today it restates those fields behind a comment with nothing checking it.
- **`preimageForSwapRecord`** — #738 deleted `rfqSecretsOfRecord` with no replacement, so nothing in `packages/swap` reads a preimage back out of a record. This is that reader, and it verifies against `paymentHash`. The salted arm has two inputs that can be wrong (key and salt) where the HD arm had one, and a caller who forgets to pass the salt gets a *wrong* preimage from a wallet that can derive, not an error — which otherwise surfaces as an opaque script failure at claim time.

`contractPreimage`'s third parameter becomes `{ stored?, salt? }`. A break, but it is new in #738 and unreleased.

## Testing

`pnpm run build`, `pnpm run lint`, all three unit suites: ts-sdk 2572, swap 371, boltz-swap 614. **Plus the `ts-sdk` regtest e2e**, run against a live stack — the full `vhtlc` suite is green, including the four pre-existing tests.

### Against a real covenant (`test/e2e/vhtlc.test.ts`)

**`should claim with a preimage re-derived from a static wallet's seed and salt`** is the property end to end. Provision on a static wallet → bind a VHTLC to `hash160(P)` with the provisioned key as receiver → fund it → discard everything but `signingDescriptor`, `preimageSaltHex` and `paymentHash` → rebuild the wallet from the key alone → re-derive → claim. The server accepting the claim is the assertion: a covenant funded before the restore, unlocked by a preimage that existed nowhere in between.

It also pins the hash-form seam, which is the part unit tests structurally cannot reach — the record commits to `sha256(P)` while the covenant pins `ripemd160(sha256(P))`, so a derived P has to satisfy a form the record never names. Both are asserted against the real script.

**I verified the test can fail.** Tampering the `ConditionWitness` preimage gets `INVALID_SIGNATURE (18)` from arkd; the passing run is not a no-op.

A second case funds nothing and just shows two swaps on one static wallet producing unrelated covenants — same key and descriptor, different addresses and preimages.

The swap package's `preimageForSwapRecord` is not exercised on-chain: it is a thin composition over `contractPreimage` plus a hash comparison, unit-covered on every branch, and the swap RFQ regtest profile stubs its solver (`"Nothing here fills the swap — a fill needs a solver that pays"`), so it could not prove more there than the ts-sdk stack already does.

### Unit tests worth looking at

- **Distinctness** — three swaps on one static wallet produce three distinct salts, preimages and payment hashes off one descriptor. The regression test for the collision the design exists to avoid.
- **Determinism** — two independently constructed wallets on one key agree, given only the record's public fields.
- **Cross-arm separation** — the same key through both derivations yields different P, plus a message-level test that the two forms cannot collide.
- **The aux_rand trap** — `signSchnorrDeterministic` must not route through `signMessage`, whose schnorr branch draws a random aux_rand. That would still verify, so only an explicit comparison against a zero-aux signature catches it. Asserted on both identities, plus that `SeedIdentity`'s two deterministic paths agree.
- **Fallback** — covered for both a signer missing the method and one that throws at call time; they take different code paths, and neither may leave a salt on the record.
- **Cross-SDK vectors** — v1 unchanged byte-for-byte; v2 pinned as literals, keyed off raw private keys so a reimplementation needs no derivation path.
- **Behind the service worker** — a static SW wallet now takes the salted arm too, and page-side and worker-side derive one preimage for one descriptor. #738's test asserting the old stored-preimage behaviour is updated rather than deleted.

## Note on #740 and #743

**Neither is a rival to this PR; both are rivals to #738.** #740 defers the preimage half explicitly and its baseline arm stores P permanently. #743 arrives at this PR's preimage reasoning independently — never derive P from a reused key, attach a random one per swap, mandate `preimageHex` — and so keeps exactly the secret at rest that this removes. Both make the same key-provisioning choice against #738: a **marker** (`senderKey: "baseline"`, `identityKey: true`) resolved by handing back `wallet.identity` unverified, where #738 stores a real descriptor and checks `equalBytes(signer.xOnlyPublicKey(), deriveDescriptorLeafPubKey(descriptor))`. A marker records *that* an arm was used; a descriptor records *which key*, and only the second survives a restore onto the wrong wallet.

Both also conflict irreconcilably with #738 — all three rewrite `packages/swap/src/secrets.ts`, which #738 deletes. #740's *persistence* half is orthogonal and conflicts with nothing: `git merge-tree pr738 pr740` puts every conflict in the key-provisioning surface and none in `rfqRecord.ts`, `indexedDbRepository.ts` or `repository.test.ts`.

Suggested order: **#738 → this → #740's persistence rebased**, with #743 closed in #738's favour. That way `RfqSwapOrigin.preimageIndex` — the slot #740 reserves for a monotonic-counter derivation — never ships, and `preimageSaltHex` takes its place. A counter needs durable state a static wallet lacks, and rebuilding it as `1 + max(index)` restarts at 0 on a wiped repository and re-derives a live swap's P.

**One thing #738 should take from #743 first:** `provisionRefundKey` calls `wallet.identity.xOnlyPublicKey()` unconditionally, so a remote-signer or readonly identity gets a descriptor nobody can sign with and fails as a `TypeError` at push time. #743's `signingIdentityOf` catches that up front; it belongs in `contractSigner` as a typed refusal. This PR does not change that path either way.

---

## Summary by CodeRabbit

* **New Features**
  * Added salted preimage derivation for shared swap descriptors, with public salt persistence and payment-hash verification.
  * Added deterministic Schnorr signing for supported identities and keys.
  * Added swap-secret recovery utilities and public SDK exports.
* **Bug Fixes**
  * Improved secret recovery validation for missing, invalid, or tampered swap data.
* **Documentation**
  * Updated swap secret provisioning, persistence, migration, and recovery guidance.
* **Chores**
  * Updated swap repository schema versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
