### PR TITLE
test(providers): freeze the clock for the longest-cooldown assertion

### DIFF
--- a/packages/ts-sdk/test/rate-gate.test.ts
+++ b/packages/ts-sdk/test/rate-gate.test.ts
@@ -127,11 +127,21 @@ describe("OriginRateGate", () => {
     });
 
     it("takes the longest cooldown, never a shorter one", () => {
-        const gate = new OriginRateGate();
-        gate.reportRateLimited("https://a.example/x", "30");
-        const long = gate.cooldownRemainingMs("https://a.example/x");
-        gate.reportRateLimited("https://a.example/x", "1");
-        expect(gate.cooldownRemainingMs("https://a.example/x")).toBe(long);
+        // Frozen, because the property is exact equality. `blockedUntil` is an
+        // absolute deadline and `cooldownRemainingMs` subtracts `Date.now()`
+        // at each call, so on a real clock the two reads are taken a moment
+        // apart and the second is lower by however long the test took — a
+        // millisecond of scheduling reads as "the shorter report won".
+        vi.useFakeTimers();
+        try {
+            const gate = new OriginRateGate();
+            gate.reportRateLimited("https://a.example/x", "30");
+            const long = gate.cooldownRemainingMs("https://a.example/x");
+            gate.reportRateLimited("https://a.example/x", "1");
+            expect(gate.cooldownRemainingMs("https://a.example/x")).toBe(long);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it("clamps an absurd Retry-After", () => {


### PR DESCRIPTION
`OriginRateGate`'s "takes the longest cooldown, never a shorter one" is flaky on a real clock. It
failed CI on an unrelated PR as:

```
AssertionError: expected 29999 to be 30000
 ❯ test/rate-gate.test.ts:134:65
```

## Why

`reportRateLimited` stores an absolute deadline — `blockedUntil = max(blockedUntil, Date.now() + cooldown)`
— and `cooldownRemainingMs` subtracts `Date.now()` again on every call. The test read it twice:

```ts
const long = gate.cooldownRemainingMs(url);   // Date.now() == T0
gate.reportRateLimited(url, "1");
expect(gate.cooldownRemainingMs(url)).toBe(long);   // Date.now() == T1
```

The two reads are taken a moment apart, so the second is lower by however long the test took. One
millisecond of scheduling between them reads as "the shorter Retry-After won" — the exact failure
the assertion exists to catch, reported for the one reason that is not a bug.

## The fix

Freeze the clock, matching what the rest of the file already does for its timing-sensitive cases
(`a queued waiter does not send into the cooldown the released request just earned`, and every test
in the herd-regression block).

Kept as exact equality rather than loosened to a tolerance: a real regression here drops the
deadline by 29 seconds, so a tolerance would still catch it — but it would stop saying that the
longer deadline is meant to be left *untouched*, which is the property.

## Test plan

`lint` and `test:unit` clean — ts-sdk 2577 passed / 1 skipped, typecheck no errors. The file was run
10× on its own to confirm it no longer depends on timing.

Nothing in `src/` changes.