### PR TITLE
docs(balance): show the new buckets and warn against netting them out of total

### DIFF
--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -341,7 +341,25 @@ console.log('Boarding Total:', balance.boarding.total)
 console.log('Offchain Available:', balance.available)
 console.log('Offchain Settled:', balance.settled)
 console.log('Offchain Preconfirmed:', balance.preconfirmed)
+console.log('Gated by a contract:', balance.gated) // swap escrow, chiefly
+console.log('Locked by an in-flight intent:', balance.intentLocked)
 console.log('Recoverable:', balance.recoverable)
+console.log('Awaiting recovery:', balance.pendingRecovery)
+```
+
+`settled` and `preconfirmed` are what the wallet OWNS; `available` is what generic
+spending will actually pick. The difference is accounted for exactly:
+
+```
+settled + preconfirmed === available + gated + intentLocked
+```
+
+To show "your money, minus what is tied up", subtract from `settled + preconfirmed`
+— **not from `total`**, which also contains `boarding.total`, `recoverable` and
+`pendingRecovery`. Those are still your funds, so subtracting a bucket from `total`
+silently drops them from the figure.
+
+```typescript
 
 // Get virtual outputs (available for offchain spending)
 const vtxos = await wallet.getVtxos()

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -347,10 +347,12 @@ console.log('Recoverable:', balance.recoverable)
 console.log('Awaiting recovery:', balance.pendingRecovery)
 ```
 
-`settled` and `preconfirmed` are what the wallet OWNS; `available` is what generic
-spending will actually pick. The difference is accounted for exactly:
+`settled` and `preconfirmed` are the owned offchain buckets this relationship is
+about — `recoverable` and `pendingRecovery` are the wallet's funds too, just held
+under a different predicate. `available` is what generic spending will actually
+pick, and the difference between the two is accounted for exactly:
 
-```
+```text
 settled + preconfirmed === available + gated + intentLocked
 ```
 

--- a/packages/ts-sdk/src/wallet/balance.ts
+++ b/packages/ts-sdk/src/wallet/balance.ts
@@ -31,7 +31,7 @@ export interface OffchainBalance {
      * Reported as zero where the caller cannot answer the question — a wallet
      * with no intent repository, or a repository read that fails — so this
      * under-reports into `available` rather than misattributing. The two callers
-     * answer from deliberately different reads (@see {@link BalanceCapabilities}),
+     * answer from deliberately different reads (see {@link BalanceCapabilities}),
      * so a worker figure and a main-thread figure need not agree unless taken
      * over the same state.
      */

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -351,8 +351,12 @@ export interface WalletBalance {
      * reported here — it does not become available when the batch settles.
      *
      * Covers this bucket only: {@link recoverable} has the same owned-versus-
-     * obtainable split under a different predicate and is not counted here, so
-     * `total - gated` still carries a recoverable component.
+     * obtainable split under a different predicate and is not counted here.
+     *
+     * Subtract this from `settled + preconfirmed`, never from `total`. `total`
+     * also carries {@link boarding}, {@link recoverable} and
+     * {@link pendingRecovery}, which are still the user's funds — netting a
+     * bucket out of it drops them from the figure with no signal.
      */
     gated: number;
     /**


### PR DESCRIPTION
Follow-up to #751, which split the unavailable remainder into `gated` and `intentLocked`. Documentation only — no behaviour, no API.

#751's motivation was a consumer who subtracted the wrong figure, and its second commit exists to fix "the docs that led the consumer astray". Three places were left saying the old thing, or inviting the same mistake.

## The README example was not updated

`packages/ts-sdk/README.md`'s "Checking Balance" still listed only the pre-#751 fields. That is the doc a consumer actually opens; the type's JSDoc is where they end up only if they go looking.

It now shows every bucket and states the identity that makes the arithmetic safe:

```
settled + preconfirmed === available + gated + intentLocked
```

with the point spelled out: subtract from `settled + preconfirmed`, **not** from `total`, which also carries `boarding.total`, `recoverable` and `pendingRecovery`. Those are still the user's funds, so netting a bucket out of `total` drops them from the figure with no signal.

## `gated`'s JSDoc invited the mistake it exists to prevent

It closed by describing what `total - gated` still carries — arithmetic against `total`, which is the operation that goes wrong. Reworded to point at `settled + preconfirmed` and to name what `total` additionally holds.

This is not hypothetical. Someone implementing the same feature independently documented the `total - available` gap and omitted `boarding.total`, for exactly this reason: the public `total` includes boarding while `available` does not.

## An `@see` block tag mid-sentence

`intentLocked`'s JSDoc had `(@see {@link BalanceCapabilities})` inside a sentence. TypeDoc hoists block tags out of the description, which would have detached the rest of the paragraph. Now a plain inline `{@link}`.

## Verification

`pnpm typecheck` and `pnpm lint` clean; full unit suite green through the pre-commit hook. No source behaviour is touched — the two `src` changes are both inside comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded balance documentation to explain gated, intent-locked, and pending-recovery funds.
  * Clarified how settled and preconfirmed balances relate to spendable funds.
  * Added guidance for calculating funds not committed to contracts or intents.
  * Improved wallet balance descriptions, including how gated and recoverable funds contribute to totals.
  * Corrected a balance documentation reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->