### PR TITLE
Upgrade regtest and support emulator v0.0.7

### DIFF
--- a/packages/ts-sdk/.env.regtest
+++ b/packages/ts-sdk/.env.regtest
@@ -3,12 +3,6 @@
 ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.14
 ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.14
 
-# Emulator v0.0.7 requires a PrevArkTx PSBT field on EVERY input of a submitted
-# ark tx / intent proof; the SDK only sets it on input 0, and only when the
-# caller supplies `Utxo.sourceTx` (recursive covenants). Until it resolves and
-# attaches prevout txs itself, stay on the last version that does not demand it.
-EMULATOR_IMAGE=ghcr.io/arkade-os/emulator:v0.0.5
-
 # Resolves to base,ark,delegate,emulator,boltz. The default is every tier, which
 # since the upgrade also starts the solver, strfry and bucket-sync — none of
 # which this suite or its setup waiter touches, and whose only effect on a

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -226,6 +226,8 @@ Wallets read onchain state (UTXOs, transactions, fee rates, chain tip) through a
 
 If you don't pass a provider explicitly, `OnchainWallet` and `Wallet.create({ ... })` both default to `EsploraProvider` pointing at the URL in `ESPLORA_URL[networkName]`.
 
+> **New:** the interface also requires `getRawTransaction(txid): Promise<Uint8Array>`, the raw wire bytes of a transaction. Emulator v0.0.7+ demands the previous transaction of every input a covenant spend or intent proof carries, and a boarding or commitment parent has no off-chain source. Both shipped providers implement it; a custom `OnchainProvider` has to add it.
+
 #### Default URLs
 
 The SDK ships with reachable defaults for each network — bitcoin, signet, and mutinynet point at Ark Labs–operated deployments; testnet falls back to mempool.space; regtest assumes a local [arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest) stack (esplora API on `http://localhost:3000/api`).

--- a/packages/ts-sdk/src/arkade/contract.ts
+++ b/packages/ts-sdk/src/arkade/contract.ts
@@ -33,6 +33,11 @@
  * param must be bound, every `$name` reference must be declared, and bound
  * values are validated against their type at compilation.
  *
+ * A covenant spend needs an `indexer`, not just an `emulator`: the co-signing
+ * service resolves each input's prevout pkScript from the previous ark tx the
+ * PSBT carries, and only the indexer can supply those bytes. Pure tapscript
+ * spends go straight to arkd and need neither.
+ *
  * @example
  * ```typescript
  * const htlcProgram = {
@@ -86,6 +91,7 @@ import {
     type ArkTxInput,
 } from "../utils/arkTransaction";
 import { ConditionWitness, PrevArkTxField, setArkPsbtField } from "../utils/unknownFields";
+import { attachPrevArkTxs, PrevTxUnavailableError } from "../utils/prevoutTx";
 import { Transaction } from "../utils/transaction";
 import { ANCHOR_PKSCRIPT } from "../utils/anchor";
 import { Extension } from "../extension";
@@ -182,10 +188,13 @@ export interface Utxo {
     vout: number;
     value: number;
     /**
-     * The ark transaction that created this VTXO. Required only by continuation
-     * /recursive covenants that inspect the input's provenance; when set, the SDK
-     * attaches it as the PrevArkTx field.
+     * Raw wire bytes of the ark transaction that created this VTXO, attached as
+     * the PrevArkTx field on input 0.
      *
+     * An override, not the only channel: covenant spends resolve the previous
+     * tx of every input through the client's indexer. Supply it when the tx is
+     * not yet indexable — a recursive covenant spending the output of an ark tx
+     * the caller just built — and the resolved value is suppressed for input 0.
      */
     sourceTx?: Uint8Array;
 }
@@ -231,8 +240,12 @@ export interface ArkadeConnectOptions {
      * tapscript contracts (multisig/timelock/hashlock) don't need it.
      */
     emulator?: EmulatorProvider;
-    /** Indexer — enables `getUtxos`/`getBalance` and coin auto-selection. */
-    indexer?: Pick<IndexerProvider, "getVtxos">;
+    /**
+     * Indexer — enables `getUtxos`/`getBalance` and coin auto-selection, and
+     * resolves the previous ark txs a covenant spend must carry (see
+     * {@link attachPrevArkTxs}). Required for covenant spends.
+     */
+    indexer?: Pick<IndexerProvider, "getVtxos" | "getVirtualTxs">;
     /** Signer for paths that require a user signature; optional for watch-only. */
     identity?: Identity;
     /** Network for address derivation; defaults to the SDK default. */
@@ -283,7 +296,7 @@ export class Arkade {
      */
     readonly emulatorKey: Uint8Array | undefined;
     readonly checkpoint: CSVMultisigTapscript.Type;
-    readonly indexer?: Pick<IndexerProvider, "getVtxos">;
+    readonly indexer?: Pick<IndexerProvider, "getVtxos" | "getVirtualTxs">;
     readonly identity?: Identity;
     /** The signing identity's x-only public key, resolved at connect — identifies which inputs the wallet signs. */
     readonly userKey?: Uint8Array;
@@ -297,7 +310,7 @@ export class Arkade {
         serverKey: Uint8Array;
         emulatorKey: Uint8Array | undefined;
         checkpoint: CSVMultisigTapscript.Type;
-        indexer?: Pick<IndexerProvider, "getVtxos">;
+        indexer?: Pick<IndexerProvider, "getVtxos" | "getVirtualTxs">;
         identity?: Identity;
         userKey?: Uint8Array;
         contractManager?: IContractManager;
@@ -658,9 +671,30 @@ export class ArkadeTransactionBuilder {
         );
 
         // Continuation context for recursive covenants — the parent ark tx that
-        // created the spent coin.
+        // created the spent coin. An explicit `sourceTx` overrides the resolved
+        // value below, which skips inputs that already carry the field (the
+        // emulator refuses an input bearing two).
         if (coin.sourceTx) {
             setArkPsbtField(arkTx, 0, PrevArkTxField, coin.sourceTx);
+        }
+
+        // Emulator v0.0.7+ requires PrevArkTx on every input of a submitted ark
+        // tx. Ark tx input i spends checkpoint i, which spends inputs[i] — so
+        // the tx to carry is the coin's own creating tx, not the checkpoint.
+        // Only the covenant path goes through the emulator; arkd-direct spends
+        // stay byte-identical.
+        if (this.fn.arkadeScript) {
+            const indexer = this.contract.client.indexer;
+            if (!indexer) {
+                throw new PrevTxUnavailableError(
+                    "covenant spends require an `indexer` on the Arkade client to resolve the previous ark tx of each input",
+                );
+            }
+            await attachPrevArkTxs(
+                arkTx,
+                [coin.txid, ...this.fundingCoins.map((c) => c.txid)],
+                indexer,
+            );
         }
 
         const condition = (def.tapscript.witness ?? []).map((w) => this.witnessBytes(w));

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -273,7 +273,17 @@ import {
     CosignerPublicKey,
     VtxoTreeExpiry,
 } from "./utils/unknownFields";
-import { Intent } from "./intent";
+import {
+    resolvePrevTxs,
+    attachPrevArkTxs,
+    attachPrevoutTxs,
+    withPrevTxs,
+    PrevTxUnavailableError,
+    type PrevTxSource,
+    type RawTxSource,
+    type WithPrevTx,
+} from "./utils/prevoutTx";
+import { Intent, type IntentCoin } from "./intent";
 import { BIP322 } from "./bip322";
 import { ArkNote } from "./arknote";
 import { ArkadeCash } from "./arkadeCash";
@@ -659,6 +669,12 @@ export {
     ConditionWitness,
     PrevArkTxField,
     PrevoutTxField,
+    // Prevout tx resolution (emulator v0.0.7+)
+    resolvePrevTxs,
+    attachPrevArkTxs,
+    attachPrevoutTxs,
+    withPrevTxs,
+    PrevTxUnavailableError,
     // Utils
     buildOffchainTx,
     assertSubmittedArkTxid,
@@ -842,6 +858,10 @@ export type {
     TapscriptType,
     ArkTxInput,
     OffchainTx,
+    PrevTxSource,
+    RawTxSource,
+    WithPrevTx,
+    IntentCoin,
     VerifyServerSignatures,
     TapLeaves,
     IncomingFunds,

--- a/packages/ts-sdk/src/intent/index.ts
+++ b/packages/ts-sdk/src/intent/index.ts
@@ -3,10 +3,19 @@ import { TransactionInput, TransactionOutput } from "@scure/btc-signer/psbt.js";
 import { schnorr } from "@noble/curves/secp256k1.js";
 import { Bytes } from "@scure/btc-signer/utils.js";
 import { Transaction } from "../utils/transaction";
-import { ConditionWitness, VtxoTaprootTree } from "../utils/unknownFields";
+import { ConditionWitness, PrevArkTxField, VtxoTaprootTree } from "../utils/unknownFields";
 import { hex } from "@scure/base";
 import { getSequence, VtxoScript } from "../script/base";
 import { ExtendedCoin } from "../wallet";
+import type { WithPrevTx } from "../utils/prevoutTx";
+
+/**
+ * A coin an intent proof proves ownership of. `prevTx` carries the raw wire
+ * bytes of the transaction that created it — required by emulator v0.0.7+ on
+ * every real input of a submitted proof. {@link Intent.create} is synchronous,
+ * so the bytes are supplied rather than fetched; `withPrevTxs` fills them in.
+ */
+export type IntentCoin = WithPrevTx<ExtendedCoin>;
 
 /**
  * Intent proof implementation for Bitcoin message signing.
@@ -51,7 +60,7 @@ export namespace Intent {
      */
     export function create(
         message: string | Message,
-        ins: (TransactionInput | ExtendedCoin)[],
+        ins: (TransactionInput | IntentCoin)[],
         outputs: TransactionOutput[] = [],
     ): Proof {
         if (typeof message !== "string") {
@@ -336,7 +345,7 @@ function hashMessage(message: string, tag: string = TAG_INTENT_PROOF): Uint8Arra
     return schnorr.utils.taggedHash(tag, new TextEncoder().encode(message));
 }
 
-function prepareCoinAsIntentProofInput(coin: ExtendedCoin | TransactionInput): TransactionInput {
+function prepareCoinAsIntentProofInput(coin: IntentCoin | TransactionInput): TransactionInput {
     if (!("tapTree" in coin)) {
         return coin;
     }
@@ -346,6 +355,11 @@ function prepareCoinAsIntentProofInput(coin: ExtendedCoin | TransactionInput): T
     const unknown = [VtxoTaprootTree.encode(coin.tapTree)];
     if (coin.extraWitness) {
         unknown.push(ConditionWitness.encode(coin.extraWitness));
+    }
+    // Lands on proof input i+1 via craftToSignTx; the synthetic input 0 needs
+    // no prevout tx, the emulator synthesises one for it.
+    if (coin.prevTx) {
+        unknown.push(PrevArkTxField.encode(coin.prevTx));
     }
 
     return {

--- a/packages/ts-sdk/src/providers/electrum.ts
+++ b/packages/ts-sdk/src/providers/electrum.ts
@@ -620,6 +620,11 @@ export class ElectrumOnchainProvider implements OnchainProvider {
         throw new Error("Only 1 or 1P1C package can be broadcast");
     }
 
+    async getRawTransaction(txid: string): Promise<Uint8Array> {
+        const [tx] = await this.chain.fetchTransactions([txid]);
+        return hex.decode(tx.hex);
+    }
+
     async getTxOutspends(txid: string): Promise<{ spent: boolean; txid: string }[]> {
         // Step 1: fetch the creating tx to get its output scripts (1 round trip)
         const [txResult] = await this.chain.fetchTransactions([txid]);

--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_NETWORK_NAME, type NetworkName } from "../networks";
 import { Coin } from "../wallet";
+import { hex } from "@scure/base";
 import { baseFetch } from "../utils/fetch";
 
 /**
@@ -90,6 +91,18 @@ export interface OnchainProvider {
      * @see ExplorerTransaction
      */
     getTransactions(address: string): Promise<ExplorerTransaction[]>;
+
+    /**
+     * Fetch the raw wire-format bytes of a transaction.
+     *
+     * @param txid - Transaction id to fetch
+     * @returns Serialized transaction bytes
+     * @throws Error if the transaction is unknown to the backend
+     * @remarks
+     * Needed to carry a boarding or commitment tx as a PSBT prevout field —
+     * those have no off-chain source, so the indexer cannot serve them.
+     */
+    getRawTransaction(txid: string): Promise<Uint8Array>;
 
     /**
      * Fetch confirmation status for a transaction.
@@ -210,6 +223,15 @@ export class EsploraProvider implements OnchainProvider {
         }
 
         return response.json();
+    }
+
+    async getRawTransaction(txid: string): Promise<Uint8Array> {
+        const response = await baseFetch(`${this.baseUrl}/tx/${txid}/hex`);
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`Failed to get raw transaction ${txid}: ${error}`);
+        }
+        return hex.decode((await response.text()).trim());
     }
 
     async getTxStatus(txid: string): Promise<

--- a/packages/ts-sdk/src/utils/prevoutTx.ts
+++ b/packages/ts-sdk/src/utils/prevoutTx.ts
@@ -1,0 +1,188 @@
+import { base64, hex } from "@scure/base";
+import { Transaction } from "./transaction";
+import { PrevArkTxField, PrevoutTxField, getArkPsbtFields, setArkPsbtField } from "./unknownFields";
+
+/**
+ * Off-chain source of previous transactions: ark, tree and checkpoint txs, as
+ * base64 PSBTs keyed by txid. Structurally satisfied by `IndexerProvider`.
+ */
+export interface PrevTxSource {
+    getVirtualTxs(txids: string[]): Promise<{ txs: string[] }>;
+}
+
+/**
+ * On-chain source of previous transactions — boarding and commitment txs, which
+ * `getVirtualTxs` does not serve. Structurally satisfied by `OnchainProvider`.
+ */
+export interface RawTxSource {
+    getRawTransaction(txid: string): Promise<Uint8Array>;
+}
+
+/**
+ * A previous transaction could not be resolved, so the emulator would reject the
+ * submission with `missing prevout tx for input N`. Distinguishes "no source is
+ * wired up" from "the source did not have it" — the remedies differ.
+ */
+export class PrevTxUnavailableError extends Error {
+    constructor(
+        message: string,
+        readonly txids: string[] = [],
+    ) {
+        super(message);
+        this.name = "PrevTxUnavailableError";
+    }
+}
+
+/**
+ * Resolve raw wire-format bytes for each txid, batched and de-duplicated.
+ *
+ * Emulator v0.0.7+ requires the raw tx behind every input of a submitted ark tx
+ * or intent proof (`PrevArkTxField`) and of an onchain tx (`PrevoutTxField`).
+ * The value is a serialized `wire.MsgTx`, *not* a PSBT — `Transaction.toBytes()`
+ * with the default `(withScriptSig=false, withWitness=false)` is exactly the
+ * preimage the emulator hashes to check the tx against the outpoint.
+ *
+ * Off-chain txs are fetched in one batched call; anything the indexer does not
+ * serve (a commitment or boarding tx) falls through to `onchain` when supplied.
+ */
+export async function resolvePrevTxs(
+    txids: string[],
+    source: PrevTxSource,
+    onchain?: RawTxSource,
+): Promise<Map<string, Uint8Array>> {
+    const resolved = new Map<string, Uint8Array>();
+    const wanted = [...new Set(txids)];
+    if (wanted.length === 0) return resolved;
+
+    // The response is not guaranteed to come back in request order, so key by
+    // the txid each PSBT actually computes to rather than by position.
+    try {
+        const { txs } = await source.getVirtualTxs(wanted);
+        for (const psbt of txs) {
+            const tx = Transaction.fromPSBT(base64.decode(psbt));
+            resolved.set(tx.id, tx.toBytes());
+        }
+    } catch (err) {
+        // An indexer that rejects the whole batch over one unknown txid must not
+        // sink a boarding tx the onchain source could have served.
+        if (!onchain) throw err;
+    }
+
+    let missing = wanted.filter((txid) => !resolved.has(txid));
+    if (missing.length > 0 && onchain) {
+        const raw = await Promise.all(
+            missing.map(async (txid) => {
+                try {
+                    return await onchain.getRawTransaction(txid);
+                } catch {
+                    return undefined; // a miss here is reported below, with all the others
+                }
+            }),
+        );
+        for (const [i, bytes] of raw.entries()) {
+            if (bytes) resolved.set(missing[i], bytes);
+        }
+        missing = missing.filter((txid) => !resolved.has(txid));
+    }
+
+    if (missing.length > 0) {
+        throw new PrevTxUnavailableError(
+            `cannot resolve the previous transaction of ${missing.join(", ")}` +
+                (onchain ? "" : " (no onchain source configured)"),
+            missing,
+        );
+    }
+    return resolved;
+}
+
+/**
+ * Attach `PrevArkTxField` to every input of `tx` that does not already carry
+ * one, resolving the bytes for `txids[i]` — the coin input `i` ultimately
+ * spends.
+ *
+ * Inputs already carrying the field are skipped rather than overwritten: the
+ * emulator rejects an input with more than one field of the same type, so a
+ * caller-supplied value (`Utxo.sourceTx`) must win outright. Nothing is fetched
+ * when every input is already covered.
+ */
+export async function attachPrevArkTxs(
+    tx: Transaction,
+    txids: string[],
+    source: PrevTxSource,
+    onchain?: RawTxSource,
+): Promise<void> {
+    const pending: number[] = [];
+    for (let i = 0; i < tx.inputsLength; i++) {
+        if (getArkPsbtFields(tx, i, PrevArkTxField).length === 0) pending.push(i);
+    }
+    if (pending.length === 0) return;
+
+    const resolved = await resolvePrevTxs(
+        pending.map((i) => txidAt(txids, i)),
+        source,
+        onchain,
+    );
+    for (const i of pending) {
+        setArkPsbtField(tx, i, PrevArkTxField, resolved.get(txidAt(txids, i))!);
+    }
+}
+
+/**
+ * Attach `PrevoutTxField` to every input of an onchain PSBT, reading each
+ * input's own outpoint — unlike an ark tx, an onchain tx spends its prevout
+ * directly, so the txid is in the PSBT already.
+ */
+export async function attachPrevoutTxs(tx: Transaction, source: RawTxSource): Promise<void> {
+    const pending: { index: number; txid: string }[] = [];
+    for (let i = 0; i < tx.inputsLength; i++) {
+        if (getArkPsbtFields(tx, i, PrevoutTxField).length > 0) continue;
+        const input = tx.getInput(i);
+        if (!input?.txid) throw new PrevTxUnavailableError(`input ${i} has no outpoint`);
+        pending.push({ index: i, txid: hex.encode(input.txid) });
+    }
+    if (pending.length === 0) return;
+
+    const resolved = new Map<string, Uint8Array>();
+    for (const txid of new Set(pending.map((p) => p.txid))) {
+        resolved.set(txid, await source.getRawTransaction(txid));
+    }
+    for (const { index, txid } of pending) {
+        setArkPsbtField(tx, index, PrevoutTxField, resolved.get(txid)!);
+    }
+}
+
+/**
+ * A coin an intent proof spends, carrying the raw previous tx the emulator needs
+ * to resolve its prevout pkScript.
+ */
+export type WithPrevTx<T> = T & { prevTx?: Uint8Array };
+
+/**
+ * Fill in `prevTx` on every coin an intent proof will spend, in one batched
+ * lookup. The proof's synthetic input 0 needs nothing — the emulator synthesises
+ * a one-output tx for it — so this covers exactly the coins, which land on proof
+ * inputs `1..n`.
+ */
+export async function withPrevTxs<T extends { txid: string; prevTx?: Uint8Array }>(
+    coins: T[],
+    source: PrevTxSource,
+    onchain?: RawTxSource,
+): Promise<T[]> {
+    const pending = coins.filter((c) => !c.prevTx);
+    if (pending.length === 0) return coins;
+
+    const resolved = await resolvePrevTxs(
+        pending.map((c) => c.txid),
+        source,
+        onchain,
+    );
+    return coins.map((c) => (c.prevTx ? c : { ...c, prevTx: resolved.get(c.txid)! }));
+}
+
+function txidAt(txids: string[], index: number): string {
+    const txid = txids[index];
+    if (txid === undefined) {
+        throw new PrevTxUnavailableError(`no source txid supplied for input ${index}`);
+    }
+    return txid;
+}

--- a/packages/ts-sdk/test/arkade-contract.test.ts
+++ b/packages/ts-sdk/test/arkade-contract.test.ts
@@ -13,12 +13,13 @@ import {
     type EmulatorInfo,
     type EmulatorProvider,
 } from "../src";
+import { getVirtualTxs, mintCoin } from "./helpers/prevArkTx";
 
 function xOnly(): Uint8Array {
     return schnorr.getPublicKey(schnorr.utils.randomSecretKey());
 }
 
-const COIN = { txid: hex.encode(new Uint8Array(32).fill(1)), vout: 0, value: 10_000 };
+const COIN = mintCoin(10_000);
 const HASH = new Uint8Array(20).fill(7);
 const AMOUNT = 10_000n;
 
@@ -90,6 +91,7 @@ function stubProviders(server: Uint8Array, emulatorKey: Uint8Array) {
         async getVtxos() {
             return { vtxos: [{ ...COIN } as any] };
         },
+        getVirtualTxs,
     };
     const captured: { arkTx?: string } = {};
     const emulator: EmulatorProvider = {

--- a/packages/ts-sdk/test/arkade-features.test.ts
+++ b/packages/ts-sdk/test/arkade-features.test.ts
@@ -11,9 +11,13 @@ import {
     Extension,
     Transaction,
     networks,
+    getArkPsbtFields,
+    PrevArkTxField,
+    PrevTxUnavailableError,
     type EmulatorInfo,
     type EmulatorProvider,
 } from "../src";
+import { getVirtualTxs, mintCoin } from "./helpers/prevArkTx";
 
 function xOnly(): Uint8Array {
     return schnorr.getPublicKey(schnorr.utils.randomSecretKey());
@@ -57,9 +61,7 @@ function claimProgram(): arkade.Program {
 function fundingCoin(value: number) {
     const vs = new VtxoScript([MultisigTapscript.encode({ pubkeys: [xOnly(), xOnly()] }).script]);
     return {
-        txid: hex.encode(xOnly()),
-        vout: 0,
-        value,
+        ...mintCoin(value),
         tapLeafScript: vs.leaves[0],
         tapTree: vs.encode(),
     };
@@ -118,6 +120,7 @@ function providers(
         async getVtxos() {
             return { vtxos: coins.map((c) => ({ ...c }) as any) };
         },
+        getVirtualTxs: vi.fn(getVirtualTxs),
     };
     const emulator: EmulatorProvider = {
         async getInfo(): Promise<EmulatorInfo> {
@@ -146,7 +149,7 @@ describe("ArkadeContract — extended features", () => {
     const server = xOnly();
     const emulatorKey = xOnly();
     const receiver = xOnly();
-    const COIN = { txid: hex.encode(new Uint8Array(32).fill(9)), vout: 0, value: 10_000 };
+    const COIN = mintCoin(10_000);
 
     it("resolves the 'user' signer from the client identity", async () => {
         const { identity, key } = mockIdentity();
@@ -212,7 +215,49 @@ describe("ArkadeContract — extended features", () => {
         ).toBe(true);
     });
 
-    it("coin.sourceTx sets the PrevArkTx field on the contract input", async () => {
+    it("resolves a PrevArkTx field for every input of a covenant spend", async () => {
+        const { arkProvider, indexer, emulator } = providers(server, emulatorKey, [COIN]);
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            emulator,
+            indexer,
+            network: networks.regtest,
+        });
+        const c = ark.contract(claimProgram(), {
+            receiver,
+            amount: AMOUNT,
+            h: new Uint8Array(20),
+        });
+        const funding = fundingCoin(60_000);
+
+        const { arkTx, checkpoints } = await c.functions
+            .claim(new Uint8Array(32).fill(0x42))
+            .from(COIN)
+            .fund([funding])
+            .to(p2tr(receiver), AMOUNT)
+            .change(p2tr())
+            .build();
+
+        // Ark tx input i spends checkpoint i, which spends the coin — so the tx
+        // carried by input i must hash to that coin's txid, not the checkpoint's.
+        for (const [i, coin] of [COIN, funding].entries()) {
+            const fields = getArkPsbtFields(arkTx, i, PrevArkTxField);
+            expect(fields).toHaveLength(1);
+            expect(Transaction.fromRaw(fields[0]).id).toBe(coin.txid);
+        }
+
+        // The indirection above only holds while checkpoint i spends coin i and
+        // ark input i spends that checkpoint's vout 0. Guard the shape.
+        for (const [i, coin] of [COIN, funding].entries()) {
+            expect(checkpoints[i].inputsLength).toBe(1);
+            expect(hex.encode(checkpoints[i].getInput(0).txid!)).toBe(coin.txid);
+            expect(checkpoints[i].outputsLength).toBe(2); // vtxo + P2A anchor
+            expect(hex.encode(arkTx.getInput(i).txid!)).toBe(checkpoints[i].id);
+            expect(arkTx.getInput(i).index).toBe(0);
+        }
+    });
+
+    it("coin.sourceTx overrides the resolved PrevArkTx on the contract input", async () => {
         const { arkProvider, indexer, emulator, captured } = providers(server, emulatorKey, [COIN]);
         const ark = await arkade.Arkade.connect({
             arkade: arkProvider,
@@ -226,27 +271,49 @@ describe("ArkadeContract — extended features", () => {
             h: new Uint8Array(20),
         });
         const sourceTx = new Uint8Array(64).fill(7);
-        const preimage = new Uint8Array(32).fill(0x42);
 
-        // baseline (no sourceTx)
-        await c.functions.claim(preimage).from(COIN).to(p2tr(receiver), AMOUNT).send();
-        const base = Transaction.fromPSBT(base64.decode(captured.arkTx!)).getInput(0).unknown ?? [];
-
-        // with sourceTx → exactly one more unknown field on input 0
         await c.functions
-            .claim(preimage)
+            .claim(new Uint8Array(32).fill(0x42))
             .from({ ...COIN, sourceTx })
             .to(p2tr(receiver), AMOUNT)
             .send();
-        const withPrev =
-            Transaction.fromPSBT(base64.decode(captured.arkTx!)).getInput(0).unknown ?? [];
 
-        expect(withPrev.length).toBe(base.length + 1);
+        // Exactly one field, the caller's — the emulator rejects an input
+        // carrying two.
+        const fields = getArkPsbtFields(
+            Transaction.fromPSBT(base64.decode(captured.arkTx!)),
+            0,
+            PrevArkTxField,
+        );
+        expect(fields).toHaveLength(1);
+        expect(hex.encode(fields[0])).toBe(hex.encode(sourceTx));
+    });
+
+    it("refuses a covenant spend with no indexer to resolve prevout txs", async () => {
+        const { arkProvider, emulator } = providers(server, emulatorKey, [COIN]);
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            emulator,
+            network: networks.regtest,
+        });
+        const c = ark.contract(claimProgram(), {
+            receiver,
+            amount: AMOUNT,
+            h: new Uint8Array(20),
+        });
+
+        await expect(
+            c.functions
+                .claim(new Uint8Array(32).fill(0x42))
+                .from(COIN)
+                .to(p2tr(receiver), AMOUNT)
+                .send(),
+        ).rejects.toBeInstanceOf(PrevTxUnavailableError);
     });
 
     it("selects the smallest contract coin covering the outputs", async () => {
-        const small = { txid: hex.encode(new Uint8Array(32).fill(1)), vout: 0, value: 5_000 };
-        const big = { txid: hex.encode(new Uint8Array(32).fill(2)), vout: 0, value: 20_000 };
+        const small = mintCoin(5_000);
+        const big = mintCoin(20_000);
         const { arkProvider, indexer, emulator, captured } = providers(server, emulatorKey, [
             small,
             big,
@@ -301,6 +368,11 @@ describe("ArkadeContract — extended features", () => {
         expect(arkProvider.submitTx).toHaveBeenCalled();
         expect(arkProvider.finalizeTx).toHaveBeenCalled();
         expect(emulator.submitTx).not.toHaveBeenCalled();
+        // Prevout resolution is emulator-only: arkd-direct spends must keep the
+        // bytes they had before v0.0.7 support landed.
+        const arkd = Transaction.fromPSBT(base64.decode(captured.arkTx!));
+        expect(getArkPsbtFields(arkd, 0, PrevArkTxField)).toHaveLength(0);
+        expect(indexer.getVirtualTxs).not.toHaveBeenCalled();
     });
 
     // A pure-tapscript spend with one funded input: two checkpoints, so the
@@ -545,7 +617,7 @@ describe("ArkadeContract — extended features", () => {
             amount: AMOUNT,
             h: new Uint8Array(20),
         });
-        const bigCoin = { txid: hex.encode(new Uint8Array(32).fill(5)), vout: 0, value: 25_000 };
+        const bigCoin = mintCoin(25_000);
         const preimage = new Uint8Array(32).fill(0x42);
 
         // surplus (25_000 in, 10_000 out) with no change → throws

--- a/packages/ts-sdk/test/e2e/arkade-script.test.ts
+++ b/packages/ts-sdk/test/e2e/arkade-script.test.ts
@@ -5,14 +5,14 @@ import { p2tr, SigHash } from "@scure/btc-signer";
 import {
     arkade,
     asset,
+    attachPrevArkTxs,
+    attachPrevoutTxs,
     buildOffchainTx,
     ArkAddress,
     EsploraProvider,
     networks,
-    PrevoutTxField,
     RestArkProvider,
     RestIndexerProvider,
-    setArkPsbtField,
     SingleKey,
     Transaction,
     Intent,
@@ -20,6 +20,7 @@ import {
     RestEmulatorProvider,
     Extension,
     EmulatorPacket,
+    withPrevTxs,
 } from "../../src";
 import type { Identity } from "../../src/identity";
 import {
@@ -339,20 +340,27 @@ describe("arkade", () => {
 
         // Create the intent proof. `script` is what marks this as a virtual output rather than a
         // boarding input, so the batch handler builds a forfeit for it.
-        const coin = {
-            txid: vtxo.txid,
-            vout: vtxo.vout,
-            value: vtxo.value,
-            tapTree,
-            forfeitTapLeafScript: arkadeLeaf,
-            intentTapLeafScript: arkadeLeaf,
-            status: vtxo.status,
-            script: vtxo.script,
-            createdAt: vtxo.createdAt,
-            isUnrolled: vtxo.isUnrolled,
-            isSpent: vtxo.isSpent,
-            virtualStatus: vtxo.virtualStatus,
-        };
+        // `prevTx` carries the raw creating tx of each real proof input — the
+        // emulator resolves the prevout pkScript from it.
+        const [coin] = await withPrevTxs(
+            [
+                {
+                    txid: vtxo.txid,
+                    vout: vtxo.vout,
+                    value: vtxo.value,
+                    tapTree,
+                    forfeitTapLeafScript: arkadeLeaf,
+                    intentTapLeafScript: arkadeLeaf,
+                    status: vtxo.status,
+                    script: vtxo.script,
+                    createdAt: vtxo.createdAt,
+                    isUnrolled: vtxo.isUnrolled,
+                    isSpent: vtxo.isSpent,
+                    virtualStatus: vtxo.virtualStatus,
+                },
+            ],
+            indexerProvider,
+        );
 
         const intentProof = Intent.create(
             message,
@@ -502,18 +510,26 @@ describe("arkade", () => {
             cosigners_public_keys: [sessionPubKey],
         };
 
-        const coin = {
-            txid: utxo.txid,
-            vout: utxo.vout,
-            value: utxo.value,
-            tapTree,
-            forfeitTapLeafScript: arkadeLeaf,
-            intentTapLeafScript: arkadeLeaf,
-            status: {
-                confirmed: utxo.status?.confirmed ?? false,
-                block_time: 0,
-            },
-        };
+        // A boarding input's prevout is an onchain funding tx — `getVirtualTxs`
+        // serves ark/tree/checkpoint txs only, so the explorer is the source.
+        const [coin] = await withPrevTxs(
+            [
+                {
+                    txid: utxo.txid,
+                    vout: utxo.vout,
+                    value: utxo.value,
+                    tapTree,
+                    forfeitTapLeafScript: arkadeLeaf,
+                    intentTapLeafScript: arkadeLeaf,
+                    status: {
+                        confirmed: utxo.status?.confirmed ?? false,
+                        block_time: 0,
+                    },
+                },
+            ],
+            indexerProvider,
+            explorer,
+        );
 
         const intentProof = Intent.create(
             message,
@@ -623,6 +639,8 @@ describe("arkade", () => {
             ark.checkpoint,
         );
 
+        await attachPrevArkTxs(arkTx, [vtxo.txid], indexerProvider);
+
         // Bob signs the arkTx and checkpoints; emulator auto-finalizes via
         // arkd because it's the last non-arkd signer.
         const bobSignedArkTx = await bob.sign(arkTx);
@@ -712,6 +730,8 @@ describe("arkade", () => {
             ark.checkpoint,
         );
 
+        await attachPrevArkTxs(mintTx, [mintVtxo.txid], indexerProvider);
+
         // Bob signs the mint tx and checkpoints; emulator auto-finalizes via
         // arkd because it's the last non-arkd signer.
         const bobSignedMintTx = await bob.sign(mintTx);
@@ -768,20 +788,25 @@ describe("arkade", () => {
         };
 
         // `script` marks this as a virtual output — see the note on `coin` in TestSettlement.
-        const settleCoin = {
-            txid: settleVtxo.txid,
-            vout: settleVtxo.vout,
-            value: settleVtxo.value,
-            tapTree: settleTapTree,
-            forfeitTapLeafScript: settleArkadeLeaf,
-            intentTapLeafScript: settleArkadeLeaf,
-            status: settleVtxo.status,
-            script: settleVtxo.script,
-            createdAt: settleVtxo.createdAt,
-            isUnrolled: settleVtxo.isUnrolled,
-            isSpent: settleVtxo.isSpent,
-            virtualStatus: settleVtxo.virtualStatus,
-        };
+        const [settleCoin] = await withPrevTxs(
+            [
+                {
+                    txid: settleVtxo.txid,
+                    vout: settleVtxo.vout,
+                    value: settleVtxo.value,
+                    tapTree: settleTapTree,
+                    forfeitTapLeafScript: settleArkadeLeaf,
+                    intentTapLeafScript: settleArkadeLeaf,
+                    status: settleVtxo.status,
+                    script: settleVtxo.script,
+                    createdAt: settleVtxo.createdAt,
+                    isUnrolled: settleVtxo.isUnrolled,
+                    isSpent: settleVtxo.isSpent,
+                    virtualStatus: settleVtxo.virtualStatus,
+                },
+            ],
+            indexerProvider,
+        );
 
         const settleIntentProof = Intent.create(
             settleMessage,
@@ -863,7 +888,6 @@ describe("arkade", () => {
         // fund the contract address on-chain
         faucetOnchain(vtxoScript.onchainAddress(networks.regtest), FUNDING_SATS);
         const utxo = await waitForUtxo(vtxoScript.onchainAddress(networks.regtest));
-        const rawFundingTx = hex.decode(await fetchTxHex(utxo.txid));
 
         // build the unsigned 1-in/1-out spend PSBT with all required arkade fields
         const tx = new Transaction({ version: 2 });
@@ -876,7 +900,7 @@ describe("arkade", () => {
             sighashType: SigHash.DEFAULT,
         });
         tx.addOutput({ script: bobP2TR, amount: SPEND_AMOUNT });
-        setArkPsbtField(tx, 0, PrevoutTxField, rawFundingTx);
+        await attachPrevoutTxs(tx, explorer);
         addEmulatorPacket(tx, [
             {
                 vin: 0,
@@ -903,12 +927,3 @@ describe("arkade", () => {
         expect(broadcastTxid).toBeTruthy();
     });
 });
-
-/** Fetch the raw hex of a transaction from the Esplora REST API */
-async function fetchTxHex(txid: string): Promise<string> {
-    const resp = await fetch(`${ESPLORA_URL}/tx/${txid}/hex`);
-    if (!resp.ok) {
-        throw new Error(`fetchTxHex failed: ${resp.statusText}`);
-    }
-    return resp.text();
-}

--- a/packages/ts-sdk/test/e2e/liquidation.test.ts
+++ b/packages/ts-sdk/test/e2e/liquidation.test.ts
@@ -5,6 +5,7 @@ import { numberToBytesBE } from "@noble/curves/utils.js";
 import {
     arkade,
     asset,
+    attachPrevArkTxs,
     buildOffchainTx,
     EmulatorPacket,
     Extension,
@@ -120,6 +121,10 @@ describe("liquidation (oracle-signed asset burn)", () => {
             ],
             ark.checkpoint,
         );
+
+        // Emulator v0.0.7+ needs the previous ark tx of every input; the builder
+        // does this itself, a hand-rolled buildOffchainTx has to ask for it.
+        await attachPrevArkTxs(mintTx, [mintCoin.txid], indexerProvider);
 
         const mintResult = await emulator.submitTx(
             base64.encode(mintTx.toPSBT()),

--- a/packages/ts-sdk/test/e2e/non-interactive-delegate.test.ts
+++ b/packages/ts-sdk/test/e2e/non-interactive-delegate.test.ts
@@ -11,13 +11,12 @@ import {
     resolveBatchExpiryPolicy,
     Intent,
     networks,
-    PrevArkTxField,
     RestArkProvider,
     RestIndexerProvider,
     RestEmulatorProvider,
-    setArkPsbtField,
     SingleKey,
     VtxoScript,
+    withPrevTxs,
 } from "../../src";
 import { Transaction } from "../../src/utils/transaction";
 import { buildForfeitTx } from "../../src/forfeit";
@@ -43,7 +42,7 @@ const delegateProgram = {
             arkadeScript: {
                 asm: [
                     "INSPECTVERSION",
-                    new Uint8Array([0x02, 0x00, 0x00, 0x00]),
+                    2,
                     "EQUALVERIFY",
                     0,
                     "INSPECTOUTPUTSCRIPTPUBKEY",
@@ -102,12 +101,6 @@ describe("arkade delegate (covenant batch refresh) — intent submission", () =>
         faucetOffchain(contract.address, DELEGATE_AMOUNT);
         const [vtxo] = await waitForVtxo(indexerProvider, delegatePkScript);
 
-        // Retrieve the funding virtual tx so we can attach PrevArkTxField.
-        const { txs: virtualTxs } = await indexerProvider.getVirtualTxs([vtxo.txid]);
-        expect(virtualTxs).toHaveLength(1);
-        const fundingTx = Transaction.fromPSBT(base64.decode(virtualTxs[0]));
-        const fundingTxRaw = fundingTx.toBytes();
-
         // The arkade forfeit leaf (server + intro_tweaked) is leaf 0.
         const arkadeLeaf = contract.leafScript(0);
         const tapTree = contract.tapTree;
@@ -126,17 +119,24 @@ describe("arkade delegate (covenant batch refresh) — intent submission", () =>
         };
 
         // Construct the extended coin shape that Intent.create expects.
-        const coin = {
-            txid: vtxo.txid,
-            vout: vtxo.vout,
-            value: vtxo.value,
-            tapTree,
-            forfeitTapLeafScript: arkadeLeaf,
-            intentTapLeafScript: arkadeLeaf,
-            status: vtxo.status,
-            isSpent: vtxo.isSpent,
-            virtualStatus: vtxo.virtualStatus,
-        };
+        // OP_INSPECTINPUTSCRIPTPUBKEY needs to resolve the prevout pkScript of
+        // every real input, so each coin carries its creating tx as PrevArkTx.
+        const [coin] = await withPrevTxs(
+            [
+                {
+                    txid: vtxo.txid,
+                    vout: vtxo.vout,
+                    value: vtxo.value,
+                    tapTree,
+                    forfeitTapLeafScript: arkadeLeaf,
+                    intentTapLeafScript: arkadeLeaf,
+                    status: vtxo.status,
+                    isSpent: vtxo.isSpent,
+                    virtualStatus: vtxo.virtualStatus,
+                },
+            ],
+            indexerProvider,
+        );
 
         // Self-send to the same pkScript with the same amount.
         const validProof = Intent.create(
@@ -153,9 +153,6 @@ describe("arkade delegate (covenant batch refresh) — intent submission", () =>
                 witness: new Uint8Array(0),
             },
         ]);
-        // OP_INSPECTINPUTSCRIPTPUBKEY needs to resolve the prevout
-        // pkScript for input 1, provided via PrevArkTxField.
-        setArkPsbtField(validProof, 1, PrevArkTxField, fundingTxRaw);
 
         const signedProof = await emulator.submitIntent({
             proof: base64.encode(validProof.toPSBT()),

--- a/packages/ts-sdk/test/e2e/utils.ts
+++ b/packages/ts-sdk/test/e2e/utils.ts
@@ -577,8 +577,10 @@ export function enforcePayTo(pkScript: Uint8Array, amount: bigint): Uint8Array {
  */
 export function enforceSelfSend(): Uint8Array {
     return arkade.ArkadeScript.encode([
+        // Emulator v0.0.7 pushes the version as a minimally-encoded script
+        // number; v0.0.5 pushed a fixed 4-byte LE word.
         "INSPECTVERSION",
-        new Uint8Array([0x02, 0x00, 0x00, 0x00]),
+        2,
         "EQUALVERIFY",
         // output[0].scriptPubKey
         0,

--- a/packages/ts-sdk/test/electrum.test.ts
+++ b/packages/ts-sdk/test/electrum.test.ts
@@ -225,6 +225,16 @@ describe("ElectrumOnchainProvider", () => {
         });
     });
 
+    describe("getRawTransaction", () => {
+        it("returns the wire bytes of the fetched tx hex", async () => {
+            wsMock.request.mockResolvedValueOnce("0200000001ab");
+
+            const raw = await provider.getRawTransaction("deadbeef");
+
+            expect(Array.from(raw)).toEqual([0x02, 0x00, 0x00, 0x00, 0x01, 0xab]);
+        });
+    });
+
     describe("getFeeRate", () => {
         it("converts BTC/kB to sat/vB with Math.max(1, ceil) guard", async () => {
             wsMock.request.mockResolvedValueOnce(0.00002);

--- a/packages/ts-sdk/test/esplora.test.ts
+++ b/packages/ts-sdk/test/esplora.test.ts
@@ -56,6 +56,35 @@ describe("EsploraProvider", () => {
         });
     });
 
+    describe("getRawTransaction", () => {
+        it("decodes the /hex endpoint into wire bytes", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                // Esplora's plain-text response is newline-terminated on some
+                // deployments; hex.decode rejects the stray byte.
+                text: () => Promise.resolve("0200000001ab\n"),
+            });
+
+            const provider = new EsploraProvider("http://localhost:3000");
+            const raw = await provider.getRawTransaction("deadbeef");
+
+            expect(mockFetch).toHaveBeenCalledWith("http://localhost:3000/tx/deadbeef/hex");
+            expect(Array.from(raw)).toEqual([0x02, 0x00, 0x00, 0x00, 0x01, 0xab]);
+        });
+
+        it("throws with the txid on a failed fetch", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                text: () => Promise.resolve("Transaction not found"),
+            });
+
+            const provider = new EsploraProvider("http://localhost:3000");
+            await expect(provider.getRawTransaction("deadbeef")).rejects.toThrow(
+                /deadbeef.*Transaction not found/,
+            );
+        });
+    });
+
     describe("getFeeRate", () => {
         const mockFeeResponse = {
             "1": 80,

--- a/packages/ts-sdk/test/helpers/prevArkTx.ts
+++ b/packages/ts-sdk/test/helpers/prevArkTx.ts
@@ -1,0 +1,35 @@
+import { base64 } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { Transaction } from "../../src";
+
+/**
+ * Emulator v0.0.7+ makes a covenant spend resolve the previous ark tx of every
+ * input through the indexer, and the resolver keys results by the txid each PSBT
+ * actually computes to. So a test coin can no longer carry a made-up txid: it
+ * has to be the real id of a tx the mock indexer can serve.
+ */
+const minted = new Map<string, string>();
+
+/** A coin whose txid is the real id of a servable stand-in previous ark tx. */
+export function mintCoin(value: number, vout = 0): { txid: string; vout: number; value: number } {
+    const seed = minted.size + 1;
+    const script = new Uint8Array([
+        0x51,
+        0x20,
+        ...schnorr.getPublicKey(new Uint8Array(32).fill(seed & 0xff || 1)),
+    ]);
+    const tx = new Transaction({ version: 3 });
+    tx.addInput({
+        txid: new Uint8Array(32).fill(seed & 0xff),
+        index: seed,
+        witnessUtxo: { script, amount: BigInt(value) },
+    });
+    tx.addOutput({ script, amount: BigInt(value) });
+    minted.set(tx.id, base64.encode(tx.toPSBT()));
+    return { txid: tx.id, vout, value };
+}
+
+/** `IndexerProvider.getVirtualTxs` over everything {@link mintCoin} has minted. */
+export async function getVirtualTxs(txids: string[]): Promise<{ txs: string[] }> {
+    return { txs: txids.map((t) => minted.get(t)).filter((p): p is string => p !== undefined) };
+}

--- a/packages/ts-sdk/test/intent.test.ts
+++ b/packages/ts-sdk/test/intent.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { Intent } from "../src/intent";
 import { Transaction } from "../src/utils/transaction";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import {
+    getArkPsbtFields,
+    MultisigTapscript,
+    PrevArkTxField,
+    VtxoScript,
+    type IntentCoin,
+} from "../src";
 
 const PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09;
 
@@ -87,6 +96,58 @@ describe("Intent", () => {
             const proof = Intent.create("msg", inputs);
 
             expect(proof.lockTime).toBe(0);
+        });
+    });
+
+    describe("prevTx (emulator v0.0.7+)", () => {
+        function vtxoCoin(seed: number, prevTx?: Uint8Array) {
+            const vs = new VtxoScript([
+                MultisigTapscript.encode({
+                    pubkeys: [
+                        schnorr.getPublicKey(new Uint8Array(32).fill(seed)),
+                        schnorr.getPublicKey(new Uint8Array(32).fill(seed + 1)),
+                    ],
+                }).script,
+            ]);
+            return {
+                txid: hex.encode(new Uint8Array(32).fill(seed)),
+                vout: 0,
+                value: 1000,
+                tapTree: vs.encode(),
+                forfeitTapLeafScript: vs.leaves[0],
+                intentTapLeafScript: vs.leaves[0],
+                prevTx,
+            } as unknown as IntentCoin;
+        }
+
+        it("puts the field on the coin's proof input, never on the synthetic input 0", () => {
+            const prevTx = new Uint8Array(40).fill(3);
+
+            const proof = Intent.create("msg", [vtxoCoin(1, prevTx)]);
+
+            expect(getArkPsbtFields(proof, 0, PrevArkTxField)).toHaveLength(0);
+            const onCoin = getArkPsbtFields(proof, 1, PrevArkTxField);
+            expect(onCoin).toHaveLength(1);
+            expect(hex.encode(onCoin[0])).toBe(hex.encode(prevTx));
+        });
+
+        it("keeps input 0's witnessUtxo at the first coin's script with a zero amount", () => {
+            // The emulator synthesises a one-output tx for input 0 from exactly
+            // these two values, so they are part of the wire contract.
+            const coin = vtxoCoin(5, new Uint8Array(40).fill(3));
+
+            const proof = Intent.create("msg", [coin]);
+
+            expect(proof.getInput(0).witnessUtxo!.amount).toBe(0n);
+            expect(hex.encode(proof.getInput(0).witnessUtxo!.script)).toBe(
+                hex.encode(proof.getInput(1).witnessUtxo!.script),
+            );
+        });
+
+        it("attaches nothing when the coin carries no prevTx", () => {
+            const proof = Intent.create("msg", [vtxoCoin(9)]);
+
+            expect(getArkPsbtFields(proof, 1, PrevArkTxField)).toHaveLength(0);
         });
     });
 

--- a/packages/ts-sdk/test/prevoutTx.test.ts
+++ b/packages/ts-sdk/test/prevoutTx.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi } from "vitest";
+import { base64, hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import {
+    Transaction,
+    resolvePrevTxs,
+    attachPrevArkTxs,
+    attachPrevoutTxs,
+    withPrevTxs,
+    PrevTxUnavailableError,
+    PrevArkTxField,
+    PrevoutTxField,
+    getArkPsbtFields,
+    setArkPsbtField,
+} from "../src";
+
+function p2tr(seed = 1): Uint8Array {
+    return new Uint8Array([
+        0x51,
+        0x20,
+        ...schnorr.getPublicKey(new Uint8Array(32).fill(seed || 1)),
+    ]);
+}
+
+/** A one-input/one-output tx standing in for a previous ark tx. */
+function prevTx(seed: number): { txid: string; psbt: string; raw: Uint8Array } {
+    const tx = new Transaction({ version: 3 });
+    tx.addInput({
+        txid: new Uint8Array(32).fill(seed),
+        index: 0,
+        witnessUtxo: { script: p2tr(seed), amount: 1_000n },
+    });
+    tx.addOutput({ script: p2tr(seed), amount: 900n });
+    return { txid: tx.id, psbt: base64.encode(tx.toPSBT()), raw: tx.toBytes() };
+}
+
+/** An indexer serving only the txs it was seeded with, in reverse request order. */
+function indexerOf(txs: { txid: string; psbt: string }[]) {
+    const byTxid = new Map(txs.map((t) => [t.txid, t.psbt]));
+    return {
+        getVirtualTxs: vi.fn(async (txids: string[]) => ({
+            // Order is not part of the contract; reverse it to prove the
+            // resolver keys by the txid each PSBT computes to.
+            txs: txids
+                .map((t) => byTxid.get(t))
+                .filter((p): p is string => p !== undefined)
+                .reverse(),
+        })),
+    };
+}
+
+/** An ark tx shaped like `buildOffchainTx` output: n inputs spending n checkpoints. */
+function arkTxWith(inputs: number): Transaction {
+    const tx = new Transaction({ version: 3 });
+    for (let i = 0; i < inputs; i++) {
+        tx.addInput({
+            txid: new Uint8Array(32).fill(0x80 + i),
+            index: 0,
+            witnessUtxo: { script: p2tr(i), amount: 1_000n },
+        });
+    }
+    tx.addOutput({ script: p2tr(9), amount: 900n });
+    return tx;
+}
+
+describe("resolvePrevTxs", () => {
+    it("batches and de-duplicates into one call", async () => {
+        const a = prevTx(1);
+        const b = prevTx(2);
+        const indexer = indexerOf([a, b]);
+
+        const got = await resolvePrevTxs([a.txid, b.txid, a.txid], indexer);
+
+        expect(indexer.getVirtualTxs).toHaveBeenCalledTimes(1);
+        expect(indexer.getVirtualTxs.mock.calls[0][0]).toEqual([a.txid, b.txid]);
+        expect(got.size).toBe(2);
+    });
+
+    it("returns the raw wire bytes that hash to the requested txid", async () => {
+        const a = prevTx(3);
+        const got = await resolvePrevTxs([a.txid], indexerOf([a]));
+
+        const raw = got.get(a.txid)!;
+        expect(hex.encode(raw)).toBe(hex.encode(a.raw));
+        expect(Transaction.fromRaw(raw).id).toBe(a.txid);
+    });
+
+    it("is a no-op with no txids", async () => {
+        const indexer = indexerOf([]);
+        expect((await resolvePrevTxs([], indexer)).size).toBe(0);
+        expect(indexer.getVirtualTxs).not.toHaveBeenCalled();
+    });
+
+    it("names the missing txids when the source comes up short", async () => {
+        const a = prevTx(4);
+        const b = prevTx(5);
+
+        await expect(resolvePrevTxs([a.txid, b.txid], indexerOf([a]))).rejects.toThrow(
+            new RegExp(b.txid),
+        );
+        await expect(resolvePrevTxs([b.txid], indexerOf([]))).rejects.toBeInstanceOf(
+            PrevTxUnavailableError,
+        );
+    });
+
+    it("falls through to the onchain source for txs the indexer does not serve", async () => {
+        const a = prevTx(6);
+        const boarding = prevTx(7);
+        const onchain = {
+            getRawTransaction: vi.fn(async (txid: string) => {
+                if (txid !== boarding.txid) throw new Error("unknown tx");
+                return boarding.raw;
+            }),
+        };
+
+        const got = await resolvePrevTxs([a.txid, boarding.txid], indexerOf([a]), onchain);
+
+        expect(onchain.getRawTransaction).toHaveBeenCalledTimes(1);
+        expect(hex.encode(got.get(boarding.txid)!)).toBe(hex.encode(boarding.raw));
+    });
+
+    it("falls through when the indexer rejects the whole batch", async () => {
+        const boarding = prevTx(9);
+        const rejecting = {
+            getVirtualTxs: vi.fn(async () => {
+                throw new Error("Failed to fetch virtual txs: Not Found");
+            }),
+        };
+        const onchain = { getRawTransaction: async () => boarding.raw };
+
+        const got = await resolvePrevTxs([boarding.txid], rejecting, onchain);
+        expect(hex.encode(got.get(boarding.txid)!)).toBe(hex.encode(boarding.raw));
+
+        // With nothing behind it, the indexer's own error is what the caller sees.
+        await expect(resolvePrevTxs([boarding.txid], rejecting)).rejects.toThrow(/Not Found/);
+    });
+
+    it("still reports what neither source could supply", async () => {
+        const missing = prevTx(8);
+        const onchain = {
+            getRawTransaction: vi.fn(async () => {
+                throw new Error("404");
+            }),
+        };
+
+        await expect(resolvePrevTxs([missing.txid], indexerOf([]), onchain)).rejects.toThrow(
+            new RegExp(missing.txid),
+        );
+    });
+});
+
+describe("attachPrevArkTxs", () => {
+    it("sets exactly one field on every input, keyed by the coin txid", async () => {
+        const coins = [prevTx(11), prevTx(12), prevTx(13)];
+        const arkTx = arkTxWith(3);
+
+        await attachPrevArkTxs(
+            arkTx,
+            coins.map((c) => c.txid),
+            indexerOf(coins),
+        );
+
+        for (const [i, coin] of coins.entries()) {
+            const fields = getArkPsbtFields(arkTx, i, PrevArkTxField);
+            expect(fields).toHaveLength(1);
+            expect(Transaction.fromRaw(fields[0]).id).toBe(coin.txid);
+        }
+    });
+
+    it("leaves an input that already carries the field alone", async () => {
+        const coins = [prevTx(14), prevTx(15)];
+        const supplied = prevTx(16);
+        const arkTx = arkTxWith(2);
+        setArkPsbtField(arkTx, 0, PrevArkTxField, supplied.raw);
+        const indexer = indexerOf(coins);
+
+        await attachPrevArkTxs(
+            arkTx,
+            coins.map((c) => c.txid),
+            indexer,
+        );
+
+        // Only the uncovered input is fetched — and input 0 keeps one field, the
+        // caller's, since the emulator refuses an input bearing two.
+        expect(indexer.getVirtualTxs.mock.calls[0][0]).toEqual([coins[1].txid]);
+        const first = getArkPsbtFields(arkTx, 0, PrevArkTxField);
+        expect(first).toHaveLength(1);
+        expect(hex.encode(first[0])).toBe(hex.encode(supplied.raw));
+        expect(getArkPsbtFields(arkTx, 1, PrevArkTxField)).toHaveLength(1);
+    });
+
+    it("fetches nothing when every input is already covered", async () => {
+        const arkTx = arkTxWith(1);
+        setArkPsbtField(arkTx, 0, PrevArkTxField, prevTx(17).raw);
+        const indexer = indexerOf([]);
+
+        await attachPrevArkTxs(arkTx, ["deadbeef"], indexer);
+
+        expect(indexer.getVirtualTxs).not.toHaveBeenCalled();
+    });
+
+    it("refuses an input with no source txid rather than submitting a tx the emulator rejects", async () => {
+        const arkTx = arkTxWith(2);
+        await expect(
+            attachPrevArkTxs(arkTx, [prevTx(18).txid], indexerOf([])),
+        ).rejects.toBeInstanceOf(PrevTxUnavailableError);
+    });
+});
+
+describe("attachPrevoutTxs", () => {
+    it("reads each input's own outpoint", async () => {
+        const funding = prevTx(21);
+        const tx = new Transaction();
+        tx.addInput({
+            txid: hex.decode(funding.txid),
+            index: 0,
+            witnessUtxo: { script: p2tr(21), amount: 900n },
+        });
+        tx.addOutput({ script: p2tr(22), amount: 800n });
+
+        await attachPrevoutTxs(tx, { getRawTransaction: async () => funding.raw });
+
+        const fields = getArkPsbtFields(tx, 0, PrevoutTxField);
+        expect(fields).toHaveLength(1);
+        expect(Transaction.fromRaw(fields[0]).id).toBe(funding.txid);
+    });
+});
+
+describe("withPrevTxs", () => {
+    it("fills prevTx on every coin and keeps one already supplied", async () => {
+        const a = prevTx(31);
+        const b = prevTx(32);
+        const preset = new Uint8Array([1, 2, 3]);
+        const indexer = indexerOf([a, b]);
+
+        const coins = await withPrevTxs(
+            [
+                { txid: a.txid, value: 1 },
+                { txid: b.txid, value: 2, prevTx: preset },
+            ],
+            indexer,
+        );
+
+        expect(indexer.getVirtualTxs.mock.calls[0][0]).toEqual([a.txid]);
+        expect(hex.encode(coins[0].prevTx!)).toBe(hex.encode(a.raw));
+        expect(coins[1].prevTx).toBe(preset);
+    });
+});


### PR DESCRIPTION
Upgrades the regtest submodule to `56dca6ed` and fixes everything the newer stack broke — arkd 0.9.14/0.9.15, and emulator v0.0.7.

## Regtest upgrade

- **`chore: upgrade regtest to 56dca6ed`** — the submodule bump.
- **`fix(sdk): settle an in-flight signer rotation before migration reads`** — a real SDK bug the upgraded stack exposed, not a test fix.
- **`chore: start only the regtest tiers the ts-sdk suite uses`** — the upgraded stack defaults to every tier (solver, strfry, bucket-sync). Nothing here calls them; on a 2-core runner the extra containers only widen timing windows.
- **`ci: drop the boltz-swap integration job` / `docs: mark boltz-swap as deprecated`** — the package still builds and ships, it just gets no integration suite.

## Emulator v0.0.7

v0.0.5 iterated over the prevout fields a PSBT *happened to carry*, so zero fields meant zero checks. v0.0.7 walks **every** input and hard-fails on a missing entry — the whole of `failed to create prevout fetcher: missing prevout tx for input 0`. It also validates each entry: the supplied tx must hash to the outpoint, and its output value and pkScript must equal the input's `WitnessUtxo` exactly.

`chore: pin the regtest emulator to v0.0.5` parked that; the last three commits resolve it and un-pin.

### What the SDK now does

New `src/utils/prevoutTx.ts` — a pure read path, no repository writes, no key material:

- `resolvePrevTxs(txids, source, onchain?)` — one batched `getVirtualTxs` call, de-duplicated, **keyed by the txid each PSBT actually computes to** rather than by position (the response order is not part of the contract, and recomputing doubles as the correctness check). Misses fall through to an optional raw on-chain source; whatever neither can supply throws a named `PrevTxUnavailableError` naming the txids.
- `attachPrevArkTxs` / `attachPrevoutTxs` / `withPrevTxs` on top, for ark txs, onchain PSBTs and intent coins.

The tx an ark-tx input must carry is **the checkpoint's parent, not the checkpoint**: input *i* spends checkpoint *i*, which spends `inputs[i]`, so it is the coin's own creating tx — already in hand at every call site, no chain walk. `ArkadeTransactionBuilder.build()` attaches it to every input, gated on `arkadeScript` so every arkd-direct path (generic wallet send, pure-tapscript arkade, settle, delegate) stays byte-identical; a golden assertion enforces that. `Utxo.sourceTx` becomes an override rather than the only channel — an input already carrying the field is skipped, never doubled, since the emulator rejects an input bearing two.

Intent proofs take the bytes through the coin's optional `prevTx`, which keeps `Intent.create` synchronous; the async `withPrevTxs` fills it. The proof's synthetic input 0 is left alone — the emulator synthesises a one-output tx for it.

### Breaking change

`OnchainProvider` gains `getRawTransaction(txid): Promise<Uint8Array>`. A boarding or commitment parent has no off-chain source, so an intent proof spending a boarding input cannot carry its prevout tx without it. Both shipped providers implement it; a third-party `OnchainProvider` has to add it.

### A second v0.0.7 change, unrelated to prevouts

`INSPECTVERSION` now pushes a **minimally-encoded script number** where v0.0.5 pushed a fixed 4-byte LE word. It could not surface until the emulator got far enough to run the script. Confirmed by bisecting the covenant opcode by opcode against the live image, and by checking that the *pre-change* delegate test fails identically on v0.0.7. Two asm literals in the e2e helpers become the numeric `2`; no `src/` code compares against a version literal.

## Testing

- Unit: 167 files / 2719 tests (ts-sdk), plus swap 585 and boltz-swap 616.
- E2E: **24/24 files, 109/109 tests green on emulator v0.0.7** from a clean `scripts/regtest.sh ts-sdk cycle`.

Two things that could only be answered by running it, both fine: arkd accepts an ark-tx PSBT carrying `PrevArkTxField`, and the indexer serves a just-submitted ark tx fast enough that `non-interactive-htlc`'s three chained sends resolve their parents with no retry.

One operational note for anyone running the suite locally: the emulator caches arkd's signer key at startup, so after the rotation suites rotate arkd mid-pass every later covenant spend fails with `missing signature for <arkd's new pubkey>`. `docker restart emulator` clears it — compose `up -d` is a no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic previous-transaction resolution for covenant, intent-proof, and on-chain inputs.
  * Added raw transaction retrieval to Esplora and Electrum providers.
  * Added support for preserving supplied transaction data and falling back to on-chain sources.
  * Exported new transaction-resolution utilities and related types.
* **Documentation**
  * Updated provider integration guidance for raw transaction retrieval and emulator compatibility.
* **Bug Fixes**
  * Improved transaction metadata attachment for emulator v0.0.7+ compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->