### PR TITLE
feat(vhtlc): add the non-interactive refund-without-receiver leaf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
               test/e2e/exitDataCapture.test.ts
               test/e2e/vhtlc.test.ts
               test/e2e/non-interactive-htlc.test.ts
+              test/e2e/non-interactive-refund-without-receiver.test.ts
               test/e2e/indexer.test.ts
               test/e2e/electrum.test.ts
               test/e2e/onchain.test.ts

--- a/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
@@ -131,21 +131,21 @@ function decodeCovenantLeaf<K extends string>(
  * the same ScriptV2 the two uses would fight over one row.
  *
  * **Which leaves this offers, and why the set is smaller than the ladder.**
- * ScriptV2 has eight leaves; a wallet holding ONE of the two participant keys
+ * ScriptV2 has nine leaves; a wallet holding ONE of the two participant keys
  * can satisfy four of them, and offering a leaf whose signature the caller
  * cannot produce is worse than offering fewer — it turns a refusal into a
  * transaction that gets built and then rejected.
  *
- * | leaf                              | needs                          | offered |
- * |-----------------------------------|--------------------------------|---------|
- * | `claim`                           | receiver + server, preimage    | yes, to the receiver |
- * | `refund`                          | sender + receiver + server     | no — needs the counterparty live |
- * | `refundWithoutReceiver`           | sender + server, CLTV          | yes, to the sender |
- * | `unilateralClaim`                 | receiver, CSV                  | yes, to the receiver |
- * | `unilateralRefund`                | sender + receiver, CSV         | no — needs the counterparty live |
- * | `unilateralRefundWithoutReceiver` | sender, CSV                    | yes, to the sender |
- * | `nonInteractiveClaim`             | server + emulator              | no — the wallet holds neither key |
- * | `nonInteractiveRefund`            | server + receiver + emulator   | no — the wallet holds neither key |
+ * | leaf                                  | needs                          | offered |
+ * |---------------------------------------|--------------------------------|---------|
+ * | `claim`                               | receiver + server, preimage    | yes, to the receiver |
+ * | `refund`                              | sender + receiver + server     | no — needs the counterparty live |
+ * | `refundWithoutReceiver`               | sender + server, CLTV          | yes, to the sender |
+ * | `unilateralClaim`                     | receiver, CSV                  | yes, to the receiver |
+ * | `unilateralRefund`                    | sender + receiver, CSV         | no — needs the counterparty live |
+ * | `unilateralRefundWithoutReceiver`     | sender, CSV                    | yes, to the sender |
+ * | `nonInteractiveClaim`                 | server + emulator              | no — the wallet holds neither key |
+ * | `nonInteractiveRefund`                | server + receiver + emulator   | no — the wallet holds neither key |
  * | `nonInteractiveRefundWithoutReceiver` | server + emulator, CLTV        | no — the wallet holds neither key |
  *
  * The two omitted interactive leaves are the same two the `vhtlc` handler

--- a/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
@@ -82,6 +82,8 @@ export interface VHTLCV2ContractParams {
     nonInteractiveRefund?: {
         senderPkScript: Uint8Array;
         emulatorPubkey: Uint8Array;
+        /** @see VHTLC.Options.nonInteractiveRefund.withoutReceiver */
+        withoutReceiver?: boolean;
     };
 }
 
@@ -144,6 +146,7 @@ function decodeCovenantLeaf<K extends string>(
  * | `unilateralRefundWithoutReceiver` | sender, CSV                    | yes, to the sender |
  * | `nonInteractiveClaim`             | server + emulator              | no — the wallet holds neither key |
  * | `nonInteractiveRefund`            | server + receiver + emulator   | no — the wallet holds neither key |
+ * | `nonInteractiveRefundWithoutReceiver` | server + emulator, CLTV        | no — the wallet holds neither key |
  *
  * The two omitted interactive leaves are the same two the `vhtlc` handler
  * omits, for the same reason: `refund` and `unilateralRefund` both need the
@@ -212,6 +215,13 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
                 nonInteractiveRefundEmulatorPubkey: hex.encode(
                     params.nonInteractiveRefund.emulatorPubkey,
                 ),
+                // Spread rather than a "false"/"undefined" string: a dropped
+                // flag re-derives the EIGHT-leaf script, a different pkScript,
+                // and registration dies at `upsertContractRow` with an opaque
+                // `Script mismatch`. Same silent-drop class as the asset keys.
+                ...(params.nonInteractiveRefund.withoutReceiver && {
+                    nonInteractiveRefundWithoutReceiver: "1",
+                }),
             }),
             // The asset must round-trip, and its absence here used to be silent
             // in the worst way. `ContractManager` re-derives a contract from
@@ -258,6 +268,24 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
                     "would re-derive the default claim covenant, which is weaker than the row asked for",
             );
         }
+        // Same silent-drop shape as the two checks above, one flag further in:
+        // a row naming this flag without the leaf it extends, or read as "not
+        // set", would re-derive a script missing this leaf.
+        if (params.nonInteractiveRefundWithoutReceiver !== undefined && !refund) {
+            throw new Error(
+                "nonInteractiveRefundWithoutReceiver without the nonInteractiveRefund keys it " +
+                    "extends: reading this as 'not set' would re-derive a script without the leaf",
+            );
+        }
+        if (
+            params.nonInteractiveRefundWithoutReceiver !== undefined &&
+            params.nonInteractiveRefundWithoutReceiver !== "1"
+        ) {
+            throw new Error(
+                `nonInteractiveRefundWithoutReceiver must be "1" when present, got ` +
+                    JSON.stringify(params.nonInteractiveRefundWithoutReceiver),
+            );
+        }
         const asset =
             params.assetTxid !== undefined && params.assetGroupIndex !== undefined
                 ? {
@@ -295,6 +323,9 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
                 nonInteractiveRefund: {
                     senderPkScript: refund.destination,
                     emulatorPubkey: refund.emulatorPubkey,
+                    ...(params.nonInteractiveRefundWithoutReceiver === "1" && {
+                        withoutReceiver: true,
+                    }),
                 },
             }),
         };

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -96,6 +96,21 @@ export namespace VHTLC {
         nonInteractiveRefund?: {
             senderPkScript: Bytes;
             emulatorPubkey: Bytes;
+            /**
+             * Also emit the timelocked twin: `server` plus the SAME
+             * covenant-tweaked co-signer, spendable after `refundLocktime`
+             * with no receiver signature and no sender signature.
+             *
+             * This is the only refund tier that needs nobody: `refund` and
+             * `refundWithoutReceiver` need the sender's key,
+             * `nonInteractiveRefund` needs the receiver's. A sender who
+             * funded a lockup and vanished is refundable through this leaf
+             * alone, by anyone, to their pre-committed address.
+             *
+             * Off by default: it is a ninth leaf, so enabling it changes the
+             * taproot merkle root and therefore the address.
+             */
+            withoutReceiver?: boolean;
         };
         /**
          * Optional: denominate this contract in an Arkade ASSET rather than in
@@ -168,6 +183,8 @@ export namespace VHTLC {
         readonly nonInteractiveClaimArkadeScript?: Bytes;
         readonly nonInteractiveRefundScript?: string;
         readonly nonInteractiveRefundArkadeScript?: Bytes;
+        readonly nonInteractiveRefundWithoutReceiverScript?: string;
+        readonly nonInteractiveRefundWithoutReceiverArkadeScript?: Bytes;
 
         protected constructor(options: Options, preimageCondition: (hash: Bytes) => Bytes) {
             validateOptions(options);
@@ -251,26 +268,42 @@ export namespace VHTLC {
 
             let arkadeScriptNir: Bytes | undefined;
             let nonInteractiveRefundScript: Bytes | undefined;
+            let nonInteractiveRefundWithoutReceiverScript: Bytes | undefined;
             if (options.nonInteractiveRefund) {
                 arkadeScriptNir = enforcePayToMaybeAsset(
                     options.nonInteractiveRefund.senderPkScript,
                     options.asset,
+                );
+                // Derived ONCE and shared by both refund covenant leaves. They
+                // pin the same destination, so they must commit to the same
+                // key; computing it twice would make that a coincidence rather
+                // than a guarantee.
+                const nirCosigner = computeArkadeScriptPublicKey(
+                    options.nonInteractiveRefund.emulatorPubkey,
+                    arkadeScriptNir,
                 );
                 // No timelock: server + receiver together can release this
                 // immediately, same as `refund` above, just without needing
                 // the sender's own signature — the covenant is what still
                 // guarantees the payout can only reach the sender.
                 nonInteractiveRefundScript = MultisigTapscript.encode({
-                    pubkeys: [
-                        server,
-                        receiver,
-                        computeArkadeScriptPublicKey(
-                            options.nonInteractiveRefund.emulatorPubkey,
-                            arkadeScriptNir,
-                        ),
-                    ],
+                    pubkeys: [server, receiver, nirCosigner],
                 }).script;
                 scripts.push(nonInteractiveRefundScript);
+
+                if (options.nonInteractiveRefund.withoutReceiver) {
+                    // The same tier `refundWithoutReceiver` reaches, reached
+                    // without the sender: their signature is replaced by the
+                    // covenant, exactly as `nonInteractiveRefund` replaces it
+                    // in `refund`. Last in `scripts`, because leaf order fixes
+                    // the merkle root and every earlier leaf must keep its
+                    // position.
+                    nonInteractiveRefundWithoutReceiverScript = CLTVMultisigTapscript.encode({
+                        absoluteTimelock: refundLocktime,
+                        pubkeys: [server, nirCosigner],
+                    }).script;
+                    scripts.push(nonInteractiveRefundWithoutReceiverScript);
+                }
             }
 
             super(scripts);
@@ -291,6 +324,12 @@ export namespace VHTLC {
             if (nonInteractiveRefundScript) {
                 this.nonInteractiveRefundScript = hex.encode(nonInteractiveRefundScript);
                 this.nonInteractiveRefundArkadeScript = arkadeScriptNir;
+            }
+            if (nonInteractiveRefundWithoutReceiverScript) {
+                this.nonInteractiveRefundWithoutReceiverScript = hex.encode(
+                    nonInteractiveRefundWithoutReceiverScript,
+                );
+                this.nonInteractiveRefundWithoutReceiverArkadeScript = arkadeScriptNir;
             }
         }
 
@@ -345,6 +384,20 @@ export namespace VHTLC {
                 this.nonInteractiveRefundArkadeScript,
             ];
         }
+
+        /** Return the timelocked non-interactive refund tapleaf and its ArkadeScript. */
+        nonInteractiveRefundWithoutReceiver(): [TapLeafScript, Bytes] {
+            if (
+                !this.nonInteractiveRefundWithoutReceiverScript ||
+                !this.nonInteractiveRefundWithoutReceiverArkadeScript
+            ) {
+                throw new Error("VHTLC has no non-interactive refund-without-receiver leaf");
+            }
+            return [
+                this.findLeaf(this.nonInteractiveRefundWithoutReceiverScript),
+                this.nonInteractiveRefundWithoutReceiverArkadeScript,
+            ];
+        }
     }
 
     /**
@@ -365,6 +418,10 @@ export namespace VHTLC {
      *   can push the sender's refund immediately, no timelock, pinned to a
      *   pre-committed destination — recoverable even if the sender's own key
      *   is lost
+     * - **nonInteractiveRefundWithoutReceiver** (optional): server + emulator
+     *   can push the sender's refund after `refundLocktime`, pinned to a
+     *   pre-committed destination — the only refund tier needing no
+     *   participant signature at all
      *
      * See {@link ScriptV2} for the current recommended construction — same
      * leaf ladder, same options shape, an added length check on the claim

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -107,8 +107,12 @@ export namespace VHTLC {
              * funded a lockup and vanished is refundable through this leaf
              * alone, by anyone, to their pre-committed address.
              *
-             * Off by default: it is a ninth leaf, so enabling it changes the
-             * taproot merkle root and therefore the address.
+             * Off by default: it is an additional leaf, appended last, so
+             * enabling it changes the taproot merkle root and therefore the
+             * address. `nonInteractiveClaim` and `nonInteractiveRefund` are
+             * independently optional, so this is the NINTH leaf only in the
+             * full swap-corridor configuration where both are set — on its
+             * own, it is the eighth.
              */
             withoutReceiver?: boolean;
         };

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -422,9 +422,10 @@ export namespace VHTLC {
          * check passing does the emulator sign for `nirCosigner` (the
          * `emulatorPubkey` tweaked by this ArkadeScript's hash); the
          * response carries the fully co-signed `signedArkTx` and
-         * `signedCheckpointTxs` (the emulator's own doc comment: "the
-         * emulator executes the arkade script and finalizes with arkd" — no
-         * separate call to arkd is made by this SDK for a covenant spend).
+         * `signedCheckpointTxs` — `ArkadeTransactionBuilder.send()`'s own
+         * comment on this path: "the emulator executes the arkade script
+         * and finalizes with arkd" — no separate call to arkd is made by
+         * this SDK for a covenant spend.
          * Neither `server` nor `receiver` play any part in that check: this
          * leaf's tapscript still requires `server`'s own signature
          * alongside `nirCosigner`'s (see the class doc above), but that is

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -389,7 +389,57 @@ export namespace VHTLC {
             ];
         }
 
-        /** Return the timelocked non-interactive refund tapleaf and its ArkadeScript. */
+        /**
+         * Return the timelocked non-interactive refund tapleaf and its ArkadeScript.
+         *
+         * SPENDING THIS LEAF, CONCRETELY — confirmed from this SDK's own
+         * emulator client and covenant-spend builder ({@link
+         * EmulatorProvider} in `src/providers/emulator.ts`, and {@link
+         * ArkadeTransactionBuilder} in `src/arkade/contract.ts`), which is
+         * the general machinery every covenant leaf in this file goes
+         * through:
+         *
+         *  1. Build the ark tx spending this leaf (this method's {@link
+         *     TapLeafScript} as `tapLeafScript`, this script's {@link
+         *     VtxoScript.encode} as `tapTree`), plus its checkpoint tx.
+         *  2. Attach the ArkadeScript this method returns to the spent
+         *     input via an `EmulatorPacket` (type 1) — `{ vin, script:
+         *     <this ArkadeScript>, witness: <empty> }`, empty because the
+         *     script pushes its own input/output index with
+         *     `PUSHCURRENTINPUTINDEX` rather than reading one from the
+         *     witness — wrapped in an `Extension` OP_RETURN output on the
+         *     ark tx.
+         *  3. Attach the spent input's OWN creating ark tx as `PrevArkTx` on
+         *     input 0 — required so the emulator can resolve that input's
+         *     prevout pkScript/value; it does not otherwise have them.
+         *  4. POST the (base64-PSBT) ark tx and checkpoint(s) as `{ arkTx,
+         *     checkpointTxs }` to the emulator's `POST /v1/tx`.
+         *
+         * THE COVENANT CHECK the emulator runs against that ArkadeScript —
+         * `enforcePayTo(senderPkScript)`, see that function above — is: the
+         * output at this SAME input's index is a v1 P2TR output paying
+         * `senderPkScript`, with a value at least the input's. Only on that
+         * check passing does the emulator sign for `nirCosigner` (the
+         * `emulatorPubkey` tweaked by this ArkadeScript's hash); the
+         * response carries the fully co-signed `signedArkTx` and
+         * `signedCheckpointTxs` (the emulator's own doc comment: "the
+         * emulator executes the arkade script and finalizes with arkd" — no
+         * separate call to arkd is made by this SDK for a covenant spend).
+         * Neither `server` nor `receiver` play any part in that check: this
+         * leaf's tapscript still requires `server`'s own signature
+         * alongside `nirCosigner`'s (see the class doc above), but that is
+         * consensus-level multisig, not something the covenant enforces.
+         *
+         * NOT SPENDABLE UNTIL `refundLocktime` MATURES — the tapscript's
+         * `OP_CHECKLOCKTIMEVERIFY` is arkd's concern, not the emulator's;
+         * the emulator will happily co-sign an immature spend and arkd will
+         * then refuse it. A block-height-typed `refundLocktime` (below the
+         * standard height/timestamp boundary this SDK names
+         * `CLTV_HEIGHT_THRESHOLD`, 500,000,000, in
+         * `src/contracts/handlers/helpers.ts`) is refused by arkd for a
+         * forfeit-eligible leaf independent of maturity — use a
+         * seconds-typed (absolute Unix timestamp) value.
+         */
         nonInteractiveRefundWithoutReceiver(): [TapLeafScript, Bytes] {
             if (
                 !this.nonInteractiveRefundWithoutReceiverScript ||
@@ -430,6 +480,21 @@ export namespace VHTLC {
      * See {@link ScriptV2} for the current recommended construction — same
      * leaf ladder, same options shape, an added length check on the claim
      * preimage. This class is unchanged and stays available as-is.
+     *
+     * **Pre-existing limitation, widened rather than introduced by
+     * `nonInteractiveRefundWithoutReceiver`.** `nonInteractiveClaim` and
+     * `nonInteractiveRefund` (and now its `withoutReceiver` leaf) build on
+     * this class exactly as they do on {@link ScriptV2} — both extend the
+     * same `BaseScript` where these leaves are constructed. But the `vhtlc`
+     * contract handler (`src/contracts/handlers/vhtlc.ts`) round-trips none
+     * of them: its params type carries no covenant fields, and
+     * `createScript` only ever builds the six signature-only leaves. A V1
+     * script built with either covenant option therefore compiles and can
+     * be funded, but cannot be registered as a `vhtlc` contract — the
+     * handler would derive a different (six-leaf) script for the same
+     * params and `ContractManager` refuses the mismatch. This was already
+     * true before `withoutReceiver` existed; it now applies to one more
+     * option than before, not to a newly-exposed one.
      *
      * @example
      * ```typescript

--- a/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
+++ b/packages/ts-sdk/test/contracts/vhtlcV2-handler.test.ts
@@ -129,6 +129,57 @@ describe("VHTLCV2ContractHandler", () => {
         );
     });
 
+    it("round-trips withoutReceiver, and a dropped flag would change the script", () => {
+        const params = fullParams({ nonInteractiveRefundWithoutReceiver: "1" });
+        const typed = VHTLCV2ContractHandler.deserializeParams(params);
+        expect(typed.nonInteractiveRefund?.withoutReceiver).toBe(true);
+
+        const reserialized = VHTLCV2ContractHandler.serializeParams(typed);
+        expect(reserialized).toEqual(params);
+        expect(reserialized.nonInteractiveRefundWithoutReceiver).toBe("1");
+
+        // Dropping the flag must re-derive a DIFFERENT script — silently
+        // re-deriving the eight-leaf script is the exact failure this
+        // round-trip exists to prevent, which would otherwise surface only
+        // as an opaque `Script mismatch` at registration.
+        const withoutFlag = fullParams();
+        expect(hex.encode(VHTLCV2ContractHandler.createScript(params).pkScript)).not.toBe(
+            hex.encode(VHTLCV2ContractHandler.createScript(withoutFlag).pkScript),
+        );
+    });
+
+    it("omits the key entirely when not opted in", () => {
+        const typed = VHTLCV2ContractHandler.deserializeParams(fullParams());
+        expect(typed.nonInteractiveRefund?.withoutReceiver).toBeUndefined();
+        const serialized = VHTLCV2ContractHandler.serializeParams(typed);
+        expect("nonInteractiveRefundWithoutReceiver" in serialized).toBe(false);
+    });
+
+    it("refuses withoutReceiver without the nonInteractiveRefund keys it extends", () => {
+        const params = {
+            sender: SENDER,
+            receiver: RECEIVER,
+            server: SERVER,
+            hash: HASH,
+            refundLocktime: "800000",
+            claimDelay: "10",
+            refundDelay: "12",
+            refundNoReceiverDelay: "14",
+            nonInteractiveRefundWithoutReceiver: "1",
+        };
+        expect(() => VHTLCV2ContractHandler.deserializeParams(params)).toThrow(
+            /without the nonInteractiveRefund keys it extends/,
+        );
+    });
+
+    it('refuses a withoutReceiver value other than "1"', () => {
+        expect(() =>
+            VHTLCV2ContractHandler.deserializeParams(
+                fullParams({ nonInteractiveRefundWithoutReceiver: "true" }),
+            ),
+        ).toThrow(/must be "1" when present/);
+    });
+
     it("round-trips the ASSET, so a re-derived contract is not silently sat-only", () => {
         // The failure this closes was silent in the worst way. `ContractManager`
         // re-derives a contract from these params; with no `asset` key the

--- a/packages/ts-sdk/test/e2e/non-interactive-refund-without-receiver.test.ts
+++ b/packages/ts-sdk/test/e2e/non-interactive-refund-without-receiver.test.ts
@@ -21,19 +21,42 @@
  *
  * THE TRAP THIS FILE EXISTS TO NAME: `refundLocktime` cannot be a small
  * block-height literal here, unlike every other VHTLC e2e fixture in this
- * suite (`vhtlc.test.ts` uses `1000` and `coreBlockCount() + 5`). Confirmed
- * against this repo's pinned arkd (v0.9.14): ANY vtxo script carrying a
- * block-typed CLTV leaf (< 500_000_000 — the same `CLTV_HEIGHT_THRESHOLD`
- * `src/contracts/handlers/helpers.ts` names) is refused at `submitTx` —
- * `INVALID_VTXO_SCRIPT (10): invalid forfeit closure, CLTV block type not
- * allowed` — for EVERY leaf in that script, not just the CLTV one.
- * Reproduced independently of this PR: `vhtlc.test.ts`'s
- * `should claim` (spends the unrelated `claim` leaf) and `should refund
- * without receiver on a post-maturity retry` both fail on it against the
- * same live stack, on `main`. So this file's `refundLocktime` is a
- * SECONDS-typed absolute timestamp (current chain median-time-past plus a
- * few seconds), matured by advancing the chain's own median-time-past — see
- * `matureAbsoluteLocktime` below — not by mining a fixed block count.
+ * suite (`vhtlc.test.ts` uses `1000` and `coreBlockCount() + 5`). This is
+ * NOT a blanket arkd rule against block-typed CLTV — it is OPERATOR
+ * CONFIGURATION, and this regtest operator's happens to refuse it. arkd's
+ * own source (a separate repo, cited here for the next reader, not part of
+ * this SDK) gates it on one flag:
+ *
+ *   // pkg/ark-lib/script/vtxo_script.go:107
+ *   if !blockTypeAllowed && !c.Locktime.IsSeconds() {
+ *       return fmt.Errorf("invalid forfeit closure, CLTV block type not allowed")
+ *   }
+ *   // internal/core/domain/settings.go:456
+ *   func (s Settings) AllowCSVBlockType() bool {
+ *       return s.VtxoTreeExpiry.Type == arklib.LocktimeTypeBlock
+ *   }
+ *
+ * `blockTypeAllowed` is true only when the OPERATOR's own `VtxoTreeExpiry`
+ * is itself block-typed — a stack configured that way would accept the same
+ * block-height `refundLocktime` every other fixture here uses. This regtest
+ * operator's is not: live `GET /v1/info` on this stack reports
+ * `unilateralExitDelay: "512"` — at/above the 512 magnitude boundary this
+ * submodule's own README documents for exactly this block-vs-seconds
+ * classification (`regtest/README.md`, "Fast VTXO expiry & sweeps") — so
+ * `AllowCSVBlockType()` is false here and a block-typed CLTV forfeit closure
+ * is refused at `submitTx`: `INVALID_VTXO_SCRIPT (10): invalid forfeit
+ * closure, CLTV block type not allowed`, for EVERY leaf in that script, not
+ * just the CLTV one (the check runs over the whole vtxo script, before
+ * reaching whichever leaf is actually being spent). Reproduced
+ * independently of this PR: `vhtlc.test.ts`'s `should claim` (spends the
+ * unrelated `claim` leaf) and `should refund without receiver on a
+ * post-maturity retry` both fail on it against this same live stack, on
+ * `main` — not because those fixtures are wrong in general, but because
+ * they assume a block-typed operator and this one isn't configured as one.
+ * So this file's `refundLocktime` is a SECONDS-typed absolute timestamp
+ * (current chain median-time-past plus a few seconds), matured by advancing
+ * the chain's own median-time-past — see `matureAbsoluteLocktime` below —
+ * not by mining a fixed block count.
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
@@ -179,23 +202,52 @@ describe("non-interactive refund without receiver (VHTLC.ScriptV2 covenant leaf)
         // right amount) — the CLTV is the only thing that can refuse this,
         // isolating arkd's own timelock gate on the new leaf from the
         // covenant the emulator evaluates.
+        // WHY THE SAME PATTERN MATCHES ALL THREE OF (2)/(4)/(5) BELOW, ON
+        // PURPOSE. `RestEmulatorProvider.submitTx` (src/providers/emulator.ts:90-93)
+        // throws `Failed to submit tx to emulator: ${errorText}`, where
+        // `errorText` is the emulator's raw HTTP response body. Checked
+        // directly against this live stack (`docker logs emulator`) for each
+        // of the three rejections below, in order: the body is, byte for
+        // byte, `{"code":13, "message":"internal error", "details":[]}` —
+        // IDENTICAL for all three, despite three genuinely different causes
+        // server-side (confirmed only in the emulator's own logs, which a
+        // real caller does not see): `FORFEIT_CLOSURE_LOCKED (11): ... >
+        // ... (blocktime)` for the immature case, `OP_EQUALVERIFY failed
+        // vin=0` for the misdirected one, `false stack entry at end of
+        // script execution vin=0` for the shortchanged one — the last two
+        // matching exactly where `enforcePayTo`'s script would fail: the
+        // destination `EQUALVERIFY` for a wrong pkScript, and the trailing
+        // bare `GREATERTHANOREQUAL` (no `VERIFY`) leaving a false stack top
+        // for a short amount, rather than throwing partway through.
+        // `REGEXP` below is deliberately the SAME for all three: it is the
+        // most specific thing the client can actually observe, and forcing
+        // three different patterns onto one indistinguishable response would
+        // manufacture a distinction the API does not provide. What each
+        // assertion still rules out, over a bare `.rejects.toThrow()`: a
+        // wrong-class failure — a bug in this test, a network-level fetch
+        // failure, a timeout somewhere else in the chain — reaching this
+        // `await` instead of a genuine emulator-side submission rejection.
+        const EMULATOR_REJECTION = /Failed to submit tx to emulator:.*"code":\s*13/;
+
         await expect(
             contract.functions.refund().to(senderPkScript, CONTRACT_AMOUNT).send(),
-        ).rejects.toThrow();
+        ).rejects.toThrow(EMULATOR_REJECTION);
 
         await matureAbsoluteLocktime(refundLocktime);
 
         // (3) MATURE, MISDIRECTED. Right amount, wrong destination — only
         // `INSPECTOUTPUTSCRIPTPUBKEY ... EQUALVERIFY` refuses this, now
-        // that the CLTV can no longer be the reason.
+        // that the CLTV can no longer be the reason (server-side:
+        // `OP_EQUALVERIFY failed vin=0`, see above).
         await expect(
             contract.functions.refund().to(randomP2TR(), CONTRACT_AMOUNT).send(),
-        ).rejects.toThrow();
+        ).rejects.toThrow(EMULATOR_REJECTION);
 
         // (4) MATURE, SHORTCHANGED. Right destination, but one sat short —
         // routed to a second output so the tx still balances — refused only
-        // by `INSPECTOUTPUTVALUE ... GREATERTHANOREQUAL`. Mirrors the
-        // wrong-amount case in `non-interactive-htlc.test.ts`.
+        // by `INSPECTOUTPUTVALUE ... GREATERTHANOREQUAL` (server-side:
+        // `false stack entry at end of script execution vin=0`, see above).
+        // Mirrors the wrong-amount case in `non-interactive-htlc.test.ts`.
         await expect(
             contract.functions
                 .refund()
@@ -204,7 +256,7 @@ describe("non-interactive refund without receiver (VHTLC.ScriptV2 covenant leaf)
                     { script: randomP2TR(), amount: 1n },
                 ])
                 .send(),
-        ).rejects.toThrow();
+        ).rejects.toThrow(EMULATOR_REJECTION);
 
         // (5) MATURE, CORRECT. The emulator signs for `nirCosigner`, arkd
         // accepts the now-matured CLTV tapscript, and the payout lands at

--- a/packages/ts-sdk/test/e2e/non-interactive-refund-without-receiver.test.ts
+++ b/packages/ts-sdk/test/e2e/non-interactive-refund-without-receiver.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Does the emulator actually sign a spend of `nonInteractiveRefundWithoutReceiver`?
+ *
+ * That leaf (`VHTLC.ScriptV2.nonInteractiveRefundWithoutReceiver`) is new:
+ * `CLTVMultisigTapscript.encode({ absoluteTimelock: refundLocktime, pubkeys:
+ * [server, nirCosigner] })`, where `nirCosigner` is the emulator key tweaked
+ * by `enforcePayTo(senderPkScript)` — the same covenant token sequence
+ * `nonInteractiveRefund` uses, just gated by a CLTV instead of the receiver's
+ * signature. `vhtlc-vectors.test.ts` pins its bytes and its position in the
+ * nine-leaf tree; nothing before this file asked the emulator to sign a real
+ * spend of it. This does three things a byte fixture cannot:
+ *
+ *  1. proves the hand-transcribed artifact below is byte-identical to what
+ *     `VHTLC.ScriptV2` actually emits for this leaf's ArkadeScript, the same
+ *     way `asset-covenant.test.ts` proves it for `nonInteractiveClaim`;
+ *  2. funds it, matures the CLTV on a REAL regtest chain, and shows the
+ *     emulator refuses a spend that misdirects the payout or shortchanges it
+ *     — the covenant is load-bearing, not decorative;
+ *  3. shows the emulator signs a spend that pays `senderPkScript` in full,
+ *     and that the resulting VTXO lands there.
+ *
+ * THE TRAP THIS FILE EXISTS TO NAME: `refundLocktime` cannot be a small
+ * block-height literal here, unlike every other VHTLC e2e fixture in this
+ * suite (`vhtlc.test.ts` uses `1000` and `coreBlockCount() + 5`). Confirmed
+ * against this repo's pinned arkd (v0.9.14): ANY vtxo script carrying a
+ * block-typed CLTV leaf (< 500_000_000 — the same `CLTV_HEIGHT_THRESHOLD`
+ * `src/contracts/handlers/helpers.ts` names) is refused at `submitTx` —
+ * `INVALID_VTXO_SCRIPT (10): invalid forfeit closure, CLTV block type not
+ * allowed` — for EVERY leaf in that script, not just the CLTV one.
+ * Reproduced independently of this PR: `vhtlc.test.ts`'s
+ * `should claim` (spends the unrelated `claim` leaf) and `should refund
+ * without receiver on a post-maturity retry` both fail on it against the
+ * same live stack, on `main`. So this file's `refundLocktime` is a
+ * SECONDS-typed absolute timestamp (current chain median-time-past plus a
+ * few seconds), matured by advancing the chain's own median-time-past — see
+ * `matureAbsoluteLocktime` below — not by mining a fixed block count.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import {
+    arkade,
+    VHTLC,
+    networks,
+    RestArkProvider,
+    RestIndexerProvider,
+    RestEmulatorProvider,
+} from "../../src";
+import { beforeEachFaucet, execCommand, faucetOffchain, mineBlocks, randomP2TR } from "./utils";
+
+const EMULATOR_URL = "http://localhost:7073";
+const ARK_SERVER_URL = "http://localhost:7070";
+const CONTRACT_AMOUNT = 10_000n;
+/** How far past the chain's current median-time-past the locktime sits at construction time — must be > 0 so the leaf is immature the moment it is built. */
+const CLTV_OFFSET_SECONDS = 8n;
+
+/**
+ * `enforcePayTo(senderPkScript)` (see `src/script/vhtlc.ts`), transcribed
+ * token for token — the same shape `asset-covenant.test.ts`'s
+ * `scriptV2Shaped` uses for its sat clause, minus the asset half this leaf
+ * doesn't carry. `resolveAsm`-equality against `VHTLC.ScriptV2`'s own output
+ * (below) is what actually proves the transcription, not this comment.
+ */
+const nirWithoutReceiverProgram = (refundLocktime: bigint) =>
+    ({
+        version: 0,
+        params: ["server", "sender"],
+        functions: {
+            refund: {
+                tapscript: { signers: ["$server"], cltv: refundLocktime },
+                arkadeScript: {
+                    asm: [
+                        "PUSHCURRENTINPUTINDEX",
+                        "DUP",
+                        "INSPECTOUTPUTSCRIPTPUBKEY",
+                        1,
+                        "EQUALVERIFY",
+                        "$sender",
+                        "EQUALVERIFY",
+                        "INSPECTOUTPUTVALUE",
+                        "PUSHCURRENTINPUTINDEX",
+                        "INSPECTINPUTVALUE",
+                        "GREATERTHANOREQUAL",
+                    ],
+                    witness: [],
+                },
+            },
+        },
+    }) satisfies arkade.Program;
+
+/** `bitcoin-cli getblockchaininfo`, parsed — the chain height and its real median-time-past (not an indexer's, which trails it). */
+function chainInfo(): { blocks: number; mediantime: number } {
+    const raw = execCommand("node regtest/regtest.mjs rpc getblockchaininfo");
+    return JSON.parse(raw);
+}
+
+/**
+ * Advance the chain's median-time-past strictly past `targetUnix`.
+ *
+ * A CLTV leaf matures against MTP (the median of the last 11 blocks'
+ * timestamps), not the wall clock or the tip's own time. Mining alone does
+ * not help until real time has actually passed `targetUnix`: a freshly mined
+ * regtest block is timestamped at `max(now, prevBlockTime + 1)`, so it can
+ * never carry a timestamp ahead of the real clock. This sleeps only as long
+ * as still needed (an already-stale MTP — the common case after any pause
+ * between stack startup and this test — may need no sleep at all, since MTP
+ * can already trail the wall clock by more than `CLTV_OFFSET_SECONDS`), then
+ * mines enough blocks that the NEW timestamps dominate the 11-block median,
+ * and verifies against a fresh read rather than assuming the wait sufficed.
+ */
+async function matureAbsoluteLocktime(targetUnix: bigint): Promise<void> {
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+        const waitSec = Number(targetUnix) - Math.floor(Date.now() / 1000) + 2;
+        if (waitSec > 0) {
+            await new Promise((r) => setTimeout(r, Math.min(waitSec, 10) * 1000));
+        }
+        mineBlocks(11);
+        if (chainInfo().mediantime > Number(targetUnix)) return;
+    }
+    throw new Error("matureAbsoluteLocktime: timed out waiting for chain MTP to mature");
+}
+
+describe("non-interactive refund without receiver (VHTLC.ScriptV2 covenant leaf)", () => {
+    const emulator = new RestEmulatorProvider(EMULATOR_URL);
+    const arkProvider = new RestArkProvider(ARK_SERVER_URL);
+    const indexerProvider = new RestIndexerProvider(ARK_SERVER_URL);
+
+    beforeEach(beforeEachFaucet, 20000);
+
+    it("the emulator signs a matured spend paying senderPkScript, and refuses one that doesn't", {
+        timeout: 180000,
+    }, async () => {
+        const senderPkScript = randomP2TR();
+        const refundLocktime = BigInt(chainInfo().mediantime) + CLTV_OFFSET_SECONDS;
+
+        // (0) THE PROOF. Same method `asset-covenant.test.ts` uses for
+        // `nonInteractiveClaim`: compile the real leaf through the SDK and
+        // compare its ArkadeScript, byte for byte, against `resolveAsm` on
+        // the artifact above. Every other VHTLC.Options field is filler —
+        // none of it reaches this leaf's ArkadeScript, only `senderPkScript`
+        // does (see `enforcePayToMaybeAsset`).
+        const fromSdk = new VHTLC.ScriptV2({
+            preimageHash: new Uint8Array(20).fill(0x11),
+            sender: schnorr.getPublicKey(new Uint8Array(32).fill(1)),
+            receiver: schnorr.getPublicKey(new Uint8Array(32).fill(2)),
+            server: schnorr.getPublicKey(new Uint8Array(32).fill(3)),
+            refundLocktime,
+            unilateralClaimDelay: { type: "seconds", value: 512n },
+            unilateralRefundDelay: { type: "seconds", value: 1024n },
+            unilateralRefundWithoutReceiverDelay: { type: "seconds", value: 1536n },
+            nonInteractiveRefund: {
+                senderPkScript,
+                emulatorPubkey: schnorr.getPublicKey(new Uint8Array(32).fill(5)),
+                withoutReceiver: true,
+            },
+        }).nonInteractiveRefundWithoutReceiverArkadeScript!;
+        const program = nirWithoutReceiverProgram(refundLocktime);
+        const fromArtifact = arkade.resolveAsm(program.functions.refund.arkadeScript.asm, {
+            sender: senderPkScript.slice(2),
+        });
+        expect(hex.encode(fromArtifact)).toBe(hex.encode(fromSdk));
+
+        // (1) Fund the covenant-CLTV contract. Immature the moment it
+        // exists: `refundLocktime` sits strictly ahead of the MTP it was
+        // read from.
+        const ark = await arkade.Arkade.connect({
+            arkade: arkProvider,
+            emulator,
+            indexer: indexerProvider,
+            network: networks.regtest,
+        });
+        const contract = ark.contract(program, { sender: senderPkScript.slice(2) });
+        faucetOffchain(contract.address, Number(CONTRACT_AMOUNT));
+        await waitForVtxo(indexerProvider, contract.pkScript);
+
+        // (2) IMMATURE. Covenant satisfied in full (right destination,
+        // right amount) — the CLTV is the only thing that can refuse this,
+        // isolating arkd's own timelock gate on the new leaf from the
+        // covenant the emulator evaluates.
+        await expect(
+            contract.functions.refund().to(senderPkScript, CONTRACT_AMOUNT).send(),
+        ).rejects.toThrow();
+
+        await matureAbsoluteLocktime(refundLocktime);
+
+        // (3) MATURE, MISDIRECTED. Right amount, wrong destination — only
+        // `INSPECTOUTPUTSCRIPTPUBKEY ... EQUALVERIFY` refuses this, now
+        // that the CLTV can no longer be the reason.
+        await expect(
+            contract.functions.refund().to(randomP2TR(), CONTRACT_AMOUNT).send(),
+        ).rejects.toThrow();
+
+        // (4) MATURE, SHORTCHANGED. Right destination, but one sat short —
+        // routed to a second output so the tx still balances — refused only
+        // by `INSPECTOUTPUTVALUE ... GREATERTHANOREQUAL`. Mirrors the
+        // wrong-amount case in `non-interactive-htlc.test.ts`.
+        await expect(
+            contract.functions
+                .refund()
+                .to([
+                    { script: senderPkScript, amount: CONTRACT_AMOUNT - 1n },
+                    { script: randomP2TR(), amount: 1n },
+                ])
+                .send(),
+        ).rejects.toThrow();
+
+        // (5) MATURE, CORRECT. The emulator signs for `nirCosigner`, arkd
+        // accepts the now-matured CLTV tapscript, and the payout lands at
+        // `senderPkScript` — the leaf this PR added, spent end to end.
+        const { txid } = await contract.functions
+            .refund()
+            .to(senderPkScript, CONTRACT_AMOUNT)
+            .send();
+
+        const [vtxo] = await waitForVtxo(indexerProvider, senderPkScript);
+        expect(vtxo.txid).toBe(txid);
+    });
+});
+
+/** Wait for at least one VTXO at the given pkScript */
+async function waitForVtxo(indexer: RestIndexerProvider, pkScript: Uint8Array, timeoutMs = 20000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const resp = await indexer.getVtxos({
+            scripts: [hex.encode(pkScript)],
+            spendableOnly: true,
+        });
+        if (resp.vtxos.length > 0) return resp.vtxos;
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+    throw new Error("waitForVtxo: timeout");
+}

--- a/packages/ts-sdk/test/fixtures/vhtlc-v2-nine-leaf.json
+++ b/packages/ts-sdk/test/fixtures/vhtlc-v2-nine-leaf.json
@@ -1,0 +1,48 @@
+{
+    "comment": "Generated from VHTLC.ScriptV2 with fixed, non-random test keys so this file is byte-reproducible. Regenerate by constructing VHTLC.ScriptV2 with: sender = schnorr.getPublicKey(Uint8Array(32).fill(1)), receiver = fill(2), server = fill(3), preimageHash = Uint8Array(20).fill(9), refundLocktime = 1000n, unilateralClaimDelay = {blocks, 100n}, unilateralRefundDelay = {blocks, 102n}, unilateralRefundWithoutReceiverDelay = {blocks, 103n}, nonInteractiveClaim = {receiverPkScript: 0x5120 || fill(4), emulatorPubkey: fill(5)}, nonInteractiveRefund = {senderPkScript: 0x5120 || fill(6), emulatorPubkey: fill(5), withoutReceiver: true} (all fill(n) via schnorr.getPublicKey(Uint8Array(32).fill(n)), @noble/curves/secp256k1.js) — then print pkScript, every script.*Script leaf, script.encode(), and both *ArkadeScript fields as hex. See test/script/vhtlc-vectors.test.ts for the exact reconstruction this pins against.",
+    "options": {
+        "sender": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+        "receiver": "024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766",
+        "server": "02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337",
+        "preimageHash": "0909090909090909090909090909090909090909",
+        "refundLocktime": "1000",
+        "unilateralClaimDelay": {
+            "type": "blocks",
+            "value": "100"
+        },
+        "unilateralRefundDelay": {
+            "type": "blocks",
+            "value": "102"
+        },
+        "unilateralRefundWithoutReceiverDelay": {
+            "type": "blocks",
+            "value": "103"
+        },
+        "nonInteractiveClaim": {
+            "receiverPkScript": "5120462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b",
+            "emulatorPubkey": "62c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f7"
+        },
+        "nonInteractiveRefund": {
+            "senderPkScript": "5120f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a",
+            "emulatorPubkey": "62c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f7",
+            "withoutReceiver": true
+        }
+    },
+    "pkScript": "51208c814f0c398c065d46d975283d24818e97d9c6e917be2d30c347f4fc11c48b5b",
+    "tapTree": "01c06082012088a91409090909090909090909090909090909090909098769204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ad20531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ac01c066201b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fad204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ad20531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ac01c04902e803b175201b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fad20531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ac01c04282012088a914090909090909090909090909090909090909090987690164b275204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ac01c0480166b275201b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fad204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ac01c0260167b275201b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fac01c06082012088a9140909090909090909090909090909090909090909876920531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ad20b39fac289b95579dfbb032f44d076375d3f3820b36021169bf63d8ec40ed99e1ac01c06620531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ad204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ad2065ed13213f33571c6666008870605652066d8879f7a972d2e34b6070e63ed9efac01c04902e803b17520531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ad2065ed13213f33571c6666008870605652066d8879f7a972d2e34b6070e63ed9efac",
+    "leaves": {
+        "claim": "82012088a91409090909090909090909090909090909090909098769204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ad20531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ac",
+        "refund": "201b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fad204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ad20531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ac",
+        "refundWithoutReceiver": "02e803b175201b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fad20531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ac",
+        "unilateralClaim": "82012088a914090909090909090909090909090909090909090987690164b275204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ac",
+        "unilateralRefund": "0166b275201b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fad204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ac",
+        "unilateralRefundWithoutReceiver": "0167b275201b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fac",
+        "nonInteractiveClaim": "82012088a9140909090909090909090909090909090909090909876920531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ad20b39fac289b95579dfbb032f44d076375d3f3820b36021169bf63d8ec40ed99e1ac",
+        "nonInteractiveRefund": "20531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ad204d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766ad2065ed13213f33571c6666008870605652066d8879f7a972d2e34b6070e63ed9efac",
+        "nonInteractiveRefundWithoutReceiver": "02e803b17520531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337ad2065ed13213f33571c6666008870605652066d8879f7a972d2e34b6070e63ed9efac"
+    },
+    "arkadeScripts": {
+        "nonInteractiveClaim": "cd76d1518820462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b88cfcdc9a2",
+        "nonInteractiveRefund": "cd76d1518820f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a88cfcdc9a2"
+    }
+}

--- a/packages/ts-sdk/test/script/vhtlc-vectors.test.ts
+++ b/packages/ts-sdk/test/script/vhtlc-vectors.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "@scure/base";
+import { RelativeTimelock, VHTLC } from "../../src";
+import fixture from "../fixtures/vhtlc-v2-nine-leaf.json";
+
+/**
+ * Cross-SDK conformance vectors for {@link VHTLC.ScriptV2}'s nine-leaf tree
+ * (both non-interactive leaves present, `nonInteractiveRefund.withoutReceiver`
+ * on). C#, Go and Rust implementations are checked against the same fixture —
+ * see `test/fixtures/vhtlc-v2-nine-leaf.json`'s own `comment` field for how to
+ * regenerate it. A byte anywhere in these leaves diverging across
+ * implementations means a silently different taproot address and unspendable
+ * funds; that is what this file exists to catch.
+ */
+
+type FixtureTimelock = { type: string; value: string };
+
+function timelockFromFixture(t: FixtureTimelock): RelativeTimelock {
+    return { type: t.type as "blocks" | "seconds", value: BigInt(t.value) };
+}
+
+/**
+ * Rebuild real {@link VHTLC.Options} (Uint8Array keys, bigint timelocks) from
+ * the fixture's JSON-safe encoding (hex strings, decimal strings).
+ *
+ * `sender`/`receiver`/`server` are stored as 33-byte compressed pubkeys, the
+ * same convention `test/fixtures/vhtlc.json` uses — {@link VHTLC.Options}
+ * itself wants only the 32-byte x-only tail.
+ */
+function optionsFromFixture(o: typeof fixture.options): VHTLC.Options {
+    return {
+        sender: hex.decode(o.sender).slice(1),
+        receiver: hex.decode(o.receiver).slice(1),
+        server: hex.decode(o.server).slice(1),
+        preimageHash: hex.decode(o.preimageHash),
+        refundLocktime: BigInt(o.refundLocktime),
+        unilateralClaimDelay: timelockFromFixture(o.unilateralClaimDelay),
+        unilateralRefundDelay: timelockFromFixture(o.unilateralRefundDelay),
+        unilateralRefundWithoutReceiverDelay: timelockFromFixture(
+            o.unilateralRefundWithoutReceiverDelay,
+        ),
+        nonInteractiveClaim: {
+            receiverPkScript: hex.decode(o.nonInteractiveClaim.receiverPkScript),
+            emulatorPubkey: hex.decode(o.nonInteractiveClaim.emulatorPubkey),
+        },
+        nonInteractiveRefund: {
+            senderPkScript: hex.decode(o.nonInteractiveRefund.senderPkScript),
+            emulatorPubkey: hex.decode(o.nonInteractiveRefund.emulatorPubkey),
+            withoutReceiver: o.nonInteractiveRefund.withoutReceiver,
+        },
+    };
+}
+
+describe("VHTLC.ScriptV2 cross-SDK vectors", () => {
+    it("matches the committed cross-SDK vectors", () => {
+        const script = new VHTLC.ScriptV2(optionsFromFixture(fixture.options));
+
+        expect(hex.encode(script.pkScript)).toBe(fixture.pkScript);
+        expect(script.claimScript).toBe(fixture.leaves.claim);
+        expect(script.refundScript).toBe(fixture.leaves.refund);
+        expect(script.refundWithoutReceiverScript).toBe(fixture.leaves.refundWithoutReceiver);
+        expect(script.unilateralClaimScript).toBe(fixture.leaves.unilateralClaim);
+        expect(script.unilateralRefundScript).toBe(fixture.leaves.unilateralRefund);
+        expect(script.unilateralRefundWithoutReceiverScript).toBe(
+            fixture.leaves.unilateralRefundWithoutReceiver,
+        );
+        expect(script.nonInteractiveClaimScript).toBe(fixture.leaves.nonInteractiveClaim);
+        expect(script.nonInteractiveRefundScript).toBe(fixture.leaves.nonInteractiveRefund);
+        expect(script.nonInteractiveRefundWithoutReceiverScript).toBe(
+            fixture.leaves.nonInteractiveRefundWithoutReceiver,
+        );
+        // Both covenant ArkadeScripts the fixture carries — not just the
+        // refund one — since a divergence in either compiles into a
+        // different emulator co-signer key and so a different leaf.
+        expect(hex.encode(script.nonInteractiveClaimArkadeScript!)).toBe(
+            fixture.arkadeScripts.nonInteractiveClaim,
+        );
+        expect(hex.encode(script.nonInteractiveRefundArkadeScript!)).toBe(
+            fixture.arkadeScripts.nonInteractiveRefund,
+        );
+    });
+
+    it("has nine leaves, in the order the merkle root depends on", () => {
+        const script = new VHTLC.ScriptV2(optionsFromFixture(fixture.options));
+        // `scripts` is the per-leaf array (VtxoScript's constructor property).
+        // `encode()` is NOT — it returns ONE serialized TapTree blob, which is
+        // what the Go side's DecodeTapTree consumes and what `tapTree` below pins.
+        expect(script.scripts.map((s) => hex.encode(s))).toEqual([
+            fixture.leaves.claim,
+            fixture.leaves.refund,
+            fixture.leaves.refundWithoutReceiver,
+            fixture.leaves.unilateralClaim,
+            fixture.leaves.unilateralRefund,
+            fixture.leaves.unilateralRefundWithoutReceiver,
+            fixture.leaves.nonInteractiveClaim,
+            fixture.leaves.nonInteractiveRefund,
+            fixture.leaves.nonInteractiveRefundWithoutReceiver,
+        ]);
+    });
+
+    it("pins the serialized taptree the Go decoder consumes", () => {
+        const script = new VHTLC.ScriptV2(optionsFromFixture(fixture.options));
+        expect(hex.encode(script.encode())).toBe(fixture.tapTree);
+    });
+});

--- a/packages/ts-sdk/test/vhtlc.test.ts
+++ b/packages/ts-sdk/test/vhtlc.test.ts
@@ -3,6 +3,7 @@ import { RelativeTimelock, VHTLC, arkade } from "../src";
 import vhtlcFixtures from "./fixtures/vhtlc.json";
 import { hex } from "@scure/base";
 import { ArkadeScript } from "../src/arkade/script";
+import { CLTVMultisigTapscript } from "../src/script/tapscript";
 import { schnorr } from "@noble/curves/secp256k1.js";
 
 describe("VHTLC address", () => {
@@ -731,6 +732,97 @@ describe("VHTLC.ScriptV2 — asset denomination", () => {
         expect(() => withAsset({ asset: { ...asset, groupIndex: -1 } })).toThrow(/\[0, 65535\]/);
         expect(() => withAsset({ asset: { ...asset, groupIndex: 0x10000 } })).toThrow(
             /\[0, 65535\]/,
+        );
+    });
+});
+
+describe("nonInteractiveRefundWithoutReceiver", () => {
+    const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
+    const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+
+    const senderPk = key(1);
+    const receiverPk = key(2);
+    const serverPk = key(3);
+    const preimageHash = new Uint8Array(20).fill(9);
+    const emulatorPubkey = key(5);
+    const senderPkScript = p2tr(key(6));
+
+    const base = {
+        sender: senderPk,
+        receiver: receiverPk,
+        server: serverPk,
+        preimageHash,
+        refundLocktime: 1000n,
+        unilateralClaimDelay: { type: "blocks", value: 100n } as const,
+        unilateralRefundDelay: { type: "blocks", value: 102n } as const,
+        unilateralRefundWithoutReceiverDelay: { type: "blocks", value: 103n } as const,
+    };
+
+    it("is absent unless opted in, and the pkScript is unchanged", () => {
+        const without = new VHTLC.ScriptV2({
+            ...base,
+            nonInteractiveRefund: { senderPkScript, emulatorPubkey },
+        });
+        expect(without.nonInteractiveRefundWithoutReceiverScript).toBeUndefined();
+        expect(() => without.nonInteractiveRefundWithoutReceiver()).toThrow(
+            "VHTLC has no non-interactive refund-without-receiver leaf",
+        );
+
+        // The claim in this test's title, actually checked: gaining the
+        // capability to opt in must not perturb the pkScript for a caller
+        // who doesn't. Compared against the same options with the flag
+        // spelled out as explicitly false — the other way "not opted in"
+        // can be written.
+        const explicitlyOff = new VHTLC.ScriptV2({
+            ...base,
+            nonInteractiveRefund: { senderPkScript, emulatorPubkey, withoutReceiver: false },
+        });
+        expect(hex.encode(explicitlyOff.pkScript)).toBe(hex.encode(without.pkScript));
+    });
+
+    it("adds exactly one leaf and changes the pkScript when opted in", () => {
+        const without = new VHTLC.ScriptV2({
+            ...base,
+            nonInteractiveRefund: { senderPkScript, emulatorPubkey },
+        });
+        const with_ = new VHTLC.ScriptV2({
+            ...base,
+            nonInteractiveRefund: { senderPkScript, emulatorPubkey, withoutReceiver: true },
+        });
+
+        expect(with_.scripts.length).toBe(without.scripts.length + 1);
+        expect(hex.encode(with_.pkScript)).not.toBe(hex.encode(without.pkScript));
+
+        // The other eight leaves are byte-identical AND in the same
+        // position — the new leaf is appended, never interleaved, since
+        // leaf order decides the taproot merkle root. (`toContain` on
+        // `.encode()`'s raw tap-tree bytes would only check for byte-VALUE
+        // membership, which almost any buffer satisfies trivially; this
+        // checks the actual per-leaf script list instead.)
+        expect(with_.scripts.slice(0, without.scripts.length).map(hex.encode)).toEqual(
+            without.scripts.map(hex.encode),
+        );
+    });
+
+    it("is CLTVMultisig{refundLocktime, [server, nonInteractiveRefund's own cosigner]}", () => {
+        const script = new VHTLC.ScriptV2({
+            ...base,
+            nonInteractiveRefund: { senderPkScript, emulatorPubkey, withoutReceiver: true },
+        });
+
+        const cosigner = arkade.computeArkadeScriptPublicKey(
+            emulatorPubkey,
+            script.nonInteractiveRefundArkadeScript!,
+        );
+        const expected = CLTVMultisigTapscript.encode({
+            absoluteTimelock: base.refundLocktime,
+            pubkeys: [serverPk, cosigner],
+        }).script;
+
+        expect(script.nonInteractiveRefundWithoutReceiverScript).toBe(hex.encode(expected));
+        // Same covenant bytes as the immediate leaf — one destination, one covenant.
+        expect(hex.encode(script.nonInteractiveRefundWithoutReceiverArkadeScript!)).toBe(
+            hex.encode(script.nonInteractiveRefundArkadeScript!),
         );
     });
 });


### PR DESCRIPTION
Adds a ninth, opt-in tapleaf to `VHTLC.ScriptV2`:
`nonInteractiveRefundWithoutReceiver` — the Arkade Service key plus the covenant-tweaked
emulator co-signer, spendable after `refundLocktime`.

## Why

Every existing route to the "refund the sender" tier needs a specific party online:

| leaf | needs | gate |
| --- | --- | --- |
| `refund` | sender + receiver + server | — |
| `refundWithoutReceiver` | sender + server | `refundLocktime` |
| `nonInteractiveRefund` | server + receiver + emulator | — |

A sender who funds a lockup and vanishes — or loses their key — therefore depends on the
**receiver's** cooperation. If the receiver is gone or uncooperative, the only path left is
`unilateralRefundWithoutReceiver`, a CSV leaf costing a real on-chain unilateral exit.

The script already implies the fix. Lining each interactive leaf up against its covenant twin
shows the rule the ladder follows, and the one cell it leaves empty:

| interactive leaf | beneficiary | covenant twin | present |
| --- | --- | --- | --- |
| `claim` | receiver | `nonInteractiveClaim` | yes |
| `refund` | sender | `nonInteractiveRefund` | yes |
| `refundWithoutReceiver` | sender | — | **no** |

The rule: *`nonInteractive X` is `X` with the beneficiary's signature replaced by an emulator key
tweaked by `enforcePayTo(their pkScript)`.* This fills the empty cell. The name is mechanical,
not chosen.

## What it is

```
CLTVMultisigTapscript.encode({
    absoluteTimelock: refundLocktime,
    pubkeys: [server, <the SAME cosigner nonInteractiveRefund already derives>],
})
```

Opt in with `nonInteractiveRefund.withoutReceiver: true`. It reuses the existing
`senderPkScript`/`emulatorPubkey` pair rather than taking its own, so the two leaves cannot be
given divergent destinations.

## Two properties worth checking in review

**The co-signer is shared structurally, not coincidentally.** Both refund covenant leaves pin the
same destination, so they must commit to the same key. There is exactly one call site to
`computeArkadeScriptPublicKey` on the refund path (`vhtlc.ts`, `nirCosigner`), consumed by both
`MultisigTapscript.encode` and `CLTVMultisigTapscript.encode`. Computing it twice would make
byte-identity a coincidence rather than a guarantee.

Consequently the emulator needs **no new key and no new evaluation path**. The two leaves cannot
cross-replay a signature despite sharing a key: BIP-341 tapscript sighashes commit to the tapleaf
hash.

**It is genuinely opt-in.** Leaf order fixes the merkle root, so the new leaf is pushed last and
every earlier leaf keeps its index. Without the flag, the derived pkScript is byte-identical to
before — asserted directly, comparing all eight prior leaves byte-for-byte rather than by count.

## Nothing else needs to change

- **arkd** — `TapscriptsVtxoScript.Decode` (`pkg/ark-lib/script/vtxo_script.go`) appends each
  decoded closure to a slice with no uniqueness constraint, so a tree carrying two
  `CLTVMultisigClosure` leaves parses. `ForfeitClosures()` already includes that type, and the new
  leaf carries `server`, satisfying the "forfeit closure must contain the signer pubkey" rule.
- **covclaimd** — decodes taptrees off the wire rather than deriving them.
- **the emulator** — same tweaked key, same covenant bytes.

## Cross-SDK conformance vectors

`test/fixtures/vhtlc-v2-nine-leaf.json` pins the pkScript, all nine leaf scripts, the serialized
taptree, and the covenant ArkadeScripts, from fixed non-random keys. It is intended to be consumed
verbatim by the C#, Go and Rust implementations, which must produce identical bytes or derive
addresses nobody can spend.

This is the failure it exists to prevent: when the SDK moved its preimage condition from
`HASH160 <h> EQUAL` to `SIZE 32 EQUALVERIFY HASH160 <h> EQUAL`, a consumer kept building the old
form, its endpoint answered **200**, and no claim was ever pushed — a silent no-op with nothing in
the logs.

The fixture carries both `leaves` (per-leaf, for byte comparison) and `tapTree` (the serialized
`encode()` blob), because the Go consumer's production path is `DecodeTapTree` over exactly those
bytes.

## Testing

- `test/vhtlc.test.ts` — 37 passed (34 pre-existing + 3 new)
- `test/contracts/vhtlcV2-handler.test.ts` — 65 passed (61 pre-existing + 4 new)
- `test/script/vhtlc-vectors.test.ts` — 3 new
- Full run: **2758 passed** vs **2746** at branch point. The 107 failures in 24 `test/e2e/*` files
  are pre-existing and require docker + regtest; the failing file list is byte-for-byte identical
  before and after.
- `tsc --noEmit` clean.

**Negative control on the vectors.** Swapping the last two leaf pushes made all three fixture
assertions fail — pkScript, leaf order, and `tapTree`. Restoring the order made them pass, with an
empty `git diff` confirming byte-identical restoration. The tests fail for the reason they claim.

## Two things reviewers should not take on trust

**No regtest spendability test.** Nothing here exercises the new leaf against arkd or the emulator
end-to-end. Byte-identity, leaf order, opt-in behaviour and key-sharing are proven; "a wallet can
actually spend this leaf" is not. The arkd analysis above says it should work, but that is
reasoning, not a spend.

**A green pre-commit hook is not evidence in this repo.** Its affected-package `lint` and
`test:unit` steps print `No projects matched the filters` and exit green **without running**. This
reproduces against unrelated diffs, so it is pre-existing and not introduced here — but it means
the test numbers above come from `npx vitest run` and `npx tsc --noEmit` invoked directly, not from
the hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional non-interactive refund path that does not require a receiver signature.
  * Added support for configuring and accessing the new refund script and covenant data.
  * Added VHTLC V2 support for the new nine-leaf contract structure.

* **Bug Fixes**
  * Added validation for invalid or incomplete refund configuration flags.

* **Tests**
  * Added coverage for serialization, script generation, leaf ordering, cross-SDK compatibility, and end-to-end refund spending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->