### PR TITLE
feat(vhtlc): let a VHTLC be denominated in an Arkade asset (ScriptV2, and v1 by inheritance)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
             group: arkade-assets
             test_files: >-
               test/e2e/asset.test.ts
+              test/e2e/asset-covenant.test.ts
               test/e2e/arkadeCash.test.ts
               test/e2e/liquidation.test.ts
           - package: ts-sdk

--- a/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
@@ -13,6 +13,35 @@ import { assertVhtlcSpendableNow, isCltvSatisfied, isCsvSpendable, resolveRole }
 import { sequenceToTimelock, timelockToSequence } from "../../utils/timelock";
 
 /**
+ * The stored `assetGroupIndex`, as a number, or a throw naming the row.
+ *
+ * `Number()` alone is not enough here, and it fails in exactly one direction
+ * that matters. `VHTLC.ScriptV2` already refuses a non-integer, a negative or
+ * anything past `0xffff`, so `"abc"`, `"1.5"` and `"-1"` die one frame down with
+ * a clear message. What survives is `Number("")`, `Number(" ")` and
+ * `Number("\t")` — all of which are **0**, a perfectly valid group index.
+ *
+ * A blank field therefore does not fail: it silently names group 0 of the same
+ * genesis transaction, which is a DIFFERENT asset. The contract then derives a
+ * different script from the one the row was written against, and registration
+ * dies at `upsertContractRow` with an opaque `Script mismatch` — the same
+ * silent-drop class the both-halves-or-neither check above exists to close, one
+ * value further in.
+ *
+ * Anchored and canonical: no sign, no point, no exponent, no leading zero, so a
+ * row that round-tripped through this handler's own `serializeParams` is the
+ * only shape accepted back.
+ */
+const parseGroupIndex = (raw: string): number => {
+    if (!/^(0|[1-9][0-9]*)$/.test(raw)) {
+        throw new Error(
+            `assetGroupIndex must be a canonical decimal integer, got ${JSON.stringify(raw)}`,
+        );
+    }
+    return Number(raw);
+};
+
+/**
  * Typed parameters for {@link VHTLC.ScriptV2} contracts.
  *
  * The eight mandatory fields are `VHTLCContractParams` verbatim — the two
@@ -233,7 +262,7 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
             params.assetTxid !== undefined && params.assetGroupIndex !== undefined
                 ? {
                       txid: hex.decode(params.assetTxid),
-                      groupIndex: Number(params.assetGroupIndex),
+                      groupIndex: parseGroupIndex(params.assetGroupIndex),
                   }
                 : undefined;
         return {

--- a/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
@@ -31,6 +31,17 @@ export interface VHTLCV2ContractParams {
     unilateralClaimDelay: RelativeTimelock;
     unilateralRefundDelay: RelativeTimelock;
     unilateralRefundWithoutReceiverDelay: RelativeTimelock;
+    /**
+     * The Arkade asset the covenant leaves bind, if any.
+     *
+     * @see VHTLC.Options.asset
+     */
+    asset?: {
+        /** The asset's genesis txid, 32 bytes, canonical order — as the serialized Asset ID carries it. */
+        txid: Uint8Array;
+        /** The asset group index within that genesis transaction. */
+        groupIndex: number;
+    };
     /** @see VHTLC.Options.nonInteractiveClaim */
     nonInteractiveClaim?: {
         receiverPkScript: Uint8Array;
@@ -160,6 +171,19 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
                     params.nonInteractiveRefund.emulatorPubkey,
                 ),
             }),
+            // The asset must round-trip, and its absence here used to be silent
+            // in the worst way. `ContractManager` re-derives a contract from
+            // these params; dropping the asset derives the SAT-ONLY script, so
+            // registration died at `upsertContractRow` with a `Script mismatch`
+            // naming two hex strings and no cause. Same silent-drop class
+            // `validateOptions` refuses one layer up.
+            //
+            // Two keys rather than one blob, mirroring the script's own view of
+            // an Asset ID as a (txid, groupIndex) pair.
+            ...(params.asset && {
+                assetTxid: hex.encode(params.asset.txid),
+                assetGroupIndex: params.asset.groupIndex.toString(),
+            }),
         };
     },
 
@@ -176,12 +200,30 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
             "nonInteractiveRefundEmulatorPubkey",
             "nonInteractiveRefund",
         );
+        // Both halves or neither: a txid without its group index names no asset,
+        // and an index without a txid names nothing at all. Either alone is a
+        // corrupt row rather than a contract that happens to lack an asset, and
+        // reading it as the latter re-derives the sat-only script — the exact
+        // silent drop this round-trip exists to close.
+        if ((params.assetTxid === undefined) !== (params.assetGroupIndex === undefined)) {
+            throw new Error(
+                "asset params are incomplete: assetTxid and assetGroupIndex must both be present or both absent",
+            );
+        }
+        const asset =
+            params.assetTxid !== undefined && params.assetGroupIndex !== undefined
+                ? {
+                      txid: hex.decode(params.assetTxid),
+                      groupIndex: Number(params.assetGroupIndex),
+                  }
+                : undefined;
         return {
             sender: hex.decode(params.sender),
             receiver: hex.decode(params.receiver),
             server: hex.decode(params.server),
             preimageHash: hex.decode(params.hash),
             refundLocktime: BigInt(params.refundLocktime),
+            ...(asset && { asset }),
             unilateralClaimDelay: sequenceToTimelock(Number(params.claimDelay)),
             unilateralRefundDelay: sequenceToTimelock(Number(params.refundDelay)),
             unilateralRefundWithoutReceiverDelay: sequenceToTimelock(

--- a/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
@@ -46,6 +46,8 @@ export interface VHTLCV2ContractParams {
     nonInteractiveClaim?: {
         receiverPkScript: Uint8Array;
         emulatorPubkey: Uint8Array;
+        /** @see VHTLC.Options.nonInteractiveClaim.strict */
+        strict?: { amount: bigint; assetAmount?: bigint };
     };
     /** @see VHTLC.Options.nonInteractiveRefund */
     nonInteractiveRefund?: {
@@ -162,6 +164,17 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
                 nonInteractiveClaimEmulatorPubkey: hex.encode(
                     params.nonInteractiveClaim.emulatorPubkey,
                 ),
+                // The opt-in quoted bound. Dropping it re-derives the DEFAULT
+                // claim covenant — a strictly weaker one — and registration dies
+                // at `upsertContractRow` with an opaque `Script mismatch`. Same
+                // silent-drop class as the asset keys above.
+                ...(params.nonInteractiveClaim.strict && {
+                    strictClaimAmount: params.nonInteractiveClaim.strict.amount.toString(),
+                    ...(params.nonInteractiveClaim.strict.assetAmount !== undefined && {
+                        strictClaimAssetAmount:
+                            params.nonInteractiveClaim.strict.assetAmount.toString(),
+                    }),
+                }),
             }),
             ...(params.nonInteractiveRefund && {
                 nonInteractiveRefundSenderPkScript: hex.encode(
@@ -210,6 +223,12 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
                 "asset params are incomplete: assetTxid and assetGroupIndex must both be present or both absent",
             );
         }
+        if (params.strictClaimAssetAmount !== undefined && params.strictClaimAmount === undefined) {
+            throw new Error(
+                "strictClaimAssetAmount without strictClaimAmount: reading this as 'not strict' " +
+                    "would re-derive the default claim covenant, which is weaker than the row asked for",
+            );
+        }
         const asset =
             params.assetTxid !== undefined && params.assetGroupIndex !== undefined
                 ? {
@@ -233,6 +252,14 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
                 nonInteractiveClaim: {
                     receiverPkScript: claim.destination,
                     emulatorPubkey: claim.emulatorPubkey,
+                    ...(params.strictClaimAmount !== undefined && {
+                        strict: {
+                            amount: BigInt(params.strictClaimAmount),
+                            ...(params.strictClaimAssetAmount !== undefined && {
+                                assetAmount: BigInt(params.strictClaimAssetAmount),
+                            }),
+                        },
+                    }),
                 },
             }),
             ...(refund && {

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -546,18 +546,29 @@ function enforcePayToAsset(
             `asset group index must be an integer in [0, 65535], got ${asset.groupIndex}`,
         );
     }
+    // REVERSED, once, here. `asset.txid` is the id in WIRE order -- the leading
+    // 32 bytes of the serialized Asset ID -- but the introspection opcodes match
+    // against those bytes reversed. Push wire order and the lookup reports the
+    // asset ABSENT (`0 0`), so the covenant fails and the contract it guards is
+    // unspendable. Nothing in the failure says so: the emulator returns only
+    // `OP_VERIFY failed`, and returns it whatever the amount comparison says.
+    // Established on regtest against a real minted asset, by elimination against
+    // a passing BTC-only control.
+    //
+    // A copy rather than an in-place reverse: the caller's id is theirs.
+    const inspectionTxid = Uint8Array.from(asset.txid).reverse();
     return ArkadeScript.encode([
         // The output carries at least as much of the asset as the input did.
         // Output index is the input's -- the same index alignment the sat
         // covenant relies on, and the same liveness obligation on whoever
         // assembles the spend.
         "PUSHCURRENTINPUTINDEX",
-        asset.txid,
+        inspectionTxid,
         asset.groupIndex,
         "INSPECTOUTASSETLOOKUP",
         "VERIFY", // PRESENT on the output, not merely "zero of it"
         "PUSHCURRENTINPUTINDEX",
-        asset.txid,
+        inspectionTxid,
         asset.groupIndex,
         "INSPECTINASSETLOOKUP",
         "VERIFY", // ...and on the input, so the comparison means something

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -68,6 +68,21 @@ export namespace VHTLC {
          * asset covenant while stripping the sats — exactly as the sat-only
          * covenant lets a spend strip the asset.
          *
+         * ONE ASSET IS BOUND, AND ONLY THAT ONE IS PROTECTED. If a VTXO funded to
+         * this contract carries ADDITIONAL assets alongside the bound one, those
+         * are not covered: whoever assembles a covenant spend chooses where they
+         * go, and can send them anywhere.
+         *
+         * `INSPECTOUTASSETCOUNT == 1` does not close that. It constrains the
+         * covenant's OUTPUT to exactly one asset — so the extras cannot ride
+         * along with the bound asset — but arkd's conservation rule is satisfied
+         * by routing them to a different output, which the covenant says nothing
+         * about. The bound asset arrives; the rest is the spender's to direct.
+         *
+         * So fund an asset contract with the asset it names and nothing else. A
+         * multi-asset VTXO behind this covenant is a loss waiting for whoever
+         * pushes the spend.
+         *
          * The id is the pair the introspection opcodes take. A canonical Asset
          * ID is `(genesis txid, group index)`, never a single blob.
          */

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -517,6 +517,29 @@ function isP2trPkScript(pkScript: Bytes): boolean {
  * them; its own aggregate refund uses the interactive leaf precisely because
  * it lacks this per-index constraint, see `refund.ts`), never a safety
  * assumption.
+ *
+ * WHY `>= input` AND NOT `>= the quoted amount`. This bound is CONSERVATION,
+ * not agreement: it says the spend may not skim, and says nothing about what
+ * any quote promised. That is deliberate, on both leaves, and it is a question
+ * worth answering here because the covenant reads like the natural place to
+ * pin a quote and is not.
+ *
+ *  - A QUOTE IS NOT THE COVENANT'S TO KNOW. Pinning one compiles it into the
+ *    leaf, hence into the emulator key, hence into the ADDRESS. Re-quoting
+ *    would move the address of a contract that may already be funded.
+ *  - MISFUNDING IS THE SENDER'S EXPOSURE. They chose the amount. A lockup that
+ *    over- or underpays the quote is theirs to have created, and the
+ *    counterparty's protection is to decline it — refuse the swap and let it
+ *    refund — which is an application-layer decision, taken where a quote
+ *    actually lives, and revisable without moving anyone's address.
+ *  - NOTHING IS CLAIMED WITHOUT THE PREIMAGE. Both covenant leaves sit behind
+ *    the hash condition, so an underfunded lockup cannot be claimed out from
+ *    under the counterparty on the covenant's say-so. The covenant's job is to
+ *    stop a spend that satisfies the condition from redirecting the value; it
+ *    is not to adjudicate whether the trade was fair.
+ *
+ * So a funding gate that compares a lockup against its quote belongs in the
+ * consumer, not here. `lightning-swap-service`'s `lockupIsFunded` is that gate.
  */
 function enforcePayTo(destinationPkScript: Bytes): Bytes {
     // validateOptions already checked this for both current call sites — kept

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -52,6 +52,31 @@ export namespace VHTLC {
             senderPkScript: Bytes;
             emulatorPubkey: Bytes;
         };
+        /**
+         * Optional: denominate this contract in an Arkade ASSET rather than in
+         * sats alone.
+         *
+         * Only the two NON-INTERACTIVE leaves change. Every other leaf is a
+         * signature path that asserts nothing about value, so an asset makes no
+         * difference to them — which is why this option reaches exactly the
+         * leaves whose covenant the emulator enforces.
+         *
+         * When set, those covenants additionally require the output to carry at
+         * least the input's amount of THIS asset, and to carry exactly one
+         * asset. The sat clause is RETAINED, not replaced: an asset-carrying
+         * VTXO carries sats too, so dropping it would let a spend satisfy the
+         * asset covenant while stripping the sats — exactly as the sat-only
+         * covenant lets a spend strip the asset.
+         *
+         * The id is the pair the introspection opcodes take. A canonical Asset
+         * ID is `(genesis txid, group index)`, never a single blob.
+         */
+        asset?: {
+            /** The asset's genesis transaction id, 32 bytes. */
+            txid: Bytes;
+            /** The asset group index within that genesis transaction. */
+            groupIndex: number;
+        };
     }
 
     /**
@@ -138,7 +163,10 @@ export namespace VHTLC {
             let arkadeScriptNic: Bytes | undefined;
             let nonInteractiveClaimScript: Bytes | undefined;
             if (options.nonInteractiveClaim) {
-                arkadeScriptNic = enforcePayTo(options.nonInteractiveClaim.receiverPkScript);
+                arkadeScriptNic = enforcePayToMaybeAsset(
+                    options.nonInteractiveClaim.receiverPkScript,
+                    options.asset,
+                );
                 nonInteractiveClaimScript = ConditionMultisigTapscript.encode({
                     conditionScript,
                     pubkeys: [
@@ -155,7 +183,10 @@ export namespace VHTLC {
             let arkadeScriptNir: Bytes | undefined;
             let nonInteractiveRefundScript: Bytes | undefined;
             if (options.nonInteractiveRefund) {
-                arkadeScriptNir = enforcePayTo(options.nonInteractiveRefund.senderPkScript);
+                arkadeScriptNir = enforcePayToMaybeAsset(
+                    options.nonInteractiveRefund.senderPkScript,
+                    options.asset,
+                );
                 // No timelock: server + receiver together can release this
                 // immediately, same as `refund` above, just without needing
                 // the sender's own signature — the covenant is what still
@@ -468,4 +499,96 @@ function enforcePayTo(destinationPkScript: Bytes): Bytes {
         "INSPECTINPUTVALUE",
         "GREATERTHANOREQUAL",
     ]);
+}
+
+/**
+ * {@link enforcePayTo} for a contract denominated in an Arkade ASSET: the same
+ * covenant, plus "carries at least the input's amount of exactly this one
+ * asset".
+ *
+ * The sat covenant is this one's TAIL, restated inline below, so an asset
+ * contract enforces everything a sat contract does and never less.  That
+ * matters because an asset-carrying VTXO carries sats too: a covenant
+ * constraining only the asset would let a spend strip the sats, and the
+ * sat-only covenant lets a spend strip the ASSET -- the loss this exists to
+ * prevent.
+ *
+ * Two opcode details decide whether it is safe, and the intuitive reading gets
+ * both wrong:
+ *
+ *  - A canonical Asset ID is TWO stack items, `asset_txid` then `asset_gidx`.
+ *    Pushing it as one 32-byte blob encodes cleanly and fails only at spend
+ *    time, once the contract is already funded.
+ *  - `INSPECTOUTASSETLOOKUP` pushes `amount 1`, or `0 0` when the asset is
+ *    ABSENT.  The `VERIFY` after each lookup pops that success flag and is
+ *    load-bearing, not defensive: without it an output carrying NONE of the
+ *    asset reports amount 0, `0 >= 0` passes, and the stripping spend succeeds
+ *    anyway.  Applied to the input lookup too, so an input whose asset is
+ *    undeclared cannot compare `0 >= 0` either.
+ *
+ * `INSPECTOUTASSETCOUNT == 1` bounds the output to the single asset bound, so
+ * nothing can be injected alongside it.  Deliberately strict: a covenant that
+ * is too permissive cannot be tightened once funds are locked to it, while a
+ * strict one can be relaxed in a later contract version.
+ */
+function enforcePayToAsset(
+    destinationPkScript: Bytes,
+    asset: { txid: Bytes; groupIndex: number },
+): Bytes {
+    if (!isP2trPkScript(destinationPkScript)) {
+        throw new Error("invalid P2TR script");
+    }
+    if (asset.txid.length !== 32) {
+        throw new Error(`asset txid must be 32 bytes, got ${asset.txid.length}`);
+    }
+    if (!Number.isInteger(asset.groupIndex) || asset.groupIndex < 0 || asset.groupIndex > 0xffff) {
+        throw new Error(
+            `asset group index must be an integer in [0, 65535], got ${asset.groupIndex}`,
+        );
+    }
+    return ArkadeScript.encode([
+        // The output carries at least as much of the asset as the input did.
+        // Output index is the input's -- the same index alignment the sat
+        // covenant relies on, and the same liveness obligation on whoever
+        // assembles the spend.
+        "PUSHCURRENTINPUTINDEX",
+        asset.txid,
+        asset.groupIndex,
+        "INSPECTOUTASSETLOOKUP",
+        "VERIFY", // PRESENT on the output, not merely "zero of it"
+        "PUSHCURRENTINPUTINDEX",
+        asset.txid,
+        asset.groupIndex,
+        "INSPECTINASSETLOOKUP",
+        "VERIFY", // ...and on the input, so the comparison means something
+        "GREATERTHANOREQUAL",
+        "VERIFY",
+        // Exactly one asset out: nothing injected alongside the one bound.
+        "PUSHCURRENTINPUTINDEX",
+        "INSPECTOUTASSETCOUNT",
+        1,
+        "EQUALVERIFY",
+        // ...then the sat covenant, byte-for-byte enforcePayTo above.
+        "PUSHCURRENTINPUTINDEX",
+        "DUP",
+        "INSPECTOUTPUTSCRIPTPUBKEY",
+        1,
+        "EQUALVERIFY",
+        destinationPkScript.subarray(2),
+        "EQUALVERIFY",
+        "INSPECTOUTPUTVALUE",
+        "PUSHCURRENTINPUTINDEX",
+        "INSPECTINPUTVALUE",
+        "GREATERTHANOREQUAL",
+    ]);
+}
+
+/** Pick the covenant this contract's denomination calls for. */
+function enforcePayToMaybeAsset(
+    destinationPkScript: Bytes,
+    asset?: { txid: Bytes; groupIndex: number },
+): Bytes {
+    return asset === undefined
+        ? enforcePayTo(destinationPkScript)
+        : enforcePayToAsset(destinationPkScript, asset);
 }

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -72,7 +72,15 @@ export namespace VHTLC {
          * ID is `(genesis txid, group index)`, never a single blob.
          */
         asset?: {
-            /** The asset's genesis transaction id, 32 bytes. */
+            /**
+             * The asset's genesis transaction id, 32 bytes, in CANONICAL order
+             * — exactly the leading 32 bytes of a serialized Asset ID, no flip.
+             *
+             * The covenant reverses it internally because the introspection
+             * opcodes match wire order; callers never do that themselves, and a
+             * caller who pre-reverses gets a contract that is unspendable on its
+             * covenant leaves with nothing in the error naming why.
+             */
             txid: Bytes;
             /** The asset group index within that genesis transaction. */
             groupIndex: number;
@@ -563,11 +571,12 @@ function enforcePayToAsset(
             `asset group index must be an integer in [0, 65535], got ${asset.groupIndex}`,
         );
     }
-    // REVERSED, once, here. `asset.txid` is the id in WIRE order -- the leading
-    // 32 bytes of the serialized Asset ID -- but the introspection opcodes match
-    // against those bytes reversed. Push wire order and the lookup reports the
-    // asset ABSENT (`0 0`), so the covenant fails and the contract it guards is
-    // unspendable. Nothing in the failure says so: the emulator returns only
+    // REVERSED, once, here. `asset.txid` is the id in CANONICAL order -- the
+    // leading 32 bytes of the serialized Asset ID, which arkd's `serializeTxHash`
+    // already reversed "to match the canonical txid format". The introspection
+    // opcodes match against WIRE order, which is those bytes reversed back. Push
+    // the canonical bytes unflipped and the lookup reports the asset ABSENT
+    // (`0 0`), so the covenant fails and the contract it guards is unspendable. Nothing in the failure says so: the emulator returns only
     // `OP_VERIFY failed`, and returns it whatever the amount comparison says.
     // Established on regtest against a real minted asset, by elimination against
     // a passing BTC-only control.

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -353,6 +353,23 @@ export namespace VHTLC {
         if (!preimageHash || preimageHash.length !== 20) {
             throw new Error("preimage hash must be 20 bytes");
         }
+        // The two non-interactive leaves are the ONLY ones carrying a covenant
+        // — the signature leaves assert nothing about value — so they are the
+        // only place an asset can be bound. Accepting `asset` without either of
+        // them would emit a sat-only contract and say nothing about it: the
+        // caller funds it believing the asset is protected, and any spend that
+        // satisfies the sat covenant walks off with the asset. The one outward
+        // difference is a pkScript matching a non-asset address, which is not
+        // something a caller thinks to check. Refuse instead of dropping it.
+        if (
+            options.asset !== undefined &&
+            !options.nonInteractiveClaim &&
+            !options.nonInteractiveRefund
+        ) {
+            throw new Error(
+                "asset has no effect without nonInteractiveClaim or nonInteractiveRefund",
+            );
+        }
         if (options.nonInteractiveClaim) {
             const { emulatorPubkey, receiverPkScript } = options.nonInteractiveClaim;
             if (!emulatorPubkey || (emulatorPubkey.length !== 32 && emulatorPubkey.length !== 33)) {

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -10,7 +10,7 @@ import {
 } from "./tapscript";
 import { hex } from "@scure/base";
 import { TapLeafScript, VtxoScript } from "./base";
-import { ArkadeScript } from "../arkade/script";
+import { ArkadeScript, type ArkadeScriptType } from "../arkade/script";
 import { computeArkadeScriptPublicKey } from "../arkade/tweak";
 
 /** Virtual Hash Time Lock Contract (VHTLC) namespace. */
@@ -32,6 +32,51 @@ export namespace VHTLC {
         nonInteractiveClaim?: {
             receiverPkScript: Bytes;
             emulatorPubkey: Bytes;
+            /**
+             * OPT-IN: also require the claim to pay at least these amounts.
+             *
+             * The covenant's default bound is conservation (`out >= in`) — see
+             * {@link enforcePayTo} for why a quote is normally not the
+             * covenant's business. This is the escape hatch for a consumer that
+             * wants the quote enforced in script rather than at its own
+             * admission layer.
+             *
+             * ADDITIVE, NEVER A REPLACEMENT. The conservation bound stays. On
+             * its own, `out >= quoted` leaves everything ABOVE the quote
+             * unconstrained, so an overfunded lockup's surplus could be routed
+             * anywhere by whoever assembles the spend — trading an underfunding
+             * hole for a skimming one. Both bounds together admit neither.
+             *
+             * WHAT IT COSTS, and it is not only opcodes:
+             *
+             *  - THE ADDRESS BECOMES A FUNCTION OF THE QUOTE. These amounts
+             *    compile into the leaf, hence the emulator key, hence the
+             *    pkScript. A re-quote is a different address, and cannot be
+             *    applied to a lockup already funded.
+             *  - AN UNDERFUNDED LOCKUP BECOMES UNCLAIMABLE. Its only exit is the
+             *    refund path, which waits out the CLTV. That is the intended
+             *    incentive and it lands on whoever misfunded — but it converts
+             *    "claim the short amount now and settle up" into "wait for the
+             *    timelock".
+             *
+             * Omit for the default. Omitting leaves every script byte unchanged,
+             * so contracts already funded keep their addresses.
+             */
+            strict?: {
+                /** Sats the claim must pay. Positive. */
+                amount: bigint;
+                /**
+                 * Asset base units the claim must pay.
+                 *
+                 * Required iff {@link VHTLC.Options.asset} is set, and refused
+                 * otherwise. Strict-on-sats-only against an asset-denominated
+                 * contract would pin the sat CARRIER and say nothing about the
+                 * asset that is the actual amount — half-enforcement that reads
+                 * like enforcement, which is the failure this option exists to
+                 * avoid rather than introduce.
+                 */
+                assetAmount?: bigint;
+            };
         };
         /**
          * Optional non-interactive refund leaf: `server` + `receiver` + a
@@ -189,6 +234,7 @@ export namespace VHTLC {
                 arkadeScriptNic = enforcePayToMaybeAsset(
                     options.nonInteractiveClaim.receiverPkScript,
                     options.asset,
+                    options.nonInteractiveClaim.strict,
                 );
                 nonInteractiveClaimScript = ConditionMultisigTapscript.encode({
                     conditionScript,
@@ -393,6 +439,34 @@ export namespace VHTLC {
                 "asset has no effect without nonInteractiveClaim or nonInteractiveRefund",
             );
         }
+
+        // The opt-in quoted bound, and every way of asking for half of it.
+        const strict = options.nonInteractiveClaim?.strict;
+        if (strict !== undefined) {
+            // `out >= 0` is satisfied by every output, so a zero would compile a
+            // bound that reads like enforcement and enforces nothing.
+            if (strict.amount <= 0n) {
+                throw new Error(`strict claim amount must be positive, got ${strict.amount}`);
+            }
+            // Strict on the sat carrier while the ASSET — the actual amount —
+            // goes unbounded. The most dangerous shape here, because the caller
+            // has explicitly asked for enforcement and would get it on the wrong
+            // quantity.
+            if (options.asset !== undefined && strict.assetAmount === undefined) {
+                throw new Error(
+                    "strict claim needs assetAmount when the contract is denominated in an asset: " +
+                        "bounding only the sats would leave the asset amount unenforced",
+                );
+            }
+            if (options.asset === undefined && strict.assetAmount !== undefined) {
+                throw new Error("strict claim assetAmount has no effect without asset");
+            }
+            if (strict.assetAmount !== undefined && strict.assetAmount <= 0n) {
+                throw new Error(
+                    `strict claim assetAmount must be positive, got ${strict.assetAmount}`,
+                );
+            }
+        }
         if (options.nonInteractiveClaim) {
             const { emulatorPubkey, receiverPkScript } = options.nonInteractiveClaim;
             if (!emulatorPubkey || (emulatorPubkey.length !== 32 && emulatorPubkey.length !== 33)) {
@@ -541,15 +615,23 @@ function isP2trPkScript(pkScript: Bytes): boolean {
  * So a funding gate that compares a lockup against its quote belongs in the
  * consumer, not here. `lightning-swap-service`'s `lockupIsFunded` is that gate.
  */
-function enforcePayTo(destinationPkScript: Bytes): Bytes {
-    // validateOptions already checked this for both current call sites — kept
-    // here too, since this covenant is the one place a wrong destination
-    // becomes irreversible (a mis-typed leaf, unlike a rejected constructor
-    // call, only surfaces once someone tries to spend it).
-    if (!isP2trPkScript(destinationPkScript)) {
-        throw new Error("invalid P2TR script");
-    }
-    return ArkadeScript.encode([
+/**
+ * The sat half of both covenants: the output at this input's index is P2TR,
+ * pays `destinationPkScript`, and carries at least the input's value.
+ *
+ * ONE COPY, shared by {@link enforcePayTo} and {@link enforcePayToAsset}. The
+ * asset covenant used to restate these tokens inline under a comment promising
+ * they matched "byte-for-byte" — a promise nothing enforced, and one that an
+ * option added to one and forgotten on the other would have broken silently.
+ *
+ * `quotedSats` is the opt-in bound from
+ * {@link VHTLC.Options.nonInteractiveClaim.strict}. It is ADDED to the
+ * conservation comparison, never substituted for it: alone, `out >= quoted`
+ * leaves everything above the quote unconstrained, so an overfunded lockup's
+ * surplus could be routed anywhere by whoever assembles the spend.
+ */
+function satClause(destinationPkScript: Bytes, quotedSats?: bigint): ArkadeScriptType {
+    return [
         "PUSHCURRENTINPUTINDEX",
         "DUP",
         "INSPECTOUTPUTSCRIPTPUBKEY",
@@ -558,10 +640,26 @@ function enforcePayTo(destinationPkScript: Bytes): Bytes {
         destinationPkScript.subarray(2),
         "EQUALVERIFY",
         "INSPECTOUTPUTVALUE",
+        // `DUP` because the output value is needed twice: once against the
+        // quote, once against the input.
+        ...(quotedSats === undefined
+            ? []
+            : (["DUP", quotedSats, "GREATERTHANOREQUAL", "VERIFY"] as ArkadeScriptType)),
         "PUSHCURRENTINPUTINDEX",
         "INSPECTINPUTVALUE",
         "GREATERTHANOREQUAL",
-    ]);
+    ];
+}
+
+function enforcePayTo(destinationPkScript: Bytes, quotedSats?: bigint): Bytes {
+    // validateOptions already checked this for both current call sites — kept
+    // here too, since this covenant is the one place a wrong destination
+    // becomes irreversible (a mis-typed leaf, unlike a rejected constructor
+    // call, only surfaces once someone tries to spend it).
+    if (!isP2trPkScript(destinationPkScript)) {
+        throw new Error("invalid P2TR script");
+    }
+    return ArkadeScript.encode(satClause(destinationPkScript, quotedSats));
 }
 
 /**
@@ -597,6 +695,8 @@ function enforcePayTo(destinationPkScript: Bytes): Bytes {
 function enforcePayToAsset(
     destinationPkScript: Bytes,
     asset: { txid: Bytes; groupIndex: number },
+    /** @see VHTLC.Options.nonInteractiveClaim.strict */
+    strict?: { amount: bigint; assetAmount?: bigint },
 ): Bytes {
     if (!isP2trPkScript(destinationPkScript)) {
         throw new Error("invalid P2TR script");
@@ -631,6 +731,12 @@ function enforcePayToAsset(
         asset.groupIndex,
         "INSPECTOUTASSETLOOKUP",
         "VERIFY", // PRESENT on the output, not merely "zero of it"
+        // The quoted bound, when the caller opted in — added to the input
+        // comparison below, not substituted for it. `DUP` because the output's
+        // asset amount is needed twice.
+        ...(strict?.assetAmount === undefined
+            ? []
+            : (["DUP", strict.assetAmount, "GREATERTHANOREQUAL", "VERIFY"] as ArkadeScriptType)),
         "PUSHCURRENTINPUTINDEX",
         inspectionTxid,
         asset.groupIndex,
@@ -643,27 +749,23 @@ function enforcePayToAsset(
         "INSPECTOUTASSETCOUNT",
         1,
         "EQUALVERIFY",
-        // ...then the sat covenant, byte-for-byte enforcePayTo above.
-        "PUSHCURRENTINPUTINDEX",
-        "DUP",
-        "INSPECTOUTPUTSCRIPTPUBKEY",
-        1,
-        "EQUALVERIFY",
-        destinationPkScript.subarray(2),
-        "EQUALVERIFY",
-        "INSPECTOUTPUTVALUE",
-        "PUSHCURRENTINPUTINDEX",
-        "INSPECTINPUTVALUE",
-        "GREATERTHANOREQUAL",
+        // ...then the sat covenant, the same tokens `enforcePayTo` emits.
+        ...satClause(destinationPkScript, strict?.amount),
     ]);
 }
 
 /** Pick the covenant this contract's denomination calls for. */
 function enforcePayToMaybeAsset(
     destinationPkScript: Bytes,
-    asset?: { txid: Bytes; groupIndex: number },
+    asset: { txid: Bytes; groupIndex: number } | undefined,
+    /**
+     * Present only for the CLAIM leaf, and only when the caller opted in. The
+     * refund leaf never receives one: a refund returns what arrived, so a quote
+     * has no place in it — see {@link enforcePayTo}.
+     */
+    strict?: { amount: bigint; assetAmount?: bigint },
 ): Bytes {
     return asset === undefined
-        ? enforcePayTo(destinationPkScript)
-        : enforcePayToAsset(destinationPkScript, asset);
+        ? enforcePayTo(destinationPkScript, strict?.amount)
+        : enforcePayToAsset(destinationPkScript, asset, strict);
 }

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -39,6 +39,8 @@ const HASH = "4d487dd3753a89bc9fe98401d1196523058251fc";
 
 /** `OP_1 <32-byte program>`; anything else fails `isP2trPkScript`. */
 const p2tr = (programHex: string): string => `5120${programHex}`;
+/** A genesis txid in canonical order — the leading 32 bytes of a serialized Asset ID. */
+const ASSET_TXID = "b2".repeat(32);
 const RECEIVER_PK_SCRIPT = p2tr(RECEIVER);
 const SENDER_PK_SCRIPT = p2tr(SENDER);
 
@@ -125,6 +127,39 @@ describe("VHTLCV2ContractHandler", () => {
         expect(hex.encode(VHTLCV2ContractHandler.createScript(reserialized).pkScript)).toBe(
             hex.encode(VHTLCV2ContractHandler.createScript(params).pkScript),
         );
+    });
+
+    it("round-trips the ASSET, so a re-derived contract is not silently sat-only", () => {
+        // The failure this closes was silent in the worst way. `ContractManager`
+        // re-derives a contract from these params; with no `asset` key the
+        // derivation produced the SAT-ONLY script, and registration died at
+        // `upsertContractRow` with a `Script mismatch` naming two hex strings
+        // and no cause. The same silent-drop class `validateOptions` refuses one
+        // layer up.
+        const params = fullParams({ assetTxid: ASSET_TXID, assetGroupIndex: "7" });
+        const typed = VHTLCV2ContractHandler.deserializeParams(params);
+        expect(typed.asset).toEqual({ txid: hex.decode(ASSET_TXID), groupIndex: 7 });
+        expect(VHTLCV2ContractHandler.serializeParams(typed)).toEqual(params);
+
+        // And the script it derives is the asset one, not the sat-only one —
+        // the assertion the round-trip exists for. Comparing against the same
+        // params minus the asset, so this cannot pass by both being equal.
+        const satOnly = fullParams();
+        expect(hex.encode(VHTLCV2ContractHandler.createScript(params).pkScript)).not.toBe(
+            hex.encode(VHTLCV2ContractHandler.createScript(satOnly).pkScript),
+        );
+    });
+
+    it("refuses half an asset rather than deriving a sat-only script from it", () => {
+        // A txid without its group index names no asset and an index without a
+        // txid names nothing at all. Reading either as "no asset" re-derives the
+        // sat-only script — exactly the silent drop above, reached by a corrupt
+        // row instead of a missing feature.
+        for (const half of [{ assetTxid: ASSET_TXID }, { assetGroupIndex: "7" }]) {
+            expect(() => VHTLCV2ContractHandler.deserializeParams(fullParams(half))).toThrow(
+                /both be present or both absent/,
+            );
+        }
     });
 
     it("round-trips a bare six-leaf contract without inventing covenant keys", () => {

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -200,6 +200,50 @@ describe("VHTLCV2ContractHandler", () => {
         }
     });
 
+    /**
+     * The one malformed group index that does not announce itself.
+     *
+     * `VHTLC.ScriptV2` already refuses a non-integer, a negative, or anything
+     * past `0xffff`, so `"abc"`, `"1.5"` and `"-1"` die one frame down with a
+     * clear message. `Number("")`, `Number(" ")` and `Number("\t")` are all
+     * **0** — a valid group index — so a blank field would name group 0 of the
+     * same genesis transaction, which is a DIFFERENT asset, and the mismatch
+     * would only surface as an opaque `Script mismatch` at registration.
+     */
+    it.each([
+        ["blank", ""],
+        ["a space", " "],
+        ["a tab", "\t"],
+        ["a leading zero", "007"],
+        ["a trailing space", "7 "],
+        ["a plus sign", "+7"],
+        ["exponent form", "1e2"],
+        ["a fraction", "1.5"],
+        ["a negative", "-1"],
+        ["not a number at all", "seven"],
+    ])("refuses %s as an asset group index", (_why, assetGroupIndex) => {
+        expect(() =>
+            VHTLCV2ContractHandler.deserializeParams(
+                fullParams({ assetTxid: ASSET_TXID, assetGroupIndex }),
+            ),
+        ).toThrow(/assetGroupIndex must be a canonical decimal integer/);
+    });
+
+    it("still accepts the boundaries of the range the script allows", () => {
+        // 0 is legitimate — the point of the check above is that a BLANK field
+        // must not become it — and 65535 is the last index a serialized Asset ID
+        // can carry.
+        for (const [raw, expected] of [
+            ["0", 0],
+            ["65535", 65_535],
+        ] as const) {
+            const typed = VHTLCV2ContractHandler.deserializeParams(
+                fullParams({ assetTxid: ASSET_TXID, assetGroupIndex: raw }),
+            );
+            expect(typed.asset?.groupIndex).toBe(expected);
+        }
+    });
+
     it("round-trips a bare six-leaf contract without inventing covenant keys", () => {
         const params = {
             sender: SENDER,

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -150,6 +150,44 @@ describe("VHTLCV2ContractHandler", () => {
         );
     });
 
+    it("round-trips the STRICT claim bound, which is opt-in and therefore droppable", () => {
+        // Dropping it re-derives the DEFAULT claim covenant — weaker than the row
+        // asked for — and dies at `upsertContractRow` with an opaque `Script
+        // mismatch`. The failure is identical to the asset drop above and just as
+        // silent, which is why an opt-in field needs the round-trip most: nothing
+        // else signals its absence.
+        const params = fullParams({
+            assetTxid: ASSET_TXID,
+            assetGroupIndex: "7",
+            strictClaimAmount: "50000",
+            strictClaimAssetAmount: "1234",
+        });
+        const typed = VHTLCV2ContractHandler.deserializeParams(params);
+        expect(typed.nonInteractiveClaim?.strict).toEqual({ amount: 50_000n, assetAmount: 1234n });
+        expect(VHTLCV2ContractHandler.serializeParams(typed)).toEqual(params);
+
+        // ...and it derives a DIFFERENT script from the same contract without it.
+        const loose = fullParams({ assetTxid: ASSET_TXID, assetGroupIndex: "7" });
+        expect(hex.encode(VHTLCV2ContractHandler.createScript(params).pkScript)).not.toBe(
+            hex.encode(VHTLCV2ContractHandler.createScript(loose).pkScript),
+        );
+    });
+
+    it("refuses a strict ASSET bound with no strict sat bound", () => {
+        // Reading it as "not strict" would re-derive the default covenant. The
+        // mirror case (sats without asset, on an asset contract) is refused by
+        // the script layer's own validation, which this defers to.
+        expect(() =>
+            VHTLCV2ContractHandler.deserializeParams(
+                fullParams({
+                    assetTxid: ASSET_TXID,
+                    assetGroupIndex: "7",
+                    strictClaimAssetAmount: "1234",
+                }),
+            ),
+        ).toThrow(/without strictClaimAmount/);
+    });
+
     it("refuses half an asset rather than deriving a sat-only script from it", () => {
         // A txid without its group index names no asset and an index without a
         // txid names nothing at all. Reading either as "no asset" re-derives the

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -69,6 +69,8 @@ const ASSET_SUPPLY = 1_000n;
 const ASSET_LOCKED = 500n;
 /** What a shortchanging spend tries to forward instead of the whole amount. */
 const ASSET_SKIMMED = 100n;
+/** A second asset funded alongside the bound one — what the count bound refuses. */
+const ASSET_TAGALONG = 7n;
 /** Room for a second output, so a misdirection spend is constructable at all. */
 const DUST_SATS = 330n;
 
@@ -174,6 +176,18 @@ describe("asset-denominated non-interactive covenant", () => {
         await waitFor(
             async () => assetBalanceOf(await alice.wallet.getBalance(), assetId) >= ASSET_LOCKED,
         );
+        // A SECOND asset, so `INSPECTOUTASSETCOUNT` has something to refuse.
+        // Without one, deleting that bound entirely goes unnoticed: every spend
+        // here carries a single asset, so the count is 1 whether or not anything
+        // checks it.
+        const { assetId: otherId } = await alice.wallet.assetManager.issue({
+            amount: ASSET_SUPPLY,
+            metadata: { decimals: 0, name: "Covenant Probe Two", ticker: "CVP2" },
+        });
+        await waitFor(
+            async () => assetBalanceOf(await alice.wallet.getBalance(), otherId) >= ASSET_TAGALONG,
+        );
+
         // Reversed HERE because this probe pushes the id into a raw artifact.
         // `VHTLC.ScriptV2` does the same flip internally, so a contract built
         // through the SDK takes the id in canonical order and callers do not think
@@ -209,7 +223,12 @@ describe("asset-denominated non-interactive covenant", () => {
             // below, which are the only ones the asset clause alone refuses,
             // would be unconstructable.
             amount: Number(CARRIER_SATS + DUST_SATS),
-            assets: [{ assetId, amount: ASSET_LOCKED }],
+            // BOTH assets, which is the shape the caveat on `VHTLC.Options.asset`
+            // warns about: only the bound one is protected.
+            assets: [
+                { assetId, amount: ASSET_LOCKED },
+                { assetId: otherId, amount: ASSET_TAGALONG },
+            ],
         });
         // Funded and visible — the value is not needed, only the arrival.
         await waitForVtxo(indexerProvider, contract.pkScript);
@@ -229,6 +248,12 @@ describe("asset-denominated non-interactive covenant", () => {
         // conservation check is satisfied and the ONLY thing left to refuse
         // them is the covenant.
         const elsewhere = randomP2TR();
+        /** Route the tag-along to one output — it must go somewhere for conservation. */
+        const tagAlongTo = (vout: number) => ({
+            assetId: otherId,
+            inputs: [{ vin: 0, amount: ASSET_TAGALONG }],
+            outputs: [{ vout, amount: ASSET_TAGALONG }],
+        });
         const payTwo = (): TransactionOutput[] => [
             { script: receiverPkScript, amount: CARRIER_SATS },
             { script: elsewhere, amount: DUST_SATS },
@@ -246,6 +271,7 @@ describe("asset-denominated non-interactive covenant", () => {
                     inputs: [{ vin: 0, amount: ASSET_LOCKED }],
                     outputs: [{ vout: 1, amount: ASSET_LOCKED }],
                 })
+                .withAsset(tagAlongTo(1))
                 .to(payTwo())
                 .send(),
         ).rejects.toThrow();
@@ -267,6 +293,24 @@ describe("asset-denominated non-interactive covenant", () => {
                         { vout: 1, amount: ASSET_LOCKED - ASSET_SKIMMED },
                     ],
                 })
+                .withAsset(tagAlongTo(1))
+                .to(payTwo())
+                .send(),
+        ).rejects.toThrow();
+
+        // (2c) INJECTION. The bound asset is forwarded in full — presence and
+        // amount both satisfied — and the tag-along is dumped onto the SAME
+        // output. Only `INSPECTOUTASSETCOUNT == 1` refuses this, and until there
+        // were two assets in play nothing could tell whether that bound existed.
+        await expect(
+            contract.functions
+                .claim(PREIMAGE)
+                .withAsset({
+                    assetId,
+                    inputs: [{ vin: 0, amount: ASSET_LOCKED }],
+                    outputs: [{ vout: 0, amount: ASSET_LOCKED }],
+                })
+                .withAsset(tagAlongTo(0))
                 .to(payTwo())
                 .send(),
         ).rejects.toThrow();
@@ -279,8 +323,14 @@ describe("asset-denominated non-interactive covenant", () => {
                 inputs: [{ vin: 0, amount: ASSET_LOCKED }],
                 outputs: [{ vout: 0, amount: ASSET_LOCKED }],
             })
-            .to(receiverPkScript, CARRIER_SATS)
-            .change(elsewhere)
+            // THE CAVEAT, MADE CONCRETE. The tag-along has to go somewhere, and
+            // the covenant says nothing about where: the spender picks. Here it
+            // goes to `elsewhere` — an address the contract never named — and the
+            // spend is ACCEPTED. That is what "only the bound asset is protected"
+            // means in practice, and why an asset contract should be funded with
+            // the asset it names and nothing else.
+            .withAsset(tagAlongTo(1))
+            .to(payTwo())
             .send();
 
         const [vtxo] = await waitForVtxo(indexerProvider, receiverPkScript);

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -45,6 +45,7 @@
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { hex } from "@scure/base";
+import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import {
     arkade,
     networks,
@@ -65,6 +66,10 @@ const PREIMAGE_HASH = hex.decode("8739f40ec4dbf569dcb38134c6e7310908566981");
 const CARRIER_SATS = 10_000n;
 const ASSET_SUPPLY = 1_000n;
 const ASSET_LOCKED = 500n;
+/** What a shortchanging spend tries to forward instead of the whole amount. */
+const ASSET_SKIMMED = 100n;
+/** Room for a second output, so a misdirection spend is constructable at all. */
+const DUST_SATS = 330n;
 
 /**
  * The asset covenant, in its minimal form.
@@ -170,17 +175,72 @@ describe("asset-denominated non-interactive covenant", () => {
         // Fund the contract WITH THE ASSET — a sat carrier plus the asset itself.
         await alice.wallet.send({
             address: contract.address,
-            amount: Number(CARRIER_SATS),
+            // CARRIER_SATS plus a dust output's worth. The sat clause pins output
+            // 0 to exactly CARRIER_SATS, so without this surplus a spend could
+            // not build a SECOND output at all — and the misdirection cases
+            // below, which are the only ones the asset clause alone refuses,
+            // would be unconstructable.
+            amount: Number(CARRIER_SATS + DUST_SATS),
             assets: [{ assetId, amount: ASSET_LOCKED }],
         });
         // Funded and visible — the value is not needed, only the arrival.
         await waitForVtxo(indexerProvider, contract.pkScript);
 
-        // (2) THE MONEY ASSERTION. Pay the sats, keep the asset. If the emulator
-        // co-signs this, the covenant is decorative and an asset lockup can be
-        // walked off with.
+        // (2) THE MONEY ASSERTIONS — the spends only this covenant refuses.
+        //
+        // WHAT IS DELIBERATELY NOT ASSERTED HERE, because it proves nothing: a
+        // spend carrying NO asset packet at all. That is refused whatever the
+        // covenant says — the emulator stops at `vm.assetPacket == nil` before
+        // reaching an asset opcode, and arkd's own `ValidateAssetTransaction`
+        // rejects it upstream regardless. Stripping-by-omission is a protocol
+        // invariant of any asset VTXO. Asserting it reads like a covenant test
+        // and is one for free; a covenant of `INSPECTOUTASSETLOOKUP VERIFY DROP`
+        // passes it, and so does a purely decorative one.
+        //
+        // Both cases below balance: asset in equals asset out, so arkd's
+        // conservation check is satisfied and the ONLY thing left to refuse
+        // them is the covenant.
+        const elsewhere = randomP2TR();
+        const payTwo = (): TransactionOutput[] => [
+            { script: receiverPkScript, amount: CARRIER_SATS },
+            { script: elsewhere, amount: DUST_SATS },
+        ];
+
+        // (2a) MISDIRECTION. The sats go exactly where the covenant demands, and
+        // the asset goes somewhere else entirely. Refused by the output lookup's
+        // VERIFY: an output carrying none of the asset reports `0 0`, and the
+        // flag is what the VERIFY pops.
         await expect(
-            contract.functions.claim(PREIMAGE).to(receiverPkScript, CARRIER_SATS).send(),
+            contract.functions
+                .claim(PREIMAGE)
+                .withAsset({
+                    assetId,
+                    inputs: [{ vin: 0, amount: ASSET_LOCKED }],
+                    outputs: [{ vout: 1, amount: ASSET_LOCKED }],
+                })
+                .to(payTwo())
+                .send(),
+        ).rejects.toThrow();
+
+        // (2b) SHORTCHANGING, and this is the one that discriminates. The asset
+        // IS on output 0, so the presence VERIFY passes and a covenant that only
+        // checked presence would co-sign — but most of it has been skimmed to
+        // another output. Only the input-relative amount comparison
+        // (`INSPECTINASSETLOOKUP ... GREATERTHANOREQUAL`) refuses this, which is
+        // exactly the clause a decorative covenant drops.
+        await expect(
+            contract.functions
+                .claim(PREIMAGE)
+                .withAsset({
+                    assetId,
+                    inputs: [{ vin: 0, amount: ASSET_LOCKED }],
+                    outputs: [
+                        { vout: 0, amount: ASSET_SKIMMED },
+                        { vout: 1, amount: ASSET_LOCKED - ASSET_SKIMMED },
+                    ],
+                })
+                .to(payTwo())
+                .send(),
         ).rejects.toThrow();
 
         // (1) Pay the asset through, and the spend is accepted.
@@ -192,6 +252,7 @@ describe("asset-denominated non-interactive covenant", () => {
                 outputs: [{ vout: 0, amount: ASSET_LOCKED }],
             })
             .to(receiverPkScript, CARRIER_SATS)
+            .change(elsewhere)
             .send();
 
         const [vtxo] = await waitForVtxo(indexerProvider, receiverPkScript);

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -143,6 +143,10 @@ describe("asset-denominated non-interactive covenant", () => {
         await waitFor(
             async () => assetBalanceOf(await alice.wallet.getBalance(), assetId) >= ASSET_LOCKED,
         );
+        // Reversed HERE because this probe pushes the id into a raw artifact.
+        // `VHTLC.ScriptV2` does the same flip internally, so a contract built
+        // through the SDK takes the id in wire order and callers do not think
+        // about it; this test is the layer below that.
         const assetTxid = hex.decode(assetId.slice(0, 64)).slice().reverse();
         const idBytes = hex.decode(assetId);
         const assetGidx = BigInt(idBytes[32]! | (idBytes[33]! << 8));

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -85,7 +85,7 @@ const DUST_SATS = 330n;
  */
 const assetCovenantHTLC = {
     version: 0,
-    params: ["hash", "receiver", "amount", "assetTxid", "assetGidx", "assetAmount", "server"],
+    params: ["hash", "receiver", "amount", "assetTxid", "assetGidx", "server"],
     functions: {
         claim: {
             inputs: [{ name: "preimage", type: "bytes" }] as const,
@@ -96,15 +96,40 @@ const assetCovenantHTLC = {
             },
             arkadeScript: {
                 asm: [
-                    // the asset must be present on output 0, in at least the locked amount
+                    // THE ASSET CLAUSE, INPUT-RELATIVE — mirroring what
+                    // `VHTLC.ScriptV2` actually builds rather than a simplified
+                    // stand-in. Two of these opcodes had never been executed by
+                    // anything in this repo: `INSPECTINASSETLOOKUP`, which is
+                    // what makes the comparison relative to what was locked
+                    // rather than to a constant baked into the script, and
+                    // `INSPECTOUTASSETCOUNT`, which stops a spend injecting
+                    // further assets alongside the bound one. A stack-order or
+                    // counting quirk in either would make every ScriptV2 asset
+                    // contract unspendable on its covenant leaves, and byte-
+                    // pinning unit tests cannot find that — they passed for the
+                    // pre-flip txid too.
+                    //
+                    // Index `0` where ScriptV2 writes `PUSHCURRENTINPUTINDEX`.
+                    // Equivalent for this spend, which has one contract input at
+                    // 0 paying output 0, and the same self-send alignment the sat
+                    // clause below already relies on.
                     0,
                     "$assetTxid",
                     "$assetGidx",
                     "INSPECTOUTASSETLOOKUP",
-                    "VERIFY",
-                    "$assetAmount",
+                    "VERIFY", // PRESENT on the output, not merely "zero of it"
+                    0,
+                    "$assetTxid",
+                    "$assetGidx",
+                    "INSPECTINASSETLOOKUP",
+                    "VERIFY", // ...and on the input, so the comparison means something
                     "GREATERTHANOREQUAL",
                     "VERIFY",
+                    // Exactly one asset out: nothing injected alongside the bound one.
+                    0,
+                    "INSPECTOUTASSETCOUNT",
+                    1,
+                    "EQUALVERIFY",
                     // ...and the sats and destination, as the BTC covenant does
                     0,
                     "DUP",
@@ -173,7 +198,6 @@ describe("asset-denominated non-interactive covenant", () => {
             amount: CARRIER_SATS,
             assetTxid,
             assetGidx,
-            assetAmount: ASSET_LOCKED,
         });
 
         // Fund the contract WITH THE ASSET — a sat carrier plus the asset itself.

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Does the emulator actually EXECUTE the asset-introspection opcodes?
+ *
+ * Everything else about the asset covenant is established from documentation:
+ * the emulator's own "Supported Opcodes" table lists
+ * `OP_INSPECTOUTASSETLOOKUP` and friends, and the SDK's `banco-btc-to-asset`
+ * program uses them. Documentation is not execution. This funds a real
+ * asset-denominated contract on regtest and asks the emulator to co-sign a
+ * spend of it.
+ *
+ * Two assertions, and the second is the one that matters:
+ *
+ *  1. a spend that pays the asset through SUCCEEDS — the opcodes execute;
+ *  2. a spend that pays the sats but STRIPS THE ASSET FAILS — the covenant
+ *     is load-bearing, not decorative.
+ *
+ * (2) is the whole reason the covenant exists. Without it the emulator would
+ * happily co-sign a spend that walks off with the asset.
+ *
+ * STATUS: SKIPPED, and deliberately kept rather than deleted.
+ *
+ * What it already established, which was the point:
+ *
+ *   The emulator EXECUTES the asset introspection opcodes. Submitting this
+ *   contract's spend returns
+ *
+ *     failed to execute arkade script: OP_VERIFY failed vin=0
+ *
+ *   An opcode the engine did not know would fail at parse, naming the opcode.
+ *   Failing at OP_VERIFY means the script ran. That was the open question, and
+ *   it is now answered: an asset-denominated covenant is executable.
+ *
+ * What is still open, and why this is skipped rather than green:
+ *
+ *   The POSITIVE case does not pass yet. Setting `assetAmount` to 0 — making
+ *   the GREATERTHANOREQUAL trivially true — still fails the same way, which
+ *   isolates the failure to the LOOKUP's own VERIFY: the emulator is not
+ *   seeing the asset at output 0. So the open question is about the HARNESS,
+ *   not the opcodes: how `withAsset({inputs, outputs})` maps onto the output
+ *   indices the covenant inspects, and whether output 0 of this spend is the
+ *   receiver output the asset actually lands on.
+ *
+ *   Until that is understood, a passing assertion here would be worth nothing
+ *   and a failing one would just be noise in the suite.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { hex } from "@scure/base";
+import {
+    arkade,
+    networks,
+    RestArkProvider,
+    RestIndexerProvider,
+    RestEmulatorProvider,
+} from "../../src";
+import { beforeEachFaucet, createTestArkWallet, faucetOffchain, randomP2TR } from "./utils";
+
+const EMULATOR_URL = "http://localhost:7073";
+const ARK_SERVER_URL = "http://localhost:7070";
+
+const PREIMAGE = new Uint8Array(32).fill(0x42);
+// RIPEMD160(SHA256(PREIMAGE)) — same constant the sibling non-interactive test uses.
+const PREIMAGE_HASH = hex.decode("8739f40ec4dbf569dcb38134c6e7310908566981");
+
+/** Sat carrier the asset VTXO rides on. Assets do not travel without one. */
+const CARRIER_SATS = 10_000n;
+const ASSET_SUPPLY = 1_000n;
+const ASSET_LOCKED = 500n;
+
+/**
+ * The asset covenant, in its minimal form.
+ *
+ * `INSPECTOUTASSETLOOKUP` takes `o asset_txid asset_gidx` and pushes
+ * `amount 1`, or `0 0` when the asset is absent — so the `VERIFY` that pops
+ * the success flag is what makes "the asset is present" mean anything. Without
+ * it, an output carrying none of the asset reports amount 0 and `0 >= n`
+ * merely fails on the amount, but with `n = 0` it would pass outright.
+ *
+ * Output index 0 throughout, matching the sibling test's shape.
+ */
+const assetCovenantHTLC = {
+    version: 0,
+    params: ["hash", "receiver", "amount", "assetTxid", "assetGidx", "assetAmount", "server"],
+    functions: {
+        claim: {
+            inputs: [{ name: "preimage", type: "bytes" }] as const,
+            tapscript: {
+                signers: ["$server"],
+                asm: ["HASH160", "$hash", "EQUAL"],
+                witness: ["preimage"],
+            },
+            arkadeScript: {
+                asm: [
+                    // the asset must be present on output 0, in at least the locked amount
+                    0,
+                    "$assetTxid",
+                    "$assetGidx",
+                    "INSPECTOUTASSETLOOKUP",
+                    "VERIFY",
+                    "$assetAmount",
+                    "GREATERTHANOREQUAL",
+                    "VERIFY",
+                    // ...and the sats and destination, as the BTC covenant does
+                    0,
+                    "DUP",
+                    "INSPECTOUTPUTSCRIPTPUBKEY",
+                    1,
+                    "EQUALVERIFY",
+                    "$receiver",
+                    "EQUALVERIFY",
+                    "INSPECTOUTPUTVALUE",
+                    "$amount",
+                    "EQUAL",
+                ],
+                witness: [],
+            },
+        },
+    },
+};
+
+describe("asset-denominated non-interactive covenant", () => {
+    const emulator = new RestEmulatorProvider(EMULATOR_URL);
+    const arkProvider = new RestArkProvider(ARK_SERVER_URL);
+    const indexerProvider = new RestIndexerProvider(ARK_SERVER_URL);
+    const receiverPkScript = randomP2TR();
+
+    beforeEach(beforeEachFaucet, 20000);
+
+    // KNOWN RED — see the header. Skipped so it does not fail the suite while
+    // the harness question is open; the finding it produced is already banked.
+    it.skip("the emulator executes the asset covenant", { timeout: 180000 }, async () => {
+        // A wallet that mints, then funds the contract with the asset.
+        const alice = await createTestArkWallet();
+        const aliceAddress = await alice.wallet.getAddress();
+        faucetOffchain(aliceAddress!, Number(CARRIER_SATS) * 6);
+        await waitFor(async () => (await alice.wallet.getBalance()).total >= Number(CARRIER_SATS));
+
+        const { assetId } = await alice.wallet.assetManager.issue({
+            amount: ASSET_SUPPLY,
+            metadata: { decimals: 0, name: "Covenant Probe", ticker: "CVP" },
+        });
+        // 68 hex characters: 32-byte genesis txid then a u16 LE group index.
+        expect(assetId).toMatch(/^[0-9a-f]{68}$/);
+        // Issuance is not immediately spendable — the balance has to reflect it
+        // first. arkade-regtest's own bootstrap waits here for the same reason.
+        await waitFor(
+            async () => assetBalanceOf(await alice.wallet.getBalance(), assetId) >= ASSET_LOCKED,
+        );
+        const assetTxid = hex.decode(assetId.slice(0, 64));
+        const idBytes = hex.decode(assetId);
+        const assetGidx = BigInt(idBytes[32]! | (idBytes[33]! << 8));
+
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            emulator,
+            indexer: indexerProvider,
+            network: networks.regtest,
+        });
+
+        const contract = ark.contract(assetCovenantHTLC, {
+            hash: PREIMAGE_HASH,
+            receiver: receiverPkScript.slice(2),
+            amount: CARRIER_SATS,
+            assetTxid,
+            assetGidx,
+            assetAmount: ASSET_LOCKED,
+        });
+
+        // Fund the contract WITH THE ASSET — a sat carrier plus the asset itself.
+        await alice.wallet.send({
+            address: contract.address,
+            amount: Number(CARRIER_SATS),
+            assets: [{ assetId, amount: ASSET_LOCKED }],
+        });
+        await waitForVtxo(indexerProvider, contract.pkScript);
+
+        // (2) THE MONEY ASSERTION. Pay the sats, keep the asset. If the emulator
+        // co-signs this, the covenant is decorative and an asset lockup can be
+        // walked off with.
+        await expect(
+            contract.functions.claim(PREIMAGE).to(receiverPkScript, CARRIER_SATS).send(),
+        ).rejects.toThrow();
+
+        // (1) Pay the asset through, and the spend is accepted.
+        const { txid } = await contract.functions
+            .claim(PREIMAGE)
+            .withAsset({
+                assetId,
+                inputs: [{ vin: 0, amount: ASSET_LOCKED }],
+                outputs: [{ vout: 0, amount: ASSET_LOCKED }],
+            })
+            .to(receiverPkScript, CARRIER_SATS)
+            .send();
+
+        const [vtxo] = await waitForVtxo(indexerProvider, receiverPkScript);
+        expect(vtxo.txid).toBe(txid);
+    });
+});
+
+async function waitFor(pred: () => Promise<boolean>, timeoutMs = 30000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        if (await pred()) return;
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+    throw new Error("waitFor: timeout");
+}
+
+/** Wait for at least one VTXO at the given pkScript */
+async function waitForVtxo(indexer: RestIndexerProvider, pkScript: Uint8Array, timeoutMs = 20000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const resp = await indexer.getVtxos({
+            scripts: [hex.encode(pkScript)],
+            spendableOnly: true,
+        });
+        if (resp.vtxos.length > 0) return resp.vtxos;
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+    throw new Error("waitForVtxo: timeout");
+}
+
+/** The wallet's balance of one asset, as a bigint. */
+function assetBalanceOf(
+    balance: { assets?: { assetId: string; amount: bigint | number }[] },
+    assetId: string,
+): bigint {
+    const entry = (balance.assets ?? []).find((a) => a.assetId === assetId);
+    return entry === undefined ? 0n : BigInt(entry.amount);
+}

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -48,6 +48,7 @@ import { hex } from "@scure/base";
 import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import {
     arkade,
+    asset as assetExt,
     networks,
     RestArkProvider,
     RestIndexerProvider,
@@ -152,9 +153,12 @@ describe("asset-denominated non-interactive covenant", () => {
         // `VHTLC.ScriptV2` does the same flip internally, so a contract built
         // through the SDK takes the id in canonical order and callers do not think
         // about it; this test is the layer below that.
-        const assetTxid = hex.decode(assetId.slice(0, 64)).slice().reverse();
-        const idBytes = hex.decode(assetId);
-        const assetGidx = BigInt(idBytes[32]! | (idBytes[33]! << 8));
+        // Namespaced: the entry point re-exports this module as `export * as
+        // asset`, so the class is `asset.AssetId` and a bare `AssetId` import
+        // type-checks (the TYPE is re-exported) and is undefined at runtime.
+        const parsed = assetExt.AssetId.fromString(assetId);
+        const assetTxid = Uint8Array.from(parsed.txid).reverse();
+        const assetGidx = BigInt(parsed.groupIndex);
 
         const ark = await arkade.Arkade.connect({
             arkade: arkProvider,

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -45,9 +45,11 @@
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
 import type { TransactionOutput } from "@scure/btc-signer/psbt.js";
 import {
     arkade,
+    VHTLC,
     asset as assetExt,
     networks,
     RestArkProvider,
@@ -143,6 +145,63 @@ const assetCovenantHTLC = {
                     "INSPECTOUTPUTVALUE",
                     "$amount",
                     "EQUAL",
+                ],
+                witness: [],
+            },
+        },
+    },
+};
+
+/**
+ * The SAME contract shape, with the arkadeScript written to match
+ * `VHTLC.ScriptV2`'s own covenant token for token.
+ *
+ * The artifact above is a probe: literal `0` for the output index, `$amount
+ * EQUAL` for the sats. Convenient — it keeps the misdirection cases
+ * constructable — and it means the emulator never executes the exact bytes a
+ * consumer locks funds to. This one closes that, and the test PROVES the match
+ * with `resolveAsm` rather than asserting it by eye.
+ */
+const scriptV2Shaped = {
+    version: 0,
+    params: ["hash", "receiver", "assetTxid", "assetGidx", "server"],
+    functions: {
+        claim: {
+            inputs: [{ name: "preimage", type: "bytes" }] as const,
+            tapscript: {
+                signers: ["$server"],
+                asm: ["HASH160", "$hash", "EQUAL"],
+                witness: ["preimage"],
+            },
+            arkadeScript: {
+                asm: [
+                    "PUSHCURRENTINPUTINDEX",
+                    "$assetTxid",
+                    "$assetGidx",
+                    "INSPECTOUTASSETLOOKUP",
+                    "VERIFY",
+                    "PUSHCURRENTINPUTINDEX",
+                    "$assetTxid",
+                    "$assetGidx",
+                    "INSPECTINASSETLOOKUP",
+                    "VERIFY",
+                    "GREATERTHANOREQUAL",
+                    "VERIFY",
+                    "PUSHCURRENTINPUTINDEX",
+                    "INSPECTOUTASSETCOUNT",
+                    1,
+                    "EQUALVERIFY",
+                    "PUSHCURRENTINPUTINDEX",
+                    "DUP",
+                    "INSPECTOUTPUTSCRIPTPUBKEY",
+                    1,
+                    "EQUALVERIFY",
+                    "$receiver",
+                    "EQUALVERIFY",
+                    "INSPECTOUTPUTVALUE",
+                    "PUSHCURRENTINPUTINDEX",
+                    "INSPECTINPUTVALUE",
+                    "GREATERTHANOREQUAL",
                 ],
                 witness: [],
             },
@@ -336,6 +395,109 @@ describe("asset-denominated non-interactive covenant", () => {
         const [vtxo] = await waitForVtxo(indexerProvider, receiverPkScript);
         expect(vtxo.txid).toBe(txid);
     });
+
+    it(
+        "spends a covenant PROVEN byte-identical to VHTLC.ScriptV2's own",
+        { timeout: 180000 },
+        async () => {
+            // THE GAP THIS CLOSES. Every other test here runs a probe artifact, so
+            // the emulator had never executed the byte sequence `ScriptV2` actually
+            // builds — the one a consumer locks funds to. A stack-order or counting
+            // quirk in it would leave every asset contract unspendable on its
+            // covenant leaves, and no test would say so.
+            // A receiver of this test's own: the module-level one is already paid
+            // by the test above, so waiting on it returns THAT spend's vtxo and
+            // the txid assertion below compares two unrelated transactions.
+            const payee = randomP2TR();
+            const alice = await createTestArkWallet();
+            const aliceAddress = await alice.wallet.getAddress();
+            faucetOffchain(aliceAddress!, Number(CARRIER_SATS) * 6);
+            await waitFor(
+                async () => (await alice.wallet.getBalance()).total >= Number(CARRIER_SATS),
+            );
+
+            const { assetId } = await alice.wallet.assetManager.issue({
+                amount: ASSET_SUPPLY,
+                metadata: { decimals: 0, name: "ScriptV2 Shaped", ticker: "SV2" },
+            });
+            await waitFor(
+                async () =>
+                    assetBalanceOf(await alice.wallet.getBalance(), assetId) >= ASSET_LOCKED,
+            );
+            const parsed = assetExt.AssetId.fromString(assetId);
+            const assetTxid = Uint8Array.from(parsed.txid).reverse();
+            const assetGidx = BigInt(parsed.groupIndex);
+
+            // THE PROOF, and the reason this is worth more than the spend below.
+            // `resolveAsm` binds the artifact's placeholders exactly as the compiler
+            // does, so this compares the bytes the emulator is about to run against
+            // the bytes `ScriptV2` emits for the same asset and destination. Equal
+            // means the spend exercises ScriptV2's covenant, not a lookalike.
+            const fromSdk = new VHTLC.ScriptV2({
+                preimageHash: PREIMAGE_HASH,
+                sender: schnorr.getPublicKey(new Uint8Array(32).fill(1)),
+                receiver: schnorr.getPublicKey(new Uint8Array(32).fill(2)),
+                server: schnorr.getPublicKey(new Uint8Array(32).fill(3)),
+                refundLocktime: 1_800_000_000n,
+                unilateralClaimDelay: { type: "seconds", value: 512n },
+                unilateralRefundDelay: { type: "seconds", value: 1024n },
+                unilateralRefundWithoutReceiverDelay: { type: "seconds", value: 1536n },
+                nonInteractiveClaim: {
+                    receiverPkScript: payee,
+                    emulatorPubkey: schnorr.getPublicKey(new Uint8Array(32).fill(5)),
+                },
+                asset: { txid: parsed.txid, groupIndex: parsed.groupIndex },
+            }).nonInteractiveClaimArkadeScript!;
+            const fromArtifact = arkade.resolveAsm(
+                scriptV2Shaped.functions.claim.arkadeScript.asm as never,
+                {
+                    hash: PREIMAGE_HASH,
+                    receiver: payee.slice(2),
+                    assetTxid,
+                    assetGidx,
+                },
+            );
+            expect(hex.encode(fromArtifact)).toBe(hex.encode(fromSdk));
+
+            const ark = await arkade.Arkade.connect({
+                arkade: arkProvider,
+                indexer: indexerProvider,
+                identity: alice.identity,
+                emulator,
+                network: networks.regtest,
+            });
+            const contract = ark.contract(scriptV2Shaped, {
+                hash: PREIMAGE_HASH,
+                receiver: payee.slice(2),
+                assetTxid,
+                assetGidx,
+            });
+
+            await alice.wallet.send({
+                address: contract.address,
+                amount: Number(CARRIER_SATS),
+                assets: [{ assetId, amount: ASSET_LOCKED }],
+            });
+            await waitForVtxo(indexerProvider, contract.pkScript);
+
+            // Everything through to output 0. Input-relative on both quantities, so
+            // the whole input must arrive — no second output, and none needed: the
+            // misdirection cases live on the probe artifact, which differs from this
+            // only in the index literal and the sat clause form.
+            const { txid } = await contract.functions
+                .claim(PREIMAGE)
+                .withAsset({
+                    assetId,
+                    inputs: [{ vin: 0, amount: ASSET_LOCKED }],
+                    outputs: [{ vout: 0, amount: ASSET_LOCKED }],
+                })
+                .to(payee, CARRIER_SATS)
+                .send();
+
+            const [vtxo] = await waitForVtxo(indexerProvider, payee);
+            expect(vtxo.txid).toBe(txid);
+        },
+    );
 });
 
 async function waitFor(pred: () => Promise<boolean>, timeoutMs = 30000) {

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -17,49 +17,30 @@
  * (2) is the whole reason the covenant exists. Without it the emulator would
  * happily co-sign a spend that walks off with the asset.
  *
- * STATUS: SKIPPED, and deliberately kept rather than deleted.
+ * RESULT: PASSES. Both assertions hold, so the covenant is spendable AND
+ * protective — the emulator co-signs a spend that pays the asset through, and
+ * refuses one that keeps the sats and strips the asset.
  *
- * What it already established, which was the point:
+ * Three things had to be right, and each was established by elimination
+ * against a passing BTC-only control (`non-interactive-htlc.test.ts`):
  *
- *   The emulator EXECUTES the asset introspection opcodes. Submitting this
- *   contract's spend returns
+ *  1. The asset input must be declared LOCAL, not INTENT. Declaring it intent
+ *     is rejected upstream by arkd itself:
+ *       ASSET_INPUT_INVALID (35): unexpected asset input type: intent
  *
- *     failed to execute arkade script: OP_VERIFY failed vin=0
+ *  2. Issuance is not immediately spendable. The wallet balance has to reflect
+ *     it before the asset can be sent, which is why the mint is followed by a
+ *     wait here, as arkade-regtest's own bootstrap does.
  *
- *   An opcode the engine did not know would fail at parse, naming the opcode.
- *   Failing at OP_VERIFY means the script ran. That was the open question, and
- *   it is now answered: an asset-denominated covenant is executable.
+ *  3. THE TXID PUSHED BY THE SCRIPT IS REVERSED relative to the serialized
+ *     Asset ID. `assetId.slice(0, 64)` is the id's leading 32 bytes; the
+ *     opcode matches only against those bytes REVERSED. With them un-reversed
+ *     the lookup returns `0 0` and the covenant's VERIFY fails — and it fails
+ *     identically whatever the amount comparison says, which is what isolated
+ *     it.
  *
- * What is still open, and why this is skipped rather than green:
- *
- *   The POSITIVE case does not pass yet. Setting `assetAmount` to 0 — making
- *   the GREATERTHANOREQUAL trivially true — still fails the same way, which
- *   isolates the failure to the LOOKUP's own VERIFY: the emulator is not
- *   seeing the asset at output 0. So the open question is about the HARNESS,
- *   not the opcodes: how `withAsset({inputs, outputs})` maps onto the output
- *   indices the covenant inspects, and whether output 0 of this spend is the
- *   receiver output the asset actually lands on.
- *
- *   DIAGNOSIS (strong, not yet proven by a passing run). `AssetSpec.inputs` is
- *   `{ vin, amount }[]`, and `ContractSpend.buildAssetPacket` turns each into
- *   `AssetInput.create(vin, amount)` — which is the **LOCAL** variant, "input
- *   from same transaction's prevouts". The sibling constructor
- *   `AssetInput.createIntent(txid, vin, amount)` exists for the **INTENT**
- *   variant, "output from intent transaction", and nothing in `AssetSpec` can
- *   reach it.
- *
- *   An Arkade contract spend takes its input through a checkpoint / intent
- *   transaction, so the asset arrives as an INTENT input. Declared LOCAL, the
- *   group does not balance; an unbalanced group makes the whole asset packet
- *   invalid; and an invalid packet means NO output is credited with the asset —
- *   which is precisely why the OUTPUT lookup returns `0 0` even with the
- *   amount comparison neutralised.
- *
- *   If that is right, this is an SDK limitation rather than a covenant problem:
- *   `AssetSpec` cannot express the input kind an Arkade contract spend actually
- *   has. Fixing it means widening `AssetSpec.inputs` to carry an optional
- *   source txid and routing to `createIntent`. That is the next step, and it is
- *   a change to this SDK, not to the covenant.
+ * (3) is the trap worth remembering: nothing about it is visible in the error,
+ * which says only `OP_VERIFY failed vin=0`.
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
@@ -144,9 +125,7 @@ describe("asset-denominated non-interactive covenant", () => {
 
     beforeEach(beforeEachFaucet, 20000);
 
-    // KNOWN RED — see the header. Skipped so it does not fail the suite while
-    // the harness question is open; the finding it produced is already banked.
-    it.skip("the emulator executes the asset covenant", { timeout: 180000 }, async () => {
+    it("the emulator executes the asset covenant", { timeout: 180000 }, async () => {
         // A wallet that mints, then funds the contract with the asset.
         const alice = await createTestArkWallet();
         const aliceAddress = await alice.wallet.getAddress();
@@ -164,7 +143,7 @@ describe("asset-denominated non-interactive covenant", () => {
         await waitFor(
             async () => assetBalanceOf(await alice.wallet.getBalance(), assetId) >= ASSET_LOCKED,
         );
-        const assetTxid = hex.decode(assetId.slice(0, 64));
+        const assetTxid = hex.decode(assetId.slice(0, 64)).slice().reverse();
         const idBytes = hex.decode(assetId);
         const assetGidx = BigInt(idBytes[32]! | (idBytes[33]! << 8));
 
@@ -190,7 +169,7 @@ describe("asset-denominated non-interactive covenant", () => {
             amount: Number(CARRIER_SATS),
             assets: [{ assetId, amount: ASSET_LOCKED }],
         });
-        await waitForVtxo(indexerProvider, contract.pkScript);
+        const [contractVtxo] = await waitForVtxo(indexerProvider, contract.pkScript);
 
         // (2) THE MONEY ASSERTION. Pay the sats, keep the asset. If the emulator
         // co-signs this, the covenant is decorative and an asset lockup can be

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -173,7 +173,8 @@ describe("asset-denominated non-interactive covenant", () => {
             amount: Number(CARRIER_SATS),
             assets: [{ assetId, amount: ASSET_LOCKED }],
         });
-        const [contractVtxo] = await waitForVtxo(indexerProvider, contract.pkScript);
+        // Funded and visible — the value is not needed, only the arrival.
+        await waitForVtxo(indexerProvider, contract.pkScript);
 
         // (2) THE MONEY ASSERTION. Pay the sats, keep the asset. If the emulator
         // co-signs this, the covenant is decorative and an asset lockup can be

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -77,6 +77,27 @@ const ASSET_TAGALONG = 7n;
 const DUST_SATS = 330n;
 
 /**
+ * The STRICT quotes, and why the asset one is deliberately over 2^31.
+ *
+ * `strict` compiles the quoted amounts into the leaf as script LITERALS, and
+ * every `GREATERTHANOREQUAL` the emulator had ever run compared two INTROSPECTED
+ * pushes against each other. Comparing an introspected amount against a literal
+ * is a different question — Bitcoin-heritage arithmetic caps script numbers at 4
+ * bytes, and `arkade/bignum.ts` documents the VM's own numbers as
+ * arbitrary-precision instead. Documentation is not execution, so the asset
+ * quote here needs 5 bytes to encode: if the VM did cap operands, this is the
+ * case that says so, and it says so before a consumer funds one.
+ */
+const STRICT_ASSET_QUOTE = 2_500_000_000n;
+/** What the asset quote is worth in sats terms: nothing. The carrier is quoted separately. */
+const STRICT_SATS_QUOTE = CARRIER_SATS;
+/** An underfunded lockup, on each quantity in turn — the only shape the quote alone refuses. */
+const STRICT_ASSET_SHORT = 2_000_000_000n;
+const STRICT_SATS_SHORT = 9_000n;
+/** Enough for the four lockups below, which is the only reason it is this large. */
+const STRICT_ASSET_SUPPLY = 12_000_000_000n;
+
+/**
  * The asset covenant, in its minimal form.
  *
  * `INSPECTOUTASSETLOOKUP` takes `o asset_txid asset_gidx` and pushes
@@ -199,6 +220,73 @@ const scriptV2Shaped = {
                     "$receiver",
                     "EQUALVERIFY",
                     "INSPECTOUTPUTVALUE",
+                    "PUSHCURRENTINPUTINDEX",
+                    "INSPECTINPUTVALUE",
+                    "GREATERTHANOREQUAL",
+                ],
+                witness: [],
+            },
+        },
+    },
+};
+
+/**
+ * `scriptV2Shaped` with the OPT-IN QUOTED BOUND, token for token.
+ *
+ * Not a parameter away from the shape above: `strict` INSERTS `DUP <quote>
+ * GREATERTHANOREQUAL VERIFY` into two clauses — after the output asset lookup,
+ * and after `INSPECTOUTPUTVALUE` — so it is a different token sequence and needs
+ * its own artifact. The `DUP` is what keeps the amount on the stack for the
+ * conservation comparison that follows; transpose it with the quote push and the
+ * script still runs, still enforces conservation, and compares the quote against
+ * ITSELF — a bound that is satisfied by every spend. That mutation is why the
+ * equality proof below is worth more than reading the tokens.
+ */
+const scriptV2StrictShaped = {
+    version: 0,
+    params: ["hash", "receiver", "assetTxid", "assetGidx", "quotedAsset", "quotedSats", "server"],
+    functions: {
+        claim: {
+            inputs: [{ name: "preimage", type: "bytes" }] as const,
+            tapscript: {
+                signers: ["$server"],
+                asm: ["HASH160", "$hash", "EQUAL"],
+                witness: ["preimage"],
+            },
+            arkadeScript: {
+                asm: [
+                    "PUSHCURRENTINPUTINDEX",
+                    "$assetTxid",
+                    "$assetGidx",
+                    "INSPECTOUTASSETLOOKUP",
+                    "VERIFY",
+                    "DUP",
+                    "$quotedAsset",
+                    "GREATERTHANOREQUAL",
+                    "VERIFY",
+                    "PUSHCURRENTINPUTINDEX",
+                    "$assetTxid",
+                    "$assetGidx",
+                    "INSPECTINASSETLOOKUP",
+                    "VERIFY",
+                    "GREATERTHANOREQUAL",
+                    "VERIFY",
+                    "PUSHCURRENTINPUTINDEX",
+                    "INSPECTOUTASSETCOUNT",
+                    1,
+                    "EQUALVERIFY",
+                    "PUSHCURRENTINPUTINDEX",
+                    "DUP",
+                    "INSPECTOUTPUTSCRIPTPUBKEY",
+                    1,
+                    "EQUALVERIFY",
+                    "$receiver",
+                    "EQUALVERIFY",
+                    "INSPECTOUTPUTVALUE",
+                    "DUP",
+                    "$quotedSats",
+                    "GREATERTHANOREQUAL",
+                    "VERIFY",
                     "PUSHCURRENTINPUTINDEX",
                     "INSPECTINPUTVALUE",
                     "GREATERTHANOREQUAL",
@@ -495,6 +583,202 @@ describe("asset-denominated non-interactive covenant", () => {
                 .send();
 
             const [vtxo] = await waitForVtxo(indexerProvider, payee);
+            expect(vtxo.txid).toBe(txid);
+        },
+    );
+
+    it(
+        "executes the STRICT quoted bound, proven byte-identical to VHTLC.ScriptV2's own",
+        { timeout: 300000 },
+        async () => {
+            // THE GAP THIS CLOSES. `strict` inserts four tokens into each of two
+            // clauses and no VM had ever run them: the byte-equality proof above
+            // builds a claim leaf WITHOUT `strict`, and the unit tests assert only
+            // that the quoted pushes are PRESENT in the decoded token array, not
+            // where. A transposition that compares the quote against itself passes
+            // every one of them, spends fine, and enforces nothing of the quote —
+            // which is the whole reason a caller opts in. Byte-pinning cannot find
+            // that; this can, and it is the same class as the reversed txid the
+            // header describes.
+            const alice = await createTestArkWallet();
+            const aliceAddress = await alice.wallet.getAddress();
+            faucetOffchain(aliceAddress!, Number(CARRIER_SATS) * 12);
+            await waitFor(
+                async () => (await alice.wallet.getBalance()).total >= Number(CARRIER_SATS) * 4,
+            );
+
+            const { assetId } = await alice.wallet.assetManager.issue({
+                amount: STRICT_ASSET_SUPPLY,
+                metadata: { decimals: 0, name: "Strict Quote", ticker: "STQ" },
+            });
+            await waitFor(
+                async () =>
+                    assetBalanceOf(await alice.wallet.getBalance(), assetId) >= STRICT_ASSET_SUPPLY,
+            );
+            const parsed = assetExt.AssetId.fromString(assetId);
+            const assetTxid = Uint8Array.from(parsed.txid).reverse();
+            const assetGidx = BigInt(parsed.groupIndex);
+
+            const ark = await arkade.Arkade.connect({
+                arkade: arkProvider,
+                indexer: indexerProvider,
+                identity: alice.identity,
+                emulator,
+                network: networks.regtest,
+            });
+
+            /**
+             * One lockup, PROVEN to carry ScriptV2's strict covenant before it is
+             * funded. Three of them below, differing only in payee — hence in
+             * address — so each underfunding case gets a lockup of its own rather
+             * than a second VTXO behind a shared address, which a claim could pick
+             * either of.
+             */
+            const proven = (payee: Uint8Array) => {
+                const binds = {
+                    hash: PREIMAGE_HASH,
+                    receiver: payee.slice(2),
+                    assetTxid,
+                    assetGidx,
+                    quotedAsset: STRICT_ASSET_QUOTE,
+                    quotedSats: STRICT_SATS_QUOTE,
+                };
+                const fromSdk = new VHTLC.ScriptV2({
+                    preimageHash: PREIMAGE_HASH,
+                    sender: schnorr.getPublicKey(new Uint8Array(32).fill(1)),
+                    receiver: schnorr.getPublicKey(new Uint8Array(32).fill(2)),
+                    server: schnorr.getPublicKey(new Uint8Array(32).fill(3)),
+                    refundLocktime: 1_800_000_000n,
+                    unilateralClaimDelay: { type: "seconds", value: 512n },
+                    unilateralRefundDelay: { type: "seconds", value: 1024n },
+                    unilateralRefundWithoutReceiverDelay: { type: "seconds", value: 1536n },
+                    nonInteractiveClaim: {
+                        receiverPkScript: payee,
+                        emulatorPubkey: schnorr.getPublicKey(new Uint8Array(32).fill(5)),
+                        strict: { amount: STRICT_SATS_QUOTE, assetAmount: STRICT_ASSET_QUOTE },
+                    },
+                    asset: { txid: parsed.txid, groupIndex: parsed.groupIndex },
+                }).nonInteractiveClaimArkadeScript!;
+                const fromArtifact = arkade.resolveAsm(
+                    scriptV2StrictShaped.functions.claim.arkadeScript.asm as never,
+                    binds,
+                );
+                expect(hex.encode(fromArtifact)).toBe(hex.encode(fromSdk));
+                return ark.contract(scriptV2StrictShaped, binds);
+            };
+
+            /** Fund one lockup and wait for it to be visible. */
+            const fund = async (
+                address: string,
+                pkScript: Uint8Array,
+                sats: bigint,
+                units: bigint,
+            ) => {
+                await waitFor(
+                    async () => assetBalanceOf(await alice.wallet.getBalance(), assetId) >= units,
+                );
+                await alice.wallet.send({
+                    address,
+                    amount: Number(sats),
+                    assets: [{ assetId, amount: units }],
+                });
+                await waitForVtxo(indexerProvider, pkScript);
+            };
+
+            const payeePaid = randomP2TR();
+            const payeeShortAsset = randomP2TR();
+            const payeeShortSats = randomP2TR();
+            const payeeControl = randomP2TR();
+            const paid = proven(payeePaid);
+            const shortAsset = proven(payeeShortAsset);
+            const shortSats = proven(payeeShortSats);
+
+            await fund(paid.address, paid.pkScript, STRICT_SATS_QUOTE, STRICT_ASSET_QUOTE);
+            await fund(
+                shortAsset.address,
+                shortAsset.pkScript,
+                STRICT_SATS_QUOTE,
+                STRICT_ASSET_SHORT,
+            );
+            await fund(
+                shortSats.address,
+                shortSats.pkScript,
+                STRICT_SATS_SHORT,
+                STRICT_ASSET_QUOTE,
+            );
+
+            // THE ASSET QUOTE IS LOAD-BEARING. Everything the lockup holds goes to
+            // output 0, so conservation, the count bound and the sat clause are all
+            // satisfied — an UNDERFUNDED lockup is the only shape where the quote
+            // and the input disagree, and refusing it is the whole point of opting
+            // in. A quote compared against itself co-signs this.
+            await expect(
+                shortAsset.functions
+                    .claim(PREIMAGE)
+                    .withAsset({
+                        assetId,
+                        inputs: [{ vin: 0, amount: STRICT_ASSET_SHORT }],
+                        outputs: [{ vout: 0, amount: STRICT_ASSET_SHORT }],
+                    })
+                    .to(payeeShortAsset, STRICT_SATS_QUOTE)
+                    .send(),
+            ).rejects.toThrow(/emulator/);
+
+            // ...and so is the SAT quote, which lives in the other clause. Same
+            // shape, short on the carrier instead of the asset.
+            await expect(
+                shortSats.functions
+                    .claim(PREIMAGE)
+                    .withAsset({
+                        assetId,
+                        inputs: [{ vin: 0, amount: STRICT_ASSET_QUOTE }],
+                        outputs: [{ vout: 0, amount: STRICT_ASSET_QUOTE }],
+                    })
+                    .to(payeeShortSats, STRICT_SATS_SHORT)
+                    .send(),
+            ).rejects.toThrow(/emulator/);
+
+            // THE CONTROL, and without it the two rejections above prove nothing.
+            // An underfunded lockup could be unspendable for reasons that have
+            // nothing to do with the quote, and both cases would still go red on
+            // cue. So: the SAME underfunding, against the DEFAULT covenant — the
+            // non-strict artifact, differing only in the four tokens `strict`
+            // inserts — is ACCEPTED. What refuses the spends above is therefore the
+            // quoted bound and nothing else.
+            const control = ark.contract(scriptV2Shaped, {
+                hash: PREIMAGE_HASH,
+                receiver: payeeControl.slice(2),
+                assetTxid,
+                assetGidx,
+            });
+            await fund(control.address, control.pkScript, STRICT_SATS_SHORT, STRICT_ASSET_SHORT);
+            await control.functions
+                .claim(PREIMAGE)
+                .withAsset({
+                    assetId,
+                    inputs: [{ vin: 0, amount: STRICT_ASSET_SHORT }],
+                    outputs: [{ vout: 0, amount: STRICT_ASSET_SHORT }],
+                })
+                .to(payeeControl, STRICT_SATS_SHORT)
+                .send();
+            await waitForVtxo(indexerProvider, payeeControl);
+
+            // A lockup that meets both quotes is claimable, so the bounds refuse
+            // underfunding rather than everything. This is also the case that
+            // answers the operand-width question: `STRICT_ASSET_QUOTE` needs five
+            // bytes to encode, and the emulator compares it against an introspected
+            // amount here.
+            const { txid } = await paid.functions
+                .claim(PREIMAGE)
+                .withAsset({
+                    assetId,
+                    inputs: [{ vin: 0, amount: STRICT_ASSET_QUOTE }],
+                    outputs: [{ vout: 0, amount: STRICT_ASSET_QUOTE }],
+                })
+                .to(payeePaid, STRICT_SATS_QUOTE)
+                .send();
+
+            const [vtxo] = await waitForVtxo(indexerProvider, payeePaid);
             expect(vtxo.txid).toBe(txid);
         },
     );

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -40,8 +40,26 @@
  *   indices the covenant inspects, and whether output 0 of this spend is the
  *   receiver output the asset actually lands on.
  *
- *   Until that is understood, a passing assertion here would be worth nothing
- *   and a failing one would just be noise in the suite.
+ *   DIAGNOSIS (strong, not yet proven by a passing run). `AssetSpec.inputs` is
+ *   `{ vin, amount }[]`, and `ContractSpend.buildAssetPacket` turns each into
+ *   `AssetInput.create(vin, amount)` — which is the **LOCAL** variant, "input
+ *   from same transaction's prevouts". The sibling constructor
+ *   `AssetInput.createIntent(txid, vin, amount)` exists for the **INTENT**
+ *   variant, "output from intent transaction", and nothing in `AssetSpec` can
+ *   reach it.
+ *
+ *   An Arkade contract spend takes its input through a checkpoint / intent
+ *   transaction, so the asset arrives as an INTENT input. Declared LOCAL, the
+ *   group does not balance; an unbalanced group makes the whole asset packet
+ *   invalid; and an invalid packet means NO output is credited with the asset —
+ *   which is precisely why the OUTPUT lookup returns `0 0` even with the
+ *   amount comparison neutralised.
+ *
+ *   If that is right, this is an SDK limitation rather than a covenant problem:
+ *   `AssetSpec` cannot express the input kind an Arkade contract spend actually
+ *   has. Fixing it means widening `AssetSpec.inputs` to carry an optional
+ *   source txid and routing to `createIntent`. That is the next step, and it is
+ *   a change to this SDK, not to the covenant.
  */
 
 import { describe, it, expect, beforeEach } from "vitest";

--- a/packages/ts-sdk/test/e2e/asset-covenant.test.ts
+++ b/packages/ts-sdk/test/e2e/asset-covenant.test.ts
@@ -150,7 +150,7 @@ describe("asset-denominated non-interactive covenant", () => {
         );
         // Reversed HERE because this probe pushes the id into a raw artifact.
         // `VHTLC.ScriptV2` does the same flip internally, so a contract built
-        // through the SDK takes the id in wire order and callers do not think
+        // through the SDK takes the id in canonical order and callers do not think
         // about it; this test is the layer below that.
         const assetTxid = hex.decode(assetId.slice(0, 64)).slice().reverse();
         const idBytes = hex.decode(assetId);

--- a/packages/ts-sdk/test/vhtlc.test.ts
+++ b/packages/ts-sdk/test/vhtlc.test.ts
@@ -425,3 +425,90 @@ describe("VHTLC address", () => {
         });
     });
 });
+
+describe("VHTLC.ScriptV2 — asset denomination", () => {
+    const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
+    const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+    const baseOptions = () => ({
+        preimageHash: new Uint8Array(20).fill(9),
+        sender: key(1),
+        receiver: key(2),
+        server: key(3),
+        refundLocktime: 1_800_000_000n,
+        unilateralClaimDelay: { type: "seconds" as const, value: 512n },
+        unilateralRefundDelay: { type: "seconds" as const, value: 1024n },
+        unilateralRefundWithoutReceiverDelay: { type: "seconds" as const, value: 1536n },
+    });
+
+    const receiverPkScript = p2tr(key(4));
+    const emulatorPubkey = key(5);
+    const asset = { txid: new Uint8Array(32).fill(0xab), groupIndex: 2 };
+
+    const withAsset = (extra: object = {}) =>
+        new VHTLC.ScriptV2({
+            ...baseOptions(),
+            nonInteractiveClaim: { receiverPkScript, emulatorPubkey },
+            nonInteractiveRefund: { senderPkScript: p2tr(key(6)), emulatorPubkey },
+            ...extra,
+        });
+
+    it("leaves every script byte-identical when no asset is given", () => {
+        // The compatibility property. Every contract already funded derives
+        // from the sat covenant; a change of one byte makes those underivable
+        // and therefore unspendable.
+        const sats = withAsset();
+        const explicitlyNone = withAsset({ asset: undefined });
+        expect(hex.encode(explicitlyNone.pkScript)).toBe(hex.encode(sats.pkScript));
+        expect(explicitlyNone.nonInteractiveClaimScript).toBe(sats.nonInteractiveClaimScript);
+        expect(explicitlyNone.nonInteractiveRefundScript).toBe(sats.nonInteractiveRefundScript);
+    });
+
+    it("changes ONLY the two non-interactive leaves", () => {
+        // Every other leaf is a signature path asserting nothing about value,
+        // so an asset must make no difference to them. This is what "mostly
+        // just the non-interactive paths" means, checked rather than asserted.
+        const sats = withAsset();
+        const assets = withAsset({ asset });
+
+        expect(assets.claimScript).toBe(sats.claimScript);
+        expect(assets.refundScript).toBe(sats.refundScript);
+        expect(assets.unilateralClaimScript).toBe(sats.unilateralClaimScript);
+        expect(assets.unilateralRefundScript).toBe(sats.unilateralRefundScript);
+        expect(assets.unilateralRefundWithoutReceiverScript).toBe(
+            sats.unilateralRefundWithoutReceiverScript,
+        );
+
+        // ...and the two that DO change, change.
+        expect(assets.nonInteractiveClaimScript).not.toBe(sats.nonInteractiveClaimScript);
+        expect(assets.nonInteractiveRefundScript).not.toBe(sats.nonInteractiveRefundScript);
+        // which necessarily moves the address
+        expect(hex.encode(assets.pkScript)).not.toBe(hex.encode(sats.pkScript));
+    });
+
+    it("keeps the sat covenant as the tail, so an asset contract never enforces less", () => {
+        const sats = withAsset();
+        const assets = withAsset({ asset });
+        const satCovenant = hex.encode(sats.nonInteractiveClaimArkadeScript!);
+        const assetCovenant = hex.encode(assets.nonInteractiveClaimArkadeScript!);
+        expect(assetCovenant.endsWith(satCovenant)).toBe(true);
+        expect(assetCovenant.length).toBeGreaterThan(satCovenant.length);
+    });
+
+    it("binds the asset id, so a different asset is a different contract", () => {
+        const a = withAsset({ asset });
+        const otherTxid = withAsset({ asset: { ...asset, txid: new Uint8Array(32).fill(0xcd) } });
+        const otherGroup = withAsset({ asset: { ...asset, groupIndex: 3 } });
+        expect(hex.encode(otherTxid.pkScript)).not.toBe(hex.encode(a.pkScript));
+        expect(hex.encode(otherGroup.pkScript)).not.toBe(hex.encode(a.pkScript));
+    });
+
+    it("refuses a malformed asset id rather than encoding one", () => {
+        expect(() => withAsset({ asset: { txid: new Uint8Array(31), groupIndex: 0 } })).toThrow(
+            /32 bytes/,
+        );
+        expect(() => withAsset({ asset: { ...asset, groupIndex: -1 } })).toThrow(/\[0, 65535\]/);
+        expect(() => withAsset({ asset: { ...asset, groupIndex: 0x10000 } })).toThrow(
+            /\[0, 65535\]/,
+        );
+    });
+});

--- a/packages/ts-sdk/test/vhtlc.test.ts
+++ b/packages/ts-sdk/test/vhtlc.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { RelativeTimelock, VHTLC, arkade } from "../src";
 import vhtlcFixtures from "./fixtures/vhtlc.json";
 import { hex } from "@scure/base";
+import { ArkadeScript } from "../src/arkade/script";
 import { schnorr } from "@noble/curves/secp256k1.js";
 
 describe("VHTLC address", () => {
@@ -523,6 +524,87 @@ describe("VHTLC.ScriptV2 — asset denomination", () => {
         const before = hex.encode(mine.txid);
         withAsset({ asset: mine });
         expect(hex.encode(mine.txid)).toBe(before);
+    });
+
+    /** An asset contract whose claim leaf opts into the quoted bound. */
+    const strictClaim = (strict: object, extra: object = {}) =>
+        withAsset({
+            asset,
+            nonInteractiveClaim: { receiverPkScript, emulatorPubkey, strict },
+            ...extra,
+        });
+
+    it("leaves EVERY byte unchanged when strict is omitted", () => {
+        // The compatibility property the option rests on. `strict` compiles into
+        // the leaf, hence the emulator key, hence the address — so if merely
+        // ADDING the option moved the default bytes, every already-funded
+        // contract would change address.
+        const plain = withAsset({ asset });
+        const explicitlyNotStrict = withAsset({
+            asset,
+            nonInteractiveClaim: { receiverPkScript, emulatorPubkey, strict: undefined },
+        });
+        expect(hex.encode(explicitlyNotStrict.pkScript)).toBe(hex.encode(plain.pkScript));
+    });
+
+    it("ADDS the quoted bound to conservation rather than replacing it", () => {
+        // Alone, `out >= quoted` leaves everything above the quote unconstrained
+        // — an overfunded lockup's surplus could be routed anywhere. A strict
+        // claim must still carry the input comparison.
+        const built = strictClaim({
+            amount: 0x1a2b3c4d5e6f7788n,
+            assetAmount: 0x1122334455667788n,
+        });
+        const ops = ArkadeScript.decode(built.nonInteractiveClaimArkadeScript!).map((op) =>
+            op instanceof Uint8Array ? hex.encode(op) : String(op),
+        );
+        // Conservation, still there, on both quantities.
+        expect(ops).toContain("INSPECTINPUTVALUE");
+        expect(ops).toContain("INSPECTINASSETLOOKUP");
+        // ...and the quotes, added.
+        const push = (v: bigint) =>
+            hex.encode(ArkadeScript.decode(ArkadeScript.encode([v]))[0] as Uint8Array);
+        expect(ops).toContain(push(0x1a2b3c4d5e6f7788n));
+        expect(ops).toContain(push(0x1122334455667788n));
+    });
+
+    it("binds the quote to the CLAIM leaf only — the refund leaf is untouched", () => {
+        // A refund returns what arrived. If the quote reached the refund covenant,
+        // re-quoting would move where an already-funded contract can refund TO.
+        const plain = withAsset({ asset });
+        const strict = strictClaim({ amount: 5_000n, assetAmount: 7n });
+        expect(hex.encode(strict.nonInteractiveClaimArkadeScript!)).not.toBe(
+            hex.encode(plain.nonInteractiveClaimArkadeScript!),
+        );
+        expect(hex.encode(strict.nonInteractiveRefundArkadeScript!)).toBe(
+            hex.encode(plain.nonInteractiveRefundArkadeScript!),
+        );
+    });
+
+    it("refuses every way of asking for HALF the enforcement", () => {
+        // A zero bound is satisfied by every output, including one carrying none
+        // of the asset — enforcement-shaped and enforcing nothing.
+        expect(() => strictClaim({ amount: 0n, assetAmount: 1n })).toThrow(
+            /amount must be positive/,
+        );
+        expect(() => strictClaim({ amount: 1n, assetAmount: 0n })).toThrow(
+            /assetAmount must be positive/,
+        );
+        // The dangerous one: strict on the sat CARRIER while the asset — the
+        // actual amount — goes unbounded.
+        expect(() => strictClaim({ amount: 1n })).toThrow(
+            /would leave the asset amount unenforced/,
+        );
+        // ...and its mirror: an asset bound on a contract that binds no asset.
+        expect(() =>
+            withAsset({
+                nonInteractiveClaim: {
+                    receiverPkScript,
+                    emulatorPubkey,
+                    strict: { amount: 1n, assetAmount: 1n },
+                },
+            }),
+        ).toThrow(/assetAmount has no effect without asset/);
     });
 
     it("refuses an asset that no leaf would bind, instead of silently dropping it", () => {

--- a/packages/ts-sdk/test/vhtlc.test.ts
+++ b/packages/ts-sdk/test/vhtlc.test.ts
@@ -502,6 +502,28 @@ describe("VHTLC.ScriptV2 — asset denomination", () => {
         expect(hex.encode(otherGroup.pkScript)).not.toBe(hex.encode(a.pkScript));
     });
 
+    it("pushes the txid REVERSED, because that is what the opcode matches", () => {
+        // `asset.txid` is WIRE order -- the leading 32 bytes of the serialized
+        // Asset ID -- but the introspection opcodes match those bytes reversed.
+        // Push wire order and the lookup reports the asset ABSENT (`0 0`), so
+        // the covenant fails and the contract it guards is unspendable, with
+        // nothing in the error naming the cause. Established on regtest against
+        // a real minted asset (see test/e2e/asset-covenant.test.ts).
+        const distinct = { txid: new Uint8Array(32).map((_, i) => i + 1), groupIndex: 1 };
+        const covenant = hex.encode(
+            withAsset({ asset: distinct }).nonInteractiveClaimArkadeScript!,
+        );
+        expect(covenant).toContain(hex.encode(Uint8Array.from(distinct.txid).reverse()));
+        expect(covenant).not.toContain(hex.encode(distinct.txid));
+    });
+
+    it("does not mutate the caller's asset id", () => {
+        const mine = { txid: new Uint8Array(32).map((_, i) => i + 1), groupIndex: 1 };
+        const before = hex.encode(mine.txid);
+        withAsset({ asset: mine });
+        expect(hex.encode(mine.txid)).toBe(before);
+    });
+
     it("refuses a malformed asset id rather than encoding one", () => {
         expect(() => withAsset({ asset: { txid: new Uint8Array(31), groupIndex: 0 } })).toThrow(
             /32 bytes/,

--- a/packages/ts-sdk/test/vhtlc.test.ts
+++ b/packages/ts-sdk/test/vhtlc.test.ts
@@ -534,6 +534,71 @@ describe("VHTLC.ScriptV2 — asset denomination", () => {
             ...extra,
         });
 
+    it("derives the pkScript it derived BEFORE strict existed, for every shape", () => {
+        // GOLDEN VECTORS, and what they are compared against is the point. The
+        // sibling test asserts `strict: undefined` equals omitting it — nearly a
+        // tautology in JS, since both are `undefined` on the property. What that
+        // cannot show is that ADDING the option left the default path's BYTES
+        // alone, and those bytes ARE the address of every contract already
+        // funded.
+        //
+        // Captured from b43534b — the commit before `strict` existed — and
+        // verified identical at the commit that added it, across all seven
+        // shapes and both script versions. A change that moves the default path
+        // fails here instead of making funded contracts underivable.
+        const claimLeaf = { receiverPkScript, emulatorPubkey };
+        const refundLeaf = { senderPkScript: p2tr(key(6)), emulatorPubkey };
+        const shapes: [string, object, string, string][] = [
+            [
+                "bare",
+                {},
+                "512069be6bafd0f15802284199463ddc3fa995fd6a5ba470d9ce02a565f286492fc8",
+                "5120f2612eed370d3603672b7e256635fdb1e8fdf2636853175cc0dbec585d50679e",
+            ],
+            [
+                "claim only",
+                { nonInteractiveClaim: claimLeaf },
+                "5120bbc33adb5e0f81ad7fd3a14380cf5d552815bdadfbffeaa1ab4938c486e16bbd",
+                "51207b87979f8e028ea914a8a53e088650c99fdcf61696cf539dc1d6412bbac88deb",
+            ],
+            [
+                "refund only",
+                { nonInteractiveClaim: undefined, nonInteractiveRefund: refundLeaf },
+                "5120699c92a6ed1b32cc9ab346d17eb9960de311172388e5f6c50212e0e91984a0d0",
+                "5120915ced574d918f70128ef16160f3b72ac05dad06e27162fffb90b33f4d2ee5c2",
+            ],
+            [
+                "both leaves",
+                { nonInteractiveClaim: claimLeaf, nonInteractiveRefund: refundLeaf },
+                "5120d155531ea89a92eac969c5e5205607b9debba9a4e66453c9410e9b6ca38e4eda",
+                "5120d8880eda3ad3281604f27e5b5dcd851631acb974f9d8aecf18a9e13e3a439f5b",
+            ],
+            [
+                "asset + both",
+                { nonInteractiveClaim: claimLeaf, nonInteractiveRefund: refundLeaf, asset },
+                "5120dd8f3358c9d8300d57772c6450f1d310086d45e5903aa1808637d8dd3e5ffea0",
+                "5120869d1ad5a5bced06a50c883c718c8e25f531168a8f536469ca58e28360a87a8e",
+            ],
+            [
+                "asset + claim only",
+                { nonInteractiveClaim: claimLeaf, nonInteractiveRefund: undefined, asset },
+                "5120e2d876c066c379b809f0c52eedc1cfb0820bf02ad9c08ed01fdc61221de89bf1",
+                "5120e768c26de90c1450f06492c212c12d2d0927fbefff866b16939ecd52d3cde9f1",
+            ],
+            [
+                "asset + refund only",
+                { nonInteractiveClaim: undefined, nonInteractiveRefund: refundLeaf, asset },
+                "51201c2b6772a07dccfa83eb07210c420d73d928d72b3d03f5e88888858743cad280",
+                "5120e953cff4c35d60942bdfbd7a741d19ebbf9ebc499f381a9d16f6945bfe317d6f",
+            ],
+        ];
+        for (const [name, extra, v2, v1] of shapes) {
+            const options = { ...baseOptions(), ...extra };
+            expect(hex.encode(new VHTLC.ScriptV2(options).pkScript), `${name} (v2)`).toBe(v2);
+            expect(hex.encode(new VHTLC.Script(options).pkScript), `${name} (v1)`).toBe(v1);
+        }
+    });
+
     it("leaves EVERY byte unchanged when strict is omitted", () => {
         // The compatibility property the option rests on. `strict` compiles into
         // the leaf, hence the emulator key, hence the address — so if merely

--- a/packages/ts-sdk/test/vhtlc.test.ts
+++ b/packages/ts-sdk/test/vhtlc.test.ts
@@ -503,9 +503,10 @@ describe("VHTLC.ScriptV2 — asset denomination", () => {
     });
 
     it("pushes the txid REVERSED, because that is what the opcode matches", () => {
-        // `asset.txid` is WIRE order -- the leading 32 bytes of the serialized
+        // `asset.txid` is CANONICAL order -- the leading 32 bytes of the serialized
         // Asset ID -- but the introspection opcodes match those bytes reversed.
-        // Push wire order and the lookup reports the asset ABSENT (`0 0`), so
+        // Push the canonical bytes unflipped and the lookup reports the asset
+        // ABSENT (`0 0`), so
         // the covenant fails and the contract it guards is unspendable, with
         // nothing in the error naming the cause. Established on regtest against
         // a real minted asset (see test/e2e/asset-covenant.test.ts).

--- a/packages/ts-sdk/test/vhtlc.test.ts
+++ b/packages/ts-sdk/test/vhtlc.test.ts
@@ -524,6 +524,58 @@ describe("VHTLC.ScriptV2 — asset denomination", () => {
         expect(hex.encode(mine.txid)).toBe(before);
     });
 
+    it("refuses an asset that no leaf would bind, instead of silently dropping it", () => {
+        // THE SILENT CASE. Both non-interactive leaves are optional, and they are
+        // the only ones carrying the covenant — the signature leaves assert
+        // nothing about value. So `asset` with neither leaf used to build a
+        // sat-only contract and say nothing: the caller funds it believing the
+        // asset is bound, and ANY spend satisfying the sat covenant walks off
+        // with the asset. The only outward difference is a pkScript that happens
+        // to match a non-asset address, which is not something a caller checks.
+        expect(
+            () =>
+                new VHTLC.ScriptV2({
+                    ...baseOptions(),
+                    asset,
+                }),
+        ).toThrow(/no effect without/);
+        // One leaf is enough to bind it, so neither is required individually.
+        expect(
+            () =>
+                new VHTLC.ScriptV2({
+                    ...baseOptions(),
+                    nonInteractiveClaim: { receiverPkScript, emulatorPubkey },
+                    asset,
+                }),
+        ).not.toThrow();
+        expect(
+            () =>
+                new VHTLC.ScriptV2({
+                    ...baseOptions(),
+                    nonInteractiveRefund: { senderPkScript: p2tr(key(6)), emulatorPubkey },
+                    asset,
+                }),
+        ).not.toThrow();
+    });
+
+    it("binds the asset on VHTLC.Script (v1) too, which inherits the same base", () => {
+        // The option lands on `BaseScript`, so v1 gets it. That is deliberate —
+        // the asset covenant is orthogonal to the preimage-condition fragment
+        // that is the ONLY difference between versions — but it has to be
+        // asserted, or v1 is carrying an untested money path.
+        const v1 = new VHTLC.Script({
+            ...baseOptions(),
+            nonInteractiveClaim: { receiverPkScript, emulatorPubkey },
+            asset,
+        });
+        const v1NoAsset = new VHTLC.Script({
+            ...baseOptions(),
+            nonInteractiveClaim: { receiverPkScript, emulatorPubkey },
+        });
+        expect(hex.encode(v1.pkScript)).not.toBe(hex.encode(v1NoAsset.pkScript));
+        expect(() => new VHTLC.Script({ ...baseOptions(), asset })).toThrow(/no effect without/);
+    });
+
     it("refuses a malformed asset id rather than encoding one", () => {
         expect(() => withAsset({ asset: { txid: new Uint8Array(31), groupIndex: 0 } })).toThrow(
             /32 bytes/,


### PR DESCRIPTION
`VHTLC.ScriptV2` gains an optional `asset`, so a VHTLC can escrow an Arkade asset
rather than only sats.

```ts
asset?: {
  txid: Bytes      // the asset's genesis transaction id, 32 bytes
  groupIndex: number  // the asset group index within that genesis transaction
}
```

## What changes, and what deliberately does not

Only `nonInteractiveClaim` and `nonInteractiveRefund` — the two leaves carrying a
covenant the emulator enforces. The interactive signature leaves are
byte-identical, because a signature path asserts nothing about value, so an asset
makes no difference there. That is asserted, not assumed.

**Omitting `asset` leaves every script byte-identical**, so contracts already
funded still derive to the same address. There is a test for exactly that.

**The sat clause is RETAINED, not replaced.** An asset-carrying VTXO carries sats
too, so a covenant constraining only the asset would let a spend keep the asset
and strip the sats — the mirror of the bug the asset clause exists to prevent.
The sat covenant becomes the asset covenant's tail.

## The trap, in case it saves someone the afternoon

**The txid the script pushes is REVERSED relative to the serialized Asset ID.**
`assetId.slice(0, 64)` is the leading 32 bytes; the introspection opcode matches
only against those bytes reversed. Push them in wire order and
`OP_INSPECTOUTASSETLOOKUP` reports the asset **absent** — which then reads as
`amount = 0`, and `0 >= 0` passes, so the asset-stripping spend the covenant
exists to stop would succeed.

Nothing in the failure names it: the emulator says only `OP_VERIFY failed vin=0`,
and it fails identically whatever the amount comparison says, which is what
isolated it. `ScriptV2` does the flip internally, so callers pass the id in wire
order and never think about it.

Two other things found the same way, by elimination against the BTC-only control
in `non-interactive-htlc.test.ts`, which passes throughout — so the stack was
never the variable:

- **the asset input is LOCAL, not INTENT.** arkd refuses the alternative outright:
  `ASSET_INPUT_INVALID (35): unexpected asset input type: intent`
- **issuance is not immediately spendable** — the balance has to reflect it first.

## Verification

- **unit**: 163 files / 2630 tests pass, 1 skipped. `tsc --noEmit` clean.
- **e2e** (`test/e2e/asset-covenant.test.ts`): the emulator co-signs a spend that
  pays the asset through, **and rejects** one that pays the sats while keeping the
  asset. Both halves of the covenant's claim.
- Re-run on a **freshly created** regtest chain, not only the one it was developed
  against, so the reversed-txid behaviour is not an artefact of a single chain.

### Running the e2e

It needs arkd intent fees zeroed. The regtest stack applies real fees at the end
of `start()`, after which the probe's faucet dies with

```
INTENT_INSUFFICIENT_FEE (31): got 0 min expected 2000
```

which looks like a covenant rejection and is not. Zero them, run, restore:

```
curl -X POST localhost:7071/v1/admin/intentFees -H 'Content-Type: application/json' \
  -d '{"fees":{"offchainInputFee":"0.0","onchainInputFee":"0.0","offchainOutputFee":"0.0","onchainOutputFee":"0.0"}}'
```

## What this does NOT establish

Worth stating plainly, because it is the difference between "the covenant works"
and "a consumer can rely on it":

The e2e proves the **emulator enforces the asset covenant** — but it builds from a
hand-rolled artifact through `ark.contract()`, not through `ScriptV2`. `ScriptV2`'s
asset support is covered by unit tests only (script construction). **No test yet
spends a `ScriptV2`-built asset lockup against the emulator**, and no e2e in this
package builds through `ScriptV2` at all — `non-interactive-htlc.test.ts` defines
its own artifact inline too.

So the two halves each have evidence and the join does not. That join is what a
consumer locking funds to a `ScriptV2` asset lockup would depend on, and it is
the next thing to write rather than something this PR should be read as covering.

The refund leaf is also not e2e-covered here — note that is equally true of BTC in
this package, so it is a pre-existing coverage level rather than an asset-specific
hole.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional asset support to VHTLC claim and refund covenants.
  - Asset-aware covenants verify asset identity, preserve satoshi requirements, and require complete asset forwarding.
  - Asset-backed VHTLC parameters now persist correctly through serialization and deserialization.
  - Satoshi-only behavior remains unchanged when no asset is configured.

- **Bug Fixes**
  - Added validation for malformed or incomplete asset configurations.

- **Tests**
  - Added unit and end-to-end coverage for asset covenant execution, compatibility, validation, and forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->