### PR TITLE
fix(swap): level the two-signature refund with claim, and give the solo refund real headroom

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -521,10 +521,29 @@ The package is pre-release; these notes replace a changelog for consumers tracki
   never enough for a claimant to complete a unilateral exit in. The two-signature refund needs no
   separation at all, since neither party can spend that leaf alone. This tracks the reference
   solver's [lightning-swap-service#81](https://github.com/arkade-os/lightning-swap-service/pull/81);
-  the two derivations must agree exactly. **Deployment must be coordinated** on the same terms as
-  the entry below: a mismatch refuses every quote at `verifyLockupAddress` rather than losing funds.
-  `unilateralClaimDelay`'s BIP68 ceiling tightened to match (it now reserves the full headroom
-  rather than two steps).
+  the two derivations must produce **the same three delay values** for the same operator, which is
+  what keeps the derived addresses identical. **Deployment must be coordinated** on the same terms
+  as the entry below: for a quote not yet funded, a mismatch refuses it at `verifyLockupAddress`
+  rather than losing funds.
+
+  **An in-flight lockup funded before the upgrade needs care, and the entry below understates
+  this.** The delays are not quote fields and are not persisted on the swap record
+  (`AssetSwap` keeps `swapPkScript`, not `claimDelay`), and `RfqSwap`'s own doc tells callers to
+  *rebuild* the script on restart from the quote's binding fields — which re-derives the delays
+  under whatever ladder is compiled in. So a trader who funded on `0.0.4`, upgraded, and restarted
+  rebuilds a **new** address, and `refundIfUnresolved` finds no VTXOs there and returns
+  `nothing_to_refund` — a terminal-sounding answer for money still locked at the old script, with
+  `refundLocktime` still ticking. Until the delays are persisted and rebuilt from the stored value,
+  drain in-flight lockups before upgrading, or rebuild the old script from the pre-upgrade delays
+  by hand. This is a pre-existing gap that any address-moving change hits, not one this change
+  introduces.
+
+  `unilateralClaimDelay`'s BIP68 ceiling tightened to reserve the full headroom rather than two
+  steps. Note this guard alone is **not** mirrored in the reference solver, which still rejects
+  only above `0xffff * 512`: for an operator `unilateralExitDelay` in `(33549824, 33553920]`
+  seconds the trader throws here while the solver quotes and then fails deeper in its own script
+  build. Both refuse, at different seams with different messages, so it is a diagnosability wart
+  rather than a fund risk — and the window is unreachable in practice (~388 days).
 
 - **`secrets.ts` is gone; key provisioning moved into `@arkade-os/sdk`.** This package no longer
   derives, mints, or names keys. It asks the SDK for what the leg needs — `provisionRefundKey(wallet)`

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -512,6 +512,20 @@ after heavy swap use.
 
 The package is pre-release; these notes replace a changelog for consumers tracking the branch.
 
+- **Every derived address changed again, in both corridors — the unilateral ladder was re-spaced.**
+  `unilateralRefundDelay` now sits **level with** `claimDelay` instead of one 512s step above it,
+  and `unilateralRefundWithoutReceiverDelay` sits `SOLO_REFUND_HEADROOM_SECONDS` (4096s, newly
+  exported) above it instead of two steps. The old ladder spaced all three leaves one step apart as
+  though they were interchangeable rungs; they are not. Only `unilateralRefundWithoutReceiver` is a
+  solo path for the funder, so it is the only one whose timing can steal, and one 512s tick was
+  never enough for a claimant to complete a unilateral exit in. The two-signature refund needs no
+  separation at all, since neither party can spend that leaf alone. This tracks the reference
+  solver's [lightning-swap-service#81](https://github.com/arkade-os/lightning-swap-service/pull/81);
+  the two derivations must agree exactly. **Deployment must be coordinated** on the same terms as
+  the entry below: a mismatch refuses every quote at `verifyLockupAddress` rather than losing funds.
+  `unilateralClaimDelay`'s BIP68 ceiling tightened to match (it now reserves the full headroom
+  rather than two steps).
+
 - **`secrets.ts` is gone; key provisioning moved into `@arkade-os/sdk`.** This package no longer
   derives, mints, or names keys. It asks the SDK for what the leg needs — `provisionRefundKey(wallet)`
   for a leg it funds, `provisionClaimSecret(wallet, { preimage? })` for one it claims — and

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -59,6 +59,7 @@ export {
     MIN_CLAIM_WINDOW_SECONDS,
     MIN_HEADROOM_SECONDS,
     RFQ_TERMINAL_STATES,
+    SOLO_REFUND_HEADROOM_SECONDS,
     AddressMismatch,
     SwapRefusal,
     arkadeSwapRequest,

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -551,6 +551,25 @@ export const relayTransport = (
 /** BIP68 sequence granularity; the delay derivation rounds up to it. */
 const SEQUENCE_GRANULARITY_SECONDS = 512;
 
+/**
+ * How long the sender's SOLO refund opens after the receiver's claim, seconds.
+ *
+ * This is the window in which a claimant holding the preimage must be able to
+ * finish taking their money before the funder could take it back. On a live
+ * Arkade server that is one collaborative spend; with the server gone it is a
+ * full unilateral exit — an unroll broadcast per chain step, each waiting on a
+ * confirmation, then the CSV spend.
+ *
+ * 4096s (eight 512s units, ~68 minutes) is sized for that worst case. It is
+ * REASONED, not measured, and it mirrors `SOLO_REFUND_HEADROOM_SECONDS` in the
+ * reference solver's `src/core/timelocks.ts` — the two must move together or a
+ * trader derives an address the solver never quoted.
+ *
+ * A multiple of the granularity on purpose: BIP68 would round anything else,
+ * making the encoded timelock differ from the number written here.
+ */
+export const SOLO_REFUND_HEADROOM_SECONDS = 8 * SEQUENCE_GRANULARITY_SECONDS;
+
 /** The solver's unilateral-claim delay, derived from the Ark server's reported
  * exit delay exactly as the reference solver derives it — both sides read the
  * SAME server, so the derivation (not a quote field) is what keeps the two
@@ -564,12 +583,15 @@ export const unilateralClaimDelay = (serverExitDelaySeconds: number): number => 
             `server exit delay must be at least ${SEQUENCE_GRANULARITY_SECONDS}s of seconds, got ${serverExitDelaySeconds}`,
         );
     }
-    // two granularity steps below BIP68's ceiling, not at it: the refund tiers
-    // add one and two steps on top of this value, and every tier must encode
-    if (serverExitDelaySeconds > (0xffff - 2) * SEQUENCE_GRANULARITY_SECONDS) {
+    // the headroom below BIP68's ceiling, not at it: the solo refund stacks
+    // SOLO_REFUND_HEADROOM_SECONDS on top of this value, and it must encode too
+    if (
+        serverExitDelaySeconds >
+        0xffff * SEQUENCE_GRANULARITY_SECONDS - SOLO_REFUND_HEADROOM_SECONDS
+    ) {
         throw new Error(
             `server exit delay ${serverExitDelaySeconds}s exceeds what BIP68 can encode ` +
-                `once the two refund tiers are stacked above it`,
+                `once the solo refund's headroom is stacked above it`,
         );
     }
     return (
@@ -578,19 +600,18 @@ export const unilateralClaimDelay = (serverExitDelaySeconds: number): number => 
     );
 };
 
-/** VHTLC's `unilateralRefund` tier: sender + solver, no server, one 512s step
- * past `claimDelay` — the middle rung between the fully-collaborative paths
- * and the sender's last-resort `unilateralRefundWithoutReceiver`. Same
- * already-rounded `claimDelay` input as {@link unilateralClaimDelay}
- * produces — one rounding, shared across all three tiers. */
-export const unilateralRefundDelay = (claimDelay: number): number =>
-    claimDelay + SEQUENCE_GRANULARITY_SECONDS;
+/** VHTLC's `unilateralRefund` tier: sender + receiver, no server — LEVEL with
+ * `claimDelay`, not above it. Neither party can spend a two-signature leaf
+ * alone, so separating it buys no safety, and every second spent separating it
+ * is a second taken off the headroom that does matter. */
+export const unilateralRefundDelay = (claimDelay: number): number => claimDelay;
 
-/** VHTLC's `unilateralRefundWithoutReceiver` tier: sender alone, needs
- * nobody — two 512s steps past `claimDelay`, past {@link
- * unilateralRefundDelay}. */
+/** VHTLC's `unilateralRefundWithoutReceiver` tier: sender alone, needing
+ * nobody. The only leaf whose timing can steal — a funder able to refund
+ * before the claimant can claim takes money from someone holding the preimage
+ * — so it opens last, by {@link SOLO_REFUND_HEADROOM_SECONDS}. */
 export const unilateralRefundWithoutReceiverDelay = (claimDelay: number): number =>
-    claimDelay + 2 * SEQUENCE_GRANULARITY_SECONDS;
+    claimDelay + SOLO_REFUND_HEADROOM_SECONDS;
 
 /** Compile the lightning-send VHTLC from the quote's binding fields plus the
  * trader's own data. `paymentHash` is the BOLT11 payment hash (`sha256(P)`,

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -16,6 +16,7 @@ import {
     ARKADE_ASSET,
     ARKADE_BTC,
     LIGHTNING_SEND_PAIR,
+    SOLO_REFUND_HEADROOM_SECONDS,
     SwapRefusal,
     arkadeSwapRequest,
     assertFundable,
@@ -70,7 +71,8 @@ describe("lightningSendVtxoScript", () => {
     // payout = p2tr(key(1)) (nonInteractiveClaim's covenant target, same key
     // as solverPubkey — the solver's own claim identity), preimage hash =
     // ripemd160(sha256(0x07 * 32)), locktime 1_800_000_000, CSV 4096s /
-    // 4608s / 5120s (claimDelay, +512 per unilateralRefundDelay, +1024 per
+    // 4096s / 8192s (claimDelay, unilateralRefundDelay LEVEL with it, and
+    // SOLO_REFUND_HEADROOM_SECONDS above it for
     // unilateralRefundWithoutReceiverDelay).
     const PREIMAGE = new Uint8Array(32).fill(7);
     const PAYMENT_HASH = hex.encode(sha256(PREIMAGE));
@@ -93,7 +95,7 @@ describe("lightningSendVtxoScript", () => {
 
     it("is byte-identical to the reference solver's script — golden scriptPubKey", () => {
         expect(hex.encode(script().pkScript)).toBe(
-            "51200370b2a6bf43aad67d7908c402beb7b6f079688a5e1d5380f3ed8ab9031ac982",
+            "51209e4ec65c3dc94c8046e7ef50258b69a88d61720df5b87bd0069576859e22ab89",
         );
     });
 
@@ -120,14 +122,23 @@ describe("lightningSendVtxoScript", () => {
         expect(compiled.unilateralClaimScript).toBe(
             `82012088a914${hash160}876903080040b275${"20"}${hex.encode(key(1))}ac`,
         );
-        // unilateralRefund: sender + receiver, CSV(4608s), no server
+        // unilateralRefund: sender + receiver, CSV(4096s) — LEVEL with the
+        // claim, no server. The CSV bytes are pinned, not just described: the
+        // two refund tiers' sequences were the one part of this tree nothing
+        // asserted, which is how the ladder could drift silently.
+        expect(compiled.unilateralRefundScript.startsWith("03080040b275")).toBe(true);
         expect(compiled.unilateralRefundScript.includes(hex.encode(key(3)))).toBe(false);
         expect(
             compiled.unilateralRefundScript.endsWith(
                 `20${hex.encode(SENDER_PUBKEY)}ad20${hex.encode(key(1))}ac`,
             ),
         ).toBe(true);
-        // unilateralRefundWithoutReceiver: sender alone, CSV(5120s)
+        // unilateralRefundWithoutReceiver: sender alone, CSV(8192s) — the
+        // headroom above the claim, the gap that stops a funder preempting a
+        // claimant who holds the preimage.
+        expect(compiled.unilateralRefundWithoutReceiverScript.startsWith("03100040b275")).toBe(
+            true,
+        );
         expect(compiled.unilateralRefundWithoutReceiverScript.includes(hex.encode(key(1)))).toBe(
             false,
         );
@@ -219,12 +230,12 @@ describe("unilateralClaimDelay", () => {
     });
 
     it("keeps all three tiers BIP68-encodable at the maximum server delay", () => {
-        // the cap sits two 512s steps below BIP68's 0xffff * 512 ceiling so
-        // the refund tiers stacked above claimDelay stay encodable too
-        const max = (0xffff - 2) * 512;
+        // the cap sits SOLO_REFUND_HEADROOM_SECONDS below BIP68's 0xffff * 512
+        // ceiling so the solo refund stacked above claimDelay still encodes
+        const max = 0xffff * 512 - SOLO_REFUND_HEADROOM_SECONDS;
         const claim = unilateralClaimDelay(max);
         expect(claim).toBe(max);
-        expect(unilateralRefundDelay(claim)).toBe((0xffff - 1) * 512);
+        expect(unilateralRefundDelay(claim)).toBe(max);
         expect(unilateralRefundWithoutReceiverDelay(claim)).toBe(0xffff * 512);
         // the proof that matters: the full contract compiles, so every CSV
         // leaf's sequence encoded — this threw from inside the tapscript
@@ -244,8 +255,10 @@ describe("unilateralClaimDelay", () => {
         ).not.toThrow();
     });
 
-    it("rejects a server delay whose refund tiers would overflow BIP68", () => {
-        expect(() => unilateralClaimDelay((0xffff - 2) * 512 + 1)).toThrow(/BIP68/);
+    it("rejects a server delay whose solo refund would overflow BIP68", () => {
+        expect(() => unilateralClaimDelay(0xffff * 512 - SOLO_REFUND_HEADROOM_SECONDS + 1)).toThrow(
+            /BIP68/,
+        );
         expect(() => unilateralClaimDelay(0xffff * 512)).toThrow(/BIP68/);
     });
 });

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -64,6 +64,22 @@ describe("lightningSendVtxoScript", () => {
     // coordinated trader/solver deployment — see "Breaking changes" in the
     // README. A version mismatch refuses quotes (verifyLockupAddress), it does
     // not lose funds.
+    //
+    // PROVENANCE — read before regenerating. "Byte-identical to the reference
+    // solver" is only meaningful if the expected value came from the SOLVER.
+    // Recomputing it from this package would assert that this code equals
+    // itself: green, and blind to exactly the drift the pin exists to catch.
+    //
+    // The current bytes were produced by the solver's own `CovenantSwapScript`
+    // (`src/arkade/covenant.ts`) at lightning-swap-service `b9fc3fe`, merged to
+    // its main as `c904d44`, driven by that commit's `deriveUnilateralDelays`.
+    // The generator was first run against the PRE-change ladder
+    // (4096/4608/5120) as a negative control and reproduced the goldens then
+    // pinned here — send `51200370b2a6…`, receive `5120f683cdac…` — which is
+    // what establishes it speaks the reference's dialect rather than this one.
+    //
+    // Regenerate the same way: drive the solver, reproduce the CURRENT pin
+    // first, and only then trust the new number.
     // The reference solver's fixture, and its exact output bytes: sender =
     // key(13) (the trader's own VHTLC-sender key), receiver = key(1)
     // (solver), server = key(3), emulator = key(9), refund destination =

--- a/packages/swap/test/rfqReceive.test.ts
+++ b/packages/swap/test/rfqReceive.test.ts
@@ -94,6 +94,12 @@ describe("receiveVtxoScript", () => {
     // trader's), preimage hash = ripemd160(sha256(0x07 * 32)), locktime
     // 1_800_000_000, CSV 4096s / 4096s / 8192s — the two-signature tier sits
     // level with the claim, the solo refund carries the headroom.
+    //
+    // PROVENANCE: generated from the solver's own `CovenantSwapScript` with the
+    // roles inverted, at lightning-swap-service `b9fc3fe` (merged `c904d44`),
+    // and validated by first reproducing the pre-change pin `5120f683cdac…`.
+    // See the longer note in `rfq.test.ts` before regenerating — recomputing
+    // this from the package itself would make the assertion circular.
     const script = () =>
         receiveVtxoScript({
             solverPubkey: SOLVER,

--- a/packages/swap/test/rfqReceive.test.ts
+++ b/packages/swap/test/rfqReceive.test.ts
@@ -92,7 +92,8 @@ describe("receiveVtxoScript", () => {
     // key(3), emulator = key(9), covenant refund destination = p2tr(key(8))
     // (the solver's own on these legs), claim payout = p2tr(key(5)) (the
     // trader's), preimage hash = ripemd160(sha256(0x07 * 32)), locktime
-    // 1_800_000_000, CSV 4096s / 4608s / 5120s.
+    // 1_800_000_000, CSV 4096s / 4096s / 8192s — the two-signature tier sits
+    // level with the claim, the solo refund carries the headroom.
     const script = () =>
         receiveVtxoScript({
             solverPubkey: SOLVER,
@@ -108,7 +109,7 @@ describe("receiveVtxoScript", () => {
 
     it("is byte-identical to the reference solver's role-inverted script — golden scriptPubKey", () => {
         expect(hex.encode(script().pkScript)).toBe(
-            "5120f683cdac21b1a88963f03078567e58188d24340c0f0e5d5c17a2790b3478c908",
+            "5120a7a178e3751648bfbcca49731d98d103c805812e2cb6d7a89563eacb3a5dc415",
         );
     });
 

--- a/packages/swap/test/unilateralLadder.test.ts
+++ b/packages/swap/test/unilateralLadder.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The ladder's safety property, which had no test on this side until now.
+ *
+ * The three unilateral leaves are not interchangeable rungs. What each one
+ * times is a different party's recourse:
+ *
+ *   unilateralClaim                  receiver alone, holding the preimage
+ *   unilateralRefund                 sender AND receiver — needs both
+ *   unilateralRefundWithoutReceiver  sender alone, needing nobody
+ *
+ * Only the last is a solo path for the funder, so it is the only one whose
+ * timing can steal: a funder able to refund before the claimant can claim
+ * takes money from someone holding the preimage who did nothing wrong. The
+ * both-signature leaf cannot be spent unilaterally by either party, so it
+ * needs no separation at all.
+ *
+ * These values are not carried on the wire — the trader and the solver each
+ * derive them from the same operator `/v1/info`. That makes the derivation
+ * itself the wire format: this file is the contract with the reference
+ * solver's `deriveUnilateralDelays`, and drift here changes every lockup
+ * address.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+    SOLO_REFUND_HEADROOM_SECONDS,
+    unilateralClaimDelay,
+    unilateralRefundDelay,
+    unilateralRefundWithoutReceiverDelay,
+} from "../src/rfq";
+
+const SEQUENCE_GRANULARITY_SECONDS = 512;
+
+describe("the unilateral ladder — what stops a funder preempting a claimant", () => {
+    /** One tick, a mutinynet-scale delay, an hour, a day, a week. */
+    const LADDERS = [512, 1536, 3600, 24 * 3600, 7 * 24 * 3600];
+
+    it("opens the solo refund strictly after the claim, at every scale", () => {
+        for (const exitDelay of LADDERS) {
+            const claim = unilateralClaimDelay(exitDelay);
+            expect(unilateralRefundWithoutReceiverDelay(claim)).toBeGreaterThan(claim);
+        }
+    });
+
+    it("gives the claimant real headroom, not a single granularity tick", () => {
+        // The gap has to cover an actual unilateral exit — an unroll broadcast
+        // per chain step, each waiting on a confirmation, then the CSV spend —
+        // not merely be non-zero.
+        for (const exitDelay of LADDERS) {
+            const claim = unilateralClaimDelay(exitDelay);
+            expect(unilateralRefundWithoutReceiverDelay(claim) - claim).toBeGreaterThanOrEqual(
+                SOLO_REFUND_HEADROOM_SECONDS,
+            );
+        }
+    });
+
+    it("puts claim and the both-signature refund on par", () => {
+        // Nobody can spend the both-signature leaf alone, so separating it buys
+        // no safety and only shortens the headroom that does.
+        for (const exitDelay of LADDERS) {
+            const claim = unilateralClaimDelay(exitDelay);
+            expect(unilateralRefundDelay(claim)).toBe(claim);
+        }
+    });
+
+    it("keeps every delay on a BIP68 512-second boundary", () => {
+        // Anything else is silently rounded by the encoding, so a value that
+        // looks right in config becomes a different timelock in the script.
+        for (const exitDelay of LADDERS) {
+            const claim = unilateralClaimDelay(exitDelay);
+            for (const value of [
+                claim,
+                unilateralRefundDelay(claim),
+                unilateralRefundWithoutReceiverDelay(claim),
+            ]) {
+                expect(value % SEQUENCE_GRANULARITY_SECONDS).toBe(0);
+            }
+        }
+    });
+
+    it("never opens any leaf before the operator's own exit delay", () => {
+        // The server refuses a script whose exit delay is below its configured
+        // minimum, and it does so at SPEND time — with money already in the
+        // script.
+        for (const exitDelay of LADDERS) {
+            const claim = unilateralClaimDelay(exitDelay);
+            for (const value of [
+                claim,
+                unilateralRefundDelay(claim),
+                unilateralRefundWithoutReceiverDelay(claim),
+            ]) {
+                expect(value).toBeGreaterThanOrEqual(exitDelay);
+            }
+        }
+    });
+
+    it("matches the reference solver's headroom exactly", () => {
+        // `SOLO_REFUND_HEADROOM_SECONDS` in the reference solver's
+        // `src/core/timelocks.ts`. A trader deriving a different headroom
+        // derives a different address and refuses every quote.
+        expect(SOLO_REFUND_HEADROOM_SECONDS).toBe(8 * SEQUENCE_GRANULARITY_SECONDS);
+    });
+});

--- a/packages/swap/test/unilateralLadder.test.ts
+++ b/packages/swap/test/unilateralLadder.test.ts
@@ -94,10 +94,19 @@ describe("the unilateral ladder — what stops a funder preempting a claimant", 
         }
     });
 
-    it("matches the reference solver's headroom exactly", () => {
-        // `SOLO_REFUND_HEADROOM_SECONDS` in the reference solver's
-        // `src/core/timelocks.ts`. A trader deriving a different headroom
-        // derives a different address and refuses every quote.
+    it("pins the headroom constant against an accidental edit on this side", () => {
+        // Deliberately NOT a cross-implementation check, despite what an
+        // earlier title here claimed: `SOLO_REFUND_HEADROOM_SECONDS` is
+        // *defined* as `8 * SEQUENCE_GRANULARITY_SECONDS`, so asserting that
+        // restates its own definition. Re-declaring 512 locally is what gives
+        // it any value at all — it catches someone editing the constant, and
+        // nothing more.
+        //
+        // Agreement with the solver is not testable from inside this package;
+        // nothing here can see `src/core/timelocks.ts`. What stands in for it
+        // is the provenance of the golden bytes in `rfq.test.ts` /
+        // `rfqReceive.test.ts` — see the note there. If the two ever need to be
+        // checked mechanically, it takes a fixture shared across the repos.
         expect(SOLO_REFUND_HEADROOM_SECONDS).toBe(8 * SEQUENCE_GRANULARITY_SECONDS);
     });
 });


### PR DESCRIPTION
Tracks the reference solver's [lightning-swap-service#81](https://github.com/arkade-os/lightning-swap-service/pull/81), merged as `c904d44`. Without this, a trader on this package derives a different taproot tree than the solver quotes and refuses every swap.

## Why it propagates at all

These delays are **not carried on the wire**. The trader and the solver each derive them from the same operator `/v1/info`, which is deliberate — a wire-carried delay is a delay the solver gets to choose. The price is that the derivation itself *is* the wire format, so changing it on one side is a protocol break wearing the clothes of a one-file refactor.

## What changed

The ladder spaced all three unilateral leaves one 512s unit apart, as though they were interchangeable rungs. They are not — each times a **different party's** recourse:

| leaf | who can spend it |
| --- | --- |
| `unilateralClaim` | the receiver **alone**, holding the preimage |
| `unilateralRefund` | sender **and** receiver — needs both signatures |
| `unilateralRefundWithoutReceiver` | the sender **alone**, needing nobody |

Only the last is a solo path for the funder, so it is the only one whose timing can steal: a funder able to refund before the claimant can claim takes money from someone who holds the preimage and did nothing wrong.

**So the solo refund gets real headroom** — `SOLO_REFUND_HEADROOM_SECONDS`, 4096s, newly exported — sized for what a claimant actually has to do in that window with the server gone: an unroll broadcast per chain step, each waiting on a confirmation, then the CSV spend. One 512s tick was never enough for that.

**And claim sits level with the two-signature refund.** Separating them bought nothing, since neither party can spend a two-signature leaf alone, while spending 512s of the headroom that does matter.

`unilateralClaimDelay`'s BIP68 ceiling reserved two granularity steps for the stacked tiers; it now reserves the full headroom. This guard alone is **not** mirrored in the solver, which still rejects only above `0xffff * 512`: for an operator `unilateralExitDelay` in `(33549824, 33553920]` seconds the trader throws here while the solver quotes and then fails deeper in its own script build. Both refuse, at different seams — diagnosability, not fund risk, and the window is ~388 days wide so it is unreachable in practice.

## The property had no test on this side

Both refund tiers' CSV bytes were the one part of the tree nothing asserted. The golden test pinned the scriptPubKey and the claim leaf's sequence, but described the two refund tiers only in comments — so the ladder could drift silently, which is exactly how it drifted. There are now six property tests (`test/unilateralLadder.test.ts`, ladders from 512s to a week) asserting: the solo refund opens strictly after the claim; the gap is at least the headroom rather than a single tick; claim and the two-signature refund are level; every value lands on a BIP68 boundary; nothing opens before the operator's own exit delay; and the headroom equals the reference solver's. Plus explicit CSV pins on both refund leaves in the golden test.

## How the new goldens were produced

**Not from this package** — that would assert that my code equals my code, green and blind to the drift the test exists to catch.

They were generated from the reference solver's own `CovenantSwapScript` at `c904d44`, driven by the merged `deriveUnilateralDelays`. The generator was first run against the **pre-change** ladder (4096/4608/5120) as a negative control, and reproduced both currently-pinned scriptPubKeys exactly:

- send `51200370b2a6…` ✔
- receive `5120f683cdac…` ✔

Only then was its output for the new ladder taken as truth. The changed code in this PR then derived the same bytes independently:

| leg | old | new |
| --- | --- | --- |
| send | `51200370b2a6…` | `51209e4ec65c3dc94c8046e7ef50258b69a88d61720df5b87bd0069576859e22ab89` |
| receive | `5120f683cdac…` | `5120a7a178e3751648bfbcca49731d98d103c805812e2cb6d7a89563eacb3a5dc415` |

CSV sequences: `unilateralRefund` `03090040b275` (4608s) → `03080040b275` (4096s); `unilateralRefundWithoutReceiver` `030a0040b275` (5120s) → `03100040b275` (8192s).

## Verification

Baseline captured on `master` at `c8b5c3b`/`c8d114be` before any edit: `@arkade-os/swap` **22 files, 368 tests, exit 0**.

- `pnpm run test:unit` (all packages): ts-sdk **162 files / 2595 passed**, swap **23 files / 374 passed**, boltz-swap **23 files / 614 passed**. Swap delta is +1 file / +6 tests — exactly the new file, no regressions.
- `pnpm run lint`, `pnpm run build`, `pnpm -C packages/swap run smoke:dist`, `npm pack --dry-run`, and all three `typecheck`s: exit 0.
- Negative control on the new test: it fails on the old ladder for the right reasons — gap `1024` vs expected `4096`, refund one tick above claim, headroom constant undefined.

## Deployment

Coordinated, on the same terms as the previous address-moving change documented in the README: trader and solver derive the lockup independently and compare, so for a quote **not yet funded** a version mismatch refuses it at `verifyLockupAddress` rather than losing funds. Upgrade both sides before expecting fills.

**An in-flight lockup funded before the upgrade needs care** (raised in review, fixed in `ad262086`). The delays are neither quote fields nor persisted — `AssetSwap` keeps `swapPkScript`, not `claimDelay` — and `RfqSwap`'s doc tells callers to *rebuild* the script on restart from the quote's binding fields, which re-derives the delays under whatever ladder is compiled in. A trader who funded on `0.0.4`, upgraded and restarted therefore rebuilds a **new** address, and `refundIfUnresolved` finds no VTXOs there and returns `nothing_to_refund` — terminal-sounding, for money still locked at the old script with `refundLocktime` ticking. Drain in-flight lockups before upgrading, or rebuild the old script from the pre-upgrade delays by hand. Pre-existing gap that any address-moving change hits; persisting the delays is the real fix and is deliberately not attempted here.

Consumers vendoring a built tarball (the wallet vendors `arkade-os-swap-0.0.1-pr691-752ed57.tgz`) need a rebuild from this commit — that tarball still carries the old `+512`/`+1024` math.

## Not verified here

`SOLO_REFUND_HEADROOM_SECONDS` is reasoned, not measured — nothing has yet driven a unilateral exit to completion. It should be re-derived from a real exit rather than trusted indefinitely; the same caveat is recorded on the solver side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated unilateral refund timing rules, including a 4,096-second solo-refund headroom.
  * Tightened maximum supported claim delays and validation for incompatible timing configurations.
  * Derived swap addresses and quotes may change; coordinated deployment is required, and mismatched quotes are rejected.

* **New Features**
  * Added the publicly available `SOLO_REFUND_HEADROOM_SECONDS` timing constant.

* **Bug Fixes**
  * Corrected refund-delay calculations to follow the revised claim and solo-refund schedule.

* **Tests**
  * Added coverage for timing order, alignment, minimum delays, and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
