### PR TITLE
fix(swap): seal claim packets with @noble/ciphers, not crypto.subtle

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -7,6 +7,11 @@ Node-specific APIs, so it runs in Node, the browser, and React Native alike. Fou
 ship — in-memory (anywhere, nothing outlives the process), IndexedDB (browser), SQLite and Realm
 (React Native, on subpath entry points) — see "Storage backends" below.
 
+The one global the core API requires is `crypto.getRandomValues`. Node and browsers have it;
+React Native does not, so install `react-native-get-random-values` (or `expo-crypto`) and import
+it before this package. `crypto.subtle` is not used. `EventSource` and `WebSocket` are needed only
+by the watch and relay transports, both of which take an injected implementation.
+
 ## Roles
 
 Arkade Intents names two participants:

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -78,6 +78,7 @@
     "dependencies": {
         "@arkade-os/sdk": "workspace:*",
         "@arkade-os/solver-discovery": "0.2.3",
+        "@noble/ciphers": "2.1.1",
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",

--- a/packages/swap/src/claimPacket.ts
+++ b/packages/swap/src/claimPacket.ts
@@ -13,6 +13,7 @@
  * against covclaimd's before production use (see the package README).
  */
 import { base64 } from "@scure/base";
+import { gcm } from "@noble/ciphers/aes.js";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { hkdf } from "@noble/hashes/hkdf.js";
 import { sha256 } from "@noble/hashes/sha2.js";
@@ -33,7 +34,7 @@ export interface ClaimPacketInput {
 }
 
 /**
- * Seal a preimage to covclaimd. WebCrypto AES-GCM, hence async.
+ * Seal a preimage to covclaimd.
  *
  * The ephemeral key and nonce are generated here and CANNOT be supplied by a
  * caller. That is the point of this signature: AES-GCM under a repeated
@@ -72,20 +73,7 @@ export async function sealWithEntropy(
     const key = hkdf(sha256, sharedX, ephemeralPub, HKDF_INFO, 32);
 
     if (nonce.length !== 12) throw new Error("nonce must be 12 bytes");
-    const aesKey = await crypto.subtle.importKey("raw", key as BufferSource, "AES-GCM", false, [
-        "encrypt",
-    ]);
-    const sealed = new Uint8Array(
-        await crypto.subtle.encrypt(
-            {
-                name: "AES-GCM",
-                iv: nonce as BufferSource,
-                additionalData: ephemeralPub as BufferSource,
-            },
-            aesKey,
-            input.preimage as BufferSource,
-        ),
-    );
+    const sealed = gcm(key, nonce, ephemeralPub).encrypt(input.preimage);
 
     const packet = new Uint8Array(33 + 12 + sealed.length);
     packet.set(ephemeralPub, 0);

--- a/packages/swap/test/claimPacket.test.ts
+++ b/packages/swap/test/claimPacket.test.ts
@@ -4,7 +4,7 @@
  * covclaimd's reference vectors before production use (see the README and
  * TODO(claim-packet-vectors) in the source).
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { base64, hex } from "@scure/base";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 
@@ -76,6 +76,27 @@ describe("sealClaimPacket", () => {
                 new Uint8Array(11),
             ),
         ).rejects.toThrow(/12 bytes/);
+    });
+
+    // Hermes has no `crypto.subtle`; the suite otherwise runs only where it exists.
+    it("seals without crypto.subtle", async () => {
+        const { getRandomValues } = globalThis.crypto;
+        vi.stubGlobal("crypto", {
+            getRandomValues: getRandomValues.bind(globalThis.crypto),
+        });
+        const packet = await (async () => {
+            try {
+                expect(globalThis.crypto.subtle).toBeUndefined();
+                return await sealClaimPacket({
+                    preimage: PREIMAGE,
+                    covclaimdPubkey: COVCLAIMD_PK,
+                });
+            } finally {
+                vi.unstubAllGlobals();
+            }
+        })();
+        const opened = await openClaimPacket(packet.ciphertext, COVCLAIMD_SK);
+        expect(hex.encode(opened)).toBe(hex.encode(PREIMAGE));
     });
 
     it("fresh randomness per packet: two seals of the same P differ", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@arkade-os/solver-discovery':
         specifier: 0.2.3
         version: 0.2.3
+      '@noble/ciphers':
+        specifier: 2.1.1
+        version: 2.1.1
       '@noble/curves':
         specifier: 2.0.1
         version: 2.0.1
@@ -1602,6 +1605,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}


### PR DESCRIPTION
Closes #789.

`sealClaimPacket` sealed with WebCrypto. Hermes ships no `SubtleCrypto`, so
`crypto.subtle.importKey` threw on device and both RFQ receive corridors —
`requestLightningReceive`, `requestOnchainReceive` — were unavailable on React
Native, one of the three targets the README advertises. These were the only
`crypto.subtle` calls in the repo; every other primitive in the same function
was already `@noble`.

```ts
const sealed = gcm(key, nonce, ephemeralPub).encrypt(input.preimage);
```

## Wire identity

**The pinned vector in `test/claimPacket.test.ts` is unchanged** — that is the
load-bearing evidence here, not the diff. WebCrypto's AES-GCM at the default
128-bit tag returns `ciphertext ‖ tag`, exactly what `gcm` returns.

Before writing the change I ran both implementations side by side: identical on
the pinned vector, identical across 200 random (ephemeral key, nonce, plaintext)
triples, and a WebCrypto `decrypt` opens a noble-sealed packet.

That last one is now permanent. `openClaimPacket` in the test helper still uses
`crypto.subtle` — correctly, since it stands in for covclaimd — so the
round-trip test seals with noble and opens with WebCrypto. It was
WebCrypto-to-WebCrypto before, i.e. self-consistent; it is a cross-implementation
check now.

`@noble/ciphers@2.1.1` was already in the lockfile via `nostr-tools`, so it
dedupes rather than resolving anything new. Zero runtime deps, ESM-only with the
same export shape as `@noble/curves` and `@noble/hashes`, which the CJS build
already externalizes.

## Two things worth review

**The signatures stay `async`.** Not just to avoid churning a public export: the
malformed-input test asserts `await expect(...).rejects.toThrow(/12 bytes/)`,
which needs a rejected promise, not a sync throw.

**The 12-byte nonce guard is load-bearing now.** WebCrypto and `gcm` both accept
other IV lengths, but under `gcm` dropping that check as redundant validation
would emit a malformed packet instead of throwing. It has to stay above the
call.

## The CI blind spot

The suite runs under vitest on Node, where `crypto.subtle` exists, so
`test/claimPacket.test.ts` was fully green on a code path that could not execute
on React Native. Fixing the call without fixing that leaves the same class of
bug free to come back.

Added `seals without crypto.subtle`, which stubs `globalThis.crypto` down to
`getRandomValues`. Reverting the source and running it reproduces the reported
`TypeError: Cannot read properties of undefined (reading 'importKey')`, so it
is not vacuous.

## Verification

`lint`, `typecheck`, `build`, `smoke:dist` clean; 3901 unit tests pass across
all three packages. `subtle` no longer appears anywhere in the built `dist`, and
`@noble/ciphers/aes.js` is externalized under both `import` and `require`.

## Not covered

**No device run.** The RN condition is reproduced by stubbing the global, not by
executing on Hermes. #789 observed the Lightning path on an Android emulator and
the onchain path by inspection; this PR does not add evidence on either.

`TODO(claim-packet-vectors)` is untouched and still open. Everything above is
byte-agreement between two AES-GCM implementations — it says nothing about
whether our scheme agrees with covclaimd's reference. If those disagree it is a
separate and more serious bug, neither introduced nor fixed here.

The README now names `crypto.getRandomValues` as the one global the core API
requires. It is the only one left after this change, RN does not ship it either,
and the "runs in Node, the browser, and React Native alike" claim was silent on
it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved claim-packet encryption compatibility in environments without WebCrypto’s `crypto.subtle`.
  - Preserved existing packet formats and encryption behavior.

- **Documentation**
  - Clarified runtime requirements for browser, Node.js, and React Native applications.
  - Documented optional setup for React Native cryptographic support and transport-specific APIs.

- **Tests**
  - Added coverage for claim-packet sealing and opening without `crypto.subtle`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->