### PR TITLE
Add deterministic order-book sweep planning

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -126,6 +126,25 @@ await wallet.send({
 });
 ```
 
+### Aggregating offers as an order book
+
+`planBookSweep` turns a relay or indexer snapshot into an integer-exact, deterministic fill plan.
+It filters one market direction, sorts by price without floating point, and selects whole funded
+offer UTXOs until the requested depth is reached. Equal prices are ordered by outpoint, so two
+clients given the same snapshot select the same inputs regardless of message arrival order.
+
+```ts
+const sweep = planBookSweep(book, assetId, "BTC", 10_000n);
+// Build one transaction which spends every sweep.fills input and includes the
+// covenant-required maker output for each. Never treat this quote as a partial fill.
+```
+
+The planner intentionally does not build or sign the transaction. The existing offer covenant is
+full-fill: each selected UTXO must be consumed in full and its committed `payAmount` delivered.
+That makes a multi-offer take atomic while keeping signing keys in the wallet and covenant
+validation in the transaction layer. A UI may render the result as continuous depth, but must show
+the possible whole-offer overfill reported by `takeAmount`.
+
 The covenant co-signer ("emulator") key defaults to the SDK's per-network pin, resolved from the
 network the Ark server reports — never fetched from the emulator itself. Pass
 `params.emulatorPubkey` (33-byte compressed hex, the same contract as `Arkade.connect`'s option)

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -9,6 +9,13 @@ export {
     type Offer,
 } from "./offer";
 export {
+    compareBookOffers,
+    planBookSweep,
+    type BookFill,
+    type BookOffer,
+    type BookSweep,
+} from "./orderbook";
+export {
     discoverMarkets,
     findMarket,
     validatePlan,

--- a/packages/swap/src/orderbook.ts
+++ b/packages/swap/src/orderbook.ts
@@ -1,0 +1,121 @@
+/**
+ * Deterministic, integer-only planning for a book of full-fill Arkade offers.
+ *
+ * This module deliberately stops at transaction construction. A book may be
+ * untrusted input; the covenant remains the authority for whether every input
+ * can be spent and which output it requires. The planner only chooses offers
+ * and totals their already-committed amounts.
+ */
+
+/** A funded offer visible to an order-book indexer. Amounts are base units. */
+export interface BookOffer {
+    /** Funding transaction id (and therefore the stable identity of a deposit). */
+    fundingTxid: string;
+    /** Asset deposited by the user. Use `BTC` for sats. */
+    offerAsset: string;
+    offerAmount: bigint;
+    /** Asset the user must receive when this input is filled. */
+    wantAsset: string;
+    wantAmount: bigint;
+    /** Optional output index; Arkade offer deposits conventionally use zero. */
+    vout?: number;
+}
+
+/** One atomic input selected from the book. */
+export interface BookFill {
+    fundingTxid: string;
+    vout: number;
+    takeAmount: bigint;
+    payAmount: bigint;
+}
+
+export interface BookSweep {
+    fills: BookFill[];
+    /** Sum delivered to the taker. */
+    takeAmount: bigint;
+    /** Sum of the deterministic covenant outputs owed to makers. */
+    payAmount: bigint;
+}
+
+const positive = (value: bigint, name: string): void => {
+    if (value <= 0n) throw new Error(`${name} must be positive`);
+};
+
+const assertOffer = (offer: BookOffer): void => {
+    if (!offer.fundingTxid) throw new Error("fundingTxid is required");
+    if (!offer.offerAsset || !offer.wantAsset || offer.offerAsset === offer.wantAsset) {
+        throw new Error("an offer must exchange two different assets");
+    }
+    positive(offer.offerAmount, "offerAmount");
+    positive(offer.wantAmount, "wantAmount");
+    if (offer.vout !== undefined && (!Number.isSafeInteger(offer.vout) || offer.vout < 0)) {
+        throw new Error("vout must be a non-negative safe integer");
+    }
+};
+
+/**
+ * Compare prices without floating point. Lower `wantAmount / offerAmount` is
+ * better for the taker. The txid and vout tie-break make every client produce
+ * the same sweep from the same snapshot, regardless of relay arrival order.
+ */
+export function compareBookOffers(a: BookOffer, b: BookOffer): number {
+    assertOffer(a);
+    assertOffer(b);
+    const left = a.wantAmount * b.offerAmount;
+    const right = b.wantAmount * a.offerAmount;
+    if (left !== right) return left < right ? -1 : 1;
+    const txid = a.fundingTxid < b.fundingTxid ? -1 : a.fundingTxid > b.fundingTxid ? 1 : 0;
+    return txid || (a.vout ?? 0) - (b.vout ?? 0);
+}
+
+/**
+ * Select whole covenant UTXOs at the best available price.
+ *
+ * Offers are indivisible: the final offer may take the result above `minimumTake`.
+ * This is intentional. Inventing a partial output would no longer satisfy the
+ * full-fill covenant. All returned inputs can instead be spent atomically in a
+ * single transaction with one deterministic maker output per input.
+ */
+export function planBookSweep(
+    offers: readonly BookOffer[],
+    offerAsset: string,
+    wantAsset: string,
+    minimumTake: bigint,
+): BookSweep {
+    positive(minimumTake, "minimumTake");
+    if (!offerAsset || !wantAsset || offerAsset === wantAsset) {
+        throw new Error("a market must contain two different assets");
+    }
+
+    const candidates = offers.filter(
+        (offer) => offer.offerAsset === offerAsset && offer.wantAsset === wantAsset,
+    );
+    for (const offer of candidates) assertOffer(offer);
+    candidates.sort(compareBookOffers);
+
+    const fills: BookFill[] = [];
+    const selected = new Set<string>();
+    let takeAmount = 0n;
+    let payAmount = 0n;
+    for (const offer of candidates) {
+        const outpoint = `${offer.fundingTxid}:${offer.vout ?? 0}`;
+        if (selected.has(outpoint)) throw new Error(`duplicate book outpoint: ${outpoint}`);
+        selected.add(outpoint);
+        fills.push({
+            fundingTxid: offer.fundingTxid,
+            vout: offer.vout ?? 0,
+            takeAmount: offer.offerAmount,
+            payAmount: offer.wantAmount,
+        });
+        takeAmount += offer.offerAmount;
+        payAmount += offer.wantAmount;
+        if (takeAmount >= minimumTake) break;
+    }
+
+    if (takeAmount < minimumTake) {
+        throw new Error(
+            `insufficient book depth: ${takeAmount} available, ${minimumTake} required`,
+        );
+    }
+    return { fills, takeAmount, payAmount };
+}

--- a/packages/swap/test/orderbook.test.ts
+++ b/packages/swap/test/orderbook.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { compareBookOffers, planBookSweep, type BookOffer } from "../src/orderbook";
+
+const offer = (fundingTxid: string, offerAmount: bigint, wantAmount: bigint): BookOffer => ({
+    fundingTxid,
+    offerAsset: "RUNE",
+    offerAmount,
+    wantAsset: "BTC",
+    wantAmount,
+});
+
+describe("order-book sweep planning", () => {
+    it("sorts with exact integer prices and a deterministic txid tie-break", () => {
+        const expensive = offer("c", 3n, 2n);
+        const cheapB = offer("b", 6n, 3n);
+        const cheapA = offer("a", 2n, 1n);
+
+        expect([expensive, cheapB, cheapA].sort(compareBookOffers)).toEqual([
+            cheapA,
+            cheapB,
+            expensive,
+        ]);
+    });
+
+    it("sweeps whole best-price UTXOs and totals their committed outputs", () => {
+        const sweep = planBookSweep(
+            [offer("worst", 10n, 20n), offer("best", 4n, 4n), offer("next", 3n, 4n)],
+            "RUNE",
+            "BTC",
+            6n,
+        );
+
+        expect(sweep).toEqual({
+            fills: [
+                { fundingTxid: "best", vout: 0, takeAmount: 4n, payAmount: 4n },
+                { fundingTxid: "next", vout: 0, takeAmount: 3n, payAmount: 4n },
+            ],
+            takeAmount: 7n,
+            payAmount: 8n,
+        });
+    });
+
+    it("filters the requested direction and rejects shallow books", () => {
+        const reverse: BookOffer = {
+            fundingTxid: "reverse",
+            offerAsset: "BTC",
+            offerAmount: 100n,
+            wantAsset: "RUNE",
+            wantAmount: 100n,
+        };
+
+        expect(() => planBookSweep([offer("only", 2n, 1n), reverse], "RUNE", "BTC", 3n)).toThrow(
+            "insufficient book depth: 2 available, 3 required",
+        );
+    });
+
+    it("rejects zero amounts before producing a plan", () => {
+        expect(() => planBookSweep([offer("bad", 0n, 1n)], "RUNE", "BTC", 1n)).toThrow(
+            "offerAmount must be positive",
+        );
+    });
+
+    it("refuses to plan the same input twice", () => {
+        expect(() =>
+            planBookSweep([offer("same", 1n, 1n), offer("same", 1n, 1n)], "RUNE", "BTC", 2n),
+        ).toThrow("duplicate book outpoint: same:0");
+    });
+});


### PR DESCRIPTION
### Motivation

- Provide a deterministic, integer-only planner for aggregating funded Arkade offer UTXOs into atomic fills so solver/trader flows can derive identical input selections from the same snapshot. 
- Avoid floating-point price comparisons and nondeterministic tie-breaks so multi-UTXO sweeps remain exact and reproducible across clients.

### Description

- Add `packages/swap/src/orderbook.ts` introducing `BookOffer`, `BookFill`, `BookSweep`, `compareBookOffers`, and `planBookSweep` which compare prices as exact rationals and select whole funded covenant UTXOs. 
- Implement deterministic tie-breaking by `fundingTxid` and `vout`, detect duplicate outpoints, and reject malformed or insufficient-depth book snapshots instead of producing partial fills. 
- Export the new APIs from the package entry point via `packages/swap/src/index.ts` and document usage and transaction-construction boundaries in `packages/swap/README.md`. 
- Add focused unit tests in `packages/swap/test/orderbook.test.ts` covering ordering, aggregation totals, direction filtering, insufficient depth, zero-amount rejection, and duplicate-outpoint detection.

### Testing

- `pnpm --dir packages/swap exec vitest run test/orderbook.test.ts` — ran the new `orderbook` tests and all 5 tests passed. 
- `pnpm --dir packages/swap run typecheck` and `pnpm --dir packages/swap run lint` — both succeeded for the package. 
- Ran repository unit checks with `pnpm run test:unit`; the workspace ran many SDK suites successfully but three SQLite-related suites failed to run on the container due to missing `node:sqlite` support on the available Node (Node 20 vs repo's Node >=24), which is an environment limitation rather than a defect in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7e519634b8832c8f677c8ab91d9927)