### PR TITLE
fix(swap): reject pending waiters when the Nostr transport closes

### DIFF
--- a/packages/swap/src/nostr.ts
+++ b/packages/swap/src/nostr.ts
@@ -86,6 +86,22 @@ export class RelayUnavailable extends Error {
 }
 
 /**
+ * `close()` was called while a negotiation was still waiting on a reply.
+ *
+ * Distinct from both a timeout and {@link RelayUnavailable}, which describe the
+ * wire; this describes a decision on our own side of it. A caller that closed
+ * deliberately — a user leaving the screen, a flow abandoning its request — can
+ * match on this and stay quiet, rather than reporting a solver failure that
+ * never happened.
+ */
+export class TransportClosed extends Error {
+    constructor() {
+        super("transport closed before the solver replied");
+        this.name = "TransportClosed";
+    }
+}
+
+/**
  * Normalise whatever `subscribeMany`'s `onclose` hands back into readable text.
  *
  * nostr-tools changed this payload WITHIN its own 2.x line: earlier versions
@@ -255,6 +271,14 @@ export const nostrRfqTransport = (options: NostrRfqOptions): RfqTransport => {
 
         async close() {
             closed = true;
+            // Reject, don't drop. `waiters.clear()` alone empties the map without
+            // ever calling the stored closures, so each caller's promise stays
+            // pending and its timer stays armed: a close mid-negotiation surfaces
+            // `timeoutMs` later as "no solver reply", blaming the solver for a
+            // teardown we chose. Each reject clears its own timer and map entry,
+            // as in `onclose` above — the two teardown paths agree on what
+            // happens to a waiter.
+            for (const waiter of waiters.values()) waiter.reject(new TransportClosed());
             waiters.clear();
             // Only tear down a pool this transport created; a shared one belongs
             // to the caller and may still be serving other swaps. On an owned

--- a/packages/swap/test/nostr.test.ts
+++ b/packages/swap/test/nostr.test.ts
@@ -7,7 +7,13 @@
 import { describe, it, expect, vi } from "vitest";
 import { generateSecretKey, getPublicKey, nip44, SimplePool, type Event } from "nostr-tools";
 import { SwapRefusal } from "../src/rfq";
-import { RFQ_AD_KIND, RFQ_DIRECTED_KIND, RelayUnavailable, nostrRfqTransport } from "../src/nostr";
+import {
+    RFQ_AD_KIND,
+    RFQ_DIRECTED_KIND,
+    RelayUnavailable,
+    TransportClosed,
+    nostrRfqTransport,
+} from "../src/nostr";
 
 /**
  * A stand-in for SimplePool that behaves like a relay the solver is also on:
@@ -233,5 +239,31 @@ describe("nostrRfqTransport", () => {
             subscribeMany.mockRestore();
             poolClose.mockRestore();
         }
+    });
+
+    /**
+     * Closing mid-negotiation must settle the caller, not abandon it.
+     *
+     * The default 30s timeout is deliberate here: it is far longer than this
+     * test is allowed to run, so a regression that goes back to dropping
+     * waiters fails as a hung test rather than passing late. The error type is
+     * half the point — waiting out the timeout would eventually reject too, but
+     * with "no solver reply", which names the wrong cause and tells a user to
+     * try a solver that was never at fault.
+     */
+    it("rejects a pending request as TransportClosed when closed mid-negotiation", async () => {
+        const solverSecret = generateSecretKey();
+        const { pool } = fakePool(solverSecret);
+        const transport = nostrRfqTransport({
+            relays: ["wss://x"],
+            solverPubkey: getPublicKey(solverSecret),
+            secretKey: generateSecretKey(),
+            pool: pool as never,
+            // no `timeoutMs`: the 30s default outlives the test's own limit
+        });
+
+        const pending = transport.requestQuote({ v: 1, type: "rfq_request", rfq_id: "abc" });
+        await transport.close();
+        await expect(pending).rejects.toBeInstanceOf(TransportClosed);
     });
 });


### PR DESCRIPTION
Follow-up to #736, taking the item its review noted as pre-existing and out of scope there. Rebased onto `master` now that #736 has merged, so the diff is one commit.

## The bug

`close()` called `waiters.clear()`, which empties the map without ever invoking the stored reject closures. Those closures own both the caller's `reject` and the `clearTimeout`, so a `close()` mid-negotiation left `requestQuote`/`status` pending with its timer still armed.

`closed = true` is set first — correctly, so the `onclose` that teardown fires isn't misreported as a lost relay — which means `onclose` is no longer the thing that settles waiters either. Nothing settled them.

Two consequences, the second worse than the first:

1. The caller hangs for the full `timeoutMs` (30s by default) after the transport is already gone.
2. It then rejects with `no solver reply within 30000ms` — the wrong cause. The wallet rewrites exactly that string into *"Lightning solver is not responding (waited 30s) — try again later"*, so a locally-initiated teardown reaches the user as a solver fault, with a remedy that doesn't apply.

## The fix

Reject each waiter with a new `TransportClosed`, mirroring what `onclose` already does, so the two teardown paths stop disagreeing about what happens to a pending waiter. Each reject clears its own timer and map entry; deleting during `Map.values()` iteration is safe, and `onclose` already relies on it.

`TransportClosed` is typed rather than a plain `Error` for the same reason `RelayUnavailable` is: a caller that closed deliberately can match on it and stay quiet instead of reporting a failure that never happened. **This is the one reviewable judgment call** — it adds public API surface, and a plain `Error` would fix the hang and the misleading message equally well. Happy to downgrade it if you'd rather not grow the surface.

## Reachability

No call site reaches this today: every in-package caller (`rfq.ts:753,1123,1536,1744`, `refund.ts:109,667`) awaits its request before closing, and the wallet's `withRfqTransport` closes only in a `finally` after the negotiation settles. So this is latent, not a live bug — which is why #736's review filed it as noted rather than blocking.

It's worth fixing because it's the precondition for cancellation. The wallet's receive screen already has an `abandoned` flag that discards the *result* on unmount without cancelling the negotiation; wiring `close()` into that unmount path is the natural way to make cancel real, and the moment someone does, every cancelled receive throws a bogus "solver is not responding" 30 seconds after the user left the screen.

## Testing

New test asserts a `requestQuote` in flight rejects as `TransportClosed` when the transport is closed under it. It uses the default 30s timeout deliberately: that outlives the test's own limit, so a regression back to dropping waiters fails as a hung test rather than passing late. Verified it fails without the fix — hangs, then fails at the 5s test limit — and passes with it.

`packages/swap`: 393 unit tests, `tsc --noEmit`, and prettier all green; the full monorepo pre-commit gate (`pnpm lint && pnpm test:unit`) passed.

## Note on #736's other follow-up

Its review also asked that the wallet's call-site workaround be removed once #736 landed. Worth flagging that the wallet went the other way in the meantime: the "workaround" was the `finally { transport.close() }`, and it was deleted outright to silence the double-close console noise — which leaked a relay connection and its subscription per negotiation instead. It has since been restored wallet-side, so #736 landing removes the noise without reintroducing the leak. Nothing left to remove there.

---
_Generated by [Claude Code](https://claude.ai/code)_