### PR TITLE
feat(swap): make the kind-gated claim callbacks optional at installation

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -573,6 +573,21 @@ terminal: the lockup stays funded and watched, a solver claim still ends the swa
 `pending`. The manager reports the same state when nothing is wired to act (`enableAutoActions:
 false`, or no callbacks) and the window has passed.
 
+**The two claim callbacks may be omitted.** `setCallbacks` accepts
+`AvailableRfqSwapManagerCallbacks` — the full contract with `claimOnchain` and `claimLockup`
+optional — so a consumer driving only lightning sends installs neither instead of stubbing them to
+throw. Dispatch is already kind-gated, so neither is reachable there. `refundArkade` and `saveSwap`
+stay required.
+
+`RfqSwapManagerCallbacks` itself is unchanged and still means "fully wired", so a helper taking one
+and calling `claimOnchain` keeps its guarantee; only the parameter widens, which every existing
+caller satisfies. What moves from compile time to runtime is bought back as a **block**: a kind
+whose claim is missing reports `needs_counterparty` naming the gap, non-terminal and re-evaluated
+every pass, lifted the moment `setCallbacks` supplies it. Not `failed` — `setCallbacks` is
+installable late by design, and a terminal state would foreclose the late wiring this exists for.
+A manager with *no* callbacks at all keeps today's manual mode on the L1 half: it reports
+`claimable` and you act by hand.
+
 `preimageForSwapRecord` is the read path to wire, not a hand-rolled `contractPreimage` call: it
 knows which of the record's fields are derivation inputs, and it verifies the result against
 `paymentHash`. A caller that forgets to pass the salt gets a _wrong_ preimage from a wallet that can
@@ -657,6 +672,11 @@ through their stored `preimageHex` or their HD descriptor, and `DB_VERSION` is u
 
 Notes from before 0.0.1, kept for consumers who tracked the branch.
 
+- **`setCallbacks` takes `AvailableRfqSwapManagerCallbacks`** — `RfqSwapManagerCallbacks` with the
+  two kind-gated claims optional. Nothing breaks: the strict interface is untouched and the widened
+  parameter accepts every existing caller. A consumer driving one kind stops stubbing the claims it
+  cannot reach; in exchange, a missing claim blocks at runtime (`needs_counterparty`, non-terminal)
+  instead of being unrepresentable.
 - **The repository interface is at version `4`.** It gained
   `getRfqSwap(rfqId): Promise<RfqSwapRecord | undefined>` — every backend is already keyed by
   `rfqId`, so a consumer updating one record no longer scans them all. A miss returns `undefined`;
@@ -872,4 +892,5 @@ scanned? })` — the server key is required because a spend is classified by reb
   receive swap monitored with nothing wired to claim it expires quietly, and a compile error is the
   right way to learn a corridor was added. A caller with only send swaps can satisfy it with a stub
   that throws. `RfqSwapActionName` gains `"claimLockup"`, so an exhaustive `switch` over it needs a
-  new arm.
+  new arm. **Superseded:** such a caller now installs `AvailableRfqSwapManagerCallbacks` and omits
+  both — see above.

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -210,6 +210,7 @@ export {
     isRfqSwapTerminal,
     nextOnchainAction,
     type ArkadeRefundResult,
+    type AvailableRfqSwapManagerCallbacks,
     type LightningReceiveSwap,
     type LightningSendSwap,
     type OnchainSendAction,

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -426,9 +426,12 @@ export interface RfqSwapManagerCallbacks {
      * checks, one of which is load-bearing — do not drop the inner one because
      * the outer one exists.
      *
-     * Required rather than optional, like {@link claimOnchain}: a receive swap
-     * monitored with nothing wired to claim it is a swap that quietly expires,
-     * and a compile error is the right way to learn that.
+     * Required here, like {@link claimOnchain}: a receive swap monitored with
+     * nothing wired to claim it is a swap that quietly expires, and a compile
+     * error is the right way to learn that. A consumer that drives only the
+     * kinds needing neither installs
+     * {@link AvailableRfqSwapManagerCallbacks} instead and takes the runtime
+     * refusal in its place.
      */
     claimLockup: (
         swap: LightningReceiveSwap,
@@ -461,6 +464,26 @@ export interface RfqSwapManagerCallbacks {
     /** Persist the record. Called after any pass that changed it. */
     saveSwap: (swap: RfqSwap) => Promise<void>;
 }
+
+/**
+ * What {@link RfqSwapManager.setCallbacks} accepts: the full contract, minus
+ * the two claims that are already kind-gated at dispatch. A consumer driving
+ * only lightning sends reaches neither, and stubbing them to throw is not a
+ * contract — it is a lie the compiler waves through.
+ *
+ * The strict {@link RfqSwapManagerCallbacks} is untouched and still means
+ * "fully wired", so a helper that takes one and calls `claimOnchain` keeps its
+ * guarantee. Only the parameter widens, which every existing caller satisfies.
+ *
+ * The compile-time guarantee this trades away is bought back at runtime: a
+ * kind whose claim is missing blocks — non-terminal, re-evaluated every pass,
+ * and lifted the moment `setCallbacks` supplies it.
+ */
+export type AvailableRfqSwapManagerCallbacks = Omit<
+    RfqSwapManagerCallbacks,
+    "claimOnchain" | "claimLockup"
+> &
+    Partial<Pick<RfqSwapManagerCallbacks, "claimOnchain" | "claimLockup">>;
 
 /** The actions the manager executes on a caller's behalf. */
 export type RfqSwapActionName = "claimOnchain" | "claimLockup" | "refundArkade";
@@ -607,7 +630,7 @@ const notify = <T extends (...args: never[]) => void>(
 export class RfqSwapManager {
     private readonly deps: RfqSwapManagerDeps;
     private readonly config: Required<Omit<RfqSwapManagerConfig, "events">>;
-    private callbacks: RfqSwapManagerCallbacks | null = null;
+    private callbacks: AvailableRfqSwapManagerCallbacks | null = null;
 
     private readonly swapUpdateListeners = new Set<SwapUpdateListener>();
     private readonly swapCompletedListeners = new Set<SwapCompletedListener>();
@@ -703,8 +726,10 @@ export class RfqSwapManager {
         }
     }
 
-    /** Wire the money-moving half. Without it the manager only watches. */
-    setCallbacks(callbacks: RfqSwapManagerCallbacks): void {
+    /** Wire the money-moving half. Without it the manager only watches. The
+     * two claims may be omitted for a consumer that drives no kind reaching
+     * them — see {@link AvailableRfqSwapManagerCallbacks}. */
+    setCallbacks(callbacks: AvailableRfqSwapManagerCallbacks): void {
         this.callbacks = callbacks;
     }
 
@@ -1246,7 +1271,7 @@ export class RfqSwapManager {
             }
         }
 
-        if (!this.callbacks) {
+        if (!this.callbacks || !this.callbacks.claimLockup) {
             // Checked BEFORE the label, unlike the auto-actions case below: a
             // wallet with nothing wired cannot claim by hand off `claimable`
             // either, so reporting the lockup as claimable would name an action
@@ -1255,7 +1280,9 @@ export class RfqSwapManager {
             // same wiring gap, and lifted the moment `setCallbacks` runs.
             return this.block(
                 swap,
-                "no callbacks are wired, so this wallet cannot claim the lockup",
+                this.callbacks
+                    ? "no claimLockup callback is wired, so this wallet cannot claim the lockup"
+                    : "no callbacks are wired, so this wallet cannot claim the lockup",
             );
         }
 
@@ -1344,8 +1371,23 @@ export class RfqSwapManager {
             // step 2 skipped this branch on it; a blocked swap keeps the txid
             // while the label defers, and re-broadcasting would publish P twice.
             if (swap.claimTxid) return "continue";
+            // Half-wired: callbacks installed, this one absent. Blocked rather
+            // than labelled `claimable`, for the reason `claimIfFunded` gives —
+            // and NOT failed, unlike the missing-`ChainSource` case above:
+            // `chain` is constructor-injected and can never arrive late, while
+            // `setCallbacks` exists precisely so a callback can, and a terminal
+            // state would foreclose the wiring this whole relaxation is for.
+            // Fully unwired keeps reporting `claimable`, which is the
+            // documented manual mode.
+            if (this.callbacks && !this.callbacks.claimOnchain) {
+                this.block(
+                    swap,
+                    "no claimOnchain callback is wired, so this wallet cannot claim the L1 fill",
+                );
+                return "handled";
+            }
             this.setOnchainState(swap, "claimable");
-            if (!this.config.enableAutoActions || !this.callbacks) return "handled";
+            if (!this.config.enableAutoActions || !this.callbacks?.claimOnchain) return "handled";
             try {
                 const { txid } = await this.callbacks.claimOnchain(swap, phase.utxo);
                 swap.claimTxid = txid;

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -53,6 +53,7 @@ import {
     type OnchainSendSwap,
     type RfqSwap,
     type RfqSwapActionName,
+    type AvailableRfqSwapManagerCallbacks,
     type RfqSwapManagerCallbacks,
     type RfqSwapState,
     type SwapContractRegistry,
@@ -479,6 +480,9 @@ const manager = (input: {
     now: number | (() => number);
     spies: Spies;
     enableAutoActions?: boolean;
+    /** What to install instead of the full spy set — a half-wired
+     * installation, which only the relaxed type makes expressible. */
+    install?: AvailableRfqSwapManagerCallbacks;
 }): RfqSwapManager => {
     const m = new RfqSwapManager(
         {
@@ -492,8 +496,18 @@ const manager = (input: {
             events: { onActionExecuted: (_s, a) => input.spies.actions.push(a) },
         },
     );
-    m.setCallbacks(input.spies.callbacks);
+    m.setCallbacks(input.install ?? input.spies.callbacks);
     return m;
+};
+
+/** The spy set minus one claim. */
+const without = (
+    s: Spies,
+    key: "claimOnchain" | "claimLockup",
+): AvailableRfqSwapManagerCallbacks => {
+    const relaxed: AvailableRfqSwapManagerCallbacks = { ...s.callbacks };
+    delete relaxed[key];
+    return relaxed;
 };
 
 describe("nextOnchainAction", () => {
@@ -1540,6 +1554,89 @@ describe("RfqSwapManager — the lightning-receive leg", () => {
  * So the state has to be reported without retrying, without `onSwapFailed`,
  * and — the item-5 interaction — without unwatching the contract.
  */
+describe("RfqSwapManager — a kind whose claim was never wired", () => {
+    const BEFORE_DEADLINE = REFUND_LOCKTIME - 3600;
+    const fundedIndexer = () =>
+        fakeIndexer({ vtxos: unspent(), funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }] });
+
+    it("drives a lightning send with neither claim wired, which used not to compile", async () => {
+        const s = spies();
+        const swap = lightningSwap();
+        const m = manager({
+            now: REFUND_LOCKTIME + 60,
+            spies: s,
+            install: { refundArkade: s.callbacks.refundArkade, saveSwap: s.callbacks.saveSwap },
+        });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("refunded");
+        expect(s.refunds).toEqual([RFQ_ID]);
+    });
+
+    it("blocks a receive swap on the missing claimLockup, naming the wiring", async () => {
+        const s = spies();
+        const swap = receiveSwap();
+        const m = manager({
+            indexer: fundedIndexer(),
+            now: BEFORE_DEADLINE,
+            spies: s,
+            install: without(s, "claimLockup"),
+        });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/no claimLockup callback is wired/);
+        expect(s.lockupClaims).toHaveLength(0);
+    });
+
+    it("blocks a claimable fill on the missing claimOnchain, and lifts once it is wired", async () => {
+        // Non-terminal is the whole point: `setCallbacks` is installable late
+        // by design, so a terminal state here would foreclose the wiring this
+        // relaxation exists for.
+        const s = spies();
+        const swap = onchainSwap();
+        const m = manager({
+            chain: fakeChain({ utxos: [FILL], mtp: SAFE_NOW }),
+            now: SAFE_NOW,
+            spies: s,
+            install: without(s, "claimOnchain"),
+        });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/no claimOnchain callback is wired/);
+        expect(isRfqSwapTerminal(swap.state)).toBe(false);
+        expect(s.claims).toHaveLength(0);
+
+        m.setCallbacks(s.callbacks);
+        await m.poll();
+
+        expect(s.claims).toHaveLength(1);
+        expect(swap.state).toBe("claimed");
+        expect(swap.claimTxid).toBe("dd".repeat(32));
+    });
+
+    it("keeps reporting a claimable fill when nothing at all is wired", async () => {
+        // The check targets the half-wired case only. Fully unwired is the
+        // documented manual mode: report `claimable`, act by hand.
+        const swap = onchainSwap();
+        const m = new RfqSwapManager(
+            {
+                indexer: fakeIndexer({ vtxos: unspent() }),
+                chain: fakeChain({ utxos: [FILL], mtp: SAFE_NOW }),
+            },
+            { now: () => SAFE_NOW },
+        );
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("claimable");
+    });
+});
+
 describe("RfqSwapManager — a refund this wallet cannot make", () => {
     const cannotSign = () =>
         new RefundNotLocallyPossibleError(


### PR DESCRIPTION
Item 6 of `plans/swap-rfq-consumer-feedback.md`. Independent of #769 — branched off `master`.

Dispatch is already kind-gated: `claimLockup` is only reachable for `lightning_receive`, `claimOnchain` only for `onchain_send`. A lightning-send-only consumer still had to supply both, and the answer has been stubs that throw.

`setCallbacks` now takes `AvailableRfqSwapManagerCallbacks` — `RfqSwapManagerCallbacks` with those two optional. The strict interface is deliberately untouched: widening a required property to optional is only safe for callback *providers*, and would be a new "possibly undefined" error for any helper that takes a `RfqSwapManagerCallbacks` and calls `claimOnchain`. Widening the *parameter* is contravariant-safe instead — every existing caller passes the strict type, which is assignable to the relaxed one — and the manager never exposes its callbacks, so the relaxed type cannot leak back out.

The requirement was a documented, deliberate choice (`swapManager.ts:429-431`: "a receive swap monitored with nothing wired to claim it is a swap that quietly expires, and a compile error is the right way to learn that"), so the compile-time guarantee is paid back rather than pocketed:

- **`claimIfFunded`** — `claimLockup` absent takes the existing no-callbacks path, with a message naming which half is missing. Checked before the `claimable` label, for the reason already documented there.
- **`driveOnchain`** — `claimOnchain` absent on a claimable fill **blocks**, not fails. `chain` is constructor-injected and can never arrive late, so failing fast on a missing `ChainSource` costs nothing; callbacks are installable late by design and a terminal `failed` would foreclose exactly the wiring this change is for. The check targets the half-wired case only — fully unwired keeps today's manual mode (report `claimable`, act by hand).

Both blocks are non-terminal and re-evaluated every pass, so wiring the callback lifts the swap while the window is still open. `refundArkade` and `saveSwap` stay required — the latter until item 7 offers the alternative.

Not taken: the optional loud ending (a marker for "a claimable fill was seen while `claimOnchain` was unwired", so a window closing unclaimed ends `failed` rather than `refunded`). The plan calls it optional polish and the non-terminal block the load-bearing half; the current `refunded` unwind is acceptable. It needs a new marker on the onchain leg plus an intercept in the refund gate, which is worth its own change rather than riding along here.

Also rejected, per the plan: refusing to *monitor* a kind whose action is unwired. `start()` cannot know whether `setCallbacks` will follow, and the blocked state already models "nobody here can act" without foreclosing late wiring.

**Tests.** Send-only manager with neither claim installed drives a swap to `refunded`; a receive swap without `claimLockup` blocks naming the gap; a half-wired onchain swap blocks on a claimable fill, stays non-terminal, and claims on the next pass once `setCallbacks` wires it; a fully unwired one still reports `claimable`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swap managers can now be configured without on-chain or lockup claim callbacks.
  * Missing claim handlers are reported as non-terminal states, allowing processing to resume when callbacks are added.
  * The callback type is now available through the package’s public exports.

* **Documentation**
  * Updated migration guidance to reflect optional claim callbacks and remove the previous lockup callback requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->