### PR TITLE
feat(swap): fillOffer — the taker side an offer has no way to reach

### DIFF
--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -6,7 +6,9 @@ export {
     decodeOffer,
     offerVtxoScript,
     swapPrograms,
+    ASSET_CARRIER_SATS,
     OFFER_PACKET_TYPE,
+    type FillFunding,
     type Offer,
 } from "./offer";
 export {

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -1,6 +1,7 @@
 export {
     createOffer,
     cancelOffer,
+    fillOffer,
     encodeOffer,
     decodeOffer,
     offerVtxoScript,

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -813,6 +813,25 @@ export async function cancelOffer(
     return txid;
 }
 
+/** Sats output 0 carries when the maker is paid in an ASSET rather than sats:
+ * the covenant checks the asset there, and the output still needs a carrier of
+ * its own. Overridable per fill via `assetCarrierSats`. */
+export const ASSET_CARRIER_SATS = BigInt(330);
+
+/**
+ * A coin the taker supplies, plus whatever assets it carries.
+ *
+ * `ArkTxInput` describes sats only, so the assets have to be declared — this is
+ * the one thing a fill cannot discover for itself, and omitting it is not
+ * cosmetic. **arkd refuses a spend whose asset packet omits an asset one of its
+ * inputs owns** (`ASSET_NOT_FOUND`), so a coin picked for its sats that happens
+ * to carry an asset takes the whole fill down unless it is named here. A
+ * wallet's own coins already carry `assets` in this shape.
+ */
+export type FillFunding = ArkTxInput & {
+    assets?: readonly { assetId: string; amount: bigint | number }[];
+};
+
 /**
  * Fill an offer — the TAKER's side, and the counterpart to {@link createOffer}.
  *
@@ -820,6 +839,17 @@ export async function cancelOffer(
  * spend to pay output 0 at least `wantAmount` to the maker's witness program, so
  * a taker cannot take the deposit without delivering. This composes that spend;
  * it does not weaken or reinterpret the covenant.
+ *
+ * **Both want sides.** For a BTC want output 0 pays `wantAmount` sats. For an
+ * ASSET want the covenant reads output 0 through `OP_INSPECTOUTASSETLOOKUP` with
+ * `lookup_index = 0`, so the wanted asset must be the FIRST group in the packet
+ * and output 0 carries only a dust sat carrier ({@link ASSET_CARRIER_SATS}).
+ * Group order follows the order the groups are added, which is why the wanted
+ * asset is added first — reordering it silently breaks the covenant.
+ *
+ * Every other asset in the spend — the deposit's own, and any the taker's
+ * funding coins carry — is routed to the taker's payout. Declaring those is not
+ * optional; see {@link FillFunding}.
  *
  * Unlike {@link cancelOffer} this writes NO local swap record. A taker filling
  * someone else's offer has no row to update — the repository dance there belongs
@@ -845,31 +875,47 @@ export async function fillOffer(
     arkServerUrl: string,
     offerHex: string,
     opts: {
-        /** Coins the taker supplies to pay `wantAmount`. Become inputs 1..n. */
-        fund: ArkTxInput[];
+        /** Coins the taker supplies to pay `wantAmount`, with any assets they
+         * carry. Become inputs 1..n. @see FillFunding */
+        fund: FillFunding[];
         /** Where the taker's proceeds land. Defaults to the wallet's own address. */
         payoutScript?: Uint8Array;
         /** Selects the deposit when the swap address holds more than one. */
         fundingTxid?: string;
         /** The funded address, to pin the server key the covenant was built with. */
         swapAddress?: string;
+        /** Sats at output 0 on an asset want. Defaults to {@link ASSET_CARRIER_SATS};
+         * raise it for a server whose dust threshold is higher. */
+        assetCarrierSats?: bigint;
     },
 ): Promise<string> {
-    const { fund, payoutScript, fundingTxid, swapAddress } = opts;
+    const {
+        fund,
+        payoutScript,
+        fundingTxid,
+        swapAddress,
+        assetCarrierSats = ASSET_CARRIER_SATS,
+    } = opts;
     const offer = decodeOffer(hex.decode(offerHex));
+    const wantedAssetId = offer.wantAsset?.toString();
 
-    // An asset want needs the taker to say which of its inputs carry the asset
-    // and how much, and needs asset change when they carry more than
-    // `wantAmount`. Guessing either produces a spend the covenant rejects for
-    // reasons the error does not explain, so this refuses rather than tries.
-    if (offer.wantAsset) {
-        throw new Error(
-            "fillOffer does not yet support an asset want: the covenant checks the asset at output 0 " +
-                "(INSPECTOUTASSETLOOKUP), which needs an explicit input->output asset binding from the caller",
-        );
-    }
     if (fund.length === 0) {
         throw new Error("fillOffer needs coins to pay wantAmount with — `fund` is empty");
+    }
+    // Checked before anything is read or spent: a fill that cannot deliver is
+    // refused here rather than by the emulator, which reports only that the
+    // covenant said no.
+    if (wantedAssetId !== undefined) {
+        const supplied = fund.reduce(
+            (sum, coin) => sum + amountOfAsset(coin.assets, wantedAssetId),
+            BigInt(0),
+        );
+        if (supplied < offer.wantAmount) {
+            throw new Error(
+                `fillOffer needs ${offer.wantAmount} of ${wantedAssetId} to pay the maker, but ` +
+                    `\`fund\` declares ${supplied} — pass coins carrying it, and declare their assets`,
+            );
+        }
     }
 
     const contractManager = await wallet.getContractManager();
@@ -908,30 +954,86 @@ export async function fillOffer(
     if (!vtxo) throw new Error("no spendable VTXO at the swap address");
 
     const payout = payoutScript ?? ArkAddress.decode(takerAddress).pkScript;
+    // A BTC want is paid in sats at output 0; an asset want is paid through the
+    // packet, so its sats leg is only the carrier the output needs to exist.
+    const makerSats = wantedAssetId === undefined ? offer.wantAmount : assetCarrierSats;
     const fill = contract.functions
         .fulfill()
         .from({ txid: vtxo.txid, vout: vtxo.vout, value: vtxo.value })
         .fund(fund)
         // Output 0, and the order is not cosmetic: the covenant inspects output
         // 0 specifically, so this must be the first `to`.
-        .to(offer.makerPkScript, offer.wantAmount)
+        .to(offer.makerPkScript, makerSats)
         // The taker's proceeds — the deposit it just took, plus any surplus of
-        // its own funding over `wantAmount`.
+        // its own funding. Appended after the outputs above, so it is vout 1.
         .change(payout);
 
-    // A deposit that IS an asset (`offerAsset`) carries it on the covenant
-    // input; move it to the taker rather than letting it vanish. Distinct from
-    // the `wantAsset` case refused above: this asset is not what the covenant
-    // checks, it is what the taker is being paid.
-    for (const a of vtxo.assets ?? []) {
-        fill.withAsset({
-            assetId: a.assetId,
-            inputs: [{ vin: 0, amount: BigInt(a.amount) }],
-            // vout 1 — output 0 is the maker's, which on a BTC want carries no asset.
-            outputs: [{ vout: 1, amount: BigInt(a.amount) }],
-        });
+    // Every asset in the spend, by the input holding it. The deposit is input 0
+    // and the funding coins are 1..n, matching the order the builder assembles.
+    const held = new Map<string, { vin: number; amount: bigint }[]>();
+    const hold = (vin: number, assets: FillFunding["assets"]) => {
+        for (const a of assets ?? []) {
+            const amount = BigInt(a.amount);
+            if (amount <= BigInt(0)) continue;
+            held.set(a.assetId, [...(held.get(a.assetId) ?? []), { vin, amount }]);
+        }
+    };
+    hold(0, vtxo.assets);
+    fund.forEach((coin, i) => hold(i + 1, coin.assets));
+
+    // The taker's asset proceeds land at vout 1 — but `change` only exists when
+    // there is a surplus, and an asset with nowhere to go is a spend arkd will
+    // refuse for a reason the error will not explain.
+    const outputsSum = makerSats;
+    const inputsSum = fund.reduce((s, c) => s + BigInt(c.value), BigInt(vtxo.value));
+    const hasPayoutOutput = inputsSum > outputsSum;
+
+    // THE WANTED ASSET FIRST — group index 0, which is the lookup index the
+    // fulfill script uses. Any other order makes the covenant read the wrong
+    // group and refuse.
+    const emitWanted = () => {
+        if (wantedAssetId === undefined) return;
+        const supplying = held.get(wantedAssetId) ?? [];
+        const supplied = supplying.reduce((s, i) => s + i.amount, BigInt(0));
+        const outputs = [{ vout: 0, amount: offer.wantAmount }];
+        const surplus = supplied - offer.wantAmount;
+        if (surplus > BigInt(0)) {
+            if (!hasPayoutOutput) {
+                throw new Error(
+                    `fillOffer has ${surplus} of ${wantedAssetId} to return but no payout output — ` +
+                        "fund with more sats than the maker's output takes",
+                );
+            }
+            outputs.push({ vout: 1, amount: surplus });
+        }
+        fill.withAsset({ assetId: wantedAssetId, inputs: supplying, outputs });
+        held.delete(wantedAssetId);
+    };
+    emitWanted();
+
+    // Everything else goes to the taker: the deposit's own asset when the maker
+    // wanted sats, and anything a funding coin happened to carry. Declaring the
+    // latter is what keeps arkd from answering ASSET_NOT_FOUND.
+    for (const [assetId, inputs] of held) {
+        const amount = inputs.reduce((s, i) => s + i.amount, BigInt(0));
+        if (!hasPayoutOutput) {
+            throw new Error(
+                `fillOffer has ${amount} of ${assetId} to return but no payout output — ` +
+                    "fund with more sats than the maker's output takes",
+            );
+        }
+        fill.withAsset({ assetId, inputs, outputs: [{ vout: 1, amount }] });
     }
 
     const { txid } = await fill.send();
     return txid;
 }
+
+/** How much of `assetId` a coin's declared assets add up to. */
+const amountOfAsset = (assets: FillFunding["assets"], assetId: string): bigint => {
+    let total = BigInt(0);
+    for (const a of assets ?? []) {
+        if (a.assetId === assetId) total += BigInt(a.amount);
+    }
+    return total;
+};

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -27,6 +27,7 @@ import { concatBytes } from "@scure/btc-signer/utils.js";
 import {
     ArkAddress,
     RestArkProvider,
+    RestEmulatorProvider,
     RestIndexerProvider,
     arkade,
     asset,
@@ -36,6 +37,7 @@ import {
     type ArkTxInput,
     type IWallet,
     type NetworkName,
+    type EmulatorProvider,
     type RelativeTimelock,
 } from "@arkade-os/sdk";
 
@@ -887,6 +889,19 @@ export async function fillOffer(
         /** Sats at output 0 on an asset want. Defaults to {@link ASSET_CARRIER_SATS};
          * raise it for a server whose dust threshold is higher. */
         assetCarrierSats?: bigint;
+        /**
+         * The co-signing service — a base URL, or a provider of your own.
+         *
+         * Required, with no default: `fulfill` is a covenant path, so the
+         * emulator is what executes the arkade script and finalizes the spend
+         * with arkd. A client without one builds the transaction and then
+         * refuses to submit it.
+         */
+        emulator: EmulatorProvider | string;
+        /** Co-signer key override (33-byte compressed hex), as `createOffer`
+         * takes. Needed on a network the SDK pins no emulator key for, where
+         * connecting with an emulator otherwise throws. */
+        emulatorPubkey?: string;
     },
 ): Promise<string> {
     const {
@@ -895,6 +910,8 @@ export async function fillOffer(
         fundingTxid,
         swapAddress,
         assetCarrierSats = ASSET_CARRIER_SATS,
+        emulator,
+        emulatorPubkey,
     } = opts;
     const offer = decodeOffer(hex.decode(offerHex));
     const wantedAssetId = offer.wantAsset?.toString();
@@ -924,6 +941,14 @@ export async function fillOffer(
         indexer: new RestIndexerProvider(arkServerUrl),
         identity: wallet.identity,
         contractManager,
+        // `fulfill` is a covenant path, so the emulator executes the arkade
+        // script and finalizes with arkd. Without it the spend is built and then
+        // refused at submission — there is no default to fall back on.
+        emulator: typeof emulator === "string" ? new RestEmulatorProvider(emulator) : emulator,
+        // Only reached for the client's own emulatorKey, which this fill never
+        // derives against — the offer's own key is bound below. It still has to
+        // resolve, and on a network with no pinned key it throws without this.
+        ...(emulatorPubkey ? { emulatorPubkey } : {}),
     });
 
     // Rebuilt with the OFFER's keys, not the client's, for the same reason

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -246,7 +246,7 @@ function u64(name: string, value: bigint): Uint8Array {
     if (value < BigInt(0) || value >> BigInt(64) > BigInt(0)) {
         throw new Error(`${name} does not fit the offer wire format (u64)`);
     }
-    const out = new Uint8Array(FIELDS.wantAmount.width);
+    const out = new Uint8Array(8);
     new DataView(out.buffer).setBigUint64(0, value, false);
     return out;
 }
@@ -977,6 +977,22 @@ export async function fillOffer(
     }
     const vtxo = fundingTxid ? vtxos.find((v) => v.txid === fundingTxid) : vtxos[0];
     if (!vtxo) throw new Error("no spendable VTXO at the swap address");
+
+    // The covenant checks OUTPUT 0 — what the maker is paid — and says nothing
+    // about what the deposit carries. `offerAsset` is a TLV claim, so a deposit
+    // holding a different asset or none at all still fills: the taker pays
+    // wantAmount and receives what was there, not what was advertised.
+    if (offer.offerAsset) {
+        const offered = offer.offerAsset.toString();
+        const deposited = amountOfAsset(vtxo.assets, offered);
+        if (deposited <= BigInt(0)) {
+            throw new Error(
+                `the deposit at the swap address carries no ${offered}, which this offer sells — ` +
+                    "filling it would pay wantAmount for nothing. The indexer may be behind, or " +
+                    "the offer may not be backed by what it advertises",
+            );
+        }
+    }
 
     const payout = payoutScript ?? ArkAddress.decode(takerAddress).pkScript;
     // A BTC want is paid in sats at output 0; an asset want is paid through the

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -25,6 +25,7 @@
 import { hex } from "@scure/base";
 import { concatBytes } from "@scure/btc-signer/utils.js";
 import {
+    ASSET_CARRIER_SATS as SDK_ASSET_CARRIER_SATS,
     ArkAddress,
     RestArkProvider,
     RestEmulatorProvider,
@@ -817,8 +818,12 @@ export async function cancelOffer(
 
 /** Sats output 0 carries when the maker is paid in an ASSET rather than sats:
  * the covenant checks the asset there, and the output still needs a carrier of
- * its own. Overridable per fill via `assetCarrierSats`. */
-export const ASSET_CARRIER_SATS = BigInt(330);
+ * its own. Overridable per fill via `assetCarrierSats`.
+ *
+ * Derived from the SDK's constant rather than restated, so the two spellings of
+ * one dust threshold cannot drift apart; `bigint` only because this package's
+ * amounts are. */
+export const ASSET_CARRIER_SATS = BigInt(SDK_ASSET_CARRIER_SATS);
 
 /**
  * A coin the taker supplies, plus whatever assets it carries.

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -33,6 +33,7 @@ import {
     getNetwork,
     resolveEmulatorPubkey,
     toXOnlySignerHex,
+    type ArkTxInput,
     type IWallet,
     type NetworkName,
     type RelativeTimelock,
@@ -809,5 +810,128 @@ export async function cancelOffer(
             await retireOfferContract(contractManager, swaps, hex.encode(offer.swapPkScript));
         }
     }
+    return txid;
+}
+
+/**
+ * Fill an offer — the TAKER's side, and the counterpart to {@link createOffer}.
+ *
+ * The covenant's `fulfill` leaf is signed by the server alone and constrains the
+ * spend to pay output 0 at least `wantAmount` to the maker's witness program, so
+ * a taker cannot take the deposit without delivering. This composes that spend;
+ * it does not weaken or reinterpret the covenant.
+ *
+ * Unlike {@link cancelOffer} this writes NO local swap record. A taker filling
+ * someone else's offer has no row to update — the repository dance there belongs
+ * to the funder, whose swap it is. The maker learns the outcome from the chain
+ * (`classifySpend`), which is the design § 7.2 of the RFQ protocol describes.
+ *
+ * `fund` is required and explicit rather than selected here. Coin selection is
+ * the caller's: only they know which coins are reserved for other flows, and a
+ * helper that picked for them would spend a corridor's float out from under it.
+ * The coins become inputs 1..n and are signed with the wallet's identity.
+ *
+ * `payoutScript` is where the taker's proceeds land — the deposit it just took,
+ * plus any surplus over `wantAmount`. Defaults to the wallet's own address.
+ *
+ * Racing a cancel is a NORMAL outcome, not a failure: cancel is a 2-of-2 of the
+ * funder and the server and does not involve the taker, so a funder may cancel
+ * between this reading the deposit and broadcasting. That surfaces the same way
+ * cancel's own race does — "no spendable VTXO at the swap address" — and a
+ * caller should treat it as "the offer is gone", not as an error to retry.
+ */
+export async function fillOffer(
+    wallet: IWallet,
+    arkServerUrl: string,
+    offerHex: string,
+    opts: {
+        /** Coins the taker supplies to pay `wantAmount`. Become inputs 1..n. */
+        fund: ArkTxInput[];
+        /** Where the taker's proceeds land. Defaults to the wallet's own address. */
+        payoutScript?: Uint8Array;
+        /** Selects the deposit when the swap address holds more than one. */
+        fundingTxid?: string;
+        /** The funded address, to pin the server key the covenant was built with. */
+        swapAddress?: string;
+    },
+): Promise<string> {
+    const { fund, payoutScript, fundingTxid, swapAddress } = opts;
+    const offer = decodeOffer(hex.decode(offerHex));
+
+    // An asset want needs the taker to say which of its inputs carry the asset
+    // and how much, and needs asset change when they carry more than
+    // `wantAmount`. Guessing either produces a spend the covenant rejects for
+    // reasons the error does not explain, so this refuses rather than tries.
+    if (offer.wantAsset) {
+        throw new Error(
+            "fillOffer does not yet support an asset want: the covenant checks the asset at output 0 " +
+                "(INSPECTOUTASSETLOOKUP), which needs an explicit input->output asset binding from the caller",
+        );
+    }
+    if (fund.length === 0) {
+        throw new Error("fillOffer needs coins to pay wantAmount with — `fund` is empty");
+    }
+
+    const contractManager = await wallet.getContractManager();
+    const client = await arkade.Arkade.connect({
+        arkade: new RestArkProvider(arkServerUrl),
+        indexer: new RestIndexerProvider(arkServerUrl),
+        identity: wallet.identity,
+        contractManager,
+    });
+
+    // Rebuilt with the OFFER's keys, not the client's, for the same reason
+    // cancelOffer does it: the derived script must match the funded address
+    // exactly or `getUtxos` silently returns nothing and the failure reads as
+    // "no deposit" rather than "wrong key".
+    const serverKey = swapAddress ? ArkAddress.decode(swapAddress).serverPubKey : client.serverKey;
+    const { program, args, keys } = swapProgramBinding(offer, serverKey);
+    const rebuilt = new arkade.ArkadeProgramScript(program, args, keys);
+    if (hex.encode(rebuilt.pkScript) !== hex.encode(offer.swapPkScript)) {
+        throw new Error(
+            "rebuilt covenant does not match the offer's swapPkScript — the server " +
+                "signing key has likely rotated since funding; pass swapAddress (the " +
+                "funded address) to pin the original key",
+        );
+    }
+    const contract = new arkade.ArkadeContract(client, program, args, keys);
+
+    const [vtxos, takerAddress] = await Promise.all([contract.getUtxos(), wallet.getAddress()]);
+    if (!fundingTxid && vtxos.length > 1) {
+        // Identical offers share one address, so guessing would fill an
+        // arbitrary deposit while the caller believes it filled a specific one.
+        throw new Error(
+            "multiple spendable deposits at the swap address — pass fundingTxid to select one",
+        );
+    }
+    const vtxo = fundingTxid ? vtxos.find((v) => v.txid === fundingTxid) : vtxos[0];
+    if (!vtxo) throw new Error("no spendable VTXO at the swap address");
+
+    const payout = payoutScript ?? ArkAddress.decode(takerAddress).pkScript;
+    const fill = contract.functions
+        .fulfill()
+        .from({ txid: vtxo.txid, vout: vtxo.vout, value: vtxo.value })
+        .fund(fund)
+        // Output 0, and the order is not cosmetic: the covenant inspects output
+        // 0 specifically, so this must be the first `to`.
+        .to(offer.makerPkScript, offer.wantAmount)
+        // The taker's proceeds — the deposit it just took, plus any surplus of
+        // its own funding over `wantAmount`.
+        .change(payout);
+
+    // A deposit that IS an asset (`offerAsset`) carries it on the covenant
+    // input; move it to the taker rather than letting it vanish. Distinct from
+    // the `wantAsset` case refused above: this asset is not what the covenant
+    // checks, it is what the taker is being paid.
+    for (const a of vtxo.assets ?? []) {
+        fill.withAsset({
+            assetId: a.assetId,
+            inputs: [{ vin: 0, amount: BigInt(a.amount) }],
+            // vout 1 — output 0 is the maker's, which on a BTC want carries no asset.
+            outputs: [{ vout: 1, amount: BigInt(a.amount) }],
+        });
+    }
+
+    const { txid } = await fill.send();
     return txid;
 }

--- a/packages/swap/test/fill.test.ts
+++ b/packages/swap/test/fill.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { hex } from "@scure/base";
 import { ArkAddress, asset, type IWallet } from "@arkade-os/sdk";
-import { fillOffer, encodeOffer, offerVtxoScript, type Offer } from "../src/offer";
+import {
+    ASSET_CARRIER_SATS,
+    fillOffer,
+    encodeOffer,
+    offerVtxoScript,
+    type Offer,
+} from "../src/offer";
 
 /**
  * `fillOffer` composes a spend the covenant will accept or reject; the tests
@@ -90,6 +96,12 @@ const wantAsset: Omit<Offer, "swapPkScript"> = {
 const assetScript = offerVtxoScript(wantAsset, fundedServerKey);
 const wantAssetHex = hex.encode(encodeOffer({ ...wantAsset, swapPkScript: assetScript.pkScript }));
 
+/** The asset each offer names, plus one nothing asked for — the case that turns
+ * an undeclared coin into an ASSET_NOT_FOUND from arkd. */
+const WANTED_ASSET = "bb".repeat(32) + "0000";
+const DEPOSIT_ASSET = "aa".repeat(32) + "0000";
+const STRAY_ASSET = "cc".repeat(32) + "0000";
+
 const TAKER_PAYOUT = hex.decode("5120" + "11".repeat(32));
 const wallet = {
     identity: {},
@@ -109,15 +121,29 @@ const reset = () => {
 };
 
 describe("fillOffer refuses what it cannot build correctly", () => {
-    it("refuses an asset want rather than guessing the input->output binding", async () => {
+    it("refuses an asset want its funding cannot pay for", async () => {
         reset();
-        // The covenant checks the asset at output 0 (INSPECTOUTASSETLOOKUP), and
-        // only the caller knows which of its coins carry that asset and how
-        // much. A guess produces a spend the covenant rejects for reasons the
-        // error does not explain, so refuse in the open.
+        // The taker's coins are the only source of the wanted asset, and only
+        // the caller knows what they carry. Building a spend that cannot deliver
+        // leaves the emulator to refuse it, reporting nothing more than that the
+        // covenant said no — so name the shortfall here instead.
         await expect(fillOffer(wallet, "http://ark", wantAssetHex, { fund })).rejects.toThrow(
-            /does not yet support an asset want/,
+            /needs 50000 of .*`fund` declares 0/,
         );
+        expect(state.sends).toBe(0);
+    });
+
+    it("refuses to strand an asset it has nowhere to return", async () => {
+        reset();
+        // Assets land on the payout output, which the builder only creates when
+        // there is a sats surplus. With none, the asset would have no output to
+        // go to and arkd would refuse the spend without explaining why.
+        state.utxos = [{ ...coin, value: 50_000, assets: [{ assetId: DEPOSIT_ASSET, amount: 7 }] }];
+        await expect(
+            fillOffer(wallet, "http://ark", wantBtcHex, {
+                fund: [{ ...fund[0], value: 0 }] as never,
+            }),
+        ).rejects.toThrow(/no payout output/);
         expect(state.sends).toBe(0);
     });
 
@@ -179,6 +205,103 @@ describe("fillOffer builds the spend the covenant inspects", () => {
         expect(to).toHaveLength(1);
         expect(hex.encode(to[0].args[0] as Uint8Array)).toBe(MAKER_PK_SCRIPT);
         expect(to[0].args[1]).toBe(BigInt(50_000));
+    });
+
+    it("pays an ASSET want through the packet, with only a carrier at output 0", async () => {
+        reset();
+        const txid = await fillOffer(wallet, "http://ark", wantAssetHex, {
+            fund: [{ ...fund[0], assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }] as never,
+            payoutScript: TAKER_PAYOUT,
+        });
+        expect(txid).toBe("ff".repeat(32));
+
+        // Output 0 carries the dust the output needs to exist, NOT wantAmount
+        // sats: on an asset want the maker is paid through the asset packet, and
+        // paying 50_000 sats there would hand over the taker's own money.
+        const to = callsOf("to");
+        expect(to).toHaveLength(1);
+        expect(hex.encode(to[0].args[0] as Uint8Array)).toBe(MAKER_PK_SCRIPT);
+        expect(to[0].args[1]).toBe(ASSET_CARRIER_SATS);
+
+        // THE WANTED ASSET IS GROUP 0 — the lookup index the fulfill script
+        // uses. It is supplied by the taker's coin (input 1) and delivered to
+        // output 0, which is what the covenant inspects.
+        const assets = callsOf("withAsset");
+        expect(assets).toHaveLength(1);
+        expect(assets[0].args[0]).toEqual({
+            assetId: WANTED_ASSET,
+            inputs: [{ vin: 1, amount: BigInt(50_000) }],
+            outputs: [{ vout: 0, amount: BigInt(50_000) }],
+        });
+    });
+
+    it("returns the taker's surplus of the wanted asset, in the same group", async () => {
+        reset();
+        await fillOffer(wallet, "http://ark", wantAssetHex, {
+            fund: [{ ...fund[0], assets: [{ assetId: WANTED_ASSET, amount: 80_000 }] }] as never,
+            payoutScript: TAKER_PAYOUT,
+        });
+        // The maker gets what the offer asked for; the rest comes back at vout 1
+        // rather than being handed over with it.
+        expect(callsOf("withAsset")[0].args[0]).toEqual({
+            assetId: WANTED_ASSET,
+            inputs: [{ vin: 1, amount: BigInt(80_000) }],
+            outputs: [
+                { vout: 0, amount: BigInt(50_000) },
+                { vout: 1, amount: BigInt(30_000) },
+            ],
+        });
+    });
+
+    it("declares an asset a FUNDING coin merely happens to carry", async () => {
+        reset();
+        // arkd answers ASSET_NOT_FOUND when an input owns an asset the packet
+        // does not mention. Coin selection picks for sats or for the wanted
+        // asset; whatever else those coins hold comes along, and undeclared it
+        // takes the whole fill down.
+        state.utxos = [{ ...coin, assets: [{ assetId: DEPOSIT_ASSET, amount: 900 }] }];
+        await fillOffer(wallet, "http://ark", wantBtcHex, {
+            fund: [{ ...fund[0], assets: [{ assetId: STRAY_ASSET, amount: 7 }] }] as never,
+            payoutScript: TAKER_PAYOUT,
+        });
+        const groups = callsOf("withAsset").map((c) => c.args[0]);
+        expect(groups).toEqual([
+            {
+                assetId: DEPOSIT_ASSET,
+                inputs: [{ vin: 0, amount: BigInt(900) }],
+                outputs: [{ vout: 1, amount: BigInt(900) }],
+            },
+            {
+                assetId: STRAY_ASSET,
+                inputs: [{ vin: 1, amount: BigInt(7) }],
+                outputs: [{ vout: 1, amount: BigInt(7) }],
+            },
+        ]);
+    });
+
+    it("puts the wanted asset first even when other assets are in the spend", async () => {
+        reset();
+        // Group order is packet order, and the fulfill script reads group 0. An
+        // unrelated asset added ahead of the wanted one makes the covenant
+        // inspect the wrong group and refuse.
+        state.utxos = [{ ...coin, assets: [{ assetId: STRAY_ASSET, amount: 3 }] }];
+        await fillOffer(wallet, "http://ark", wantAssetHex, {
+            fund: [{ ...fund[0], assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }] as never,
+            payoutScript: TAKER_PAYOUT,
+        });
+        const groups = callsOf("withAsset").map((c) => (c.args[0] as { assetId: string }).assetId);
+        expect(groups[0]).toBe(WANTED_ASSET);
+        expect(groups).toEqual([WANTED_ASSET, STRAY_ASSET]);
+    });
+
+    it("lets the caller raise the carrier for a higher dust threshold", async () => {
+        reset();
+        await fillOffer(wallet, "http://ark", wantAssetHex, {
+            fund: [{ ...fund[0], assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }] as never,
+            payoutScript: TAKER_PAYOUT,
+            assetCarrierSats: BigInt(1_000),
+        });
+        expect(callsOf("to")[0].args[1]).toBe(BigInt(1_000));
     });
 
     it("takes the deposit as input 0 and the taker's coins as inputs 1..n", async () => {

--- a/packages/swap/test/fill.test.ts
+++ b/packages/swap/test/fill.test.ts
@@ -25,6 +25,9 @@ const state = vi.hoisted(() => ({
     }[],
     // What the fulfill builder received, in call order.
     calls: [] as { fn: string; args: unknown[] }[],
+    // What `Arkade.connect` was configured with — the emulator lives here, and
+    // the builder refuses a covenant spend without one.
+    connects: [] as { emulator?: unknown }[],
     sends: 0,
 }));
 
@@ -35,7 +38,10 @@ vi.mock("@arkade-os/sdk", async (importOriginal) => {
         arkade: {
             ...mod.arkade,
             Arkade: {
-                connect: async () => ({ serverKey: state.serverKey }),
+                connect: async (opts: { emulator?: unknown }) => {
+                    state.connects.push(opts);
+                    return { serverKey: state.serverKey };
+                },
             },
             ArkadeContract: class {
                 getUtxos = async () => state.utxos;
@@ -87,7 +93,8 @@ const btcScript = offerVtxoScript(wantBtc, fundedServerKey);
 const wantBtcHex = hex.encode(encodeOffer({ ...wantBtc, swapPkScript: btcScript.pkScript }));
 const fundedAddress = new ArkAddress(fundedServerKey, btcScript.tweakedPublicKey, "tark").encode();
 
-/** A want-ASSET offer — the case this helper refuses. */
+/** A want-ASSET offer: the fill must deliver the asset at output 0, through the
+ * packet, with only a sat carrier on the output itself. */
 const wantAsset: Omit<Offer, "swapPkScript"> = {
     ...wantBtc,
     offerAsset: undefined,
@@ -102,6 +109,10 @@ const WANTED_ASSET = "bb".repeat(32) + "0000";
 const DEPOSIT_ASSET = "aa".repeat(32) + "0000";
 const STRAY_ASSET = "cc".repeat(32) + "0000";
 
+/** `fulfill` is a covenant path, so the builder refuses to submit without a
+ * co-signer. Required, hence present on every call below. */
+const EMULATOR = "http://emulator.test";
+
 const TAKER_PAYOUT = hex.decode("5120" + "11".repeat(32));
 const wallet = {
     identity: {},
@@ -111,12 +122,19 @@ const wallet = {
 } as unknown as IWallet;
 
 const coin = { txid: "dd".repeat(32), vout: 0, value: 60_000 };
-const fund = [{ txid: "ee".repeat(32), vout: 1, value: 80_000 }] as never;
+/** One taker coin. `as never` because a real `ArkTxInput` also carries a
+ * tapLeafScript and an encoded vtxo script, neither of which the mocked builder
+ * looks at — the shape under test is what the fill ASKS for, not the coin. */
+const fundingCoin = (
+    over: { value?: number; assets?: { assetId: string; amount: number }[] } = {},
+) => [{ txid: "ee".repeat(32), vout: 1, value: 80_000, ...over }] as never;
+const fund = fundingCoin();
 
 const reset = () => {
     state.serverKey = fundedServerKey;
     state.utxos = [coin];
     state.calls = [];
+    state.connects = [];
     state.sends = 0;
 };
 
@@ -127,9 +145,9 @@ describe("fillOffer refuses what it cannot build correctly", () => {
         // the caller knows what they carry. Building a spend that cannot deliver
         // leaves the emulator to refuse it, reporting nothing more than that the
         // covenant said no — so name the shortfall here instead.
-        await expect(fillOffer(wallet, "http://ark", wantAssetHex, { fund })).rejects.toThrow(
-            /needs 50000 of .*`fund` declares 0/,
-        );
+        await expect(
+            fillOffer(wallet, "http://ark", wantAssetHex, { fund, emulator: EMULATOR }),
+        ).rejects.toThrow(/needs 50000 of .*`fund` declares 0/);
         expect(state.sends).toBe(0);
     });
 
@@ -141,7 +159,8 @@ describe("fillOffer refuses what it cannot build correctly", () => {
         state.utxos = [{ ...coin, value: 50_000, assets: [{ assetId: DEPOSIT_ASSET, amount: 7 }] }];
         await expect(
             fillOffer(wallet, "http://ark", wantBtcHex, {
-                fund: [{ ...fund[0], value: 0 }] as never,
+                fund: fundingCoin({ value: 0 }),
+                emulator: EMULATOR,
             }),
         ).rejects.toThrow(/no payout output/);
         expect(state.sends).toBe(0);
@@ -149,9 +168,9 @@ describe("fillOffer refuses what it cannot build correctly", () => {
 
     it("refuses an empty fund, since nothing would pay wantAmount", async () => {
         reset();
-        await expect(fillOffer(wallet, "http://ark", wantBtcHex, { fund: [] })).rejects.toThrow(
-            /`fund` is empty/,
-        );
+        await expect(
+            fillOffer(wallet, "http://ark", wantBtcHex, { fund: [], emulator: EMULATOR }),
+        ).rejects.toThrow(/`fund` is empty/);
         expect(state.sends).toBe(0);
     });
 
@@ -160,17 +179,17 @@ describe("fillOffer refuses what it cannot build correctly", () => {
         state.serverKey = rotatedServerKey;
         // Same failure mode cancelOffer names: a mismatched rebuild makes
         // getUtxos return nothing, and "no deposit" is the wrong diagnosis.
-        await expect(fillOffer(wallet, "http://ark", wantBtcHex, { fund })).rejects.toThrow(
-            /signing key has likely rotated/,
-        );
+        await expect(
+            fillOffer(wallet, "http://ark", wantBtcHex, { fund, emulator: EMULATOR }),
+        ).rejects.toThrow(/signing key has likely rotated/);
     });
 
     it("refuses to guess which deposit to fill when the address holds several", async () => {
         reset();
         state.utxos = [coin, { ...coin, txid: "ab".repeat(32) }];
-        await expect(fillOffer(wallet, "http://ark", wantBtcHex, { fund })).rejects.toThrow(
-            /pass fundingTxid/,
-        );
+        await expect(
+            fillOffer(wallet, "http://ark", wantBtcHex, { fund, emulator: EMULATOR }),
+        ).rejects.toThrow(/pass fundingTxid/);
         expect(state.sends).toBe(0);
     });
 
@@ -180,9 +199,9 @@ describe("fillOffer refuses what it cannot build correctly", () => {
         // A funder may cancel between the read and the broadcast. Cancel's own
         // JSDoc uses this wording for the mirror case; a caller should read it
         // as "the offer is gone", not as a fault.
-        await expect(fillOffer(wallet, "http://ark", wantBtcHex, { fund })).rejects.toThrow(
-            /no spendable VTXO at the swap address/,
-        );
+        await expect(
+            fillOffer(wallet, "http://ark", wantBtcHex, { fund, emulator: EMULATOR }),
+        ).rejects.toThrow(/no spendable VTXO at the swap address/);
     });
 });
 
@@ -193,6 +212,7 @@ describe("fillOffer builds the spend the covenant inspects", () => {
         reset();
         const txid = await fillOffer(wallet, "http://ark", wantBtcHex, {
             fund,
+            emulator: EMULATOR,
             payoutScript: TAKER_PAYOUT,
         });
         expect(txid).toBe("ff".repeat(32));
@@ -210,7 +230,8 @@ describe("fillOffer builds the spend the covenant inspects", () => {
     it("pays an ASSET want through the packet, with only a carrier at output 0", async () => {
         reset();
         const txid = await fillOffer(wallet, "http://ark", wantAssetHex, {
-            fund: [{ ...fund[0], assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }] as never,
+            fund: fundingCoin({ assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }),
+            emulator: EMULATOR,
             payoutScript: TAKER_PAYOUT,
         });
         expect(txid).toBe("ff".repeat(32));
@@ -238,7 +259,8 @@ describe("fillOffer builds the spend the covenant inspects", () => {
     it("returns the taker's surplus of the wanted asset, in the same group", async () => {
         reset();
         await fillOffer(wallet, "http://ark", wantAssetHex, {
-            fund: [{ ...fund[0], assets: [{ assetId: WANTED_ASSET, amount: 80_000 }] }] as never,
+            fund: fundingCoin({ assets: [{ assetId: WANTED_ASSET, amount: 80_000 }] }),
+            emulator: EMULATOR,
             payoutScript: TAKER_PAYOUT,
         });
         // The maker gets what the offer asked for; the rest comes back at vout 1
@@ -261,7 +283,8 @@ describe("fillOffer builds the spend the covenant inspects", () => {
         // takes the whole fill down.
         state.utxos = [{ ...coin, assets: [{ assetId: DEPOSIT_ASSET, amount: 900 }] }];
         await fillOffer(wallet, "http://ark", wantBtcHex, {
-            fund: [{ ...fund[0], assets: [{ assetId: STRAY_ASSET, amount: 7 }] }] as never,
+            fund: fundingCoin({ assets: [{ assetId: STRAY_ASSET, amount: 7 }] }),
+            emulator: EMULATOR,
             payoutScript: TAKER_PAYOUT,
         });
         const groups = callsOf("withAsset").map((c) => c.args[0]);
@@ -286,7 +309,8 @@ describe("fillOffer builds the spend the covenant inspects", () => {
         // inspect the wrong group and refuse.
         state.utxos = [{ ...coin, assets: [{ assetId: STRAY_ASSET, amount: 3 }] }];
         await fillOffer(wallet, "http://ark", wantAssetHex, {
-            fund: [{ ...fund[0], assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }] as never,
+            fund: fundingCoin({ assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }),
+            emulator: EMULATOR,
             payoutScript: TAKER_PAYOUT,
         });
         const groups = callsOf("withAsset").map((c) => (c.args[0] as { assetId: string }).assetId);
@@ -297,16 +321,38 @@ describe("fillOffer builds the spend the covenant inspects", () => {
     it("lets the caller raise the carrier for a higher dust threshold", async () => {
         reset();
         await fillOffer(wallet, "http://ark", wantAssetHex, {
-            fund: [{ ...fund[0], assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }] as never,
+            fund: fundingCoin({ assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }),
+            emulator: EMULATOR,
             payoutScript: TAKER_PAYOUT,
             assetCarrierSats: BigInt(1_000),
         });
         expect(callsOf("to")[0].args[1]).toBe(BigInt(1_000));
     });
 
+    it("connects WITH an emulator, without which the spend cannot be submitted", async () => {
+        reset();
+        // `fulfill` carries an arkadeScript, so ArkadeTransactionBuilder.send()
+        // takes the covenant branch and throws "covenant spends require an
+        // `emulator` on the Arkade client" when the client has none. There is no
+        // per-network default to fall back on, so it has to come from the caller
+        // — and every other test here mocks the builder, so nothing else would
+        // notice a client built without one.
+        await fillOffer(wallet, "http://ark", wantBtcHex, {
+            fund,
+            emulator: EMULATOR,
+            payoutScript: TAKER_PAYOUT,
+        });
+        expect(state.connects).toHaveLength(1);
+        expect(state.connects[0].emulator).toBeDefined();
+    });
+
     it("takes the deposit as input 0 and the taker's coins as inputs 1..n", async () => {
         reset();
-        await fillOffer(wallet, "http://ark", wantBtcHex, { fund, payoutScript: TAKER_PAYOUT });
+        await fillOffer(wallet, "http://ark", wantBtcHex, {
+            fund,
+            emulator: EMULATOR,
+            payoutScript: TAKER_PAYOUT,
+        });
         const from = callsOf("from");
         expect(from).toHaveLength(1);
         expect((from[0].args[0] as { txid: string }).txid).toBe(coin.txid);
@@ -317,7 +363,11 @@ describe("fillOffer builds the spend the covenant inspects", () => {
 
     it("sends the taker's proceeds to the payout script it was given", async () => {
         reset();
-        await fillOffer(wallet, "http://ark", wantBtcHex, { fund, payoutScript: TAKER_PAYOUT });
+        await fillOffer(wallet, "http://ark", wantBtcHex, {
+            fund,
+            emulator: EMULATOR,
+            payoutScript: TAKER_PAYOUT,
+        });
         expect(hex.encode(callsOf("change")[0].args[0] as Uint8Array)).toBe(
             hex.encode(TAKER_PAYOUT),
         );
@@ -325,7 +375,7 @@ describe("fillOffer builds the spend the covenant inspects", () => {
 
     it("defaults the payout to the wallet's own address when none is given", async () => {
         reset();
-        await fillOffer(wallet, "http://ark", wantBtcHex, { fund });
+        await fillOffer(wallet, "http://ark", wantBtcHex, { fund, emulator: EMULATOR });
         const expected = ArkAddress.decode(await wallet.getAddress()).pkScript;
         expect(hex.encode(callsOf("change")[0].args[0] as Uint8Array)).toBe(hex.encode(expected));
     });
@@ -334,7 +384,11 @@ describe("fillOffer builds the spend the covenant inspects", () => {
         reset();
         const assetId = "aa".repeat(32) + "0000";
         state.utxos = [{ ...coin, assets: [{ assetId, amount: 2_000 }] }];
-        await fillOffer(wallet, "http://ark", wantBtcHex, { fund, payoutScript: TAKER_PAYOUT });
+        await fillOffer(wallet, "http://ark", wantBtcHex, {
+            fund,
+            emulator: EMULATOR,
+            payoutScript: TAKER_PAYOUT,
+        });
 
         const spec = callsOf("withAsset")[0].args[0] as {
             assetId: string;
@@ -354,6 +408,7 @@ describe("fillOffer builds the spend the covenant inspects", () => {
         state.utxos = [coin, wanted];
         await fillOffer(wallet, "http://ark", wantBtcHex, {
             fund,
+            emulator: EMULATOR,
             fundingTxid: wanted.txid,
             payoutScript: TAKER_PAYOUT,
         });
@@ -365,6 +420,7 @@ describe("fillOffer builds the spend the covenant inspects", () => {
         state.serverKey = rotatedServerKey;
         const txid = await fillOffer(wallet, "http://ark", wantBtcHex, {
             fund,
+            emulator: EMULATOR,
             swapAddress: fundedAddress,
             payoutScript: TAKER_PAYOUT,
         });

--- a/packages/swap/test/fill.test.ts
+++ b/packages/swap/test/fill.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from "vitest";
+import { hex } from "@scure/base";
+import { ArkAddress, asset, type IWallet } from "@arkade-os/sdk";
+import { fillOffer, encodeOffer, offerVtxoScript, type Offer } from "../src/offer";
+
+/**
+ * `fillOffer` composes a spend the covenant will accept or reject; the tests
+ * that matter are about the SHAPE it builds, not about the network. Same seam
+ * as `cancel.test.ts`: mock `Arkade.connect` and `ArkadeContract`, keep the real
+ * covenant derivation underneath, and record what the builder was asked for.
+ */
+const state = vi.hoisted(() => ({
+    serverKey: new Uint8Array(0) as Uint8Array,
+    utxos: [] as {
+        txid: string;
+        vout: number;
+        value: number;
+        assets?: { assetId: string; amount: number }[];
+    }[],
+    // What the fulfill builder received, in call order.
+    calls: [] as { fn: string; args: unknown[] }[],
+    sends: 0,
+}));
+
+vi.mock("@arkade-os/sdk", async (importOriginal) => {
+    const mod = await importOriginal<typeof import("@arkade-os/sdk")>();
+    return {
+        ...mod,
+        arkade: {
+            ...mod.arkade,
+            Arkade: {
+                connect: async () => ({ serverKey: state.serverKey }),
+            },
+            ArkadeContract: class {
+                getUtxos = async () => state.utxos;
+                functions = {
+                    fulfill: () => {
+                        const record =
+                            (fn: string) =>
+                            (...args: unknown[]) => {
+                                state.calls.push({ fn, args });
+                                return chain;
+                            };
+                        const chain = {
+                            from: record("from"),
+                            fund: record("fund"),
+                            to: record("to"),
+                            change: record("change"),
+                            withAsset: record("withAsset"),
+                            send: async () => {
+                                state.sends += 1;
+                                return { txid: "ff".repeat(32) };
+                            },
+                        };
+                        return chain;
+                    },
+                };
+            },
+        },
+    };
+});
+
+const fundedServerKey = hex.decode(
+    "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+);
+const rotatedServerKey = hex.decode(
+    "466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
+);
+
+const MAKER_PK_SCRIPT = "51203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1";
+
+/** A want-BTC offer: the funder deposited an asset and wants sats. */
+const wantBtc: Omit<Offer, "swapPkScript"> = {
+    wantAmount: BigInt(50_000),
+    offerAsset: asset.AssetId.fromString("aa".repeat(32) + "0000"),
+    makerPkScript: hex.decode(MAKER_PK_SCRIPT),
+    makerPublicKey: hex.decode("3c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1"),
+    emulatorPubkey: hex.decode("466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27"),
+};
+const btcScript = offerVtxoScript(wantBtc, fundedServerKey);
+const wantBtcHex = hex.encode(encodeOffer({ ...wantBtc, swapPkScript: btcScript.pkScript }));
+const fundedAddress = new ArkAddress(fundedServerKey, btcScript.tweakedPublicKey, "tark").encode();
+
+/** A want-ASSET offer — the case this helper refuses. */
+const wantAsset: Omit<Offer, "swapPkScript"> = {
+    ...wantBtc,
+    offerAsset: undefined,
+    wantAsset: asset.AssetId.fromString("bb".repeat(32) + "0000"),
+};
+const assetScript = offerVtxoScript(wantAsset, fundedServerKey);
+const wantAssetHex = hex.encode(encodeOffer({ ...wantAsset, swapPkScript: assetScript.pkScript }));
+
+const TAKER_PAYOUT = hex.decode("5120" + "11".repeat(32));
+const wallet = {
+    identity: {},
+    getAddress: async () =>
+        new ArkAddress(fundedServerKey, hex.decode("22".repeat(32)), "tark").encode(),
+    getContractManager: async () => ({}),
+} as unknown as IWallet;
+
+const coin = { txid: "dd".repeat(32), vout: 0, value: 60_000 };
+const fund = [{ txid: "ee".repeat(32), vout: 1, value: 80_000 }] as never;
+
+const reset = () => {
+    state.serverKey = fundedServerKey;
+    state.utxos = [coin];
+    state.calls = [];
+    state.sends = 0;
+};
+
+describe("fillOffer refuses what it cannot build correctly", () => {
+    it("refuses an asset want rather than guessing the input->output binding", async () => {
+        reset();
+        // The covenant checks the asset at output 0 (INSPECTOUTASSETLOOKUP), and
+        // only the caller knows which of its coins carry that asset and how
+        // much. A guess produces a spend the covenant rejects for reasons the
+        // error does not explain, so refuse in the open.
+        await expect(fillOffer(wallet, "http://ark", wantAssetHex, { fund })).rejects.toThrow(
+            /does not yet support an asset want/,
+        );
+        expect(state.sends).toBe(0);
+    });
+
+    it("refuses an empty fund, since nothing would pay wantAmount", async () => {
+        reset();
+        await expect(fillOffer(wallet, "http://ark", wantBtcHex, { fund: [] })).rejects.toThrow(
+            /`fund` is empty/,
+        );
+        expect(state.sends).toBe(0);
+    });
+
+    it("diagnoses a rotated server key instead of reporting a missing deposit", async () => {
+        reset();
+        state.serverKey = rotatedServerKey;
+        // Same failure mode cancelOffer names: a mismatched rebuild makes
+        // getUtxos return nothing, and "no deposit" is the wrong diagnosis.
+        await expect(fillOffer(wallet, "http://ark", wantBtcHex, { fund })).rejects.toThrow(
+            /signing key has likely rotated/,
+        );
+    });
+
+    it("refuses to guess which deposit to fill when the address holds several", async () => {
+        reset();
+        state.utxos = [coin, { ...coin, txid: "ab".repeat(32) }];
+        await expect(fillOffer(wallet, "http://ark", wantBtcHex, { fund })).rejects.toThrow(
+            /pass fundingTxid/,
+        );
+        expect(state.sends).toBe(0);
+    });
+
+    it("reports a vanished deposit the way a lost race reads", async () => {
+        reset();
+        state.utxos = [];
+        // A funder may cancel between the read and the broadcast. Cancel's own
+        // JSDoc uses this wording for the mirror case; a caller should read it
+        // as "the offer is gone", not as a fault.
+        await expect(fillOffer(wallet, "http://ark", wantBtcHex, { fund })).rejects.toThrow(
+            /no spendable VTXO at the swap address/,
+        );
+    });
+});
+
+describe("fillOffer builds the spend the covenant inspects", () => {
+    const callsOf = (fn: string) => state.calls.filter((c) => c.fn === fn);
+
+    it("pays the maker at OUTPUT 0, which is the output the covenant checks", async () => {
+        reset();
+        const txid = await fillOffer(wallet, "http://ark", wantBtcHex, {
+            fund,
+            payoutScript: TAKER_PAYOUT,
+        });
+        expect(txid).toBe("ff".repeat(32));
+
+        // `to` is called exactly once, so the maker's output is index 0. The
+        // covenant's asm is `0 INSPECTOUTPUTVALUE ... 0 INSPECTOUTPUTSCRIPTPUBKEY`
+        // — it inspects output 0 specifically, so a second `to` before this one
+        // would build a spend the server refuses to co-sign.
+        const to = callsOf("to");
+        expect(to).toHaveLength(1);
+        expect(hex.encode(to[0].args[0] as Uint8Array)).toBe(MAKER_PK_SCRIPT);
+        expect(to[0].args[1]).toBe(BigInt(50_000));
+    });
+
+    it("takes the deposit as input 0 and the taker's coins as inputs 1..n", async () => {
+        reset();
+        await fillOffer(wallet, "http://ark", wantBtcHex, { fund, payoutScript: TAKER_PAYOUT });
+        const from = callsOf("from");
+        expect(from).toHaveLength(1);
+        expect((from[0].args[0] as { txid: string }).txid).toBe(coin.txid);
+        // `fund` is what makes this a fill rather than a sweep: the maker is paid
+        // from the TAKER's coins, not out of the deposit.
+        expect(callsOf("fund")[0].args[0]).toBe(fund);
+    });
+
+    it("sends the taker's proceeds to the payout script it was given", async () => {
+        reset();
+        await fillOffer(wallet, "http://ark", wantBtcHex, { fund, payoutScript: TAKER_PAYOUT });
+        expect(hex.encode(callsOf("change")[0].args[0] as Uint8Array)).toBe(
+            hex.encode(TAKER_PAYOUT),
+        );
+    });
+
+    it("defaults the payout to the wallet's own address when none is given", async () => {
+        reset();
+        await fillOffer(wallet, "http://ark", wantBtcHex, { fund });
+        const expected = ArkAddress.decode(await wallet.getAddress()).pkScript;
+        expect(hex.encode(callsOf("change")[0].args[0] as Uint8Array)).toBe(hex.encode(expected));
+    });
+
+    it("moves an asset-carrying DEPOSIT to the taker, not to the maker", async () => {
+        reset();
+        const assetId = "aa".repeat(32) + "0000";
+        state.utxos = [{ ...coin, assets: [{ assetId, amount: 2_000 }] }];
+        await fillOffer(wallet, "http://ark", wantBtcHex, { fund, payoutScript: TAKER_PAYOUT });
+
+        const spec = callsOf("withAsset")[0].args[0] as {
+            assetId: string;
+            inputs: { vin: number; amount: bigint }[];
+            outputs: { vout: number; amount: bigint }[];
+        };
+        // From input 0 — the deposit — to vout 1, the taker's. Output 0 is the
+        // maker's and on a BTC want carries no asset; sending it there would pay
+        // the maker the asset AND the sats.
+        expect(spec.inputs).toEqual([{ vin: 0, amount: BigInt(2_000) }]);
+        expect(spec.outputs).toEqual([{ vout: 1, amount: BigInt(2_000) }]);
+    });
+
+    it("selects a named deposit when the address holds several", async () => {
+        reset();
+        const wanted = { ...coin, txid: "ab".repeat(32) };
+        state.utxos = [coin, wanted];
+        await fillOffer(wallet, "http://ark", wantBtcHex, {
+            fund,
+            fundingTxid: wanted.txid,
+            payoutScript: TAKER_PAYOUT,
+        });
+        expect((callsOf("from")[0].args[0] as { txid: string }).txid).toBe(wanted.txid);
+    });
+
+    it("pins the funded server key when swapAddress is given, past a rotation", async () => {
+        reset();
+        state.serverKey = rotatedServerKey;
+        const txid = await fillOffer(wallet, "http://ark", wantBtcHex, {
+            fund,
+            swapAddress: fundedAddress,
+            payoutScript: TAKER_PAYOUT,
+        });
+        expect(txid).toBe("ff".repeat(32));
+    });
+});

--- a/packages/swap/test/fill.test.ts
+++ b/packages/swap/test/fill.test.ts
@@ -121,7 +121,11 @@ const wallet = {
     getContractManager: async () => ({}),
 } as unknown as IWallet;
 
-const coin = { txid: "dd".repeat(32), vout: 0, value: 60_000 };
+/** A sats-only deposit — what a want-ASSET offer is funded with. */
+const satsDeposit = { txid: "dd".repeat(32), vout: 0, value: 60_000 };
+/** A want-BTC deposit carrying the asset the offer sells — the covenant does not
+ * check that it does, so `fillOffer` has to. */
+const coin = { ...satsDeposit, assets: [{ assetId: DEPOSIT_ASSET, amount: 7 }] };
 /** One taker coin. `as never` because a real `ArkTxInput` also carries a
  * tapLeafScript and an encoded vtxo script, neither of which the mocked builder
  * looks at — the shape under test is what the fill ASKS for, not the coin. */
@@ -130,9 +134,9 @@ const fundingCoin = (
 ) => [{ txid: "ee".repeat(32), vout: 1, value: 80_000, ...over }] as never;
 const fund = fundingCoin();
 
-const reset = () => {
+const reset = (deposit: (typeof coin)[] = [coin]) => {
     state.serverKey = fundedServerKey;
-    state.utxos = [coin];
+    state.utxos = deposit;
     state.calls = [];
     state.connects = [];
     state.sends = 0;
@@ -203,6 +207,21 @@ describe("fillOffer refuses what it cannot build correctly", () => {
             fillOffer(wallet, "http://ark", wantBtcHex, { fund, emulator: EMULATOR }),
         ).rejects.toThrow(/no spendable VTXO at the swap address/);
     });
+
+    // `offerAsset` is a TLV claim about a deposit the covenant never inspects:
+    // it gates output 0 only. A fill against an unbacked deposit succeeds
+    // on-chain and pays wantAmount for nothing.
+    it.each([
+        ["carrying nothing", undefined],
+        ["carrying a different asset", [{ assetId: STRAY_ASSET, amount: 9 }]],
+        ["carrying a zero amount of it", [{ assetId: DEPOSIT_ASSET, amount: 0 }]],
+    ])("refuses a deposit %s the offer says it sells", async (_label, assets) => {
+        reset([{ ...satsDeposit, ...(assets ? { assets } : {}) }]);
+        await expect(
+            fillOffer(wallet, "http://ark", wantBtcHex, { fund, emulator: EMULATOR }),
+        ).rejects.toThrow(/carries no aa+0000, which this offer sells/);
+        expect(state.sends).toBe(0);
+    });
 });
 
 describe("fillOffer builds the spend the covenant inspects", () => {
@@ -228,7 +247,7 @@ describe("fillOffer builds the spend the covenant inspects", () => {
     });
 
     it("pays an ASSET want through the packet, with only a carrier at output 0", async () => {
-        reset();
+        reset([satsDeposit]);
         const txid = await fillOffer(wallet, "http://ark", wantAssetHex, {
             fund: fundingCoin({ assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }),
             emulator: EMULATOR,
@@ -257,7 +276,7 @@ describe("fillOffer builds the spend the covenant inspects", () => {
     });
 
     it("returns the taker's surplus of the wanted asset, in the same group", async () => {
-        reset();
+        reset([satsDeposit]);
         await fillOffer(wallet, "http://ark", wantAssetHex, {
             fund: fundingCoin({ assets: [{ assetId: WANTED_ASSET, amount: 80_000 }] }),
             emulator: EMULATOR,
@@ -319,7 +338,7 @@ describe("fillOffer builds the spend the covenant inspects", () => {
     });
 
     it("lets the caller raise the carrier for a higher dust threshold", async () => {
-        reset();
+        reset([satsDeposit]);
         await fillOffer(wallet, "http://ark", wantAssetHex, {
             fund: fundingCoin({ assets: [{ assetId: WANTED_ASSET, amount: 50_000 }] }),
             emulator: EMULATOR,
@@ -400,6 +419,32 @@ describe("fillOffer builds the spend the covenant inspects", () => {
         // the maker the asset AND the sats.
         expect(spec.inputs).toEqual([{ vin: 0, amount: BigInt(2_000) }]);
         expect(spec.outputs).toEqual([{ vout: 1, amount: BigInt(2_000) }]);
+    });
+
+    it("declares BOTH assets when one deposit VTXO carries two", async () => {
+        reset([
+            {
+                ...satsDeposit,
+                assets: [
+                    { assetId: DEPOSIT_ASSET, amount: 2_000 },
+                    { assetId: STRAY_ASSET, amount: 5 },
+                ],
+            },
+        ]);
+        await fillOffer(wallet, "http://ark", wantBtcHex, {
+            fund,
+            emulator: EMULATOR,
+            payoutScript: TAKER_PAYOUT,
+        });
+
+        const specs = callsOf("withAsset").map(
+            (c) => c.args[0] as { assetId: string; inputs: unknown[]; outputs: unknown[] },
+        );
+        expect(specs.map((s) => s.assetId)).toEqual([DEPOSIT_ASSET, STRAY_ASSET]);
+        for (const spec of specs) {
+            expect(spec.inputs).toEqual([{ vin: 0, amount: expect.any(BigInt) }]);
+            expect(spec.outputs).toEqual([{ vout: 1, amount: expect.any(BigInt) }]);
+        }
     });
 
     it("selects a named deposit when the address holds several", async () => {

--- a/packages/swap/test/fillBuilder.test.ts
+++ b/packages/swap/test/fillBuilder.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import {
+    ArkAddress,
+    CSVMultisigTapscript,
+    MultisigTapscript,
+    Transaction,
+    VtxoScript,
+    asset,
+    type IWallet,
+} from "@arkade-os/sdk";
+import { encodeOffer, fillOffer, offerVtxoScript, type Offer } from "../src/offer";
+
+/**
+ * `fill.test.ts` mocks `ArkadeContract`, so the real builder is never
+ * constructed — which is how `fillOffer` shipped unable to submit anything.
+ * Here only the three REST providers are stubbed, and the assertions read the
+ * ark tx the emulator was actually handed.
+ */
+const state = vi.hoisted(() => ({
+    vtxos: [] as unknown[],
+    managed: null as unknown,
+    emulatorSubmits: 0,
+    arkTx: undefined as string | undefined,
+    prevTxs: new Map<string, string>(),
+}));
+
+vi.mock("@arkade-os/sdk", async (importOriginal) => {
+    const mod = await importOriginal<typeof import("@arkade-os/sdk")>();
+    return {
+        ...mod,
+        RestArkProvider: class {
+            async getInfo() {
+                return {
+                    signerPubkey: `02${hex.encode(SERVER_KEY)}`,
+                    checkpointTapscript: CHECKPOINT,
+                };
+            }
+        },
+        RestIndexerProvider: class {
+            async getVtxos() {
+                return { vtxos: state.vtxos };
+            }
+            async getVirtualTxs(txids: string[]) {
+                return {
+                    txs: txids
+                        .map((t) => state.prevTxs.get(t))
+                        .filter((p): p is string => p !== undefined),
+                };
+            }
+        },
+        RestEmulatorProvider: class {
+            constructor(readonly url: string) {}
+            async submitTx(arkTx: string, checkpointTxs: string[]) {
+                state.emulatorSubmits += 1;
+                state.arkTx = arkTx;
+                return { signedArkTx: arkTx, signedCheckpointTxs: checkpointTxs };
+            }
+        },
+    };
+});
+
+const SERVER_KEY = hex.decode("4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa");
+const CHECKPOINT = hex.encode(
+    CSVMultisigTapscript.encode({
+        timelock: { type: "blocks", value: BigInt(10) },
+        pubkeys: [SERVER_KEY],
+    }).script,
+);
+
+// Real curve points: the builder decodes every output script as taproot.
+const MAKER_KEY = "71102fc86b5c576c72f411e083cc03eb83d1b55065406ba2a483208dbb5074ab";
+const MAKER_PK_SCRIPT = `5120${MAKER_KEY}`;
+const TAKER_PAYOUT = hex.decode(
+    "512035f737927627c4af1e9a39ae02b086c6b31426d0d64f01e5ce3ee8a445bbd667",
+);
+const DEPOSIT_ASSET = "aa".repeat(32) + "0000";
+
+const offer: Omit<Offer, "swapPkScript"> = {
+    wantAmount: BigInt(50_000),
+    offerAsset: asset.AssetId.fromString(DEPOSIT_ASSET),
+    makerPkScript: hex.decode(MAKER_PK_SCRIPT),
+    makerPublicKey: hex.decode(MAKER_KEY),
+    emulatorPubkey: hex.decode("466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27"),
+};
+const script = offerVtxoScript(offer, SERVER_KEY);
+const offerHex = hex.encode(encodeOffer({ ...offer, swapPkScript: script.pkScript }));
+
+/** A coin whose txid is the real id of a prev ark tx the stub indexer serves —
+ * the covenant path resolves one per input and keys them by computed id. */
+let minted = 0;
+const mintCoin = (value: number) => {
+    const seed = ++minted;
+    const key = new Uint8Array([
+        0x51,
+        0x20,
+        ...schnorr.getPublicKey(new Uint8Array(32).fill(seed)),
+    ]);
+    const tx = new Transaction({ version: 3 });
+    tx.addInput({
+        txid: new Uint8Array(32).fill(seed),
+        index: seed,
+        witnessUtxo: { script: key, amount: BigInt(value) },
+    });
+    tx.addOutput({ script: key, amount: BigInt(value) });
+    state.prevTxs.set(tx.id, base64.encode(tx.toPSBT()));
+    return { txid: tx.id, vout: 0, value };
+};
+
+const takerKey = schnorr.getPublicKey(new Uint8Array(32).fill(0x7a));
+const identity = {
+    xOnlyPublicKey: async () => takerKey,
+    sign: vi.fn(async (tx: Transaction) => tx),
+};
+const wallet = {
+    identity,
+    getAddress: async () =>
+        new ArkAddress(SERVER_KEY, hex.decode("22".repeat(32)), "tark").encode(),
+    getContractManager: async () => state.managed,
+} as unknown as IWallet;
+
+const fundingCoin = (value: number) => {
+    const vs = new VtxoScript([
+        MultisigTapscript.encode({ pubkeys: [takerKey, SERVER_KEY] }).script,
+    ]);
+    return { ...mintCoin(value), tapLeafScript: vs.leaves[0], tapTree: vs.encode() };
+};
+
+const deposit = () => ({
+    ...mintCoin(60_000),
+    assets: [{ assetId: DEPOSIT_ASSET, amount: 2_000 }],
+});
+
+const reset = () => {
+    state.managed = null;
+    state.emulatorSubmits = 0;
+    state.arkTx = undefined;
+    identity.sign.mockClear();
+};
+
+const built = () => Transaction.fromPSBT(base64.decode(state.arkTx!));
+
+describe("fillOffer against the REAL Arkade builder", () => {
+    it("reaches the emulator instead of refusing to submit", async () => {
+        reset();
+        state.vtxos = [deposit()];
+        const txid = await fillOffer(wallet, "http://ark", offerHex, {
+            fund: [fundingCoin(80_000)] as never,
+            emulator: "http://emulator.test",
+            payoutScript: TAKER_PAYOUT,
+        });
+        expect(state.emulatorSubmits).toBe(1);
+        expect(txid).toBe(built().id);
+    });
+
+    // `fillOffer` hardcodes vout 1 for every asset it routes, which is only
+    // safe while `.change()` lands there. Pinned against the builder that
+    // decides, with an asset packet in the spend.
+    it("puts the maker at output 0 and the taker's payout at output 1", async () => {
+        reset();
+        state.vtxos = [deposit()];
+        await fillOffer(wallet, "http://ark", offerHex, {
+            fund: [fundingCoin(80_000)] as never,
+            emulator: "http://emulator.test",
+            payoutScript: TAKER_PAYOUT,
+        });
+
+        const tx = built();
+        expect(hex.encode(tx.getOutput(0)!.script!)).toBe(MAKER_PK_SCRIPT);
+        expect(tx.getOutput(0)!.amount).toBe(BigInt(50_000));
+        expect(hex.encode(tx.getOutput(1)!.script!)).toBe(hex.encode(TAKER_PAYOUT));
+        expect(tx.getOutput(1)!.amount).toBe(BigInt(90_000));
+    });
+
+    it("hands the wallet's contract manager to the arkade client", async () => {
+        reset();
+        // Behavioural: the manager is the only source of the deposit here.
+        const registered = deposit();
+        state.vtxos = [];
+        state.managed = {
+            getContracts: async () => [{ script: hex.encode(script.pkScript) }],
+            getContractsWithVtxos: async () => [{ vtxos: [registered] }],
+        };
+        await fillOffer(wallet, "http://ark", offerHex, {
+            fund: [fundingCoin(80_000)] as never,
+            emulator: "http://emulator.test",
+            payoutScript: TAKER_PAYOUT,
+        });
+        expect(state.emulatorSubmits).toBe(1);
+        // 60_000 (the manager's deposit) + 80_000 − 50_000: the payout can only
+        // balance if the coin the manager served is the one that was spent.
+        expect(built().getOutput(1)!.amount).toBe(BigInt(registered.value + 80_000 - 50_000));
+    });
+
+    it("forwards emulatorPubkey, which is the only thing that validates it", async () => {
+        reset();
+        state.vtxos = [deposit()];
+        await expect(
+            fillOffer(wallet, "http://ark", offerHex, {
+                fund: [fundingCoin(80_000)] as never,
+                emulator: "http://emulator.test",
+                emulatorPubkey: "not-a-pubkey",
+                payoutScript: TAKER_PAYOUT,
+            }),
+        ).rejects.toThrow(/33-byte compressed secp256k1 hex/);
+        expect(state.emulatorSubmits).toBe(0);
+    });
+});


### PR DESCRIPTION
Closes #775.

`@arkade-os/swap` can build an offer, fund it, and cancel it. It cannot **fill**
one — so a solver holding the coins an offer asks for has no way through this
package to take it, and the atomic corridor has a maker half and no taker half.

## What it does

```ts
await fillOffer(wallet, arkServerUrl, offerHex, {
  fund,             // coins the taker supplies - inputs 1..n
  emulator,         // REQUIRED: co-signing service URL, or a provider of your own
  payoutScript,     // where the taker's proceeds land; defaults to its own address
  fundingTxid,      // selects the deposit when the swap address holds more than one
  swapAddress,      // pins the server key the covenant was built with
  assetCarrierSats, // sats at output 0 on an asset want
  emulatorPubkey,   // co-signer key override, for a network the SDK pins none for
})
```

Spends the offer's `fulfill` leaf: the deposit becomes input 0, the taker's coins
follow, output 0 pays the maker, and the change is the taker's payout. That
output-0 binding is the covenant's whole enforcement, so the fill either
satisfies it or the spend is invalid. There is no exposure window and nothing to
unwind on failure.

Both directions are supported: a **BTC want** pays `wantAmount` in sats at output
0, and an **asset want** pays through the asset packet with only a carrier on the
output itself. The wanted asset is emitted as group 0, which is the lookup index
`fulfill` reads.

## Decisions worth review

**`emulator` is required, with no default.** `fulfill` carries an
`arkadeScript`, so `ArkadeTransactionBuilder.send()` takes the covenant branch
and needs a co-signer; without one it builds the transaction and then refuses to
submit it. There is no discovery path - `ArkInfo` exposes no emulator endpoint -
so it is a pass-through parameter, mirroring `arkServerUrl`. This is the shape
@pietro909 confirmed against arkd and NArk master: arkd's `VerifyVtxoTapscriptSigs`
demands a signature from every non-server pubkey in the closure, and for a
covenant leaf that includes the emulator key tweaked by the arkade-script hash,
so a hand-assembled spend through plain `submitTx` dies as `INVALID_SIGNATURE`.
The taker of an offer is a solver, which already runs emulator-wired
infrastructure; the maker paths (`createOffer`, `cancelOffer`) need none.

**The deposit is checked against what the offer advertises.** `offerAsset` is a
TLV claim about a deposit the covenant never inspects - `fulfill` gates output 0,
what the *maker* is paid. So a fill against a deposit carrying a different asset,
or none, would go through: the taker pays `wantAmount` and receives whatever
happened to be there. Refused before the spend is built.

**`swapAddress` pins the server key.** The covenant is built against a specific
Arkade Service key; deriving it from anything but the funded address risks
reconstructing a different script than the one holding the money.

## Verification

Two test files, at two different seams, and the split is the point:

- `test/fill.test.ts` (23 tests) mocks `ArkadeContract` and records what the
  builder was asked for - the right level for shape, refusals and asset routing.
- `test/fillBuilder.test.ts` (4 tests) stubs **only** the three REST providers.
  `Arkade.connect`, the contract, the builder, the checkpoints and the packets
  are real, and the assertions read the ark tx the emulator was handed.

The second file exists because the first cannot catch a whole class of bug: with
`ArkadeContract` mocked, the real builder is never constructed, which is how a
`fillOffer` that could never submit anything passed a fully green suite. It pins
that the spend reaches the emulator, that the maker is at output 0 and the
taker's payout at output 1 (the ordering `withAsset({ vout: 1 })` depends on,
with an asset packet present), that the contract manager reaches the client, and
that `emulatorPubkey` is forwarded.

Rebased onto `master` (`45a5369`). `pnpm -r build` exit 0, then
`pnpm run test:unit`: **234 files / 4392 passed / 1 skipped / 0 failing**,
against a `45a5369` baseline of 232 / 4365 / 1 / 0.

## Not covered

**No live-relay or regtest run.** The emulator round trip is stubbed, not
exercised: this has never filled a real offer against a running Arkade Service
and emulator. That is the claim I would most expect to be wrong. A regtest e2e
against the existing `emulator` compose profile is the right next gate.

**Checkpoint completeness is not asserted on the emulator's reply.** NArk's
submitter checks that the response is fully co-signed;
`ArkadeTransactionBuilder.send()` does not. That belongs in `packages/ts-sdk`,
where it would change every covenant spend, and is deliberately not bundled
here.

The solver-side pieces that would exercise it — an offer-fill store, the fill
adapter, inventory, and a deposit observer — already exist in the service repo.
This is the SDK primitive they are all waiting on; the orchestrator that joins
them is the next piece and is deliberately not in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for completing offers involving asset payments and asset-aware funding.
  * Added asset delivery to takers, maker payouts, surplus returns, and configurable satoshi carriers.
  * Exposed offer-filling functionality, funding types, and the asset-carrier amount for integrators.

* **Bug Fixes**
  * Improved validation for insufficient asset funding, unavailable or ambiguous deposits, unsupported assets, invalid keys, and deposits lacking the advertised asset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
