### PR TITLE
fix(swap): refuse a height-shaped refundLocktime

### DIFF
--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -131,6 +131,7 @@ export {
     type RfqTransport,
 } from "./rfq";
 export {
+    LOCKTIME_THRESHOLD,
     ONCHAIN_DUST_SATS,
     ONCHAIN_SECONDS_PER_BLOCK,
     awaitOnchainFill,

--- a/packages/swap/src/onchainHtlc.ts
+++ b/packages/swap/src/onchainHtlc.ts
@@ -36,6 +36,13 @@ export const ONCHAIN_ORDER_MARGIN_SECONDS = 2 * 60 * 60;
 export const ONCHAIN_CLAIM_MARGIN_SECONDS = 90 * 60;
 /** Bounds on the confirmation depth a quote may demand. */
 export const MAX_MIN_CONFIRMATIONS = 6;
+/**
+ * BIP65's boundary between the two things an absolute locktime can mean.
+ * Below it consensus reads the value as a block height; at or above it, as a
+ * unix timestamp. 500,000,000 itself is 1985-07-05 and is a timestamp, so the
+ * comparison against it is strict.
+ */
+export const LOCKTIME_THRESHOLD = 500_000_000;
 /** Conservative block interval for converting depths into wall-clock time. */
 export const ONCHAIN_SECONDS_PER_BLOCK = 600;
 /**
@@ -127,6 +134,18 @@ export function onchainHtlcScript(params: OnchainHtlcParams, network: OnchainNet
     if (!Number.isInteger(params.refundLocktime) || params.refundLocktime <= 0) {
         throw new Error(
             `refundLocktime must be a positive unix timestamp, got ${params.refundLocktime}`,
+        );
+    }
+    // The bare `number` cannot say which of the two things it means, so a
+    // height-shaped value builds a refund leaf that matures at block ~500
+    // million rather than failing — the caller that dropped a `/ 1000`, or a
+    // solver quoting a height, gets an HTLC whose refund path is dead for
+    // millennia. Nothing downstream can detect it: the address is well-formed
+    // and the funding confirms.
+    if (params.refundLocktime < LOCKTIME_THRESHOLD) {
+        throw new Error(
+            `refundLocktime ${params.refundLocktime} is below LOCKTIME_THRESHOLD ` +
+                `(${LOCKTIME_THRESHOLD}) and would be interpreted as a block height`,
         );
     }
     // Refused rather than defaulted: an unknown network reaches `btc.p2tr` as

--- a/packages/swap/test/onchainHtlc.test.ts
+++ b/packages/swap/test/onchainHtlc.test.ts
@@ -14,6 +14,7 @@ import { schnorr } from "@noble/curves/secp256k1.js";
 import * as btc from "@scure/btc-signer";
 
 import {
+    LOCKTIME_THRESHOLD,
     ONCHAIN_CLAIM_MARGIN_SECONDS,
     awaitOnchainFill,
     buildHtlcClaim,
@@ -109,6 +110,24 @@ describe("onchainHtlcScript — golden", () => {
                 "bitcoin",
             ),
         ).toThrow(/positive/);
+    });
+
+    it("rejects a height-shaped refundLocktime, and accepts the boundary itself", () => {
+        // Below BIP65's threshold consensus reads the value as a block height,
+        // so the refund leaf would mature at block ~500 million. 500_000_000 is
+        // 1985-07-05 — a timestamp, and the last value that is one.
+        const params = (refundLocktime: number) => ({
+            paymentHash: PAYMENT_HASH,
+            claimKey: key(1),
+            refundKey: key(3),
+            refundLocktime,
+        });
+        expect(() => onchainHtlcScript(params(499_999_999), "bitcoin")).toThrow(
+            /below LOCKTIME_THRESHOLD/,
+        );
+        expect(onchainHtlcScript(params(LOCKTIME_THRESHOLD), "bitcoin").refundLocktime).toBe(
+            LOCKTIME_THRESHOLD,
+        );
     });
 
     it("rejects a network it cannot build for, rather than defaulting to mainnet", () => {


### PR DESCRIPTION
Closes #774.

`onchainHtlcScript` accepted any positive integer, so anything below BIP65's threshold — a solver quoting a height, or a caller that dropped a `/ 1000` — produced a refund leaf that matures at block ~500 million. The address is well-formed and the funding confirms, so nothing downstream could catch it.

Guard is strictly-less-than: 500,000,000 is 1985-07-05 and is a valid timestamp. `LOCKTIME_THRESHOLD` is exported so lightning-swap-service can drop its own `assertAbsoluteLocktime` copy (arkade-os/lightning-swap-service#145) rather than keeping a guard in front of every SDK call.

Tests cover both sides of the boundary.