### PR TITLE
fix(swap): admit the rate_limited refusal the solver actually sends

### DIFF
--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -151,7 +151,8 @@ export type RfqRefusalReason =
     | "exposure_cap"
     | "invoice_expired"
     | "quote_conflict"
-    | "pricing_unavailable";
+    | "pricing_unavailable"
+    | "rate_limited";
 
 /** Lifecycle vocabulary; states after which nothing more will happen. */
 export const RFQ_TERMINAL_STATES = ["settled", "refused", "expired", "refunded", "stuck"] as const;


### PR DESCRIPTION
Closes #772.

`RfqRefusalReason` stopped at `pricing_unavailable`, but the reference solver emits `rate_limited` from its default quote rate limiter ([`src/wire/payloads.ts`](https://github.com/arkade-os/lightning-swap-service/blob/main/src/wire/payloads.ts)). `SwapRefusal.reason` is typed `string`, so nothing broke at runtime — but an exhaustive `switch` over the union missed the one refusal worth retrying.

No test: `tsconfig` excludes `test/` in every package, so a `satisfies RfqRefusalReason[]` pin would never be typechecked. The union is the assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RFQ refusals by recognizing pricing-unavailable and rate-limited responses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->