### PR TITLE
feat(swap): carry rfq records on the sqlite and realm backends

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -116,13 +116,22 @@ uncached discovery.
 Neither subpath adds a dependency: they take the SDK's structural `SQLExecutor` / `RealmLike`
 handles, so you pass the database you already opened.
 
+All four carry both record types: asset swaps and the monitored RFQ swaps
+(`saveRfqSwap` / `getAllRfqSwaps` / `removeRfqSwap`). Each keeps them in a store of their own — a
+second object store on IndexedDB, an `…rfq_swaps` table on SQLite, the `ArkadeRfqSwap` class on
+Realm — since the two record types have different keys and no consumer wants them interleaved.
+
 **Records are stored whole.** The SQLite and Realm backends serialize each record to **JSON** in a
-`data` column, with only `status` / `createdAt` mapped out for querying — so a field they do not
-know about survives, which is what the `quote`-shaped extension in `MIGRATION.md` relies on. JSON is
+`data` column, with only `status` / `createdAt` (and an RFQ record's `state` / `updatedAt`) mapped
+out for querying — so a field they do not know about survives, which is what the `quote`-shaped
+extension in `MIGRATION.md` relies on. It is also what keeps an RFQ record's corridor `profile`
+intact: `profile.hashlock` is a nested object holding the payment hash and any preimage material, and
+a field-mapped backend is exactly what would lose it. JSON is
 the boundary, though, and it is narrower than IndexedDB's structured clone: a `Date` in a
 consumer-added field comes back an ISO **string**, a `Set` or `Map` comes back empty, and a `bigint`
-makes `saveSwap` **throw**. `AssetSwap` itself is JSON-safe by design (amounts are strings); keep
-your own added fields that way too.
+makes `saveSwap` **throw**. `AssetSwap` and `RfqSwapRecord` are both JSON-safe by design (amounts are
+strings, binary is hex), and a corridor `profile` is plain JSON by the handler contract; keep your own
+added fields — and any corridor profile you write — that way too.
 
 ### SQLite
 
@@ -169,9 +178,15 @@ const realm = await Realm.open({
 const swaps = new RealmAssetSwapRepository(realm);
 ```
 
-Three classes land in your Realm namespace: `ArkadeAssetSwap`, `ArkadeAssetSwapScannedTxid`,
-`ArkadeAssetSwapMarketsCache`. Unlike SQLite there is no prefix option — a Realm schema name is
-baked into the schema objects you register — so reconcile against your own models by name.
+Four classes land in your Realm namespace: `ArkadeAssetSwap`, `ArkadeRfqSwap`,
+`ArkadeAssetSwapScannedTxid`, `ArkadeAssetSwapMarketsCache`. Unlike SQLite there is no prefix option
+— a Realm schema name is baked into the schema objects you register — so reconcile against your own
+models by name.
+
+`ArkadeRfqSwap` arrived after the other three. **If you already shipped them, add it and bump
+`schemaVersion` again**: Realm creates schemas at open, so a config still listing three fails on the
+first RFQ read rather than at open. SQLite needs nothing — its DDL runs `CREATE TABLE IF NOT EXISTS`
+on every init, so the table appears on the next operation.
 
 ## Creating an offer
 

--- a/packages/swap/scripts/smoke-dist.mjs
+++ b/packages/swap/scripts/smoke-dist.mjs
@@ -70,8 +70,8 @@ for (const specifier of specifiers) {
 const stubExecutor = { run: async () => {}, get: async () => undefined, all: async () => [] };
 new SQLiteAssetSwapRepository(stubExecutor);
 new RealmAssetSwapRepository({});
-if (AssetSwapRealmSchemas.length !== 3) {
-    throw new Error(`expected 3 Realm schemas, got ${AssetSwapRealmSchemas.length}`);
+if (AssetSwapRealmSchemas.length !== 4) {
+    throw new Error(`expected 4 Realm schemas, got ${AssetSwapRealmSchemas.length}`);
 }
 
 const server = hex.decode("4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa");

--- a/packages/swap/src/repositories/realm/repository.ts
+++ b/packages/swap/src/repositories/realm/repository.ts
@@ -5,8 +5,10 @@ import {
     type MarketsCacheEntry,
 } from "../../repository";
 import type { AssetSwap } from "../../store";
+import type { RfqSwapRecord } from "../../rfqRecord";
 
 const SWAPS = "ArkadeAssetSwap";
+const RFQ_SWAPS = "ArkadeRfqSwap";
 const SCANNED = "ArkadeAssetSwapScannedTxid";
 const MARKETS = "ArkadeAssetSwapMarketsCache";
 
@@ -22,13 +24,16 @@ const MARKETS = "ArkadeAssetSwapMarketsCache";
  * record can be dropped. That holds for JSON-safe values: a consumer-added
  * `Date` comes back a string and a `bigint` throws on save, unlike the
  * IndexedDB backend's structured clone. `AssetSwap` itself is JSON-safe by
- * design.
+ * design, and so is `RfqSwapRecord` — including its corridor `profile`, which is
+ * plain JSON by the handler contract (see `rfqCorridor.ts`). Whole-record
+ * storage is what keeps a nested `profile.hashlock` from being lost the way a
+ * field-mapped backend could lose it.
  *
  * Realm creates the schemas on open, so there is nothing to initialise. The
  * consumer owns the Realm lifecycle — `[Symbol.asyncDispose]` is a no-op.
  */
 export class RealmAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 2 as const;
+    readonly version = 3 as const;
 
     constructor(private readonly realm: RealmLike) {}
 
@@ -51,6 +56,35 @@ export class RealmAssetSwapRepository implements AssetSwapRepository {
         return [...this.realm.objects<{ data: string }>(SWAPS)].map(
             (o) => JSON.parse(o.data) as AssetSwap,
         );
+    }
+
+    async saveRfqSwap(record: RfqSwapRecord): Promise<void> {
+        this.realm.write(() => {
+            this.realm.create(
+                RFQ_SWAPS,
+                {
+                    rfqId: record.rfqId,
+                    state: record.state,
+                    updatedAt: record.updatedAt,
+                    data: JSON.stringify(record),
+                },
+                "modified",
+            );
+        });
+    }
+
+    async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {
+        return [...this.realm.objects<{ data: string }>(RFQ_SWAPS)].map(
+            (o) => JSON.parse(o.data) as RfqSwapRecord,
+        );
+    }
+
+    async removeRfqSwap(rfqId: string): Promise<void> {
+        this.realm.write(() => {
+            this.realm.delete(
+                this.realm.objects<{ rfqId: string }>(RFQ_SWAPS).filtered("rfqId == $0", rfqId),
+            );
+        });
     }
 
     async getScannedTxids(): Promise<Set<string>> {
@@ -89,12 +123,12 @@ export class RealmAssetSwapRepository implements AssetSwapRepository {
         });
     }
 
-    /** All three schemas in one write: clearing swaps but keeping scanned txids
-     * would leave the restore scan permanently skipping those funding txs, so
-     * a partial clear must not be observable. */
+    /** Every schema in one write: clearing swaps but keeping scanned txids would
+     * leave the restore scan permanently skipping those funding txs, so a
+     * partial clear must not be observable. */
     async clear(): Promise<void> {
         this.realm.write(() => {
-            for (const name of [SWAPS, SCANNED, MARKETS]) {
+            for (const name of [SWAPS, RFQ_SWAPS, SCANNED, MARKETS]) {
                 this.realm.delete(this.realm.objects(name));
             }
         });

--- a/packages/swap/src/repositories/realm/schemas.ts
+++ b/packages/swap/src/repositories/realm/schemas.ts
@@ -11,6 +11,11 @@
  * objects conforming to Realm's ObjectSchema shape. They are new, so a consumer
  * adds them to its Realm config and bumps its own `schemaVersion`; no migration
  * helper ships here.
+ *
+ * `ArkadeRfqSwap` arrived after the first three. A consumer already shipping
+ * those has to add it and bump `schemaVersion` again — Realm creates schemas on
+ * open, so a config that lists three while the code reads four fails on the
+ * fourth `realm.objects(…)` rather than at open.
  */
 
 export const ArkadeAssetSwapSchema = {
@@ -41,7 +46,22 @@ export const ArkadeAssetSwapMarketsCacheSchema = {
     },
 };
 
+/** Monitored RFQ swaps, keyed by `rfqId`. `state` and `updatedAt` are mapped out
+ * for querying and for the retention sweep (`shouldRetainRfqSwap`); the record
+ * itself goes in whole, `profile` included. */
+export const ArkadeRfqSwapSchema = {
+    name: "ArkadeRfqSwap",
+    primaryKey: "rfqId",
+    properties: {
+        rfqId: "string",
+        state: "string",
+        updatedAt: "int",
+        data: "string",
+    },
+};
+
 export const AssetSwapRealmSchemas = [
+    ArkadeRfqSwapSchema,
     ArkadeAssetSwapSchema,
     ArkadeAssetSwapScannedTxidSchema,
     ArkadeAssetSwapMarketsCacheSchema,

--- a/packages/swap/src/repositories/sqlite/repository.ts
+++ b/packages/swap/src/repositories/sqlite/repository.ts
@@ -9,6 +9,7 @@ import {
     type MarketsCacheEntry,
 } from "../../repository";
 import type { AssetSwap } from "../../store";
+import type { RfqSwapRecord } from "../../rfqRecord";
 
 const DEFAULT_PREFIX = "arkade_";
 // SQLite's default parameter ceiling is 999; stay well under it per statement.
@@ -22,18 +23,26 @@ const INSERT_CHUNK = 500;
  * and `created_at` are mapped out for querying only, so no field of a record
  * can be dropped. That holds for JSON-safe values: a consumer-added `Date`
  * comes back a string and a `bigint` throws on save, unlike the IndexedDB
- * backend's structured clone. `AssetSwap` itself is JSON-safe by design.
+ * backend's structured clone. `AssetSwap` itself is JSON-safe by design, and so
+ * is `RfqSwapRecord` — including its corridor `profile`, which is plain JSON by
+ * the handler contract (see `rfqCorridor.ts`). Whole-record storage is what
+ * keeps a nested `profile.hashlock` from being lost the way a field-mapped
+ * backend could lose it.
  *
- * Tables are created lazily on first operation. The consumer owns the
+ * Tables are created lazily on first operation, and `CREATE TABLE IF NOT
+ * EXISTS` runs on every init — so the `rfq_swaps` table appears for an existing
+ * database on its next operation, with no migration and no version to bump.
+ * The consumer owns the
  * `SQLExecutor` lifecycle — `[Symbol.asyncDispose]` is a no-op — and must pass
  * the **same executor instance** to every repository on the database: the
  * write chain is keyed by that object, and a per-repository literal splits it.
  */
 export class SQLiteAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 2 as const;
+    readonly version = 3 as const;
     private initPromise: Promise<void> | null = null;
     private readonly prefix: string;
     private readonly swaps: string;
+    private readonly rfqSwaps: string;
     private readonly scanned: string;
     private readonly markets: string;
 
@@ -43,6 +52,7 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
     ) {
         this.prefix = sanitizeTablePrefix(options?.prefix ?? DEFAULT_PREFIX);
         this.swaps = `${this.prefix}asset_swaps`;
+        this.rfqSwaps = `${this.prefix}rfq_swaps`;
         this.scanned = `${this.prefix}asset_swap_scanned_txids`;
         this.markets = `${this.prefix}asset_swap_markets`;
     }
@@ -77,6 +87,19 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
             await this.db.run(
                 `CREATE INDEX IF NOT EXISTS idx_${this.prefix}asset_swaps_created_at ON ${this.swaps} (created_at)`,
             );
+            // A separate table rather than a `kind` column on the one above: the
+            // two record types have different keys and no consumer wants them
+            // interleaved. `state` and `updated_at` are mapped out for querying
+            // and for the retention sweep; the record itself still goes in whole.
+            await this.db.run(`CREATE TABLE IF NOT EXISTS ${this.rfqSwaps} (
+                rfq_id TEXT PRIMARY KEY,
+                state TEXT NOT NULL,
+                updated_at INTEGER NOT NULL,
+                data TEXT NOT NULL
+            )`);
+            await this.db.run(
+                `CREATE INDEX IF NOT EXISTS idx_${this.prefix}rfq_swaps_state ON ${this.rfqSwaps} (state)`,
+            );
             await this.db.run(`CREATE TABLE IF NOT EXISTS ${this.scanned} (txid TEXT PRIMARY KEY)`);
             await this.db.run(
                 `CREATE TABLE IF NOT EXISTS ${this.markets} (cache_key TEXT PRIMARY KEY, data TEXT NOT NULL)`,
@@ -109,6 +132,30 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
         await this.ensureInit();
         const rows = await this.db.all<{ data: string }>(`SELECT data FROM ${this.swaps}`);
         return rows.map((r) => JSON.parse(r.data) as AssetSwap);
+    }
+
+    async saveRfqSwap(record: RfqSwapRecord): Promise<void> {
+        await this.ensureInit();
+        await this.withTx(async () => {
+            await this.db.run(
+                `INSERT OR REPLACE INTO ${this.rfqSwaps} (rfq_id, state, updated_at, data)
+                 VALUES (?, ?, ?, ?)`,
+                [record.rfqId, record.state, record.updatedAt, JSON.stringify(record)],
+            );
+        });
+    }
+
+    async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {
+        await this.ensureInit();
+        const rows = await this.db.all<{ data: string }>(`SELECT data FROM ${this.rfqSwaps}`);
+        return rows.map((r) => JSON.parse(r.data) as RfqSwapRecord);
+    }
+
+    async removeRfqSwap(rfqId: string): Promise<void> {
+        await this.ensureInit();
+        await this.withTx(async () => {
+            await this.db.run(`DELETE FROM ${this.rfqSwaps} WHERE rfq_id = ?`, [rfqId]);
+        });
     }
 
     async getScannedTxids(): Promise<Set<string>> {
@@ -160,13 +207,14 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
         });
     }
 
-    /** All three tables in one transaction: clearing swaps but keeping scanned
-     * txids would leave the restore scan permanently skipping those funding
-     * txs, so a partial clear must not be observable. */
+    /** Every table in one transaction: clearing swaps but keeping scanned txids
+     * would leave the restore scan permanently skipping those funding txs, so a
+     * partial clear must not be observable. */
     async clear(): Promise<void> {
         await this.ensureInit();
         await this.withTx(async () => {
             await this.db.run(`DELETE FROM ${this.swaps}`);
+            await this.db.run(`DELETE FROM ${this.rfqSwaps}`);
             await this.db.run(`DELETE FROM ${this.scanned}`);
             await this.db.run(`DELETE FROM ${this.markets}`);
         });

--- a/packages/swap/test/repository.test.ts
+++ b/packages/swap/test/repository.test.ts
@@ -54,6 +54,7 @@ const backends: [string, () => AssetSwapRepository][] = [
             new RealmAssetSwapRepository(
                 createMockRealm({
                     ArkadeAssetSwap: "id",
+                    ArkadeRfqSwap: "rfqId",
                     ArkadeAssetSwapScannedTxid: "txid",
                     ArkadeAssetSwapMarketsCache: "key",
                 }),
@@ -222,8 +223,39 @@ describe("SQLiteAssetSwapRepository", () => {
         await using app = new SQLiteAssetSwapRepository(db, { prefix: "app2_" });
         await using dflt = new SQLiteAssetSwapRepository(db);
         await app.saveSwap(swap("a"));
+        await app.saveRfqSwap(rfqRecord("r1"));
         expect((await app.getAllSwaps()).map((s) => s.id)).toEqual(["a"]);
         expect(await dflt.getAllSwaps()).toEqual([]);
+        // the rfq table is prefixed too — a hardcoded name would leak records
+        // between two apps sharing one connection
+        expect((await app.getAllRfqSwaps()).map((r) => r.rfqId)).toEqual(["r1"]);
+        expect(await dflt.getAllRfqSwaps()).toEqual([]);
+    });
+
+    // The counterpart of the IndexedDB migration test below, and the same
+    // riskiest-claim shape: the rfq table has to appear for a database that
+    // predates it. Nothing here bumps a version, so `CREATE TABLE IF NOT EXISTS`
+    // on every init is the entire mechanism — and this is what says so.
+    it("adds the rfq table to a database that only has the original three", async () => {
+        const db = createNodeSQLExecutor();
+        // A pre-RFQ database, created the way the old init created it.
+        await db.run(`CREATE TABLE arkade_asset_swaps (
+            id TEXT PRIMARY KEY, status TEXT NOT NULL, created_at INTEGER NOT NULL, data TEXT NOT NULL
+        )`);
+        await db.run(`CREATE TABLE arkade_asset_swap_scanned_txids (txid TEXT PRIMARY KEY)`);
+        await db.run(
+            `CREATE TABLE arkade_asset_swap_markets (cache_key TEXT PRIMARY KEY, data TEXT NOT NULL)`,
+        );
+        await db.run(
+            `INSERT INTO arkade_asset_swaps (id, status, created_at, data) VALUES (?, ?, ?, ?)`,
+            ["legacy", "pending", 1, JSON.stringify(swap("legacy"))],
+        );
+
+        await using repository = new SQLiteAssetSwapRepository(db);
+        await repository.saveRfqSwap(rfqRecord("r1"));
+        expect((await repository.getAllRfqSwaps()).map((r) => r.rfqId)).toEqual(["r1"]);
+        // and the rows that were already there are untouched
+        expect((await repository.getAllSwaps()).map((s) => s.id)).toEqual(["legacy"]);
     });
 
     it("rejects a prefix that is not a SQL identifier", () => {
@@ -237,21 +269,10 @@ describe("SQLiteAssetSwapRepository", () => {
     });
 });
 
-/**
- * The RFQ half, over the backends that implement it.
- *
- * Its own matrix rather than the one above, because the SQLite and Realm
- * backends do not carry `saveRfqSwap` / `getAllRfqSwaps` / `removeRfqSwap` yet —
- * the interface bump makes that a compile error, and the parity work is a
- * separate change. When it lands, these move into the matrix above and this
- * list goes away.
- */
-const rfqBackends: [string, () => AssetSwapRepository][] = [
-    ["inMemory", () => new InMemoryAssetSwapRepository()],
-    ["indexedDb", () => new IndexedDbAssetSwapRepository(`test-rfq-${Math.random()}`)],
-];
-
-describe.each(rfqBackends)("RFQ swap records (%s)", (_, create) => {
+/** The RFQ half, over EVERY backend — which is the point of this matrix: all
+ * four implement the same three methods, and a backend that stores a record
+ * short a field fails here rather than at a claim. */
+describe.each(backends)("RFQ swap records (%s)", (_, create) => {
     it("upserts rfq swaps by rfqId and returns them all", async () => {
         await using repository = create();
         await repository.saveRfqSwap(rfqRecord("r1"));


### PR DESCRIPTION
Stacked on #746 — **base is `feat/rfq-persistence-only`, not `master`.** Merge this into that branch
before merging #746: #746's typecheck is red by construction until it does, and this is what makes it
green.

## Why this exists

#746 adds `saveRfqSwap` / `getAllRfqSwaps` / `removeRfqSwap` to `AssetSwapRepository` and moves the
interface to `version: 3`. #758 landed the SQLite and Realm backends while those methods were in
flight, so on the merged tree both are `implements AssetSwapRepository` with `version = 2` and no RFQ
methods — two `TS2416`s, and a `TS2420` for the missing methods once the version matches. Neither
branch conflicts textually with the other; the incompatibility only exists in the merge, which is why
it needs its own change rather than a rebase.

## What it does

Each backend gets a store of its own for RFQ records — the two record types have different keys and
no consumer wants them interleaved:

- **SQLite**: an `…rfq_swaps` table (`rfq_id` primary key, `state` and `updated_at` mapped out for
  querying and for the retention sweep, the record whole in `data`), prefixed like the others, and
  wiped by `clear()` inside the same transaction.
- **Realm**: an `ArkadeRfqSwap` class, same shape, added to `AssetSwapRealmSchemas` and to `clear()`'s
  single write.

Both serialize the record **whole** into a `data` column, which is the property that matters here: an
RFQ record's corridor `profile` holds `profile.hashlock` — the payment hash plus any preimage
material — two levels down, and a field-mapped backend is exactly what would lose it. `RfqSwapRecord`
is JSON-safe by declaration and a corridor profile is plain JSON by the handler contract, so the JSON
boundary these two backends impose costs nothing.

**Migration:** SQLite needs none — its DDL is `CREATE TABLE IF NOT EXISTS` on every init, so the
table appears on an existing database's next operation, with no version to bump. **Realm consumers
must add the fourth schema and bump their own `schemaVersion`**: Realm creates schemas at open, so a
config still listing three fails on the first RFQ read rather than at open. The README says so where
it documents the Realm setup.

## Test plan

`build`, `lint`, `typecheck` clean — the two `TS2416`s and the `TS2420` are gone, which is the
mechanical proof this is complete. `test:unit` **3734 passed / 1 skipped** (ts-sdk 2625, swap 486,
boltz-swap 614), and `scripts/smoke-dist.mjs` passes with its schema count moved 3 → 4.

- **The RFQ suite now runs over all four backends** instead of two — including "stores the record
  whole, down to the fields nothing else can recover", which is the one that exercises the nested
  `profile.hashlock` through JSON.
- **A database that predates the table** gets it: the test creates the three original SQLite tables
  by hand, writes a legacy swap row, then opens the repository and asserts an RFQ record round-trips
  while the existing row is untouched. This is the counterpart of #746's IndexedDB v1 → v2 test, and
  it is what backs the "no migration" claim above rather than leaving it as prose.
- **Prefix isolation covers the new table**, so a hardcoded name cannot leak records between two apps
  sharing one connection.

One fix that belongs to the rebase rather than to this change is in #746 itself
(`test(swap): keep the rfq repository tests in their own backend matrix`): rebasing onto #758 dropped
those tests into its SQLite-only `describe`, where `create` is not in scope — five tests failing on a
`ReferenceError` rather than on anything they assert. They sat in their own two-backend matrix there;
this PR folds them into the full one.

## Not verified

The Realm backend is exercised against the repo's `createMockRealm`, not a real Realm instance — the
same coverage #758 shipped with. SQLite runs against `node:sqlite` through the shared test executor.
