### PR TITLE
feat(balance): add an escrow bucket to WalletBalance

### DIFF
--- a/packages/ts-sdk/src/wallet/balance.ts
+++ b/packages/ts-sdk/src/wallet/balance.ts
@@ -11,6 +11,16 @@ export interface OffchainBalance {
     settled: number;
     preconfirmed: number;
     available: number;
+    /**
+     * The part of `settled + preconfirmed` held at contracts generic spending
+     * is gated from — swap escrow, chiefly. Counted in the owned buckets and in
+     * `total`, since it is still the user's money, but never in `available`.
+     *
+     * Disjoint from `available` by construction. The remainder,
+     * `settled + preconfirmed - available - escrow`, is what an in-flight
+     * settlement intent has locked.
+     */
+    escrow: number;
     recoverable: number;
     pendingRecovery: number;
     /** `settled + preconfirmed + recoverable + pendingRecovery` — the buckets are disjoint. */
@@ -57,6 +67,7 @@ export function computeOffchainBalance(
     let settled = 0;
     let preconfirmed = 0;
     let available = 0;
+    let escrow = 0;
     let recoverable = 0;
     let pendingRecovery = 0;
     const owned = new Map<string, bigint>();
@@ -94,7 +105,12 @@ export function computeOffchainBalance(
         } else {
             settled += vtxo.value;
         }
-        if (isGenericallySpendable(vtxo) && isUnlocked(vtxo)) {
+        // Gate first, so the two buckets are disjoint: a coin that is both gated
+        // and intent-locked is escrow, and the intent-locked remainder stays
+        // derivable as `settled + preconfirmed - available - escrow`.
+        if (!isGenericallySpendable(vtxo)) {
+            escrow += vtxo.value;
+        } else if (isUnlocked(vtxo)) {
             available += vtxo.value;
             addAssets(spendable, vtxo);
         }
@@ -107,6 +123,7 @@ export function computeOffchainBalance(
         settled,
         preconfirmed,
         available,
+        escrow,
         recoverable,
         pendingRecovery,
         total: settled + preconfirmed + recoverable + pendingRecovery,

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -341,14 +341,18 @@ export interface WalletBalance {
      */
     available: number;
     /**
-     * Funds held at contracts that generic spending is gated from — swap escrow,
-     * chiefly. Still the user's money, so counted in `settled`/`preconfirmed` and
-     * in `total`; never in `available`.
+     * Funds held at contracts the generic-spending gate closes. Swap escrow is
+     * the common case, but the gate is default-closed: a contract type with no
+     * registered handler, a plugin type, and an `arkade` contract whose metadata
+     * does not explicitly set `genericallySpendable` all land here too. Still the
+     * user's money, so counted in `settled`/`preconfirmed` and in `total`; never
+     * in `available`.
      *
      * Present so a consumer can explain the gap between `total` and `available`
      * without re-deriving the contract gate itself. The rest of that gap is
-     * `recoverable`, `pendingRecovery`, and intent-locked funds — the last of
-     * which is `settled + preconfirmed - available - escrow`.
+     * `boarding.total`, `recoverable`, `pendingRecovery`, and intent-locked
+     * offchain funds — the last of which is
+     * `settled + preconfirmed - available - escrow` (all four offchain terms).
      */
     escrow: number;
     /**

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -341,6 +341,17 @@ export interface WalletBalance {
      */
     available: number;
     /**
+     * Funds held at contracts that generic spending is gated from — swap escrow,
+     * chiefly. Still the user's money, so counted in `settled`/`preconfirmed` and
+     * in `total`; never in `available`.
+     *
+     * Present so a consumer can explain the gap between `total` and `available`
+     * without re-deriving the contract gate itself. The rest of that gap is
+     * `recoverable`, `pendingRecovery`, and intent-locked funds — the last of
+     * which is `settled + preconfirmed - available - escrow`.
+     */
+    escrow: number;
+    /**
      * Recoverable balance from subdust or expired (swept) virtual outputs —
      * recoverable in principle, so a lockup whose contract refuses a spend right
      * now is still counted and `total` does not lose it.

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1553,6 +1553,7 @@ export class WalletMessageHandler
             settled: offchain.settled,
             preconfirmed: offchain.preconfirmed,
             available: offchain.available,
+            escrow: offchain.escrow,
             recoverable: offchain.recoverable,
             pendingRecovery: offchain.pendingRecovery,
             total: totalBoarding + offchain.total,

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -1202,6 +1202,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             settled: offchain.settled,
             preconfirmed: offchain.preconfirmed,
             available: offchain.available,
+            escrow: offchain.escrow,
             recoverable: offchain.recoverable,
             pendingRecovery: offchain.pendingRecovery,
             total: totalBoarding + offchain.total,

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -1705,7 +1705,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
         expect(manager.getContracts).toHaveBeenCalledTimes(1);
         expect(response).toMatchObject({
             type: "BALANCE",
-            payload: { settled: 30000, total: 30000, available: 0 },
+            payload: { settled: 30000, total: 30000, available: 0, escrow: 30000 },
         });
     });
 

--- a/packages/ts-sdk/test/wallet/balance.test.ts
+++ b/packages/ts-sdk/test/wallet/balance.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { computeOffchainBalance, type BalanceCapabilities } from "../../src/wallet/balance";
 import type { NormalizedExtendedVirtualCoin } from "../../src/wallet/vtxo";
-import type { WalletBalance } from "../../src/wallet";
 
 /**
  * A plainly spendable coin: not spent, not swept, no expiry in the past.
@@ -110,37 +109,5 @@ describe("computeOffchainBalance escrow bucket", () => {
 
         expect(balance.recoverable).toBe(1000);
         expect(balance.escrow).toBe(0);
-    });
-});
-
-describe("WalletBalance carries escrow through both getBalance paths", () => {
-    it("is present on the shape both callers assemble", () => {
-        const balance = computeOffchainBalance(
-            [vtxo("a", 1000, "gated")],
-            caps({ isGenericallySpendable: () => false }),
-        );
-
-        // Exactly the object literal both `Wallet.getBalance` and the worker's
-        // `handleGetBalance` build. Annotated as `WalletBalance` on purpose: the
-        // annotation pins this literal to the real return shape, so a drift
-        // between either `getBalance` implementation and the type surfaces
-        // here. Note this package's `tsconfig.json` excludes `**/*.test.ts`,
-        // so `pnpm typecheck` does not see it — the check only fires in an
-        // editor or under a typecheck that does cover test files.
-        const assembled: WalletBalance = {
-            boarding: { confirmed: 0, unconfirmed: 0, total: 0 },
-            settled: balance.settled,
-            preconfirmed: balance.preconfirmed,
-            available: balance.available,
-            escrow: balance.escrow,
-            recoverable: balance.recoverable,
-            pendingRecovery: balance.pendingRecovery,
-            total: 0 + balance.total,
-            assets: balance.assets,
-            availableAssets: balance.availableAssets,
-        };
-
-        expect(assembled.escrow).toBe(1000);
-        expect(assembled.total).toBe(1000);
     });
 });

--- a/packages/ts-sdk/test/wallet/balance.test.ts
+++ b/packages/ts-sdk/test/wallet/balance.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { computeOffchainBalance, type BalanceCapabilities } from "../../src/wallet/balance";
+import type { NormalizedExtendedVirtualCoin } from "../../src/wallet/vtxo";
+
+/**
+ * A plainly spendable coin: not spent, not swept, no expiry in the past.
+ * `canSpendOffchain` reads exactly those facts, so this lands in
+ * settled/preconfirmed and the capability predicates decide the rest.
+ */
+const vtxo = (txid: string, value: number, script = "aa"): NormalizedExtendedVirtualCoin =>
+    ({
+        txid,
+        vout: 0,
+        value,
+        script,
+        isPreconfirmed: false,
+        isSwept: false,
+        isSpent: false,
+    }) as unknown as NormalizedExtendedVirtualCoin;
+
+const caps = (over: Partial<BalanceCapabilities> = {}): BalanceCapabilities => ({
+    now: { timestamp: new Date() },
+    isPendingRecovery: () => false,
+    isGenericallySpendable: () => true,
+    isUnlocked: () => true,
+    ...over,
+});
+
+describe("computeOffchainBalance escrow bucket", () => {
+    it("counts a contract-gated coin as escrow, not available", () => {
+        const gated = vtxo("a", 1000, "gated");
+        const free = vtxo("b", 500, "free");
+
+        const balance = computeOffchainBalance(
+            [gated, free],
+            caps({ isGenericallySpendable: (v) => v.script !== "gated" }),
+        );
+
+        expect(balance.escrow).toBe(1000);
+        expect(balance.available).toBe(500);
+    });
+
+    it("leaves owned buckets unchanged — escrow is a view, not a fifth exclusive branch", () => {
+        const gated = vtxo("a", 1000, "gated");
+        const free = vtxo("b", 500, "free");
+
+        const balance = computeOffchainBalance(
+            [gated, free],
+            caps({ isGenericallySpendable: (v) => v.script !== "gated" }),
+        );
+
+        expect(balance.settled).toBe(1500);
+        expect(balance.total).toBe(1500);
+    });
+
+    it("attributes an intent-locked but ungated coin to neither available nor escrow", () => {
+        const locked = vtxo("a", 1000);
+
+        const balance = computeOffchainBalance([locked], caps({ isUnlocked: () => false }));
+
+        expect(balance.available).toBe(0);
+        expect(balance.escrow).toBe(0);
+        expect(balance.settled).toBe(1000);
+    });
+
+    it("counts a coin that is both gated and intent-locked as escrow only, so buckets stay disjoint", () => {
+        const both = vtxo("a", 1000);
+
+        const balance = computeOffchainBalance(
+            [both],
+            caps({ isGenericallySpendable: () => false, isUnlocked: () => false }),
+        );
+
+        expect(balance.escrow).toBe(1000);
+        expect(balance.available).toBe(0);
+    });
+
+    it("holds the closure invariant: available + escrow + intent-locked === settled + preconfirmed", () => {
+        const gated = vtxo("a", 1000, "gated");
+        const lockedCoin = vtxo("b", 700);
+        const free = vtxo("c", 500);
+
+        const balance = computeOffchainBalance(
+            [gated, lockedCoin, free],
+            caps({
+                isGenericallySpendable: (v) => v.script !== "gated",
+                isUnlocked: (v) => v.txid !== "b",
+            }),
+        );
+
+        const intentLocked =
+            balance.settled + balance.preconfirmed - balance.available - balance.escrow;
+        expect(intentLocked).toBe(700);
+        expect(balance.available + balance.escrow + intentLocked).toBe(
+            balance.settled + balance.preconfirmed,
+        );
+    });
+
+    it("does not count a recoverable coin as escrow even when gated", () => {
+        const swept = {
+            ...vtxo("a", 1000),
+            isSwept: true,
+        } as unknown as NormalizedExtendedVirtualCoin;
+
+        const balance = computeOffchainBalance(
+            [swept],
+            caps({ isGenericallySpendable: () => false }),
+        );
+
+        expect(balance.recoverable).toBe(1000);
+        expect(balance.escrow).toBe(0);
+    });
+});

--- a/packages/ts-sdk/test/wallet/balance.test.ts
+++ b/packages/ts-sdk/test/wallet/balance.test.ts
@@ -122,8 +122,11 @@ describe("WalletBalance carries escrow through both getBalance paths", () => {
 
         // Exactly the object literal both `Wallet.getBalance` and the worker's
         // `handleGetBalance` build. Annotated as `WalletBalance` on purpose: the
-        // annotation is what makes this fail before the field exists, and what
-        // keeps it pinned to the real return shape afterwards.
+        // annotation pins this literal to the real return shape, so a drift
+        // between either `getBalance` implementation and the type surfaces
+        // here. Note this package's `tsconfig.json` excludes `**/*.test.ts`,
+        // so `pnpm typecheck` does not see it — the check only fires in an
+        // editor or under a typecheck that does cover test files.
         const assembled: WalletBalance = {
             boarding: { confirmed: 0, unconfirmed: 0, total: 0 },
             settled: balance.settled,

--- a/packages/ts-sdk/test/wallet/balance.test.ts
+++ b/packages/ts-sdk/test/wallet/balance.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { computeOffchainBalance, type BalanceCapabilities } from "../../src/wallet/balance";
 import type { NormalizedExtendedVirtualCoin } from "../../src/wallet/vtxo";
+import type { WalletBalance } from "../../src/wallet";
 
 /**
  * A plainly spendable coin: not spent, not swept, no expiry in the past.
@@ -109,5 +110,34 @@ describe("computeOffchainBalance escrow bucket", () => {
 
         expect(balance.recoverable).toBe(1000);
         expect(balance.escrow).toBe(0);
+    });
+});
+
+describe("WalletBalance carries escrow through both getBalance paths", () => {
+    it("is present on the shape both callers assemble", () => {
+        const balance = computeOffchainBalance(
+            [vtxo("a", 1000, "gated")],
+            caps({ isGenericallySpendable: () => false }),
+        );
+
+        // Exactly the object literal both `Wallet.getBalance` and the worker's
+        // `handleGetBalance` build. Annotated as `WalletBalance` on purpose: the
+        // annotation is what makes this fail before the field exists, and what
+        // keeps it pinned to the real return shape afterwards.
+        const assembled: WalletBalance = {
+            boarding: { confirmed: 0, unconfirmed: 0, total: 0 },
+            settled: balance.settled,
+            preconfirmed: balance.preconfirmed,
+            available: balance.available,
+            escrow: balance.escrow,
+            recoverable: balance.recoverable,
+            pendingRecovery: balance.pendingRecovery,
+            total: 0 + balance.total,
+            assets: balance.assets,
+            availableAssets: balance.availableAssets,
+        };
+
+        expect(assembled.escrow).toBe(1000);
+        expect(assembled.total).toBe(1000);
     });
 });


### PR DESCRIPTION
Adds an `escrow` bucket to `WalletBalance` so a consumer can isolate contract-gated funds from the rest of the `total - available` gap.

Picks up the follow-up [arkade-os/wallet#913](https://github.com/arkade-os/wallet/pull/913) named in its own out-of-scope section:

> The BTC home-screen total is still wrong, for the same root cause. It cannot be fixed cleanly at the display layer today: `total - available` also folds in `recoverable`, `pendingRecovery` and intent-locked funds, and `WalletBalance` has no bucket isolating escrow. Showing `available` instead would erase swept and awaiting-recovery funds from the hero — a regression in the opposite direction. This wants an escrow bucket on `WalletBalance` upstream; `computeOffchainBalance` already has `isGenericallySpendable` in hand.

## The change

`computeOffchainBalance` already evaluated `isGenericallySpendable(vtxo)` to decide `available`. That single condition is split so gated funds land in their own accumulator:

```ts
// before
if (isGenericallySpendable(vtxo) && isUnlocked(vtxo)) {
    available += vtxo.value;
    addAssets(spendable, vtxo);
}

// after — gate first, so the buckets are disjoint
if (!isGenericallySpendable(vtxo)) {
    escrow += vtxo.value;
} else if (isUnlocked(vtxo)) {
    available += vtxo.value;
    addAssets(spendable, vtxo);
}
```

`available` is still reached on exactly `isGenericallySpendable && isUnlocked`, including short-circuit order — `isUnlocked` is evaluated only when `isGenericallySpendable` holds, in both forms. **No existing bucket changes value for any input.**

`escrow` is a *view* over coins already counted in `settled`/`preconfirmed`, not a fifth exclusive branch. It accumulates after the settled/preconfirmed split with no intervening `continue`, so `total` is untouched. That ordering is deliberate: `balance.ts` already carries a comment explaining why the gate is not applied earlier — a gated coin dropped from `recoverable` would fail `canSpendOffchain` too and land in no bucket at all.

The field is surfaced through both `WalletBalance` assembly sites — `Wallet.getBalance` and the service worker's `handleGetBalance`. The second is the one that matters in practice: apps render from `ServiceWorkerWallet`, so a field present only in the first would be permanently `0` in a wallet while typechecking fine. `expo/wallet.ts` and `serviceWorker/wallet.ts` forward rather than assemble, so there is no third site.

## Deriving the rest of the gap

The JSDoc states the whole identity, because the intent-locked portion is deliberately left derivable rather than bucketed:

```
total - available = boarding.total + recoverable + pendingRecovery + escrow + intentLocked
intentLocked      = settled + preconfirmed - available - escrow
```

`boarding.total` is in there because the public `total` is `totalBoarding + offchain.total` while `available` is `offchain.available` only. The twin JSDoc on the internal `OffchainBalance.escrow` correctly omits boarding, since that type's `total` has none.

## What `escrow` actually contains

Broader than swaps, and the JSDoc says so. `isContractGenericallySpendable` is default-closed, so a contract with no registered handler, a plugin type, or an `arkade` contract without `metadata.genericallySpendable === true` all land here. Swap escrow is the common case, not the only one.

The name follows existing vocabulary rather than introducing new: `index.ts` ("escrowed, intent-locked or awaiting recovery"), `balance.ts`, `wallet.ts` and `contracts/types.ts` already use "escrow" for precisely this set. This promotes documented prose into a machine-readable value.

## Compatibility

`escrow` is **required, not optional**. Optional would force `?? 0` at every call site and reintroduce the ambiguity the field exists to remove. Consumers that only *read* a balance are unaffected; code that *constructs* one — an alternate `IWallet` implementation, or a test mock building a full `WalletBalance` — needs the new field. This matches how `recoverable`, `pendingRecovery` and `availableAssets` were added.

## Tests

`test/wallet/balance.test.ts` covers the bucketing: gated coin counted as escrow and not available; owned buckets unchanged; intent-locked-but-ungated in neither; a coin both gated and intent-locked counted once as escrow; the closure invariant; and a recoverable coin staying out of escrow even when gated.

`test/wallet-message-handler.test.ts` pins the service-worker path through the real `handleGetBalance` with a gated `arkade` contract, using the existing fixture.

Full suite unchanged against `master`: ts-sdk 163 files / 2601 passed / 1 skipped / 0 failed, swap 22 / 368, boltz-swap 23 / 614 with no type errors.

## Deliberately not here

- **`escrowAssets`**, the asset-side twin. `assets - availableAssets` already expresses the held-not-selectable set, and wallet#913 handled the asset half. A symmetric bucket needs the same three-way split on the asset side — its own design question.
- **An `intentLocked` bucket.** Derivable from the four fields above, with the formula stated on the type.
- **Any wallet-side change.** The consumer stacks on wallet#913.
