### PR TITLE
feat(balance): split the unavailable remainder into gated and intentLocked

### DIFF
--- a/packages/ts-sdk/src/wallet/balance.ts
+++ b/packages/ts-sdk/src/wallet/balance.ts
@@ -11,6 +11,31 @@ export interface OffchainBalance {
     settled: number;
     preconfirmed: number;
     available: number;
+    /**
+     * Spendable-but-for-the-gate funds: VTXOs under a contract
+     * {@link BalanceCapabilities.isGenericallySpendable} refuses — a VHTLC
+     * lockup, an unmarked `arkade` program, or a type whose handler this runtime
+     * never registered. Counted in `settled`/`preconfirmed` and `total`, never
+     * in `available`.
+     *
+     * Tested before {@link intentLocked}: the gate is a durable property of the
+     * contract while an intent lock clears on its own, so a VTXO that is both is
+     * reported here — it does not become available when the batch settles.
+     */
+    gated: number;
+    /**
+     * Funds committed to an in-flight (non-terminal) intent, and not already
+     * counted in {@link gated}. Unlike `gated`, these return to `available` when
+     * the intent reaches a terminal state.
+     *
+     * Reported as zero where the caller cannot answer the question — a wallet
+     * with no intent repository, or a repository read that fails — so this
+     * under-reports into `available` rather than misattributing. The two callers
+     * answer from deliberately different reads (@see {@link BalanceCapabilities}),
+     * so a worker figure and a main-thread figure need not agree unless taken
+     * over the same state.
+     */
+    intentLocked: number;
     recoverable: number;
     pendingRecovery: number;
     /** `settled + preconfirmed + recoverable + pendingRecovery` — the buckets are disjoint. */
@@ -57,6 +82,8 @@ export function computeOffchainBalance(
     let settled = 0;
     let preconfirmed = 0;
     let available = 0;
+    let gated = 0;
+    let intentLocked = 0;
     let recoverable = 0;
     let pendingRecovery = 0;
     const owned = new Map<string, bigint>();
@@ -94,7 +121,13 @@ export function computeOffchainBalance(
         } else {
             settled += vtxo.value;
         }
-        if (isGenericallySpendable(vtxo) && isUnlocked(vtxo)) {
+        // Disjoint by construction, so `settled + preconfirmed` splits exactly
+        // three ways. Gate before lock: see `gated`.
+        if (!isGenericallySpendable(vtxo)) {
+            gated += vtxo.value;
+        } else if (!isUnlocked(vtxo)) {
+            intentLocked += vtxo.value;
+        } else {
             available += vtxo.value;
             addAssets(spendable, vtxo);
         }
@@ -107,6 +140,8 @@ export function computeOffchainBalance(
         settled,
         preconfirmed,
         available,
+        gated,
+        intentLocked,
         recoverable,
         pendingRecovery,
         total: settled + preconfirmed + recoverable + pendingRecovery,

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -341,6 +341,27 @@ export interface WalletBalance {
      */
     available: number;
     /**
+     * Spendable-but-for-the-gate funds: VTXOs under a contract the
+     * generic-spending gate refuses — a VHTLC lockup, an unmarked `arkade`
+     * program, or a type whose handler this runtime never registered. Counted in
+     * `settled`/`preconfirmed` and `total`, never in `available`.
+     *
+     * Tested before {@link intentLocked}: the gate is a durable property of the
+     * contract while an intent lock clears on its own, so a VTXO that is both is
+     * reported here — it does not become available when the batch settles.
+     */
+    gated: number;
+    /**
+     * Funds committed to an in-flight (non-terminal) intent, and not already
+     * counted in {@link gated}. Unlike `gated`, these return to `available` when
+     * the intent reaches a terminal state.
+     *
+     * Reported as zero where the wallet cannot answer the question — no intent
+     * repository, or a repository read that fails — so this under-reports into
+     * `available` rather than misattributing.
+     */
+    intentLocked: number;
+    /**
      * Recoverable balance from subdust or expired (swept) virtual outputs —
      * recoverable in principle, so a lockup whose contract refuses a spend right
      * now is still counted and `total` does not lose it.

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -330,14 +330,14 @@ export interface WalletBalance {
         /** Combined boarding balance (`confirmed` + `unconfirmed`) */
         total: number;
     };
-    /** Spendable settled (finalized) balance. */
+    /** Settled (finalized) balance the wallet owns, including gated and intent-locked funds. */
     settled: number;
-    /** Spendable preconfirmed (unfinalized) balance. */
+    /** Preconfirmed (unfinalized) balance the wallet owns, on the same owned rule as {@link settled}. */
     preconfirmed: number;
     /**
-     * Immediately spendable offchain balance: the `settled + preconfirmed`
-     * rule applied only to VTXOs not locked by an in-flight (non-terminal)
-     * intent. Equals `settled + preconfirmed` when nothing is intent-locked.
+     * Immediately spendable offchain balance — what generic selection would
+     * pick, so nothing counted here can be refused by `send`:
+     * `settled + preconfirmed - gated - intentLocked`.
      */
     available: number;
     /**
@@ -349,6 +349,10 @@ export interface WalletBalance {
      * Tested before {@link intentLocked}: the gate is a durable property of the
      * contract while an intent lock clears on its own, so a VTXO that is both is
      * reported here — it does not become available when the batch settles.
+     *
+     * Covers this bucket only: {@link recoverable} has the same owned-versus-
+     * obtainable split under a different predicate and is not counted here, so
+     * `total - gated` still carries a recoverable component.
      */
     gated: number;
     /**
@@ -386,9 +390,9 @@ export interface WalletBalance {
 
     /**
      * The subset of {@link assets} generic spending will accept, i.e. the asset
-     * analogue of {@link available}. Assets have no owned/spendable split of
-     * their own, so `assets - availableAssets` is what is held but not
-     * selectable — escrowed, intent-locked or awaiting recovery.
+     * analogue of {@link available}. `assets - availableAssets` is what is held
+     * but not selectable, for the {@link gated} and {@link intentLocked} causes
+     * plus recovery — assets have no per-cause split of their own.
      */
     availableAssets: Asset[];
 }

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1553,6 +1553,8 @@ export class WalletMessageHandler
             settled: offchain.settled,
             preconfirmed: offchain.preconfirmed,
             available: offchain.available,
+            gated: offchain.gated,
+            intentLocked: offchain.intentLocked,
             recoverable: offchain.recoverable,
             pendingRecovery: offchain.pendingRecovery,
             total: totalBoarding + offchain.total,

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -1202,6 +1202,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
             settled: offchain.settled,
             preconfirmed: offchain.preconfirmed,
             available: offchain.available,
+            gated: offchain.gated,
+            intentLocked: offchain.intentLocked,
             recoverable: offchain.recoverable,
             pendingRecovery: offchain.pendingRecovery,
             total: totalBoarding + offchain.total,

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -333,6 +333,32 @@ describe("getSpendableVtxos", () => {
 });
 
 describe("getBalance", () => {
+    /** `settled + preconfirmed === available + gated + intentLocked`. */
+    const expectSplit = (balance: {
+        settled: number;
+        preconfirmed: number;
+        available: number;
+        gated: number;
+        intentLocked: number;
+    }) =>
+        expect(balance.settled + balance.preconfirmed).toBe(
+            balance.available + balance.gated + balance.intentLocked,
+        );
+
+    const lockOutpoint = async (intents: InMemoryIntentRepository, txid: string) =>
+        intents.saveIntent({
+            intentTxId: `i-${txid.slice(0, 4)}`,
+            createdAt: 1,
+            updatedAt: 1,
+            registerProof: "",
+            registerProofMessage: "",
+            deleteProof: "",
+            deleteProofMessage: "",
+            partialForfeits: [],
+            state: "batch_in_progress",
+            intentVtxos: [{ txid, vout: 0 }],
+        });
+
     it("counts gated funds as owned but not as available (D1c)", async () => {
         const { wallet } = await seededWallet();
         const balance = await wallet.getBalance();
@@ -342,6 +368,41 @@ describe("getBalance", () => {
         expect(balance.total).toBe(70_000);
         // …minus the escrowed and the unknown-type contract.
         expect(balance.available).toBe(50_000);
+        expect(balance.gated).toBe(20_000);
+        expect(balance.intentLocked).toBe(0);
+        expectSplit(balance);
+    });
+
+    it("counts a gated-and-locked VTXO once, as gated", async () => {
+        const intents = new InMemoryIntentRepository();
+        const { wallet } = await seededWallet({ intents });
+        const escrowTxid = ESCROW_SCRIPT.slice(-2).repeat(32);
+        await lockOutpoint(intents, escrowTxid);
+
+        // Without this the case passes for the wrong reason: no overlap gives
+        // the same buckets as an overlap counted once.
+        expect(await intents.getLockedVtxoOutpoints()).toContainEqual({
+            txid: escrowTxid,
+            vout: 0,
+        });
+
+        const balance = await wallet.getBalance();
+        expect(balance.gated).toBe(20_000);
+        expect(balance.intentLocked).toBe(0);
+        expect(balance.available).toBe(50_000);
+        expectSplit(balance);
+    });
+
+    it("reports an ungated intent-locked VTXO as intentLocked", async () => {
+        const intents = new InMemoryIntentRepository();
+        const { wallet, defaultScript } = await seededWallet({ intents });
+        await lockOutpoint(intents, defaultScript.slice(-2).repeat(32));
+
+        const balance = await wallet.getBalance();
+        expect(balance.intentLocked).toBe(40_000);
+        expect(balance.gated).toBe(20_000);
+        expect(balance.available).toBe(10_000); // only MARKED_SCRIPT survives
+        expectSplit(balance);
     });
 
     it("gives assets the same owned/spendable split (D1e)", async () => {

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -7,6 +7,7 @@ import {
     deserializeMigrationReport,
 } from "../src/wallet/serviceWorker/wallet-message-handler";
 import { InMemoryWalletRepository } from "../src";
+import { InMemoryIntentRepository } from "../src/repositories/inMemory/intentRepository";
 import {
     createMockExtendedVtxo,
     createMockIndexerProvider,
@@ -1487,7 +1488,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
         tag: DEFAULT_MESSAGE_TAG,
     });
 
-    const setupHandler = (contracts: any[] = []) => {
+    const setupHandler = (contracts: any[] = [], intents?: InMemoryIntentRepository) => {
         mockIndexer = createMockIndexerProvider();
         walletRepo = new InMemoryWalletRepository();
 
@@ -1501,6 +1502,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
                 commitmentsToIgnore: new Set(),
             }),
             dustAmount: 546n,
+            ...(intents ? { intentRepository: intents } : {}),
             pendingRecoveryOutpoints: vi.fn().mockResolvedValue(new Set<string>()),
             pendingRecoveryOutpointsIn: vi.fn().mockReturnValue(new Set<string>()),
             getContractManager: vi.fn().mockResolvedValue({
@@ -1859,9 +1861,47 @@ describe("WalletMessageHandler repo-backed reads", () => {
                 settled: 30000,
                 total: 30000,
                 available: 10000,
+                gated: 20000,
+                intentLocked: 0,
                 assets: [{ assetId: "cc".repeat(32), amount: 7n }],
                 availableAssets: [{ assetId: "cc".repeat(32), amount: 3n }],
             },
+        });
+    });
+
+    it("GET_BALANCE reports an intent-locked VTXO as intentLocked", async () => {
+        const intents = new InMemoryIntentRepository();
+        setupHandler([{ address: "contract-1", script: "s1", type: "default" }], intents);
+
+        await walletRepo.saveVtxos("contract-1", [
+            createMockExtendedVtxo({
+                txid: "aa".repeat(32),
+                value: 10000,
+                virtualStatus: { state: "settled" },
+                script: "s1",
+            }),
+        ]);
+        await intents.saveIntent({
+            intentTxId: "i",
+            createdAt: 1,
+            updatedAt: 1,
+            registerProof: "",
+            registerProofMessage: "",
+            deleteProof: "",
+            deleteProofMessage: "",
+            partialForfeits: [],
+            state: "batch_in_progress",
+            intentVtxos: [{ txid: "aa".repeat(32), vout: 0 }],
+        });
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "GET_BALANCE",
+        } as any);
+
+        expect(response).toMatchObject({
+            type: "BALANCE",
+            payload: { settled: 10000, available: 0, gated: 0, intentLocked: 10000 },
         });
     });
 


### PR DESCRIPTION
## Problem

`WalletBalance` reports what the wallet owns (`settled`, `preconfirmed`, `total`) and what generic
spending will accept (`available`), but not **why** the difference exists. A consumer that wants to
show "your money" minus "funds tied up in a swap" has no field to subtract:

- `total - available` folds in `recoverable` and `pendingRecovery`, so swept and awaiting-recovery
  funds vanish from the headline figure too.
- `settled + preconfirmed - available` is the size of the **union** of two unrelated exclusions —
  the contract gate and intent locks — with no way to tell them apart.

This surfaced downstream: the Arkade Wallet displays `total`, so after paying a Lightning invoice
over `@arkade-os/swap` the balance does not drop — the spent input leaves and a covenant VTXO of the
same size arrives in its place.

## Change

`computeOffchainBalance` applied both predicates in one condition and recorded only the conjunction.
The post-`canSpendOffchain` arm now splits three ways, so one identity holds exactly:

```
settled + preconfirmed === available + gated + intentLocked
```

`gated` is named for the mechanism, not for today's most common occupant: the gate closes for a
VHTLC lockup, an unmarked `arkade` program, *and* a type whose handler this runtime never registered.
Calling it `escrowed` would report the third case as something in flight when nothing is. It also
keeps plugin vocabulary out of the core balance shape (`AGENTS.md`) — a consumer that needs to
distinguish swap escrow from other gated causes reads `metadata.kind` off the contract row.

**Precedence: gate before lock.** The two overlap — a gated VTXO can still be named explicitly in
`settle({ inputs })`, which registers an intent — so the order matters, and this mirrors the rule
already in the file (`isPendingRecovery` before `canRecoverOnchain`). Reporting a gated-and-locked
VTXO as `intentLocked` would tell a consumer those funds return when the batch settles, which is
false: they stay gated afterwards.

Scope is the arm below `canSpendOffchain` only. `recoverable` and `pendingRecovery` are deliberately
untouched — gating `recoverable` is a recorded no (`plans/pr-702-followup.md` §C, shipped in
`6779b508`): a gated coin falling through it would meet `canSpendOffchain`, be false there too, and
land in no bucket at all, silently dropping out of `total`.

Assets are out of scope for the same reason: `gatedAssets`/`intentLockedAssets` apply mechanically,
but the only consumer need today is met by `availableAssets`, and adding four fields where two have
consumers invites the untested pair to drift.

The second commit fixes the docs that led the consumer astray — `settled`/`preconfirmed` were
described as spendable when they include gated escrow, and `available` was described as excluding
only in-flight intents.

## What `gated` does not cover

`recoverable` has the same owned-versus-obtainable split, one bucket over, and this change does not
touch it: `VtxoManager.getRecoverableBalance()` excludes lockups whose contract refuses a spend right
now, while `Balance.recoverable` keeps counting them so `total` does not lose the funds. So a
headline `total - gated` still carries a `recoverable` component that can overstate what a recovery
batch would hand back today. Different predicate (a per-input timelock, not the contract gate), on a
bucket this change deliberately leaves alone.

## Compatibility

Additive. No existing field changes value, `total` is untouched, and `OffchainBalance` is internal to
the SDK. The one break: an embedder with its own `IWallet` implementation returning a `WalletBalance`
object literal fails to typecheck against the wider interface — compile-time, with an obvious fix.

## Tests

- `spendability-gate.test.ts`: D1c extended with the buckets and the identity; the **overlap** case
  (an intent registered over the escrow outpoint counts once, in `gated`) with a positive
  precondition on `getLockedVtxoOutpoints()` so it cannot pass for the wrong reason; and lock-without-gate.
- `wallet-message-handler.test.ts`: `gated` on the existing worker `GET_BALANCE` case, plus an
  `intentLocked` case — the mock `readonlyWallet` gained an `intentRepository`, without which the
  worker can only ever answer `0`.
- Every existing balance assertion passes unmodified. If one had needed editing, `available` would
  have changed value and the if/else chain would not be the negation of the conjunction it replaced.

Unit suites green across all three packages; `tsc --noEmit` clean for `ts-sdk`, `swap` and
`boltz-swap` against a fresh `ts-sdk` build. No integration/e2e run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet balances now separately report available, gated, and intent-locked funds.
  * Settled and preconfirmed totals include all owned funds, while available balances exclude restricted amounts.
  * Intent-locked funds can be reflected as available once their associated intent is completed.
  * Balance responses consistently expose the new categories across wallet interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->