### PR TITLE
feat(swap): persist the onchain leg, behind a corridor handler registry

### DIFF
--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -35,6 +35,19 @@ export {
 } from "./repository";
 export { IndexedDbAssetSwapRepository } from "./indexedDbRepository";
 export {
+    rfqCorridorHandlers,
+    type RfqCorridorContext,
+    type RfqCorridorHandler,
+    type RfqSwapCommonFields,
+} from "./rfqCorridor";
+export {
+    LightningReceiveCorridor,
+    LightningSendCorridor,
+    OnchainSendCorridor,
+    type LightningReceiveProfile,
+    type OnchainSendProfile,
+} from "./rfqCorridors";
+export {
     RFQ_SWAP_RETENTION_SECONDS,
     createRfqSwapRecord,
     rebuildRfqSwap,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -36,7 +36,11 @@ export {
 export { IndexedDbAssetSwapRepository } from "./indexedDbRepository";
 // The corridor handlers and their registry are internal — see `rfqCorridor.ts`
 // for why. What a consumer writes into `RfqSwapOrigin.profile` is these:
-export type { LightningReceiveProfile, OnchainSendProfile } from "./rfqCorridors";
+export {
+    onchainSendProfile,
+    type LightningReceiveProfile,
+    type OnchainSendProfile,
+} from "./rfqCorridors";
 export {
     RFQ_SWAP_RETENTION_SECONDS,
     createRfqSwapRecord,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -34,19 +34,9 @@ export {
     InMemoryAssetSwapRepository,
 } from "./repository";
 export { IndexedDbAssetSwapRepository } from "./indexedDbRepository";
-export {
-    rfqCorridorHandlers,
-    type RfqCorridorContext,
-    type RfqCorridorHandler,
-    type RfqSwapCommonFields,
-} from "./rfqCorridor";
-export {
-    LightningReceiveCorridor,
-    LightningSendCorridor,
-    OnchainSendCorridor,
-    type LightningReceiveProfile,
-    type OnchainSendProfile,
-} from "./rfqCorridors";
+// The corridor handlers and their registry are internal — see `rfqCorridor.ts`
+// for why. What a consumer writes into `RfqSwapOrigin.profile` is these:
+export type { LightningReceiveProfile, OnchainSendProfile } from "./rfqCorridors";
 export {
     RFQ_SWAP_RETENTION_SECONDS,
     createRfqSwapRecord,

--- a/packages/swap/src/onchainHtlc.ts
+++ b/packages/swap/src/onchainHtlc.ts
@@ -129,6 +129,18 @@ export function onchainHtlcScript(params: OnchainHtlcParams, network: OnchainNet
             `refundLocktime must be a positive unix timestamp, got ${params.refundLocktime}`,
         );
     }
+    // Refused rather than defaulted: an unknown network reaches `btc.p2tr` as
+    // `undefined`, which it reads as mainnet — so a regtest HTLC rebuilt from a
+    // record whose `network` was garbled comes back with a `bc1p…` address and
+    // no complaint. The output key is network-independent, so the leaves and
+    // pkScript would still be right; only the address would lie, which is the
+    // worst shape for it to fail in.
+    if (!Object.hasOwn(L1_NETWORKS, network)) {
+        throw new Error(
+            `unknown L1 network '${String(network)}' — expected one of ` +
+                `${Object.keys(L1_NETWORKS).join(", ")}`,
+        );
+    }
     const h160 = h160FromPaymentHash(params.paymentHash);
     const claim = btc.Script.encode([
         "SIZE",

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -999,6 +999,10 @@ export function deriveOnchainSend(input: {
      * contract is Bitcoin L1 — there is no Arkade contract row for it, so a
      * consumer persisting the swap has no other route to rebuilding it. */
     htlcParams: OnchainHtlcParams;
+    /** Echoed from the input, so a result is a complete description of the L1
+     * half rather than one a caller has to re-assemble from what it passed in.
+     * {@link onchainSendProfile} reads it from here. */
+    l1Network: OnchainNetwork;
     refundLocktime: number;
     htlcLocktime: number;
     minConfirmations: number;
@@ -1053,6 +1057,7 @@ export function deriveOnchainSend(input: {
         script,
         htlc,
         htlcParams,
+        l1Network: input.l1Network,
         refundLocktime,
         htlcLocktime,
         minConfirmations,
@@ -1116,8 +1121,21 @@ export async function requestOnchainSend(
      * lockup there is no contract row holding its parameters. Persist
      * `htlc.address` alongside them (`OnchainSendProfile.htlcAddress`): the
      * rebuild checks the two against each other, which is the only check
-     * available on a leg with no second copy of its covenant. */
+     * available on a leg with no second copy of its covenant.
+     *
+     * `onchainSendProfile(result)` does all of that mapping for you; prefer it
+     * to reading these fields across by hand. */
     htlcParams: OnchainHtlcParams;
+    /**
+     * Which bitcoin network the L1 HTLC was derived for.
+     *
+     * Returned because it is NOT the ark network name and cannot be recovered
+     * from one by inspection: this call maps `info.network` through a private
+     * narrowing where signet, mutinynet and testnet4 all become `"testnet"`.
+     * A caller reconstructing it from context would be re-deriving a mapping
+     * it cannot see, and a value the profile needs verbatim.
+     */
+    l1Network: OnchainNetwork;
     /** `profile.min_confirmations`; gates when the L1 fill becomes claimable,
      * and part of what a restored swap needs to drive its own claim. */
     minConfirmations: number;
@@ -1201,6 +1219,7 @@ export async function requestOnchainSend(
         refundAddress,
         htlc: derived.htlc,
         htlcParams: derived.htlcParams,
+        l1Network: derived.l1Network,
         minConfirmations: derived.minConfirmations,
         senderPubkey,
         secrets,

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -66,6 +66,7 @@ import {
     onchainHtlcScript,
     paymentHashOf,
     type OnchainHtlc,
+    type OnchainHtlcParams,
     type OnchainNetwork,
 } from "./onchainHtlc";
 
@@ -993,6 +994,11 @@ export function deriveOnchainSend(input: {
      * so the row can never key on a script other than the derived one. */
     script: InstanceType<typeof VHTLC.ScriptV2>;
     htlc: OnchainHtlc;
+    /** The inputs {@link htlc} was built from. Returned because nothing else
+     * can give them back: `OnchainHtlc` exposes only derived values, and this
+     * contract is Bitcoin L1 — there is no Arkade contract row for it, so a
+     * consumer persisting the swap has no other route to rebuilding it. */
+    htlcParams: OnchainHtlcParams;
     refundLocktime: number;
     htlcLocktime: number;
     minConfirmations: number;
@@ -1029,15 +1035,16 @@ export function deriveOnchainSend(input: {
     const address = script.address(input.hrp, input.serverPubkey).encode();
     verifyLockupAddress(quote, address);
 
-    const htlc = onchainHtlcScript(
-        {
-            paymentHash: input.paymentHash,
-            claimKey: input.payoutPubkey,
-            refundKey: xOnly(hex.decode(htlcPubkey), "solver L1 htlc key"),
-            refundLocktime: htlcLocktime,
-        },
-        input.l1Network,
-    );
+    // Named so the inputs can be handed back: `OnchainHtlc` carries only
+    // derived values, and unlike the Arkade lockup this HTLC has no contract
+    // row, so these are the only route to rebuilding it after a restart.
+    const htlcParams = {
+        paymentHash: input.paymentHash,
+        claimKey: input.payoutPubkey,
+        refundKey: xOnly(hex.decode(htlcPubkey), "solver L1 htlc key"),
+        refundLocktime: htlcLocktime,
+    };
+    const htlc = onchainHtlcScript(htlcParams, input.l1Network);
     if (htlc.address !== htlcAddress) throw new AddressMismatch(htlc.address, htlcAddress);
 
     return {
@@ -1045,6 +1052,7 @@ export function deriveOnchainSend(input: {
         swapPkScript: script.pkScript,
         script,
         htlc,
+        htlcParams,
         refundLocktime,
         htlcLocktime,
         minConfirmations,
@@ -1102,6 +1110,14 @@ export async function requestOnchainSend(
     refundAddress: string;
     /** The EXPECTED L1 fill, derived locally — watch and claim against this. */
     htlc: OnchainHtlc;
+    /** The inputs {@link htlc} was built from — persist these to rebuild it
+     * after a restart. Nothing else gives them back: `OnchainHtlc` exposes only
+     * derived values, and this contract is Bitcoin L1, so unlike the arkade
+     * lockup there is no contract row holding its parameters. */
+    htlcParams: OnchainHtlcParams;
+    /** `profile.min_confirmations`; gates when the L1 fill becomes claimable,
+     * and part of what a restored swap needs to drive its own claim. */
+    minConfirmations: number;
     /** The VHTLC `sender` x-only key, bound into the covenant. Public. */
     senderPubkey: Uint8Array;
     /** How the preimage and the `sender` key are recovered later. Persist it
@@ -1181,6 +1197,8 @@ export async function requestOnchainSend(
         script: derived.script,
         refundAddress,
         htlc: derived.htlc,
+        htlcParams: derived.htlcParams,
+        minConfirmations: derived.minConfirmations,
         senderPubkey,
         secrets,
     };

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -1113,7 +1113,10 @@ export async function requestOnchainSend(
     /** The inputs {@link htlc} was built from — persist these to rebuild it
      * after a restart. Nothing else gives them back: `OnchainHtlc` exposes only
      * derived values, and this contract is Bitcoin L1, so unlike the arkade
-     * lockup there is no contract row holding its parameters. */
+     * lockup there is no contract row holding its parameters. Persist
+     * `htlc.address` alongside them (`OnchainSendProfile.htlcAddress`): the
+     * rebuild checks the two against each other, which is the only check
+     * available on a leg with no second copy of its covenant. */
     htlcParams: OnchainHtlcParams;
     /** `profile.min_confirmations`; gates when the L1 fill becomes claimable,
      * and part of what a restored swap needs to drive its own claim. */

--- a/packages/swap/src/rfqCorridor.ts
+++ b/packages/swap/src/rfqCorridor.ts
@@ -17,18 +17,18 @@
  * repository writes whole, so a backend that mangles unknown keys would lose a
  * corridor's half without saying so — which is why `serialize` returns a flat
  * object rather than anything class-shaped.
+ *
+ * **A seam for this package, not for consumers**, and none of it is exported
+ * from the index. `RfqSwapManager` branches on `RfqSwap["kind"]` to decide what
+ * it drives — `driveReceiveClaim`, `driveOnchain`, `traderClaimTxid` — so a
+ * corridor registered from outside would persist and restore correctly and then
+ * sit unmonitored, which is worse than not being storable at all. `kind` is
+ * typed to the manager's union to keep the two in step: a corridor becomes
+ * storable in the same change that makes it drivable, or not at all. What a
+ * consumer needs is the profile types, so those are exported and this is not.
  */
 import type { VHTLC } from "@arkade-os/sdk";
 import type { RfqSwap } from "./swapManager";
-
-/** The record fields every corridor shares, as a handler sees them. */
-export interface RfqSwapCommonFields {
-    rfqId: string;
-    paymentHash: string;
-    lockupAddress: string;
-    signingDescriptor: string;
-    preimageHex?: string;
-}
 
 /**
  * How one corridor persists and restores its own half.
@@ -42,8 +42,9 @@ export interface RfqSwapCommonFields {
  * covenant it is handed.
  */
 export interface RfqCorridorHandler<P extends Record<string, unknown> = Record<string, unknown>> {
-    /** The `RfqSwap["kind"]` this handles. */
-    readonly kind: string;
+    /** The swap kind this handles. The manager's own union, so a handler can
+     * only ever exist for a corridor the manager can drive. */
+    readonly kind: RfqSwap["kind"];
 
     /**
      * The parts of the profile the MANAGER can change, projected off the live
@@ -97,6 +98,10 @@ class RfqCorridorRegistry {
         this.handlers.set(handler.kind, handler as RfqCorridorHandler);
     }
 
+    /** Takes a bare `string`, deliberately, where {@link RfqCorridorHandler.kind}
+     * is the manager's union: a lookup key comes off a record a backend handed
+     * back, and that it typechecks as a `kind` is a claim about the type, not
+     * about what was stored. Narrowing this would read as a check already made. */
     get(kind: string): RfqCorridorHandler | undefined {
         return this.handlers.get(kind);
     }

--- a/packages/swap/src/rfqCorridor.ts
+++ b/packages/swap/src/rfqCorridor.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-corridor persistence, kept out of the record.
+ *
+ * The record itself is corridor-agnostic: identity, manager state, the pointer
+ * to the lockup's contract row, and one opaque `profile` it never interprets.
+ * Everything a corridor needs beyond that — the receive leg's value gate, the
+ * onchain leg's L1 contract — lives in its own handler.
+ *
+ * This mirrors the contract layer's `contractHandlers` registry, deliberately:
+ * that solved the same problem for VTXO scripts, and adding a contract type
+ * there is a new file plus one `register()` call rather than an edit to a
+ * shared type. Adding a corridor here should cost the same. Nothing in
+ * `rfqRecord.ts`, `repository.ts` or `indexedDbRepository.ts` names a corridor,
+ * so a new one changes no stored schema and no shared switch.
+ *
+ * The `profile` is plain JSON by contract. It rides in the same record the
+ * repository writes whole, so a backend that mangles unknown keys would lose a
+ * corridor's half without saying so — which is why `serialize` returns a flat
+ * object rather than anything class-shaped.
+ */
+import type { VHTLC } from "@arkade-os/sdk";
+import type { RfqSwap } from "./swapManager";
+
+/** The record fields every corridor shares, as a handler sees them. */
+export interface RfqSwapCommonFields {
+    rfqId: string;
+    paymentHash: string;
+    lockupAddress: string;
+    signingDescriptor: string;
+    preimageHex?: string;
+}
+
+/**
+ * How one corridor persists and restores its own half.
+ *
+ * `serialize` is given the live swap and returns the corridor's `profile`.
+ * `hydrate` is given the stored profile plus the rebuilt lockup covenant and
+ * returns the corridor-specific fields to merge onto the live record.
+ *
+ * Both are pure. A handler must not reach for a wallet, an indexer or a
+ * network: everything it needs is either on the profile it wrote or on the
+ * covenant it is handed.
+ */
+export interface RfqCorridorHandler<P extends Record<string, unknown> = Record<string, unknown>> {
+    /** The `RfqSwap["kind"]` this handles. */
+    readonly kind: string;
+
+    /**
+     * The parts of the profile the MANAGER can change, projected off the live
+     * swap. Merged over the profile the caller wrote at creation.
+     *
+     * Deliberately not the whole profile: half of what a corridor persists is
+     * only in the request result and never reaches an `RfqSwap` — the onchain
+     * leg's L1 keys are the clearest case, since `OnchainHtlc` exposes only
+     * derived values. So the caller supplies the profile once and this keeps it
+     * current.
+     *
+     * Return `{}` for a corridor with nothing mutable of its own.
+     */
+    project(swap: RfqSwap): Partial<P>;
+
+    /**
+     * Rebuild the corridor's live fields from what was stored.
+     *
+     * Throw rather than defaulting when something required is missing: a swap
+     * restored without the half that drives it is worse than one that refuses
+     * to restore, because it looks monitored while a deadline passes.
+     */
+    hydrate(profile: P, context: RfqCorridorContext): Record<string, unknown>;
+}
+
+/** What a handler may read beyond its own profile: the common record fields it
+ * shares with every corridor, and the rebuilt lockup covenant. */
+export interface RfqCorridorContext {
+    /** `sha256(P)`, hex. On the covenant it appears only as `hash160(P)`, so a
+     * corridor needing the preimage hash proper takes it from here. */
+    paymentHash: string;
+    lockup: InstanceType<typeof VHTLC.ScriptV2>;
+}
+
+/**
+ * Registry of corridor handlers, keyed by `kind`.
+ *
+ * Same contract as `contractHandlers`: registering a duplicate throws rather
+ * than silently replacing, because two handlers for one kind would make which
+ * of them restores a swap depend on import order.
+ */
+class RfqCorridorRegistry {
+    private handlers = new Map<string, RfqCorridorHandler>();
+
+    register(handler: RfqCorridorHandler): void {
+        if (this.handlers.has(handler.kind)) {
+            throw new Error(
+                `RFQ corridor handler for kind '${handler.kind}' is already registered`,
+            );
+        }
+        this.handlers.set(handler.kind, handler as RfqCorridorHandler);
+    }
+
+    get(kind: string): RfqCorridorHandler | undefined {
+        return this.handlers.get(kind);
+    }
+
+    /**
+     * The handler for a kind, or a loud failure.
+     *
+     * A record whose corridor is not registered cannot be restored, and
+     * guessing would monitor a swap with no idea how to drive it. Names the
+     * registered kinds so a missing `register()` call is obvious.
+     */
+    getOrThrow(kind: string): RfqCorridorHandler {
+        const handler = this.get(kind);
+        if (!handler) {
+            throw new Error(
+                `no RFQ corridor handler registered for kind '${kind}'; registered: ` +
+                    `${this.registeredKinds().join(", ") || "none"}`,
+            );
+        }
+        return handler;
+    }
+
+    has(kind: string): boolean {
+        return this.handlers.has(kind);
+    }
+
+    registeredKinds(): string[] {
+        return [...this.handlers.keys()];
+    }
+
+    /** Test seam, mirroring the contract registry's. */
+    unregister(kind: string): boolean {
+        return this.handlers.delete(kind);
+    }
+}
+
+export const rfqCorridorHandlers = new RfqCorridorRegistry();

--- a/packages/swap/src/rfqCorridors.ts
+++ b/packages/swap/src/rfqCorridors.ts
@@ -29,15 +29,33 @@ export interface LightningReceiveProfile extends Record<string, unknown> {
     expectedAmount: number;
     /** Where the claim pays. */
     payoutAddress: string;
+    /**
+     * Our Arkade claim's txid, once submitted.
+     *
+     * Here rather than on the record's common half, which is for fields all
+     * three legs carry: this one is the receive leg's alone, the counterpart of
+     * the onchain leg's `claimTxid`. Restoring without it re-arms the value gate
+     * against a lockup we have already partly claimed — `claimIfFunded` reads
+     * `partiallyClaimed` off exactly this — so the remainder is refused over a
+     * preimage that is already public, and a swap that did claim is relabelled
+     * `needs_counterparty` once its window shuts.
+     */
+    claimArkTxid?: string;
 }
 
 export const LightningReceiveCorridor: RfqCorridorHandler<LightningReceiveProfile> = {
     kind: "lightning_receive",
 
-    // `expectedAmount` is the only half the manager holds; `payoutAddress`
-    // comes from the request result and never changes, so the caller writes it
-    // once and this leaves it alone.
-    project: (swap: RfqSwap) => ({ expectedAmount: (swap as LightningReceiveSwap).expectedAmount }),
+    // What the manager holds: the amount gate, and its own claim once it lands.
+    // `payoutAddress` comes from the request result and never changes, so the
+    // caller writes it once and this leaves it alone.
+    project: (swap: RfqSwap) => {
+        const receive = swap as LightningReceiveSwap;
+        return {
+            expectedAmount: receive.expectedAmount,
+            ...(receive.claimArkTxid ? { claimArkTxid: receive.claimArkTxid } : {}),
+        };
+    },
 
     hydrate(profile) {
         // Required, never defaulted: the manager reports `needs_counterparty`
@@ -51,7 +69,10 @@ export const LightningReceiveCorridor: RfqCorridorHandler<LightningReceiveProfil
         ) {
             throw new Error("lightning_receive record carries no expectedAmount; it cannot claim");
         }
-        return { expectedAmount: profile.expectedAmount };
+        return {
+            expectedAmount: profile.expectedAmount,
+            ...(profile.claimArkTxid ? { claimArkTxid: profile.claimArkTxid } : {}),
+        };
     },
 };
 
@@ -99,6 +120,20 @@ export const OnchainSendCorridor: RfqCorridorHandler<OnchainSendProfile> = {
             throw new Error(
                 "onchain_send record carries no L1 keys; its HTLC cannot be rebuilt and its " +
                     "refund window would pass unwatched",
+            );
+        }
+        // Required, never defaulted, for the same reason the receive leg's
+        // `expectedAmount` is: `classifyOnchainHtlc` gates on
+        // `confirmations < minConfirmations`, and that comparison against
+        // `undefined` is false — so a missing value does not fail the
+        // confirmation gate, it DELETES it, and the swap claims an unconfirmed
+        // fill with the preimage. The other L1 inputs are checked by
+        // `onchainHtlcScript`, which refuses a bad locktime, key or network.
+        if (!Number.isInteger(profile.minConfirmations) || profile.minConfirmations < 1) {
+            throw new Error(
+                `onchain_send record carries no usable minConfirmations ` +
+                    `(${String(profile.minConfirmations)}); the confirmation gate cannot be ` +
+                    `checked — refusing to restore a swap that would claim an unconfirmed fill`,
             );
         }
         return {

--- a/packages/swap/src/rfqCorridors.ts
+++ b/packages/swap/src/rfqCorridors.ts
@@ -1,0 +1,127 @@
+/**
+ * The corridors this package persists, one handler each.
+ *
+ * Adding a corridor is a handler here plus a `register()` call at the bottom —
+ * no edit to `RfqSwapRecord`, the repository, or the IndexedDB store, none of
+ * which name a corridor. See `rfqCorridor.ts` for why it is shaped this way.
+ */
+import { hex } from "@scure/base";
+import {
+    rfqCorridorHandlers,
+    type RfqCorridorContext,
+    type RfqCorridorHandler,
+} from "./rfqCorridor";
+import { onchainHtlcScript, type OnchainNetwork } from "./onchainHtlc";
+import type { LightningReceiveSwap, OnchainSendSwap, RfqSwap } from "./swapManager";
+
+/** `arkade:BTC->lightning:BTC`. Nothing beyond the covenant and the common
+ * fields: the solver claims the lockup, the trader's only move is the refund,
+ * and both are fully described by the contract row. */
+export const LightningSendCorridor: RfqCorridorHandler<Record<string, never>> = {
+    kind: "lightning_send",
+    project: () => ({}),
+    hydrate: () => ({}),
+};
+
+/** `lightning:BTC->arkade:BTC`. */
+export interface LightningReceiveProfile extends Record<string, unknown> {
+    /** The quote's `to_amount`, captured at REQUEST time. */
+    expectedAmount: number;
+    /** Where the claim pays. */
+    payoutAddress: string;
+}
+
+export const LightningReceiveCorridor: RfqCorridorHandler<LightningReceiveProfile> = {
+    kind: "lightning_receive",
+
+    // `expectedAmount` is the only half the manager holds; `payoutAddress`
+    // comes from the request result and never changes, so the caller writes it
+    // once and this leaves it alone.
+    project: (swap: RfqSwap) => ({ expectedAmount: (swap as LightningReceiveSwap).expectedAmount }),
+
+    hydrate(profile) {
+        // Required, never defaulted: the manager reports `needs_counterparty`
+        // rather than claiming when this is not a finite number, and a
+        // comparison against `undefined` would delete the value gate instead of
+        // failing it. Read at claim time it would be whatever the solver
+        // funded, which is the dust-funding attack rather than a check on it.
+        if (
+            typeof profile.expectedAmount !== "number" ||
+            !Number.isFinite(profile.expectedAmount)
+        ) {
+            throw new Error("lightning_receive record carries no expectedAmount; it cannot claim");
+        }
+        return { expectedAmount: profile.expectedAmount };
+    },
+};
+
+/** `arkade:BTC->onchain:BTC`. */
+export interface OnchainSendProfile extends Record<string, unknown> {
+    /** The trader's L1 claim key. */
+    claimKey: string;
+    /** The solver's L1 key, from `profile.htlc_pubkey`. */
+    refundKey: string;
+    /** `profile.htlc_locktime` — the trader's L1 recourse deadline, distinct
+     * from the arkade lockup's `refundLocktime`. */
+    htlcLocktime: number;
+    network: OnchainNetwork;
+    /** `profile.min_confirmations`; gates when the fill is claimable. */
+    minConfirmations: number;
+    /** The fill's outpoint, learned on first sighting. Without it a SPENT htlc
+     * reads as never funded — see `classifyOnchainHtlc`. */
+    funding?: { txid: string; vout: number };
+    /** Our own L1 claim, so a restart does not re-broadcast it. */
+    claimTxid?: string;
+}
+
+/**
+ * The one corridor that stores script parameters, because nothing else holds
+ * them: its arkade lockup has a contract row, but the HTLC is Bitcoin L1 — not
+ * an arkade contract — and `OnchainHtlc` exposes only derived values, never the
+ * keys it was built from.
+ */
+export const OnchainSendCorridor: RfqCorridorHandler<OnchainSendProfile> = {
+    kind: "onchain_send",
+
+    // The L1 keys and the network are only in the request result — nothing on
+    // `OnchainSendSwap` carries them — so the caller writes them once. What the
+    // manager learns as it drives the swap is the fill and our own claim.
+    project: (swap: RfqSwap) => {
+        const send = swap as OnchainSendSwap;
+        return {
+            ...(send.funding ? { funding: send.funding } : {}),
+            ...(send.claimTxid ? { claimTxid: send.claimTxid } : {}),
+        };
+    },
+
+    hydrate(profile, { paymentHash }: RfqCorridorContext) {
+        if (!profile.claimKey || !profile.refundKey) {
+            throw new Error(
+                "onchain_send record carries no L1 keys; its HTLC cannot be rebuilt and its " +
+                    "refund window would pass unwatched",
+            );
+        }
+        return {
+            htlc: onchainHtlcScript(
+                {
+                    // From the record, not the covenant: the lockup commits to
+                    // `hash160(P)`, and the HTLC needs `sha256(P)`. One P
+                    // unlocks both legs, but only one of the two hashes of it
+                    // is recoverable here.
+                    paymentHash,
+                    claimKey: hex.decode(profile.claimKey),
+                    refundKey: hex.decode(profile.refundKey),
+                    refundLocktime: profile.htlcLocktime,
+                },
+                profile.network,
+            ),
+            minConfirmations: profile.minConfirmations,
+            ...(profile.funding ? { funding: profile.funding } : {}),
+            ...(profile.claimTxid ? { claimTxid: profile.claimTxid } : {}),
+        };
+    },
+};
+
+rfqCorridorHandlers.register(LightningSendCorridor as RfqCorridorHandler);
+rfqCorridorHandlers.register(LightningReceiveCorridor as RfqCorridorHandler);
+rfqCorridorHandlers.register(OnchainSendCorridor as RfqCorridorHandler);

--- a/packages/swap/src/rfqCorridors.ts
+++ b/packages/swap/src/rfqCorridors.ts
@@ -11,7 +11,12 @@ import {
     type RfqCorridorContext,
     type RfqCorridorHandler,
 } from "./rfqCorridor";
-import { onchainHtlcScript, type OnchainNetwork } from "./onchainHtlc";
+import {
+    onchainHtlcScript,
+    type OnchainHtlc,
+    type OnchainHtlcParams,
+    type OnchainNetwork,
+} from "./onchainHtlc";
 import type { LightningReceiveSwap, OnchainSendSwap, RfqSwap } from "./swapManager";
 
 /** `arkade:BTC->lightning:BTC`. Nothing beyond the covenant and the common
@@ -107,6 +112,41 @@ export interface OnchainSendProfile extends Record<string, unknown> {
     funding?: { txid: string; vout: number };
     /** Our own L1 claim, so a restart does not re-broadcast it. */
     claimTxid?: string;
+}
+
+/**
+ * Build the profile from what `requestOnchainSend` returned.
+ *
+ * Pass the whole result: every field this needs is on it, so the mapping is
+ * done here, once, instead of at each call site.
+ *
+ * That mapping is the reason this exists. `htlcParams.refundLocktime` becomes
+ * `htlcLocktime` — the same value under a different name, because the record
+ * already has a `refundLocktime` and it is the arkade lockup's, a different
+ * deadline entirely. The keys go from bytes to hex. `htlcAddress` is not an
+ * input to anything, it is the derived value the rebuild checks the inputs
+ * against, so writing it is easy to skip and impossible to reconstruct later.
+ * A caller copying fields across by hand gets all three right or restores a
+ * swap that watches nothing.
+ *
+ * The other two corridors have no such builder, deliberately: their profiles
+ * are the request result's own fields under their own names, with nothing
+ * derived and nothing renamed.
+ */
+export function onchainSendProfile(result: {
+    htlc: Pick<OnchainHtlc, "address">;
+    htlcParams: OnchainHtlcParams;
+    l1Network: OnchainNetwork;
+    minConfirmations: number;
+}): OnchainSendProfile {
+    return {
+        claimKey: hex.encode(result.htlcParams.claimKey),
+        refundKey: hex.encode(result.htlcParams.refundKey),
+        htlcLocktime: result.htlcParams.refundLocktime,
+        network: result.l1Network,
+        htlcAddress: result.htlc.address,
+        minConfirmations: result.minConfirmations,
+    };
 }
 
 /**

--- a/packages/swap/src/rfqCorridors.ts
+++ b/packages/swap/src/rfqCorridors.ts
@@ -86,6 +86,20 @@ export interface OnchainSendProfile extends Record<string, unknown> {
      * from the arkade lockup's `refundLocktime`. */
     htlcLocktime: number;
     network: OnchainNetwork;
+    /**
+     * The L1 address the fill was expected at — `htlc.address` from
+     * `requestOnchainSend`, which `deriveOnchainSend` has already checked
+     * against the quote's own `profile.htlc_address`.
+     *
+     * The counterpart of the record's `lockupAddress`, and here for the same
+     * reason: the inputs above and this address reach the record by independent
+     * routes, so requiring the rebuild to reproduce it is what catches a
+     * parameter that came back wrong. The arkade lockup gets that check from
+     * `rebuildRfqSwap`; this leg, the one whose parameters have no second source
+     * anywhere, would otherwise get none — and a swapped or corrupted key
+     * derives another perfectly valid HTLC, at an address nobody funded.
+     */
+    htlcAddress: string;
     /** `profile.min_confirmations`; gates when the fill is claimable. */
     minConfirmations: number;
     /** The fill's outpoint, learned on first sighting. Without it a SPENT htlc
@@ -136,20 +150,31 @@ export const OnchainSendCorridor: RfqCorridorHandler<OnchainSendProfile> = {
                     `checked — refusing to restore a swap that would claim an unconfirmed fill`,
             );
         }
+        const htlc = onchainHtlcScript(
+            {
+                // From the record, not the covenant: the lockup commits to
+                // `hash160(P)`, and the HTLC needs `sha256(P)`. One P
+                // unlocks both legs, but only one of the two hashes of it
+                // is recoverable here.
+                paymentHash,
+                claimKey: hex.decode(profile.claimKey),
+                refundKey: hex.decode(profile.refundKey),
+                refundLocktime: profile.htlcLocktime,
+            },
+            profile.network,
+        );
+        // What `rebuildRfqSwap` does for the arkade lockup, on the leg that
+        // cannot borrow a contract row to do it: parameters that derive some
+        // other HTLC are caught here, at restore, rather than by a claim that
+        // watches an address nobody funded until the refund window shuts.
+        if (htlc.address !== profile.htlcAddress) {
+            throw new Error(
+                `onchain_send record's L1 inputs derive ${htlc.address}, but the fill was ` +
+                    `expected at ${String(profile.htlcAddress)} — these are not this swap's`,
+            );
+        }
         return {
-            htlc: onchainHtlcScript(
-                {
-                    // From the record, not the covenant: the lockup commits to
-                    // `hash160(P)`, and the HTLC needs `sha256(P)`. One P
-                    // unlocks both legs, but only one of the two hashes of it
-                    // is recoverable here.
-                    paymentHash,
-                    claimKey: hex.decode(profile.claimKey),
-                    refundKey: hex.decode(profile.refundKey),
-                    refundLocktime: profile.htlcLocktime,
-                },
-                profile.network,
-            ),
+            htlc,
             minConfirmations: profile.minConfirmations,
             ...(profile.funding ? { funding: profile.funding } : {}),
             ...(profile.claimTxid ? { claimTxid: profile.claimTxid } : {}),

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -38,7 +38,8 @@ import {
     type OnchainSendSwap,
     type RfqSwapState,
 } from "./swapManager";
-import { onchainHtlcScript, type OnchainNetwork } from "./onchainHtlc";
+import { rfqCorridorHandlers } from "./rfqCorridor";
+import "./rfqCorridors";
 
 /**
  * The swap kinds this projection covers — all three the manager monitors.
@@ -79,21 +80,12 @@ export const RFQ_SWAP_RETENTION_SECONDS = 30 * 24 * 60 * 60;
 /** The immutable request-time half. Hex for everything binary, so the record is
  * plain JSON and survives any structured-clone backend unchanged. */
 export interface RfqSwapOrigin {
-    kind: "lightning_send" | "lightning_receive" | "onchain_send";
+    /** Which corridor this is. Resolves the handler that owns
+     * {@link profile}; see `rfqCorridor.ts`. */
+    kind: string;
 
     /**
-     * `sha256(P)`, hex — the BOLT11 payment hash.
-     *
-     * Not recoverable from the covenant, which commits to `hash160(P)`: 20
-     * bytes, the conventional HTLC shape. Kept so a swap can be correlated to
-     * the payer's invoice — the fate check itself does not need it, since
-     * `hash160(candidate)` against the covenant's own `preimageHash` proves the
-     * same thing about the same witness.
-     */
-    paymentHash: string;
-
-    /**
-     * The Arkade address that was actually funded.
+     * The Arkade address that was funded.
      *
      * Both the swap's handle on its covenant — {@link lockupContractParams}
      * looks the contract row up by the script it decodes to — and, being taken
@@ -102,6 +94,16 @@ export interface RfqSwapOrigin {
      */
     lockupAddress: string;
 
+    /**
+     * `sha256(P)`, hex — the BOLT11 payment hash.
+     *
+     * Not recoverable from the covenant, which commits to `hash160(P)`: 20
+     * bytes, the conventional HTLC shape. Kept so a swap can be correlated to
+     * the payer's invoice, and because a corridor whose own contract commits to
+     * the `sha256` form has nowhere else to read it.
+     */
+    paymentHash: string;
+
     // ── Secrets projection (see `swapSecretsToRecord`) ─────────────────────
     /** Public wallet descriptor that recovers the covenant signer. */
     signingDescriptor: string;
@@ -109,49 +111,18 @@ export interface RfqSwapOrigin {
      * claim secret says P cannot be re-derived. */
     preimageHex?: string;
 
-    // ── Onchain-send leg ─────────────────────────────────────────────────────
     /**
-     * The L1 HTLC's own inputs. Onchain-send only, and required there.
+     * The corridor's own half, as plain JSON — written by the caller from the
+     * request result, kept current by the handler's `project`.
      *
-     * The Arkade lockup gets a contract row; this does not — the HTLC is
-     * Bitcoin L1, not an Arkade contract — and `OnchainHtlc` hands back only
-     * derived values, never the keys it was built from. So these are the one
-     * set of script parameters this record legitimately stores, and dropping
-     * them would leave a restored swap unable to claim the fill or take the
-     * HTLC back at `htlcLocktime`.
-     *
-     * All public: two counterparty x-only keys, a locktime and a network.
+     * Opaque here on purpose. Nothing in this file, the repository or the
+     * IndexedDB store interprets it, which is what lets a new corridor ship
+     * without touching any of them.
      */
-    onchain?: {
-        /** VHTLC-side claim key — the trader's payout key. */
-        claimKey: string;
-        /** The solver's L1 key, from `profile.htlc_pubkey`. */
-        refundKey: string;
-        /** `profile.htlc_locktime` — the trader's own L1 recourse deadline,
-         * distinct from the Arkade lockup's `refundLocktime`. */
-        htlcLocktime: number;
-        network: OnchainNetwork;
-        /** `profile.min_confirmations`, which gates when the fill is claimable. */
-        minConfirmations: number;
-    };
+    profile: Record<string, unknown>;
 
-    // ── Receive-leg facts ────────────────────────────────────────────────────
-    /**
-     * What the lockup must carry before the claim will publish `P`.
-     *
-     * Receive only, and **not re-derivable**: read at claim time it would be
-     * whatever the solver funded, which is the dust-funding attack rather than
-     * a check on it.
-     */
-    expectedAmount?: number;
-    /** Where the claim pays. Kept for display: the covenant pins the payout
-     * pkScript, but an address also carries the network the record was made
-     * on, which a local re-derivation would silently take from the SDK's
-     * default. */
-    payoutAddress?: string;
-
-    /** Consumer display metadata. {@link rebuildRfqSwap} ignores it —
-     * `RfqSwapCommon` carries no amount of its own. */
+    /** Consumer display metadata. The rebuild ignores it — `RfqSwapCommon`
+     * carries no amount of its own. */
     amount?: number;
 }
 
@@ -165,26 +136,22 @@ export interface RfqSwapRecord extends RfqSwapOrigin {
     claimArkTxid?: string;
     failure?: string;
     blockedReason?: string;
-    /** Onchain-send only: the fill's outpoint, learned on first sighting.
-     * Without it a SPENT htlc reads as never funded — see
-     * `classifyOnchainHtlc`. */
-    funding?: { txid: string; vout: number };
-    /** Onchain-send only: our own L1 claim. */
-    claimTxid?: string;
 }
 
-/** The manager's mutable half, projected off a live record. */
+/**
+ * The manager's mutable half, projected off a live record.
+ *
+ * Corridor-agnostic by construction: `claimArkTxid` is the only per-kind field
+ * left on `RfqSwapCommon` itself, and everything else a corridor tracks goes
+ * through its handler's `project`.
+ */
 const managerState = (swap: PersistableRfqSwap) => ({
     rfqId: swap.rfqId,
     state: swap.state,
     createdAt: swap.createdAt,
     updatedAt: swap.updatedAt,
     ...(swap.refundArkTxid ? { refundArkTxid: swap.refundArkTxid } : {}),
-    ...(swap.kind === "lightning_receive" && swap.claimArkTxid
-        ? { claimArkTxid: swap.claimArkTxid }
-        : {}),
-    ...(swap.kind === "onchain_send" && swap.funding ? { funding: swap.funding } : {}),
-    ...(swap.kind === "onchain_send" && swap.claimTxid ? { claimTxid: swap.claimTxid } : {}),
+    ...("claimArkTxid" in swap && swap.claimArkTxid ? { claimArkTxid: swap.claimArkTxid } : {}),
     ...(swap.failure ? { failure: swap.failure } : {}),
     ...(swap.blockedReason ? { blockedReason: swap.blockedReason } : {}),
 });
@@ -194,7 +161,14 @@ export function createRfqSwapRecord(
     origin: RfqSwapOrigin,
     swap: PersistableRfqSwap,
 ): RfqSwapRecord {
-    return { ...origin, ...managerState(swap) };
+    const handler = rfqCorridorHandlers.getOrThrow(origin.kind);
+    return {
+        ...origin,
+        ...managerState(swap),
+        // The caller wrote what only the request result knows; the handler adds
+        // what the live swap already carries.
+        profile: { ...origin.profile, ...handler.project(swap) },
+    };
 }
 
 /**
@@ -217,16 +191,15 @@ export function updateRfqSwapRecord(
         blockedReason: _blockedReason,
         ...origin
     } = record;
-    return { ...origin, ...managerState(swap) };
-}
-
-/** Names the missing field rather than letting a rebuild continue with a value
- * whose absence only shows up as a gate that never fires. */
-function required<T>(value: T | undefined, name: string): T {
-    if (value === undefined) {
-        throw new Error(`rfq swap record is missing ${name}; its swap cannot be rebuilt`);
-    }
-    return value;
+    const handler = rfqCorridorHandlers.getOrThrow(record.kind);
+    // The profile MERGES rather than being replaced: `project` returns only
+    // what the manager can change, and the rest came from the request result
+    // and has no other source.
+    return {
+        ...origin,
+        ...managerState(swap),
+        profile: { ...record.profile, ...handler.project(swap) },
+    };
 }
 
 /**
@@ -283,44 +256,16 @@ export function rebuildRfqSwap(record: RfqSwapRecord, params: LockupParams): Per
         ...(record.blockedReason ? { blockedReason: record.blockedReason } : {}),
     };
 
-    if (record.kind === "lightning_send") {
-        return { ...common, kind: "lightning_send" } satisfies LightningSendSwap;
-    }
-
-    if (record.kind === "onchain_send") {
-        // Required, not defaulted: an onchain-send swap restored without its L1
-        // half would be monitored on the Arkade side while its HTLC refund
-        // window passed unwatched — the one failure `RfqSwapManager` refuses by
-        // name elsewhere.
-        const l1 = required(record.onchain, "onchain");
-        return {
-            ...common,
-            kind: "onchain_send",
-            htlc: onchainHtlcScript(
-                {
-                    paymentHash: record.paymentHash,
-                    claimKey: hex.decode(l1.claimKey),
-                    refundKey: hex.decode(l1.refundKey),
-                    refundLocktime: l1.htlcLocktime,
-                },
-                l1.network,
-            ),
-            minConfirmations: l1.minConfirmations,
-            ...(record.funding ? { funding: record.funding } : {}),
-            ...(record.claimTxid ? { claimTxid: record.claimTxid } : {}),
-        } satisfies OnchainSendSwap;
-    }
-
+    // Corridor-agnostic from here: the handler for this record's kind supplies
+    // whatever its leg needs, and this file names none of them. A kind with no
+    // handler registered throws rather than restoring a swap nothing knows how
+    // to drive.
+    const handler = rfqCorridorHandlers.getOrThrow(record.kind);
     return {
         ...common,
-        kind: "lightning_receive",
-        // Required, not defaulted: the manager reports `needs_counterparty`
-        // rather than claiming when this is not a finite number, and a
-        // comparison against `undefined` would delete the value gate instead of
-        // failing it.
-        expectedAmount: required(record.expectedAmount, "expectedAmount"),
-        ...(record.claimArkTxid ? { claimArkTxid: record.claimArkTxid } : {}),
-    } satisfies LightningReceiveSwap;
+        kind: record.kind,
+        ...handler.hydrate(record.profile, { paymentHash: record.paymentHash, lockup: script }),
+    } as PersistableRfqSwap;
 }
 
 /**

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -80,9 +80,16 @@ export const RFQ_SWAP_RETENTION_SECONDS = 30 * 24 * 60 * 60;
 /** The immutable request-time half. Hex for everything binary, so the record is
  * plain JSON and survives any structured-clone backend unchanged. */
 export interface RfqSwapOrigin {
-    /** Which corridor this is. Resolves the handler that owns
-     * {@link profile}; see `rfqCorridor.ts`. */
-    kind: string;
+    /**
+     * Which corridor this is. Resolves the handler that owns {@link profile};
+     * see `rfqCorridor.ts`.
+     *
+     * The manager's own union, not an open string: `RfqSwapManager` branches on
+     * `kind` to decide what to drive, so a corridor it does not know could be
+     * persisted and rebuilt here and then never driven — which is the failure
+     * this whole file is arranged to make impossible.
+     */
+    kind: PersistableRfqSwap["kind"];
 
     /**
      * The Arkade address that was funded.
@@ -157,11 +164,43 @@ const managerState = (swap: PersistableRfqSwap) => ({
     ...(swap.blockedReason ? { blockedReason: swap.blockedReason } : {}),
 });
 
+/**
+ * The origin and the live swap must be halves of one swap.
+ *
+ * They arrive separately — the origin written from the request result, the swap
+ * built by the entry point — and these two functions are the only place both are
+ * in hand, so they are the only place the pairing can be checked at all.
+ *
+ * Neither mismatch is loud on its own. A `kind` that disagrees runs the wrong
+ * handler's `project`, which casts on kind: a receive origin projected off a
+ * send swap writes `expectedAmount: undefined` OVER the value the caller just
+ * supplied, deleting the gate at the moment it was being recorded. An address
+ * that disagrees is quieter still — the record stores no `lockupPkScript`, so
+ * {@link rebuildRfqSwap} derives one from `lockupAddress`, and the restored swap
+ * watches a covenant that is not the one this swap was monitoring.
+ */
+function assertSameSwap(origin: RfqSwapOrigin, swap: PersistableRfqSwap): void {
+    if (origin.kind !== swap.kind) {
+        throw new Error(
+            `rfq swap record is a ${origin.kind} origin paired with a ${swap.kind} swap`,
+        );
+    }
+    const funded = hex.encode(ArkAddress.decode(origin.lockupAddress).pkScript);
+    const watched = hex.encode(swap.lockupPkScript);
+    if (funded !== watched) {
+        throw new Error(
+            `rfq swap record's lockup address holds ${funded}, but the swap watches ${watched} — ` +
+                `these are not the same swap`,
+        );
+    }
+}
+
 /** First write, at the moment the caller hands the swap to the manager. */
 export function createRfqSwapRecord(
     origin: RfqSwapOrigin,
     swap: PersistableRfqSwap,
 ): RfqSwapRecord {
+    assertSameSwap(origin, swap);
     const handler = rfqCorridorHandlers.getOrThrow(origin.kind);
     return {
         ...origin,
@@ -185,6 +224,11 @@ export function updateRfqSwapRecord(
     record: RfqSwapRecord,
     swap: PersistableRfqSwap,
 ): RfqSwapRecord {
+    // Re-checked on every write, not just the first: a manager driving several
+    // swaps hands this a record and a live swap looked up separately, and
+    // updating one swap's record from another's is exactly how a good record
+    // acquires another swap's state.
+    assertSameSwap(record, swap);
     const {
         refundArkTxid: _refundArkTxid,
         failure: _failure,

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -35,19 +35,23 @@ import {
     isRfqSwapTerminal,
     type LightningReceiveSwap,
     type LightningSendSwap,
+    type OnchainSendSwap,
     type RfqSwapState,
 } from "./swapManager";
+import { onchainHtlcScript, type OnchainNetwork } from "./onchainHtlc";
 
 /**
- * The swap kinds this projection covers.
+ * The swap kinds this projection covers — all three the manager monitors.
  *
- * `onchain_send` is deliberately absent: no contract row and no record here
- * carries an L1 half, so a rebuild could not reproduce its `htlc`, `funding`,
- * `claimTxid` or `minConfirmations`, and storing one would round-trip a swap
- * whose L1 refund window nothing is watching. Taking this rather than `RfqSwap`
- * is what makes that a compile error at the call site instead of a silent loss.
+ * `onchain_send` carries an L1 half nothing else can rebuild. Its Arkade lockup
+ * has a contract row like the others, but the HTLC is Bitcoin L1, not an Arkade
+ * contract, so no row exists for it; and `OnchainHtlc` exposes only derived
+ * values — `address`, `pkScript`, `leaves`, `controlBlocks` — never the
+ * `claimKey`/`refundKey` `onchainHtlcScript` takes as inputs. So the record
+ * carries {@link RfqSwapOrigin.onchain}, and without it a restored swap would
+ * let its L1 refund window pass unwatched.
  */
-export type PersistableRfqSwap = LightningSendSwap | LightningReceiveSwap;
+export type PersistableRfqSwap = LightningSendSwap | LightningReceiveSwap | OnchainSendSwap;
 
 /**
  * The serialized covenant parameters a rebuild is given.
@@ -75,7 +79,7 @@ export const RFQ_SWAP_RETENTION_SECONDS = 30 * 24 * 60 * 60;
 /** The immutable request-time half. Hex for everything binary, so the record is
  * plain JSON and survives any structured-clone backend unchanged. */
 export interface RfqSwapOrigin {
-    kind: "lightning_send" | "lightning_receive";
+    kind: "lightning_send" | "lightning_receive" | "onchain_send";
 
     /**
      * `sha256(P)`, hex — the BOLT11 payment hash.
@@ -104,6 +108,32 @@ export interface RfqSwapOrigin {
     /** The only secret this record may hold; present when the provisioned
      * claim secret says P cannot be re-derived. */
     preimageHex?: string;
+
+    // ── Onchain-send leg ─────────────────────────────────────────────────────
+    /**
+     * The L1 HTLC's own inputs. Onchain-send only, and required there.
+     *
+     * The Arkade lockup gets a contract row; this does not — the HTLC is
+     * Bitcoin L1, not an Arkade contract — and `OnchainHtlc` hands back only
+     * derived values, never the keys it was built from. So these are the one
+     * set of script parameters this record legitimately stores, and dropping
+     * them would leave a restored swap unable to claim the fill or take the
+     * HTLC back at `htlcLocktime`.
+     *
+     * All public: two counterparty x-only keys, a locktime and a network.
+     */
+    onchain?: {
+        /** VHTLC-side claim key — the trader's payout key. */
+        claimKey: string;
+        /** The solver's L1 key, from `profile.htlc_pubkey`. */
+        refundKey: string;
+        /** `profile.htlc_locktime` — the trader's own L1 recourse deadline,
+         * distinct from the Arkade lockup's `refundLocktime`. */
+        htlcLocktime: number;
+        network: OnchainNetwork;
+        /** `profile.min_confirmations`, which gates when the fill is claimable. */
+        minConfirmations: number;
+    };
 
     // ── Receive-leg facts ────────────────────────────────────────────────────
     /**
@@ -135,6 +165,12 @@ export interface RfqSwapRecord extends RfqSwapOrigin {
     claimArkTxid?: string;
     failure?: string;
     blockedReason?: string;
+    /** Onchain-send only: the fill's outpoint, learned on first sighting.
+     * Without it a SPENT htlc reads as never funded — see
+     * `classifyOnchainHtlc`. */
+    funding?: { txid: string; vout: number };
+    /** Onchain-send only: our own L1 claim. */
+    claimTxid?: string;
 }
 
 /** The manager's mutable half, projected off a live record. */
@@ -147,6 +183,8 @@ const managerState = (swap: PersistableRfqSwap) => ({
     ...(swap.kind === "lightning_receive" && swap.claimArkTxid
         ? { claimArkTxid: swap.claimArkTxid }
         : {}),
+    ...(swap.kind === "onchain_send" && swap.funding ? { funding: swap.funding } : {}),
+    ...(swap.kind === "onchain_send" && swap.claimTxid ? { claimTxid: swap.claimTxid } : {}),
     ...(swap.failure ? { failure: swap.failure } : {}),
     ...(swap.blockedReason ? { blockedReason: swap.blockedReason } : {}),
 });
@@ -248,6 +286,31 @@ export function rebuildRfqSwap(record: RfqSwapRecord, params: LockupParams): Per
     if (record.kind === "lightning_send") {
         return { ...common, kind: "lightning_send" } satisfies LightningSendSwap;
     }
+
+    if (record.kind === "onchain_send") {
+        // Required, not defaulted: an onchain-send swap restored without its L1
+        // half would be monitored on the Arkade side while its HTLC refund
+        // window passed unwatched — the one failure `RfqSwapManager` refuses by
+        // name elsewhere.
+        const l1 = required(record.onchain, "onchain");
+        return {
+            ...common,
+            kind: "onchain_send",
+            htlc: onchainHtlcScript(
+                {
+                    paymentHash: record.paymentHash,
+                    claimKey: hex.decode(l1.claimKey),
+                    refundKey: hex.decode(l1.refundKey),
+                    refundLocktime: l1.htlcLocktime,
+                },
+                l1.network,
+            ),
+            minConfirmations: l1.minConfirmations,
+            ...(record.funding ? { funding: record.funding } : {}),
+            ...(record.claimTxid ? { claimTxid: record.claimTxid } : {}),
+        } satisfies OnchainSendSwap;
+    }
+
     return {
         ...common,
         kind: "lightning_receive",

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -133,7 +133,6 @@ export interface RfqSwapRecord extends RfqSwapOrigin {
     createdAt: number;
     updatedAt: number;
     refundArkTxid?: string;
-    claimArkTxid?: string;
     failure?: string;
     blockedReason?: string;
 }
@@ -141,9 +140,12 @@ export interface RfqSwapRecord extends RfqSwapOrigin {
 /**
  * The manager's mutable half, projected off a live record.
  *
- * Corridor-agnostic by construction: `claimArkTxid` is the only per-kind field
- * left on `RfqSwapCommon` itself, and everything else a corridor tracks goes
- * through its handler's `project`.
+ * Corridor-agnostic by construction: every field here is one `RfqSwapCommon`
+ * declares, so each is on all three legs, and anything a single corridor tracks
+ * goes through its handler's `project` instead — `claimArkTxid` included, which
+ * only the receive leg has. A per-kind field lifted to here would be written by
+ * this function and restored by nobody, since `rebuildRfqSwap` builds the
+ * common half from `RfqSwapCommon` alone.
  */
 const managerState = (swap: PersistableRfqSwap) => ({
     rfqId: swap.rfqId,
@@ -151,7 +153,6 @@ const managerState = (swap: PersistableRfqSwap) => ({
     createdAt: swap.createdAt,
     updatedAt: swap.updatedAt,
     ...(swap.refundArkTxid ? { refundArkTxid: swap.refundArkTxid } : {}),
-    ...("claimArkTxid" in swap && swap.claimArkTxid ? { claimArkTxid: swap.claimArkTxid } : {}),
     ...(swap.failure ? { failure: swap.failure } : {}),
     ...(swap.blockedReason ? { blockedReason: swap.blockedReason } : {}),
 });
@@ -186,7 +187,6 @@ export function updateRfqSwapRecord(
 ): RfqSwapRecord {
     const {
         refundArkTxid: _refundArkTxid,
-        claimArkTxid: _claimArkTxid,
         failure: _failure,
         blockedReason: _blockedReason,
         ...origin

--- a/packages/swap/test/onchainHtlc.test.ts
+++ b/packages/swap/test/onchainHtlc.test.ts
@@ -110,6 +110,22 @@ describe("onchainHtlcScript — golden", () => {
             ),
         ).toThrow(/positive/);
     });
+
+    it("rejects a network it cannot build for, rather than defaulting to mainnet", () => {
+        // `btc.p2tr` reads an absent network as mainnet, so a garbled value
+        // would come back as a valid-looking `bc1p…` address for what was meant
+        // to be a regtest HTLC. The output key is network-independent, so the
+        // leaves and pkScript would still be right and only the address would
+        // lie — the worst shape for this to fail in.
+        const params = {
+            paymentHash: PAYMENT_HASH,
+            claimKey: key(1),
+            refundKey: key(3),
+            refundLocktime: LOCKTIME,
+        };
+        expect(() => onchainHtlcScript(params, "signet" as never)).toThrow(/unknown L1 network/);
+        expect(() => onchainHtlcScript(params, undefined as never)).toThrow(/unknown L1 network/);
+    });
 });
 
 describe("buildHtlcClaim", () => {

--- a/packages/swap/test/onchainRfq.test.ts
+++ b/packages/swap/test/onchainRfq.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it } from "vitest";
 import { hex } from "@scure/base";
 import { schnorr } from "@noble/curves/secp256k1.js";
-import { ArkAddress } from "@arkade-os/sdk";
+import { ArkAddress, VHTLCV2ContractHandler } from "@arkade-os/sdk";
 
 import {
     ARKADE_BTC,
@@ -24,7 +24,9 @@ import {
     onchainSendRequest,
     type RfqQuote,
 } from "../src/rfq";
-import { onchainHtlcScript, paymentHashOf } from "../src/onchainHtlc";
+import { onchainHtlcScript, paymentHashOf, type OnchainHtlc } from "../src/onchainHtlc";
+import { onchainSendProfile } from "../src/rfqCorridors";
+import { createRfqSwapRecord, rebuildRfqSwap } from "../src/rfqRecord";
 import { InMemoryAssetSwapRepository } from "../src/repository";
 import { addAssetSwap, getAssetSwaps, type AssetSwap } from "../src/store";
 
@@ -273,6 +275,71 @@ describe("deriveOnchainSend", () => {
         const quote = consistentQuote();
         delete quote.profile.htlc_locktime;
         expect(() => deriveOnchainSend({ quote, ...derivation() })).toThrow(/binding field/);
+    });
+
+    it("hands back the L1 network, which the ark network name does not give", () => {
+        // The mapping from `info.network` is private and lossy — signet,
+        // mutinynet and testnet4 all land on `"testnet"` — so a caller
+        // reconstructing this from context is re-deriving something it cannot
+        // see, for a field the profile needs verbatim.
+        expect(deriveOnchainSend({ quote: consistentQuote(), ...derivation() }).l1Network).toBe(
+            "regtest",
+        );
+    });
+
+    it("maps the derivation onto the profile, renames and all", () => {
+        // The three that are not a straight copy, in one place so the mapping
+        // is auditable: the L1 locktime is `htlcLocktime` on the profile
+        // (`refundLocktime` there is the arkade lockup's, another deadline
+        // entirely), the keys go to hex, and `htlcAddress` is derived — no
+        // input carries it, and it is what the rebuild checks against.
+        const derived = deriveOnchainSend({ quote: consistentQuote(), ...derivation() });
+        expect(onchainSendProfile(derived)).toEqual({
+            claimKey: hex.encode(key(5)),
+            refundKey: hex.encode(key(11)),
+            htlcLocktime: HTLC_LOCKTIME,
+            network: "regtest",
+            htlcAddress: derived.htlc.address,
+            minConfirmations: 2,
+        });
+    });
+
+    it("round-trips the L1 half from a real derivation through a record", () => {
+        // End to end over the seam the builder exists for: derive, persist,
+        // rebuild, and land on the same contract. A field mapped wrong here
+        // does not fail at the write — it fails at the restore, against an
+        // HTLC nobody funded.
+        const derived = deriveOnchainSend({ quote: consistentQuote(), ...derivation() });
+        const record = createRfqSwapRecord(
+            {
+                kind: "onchain_send",
+                paymentHash: PAYMENT_HASH,
+                lockupAddress: derived.address,
+                signingDescriptor: `tr(${hex.encode(SENDER_PUBKEY)})`,
+                profile: onchainSendProfile(derived),
+            },
+            {
+                kind: "onchain_send",
+                rfqId: RFQ_ID,
+                state: "pending",
+                lockupPkScript: derived.swapPkScript,
+                paymentHash: PAYMENT_HASH,
+                refundLocktime: derived.refundLocktime,
+                htlc: derived.htlc,
+                minConfirmations: derived.minConfirmations,
+                createdAt: NOW,
+                updatedAt: NOW,
+            } as unknown as Parameters<typeof createRfqSwapRecord>[1],
+        );
+
+        const rebuilt = rebuildRfqSwap(
+            record,
+            VHTLCV2ContractHandler.serializeParams(derived.script.options),
+        ) as { htlc: OnchainHtlc; minConfirmations: number };
+
+        expect(rebuilt.htlc.address).toBe(derived.htlc.address);
+        expect(hex.encode(rebuilt.htlc.pkScript)).toBe(hex.encode(derived.htlc.pkScript));
+        expect(rebuilt.minConfirmations).toBe(2);
     });
 });
 

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -174,6 +174,88 @@ describe("rebuildRfqSwap", () => {
     });
 });
 
+describe("an onchain-send record carries its L1 half", () => {
+    // The arkade lockup has a contract row; the HTLC does not — it is Bitcoin
+    // L1, not an arkade contract — and `OnchainHtlc` hands back only derived
+    // values. So this is the one set of script parameters the record stores,
+    // and a restored swap without them would let its L1 refund window pass
+    // unwatched.
+    const L1 = {
+        claimKey: hex.encode(key(15)),
+        refundKey: hex.encode(key(11)),
+        htlcLocktime: 1_850_000_000,
+        network: "regtest" as const,
+        minConfirmations: 2,
+    };
+
+    const onchainOrigin: RfqSwapOrigin = {
+        kind: "onchain_send",
+        paymentHash: PAYMENT_HASH,
+        lockupAddress: SEND_LOCKUP.address,
+        signingDescriptor: `tr(${hex.encode(key(7))})`,
+        onchain: L1,
+        amount: 100_000,
+    };
+
+    const onchainSwap = (over: Record<string, unknown> = {}) =>
+        ({
+            kind: "onchain_send",
+            rfqId: "rfq-1",
+            state: "pending",
+            lockupPkScript: p2tr(key(11)),
+            paymentHash: PAYMENT_HASH,
+            refundLocktime: REFUND_LOCKTIME,
+            htlc: {},
+            minConfirmations: 2,
+            createdAt: 1_000,
+            updatedAt: 1_000,
+            ...over,
+        }) as unknown as Parameters<typeof createRfqSwapRecord>[1];
+
+    it("rebuilds the L1 htlc from the stored inputs", () => {
+        const record = createRfqSwapRecord(onchainOrigin, onchainSwap());
+        const rebuilt = rebuildRfqSwap(record, SEND_LOCKUP.params);
+
+        expect(rebuilt.kind).toBe("onchain_send");
+        const onchain = rebuilt as { htlc: { address: string }; minConfirmations: number };
+        expect(onchain.htlc.address).toBeTruthy();
+        expect(onchain.minConfirmations).toBe(2);
+        // the same inputs must give the same contract back
+        expect(onchain.htlc.address).toBe(
+            (rebuildRfqSwap(record, SEND_LOCKUP.params) as { htlc: { address: string } }).htlc
+                .address,
+        );
+    });
+
+    it("refuses an onchain record with no L1 half rather than half-driving it", () => {
+        const record = createRfqSwapRecord(onchainOrigin, onchainSwap());
+        expect(() => rebuildRfqSwap({ ...record, onchain: undefined }, SEND_LOCKUP.params)).toThrow(
+            /onchain/,
+        );
+    });
+
+    it("carries the fill outpoint and our claim through the mutable half", () => {
+        // Without `funding` a SPENT htlc reads as never funded; without
+        // `claimTxid` a restored swap would re-broadcast a claim it already made.
+        const record = updateRfqSwapRecord(
+            createRfqSwapRecord(onchainOrigin, onchainSwap()),
+            onchainSwap({
+                funding: { txid: "ab".repeat(32), vout: 1 },
+                claimTxid: "cd".repeat(32),
+            }),
+        );
+        expect(record.funding).toEqual({ txid: "ab".repeat(32), vout: 1 });
+        expect(record.claimTxid).toBe("cd".repeat(32));
+
+        const rebuilt = rebuildRfqSwap(record, SEND_LOCKUP.params) as {
+            funding?: { txid: string };
+            claimTxid?: string;
+        };
+        expect(rebuilt.funding?.txid).toBe("ab".repeat(32));
+        expect(rebuilt.claimTxid).toBe("cd".repeat(32));
+    });
+});
+
 describe("the record never carries a private key", () => {
     it.each([
         ["lightning_send", sendOrigin],

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -172,6 +172,27 @@ describe("rebuildRfqSwap", () => {
             /expectedAmount/,
         );
     });
+
+    it("carries the receive leg's own claim txid through a restart", () => {
+        // Per-kind, and so on the profile rather than the record's common half:
+        // it is the counterpart of the onchain leg's `claimTxid`, and the two
+        // send legs have no such txid at all. Losing it re-arms the value gate
+        // against a lockup we have already partly claimed — `claimIfFunded`
+        // reads `partiallyClaimed` off exactly this — so the remainder is
+        // refused over a preimage that is already public, and a swap that did
+        // claim is relabelled `needs_counterparty` once its window shuts.
+        const record = updateRfqSwapRecord(
+            createRfqSwapRecord(receiveOrigin, swapOf(receiveOrigin)),
+            {
+                ...swapOf(receiveOrigin, "claimed"),
+                claimArkTxid: "ab".repeat(32),
+            } as LightningReceiveSwap,
+        );
+        expect(record.profile.claimArkTxid).toBe("ab".repeat(32));
+
+        const rebuilt = rebuildRfqSwap(record, RECEIVE_LOCKUP.params) as LightningReceiveSwap;
+        expect(rebuilt.claimArkTxid).toBe("ab".repeat(32));
+    });
 });
 
 describe("an onchain-send record carries its L1 half", () => {
@@ -232,6 +253,31 @@ describe("an onchain-send record carries its L1 half", () => {
         expect(() => rebuildRfqSwap({ ...record, profile: {} }, SEND_LOCKUP.params)).toThrow(
             /L1 keys/,
         );
+    });
+
+    it("refuses an onchain record whose confirmation gate cannot be checked", () => {
+        // The onchain leg's counterpart to the receive leg's `expectedAmount`:
+        // `classifyOnchainHtlc` gates on `confirmations < minConfirmations`, and
+        // that comparison against `undefined` is false — so a missing value does
+        // not fail the gate, it deletes it, and the swap publishes `P` against
+        // an unconfirmed fill.
+        const record = createRfqSwapRecord(onchainOrigin, onchainSwap());
+        const { minConfirmations: _dropped, ...profile } = record.profile;
+        expect(() => rebuildRfqSwap({ ...record, profile }, SEND_LOCKUP.params)).toThrow(
+            /minConfirmations/,
+        );
+    });
+
+    it("refuses an onchain record naming a network it cannot build for", () => {
+        // `btc.p2tr` reads an unknown network as mainnet, so this would restore
+        // a regtest swap holding a `bc1p…` address and say nothing about it.
+        const record = createRfqSwapRecord(onchainOrigin, onchainSwap());
+        expect(() =>
+            rebuildRfqSwap(
+                { ...record, profile: { ...record.profile, network: "signet" } },
+                SEND_LOCKUP.params,
+            ),
+        ).toThrow(/unknown L1 network/);
     });
 
     it("carries the fill outpoint and our claim through the mutable half", () => {

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -77,6 +77,7 @@ const sendOrigin: RfqSwapOrigin = {
     paymentHash: PAYMENT_HASH,
     lockupAddress: SEND_LOCKUP.address,
     signingDescriptor: `tr(${hex.encode(key(7))})`,
+    profile: {},
     amount: 25_000,
 };
 
@@ -84,10 +85,9 @@ const receiveOrigin: RfqSwapOrigin = {
     kind: "lightning_receive",
     paymentHash: PAYMENT_HASH,
     lockupAddress: RECEIVE_LOCKUP.address,
-    payoutAddress: "tark1qpayout",
-    expectedAmount: 20_000,
     signingDescriptor: `tr(${hex.encode(key(15))})`,
     preimageHex: "ee".repeat(32),
+    profile: { expectedAmount: 20_000, payoutAddress: "tark1qpayout" },
     amount: 20_400,
 };
 
@@ -112,7 +112,7 @@ const swapOf = (
         : ({
               ...common,
               kind: "lightning_receive",
-              expectedAmount: origin.expectedAmount!,
+              expectedAmount: origin.profile.expectedAmount as number,
           } as LightningReceiveSwap);
 };
 
@@ -168,9 +168,9 @@ describe("rebuildRfqSwap", () => {
         // leaves the params and the lockup check intact, so nothing about the
         // address would catch it — only this does.
         const record = createRfqSwapRecord(receiveOrigin, swapOf(receiveOrigin));
-        expect(() =>
-            rebuildRfqSwap({ ...record, expectedAmount: undefined }, RECEIVE_LOCKUP.params),
-        ).toThrow(/expectedAmount/);
+        expect(() => rebuildRfqSwap({ ...record, profile: {} }, RECEIVE_LOCKUP.params)).toThrow(
+            /expectedAmount/,
+        );
     });
 });
 
@@ -193,7 +193,7 @@ describe("an onchain-send record carries its L1 half", () => {
         paymentHash: PAYMENT_HASH,
         lockupAddress: SEND_LOCKUP.address,
         signingDescriptor: `tr(${hex.encode(key(7))})`,
-        onchain: L1,
+        profile: { ...L1 },
         amount: 100_000,
     };
 
@@ -229,8 +229,8 @@ describe("an onchain-send record carries its L1 half", () => {
 
     it("refuses an onchain record with no L1 half rather than half-driving it", () => {
         const record = createRfqSwapRecord(onchainOrigin, onchainSwap());
-        expect(() => rebuildRfqSwap({ ...record, onchain: undefined }, SEND_LOCKUP.params)).toThrow(
-            /onchain/,
+        expect(() => rebuildRfqSwap({ ...record, profile: {} }, SEND_LOCKUP.params)).toThrow(
+            /L1 keys/,
         );
     });
 
@@ -244,8 +244,8 @@ describe("an onchain-send record carries its L1 half", () => {
                 claimTxid: "cd".repeat(32),
             }),
         );
-        expect(record.funding).toEqual({ txid: "ab".repeat(32), vout: 1 });
-        expect(record.claimTxid).toBe("cd".repeat(32));
+        expect(record.profile.funding).toEqual({ txid: "ab".repeat(32), vout: 1 });
+        expect(record.profile.claimTxid).toBe("cd".repeat(32));
 
         const rebuilt = rebuildRfqSwap(record, SEND_LOCKUP.params) as {
             funding?: { txid: string };

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -23,6 +23,7 @@ import {
     type RfqSwapRecord,
 } from "../src/rfqRecord";
 import { lightningSendVtxoScript, receiveVtxoScript } from "../src/rfq";
+import { onchainHtlcScript } from "../src/onchainHtlc";
 import type { LightningReceiveSwap, LightningSendSwap, RfqSwapState } from "../src/swapManager";
 
 const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
@@ -42,6 +43,10 @@ const SERVER = key(3);
 const lockupOf = (script: ReturnType<typeof receiveVtxoScript>) => ({
     params: VHTLCV2ContractHandler.serializeParams(script.options),
     address: script.address("tark", SERVER).encode(),
+    // The live swap watches this, and the record stores only the address it
+    // decodes from — so a fixture that let the two disagree would be a swap no
+    // consumer could build.
+    pkScript: script.pkScript,
 });
 
 const SEND_LOCKUP = lockupOf(
@@ -91,8 +96,10 @@ const receiveOrigin: RfqSwapOrigin = {
     amount: 20_400,
 };
 
-const paramsOf = (origin: RfqSwapOrigin): LockupParams =>
-    origin.kind === "lightning_send" ? SEND_LOCKUP.params : RECEIVE_LOCKUP.params;
+const lockupFor = (origin: RfqSwapOrigin) =>
+    origin.kind === "lightning_receive" ? RECEIVE_LOCKUP : SEND_LOCKUP;
+
+const paramsOf = (origin: RfqSwapOrigin): LockupParams => lockupFor(origin).params;
 
 const swapOf = (
     origin: RfqSwapOrigin,
@@ -101,7 +108,7 @@ const swapOf = (
     const common = {
         rfqId: "rfq-1",
         state,
-        lockupPkScript: p2tr(key(11)),
+        lockupPkScript: lockupFor(origin).pkScript,
         paymentHash: origin.paymentHash,
         refundLocktime: REFUND_LOCKTIME,
         createdAt: 1_000,
@@ -201,11 +208,24 @@ describe("an onchain-send record carries its L1 half", () => {
     // values. So this is the one set of script parameters the record stores,
     // and a restored swap without them would let its L1 refund window pass
     // unwatched.
+    const HTLC_LOCKTIME = 1_850_000_000;
+    // The contract the request derived — what the record's inputs must give back.
+    const L1_HTLC = onchainHtlcScript(
+        {
+            paymentHash: PAYMENT_HASH,
+            claimKey: key(15),
+            refundKey: key(11),
+            refundLocktime: HTLC_LOCKTIME,
+        },
+        "regtest",
+    );
+
     const L1 = {
         claimKey: hex.encode(key(15)),
         refundKey: hex.encode(key(11)),
-        htlcLocktime: 1_850_000_000,
+        htlcLocktime: HTLC_LOCKTIME,
         network: "regtest" as const,
+        htlcAddress: L1_HTLC.address,
         minConfirmations: 2,
     };
 
@@ -223,7 +243,7 @@ describe("an onchain-send record carries its L1 half", () => {
             kind: "onchain_send",
             rfqId: "rfq-1",
             state: "pending",
-            lockupPkScript: p2tr(key(11)),
+            lockupPkScript: SEND_LOCKUP.pkScript,
             paymentHash: PAYMENT_HASH,
             refundLocktime: REFUND_LOCKTIME,
             htlc: {},
@@ -239,12 +259,20 @@ describe("an onchain-send record carries its L1 half", () => {
 
         expect(rebuilt.kind).toBe("onchain_send");
         const onchain = rebuilt as { htlc: { address: string }; minConfirmations: number };
-        expect(onchain.htlc.address).toBeTruthy();
+        // the contract the request derived, not merely a well-formed one
+        expect(onchain.htlc.address).toBe(L1_HTLC.address);
         expect(onchain.minConfirmations).toBe(2);
-        // the same inputs must give the same contract back
-        expect(onchain.htlc.address).toBe(
-            (rebuildRfqSwap(record, SEND_LOCKUP.params) as { htlc: { address: string } }).htlc
-                .address,
+    });
+
+    it("refuses L1 inputs that derive some other HTLC", () => {
+        // The check `rebuildRfqSwap` makes for the arkade lockup, on the leg
+        // that has no contract row to make it from. Swapping the two keys is
+        // the case nothing else catches: every input stays well formed, the
+        // rebuild succeeds, and the address it produces is one nobody funded.
+        const record = createRfqSwapRecord(onchainOrigin, onchainSwap());
+        const swapped = { ...record.profile, claimKey: L1.refundKey, refundKey: L1.claimKey };
+        expect(() => rebuildRfqSwap({ ...record, profile: swapped }, SEND_LOCKUP.params)).toThrow(
+            /not this swap's/,
         );
     });
 
@@ -323,6 +351,36 @@ describe("the record never carries a private key", () => {
         // what the record keeps.
         const record = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin));
         expect(JSON.stringify(record)).not.toContain(hex.encode(key(1)));
+    });
+});
+
+describe("the origin and the live swap must be one swap", () => {
+    it("refuses an origin whose kind is not the swap's", () => {
+        // Not cosmetic: the handler resolved from `kind` casts on it, so a
+        // receive origin projected off a send swap writes
+        // `expectedAmount: undefined` over the value the caller just supplied —
+        // deleting the value gate at the moment it was being recorded.
+        expect(() => createRfqSwapRecord(receiveOrigin, swapOf(sendOrigin))).toThrow(
+            /lightning_receive origin paired with a lightning_send swap/,
+        );
+    });
+
+    it("refuses an origin whose lockup is not the one the swap watches", () => {
+        // The record stores no `lockupPkScript` — the rebuild derives it from
+        // `lockupAddress` — so a disagreement here restores a swap watching a
+        // covenant this one never had, and only these two functions ever hold
+        // both halves.
+        const wrongLockup = { ...sendOrigin, lockupAddress: RECEIVE_LOCKUP.address };
+        expect(() => createRfqSwapRecord(wrongLockup, swapOf(sendOrigin))).toThrow(
+            /not the same swap/,
+        );
+    });
+
+    it("re-checks on every write, not just the first", () => {
+        const record = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin));
+        expect(() => updateRfqSwapRecord(record, swapOf(receiveOrigin, "claimed"))).toThrow(
+            /lightning_send origin paired with a lightning_receive swap/,
+        );
     });
 });
 


### PR DESCRIPTION
Stacked on #746 — review that first; this is two commits on top of its branch.

Follow-up to [the discussion there](https://github.com/arkade-os/ts-sdk/pull/746#issuecomment-5279946271). Two changes, second one is the point.

## 1. Persist the onchain-send leg (`8a26aec6`)

`PersistableRfqSwap` excluded `onchain_send` because its L1 half could not be reproduced. That was accurate, and this removes the cause.

The arkade lockup gets a contract row like every other corridor. The HTLC does not — it is Bitcoin L1, not an arkade contract, so nothing registers it — and `OnchainHtlc` hands back only derived values (`address`, `pkScript`, `leaves`, `controlBlocks`), never the `claimKey`/`refundKey` that `onchainHtlcScript` takes as inputs. A consumer holding `result.htlc` therefore had no route to rebuilding it after a restart.

`deriveOnchainSend`/`requestOnchainSend` now return `htlcParams` and `minConfirmations`, and the record persists them.

## 2. Per-corridor persistence behind a handler registry (`a3b08713`)

The record was growing a field per corridor — `expectedAmount`/`payoutAddress` for receive, an `onchain` block for the L1 leg — so each new corridor meant editing a shared type, with the repository and IndexedDB store inheriting the churn. Commit 1 made that worse before this makes it better.

It now mirrors `contractHandlers`, which solved the same problem for VTXO scripts:

```ts
interface RfqCorridorHandler<P> {
  readonly kind: string
  project(swap): Partial<P>              // only what the MANAGER can change
  hydrate(profile, ctx): Record<...>     // rebuild the corridor's live half
}
rfqCorridorHandlers.register(OnchainSendCorridor)
```

The record carries one opaque `profile`. **`rfqRecord.ts`, `repository.ts` and `indexedDbRepository.ts` no longer name a corridor** — adding one is a handler plus a `register()` call: no shared type, no stored schema change, no switch to extend.

### Why the profile has two authors

`project` returns only the part the manager can change, not the whole profile, because half of what a corridor persists never reaches an `RfqSwap`: the onchain leg's L1 keys are the clearest case. So the caller writes the profile once from the request result and `project` keeps it current.

That gives the two halves opposite update rules, which is deliberate: the profile MERGES (the caller's half has no other source), while the manager-state half is still REPLACED (so a cleared `blockedReason` can actually clear — see the earlier review on #746).

`hydrate` takes the common fields alongside its own profile. The onchain handler needs that: it rebuilds from `sha256(P)` and the covenant binds only `hash160(P)`, so the payment hash must come from the record rather than the tree.

A kind with no handler registered throws and names what is registered, rather than restoring a swap nothing knows how to drive.

## Tests

411, typecheck and lint clean. New coverage: the onchain L1 round trip, the fill/claim outpoints surviving the mutable half, and refusal when a record's L1 keys or a receive's `expectedAmount` are missing.

## Not included

Stripping `treeParams` from the two lightning corridors — dead weight there now the contract row owns their covenant, while the identical shape is exactly what onchain needed. Purely subtractive on a public surface, so it belongs on its own rather than mixed with a feature. Happy to add it here or send it separately.
