### PR TITLE
feat(sdk): surface maxTxWeight and maxOpReturnOutputs from GetInfo

### DIFF
--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -189,6 +189,21 @@ export interface ArkInfo {
      */
     vtxoTreeExpiry?: bigint;
     /**
+     * Weight budget an ark transaction must stay under; the server answers
+     * `TX_TOO_LARGE` past it.
+     *
+     * `undefined` when not advertised — never coerce to `0n`, which reads as a
+     * server that accepts no transaction at all.
+     */
+    maxTxWeight?: bigint;
+    /**
+     * Maximum OP_RETURN outputs the server accepts per transaction.
+     *
+     * `undefined` when not advertised — never coerce to `0n`, which reads as a
+     * server that forbids them outright.
+     */
+    maxOpReturnOutputs?: bigint;
+    /**
      * Maximum boarding input amount.
      *
      * @remarks
@@ -474,6 +489,12 @@ export class RestArkProvider implements ArkProvider {
             unilateralExitDelay: BigInt(fromServer.unilateralExitDelay ?? 0),
             vtxoTreeExpiry:
                 fromServer.vtxoTreeExpiry != null ? BigInt(fromServer.vtxoTreeExpiry) : undefined,
+            maxTxWeight:
+                fromServer.maxTxWeight != null ? BigInt(fromServer.maxTxWeight) : undefined,
+            maxOpReturnOutputs:
+                fromServer.maxOpReturnOutputs != null
+                    ? BigInt(fromServer.maxOpReturnOutputs)
+                    : undefined,
             utxoMaxAmount: BigInt(fromServer.utxoMaxAmount ?? -1),
             utxoMinAmount: BigInt(fromServer.utxoMinAmount ?? 0),
             version: fromServer.version ?? "",

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -192,15 +192,17 @@ export interface ArkInfo {
      * Weight budget an ark transaction must stay under; the server answers
      * `TX_TOO_LARGE` past it.
      *
-     * `undefined` when not advertised — never coerce to `0n`, which reads as a
-     * server that accepts no transaction at all.
+     * `undefined` when not advertised — a server that omits the field and one
+     * that sends `0` both mean "no limit stated". Never `0n`, which would read
+     * as a server that accepts no transaction at all.
      */
     maxTxWeight?: bigint;
     /**
      * Maximum OP_RETURN outputs the server accepts per transaction.
      *
-     * `undefined` when not advertised — never coerce to `0n`, which reads as a
-     * server that forbids them outright.
+     * `undefined` when not advertised — a server that omits the field and one
+     * that sends `0` both mean "no limit stated". Never `0n`, which would read
+     * as a server that forbids them outright.
      */
     maxOpReturnOutputs?: bigint;
     /**
@@ -299,6 +301,24 @@ export interface ArkProvider {
 
     /** Fetch pending transactions for a signed get-pending-tx intent. */
     getPendingTxs(intent: SignedIntent<Intent.GetPendingTxMessage>): Promise<PendingTx[]>;
+}
+
+/**
+ * Reads a transaction limit the operator advertises on `GetInfo`.
+ *
+ * `max_tx_weight` and `max_op_return_outputs` are non-optional `int64` in
+ * `GetInfoResponse`, and the gateway marshals with EmitUnpopulated, so an arkd
+ * carrying the fields but not configuring them sends `"0"` instead of omitting
+ * them. Field absent (an arkd predating them) and field zero are the same
+ * statement — the operator did not advertise a limit — so both answer
+ * `undefined`. `0n` would read as a server that accepts no transaction at all
+ * and forbids OP_RETURN outright, which is the opposite of "did not say".
+ * NArk reads the same zero as unset (`SpendingService.GetMaxOpReturnOutputs`).
+ */
+function advertisedLimit(fromServer: unknown): bigint | undefined {
+    if (fromServer == null) return undefined;
+    const limit = BigInt(fromServer as string | number | bigint);
+    return limit > 0n ? limit : undefined;
 }
 
 /**
@@ -489,12 +509,8 @@ export class RestArkProvider implements ArkProvider {
             unilateralExitDelay: BigInt(fromServer.unilateralExitDelay ?? 0),
             vtxoTreeExpiry:
                 fromServer.vtxoTreeExpiry != null ? BigInt(fromServer.vtxoTreeExpiry) : undefined,
-            maxTxWeight:
-                fromServer.maxTxWeight != null ? BigInt(fromServer.maxTxWeight) : undefined,
-            maxOpReturnOutputs:
-                fromServer.maxOpReturnOutputs != null
-                    ? BigInt(fromServer.maxOpReturnOutputs)
-                    : undefined,
+            maxTxWeight: advertisedLimit(fromServer.maxTxWeight),
+            maxOpReturnOutputs: advertisedLimit(fromServer.maxOpReturnOutputs),
             utxoMaxAmount: BigInt(fromServer.utxoMaxAmount ?? -1),
             utxoMinAmount: BigInt(fromServer.utxoMinAmount ?? 0),
             version: fromServer.version ?? "",

--- a/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
+++ b/packages/ts-sdk/src/wallet/arkInfoSnapshot.ts
@@ -39,6 +39,10 @@ export type StoredArkInfoSnapshot = {
         boardingExitDelay: string;
         /** Absent on snapshots written before the operator advertised it. */
         vtxoTreeExpiry?: string;
+        /** Absent on snapshots written before the operator advertised it. */
+        maxTxWeight?: string;
+        /** Absent on snapshots written before the operator advertised it. */
+        maxOpReturnOutputs?: string;
         sessionDuration: string;
         dust: string;
         fees: FeeInfo;
@@ -89,6 +93,8 @@ export function serializeArkInfoSnapshot(info: ArkInfo, savedAt: number): Stored
             unilateralExitDelay: info.unilateralExitDelay.toString(),
             boardingExitDelay: info.boardingExitDelay.toString(),
             vtxoTreeExpiry: info.vtxoTreeExpiry?.toString(),
+            maxTxWeight: info.maxTxWeight?.toString(),
+            maxOpReturnOutputs: info.maxOpReturnOutputs?.toString(),
             sessionDuration: info.sessionDuration.toString(),
             dust: info.dust.toString(),
             fees: info.fees,
@@ -149,6 +155,9 @@ export function hydrateArkInfo(snapshot: StoredArkInfoSnapshot): ArkInfo {
         signerPubkey: a.signerPubkey,
         unilateralExitDelay: BigInt(a.unilateralExitDelay),
         vtxoTreeExpiry: a.vtxoTreeExpiry !== undefined ? BigInt(a.vtxoTreeExpiry) : undefined,
+        maxTxWeight: a.maxTxWeight !== undefined ? BigInt(a.maxTxWeight) : undefined,
+        maxOpReturnOutputs:
+            a.maxOpReturnOutputs !== undefined ? BigInt(a.maxOpReturnOutputs) : undefined,
         utxoMaxAmount: BigInt(a.utxoMaxAmount),
         utxoMinAmount: BigInt(a.utxoMinAmount),
         version: a.version,
@@ -231,8 +240,10 @@ export function parseStoredArkInfoSnapshot(raw: unknown): StoredArkInfoSnapshot 
     ]) {
         assertDecimalString(a[field], `arkInfo.${field}`);
     }
-    if (a.vtxoTreeExpiry !== undefined) {
-        assertDecimalString(a.vtxoTreeExpiry, "arkInfo.vtxoTreeExpiry");
+    for (const field of ["vtxoTreeExpiry", "maxTxWeight", "maxOpReturnOutputs"]) {
+        if (a[field] !== undefined) {
+            assertDecimalString(a[field], `arkInfo.${field}`);
+        }
     }
     assertFeeInfo(a.fees, "arkInfo.fees");
 

--- a/packages/ts-sdk/test/ark-info-snapshot.test.ts
+++ b/packages/ts-sdk/test/ark-info-snapshot.test.ts
@@ -111,6 +111,38 @@ describe("serializeArkInfoSnapshot / hydrateArkInfo", () => {
         expect(() => parseStoredArkInfoSnapshot(raw)).not.toThrow();
         expect(hydrateArkInfo(parseStoredArkInfoSnapshot(raw)).vtxoTreeExpiry).toBeUndefined();
     });
+
+    it("round-trips the transaction limits when advertised", () => {
+        const info = makeArkInfo({ maxTxWeight: 40_000n, maxOpReturnOutputs: 3n });
+        const snapshot = serializeArkInfoSnapshot(info, 1);
+        expect(snapshot.arkInfo.maxTxWeight).toBe("40000");
+        expect(snapshot.arkInfo.maxOpReturnOutputs).toBe("3");
+        expect(hydrateArkInfo(snapshot)).toEqual({ ...info, serviceStatus: {} });
+    });
+
+    it("keeps the transaction limits undefined when not advertised — never 0n", () => {
+        // 0n would read as a server that accepts no transaction and forbids
+        // OP_RETURN outright, which is the opposite of "did not say".
+        const snapshot = serializeArkInfoSnapshot(makeArkInfo(), 1);
+        expect(hydrateArkInfo(snapshot).maxTxWeight).toBeUndefined();
+        expect(hydrateArkInfo(snapshot).maxOpReturnOutputs).toBeUndefined();
+    });
+
+    it("accepts a snapshot written before the transaction limits existed", () => {
+        const raw = JSON.parse(
+            JSON.stringify(
+                serializeArkInfoSnapshot(
+                    makeArkInfo({ maxTxWeight: 40_000n, maxOpReturnOutputs: 3n }),
+                    1,
+                ),
+            ),
+        );
+        delete raw.arkInfo.maxTxWeight;
+        delete raw.arkInfo.maxOpReturnOutputs;
+        const hydrated = hydrateArkInfo(parseStoredArkInfoSnapshot(raw));
+        expect(hydrated.maxTxWeight).toBeUndefined();
+        expect(hydrated.maxOpReturnOutputs).toBeUndefined();
+    });
 });
 
 describe("parseStoredArkInfoSnapshot", () => {

--- a/packages/ts-sdk/test/ark-provider.test.ts
+++ b/packages/ts-sdk/test/ark-provider.test.ts
@@ -101,4 +101,14 @@ describe("RestArkProvider.getInfo transaction limits", () => {
         expect(info.maxTxWeight).toBeUndefined();
         expect(info.maxOpReturnOutputs).toBeUndefined();
     });
+
+    it("reads a server-emitted zero as unadvertised, not as a limit of nothing", async () => {
+        // Both fields are non-optional int64 on GetInfoResponse and the gateway
+        // marshals with EmitUnpopulated, so an arkd that carries them without
+        // configuring them sends "0" rather than omitting them. That is the same
+        // statement as omitting them, and must not surface as 0n.
+        const info = await infoResponse({ maxTxWeight: "0", maxOpReturnOutputs: "0" });
+        expect(info.maxTxWeight).toBeUndefined();
+        expect(info.maxOpReturnOutputs).toBeUndefined();
+    });
 });

--- a/packages/ts-sdk/test/ark-provider.test.ts
+++ b/packages/ts-sdk/test/ark-provider.test.ts
@@ -74,3 +74,31 @@ describe("RestArkProvider.getEventStream", () => {
         await pending.catch(() => {});
     });
 });
+
+describe("RestArkProvider.getInfo transaction limits", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    const infoResponse = (body: Record<string, unknown>) => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => ({ ok: true, json: async () => body })),
+        );
+        return new RestArkProvider("http://ark.test").getInfo();
+    };
+
+    it("reads maxTxWeight and maxOpReturnOutputs off the wire", async () => {
+        const info = await infoResponse({ maxTxWeight: "40000", maxOpReturnOutputs: "3" });
+        expect(info.maxTxWeight).toBe(40_000n);
+        expect(info.maxOpReturnOutputs).toBe(3n);
+    });
+
+    it("leaves them undefined when the operator advertises neither", async () => {
+        // 0n would read as a weight budget of nothing and OP_RETURN forbidden,
+        // which an older arkd is not saying.
+        const info = await infoResponse({});
+        expect(info.maxTxWeight).toBeUndefined();
+        expect(info.maxOpReturnOutputs).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Closes #382. Also covers #367, closed against this one.

arkd has advertised `max_tx_weight` and `max_op_return_outputs` on `GetInfoResponse` since go-sdk#118; `ArkInfo` carried neither, so a caller validating transaction construction against the server's limits had nothing to read.

Both are optional and stay `undefined` when unadvertised, following `vtxoTreeExpiry`: `0n` would read as a server that accepts no transaction at all and forbids OP_RETURN outright, which an older arkd is not saying.

The cached info snapshot round-trips them too, so a wallet booting from cache keeps the limits it last saw rather than silently losing them.

Not in scope: `MAX_VTXOS_PER_SETTLEMENT = 50` in `vtxo-manager.ts` is a conservative stand-in for exactly this weight budget, and could now be derived from `maxTxWeight` instead of guessed — a behavioural change worth its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reporting maximum transaction weight and OP_RETURN output limits.
  * Preserved these limits when saving and restoring wallet information.
  * Handles missing, zero, and positive server-provided limit values appropriately.

* **Bug Fixes**
  * Improved compatibility with older saved wallet information that does not include transaction limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->