### PR TITLE
feat(swap): ship arkadeRefunder and the activity correlation helper

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -588,6 +588,23 @@ installable late by design, and a terminal state would foreclose the late wiring
 A manager with *no* callbacks at all keeps today's manual mode on the L1 half: it reports
 `claimable` and you act by hand.
 
+**Take `arkadeRefunder` rather than assembling `refundArkade` by hand.** It composes the atomic
+push and keeps the three rules the manager relies on structural instead of documented — an empty
+lockup returns `null`, and both `RefundNotLocallyPossibleError` and `LockupNeedsRecoveryError`
+propagate untouched.
+
+```ts
+manager.setCallbacks({
+    // `repository` is how it reaches `profile.signer`: the live swap the manager
+    // passes carries no descriptor, so the refund key is resolved by `rfqId`.
+    refundArkade: arkadeRefunder({ ark, indexer, wallet, repository }),
+    saveSwap,
+});
+```
+
+Keep the covenant on the swap (`request*`'s `script`, as a record's `lockup`): the refund is built
+from it, and a swap carrying only `lockupPkScript` is refused rather than pushed.
+
 `preimageForSwapRecord` is the read path to wire, not a hand-rolled `contractPreimage` call: it
 knows which of the record's fields are derivation inputs, and it verifies the result against
 `paymentHash`. A caller that forgets to pass the salt gets a _wrong_ preimage from a wallet that can
@@ -672,6 +689,15 @@ through their stored `preimageHex` or their HD descriptor, and `DB_VERSION` is u
 
 Notes from before 0.0.1, kept for consumers who tracked the branch.
 
+- **`arkadeRefunder({ ark, indexer, wallet, repository })` ships the `refundArkade` wiring** that
+  was prose in two places. New export, nothing removed.
+- **`rfqSwapActivityInputs({ repository, indexer })` derives `SwapActivityInput[]` from the record
+  store** — the correlation helper `activity.ts` promised. `SwapActivityInput["kind"]` is now
+  `RfqSwapRecord["kind"]` rather than a literal union repeating it; source-compatible. Corridor
+  handlers gained an optional `activityTxids(profile)` so a leg's own claim txid comes from the
+  handler instead of a kind switch. The `indexer` is optional and consulted only for what a record
+  cannot answer: a record predating `fundingArkTxid`, and the counterparty's spend on a swap no
+  refund of ours ended. An unreachable indexer costs that record its extra txids, never a throw.
 - **`setCallbacks` takes `AvailableRfqSwapManagerCallbacks`** — `RfqSwapManagerCallbacks` with the
   two kind-gated claims optional. Nothing breaks: the strict interface is untouched and the widened
   parameter accepts every existing caller. A consumer driving one kind stops stubbing the claims it

--- a/packages/swap/src/activity.ts
+++ b/packages/swap/src/activity.ts
@@ -1,23 +1,31 @@
-import type { ActivityResolver, ArkTransaction, GroupMembership } from "@arkade-os/sdk";
-import type { RfqSwapState } from "./swapManager";
+import {
+    ArkAddress,
+    type ActivityResolver,
+    type ArkTransaction,
+    type GroupMembership,
+} from "@arkade-os/sdk";
+import { hex } from "@scure/base";
+import { isRfqSwapTerminal, type RfqSwapState } from "./swapManager";
+import type { LockupSpendIndexer } from "./refund";
+import { rfqCorridorHandlers } from "./rfqCorridor";
+// Side-effecting, as in `rfqRecord.ts`: the type-only import below erases, so
+// nothing else here would register the handlers this reads.
+import "./rfqCorridors";
+import type { AssetSwapRepository } from "./repository";
+import type { RfqSwapRecord } from "./rfqRecord";
 
 /**
  * One swap, flattened to what grouping needs: an identity, a corridor, an
  * outcome, and every Arkade transaction that belongs to it.
  *
  * Deliberately not a stored swap record itself — resolution should stay
- * testable with plain data rather than a repository. A correlation helper
- * that derives these from the record store and the funding lockup's VTXOs
- * lands separately.
+ * testable with plain data rather than a repository. {@link rfqSwapActivityInputs}
+ * derives these from the record store and, where a record cannot answer, the
+ * funding lockup's VTXOs.
  */
 export interface SwapActivityInput {
     rfqId: string;
-    /**
-     * Literal union rather than `RfqSwapRecord["kind"]` — `RfqSwapRecord` lives
-     * only on the unmerged rfq-persistence branch, not on master. Reconcile
-     * with `RfqSwapRecord["kind"]` once that branch lands.
-     */
-    kind: "lightning_send" | "lightning_receive" | "onchain_send";
+    kind: RfqSwapRecord["kind"];
     state: RfqSwapState;
     /** Funding, claim and refund txids, in whatever order. */
     txids: readonly string[];
@@ -111,4 +119,92 @@ export function swapActivityResolver(deps: {
             ];
         },
     };
+}
+
+export interface RfqSwapActivityDeps {
+    repository: Pick<AssetSwapRepository, "getAllRfqSwaps">;
+    /**
+     * Consulted only for what a record cannot answer: a record written before
+     * `fundingArkTxid` existed, and the counterparty's spend on a swap that
+     * ended without a refund of ours.
+     *
+     * Optional because the stored fields are the primary source — cheaper, and
+     * they work offline, which is the resolver's whole posture. An indexer that
+     * throws costs that record its extra txids and nothing else.
+     */
+    indexer?: LockupSpendIndexer;
+}
+
+/**
+ * Every stored RFQ swap, flattened into what {@link swapActivityResolver}
+ * groups on.
+ *
+ * The txids come from four places, in order of preference: the record's own
+ * `fundingArkTxid` and `refundArkTxid`, the corridor's `activityTxids` (the
+ * receive leg's Arkade claim, the onchain leg's L1 one), and — only when the
+ * first two cannot answer — one read of the lockup's VTXOs.
+ *
+ * A missing txid costs an activity a row, never a wrong one: a swap that
+ * contributes fewer txids simply leaves those transactions ungrouped, which is
+ * what they already are.
+ */
+export async function rfqSwapActivityInputs(
+    deps: RfqSwapActivityDeps,
+): Promise<SwapActivityInput[]> {
+    const records = await deps.repository.getAllRfqSwaps();
+    return Promise.all(records.map((record) => activityInputOf(record, deps.indexer)));
+}
+
+async function activityInputOf(
+    record: RfqSwapRecord,
+    indexer?: LockupSpendIndexer,
+): Promise<SwapActivityInput> {
+    const txids = new Set<string>();
+    if (record.fundingArkTxid) txids.add(record.fundingArkTxid);
+    if (record.refundArkTxid) txids.add(record.refundArkTxid);
+    const handler = rfqCorridorHandlers.getOrThrow(record.kind);
+    for (const txid of handler.activityTxids?.(record.profile) ?? []) txids.add(txid);
+
+    // The counterparty's spend is what ended a swap the trader did not refund
+    // itself — a solver claim on a send leg, a solver reclaim on a receive one.
+    const spendUnknown = isRfqSwapTerminal(record.state) && !record.refundArkTxid;
+    if (indexer && (!record.fundingArkTxid || spendUnknown)) {
+        for (const txid of await lockupTxids(indexer, record, !record.fundingArkTxid)) {
+            txids.add(txid);
+        }
+    }
+
+    return { rfqId: record.rfqId, kind: record.kind, state: record.state, txids: [...txids] };
+}
+
+/** One read of everything at the lockup: the transactions that funded it, and
+ * the ark transactions that spent it. Ask-the-indexer, don't-trust-local-state
+ * — the same posture `readLockupFate` establishes, and the same seam. */
+async function lockupTxids(
+    indexer: LockupSpendIndexer,
+    record: RfqSwapRecord,
+    wantFunding: boolean,
+): Promise<string[]> {
+    let script: string;
+    try {
+        script = hex.encode(ArkAddress.decode(record.lockupAddress).pkScript);
+    } catch {
+        return []; // an address that will not decode names no lockup to read
+    }
+    try {
+        const { vtxos } = await indexer.getVtxos({ scripts: [script] });
+        const out: string[] = [];
+        for (const vtxo of vtxos ?? []) {
+            // The transaction that CREATED the output is the funding.
+            if (wantFunding) out.push(vtxo.txid);
+            // `spentBy` names the checkpoint; `arkTxId` names the ark
+            // transaction, which is the one history carries.
+            if (vtxo.arkTxId) out.push(vtxo.arkTxId);
+        }
+        return out;
+    } catch {
+        // Offline-first: fewer txids, never a throw that sinks every other
+        // record's activity along with this one's.
+        return [];
+    }
 }

--- a/packages/swap/src/arkadeRefunder.ts
+++ b/packages/swap/src/arkadeRefunder.ts
@@ -58,7 +58,11 @@ export function arkadeRefunder(
             // A wiring mistake, not a swap outcome: `lockup` is optional only
             // because the manager can still watch without it, and no refund can
             // be built from the pkScript alone. Keep `request*`'s `script` on
-            // the swap.
+            // the swap. Untyped on purpose: the manager retries this once a
+            // poll and ends the swap `failed` at the deadline (see
+            // `RfqSwapManagerCallbacks.refundArkade`), which is the loud
+            // outcome a wiring mistake deserves — not the quiet permanent
+            // refusal a typed error would produce.
             throw new Error(
                 `swap ${swap.rfqId} carries no lockup covenant, so its refund cannot be built`,
             );
@@ -80,6 +84,13 @@ export function arkadeRefunder(
             );
         }
 
+        // The `?? {}` is a refusal, not a default: a record with no
+        // `profile.signer` reaches `senderIdentityForSwapRecord` without a
+        // `signingDescriptor`, which is what turns it into the same typed
+        // `RefundNotLocallyPossibleError("no-secrets")` thrown above. Written
+        // this way rather than as a second explicit throw so that the one place
+        // deciding what "this wallet cannot sign this swap" means stays
+        // `senderIdentityForSwapRecord`.
         const sender = await senderIdentityForSwapRecord(deps.wallet, rfqSignerOf(record) ?? {});
         return pushRefundWithoutReceiver(deps.ark, { script, sender, vtxos });
     };

--- a/packages/swap/src/arkadeRefunder.ts
+++ b/packages/swap/src/arkadeRefunder.ts
@@ -1,0 +1,86 @@
+/**
+ * The `refundArkade` callback, assembled.
+ *
+ * The wiring this replaces was prose in two places — `swapManager.ts`'s
+ * callback doc and the README — because it is the one callback whose obvious
+ * implementation is wrong: `refundIfUnresolved` is the single-swap version of
+ * `RfqSwapManager` itself and brings its own status polling and MTP retry loop,
+ * which would nest inside the manager's. Composing the atomic push here makes
+ * that mistake something a consumer has to go out of their way to make.
+ *
+ * The three semantic rules the manager relies on are structural rather than
+ * documented: an empty lockup returns `null`, and both
+ * {@link RefundNotLocallyPossibleError} and {@link LockupNeedsRecoveryError}
+ * propagate untouched — the manager reads the first as permanent and surfaces
+ * the second as `needs_recovery`, and catching either here would turn a state
+ * the trader must act on into a retry that grinds the window away.
+ */
+import type { IWallet } from "@arkade-os/sdk";
+import {
+    findLockupVtxos,
+    pushRefundWithoutReceiver,
+    type RefundArkProvider,
+    type RefundIndexer,
+} from "./refund";
+import { RefundNotLocallyPossibleError, senderIdentityForSwapRecord } from "./refundBlocked";
+import { rfqSignerOf } from "./rfqProfileParts";
+import type { AssetSwapRepository } from "./repository";
+import type { ArkadeRefundResult, RfqSwap } from "./swapManager";
+
+export interface ArkadeRefunderDeps {
+    ark: RefundArkProvider;
+    indexer: RefundIndexer;
+    /** Asked for the descriptor's signer; never asked to mint a key. */
+    wallet: IWallet;
+    /**
+     * The record store. The live `RfqSwap` the manager passes carries no
+     * `signingDescriptor` — that lives in the record's `profile.signer` — so
+     * the refund key is resolved by key, which is what `getRfqSwap` is for.
+     */
+    repository: Pick<AssetSwapRepository, "getRfqSwap">;
+}
+
+/**
+ * Build the `refundArkade` callback for `RfqSwapManager.setCallbacks`.
+ *
+ * @example
+ * manager.setCallbacks({
+ *     refundArkade: arkadeRefunder({ ark, indexer, wallet, repository }),
+ *     saveSwap,
+ * });
+ */
+export function arkadeRefunder(
+    deps: ArkadeRefunderDeps,
+): (swap: RfqSwap) => Promise<ArkadeRefundResult> {
+    return async (swap) => {
+        const script = swap.lockup?.script;
+        if (!script) {
+            // A wiring mistake, not a swap outcome: `lockup` is optional only
+            // because the manager can still watch without it, and no refund can
+            // be built from the pkScript alone. Keep `request*`'s `script` on
+            // the swap.
+            throw new Error(
+                `swap ${swap.rfqId} carries no lockup covenant, so its refund cannot be built`,
+            );
+        }
+
+        // Before the store read: a lockup holding nothing needs no signer, and
+        // `null` is the manager's "nothing to do" rather than a failure.
+        const vtxos = await findLockupVtxos(deps.indexer, swap.lockupPkScript);
+        if (vtxos.length === 0) return null;
+
+        const record = await deps.repository.getRfqSwap(swap.rfqId);
+        if (!record) {
+            // Permanent, and typed as such: the record is written at request
+            // time, so one the store has never seen is not one that will
+            // appear. Retrying would grind until the window shut.
+            throw new RefundNotLocallyPossibleError(
+                "no-secrets",
+                `no stored record for ${swap.rfqId}; the descriptor that signs its refund lives there`,
+            );
+        }
+
+        const sender = await senderIdentityForSwapRecord(deps.wallet, rfqSignerOf(record) ?? {});
+        return pushRefundWithoutReceiver(deps.ark, { script, sender, vtxos });
+    };
+}

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -193,6 +193,7 @@ export {
     type RefundIndexer,
     type RefundOutcome,
 } from "./refund";
+export { arkadeRefunder, type ArkadeRefunderDeps } from "./arkadeRefunder";
 export {
     LockupContractMissing,
     LockupRegistrationFailed,
@@ -226,4 +227,9 @@ export {
     type RfqSwapState,
     type SwapContractRegistry,
 } from "./swapManager";
-export { swapActivityResolver, type SwapActivityInput } from "./activity";
+export {
+    rfqSwapActivityInputs,
+    swapActivityResolver,
+    type RfqSwapActivityDeps,
+    type SwapActivityInput,
+} from "./activity";

--- a/packages/swap/src/rfqCorridor.ts
+++ b/packages/swap/src/rfqCorridor.ts
@@ -80,6 +80,18 @@ export interface RfqCorridorHandler<P extends Record<string, unknown> = Record<s
     claimSecret?(profile: P): RfqClaimSecretProjection;
 
     /**
+     * The corridor's own transaction ids off its profile — the ones that are
+     * this leg's alone, like the receive leg's `claimArkTxid` or the onchain
+     * leg's L1 `claimTxid`. Whatever the record's common half already carries
+     * (`fundingArkTxid`, `refundArkTxid`) is read there, not here.
+     *
+     * Answered by the handler rather than by a kind switch in `activity.ts`,
+     * so a corridor added later contributes its txids without any edit
+     * outside this file. Omit it for a corridor with none.
+     */
+    activityTxids?(profile: P): readonly string[];
+
+    /**
      * Rebuild the corridor's live fields from what was stored.
      *
      * Throw rather than defaulting when something required is missing: a swap

--- a/packages/swap/src/rfqCorridors.ts
+++ b/packages/swap/src/rfqCorridors.ts
@@ -100,6 +100,8 @@ export const LightningReceiveCorridor: RfqCorridorHandler<LightningReceiveProfil
     // We are the claimant here, so the preimage material on the hashlock is
     // ours to use.
     claimSecret: (profile) => ({ ...profile.signer, ...profile.hashlock }),
+
+    activityTxids: (profile) => (profile.claimArkTxid ? [profile.claimArkTxid] : []),
 };
 
 /** `arkade:BTC->onchain:BTC`. */
@@ -257,6 +259,11 @@ export const OnchainSendCorridor: RfqCorridorHandler<OnchainSendProfile> = {
     // The trader claims the L1 HTLC with P, so this leg's preimage material is
     // ours.
     claimSecret: (profile) => ({ ...profile.signer, ...profile.hashlock }),
+
+    // Our own L1 claim only. `funding` is the SOLVER's fill into the HTLC —
+    // not a transaction of ours, so grouping it would claim a row this wallet
+    // never made.
+    activityTxids: (profile) => (profile.claimTxid ? [profile.claimTxid] : []),
 };
 
 rfqCorridorHandlers.register(LightningSendCorridor as RfqCorridorHandler);

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -398,12 +398,14 @@ export type ArkadeRefundResult = { arkTxid: string; amount: number } | null;
 /**
  * The money-moving half, injected. The manager decides when; these do it.
  *
- * Neither action gets a retry loop of its own here — see the module doc. Do
- * NOT wire `refundArkade` to `refundIfUnresolved`: that function is the
+ * Neither action gets a retry loop of its own here — see the module doc. Take
+ * `arkadeRefunder` for `refundArkade` rather than assembling it: it composes
+ * the atomic push (`findLockupVtxos` + `senderIdentityForSwapRecord` +
+ * `pushRefundWithoutReceiver`) and keeps the three rules below structural.
+ *
+ * Do NOT wire `refundArkade` to `refundIfUnresolved`: that function is the
  * single-swap version of this whole class and brings its own status polling
- * and its own MTP retry loop, which would nest inside the manager's. Wire it
- * to `findLockupVtxos` + `pushRefundWithoutReceiver`, which is the atomic push
- * `refundIfUnresolved` itself calls.
+ * and its own MTP retry loop, which would nest inside the manager's.
  *
  * Resolve the sender key through `senderIdentityForSwapRecord`: it is
  * what turns "this wallet cannot sign this swap" into

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -445,10 +445,24 @@ export interface RfqSwapManagerCallbacks {
             partiallyClaimed: boolean;
         },
     ) => Promise<{ arkTxid: string; amount: number }>;
-    /** Push `refundWithoutReceiver` for every output at the lockup. See
+    /**
+     * Push `refundWithoutReceiver` for every output at the lockup. See
      * `pushRefundWithoutReceiver`; return `null` for an empty lockup. Never
      * called for a {@link LightningReceiveSwap} — that leg's refund leaf is the
-     * solver's. */
+     * solver's.
+     *
+     * Only {@link RefundNotLocallyPossibleError} is read as permanent. Every
+     * other throw is treated as transient and RETRIED once a poll: each attempt
+     * reports through `onSwapFailed` unwrapped, and the swap ends `failed` only
+     * past `refundLocktime + REFUND_MTP_LAG_SECONDS`. That is deliberate for a
+     * genuinely transient failure — `LockupNeedsRecoveryError` is the
+     * case it is built for, since recovery is something the caller can perform
+     * while the window is still open — but it means a wiring mistake that
+     * throws unconditionally does not read as `needs_counterparty`. It reports
+     * once a poll for the rest of the refund window and then ends `failed`.
+     * Throw {@link RefundNotLocallyPossibleError} for anything this wallet will
+     * never be able to do.
+     */
     refundArkade: (swap: RfqSwap) => Promise<ArkadeRefundResult>;
     /**
      * Whether a local refund is possible at all — the record's secrets, against

--- a/packages/swap/test/activity.test.ts
+++ b/packages/swap/test/activity.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from "vitest";
 import type { ArkTransaction } from "@arkade-os/sdk";
-import { swapActivityResolver, type SwapActivityInput } from "../src/activity";
+import {
+    rfqSwapActivityInputs,
+    swapActivityResolver,
+    type SwapActivityInput,
+} from "../src/activity";
+import { InMemoryAssetSwapRepository } from "../src/repository";
+import type { LockupSpendIndexer } from "../src/refund";
+import type { RfqSwapRecord } from "../src/rfqRecord";
+import { lightningSendVtxoScript } from "../src/rfq";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hex } from "@scure/base";
 
 const tx = (arkTxid: string): ArkTransaction =>
     ({
@@ -130,5 +141,138 @@ describe("swapActivityResolver", () => {
         const resolver = swapActivityResolver({ listSwaps: async () => [] });
 
         expect(resolver.resolve(tx("fund"))).toBeUndefined();
+    });
+});
+
+describe("rfqSwapActivityInputs", () => {
+    const key = (fill: number) => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
+    const p2tr = (program: Uint8Array) => Uint8Array.from([0x51, 0x20, ...program]);
+    /** A real lockup address: the helper decodes it to ask the indexer, so a
+     * made-up one would exercise the wrong branch. */
+    const LOCKUP_ADDRESS = lightningSendVtxoScript({
+        solverPubkey: key(1),
+        serverPubkey: key(3),
+        paymentHash: hex.encode(sha256(new Uint8Array(32).fill(7))),
+        refundLocktime: 1_800_000_000,
+        claimDelay: 4096,
+        emulatorPubkey: key(9),
+        refundPkScript: p2tr(key(5)),
+        senderPubkey: key(13),
+        receiverPkScript: p2tr(key(1)),
+    })
+        .address("tark", key(3))
+        .encode();
+
+    const record = (over: Partial<RfqSwapRecord> = {}): RfqSwapRecord => ({
+        rfqId: "r1",
+        kind: "lightning_send",
+        state: "settled",
+        lockupAddress: LOCKUP_ADDRESS,
+        profile: {
+            signer: { signingDescriptor: `tr(${"a7".repeat(32)})` },
+            hashlock: { paymentHash: "d4".repeat(32) },
+        },
+        createdAt: 1,
+        updatedAt: 1,
+        ...over,
+    });
+
+    const storeOf = async (...records: RfqSwapRecord[]) => {
+        const repository = new InMemoryAssetSwapRepository();
+        for (const r of records) await repository.saveRfqSwap(r);
+        return repository;
+    };
+
+    /** Everything at the lockup, as the fate read shapes it. */
+    const fakeIndexer = (
+        vtxos: { txid: string; arkTxId?: string }[],
+        over: { fail?: boolean } = {},
+    ) =>
+        ({
+            async getVtxos() {
+                if (over.fail) throw new Error("indexer unreachable");
+                return { vtxos };
+            },
+        }) as unknown as LockupSpendIndexer;
+
+    it("flattens a send record's own txids without asking anyone", async () => {
+        const repository = await storeOf(
+            record({ state: "refunded", fundingArkTxid: "fund", refundArkTxid: "refund" }),
+        );
+        expect(await rfqSwapActivityInputs({ repository })).toEqual([
+            { rfqId: "r1", kind: "lightning_send", state: "refunded", txids: ["fund", "refund"] },
+        ]);
+    });
+
+    it("takes each corridor's own claim txid from its handler", async () => {
+        const repository = await storeOf(
+            record({
+                rfqId: "receive",
+                kind: "lightning_receive",
+                fundingArkTxid: "fund",
+                profile: {
+                    signer: { signingDescriptor: `tr(${"a7".repeat(32)})` },
+                    hashlock: { paymentHash: "d4".repeat(32) },
+                    expectedAmount: 1000,
+                    payoutAddress: "tark1qpayout",
+                    claimArkTxid: "claim",
+                },
+            }),
+        );
+        const [input] = await rfqSwapActivityInputs({ repository });
+        expect(input.txids).toEqual(["fund", "claim"]);
+    });
+
+    it("reads the counterparty's spend off the lockup when no refund of ours ended it", async () => {
+        // `settled` means the SOLVER claimed: the transaction that closed the
+        // swap is one no record of ours carries.
+        const repository = await storeOf(record({ fundingArkTxid: "fund" }));
+        const [input] = await rfqSwapActivityInputs({
+            repository,
+            indexer: fakeIndexer([{ txid: "fund", arkTxId: "solver-claim" }]),
+        });
+        expect(input.txids).toEqual(["fund", "solver-claim"]);
+    });
+
+    it("recovers the funding txid of a record written before the field existed", async () => {
+        const repository = await storeOf(record({ state: "pending" }));
+        const [input] = await rfqSwapActivityInputs({
+            repository,
+            indexer: fakeIndexer([{ txid: "fund" }]),
+        });
+        expect(input.txids).toEqual(["fund"]);
+    });
+
+    it("asks nobody when the record answers on its own", async () => {
+        let calls = 0;
+        const counting = {
+            async getVtxos() {
+                calls += 1;
+                return { vtxos: [] };
+            },
+        } as unknown as LockupSpendIndexer;
+        const repository = await storeOf(
+            record({ state: "refunded", fundingArkTxid: "fund", refundArkTxid: "refund" }),
+        );
+        await rfqSwapActivityInputs({ repository, indexer: counting });
+        expect(calls).toBe(0);
+    });
+
+    it("degrades to fewer txids when the indexer is unreachable, never to a throw", async () => {
+        const repository = await storeOf(record({ fundingArkTxid: "fund" }));
+        const [input] = await rfqSwapActivityInputs({
+            repository,
+            indexer: fakeIndexer([], { fail: true }),
+        });
+        expect(input.txids).toEqual(["fund"]);
+    });
+
+    it("groups what it produced, which is the whole point", async () => {
+        const repository = await storeOf(
+            record({ state: "refunded", fundingArkTxid: "fund", refundArkTxid: "refund" }),
+        );
+        const resolver = await preparedResolver(await rfqSwapActivityInputs({ repository }));
+        expect(resolver.resolve(tx("fund"))?.[0].groupId).toBe("swap:r1");
+        expect(resolver.resolve(tx("refund"))?.[0].groupId).toBe("swap:r1");
     });
 });

--- a/packages/swap/test/arkadeRefunder.test.ts
+++ b/packages/swap/test/arkadeRefunder.test.ts
@@ -1,0 +1,168 @@
+/**
+ * The `refundArkade` callback the manager is meant to be wired to.
+ *
+ * The three semantic rules are the point: an empty lockup is `null` rather
+ * than a failure, and both typed refusals reach the manager intact — one it
+ * reads as permanent, one it surfaces as `needs_recovery`. A factory that
+ * caught either would turn a state the trader must act on into a retry.
+ */
+import { describe, expect, it } from "vitest";
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { CSVMultisigTapscript, SingleKey, Transaction, type IWallet } from "@arkade-os/sdk";
+
+import { lightningSendVtxoScript } from "../src/rfq";
+import { arkadeRefunder } from "../src/arkadeRefunder";
+import { RefundNotLocallyPossibleError } from "../src/refundBlocked";
+import { LockupNeedsRecoveryError, type RefundArkProvider } from "../src/refund";
+import { InMemoryAssetSwapRepository } from "../src/repository";
+import type { RfqSwapRecord } from "../src/rfqRecord";
+import type { LightningSendSwap } from "../src/swapManager";
+
+const priv = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+const key = (fill: number): Uint8Array => schnorr.getPublicKey(priv(fill));
+const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+
+const RFQ_ID = "a1".repeat(32);
+const REFUND_LOCKTIME = 1_800_000_000;
+const SENDER = SingleKey.fromPrivateKey(priv(13));
+const PAYMENT_HASH = hex.encode(sha256(new Uint8Array(32).fill(7)));
+
+const LOCKUP = lightningSendVtxoScript({
+    solverPubkey: key(1),
+    serverPubkey: key(3),
+    paymentHash: PAYMENT_HASH,
+    refundLocktime: REFUND_LOCKTIME,
+    claimDelay: 4096,
+    emulatorPubkey: key(9),
+    refundPkScript: p2tr(key(5)),
+    senderPubkey: key(13),
+    receiverPkScript: p2tr(key(1)),
+});
+
+const CHECKPOINT_TAPSCRIPT = hex.encode(
+    CSVMultisigTapscript.encode({
+        timelock: { type: "blocks", value: BigInt(144) },
+        pubkeys: [key(3)],
+    }).script,
+);
+
+const fakeArk = (): RefundArkProvider =>
+    ({
+        getInfo: async () => ({ checkpointTapscript: CHECKPOINT_TAPSCRIPT }),
+        submitTx: async (arkTx: string, checkpoints: string[]) => ({
+            arkTxid: Transaction.fromPSBT(base64.decode(arkTx)).id,
+            finalArkTx: arkTx,
+            signedCheckpointTxs: checkpoints,
+        }),
+        finalizeTx: async () => {},
+    }) as unknown as RefundArkProvider;
+
+/** The lockup as the indexer reports it: `getVtxos` is asked twice, once per
+ * filter, and only the spendable half answers unless a test says otherwise. */
+const fakeIndexer = (over: { spendable?: unknown[]; recoverable?: unknown[] } = {}) =>
+    ({
+        getVtxos: async (opts?: { spendableOnly?: boolean; recoverableOnly?: boolean }) => ({
+            vtxos: opts?.spendableOnly
+                ? (over.spendable ?? [])
+                : opts?.recoverableOnly
+                  ? (over.recoverable ?? [])
+                  : [],
+        }),
+    }) as never;
+
+const FUNDED = [{ txid: "11".repeat(32), vout: 0, value: 60_000 }];
+
+const walletFor = (identity = SENDER) => ({ identity }) as unknown as IWallet;
+
+const swap = (): LightningSendSwap =>
+    ({
+        rfqId: RFQ_ID,
+        kind: "lightning_send",
+        state: "pending",
+        lockupPkScript: LOCKUP.pkScript,
+        lockup: { script: LOCKUP, address: "ark1lockup" },
+        paymentHash: PAYMENT_HASH,
+        refundLocktime: REFUND_LOCKTIME,
+        createdAt: 1,
+        updatedAt: 1,
+    }) as LightningSendSwap;
+
+const record = async (over: Partial<RfqSwapRecord> = {}): Promise<RfqSwapRecord> => ({
+    rfqId: RFQ_ID,
+    kind: "lightning_send",
+    state: "pending",
+    lockupAddress: "ark1lockup",
+    profile: {
+        signer: { signingDescriptor: `tr(${hex.encode(await SENDER.xOnlyPublicKey())})` },
+        hashlock: { paymentHash: PAYMENT_HASH },
+    },
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+});
+
+const refunderWith = async (
+    input: {
+        indexer?: ReturnType<typeof fakeIndexer>;
+        stored?: RfqSwapRecord | null;
+        wallet?: IWallet;
+    } = {},
+) => {
+    const repository = new InMemoryAssetSwapRepository();
+    const stored = input.stored === null ? undefined : (input.stored ?? (await record()));
+    if (stored) await repository.saveRfqSwap(stored);
+    return arkadeRefunder({
+        ark: fakeArk(),
+        indexer: input.indexer ?? fakeIndexer({ spendable: FUNDED }),
+        wallet: input.wallet ?? walletFor(),
+        repository,
+    });
+};
+
+describe("arkadeRefunder", () => {
+    it("pushes refundWithoutReceiver and reports the txid and amount", async () => {
+        const refund = await refunderWith();
+        const result = await refund(swap());
+
+        expect(result?.amount).toBe(60_000);
+        expect(result?.arkTxid).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("returns null for an empty lockup, which is not a failure", async () => {
+        const refund = await refunderWith({ indexer: fakeIndexer() });
+        await expect(refund(swap())).resolves.toBeNull();
+    });
+
+    it("lets RefundNotLocallyPossibleError through when the record names no key", async () => {
+        const refund = await refunderWith({ stored: await record({ profile: {} }) });
+        await expect(refund(swap())).rejects.toThrow(RefundNotLocallyPossibleError);
+    });
+
+    it("reports a record the store never saw as permanent, not as something to retry", async () => {
+        const refund = await refunderWith({ stored: null });
+        await expect(refund(swap())).rejects.toMatchObject({
+            name: "RefundNotLocallyPossibleError",
+            reason: "no-secrets",
+        });
+    });
+
+    it("lets RefundNotLocallyPossibleError through for another wallet's key", async () => {
+        const refund = await refunderWith({ wallet: walletFor(SingleKey.fromRandomBytes()) });
+        await expect(refund(swap())).rejects.toMatchObject({ reason: "foreign-descriptor" });
+    });
+
+    it("lets LockupNeedsRecoveryError through instead of retrying the window away", async () => {
+        const refund = await refunderWith({
+            indexer: fakeIndexer({ recoverable: FUNDED }),
+        });
+        await expect(refund(swap())).rejects.toThrow(LockupNeedsRecoveryError);
+    });
+
+    it("refuses a swap carrying no covenant rather than building a refund from the pkScript", async () => {
+        const refund = await refunderWith();
+        const { lockup: _dropped, ...bare } = swap();
+        await expect(refund(bare as LightningSendSwap)).rejects.toThrow(/no lockup covenant/);
+    });
+});


### PR DESCRIPTION
Items 4 and 6-of-the-consumer's-numbering — `plans/swap-rfq-consumer-feedback.md` items 4 and 5. **Stacked on #769**; base retargets to `master` when that merges. Review the second commit only.

## `arkadeRefunder` (plan item 4)

The wiring contract existed only as prose, in two places that agree: `swapManager.ts`'s callback doc and the README. Every consumer hand-assembled `findLockupVtxos` + `senderIdentityForSwapRecord` + `pushRefundWithoutReceiver`, plus the three semantic rules the manager relies on. Those are now structural rather than documented:

1. empty lockup returns `null` — checked before the store read, since a lockup holding nothing needs no signer;
2. `RefundNotLocallyPossibleError` propagates — the manager reads it as permanent;
3. `LockupNeedsRecoveryError` propagates — the manager surfaces `needs_recovery` rather than retrying the window away.

The non-obvious input is the signer: the callback receives the live `RfqSwap`, but `senderIdentityForSwapRecord` needs `{ signingDescriptor }`, which lives in the *record's* `profile.signer`. So the factory takes the repository and resolves `getRfqSwap(swap.rfqId)` → `rfqSignerOf` → `senderIdentityForSwapRecord` — which is what made #769's keyed read a prerequisite.

A record the store has never seen is a typed `no-secrets` refusal rather than a retry: records are written at request time, so one that is absent is not one that will appear. A swap carrying no `lockup` covenant is refused outright — `lockup` is optional only because the manager can watch without it, and no refund can be built from the pkScript alone.

Composing the atomic push is also what converts the "do NOT wire `refundArkade` to `refundIfUnresolved`" prose into structure: nesting that function's own status polling and MTP retry loop inside the manager's is now something a consumer has to go out of their way to do.

## `rfqSwapActivityInputs` (plan item 5)

`activity.ts:10-11` promised verbatim: "A correlation helper that derives these from the record store and the funding lockup's VTXOs lands separately." It never did; every consumer wrote it.

Txids come from four places in order of preference: the record's `fundingArkTxid` (new in #769) and `refundArkTxid`, the corridor's own claim txid, and — only when the first two cannot answer — one read of the lockup's VTXOs.

That third source is a new optional `activityTxids(profile)` on `RfqCorridorHandler` rather than a kind switch in `activity.ts`. `rfqCorridors.ts` states the invariant it protects: adding a corridor is a handler plus a `register()` call, with no edit anywhere else. A kind switch would have broken that. The onchain leg contributes its L1 `claimTxid` but **not** `funding` — that is the solver's fill, not a transaction of ours.

The indexer is optional and consulted only for what a record cannot answer: a record written before `fundingArkTxid` existed, and the counterparty's spend on a swap no refund of ours ended (a solver claim on a send leg, a solver reclaim on a receive one). The stored fields are the primary source — cheaper, and they work offline, which is the resolver's whole posture. An unreachable indexer costs that record its extra txids and nothing else; it never throws and never sinks the other records' activities.

Also fixed, since the comment instructed it: `SwapActivityInput["kind"]` was a literal union with a note saying "`RfqSwapRecord` lives only on the unmerged rfq-persistence branch, reconcile once it lands." It landed. It is now `RfqSwapRecord["kind"]`, which is source-compatible.

## Tests

Refunder: happy path; empty lockup → `null`; no descriptor, missing record and another wallet's key → the typed refusals; swept outputs → `LockupNeedsRecoveryError`; a covenant-less swap refused.

Activity: a record's own txids with nobody asked; a corridor's claim txid via its handler; the counterparty's spend read off the lockup; a pre-`fundingArkTxid` record recovered; no indexer call when the record answers alone; an unreachable indexer degrading to fewer txids; and the output actually grouping through `swapActivityResolver`.