### PR TITLE
fix(exit): graph mode under-quotes funding by one dust floor

### DIFF
--- a/packages/ts-sdk/src/wallet/exit/estimate.ts
+++ b/packages/ts-sdk/src/wallet/exit/estimate.ts
@@ -278,10 +278,22 @@ export async function computeExitLayout(opts: ExitOptions, feeRate: number): Pro
         // splitter. funded: + 1 splitter tx and pre-signed children.
         txCount: (graph ? 0 : steps.length > 0 ? 1 : 0) + steps.length * 2 + sweeps.length,
         totalFeeSats: splitterFee + stepFees + sweepFees,
-        // graph funding is what the executor sends to its own fee address:
-        // just the CPFP fees (change recycles); funded also locks the
-        // per-child dust into the splitter.
-        fundingRequiredSats: graph ? stepFees : splitterFee + fundingTotal,
+        // graph funding is what the executor sends to its own fee address: the
+        // CPFP fees, plus one dust floor. Change recycles through that single
+        // address, so each bump hands its remainder to the next and only the
+        // *final* change has to clear `CHILD_DUST_AMOUNT` — but it does have to,
+        // and `buildAnchorChild` throws rather than absorbing a short remainder
+        // into the fee. Quoting bare fees quotes an amount that strands the last
+        // bump and every sweep behind it.
+        //
+        // funded reserves the same floor per step instead of once overall (see
+        // `stepFundingAmount`), because it pre-funds each child separately
+        // through the splitter rather than recycling one output.
+        fundingRequiredSats: graph
+            ? steps.length > 0
+                ? stepFees + CHILD_OUTPUT_DUST
+                : 0
+            : splitterFee + fundingTotal,
         recoveredSats: sweeps.reduce((s, x) => s + (x.vtxo.value - x.sweepFee), 0),
     };
 

--- a/packages/ts-sdk/src/wallet/exit/prepare.ts
+++ b/packages/ts-sdk/src/wallet/exit/prepare.ts
@@ -6,6 +6,7 @@ import { TxWeightEstimator } from "../../utils/txSizeEstimator";
 import { selectCoins } from "../onchain";
 import { DUST_AMOUNT } from "../utils";
 import {
+    CHILD_OUTPUT_DUST,
     computeExitLayout,
     ExitOptions,
     resolveFeeRate,
@@ -114,7 +115,10 @@ export async function prepare(opts: ExitOptions): Promise<ExitPackage> {
             totals: {
                 txCount: bumpSteps.length * 2 + sweepSteps.length,
                 totalFeeSats: stepFees + sweepFees,
-                fundingRequiredSats: stepFees,
+                // Fees plus the single dust floor the recycling change output
+                // must keep clear; see the note in `estimate.ts`. Must match
+                // the quote `estimate` gives for the same package.
+                fundingRequiredSats: bumpSteps.length > 0 ? stepFees + CHILD_OUTPUT_DUST : 0,
                 recoveredSats: recovered,
             },
             vtxos: layout.infos,

--- a/packages/ts-sdk/test/exit-estimate.test.ts
+++ b/packages/ts-sdk/test/exit-estimate.test.ts
@@ -300,3 +300,61 @@ describe("estimate", () => {
         await expect(estimate(exitOpts)).rejects.toThrow(/no contract registered/);
     });
 });
+
+describe("graph-mode funding quote", () => {
+    /**
+     * Graph mode funds CPFP bumps at execution time from one recycling change
+     * address, and `buildAnchorChild` refuses to write a change output below
+     * `CHILD_DUST_AMOUNT`. Quoting bare fees therefore quotes an amount that
+     * cannot finish the exit: the last bump has nowhere legal to put what is
+     * left, and both it and every sweep depending on it fail.
+     *
+     * `funded` mode already reserves this — `stepFundingAmount` is
+     * `stepFee + CHILD_OUTPUT_DUST` per step, because each child is pre-funded
+     * separately. Graph mode needs exactly one reserve, since the change from
+     * each bump pays for the next.
+     */
+    it("reserves one dust floor on top of the CPFP fees", async () => {
+        const { exitOpts } = await estimateFixture();
+        const quote = await estimate({ ...exitOpts, mode: "graph" });
+
+        const sweepFees = quote.vtxos.reduce((s, v) => s + (v.sweepFee ?? 0), 0);
+        const stepFees = quote.totals.totalFeeSats - sweepFees;
+
+        expect(stepFees).toBeGreaterThan(0);
+        expect(quote.totals.fundingRequiredSats).toBe(stepFees + CHILD_OUTPUT_DUST);
+        expect(quote.shortfallSats).toBe(quote.totals.fundingRequiredSats);
+    });
+
+    /**
+     * The property that actually matters: deposit exactly what we quote, spend
+     * each bump in turn, and every change output must clear the dust floor. On
+     * the bare-fee quote the final change lands at 0 and the exit dies there.
+     */
+    it("quotes an amount that survives every bump", async () => {
+        const { exitOpts } = await estimateFixture();
+        const quote = await estimate({ ...exitOpts, mode: "graph" });
+
+        const sweepFees = quote.vtxos.reduce((s, v) => s + (v.sweepFee ?? 0), 0);
+        const stepFees = quote.totals.totalFeeSats - sweepFees;
+        // Two package steps in this fixture; the split is even here.
+        const bumps = (quote.totals.txCount - quote.vtxos.length) / 2;
+        const perBump = stepFees / bumps;
+
+        let balance = quote.totals.fundingRequiredSats;
+        for (let i = 0; i < bumps; i++) {
+            balance -= perBump;
+            expect(balance).toBeGreaterThanOrEqual(CHILD_OUTPUT_DUST);
+        }
+    });
+
+    it("leaves the funded-mode quote alone", async () => {
+        const { exitOpts } = await estimateFixture();
+        const quote = await estimate(exitOpts);
+        const sweepFees = quote.vtxos.reduce((s, v) => s + (v.sweepFee ?? 0), 0);
+        // One dust per step, not one overall: funded pre-funds each child.
+        expect(quote.totals.fundingRequiredSats).toBe(
+            quote.totals.totalFeeSats - sweepFees + 2 * CHILD_OUTPUT_DUST,
+        );
+    });
+});

--- a/packages/ts-sdk/test/exit-prepare.test.ts
+++ b/packages/ts-sdk/test/exit-prepare.test.ts
@@ -6,6 +6,7 @@ import { getNetwork } from "../src/networks";
 import { ChainTxType } from "../src/providers/indexer";
 import { InMemoryContractRepository } from "../src/repositories/inMemory/contractRepository";
 import { VtxoScript } from "../src/script/base";
+import { CHILD_OUTPUT_DUST } from "../src/wallet/exit/estimate";
 import { CSVMultisigTapscript } from "../src/script/tapscript";
 import { timelockToSequence } from "../src/utils/timelock";
 import { P2A } from "../src/utils/anchor";
@@ -199,10 +200,14 @@ describe("prepare", () => {
         // sweep still pre-signed by the wallet key
         expect(pkg.steps.some((s) => s.kind === "sweep")).toBe(true);
 
-        // funding guidance = CPFP fees only (no splitter, no per-child dust)
-        const stepFeeSum = pkg.totals.totalFeeSats; // no splitter fee in graph mode besides sweeps
-        expect(pkg.totals.fundingRequiredSats).toBeGreaterThan(0);
-        expect(pkg.totals.fundingRequiredSats).toBeLessThan(stepFeeSum + 1); // <= totalFee
+        // Funding guidance = CPFP fees + one dust floor. No splitter and no
+        // per-child dust (that is funded mode, which pre-funds each child), but
+        // the recycling change output still has to stay above
+        // `CHILD_DUST_AMOUNT` or the final bump cannot be built at all.
+        const sweepFeeSum = pkg.vtxos.reduce((s, v) => s + (v.sweepFee ?? 0), 0);
+        const stepFeeSum = pkg.totals.totalFeeSats - sweepFeeSum;
+        expect(stepFeeSum).toBeGreaterThan(0);
+        expect(pkg.totals.fundingRequiredSats).toBe(stepFeeSum + CHILD_OUTPUT_DUST);
     });
 
     it("quotes enough for the deposit UTXO when the wallet holds pre-existing dust", async () => {


### PR DESCRIPTION
## The bug

A graph-mode package quotes `fundingRequiredSats` as the plain sum of its CPFP step fees. Deposit exactly that and the exit **cannot finish**.

`buildAnchorChild` always writes one change output and rejects change below `CHILD_DUST_AMOUNT` — there is no absorb-the-remainder-into-fee path:

```ts
const change = total + P2A.amount - BigInt(fee);
if (change < BigInt(CHILD_DUST_AMOUNT)) {
    throw new Error(`insufficient funding for anchor child: need change >= ${CHILD_DUST_AMOUNT}, got ${change}`);
}
```

Change recycles through a single address, so each bump hands its remainder to the next and only the *final* change has to clear the floor — but it does have to. With four 278-sat bumps against the quoted 1112:

| balance | bump | change | legal? |
|---|---|---|---|
| 1112 | 1 | 834 | yes |
| 834 | 2 | 556 | yes |
| 556 | 3 | **278** | **no — dies here** |

The failing bump marks its branch dead, and every sweep behind it fails with it. A 546-sat under-quote costs whole VTXOs.

This is not hypothetical — it happened on mainnet. A user funded a 4-VTXO graph exit with exactly the quoted 1112 sats; two unrolls confirmed, the third and fourth failed with `need change >= 546, got 278`, and both their sweeps failed as `branch failed earlier`.

## The fix

`funded` mode already reserves this floor — once **per step**, via `stepFundingAmount` (`stepFee + CHILD_OUTPUT_DUST`) — because it pre-funds each child separately through the splitter. Graph mode reserved none. It needs exactly **one**, since each bump's change pays for the next.

Both sites that compute the figure now quote `stepFees + CHILD_OUTPUT_DUST`, keeping `prepare` in step with `estimate` so a package's own totals match the quote it was estimated from.

## Why the suite missed it

The e2e tests faucet `fundingRequiredSats + 20_000`, which hides any shortfall smaller than the margin. The new unit tests assert the exact figure *and* walk the balance forward bump by bump, so the property is checked rather than a constant:

```ts
let balance = quote.totals.fundingRequiredSats;
for (let i = 0; i < bumps; i++) {
    balance -= perBump;
    expect(balance).toBeGreaterThanOrEqual(CHILD_OUTPUT_DUST);
}
```

On the old quote that final assertion fails at `expected 0 to be greater than or equal to 546`.

One existing assertion in `exit-prepare.test.ts` encoded the bug — funding `<= totalFeeSats`, commented "no per-child dust". Right about *per-child*, wrong about the single recycling reserve. It now asserts the corrected contract rather than being relaxed.

## Test plan

- `pnpm -C packages/ts-sdk test:unit` — **2705 passed, 1 skipped, 0 failed** (166 files)
- `pnpm run test:unit` across the monorepo — ts-sdk 2705, swap 585, boltz-swap 616, all passing
- `pnpm run build` — clean
- `biome format` clean on all four changed files

## Related, not fixed here

`buildBumpPackage` selects coins with `selectCoins(coins, probeFee, true)` — no dust awareness. With funds split across several UTXOs it can select a subset whose change is dust even when the wallet holds plenty, and throw unnecessarily. It does not bite the normal graph flow (one deposit, one recycling output), so I left it out of this change rather than widen the diff into shared selection logic. Happy to follow up if you'd like it addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph-mode exit funding estimates by including the required dust reserve for recycling change outputs.
  * Ensured funding guidance remains sufficient throughout all bump steps while keeping change outputs above the dust threshold.
  * Preserved existing funded-mode funding calculations.

* **Tests**
  * Added coverage for graph-mode funding estimates, bump-step behavior, dust requirements, and unchanged funded-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->