### PR TITLE
chore: scope pre-commit lint/test to changed packages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
-pnpm lint
-pnpm test:unit
+pnpm exec prettier --check config
+pnpm --filter="...[HEAD]" run --if-present lint
+pnpm --filter="...[HEAD]" run --if-present test:unit


### PR DESCRIPTION
**One commit takes 3-4 minutes on my computer.**

## Summary
- Pre-commit previously ran `pnpm lint` and `pnpm test:unit` across the entire monorepo on every commit.
- Now uses pnpm's git-diff package filtering (`--filter="...[HEAD]"`) so lint and test:unit only run for packages that changed since HEAD, plus any packages that depend on them (e.g. a `ts-sdk` change still exercises `boltz-swap`/`swap`, since both declare it as a `workspace:*` dependency).
- The root `prettier --check config` check still always runs (cheap, and not package-scoped).

## Test plan
- [x] No changes staged/unstaged → hook runs only the config prettier check, exits 0.
- [x] Change scoped to `packages/swap` only → hook ran only swap's lint + test:unit (27 files, 583 tests passed), did not touch `ts-sdk` or `boltz-swap`.
- [x] Change in `packages/ts-sdk` → filter correctly includes `boltz-swap` and `swap` as dependents (verified via `pnpm --filter="...[HEAD]" ls`).