### PR TITLE
fix(sdk): recover from closed IndexedDB connections everywhere

### DIFF
--- a/packages/boltz-swap/src/repositories/IndexedDb/swap-repository.ts
+++ b/packages/boltz-swap/src/repositories/IndexedDb/swap-repository.ts
@@ -6,7 +6,7 @@ import {
     hasImpossibleSwapsFilter,
     SwapRepository,
 } from "../swap-repository";
-import { closeDatabase, openDatabase } from "@arkade-os/sdk";
+import { createManagedConnection, type ManagedConnection } from "@arkade-os/sdk";
 
 const DEFAULT_DB_NAME = "arkade-boltz-swap";
 const DB_VERSION = 2;
@@ -30,14 +30,14 @@ function asArray<T>(v: T | T[] | undefined): T[] | undefined {
 
 export class IndexedDbSwapRepository implements SwapRepository {
     readonly version = 1 as const;
-    private db: IDBDatabase | null = null;
+    private readonly connection: ManagedConnection;
 
-    constructor(private readonly dbName: string = DEFAULT_DB_NAME) {}
+    constructor(dbName: string = DEFAULT_DB_NAME) {
+        this.connection = createManagedConnection(dbName, DB_VERSION, initDatabase);
+    }
 
-    private async getDB(): Promise<IDBDatabase> {
-        if (this.db) return this.db;
-        this.db = await openDatabase(this.dbName, DB_VERSION, initDatabase);
-        return this.db;
+    private getDB(): Promise<IDBDatabase> {
+        return this.connection.get();
     }
 
     async saveSwap<T extends BoltzSwap>(swap: T): Promise<void> {
@@ -181,8 +181,6 @@ export class IndexedDbSwapRepository implements SwapRepository {
     }
 
     async [Symbol.asyncDispose](): Promise<void> {
-        if (!this.db) return;
-        await closeDatabase(this.dbName);
-        this.db = null;
+        await this.connection[Symbol.asyncDispose]();
     }
 }

--- a/packages/boltz-swap/src/repositories/IndexedDb/swap-repository.ts
+++ b/packages/boltz-swap/src/repositories/IndexedDb/swap-repository.ts
@@ -6,7 +6,13 @@ import {
     hasImpossibleSwapsFilter,
     SwapRepository,
 } from "../swap-repository";
-import { createManagedConnection, type ManagedConnection } from "@arkade-os/sdk";
+import {
+    awaitTransaction,
+    createManagedConnection,
+    getAllByIndexValues,
+    promisifyRequest,
+    type ManagedConnection,
+} from "@arkade-os/sdk";
 
 const DEFAULT_DB_NAME = "arkade-boltz-swap";
 const DB_VERSION = 2;
@@ -42,24 +48,16 @@ export class IndexedDbSwapRepository implements SwapRepository {
 
     async saveSwap<T extends BoltzSwap>(swap: T): Promise<void> {
         const db = await this.getDB();
-        return new Promise((resolve, reject) => {
-            const transaction = db.transaction([STORE_SWAPS_STATE], "readwrite");
-            const store = transaction.objectStore(STORE_SWAPS_STATE);
-            const request = store.put(swap);
-            request.onsuccess = () => resolve();
-            request.onerror = () => reject(request.error);
-        });
+        const transaction = db.transaction([STORE_SWAPS_STATE], "readwrite");
+        transaction.objectStore(STORE_SWAPS_STATE).put(swap);
+        await awaitTransaction(transaction);
     }
 
     async deleteSwap(id: string): Promise<void> {
         const db = await this.getDB();
-        return new Promise((resolve, reject) => {
-            const transaction = db.transaction([STORE_SWAPS_STATE], "readwrite");
-            const store = transaction.objectStore(STORE_SWAPS_STATE);
-            const request = store.delete(id);
-            request.onsuccess = () => resolve();
-            request.onerror = () => reject(request.error);
-        });
+        const transaction = db.transaction([STORE_SWAPS_STATE], "readwrite");
+        transaction.objectStore(STORE_SWAPS_STATE).delete(id);
+        await awaitTransaction(transaction);
     }
 
     async getAllSwaps<T extends BoltzSwap>(filter?: GetSwapsFilter): Promise<T[]> {
@@ -68,31 +66,9 @@ export class IndexedDbSwapRepository implements SwapRepository {
 
     async clear(): Promise<void> {
         const db = await this.getDB();
-        return new Promise((resolve, reject) => {
-            const transaction = db.transaction([STORE_SWAPS_STATE], "readwrite");
-            const store = transaction.objectStore(STORE_SWAPS_STATE);
-            const request = store.clear();
-            request.onsuccess = () => resolve();
-            request.onerror = () => reject(request.error);
-        });
-    }
-
-    private getSwapsByIndexValues<T>(
-        store: IDBObjectStore,
-        indexName: string,
-        values: string[],
-    ): Promise<T[]> {
-        if (values.length === 0) return Promise.resolve([]);
-        const index = store.index(indexName);
-        const requests = values.map(
-            (value) =>
-                new Promise<T[]>((resolve, reject) => {
-                    const request = index.getAll(value);
-                    request.onerror = () => reject(request.error);
-                    request.onsuccess = () => resolve(request.result ?? []);
-                }),
-        );
-        return Promise.all(requests).then((results) => results.flatMap((result) => result));
+        const transaction = db.transaction([STORE_SWAPS_STATE], "readwrite");
+        transaction.objectStore(STORE_SWAPS_STATE).clear();
+        await awaitTransaction(transaction);
     }
 
     private async getAllSwapsFromStore<
@@ -111,37 +87,26 @@ export class IndexedDbSwapRepository implements SwapRepository {
             .objectStore(STORE_SWAPS_STATE);
 
         if (!filter || Object.keys(filter).length === 0) {
-            return new Promise((resolve, reject) => {
-                const request = store.getAll();
-                request.onsuccess = () => resolve((request.result ?? []) as T[]);
-                request.onerror = () => reject(request.error);
-            });
+            return (await promisifyRequest<T[]>(store.getAll())) ?? [];
         }
 
         const ids = asArray(filter.id);
         if (ids) {
             const swaps = await Promise.all(
-                ids.map(
-                    (id) =>
-                        new Promise<T | undefined>((resolve, reject) => {
-                            const request = store.get(id);
-                            request.onsuccess = () => resolve(request.result as T | undefined);
-                            request.onerror = () => reject(request.error);
-                        }),
-                ),
+                ids.map((id) => promisifyRequest<T | undefined>(store.get(id))),
             );
             return applyCreatedAtOrder(applySwapsFilter(swaps, filter) as T[], filter);
         }
 
         const types = asArray(filter.type);
         if (types) {
-            const swaps = await this.getSwapsByIndexValues<T>(store, "type", types);
+            const swaps = await getAllByIndexValues<T>(store, "type", types);
             return applyCreatedAtOrder(applySwapsFilter(swaps, filter) as T[], filter);
         }
 
         const statuses = asArray(filter.status);
         if (statuses) {
-            const swaps = await this.getSwapsByIndexValues<T>(store, "status", statuses);
+            const swaps = await getAllByIndexValues<T>(store, "status", statuses);
             return applyCreatedAtOrder(applySwapsFilter(swaps, filter) as T[], filter);
         }
 
@@ -149,11 +114,7 @@ export class IndexedDbSwapRepository implements SwapRepository {
             return this.getAllSwapsByCreatedAt<T>(store, filter.orderDirection);
         }
 
-        const allSwaps = await new Promise<T[]>((resolve, reject) => {
-            const request = store.getAll();
-            request.onsuccess = () => resolve(request.result ?? []);
-            request.onerror = () => reject(request.error);
-        });
+        const allSwaps = (await promisifyRequest<T[]>(store.getAll())) ?? [];
 
         return applyCreatedAtOrder(applySwapsFilter(allSwaps, filter) as T[], filter);
     }

--- a/packages/boltz-swap/test/swap-repository.test.ts
+++ b/packages/boltz-swap/test/swap-repository.test.ts
@@ -264,4 +264,52 @@ describe("SwapRepository implementations", () => {
             ]);
         });
     });
+
+    /** The connection contract of the shared managed-connection helper, seen
+     * through this repository: a connection that goes away is forgotten and
+     * reopened instead of bricking the store until reload. */
+    describe("IndexedDbSwapRepository whose connection went away", () => {
+        const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+        it("reopens after an external delete", async () => {
+            const dbName = `swap-reopen-${Math.random()}`;
+            const repo = new IndexedDbSwapRepository(dbName);
+            await repo.saveSwap(createReverseSwap("reverse-1", "swap.created"));
+
+            await new Promise<void>((resolve, reject) => {
+                const del = indexedDB.deleteDatabase(dbName);
+                del.onsuccess = () => resolve();
+                del.onerror = () => reject(del.error);
+            });
+            await flush();
+
+            // recreated and empty, the point being that it opens one at all
+            await repo.saveSwap(createReverseSwap("reverse-2", "swap.created"));
+            expect((await repo.getAllSwaps()).map((s) => s.id)).toEqual(["reverse-2"]);
+            await repo[Symbol.asyncDispose]();
+        });
+
+        it("fails honestly, and repeatably, when another tab upgraded past it", async () => {
+            const dbName = `swap-newer-${Math.random()}`;
+            const repo = new IndexedDbSwapRepository(dbName);
+            await repo.saveSwap(createReverseSwap("reverse-1", "swap.created"));
+
+            const newer = await new Promise<IDBDatabase>((resolve, reject) => {
+                const open = indexedDB.open(dbName, 99);
+                open.onsuccess = () => resolve(open.result);
+                open.onerror = () => reject(open.error);
+            });
+            await flush();
+            try {
+                for (const attempt of [1, 2]) {
+                    await expect(
+                        repo.saveSwap(createReverseSwap(`reverse-${attempt}`, "swap.created")),
+                        `attempt ${attempt}`,
+                    ).rejects.toMatchObject({ name: "VersionError" });
+                }
+            } finally {
+                newer.close();
+            }
+        });
+    });
 });

--- a/packages/swap/src/indexedDbRepository.ts
+++ b/packages/swap/src/indexedDbRepository.ts
@@ -1,4 +1,4 @@
-import { closeDatabase, openDatabase } from "@arkade-os/sdk";
+import { createManagedConnection, type ManagedConnection } from "@arkade-os/sdk";
 import { marketsCacheKey, type AssetSwapRepository, type MarketsCacheEntry } from "./repository";
 import type { AssetSwap } from "./store";
 import type { RfqSwapRecord } from "./rfqRecord";
@@ -65,45 +65,14 @@ const txDone = (tx: IDBTransaction): Promise<void> =>
  * infrastructure the wallet already uses for its Boltz swap repository. */
 export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
     readonly version = 3 as const;
-    // the promise, not the resolved database: openDatabase bumps a refcount on
-    // every call including cache hits, while dispose closes once, so two
-    // concurrent first calls would strand the refcount above zero and leak the
-    // connection for the process lifetime. Cleared on failure so a failed open
-    // can be retried rather than cached forever.
-    private dbPromise: Promise<IDBDatabase> | null = null;
+    private readonly connection: ManagedConnection;
 
-    constructor(private readonly dbName: string = DEFAULT_DB_NAME) {}
+    constructor(dbName: string = DEFAULT_DB_NAME) {
+        this.connection = createManagedConnection(dbName, DB_VERSION, initDatabase);
+    }
 
     private ensureDb(): Promise<IDBDatabase> {
-        if (this.dbPromise) return this.dbPromise;
-        const opening = openDatabase(this.dbName, DB_VERSION, initDatabase)
-            .then((db) => {
-                // A connection that goes away must be forgotten, or every later
-                // transaction throws `InvalidStateError` with no path back — the
-                // manager closes the database on `versionchange` and this cache
-                // would still hold the closed handle. Reopening either recovers
-                // (an external delete, an eviction) or fails honestly with
-                // `VersionError` when another tab upgraded past this bundle,
-                // which names the reload instead of implying a client bug.
-                const forget = () => {
-                    // identity check: a reopen may already have replaced this
-                    // promise, and nulling that one would drop a live connection
-                    if (this.dbPromise === opening) this.dbPromise = null;
-                };
-                // addEventListener, not `db.onversionchange =`: that handler is
-                // the manager's, and its close is what we want to keep. `close`
-                // fires only on ABNORMAL termination per spec — never on an
-                // explicit close() — so the two never double-fire.
-                db.addEventListener("versionchange", forget);
-                db.addEventListener("close", forget);
-                return db;
-            })
-            .catch((err) => {
-                this.dbPromise = null;
-                throw err;
-            });
-        this.dbPromise = opening;
-        return opening;
+        return this.connection.get();
     }
 
     private async readStore(name: string): Promise<IDBObjectStore> {
@@ -187,8 +156,6 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
     }
 
     async [Symbol.asyncDispose](): Promise<void> {
-        if (!this.dbPromise) return;
-        await closeDatabase(this.dbName);
-        this.dbPromise = null;
+        await this.connection[Symbol.asyncDispose]();
     }
 }

--- a/packages/swap/src/indexedDbRepository.ts
+++ b/packages/swap/src/indexedDbRepository.ts
@@ -1,4 +1,9 @@
-import { createManagedConnection, type ManagedConnection } from "@arkade-os/sdk";
+import {
+    awaitTransaction,
+    createManagedConnection,
+    promisifyRequest,
+    type ManagedConnection,
+} from "@arkade-os/sdk";
 import { marketsCacheKey, type AssetSwapRepository, type MarketsCacheEntry } from "./repository";
 import type { AssetSwap } from "./store";
 import type { RfqSwapRecord } from "./rfqRecord";
@@ -45,22 +50,6 @@ function initDatabase(db: IDBDatabase, oldVersion: number, transaction: IDBTrans
     }
 }
 
-const request = <T>(req: IDBRequest<T>): Promise<T> =>
-    new Promise((resolve, reject) => {
-        req.onsuccess = () => resolve(req.result);
-        req.onerror = () => reject(req.error);
-    });
-
-/** A write is durable at *commit*, not at request success — quota pressure and
- * storage eviction abort a transaction whose every request already succeeded.
- * Reads may resolve on the request; writes must await this. */
-const txDone = (tx: IDBTransaction): Promise<void> =>
-    new Promise((resolve, reject) => {
-        tx.oncomplete = () => resolve();
-        tx.onerror = () => reject(tx.error);
-        tx.onabort = () => reject(tx.error);
-    });
-
 /** Browser backend over the SDK's shared IndexedDB manager — the same
  * infrastructure the wallet already uses for its Boltz swap repository. */
 export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
@@ -81,10 +70,10 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
 
     /** Every write in one place, so none of them can forget to await the
      * commit. Requests need no individual await: a failed one aborts the
-     * transaction, which `txDone` reports. */
+     * transaction, which `awaitTransaction` reports. */
     private async write(name: string, apply: (store: IDBObjectStore) => void): Promise<void> {
         const tx = (await this.ensureDb()).transaction([name], "readwrite");
-        const done = txDone(tx);
+        const done = awaitTransaction(tx);
         apply(tx.objectStore(name));
         await done;
     }
@@ -96,7 +85,7 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
     }
 
     async getAllSwaps(): Promise<AssetSwap[]> {
-        return request((await this.readStore(STORE_SWAPS)).getAll());
+        return promisifyRequest((await this.readStore(STORE_SWAPS)).getAll());
     }
 
     async saveRfqSwap(record: RfqSwapRecord): Promise<void> {
@@ -106,7 +95,7 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
     }
 
     async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {
-        return request((await this.readStore(STORE_RFQ_SWAPS)).getAll());
+        return promisifyRequest((await this.readStore(STORE_RFQ_SWAPS)).getAll());
     }
 
     async removeRfqSwap(rfqId: string): Promise<void> {
@@ -116,7 +105,7 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
     }
 
     async getScannedTxids(): Promise<Set<string>> {
-        const keys = await request((await this.readStore(STORE_SCANNED)).getAllKeys());
+        const keys = await promisifyRequest((await this.readStore(STORE_SCANNED)).getAllKeys());
         return new Set(keys as string[]);
     }
 
@@ -131,7 +120,7 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
         registry: string,
     ): Promise<MarketsCacheEntry | undefined> {
         const store = await this.readStore(STORE_MARKETS);
-        return request(store.get(marketsCacheKey(network, registry)));
+        return promisifyRequest(store.get(marketsCacheKey(network, registry)));
     }
 
     async saveCachedMarkets(
@@ -150,7 +139,7 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
     async clear(): Promise<void> {
         const stores = STORES.map(([name]) => name);
         const tx = (await this.ensureDb()).transaction(stores, "readwrite");
-        const done = txDone(tx);
+        const done = awaitTransaction(tx);
         for (const name of stores) tx.objectStore(name).clear();
         await done;
     }

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -513,6 +513,11 @@ import {
     BLOCKED_UPGRADE_TIMEOUT_MS,
 } from "./repositories/indexedDB/manager";
 import {
+    createManagedConnection,
+    ConnectionDisposedError,
+} from "./repositories/indexedDB/managedConnection";
+import type { ManagedConnection } from "./repositories/indexedDB/managedConnection";
+import {
     WalletMessageHandler,
     WalletNotInitializedError,
     ReadonlyWalletError,
@@ -689,7 +694,9 @@ export {
     // DB
     closeDatabase,
     openDatabase,
+    createManagedConnection,
     DatabaseUpgradeBlockedError,
+    ConnectionDisposedError,
     BLOCKED_UPGRADE_TIMEOUT_MS,
 
     // Repositories
@@ -1041,6 +1048,7 @@ export type {
     DelegateOptions,
 
     // Repositories
+    ManagedConnection,
     WalletRepository,
     ContractRepository,
     MigrationStatus,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -516,6 +516,12 @@ import {
     createManagedConnection,
     ConnectionDisposedError,
 } from "./repositories/indexedDB/managedConnection";
+import {
+    promisifyRequest,
+    awaitTransaction,
+    deleteByIndex,
+    getAllByIndexValues,
+} from "./repositories/indexedDB/idbUtils";
 import type { ManagedConnection } from "./repositories/indexedDB/managedConnection";
 import {
     WalletMessageHandler,
@@ -698,6 +704,10 @@ export {
     DatabaseUpgradeBlockedError,
     ConnectionDisposedError,
     BLOCKED_UPGRADE_TIMEOUT_MS,
+    promisifyRequest,
+    awaitTransaction,
+    deleteByIndex,
+    getAllByIndexValues,
 
     // Repositories
     IndexedDBWalletRepository,

--- a/packages/ts-sdk/src/repositories/indexedDB/contractRepository.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/contractRepository.ts
@@ -1,6 +1,7 @@
 import { DB_VERSION, STORE_CONTRACTS } from "./db";
 import { Contract, watchStateOf } from "../../contracts";
 import { ContractFilter, ContractRepository } from "../contractRepository";
+import { awaitTransaction, getAllByIndexValues, promisifyRequest } from "./idbUtils";
 import { createManagedConnection, ManagedConnection } from "./managedConnection";
 import { initDatabase } from "./schema";
 import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
@@ -21,28 +22,9 @@ export class IndexedDBContractRepository implements ContractRepository {
     async clear(): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_CONTRACTS], "readwrite");
-                const contractDataStore = transaction.objectStore(STORE_CONTRACTS);
-                const contractsStore = transaction.objectStore(STORE_CONTRACTS);
-
-                const contractDataRequest = contractDataStore.clear();
-                const contractsRequest = contractsStore.clear();
-
-                let completed = 0;
-                const checkComplete = () => {
-                    completed++;
-                    if (completed === 2) {
-                        resolve();
-                    }
-                };
-
-                contractDataRequest.onsuccess = checkComplete;
-                contractsRequest.onsuccess = checkComplete;
-
-                contractDataRequest.onerror = () => reject(contractDataRequest.error);
-                contractsRequest.onerror = () => reject(contractsRequest.error);
-            });
+            const transaction = db.transaction([STORE_CONTRACTS], "readwrite");
+            transaction.objectStore(STORE_CONTRACTS).clear();
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error("Failed to clear contract data:", error);
             throw error;
@@ -57,11 +39,7 @@ export class IndexedDBContractRepository implements ContractRepository {
                 .objectStore(STORE_CONTRACTS);
 
             if (!filter || Object.keys(filter).length === 0) {
-                return new Promise((resolve, reject) => {
-                    const request = store.getAll();
-                    request.onerror = () => reject(request.error);
-                    request.onsuccess = () => resolve(request.result ?? []);
-                });
+                return (await promisifyRequest<Contract[]>(store.getAll())) ?? [];
             }
 
             const normalizedFilter = normalizeFilter(filter);
@@ -70,13 +48,8 @@ export class IndexedDBContractRepository implements ContractRepository {
             if (normalizedFilter.has("script")) {
                 const scripts = normalizedFilter.get("script")!;
                 const contracts = await Promise.all(
-                    scripts.map(
-                        (script) =>
-                            new Promise<Contract | undefined>((resolve, reject) => {
-                                const req = store.get(script);
-                                req.onerror = () => reject(req.error);
-                                req.onsuccess = () => resolve(req.result);
-                            }),
+                    scripts.map((script) =>
+                        promisifyRequest<Contract | undefined>(store.get(script)),
                     ),
                 );
                 return this.applyContractFilter(contracts, normalizedFilter);
@@ -84,7 +57,7 @@ export class IndexedDBContractRepository implements ContractRepository {
 
             // by state, still an index
             if (normalizedFilter.has("state")) {
-                const contracts = await this.getContractsByIndexValues(
+                const contracts = await getAllByIndexValues<Contract>(
                     store,
                     "state",
                     normalizedFilter.get("state")!,
@@ -94,7 +67,7 @@ export class IndexedDBContractRepository implements ContractRepository {
 
             // by type, still an index
             if (normalizedFilter.has("type")) {
-                const contracts = await this.getContractsByIndexValues(
+                const contracts = await getAllByIndexValues<Contract>(
                     store,
                     "type",
                     normalizedFilter.get("type")!,
@@ -103,11 +76,7 @@ export class IndexedDBContractRepository implements ContractRepository {
             }
 
             // any other filtering happens in-memory
-            const allContracts = await new Promise<Contract[]>((resolve, reject) => {
-                const request = store.getAll();
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => resolve(request.result ?? []);
-            });
+            const allContracts = (await promisifyRequest<Contract[]>(store.getAll())) ?? [];
             return this.applyContractFilter(allContracts, normalizedFilter);
         } catch (error) {
             console.error("Failed to get contracts:", error);
@@ -118,13 +87,9 @@ export class IndexedDBContractRepository implements ContractRepository {
     async saveContract(contract: Contract): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_CONTRACTS], "readwrite");
-                const store = transaction.objectStore(STORE_CONTRACTS);
-                const request = store.put(contract);
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => resolve();
-            });
+            const transaction = db.transaction([STORE_CONTRACTS], "readwrite");
+            transaction.objectStore(STORE_CONTRACTS).put(contract);
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error("Failed to save contract:", error);
             throw error;
@@ -134,41 +99,13 @@ export class IndexedDBContractRepository implements ContractRepository {
     async deleteContract(script: string): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_CONTRACTS], "readwrite");
-                const store = transaction.objectStore(STORE_CONTRACTS);
-                const getRequest = store.get(script);
-
-                getRequest.onerror = () => reject(getRequest.error);
-                getRequest.onsuccess = () => {
-                    const request = store.delete(script);
-
-                    request.onerror = () => reject(request.error);
-                    request.onsuccess = () => resolve();
-                };
-            });
+            const transaction = db.transaction([STORE_CONTRACTS], "readwrite");
+            transaction.objectStore(STORE_CONTRACTS).delete(script);
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error(`Failed to delete contract ${script}:`, error);
             throw error;
         }
-    }
-
-    private getContractsByIndexValues(
-        store: IDBObjectStore,
-        indexName: string,
-        values: string[],
-    ): Promise<Contract[]> {
-        if (values.length === 0) return Promise.resolve([]);
-        const index = store.index(indexName);
-        const requests = values.map(
-            (value) =>
-                new Promise<Contract[]>((resolve, reject) => {
-                    const request = index.getAll(value);
-                    request.onerror = () => reject(request.error);
-                    request.onsuccess = () => resolve(request.result ?? []);
-                }),
-        );
-        return Promise.all(requests).then((results) => results.flatMap((result) => result));
     }
 
     private applyContractFilter(

--- a/packages/ts-sdk/src/repositories/indexedDB/contractRepository.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/contractRepository.ts
@@ -1,7 +1,7 @@
 import { DB_VERSION, STORE_CONTRACTS } from "./db";
 import { Contract, watchStateOf } from "../../contracts";
 import { ContractFilter, ContractRepository } from "../contractRepository";
-import { closeDatabase, openDatabase } from "./manager";
+import { createManagedConnection, ManagedConnection } from "./managedConnection";
 import { initDatabase } from "./schema";
 import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
 
@@ -12,9 +12,11 @@ import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
  */
 export class IndexedDBContractRepository implements ContractRepository {
     readonly version = 2 as const;
-    private db: IDBDatabase | null = null;
+    private readonly connection: ManagedConnection;
 
-    constructor(private readonly dbName: string = DEFAULT_DB_NAME) {}
+    constructor(dbName: string = DEFAULT_DB_NAME) {
+        this.connection = createManagedConnection(dbName, DB_VERSION, initDatabase);
+    }
 
     async clear(): Promise<void> {
         try {
@@ -188,21 +190,12 @@ export class IndexedDBContractRepository implements ContractRepository {
         }) as Contract[];
     }
 
-    // ponytail: this caches the connection, not the open promise, and never
-    // forgets it — so once the manager closes on `versionchange`, every later
-    // transaction here throws `InvalidStateError` with no path back. Reachable
-    // only on a version increase; see `IndexedDbAssetSwapRepository.ensureDb`
-    // in the swap package for the forget-and-reopen shape to copy.
-    private async getDB(): Promise<IDBDatabase> {
-        if (this.db) return this.db;
-        this.db = await openDatabase(this.dbName, DB_VERSION, initDatabase);
-        return this.db;
+    private getDB(): Promise<IDBDatabase> {
+        return this.connection.get();
     }
 
     async [Symbol.asyncDispose](): Promise<void> {
-        if (!this.db) return;
-        await closeDatabase(this.dbName);
-        this.db = null;
+        await this.connection[Symbol.asyncDispose]();
     }
 }
 

--- a/packages/ts-sdk/src/repositories/indexedDB/idbUtils.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/idbUtils.ts
@@ -1,5 +1,7 @@
-// Shared promise adapters for the raw IndexedDB API, used across the
-// IndexedDB-backed repositories in this directory.
+// Shared promise adapters for the raw IndexedDB API. Used by every
+// IndexedDB-backed repository in the SDK, and re-exported from the package root
+// so plugin packages build on these rather than re-deriving the request and
+// commit semantics per repository.
 
 /** Resolve with an {@link IDBRequest}'s result, or reject with its error. */
 export const promisifyRequest = <T>(request: IDBRequest<T>): Promise<T> =>
@@ -8,10 +10,49 @@ export const promisifyRequest = <T>(request: IDBRequest<T>): Promise<T> =>
         request.onerror = () => reject(request.error);
     });
 
-/** Resolve once a transaction commits, or reject if it errors or aborts. */
+/**
+ * Resolve once a transaction commits, or reject if it errors or aborts.
+ *
+ * A write is durable at *commit*, not at request success — quota pressure and
+ * storage eviction abort a transaction whose every request already succeeded.
+ * Reads may resolve on {@link promisifyRequest}; writes must await this.
+ */
 export const awaitTransaction = (transaction: IDBTransaction): Promise<void> =>
     new Promise((resolve, reject) => {
         transaction.oncomplete = () => resolve();
         transaction.onerror = () => reject(transaction.error);
         transaction.onabort = () => reject(transaction.error ?? new Error("transaction aborted"));
     });
+
+/**
+ * Queue a delete for every row an index matches. Fire-and-forget by design:
+ * the requests are queued as the cursor walks and the caller learns they
+ * committed by awaiting the transaction, not this. A failing cursor or delete
+ * aborts the transaction, which {@link awaitTransaction} reports.
+ */
+export const deleteByIndex = (
+    store: IDBObjectStore,
+    indexName: string,
+    value: IDBValidKey,
+): void => {
+    const request = store.index(indexName).openCursor(IDBKeyRange.only(value));
+    request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) return;
+        cursor.delete();
+        cursor.continue();
+    };
+};
+
+/** Read every row matching any of `values` on an index, flattened. */
+export const getAllByIndexValues = <T>(
+    store: IDBObjectStore,
+    indexName: string,
+    values: readonly IDBValidKey[],
+): Promise<T[]> => {
+    if (values.length === 0) return Promise.resolve([]);
+    const index = store.index(indexName);
+    return Promise.all(values.map((value) => promisifyRequest<T[]>(index.getAll(value)))).then(
+        (results) => results.flat(),
+    );
+};

--- a/packages/ts-sdk/src/repositories/indexedDB/intentRepository.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/intentRepository.ts
@@ -8,7 +8,7 @@ import {
     isTerminalIntentState,
 } from "../intentRepository";
 import { awaitTransaction, promisifyRequest } from "./idbUtils";
-import { closeDatabase, openDatabase } from "./manager";
+import { createManagedConnection, ManagedConnection } from "./managedConnection";
 import { initDatabaseWithIntents, INTENT_DB_VERSION, STORE_INTENTS } from "./schema";
 import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
 
@@ -21,13 +21,17 @@ import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
  */
 export class IndexedDBIntentRepository implements IntentRepository {
     readonly version = 1 as const;
-    private db: IDBDatabase | null = null;
-    constructor(private readonly dbName: string = DEFAULT_DB_NAME) {}
+    private readonly connection: ManagedConnection;
+    constructor(dbName: string = DEFAULT_DB_NAME) {
+        this.connection = createManagedConnection(
+            dbName,
+            INTENT_DB_VERSION,
+            initDatabaseWithIntents,
+        );
+    }
 
-    private async getDB(): Promise<IDBDatabase> {
-        if (!this.db)
-            this.db = await openDatabase(this.dbName, INTENT_DB_VERSION, initDatabaseWithIntents);
-        return this.db;
+    private getDB(): Promise<IDBDatabase> {
+        return this.connection.get();
     }
 
     async clear(): Promise<void> {
@@ -65,8 +69,6 @@ export class IndexedDBIntentRepository implements IntentRepository {
     }
 
     async [Symbol.asyncDispose](): Promise<void> {
-        if (!this.db) return;
-        await closeDatabase(this.dbName);
-        this.db = null;
+        await this.connection[Symbol.asyncDispose]();
     }
 }

--- a/packages/ts-sdk/src/repositories/indexedDB/managedConnection.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/managedConnection.ts
@@ -1,0 +1,84 @@
+import { closeDatabase, openDatabase } from "./manager";
+
+/** A disposed {@link ManagedConnection} was read from. Reopening instead would
+ * take a refcount nothing will ever release, so this is loud rather than
+ * silently leaky: the fix belongs at the caller, which is using a repository it
+ * already tore down. */
+export class ConnectionDisposedError extends Error {
+    override readonly name = "ConnectionDisposedError";
+    constructor(readonly dbName: string) {
+        super(`connection to database "${dbName}" was disposed`);
+    }
+}
+
+/** Lazily-opened, self-healing handle on one IndexedDB database. */
+export interface ManagedConnection extends AsyncDisposable {
+    /** The open connection, opening it on first call. Rejects with
+     * {@link ConnectionDisposedError} after dispose. */
+    get(): Promise<IDBDatabase>;
+}
+
+/**
+ * Forget-and-reopen around {@link openDatabase}, shared by every IndexedDB
+ * repository. Caching the resolved `IDBDatabase` is the defect this exists to
+ * remove: once the manager closes on `versionchange`, every later transaction on
+ * that handle throws `InvalidStateError` with no path back.
+ *
+ * Opens nothing until the first {@link ManagedConnection.get} — repositories
+ * construct their storage in their own constructors, and an eager open would
+ * move the "IndexedDB is not available in this environment" throw to
+ * construction time.
+ */
+export function createManagedConnection(
+    dbName: string,
+    version: number,
+    initDatabase: (db: IDBDatabase, oldVersion: number, transaction: IDBTransaction | null) => void,
+): ManagedConnection {
+    // the opening promise, not the resolved database: openDatabase bumps a
+    // refcount on every call including cache hits, while dispose closes once, so
+    // two concurrent first calls would strand the refcount above zero and leak
+    // the connection for the process lifetime.
+    let current: Promise<IDBDatabase> | null = null;
+    let disposed = false;
+
+    return {
+        get(): Promise<IDBDatabase> {
+            if (disposed) return Promise.reject(new ConnectionDisposedError(dbName));
+            if (current) return current;
+            const opening = openDatabase(dbName, version, initDatabase)
+                .then((db) => {
+                    // identity check: a reopen may already have replaced this
+                    // promise, and nulling that one would drop a live connection
+                    const forget = () => {
+                        if (current === opening) current = null;
+                    };
+                    // addEventListener, not `db.onversionchange =`: that handler
+                    // is the manager's, and its close is what we want to keep.
+                    // `close` fires only on ABNORMAL termination per spec — never
+                    // on an explicit close() — so the two never double-fire.
+                    db.addEventListener("versionchange", forget);
+                    db.addEventListener("close", forget);
+                    return db;
+                })
+                .catch((err) => {
+                    // forgotten so a retry is possible at all — otherwise a
+                    // VersionError from a newer tab sticks instead of failing
+                    // repeatably
+                    if (current === opening) current = null;
+                    throw err;
+                });
+            current = opening;
+            return opening;
+        },
+
+        async [Symbol.asyncDispose](): Promise<void> {
+            if (disposed) return;
+            disposed = true;
+            // only while a promise is held: every rejection path already nulled
+            // it, and closing then would decrement a successor's refcount
+            if (!current) return;
+            current = null;
+            await closeDatabase(dbName);
+        },
+    };
+}

--- a/packages/ts-sdk/src/repositories/indexedDB/managedConnection.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/managedConnection.ts
@@ -13,8 +13,37 @@ export class ConnectionDisposedError extends Error {
 
 /** Lazily-opened, self-healing handle on one IndexedDB database. */
 export interface ManagedConnection extends AsyncDisposable {
-    /** The open connection, opening it on first call. Rejects with
-     * {@link ConnectionDisposedError} after dispose. */
+    /**
+     * The open connection, opening it on first call.
+     *
+     * Call this once per operation and use the handle for the transaction you
+     * start right away — never store it on the repository, and never carry it
+     * across an `await`. The connection can be closed underneath you at any
+     * time (a `versionchange` from another tab, eviction, "clear site data"),
+     * after which every transaction on that handle throws `InvalidStateError`;
+     * a later `get()` transparently reopens, but only for callers that ask
+     * again. Holding the resolved database is exactly the defect this type
+     * exists to remove.
+     *
+     * ## The dispose boundary
+     *
+     * `get()` is valid only before `[Symbol.asyncDispose]`. Afterwards it
+     * rejects with {@link ConnectionDisposedError}, permanently: dispose has
+     * released this connection's single reference, and reopening would take a
+     * refcount nothing is left to release. Disposal is final by design — there
+     * is no revive; construct a new repository, which constructs a new
+     * connection, instead.
+     *
+     * Dispose neither awaits nor cancels work already in flight. A transaction
+     * started just before it can abort when the underlying handle closes, and
+     * an in-flight `get()` may resolve to a database that is closing. So
+     * sequence disposal after the operations you care about have settled —
+     * `await` the repository's outstanding calls first — rather than racing it
+     * against them.
+     *
+     * Callers must not close the database themselves; the reference this
+     * connection holds is released by its own dispose, once.
+     */
     get(): Promise<IDBDatabase>;
 }
 

--- a/packages/ts-sdk/src/repositories/indexedDB/manager.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/manager.ts
@@ -46,6 +46,19 @@ const dbCache = new Map<string, DBCacheEntry>();
 const refCounts = new Map<string, number>();
 
 /**
+ * Drop the bookkeeping for a connection, but only while it is still the current
+ * one. Unreachable today — every removal path also kills the connection, so a
+ * stale one cannot outlive its entry — but it is the precondition for adding
+ * event sources like the `close` arm below, whose whole point is firing at a
+ * connection the maps may already have moved past.
+ */
+function forget(dbName: string, promise: Promise<IDBDatabase>): void {
+    if (dbCache.get(dbName)?.promise !== promise) return;
+    dbCache.delete(dbName);
+    refCounts.delete(dbName);
+}
+
+/**
  * Opens an IndexedDB database and increments the reference count.
  * Handles global object detection and callbacks.
  *
@@ -118,9 +131,15 @@ export async function openDatabase(
             // (or a version upgrade in another tab) isn't blocked by this connection.
             db.onversionchange = () => {
                 db.close();
-                dbCache.delete(dbName);
-                refCounts.delete(dbName);
+                forget(dbName, dbPromise);
             };
+            // Abnormal termination — eviction, "clear site data", storage
+            // pressure — closes the connection without any explicit close() and
+            // fires this. Without it the cache keeps serving a dead handle, and
+            // a consumer's own recovery reopen cache-hits it and strands a
+            // refcount. Per spec `close` never fires for the close() above, so
+            // the two arms cannot double-forget.
+            db.addEventListener("close", () => forget(dbName, dbPromise));
             resolve(db);
         };
         request.onupgradeneeded = (event) => {
@@ -158,6 +177,12 @@ export async function openDatabase(
 
 /**
  * Decrements the reference count and closes the database when no references remain.
+ *
+ * Refcount contract: call once per *successful* {@link openDatabase}, never per
+ * rejection. A rejected open already cleared its own bookkeeping, so a call
+ * paired with it decrements whatever entry a successor installed under the same
+ * name. {@link createManagedConnection} honours this — it only closes while it
+ * holds a promise, and every rejection path drops that promise first.
  *
  * @param dbName The name of the database to close.
  *

--- a/packages/ts-sdk/src/repositories/indexedDB/manager.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/manager.ts
@@ -46,11 +46,16 @@ const dbCache = new Map<string, DBCacheEntry>();
 const refCounts = new Map<string, number>();
 
 /**
- * Drop the bookkeeping for a connection, but only while it is still the current
- * one. Unreachable today — every removal path also kills the connection, so a
- * stale one cannot outlive its entry — but it is the precondition for adding
- * event sources like the `close` arm below, whose whole point is firing at a
- * connection the maps may already have moved past.
+ * Drop the bookkeeping for one open, but only while it still owns the entry.
+ *
+ * Every cleanup path below routes through this, because an open can outlive its
+ * own entry: `closeDatabase` deletes the entry synchronously and only then
+ * awaits the promise, so a caller that closes while an open is still pending
+ * lets the next `openDatabase` install a successor under the same name. The
+ * `settled` flag does not cover that — it is still false — and an unguarded
+ * delete would drop the successor's entry and refcount, leaving its connection
+ * open and untracked for the page's lifetime. Connection events (`versionchange`,
+ * `close`) can arrive equally late.
  */
 function forget(dbName: string, promise: Promise<IDBDatabase>): void {
     if (dbCache.get(dbName)?.promise !== promise) return;
@@ -110,10 +115,9 @@ export async function openDatabase(
 
         request.onerror = () => {
             clearBlockedTimer();
-            if (settled) return; // the maps belong to a successor now
+            if (settled) return; // this open already reported its outcome
             settled = true;
-            dbCache.delete(dbName); // Clean up on failure
-            refCounts.delete(dbName);
+            forget(dbName, dbPromise); // clean up on failure, if still ours
             reject(request.error);
         };
         request.onsuccess = () => {
@@ -161,8 +165,7 @@ export async function openDatabase(
                 settled = true;
                 // cleared so a retry is possible at all — `openDatabase` would
                 // otherwise serve this rejected promise from the cache forever
-                dbCache.delete(dbName);
-                refCounts.delete(dbName);
+                forget(dbName, dbPromise);
                 reject(new DatabaseUpgradeBlockedError(dbName));
             }, BLOCKED_UPGRADE_TIMEOUT_MS);
         };

--- a/packages/ts-sdk/src/repositories/indexedDB/virtualTxRepository.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/virtualTxRepository.ts
@@ -6,7 +6,7 @@ import {
     VtxoBranch,
 } from "../virtualTxRepository";
 import { awaitTransaction, promisifyRequest } from "./idbUtils";
-import { closeDatabase, openDatabase } from "./manager";
+import { createManagedConnection, ManagedConnection } from "./managedConnection";
 import {
     initDatabaseWithIntents,
     INTENT_DB_VERSION,
@@ -24,13 +24,17 @@ import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
  */
 export class IndexedDBVirtualTxRepository implements VirtualTxRepository {
     readonly version = 1 as const;
-    private db: IDBDatabase | null = null;
-    constructor(private readonly dbName: string = DEFAULT_DB_NAME) {}
+    private readonly connection: ManagedConnection;
+    constructor(dbName: string = DEFAULT_DB_NAME) {
+        this.connection = createManagedConnection(
+            dbName,
+            INTENT_DB_VERSION,
+            initDatabaseWithIntents,
+        );
+    }
 
-    private async getDB(): Promise<IDBDatabase> {
-        if (!this.db)
-            this.db = await openDatabase(this.dbName, INTENT_DB_VERSION, initDatabaseWithIntents);
-        return this.db;
+    private getDB(): Promise<IDBDatabase> {
+        return this.connection.get();
     }
 
     async clear(): Promise<void> {
@@ -180,8 +184,6 @@ export class IndexedDBVirtualTxRepository implements VirtualTxRepository {
     }
 
     async [Symbol.asyncDispose](): Promise<void> {
-        if (!this.db) return;
-        await closeDatabase(this.dbName);
-        this.db = null;
+        await this.connection[Symbol.asyncDispose]();
     }
 }

--- a/packages/ts-sdk/src/repositories/indexedDB/walletRepository.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/walletRepository.ts
@@ -12,6 +12,7 @@ import {
     SerializedVtxo,
     DB_VERSION,
 } from "./db";
+import { awaitTransaction, deleteByIndex, promisifyRequest } from "./idbUtils";
 import { createManagedConnection, ManagedConnection } from "./managedConnection";
 import { initDatabase } from "./schema";
 import { scriptFromArkAddress } from "../scriptFromAddress";
@@ -32,36 +33,10 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async clear(): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction(
-                    [STORE_VTXOS, STORE_UTXOS, STORE_TRANSACTIONS, STORE_WALLET_STATE],
-                    "readwrite",
-                );
-                const vtxosStore = transaction.objectStore(STORE_VTXOS);
-                const utxosStore = transaction.objectStore(STORE_UTXOS);
-                const transactionsStore = transaction.objectStore(STORE_TRANSACTIONS);
-                const walletStateStore = transaction.objectStore(STORE_WALLET_STATE);
-
-                const requests = [
-                    vtxosStore.clear(),
-                    utxosStore.clear(),
-                    transactionsStore.clear(),
-                    walletStateStore.clear(),
-                ];
-
-                let completed = 0;
-                const checkComplete = () => {
-                    completed++;
-                    if (completed === requests.length) {
-                        resolve();
-                    }
-                };
-
-                requests.forEach((request) => {
-                    request.onsuccess = checkComplete;
-                    request.onerror = () => reject(request.error);
-                });
-            });
+            const stores = [STORE_VTXOS, STORE_UTXOS, STORE_TRANSACTIONS, STORE_WALLET_STATE];
+            const transaction = db.transaction(stores, "readwrite");
+            for (const name of stores) transaction.objectStore(name).clear();
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error("Failed to clear wallet data:", error);
             throw error;
@@ -75,28 +50,15 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async getVtxos(address: string): Promise<ExtendedVirtualCoin[]> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_VTXOS], "readonly");
-                const store = transaction.objectStore(STORE_VTXOS);
-                const index = store.index("address");
-                const request: IDBRequest<(SerializedVtxo & { address: string })[]> =
-                    index.getAll(address);
-
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const results = request.result || [];
-                    // Wrap `.map` in try/catch so a bad row (e.g. a legacy
-                    // VTXO whose address can't be decoded during backfill)
-                    // rejects the promise instead of silently throwing
-                    // inside the IDB event handler, which would otherwise
-                    // hang the caller.
-                    try {
-                        resolve(results.map(deserializeVtxoWithBackfill));
-                    } catch (err) {
-                        reject(err);
-                    }
-                };
-            });
+            const store = db.transaction([STORE_VTXOS], "readonly").objectStore(STORE_VTXOS);
+            const results = await promisifyRequest<(SerializedVtxo & { address: string })[]>(
+                store.index("address").getAll(address),
+            );
+            // A bad row (e.g. a legacy VTXO whose address can't be decoded
+            // during backfill) throws here, in ordinary async code, so the
+            // outer catch reports it rather than it being lost inside an IDB
+            // event handler.
+            return (results || []).map(deserializeVtxoWithBackfill);
         } catch (error) {
             console.error(`Failed to get VTXOs for address ${address}:`, error);
             return [];
@@ -106,30 +68,13 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async saveVtxos(address: string, vtxos: ExtendedVirtualCoin[]): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_VTXOS], "readwrite");
-                const store = transaction.objectStore(STORE_VTXOS);
-
-                const promises = vtxos.map((vtxo) => {
-                    return new Promise<void>((resolveItem, rejectItem) => {
-                        const serialized: SerializedVtxo = serializeVtxo(vtxo);
-                        const item = {
-                            address,
-                            ...serialized,
-                        };
-                        const request = store.put(item);
-
-                        request.onerror = () => rejectItem(request.error);
-                        request.onsuccess = () => resolveItem();
-                    });
-                });
-
-                Promise.all(promises)
-                    .then(() => resolve())
-                    .catch(reject);
-
-                transaction.onerror = () => reject(transaction.error);
-            });
+            const transaction = db.transaction([STORE_VTXOS], "readwrite");
+            const store = transaction.objectStore(STORE_VTXOS);
+            for (const vtxo of vtxos) {
+                const serialized: SerializedVtxo = serializeVtxo(vtxo);
+                store.put({ address, ...serialized });
+            }
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error(`Failed to save VTXOs for address ${address}:`, error);
             throw error;
@@ -139,23 +84,9 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async deleteVtxos(address: string): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_VTXOS], "readwrite");
-                const store = transaction.objectStore(STORE_VTXOS);
-                const index = store.index("address");
-                const request = index.openCursor(IDBKeyRange.only(address));
-
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const cursor = request.result;
-                    if (cursor) {
-                        cursor.delete();
-                        cursor.continue();
-                    } else {
-                        resolve();
-                    }
-                };
-            });
+            const transaction = db.transaction([STORE_VTXOS], "readwrite");
+            deleteByIndex(transaction.objectStore(STORE_VTXOS), "address", address);
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error(`Failed to clear VTXOs for address ${address}:`, error);
             throw error;
@@ -165,41 +96,29 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async getVtxosForScript(script: string): Promise<ExtendedVirtualCoin[]> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_VTXOS], "readonly");
-                const store = transaction.objectStore(STORE_VTXOS);
-                const index = store.index("script");
-                const request: IDBRequest<(SerializedVtxo & { address: string })[]> =
-                    index.getAll(script);
+            const store = db.transaction([STORE_VTXOS], "readonly").objectStore(STORE_VTXOS);
+            const results = await promisifyRequest<(SerializedVtxo & { address: string })[]>(
+                store.index("script").getAll(script),
+            );
 
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const results = request.result || [];
-                    try {
-                        // Defensive filter: only rows whose script matches.
-                        const matching = results.filter((r) => r.script === script);
+            // Defensive filter: only rows whose script matches.
+            const matching = (results || []).filter((r) => r.script === script);
 
-                        // Dedup same outpoint rows across address buckets.
-                        // Work on raw rows so the address field is available
-                        // for the canonicality tiebreaker.
-                        const byOutpoint = new Map<string, SerializedVtxo & { address: string }>();
-                        for (const row of matching) {
-                            const outpoint = `${row.txid}:${row.vout}`;
-                            const existing = byOutpoint.get(outpoint);
-                            if (!existing) {
-                                byOutpoint.set(outpoint, row);
-                                continue;
-                            }
-                            if (shouldReplaceVtxo(existing, row)) {
-                                byOutpoint.set(outpoint, row);
-                            }
-                        }
-                        resolve(Array.from(byOutpoint.values()).map(deserializeVtxoWithBackfill));
-                    } catch (err) {
-                        reject(err);
-                    }
-                };
-            });
+            // Dedup same outpoint rows across address buckets. Work on raw rows
+            // so the address field is available for the canonicality tiebreaker.
+            const byOutpoint = new Map<string, SerializedVtxo & { address: string }>();
+            for (const row of matching) {
+                const outpoint = `${row.txid}:${row.vout}`;
+                const existing = byOutpoint.get(outpoint);
+                if (!existing) {
+                    byOutpoint.set(outpoint, row);
+                    continue;
+                }
+                if (shouldReplaceVtxo(existing, row)) {
+                    byOutpoint.set(outpoint, row);
+                }
+            }
+            return Array.from(byOutpoint.values()).map(deserializeVtxoWithBackfill);
         } catch (error) {
             console.error(`Failed to get VTXOs for script ${script}:`, error);
             throw error;
@@ -223,23 +142,9 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async deleteVtxosForScript(script: string): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_VTXOS], "readwrite");
-                const store = transaction.objectStore(STORE_VTXOS);
-                const index = store.index("script");
-                const request = index.openCursor(IDBKeyRange.only(script));
-
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const cursor = request.result;
-                    if (cursor) {
-                        cursor.delete();
-                        cursor.continue();
-                    } else {
-                        resolve();
-                    }
-                };
-            });
+            const transaction = db.transaction([STORE_VTXOS], "readwrite");
+            deleteByIndex(transaction.objectStore(STORE_VTXOS), "script", script);
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error(`Failed to clear VTXOs for script ${script}:`, error);
             throw error;
@@ -249,19 +154,9 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async getUtxos(address: string): Promise<ExtendedCoin[]> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_UTXOS], "readonly");
-                const store = transaction.objectStore(STORE_UTXOS);
-                const index = store.index("address");
-                const request = index.getAll(address);
-
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const results = request.result || [];
-                    const utxos = results.map(deserializeUtxo);
-                    resolve(utxos);
-                };
-            });
+            const store = db.transaction([STORE_UTXOS], "readonly").objectStore(STORE_UTXOS);
+            const results = await promisifyRequest(store.index("address").getAll(address));
+            return (results || []).map(deserializeUtxo);
         } catch (error) {
             console.error(`Failed to get UTXOs for address ${address}:`, error);
             return [];
@@ -271,30 +166,10 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async saveUtxos(address: string, utxos: ExtendedCoin[]): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_UTXOS], "readwrite");
-                const store = transaction.objectStore(STORE_UTXOS);
-
-                const promises = utxos.map((utxo) => {
-                    return new Promise<void>((resolveItem, rejectItem) => {
-                        const serialized = serializeUtxo(utxo);
-                        const item = {
-                            address,
-                            ...serialized,
-                        };
-                        const request = store.put(item);
-
-                        request.onerror = () => rejectItem(request.error);
-                        request.onsuccess = () => resolveItem();
-                    });
-                });
-
-                Promise.all(promises)
-                    .then(() => resolve())
-                    .catch(reject);
-
-                transaction.onerror = () => reject(transaction.error);
-            });
+            const transaction = db.transaction([STORE_UTXOS], "readwrite");
+            const store = transaction.objectStore(STORE_UTXOS);
+            for (const utxo of utxos) store.put({ address, ...serializeUtxo(utxo) });
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error(`Failed to save UTXOs for address ${address}:`, error);
             throw error;
@@ -304,23 +179,9 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async deleteUtxos(address: string): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_UTXOS], "readwrite");
-                const store = transaction.objectStore(STORE_UTXOS);
-                const index = store.index("address");
-                const request = index.openCursor(IDBKeyRange.only(address));
-
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const cursor = request.result;
-                    if (cursor) {
-                        cursor.delete();
-                        cursor.continue();
-                    } else {
-                        resolve();
-                    }
-                };
-            });
+            const transaction = db.transaction([STORE_UTXOS], "readwrite");
+            deleteByIndex(transaction.objectStore(STORE_UTXOS), "address", address);
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error(`Failed to clear UTXOs for address ${address}:`, error);
             throw error;
@@ -330,18 +191,13 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async getTransactionHistory(address: string): Promise<ArkTransaction[]> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_TRANSACTIONS], "readonly");
-                const store = transaction.objectStore(STORE_TRANSACTIONS);
-                const index = store.index("address");
-                const request = index.getAll(address);
-
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const results = request.result || [];
-                    resolve(results.sort((a, b) => a.createdAt - b.createdAt));
-                };
-            });
+            const store = db
+                .transaction([STORE_TRANSACTIONS], "readonly")
+                .objectStore(STORE_TRANSACTIONS);
+            const results = await promisifyRequest<ArkTransaction[]>(
+                store.index("address").getAll(address),
+            );
+            return (results || []).sort((a, b) => a.createdAt - b.createdAt);
         } catch (error) {
             console.error(`Failed to get transaction history for address ${address}:`, error);
             return [];
@@ -351,27 +207,18 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async saveTransactions(address: string, txs: ArkTransaction[]): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_TRANSACTIONS], "readwrite");
-                const store = transaction.objectStore(STORE_TRANSACTIONS);
-
-                // Queue all put operations
-                txs.forEach((tx) => {
-                    const item = {
-                        address,
-                        ...tx,
-                        keyBoardingTxid: tx.key.boardingTxid,
-                        keyCommitmentTxid: tx.key.commitmentTxid,
-                        keyArkTxid: tx.key.arkTxid,
-                    };
-                    store.put(item);
+            const transaction = db.transaction([STORE_TRANSACTIONS], "readwrite");
+            const store = transaction.objectStore(STORE_TRANSACTIONS);
+            for (const tx of txs) {
+                store.put({
+                    address,
+                    ...tx,
+                    keyBoardingTxid: tx.key.boardingTxid,
+                    keyCommitmentTxid: tx.key.commitmentTxid,
+                    keyArkTxid: tx.key.arkTxid,
                 });
-
-                // Handle transaction completion
-                transaction.oncomplete = () => resolve();
-                transaction.onerror = () => reject(transaction.error);
-                transaction.onabort = () => reject(new Error("Transaction aborted"));
-            });
+            }
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error(`Failed to save transactions for address ${address}:`, error);
             throw error;
@@ -381,23 +228,9 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async deleteTransactions(address: string): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_TRANSACTIONS], "readwrite");
-                const store = transaction.objectStore(STORE_TRANSACTIONS);
-                const index = store.index("address");
-                const request = index.openCursor(IDBKeyRange.only(address));
-
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const cursor = request.result;
-                    if (cursor) {
-                        cursor.delete();
-                        cursor.continue();
-                    } else {
-                        resolve();
-                    }
-                };
-            });
+            const transaction = db.transaction([STORE_TRANSACTIONS], "readwrite");
+            deleteByIndex(transaction.objectStore(STORE_TRANSACTIONS), "address", address);
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error(`Failed to clear transactions for address ${address}:`, error);
             throw error;
@@ -407,21 +240,13 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async getWalletState(): Promise<WalletState | null> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_WALLET_STATE], "readonly");
-                const store = transaction.objectStore(STORE_WALLET_STATE);
-                const request = store.get("state");
-
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const result = request.result;
-                    if (result && result.data) {
-                        resolve(result.data);
-                    } else {
-                        resolve(null);
-                    }
-                };
-            });
+            const store = db
+                .transaction([STORE_WALLET_STATE], "readonly")
+                .objectStore(STORE_WALLET_STATE);
+            const result = await promisifyRequest<{ data?: WalletState } | undefined>(
+                store.get("state"),
+            );
+            return result?.data ?? null;
         } catch (error) {
             console.error("Failed to get wallet state:", error);
             return null;
@@ -431,18 +256,9 @@ export class IndexedDBWalletRepository implements WalletRepository {
     async saveWalletState(state: WalletState): Promise<void> {
         try {
             const db = await this.getDB();
-            return new Promise((resolve, reject) => {
-                const transaction = db.transaction([STORE_WALLET_STATE], "readwrite");
-                const store = transaction.objectStore(STORE_WALLET_STATE);
-                const item = {
-                    key: "state",
-                    data: state,
-                };
-                const request = store.put(item);
-
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => resolve();
-            });
+            const transaction = db.transaction([STORE_WALLET_STATE], "readwrite");
+            transaction.objectStore(STORE_WALLET_STATE).put({ key: "state", data: state });
+            await awaitTransaction(transaction);
         } catch (error) {
             console.error("Failed to save wallet state:", error);
             throw error;

--- a/packages/ts-sdk/src/repositories/indexedDB/walletRepository.ts
+++ b/packages/ts-sdk/src/repositories/indexedDB/walletRepository.ts
@@ -12,7 +12,7 @@ import {
     SerializedVtxo,
     DB_VERSION,
 } from "./db";
-import { closeDatabase, openDatabase } from "./manager";
+import { createManagedConnection, ManagedConnection } from "./managedConnection";
 import { initDatabase } from "./schema";
 import { scriptFromArkAddress } from "../scriptFromAddress";
 import { DEFAULT_DB_NAME } from "../../worker/browser/utils";
@@ -23,9 +23,11 @@ import { isVtxoForScript } from "../../contracts/vtxoOwnership";
  */
 export class IndexedDBWalletRepository implements WalletRepository {
     readonly version = 1 as const;
-    private db: IDBDatabase | null = null;
+    private readonly connection: ManagedConnection;
 
-    constructor(private readonly dbName: string = DEFAULT_DB_NAME) {}
+    constructor(dbName: string = DEFAULT_DB_NAME) {
+        this.connection = createManagedConnection(dbName, DB_VERSION, initDatabase);
+    }
 
     async clear(): Promise<void> {
         try {
@@ -67,9 +69,7 @@ export class IndexedDBWalletRepository implements WalletRepository {
     }
 
     async [Symbol.asyncDispose](): Promise<void> {
-        if (!this.db) return;
-        await closeDatabase(this.dbName);
-        this.db = null;
+        await this.connection[Symbol.asyncDispose]();
     }
 
     async getVtxos(address: string): Promise<ExtendedVirtualCoin[]> {
@@ -449,10 +449,8 @@ export class IndexedDBWalletRepository implements WalletRepository {
         }
     }
 
-    private async getDB(): Promise<IDBDatabase> {
-        if (this.db) return this.db;
-        this.db = await openDatabase(this.dbName, DB_VERSION, initDatabase);
-        return this.db;
+    private getDB(): Promise<IDBDatabase> {
+        return this.connection.get();
     }
 }
 

--- a/packages/ts-sdk/test/indexeddb-managed-connection.test.ts
+++ b/packages/ts-sdk/test/indexeddb-managed-connection.test.ts
@@ -56,6 +56,47 @@ describe("the manager's connection cache", () => {
         await closeDatabase(dbName);
     });
 
+    it("does not drop a successor's entry when a pending open fails late", async () => {
+        // `closeDatabase` deletes the entry synchronously and only then awaits
+        // the promise, so closing while an open is still pending lets the next
+        // `openDatabase` install a successor under the same name. The failing
+        // open's cleanup must not touch it — `settled` is still false, so the
+        // identity check is the only thing standing between the successor and a
+        // connection nothing tracks.
+        const dbName = `late-failure-${Math.random()}`;
+        const external = await new Promise<IDBDatabase>((resolve, reject) => {
+            const open = indexedDB.open(dbName, 5);
+            open.onupgradeneeded = () => init(open.result);
+            open.onsuccess = () => resolve(open.result);
+            open.onerror = () => reject(open.error);
+        });
+
+        const spy = vi.spyOn(indexedDB, "open");
+        try {
+            // fails: v1 is below the existing v5. Its entry is installed now and
+            // its onerror fires later.
+            const failing = openDatabase(dbName, 1, init);
+            void closeDatabase(dbName); // deletes that entry while still pending
+            const successor = openDatabase(dbName, 5, init); // installs its own
+
+            await expect(failing).rejects.toMatchObject({ name: "VersionError" });
+            const db = await successor;
+
+            // the successor is still cached: another open cache-hits it rather
+            // than opening a second, untracked connection
+            const opensBefore = spy.mock.calls.length;
+            expect(await openDatabase(dbName, 5, init)).toBe(db);
+            expect(spy.mock.calls.length).toBe(opensBefore);
+
+            await roundTrip(db, "usable");
+            await closeDatabase(dbName);
+            await closeDatabase(dbName);
+        } finally {
+            spy.mockRestore();
+            external.close();
+        }
+    });
+
     it("does not fire the close arm for its own versionchange close", async () => {
         // The two arms forget the same entry; if `close` also fired on an
         // explicit close(), the second would drop a successor's entry.

--- a/packages/ts-sdk/test/indexeddb-managed-connection.test.ts
+++ b/packages/ts-sdk/test/indexeddb-managed-connection.test.ts
@@ -1,0 +1,203 @@
+/**
+ * A connection that went away must be forgotten, at both levels: the manager's
+ * name-keyed cache and the per-repository handle built on top of it.
+ *
+ * Caching the resolved `IDBDatabase` bricks a store until reload — the manager
+ * closes on `versionchange`, and every later transaction on the cached handle
+ * throws `InvalidStateError` with no path back. `close` is the same defect with
+ * no explicit trigger at all: eviction or "clear site data" kills the connection
+ * while both caches keep serving it.
+ */
+import { describe, it, expect, vi } from "vitest";
+import forceCloseDatabase from "fake-indexeddb/lib/forceCloseDatabase";
+import { openDatabase, closeDatabase } from "../src/repositories/indexedDB/manager";
+import {
+    createManagedConnection,
+    ConnectionDisposedError,
+} from "../src/repositories/indexedDB/managedConnection";
+
+const STORE = "rows";
+const init = (db: IDBDatabase) => {
+    if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+};
+
+/** fake-indexeddb dispatches events on the task queue. */
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const deleteDb = (dbName: string) =>
+    new Promise<void>((resolve, reject) => {
+        const del = indexedDB.deleteDatabase(dbName);
+        del.onsuccess = () => resolve();
+        del.onerror = () => reject(del.error);
+    });
+
+/** A real round-trip, which is what proves the handle is live rather than a
+ * connection object that merely exists. */
+const roundTrip = async (db: IDBDatabase, key: string) => {
+    const tx = db.transaction([STORE], "readwrite");
+    tx.objectStore(STORE).put(key, key);
+    await new Promise<void>((resolve, reject) => {
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.onabort = () => reject(tx.error);
+    });
+};
+
+describe("the manager's connection cache", () => {
+    it("drops an abnormally closed connection instead of serving it", async () => {
+        const dbName = `mgr-close-${Math.random()}`;
+        const db = await openDatabase(dbName, 1, init);
+        forceCloseDatabase(db);
+        await flush();
+
+        const reopened = await openDatabase(dbName, 1, init);
+        expect(reopened).not.toBe(db);
+        await roundTrip(reopened, "k");
+        await closeDatabase(dbName);
+    });
+
+    it("does not fire the close arm for its own versionchange close", async () => {
+        // The two arms forget the same entry; if `close` also fired on an
+        // explicit close(), the second would drop a successor's entry.
+        const dbName = `mgr-both-${Math.random()}`;
+        const db = await openDatabase(dbName, 1, init);
+        const closes = vi.fn();
+        db.addEventListener("close", closes);
+
+        await deleteDb(dbName); // fires versionchange, manager closes
+        await flush();
+        expect(closes).not.toHaveBeenCalled();
+    });
+});
+
+describe("a managed connection", () => {
+    it("opens nothing until the first get()", async () => {
+        const spy = vi.spyOn(indexedDB, "open");
+        try {
+            const dbName = `lazy-${Math.random()}`;
+            const connection = createManagedConnection(dbName, 1, init);
+            expect(spy).not.toHaveBeenCalled();
+
+            await connection.get();
+            expect(spy).toHaveBeenCalledTimes(1);
+            await connection[Symbol.asyncDispose]();
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it("reopens after an external delete", async () => {
+        const dbName = `reopen-${Math.random()}`;
+        const connection = createManagedConnection(dbName, 1, init);
+        const db = await connection.get();
+        await roundTrip(db, "before");
+
+        await deleteDb(dbName);
+        await flush();
+
+        const reopened = await connection.get();
+        expect(reopened).not.toBe(db);
+        await roundTrip(reopened, "after");
+        await connection[Symbol.asyncDispose]();
+    });
+
+    it("reopens after abnormal termination", async () => {
+        const dbName = `evicted-${Math.random()}`;
+        const connection = createManagedConnection(dbName, 1, init);
+        const db = await connection.get();
+
+        forceCloseDatabase(db);
+        await flush();
+
+        const reopened = await connection.get();
+        expect(reopened).not.toBe(db);
+        await roundTrip(reopened, "after");
+        await connection[Symbol.asyncDispose]();
+    });
+
+    it("fails honestly, and repeatably, when another tab upgraded past it", async () => {
+        const dbName = `newer-${Math.random()}`;
+        const connection = createManagedConnection(dbName, 1, init);
+        await connection.get();
+
+        const newer = await new Promise<IDBDatabase>((resolve, reject) => {
+            const open = indexedDB.open(dbName, 100);
+            open.onsuccess = () => resolve(open.result);
+            open.onerror = () => reject(open.error);
+        });
+        await flush();
+        try {
+            for (const attempt of [1, 2]) {
+                await expect(connection.get(), `attempt ${attempt}`).rejects.toMatchObject({
+                    name: "VersionError",
+                });
+            }
+        } finally {
+            newer.close();
+        }
+    });
+
+    it("throws after dispose, and disposes idempotently", async () => {
+        const dbName = `disposed-${Math.random()}`;
+        const connection = createManagedConnection(dbName, 1, init);
+        await connection.get();
+
+        await connection[Symbol.asyncDispose]();
+        await expect(connection.get()).rejects.toBeInstanceOf(ConnectionDisposedError);
+        await expect(connection[Symbol.asyncDispose]()).resolves.toBeUndefined();
+    });
+
+    it("returns without throwing when closed after a rejected open", async () => {
+        // Refcount sanity: the rejection already cleared the manager's entry, so
+        // dispose must not decrement whatever a successor installed.
+        const dbName = `rejected-${Math.random()}`;
+        const blocker = await new Promise<IDBDatabase>((resolve, reject) => {
+            const open = indexedDB.open(dbName, 5);
+            open.onupgradeneeded = () => init(open.result);
+            open.onsuccess = () => resolve(open.result);
+            open.onerror = () => reject(open.error);
+        });
+        const connection = createManagedConnection(dbName, 1, init);
+        await expect(connection.get()).rejects.toMatchObject({ name: "VersionError" });
+        blocker.close();
+        await expect(connection[Symbol.asyncDispose]()).resolves.toBeUndefined();
+    });
+});
+
+/**
+ * Several repositories share one database name — wallet + contract on the
+ * service-worker DB, intent + virtualTx on theirs. Each holds its own handle
+ * over one manager entry, so recovery and refcounts have to work per-handle.
+ */
+describe("several managed connections on one name", () => {
+    it("all recover after an external delete", async () => {
+        const dbName = `shared-delete-${Math.random()}`;
+        const first = createManagedConnection(dbName, 1, init);
+        const second = createManagedConnection(dbName, 1, init);
+        await first.get();
+        await second.get();
+
+        await deleteDb(dbName);
+        await flush();
+
+        await roundTrip(await first.get(), "a");
+        await roundTrip(await second.get(), "b");
+        await first[Symbol.asyncDispose]();
+        await second[Symbol.asyncDispose]();
+    });
+
+    it("stays usable until the last one disposes, then actually closes", async () => {
+        const dbName = `shared-dispose-${Math.random()}`;
+        const first = createManagedConnection(dbName, 1, init);
+        const second = createManagedConnection(dbName, 1, init);
+        const db = await first.get();
+        expect(await second.get()).toBe(db);
+
+        await first[Symbol.asyncDispose]();
+        await roundTrip(await second.get(), "still-live");
+
+        await second[Symbol.asyncDispose]();
+        // a closed connection throws InvalidStateError on `transaction`
+        expect(() => db.transaction([STORE], "readonly")).toThrow();
+    });
+});

--- a/packages/ts-sdk/test/repositories/contractRepository.test.ts
+++ b/packages/ts-sdk/test/repositories/contractRepository.test.ts
@@ -30,7 +30,7 @@ describe.each(contractRepositoryImplementations)("ContractRepository: $name", ({
     });
 
     afterEach(async () => {
-        repository?.clear();
+        await repository?.clear();
         await repository?.[Symbol.asyncDispose]();
     });
 

--- a/packages/ts-sdk/test/repositories/walletRepository.test.ts
+++ b/packages/ts-sdk/test/repositories/walletRepository.test.ts
@@ -42,7 +42,7 @@ describe.each(walletRepositoryImplementations)("WalletRepository: $name", ({ fac
     });
 
     afterEach(async () => {
-        repository?.clear();
+        await repository?.clear();
         await repository?.[Symbol.asyncDispose]();
     });
 


### PR DESCRIPTION
Implements `plans/cached-closed-handle-indexed-db.md` — finding 1 of the #746 review.

## Problem

Six `openDatabase` consumers cached the resolved `IDBDatabase` and never forgot it. Once the manager closes on `versionchange`, every later transaction throws `InvalidStateError` with no path back — the store is bricked until reload. #746 fixed only `IndexedDbAssetSwapRepository`; `IndexedDBContractRepository` carried a `ponytail:` note describing the defect.

Latent only because the wallet DB is pinned at v3 — pinned *because* this recovery story didn't exist. This is the prerequisite for any future store addition.

## Changes

**`createManagedConnection(dbName, version, initDatabase) -> ManagedConnection`** (`repositories/indexedDB/managedConnection.ts`), lifted from `IndexedDbAssetSwapRepository.ensureDb`:

- caches the *opening promise*, not the handle (`openDatabase` refcounts per call including cache hits, dispose closes once);
- identity-checked forget on `versionchange` and `close`, via `addEventListener` so the manager's own `onversionchange` close survives;
- nulls on reject, so a `VersionError` from a newer tab fails repeatably instead of sticking;
- opens nothing until the first `get()` — repositories build storage in their constructors, and an eager open would move the "IndexedDB is not available" throw to construction;
- `get()` after dispose rejects with `ConnectionDisposedError` (reopening would take a refcount nothing releases); dispose is idempotent.

**Manager hardening** (`manager.ts`): the cache wipe is now identity-checked, and there's a `close` arm. Without it, abnormal termination (eviction, "clear site data") leaves the manager serving a dead handle — which silently defeats a consumer's own recovery, and strands a refcount on every retry since `openDatabase` bumps it on cache hits. Per spec `close` never fires for an explicit `close()`, so the two arms can't double-forget; there's a test for that.

The identity check itself is hardening, not a bug fix — no shipped path can reach it (every removal path also kills the connection), so it has no regression test. It's the precondition for the `close` arm and for any caller-side `closeDatabase` change.

**Adoption**: `walletRepository`, `contractRepository` (drops the `ponytail:` note), `intentRepository`, `virtualTxRepository`, `@arkade-os/swap`, `@arkade-os/boltz-swap`. Method bodies still call a private `getDB()` that now delegates, so the diff stays at the plumbing layer.

## Tests

New `packages/ts-sdk/test/indexeddb-managed-connection.test.ts` (10 cases): manager-level `close` recovery and no-double-fire; helper-level lazy open, recovery after external delete and after `forceCloseDatabase`, repeatable `VersionError`, use-after-dispose, refcount sanity. Plus N-helpers-on-one-name — all recover, disposing the first leaves the second working, disposing the last actually closes. Boltz-swap gets the two connection tests mirrored; the swap package's existing ones now cover the shared implementation.

Verified sensitivity: removing the manager's `close` arm fails 2 of the 10.

## Notes

- No schema or DB-version change. `openDatabase`/`closeDatabase` semantics unchanged; the factory, handle type and error are additive exports from `@arkade-os/sdk`.
- Behavior changes, both intended: a version increase or eviction now reopens instead of bricking; reading from a disposed repository now throws instead of silently opening a connection nothing will close.
- Read-after-dispose audit (plan step 3): nothing in the SDK disposes these repositories — no `closeDatabase` caller outside them, and neither `Wallet.dispose` nor the service-worker teardown touches them. No ordering fix needed.
- Two `afterEach` hooks (`test/repositories/{wallet,contract}Repository.test.ts`) dropped an `await` on `clear()`. It only passed because the old dispose bailed out while the open was still in flight, leaking the refcount; now dispose actually closes and the unawaited `clear()` surfaces as an unhandled `InvalidStateError`. Added the `await`.
- No CHANGELOG entry: the root `CHANGELOG.md` stops at 0.4.23 (package is at 0.4.64) and has no Unreleased section — happy to add one if you want it revived.
- Left alone per the plan: the intent/virtualtx repos still default to `DEFAULT_DB_NAME` (the shared wallet DB) despite `schema.ts` promising a dedicated name. Pre-existing and orthogonal; needs its own migration reasoning.

No integration tests needed — this is all `fake-indexeddb`-level.

---

## Second commit: one set of request/transaction adapters

`idbUtils` (`promisifyRequest`, `awaitTransaction`) was used by 2 of the 6 IndexedDB repositories — the two newest. The other four hand-rolled `new Promise` 33 times, and it wasn't exported from the package root, so `@arkade-os/swap` kept local `request`/`txDone` copies and boltz-swap inlined the same shape 8 times.

**This is a correctness fix, not just line count.** 14 of the 15 `readwrite` transactions across `walletRepository`, `contractRepository` and boltz-swap resolved on *request success* rather than commit — reporting a write durable when a quota-pressure or eviction abort would still roll it back. Only the repositories already using `awaitTransaction` got this right; the rule was documented in exactly one place (the swap package's `txDone`). Every write now awaits commit, and that rationale moved onto `awaitTransaction` where it governs all six callers.

Two new shared helpers, both extracted from duplicates rather than invented:

- `deleteByIndex` — `walletRepository` had four copies of the same cursor-delete walk.
- `getAllByIndexValues` — `contractRepository.getContractsByIndexValues` and boltz-swap's `getSwapsByIndexValues` were the same function in two packages.

All four helpers are now exported from `@arkade-os/sdk`, so plugins build on them instead of re-deriving request and commit semantics per repository — the direction AGENTS.md asks for.

Incidental cleanups that fell out of the rewrites, each behavior-preserving:

- `contractRepository.clear()` opened `STORE_CONTRACTS` twice under two names, cleared it twice, and counted to two.
- `contractRepository.deleteContract()` did a `get` whose result was discarded before the `delete` — a round trip guarding nothing.
- `getVtxos` / `getVtxosForScript` wrapped their `.map` in try/catch because a throw inside an IDB event handler can't reject the enclosing promise. After the `await` it's ordinary async code and the outer catch handles it.

Net −246 lines. One `new Promise` survives, in boltz-swap's `getAllSwapsByCreatedAt` — an ordered cursor collect, a genuinely different shape with one call site.

Full suite green: 2641 ts-sdk + 503 swap + 616 boltz-swap.

---

## Third commit: identity-check the failing-open cleanup paths too

Review follow-up. `request.onerror` and the blocked-upgrade timeout still deleted the cache entry by name, and the `settled` guard does not cover that case.

`closeDatabase` deletes the entry **synchronously and only then awaits** the promise. So:

1. `openDatabase` installs entry E1, request pending
2. `closeDatabase` drops the refcount to 0 → deletes E1 → awaits the still-pending promise
3. another `openDatabase` finds a cache miss → installs E2
4. the original request fails — `settled` is still `false` — and the unguarded delete drops **E2**, leaving E2's connection open and untracked for the page's lifetime

Two repositories sharing a DB name reach this whenever one disposes while its first `get()` is in flight.

This corrects the reasoning in the first commit. The unreachability argument required a live `IDBDatabase` to outlive its own entry, and every path that removes an entry does kill the connection — but that only covers `versionchange`/`close`. A pending *request* has no connection at all, so the argument never applied to `onerror` or the blocked timeout.

Both paths now route through `forget`. Added the regression test the plan said could not exist — `does not drop a successor's entry when a pending open fails late` — using the public API only, no test-only export. Verified sensitive: reverting just the `onerror` line fails it.

`plans/cached-closed-handle-indexed-db.md` corrected in the two places that asserted unreachability, so the doc no longer contradicts the test sitting next to it.

The `settled` guard stays — it prevents a late `onsuccess` from installing handlers or double-settling, which the identity check does not subsume.

Suite green: 2641 ts-sdk + 503 swap + 616 boltz-swap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IndexedDB reliability during unexpected closures, database deletion, upgrades, and failed connection attempts.
  * Ensured repository operations complete transactions consistently and recover cleanly from connection errors.
  * Improved disposal and shared-connection handling to prevent stale or duplicate database closures.

* **New Features**
  * Added reusable IndexedDB connection management and utility APIs to the SDK.
  * Added support for indexed multi-value reads and cursor-based deletion.

* **Tests**
  * Expanded coverage for connection recovery, version errors, disposal, concurrency, and repository cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->