### PR TITLE
fix(exit): alias the dust floor instead of redeclaring it

### DIFF
--- a/packages/ts-sdk/src/wallet/exit/estimate.ts
+++ b/packages/ts-sdk/src/wallet/exit/estimate.ts
@@ -11,13 +11,22 @@ import type { Wallet } from "../wallet";
 import { getNormalizedVtxos } from "../vtxo";
 import { buildExitDag, DagNode, topoSortByDeps } from "./chain";
 import { createExitChainResolver } from "./resolver";
+import { CHILD_DUST_AMOUNT } from "../../utils/anchor";
 import { finalizeVirtualTx } from "./finalizeVirtualTx";
 import { ExitPathError, ResolvedExitPath, resolveUnilateralPath } from "./path";
 import { sweepFeeFor } from "./sweep";
 import { ExitDelay, ExitMode, ExitQuote, ExitTotals, ExitVtxoInfo } from "./types";
 
-/** Dust floor granted to every fee child's change output. */
-export const CHILD_OUTPUT_DUST = 546;
+/**
+ * Dust floor granted to every fee child's change output.
+ *
+ * An alias, not a second constant: `buildAnchorChild` throws when change falls
+ * below {@link CHILD_DUST_AMOUNT}, so that is the floor the quote has to
+ * reserve. Declaring 546 independently here meant the two could drift — and a
+ * quote that under-reserves by even one sat strands the final bump, which is
+ * the failure this whole path exists to avoid.
+ */
+export const CHILD_OUTPUT_DUST = CHILD_DUST_AMOUNT;
 
 export type ExitOptions = {
     /** Wallet owning the VTXOs: identity (signing) + indexer + onchain provider. */

--- a/packages/ts-sdk/test/exit-estimate.test.ts
+++ b/packages/ts-sdk/test/exit-estimate.test.ts
@@ -12,7 +12,7 @@ import { P2A } from "../src/utils/anchor";
 import { Transaction } from "../src/utils/transaction";
 import { buildExitDag } from "../src/wallet/exit/chain";
 import { IndexerExitDataSource } from "../src/wallet/exit/indexerSource";
-import { CHILD_OUTPUT_DUST, estimate } from "../src/wallet/exit/estimate";
+import { CHILD_OUTPUT_DUST, computeExitLayout, estimate } from "../src/wallet/exit/estimate";
 import type { ExitOptions } from "../src/wallet/exit/estimate";
 
 const COMMIT = "c0".repeat(32);
@@ -333,19 +333,24 @@ describe("graph-mode funding quote", () => {
      */
     it("quotes an amount that survives every bump", async () => {
         const { exitOpts } = await estimateFixture();
-        const quote = await estimate({ ...exitOpts, mode: "graph" });
+        const opts = { ...exitOpts, mode: "graph" as const };
+        const quote = await estimate(opts);
+        // Each step's own fee, not an average of them: `perBump = total / count`
+        // is a float, so the final balance lands on the floor plus or minus an
+        // epsilon and a fixture with indivisible fees would fail spuriously.
+        // The property holds for any distribution — uniformity is incidental.
+        const { steps } = await computeExitLayout(opts, quote.feeRate);
 
-        const sweepFees = quote.vtxos.reduce((s, v) => s + (v.sweepFee ?? 0), 0);
-        const stepFees = quote.totals.totalFeeSats - sweepFees;
-        // Two package steps in this fixture; the split is even here.
-        const bumps = (quote.totals.txCount - quote.vtxos.length) / 2;
-        const perBump = stepFees / bumps;
+        expect(steps.length).toBeGreaterThan(1);
 
         let balance = quote.totals.fundingRequiredSats;
-        for (let i = 0; i < bumps; i++) {
-            balance -= perBump;
+        for (const step of steps) {
+            balance -= step.stepFee;
             expect(balance).toBeGreaterThanOrEqual(CHILD_OUTPUT_DUST);
         }
+        // Exactly one floor is reserved, and it is all that is left: quoting
+        // more would over-charge, quoting less would strand the last bump.
+        expect(balance).toBe(CHILD_OUTPUT_DUST);
     });
 
     it("leaves the funded-mode quote alone", async () => {


### PR DESCRIPTION
Follow-up to #806, addressing `arkana-ai-bot`'s review findings (that review landed after the PR had merged).

## The drift risk re-armed the bug we just fixed

`estimate.ts:20` declared `CHILD_OUTPUT_DUST = 546` independently of `anchor.ts:52`'s `CHILD_DUST_AMOUNT = 546`. Both guard the same invariant — the floor `buildAnchorChild` throws below. If that floor ever moves (a relay policy change, say), the quote silently under-reserves again, which is precisely the failure #806 existed to remove.

Now an alias, so there is one source of truth.

## The walk-forward test could fail spuriously

The test #806 added subtracted an average:

```ts
const perBump = stepFees / bumps;   // float
balance -= perBump;
expect(balance).toBeGreaterThanOrEqual(CHILD_OUTPUT_DUST);
```

With indivisible step fees the final balance lands on the floor ± ε, so a future fixture could fail on `545.999… >= 546`. It now walks each step's own `stepFee` from the layout — the property holds for **any** distribution of fees, and the uniformity in today's fixture was incidental rather than load-bearing. The misleading comment saying otherwise is gone.

Also added the post-loop assertion the review suggested:

```ts
expect(balance).toBe(CHILD_OUTPUT_DUST);
```

That locks the contract in both directions: reserving less strands the last bump, reserving more over-charges. The loop alone allowed either.

## Test plan

- `pnpm -C packages/ts-sdk test:unit` — **2711 passed, 1 skipped, 0 failed** (167 files), identical to master's count: no tests added, existing ones hardened
- `pnpm -C packages/ts-sdk tsc --noEmit` — 0 errors
- `biome format` clean on both files

## Not addressed here

The review's other two notes are on #807 and both are non-blocking:

- **`broadcastPackage` returns an object while `broadcastTransaction` is typed `Promise<string>`** — pre-existing, invisible because `json()` is `any`. Every current 2-arg caller discards the value, but a future caller expecting a txid would silently get an object. Wants either a narrowed return type or a real txid extraction from `tx-results` — a bigger change than this PR's scope.
- **Unrecognised success-level `package_msg` values** — if Core ever adds a second success message, the guard would throw a false rejection. Correct against Core's current API; something to watch on upgrades.

Happy to take the first as its own PR if you'd like it.

## Note on master CI

Master is currently red at `bdaec281` (#807's merge), but not from these changes: `Integration (ts-sdk / exit-providers-rotation)` failed with `INVALID_INTENT_PROOF (23)` / `VTXO_ALREADY_SPENT` in the settle path. The identical job failed with the identical signature on `6facedb8` (2026-08-25), two days before any of this work — it looks like regtest state pollution, and 3 of the last 8 master runs have failed the same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exit fee and balance calculations by consistently applying the shared minimum child-output amount.
  * Updated graph-mode exit estimates to account for the actual fee at each step, improving accuracy across multi-step exits.

* **Tests**
  * Added coverage ensuring balances remain above the required minimum throughout the exit process and finish at the expected amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->