### PR TITLE
feat(sdk): export toXOnly, the bytes-level x-only normalizer

### DIFF
--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -54,6 +54,7 @@ import {
     asset,
     getNetwork,
     resolveEmulatorPubkey,
+    toXOnly,
     type IWallet,
     type NetworkName,
 } from "@arkade-os/sdk";
@@ -84,15 +85,6 @@ import {
 } from "@arkade-os/sdk";
 import { sealClaimPacket } from "./claimPacket";
 import { registerLockupContract } from "./lockupContract";
-
-/** Drop the prefix of a 33-byte compressed key; pass an x-only key through. */
-const xOnly = (key: Uint8Array, label: string): Uint8Array => {
-    if (key.length === 32) return key;
-    if (key.length !== 33 || (key[0] !== 0x02 && key[0] !== 0x03)) {
-        throw new Error(`${label} is not a compressed or x-only public key`);
-    }
-    return key.slice(1);
-};
 
 /** Decode a solver-supplied hex field, turning a malformed value (odd length,
  * non-hex chars) into a solver-blaming diagnostic instead of a bare
@@ -906,17 +898,17 @@ export async function requestLightningSend(
         );
     }
 
-    const serverPubkey = xOnly(hex.decode(info.signerPubkey), "ark signer key");
+    const serverPubkey = toXOnly(hex.decode(info.signerPubkey), "ark signer key");
     const network = getNetwork(info.network as NetworkName);
     // Named rather than inlined so the exact inputs the covenant was built from
     // can be returned to the caller — see `treeParams` on the return type.
     const treeParams = {
-        solverPubkey: xOnly(hex.decode(quote.solver_pubkey), "solver key"),
+        solverPubkey: toXOnly(hex.decode(quote.solver_pubkey), "solver key"),
         refundLocktime: quote.refund_locktime,
         serverPubkey,
         paymentHash: params.invoice.paymentHash,
         claimDelay: unilateralClaimDelay(Number(info.unilateralExitDelay)),
-        emulatorPubkey: xOnly(
+        emulatorPubkey: toXOnly(
             hex.decode(resolveEmulatorPubkey(network, params.emulatorPubkey)),
             "emulator signer key",
         ),
@@ -1140,7 +1132,7 @@ export function deriveOnchainSend(input: {
     }
 
     const script = lightningSendVtxoScript({
-        solverPubkey: xOnly(hex.decode(quote.solver_pubkey), "solver key"),
+        solverPubkey: toXOnly(hex.decode(quote.solver_pubkey), "solver key"),
         refundLocktime,
         serverPubkey: input.serverPubkey,
         paymentHash: input.paymentHash,
@@ -1159,7 +1151,7 @@ export function deriveOnchainSend(input: {
     const htlcParams = {
         paymentHash: input.paymentHash,
         claimKey: input.payoutPubkey,
-        refundKey: xOnly(hex.decode(htlcPubkey), "solver L1 htlc key"),
+        refundKey: toXOnly(hex.decode(htlcPubkey), "solver L1 htlc key"),
         refundLocktime: htlcLocktime,
     };
     const htlc = onchainHtlcScript(htlcParams, input.l1Network);
@@ -1295,8 +1287,8 @@ export async function requestOnchainSend(
         quote,
         paymentHash,
         payoutPubkey: params.payoutPubkey,
-        serverPubkey: xOnly(hex.decode(info.signerPubkey), "ark signer key"),
-        emulatorPubkey: xOnly(
+        serverPubkey: toXOnly(hex.decode(info.signerPubkey), "ark signer key"),
+        emulatorPubkey: toXOnly(
             hex.decode(resolveEmulatorPubkey(network, params.emulatorPubkey)),
             "emulator signer key",
         ),
@@ -1590,7 +1582,7 @@ export function deriveLightningReceive(input: {
     // Named rather than inlined so the exact inputs can be handed back — see
     // `treeParams` on the return type.
     const treeParams = {
-        solverPubkey: xOnly(hex.decode(quote.solver_pubkey), "solver key"),
+        solverPubkey: toXOnly(hex.decode(quote.solver_pubkey), "solver key"),
         refundLocktime,
         serverPubkey: input.serverPubkey,
         paymentHash: input.paymentHash,
@@ -1728,8 +1720,8 @@ export async function requestLightningReceive(
         paymentHash,
         payoutPubkey,
         payoutAddress,
-        serverPubkey: xOnly(hex.decode(info.signerPubkey), "ark signer key"),
-        emulatorPubkey: xOnly(
+        serverPubkey: toXOnly(hex.decode(info.signerPubkey), "ark signer key"),
+        emulatorPubkey: toXOnly(
             hex.decode(resolveEmulatorPubkey(network, params.emulatorPubkey)),
             "emulator signer key",
         ),
@@ -1817,7 +1809,7 @@ export function deriveOnchainReceive(input: {
     }
 
     const script = receiveVtxoScript({
-        solverPubkey: xOnly(hex.decode(quote.solver_pubkey), "solver key"),
+        solverPubkey: toXOnly(hex.decode(quote.solver_pubkey), "solver key"),
         refundLocktime,
         serverPubkey: input.serverPubkey,
         paymentHash: input.paymentHash,
@@ -1833,7 +1825,7 @@ export function deriveOnchainReceive(input: {
     const htlc = onchainHtlcScript(
         {
             paymentHash: input.paymentHash,
-            claimKey: xOnly(hex.decode(claimPubkey), "solver L1 claim key"),
+            claimKey: toXOnly(hex.decode(claimPubkey), "solver L1 claim key"),
             refundKey: input.refundPubkey,
             refundLocktime: htlcLocktime,
         },
@@ -1943,8 +1935,8 @@ export async function requestOnchainReceive(
         payoutPubkey,
         payoutAddress,
         refundPubkey: params.refundPubkey,
-        serverPubkey: xOnly(hex.decode(info.signerPubkey), "ark signer key"),
-        emulatorPubkey: xOnly(
+        serverPubkey: toXOnly(hex.decode(info.signerPubkey), "ark signer key"),
+        emulatorPubkey: toXOnly(
             hex.decode(resolveEmulatorPubkey(network, params.emulatorPubkey)),
             "emulator signer key",
         ),

--- a/packages/ts-sdk/src/arkade/batch.ts
+++ b/packages/ts-sdk/src/arkade/batch.ts
@@ -41,6 +41,7 @@ import { buildForfeitTx } from "../forfeit";
 import { Batch } from "../wallet/batch";
 import { Intent } from "../intent";
 import { isRecoverable, isSubdust, isVirtualCoin } from "../wallet";
+import { toXOnly } from "../utils/keys";
 import type { ExtendedVirtualCoin } from "../wallet";
 import type { TxTree } from "../tree/txTree";
 
@@ -120,7 +121,7 @@ export function createArkadeBatchHandler(
 
             const sweepTapscript = CSVMultisigTapscript.encode({
                 timelock,
-                pubkeys: [hex.decode(info.forfeitPubkey).subarray(1)],
+                pubkeys: [toXOnly(hex.decode(info.forfeitPubkey), "forfeit key")],
             }).script;
 
             sweepTapTreeRoot = tapLeafHash(sweepTapscript);
@@ -132,8 +133,10 @@ export function createArkadeBatchHandler(
             vtxoTree: TxTree,
         ): Promise<{ skip: boolean }> => {
             const signerPubKey = await session.getPublicKey();
-            const xonlySignerPubKey = signerPubKey.subarray(1);
-            const xOnlyPubkeys = event.cosignersPublicKeys.map((k) => k.slice(2));
+            const xonlySignerPubKey = toXOnly(signerPubKey, "signer key");
+            const xOnlyPubkeys = event.cosignersPublicKeys.map((k) =>
+                hex.encode(toXOnly(hex.decode(k), "cosigner key")),
+            );
 
             if (!xOnlyPubkeys.includes(hex.encode(xonlySignerPubKey))) {
                 return { skip: true };

--- a/packages/ts-sdk/src/arkade/contract.ts
+++ b/packages/ts-sdk/src/arkade/contract.ts
@@ -78,6 +78,7 @@ import type { VirtualCoin } from "../wallet";
 import { getNormalizedVtxos, hasTerminalSpend } from "../wallet";
 import { CSVMultisigTapscript } from "../script/tapscript";
 import type { TapLeafScript } from "../script/base";
+import { toXOnly } from "../utils/keys";
 import {
     assertSubmittedArkTxid,
     buildOffchainTx,
@@ -316,7 +317,7 @@ export class Arkade {
     /** Connect and resolve the server key, checkpoint closure and (if present) the co-signer key. */
     static async connect(opts: ArkadeConnectOptions): Promise<Arkade> {
         const info = await opts.arkade.getInfo();
-        const serverKey = hex.decode(info.signerPubkey).slice(1);
+        const serverKey = toXOnly(hex.decode(info.signerPubkey), "ark signer key");
         const checkpoint = CSVMultisigTapscript.decode(hex.decode(info.checkpointTapscript));
         const network = opts.network ?? DEFAULT_NETWORK;
 
@@ -338,8 +339,7 @@ export class Arkade {
         // and the builder can identify which inputs the wallet signs.
         let userKey: Uint8Array | undefined;
         if (opts.identity) {
-            const pub = await opts.identity.xOnlyPublicKey();
-            userKey = pub.length === 33 ? pub.slice(1) : pub;
+            userKey = toXOnly(await opts.identity.xOnlyPublicKey(), "identity key");
         }
 
         return new Arkade({

--- a/packages/ts-sdk/src/arkade/tweak.ts
+++ b/packages/ts-sdk/src/arkade/tweak.ts
@@ -11,6 +11,8 @@
 import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
 import { bytesToNumberBE } from "@noble/curves/utils.js";
 
+import { toXOnly } from "../utils/keys";
+
 const TAG_SCRIPT = "ArkScriptHash";
 const TAG_WITNESS = "ArkWitnessHash";
 
@@ -53,8 +55,7 @@ export function arkadeWitnessHash(witness: Uint8Array): Uint8Array {
 export function computeArkadeScriptPublicKey(pubKey: Uint8Array, script: Uint8Array): Uint8Array {
     const hash = arkadeScriptHash(script);
 
-    const xOnly = pubKey.length === 33 ? pubKey.subarray(1) : pubKey;
-    const point = schnorr.utils.lift_x(bytesToNumberBE(xOnly));
+    const point = schnorr.utils.lift_x(bytesToNumberBE(toXOnly(pubKey, "emulator key")));
 
     // tweak = (scriptHash mod n) * G
     const scalar = bytesToNumberBE(hash) % secp256k1.Point.CURVE().n;

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -505,6 +505,7 @@ import type {
 } from "./contracts/types";
 import type { ScanResult, ScanContractsOptions, HandlerError } from "./contracts/contractManager";
 import { timelockToSequence, sequenceToTimelock } from "./utils/timelock";
+import { toXOnly } from "./utils/keys";
 import { buildVersion, sdkVersion, FetchError } from "./utils/fetch";
 import {
     closeDatabase,
@@ -749,6 +750,7 @@ export {
     TxWeightEstimator,
     timelockToSequence,
     sequenceToTimelock,
+    toXOnly,
 
     // Errors
     ArkError,

--- a/packages/ts-sdk/src/utils/arkTransaction.ts
+++ b/packages/ts-sdk/src/utils/arkTransaction.ts
@@ -18,6 +18,7 @@ import { Transaction } from "./transaction";
 import { ArkAddress } from "../script/address";
 import { Extension } from "../extension";
 import { ServerResponseMismatchError } from "../providers/errors";
+import { toXOnly } from "./keys";
 
 export type ArkTxInput = {
     // the script used to spend the virtual output
@@ -702,11 +703,7 @@ export async function submitOffchainTx(
             );
         }
         const finalArkTx = Transaction.fromPSBT(base64.decode(response.finalArkTx));
-        const serverPubkeyHex = hex.encode(
-            verify.serverPubkey.length === 33
-                ? verify.serverPubkey.subarray(1)
-                : verify.serverPubkey,
-        );
+        const serverPubkeyHex = hex.encode(toXOnly(verify.serverPubkey, "server key"));
         for (let i = 0; i < offchainTx.arkTx.inputsLength; i++) {
             assertServerSignedLeaf(
                 finalArkTx,

--- a/packages/ts-sdk/src/utils/keys.ts
+++ b/packages/ts-sdk/src/utils/keys.ts
@@ -10,8 +10,8 @@
  * uncompressed key, stripped of one byte, yields a plausible 32-byte value
  * that is not the key, which surfaces as an address nobody funded.
  *
- * The result may alias `key` rather than copy it; callers that mutate their
- * input must copy first.
+ * The result may alias `key` rather than copy it; callers that mutate either
+ * value after normalization should copy first.
  *
  * @param key - 32-byte x-only or 33-byte compressed public key
  * @param label - Name used in the error, e.g. `"ark signer key"`

--- a/packages/ts-sdk/src/utils/keys.ts
+++ b/packages/ts-sdk/src/utils/keys.ts
@@ -1,0 +1,24 @@
+/**
+ * Normalize a secp256k1 public key to the 32-byte x-only form every tapscript,
+ * covenant param and `params.serverPubKey` in this SDK is denominated in.
+ *
+ * A compressed key drops its parity prefix; an x-only key passes through. Both
+ * arrive over the same wires — arkd advertises `signerPubkey` either way,
+ * `Identity.xOnlyPublicKey` implementations vary, and solver-supplied fields
+ * are whatever the peer sent — so the caller usually cannot know which it
+ * holds. Anything else is refused rather than silently truncated: a 65-byte
+ * uncompressed key, stripped of one byte, yields a plausible 32-byte value
+ * that is not the key, which surfaces as an address nobody funded.
+ *
+ * The result may alias `key` rather than copy it; callers that mutate their
+ * input must copy first.
+ *
+ * @param key - 32-byte x-only or 33-byte compressed public key
+ * @param label - Name used in the error, e.g. `"ark signer key"`
+ * @see toXOnlySignerHex for the hex-in, hex-out signer-rotation equivalent
+ */
+export function toXOnly(key: Uint8Array, label = "public key"): Uint8Array {
+    if (key.length === 32) return key;
+    if (key.length === 33 && (key[0] === 0x02 || key[0] === 0x03)) return key.subarray(1);
+    throw new Error(`${label} is not a compressed or x-only public key`);
+}

--- a/packages/ts-sdk/src/wallet/signerRotation.ts
+++ b/packages/ts-sdk/src/wallet/signerRotation.ts
@@ -1,5 +1,6 @@
 import { hex } from "@scure/base";
 import type { ArkInfo } from "../providers/ark";
+import { toXOnly } from "../utils/keys";
 
 /**
  * Machine-readable classification of a contract's server signer relative to a
@@ -70,15 +71,13 @@ export interface SignerSet {
 /**
  * Normalize a server signer pubkey hex to the x-only (32-byte) form contract
  * scripts and `params.serverPubKey` use. A 33-byte compressed key drops its
- * parity prefix; a 32-byte key is canonicalized to lowercase. Mirrors the
- * wallet's `hex.decode(info.signerPubkey).slice(1)` setup path so the active
+ * parity prefix; a 32-byte key is canonicalized to lowercase. The active
  * signer and the deprecated signers (which arkd may advertise compressed)
  * compare equal to the x-only `params.serverPubKey` persisted on contracts.
  */
 export function toXOnlySignerHex(pubkeyHex: string): string {
     const bytes = hex.decode(pubkeyHex);
-    if (bytes.length === 33) return hex.encode(bytes.slice(1));
-    if (bytes.length === 32) return hex.encode(bytes);
+    if (bytes.length === 32 || bytes.length === 33) return hex.encode(toXOnly(bytes, "signer key"));
     throw new Error(`invalid signer pubkey length: expected 32 or 33 bytes, got ${bytes.length}`);
 }
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -89,6 +89,7 @@ import {
     submitOffchainTx,
     type OffchainTxSigner,
 } from "../utils/arkTransaction";
+import { toXOnly } from "../utils/keys";
 import {
     byValueDescending,
     DEFAULT_RENEWAL_CONFIG,
@@ -233,16 +234,6 @@ export const MAX_USED_SIGNING_DESCRIPTORS_LOOK_AHEAD = 1_000;
 // Kept so existing wallets can still discover and spend VTXOs sent to the
 // legacy address after arkd starts advertising a different delay.
 const MAINNET_UNILATERAL_EXIT_DELAY = 605184n;
-
-// Normalize a server signer pubkey to the x-only (32-byte) form script
-// encoding requires (CSVMultisigTapscript.encode throws on anything else).
-// A 33-byte compressed key drops its parity prefix; a 32-byte key is already
-// x-only. Mirrors the setup path's `hex.decode(info.signerPubkey).slice(1)`.
-function toXOnlyPubKey(pubkey: Uint8Array): Uint8Array {
-    if (pubkey.length === 33) return pubkey.slice(1);
-    if (pubkey.length === 32) return pubkey;
-    throw new Error(`invalid signer pubkey length: expected 32 or 33, got ${pubkey.length}`);
-}
 
 function delayToTimelock(delay: bigint): RelativeTimelock {
     return {
@@ -1036,17 +1027,17 @@ export class ReadonlyWallet implements IReadonlyWallet {
         };
 
         // Generate tapscripts for offchain and boarding address
-        const serverPubKey = hex.decode(info.signerPubkey).slice(1);
+        const serverPubKey = toXOnly(hex.decode(info.signerPubkey), "ark signer key");
 
         const delegatePubKey = config.delegateProvider
             ? await config.delegateProvider
                   .getDelegateInfo()
-                  .then((info) => hex.decode(info.pubkey).slice(1))
+                  .then((info) => toXOnly(hex.decode(info.pubkey), "delegate key"))
                   .catch(() => undefined)
             : config.delegatorProvider
               ? await config.delegatorProvider
                     .getDelegateInfo()
-                    .then((info) => hex.decode(info.pubkey).slice(1))
+                    .then((info) => toXOnly(hex.decode(info.pubkey), "delegate key"))
                     .catch(() => undefined)
               : undefined;
 
@@ -2673,7 +2664,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
      * the stable public API.
      */
     async rotateServerSigner(newServerPubKey: Bytes, checkpointTapscript: string): Promise<void> {
-        const xonly = toXOnlyPubKey(newServerPubKey);
+        const xonly = toXOnly(newServerPubKey, "ark signer key");
 
         // Decode and validate the new epoch's checkpoint script FIRST, before
         // any persistence. The checkpoint script is server-controlled state the
@@ -2945,9 +2936,9 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         // snapshot rather than `this.offchainTapscript.options.serverPubKey`
         // avoids mixing a stale instance signer with fresh history.
         const arkInfo = await this.arkProvider.getInfo();
-        const currentSignerPubKey = toXOnlyPubKey(hex.decode(arkInfo.signerPubkey));
+        const currentSignerPubKey = toXOnly(hex.decode(arkInfo.signerPubkey), "ark signer key");
         const deprecatedSignerPubKeys = arkInfo.deprecatedSigners.map((s) =>
-            toXOnlyPubKey(hex.decode(s.pubkey)),
+            toXOnly(hex.decode(s.pubkey), "deprecated signer key"),
         );
 
         const deps: DiscoveryDeps = {
@@ -3241,7 +3232,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
 
         // parse the server forfeit address
         // server is expecting funds to be sent to this address
-        const forfeitPubkey = hex.decode(setup.info.forfeitPubkey).slice(1);
+        const forfeitPubkey = toXOnly(hex.decode(setup.info.forfeitPubkey), "forfeit key");
         const forfeitAddress = Address(setup.network).decode(setup.info.forfeitAddress);
         const forfeitOutputScript = OutScript.encode(forfeitAddress);
 
@@ -4217,9 +4208,11 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                     throw new Error("Sweep tap tree root not set");
                 }
 
-                const xOnlyPublicKeys = event.cosignersPublicKeys.map((k) => k.slice(2));
+                const xOnlyPublicKeys = event.cosignersPublicKeys.map((k) =>
+                    hex.encode(toXOnly(hex.decode(k), "cosigner key")),
+                );
                 const signerPublicKey = await session.getPublicKey();
-                const xonlySignerPublicKey = signerPublicKey.subarray(1);
+                const xonlySignerPublicKey = toXOnly(signerPublicKey, "signer key");
 
                 if (!xOnlyPublicKeys.includes(hex.encode(xonlySignerPublicKey))) {
                     // not a cosigner, skip the signing

--- a/packages/ts-sdk/test/keys.test.ts
+++ b/packages/ts-sdk/test/keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
+
+import { toXOnly } from "../src/utils/keys";
+
+describe("toXOnly", () => {
+    const priv = new Uint8Array(32).fill(9);
+    const compressed = secp256k1.getPublicKey(priv, true);
+    const xonly = schnorr.getPublicKey(priv);
+
+    it("strips the parity prefix of a compressed key and passes an x-only key through", () => {
+        expect(toXOnly(compressed)).toEqual(xonly);
+        expect(toXOnly(xonly)).toBe(xonly);
+    });
+
+    it("refuses anything else, naming the caller's label", () => {
+        // An uncompressed key is the case worth refusing: dropping one byte
+        // yields a well-formed 32-byte value that is not the key.
+        const uncompressed = secp256k1.getPublicKey(priv, false);
+        expect(() => toXOnly(uncompressed, "solver key")).toThrow(
+            /solver key is not a compressed or x-only public key/,
+        );
+        expect(() => toXOnly(new Uint8Array(33), "solver key")).toThrow(/solver key/);
+        expect(() => toXOnly(new Uint8Array(0))).toThrow(/public key/);
+    });
+});

--- a/packages/ts-sdk/test/signerRotation.test.ts
+++ b/packages/ts-sdk/test/signerRotation.test.ts
@@ -111,6 +111,10 @@ describe("signerRotation - classification", () => {
     it("rejects malformed signer key lengths", () => {
         expect(() => toXOnlySignerHex("aabb")).toThrow(/invalid signer pubkey length/);
     });
+
+    it("rejects malformed compressed signer key prefixes", () => {
+        expect(() => toXOnlySignerHex("00" + "aa".repeat(32))).toThrow(/signer key/);
+    });
 });
 
 describe("RestArkProvider.getInfo - deprecated signer parsing", () => {


### PR DESCRIPTION
Closes #733.

`toXOnlySignerHex` covered hex→hex; there was no `Uint8Array → 32-byte Uint8Array` equivalent, so the SDK stripped the compressed prefix inline wherever it needed one (`arkade/tweak.ts`, `arkade/contract.ts`, …) and `@arkade-os/swap` kept a private copy of the same function.

`toXOnly(key, label?)` in `src/utils/keys.ts`, exported from the index:
- rewires the three `arkade/` sites, two of which had no validation at all — `contract.ts` did an unconditional `.slice(1)` on `info.signerPubkey`, which silently truncates an x-only key arkd advertised in that form;
- replaces swap's local copy at all 14 call sites, keeping the per-call label so refusals still name which key was wrong.

Refuses anything that is neither compressed nor x-only. An uncompressed key stripped of one byte yields a well-formed 32-byte value that is not the key, which would surface later as an address nobody funded.

`toXOnlySignerHex` is left alone — it is signer-rotation-specific (hex in, lowercase hex out, its own error vocabulary pinned by a test).