### PR TITLE
feat(swap): let RfqSwapManager own its record persistence

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -576,8 +576,8 @@ false`, or no callbacks) and the window has passed.
 **The two claim callbacks may be omitted.** `setCallbacks` accepts
 `AvailableRfqSwapManagerCallbacks` — the full contract with `claimOnchain` and `claimLockup`
 optional — so a consumer driving only lightning sends installs neither instead of stubbing them to
-throw. Dispatch is already kind-gated, so neither is reachable there. `refundArkade` and `saveSwap`
-stay required.
+throw. Dispatch is already kind-gated, so neither is reachable there. `saveSwap` is optional too
+(see below); `refundArkade` stays required.
 
 `RfqSwapManagerCallbacks` itself is unchanged and still means "fully wired", so a helper taking one
 and calling `claimOnchain` keeps its guarantee; only the parameter widens, which every existing
@@ -604,6 +604,69 @@ manager.setCallbacks({
 
 Keep the covenant on the swap (`request*`'s `script`, as a record's `lockup`): the refund is built
 from it, and a swap carrying only `lockupPkScript` is refused rather than pushed.
+
+### Let the manager own the records
+
+Give `RfqSwapManager` a `repository` and it persists RFQ swaps itself — the restore loop, the
+retention pass and every write, none of which a consumer has to compose:
+
+```ts
+const manager = new RfqSwapManager({
+    indexer,
+    contracts: await wallet.getContractManager(),
+    repository, // any AssetSwapRepository
+});
+manager.setCallbacks({ refundArkade, claimLockup });
+
+// Rebuild what was stored: retention first, then each record's covenant from
+// its own contract row, then `rebuildRfqSwap`. No caller input at all.
+const { restored, failed, pruned } = await manager.restoreFromRepository();
+await manager.start();
+
+// A NEW swap arrives with the request-time half a live record cannot carry.
+await manager.addSwap(swap, {
+    kind: "lightning_send",
+    lockupAddress: request.lockupAddress,
+    profile: rfqSecretsProfile(secrets, paymentHash),
+    fundingArkTxid,
+    amount,
+});
+```
+
+That second argument is the whole point. Composing the write by hand runs into an **origin trap**:
+`updateRfqSwapRecord(record, swap)` needs the record that does not exist yet, and
+`createRfqSwapRecord(origin, swap)` needs request-time facts the live swap never carried — so a
+swap's *first* record cannot be built from the swap alone. `addSwap`'s `origin` is where those
+facts arrive, and the manager keeps them for the swap's life. Omit it and one of two things
+happens: the store already holds a record, which *is* the origin, and it is read back; or it does
+not, and you get `RfqSwapOriginRequired` at the door rather than an unwritable record a pass later.
+`start(swaps)` applies the same rule and is otherwise unchanged. Restored swaps carry their own.
+
+`restoreFromRepository` returns three disjoint lists, and every stored record is in exactly one.
+A record that cannot be rebuilt — no contract row (`LockupContractMissing`), covenant params that
+do not derive the funded address, a corridor with no handler — lands in `failed` with its error and
+stays in the store; it never strands the others and it is never silently dropped. `pruned` names
+what retention removed: terminal and more than `RFQ_SWAP_RETENTION_SECONDS` past `updatedAt`, never
+`needs_counterparty`. Retention runs first, so a retired record costs no contract lookup on its way
+out; `pruneRetiredSwaps()` is public for a process that wants it on its own cadence. Pass
+`{ params }` to take covenants from somewhere other than the contract store.
+
+**Two sinks, and both gate.** With a repository wired the canonical `RfqSwapRecord` is written
+first, then `saveSwap` if one is installed, and the pass counts as persisted only when both
+succeeded — which is exactly today's rule for `saveSwap`, applied to whichever sinks exist. A
+rejection from either leaves the record dirty and monitored, so waiters stay unsettled and a
+terminal swap is not finalized until the write it claims lands. A failed canonical write skips
+`saveSwap` entirely: projecting a state the record of record has just refused would put the
+secondary sink ahead of the primary. If your `saveSwap` writes that same repository by hand, delete
+the duplicate when you wire the dep — otherwise every pass writes twice — and keep the callback for
+genuinely secondary sinks. With neither wired, state stays in memory and dies with the process.
+
+**Terminal records name the transaction that ended them.** `RfqSwap.lockupSpendArkTxids` is
+stamped from the chain read that resolved the swap — the solver's claim on a send leg, its reclaim
+on a receive one, the trader's own claim when a receive settles. Nothing local produces those
+transactions, so no other field can name them, and without the stamp the only way to find them is
+another lockup read per terminal swap. Absent when the indexer named the checkpoint but not the ark
+transaction: fewer txids beats a wrong one.
 
 `preimageForSwapRecord` is the read path to wire, not a hand-rolled `contractPreimage` call: it
 knows which of the record's fields are derivation inputs, and it verifies the result against
@@ -689,6 +752,31 @@ through their stored `preimageHex` or their HD descriptor, and `DB_VERSION` is u
 
 Notes from before 0.0.1, kept for consumers who tracked the branch.
 
+- **`RfqSwapManager` can own its own persistence.** New optional
+  `RfqSwapManagerDeps.repository`, new `restoreFromRepository()` and `pruneRetiredSwaps()`, and
+  `addSwap(swap, origin?)` gains an optional second argument. Nothing narrows and nothing is
+  removed, so no existing caller changes: without a repository the manager persists through
+  `saveSwap` exactly as before. Two things to know if you wire it. `saveSwap` becomes a **second**
+  sink rather than the only one — it still gates waiters and finalization, so its semantics are
+  unchanged, but a callback that writes the same repository by hand now double-writes and should
+  drop the duplicate. And `addSwap` for a swap the store has never seen throws
+  `RfqSwapOriginRequired` unless you pass its origin, which is the only way its first record can be
+  written at all.
+- **`saveSwap` is optional at installation**, alongside the two claims — the same
+  `AvailableRfqSwapManagerCallbacks` relaxation extended one field. Omit it with a repository wired
+  and the record store is the only sink; omit both and state is process-local, which is what a
+  manager with no callbacks already did.
+- **`RfqSwap` and `RfqSwapRecord` gained `lockupSpendArkTxids?: string[]`** — the ark transactions
+  that spent the lockup, stamped by the manager from the chain read that ended the swap. Optional
+  and additive: no repository version bump, and a backend storing records whole already carries it.
+- **`RfqSwapState`, `RFQ_SWAP_TERMINAL_STATES` and `isRfqSwapTerminal` moved to
+  `src/rfqSwapState.ts`** so the record layer can read them without importing the manager at
+  runtime. `swapManager.ts` re-exports all three and the package entry point is unchanged, so no
+  import path breaks.
+- **`rfqSwapOriginOf(record)` is new** — a record's immutable half on its own. A record *is* an
+  origin plus manager state, so passing one where an origin is wanted type-checks and quietly
+  carries the old `failure`, `blockedReason` and `refundArkTxid` past `managerState`, which can
+  only set those fields and never clear them. Use this instead of spreading the record.
 - **`arkadeRefunder({ ark, indexer, wallet, repository })` ships the `refundArkade` wiring** that
   was prose in two places. New export, nothing removed.
 - **`rfqSwapActivityInputs({ repository, indexer })` derives `SwapActivityInput[]` from the record
@@ -881,14 +969,18 @@ scanned? })` — the server key is required because a spend is classified by reb
     the contract store can keep its own copy of
     `VHTLCV2ContractHandler.serializeParams(script.options)` and pass that instead; either way the
     params are checked against the record's `lockupAddress` before a swap is handed back, so the wrong
-    row fails at restore rather than at refund time.
+    row fails at restore rather than at refund time. **Superseded** for a consumer that wires
+    `RfqSwapManagerDeps.repository`: `restoreFromRepository()` is this loop, over every stored
+    record, with retention in front of it.
 
-- **Pruning is the consumer's, and nothing here does it for you.** `shouldRetainRfqSwap(record, now)`
-  answers whether a record is still worth keeping — live swaps and `needs_counterparty` always,
-  terminal ones for `RFQ_SWAP_RETENTION_SECONDS` (30 days) after `updatedAt`. Sweep with it at boot
-  and pass the rejects to `removeRfqSwap`; skip it and a hot wallet's `rfqSwaps` store grows without
-  bound. `now` is **unix seconds**, the unit `RfqSwap.updatedAt` carries — `Date.now()` would retire
-  every terminal record after ~43 minutes.
+- **Pruning is the consumer's unless the manager holds the repository.** `shouldRetainRfqSwap(record,
+  now)` answers whether a record is still worth keeping — live swaps and `needs_counterparty`
+  always, terminal ones for `RFQ_SWAP_RETENTION_SECONDS` (30 days) after `updatedAt`. Sweep with it
+  at boot and pass the rejects to `removeRfqSwap`; skip it and a hot wallet's `rfqSwaps` store grows
+  without bound. `now` is **unix seconds**, the unit `RfqSwap.updatedAt` carries — `Date.now()` would
+  retire every terminal record after ~43 minutes. **Superseded** for a consumer that wires
+  `RfqSwapManagerDeps.repository`: `pruneRetiredSwaps()` is that sweep, and
+  `restoreFromRepository()` runs it first.
 - **A write that gates something irreversible throws; one that follows it does not.**
   `addAssetSwap` and `updateAssetSwap` throw on a failed read or write — nothing irreversible may
   happen until the record is durable, which is why `cancelOffer` writes its `cancelling` marker

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -640,6 +640,8 @@ swap's *first* record cannot be built from the swap alone. `addSwap`'s `origin` 
 facts arrive, and the manager keeps them for the swap's life. Omit it and one of two things
 happens: the store already holds a record, which *is* the origin, and it is read back; or it does
 not, and you get `RfqSwapOriginRequired` at the door rather than an unwritable record a pass later.
+An origin whose `kind` or `lockupAddress` is not this swap's is refused at that same door, for the
+same reason: the write that would catch it happens a pass later, with the funding broadcast.
 `start(swaps)` applies the same rule and is otherwise unchanged. Restored swaps carry their own.
 
 `restoreFromRepository` returns three disjoint lists, and every stored record is in exactly one.

--- a/packages/swap/src/activity.ts
+++ b/packages/swap/src/activity.ts
@@ -164,10 +164,21 @@ async function activityInputOf(
     if (record.refundArkTxid) txids.add(record.refundArkTxid);
     const handler = rfqCorridorHandlers.getOrThrow(record.kind);
     for (const txid of handler.activityTxids?.(record.profile) ?? []) txids.add(txid);
+    // The manager stamps these from the chain read that ended the swap, which
+    // is why this field exists at all: without it the counterparty's spend
+    // costs a lockup read per terminal swap, on the path least able to afford
+    // one. Drained before the fallback below, so a record that already knows
+    // never reaches the network.
+    for (const txid of record.lockupSpendArkTxids ?? []) txids.add(txid);
 
     // The counterparty's spend is what ended a swap the trader did not refund
     // itself — a solver claim on a send leg, a solver reclaim on a receive one.
-    const spendUnknown = isRfqSwapTerminal(record.state) && !record.refundArkTxid;
+    // Unknown only when neither the trader's own refund nor the manager's stamp
+    // names it.
+    const spendUnknown =
+        isRfqSwapTerminal(record.state) &&
+        !record.refundArkTxid &&
+        !record.lockupSpendArkTxids?.length;
     if (indexer && (!record.fundingArkTxid || spendUnknown)) {
         for (const txid of await lockupTxids(indexer, record, !record.fundingArkTxid)) {
             txids.add(txid);

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -61,6 +61,7 @@ export {
     RFQ_SWAP_RETENTION_SECONDS,
     createRfqSwapRecord,
     rebuildRfqSwap,
+    rfqSwapOriginOf,
     shouldRetainRfqSwap,
     updateRfqSwapRecord,
     type LockupParams,
@@ -208,6 +209,7 @@ export {
 export {
     RFQ_SWAP_TERMINAL_STATES,
     RfqSwapManager,
+    RfqSwapOriginRequired,
     isRfqSwapTerminal,
     nextOnchainAction,
     type ArkadeRefundResult,
@@ -216,6 +218,9 @@ export {
     type LightningSendSwap,
     type OnchainSendAction,
     type OnchainSendSwap,
+    type RfqRestoreFailure,
+    type RfqRestoreOptions,
+    type RfqRestoreResult,
     type RfqSwap,
     type RfqSwapActionName,
     type RfqSwapLockup,
@@ -224,6 +229,7 @@ export {
     type RfqSwapManagerDeps,
     type RfqSwapManagerEvents,
     type RfqSwapOutcome,
+    type RfqSwapRecordStore,
     type RfqSwapState,
     type SwapContractRegistry,
 } from "./swapManager";

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -179,8 +179,13 @@ const managerState = (swap: PersistableRfqSwap) => ({
  * The origin and the live swap must be halves of one swap.
  *
  * They arrive separately — the origin written from the request result, the swap
- * built by the entry point — and these two functions are the only place both are
- * in hand, so they are the only place the pairing can be checked at all.
+ * built by the entry point — and the record functions below are where both are
+ * in hand, so that is where the pairing can be checked at all.
+ *
+ * Exported so `RfqSwapManager.addSwap` can run the same check at admission
+ * rather than at the first write. The write happens a pass later, by which time
+ * the funding is broadcast and the swap is monitored — the same argument
+ * `RfqSwapOriginRequired` makes for refusing a missing origin at the door.
  *
  * Neither mismatch is loud on its own. A `kind` that disagrees runs the wrong
  * handler's `project`, which casts on kind: a receive origin projected off a
@@ -190,7 +195,7 @@ const managerState = (swap: PersistableRfqSwap) => ({
  * {@link rebuildRfqSwap} derives one from `lockupAddress`, and the restored swap
  * watches a covenant that is not the one this swap was monitoring.
  */
-function assertSameSwap(origin: RfqSwapOrigin, swap: PersistableRfqSwap): void {
+export function assertSameSwap(origin: RfqSwapOrigin, swap: PersistableRfqSwap): void {
     if (origin.kind !== swap.kind) {
         throw new Error(
             `rfq swap record is a ${origin.kind} origin paired with a ${swap.kind} swap`,

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -37,13 +37,10 @@
  */
 import { ArkAddress, VHTLCV2ContractHandler, type VHTLC } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
-import {
-    isRfqSwapTerminal,
-    type LightningReceiveSwap,
-    type LightningSendSwap,
-    type OnchainSendSwap,
-    type RfqSwapState,
-} from "./swapManager";
+import type { LightningReceiveSwap, LightningSendSwap, OnchainSendSwap } from "./swapManager";
+// From the vocabulary module, not from `swapManager`: the manager persists
+// through this file, so a runtime edge back to it would close a cycle.
+import { isRfqSwapTerminal, type RfqSwapState } from "./rfqSwapState";
 import { rfqCorridorHandlers } from "./rfqCorridor";
 import "./rfqCorridors";
 
@@ -147,6 +144,10 @@ export interface RfqSwapRecord extends RfqSwapOrigin {
     createdAt: number;
     updatedAt: number;
     refundArkTxid?: string;
+    /** The ark transactions that spent the lockup, stamped by the manager from
+     * the chain read that ended the swap. See
+     * `RfqSwapCommon.lockupSpendArkTxids`. */
+    lockupSpendArkTxids?: string[];
     failure?: string;
     blockedReason?: string;
 }
@@ -167,6 +168,9 @@ const managerState = (swap: PersistableRfqSwap) => ({
     createdAt: swap.createdAt,
     updatedAt: swap.updatedAt,
     ...(swap.refundArkTxid ? { refundArkTxid: swap.refundArkTxid } : {}),
+    ...(swap.lockupSpendArkTxids?.length
+        ? { lockupSpendArkTxids: [...swap.lockupSpendArkTxids] }
+        : {}),
     ...(swap.failure ? { failure: swap.failure } : {}),
     ...(swap.blockedReason ? { blockedReason: swap.blockedReason } : {}),
 });
@@ -238,6 +242,7 @@ export function updateRfqSwapRecord(
     assertSameSwap(record, swap);
     const {
         refundArkTxid: _refundArkTxid,
+        lockupSpendArkTxids: _lockupSpendArkTxids,
         failure: _failure,
         blockedReason: _blockedReason,
         ...origin
@@ -250,6 +255,30 @@ export function updateRfqSwapRecord(
         ...origin,
         ...managerState(swap),
         profile: { ...record.profile, ...handler.project(swap) },
+    };
+}
+
+/**
+ * The immutable half of a stored record, on its own.
+ *
+ * A record IS an origin plus manager state, so `record` where an
+ * {@link RfqSwapOrigin} is wanted type-checks — and is a bug. Spread into
+ * {@link createRfqSwapRecord} it carries the OLD state's `failure`,
+ * `blockedReason` and `refundArkTxid` past `managerState`, which omits a field
+ * the live swap no longer has and therefore cannot clear one. That is the same
+ * trap {@link updateRfqSwapRecord} strips those three fields to avoid; this is
+ * how a caller holding only a record gets an origin that is safe to keep.
+ *
+ * What `RfqSwapManager.restoreFromRepository` remembers for each record it
+ * rebuilds, so a later write can create the record again if the store lost it.
+ */
+export function rfqSwapOriginOf(record: RfqSwapRecord): RfqSwapOrigin {
+    return {
+        kind: record.kind,
+        lockupAddress: record.lockupAddress,
+        profile: { ...record.profile },
+        ...(record.amount !== undefined ? { amount: record.amount } : {}),
+        ...(record.fundingArkTxid ? { fundingArkTxid: record.fundingArkTxid } : {}),
     };
 }
 
@@ -302,6 +331,9 @@ export function rebuildRfqSwap(record: RfqSwapRecord, params: LockupParams): Per
         createdAt: record.createdAt,
         updatedAt: record.updatedAt,
         ...(record.refundArkTxid ? { refundArkTxid: record.refundArkTxid } : {}),
+        ...(record.lockupSpendArkTxids?.length
+            ? { lockupSpendArkTxids: [...record.lockupSpendArkTxids] }
+            : {}),
         ...(record.failure ? { failure: record.failure } : {}),
         ...(record.blockedReason ? { blockedReason: record.blockedReason } : {}),
     };

--- a/packages/swap/src/rfqSwapState.ts
+++ b/packages/swap/src/rfqSwapState.ts
@@ -1,0 +1,88 @@
+/**
+ * Where a monitored RFQ swap stands, and which of those states end it.
+ *
+ * Its own module rather than a corner of `swapManager.ts` because the
+ * dependency runs the other way: the record layer decides retention from
+ * {@link isRfqSwapTerminal}, and the manager persists through the record
+ * layer. With the vocabulary here, neither has to import the other at runtime.
+ * `swapManager.ts` re-exports all three names, so nothing about the public
+ * surface moved.
+ */
+
+/**
+ * Where a monitored swap stands.
+ *
+ * `claimable` and `claimed` are the states of a swap the TRADER has something
+ * to claim on: the L1 fill on an onchain send, and the solver-funded lockup on
+ * a receive. Only `lightning_send` has neither — there the solver claims the
+ * lockup, and the trader's only move is the refund.
+ */
+export type RfqSwapState =
+    /** Live; nothing actionable yet. On a receive leg this covers the whole
+     * stretch before the solver funds anything. */
+    | "pending"
+    /** There is something for the trader to take, and the window to take it is
+     * open: the confirmed L1 fill on an onchain send, or a lockup funded for at
+     * least `expectedAmount` on a receive. */
+    | "claimable"
+    /**
+     * The trader's claim has been made — its L1 broadcast on an onchain send,
+     * its Arkade submission on a receive.
+     *
+     * **On a receive this is a local belief and not a chain fact**, which is
+     * why it is not terminal: `settled` is the chain's answer, and `refunded`
+     * is still reachable from here if the claim never lands and the solver
+     * takes the lockup back.
+     */
+    | "claimed"
+    /**
+     * This wallet will not act, and only the counterparty can change that.
+     *
+     * On a send leg: the Arkade refund cannot be pushed from here — no secrets
+     * on the record, a descriptor from another seed, or nothing wired to act —
+     * so the lockup comes back only if the counterparty claims it or the wallet
+     * that can sign it is restored. On a receive leg: the trader holds no
+     * refund at all, so this is a lockup that cannot be claimed — funded for
+     * less than the swap agreed (publishing `P` for it is the whole attack
+     * `LockupAmountMismatchError` exists to refuse), or one whose claim window
+     * shut unclaimed. `RfqSwapCommon.blockedReason` says which.
+     *
+     * **Not terminal, and not a dead end.** The money is still at the lockup,
+     * so the counterparty's move is still observable and still ends the swap;
+     * and the refusal is re-checked every pass, so restoring the right wallet,
+     * wiring the callbacks, or the solver topping the lockup up returns the
+     * swap to `pending` and resumes the normal drive. For an onchain-send swap
+     * it says nothing about the L1 half, which keeps being driven and claimed.
+     */
+    | "needs_counterparty"
+    /**
+     * Terminal: the lockup was spent by a hash-verified claim. Read off chain,
+     * never reported.
+     *
+     * On a send leg that claim is the counterparty's, and it is proof the
+     * counterparty completed its side. On a receive leg it is the TRADER's own
+     * — matched by the hash and not by our txid, so a claim that lands without
+     * us still counts (see `RfqSwapManager`).
+     */
+    | "settled"
+    /**
+     * Terminal: the lockup was spent by something other than a claim.
+     *
+     * On a send leg that is the money coming back, by the solver's hand or the
+     * trader's. **On a receive leg it is a LOSS**: the lockup was the solver's
+     * money, every non-claim leaf is the solver's, and a swap that ends here
+     * ended with the trader's incoming payment never arriving. It is also where
+     * a receive swap ends when its window closes with nothing left to observe —
+     * see `RfqSwapManager`.
+     */
+    | "refunded"
+    /** Terminal: an action failed and its window closed. */
+    | "failed";
+
+/** The states after which the manager stops monitoring a swap. Deliberately
+ * without `needs_counterparty`: retiring on it would unwatch a funded lockup
+ * whose claim is still the thing that ends the swap. */
+export const RFQ_SWAP_TERMINAL_STATES = ["settled", "refunded", "failed"] as const;
+
+export const isRfqSwapTerminal = (state: RfqSwapState): boolean =>
+    (RFQ_SWAP_TERMINAL_STATES as readonly string[]).includes(state);

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -14,8 +14,9 @@
  *
  * The shape is deliberately the one `packages/boltz-swap`'s `SwapManager`
  * arrived at — monitor a set, act automatically through injected callbacks,
- * persist through an injected `saveSwap`, expose events plus a promise-based
- * escape hatch. Three things are different, each for a reason:
+ * persist through an injected `saveSwap` or a repository of its own, expose
+ * events plus a promise-based escape hatch. Three things are different, each
+ * for a reason:
  *
  * - **The solver is never asked.** This manager holds no `RfqTransport` at
  *   all: every fact it acts on is read from chain. What became of the
@@ -91,91 +92,30 @@ import {
     findLockupVtxos,
     readLockupFate,
     type LockupFate,
+    type LockupSpend,
     type LockupSpendIndexer,
     type LockupVtxo,
 } from "./refund";
-import { registerLockupContract } from "./lockupContract";
+import { lockupContractParams, registerLockupContract } from "./lockupContract";
+import {
+    createRfqSwapRecord,
+    rebuildRfqSwap,
+    rfqSwapOriginOf,
+    shouldRetainRfqSwap,
+    updateRfqSwapRecord,
+    type LockupParams,
+    type RfqSwapOrigin,
+    type RfqSwapRecord,
+} from "./rfqRecord";
 import { RefundNotLocallyPossibleError } from "./refundBlocked";
+import { isRfqSwapTerminal, type RfqSwapState } from "./rfqSwapState";
 
 // ── Records ──────────────────────────────────────────────────────────────────
 
-/**
- * Where a monitored swap stands.
- *
- * `claimable` and `claimed` are the states of a swap the TRADER has something
- * to claim on: the L1 fill on an onchain send, and the solver-funded lockup on
- * a receive. Only `lightning_send` has neither — there the solver claims the
- * lockup, and the trader's only move is the refund.
- */
-export type RfqSwapState =
-    /** Live; nothing actionable yet. On a receive leg this covers the whole
-     * stretch before the solver funds anything. */
-    | "pending"
-    /** There is something for the trader to take, and the window to take it is
-     * open: the confirmed L1 fill on an onchain send, or a lockup funded for at
-     * least `expectedAmount` on a receive. */
-    | "claimable"
-    /**
-     * The trader's claim has been made — its L1 broadcast on an onchain send,
-     * its Arkade submission on a receive.
-     *
-     * **On a receive this is a local belief and not a chain fact**, which is
-     * why it is not terminal: `settled` is the chain's answer, and `refunded`
-     * is still reachable from here if the claim never lands and the solver
-     * takes the lockup back.
-     */
-    | "claimed"
-    /**
-     * This wallet will not act, and only the counterparty can change that.
-     *
-     * On a send leg: the Arkade refund cannot be pushed from here — no secrets
-     * on the record, a descriptor from another seed, or nothing wired to act —
-     * so the lockup comes back only if the counterparty claims it or the wallet
-     * that can sign it is restored. On a receive leg: the trader holds no
-     * refund at all, so this is a lockup that cannot be claimed — funded for
-     * less than the swap agreed (publishing `P` for it is the whole attack
-     * `LockupAmountMismatchError` exists to refuse), or one whose claim window
-     * shut unclaimed. {@link RfqSwapCommon.blockedReason} says which.
-     *
-     * **Not terminal, and not a dead end.** The money is still at the lockup,
-     * so the counterparty's move is still observable and still ends the swap;
-     * and the refusal is re-checked every pass, so restoring the right wallet,
-     * wiring the callbacks, or the solver topping the lockup up returns the
-     * swap to `pending` and resumes the normal drive. For an onchain-send swap
-     * it says nothing about the L1 half, which keeps being driven and claimed.
-     */
-    | "needs_counterparty"
-    /**
-     * Terminal: the lockup was spent by a hash-verified claim. Read off chain,
-     * never reported.
-     *
-     * On a send leg that claim is the counterparty's, and it is proof the
-     * counterparty completed its side. On a receive leg it is the TRADER's own
-     * — matched by the hash and not by our txid, so a claim that lands without
-     * us still counts (see {@link RfqSwapManager}).
-     */
-    | "settled"
-    /**
-     * Terminal: the lockup was spent by something other than a claim.
-     *
-     * On a send leg that is the money coming back, by the solver's hand or the
-     * trader's. **On a receive leg it is a LOSS**: the lockup was the solver's
-     * money, every non-claim leaf is the solver's, and a swap that ends here
-     * ended with the trader's incoming payment never arriving. It is also where
-     * a receive swap ends when its window closes with nothing left to observe —
-     * see {@link RfqSwapManager}.
-     */
-    | "refunded"
-    /** Terminal: an action failed and its window closed. */
-    | "failed";
-
-/** The states after which the manager stops monitoring a swap. Deliberately
- * without `needs_counterparty`: retiring on it would unwatch a funded lockup
- * whose claim is still the thing that ends the swap. */
-export const RFQ_SWAP_TERMINAL_STATES = ["settled", "refunded", "failed"] as const;
-
-export const isRfqSwapTerminal = (state: RfqSwapState): boolean =>
-    (RFQ_SWAP_TERMINAL_STATES as readonly string[]).includes(state);
+// Re-exported so this module stays the one place a consumer imports the swap
+// vocabulary from; the definitions live in `rfqSwapState.ts` because the record
+// layer needs them too and must not import the manager at runtime.
+export { RFQ_SWAP_TERMINAL_STATES, isRfqSwapTerminal, type RfqSwapState } from "./rfqSwapState";
 
 /**
  * What the manager needs to register a swap's lockup with the wallet, so the
@@ -239,6 +179,27 @@ interface RfqSwapCommon {
     updatedAt: number;
     /** Set once the trader's own `refundWithoutReceiver` push landed. */
     refundArkTxid?: string;
+    /**
+     * The ark transactions that SPENT the lockup, stamped from the chain read
+     * that ended the swap — `LockupFate.spends`, whichever verdict it reached.
+     *
+     * The counterparty's move, on every leg but one: a solver claim on a send,
+     * a solver reclaim on a receive, and — the exception — the trader's own
+     * claim when a receive settles. What they have in common is that no local
+     * action produced them, so nothing else on this record can name them:
+     * {@link refundArkTxid} names only a push this wallet made, and
+     * `claimArkTxid` only a submission it made.
+     *
+     * Stamped so a terminal record answers "which transaction ended this" from
+     * storage. Without it the only source is another read of the lockup — a
+     * network round trip per terminal swap, which is what activity correlation
+     * has to pay on the offline-first path where it is least affordable.
+     *
+     * Absent when the swap ended without a chain verdict, or when the indexer
+     * named the checkpoint but not the ark transaction — the same `arkTxid`
+     * `LockupSpend` declares optional, for the same reason.
+     */
+    lockupSpendArkTxids?: string[];
     /** Why `state` is `failed`. */
     failure?: string;
     /** Why `state` is `needs_counterparty`. Distinct from {@link failure},
@@ -309,12 +270,14 @@ export interface LightningReceiveSwap extends RfqSwapCommon {
  * A monitored swap.
  *
  * This is a live record, not a serialization format: `lockupPkScript` and
- * `htlc` hold derived `Uint8Array`s, and
- * {@link RfqSwapManagerCallbacks.saveSwap} is where a caller projects it into
- * whatever it stores. Rebuild it on restart the way it was made —
- * `lightningSendVtxoScript` / `receiveVtxoScript` / `onchainHtlcScript` over
- * the quote's binding fields — and hand the result to
- * {@link RfqSwapManager.start}.
+ * `htlc` hold derived `Uint8Array`s, and `RfqSwapRecord` is its storable
+ * projection. Give the manager a {@link RfqSwapManagerDeps.repository} and it
+ * writes and rebuilds these itself, through
+ * {@link RfqSwapManager.restoreFromRepository}. A caller keeping its own store
+ * projects it in {@link RfqSwapManagerCallbacks.saveSwap} instead, rebuilds it
+ * on restart the way it was made — `lightningSendVtxoScript` /
+ * `receiveVtxoScript` / `onchainHtlcScript` over the quote's binding fields —
+ * and hands the result to {@link RfqSwapManager.start}.
  *
  * **`onchain:BTC->arkade:BTC` is deliberately not a member yet.** Its Arkade
  * half is the same solver-funded lockup as {@link LightningReceiveSwap}'s, but
@@ -477,15 +440,34 @@ export interface RfqSwapManagerCallbacks {
      * call belongs here.
      */
     canRefundArkade?: (swap: RfqSwap) => Promise<{ ok: true } | { ok: false; reason: string }>;
-    /** Persist the record. Called after any pass that changed it. */
+    /**
+     * Persist the record. Called after any pass that changed it.
+     *
+     * With {@link RfqSwapManagerDeps.repository} wired this is the SECOND
+     * write of the pass, not the only one: the manager writes the canonical
+     * `RfqSwapRecord` itself and then calls this. Both must succeed for the
+     * pass to count as persisted, so a rejection here still holds waiters and
+     * finalization back exactly as it does without a repository. A consumer
+     * whose `saveSwap` writes that same repository by hand should
+     * drop the duplicate when it wires the dep, and keep this for genuinely
+     * secondary sinks: metrics, a cache, a second store.
+     */
     saveSwap: (swap: RfqSwap) => Promise<void>;
 }
 
 /**
  * What {@link RfqSwapManager.setCallbacks} accepts: the full contract, minus
- * the two claims that are already kind-gated at dispatch. A consumer driving
- * only lightning sends reaches neither, and stubbing them to throw is not a
- * contract — it is a lie the compiler waves through.
+ * the two claims that are already kind-gated at dispatch, and minus
+ * `saveSwap`. A consumer driving only lightning sends reaches neither claim,
+ * and stubbing them to throw is not a contract — it is a lie the compiler
+ * waves through.
+ *
+ * `saveSwap` is optional for the same reason one step removed: with
+ * {@link RfqSwapManagerDeps.repository} wired the manager writes the record
+ * itself, so a consumer with no second sink has nothing to put here, and a
+ * no-op stub would be that same lie. Omitting BOTH is the documented
+ * process-local mode: state is kept in memory and dies with the process,
+ * which is what a manager with no callbacks at all already does today.
  *
  * The strict {@link RfqSwapManagerCallbacks} is untouched and still means
  * "fully wired", so a helper that takes one and calls `claimOnchain` keeps its
@@ -497,9 +479,9 @@ export interface RfqSwapManagerCallbacks {
  */
 export type AvailableRfqSwapManagerCallbacks = Omit<
     RfqSwapManagerCallbacks,
-    "claimOnchain" | "claimLockup"
+    "claimOnchain" | "claimLockup" | "saveSwap"
 > &
-    Partial<Pick<RfqSwapManagerCallbacks, "claimOnchain" | "claimLockup">>;
+    Partial<Pick<RfqSwapManagerCallbacks, "claimOnchain" | "claimLockup" | "saveSwap">>;
 
 /** The actions the manager executes on a caller's behalf. */
 export type RfqSwapActionName = "claimOnchain" | "claimLockup" | "refundArkade";
@@ -549,6 +531,83 @@ export type SwapContractRegistry = Pick<
     "createContract" | "getContracts" | "onContractEvent" | "setContractWatchState"
 >;
 
+/**
+ * The record store the manager writes to, narrowed to the four RFQ methods —
+ * the same seam style as {@link LockupSpendIndexer} and
+ * {@link SwapContractRegistry}, and satisfied structurally by a real
+ * `AssetSwapRepository`.
+ *
+ * Narrowed rather than imported whole so this module keeps no runtime edge to
+ * `repository.ts`, and so a caller with a different backing store — a server
+ * process holding many wallets' records in one table — can satisfy it without
+ * implementing the offer-swap and markets halves it has no use for.
+ */
+export interface RfqSwapRecordStore {
+    saveRfqSwap(record: RfqSwapRecord): Promise<void>;
+    getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined>;
+    getAllRfqSwaps(): Promise<RfqSwapRecord[]>;
+    removeRfqSwap(rfqId: string): Promise<void>;
+}
+
+/**
+ * A swap was handed to the manager with a repository wired, no origin, and no
+ * record already in the store.
+ *
+ * Thrown at the door rather than at the first write, because the write happens
+ * a pass later and by then the funding is broadcast: a swap admitted here and
+ * refused at `save` would be monitored, acted on, and unwritable — the record
+ * would exist only in memory while its lockup held money, and a restart would
+ * lose it. The remedy is to pass the origin, which the caller has: it is what
+ * the request entrypoint returned.
+ */
+export class RfqSwapOriginRequired extends Error {
+    /** The swap that could not be admitted. */
+    readonly rfqId: string;
+    constructor(rfqId: string) {
+        super(
+            `rfq swap ${rfqId} has no stored record and no origin was supplied; pass the ` +
+                `request-time origin as addSwap's second argument so its first record can be ` +
+                `written`,
+        );
+        this.name = "RfqSwapOriginRequired";
+        this.rfqId = rfqId;
+    }
+}
+
+/** One stored record that could not be turned back into a live swap. */
+export interface RfqRestoreFailure {
+    rfqId: string;
+    /** Why — a covenant that does not derive the funded address, a lockup with
+     * no contract row, a corridor with no handler registered. */
+    error: Error;
+}
+
+export interface RfqRestoreOptions {
+    /**
+     * Where each record's covenant parameters come from. Defaults to the
+     * lockup's own contract row, read through
+     * {@link RfqSwapManagerDeps.contracts}.
+     *
+     * Override it when the covenant lives somewhere else — a consumer keeping
+     * its own copy of `VHTLCV2ContractHandler.serializeParams(...)`, or a
+     * process with no contract manager at all. Whatever it returns is still
+     * checked against the record's funded address by `rebuildRfqSwap`, so an
+     * override cannot produce a swap watching the wrong covenant.
+     */
+    params?: (record: RfqSwapRecord) => Promise<LockupParams>;
+}
+
+/** What {@link RfqSwapManager.restoreFromRepository} did. Every stored record
+ * is in exactly one of the three lists. */
+export interface RfqRestoreResult {
+    /** Rebuilt: monitored, or kept as finished when already terminal. */
+    restored: RfqSwap[];
+    /** Kept in the store, but not rebuildable right now. */
+    failed: RfqRestoreFailure[];
+    /** Removed: terminal and past `RFQ_SWAP_RETENTION_SECONDS`. */
+    pruned: string[];
+}
+
 /** The observation seams. None is owned by the manager, and none holds keys —
  * same philosophy as `onchainHtlc.ts`'s `ChainSource`. There is no
  * `RfqTransport` here on purpose: nothing this manager decides depends on the
@@ -560,6 +619,24 @@ export interface RfqSwapManagerDeps {
     /** L1 access. Required to monitor onchain-send swaps; a lightning-only
      * caller can leave it out. */
     chain?: ChainSource;
+    /**
+     * Where the manager persists RFQ swap records, when a caller wants it to.
+     *
+     * Wiring it makes the repository the CANONICAL sink: every pass that
+     * changed a swap is written here as an {@link RfqSwapRecord}, and
+     * {@link RfqSwapManager.restoreFromRepository} reads it back. That removes
+     * the origin trap a caller otherwise hits assembling the write by hand —
+     * `updateRfqSwapRecord` needs the existing record and
+     * `createRfqSwapRecord` needs request-time facts the live swap does not
+     * carry, so the first write of a swap cannot be composed from the swap
+     * alone. The manager resolves that itself, which is what
+     * {@link RfqSwapManager.addSwap}'s `origin` parameter is for.
+     *
+     * Optional, like every other dep here: without it the manager persists
+     * through {@link RfqSwapManagerCallbacks.saveSwap} exactly as before, and
+     * without either it keeps its state in memory.
+     */
+    repository?: RfqSwapRecordStore;
     /**
      * The wallet's contract manager, when there is one. Optional in the same
      * way {@link chain} is: a caller with no wallet, or one that only wants the
@@ -717,7 +794,20 @@ export class RfqSwapManager {
         string,
         Set<{ resolve: (v: RfqSwapOutcome) => void; reject: (e: Error) => void }>
     >();
-    /** Records changed during the current pass, flushed through `saveSwap`. */
+    /**
+     * The request-time origin of each swap the manager may have to CREATE a
+     * record for, by rfqId.
+     *
+     * Needed only for a swap the store has never seen: once a record exists,
+     * `updateRfqSwapRecord` carries the origin half through and the map is
+     * redundant. It is kept anyway for the swap's whole life, so a record the
+     * store loses between passes is rewritten rather than lost — and dropped
+     * by {@link removeSwap} and by retention, which are the two places a swap
+     * stops being this manager's business.
+     */
+    private readonly origins = new Map<string, RfqSwapOrigin>();
+    /** Records changed during the current pass, flushed to the repository and
+     * through `saveSwap`. */
     private readonly dirty = new Set<string>();
     /** Race guard: one action at a time per swap. */
     private readonly inProgress = new Set<string>();
@@ -770,6 +860,142 @@ export class RfqSwapManager {
     }
 
     /**
+     * Rebuild every stored swap and take over monitoring them.
+     *
+     * The composition a consumer otherwise writes by hand, and the one place
+     * all four pieces meet: retention decides what to keep
+     * (`shouldRetainRfqSwap`), the lockup's contract row supplies the covenant
+     * (`lockupContractParams`), `rebuildRfqSwap` turns a record back into a
+     * live swap, and each rebuilt swap arrives with its own origin, so nothing
+     * is asked of the caller.
+     *
+     * **Deliberately not part of {@link start}.** A consumer that wants to
+     * look at its records — count them, show them, prune and stop — is not
+     * forced to start driving money to do it. Call this first and `start()`
+     * after; a manager already running polls the restored swaps at once.
+     *
+     * Retention runs BEFORE the rebuild, so a record past
+     * `RFQ_SWAP_RETENTION_SECONDS` costs no contract lookup on its way to being
+     * dropped.
+     *
+     * **A record that cannot be rebuilt is reported, never swallowed and never
+     * fatal.** `rebuildRfqSwap` throws by design when the covenant params do
+     * not derive the funded address, and `lockupContractParams` throws
+     * `LockupContractMissing` when the wallet has no row for the lockup — both
+     * say something true about that one record, and neither is a reason to
+     * strand the others. They come back in {@link RfqRestoreResult.failed}.
+     */
+    async restoreFromRepository(options: RfqRestoreOptions = {}): Promise<RfqRestoreResult> {
+        const repository = this.requireRepository("restoreFromRepository");
+        const params = options.params ?? this.paramsFromContracts();
+
+        // One read for both halves: retention and the rebuild want the same
+        // records, and asking twice would let a write between the two reads
+        // hand the rebuild a record retention had already dropped.
+        const records = await repository.getAllRfqSwaps();
+        const pruned = await this.dropRetired(repository, records);
+        const retired = new Set(pruned);
+
+        const restored: RfqSwap[] = [];
+        const failed: RfqRestoreFailure[] = [];
+        for (const record of records) {
+            if (retired.has(record.rfqId)) continue;
+            let swap: RfqSwap;
+            try {
+                swap = rebuildRfqSwap(record, await params(record));
+            } catch (error) {
+                failed.push({
+                    rfqId: record.rfqId,
+                    error: error instanceof Error ? error : new Error(errorMessage(error)),
+                });
+                continue;
+            }
+            this.origins.set(record.rfqId, rfqSwapOriginOf(record));
+            if (isRfqSwapTerminal(swap.state)) this.finished.set(swap.rfqId, swap);
+            else this.track(swap);
+            restored.push(swap);
+        }
+
+        // One concurrent sweep rather than a poll per swap as they are added:
+        // a restore is the case with the most swaps and the most already past a
+        // deadline, and serialising it would make the last one wait out all the
+        // others' network round trips.
+        if (this.running) {
+            await Promise.allSettled(
+                restored
+                    .filter((swap) => this.monitored.has(swap.rfqId))
+                    .map((swap) => this.pollSwap(swap)),
+            );
+        }
+        return { restored, failed, pruned };
+    }
+
+    /**
+     * Drop stored records that are terminal and past
+     * `RFQ_SWAP_RETENTION_SECONDS`, and return their ids.
+     *
+     * `needs_counterparty` is never dropped, however old: the money is still at
+     * the lockup and the counterparty's move still ends the swap. That rule
+     * lives in `shouldRetainRfqSwap`, which this defers to rather than
+     * restating.
+     *
+     * Public because retention is a caller's cadence, not the manager's: a
+     * long-lived process wants it on a timer of its own, a mobile app wants it
+     * at boot. {@link restoreFromRepository} runs it first, so the boot path
+     * needs no separate call.
+     */
+    async pruneRetiredSwaps(): Promise<string[]> {
+        const repository = this.deps.repository;
+        if (!repository) return [];
+        return this.dropRetired(repository, await repository.getAllRfqSwaps());
+    }
+
+    private async dropRetired(
+        repository: RfqSwapRecordStore,
+        records: readonly RfqSwapRecord[],
+    ): Promise<string[]> {
+        const now = this.config.now();
+        const dropped: string[] = [];
+        for (const record of records) {
+            if (shouldRetainRfqSwap(record, now)) continue;
+            await repository.removeRfqSwap(record.rfqId);
+            // The in-memory copies go with it. `finished` is only there so a
+            // late `waitForSwapCompletion` can answer, and answering from a
+            // record the store has just dropped is the one thing retention is
+            // meant to stop growing.
+            this.finished.delete(record.rfqId);
+            this.origins.delete(record.rfqId);
+            dropped.push(record.rfqId);
+        }
+        return dropped;
+    }
+
+    private requireRepository(method: string): RfqSwapRecordStore {
+        const repository = this.deps.repository;
+        if (!repository) {
+            throw new Error(
+                `${method} needs a record store; pass one as RfqSwapManagerDeps.repository`,
+            );
+        }
+        return repository;
+    }
+
+    /** The default covenant source: the wallet's own contract row for each
+     * lockup, which is where registration put it before the address could be
+     * funded. */
+    private paramsFromContracts(): (record: RfqSwapRecord) => Promise<LockupParams> {
+        const contracts = this.deps.contracts;
+        if (!contracts) {
+            throw new Error(
+                "restoreFromRepository needs the covenant parameters: wire " +
+                    "RfqSwapManagerDeps.contracts so each lockup's contract row can be read, or " +
+                    "pass options.params",
+            );
+        }
+        return (record) => lockupContractParams(contracts, record.lockupAddress);
+    }
+
+    /**
      * Load records and begin monitoring. Runs one pass immediately — a caller
      * resuming after a restart may be well past a deadline already — then
      * every `pollIntervalMs`. Records that are already terminal are kept only
@@ -778,8 +1004,17 @@ export class RfqSwapManager {
      * Calling it again while running loads the records and returns rather than
      * re-arming — dropping them silently would strand a funded swap on a
      * caller's harmless double-start.
+     *
+     * The signature is unchanged with a {@link RfqSwapManagerDeps.repository}
+     * wired; the origins are resolved from the store instead, by the same rule
+     * {@link addSwap} applies. A swap the store has never seen throws
+     * {@link RfqSwapOriginRequired} — hand that one to `addSwap` with its
+     * origin, or restore the whole set with {@link restoreFromRepository},
+     * which needs no caller input at all. Every swap is checked before any is
+     * tracked, so a bad one in the list does not leave a half-loaded manager.
      */
     async start(swaps: readonly RfqSwap[] = []): Promise<void> {
+        for (const swap of swaps) await this.admit(swap);
         for (const swap of swaps) {
             if (isRfqSwapTerminal(swap.state)) this.finished.set(swap.rfqId, swap);
             else this.track(swap);
@@ -813,15 +1048,60 @@ export class RfqSwapManager {
         this.unsubscribeContracts = null;
     }
 
-    /** Begin monitoring a swap. Polled immediately when the manager is running,
-     * so a just-funded swap does not wait out a whole interval. */
-    async addSwap(swap: RfqSwap): Promise<void> {
+    /**
+     * Begin monitoring a swap. Polled immediately when the manager is running,
+     * so a just-funded swap does not wait out a whole interval.
+     *
+     * `origin` is the request-time half a live swap cannot carry — the corridor,
+     * the funded address, the corridor's profile, the funding txid — and it is
+     * what lets the manager write this swap's FIRST record. Supply it whenever
+     * a {@link RfqSwapManagerDeps.repository} is wired and the swap is new. It
+     * may be omitted for a swap the store already holds a record for, which is
+     * then read to confirm it; omitting it for one the store has never seen
+     * throws {@link RfqSwapOriginRequired} rather than admitting a swap whose
+     * record could never be written. With no repository wired the parameter is
+     * inert.
+     */
+    async addSwap(swap: RfqSwap, origin?: RfqSwapOrigin): Promise<void> {
+        await this.admit(swap, origin);
         if (isRfqSwapTerminal(swap.state)) {
             this.finished.set(swap.rfqId, swap);
             return;
         }
         this.track(swap);
         if (this.running) await this.pollSwap(swap);
+    }
+
+    /**
+     * Settle where this swap's record will come from, before it is monitored.
+     *
+     * Three ways it can be answered, in order: the caller passed an origin, one
+     * is already remembered from an earlier `addSwap`, or the store holds a
+     * record — which is the origin, already written. Only the last costs a read,
+     * and only when the first two are absent.
+     */
+    private async admit(swap: RfqSwap, origin?: RfqSwapOrigin): Promise<void> {
+        if (origin) {
+            this.origins.set(swap.rfqId, origin);
+            // An origin means a swap the caller is introducing, so the first
+            // pass writes it whether or not anything changed. Waiting for a
+            // change would leave a funded lockup with no record at all for as
+            // long as it sat `pending` — which is most of a swap's life, and
+            // exactly the stretch a restart has to survive.
+            if (this.deps.repository && !isRfqSwapTerminal(swap.state)) {
+                this.dirty.add(swap.rfqId);
+            }
+            return;
+        }
+        const repository = this.deps.repository;
+        if (!repository || this.origins.has(swap.rfqId)) return;
+        // A read that THROWS is a storage failure, not a miss, and is left to
+        // propagate: admitting the swap would monitor something whose record
+        // may or may not exist, and the caller can retry — or pass the origin,
+        // which skips this read entirely.
+        const stored = await repository.getRfqSwap(swap.rfqId);
+        if (!stored) throw new RfqSwapOriginRequired(swap.rfqId);
+        this.origins.set(swap.rfqId, rfqSwapOriginOf(stored));
     }
 
     /** Forget a swap entirely, monitored or finished.
@@ -846,6 +1126,7 @@ export class RfqSwapManager {
         }
         this.waiters.delete(rfqId);
         this.dirty.delete(rfqId);
+        this.origins.delete(rfqId);
     }
 
     /** Every swap still being monitored. */
@@ -1092,13 +1373,14 @@ export class RfqSwapManager {
             // that awaits completion and then reads its own storage must not
             // find the record still saying `pending`.
             //
-            // And nothing observable happens unless that write SUCCEEDED. A
-            // rejected `saveSwap` used to settle waiters and finalize anyway,
-            // so a caller saw a swap complete that its own storage had never
-            // recorded — and on restart the manager re-drove the stale record,
-            // replaying action callbacks for a swap the caller already treated
-            // as done. Leaving it dirty and monitored makes the next pass
-            // retry the write instead.
+            // And nothing observable happens unless that write SUCCEEDED —
+            // every write of it, the canonical record and `saveSwap` alike
+            // (see `save`). A rejected `saveSwap` used to settle waiters and
+            // finalize anyway, so a caller saw a swap complete that its own
+            // storage had never recorded — and on restart the manager re-drove
+            // the stale record, replaying action callbacks for a swap the
+            // caller already treated as done. Leaving it dirty and monitored
+            // makes the next pass retry the write instead.
             const persisted = this.dirty.has(swap.rfqId) ? await this.save(swap) : true;
             if (persisted) {
                 this.dirty.delete(swap.rfqId);
@@ -1137,6 +1419,10 @@ export class RfqSwapManager {
             fate = { fate: "unknown" };
         }
         if (fate.fate === "claimed" || fate.fate === "returned") {
+            // Stamped before the state change, so the write that `setState`
+            // makes dirty carries the spend with it — one write, not two, and
+            // no window in which a terminal record names no ending transaction.
+            this.stampLockupSpends(swap, fate.spends);
             this.setState(swap, fate.fate === "claimed" ? "settled" : "refunded");
             return;
         }
@@ -1591,6 +1877,27 @@ export class RfqSwapManager {
         this.setState(swap, traderClaimTxid(swap) ? "claimed" : "pending");
     }
 
+    /**
+     * Record which ark transactions ended the lockup.
+     *
+     * Only the ones the indexer actually named: `LockupSpend.arkTxid` is
+     * optional, and a checkpoint txid is not what history correlates on — a
+     * record carrying one would name a transaction the wallet's own activity
+     * never shows. Fewer txids is the right failure here.
+     *
+     * Assigned rather than merged: the fate is one read of the whole lockup,
+     * so it is the complete answer for this swap, and a swap only reaches a
+     * verdict once.
+     */
+    private stampLockupSpends(swap: RfqSwap, spends: readonly LockupSpend[]): void {
+        const arkTxids = spends
+            .map((spend) => spend.arkTxid)
+            .filter((txid): txid is string => txid !== undefined);
+        if (arkTxids.length === 0) return;
+        swap.lockupSpendArkTxids = arkTxids;
+        this.touch(swap);
+    }
+
     private touch(swap: RfqSwap): void {
         swap.updatedAt = this.config.now();
         this.dirty.add(swap.rfqId);
@@ -1624,9 +1931,29 @@ export class RfqSwapManager {
         notify(this.actionExecutedListeners, (listener) => listener(swap, action));
     }
 
-    /** Whether the record is now persisted — false only when `saveSwap` threw. */
+    /**
+     * Flush a changed record to every sink that is wired, and say whether all
+     * of them took it.
+     *
+     * Up to two writes, in this order: the canonical `RfqSwapRecord` to
+     * {@link RfqSwapManagerDeps.repository}, then
+     * {@link RfqSwapManagerCallbacks.saveSwap}. Both gate — a rejection from
+     * either leaves the record dirty and monitored, so waiters stay unsettled
+     * and a terminal swap is not finalized until the write it claims lands.
+     * That is exactly today's rule for `saveSwap`, applied to whichever sinks
+     * exist; wiring the repository does not weaken it.
+     *
+     * The canonical write goes FIRST and a failure there skips the second.
+     * `saveSwap` is a projection of the record, and projecting a state the
+     * record of record has just refused would leave the secondary sink ahead
+     * of the primary — the one ordering that survives no restart.
+     *
+     * With neither wired the state is process-local, which is what a manager
+     * with no callbacks has always done.
+     */
     private async save(swap: RfqSwap): Promise<boolean> {
-        if (!this.callbacks) return true;
+        if (!(await this.saveRecord(swap))) return false;
+        if (!this.callbacks?.saveSwap) return true;
         try {
             await this.callbacks.saveSwap(swap);
             return true;
@@ -1640,6 +1967,38 @@ export class RfqSwapManager {
             this.emitFailed(swap, error);
             return false;
         }
+    }
+
+    /** The canonical write. True when there is no repository to write to. */
+    private async saveRecord(swap: RfqSwap): Promise<boolean> {
+        const repository = this.deps.repository;
+        if (!repository) return true;
+        try {
+            // Read-then-write per pass rather than caching the record: the
+            // store is the system of record, and a consumer that edited a
+            // record's origin half — a `fundingArkTxid` learned late, a
+            // corridor field its own code owns — must not have that edit
+            // overwritten by a copy this manager took at boot.
+            const stored = await repository.getRfqSwap(swap.rfqId);
+            const record = stored
+                ? updateRfqSwapRecord(stored, swap)
+                : createRfqSwapRecord(this.originOrThrow(swap), swap);
+            await repository.saveRfqSwap(record);
+            return true;
+        } catch (error) {
+            this.emitFailed(swap, error);
+            return false;
+        }
+    }
+
+    private originOrThrow(swap: RfqSwap): RfqSwapOrigin {
+        const origin = this.origins.get(swap.rfqId);
+        // Unreachable through `addSwap`/`start`/`restoreFromRepository`, all of
+        // which settle the origin before the swap is tracked. Reachable if the
+        // store dropped the record after admission, which is why the write path
+        // says so instead of assuming.
+        if (!origin) throw new RfqSwapOriginRequired(swap.rfqId);
+        return origin;
     }
 
     /**

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -98,6 +98,7 @@ import {
 } from "./refund";
 import { lockupContractParams, registerLockupContract } from "./lockupContract";
 import {
+    assertSameSwap,
     createRfqSwapRecord,
     rebuildRfqSwap,
     rfqSwapOriginOf,
@@ -541,6 +542,12 @@ export type SwapContractRegistry = Pick<
  * `repository.ts`, and so a caller with a different backing store — a server
  * process holding many wallets' records in one table — can satisfy it without
  * implementing the offer-swap and markets halves it has no use for.
+ *
+ * Expect TWO calls per dirty swap per poll: `getRfqSwap` then `saveRfqSwap`.
+ * The read is deliberate — the store is the system of record, so a consumer's
+ * own edit to a record's origin half must not be overwritten by a copy the
+ * manager took at boot — but a backend where a keyed read is expensive should
+ * know it is on the write path, not just the restore path.
  */
 export interface RfqSwapRecordStore {
     saveRfqSwap(record: RfqSwapRecord): Promise<void>;
@@ -964,7 +971,17 @@ export class RfqSwapManager {
             // record the store has just dropped is the one thing retention is
             // meant to stop growing.
             this.finished.delete(record.rfqId);
-            this.origins.delete(record.rfqId);
+            // The origin outlives the record for a swap still being monitored.
+            // A stored record can be terminal and retention-aged while its swap
+            // is still tracked: `save` counts a pass as persisted only when
+            // BOTH sinks took it, so a canonical write that landed alongside a
+            // `saveSwap` that keeps rejecting leaves the swap dirty and
+            // monitored with a terminal record ageing behind it. Dropping the
+            // origin there would leave the next pass unable to recreate the
+            // record it just deleted — `originOrThrow` throwing
+            // `RfqSwapOriginRequired` every poll, for a swap the manager is
+            // otherwise driving correctly.
+            if (!this.monitored.has(record.rfqId)) this.origins.delete(record.rfqId);
             dropped.push(record.rfqId);
         }
         return dropped;
@@ -1082,6 +1099,14 @@ export class RfqSwapManager {
      */
     private async admit(swap: RfqSwap, origin?: RfqSwapOrigin): Promise<void> {
         if (origin) {
+            // Checked here, not left to the first write. A `kind` or
+            // `lockupAddress` that disagrees is a programming error either way,
+            // but at the write it surfaces a pass later — the swap monitored,
+            // the funding broadcast — and then keeps surfacing, since the write
+            // path retries a dirty record every poll and this throw is
+            // deterministic. Refusing at the door is the same trade
+            // `RfqSwapOriginRequired` already makes for the missing-origin case.
+            assertSameSwap(origin, swap);
             this.origins.set(swap.rfqId, origin);
             // An origin means a swap the caller is introducing, so the first
             // pass writes it whether or not anything changed. Waiting for a

--- a/packages/swap/test/activity.test.ts
+++ b/packages/swap/test/activity.test.ts
@@ -258,6 +258,43 @@ describe("rfqSwapActivityInputs", () => {
         expect(calls).toBe(0);
     });
 
+    it("takes the counterparty's spend off the record with no indexer wired at all", async () => {
+        // The offline-first case `lockupSpendArkTxids` exists for: the manager
+        // stamped the solver's claim when it ended the swap, so the txid that
+        // closed it is already stored and nothing has to go to the network.
+        const repository = await storeOf(
+            record({ fundingArkTxid: "fund", lockupSpendArkTxids: ["solver-claim"] }),
+        );
+        const [input] = await rfqSwapActivityInputs({ repository });
+        expect(input.txids).toEqual(["fund", "solver-claim"]);
+    });
+
+    it("asks nobody when the record's own stamp names the spend that ended it", async () => {
+        let calls = 0;
+        const counting = {
+            async getVtxos() {
+                calls += 1;
+                return { vtxos: [] };
+            },
+        } as unknown as LockupSpendIndexer;
+        const repository = await storeOf(
+            record({ fundingArkTxid: "fund", lockupSpendArkTxids: ["solver-claim"] }),
+        );
+        await rfqSwapActivityInputs({ repository, indexer: counting });
+        expect(calls).toBe(0);
+    });
+
+    it("still reads the lockup when the stamp is absent, which is what makes it a fallback", async () => {
+        // A record written before the manager owned persistence carries no
+        // stamp, so the indexer is still the only source for its spend.
+        const repository = await storeOf(record({ fundingArkTxid: "fund" }));
+        const [input] = await rfqSwapActivityInputs({
+            repository,
+            indexer: fakeIndexer([{ txid: "fund", arkTxId: "solver-claim" }]),
+        });
+        expect(input.txids).toEqual(["fund", "solver-claim"]);
+    });
+
     it("degrades to fewer txids when the indexer is unreachable, never to a throw", async () => {
         const repository = await storeOf(record({ fundingArkTxid: "fund" }));
         const [input] = await rfqSwapActivityInputs({

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -16,6 +16,7 @@ import {
     RFQ_SWAP_RETENTION_SECONDS,
     createRfqSwapRecord,
     rebuildRfqSwap,
+    rfqSwapOriginOf,
     shouldRetainRfqSwap,
     updateRfqSwapRecord,
     type LockupParams,
@@ -486,5 +487,69 @@ describe("shouldRetainRfqSwap", () => {
         // A swap created long ago but settled a moment ago is fresh history.
         const record = at("settled", 10 * RFQ_SWAP_RETENTION_SECONDS);
         expect(shouldRetainRfqSwap(record, 10 * RFQ_SWAP_RETENTION_SECONDS + 1)).toBe(true);
+    });
+});
+
+/**
+ * The origin projection, and why it is not just `record`.
+ *
+ * A record IS an origin plus manager state, so passing one where an origin is
+ * wanted type-checks — and quietly carries the old state's `failure`,
+ * `blockedReason` and `refundArkTxid` into the next `createRfqSwapRecord`,
+ * where `managerState` cannot clear them because it omits what the live swap
+ * no longer has. That is the same trap `updateRfqSwapRecord` strips those
+ * fields to avoid, and this is the other half of it.
+ */
+describe("rfqSwapOriginOf", () => {
+    const ended: RfqSwapRecord = {
+        ...createRfqSwapRecord(sendOrigin, swapOf(sendOrigin)),
+        state: "failed",
+        failure: "the push was refused",
+        blockedReason: "no signer for this descriptor",
+        refundArkTxid: "ff".repeat(32),
+        lockupSpendArkTxids: ["ab".repeat(32)],
+    };
+
+    it("keeps every request-time fact", () => {
+        const origin = rfqSwapOriginOf(ended);
+        expect(origin.kind).toBe("lightning_send");
+        expect(origin.lockupAddress).toBe(SEND_LOCKUP.address);
+        expect(origin.amount).toBe(sendOrigin.amount);
+        expect(signerOf(origin).signingDescriptor).toBe(signerOf(ended).signingDescriptor);
+    });
+
+    it("drops the manager's state, so a re-create cannot resurrect it", () => {
+        const rebuilt = createRfqSwapRecord(rfqSwapOriginOf(ended), swapOf(sendOrigin));
+        expect(rebuilt.state).toBe("pending");
+        expect(rebuilt.failure).toBeUndefined();
+        expect(rebuilt.blockedReason).toBeUndefined();
+        expect(rebuilt.refundArkTxid).toBeUndefined();
+        expect(rebuilt.lockupSpendArkTxids).toBeUndefined();
+    });
+
+    it("copies the profile rather than aliasing it", () => {
+        const origin = rfqSwapOriginOf(ended);
+        origin.profile.injected = true;
+        expect(ended.profile.injected).toBeUndefined();
+    });
+});
+
+describe("the spend that ended the swap", () => {
+    it("round-trips through the record and back onto the live swap", () => {
+        const spends = ["ab".repeat(32), "cd".repeat(32)];
+        const swap = { ...swapOf(sendOrigin, "settled"), lockupSpendArkTxids: spends };
+        const record = createRfqSwapRecord(sendOrigin, swap);
+        expect(record.lockupSpendArkTxids).toEqual(spends);
+        expect(rebuildRfqSwap(record, paramsOf(sendOrigin)).lockupSpendArkTxids).toEqual(spends);
+    });
+
+    it("is cleared by an update whose swap no longer carries it", () => {
+        // Same rule as `failure` and `blockedReason`: the mutable half is
+        // REPLACED, so a field the live swap dropped leaves the record.
+        const record = createRfqSwapRecord(sendOrigin, {
+            ...swapOf(sendOrigin, "settled"),
+            lockupSpendArkTxids: ["ab".repeat(32)],
+        });
+        expect(updateRfqSwapRecord(record, swapOf(sendOrigin)).lockupSpendArkTxids).toBeUndefined();
     });
 });

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -527,7 +527,12 @@ describe("rfqSwapOriginOf", () => {
         expect(rebuilt.lockupSpendArkTxids).toBeUndefined();
     });
 
-    it("copies the profile rather than aliasing it", () => {
+    it("gives the profile its own top-level object, so a new key does not reach the record", () => {
+        // A shallow copy, deliberately: `profile` is `Record<string, unknown>`
+        // and a consumer owns what goes in it, so `structuredClone` would trade
+        // a nested-aliasing edge case for a throw on any function or class
+        // instance a consumer stored. `createRfqSwapRecord` spreads it the same
+        // way; this is the module's posture, not an oversight here.
         const origin = rfqSwapOriginOf(ended);
         origin.profile.injected = true;
         expect(ended.profile.injected).toBeUndefined();

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -44,7 +44,14 @@ import {
 import { SWAP_LOCKUP_CONTRACT_TYPE } from "../src/lockupContract";
 import { RefundNotLocallyPossibleError } from "../src/refundBlocked";
 import {
+    RFQ_SWAP_RETENTION_SECONDS,
+    createRfqSwapRecord,
+    type RfqSwapOrigin,
+    type RfqSwapRecord,
+} from "../src/rfqRecord";
+import {
     RfqSwapManager,
+    RfqSwapOriginRequired,
     isRfqSwapTerminal,
     nextOnchainAction,
     type ArkadeRefundResult,
@@ -55,6 +62,7 @@ import {
     type RfqSwapActionName,
     type AvailableRfqSwapManagerCallbacks,
     type RfqSwapManagerCallbacks,
+    type RfqSwapRecordStore,
     type RfqSwapState,
     type SwapContractRegistry,
 } from "../src/swapManager";
@@ -124,6 +132,9 @@ const LOCKUP_OUTPOINT = { txid: "99".repeat(32), vout: 0 };
 const LOCKUP_VALUE = 100_000;
 /** The txid our own receive claim comes back with. */
 const CLAIM_ARK_TXID = "ac".repeat(32);
+/** The ark transaction a lockup spend is carried by — the counterparty's, on
+ * every leg but a settled receive. */
+const ARK_TXID = "ab".repeat(32);
 
 const UNROLL = CSVMultisigTapscript.encode({
     timelock: { type: "blocks", value: BigInt(144) },
@@ -189,6 +200,10 @@ interface FakeVtxo {
      * to name. On its own it does NOT mean unspent: the wire contract permits
      * `isSpent: true` alongside it. */
     spentBy: string;
+    /** The ark transaction that spent the checkpoint `spentBy` names — what
+     * history correlates on, and what the manager stamps onto a terminal
+     * record. Optional on the wire, so its absence is a case of its own. */
+    arkTxId?: string;
     isSpent?: boolean;
     settledBy?: string;
 }
@@ -477,6 +492,7 @@ const manager = (input: {
     indexer?: LockupSpendIndexer;
     chain?: ChainSource;
     contracts?: SwapContractRegistry;
+    repository?: RfqSwapRecordStore;
     now: number | (() => number);
     spies: Spies;
     enableAutoActions?: boolean;
@@ -489,6 +505,7 @@ const manager = (input: {
             indexer: input.indexer ?? fakeIndexer({ vtxos: unspent() }),
             chain: input.chain,
             contracts: input.contracts,
+            repository: input.repository,
         },
         {
             now: typeof input.now === "function" ? input.now : () => input.now as number,
@@ -2523,5 +2540,503 @@ describe("RfqSwapManager — the lockup as a contract", () => {
 
         expect(indexer.vtxoCalls).toBe(before);
         await m.stop();
+    });
+});
+
+/**
+ * The manager as the owner of its own persistence.
+ *
+ * What a consumer used to write by hand — the restore loop, the retention
+ * pass, and a `saveSwap` that could not compose the FIRST write of a swap at
+ * all, because `createRfqSwapRecord` wants request-time facts the live record
+ * does not carry and `updateRfqSwapRecord` wants a record that does not exist
+ * yet. That origin trap is what these tests are mostly about: where the origin
+ * comes from, what happens when it cannot, and that the write it produces is
+ * the one waiters and finalization are gated on.
+ *
+ * The other half is the sink matrix. A repository and a `saveSwap` are
+ * independent options, so there are four configurations and each has a rule:
+ * both gate, either alone gates, and neither means process-local. Wiring the
+ * repository does NOT weaken `saveSwap` — a rejection from it still holds the
+ * pass back, exactly as it does today.
+ */
+describe("RfqSwapManager — manager-owned persistence", () => {
+    const LOCKUP_ADDRESS = LOCKUP.address("tark", key(3)).encode();
+    const RECEIVE_ADDRESS = RECEIVE_LOCKUP.address("tark", key(3)).encode();
+
+    const sendOrigin = (over: Partial<RfqSwapOrigin> = {}): RfqSwapOrigin => ({
+        kind: "lightning_send",
+        lockupAddress: LOCKUP_ADDRESS,
+        profile: {
+            signer: { signingDescriptor: `tr(${hex.encode(key(13))})` },
+            hashlock: { paymentHash: PAYMENT_HASH },
+        },
+        amount: LOCKUP_VALUE,
+        fundingArkTxid: "fa".repeat(32),
+        ...over,
+    });
+
+    const receiveOrigin = (): RfqSwapOrigin => ({
+        kind: "lightning_receive",
+        lockupAddress: RECEIVE_ADDRESS,
+        profile: {
+            signer: { signingDescriptor: `tr(${hex.encode(key(13))})` },
+            hashlock: { paymentHash: PAYMENT_HASH },
+            expectedAmount: LOCKUP_VALUE,
+            payoutAddress: "tark1payout",
+        },
+    });
+
+    /**
+     * A record store that can be made to fail. Typed against the production
+     * seam, so a change to `RfqSwapRecordStore` breaks this at compile time,
+     * and it counts writes — several tests turn on a write NOT having happened.
+     */
+    type FakeStore = RfqSwapRecordStore & {
+        records: Map<string, RfqSwapRecord>;
+        writes: RfqSwapRecord[];
+        removed: string[];
+        failWrite?: boolean;
+        failRead?: boolean;
+    };
+
+    const fakeStore = (seed: RfqSwapRecord[] = []): FakeStore => {
+        const store: FakeStore = {
+            records: new Map(seed.map((record) => [record.rfqId, record])),
+            writes: [],
+            removed: [],
+            async saveRfqSwap(record) {
+                if (store.failWrite) throw new Error("record store unavailable");
+                store.writes.push(record);
+                store.records.set(record.rfqId, record);
+            },
+            async getRfqSwap(rfqId) {
+                if (store.failRead) throw new Error("record store unavailable");
+                return store.records.get(rfqId);
+            },
+            async getAllRfqSwaps() {
+                if (store.failRead) throw new Error("record store unavailable");
+                return [...store.records.values()];
+            },
+            async removeRfqSwap(rfqId) {
+                store.removed.push(rfqId);
+                store.records.delete(rfqId);
+            },
+        };
+        return store;
+    };
+
+    /** The contract row registration writes before an address can be funded —
+     * which is where `restoreFromRepository` gets each covenant back from. */
+    const rowFor = (script: typeof LOCKUP, address: string): CreateContractParams => ({
+        type: SWAP_LOCKUP_CONTRACT_TYPE,
+        params: VHTLCV2ContractHandler.serializeParams(script.options),
+        script: hex.encode(script.pkScript),
+        address,
+    });
+
+    const storedSend = (over: Partial<RfqSwapRecord> = {}): RfqSwapRecord => ({
+        ...createRfqSwapRecord(sendOrigin(), lightningSwap()),
+        ...over,
+    });
+
+    /** An indexer that ends the swap `settled`, so a pass has something to
+     * write. Most tests here are about the WRITE, and a swap that stays
+     * `pending` past its first record makes none. */
+    const settlingIndexer = () =>
+        fakeIndexer({ vtxos: spentBy(CLAIM_SPEND.txid), txs: [CLAIM_SPEND] });
+
+    describe("where the first record's origin comes from", () => {
+        it("writes a swap's first record from the origin handed to addSwap", async () => {
+            const store = fakeStore();
+            const s = spies();
+            const m = manager({ repository: store, now: SAFE_NOW, spies: s });
+
+            await m.addSwap(lightningSwap(), sendOrigin());
+            await m.poll();
+
+            const record = store.records.get(RFQ_ID);
+            expect(record?.kind).toBe("lightning_send");
+            expect(record?.state).toBe("pending");
+            // The origin half is what no live swap carries and no later pass
+            // can reconstruct — the whole reason the parameter exists.
+            expect(record?.lockupAddress).toBe(LOCKUP_ADDRESS);
+            expect(record?.fundingArkTxid).toBe("fa".repeat(32));
+            expect(record?.amount).toBe(LOCKUP_VALUE);
+        });
+
+        it("resolves the origin from the store for a swap it already holds", async () => {
+            // The restart case: the consumer rebuilt the swap itself and hands
+            // it over with no origin, because the store is already the origin.
+            const store = fakeStore([storedSend()]);
+            const s = spies();
+            const m = manager({
+                indexer: settlingIndexer(),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            await m.addSwap(lightningSwap({ state: "pending" }));
+            await m.poll();
+
+            expect(store.writes.at(-1)?.state).toBe("settled");
+            expect(store.writes.at(-1)?.lockupAddress).toBe(LOCKUP_ADDRESS);
+            expect(store.writes.at(-1)?.fundingArkTxid).toBe("fa".repeat(32));
+        });
+
+        it("refuses a swap the store has never seen and that carries no origin", async () => {
+            // At the DOOR, not at the first write: by then the funding is
+            // broadcast and the record would exist only in memory.
+            const store = fakeStore();
+            const s = spies();
+            const m = manager({ repository: store, now: SAFE_NOW, spies: s });
+
+            await expect(m.addSwap(lightningSwap())).rejects.toBeInstanceOf(RfqSwapOriginRequired);
+            expect(await m.hasSwap(RFQ_ID)).toBe(false);
+            expect(store.writes).toHaveLength(0);
+        });
+
+        it("applies the same rule to start(), and tracks nothing when it fails", async () => {
+            const store = fakeStore();
+            const s = spies();
+            const m = manager({ repository: store, now: SAFE_NOW, spies: s });
+
+            await expect(
+                m.start([lightningSwap(), lightningSwap({ rfqId: "b2".repeat(32) })]),
+            ).rejects.toBeInstanceOf(RfqSwapOriginRequired);
+            expect(await m.getPendingSwaps()).toHaveLength(0);
+            await m.stop();
+        });
+
+        it("leaves the parameter inert with no repository wired", async () => {
+            const s = spies();
+            const m = manager({ now: SAFE_NOW, spies: s });
+
+            await m.addSwap(lightningSwap());
+
+            expect(await m.hasSwap(RFQ_ID)).toBe(true);
+        });
+    });
+
+    describe("the write, and what it gates", () => {
+        it("persists the new state on any pass that changed one", async () => {
+            const store = fakeStore();
+            const s = spies();
+            const m = manager({
+                indexer: settlingIndexer(),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            await m.addSwap(lightningSwap(), sendOrigin());
+            await m.poll();
+
+            expect(store.records.get(RFQ_ID)?.state).toBe("settled");
+        });
+
+        it("holds waiters and finalization back when the canonical write fails", async () => {
+            const store = fakeStore();
+            store.failWrite = true;
+            const failures: string[] = [];
+            const s = spies();
+            const m = manager({
+                indexer: settlingIndexer(),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+            m.onSwapFailed((_swap, error) => failures.push(error.message));
+            const completed: string[] = [];
+            m.onSwapCompleted((swap) => completed.push(swap.rfqId));
+
+            await m.addSwap(lightningSwap(), sendOrigin());
+            await m.poll();
+
+            expect(failures.some((message) => message.includes("record store"))).toBe(true);
+            expect(completed).toHaveLength(0);
+            // Still monitored, so the next pass retries the write.
+            expect(await m.hasSwap(RFQ_ID)).toBe(true);
+            // And the secondary sink never saw a state the record of record
+            // refused: projecting it would put `saveSwap` ahead of the store.
+            expect(s.saved).toHaveLength(0);
+
+            store.failWrite = false;
+            await m.poll();
+
+            expect(store.records.get(RFQ_ID)?.state).toBe("settled");
+            expect(completed).toEqual([RFQ_ID]);
+            expect(s.saved).toContain("settled");
+        });
+
+        it("still lets a rejected saveSwap hold the pass back, repository or not", async () => {
+            // The regression guard for the one thing this item could plausibly
+            // have weakened. `saveSwap` is a second sink now, not a demoted
+            // one: both writes gate.
+            const store = fakeStore();
+            const s = spies();
+            s.callbacks.saveSwap = async () => {
+                throw new Error("secondary sink unavailable");
+            };
+            const completed: string[] = [];
+            const m = manager({
+                indexer: settlingIndexer(),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+            m.onSwapCompleted((swap) => completed.push(swap.rfqId));
+
+            await m.addSwap(lightningSwap(), sendOrigin());
+            await m.poll();
+
+            // The canonical write DID land — it runs first and succeeded.
+            expect(store.records.get(RFQ_ID)?.state).toBe("settled");
+            expect(completed).toHaveLength(0);
+            expect(await m.hasSwap(RFQ_ID)).toBe(true);
+        });
+
+        it("keeps state process-local when neither sink is wired", async () => {
+            const swap = lightningSwap();
+            const completed: string[] = [];
+            const m = new RfqSwapManager(
+                { indexer: fakeIndexer({ vtxos: spentBy(CLAIM_SPEND.txid), txs: [CLAIM_SPEND] }) },
+                { now: () => SAFE_NOW },
+            );
+            m.setCallbacks({ refundArkade: async () => null });
+            m.onSwapCompleted((s) => completed.push(s.rfqId));
+
+            await m.addSwap(swap);
+            await m.poll();
+
+            expect(swap.state).toBe("settled");
+            expect(completed).toEqual([RFQ_ID]);
+        });
+    });
+
+    describe("restoreFromRepository", () => {
+        const contractsFor = (...rows: CreateContractParams[]) =>
+            fakeContracts({ preexisting: rows });
+
+        it("rebuilds every stored record and drives it", async () => {
+            const store = fakeStore([storedSend()]);
+            const s = spies();
+            const m = manager({
+                indexer: settlingIndexer(),
+                contracts: contractsFor(rowFor(LOCKUP, LOCKUP_ADDRESS)),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            const result = await m.restoreFromRepository();
+
+            expect(result.restored.map((swap) => swap.rfqId)).toEqual([RFQ_ID]);
+            expect(result.failed).toHaveLength(0);
+            expect(await m.hasSwap(RFQ_ID)).toBe(true);
+
+            await m.poll();
+
+            expect(store.records.get(RFQ_ID)?.state).toBe("settled");
+        });
+
+        it("carries a restored swap's origin, so its record can be rewritten", async () => {
+            // The store losing a record mid-life is the case the in-memory
+            // origin map exists for: without it the next write would have
+            // nothing to build a create from.
+            const store = fakeStore([storedSend()]);
+            const s = spies();
+            const m = manager({
+                indexer: settlingIndexer(),
+                contracts: contractsFor(rowFor(LOCKUP, LOCKUP_ADDRESS)),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            await m.restoreFromRepository();
+            store.records.clear();
+            await m.poll();
+
+            expect(store.records.get(RFQ_ID)?.lockupAddress).toBe(LOCKUP_ADDRESS);
+            // And it is a CLEAN origin, not the old record spread whole: a
+            // stale `blockedReason` carried through would read as a live
+            // refusal on a swap that is running.
+            expect(store.records.get(RFQ_ID)?.blockedReason).toBeUndefined();
+        });
+
+        it("reports a record it cannot rebuild without stranding the others", async () => {
+            const orphan = {
+                ...createRfqSwapRecord(receiveOrigin(), receiveSwap()),
+                rfqId: "b2".repeat(32),
+            };
+            const store = fakeStore([storedSend(), orphan]);
+            const s = spies();
+            const m = manager({
+                // Only the send lockup has a row; the receive one has none.
+                contracts: contractsFor(rowFor(LOCKUP, LOCKUP_ADDRESS)),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            const result = await m.restoreFromRepository();
+
+            expect(result.restored.map((swap) => swap.rfqId)).toEqual([RFQ_ID]);
+            expect(result.failed.map((failure) => failure.rfqId)).toEqual(["b2".repeat(32)]);
+            expect(result.failed[0].error.name).toBe("LockupContractMissing");
+            // Kept in the store: the record is fine, the wallet's copy of the
+            // covenant is what is missing.
+            expect(store.removed).toHaveLength(0);
+        });
+
+        it("takes the covenant from an override instead of the contract store", async () => {
+            const store = fakeStore([storedSend()]);
+            const s = spies();
+            const m = manager({ repository: store, now: SAFE_NOW, spies: s });
+
+            const result = await m.restoreFromRepository({
+                params: async () => VHTLCV2ContractHandler.serializeParams(LOCKUP.options),
+            });
+
+            expect(result.restored).toHaveLength(1);
+        });
+
+        it("refuses when there is no covenant source at all", async () => {
+            const store = fakeStore([storedSend()]);
+            const s = spies();
+            const m = manager({ repository: store, now: SAFE_NOW, spies: s });
+
+            await expect(m.restoreFromRepository()).rejects.toThrow(/contracts/);
+        });
+
+        it("refuses when no repository is wired", async () => {
+            const s = spies();
+            const m = manager({ now: SAFE_NOW, spies: s });
+
+            await expect(m.restoreFromRepository()).rejects.toThrow(/repository/);
+        });
+    });
+
+    describe("retention", () => {
+        const LONG_AGO = SAFE_NOW - RFQ_SWAP_RETENTION_SECONDS - 1;
+
+        it("drops a terminal record past the window and keeps a fresh one", async () => {
+            const store = fakeStore([
+                storedSend({ state: "settled", updatedAt: LONG_AGO }),
+                storedSend({ rfqId: "b2".repeat(32), state: "settled", updatedAt: SAFE_NOW - 10 }),
+            ]);
+            const s = spies();
+            const m = manager({ repository: store, now: SAFE_NOW, spies: s });
+
+            expect(await m.pruneRetiredSwaps()).toEqual([RFQ_ID]);
+            expect([...store.records.keys()]).toEqual(["b2".repeat(32)]);
+        });
+
+        it("never drops needs_counterparty, however old", async () => {
+            // The money is still at the lockup and the counterparty's move is
+            // still what ends the swap — `shouldRetainRfqSwap` encodes this and
+            // the manager defers to it rather than restating the rule.
+            const store = fakeStore([
+                storedSend({ state: "needs_counterparty", updatedAt: LONG_AGO }),
+            ]);
+            const s = spies();
+            const m = manager({ repository: store, now: SAFE_NOW, spies: s });
+
+            expect(await m.pruneRetiredSwaps()).toEqual([]);
+            expect(store.records.has(RFQ_ID)).toBe(true);
+        });
+
+        it("prunes before the rebuild, so a retired record costs no lookup", async () => {
+            const contracts = fakeContracts({ preexisting: [rowFor(LOCKUP, LOCKUP_ADDRESS)] });
+            const store = fakeStore([storedSend({ state: "settled", updatedAt: LONG_AGO })]);
+            const s = spies();
+            const m = manager({
+                contracts,
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            const result = await m.restoreFromRepository();
+
+            expect(result.pruned).toEqual([RFQ_ID]);
+            expect(result.restored).toHaveLength(0);
+            expect(result.failed).toHaveLength(0);
+        });
+
+        it("is a no-op with no repository wired", async () => {
+            const s = spies();
+            const m = manager({ now: SAFE_NOW, spies: s });
+            expect(await m.pruneRetiredSwaps()).toEqual([]);
+        });
+    });
+
+    describe("stamping the spend that ended the swap", () => {
+        it("records the ark transactions the chain read named", async () => {
+            const store = fakeStore();
+            const s = spies();
+            const swap = lightningSwap();
+            const m = manager({
+                indexer: fakeIndexer({
+                    vtxos: [{ ...LOCKUP_OUTPOINT, spentBy: CLAIM_SPEND.txid, arkTxId: ARK_TXID }],
+                    txs: [CLAIM_SPEND],
+                }),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            await m.addSwap(swap, sendOrigin());
+            await m.poll();
+
+            expect(swap.state).toBe("settled");
+            // The counterparty's transaction — nothing local produced it, so no
+            // other field on the record can name it.
+            expect(swap.lockupSpendArkTxids).toEqual([ARK_TXID]);
+            expect(store.records.get(RFQ_ID)?.lockupSpendArkTxids).toEqual([ARK_TXID]);
+        });
+
+        it("stamps nothing when the indexer named the checkpoint but not the ark tx", async () => {
+            // `LockupSpend.arkTxid` is optional, and a checkpoint txid is not
+            // what history correlates on. Fewer txids beats a wrong one.
+            const store = fakeStore();
+            const s = spies();
+            const swap = lightningSwap();
+            const m = manager({
+                indexer: settlingIndexer(),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            await m.addSwap(swap, sendOrigin());
+            await m.poll();
+
+            expect(swap.state).toBe("settled");
+            expect(swap.lockupSpendArkTxids).toBeUndefined();
+        });
+
+        it("survives the record round trip", async () => {
+            const store = fakeStore([
+                storedSend({
+                    state: "settled",
+                    updatedAt: SAFE_NOW - 10,
+                    lockupSpendArkTxids: [ARK_TXID],
+                }),
+            ]);
+            const s = spies();
+            const m = manager({
+                contracts: fakeContracts({ preexisting: [rowFor(LOCKUP, LOCKUP_ADDRESS)] }),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            const result = await m.restoreFromRepository();
+
+            expect(result.restored[0].lockupSpendArkTxids).toEqual([ARK_TXID]);
+        });
     });
 });

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -2697,6 +2697,39 @@ describe("RfqSwapManager — manager-owned persistence", () => {
             expect(store.writes).toHaveLength(0);
         });
 
+        it("refuses an origin belonging to a different corridor, at the same door", async () => {
+            // Left to the first write this surfaces a pass later, with the swap
+            // monitored and the funding broadcast — and then keeps surfacing,
+            // since the write path retries a dirty record every poll and the
+            // mismatch throws deterministically. A receive origin projected off
+            // a send swap also writes `expectedAmount: undefined` over the
+            // caller's own value, so the record would be wrong, not just late.
+            const store = fakeStore();
+            const s = spies();
+            const m = manager({ repository: store, now: SAFE_NOW, spies: s });
+
+            await expect(m.addSwap(lightningSwap(), receiveOrigin())).rejects.toThrow(
+                /lightning_receive origin paired with a lightning_send swap/,
+            );
+            expect(await m.hasSwap(RFQ_ID)).toBe(false);
+            expect(store.writes).toHaveLength(0);
+        });
+
+        it("refuses an origin naming a lockup this swap does not watch", async () => {
+            // The quieter half of the same check: the record stores no
+            // `lockupPkScript`, so a restore would derive one from this address
+            // and watch a covenant the swap never had.
+            const store = fakeStore();
+            const s = spies();
+            const m = manager({ repository: store, now: SAFE_NOW, spies: s });
+
+            await expect(
+                m.addSwap(lightningSwap(), sendOrigin({ lockupAddress: RECEIVE_ADDRESS })),
+            ).rejects.toThrow(/not the same swap/);
+            expect(await m.hasSwap(RFQ_ID)).toBe(false);
+            expect(store.writes).toHaveLength(0);
+        });
+
         it("applies the same rule to start(), and tracks nothing when it fails", async () => {
             const store = fakeStore();
             const s = spies();
@@ -2964,6 +2997,49 @@ describe("RfqSwapManager — manager-owned persistence", () => {
             expect(result.pruned).toEqual([RFQ_ID]);
             expect(result.restored).toHaveLength(0);
             expect(result.failed).toHaveLength(0);
+        });
+
+        it("keeps a still-monitored swap's origin, so the next pass can rewrite its record", async () => {
+            // The reachable orphan: `save` counts a pass as persisted only when
+            // BOTH sinks took it, so a canonical write that landed beside a
+            // `saveSwap` that keeps rejecting leaves the swap monitored and
+            // dirty with a TERMINAL record ageing behind it. Retention judges
+            // the stored record, so it retires one the manager is still
+            // driving — and dropping the origin with it would leave every
+            // later pass throwing `RfqSwapOriginRequired` for a swap that was
+            // otherwise fine.
+            const store = fakeStore();
+            const s = spies();
+            s.callbacks.saveSwap = async () => {
+                throw new Error("secondary sink unavailable");
+            };
+            const failures: string[] = [];
+            const m = manager({
+                indexer: settlingIndexer(),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+            m.onSwapFailed((_swap, error) => failures.push(error.message));
+
+            await m.addSwap(lightningSwap(), sendOrigin());
+            await m.poll();
+            expect(store.records.get(RFQ_ID)?.state).toBe("settled");
+            expect(await m.hasSwap(RFQ_ID)).toBe(true);
+
+            // The stored record ages past the window while its swap is still
+            // monitored, and retention takes it.
+            store.records.get(RFQ_ID)!.updatedAt = LONG_AGO;
+            expect(await m.pruneRetiredSwaps()).toEqual([RFQ_ID]);
+
+            s.callbacks.saveSwap = async () => {};
+            await m.poll();
+
+            // Recreated from the origin the manager kept, rather than spinning
+            // on a swap whose record could never be written again.
+            expect(store.records.get(RFQ_ID)?.state).toBe("settled");
+            expect(store.records.get(RFQ_ID)?.lockupAddress).toBe(LOCKUP_ADDRESS);
+            expect(failures.some((message) => message.includes("origin"))).toBe(false);
         });
 
         it("is a no-op with no repository wired", async () => {


### PR DESCRIPTION
Item 7 of the RFQ swap consumer feedback — the last of the seven upstream asks.

> **Stacked on #770.** Base is `feat/rfq-optional-claim-callbacks`, because this extends that PR's
> relaxed installation type to `saveSwap`. Basing it on `master` would have redefined
> `AvailableRfqSwapManagerCallbacks` and conflicted with #770 whichever landed second. Review the
> last commit only; #770's is the parent.

## The gap

Everything a consumer needs to persist RFQ swaps already exists — `rebuildRfqSwap`,
`shouldRetainRfqSwap`, `lockupContractParams`. What does not exist is their composition, so every
consumer writes the restore loop, the retention pass and the persistence callback themselves.

And composing that write by hand runs into an **origin trap**, confirmed by construction and only
discoverable by reading `rfqRecord.ts` closely: `updateRfqSwapRecord(record, swap)` needs the record
that does not exist yet, and `createRfqSwapRecord(origin, swap)` needs request-time facts the live
swap never carried. A swap's *first* record cannot be built from the swap alone, which is exactly
what `saveSwap(swap)` hands you.

## The shape

`RfqSwapManagerDeps` gains an optional `repository`. With it wired the manager writes the canonical
`RfqSwapRecord` itself, rebuilds the whole store through `restoreFromRepository()`, and sweeps
retention through `pruneRetiredSwaps()`.

```ts
const manager = new RfqSwapManager({ indexer, contracts, repository });
manager.setCallbacks({ refundArkade, claimLockup });

const { restored, failed, pruned } = await manager.restoreFromRepository();
await manager.start();

await manager.addSwap(swap, { kind, lockupAddress, profile, fundingArkTxid, amount });
```

That second argument is the point. Omit it and one of two things happens: the store already holds a
record — which *is* the origin, and is read back — or it does not, and you get
`RfqSwapOriginRequired` **at the door** rather than an unwritable record a pass later, once the
funding is broadcast. `start(swaps)` applies the same rule, signature unchanged.

`restoreFromRepository` returns three disjoint lists. A record that cannot be rebuilt —
`LockupContractMissing`, covenant params that do not derive the funded address, a corridor with no
handler — lands in `failed` with its error, stays in the store, and never strands the others.
Retention runs first, so a retired record costs no contract lookup on its way out. Pass `{ params }`
to take covenants from somewhere other than the contract store.

## Not breaking, and deliberately so

The plan for this item proposed demoting `saveSwap` to a post-persist secondary sink whose rejection
no longer blocks waiters or finalization. **That was rejected on review and is not in this PR.**

With a repository wired the canonical record is written first and `saveSwap` second, and the pass
counts as persisted only when **both** succeeded — today's rule, applied to whichever sinks exist.
So a rejection from either still leaves the record dirty and monitored, waiters unsettled and a
terminal swap unfinalized, exactly as now. A failed canonical write **skips** `saveSwap` entirely:
projecting a state the record of record just refused would put the secondary sink ahead of the
primary, which is the one ordering no restart survives.

Nothing narrows, nothing is removed: `repository` is optional, `addSwap`'s parameter is optional,
`restoreFromRepository` and `pruneRetiredSwaps` are new. The one thing to tell consumers, and the
README does: a `saveSwap` that writes the same repository by hand will **double-write** once the dep
is wired, and should drop the duplicate.

## Three divergences from the plan worth a reviewer's eye

1. **Admission writes the first record.** The plan gated every write on `dirty`, which turned out to
   be a hole: a swap that stays `pending` — most of a swap's life — is never dirty, so its record
   would first appear at settlement and a restart before then would lose it entirely. `addSwap` with
   an origin now marks the swap dirty. An origin *is* the signal that the caller is introducing a new
   swap, so this needs no extra parameter and costs a stored swap nothing.
2. **`RfqSwapState`, `RFQ_SWAP_TERMINAL_STATES` and `isRfqSwapTerminal` moved to
   `src/rfqSwapState.ts`.** Having the manager write records means importing `rfqRecord.ts` at
   runtime, and `rfqRecord.ts` imported `isRfqSwapTerminal` back from the manager — a runtime cycle.
   `swapManager.ts` re-exports all three, so no import path changes. Worth doing anyway: the record
   layer depending on the 1700-line manager for a state enum was the dependency running backwards.
3. **`rfqSwapOriginOf(record)` is new and load-bearing.** A record *is* an origin plus manager state,
   so `createRfqSwapRecord(record, swap)` type-checks and quietly carries the old `failure`,
   `blockedReason` and `refundArkTxid` past `managerState`, which can only set those fields and never
   clear them — the same trap `updateRfqSwapRecord` already strips them to avoid. Both the restore
   path and the store-resolved `addSwap` path need an origin out of a record, so the projection is
   explicit and tested rather than a spread waiting to be got wrong.

## Fate stamping

`RfqSwap` and `RfqSwapRecord` gain `lockupSpendArkTxids?: string[]`, stamped from the chain read that
ended the swap — the solver's claim on a send leg, its reclaim on a receive one, the trader's own
claim when a receive settles. Nothing local produces those transactions, so no other field can name
them; without the stamp the only source is another lockup read per terminal swap. Written only for
spends the indexer named an `arkTxid` for: a checkpoint txid is not what history correlates on, and
fewer txids beats a wrong one.

Optional and additive, so no repository `version` bump — every backend stores records whole.

**Known gap, by choice of base:** #771's `rfqSwapActivityInputs` is the reader that would consume
this, and it is not on this branch. The field and the write ship here; wiring `activityInputOf` to
prefer it over the indexer fallback is one line once both this and #771 are on `master`.

## Tests

24 new cases in `test/swapManager.test.ts` and 5 in `test/rfqRecord.test.ts`:

- where the first record's origin comes from — supplied, resolved from the store, refused at the
  door, the same rule on `start()`, and inert with no repository
- the sink matrix — canonical write gates and holds waiters back; `saveSwap` still gates after a
  successful canonical write (the regression guard for the change that was *not* made); a failed
  canonical write does not fire `saveSwap`; neither wired is process-local
- restore — rebuilds and drives, carries a clean origin so a lost record is rewritten, reports an
  unrebuildable record without stranding the others, the `params` override, both refusals
- retention — drops terminal past the window, never `needs_counterparty`, prunes before the rebuild
- stamping — records what the chain read named, stamps nothing when only the checkpoint was named,
  survives the record round trip
- `rfqSwapOriginOf` — keeps the request-time facts, drops the manager state so a re-create cannot
  resurrect it, copies rather than aliases the profile

`packages/swap` is at 563 passing; build and lint green across the monorepo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added repository-backed persistence, restoration, and retention pruning for RFQ swaps.
  - Added origin tracking and validation for newly added swaps.
  - Added public swap lifecycle states, including pending, claimable, settled, refunded, and failed.
  - Added support for swaps requiring counterparty action.
  - Recorded lockup-spending transaction IDs for improved activity tracking.

- **Bug Fixes**
  - Improved persistence reliability by ensuring required writes complete before swaps are finalized.
  - Reduced unnecessary indexer lookups when spend details are already available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->