### PR TITLE
fix(spendability): say whether the gate closed or the handler is missing

### DIFF
--- a/packages/ts-sdk/src/contracts/spendability.ts
+++ b/packages/ts-sdk/src/contracts/spendability.ts
@@ -40,11 +40,29 @@ export type ExcludableVtxo = { txid: string; vout: number; script?: string };
  */
 export type VtxoExclusion = (vtxo: ExcludableVtxo) => string | undefined;
 
-/** The contract gate as an exclusion, naming the type that closed it. */
+/**
+ * The contract gate as an exclusion, naming why it closed: a handler ran and
+ * declined, or this build has no handler for the type at all.
+ *
+ * The two want opposite reactions from whoever reads the log. A decline is
+ * the gate working as designed — nothing to do. A missing handler means a
+ * contract row this build cannot interpret, e.g. a vendoring or version
+ * mismatch, which is worth a reader's attention. `contractHandlers` is
+ * already available here, so the message can tell them apart instead of
+ * collapsing both into one sentence that reads as the same case either way.
+ */
 export function gateExclusion(gated: ReadonlyMap<string, string>): VtxoExclusion {
     return (vtxo) => {
         const type = vtxo.script === undefined ? undefined : gated.get(vtxo.script);
         if (type === undefined) return undefined;
+        // A handler present but declaring no `isGenericallySpendable` predicate
+        // reads the same as an explicit decline here: both are this build
+        // recognizing the type and landing on "closed", not failing to
+        // interpret the row. Splitting that case out further would flag a
+        // plugin-authoring gap, not something an operator can act on.
+        if (!contractHandlers.has(type)) {
+            return `at ${vtxo.script} (contract type '${type}') has no handler registered in this build`;
+        }
         return `at ${vtxo.script} (contract type '${type}') is not generically spendable`;
     };
 }

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -4,6 +4,7 @@ import {
     BoardingContractHandler,
     DefaultContractHandler,
     DelegateContractHandler,
+    gateExclusion,
     InMemoryContractRepository,
     InMemoryWalletRepository,
     isContractGenericallySpendable,
@@ -519,6 +520,32 @@ describe("spending sites consume the accessor", () => {
             }),
         ).rejects.toThrow();
         expect(wallet.getSpendableVtxos).toHaveBeenCalled();
+    });
+});
+
+describe("gateExclusion", () => {
+    const GATED_SCRIPT = "51200000000000000000000000000000000000000000000000000000000000000006";
+
+    it("names the ordinary refusal for a type this build has a handler for", () => {
+        // vhtlc-v2 is a real registered handler (see handlers/index.ts) that
+        // simply declines: the gate is working as designed here.
+        const exclusion = gateExclusion(new Map([[GATED_SCRIPT, "vhtlc-v2"]]));
+        expect(exclusion({ txid: "a", vout: 0, script: GATED_SCRIPT })).toBe(
+            `at ${GATED_SCRIPT} (contract type 'vhtlc-v2') is not generically spendable`,
+        );
+    });
+
+    it("names the missing handler for a type this build never registered", () => {
+        const exclusion = gateExclusion(new Map([[GATED_SCRIPT, "not-a-registered-type"]]));
+        expect(exclusion({ txid: "a", vout: 0, script: GATED_SCRIPT })).toBe(
+            `at ${GATED_SCRIPT} (contract type 'not-a-registered-type') has no handler registered in this build`,
+        );
+    });
+
+    it("returns undefined for a vtxo the gate does not cover", () => {
+        const exclusion = gateExclusion(new Map([[GATED_SCRIPT, "vhtlc-v2"]]));
+        expect(exclusion({ txid: "a", vout: 0, script: "not-gated" })).toBeUndefined();
+        expect(exclusion({ txid: "a", vout: 0 })).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
`gateExclusion` emitted one message for causes that want opposite reactions from whoever reads the log.

`isContractGenericallySpendable` is:

```ts
contractHandlers.get(contract.type)?.isGenericallySpendable?.(contract) === true
```

so it is falsy when there is **no handler registered for the type**, when the handler declares **no predicate**, and when the handler **ran and declined**. All three produced:

```
[spendability] getSpendableVtxos: <outpoint> at <script> (contract type 'X') is not generically spendable
```

A decline is the gate working as designed — nothing to do. A missing handler means a contract row this build cannot interpret, typically a vendoring or version mismatch, and is worth attention. Reading that line, they are indistinguishable.

That is not hypothetical. Someone debugging a stuck `vhtlc-v2` lockup read this exact line and concluded the wallet build was missing its handler. The handler was present and deliberately declining; the wrong conclusion was acted on before it was caught.

## Change

The handler-absent case now says so:

```
at <script> (contract type 'X') has no handler registered in this build
```

The ordinary decline keeps its existing wording.

`contractHandlers` is already imported in this file, so the distinction costs a `has()` lookup at the message site. `has` and `get` both delegate to the registry's single map, so `has(type) === false` implies `get(type) === undefined` — the equivalence the branch rests on.

## Scope

**Log text only.** `isContractGenericallySpendable`, `gatedContracts`, and which VTXOs generic spending excludes are untouched — `gateExclusion` still returns `undefined` for exactly the inputs it did before.

A handler that exists but declares no `isGenericallySpendable` predicate is folded in with the decline, with the reasoning in an inline comment: both are this build recognising the type and landing on "closed", rather than failing to interpret the row. Splitting it out would flag a plugin-authoring gap, which is not something an operator reading this log can act on. Every shipped handler declares the predicate explicitly today, as `isContractGenericallySpendable`'s own doc notes, so the sub-case is unreachable through any handler in this repo.

## Tests

Three cases in `packages/ts-sdk/test/spendability-gate.test.ts`. Stated plainly: **one is a genuine regression guard** — the unregistered-type case, which fails against the previous unconditional message. The other two pin behaviour this change does not alter (the ordinary decline, and returning `undefined` for a non-gated or script-less VTXO) and would pass either way.

Full suite: ts-sdk 162 files / 2620 passed / 1 skipped, swap 24 / 391, boltz-swap 23 / 614, no type errors — baseline plus exactly the added tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spendability diagnostics by distinguishing contracts without registered handlers from contracts rejected by recognized handlers.
  * Added clearer messages identifying the affected script and contract type when a handler is missing.
  * Preserved existing exclusion messages for recognized but non-spendable contracts.
  * Confirmed that non-gated VTXOs continue to return no exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->