### PR TITLE
fix(provider): a rejected 1P1C package reported success

### DIFF
--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -396,7 +396,21 @@ export class EsploraProvider implements OnchainProvider {
             throw new Error(`Failed to broadcast package: ${error}`);
         }
 
-        return response.json();
+        // `/txs/package` proxies Bitcoin Core's `submitpackage`, which reports
+        // per-transaction results in the body. A package whose transactions
+        // were all rejected still answers 200, so the HTTP status alone cannot
+        // tell acceptance from refusal:
+        //
+        //   200 {"package_msg":"transaction failed",
+        //        "tx-results":{"<wtxid>":{"txid":"...",
+        //                                 "error":"bad-txns-inputs-missingorspent"}}}
+        //
+        // Returning that as success is worse than failing: the caller believes
+        // the transaction is in flight and waits for a confirmation that cannot
+        // come, while the node already said exactly why it will not.
+        const result = await response.json();
+        assertPackageAccepted(result);
+        return result;
     }
 
     private async broadcastTx(tx: string): Promise<string> {
@@ -415,6 +429,40 @@ export class EsploraProvider implements OnchainProvider {
 
         return response.text();
     }
+}
+
+/**
+ * Throw when a 200 response describes a rejected package.
+ *
+ * Deliberately permissive: only a body that carries Core's own verdict is
+ * judged. Not every Esplora deployment proxies that shape, and treating an
+ * unrecognised body as failure would break broadcasting against the ones that
+ * do not.
+ */
+function assertPackageAccepted(result: unknown): void {
+    if (!result || typeof result !== "object") return;
+    const r = result as {
+        package_msg?: unknown;
+        "tx-results"?: Record<string, { txid?: unknown; error?: unknown }>;
+    };
+    const msg = typeof r.package_msg === "string" ? r.package_msg : undefined;
+    if (msg === undefined || msg === "success") return;
+
+    const reasons: string[] = [];
+    const results = r["tx-results"];
+    if (results && typeof results === "object") {
+        for (const entry of Object.values(results)) {
+            if (!entry || typeof entry !== "object" || entry.error === undefined) continue;
+            const txid = typeof entry.txid === "string" ? entry.txid : "unknown tx";
+            reasons.push(`${txid}: ${String(entry.error)}`);
+        }
+    }
+
+    throw new Error(
+        reasons.length > 0
+            ? `Package rejected (${msg}) — ${reasons.join("; ")}`
+            : `Package rejected (${msg})`,
+    );
 }
 
 function isValidBlocksTip(tip: any): tip is { id: string; height: number; mediantime: number }[] {

--- a/packages/ts-sdk/test/broadcast-package.test.ts
+++ b/packages/ts-sdk/test/broadcast-package.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { EsploraProvider } from "../src/providers/onchain";
+
+const PARENT = "aa".repeat(40);
+const CHILD = "bb".repeat(40);
+
+function mockFetch(status: number, body: unknown) {
+    const spy = vi.fn(async () => ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+        text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    }));
+    vi.stubGlobal("fetch", spy);
+    return spy;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("broadcasting a 1P1C package", () => {
+    /**
+     * Captured from a real mainnet failure. `/txs/package` proxies Bitcoin
+     * Core's `submitpackage`, which reports per-transaction results in the body
+     * — so a package whose transactions were all rejected still answers 200.
+     *
+     * Checking only the HTTP status therefore reads "transaction failed" as
+     * success. Downstream, the exit executor took that as a broadcast, emitted
+     * a broadcast event, and settled into `waitConfirmed` polling for a
+     * transaction that was never accepted: a permanent spinner where the node
+     * had given a precise reason.
+     */
+    const REJECTED = {
+        package_msg: "transaction failed",
+        "tx-results": {
+            "736db81c94ac2a2fe60c64a2030e930be1a1ebe1660506430a1e4b7aa4f177ca": {
+                txid: "4bd17634ce487df3bb2c47df7ada651f4ee7cbe8df6fb98529ff75bc8ec57d6b",
+                error: "bad-txns-inputs-missingorspent",
+            },
+            be2000793183a0ed026e092e5df45289317ed004fb10514ab6eb2d98700c037c: {
+                txid: "926751c5710257dd2617530c6e891cc07975715787c2e77c067e621d0e9754c4",
+                error: "bad-txns-inputs-missingorspent",
+            },
+        },
+        "replaced-transactions": [],
+    };
+
+    it("throws when a 200 body reports the package failed", async () => {
+        mockFetch(200, REJECTED);
+        const p = new EsploraProvider("https://example.invalid/api");
+        await expect(p.broadcastTransaction(PARENT, CHILD)).rejects.toThrow(/transaction failed/i);
+    });
+
+    // The reason is the whole value of the failure: "already spent" means the
+    // branch is dead and no retry helps, while a fee error means top up and
+    // retry. Losing it leaves the caller unable to tell those apart.
+    it("surfaces the node's per-transaction reason", async () => {
+        mockFetch(200, REJECTED);
+        const p = new EsploraProvider("https://example.invalid/api");
+        await expect(p.broadcastTransaction(PARENT, CHILD)).rejects.toThrow(
+            /bad-txns-inputs-missingorspent/,
+        );
+    });
+
+    it("names the transaction that failed, not just the package", async () => {
+        mockFetch(200, REJECTED);
+        const p = new EsploraProvider("https://example.invalid/api");
+        await expect(p.broadcastTransaction(PARENT, CHILD)).rejects.toThrow(/4bd17634/);
+    });
+
+    it("still accepts a successful submit", async () => {
+        mockFetch(200, { package_msg: "success", "tx-results": {}, "replaced-transactions": [] });
+        const p = new EsploraProvider("https://example.invalid/api");
+        await expect(p.broadcastTransaction(PARENT, CHILD)).resolves.toBeDefined();
+    });
+
+    // Not every Esplora proxies Core's shape. An unrecognised 200 body must
+    // stay a success, or this hardening breaks working deployments.
+    it("accepts a 200 whose body carries no package verdict", async () => {
+        mockFetch(200, { txid: "cc".repeat(32) });
+        const p = new EsploraProvider("https://example.invalid/api");
+        await expect(p.broadcastTransaction(PARENT, CHILD)).resolves.toBeDefined();
+    });
+
+    it("still throws on a non-2xx response", async () => {
+        mockFetch(400, "sendrawtransaction RPC error");
+        const p = new EsploraProvider("https://example.invalid/api");
+        await expect(p.broadcastTransaction(PARENT, CHILD)).rejects.toThrow(/Failed to broadcast/);
+    });
+});


### PR DESCRIPTION
## The bug

`/txs/package` proxies Bitcoin Core's `submitpackage`, which reports results **per transaction, in the body**. A package whose transactions were all rejected still answers HTTP 200 — so `response.ok` cannot distinguish acceptance from refusal. The body was parsed and then discarded by every caller.

Captured from a real mainnet failure (user's HAR):

```
POST https://mempool.arkade.sh/api/txs/package  →  200
{"package_msg":"transaction failed",
 "tx-results":{
   "736db81c…":{"txid":"4bd17634…","error":"bad-txns-inputs-missingorspent"},
   "be200079…":{"txid":"926751c5…","error":"bad-txns-inputs-missingorspent"}},
 "replaced-transactions":[]}
```

## Why it matters

`UnilateralExit.Executor` treats a non-throwing `broadcastTransaction` as a successful broadcast: it emits a `broadcast` event and drops into `waitConfirmed`, polling for a transaction the node had already refused. `waitConfirmed` has no timeout and swallows lookup errors, so it polls a 404 forever.

The user watched "In flight" spin indefinitely on a step that was never going to land. The operator had swept that batch at expiry, so the branch was permanently dead — and the node had said exactly that, in a field nothing read. Worse, the executor blocks all later steps behind `waitConfirmed`, so the rest of the exit stalled too.

Turning this into a thrown error converts a silent permanent hang into a `Failed` step with the node's reason attached — and the reason is the whole point: `bad-txns-inputs-missingorspent` means the branch is gone and retrying is futile, while a fee error means top up and retry. Indistinguishable today.

## The change

Inspect the verdict after the status check and throw with the per-transaction reasons:

```
Package rejected (transaction failed) — 4bd17634…: bad-txns-inputs-missingorspent; 926751c5…: bad-txns-inputs-missingorspent
```

Deliberately permissive: **only** a body carrying Core's own `package_msg` is judged, and `"success"` passes. Not every Esplora deployment proxies that shape, and failing on an unrecognised body would break broadcasting against the ones that don't — so an unknown 200 body stays a success.

## Test plan

- `pnpm -C packages/ts-sdk test:unit` — **2708 passed, 1 skipped, 0 failed** (167 files; clean master is 2702, +6 here)
- `pnpm -C packages/ts-sdk tsc --noEmit` — 0 errors
- `biome format` clean on both files

New tests use the exact captured response, and cover both directions: rejection throws with txid and reason; `package_msg: "success"`, an unrecognised body, and a non-2xx all keep their existing behaviour.

One flake seen and ruled out: `hdWalletCapable.test.ts > caps excessive finite look-ahead` timed out at 5022ms on one run, passed in isolation (22/22) and on a full re-run. It references none of the changed code.

## Related

- #806 — graph-mode funding under-quote, the bug that stranded these bumps in the first place.
