### PR TITLE
chore: upgrade regtest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,9 @@ jobs:
               test/e2e/onchain.test.ts
               test/e2e/deprecatedSignerMigration.test.ts
               test/e2e/digestMismatch.test.ts
-          - package: boltz-swap
-            group: all
-            test_files: ""
+          # boltz-swap is deprecated: no integration stack is spun up for it.
+          # The check job still type-checks, builds and smoke-tests it, since
+          # release.yml can still publish the package.
           - package: swap
             group: all
             test_files: ""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,14 @@ and naming when they conflict with the inherited Go-shaped patterns here.
 
 ## Core Package, Plugins & Code Reuse
 
-`@arkade-os/sdk` is the core package. `@arkade-os/boltz-swap` and `@arkade-os/swap` should be
-treated as plugin-style extensions of that core, and as examples of the many integrations/plugins
-expected to exist over time. Prefer reusing existing SDK utilities, types, primitives, and helper
-functions from `packages/ts-sdk` instead of duplicating equivalent logic in a plugin. When shared
-behavior is generally useful beyond one plugin and belongs to the wallet/protocol core, promote it
-into `ts-sdk` rather than copying it outward.
+`@arkade-os/sdk` is the core package. `@arkade-os/swap` should be treated as a plugin-style
+extension of that core, and as an example of the many integrations/plugins expected to exist over
+time. `@arkade-os/boltz-swap` is **deprecated and unmaintained** — it still builds and ships, but
+runs no integration suite; do not extend it or treat its patterns as precedent. Prefer reusing
+existing SDK utilities, types, primitives, and helper functions from `packages/ts-sdk` instead of
+duplicating equivalent logic in a plugin. When shared behavior is generally useful beyond one
+plugin and belongs to the wallet/protocol core, promote it into `ts-sdk` rather than copying it
+outward.
 
 Keep the dependency and ownership direction clear: plugins may depend on and consume `ts-sdk`, but
 `ts-sdk` must remain independent of plugin packages and must not import from or special-case any of

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Arkade Monorepo
 
-TypeScript packages for the Arkade Bitcoin wallet ecosystem — on-chain/off-chain wallets via the Ark protocol and Lightning/chain swaps via Boltz.
+TypeScript packages for the Arkade Bitcoin wallet ecosystem — on-chain/off-chain wallets via the Ark protocol and Arkade Intents asset swaps.
 
 ## Packages
 
 | Package | Description |
 |---------|-------------|
 | [`@arkade-os/sdk`](packages/ts-sdk/) | Bitcoin wallet SDK with Taproot and Ark protocol support |
-| [`@arkade-os/boltz-swap`](packages/boltz-swap/) | Lightning and chain swaps using Boltz |
+| [`@arkade-os/boltz-swap`](packages/boltz-swap/) | **Deprecated, unmaintained.** Lightning and chain swaps using Boltz |
 | [`@arkade-os/swap`](packages/swap/) | Client-side Arkade Intents asset swaps: market discovery, offers, RFQ, restore |
 
 The [`regtest/`](regtest/) directory is a shared regtest environment, vendored as the

--- a/packages/boltz-swap/README.md
+++ b/packages/boltz-swap/README.md
@@ -1,5 +1,12 @@
 # Arkade Swaps
 
+> [!WARNING]
+> **Deprecated and unmaintained.** This package is no longer actively developed
+> and receives no integration testing — its regtest CI job was removed. It is
+> left published so existing integrations keep resolving, but expect no fixes,
+> no compatibility work against newer `@arkade-os/sdk` releases, and no support.
+> Do not build anything new on it.
+
 > Lightning and chain swaps for Arkade using Boltz
 
 `@arkade-os/boltz-swap` provides seamless integration with the Lightning Network and Bitcoin on-chain through Boltz swaps, allowing users to move funds between Arkade, Lightning, and Bitcoin.

--- a/packages/ts-sdk/.env.regtest
+++ b/packages/ts-sdk/.env.regtest
@@ -9,6 +9,13 @@ ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.14
 # attaches prevout txs itself, stay on the last version that does not demand it.
 EMULATOR_IMAGE=ghcr.io/arkade-os/emulator:v0.0.5
 
+# Resolves to base,ark,delegate,emulator,boltz. The default is every tier, which
+# since the upgrade also starts the solver, strfry and bucket-sync — none of
+# which this suite or its setup waiter touches, and whose only effect on a
+# 2-core CI runner is contention that widens timing windows. `boltz` stays even
+# though no test calls it: test/setup.mjs blocks on waitForBoltzPairs().
+REGTEST_PROFILES=delegate,emulator,boltz
+
 # Match old ts-sdk docker-compose arkd config
 ARKD_VTXO_TREE_EXPIRY=20
 ARKD_BOARDING_EXIT_DELAY=40

--- a/packages/ts-sdk/.env.regtest
+++ b/packages/ts-sdk/.env.regtest
@@ -3,6 +3,12 @@
 ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.14
 ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.14
 
+# Emulator v0.0.7 requires a PrevArkTx PSBT field on EVERY input of a submitted
+# ark tx / intent proof; the SDK only sets it on input 0, and only when the
+# caller supplies `Utxo.sourceTx` (recursive covenants). Until it resolves and
+# attaches prevout txs itself, stay on the last version that does not demand it.
+EMULATOR_IMAGE=ghcr.io/arkade-os/emulator:v0.0.5
+
 # Match old ts-sdk docker-compose arkd config
 ARKD_VTXO_TREE_EXPIRY=20
 ARKD_BOARDING_EXIT_DELAY=40

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -844,7 +844,12 @@ export interface MigrationLegReport {
  * separate settle-backed migration. They are never combined into one intent.
  */
 export interface DeprecatedSignerMigrationReport {
-    /** Whether a mid-session server-signer rotation was applied first. */
+    /**
+     * Whether this pass moved the wallet's receive state onto the active
+     * signer — directly, or through the server-info refresh it opens with.
+     * `false` when the wallet was already there, which includes a rotation an
+     * earlier refresh elsewhere in the session already applied.
+     */
     rotated: boolean;
     /** Global skip; when set, neither leg is present. */
     skipped?: MigrationGlobalSkipReason;
@@ -881,6 +886,13 @@ interface MigrationCapableWallet {
     rotateServerSigner(newServerPubKey: Uint8Array, checkpointTapscript: string): Promise<void>;
     /** Refresh the wallet's cached deprecated-signer set from a fresh {@link ArkInfo} snapshot. */
     refreshDeprecatedSigners(info: ArkInfo): void;
+    /**
+     * Drain a rotation the wallet is applying off an `onServerInfoChanged`
+     * emit, so this pass classifies against a settled signer snapshot instead
+     * of a half-rotated one. Optional: only the concrete `Wallet` subscribes to
+     * server-info events, so proxy / mock implementations omit it.
+     */
+    settleServerInfoChanges?(): Promise<void>;
     /**
      * Spend an explicit set of the wallet's own deprecated-signer VTXOs into a
      * single full-value active-signer output through the Ark send path (not
@@ -1993,6 +2005,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     async getDeprecatedSignerStatus(): Promise<DeprecatedSignerReport[]> {
         const wallet = this.requireMigrationCapableWallet();
         const info = await wallet.arkProvider.getInfo();
+        // This refresh can itself surface a rotated operator config, which the
+        // wallet applies off the emit. Let it settle so the counts below are
+        // read from one signer epoch rather than a half-rotated wallet.
+        await wallet.settleServerInfoChanges?.();
         const { reports: vtxoReports } = await this.classifyDeprecatedSignerContracts(info);
         const { reports: boardingReports } = await this.classifyDeprecatedSignerBoarding(info);
         return mergeSignerReports(vtxoReports, boardingReports);
@@ -2009,7 +2025,18 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         options?: MigrateDeprecatedSignerOptions,
     ): Promise<DeprecatedSignerMigrationReport> {
         const wallet = this.requireMigrationCapableWallet();
+        // Read BEFORE the refresh: the refresh itself can surface a rotated
+        // operator config, which the wallet applies off the emit — so the
+        // rotation this pass reports may be the one that handler performed
+        // rather than the one `ensureReceiveOnActiveSigner` performs below.
+        const signerBeforeRefresh = hex.encode(wallet.arkServerPublicKey);
         const info = await wallet.arkProvider.getInfo();
+        // Drain that handler before reading anything signer-derived: mid-rotation
+        // the active signer's contract rows are already persisted while
+        // `arkServerPublicKey` still holds the deprecated one, and both chains
+        // would otherwise race to rotate.
+        await wallet.settleServerInfoChanges?.();
+        const rotatedOnRefresh = signerBeforeRefresh !== hex.encode(wallet.arkServerPublicKey);
         // Refresh the wallet's cached deprecated-signer set from this fresh
         // snapshot before any classification or early-exit, so the spendability
         // filter that excludes EXPIRED deprecated-signer inputs from settle() is
@@ -2026,7 +2053,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // Common cheap exit: nothing deprecated advertised and our own snapshot
         // is current → no contract sweep, no indexer round-trip.
         if (signerSet.deprecated.size === 0 && walletClass.status === "CURRENT") {
-            return { rotated: false, expired: [], signers: [] };
+            return { rotated: rotatedOnRefresh, expired: [], signers: [] };
         }
 
         // The wallet's own signer is neither active nor advertised deprecated:
@@ -2036,7 +2063,11 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             const { reports: vtxoReports } = await this.classifyDeprecatedSignerContracts(info);
             const { reports: boardingReports } = await this.classifyDeprecatedSignerBoarding(info);
             return {
-                rotated: false,
+                // Normally false here — a drained rotation targets the active
+                // signer, which classifies CURRENT, not UNKNOWN. It is true only
+                // when a second rotation landed inside the drain, leaving us on a
+                // signer newer than `info`: still a rotation this pass applied.
+                rotated: rotatedOnRefresh,
                 expired: [],
                 signers: mergeSignerReports(vtxoReports, boardingReports),
                 skipped: "unknown-wallet-signer",
@@ -2049,7 +2080,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
         // (UNKNOWN_SIGNER already returned above, so the guard rotates here iff
         // the snapshot is MIGRATABLE/DUE_NOW/EXPIRED — identical to the prior
         // `!== CURRENT` test.)
-        const rotated = await this.ensureReceiveOnActiveSigner(info);
+        const rotated = (await this.ensureReceiveOnActiveSigner(info)) || rotatedOnRefresh;
 
         // Collect stale VTXOs AND boarding UTXOs AFTER any rotation, so the
         // just-deprecated former receive/boarding contracts are included in the

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -2329,6 +2329,29 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
             console.warn("server-signer rotation on info change failed", e);
         }
     }
+
+    /**
+     * Await an `onServerInfoChanged` handler still applying a rotation.
+     *
+     * The provider emits synchronously but {@link handleServerInfoChanged} runs
+     * off the emit, so between the two a caller can observe a half-applied
+     * rotation: {@link rotateServerSigner} persists the active signer's contract
+     * rows *before* committing the tapscripts, so `arkServerPublicKey` still
+     * reads the old key while the new key's rows are already in the repository.
+     * A path that refreshes server info and then reads signer-derived state must
+     * drain the chain first, or it both reads that torn state and races the
+     * handler for the rotation itself.
+     *
+     * Resolves once the chain is idle; a handler that threw already logged, and
+     * its rejection is swallowed here.
+     *
+     * @internal Invoked by {@link dispose} and the {@link VtxoManager} migration
+     * pass; not part of the stable public API.
+     */
+    async settleServerInfoChanges(): Promise<void> {
+        await this._serverInfoInFlight?.catch(() => undefined);
+    }
+
     private _receiveRotatorInstalled = false;
 
     /**
@@ -3162,7 +3185,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         // dispose the contract manager underneath it.
         this._serverInfoUnsub?.();
         this._serverInfoUnsub = undefined;
-        await this._serverInfoInFlight?.catch(() => undefined);
+        await this.settleServerInfoChanges();
 
         // Tear down the rotation subscription + drain in-flight rotations
         // first so no late `vtxo_received` event can queue work on a

--- a/packages/ts-sdk/test/deprecatedSignerMigration.test.ts
+++ b/packages/ts-sdk/test/deprecatedSignerMigration.test.ts
@@ -142,6 +142,12 @@ interface MigrationMockOptions {
     address?: string;
     /** Boarding groups returned by `getBoardingUtxosForSigners` (Section 7). */
     boardingGroups?: BoardingUtxoGroup[];
+    /**
+     * x-only hex the wallet lands on when `settleServerInfoChanges` drains —
+     * models the real wallet applying a rotation off an `onServerInfoChanged`
+     * emit that its own `getInfo` produced.
+     */
+    rotateOnSettle?: string;
 }
 
 function createMigrationMockWallet(opts: MigrationMockOptions) {
@@ -163,6 +169,9 @@ function createMigrationMockWallet(opts: MigrationMockOptions) {
     // The migration pass refreshes the wallet's deprecated-signer cache from the
     // fresh info snapshot (the real Wallet inherits this from ReadonlyWallet).
     const refreshDeprecatedSigners = vi.fn();
+    const settleServerInfoChanges = vi.fn(async () => {
+        if (opts.rotateOnSettle) arkServerPublicKey = hex.decode(opts.rotateOnSettle);
+    });
 
     const wallet = {
         get arkServerPublicKey() {
@@ -170,6 +179,7 @@ function createMigrationMockWallet(opts: MigrationMockOptions) {
         },
         arkProvider: { getInfo },
         refreshDeprecatedSigners,
+        settleServerInfoChanges,
         rotateServerSigner,
         getContractManager: vi.fn().mockResolvedValue({
             getContractsWithVtxos,
@@ -202,6 +212,7 @@ function createMigrationMockWallet(opts: MigrationMockOptions) {
         getBoardingUtxosForSigners,
         getInfo,
         refreshDeprecatedSigners,
+        settleServerInfoChanges,
     };
 }
 
@@ -336,6 +347,58 @@ describe("VtxoManager - deprecated-signer migration", () => {
         expect(report.rotated).toBe(true);
         expect(report.vtxos?.migrated).toHaveLength(1);
         expect(sendSelectedVtxosToSelf).toHaveBeenCalledOnce();
+    });
+
+    it("credits a rotation its own info refresh applied, instead of racing it", async () => {
+        // A `getInfo` can surface a rotated operator config, which the wallet
+        // applies off that emit rather than inline. The pass must drain that
+        // handler before classifying — otherwise it reads a wallet whose new
+        // signer's contract rows are persisted but whose `arkServerPublicKey`
+        // still holds the old key — and must still report `rotated`, even
+        // though by then it has nothing left to rotate itself.
+        const {
+            wallet,
+            rotateServerSigner,
+            sendSelectedVtxosToSelf,
+            settleServerInfoChanges,
+            getContractsWithVtxos,
+        } = createMigrationMockWallet({
+            walletSigner: DEP_A,
+            rotateOnSettle: ACTIVE,
+            info: makeInfo(ACTIVE, [{ pubkey: DEP_A, cutoffDate: BigInt(NOW_S + 5000) }]),
+            contractsWithVtxos: [cwv(DEP_A, [makeVtxo("default-" + DEP_A, 8000)])],
+        });
+
+        const report = await newManager(wallet).migrateDeprecatedSignerVtxos();
+
+        expect(settleServerInfoChanges).toHaveBeenCalledOnce();
+        expect(settleServerInfoChanges.mock.invocationCallOrder[0]).toBeLessThan(
+            getContractsWithVtxos.mock.invocationCallOrder[0],
+        );
+        expect(rotateServerSigner).not.toHaveBeenCalled();
+        expect(report.rotated).toBe(true);
+        expect(report.vtxos?.migrated).toHaveLength(1);
+        expect(sendSelectedVtxosToSelf).toHaveBeenCalledOnce();
+    });
+
+    it("settles an in-flight rotation before reporting deprecated-signer status", async () => {
+        const { wallet, settleServerInfoChanges, getContractsWithVtxos } =
+            createMigrationMockWallet({
+                walletSigner: DEP_A,
+                rotateOnSettle: ACTIVE,
+                info: makeInfo(ACTIVE, [{ pubkey: DEP_A, cutoffDate: BigInt(NOW_S + 5000) }]),
+                contractsWithVtxos: [cwv(DEP_A, [makeVtxo("default-" + DEP_A, 8000)])],
+            });
+
+        const status = await newManager(wallet).getDeprecatedSignerStatus();
+
+        expect(settleServerInfoChanges).toHaveBeenCalledOnce();
+        expect(settleServerInfoChanges.mock.invocationCallOrder[0]).toBeLessThan(
+            getContractsWithVtxos.mock.invocationCallOrder[0],
+        );
+        // Classified from the settled snapshot: DEP_A is deprecated, not the
+        // wallet's own (now rotated away) signer.
+        expect(status.map((s) => s.signerPubKey)).toEqual([DEP_A]);
     });
 
     it("does not rotate or migrate when the wallet's own signer is unknown", async () => {

--- a/packages/ts-sdk/test/e2e/deprecatedSignerMigration.test.ts
+++ b/packages/ts-sdk/test/e2e/deprecatedSignerMigration.test.ts
@@ -36,6 +36,13 @@ const arkUrl = "http://localhost:7070";
  * classifies `DUE_NOW`; a future cutoff classifies `MIGRATABLE`; a past cutoff
  * classifies `EXPIRED` (cooperative migration closed).
  *
+ * What these tests do NOT pin is which call performs the re-derive onto the
+ * active signer. A rotation is observable from any `getInfo`, and the wallet
+ * applies it off that emit — so a status poll can rotate the wallet before
+ * `migrateDeprecatedSignerVtxos` runs, leaving `report.rotated` false and the
+ * active-signer contract rows already present. Assertions are therefore scoped
+ * to the deprecated signer's rows and to the durable post-conditions.
+ *
  * Boarding migration is also real on the pinned images: a pre-rotation boarding
  * UTXO under a deprecated signer is discovered, settled cooperatively, and
  * reported in the migration result. (VTXO migration co-signs the forfeit with the
@@ -183,13 +190,14 @@ describe("deprecated-signer migration (real rotation)", () => {
             const { wallet, vtxoManager, contractManager, amount, stale, fromX, toX } =
                 await fundVtxoUnderAThenRotate(A_SEC, useMnemonic);
             try {
-                // Check contracts before migration
+                // Before migration, scoped to the deprecated signer's rows —
+                // the active-signer ones may already be present (see header).
                 const before = await contractManager.getContracts();
-                expect(before.filter((c) => c.params.serverPubKey === A_PUB)).toHaveLength(2);
-                expect(before.filter((c) => c.type === "boarding")).toHaveLength(1);
-                expect(before.filter((c) => c.type === "default")).toHaveLength(1);
-                expect(before.filter((c) => c.state === "active")).toHaveLength(2);
-                expect(before).toHaveLength(2);
+                const staleRows = before.filter((c) => c.params.serverPubKey === A_PUB);
+                expect(staleRows).toHaveLength(2);
+                expect(staleRows.filter((c) => c.type === "boarding")).toHaveLength(1);
+                expect(staleRows.filter((c) => c.type === "default")).toHaveLength(1);
+                expect(staleRows.every((c) => c.state === "active")).toBe(true);
 
                 const status = await vtxoManager.getDeprecatedSignerStatus();
                 expect(status).toHaveLength(1);
@@ -203,7 +211,6 @@ describe("deprecated-signer migration (real rotation)", () => {
 
                 const balanceBefore = await wallet.getBalance();
                 const report = await vtxoManager.migrateDeprecatedSignerVtxos();
-                expect(report.rotated).toBe(true);
                 // VTXO leg ran through the send path; `txid` is the Ark
                 // transaction id from send, NOT a settle commitment txid.
                 expect(report.vtxos?.txid).toBeDefined();
@@ -262,13 +269,14 @@ describe("deprecated-signer migration (real rotation)", () => {
                     useMnemonic,
                 );
             try {
-                // Check contracts before migration
+                // Before migration, scoped to the deprecated signer's rows —
+                // the active-signer ones may already be present (see header).
                 const before = await contractManager.getContracts();
-                expect(before.filter((c) => c.params.serverPubKey === A_PUB)).toHaveLength(2);
-                expect(before.filter((c) => c.type === "boarding")).toHaveLength(1);
-                expect(before.filter((c) => c.type === "default")).toHaveLength(1);
-                expect(before.filter((c) => c.state === "active")).toHaveLength(2);
-                expect(before).toHaveLength(2);
+                const staleRows = before.filter((c) => c.params.serverPubKey === A_PUB);
+                expect(staleRows).toHaveLength(2);
+                expect(staleRows.filter((c) => c.type === "boarding")).toHaveLength(1);
+                expect(staleRows.filter((c) => c.type === "default")).toHaveLength(1);
+                expect(staleRows.every((c) => c.state === "active")).toBe(true);
 
                 const status = await vtxoManager.getDeprecatedSignerStatus();
                 expect(status).toHaveLength(1);
@@ -283,7 +291,6 @@ describe("deprecated-signer migration (real rotation)", () => {
 
                 const balanceBefore = await wallet.getBalance();
                 const report = await vtxoManager.migrateDeprecatedSignerVtxos();
-                expect(report.rotated).toBe(true);
                 // VTXO leg send id (not a settle commitment txid).
                 expect(report.vtxos?.txid).toBeDefined();
                 expect(report.vtxos?.error).toBeUndefined();
@@ -341,13 +348,14 @@ describe("deprecated-signer migration (real rotation)", () => {
                     useMnemonic,
                 );
             try {
-                // Check contracts before migration
+                // Before migration, scoped to the deprecated signer's rows —
+                // the active-signer ones may already be present (see header).
                 const before = await contractManager.getContracts();
-                expect(before.filter((c) => c.params.serverPubKey === A_PUB)).toHaveLength(2);
-                expect(before.filter((c) => c.type === "boarding")).toHaveLength(1);
-                expect(before.filter((c) => c.type === "default")).toHaveLength(1);
-                expect(before.filter((c) => c.state === "active")).toHaveLength(2);
-                expect(before).toHaveLength(2);
+                const staleRows = before.filter((c) => c.params.serverPubKey === A_PUB);
+                expect(staleRows).toHaveLength(2);
+                expect(staleRows.filter((c) => c.type === "boarding")).toHaveLength(1);
+                expect(staleRows.filter((c) => c.type === "default")).toHaveLength(1);
+                expect(staleRows.every((c) => c.state === "active")).toBe(true);
 
                 const status = await vtxoManager.getDeprecatedSignerStatus();
                 expect(status).toHaveLength(1);
@@ -365,7 +373,6 @@ describe("deprecated-signer migration (real rotation)", () => {
                 // submitted — the stale VTXO is reported as expired (it recovers via
                 // the server batch sweep, not a cooperative settle).
                 const report = await vtxoManager.migrateDeprecatedSignerVtxos();
-                expect(report.rotated).toBe(true);
                 expect(hex.encode(wallet.arkServerPublicKey)).toBe(toX);
                 // Past cutoff: no migratable inputs → neither leg, global skip.
                 expect(report.vtxos).toBeUndefined();
@@ -463,7 +470,6 @@ describe("deprecated-signer migration (real rotation)", () => {
                 // migrates the boarding input into a fresh VTXO under B.
                 const stale = `${boarding[0].txid}:${boarding[0].vout}`;
                 const report = await vtxoManager.migrateDeprecatedSignerVtxos();
-                expect(report.rotated).toBe(true);
                 expect(hex.encode(wallet.arkServerPublicKey)).toBe(toX);
                 // Boarding migrates through its OWN settle leg (separate from
                 // the send-based VTXO leg); its txid is a settle commitment.


### PR DESCRIPTION
Bumps the regtest submodule to `56dca6ed`.

Also carries one SDK fix: the deprecated-signer migration now drains an
in-flight server-info rotation before reading signer-derived state, so
`report.rotated` is no longer nondeterministic and callers cannot observe a
half-applied rotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deprecated-signer migration now waits for pending wallet information updates before evaluating signer status.
  - Migration results more accurately report wallet key rotations, including rotations triggered during status refreshes.
  - Improved consistency between migration status checks and migration execution.

- **Documentation**
  - Clarified when wallet rotation is reflected in migration results and status checks.
  - Marked the Boltz swap package as deprecated and unmaintained.

- **Tests**
  - Added coverage for rotations occurring during settlement and status polling.
  - Updated integration checks to reflect rotation timing and package maintenance status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->