### PR TITLE
Update RFQ documentation references to public schema docs

### DIFF
--- a/packages/swap/src/nostr.ts
+++ b/packages/swap/src/nostr.ts
@@ -1,6 +1,7 @@
 /**
- * The Nostr RFQ transport — the PRODUCTION one (docs/rfq-protocol.md § 3.1 in
- * arkade-os/lightning-swap-service).
+ * The Nostr RFQ transport — the PRODUCTION one (the kind, the NIP-44 framing
+ * and the payloads it carries are public at
+ * https://docs.arkadeos.com/intents/reference/rfq).
  *
  * `rfq.ts` ships two other transports: `httpTransport`, and `relayTransport`
  * which speaks the dev broker's `{op:"sub"|"event"}` framing. Neither is what a

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -200,9 +200,10 @@ export interface RfqStatus {
  * `senderPubkey` is the trader's own key for the VHTLC's sender-side leaves
  * (see {@link lightningSendVtxoScript}) — required, never sent anywhere else,
  * never trusted by the solver as anything but a pubkey to bind into the
- * script. On the wire it's `client_refund_pubkey` (docs/rfq-protocol.md —
- * the solver's schema is `.strict()`, so both the wrong name AND the missing
- * required field would refuse every request). */
+ * script. On the wire it's `client_refund_pubkey` (the payload schemas are
+ * public at https://docs.arkadeos.com/intents/reference/rfq — the solver's schema
+ * is `.strict()`, so both the wrong name AND the missing required field would
+ * refuse every request). */
 export const lightningSendRequest = (input: {
     rfqId: string;
     invoice: string;


### PR DESCRIPTION
## Summary
Updated internal documentation comments to reference the public RFQ schema documentation instead of internal repository paths.

## Changes
- **packages/swap/src/rfq.ts**: Updated the `lightningSendRequest` comment to reference the public schema documentation at https://docs.arkadeos.com/intents/reference/rfq instead of the internal `docs/rfq-protocol.md` file
- **packages/swap/src/nostr.ts**: Updated the Nostr RFQ transport module comment to reference the public documentation URL for the transport specification, NIP-44 framing, and payload schemas

## Details
These changes improve developer experience by directing users to the authoritative public documentation for RFQ protocol details rather than internal repository files. The comments maintain their technical accuracy while providing more accessible reference points for understanding the wire format (`client_refund_pubkey`), schema validation behavior, and transport specifications.

https://claude.ai/code/session_01FTWxNaCx8rQ9vcAbvjSZXK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RFQ transport and lightning-send request documentation to link to the public RFQ protocol documentation.
  * Replaced outdated local specification references with the current online schema and protocol URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->