### PR TITLE
feat(swap): name lockup spends, add fundingArkTxid and getRfqSwap

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -117,7 +117,7 @@ Neither subpath adds a dependency: they take the SDK's structural `SQLExecutor` 
 handles, so you pass the database you already opened.
 
 All four carry both record types: asset swaps and the monitored RFQ swaps
-(`saveRfqSwap` / `getAllRfqSwaps` / `removeRfqSwap`). Each keeps them in a store of their own — a
+(`saveRfqSwap` / `getRfqSwap` / `getAllRfqSwaps` / `removeRfqSwap`). Each keeps them in a store of their own — a
 second object store on IndexedDB, an `…rfq_swaps` table on SQLite, the `ArkadeRfqSwap` class on
 Realm — since the two record types have different keys and no consumer wants them interleaved.
 
@@ -656,6 +656,23 @@ through their stored `preimageHex` or their HD descriptor, and `DB_VERSION` is u
 ## Breaking changes on this branch (pre-release migration notes)
 
 Notes from before 0.0.1, kept for consumers who tracked the branch.
+
+- **The repository interface is at version `4`.** It gained
+  `getRfqSwap(rfqId): Promise<RfqSwapRecord | undefined>` — every backend is already keyed by
+  `rfqId`, so a consumer updating one record no longer scans them all. A miss returns `undefined`;
+  retention prunes terminal records, so absence is ordinary. All four in-tree backends implement it
+  and `DB_VERSION` is unchanged; a custom implementor adds the two-line read and bumps its own
+  `version` to `4`.
+- **`RfqSwapOrigin` gained `fundingArkTxid?`** — the ark transaction that funded the lockup. It is
+  origin, not manager state: the caller broadcasts the funding and knows the txid, while the manager
+  watches the lockup by script and never learns it. Optional and stored whole, so no migration.
+  Consumers stashing it in `profile` should move it: `profile` is merged as
+  `{ ...profile, ...handler.project(swap) }` on every write, so a key a corridor also projects is
+  silently overwritten.
+- **`readLockupFate` names the spends it observed.** `claimed` and `returned` now carry
+  `spends: readonly LockupSpend[]`, one per spent lockup output, with the `checkpointTxid` that
+  `spentBy` names and the `arkTxid` that rode it. History correlation wants `arkTxid`; the
+  checkpoint txid is the wrong value to correlate on alone. `unknown` and `open` claim no spend.
 
 - **Every derived address changed again, in both corridors — the unilateral ladder was re-spaced.**
   `unilateralRefundDelay` now sits **level with** `claimDelay` instead of one 512s step above it,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -186,6 +186,7 @@ export {
     readLockupFate,
     refundIfUnresolved,
     type LockupFate,
+    type LockupSpend,
     type LockupSpendIndexer,
     type LockupVtxo,
     type RefundArkProvider,

--- a/packages/swap/src/indexedDbRepository.ts
+++ b/packages/swap/src/indexedDbRepository.ts
@@ -53,7 +53,7 @@ function initDatabase(db: IDBDatabase, oldVersion: number, transaction: IDBTrans
 /** Browser backend over the SDK's shared IndexedDB manager — the same
  * infrastructure the wallet already uses for its Boltz swap repository. */
 export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 3 as const;
+    readonly version = 4 as const;
     private readonly connection: ManagedConnection;
 
     constructor(dbName: string = DEFAULT_DB_NAME) {
@@ -92,6 +92,10 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
         await this.write(STORE_RFQ_SWAPS, (store) => {
             store.put(record);
         });
+    }
+
+    async getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined> {
+        return promisifyRequest((await this.readStore(STORE_RFQ_SWAPS)).get(rfqId));
     }
 
     async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {

--- a/packages/swap/src/refund.ts
+++ b/packages/swap/src/refund.ts
@@ -308,16 +308,25 @@ export type LockupSpendIndexer = Pick<RestIndexerProvider, "getVtxos" | "getVirt
  * What chain data says became of a swap lockup — the whole answer, with no
  * solver involvement and nothing taken on the solver's word.
  */
+export interface LockupSpend {
+    /** What the vtxo's `spentBy` names — the checkpoint, never the ark
+     * transaction. */
+    checkpointTxid: string;
+    /** The ark transaction that spent the above checkpoint output. What
+     * history correlation matches on; absent when the indexer omitted it. */
+    arkTxid?: string;
+}
+
 export type LockupFate =
     /** At least one output at the lockup is still unspent. Not over. */
     | { fate: "open" }
     /** Spent by a witness carrying a preimage that HASHES to the quote's
      * `payment_hash`. Only the claim leaf can reveal one, and the only
      * legitimate way the solver obtains it is by completing its side. */
-    | { fate: "claimed"; preimage: Uint8Array }
+    | { fate: "claimed"; preimage: Uint8Array; spends: readonly LockupSpend[] }
     /** Fully spent, and nothing that spent it revealed a matching preimage —
      * so the money went back to the trader. See {@link readLockupFate}. */
-    | { fate: "returned" }
+    | { fate: "returned"; spends: readonly LockupSpend[] }
     /** Nothing was learned: no outputs visible, an output spent by nothing the
      * indexer names, a spend it could not produce, or a blob that would not
      * decode. Never an answer. */
@@ -392,7 +401,7 @@ export async function readLockupFate(
     const all = vtxos ?? [];
     if (all.length === 0) return { fate: "unknown" };
 
-    const spentBy = new Set<string>();
+    const spentBy = new Map<string, LockupSpend>();
     let everySpendNamed = true;
     for (const vtxo of all) {
         // Unions all three spend facts rather than trusting `spentBy` alone:
@@ -408,13 +417,18 @@ export async function readLockupFate(
         // checkpoint per input, and that checkpoint's single input is the one
         // holding the lockup's `tapLeafScript`. The ark transaction spends the
         // checkpoint, not the lockup, so it is the wrong place to look.
-        if (vtxo.spentBy) spentBy.add(vtxo.spentBy);
+        if (vtxo.spentBy)
+            spentBy.set(vtxo.spentBy, {
+                checkpointTxid: vtxo.spentBy,
+                arkTxid: vtxo.arkTxId,
+            });
         // Spent, but by nothing this can go and read. No witness to verify, so
         // this output can never contribute proof either way.
         else everySpendNamed = false;
     }
 
-    const { txs } = await indexer.getVirtualTxs([...spentBy]);
+    const spends = [...spentBy.values()];
+    const { txs } = await indexer.getVirtualTxs([...spentBy.keys()]);
     const observed = new Set<string>();
     for (const raw of txs) {
         let tx: Transaction;
@@ -437,7 +451,7 @@ export async function readLockupFate(
             if (!all.some((vtxo) => vtxo.txid === txid && vtxo.vout === spent.index)) continue;
             for (const candidate of candidateWitnessItems(tx, i)) {
                 if (hashesTo(candidate, input.paymentHash)) {
-                    return { fate: "claimed", preimage: candidate };
+                    return { fate: "claimed", preimage: candidate, spends };
                 }
             }
         }
@@ -445,7 +459,7 @@ export async function readLockupFate(
 
     // Only a lockup whose every spend was actually seen can be called returned.
     return everySpendNamed && observed.size === spentBy.size
-        ? { fate: "returned" }
+        ? { fate: "returned", spends }
         : { fate: "unknown" };
 }
 

--- a/packages/swap/src/repositories/realm/repository.ts
+++ b/packages/swap/src/repositories/realm/repository.ts
@@ -33,7 +33,7 @@ const MARKETS = "ArkadeAssetSwapMarketsCache";
  * consumer owns the Realm lifecycle — `[Symbol.asyncDispose]` is a no-op.
  */
 export class RealmAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 3 as const;
+    readonly version = 4 as const;
 
     constructor(private readonly realm: RealmLike) {}
 
@@ -71,6 +71,13 @@ export class RealmAssetSwapRepository implements AssetSwapRepository {
                 "modified",
             );
         });
+    }
+
+    async getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined> {
+        const [found] = [
+            ...this.realm.objects<{ data: string }>(RFQ_SWAPS).filtered("rfqId == $0", rfqId),
+        ];
+        return found ? (JSON.parse(found.data) as RfqSwapRecord) : undefined;
     }
 
     async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {

--- a/packages/swap/src/repositories/sqlite/repository.ts
+++ b/packages/swap/src/repositories/sqlite/repository.ts
@@ -38,7 +38,7 @@ const INSERT_CHUNK = 500;
  * write chain is keyed by that object, and a per-repository literal splits it.
  */
 export class SQLiteAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 3 as const;
+    readonly version = 4 as const;
     private initPromise: Promise<void> | null = null;
     private readonly prefix: string;
     private readonly swaps: string;
@@ -143,6 +143,15 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
                 [record.rfqId, record.state, record.updatedAt, JSON.stringify(record)],
             );
         });
+    }
+
+    async getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined> {
+        await this.ensureInit();
+        const rows = await this.db.all<{ data: string }>(
+            `SELECT data FROM ${this.rfqSwaps} WHERE rfq_id = ?`,
+            [rfqId],
+        );
+        return rows.length > 0 ? (JSON.parse(rows[0].data) as RfqSwapRecord) : undefined;
     }
 
     async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {

--- a/packages/swap/src/repositories/sqlite/repository.ts
+++ b/packages/swap/src/repositories/sqlite/repository.ts
@@ -147,11 +147,11 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
 
     async getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined> {
         await this.ensureInit();
-        const rows = await this.db.all<{ data: string }>(
+        const row = await this.db.get<{ data: string }>(
             `SELECT data FROM ${this.rfqSwaps} WHERE rfq_id = ?`,
             [rfqId],
         );
-        return rows.length > 0 ? (JSON.parse(rows[0].data) as RfqSwapRecord) : undefined;
+        return row ? (JSON.parse(row.data) as RfqSwapRecord) : undefined;
     }
 
     async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {

--- a/packages/swap/src/repository.ts
+++ b/packages/swap/src/repository.ts
@@ -31,10 +31,11 @@ export const marketsCacheKey = (network: string, registry: string) =>
  * subset queries.
  */
 export interface AssetSwapRepository extends AsyncDisposable {
-    /** 3 adds the RFQ methods below. 2 was the released shape — swaps, scan
-     * cursor, markets, with `preimageSaltHex` on the swap record — so an
-     * implementor built against that cannot satisfy this one silently. */
-    readonly version: 3;
+    /** 4 adds `getRfqSwap`. 3 added the other RFQ methods below; 2 was the
+     * released shape — swaps, scan cursor, markets, with `preimageSaltHex` on
+     * the swap record — so an implementor built against either cannot satisfy
+     * this one silently. */
+    readonly version: 4;
 
     /** Insert or replace a swap by id. Store the record whole: `preimageHex`
      * and `preimageSaltHex` both leave the swap unclaimable if a field-mapped
@@ -61,6 +62,9 @@ export interface AssetSwapRepository extends AsyncDisposable {
      * as a refund that cannot be signed, long after the write.
      */
     saveRfqSwap(record: RfqSwapRecord): Promise<void>;
+    /** One record by key. `undefined` on a miss — retention prunes terminal
+     * records, so absence is ordinary and not an error. */
+    getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined>;
     /** Every stored RFQ swap record, in no particular order. */
     getAllRfqSwaps(): Promise<RfqSwapRecord[]>;
     /** Drop one, once it is past retention — see `shouldRetainRfqSwap`. */
@@ -78,7 +82,7 @@ export interface AssetSwapRepository extends AsyncDisposable {
 }
 
 export class InMemoryAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 3 as const;
+    readonly version = 4 as const;
     private readonly swaps = new Map<string, AssetSwap>();
     private readonly rfqSwaps = new Map<string, RfqSwapRecord>();
     private readonly scanned = new Set<string>();
@@ -94,6 +98,10 @@ export class InMemoryAssetSwapRepository implements AssetSwapRepository {
 
     async saveRfqSwap(record: RfqSwapRecord): Promise<void> {
         this.rfqSwaps.set(record.rfqId, record);
+    }
+
+    async getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined> {
+        return this.rfqSwaps.get(rfqId);
     }
 
     async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -118,12 +118,26 @@ export interface RfqSwapOrigin {
      * its state: `signer` (which wallet key signs this leg) and, on a corridor
      * locked to a preimage, `hashlock` — see `rfqProfileParts.ts`, and write
      * both with `rfqSecretsProfile` rather than by hand.
+     *
+     * Not a consumer scratchpad: every write merges it as `{ ...profile,
+     * ...handler.project(swap) }`, so a consumer key colliding with one the
+     * handler projects is silently overwritten on every pass.
      */
     profile: Record<string, unknown>;
 
     /** Consumer display metadata. The rebuild ignores it — `RfqSwapCommon`
      * carries no amount of its own. */
     amount?: number;
+
+    /**
+     * The ark transaction that funded {@link lockupAddress}.
+     *
+     * Origin, not manager state: the caller broadcasts the funding and knows
+     * its txid, while the manager watches the lockup by script and never
+     * learns it. So it is written once at record creation, like {@link amount},
+     * and no corridor `project` emits it.
+     */
+    fundingArkTxid?: string;
 }
 
 /** The stored record: the origin plus the manager's mutable state. */

--- a/packages/swap/test/refund.test.ts
+++ b/packages/swap/test/refund.test.ts
@@ -20,7 +20,9 @@ import {
     findLockupVtxos,
     isRfqTerminal,
     pushRefundWithoutReceiver,
+    readLockupFate,
     refundIfUnresolved,
+    type LockupSpendIndexer,
     type LockupVtxo,
     type RefundArkProvider,
     type RefundIndexer,
@@ -537,5 +539,108 @@ describe("refundIfUnresolved", () => {
         });
         expect(result.outcome).toBe("nothing_to_refund");
         expect(ark.submitted).toHaveLength(0);
+    });
+});
+
+describe("readLockupFate", () => {
+    const PREIMAGE = new Uint8Array(32).fill(9);
+    const PAYMENT_HASH = hex.encode(sha256(PREIMAGE));
+    const SWAP_PK_SCRIPT = p2tr(key(21));
+    const OUT_A = { txid: "b2".repeat(32), vout: 0 };
+    const OUT_B = { txid: "b3".repeat(32), vout: 1 };
+
+    /** A checkpoint spending one lockup output, as the indexer hands it back. */
+    const spendOf = (
+        out: { txid: string; vout: number },
+        witness?: Uint8Array[],
+    ): { txid: string; psbt: string } => {
+        const tx = new Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true });
+        tx.addInput({ txid: out.txid, index: out.vout });
+        tx.addOutput({ script: REFUND_PK_SCRIPT, amount: 1_000n });
+        if (witness) tx.updateInput(0, { finalScriptWitness: witness });
+        return { txid: tx.id, psbt: base64.encode(tx.toPSBT()) };
+    };
+
+    interface FateVtxo {
+        txid: string;
+        vout: number;
+        spentBy: string;
+        isSpent?: boolean;
+        arkTxId?: string;
+    }
+
+    const fateIndexer = (
+        vtxos: FateVtxo[],
+        txs: { txid: string; psbt: string }[] = [],
+    ): LockupSpendIndexer =>
+        ({
+            async getVtxos() {
+                return { vtxos };
+            },
+            async getVirtualTxs(txids: string[]) {
+                const known = new Map(txs.map((t) => [t.txid, t.psbt]));
+                return { txs: txids.map((id) => known.get(id)).filter((psbt) => !!psbt) };
+            },
+        }) as unknown as LockupSpendIndexer;
+
+    const read = (indexer: LockupSpendIndexer) =>
+        readLockupFate(indexer, { swapPkScript: SWAP_PK_SCRIPT, paymentHash: PAYMENT_HASH });
+
+    it("names every checkpoint that spent a multi-output lockup, and the ark tx each rode", async () => {
+        const first = spendOf(OUT_A);
+        const second = spendOf(OUT_B);
+        const fate = await read(
+            fateIndexer(
+                [
+                    { ...OUT_A, spentBy: first.txid, arkTxId: "c1".repeat(32) },
+                    { ...OUT_B, spentBy: second.txid, arkTxId: "c2".repeat(32) },
+                ],
+                [first, second],
+            ),
+        );
+        expect(fate).toEqual({
+            fate: "returned",
+            spends: [
+                { checkpointTxid: first.txid, arkTxid: "c1".repeat(32) },
+                { checkpointTxid: second.txid, arkTxid: "c2".repeat(32) },
+            ],
+        });
+    });
+
+    it("still names the checkpoint when the indexer omitted the ark tx", async () => {
+        const spend = spendOf(OUT_A);
+        const fate = await read(fateIndexer([{ ...OUT_A, spentBy: spend.txid }], [spend]));
+        expect(fate).toEqual({
+            fate: "returned",
+            spends: [{ checkpointTxid: spend.txid, arkTxid: undefined }],
+        });
+    });
+
+    it("names the spend that carried the preimage too", async () => {
+        const spend = spendOf(OUT_A, [PREIMAGE]);
+        const fate = await read(
+            fateIndexer([{ ...OUT_A, spentBy: spend.txid, arkTxId: "c3".repeat(32) }], [spend]),
+        );
+        expect(fate).toEqual({
+            fate: "claimed",
+            preimage: PREIMAGE,
+            spends: [{ checkpointTxid: spend.txid, arkTxid: "c3".repeat(32) }],
+        });
+    });
+
+    it("claims no spend when the lockup is still open", async () => {
+        expect(await read(fateIndexer([{ ...OUT_A, spentBy: "" }]))).toEqual({ fate: "open" });
+    });
+
+    it("claims no spend when a spend was not named, or could not be produced", async () => {
+        const spend = spendOf(OUT_A);
+        // spent, but by nothing the indexer names
+        expect(await read(fateIndexer([{ ...OUT_A, spentBy: "", isSpent: true }]))).toEqual({
+            fate: "unknown",
+        });
+        // named, but the indexer cannot produce it
+        expect(await read(fateIndexer([{ ...OUT_A, spentBy: spend.txid }]))).toEqual({
+            fate: "unknown",
+        });
     });
 });

--- a/packages/swap/test/refund.test.ts
+++ b/packages/swap/test/refund.test.ts
@@ -607,6 +607,29 @@ describe("readLockupFate", () => {
         });
     });
 
+    it("keeps each output's own ark tx when only one of them has it", async () => {
+        // The shape a single hoisted `arkTxid` would get wrong: two outputs,
+        // one named, one not.
+        const first = spendOf(OUT_A);
+        const second = spendOf(OUT_B);
+        const fate = await read(
+            fateIndexer(
+                [
+                    { ...OUT_A, spentBy: first.txid },
+                    { ...OUT_B, spentBy: second.txid, arkTxId: "c4".repeat(32) },
+                ],
+                [first, second],
+            ),
+        );
+        expect(fate).toEqual({
+            fate: "returned",
+            spends: [
+                { checkpointTxid: first.txid, arkTxid: undefined },
+                { checkpointTxid: second.txid, arkTxid: "c4".repeat(32) },
+            ],
+        });
+    });
+
     it("still names the checkpoint when the indexer omitted the ark tx", async () => {
         const spend = spendOf(OUT_A);
         const fate = await read(fateIndexer([{ ...OUT_A, spentBy: spend.txid }], [spend]));

--- a/packages/swap/test/repository.test.ts
+++ b/packages/swap/test/repository.test.ts
@@ -308,6 +308,22 @@ describe.each(backends)("RFQ swap records (%s)", (_, create) => {
         expect(restored).toEqual(record);
     });
 
+    it("reads one record by key, and reports a miss as undefined", async () => {
+        await using repository = create();
+        await repository.saveRfqSwap(rfqRecord("r1"));
+        await repository.saveRfqSwap(rfqRecord("r2"));
+        expect(await repository.getRfqSwap("r2")).toEqual(rfqRecord("r2"));
+        // retention prunes terminal records, so a miss is ordinary
+        expect(await repository.getRfqSwap("gone")).toBeUndefined();
+    });
+
+    it("carries the caller's funding txid through the round trip", async () => {
+        await using repository = create();
+        const record = { ...rfqRecord("r1"), fundingArkTxid: "f0".repeat(32) };
+        await repository.saveRfqSwap(record);
+        expect(await repository.getRfqSwap("r1")).toEqual(record);
+    });
+
     it("removes an rfq swap by id and leaves the others", async () => {
         await using repository = create();
         await repository.saveRfqSwap(rfqRecord("r1"));

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -437,6 +437,15 @@ describe("updateRfqSwapRecord", () => {
         expect(recovered.lockupAddress).toBe(sendOrigin.lockupAddress);
     });
 
+    it("carries the caller's funding txid, which no corridor projects", () => {
+        const origin = { ...sendOrigin, fundingArkTxid: "f0".repeat(32) };
+        const record = createRfqSwapRecord(origin, swapOf(origin));
+        expect(record.fundingArkTxid).toBe("f0".repeat(32));
+        expect(updateRfqSwapRecord(record, swapOf(origin, "settled")).fundingArkTxid).toBe(
+            "f0".repeat(32),
+        );
+    });
+
     it("keeps a rebuilt covenant identical across a state change", () => {
         const record = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin));
         const moved = updateRfqSwapRecord(record, swapOf(sendOrigin, "settled"));

--- a/packages/swap/test/store.test.ts
+++ b/packages/swap/test/store.test.ts
@@ -73,12 +73,13 @@ describe("asset swap store", () => {
 
     it("reports failed add writes and keeps update writes best-effort", async () => {
         const broken = (existing: AssetSwap[] = []): AssetSwapRepository => ({
-            version: 3,
+            version: 4,
             saveSwap: async () => {
                 throw new Error("quota exceeded");
             },
             getAllSwaps: async () => existing,
             saveRfqSwap: async () => {},
+            getRfqSwap: async () => undefined,
             getAllRfqSwaps: async () => [],
             removeRfqSwap: async () => {},
             getScannedTxids: async () => new Set(),
@@ -110,12 +111,13 @@ describe("asset swap store", () => {
 
     it("reads a failed read as empty history, but never writes on one", async () => {
         const broken: AssetSwapRepository = {
-            version: 3,
+            version: 4,
             saveSwap: async () => {},
             getAllSwaps: async () => {
                 throw new Error("backend gone");
             },
             saveRfqSwap: async () => {},
+            getRfqSwap: async () => undefined,
             getAllRfqSwaps: async () => [],
             removeRfqSwap: async () => {},
             getScannedTxids: async () => new Set(),


### PR DESCRIPTION
First three items of `plans/swap-rfq-consumer-feedback.md`, grouped because each is small and they only touch adjacent surfaces.

**1 — `readLockupFate` names the spends it observed.** `claimed` and `returned` now carry `spends: readonly LockupSpend[]`, one per spent lockup output: the `checkpointTxid` that `spentBy` names plus the `arkTxid` that rode it. The read already had both in hand and discarded them, so consumers re-derived the spender. `arkTxid` is optional because the indexer documents it "if applicable"; `open` and `unknown` claim no spend.

**2 — `RfqSwapOrigin.fundingArkTxid?`.** Origin, not manager state: the caller broadcasts the funding and knows the txid, the manager watches by script and never learns it. Consumers stashed it in `profile`, which every write merges as `{ ...profile, ...handler.project(swap) }` — a colliding key is silently overwritten. That merge rule is now documented on the field.

**3 — `AssetSwapRepository.getRfqSwap(rfqId)`, version 3 → 4.** Every backend was already keyed by `rfqId`; without a keyed read a callback updating one record scanned them all. A miss returns `undefined` — retention prunes terminal records, so absence is ordinary.

No known custom implementors (the four backends are all in-tree and all updated here), so the version bump costs no coordination — but it happens per the convention: it turns a silent `getRfqSwap is not a function` into a compile error for anyone we don't know about.

Nothing here is breaking. Items 1 and 2 are additive; 3 extends the interface. `fundingArkTxid` needs no migration — all three persistent backends store the record whole.

Unblocks items 4 (`arkadeRefunder`), 5 (activity helper) and 7 (manager persistence).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added RFQ swap lookup by ID across supported storage backends, with no result returned when a record is unavailable.
  - Added optional funding transaction details to RFQ swap records.
  - Lockup outcomes now report checkpoint and optional Ark transaction spend details for claimed or returned funds.
  - Exported the new spend record type.

- **Documentation**
  - Updated swap documentation to describe RFQ lookup, funding metadata, and lockup spend results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->