### PR TITLE
docs: trim the README and move release detail to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,19 @@ pnpm run test:integration              # Every package, end-to-end
 pnpm run test:integration:ts-sdk       # ts-sdk only
 pnpm run test:integration:boltz-swap   # boltz-swap only
 pnpm run test:integration:swap         # swap only
+pnpm run test:integration:swap-rfq     # swap's RFQ corridor only
 ```
+
+Each package's stack is configured by its own env file — `packages/<pkg>/.env.regtest` — except
+`swap-rfq`, which is a second profile of the `swap` package configured by
+`packages/swap/.env.regtest.rfq`. The two swap corridors need opposite arkd timelock *types* —
+block-typed for offers, seconds-typed for RFQ — and one arkd cannot serve both, so each profile gets
+its own stack. They share ports, so only one can be up at a time locally; CI runs them as separate
+matrix jobs.
 
 ### Per-package stack control
 
-Replace `:ts-sdk` with `:boltz-swap` or `:swap` for the other packages.
+Replace `:ts-sdk` with `:boltz-swap`, `:swap`, or `:swap-rfq` for the other packages.
 
 ```bash
 pnpm run regtest:up:ts-sdk
@@ -54,7 +62,11 @@ pnpm run release:dry-run -- sdk patch         # Preview without changes
 pnpm run release:cleanup                      # Auto-detect dirty release artifacts
 ```
 
-Tags are `@arkade-os/<package>/<version>` — e.g. `@arkade-os/sdk/0.4.57` (no `v<version>`).
+Tags are `<package-name>/<version>` — e.g. `@arkade-os/sdk/0.4.57` (no `v<version>`).
+
+Bumps accept `patch | minor | major | prepatch | preminor | premajor | prerelease` or a literal
+semver such as `0.5.0-beta.0`. Prerelease bumps require `--preid alpha|beta|rc|next`, and publish
+under a matching npm dist-tag — never `latest`.
 
 Releasing SDK implies a dependent release of every package that depends on it via `workspace:*`
 (`boltz-swap` and `swap`), because pnpm rewrites `workspace:*` to an exact version on publish, so a
@@ -63,6 +75,12 @@ with `--boltz-bump` / `--swap-bump <bump-or-version>`.
 
 The script runs tests, builds, commits, tags, publishes to npm (requires local npm credentials),
 and pushes commit + tags to `origin`.
+
+`release:cleanup` restores the selected package manifests and deletes the matching **local** tags —
+nothing else. It never deletes remote tags and never resets commits, so if the release commit was
+already created, inspect `git log` and undo it yourself (e.g. `git reset --hard HEAD~1`) before
+retrying. With no target it auto-detects from release state or dirty manifests; pass one to narrow
+it (`pnpm run release:cleanup -- sdk`).
 
 Stable versions must be released from `master`; prereleases may come from any branch.
 `--allow-any-branch` is the escape hatch for a stable release off a feature branch — the release

--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ TypeScript packages for the Arkade Bitcoin wallet ecosystem — on-chain/off-cha
 |---------|-------------|
 | [`@arkade-os/sdk`](packages/ts-sdk/) | Bitcoin wallet SDK with Taproot and Ark protocol support |
 | [`@arkade-os/boltz-swap`](packages/boltz-swap/) | Lightning and chain swaps using Boltz |
-| [`@arkade-os/swap`](packages/swap/) | Client-side Arkade Intents asset swaps: market discovery, offers, restore |
-| [Regtest stack](regtest/) | Shared regtest environment ([arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest) submodule) |
+| [`@arkade-os/swap`](packages/swap/) | Client-side Arkade Intents asset swaps: market discovery, offers, RFQ, restore |
+
+The [`regtest/`](regtest/) directory is a shared regtest environment, vendored as the
+[arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest) git submodule.
 
 ## Prerequisites
 
-- Node.js >= 24.15.0 (LTS — see `.nvmrc`)
-- pnpm >= 10.25.0
+- Node.js >= 24.15.0 < 27 (LTS; see `.nvmrc`)
+- pnpm >= 10.25.0 < 11
 
 ```bash
 corepack enable
@@ -44,38 +46,10 @@ pnpm -C packages/ts-sdk vitest run -t "test name pattern"
 
 ### Integration tests
 
-Integration tests use the shared [arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest) environment (git submodule). Each package runs against its own regtest stack via a per-package override file:
-
-- `packages/ts-sdk/.env.regtest`
-- `packages/boltz-swap/.env.regtest`
-
-#### All packages
-
-```bash
-pnpm run test:integration   # Runs test:integration:ts-sdk, then test:integration:boltz-swap
-```
-
-Each script invokes `scripts/regtest.sh <pkg> cycle`, where `cycle` means `reset + up + setup + test` against that package's stack.
-
-#### Single package
-
-Per-package commands let you control the stack directly. Replace `:ts-sdk` with `:boltz-swap` for the other package.
-
-```bash
-pnpm run regtest:up:ts-sdk      # Start the package's regtest stack
-pnpm run regtest:setup:ts-sdk   # Initialize wallets and fixtures
-pnpm run regtest:test:ts-sdk    # Run the package's e2e suite (assumes stack is up)
-pnpm run regtest:down:ts-sdk    # Stop the stack (preserves data)
-pnpm run regtest:reset:ts-sdk   # Remove containers and volumes
-```
-
-`regtest:test` accepts optional test-file paths to run just a subset against the running stack:
-
-```bash
-pnpm run regtest:test:ts-sdk test/e2e/asset.test.ts test/e2e/arkadeCash.test.ts
-```
-
-CI uses this to fan the ts-sdk e2e suite out across parallel groups (see the `integration` matrix in `.github/workflows/ci.yml`); the same file lists reproduce a single group locally.
+Integration tests run against the shared regtest stack; `pnpm run test:integration` cycles every
+package's suite (ts-sdk, boltz-swap, swap, and the swap RFQ profile) end-to-end. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for per-package stack control, running selected test files, and
+how CI fans the ts-sdk e2e suite out across parallel groups.
 
 ### Documentation
 
@@ -83,35 +57,31 @@ TypeDoc-generated API docs for `@arkade-os/sdk` are written to the repo-root `do
 
 ```bash
 pnpm -C packages/ts-sdk run docs:build   # Build into ./docs at the repo root
-pnpm -C packages/ts-sdk run docs:open    # Open ./docs/index.html in the browser
+pnpm -C packages/ts-sdk run docs:open    # Open ./docs/index.html (macOS `open`)
 ```
 
 After regenerating, sanity-check that source links in the generated HTML point to monorepo-style paths (e.g. `packages/ts-sdk/src/...`) before publishing.
 
 ## Releasing
 
-Releases run from the repository root and are package-scoped. Each package is released independently with its own version and its own `<package-name>/<version>` tag (e.g. `@arkade-os/sdk/0.4.28`). Releasing `@arkade-os/sdk` also releases `@arkade-os/boltz-swap` and `@arkade-os/swap` by default, because both depend on SDK via `workspace:*`, which pnpm rewrites to an exact version at publish time — a dependent left unreleased stays pinned to the previous SDK.
+Releases run from the repository root and are package-scoped (`sdk`, `boltz-swap`, `swap`, or `all`),
+each with its own version and tag. Releasing `sdk` also bumps the dependents (`boltz-swap`, `swap`),
+so they never stay pinned to a stale SDK:
 
 ```bash
-pnpm run release -- boltz-swap patch          # Boltz bugfix only
-pnpm run release -- swap patch                # Swap bugfix only
-pnpm run release -- sdk patch                 # SDK + dependent boltz-swap/swap patch
-pnpm run release -- sdk minor --boltz-bump patch --swap-bump minor
-pnpm run release -- all patch                 # Bump every package
-pnpm run release -- sdk prepatch --preid beta # Mirrors prerelease into the dependents
-
-pnpm run release:dry-run -- sdk patch
-pnpm run release:cleanup                      # Auto-detect dirty artifacts
-pnpm run release:cleanup -- sdk               # Clean only sdk artifacts
+pnpm run release -- sdk patch           # SDK + dependent boltz-swap/swap patch
+pnpm run release:dry-run -- sdk patch   # Preview the plan without changing files
+pnpm run release:cleanup                # Restore manifests, delete local tags
 ```
 
-Targets are `sdk`, `boltz-swap`, `swap`, or `all`. Bumps accept `patch | minor | major | prepatch | preminor | premajor | prerelease` or a literal semver. Prerelease bumps require `--preid alpha|beta|rc|next`.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for all targets, bump types, prerelease flags, and cleanup
+behavior.
 
-When SDK is released, each dependent bump (boltz-swap, swap) defaults to `patch`; prerelease SDK bumps mirror the prerelease shape and `--preid` into the dependents unless overridden with `--boltz-bump` / `--swap-bump`. Before publishing a dependent, the release script packs it to a temp dir and verifies that the packed manifest pins the intended `@arkade-os/sdk` version.
+## More
 
-The release script runs unit tests, builds all packages, creates a release commit, tags it, publishes to npm (requires local npm credentials), then pushes the commit and tags to `origin`.
-
-Cleanup restores selected package manifests and removes selected local `<package>/<version>` tags. It never deletes remote tags and never resets commits; if a release commit was already created, run `git reset --hard HEAD~1` manually after inspecting `git log`. Package-local release scripts are disabled.
+- [CHANGELOG.md](CHANGELOG.md) — release history
+- [CONTRIBUTING.md](CONTRIBUTING.md) — integration testing and releasing in detail
+- [SECURITY.md](SECURITY.md) — security policy
 
 ## License
 


### PR DESCRIPTION
Leans out the README and fixes what the trim broke:

- `pnpm run release:dry-run` was documented without a target, which exits 1 — `release.mjs` requires one even under `--dry-run`.
- The README pointed at CONTRIBUTING for bump types, preids, and cleanup behavior that lived nowhere. Written there now, including that cleanup restores manifests and deletes local tags but leaves the release commit standing.
- Only ts-sdk is fanned out across CI groups; the swap profiles differ by timelock *type* and share ports, so only one stack runs at a time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring and manually controlling the `swap-rfq` integration-test profile.
  * Clarified supported release tag formats, version bump options, prerelease behavior, and cleanup commands.
  * Updated prerequisites for supported Node.js and pnpm versions.
  * Improved README coverage of RFQ support, integration testing, package-scoped releases, and project documentation links.
  * Updated the documentation-opening command description for macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->