### PR TITLE
feat(swap): name the asset id in the arkade pair leg

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -290,7 +290,9 @@ message anywhere: **acceptance is funding**.
   offline. The solver observes the funding on-chain, pays the invoice, and claims with the
   preimage — which lands publicly in the claim witness as the receipt. A failed swap refunds by
   covenant to the trader's address, pushable by anyone, no trader keys or state.
-- **Arkade ↔ arkade** (BTC↔asset, asset↔asset): the trader accepts a quote by creating and funding
+- **Arkade ↔ arkade** (BTC↔asset, asset↔asset): an arkade asset leg names the asset id itself —
+  `arkade:<68-hex>`, built with `arkadeAssetLeg` (the deprecated coarse `ARKADE_ASSET` is served by
+  no solver). The trader accepts a quote by creating and funding
   an **offer** (layer 1) bound to the quoted terms before `valid_until`. The offer covenant only
   releases the deposit to a fill that delivers the quoted amount, so the solver fills or nothing
   moves; an unfilled offer is cancelled cooperatively. The quote wire shape ships here; the

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -55,6 +55,7 @@ export {
 } from "./watch";
 export { retireSettledOfferContracts, type OfferContractRetirer } from "./coverage";
 export {
+    /** @deprecated no solver serves the coarse asset leg — use `arkadeAssetLeg` */
     ARKADE_ASSET,
     ARKADE_BTC,
     LIGHTNING_BTC,
@@ -66,6 +67,7 @@ export {
     SOLO_REFUND_HEADROOM_SECONDS,
     AddressMismatch,
     SwapRefusal,
+    arkadeAssetLeg,
     arkadeSwapRequest,
     assertFundable,
     assertReceivable,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -55,7 +55,8 @@ export {
 } from "./watch";
 export { retireSettledOfferContracts, type OfferContractRetirer } from "./coverage";
 export {
-    /** @deprecated no solver serves the coarse asset leg — use `arkadeAssetLeg` */
+    // deprecated — use arkadeAssetLeg; the @deprecated that editors read is on
+    // the declaration in rfq.ts, reached through this alias
     ARKADE_ASSET,
     ARKADE_BTC,
     LIGHTNING_BTC,

--- a/packages/swap/src/nostr.ts
+++ b/packages/swap/src/nostr.ts
@@ -28,7 +28,7 @@
  * eagerly, on purpose (see below), so an async factory would push a `await`
  * into every caller for no benefit the subpath does not already give.
  */
-import { SwapRefusal, type RfqQuote, type RfqStatus, type RfqTransport } from "./rfq";
+import { expectQuote, pairOf, type RfqStatus, type RfqTransport } from "./rfq";
 import {
     finalizeEvent,
     generateSecretKey,
@@ -119,24 +119,6 @@ const closeReasons = (raw: readonly unknown[]): string[] =>
         const { url, reason } = (entry ?? {}) as { url?: string; reason?: string };
         return url ? `${url}: ${reason ?? "closed"}` : (reason ?? "closed");
     });
-
-/**
- * Discriminate a decrypted reply, mirroring the client's own rule: a refusal
- * carries a closed-set reason and is thrown as `SwapRefusal`; anything that is
- * not a quote for THIS negotiation is an error rather than a value.
- *
- * The `rfq_id` check is what stops a reply to one negotiation being accepted as
- * the answer to another — on a shared relay the solver's events all arrive on
- * the same subscription.
- */
-const asQuote = (payload: unknown, rfqId: string): RfqQuote => {
-    const p = payload as { type?: string; reason?: string; rfq_id?: string } | null;
-    if (p?.type === "rfq_refusal") throw new SwapRefusal(p.reason ?? "unknown", p.rfq_id ?? rfqId);
-    if (p?.type !== "rfq_quote" || p.rfq_id !== rfqId) {
-        throw new Error(`unexpected reply: ${p?.type ?? "no payload"}`);
-    }
-    return payload as RfqQuote;
-};
 
 export interface NostrRfqOptions {
     /** Relay URLs from the solver's card. The rendezvous, not solver endpoints. */
@@ -257,7 +239,7 @@ export const nostrRfqTransport = (options: NostrRfqOptions): RfqTransport => {
             // publish promise is still settling.
             const reply = awaitReply(rfqId);
             await send(payload);
-            return asQuote(await reply, rfqId);
+            return expectQuote(await reply, rfqId, pairOf(payload));
         },
 
         async status(rfqId) {

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -106,14 +106,28 @@ const solverHex = (value: string, field: string): Uint8Array => {
 
 // ── Pairs ────────────────────────────────────────────────────────────────────
 
-/** Legs are `<corridor>:<asset>`; a pair is directional, `from->to`. Arkade
- * asset legs stay coarse (`arkade:ASSET`) — the exact asset ids ride the
- * request profile, mirroring how the offer TLV identifies assets. */
+/** Legs are `<corridor>:<asset>`; a pair is directional, `from->to`. */
 export const ARKADE_BTC = "arkade:BTC";
-export const ARKADE_ASSET = "arkade:ASSET";
 export const LIGHTNING_BTC = "lightning:BTC";
 
 export const ONCHAIN_BTC = "onchain:BTC";
+
+/** The arkade leg for an asset: the asset id itself, 68 lowercase hex. The id
+ * lives in the pair rather than the profile because the pair is the field both
+ * sides route and subscribe on, and a coarse leg cannot say which asset a
+ * market key is for.
+ *
+ * Taking an `AssetId` rather than a string is what enforces the case rule:
+ * `hex.decode` accepts uppercase while `hex.encode` only emits lowercase, so a
+ * value that reached us as `A1B2…` leaves here as `a1b2…`. Solvers compare pair
+ * strings byte for byte — a sender that normalised only in its key derivation
+ * would reach the right subscription and then be skipped as an unserved pair. */
+export const arkadeAssetLeg = (id: asset.AssetId): string => `arkade:${id.toString()}`;
+
+/** @deprecated The coarse asset leg. No solver serves it: `ASSET` is neither a
+ * registered ticker nor a 68-hex asset id, so a solver's market-key derivation
+ * throws on it. Use {@link arkadeAssetLeg}. Removed next major. */
+export const ARKADE_ASSET = "arkade:ASSET";
 
 export const rfqPair = (from: string, to: string): string => `${from}->${to}`;
 
@@ -223,9 +237,9 @@ export const lightningSendRequest = (input: {
 });
 
 /** The rfq_request for an arkade↔arkade swap. Exactly one side may name an
- * asset id per direction (BTC has none); the pair string stays coarse and the
- * ids ride the profile, like the offer TLV. Forward-looking: the wire shape is
- * specified, the reference solver does not serve it yet. */
+ * asset id per direction (BTC has none), and the id is the leg itself — see
+ * {@link arkadeAssetLeg}. Forward-looking: the wire shape is specified, the
+ * reference solver does not serve it yet. */
 export const arkadeSwapRequest = (input: {
     rfqId: string;
     /** Asset the trader deposits; omit when depositing BTC. */
@@ -237,22 +251,29 @@ export const arkadeSwapRequest = (input: {
     amount: number;
 }): Record<string, unknown> => {
     if (Boolean(input.wantAsset) === Boolean(input.offerAsset)) {
-        throw new Error("set exactly one of wantAsset (BTC->asset) or offerAsset (asset->BTC)");
+        throw new Error(
+            "set exactly one of wantAsset (BTC->asset) or offerAsset (asset->BTC) — " +
+                "asset->asset is nameable on the wire but no solver quotes it yet",
+        );
     }
+    const pair = rfqPair(
+        input.offerAsset ? arkadeAssetLeg(input.offerAsset) : ARKADE_BTC,
+        input.wantAsset ? arkadeAssetLeg(input.wantAsset) : ARKADE_BTC,
+    );
+    assertPairLength(pair);
     return {
         v: 1,
         type: "rfq_request",
         rfq_id: input.rfqId,
-        pair: rfqPair(
-            input.offerAsset ? ARKADE_ASSET : ARKADE_BTC,
-            input.wantAsset ? ARKADE_ASSET : ARKADE_BTC,
-        ),
+        pair,
         amount_side: input.amountSide,
         amount: input.amount,
-        profile: {
-            ...(input.offerAsset && { offer_asset: hex.encode(input.offerAsset.serialize()) }),
-            ...(input.wantAsset && { want_asset: hex.encode(input.wantAsset.serialize()) }),
-        },
+        // The pair is the only place the asset ids appear. Repeating them here
+        // would be a key the solver's `.strict()` profile schema does not
+        // declare, and an undeclared key is `unsupported_payload` — a refusal,
+        // not an ignored extra. Empty, not absent: `profile` is required on
+        // every other request shape this wire carries.
+        profile: {},
     };
 };
 
@@ -293,6 +314,34 @@ const gateError = (reason: string, message: string): Error & { reason: string } 
 const assertFinite = (value: number | undefined, reason: string, label: string): void => {
     if (value !== undefined && !Number.isFinite(value)) {
         throw gateError(reason, `${label} is not a finite number (${String(value)})`);
+    }
+};
+
+/** The wire's cap on a pair string, mirrored so an over-long pair fails here
+ * with a reason instead of arriving as a bare `unsupported_payload`.
+ *
+ * 158 = ("lightning".length + 1 + 68) * 2 + "->".length — the longest corridor
+ * name, a full 68-hex asset id on each leg, and the arrow. The longest pair
+ * anyone can build is `arkade:<68>->arkade:<68>`, at 152 — and until the
+ * exactly-one-asset guard in {@link arkadeSwapRequest} relaxes, this package
+ * tops out at 87, so the guard is dormant on purpose.
+ *
+ * Restated rather than re-derived from this package's own corridor names: a
+ * local cap BELOW the solver's would refuse a pair the solver would have
+ * served, which is worse than the remote refusal this exists to pre-empt. The
+ * test pins the number so a drift is a failure, not a surprise.
+ *
+ * Module-level, not in `index.ts`: it mirrors a number this repo does not own,
+ * and publishing it would turn a remote edit into a semver event here. */
+export const MAX_PAIR_LENGTH = 158;
+
+/** Exported for the tests — a dormant guard still needs one, and no public
+ * entry point can reach it. Not in `index.ts`. */
+export const assertPairLength = (pair: string): void => {
+    if (pair.length > MAX_PAIR_LENGTH) {
+        throw new Error(
+            `pair is ${pair.length} characters, over the wire's ${MAX_PAIR_LENGTH}-character limit`,
+        );
     }
 };
 

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -250,7 +250,16 @@ export const arkadeSwapRequest = (input: {
     /** Integer base units of the side named by `amountSide`. */
     amount: number;
 }): Record<string, unknown> => {
-    if (Boolean(input.wantAsset) === Boolean(input.offerAsset)) {
+    // Both refusals say "exactly one", but the causes differ and so do the
+    // remedies: neither side named is a degenerate request, both sides named is
+    // a real corridor still waiting on a counterparty.
+    if (!input.wantAsset && !input.offerAsset) {
+        throw new Error(
+            "set exactly one of wantAsset (BTC->asset) or offerAsset (asset->BTC) — " +
+                "with neither set both legs are BTC, which is not a swap",
+        );
+    }
+    if (input.wantAsset && input.offerAsset) {
         throw new Error(
             "set exactly one of wantAsset (BTC->asset) or offerAsset (asset->BTC) — " +
                 "asset->asset is nameable on the wire but no solver quotes it yet",

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -432,14 +432,43 @@ export interface RfqTransport {
     close(): Promise<void>;
 }
 
-const expectQuote = (payload: unknown, rfqId: string): RfqQuote => {
-    const p = payload as { type?: string; reason?: string; rfq_id?: string } | null;
+/**
+ * Discriminate a solver reply: a refusal carries a closed-set reason and is
+ * thrown as {@link SwapRefusal}; anything that is not a quote for THIS
+ * negotiation is an error rather than a value. The `rfq_id` check is what stops
+ * a reply to one negotiation being accepted as the answer to another — on a
+ * shared relay the solver's events all arrive on the same subscription.
+ *
+ * `pair` is compared for the same reason the solver compares it byte for byte:
+ * a solver that normalises case, or quotes a market other than the one asked
+ * for, is otherwise undetectable client-side. Note the quote's pair is a
+ * constant the solver restates rather than the request's echoed back, so this
+ * binds every solver to the exact spellings this module builds.
+ *
+ * `requestedPair` is optional by value, not by parameter: callers pass a
+ * payload they built, and a payload with no `pair` is not one whose pair can be
+ * wrong. Comparing `String(undefined)` would refuse every quote.
+ *
+ * Shared with the nostr transport (`nostr.ts`), which used to carry a
+ * byte-identical copy — module-level only, never re-exported from `index.ts`.
+ */
+export const expectQuote = (payload: unknown, rfqId: string, requestedPair?: string): RfqQuote => {
+    const p = payload as { type?: string; reason?: string; rfq_id?: string; pair?: unknown } | null;
     if (p?.type === "rfq_refusal") throw new SwapRefusal(p.reason ?? "unknown", p.rfq_id ?? rfqId);
     if (p?.type !== "rfq_quote" || p.rfq_id !== rfqId) {
         throw new Error(`unexpected reply: ${p?.type ?? "no payload"}`);
     }
+    if (requestedPair !== undefined && p.pair !== requestedPair) {
+        throw new Error(
+            `solver quoted ${JSON.stringify(p.pair)}, not the requested ${requestedPair}`,
+        );
+    }
     return payload as RfqQuote;
 };
+
+/** The pair of a request we built, when it named one. */
+export const pairOf = (payload: Record<string, unknown>): string | undefined =>
+    typeof payload.pair === "string" ? payload.pair : undefined;
 
 /** HTTP: POST /v1/swap for quotes, GET /v1/rfq/<rfq_id> for status.
  * `fetchImpl` is injectable for tests and non-global-fetch runtimes. */
@@ -474,7 +503,11 @@ export const httpTransport = (
                 headers: { "content-type": "application/json" },
                 body: JSON.stringify(payload),
             });
-            return expectQuote(await readJson(response, "quote request"), String(payload.rfq_id));
+            return expectQuote(
+                await readJson(response, "quote request"),
+                String(payload.rfq_id),
+                pairOf(payload),
+            );
         },
         async status(rfqId) {
             const response = await fetchImpl(`${baseUrl}/v1/rfq/${rfqId}`, { method: "GET" });
@@ -577,6 +610,7 @@ export const relayTransport = (
             return expectQuote(
                 await roundTrip(payload, String(payload.rfq_id)),
                 String(payload.rfq_id),
+                pairOf(payload),
             );
         },
         async status(rfqId) {

--- a/packages/swap/test/nostr.test.ts
+++ b/packages/swap/test/nostr.test.ts
@@ -149,6 +149,34 @@ describe("nostrRfqTransport", () => {
         await transport.close();
     });
 
+    /** Asserted behaviourally rather than by inspecting imports: this transport
+     * used to carry its own copy of the quote check, and a second copy
+     * reappearing is invisible any other way. */
+    it("rejects a quote for a pair other than the one it asked about", async () => {
+        const solverSecret = generateSecretKey();
+        const { pool, solverReplies } = fakePool(solverSecret);
+        const secretKey = generateSecretKey();
+        const transport = nostrRfqTransport({
+            relays: ["wss://x"],
+            solverPubkey: getPublicKey(solverSecret),
+            secretKey,
+            pool: pool as never,
+        });
+
+        const pending = transport.requestQuote({
+            v: 1,
+            type: "rfq_request",
+            rfq_id: "abc",
+            pair: "arkade:BTC->lightning:BTC",
+        });
+        solverReplies(getPublicKey(secretKey), {
+            ...quote("abc"),
+            pair: "arkade:BTC->onchain:BTC",
+        });
+        await expect(pending).rejects.toThrow(/not the requested/);
+        await transport.close();
+    });
+
     it("ignores a reply for a different negotiation", async () => {
         const solverSecret = generateSecretKey();
         const { pool, solverReplies } = fakePool(solverSecret);

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -22,6 +22,7 @@ import {
     arkadeSwapRequest,
     assertFundable,
     assertPairLength,
+    expectQuote,
     httpTransport,
     lightningSendRequest,
     lightningSendVtxoScript,
@@ -406,6 +407,33 @@ describe("guardrails", () => {
         expect(() => assertFundable({ quote: short, invoiceExpiresAt: now + 7200, now })).toThrow(
             /headroom/,
         );
+    });
+});
+
+describe("expectQuote", () => {
+    it("refuses a quote for a pair other than the one requested, case included", () => {
+        const requested = LIGHTNING_SEND_PAIR;
+        expect(expectQuote(quoteFixture(), RFQ_ID, requested).to_amount).toBe(2100);
+        expect(() =>
+            expectQuote(quoteFixture({ pair: "onchain:BTC->arkade:BTC" }), RFQ_ID, requested),
+        ).toThrow(/not the requested/);
+        expect(() =>
+            expectQuote(quoteFixture({ pair: requested.toUpperCase() }), RFQ_ID, requested),
+        ).toThrow(/not the requested/);
+    });
+
+    it("accepts any pair when the request named none", () => {
+        expect(expectQuote(quoteFixture({ pair: "anything" }), RFQ_ID).rfq_id).toBe(RFQ_ID);
+    });
+
+    it("still reports a refusal as a refusal, not as a pair mismatch", () => {
+        expect(() =>
+            expectQuote(
+                { v: 1, type: "rfq_refusal", rfq_id: RFQ_ID, reason: "exposure_cap" },
+                RFQ_ID,
+                LIGHTNING_SEND_PAIR,
+            ),
+        ).toThrow(SwapRefusal);
     });
 });
 

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -13,19 +13,22 @@ import { ripemd160 } from "@noble/hashes/legacy.js";
 
 import {
     AddressMismatch,
-    ARKADE_ASSET,
     ARKADE_BTC,
     LIGHTNING_SEND_PAIR,
+    MAX_PAIR_LENGTH,
     SOLO_REFUND_HEADROOM_SECONDS,
     SwapRefusal,
+    arkadeAssetLeg,
     arkadeSwapRequest,
     assertFundable,
+    assertPairLength,
     httpTransport,
     lightningSendRequest,
     lightningSendVtxoScript,
     newRfqId,
     offerTermsFromQuote,
     relayTransport,
+    rfqPair,
     unilateralClaimDelay,
     unilateralRefundDelay,
     unilateralRefundWithoutReceiverDelay,
@@ -33,7 +36,7 @@ import {
     type RelaySocket,
     type RfqQuote,
 } from "../src/rfq";
-import { USD_ID } from "./fixtures";
+import { CHF_ID, USD_ID } from "./fixtures";
 import { asset } from "@arkade-os/sdk";
 
 const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
@@ -302,21 +305,85 @@ describe("requests", () => {
         });
     });
 
-    it("builds an arkade swap request with asset ids riding the profile", () => {
-        const wantAsset = asset.AssetId.fromBytes(hex.decode(USD_ID));
-        const request = arkadeSwapRequest({
+    it("names the asset id in the pair, in both directions", () => {
+        const usd = asset.AssetId.fromString(USD_ID);
+        const wanting = arkadeSwapRequest({
             rfqId: RFQ_ID,
-            wantAsset,
+            wantAsset: usd,
             amountSide: "from",
             amount: 5000,
         }) as Record<string, unknown>;
-        expect(request.pair).toBe(`${ARKADE_BTC}->${ARKADE_ASSET}`);
-        expect(request.amount).toBe(5000);
-        expect((request.profile as Record<string, unknown>).want_asset).toBe(USD_ID);
-        // Exactly one side names an asset.
+        expect(wanting.pair).toBe(`arkade:BTC->arkade:${USD_ID}`);
+        expect(wanting.amount).toBe(5000);
+
+        const offering = arkadeSwapRequest({
+            rfqId: RFQ_ID,
+            offerAsset: usd,
+            amountSide: "to",
+            amount: 5000,
+        }) as Record<string, unknown>;
+        expect(offering.pair).toBe(`arkade:${USD_ID}->arkade:BTC`);
+    });
+
+    /** Solvers compare pair strings byte for byte, so an uppercase id reaching
+     * the wire is a silent unserved-pair miss. Taking an `AssetId` is the
+     * normalisation. */
+    it("emits a lowercase leg for an asset id built from uppercase hex", () => {
+        const request = arkadeSwapRequest({
+            rfqId: RFQ_ID,
+            wantAsset: asset.AssetId.fromString(USD_ID.toUpperCase()),
+            amountSide: "from",
+            amount: 1,
+        }) as Record<string, unknown>;
+        expect(request.pair).toBe(`arkade:BTC->arkade:${USD_ID}`);
+    });
+
+    it("refuses neither asset and both — asset->asset has no counterparty yet", () => {
+        const usd = asset.AssetId.fromString(USD_ID);
+        const chf = asset.AssetId.fromString(CHF_ID);
         expect(() => arkadeSwapRequest({ rfqId: RFQ_ID, amountSide: "to", amount: 1 })).toThrow(
             /exactly one/,
         );
+        expect(() =>
+            arkadeSwapRequest({
+                rfqId: RFQ_ID,
+                offerAsset: usd,
+                wantAsset: chf,
+                amountSide: "to",
+                amount: 1,
+            }),
+        ).toThrow(/no solver quotes it yet/);
+    });
+
+    /** Load-bearing against the solver's `.strict()` profile schema: a key it
+     * does not declare refuses the whole request. */
+    it("sends an empty profile, with no asset keys left in it", () => {
+        const request = arkadeSwapRequest({
+            rfqId: RFQ_ID,
+            wantAsset: asset.AssetId.fromString(USD_ID),
+            amountSide: "from",
+            amount: 5000,
+        }) as Record<string, unknown>;
+        expect(Object.keys(request.profile as Record<string, unknown>)).toHaveLength(0);
+    });
+
+    it("mirrors the wire's pair-length cap, dormant until asset->asset lands", () => {
+        expect(MAX_PAIR_LENGTH).toBe(158);
+        const both = rfqPair(
+            arkadeAssetLeg(asset.AssetId.fromString(USD_ID)),
+            arkadeAssetLeg(asset.AssetId.fromString(CHF_ID)),
+        );
+        expect(both.length).toBe(152);
+        expect(() => assertPairLength("x".repeat(MAX_PAIR_LENGTH + 1))).toThrow(/158/);
+        // What the builder can actually emit today — the number that makes the
+        // guard unreachable until the exactly-one-asset rule relaxes.
+        const request = arkadeSwapRequest({
+            rfqId: RFQ_ID,
+            wantAsset: asset.AssetId.fromString(USD_ID),
+            amountSide: "from",
+            amount: 1,
+        }) as Record<string, unknown>;
+        expect((request.pair as string).length).toBe(87);
     });
 });
 

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -339,11 +339,14 @@ describe("requests", () => {
         expect(request.pair).toBe(`arkade:BTC->arkade:${USD_ID}`);
     });
 
-    it("refuses neither asset and both — asset->asset has no counterparty yet", () => {
+    /** Each refusal names its own cause: neither set is degenerate, both set is
+     * a real corridor with no counterparty. One shared message would tell the
+     * BTC->BTC caller to wait for a solver that will never help it. */
+    it("refuses neither asset and both, for the reason that applies", () => {
         const usd = asset.AssetId.fromString(USD_ID);
         const chf = asset.AssetId.fromString(CHF_ID);
         expect(() => arkadeSwapRequest({ rfqId: RFQ_ID, amountSide: "to", amount: 1 })).toThrow(
-            /exactly one/,
+            /exactly one.*not a swap/s,
         );
         expect(() =>
             arkadeSwapRequest({


### PR DESCRIPTION
Makes `@arkade-os/swap` interoperable with lightning-swap-service#113: an arkade asset leg is the asset id itself (`arkade:<68-hex>`, via `arkadeAssetLeg`) instead of the coarse `arkade:ASSET`, which no solver serves.

- the pair is what both sides route and subscribe on, so the asset id moves there; `profile` goes empty (the solver's schemas are `.strict()`)
- `ARKADE_ASSET` deprecated, not removed
- `MAX_PAIR_LENGTH` mirrors the wire's 158-char cap — dormant until asset↔asset lands
- second commit: `expectQuote` compares the quoted pair against the requested one, and the nostr transport's duplicate copy of it is gone. Independent of the asset work; revertable on its own.

Safe to ship before https://github.com/arkade-os/lightning-swap-service/pull/113: no solver serves arkade↔arkade in any spelling, so behaviour on live corridors is unchanged.