### PR TITLE
fix(sdk): push service-worker events instead of holding them for the tick

### DIFF
--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -924,7 +924,9 @@ export class WalletMessageHandler
     }
 
     // lifecycle methods
-    async start(...params: Parameters<MessageHandler["start"]>): Promise<void> {
+    async start(
+        ...params: Parameters<MessageHandler<WalletUpdaterRequest, WalletUpdaterResponse>["start"]>
+    ): Promise<void> {
         const [services, repositories, channel] = params;
         this.readonlyWallet = services.readonlyWallet;
         this.wallet = services.wallet;

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -874,6 +874,18 @@ export type WalletUpdaterResponse = ResponseEnvelope &
         | ResponseRestoreWallet
     );
 
+/** What a generation counter covers: a subscription field, or the request stream. */
+type Scope = "incomingFunds" | "contractEvents" | "request";
+
+/**
+ * Bound to the generation live when it was created. Re-check `stale` after
+ * every await that precedes a side effect — an emit, a repository write, or a
+ * subscription-field assignment.
+ */
+type Generation = { readonly stale: boolean };
+
+type Emitter = Generation & { emit(response: WalletUpdaterResponse | null): void };
+
 export class WalletMessageHandler
     implements MessageHandler<WalletUpdaterRequest, WalletUpdaterResponse>
 {
@@ -889,6 +901,18 @@ export class WalletMessageHandler
     private incomingFundsSubscription: (() => void) | undefined;
     private contractEventsSubscription: (() => void) | undefined;
     private onNextTick: (() => WalletUpdaterResponse | null)[] = [];
+    private channel: { broadcast(response: WalletUpdaterResponse): void } | undefined;
+
+    // One counter per subscription field, bumped exactly where that field is
+    // dropped — never where a neighbour's is. They cannot be merged:
+    // `onWalletInitialized` re-subscribes incoming funds while
+    // `ensureContractEventBroadcasting` deliberately keeps its subscription, so
+    // a shared bump would leave the live contract-event emitter permanently
+    // stale, and folding requests in would truncate an in-flight settle.
+    private incomingFundsEpoch = 0;
+    private contractEventsEpoch = 0;
+    /** Per-request progress callbacks: ends with the handler, not with a re-init. */
+    private requestEpoch = 0;
 
     /**
      * Instantiate a new WalletUpdater.
@@ -901,14 +925,25 @@ export class WalletMessageHandler
 
     // lifecycle methods
     async start(...params: Parameters<MessageHandler["start"]>): Promise<void> {
-        const [services, repositories] = params;
+        const [services, repositories, channel] = params;
         this.readonlyWallet = services.readonlyWallet;
         this.wallet = services.wallet;
         this.arkProvider = services.arkProvider;
         this.walletRepository = repositories.walletRepository;
+        this.channel = channel;
+        this.onNextTick = [];
     }
 
     async stop() {
+        // Before the async disposal below: an uncancelled handleMessage keeps
+        // invoking its progress callback, and without the bumps it would re-arm
+        // the tick queue that this just emptied.
+        this.requestEpoch++;
+        this.incomingFundsEpoch++;
+        this.contractEventsEpoch++;
+        this.channel = undefined;
+        this.onNextTick = [];
+
         if (this.incomingFundsSubscription) {
             this.incomingFundsSubscription();
             this.incomingFundsSubscription = undefined;
@@ -937,8 +972,10 @@ export class WalletMessageHandler
     }
 
     async tick(_now: number) {
-        const results = await Promise.allSettled(this.onNextTick.map((fn) => fn()));
-        this.onNextTick = [];
+        // Drain atomically: assigning [] after the await would re-clear anything
+        // a concurrent stop()/clear() queued, and resurrect what it dropped.
+        const pending = this.onNextTick.splice(0);
+        const results = await Promise.allSettled(pending.map((fn) => fn()));
         return results
             .map((result) => {
                 if (result.status === "fulfilled") {
@@ -952,8 +989,46 @@ export class WalletMessageHandler
             .filter((response) => response !== null);
     }
 
-    private scheduleForNextTick(callback: () => WalletUpdaterResponse | null) {
-        this.onNextTick.push(callback);
+    private epochOf(scope: Scope): number {
+        switch (scope) {
+            case "incomingFunds":
+                return this.incomingFundsEpoch;
+            case "contractEvents":
+                return this.contractEventsEpoch;
+            case "request":
+                return this.requestEpoch;
+        }
+    }
+
+    private newGeneration(scope: Scope): Generation {
+        const born = this.epochOf(scope);
+        const stale = () => born !== this.epochOf(scope);
+        return {
+            get stale() {
+                return stale();
+            },
+        };
+    }
+
+    /**
+     * A handle rather than a `broadcast(response, epoch)` call, because it can
+     * only be written where the closure it guards is created — an epoch passed
+     * at the call site reads identically whether it guards anything or not.
+     */
+    private newEmitter(scope: Scope): Emitter {
+        const gen = this.newGeneration(scope);
+        return {
+            get stale() {
+                return gen.stale;
+            },
+            emit: (response) => {
+                // Before the channel branch, so a dead generation reaches
+                // neither delivery path.
+                if (!response || gen.stale) return;
+                if (this.channel) return this.channel.broadcast(response);
+                this.onNextTick.push(() => response); // no channel: legacy tick delivery
+            },
+        };
     }
 
     private requireWallet(): Wallet {
@@ -992,6 +1067,9 @@ export class WalletMessageHandler
 
     async handleMessage(message: WalletUpdaterRequest): Promise<WalletUpdaterResponse> {
         const id = message.id;
+        // Shared by the progress callbacks below: they are inline case blocks,
+        // so there is no per-request handler of their own to capture at.
+        const emitter = this.newEmitter("request");
         if (message.type === "INIT_WALLET") {
             await this.handleInitWallet(message);
             return this.tagged({
@@ -1387,7 +1465,7 @@ export class WalletMessageHandler
                     const wallet = this.requireWallet();
                     const vtxoManager = await wallet.getVtxoManager();
                     const txid = await vtxoManager.recoverVtxos((e) => {
-                        this.scheduleForNextTick(() =>
+                        emitter.emit(
                             this.tagged({
                                 id,
                                 type: "RECOVER_VTXOS_EVENT",
@@ -1432,7 +1510,7 @@ export class WalletMessageHandler
                     const wallet = this.requireWallet();
                     const vtxoManager = await wallet.getVtxoManager();
                     const txid = await vtxoManager.renewVtxos((e) => {
-                        this.scheduleForNextTick(() =>
+                        emitter.emit(
                             this.tagged({
                                 id,
                                 type: "RENEW_VTXOS_EVENT",
@@ -1471,7 +1549,7 @@ export class WalletMessageHandler
                     const vtxoManager = await wallet.getVtxoManager();
                     const report = await vtxoManager.migrateDeprecatedSignerVtxos({
                         eventCallback: (e) => {
-                            this.scheduleForNextTick(() =>
+                            emitter.emit(
                                 this.tagged({
                                     id,
                                     type: "MIGRATE_DEPRECATED_SIGNER_VTXOS_EVENT",
@@ -1602,21 +1680,27 @@ export class WalletMessageHandler
         return this.readonlyWallet.getBoardingUtxos();
     }
     private async onWalletInitialized() {
-        if (
-            !this.readonlyWallet ||
-            !this.arkProvider ||
-            !this.indexerProvider ||
-            !this.walletRepository
-        ) {
+        const wallet = this.readonlyWallet;
+        if (!wallet || !this.arkProvider || !this.indexerProvider || !this.walletRepository) {
             return;
         }
+
+        // Bounds each await below to the generation that entered: a stop(),
+        // CLEAR or re-init landing inside one must not let the stale
+        // initializer resume and overwrite the new wallet's subscription.
+        // `incomingFundsEpoch` doubles as mutual exclusion between two
+        // overlapping INIT_WALLETs — whichever reaches the bump first makes the
+        // other return before it can unsubscribe the winner.
+        const init = this.newGeneration("incomingFunds");
 
         // Initialize contract manager FIRST — this populates the repository
         // with full virtual output history for all contracts (one indexer call per contract)
         await this.ensureContractEventBroadcasting();
+        if (init.stale) return;
 
         // Refresh cached data (virtual outputs, boarding inputs, tx history)
         await this.refreshCachedData();
+        if (init.stale) return;
 
         // Recover pending transactions (init-only, not on reload).
         // Pending txs only exist if a send was interrupted mid-finalization.
@@ -1632,104 +1716,120 @@ export class WalletMessageHandler
             } catch (error: unknown) {
                 console.error("Error recovering pending transactions:", error);
             }
+            if (init.stale) return;
         }
 
         // unsubscribe previous subscription if any
         if (this.incomingFundsSubscription) this.incomingFundsSubscription();
+        this.incomingFundsSubscription = undefined;
+        this.incomingFundsEpoch++;
+        // The new generation starts here — `init` is stale from now on.
+        const emitter = this.newEmitter("incomingFunds");
 
-        const address = await this.readonlyWallet.getAddress();
+        const address = await wallet.getAddress();
 
         // subscribe for incoming funds and notify all clients when new funds arrive
-        this.incomingFundsSubscription = await this.readonlyWallet.notifyIncomingFunds(
-            async (funds) => {
-                if (funds.type === "vtxo") {
-                    // `funds.newVtxos` / `funds.spentVtxos` are already
-                    // ExtendedVirtualCoin — annotation happened inside the
-                    // underlying Wallet's subscription handler before this
-                    // callback fired. Re-annotating here would only duplicate
-                    // work and re-expose us to `annotateVtxos` throws.
-                    const { newVtxos, spentVtxos } = funds;
+        const unsubscribe = await wallet.notifyIncomingFunds(async (funds) => {
+            if (emitter.stale) return;
+            if (funds.type === "vtxo") {
+                // `funds.newVtxos` / `funds.spentVtxos` are already
+                // ExtendedVirtualCoin — annotation happened inside the
+                // underlying Wallet's subscription handler before this
+                // callback fired. Re-annotating here would only duplicate
+                // work and re-expose us to `annotateVtxos` throws.
+                const { newVtxos, spentVtxos } = funds;
 
-                    if (newVtxos.length + spentVtxos.length === 0) return;
+                if (newVtxos.length + spentVtxos.length === 0) return;
 
-                    // Save virtual outputs using unified repository. The
-                    // event may carry rows for several scripts (other
-                    // contracts the wallet watches), so split by script and
-                    // save each bucket under its own contract address rather
-                    // than saving a mixed-script array under one address.
-                    const byScript = new Map<string, ExtendedVirtualCoin[]>();
-                    for (const v of [...newVtxos, ...spentVtxos]) {
-                        if (!v.script) {
-                            // Without a script we can't route the row to the
-                            // right contract bucket; surface the drop instead
-                            // of silently losing the VTXO.
-                            console.warn(
-                                `WalletMessageHandler.notifyIncomingFunds: dropping VTXO without script ${v.txid}:${v.vout}`,
-                            );
-                            continue;
-                        }
-                        const arr = byScript.get(v.script) ?? [];
-                        arr.push(v);
-                        byScript.set(v.script, arr);
-                    }
-                    let walletScript: string | undefined;
-                    try {
-                        walletScript = scriptFromArkAddress(address);
-                    } catch {
-                        walletScript = undefined;
-                    }
-                    const cm = await this.readonlyWallet!.getContractManager();
-                    const contracts = await cm.getContracts();
-                    const addrByScript = new Map(contracts.map((c) => [c.script, c.address]));
-                    for (const [script, vtxos] of byScript) {
-                        const filtered = warnAndFilterVtxosForScript(
-                            vtxos,
-                            script,
-                            "WalletMessageHandler.notifyIncomingFunds",
+                // Save virtual outputs using unified repository. The
+                // event may carry rows for several scripts (other
+                // contracts the wallet watches), so split by script and
+                // save each bucket under its own contract address rather
+                // than saving a mixed-script array under one address.
+                const byScript = new Map<string, ExtendedVirtualCoin[]>();
+                for (const v of [...newVtxos, ...spentVtxos]) {
+                    if (!v.script) {
+                        // Without a script we can't route the row to the
+                        // right contract bucket; surface the drop instead
+                        // of silently losing the VTXO.
+                        console.warn(
+                            `WalletMessageHandler.notifyIncomingFunds: dropping VTXO without script ${v.txid}:${v.vout}`,
                         );
-                        if (filtered.length === 0) continue;
-                        const targetAddress =
-                            script === walletScript ? address : addrByScript.get(script);
-                        if (!targetAddress) continue;
-                        if (this.walletRepository) {
-                            await saveVtxosForContract(
-                                this.walletRepository,
-                                { script, address: targetAddress },
-                                filtered,
-                            );
-                        }
+                        continue;
                     }
-
-                    // notify all clients about the virtual output state update
-                    this.scheduleForNextTick(() =>
-                        this.tagged({
-                            type: "VTXO_UPDATE",
-                            broadcast: true,
-                            payload: { newVtxos, spentVtxos },
-                        }),
-                    );
+                    const arr = byScript.get(v.script) ?? [];
+                    arr.push(v);
+                    byScript.set(v.script, arr);
                 }
-                if (funds.type === "utxo") {
-                    // A deposit may land on the current OR a previous boarding
-                    // address (per-derivation rotation, plan §6-IV.2). The
-                    // notified `coins` carry no address, so re-fetch + re-cache
-                    // the full boarding-address set via getBoardingUtxos, which
-                    // buckets each UTXO under the address it sits on with the
-                    // correct per-UTXO tapscript — instead of assuming the
-                    // current boarding address.
-                    const utxos = await this.readonlyWallet!.getBoardingUtxos();
-
-                    // notify all clients about the boarding input state update
-                    this.scheduleForNextTick(() =>
-                        this.tagged({
-                            type: "UTXO_UPDATE",
-                            broadcast: true,
-                            payload: { coins: utxos },
-                        }),
-                    );
+                let walletScript: string | undefined;
+                try {
+                    walletScript = scriptFromArkAddress(address);
+                } catch {
+                    walletScript = undefined;
                 }
-            },
-        );
+                // Re-checked after every await: this callback *writes* before
+                // it emits, and `clear()` leaves `walletRepository` set, so
+                // guarding only the emit would resurrect the rows the wipe
+                // just deleted while telling the page nothing.
+                const cm = await wallet.getContractManager();
+                if (emitter.stale) return;
+                const contracts = await cm.getContracts();
+                if (emitter.stale) return;
+                const addrByScript = new Map(contracts.map((c) => [c.script, c.address]));
+                for (const [script, vtxos] of byScript) {
+                    const filtered = warnAndFilterVtxosForScript(
+                        vtxos,
+                        script,
+                        "WalletMessageHandler.notifyIncomingFunds",
+                    );
+                    if (filtered.length === 0) continue;
+                    const targetAddress =
+                        script === walletScript ? address : addrByScript.get(script);
+                    if (!targetAddress) continue;
+                    if (this.walletRepository) {
+                        if (emitter.stale) return;
+                        await saveVtxosForContract(
+                            this.walletRepository,
+                            { script, address: targetAddress },
+                            filtered,
+                        );
+                    }
+                }
+
+                // notify all clients about the virtual output state update
+                emitter.emit(
+                    this.tagged({
+                        type: "VTXO_UPDATE",
+                        broadcast: true,
+                        payload: { newVtxos, spentVtxos },
+                    }),
+                );
+            }
+            if (funds.type === "utxo") {
+                // A deposit may land on the current OR a previous boarding
+                // address (per-derivation rotation, plan §6-IV.2). The
+                // notified `coins` carry no address, so re-fetch + re-cache
+                // the full boarding-address set via getBoardingUtxos, which
+                // buckets each UTXO under the address it sits on with the
+                // correct per-UTXO tapscript — instead of assuming the
+                // current boarding address.
+                if (emitter.stale) return; // its re-cache is internal: bail before the call
+                const utxos = await wallet.getBoardingUtxos();
+
+                // notify all clients about the boarding input state update
+                emitter.emit(
+                    this.tagged({
+                        type: "UTXO_UPDATE",
+                        broadcast: true,
+                        payload: { coins: utxos },
+                    }),
+                );
+            }
+        });
+        // Teardown landed mid-registration: the subscription is already live, so
+        // a bare return would leave a callback nothing can unsubscribe.
+        if (emitter.stale) return unsubscribe();
+        this.incomingFundsSubscription = unsubscribe;
 
         // Eagerly start the VtxoManager so its background tasks (auto-renewal,
         // boarding input polling/sweep) run inside the service worker without
@@ -1793,9 +1893,10 @@ export class WalletMessageHandler
     }
 
     private async handleSettle(message: RequestSettle) {
+        const emitter = this.newEmitter("request");
         const wallet = this.requireWallet();
         const txid = await wallet.settle(message.payload.params, (e) => {
-            this.scheduleForNextTick(() =>
+            emitter.emit(
                 this.tagged({
                     id: message.id,
                     type: "SETTLE_EVENT",
@@ -1920,6 +2021,15 @@ export class WalletMessageHandler
         const wallet = this.wallet ?? this.readonlyWallet;
         if (!wallet) return;
 
+        // The bus generation is untouched here, so the channel stays: dropping
+        // it would push later emits back onto the tick queue. The counters are
+        // what stop an in-flight callback from emitting — or writing — a
+        // just-wiped wallet's state.
+        this.requestEpoch++;
+        this.incomingFundsEpoch++;
+        this.contractEventsEpoch++;
+        this.onNextTick = [];
+
         if (this.incomingFundsSubscription) {
             this.incomingFundsSubscription();
             this.incomingFundsSubscription = undefined;
@@ -2043,12 +2153,19 @@ export class WalletMessageHandler
     }
 
     private async ensureContractEventBroadcasting() {
-        if (!this.readonlyWallet) return;
+        const wallet = this.readonlyWallet;
+        if (!wallet) return;
         if (this.contractEventsSubscription) return;
+        const gen = this.newGeneration("contractEvents");
         try {
-            const manager = await this.readonlyWallet.getContractManager();
+            const manager = await wallet.getContractManager();
+            // A stale run assigning the field would make the early return above
+            // swallow every later call, killing delivery for good; and a peer
+            // may have subscribed while we awaited.
+            if (gen.stale || this.contractEventsSubscription) return;
+            const emitter = this.newEmitter("contractEvents");
             this.contractEventsSubscription = manager.onContractEvent((event) => {
-                this.scheduleForNextTick(() =>
+                emitter.emit(
                     this.tagged({
                         type: "CONTRACT_EVENT",
                         broadcast: true,

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -999,6 +999,15 @@ export class WalletMessageHandler
                 return this.contractEventsEpoch;
             case "request":
                 return this.requestEpoch;
+            default: {
+                // `never` here while the switch covers every Scope: a new
+                // member fails to compile instead of falling through. Without
+                // this (no noImplicitReturns in tsconfig) the fallthrough
+                // returns `undefined`, and `born !== undefined` makes every
+                // emitter for the new scope born stale — events lost silently.
+                const _exhaustive: never = scope;
+                throw new Error(`Unknown scope: ${_exhaustive}`);
+            }
         }
     }
 

--- a/packages/ts-sdk/src/worker/browser/README.md
+++ b/packages/ts-sdk/src/worker/browser/README.md
@@ -43,24 +43,30 @@ scheduler.
    outright and must wire the repository itself.
 4. Subsequent client messages are routed by `tag` (the handler's `messageTag`)
    or broadcast to all handlers.
-5. Handlers can respond immediately (via `handleMessage`) or later (via `tick`).
-   Responses are posted back to clients.
+5. Handlers can respond immediately (via `handleMessage`), push at any time
+   (via `channel.broadcast`), or wait for cadence (via `tick`). Responses are
+   posted back to clients.
 
 ## MessageHandler Interface
 
 Each handler implements the `MessageHandler` interface:
 
 - `messageTag` — unique string used to route messages to this handler.
-- `start(services, repositories)` — called once after initialization with the
-  wallet, Ark provider, and repositories.
+- `start(services, repositories, channel?)` — called once after initialization
+  with the wallet, Ark provider, repositories, and a push channel to the
+  clients. The channel is scoped to the generation it was handed out in and
+  goes inert on its own after a re-init or `stop()`.
 - `stop()` — called on shutdown.
-- `tick(now)` — called periodically; returns responses to broadcast to clients.
+- `tick(now)` — called periodically, for cadence-driven work; returns responses
+  to broadcast to clients.
 - `handleMessage(message)` — handles a routed message and returns a response.
 
 ## Trade-Offs
 
-- **Polling-based updates**: The tick loop uses `setTimeout`. Updates arrive at
-  most every `tickIntervalMs` (default 10s).
+- **Two delivery paths**: events pushed through `channel.broadcast` go out as
+  soon as the fan-out can post them. Only responses a handler holds for its
+  `tick` are bounded by `tickIntervalMs` (default 10s), whose `setTimeout` loop
+  is for periodic work.
 - **No persistence**: Handler state is in-memory. If the browser kills the
   service worker, state is lost unless the handler persists it elsewhere.
 - **Minimal lifecycle hooks**: Only `install` and `activate` are used. There is

--- a/packages/ts-sdk/src/worker/browser/README.md
+++ b/packages/ts-sdk/src/worker/browser/README.md
@@ -64,9 +64,11 @@ Each handler implements the `MessageHandler` interface:
 ## Trade-Offs
 
 - **Two delivery paths**: events pushed through `channel.broadcast` go out as
-  soon as the fan-out can post them. Only responses a handler holds for its
-  `tick` are bounded by `tickIntervalMs` (default 10s), whose `setTimeout` loop
-  is for periodic work.
+  soon as the fan-out can post them. Responses a handler holds for its `tick`
+  wait for the `setTimeout` loop instead, which paces periodic work rather than
+  bounding delivery: `tickIntervalMs` (default 10s) is a floor measured from the
+  previous tick's end, and a slow handler or an in-flight init pushes it out
+  further.
 - **No persistence**: Handler state is in-memory. If the browser kills the
   service worker, state is lost unless the handler persists it elsewhere.
 - **Minimal lifecycle hooks**: Only `install` and `activate` are used. There is

--- a/packages/ts-sdk/src/worker/messageBus.ts
+++ b/packages/ts-sdk/src/worker/messageBus.ts
@@ -310,7 +310,10 @@ export class MessageBus {
             while (this.broadcastQueue.length) {
                 const epoch = this.broadcastEpoch;
                 const batch = this.broadcastQueue.splice(0);
-                if (!this.running) return;
+                if (!this.running) {
+                    this.logDroppedBroadcasts(batch, "bus stopped");
+                    return;
+                }
 
                 let clients: readonly Client[];
                 try {
@@ -318,20 +321,29 @@ export class MessageBus {
                         includeUncontrolled: true,
                         type: "window",
                     });
-                } catch {
+                } catch (err) {
+                    this.logDroppedBroadcasts(batch, "clients.matchAll failed", err);
                     continue; // lose the batch, never the loop
                 }
 
-                if (!this.running) return; // stop() landed during matchAll
-                if (this.broadcastEpoch !== epoch) continue; // re-init landed
+                if (!this.running) {
+                    this.logDroppedBroadcasts(batch, "bus stopped during matchAll");
+                    return;
+                }
+                if (this.broadcastEpoch !== epoch) {
+                    this.logDroppedBroadcasts(batch, "re-init landed during matchAll");
+                    continue;
+                }
 
                 for (const message of batch) {
                     for (const client of clients) {
                         try {
                             client.postMessage(message);
-                        } catch {
+                        } catch (err) {
                             // a non-cloneable payload or a dead client must not
                             // cost the other windows their message
+                            if (this.debug)
+                                console.warn(`[${message.tag}] broadcast to client failed`, err);
                         }
                     }
                 }
@@ -344,6 +356,23 @@ export class MessageBus {
             // an early return must not leave work queued with nobody draining.
             if (this.running && this.broadcastQueue.length) void this.drain();
         }
+    }
+
+    /**
+     * A dropped batch has no periodic recovery to fall back on now that events
+     * no longer ride the tick, so name the loss under {@link Options.debug}.
+     */
+    private logDroppedBroadcasts(
+        batch: ResponseEnvelope[],
+        reason: string,
+        ...error: unknown[]
+    ): void {
+        if (!this.debug) return;
+        console.warn(
+            `dropping ${batch.length} broadcast(s): ${reason}`,
+            batch.map((response) => response.tag),
+            ...error,
+        );
     }
 
     private scheduleNextTick() {

--- a/packages/ts-sdk/src/worker/messageBus.ts
+++ b/packages/ts-sdk/src/worker/messageBus.ts
@@ -50,6 +50,11 @@ export interface MessageHandler<
      * Called once when the SW is starting up
      * @param services - Providers and wallet instances available to the handler.
      * @param repositories - Repositories available to the handler.
+     * @param channel - Push channel to clients, for responses that answer no
+     * request. Use it instead of holding events for the next {@link tick}.
+     * The channel is scoped to the generation it was handed out in: after a
+     * bus re-init or `stop()` it goes inert on its own, so retaining one past
+     * `stop()` cannot post.
      **/
     start(
         services: {
@@ -59,6 +64,9 @@ export interface MessageHandler<
         },
         repositories: {
             walletRepository: WalletRepository;
+        },
+        channel?: {
+            broadcast(response: RES): void;
         },
     ): Promise<void>;
 
@@ -201,6 +209,11 @@ export class MessageBus {
     }>;
     private readonly boundOnMessage = this.onMessage.bind(this);
     private readonly intentRepository?: IntentRepository;
+    /** Pending broadcasts, drained FIFO by a single {@link drain} loop. */
+    private broadcastQueue: ResponseEnvelope[] = [];
+    private draining = false;
+    /** Bumped wherever the generation owning the queued broadcasts ends. */
+    private broadcastEpoch = 0;
 
     /** Create the service-worker message bus with repositories and handler configuration. */
     constructor(
@@ -254,6 +267,9 @@ export class MessageBus {
         this.running = false;
         this.tickInProgress = false;
         this.initialized = false;
+        // Before the handlers' own stop(), so anything they emit while tearing
+        // down is already on the dead generation.
+        this.invalidateBroadcasts();
 
         if (this.tickTimeout !== null) {
             self.clearTimeout(this.tickTimeout);
@@ -269,6 +285,65 @@ export class MessageBus {
         self.removeEventListener("message", this.boundOnMessage);
 
         await Promise.all(Array.from(this.handlers.values()).map((updater) => updater.stop()));
+    }
+
+    /** Invalidate every broadcast belonging to the outgoing generation. */
+    private invalidateBroadcasts(): void {
+        this.broadcastEpoch++;
+        this.broadcastQueue.length = 0;
+    }
+
+    private broadcastToClients(responses: ResponseEnvelope[]): void {
+        this.broadcastQueue.push(...responses);
+        void this.drain();
+    }
+
+    /**
+     * Single fan-out loop, so pushes and tick responses keep one FIFO order.
+     * A helper posting per response would race: `clients.matchAll()` gives no
+     * cross-call resolution order, and it would de-batch `runTick`.
+     */
+    private async drain(): Promise<void> {
+        if (this.draining) return;
+        this.draining = true;
+        try {
+            while (this.broadcastQueue.length) {
+                const epoch = this.broadcastEpoch;
+                const batch = this.broadcastQueue.splice(0);
+                if (!this.running) return;
+
+                let clients: readonly Client[];
+                try {
+                    clients = await self.clients.matchAll({
+                        includeUncontrolled: true,
+                        type: "window",
+                    });
+                } catch {
+                    continue; // lose the batch, never the loop
+                }
+
+                if (!this.running) return; // stop() landed during matchAll
+                if (this.broadcastEpoch !== epoch) continue; // re-init landed
+
+                for (const message of batch) {
+                    for (const client of clients) {
+                        try {
+                            client.postMessage(message);
+                        } catch {
+                            // a non-cloneable payload or a dead client must not
+                            // cost the other windows their message
+                        }
+                    }
+                }
+            }
+        } catch {
+            // never let a rejection escape a `void this.drain()` call
+        } finally {
+            this.draining = false;
+            // Events no longer ride the tick, so there is no periodic recovery:
+            // an early return must not leave work queued with nobody draining.
+            if (this.running && this.broadcastQueue.length) void this.drain();
+        }
     }
 
     private scheduleNextTick() {
@@ -308,18 +383,7 @@ export class MessageBus {
                     if (this.debug)
                         console.log(`[${updater.messageTag}] outgoing tick response:`, response);
                     if (response && response.length > 0) {
-                        self.clients
-                            .matchAll({
-                                includeUncontrolled: true,
-                                type: "window",
-                            })
-                            .then((clients) => {
-                                for (const message of response) {
-                                    clients.forEach((client) => {
-                                        client.postMessage(message);
-                                    });
-                                }
-                            });
+                        this.broadcastToClients(response);
                     }
                 } catch (err) {
                     if (this.debug) console.error(`[${updater.messageTag}] tick failed`, err);
@@ -366,6 +430,18 @@ export class MessageBus {
             self.clearTimeout(this.tickTimeout);
             this.tickTimeout = null;
         }
+        // `running` stays true across a re-init, so only the epoch can drop a
+        // batch already in flight when the outgoing handlers stop.
+        this.invalidateBroadcasts();
+        const epoch = this.broadcastEpoch;
+        // One channel per generation, shared by every handler started here. The
+        // bus, not the implementor, is what makes a retained channel inert.
+        const channel = {
+            broadcast: (response: ResponseEnvelope) => {
+                if (epoch !== this.broadcastEpoch) return;
+                this.broadcastToClients([response]);
+            },
+        };
         if (this.initialized) {
             // Clear the flag first so onMessage() rejects incoming messages
             this.initialized = false;
@@ -385,9 +461,7 @@ export class MessageBus {
         try {
             for (const updater of this.handlers.values()) {
                 if (this.debug) console.log(`Starting updater: ${updater.messageTag}`);
-                await updater.start(services, {
-                    walletRepository: this.walletRepository,
-                });
+                await updater.start(services, { walletRepository: this.walletRepository }, channel);
                 started.push(updater);
             }
         } catch (err) {

--- a/packages/ts-sdk/test/serviceWorker/worker.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/worker.test.ts
@@ -248,6 +248,9 @@ describe("Worker", () => {
                 readonlyWallet: {},
             },
             { walletRepository },
+            // What the channel *does* is messageBus.test.ts's; here it only has
+            // to reach the handler.
+            { broadcast: expect.any(Function) },
         );
     });
 
@@ -321,45 +324,6 @@ describe("Worker", () => {
         expect(updaterB.handleMessage).toHaveBeenCalledWith(payload);
         expect(source.postMessage).toHaveBeenCalledWith({ tag: "a", id: "1" });
         expect(source.postMessage).toHaveBeenCalledWith({ tag: "b", id: "1" });
-    });
-
-    it("broadcasts tick responses to all clients", async () => {
-        const clientA = { postMessage: vi.fn() };
-        const clientB = { postMessage: vi.fn() };
-        selfMock.clients.matchAll.mockResolvedValue([clientA, clientB]);
-
-        const updater: TestUpdater = {
-            messageTag: "wallet",
-            start: vi.fn().mockResolvedValue(undefined),
-            stop: vi.fn().mockResolvedValue(undefined),
-            tick: vi.fn().mockResolvedValue([{ tag: "wallet", id: "broadcast", broadcast: true }]),
-            handleMessage: vi.fn().mockResolvedValue(null),
-        };
-
-        const sw = new MessageBus(
-            new InMemoryWalletRepository(),
-            new InMemoryContractRepository(),
-            {
-                messageHandlers: [updater],
-            },
-        );
-        await sw.start();
-        await (sw as any).runTick();
-
-        expect(selfMock.clients.matchAll).toHaveBeenCalledWith({
-            includeUncontrolled: true,
-            type: "window",
-        });
-        expect(clientA.postMessage).toHaveBeenCalledWith({
-            tag: "wallet",
-            id: "broadcast",
-            broadcast: true,
-        });
-        expect(clientB.postMessage).toHaveBeenCalledWith({
-            tag: "wallet",
-            id: "broadcast",
-            broadcast: true,
-        });
     });
 });
 

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -2300,6 +2300,28 @@ describe("WalletMessageHandler event-push generations", () => {
         (updater as any).refreshCachedData = vi.fn().mockResolvedValue(undefined);
     });
 
+    it("does not let tick() wipe what was queued while it drained", async () => {
+        // tick() splices up front precisely so "stop()/clear() clears
+        // onNextTick" means something: assigning [] after the await clobbers
+        // whatever landed in the window instead, and nothing else guards this.
+        const queue = () => (updater as any).onNextTick as (() => any)[];
+        const inFlight = deferred<any>();
+        const drained = { tag: updater.messageTag, type: "DRAINED" };
+        const late = { tag: updater.messageTag, type: "LATE" };
+
+        // No channel attached: this is the tick fallback path.
+        expect((updater as any).channel).toBeUndefined();
+        queue().push(() => inFlight.promise);
+
+        const pending = updater.tick(Date.now());
+        // Lands mid-drain, exactly where a teardown or a live emit would.
+        queue().push(() => late);
+        inFlight.resolve(drained);
+
+        expect(await pending).toEqual([drained]);
+        expect(await updater.tick(Date.now())).toEqual([late]);
+    });
+
     it("drops a suspended incoming-funds callback across stop() + start()", async () => {
         // Without the counter this emit lands on the *new* channel carrying the
         // previous wallet's vtxos, and VTXO_UPDATE carries no id to filter on.

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -515,6 +515,34 @@ describe("WalletMessageHandler handleMessage", () => {
         });
     });
 
+    it("pushes contract events straight to the channel", async () => {
+        const manager = {
+            onContractEvent: vi.fn((cb: any) => {
+                eventCallback = cb;
+                return vi.fn();
+            }),
+        };
+        let eventCallback: ((event: any) => void) | undefined;
+        const broadcast = vi.fn();
+        (updater as any).readonlyWallet = {
+            getContractManager: vi.fn().mockResolvedValue(manager),
+        };
+        (updater as any).channel = { broadcast };
+
+        await (updater as any).ensureContractEventBroadcasting();
+
+        const event = { type: "test", contractId: "c1" };
+        eventCallback?.(event);
+
+        expect(broadcast).toHaveBeenCalledWith({
+            tag: updater.messageTag,
+            type: "CONTRACT_EVENT",
+            broadcast: true,
+            payload: { event },
+        });
+        expect(await updater.tick(Date.now())).toEqual([]);
+    });
+
     it("broadcasts contract events without subscriptions", async () => {
         const unsubscribe = vi.fn();
         let eventCallback: ((event: any) => void) | undefined;
@@ -834,6 +862,37 @@ describe("WalletMessageHandler handleMessage", () => {
             type: "RECOVER_VTXOS_SUCCESS",
             payload: { txid: "recover-txid" },
         });
+    });
+
+    it("RECOVER_VTXOS pushes settlement events straight to the channel", async () => {
+        // The three progress cases share a shape; one channel-wired variant
+        // covers them.
+        const event = { type: "batch_started", id: "b1" };
+        const broadcast = vi.fn();
+        const vtxoManager = {
+            recoverVtxos: vi.fn().mockImplementation(async (cb: any) => {
+                cb(event);
+                return "recover-txid";
+            }),
+        };
+        (updater as any).readonlyWallet = {};
+        (updater as any).wallet = {
+            getVtxoManager: vi.fn().mockResolvedValue(vtxoManager),
+        };
+        (updater as any).channel = { broadcast };
+
+        await updater.handleMessage({
+            ...baseMessage("r1"),
+            type: "RECOVER_VTXOS",
+        } as any);
+
+        expect(broadcast).toHaveBeenCalledWith({
+            tag: updater.messageTag,
+            id: "r1",
+            type: "RECOVER_VTXOS_EVENT",
+            payload: event,
+        });
+        expect(await updater.tick(Date.now())).toEqual([]);
     });
 
     it("RECOVER_VTXOS forwards settlement events via tick", async () => {
@@ -2184,5 +2243,352 @@ describe("WalletMessageHandler repo-backed reads", () => {
         await expect((updater as any).getVtxosFromRepo()).rejects.toThrow(
             /failed to derive script from wallet address/,
         );
+    });
+});
+
+describe("WalletMessageHandler event-push generations", () => {
+    const deferred = <T = void>() => {
+        let resolve!: (value: T) => void;
+        const promise = new Promise<T>((r) => {
+            resolve = r;
+        });
+        return { promise, resolve };
+    };
+    const flush = async (turns = 10) => {
+        for (let i = 0; i < turns; i++) await Promise.resolve();
+    };
+
+    const makeWallet = (overrides: Record<string, any> = {}) => ({
+        getAddress: vi.fn().mockResolvedValue(TEST_DEFAULT_ARK_ADDRESS),
+        getContractManager: vi.fn().mockResolvedValue({
+            onContractEvent: vi.fn(() => vi.fn()),
+            getContracts: vi.fn().mockResolvedValue([]),
+        }),
+        notifyIncomingFunds: vi.fn().mockResolvedValue(vi.fn()),
+        getBoardingUtxos: vi.fn().mockResolvedValue([]),
+        dispose: vi.fn().mockResolvedValue(undefined),
+        clear: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    });
+
+    const vtxoFunds = () => ({
+        type: "vtxo",
+        newVtxos: [createMockExtendedVtxo()],
+        spentVtxos: [],
+    });
+
+    let updater: WalletMessageHandler;
+    let repository: InMemoryWalletRepository;
+    let broadcast: ReturnType<typeof vi.fn>;
+
+    const attach = (wallet: any) => {
+        (updater as any).readonlyWallet = wallet;
+        (updater as any).arkProvider = {};
+        (updater as any).indexerProvider = {};
+        (updater as any).walletRepository = repository;
+        (updater as any).channel = { broadcast };
+    };
+
+    const emitted = (type: string) =>
+        broadcast.mock.calls.some(([response]) => response?.type === type);
+
+    beforeEach(() => {
+        updater = new WalletMessageHandler();
+        repository = new InMemoryWalletRepository();
+        broadcast = vi.fn();
+        // Not under test, and the real one talks to the indexer.
+        (updater as any).refreshCachedData = vi.fn().mockResolvedValue(undefined);
+    });
+
+    it("drops a suspended incoming-funds callback across stop() + start()", async () => {
+        // Without the counter this emit lands on the *new* channel carrying the
+        // previous wallet's vtxos, and VTXO_UPDATE carries no id to filter on.
+        const gate = deferred();
+        let fundsCallback: ((funds: any) => Promise<void>) | undefined;
+        const wallet = makeWallet({
+            getContractManager: vi.fn().mockResolvedValue({
+                onContractEvent: vi.fn(() => vi.fn()),
+                getContracts: vi.fn(async () => {
+                    await gate.promise;
+                    return [];
+                }),
+            }),
+            notifyIncomingFunds: vi.fn(async (cb: any) => {
+                fundsCallback = cb;
+                return vi.fn();
+            }),
+        });
+        attach(wallet);
+        await (updater as any).onWalletInitialized();
+
+        const inFlight = fundsCallback!(vtxoFunds());
+        await flush();
+
+        await updater.stop();
+        const nextBroadcast = vi.fn();
+        await updater.start(
+            { readonlyWallet: makeWallet(), arkProvider: {} } as any,
+            { walletRepository: repository },
+            { broadcast: nextBroadcast },
+        );
+
+        gate.resolve();
+        await inFlight;
+
+        expect(emitted("VTXO_UPDATE")).toBe(false);
+        expect(nextBroadcast).not.toHaveBeenCalled();
+        expect(await repository.getVtxosForScript(TEST_DEFAULT_SCRIPT)).toEqual([]);
+    });
+
+    it("does not re-arm the tick queue with progress events emitted after stop()", async () => {
+        // The fallback branch of the same guard: stop() clears onNextTick, and
+        // an uncancelled handleMessage must not refill it.
+        const started = deferred();
+        const gate = deferred();
+        const vtxoManager = {
+            recoverVtxos: vi.fn(async (cb: any) => {
+                started.resolve();
+                await gate.promise;
+                cb({ type: "batch_started" });
+                return "recover-txid";
+            }),
+        };
+        (updater as any).readonlyWallet = makeWallet();
+        (updater as any).wallet = {
+            getVtxoManager: vi.fn().mockResolvedValue(vtxoManager),
+            dispose: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const inFlight = updater.handleMessage({
+            ...baseMessage("r1"),
+            type: "RECOVER_VTXOS",
+        } as any);
+        await started.promise;
+
+        await updater.stop();
+        gate.resolve();
+        await inFlight;
+
+        expect((updater as any).onNextTick).toEqual([]);
+    });
+
+    it("neither emits nor writes from a callback suspended across CLEAR", async () => {
+        // A channel-only assertion passes while saveVtxosForContract resurrects
+        // the rows wallet.clear() just deleted — assert the repository too.
+        const gate = deferred();
+        let fundsCallback: ((funds: any) => Promise<void>) | undefined;
+        const wallet = makeWallet({
+            getContractManager: vi.fn().mockResolvedValue({
+                getContracts: vi.fn(async () => {
+                    await gate.promise;
+                    return [];
+                }),
+            }),
+            notifyIncomingFunds: vi.fn(async (cb: any) => {
+                fundsCallback = cb;
+                return vi.fn();
+            }),
+        });
+        attach(wallet);
+        await (updater as any).onWalletInitialized();
+
+        const inFlight = fundsCallback!(vtxoFunds());
+        await flush();
+
+        await (updater as any).clear();
+        expect(wallet.clear).toHaveBeenCalled();
+        gate.resolve();
+        await inFlight;
+
+        expect(emitted("VTXO_UPDATE")).toBe(false);
+        expect(await repository.getVtxosForScript(TEST_DEFAULT_SCRIPT)).toEqual([]);
+        // clear() does not end the bus generation, so the channel survives it.
+        expect((updater as any).channel).toBeDefined();
+    });
+
+    it("keeps contract-event delivery alive across a second INIT_WALLET", async () => {
+        // Regression test for collapsing the two subscription counters: sharing
+        // a bump with the incoming-funds re-subscribe would make this emitter
+        // permanently stale, and nothing re-registers it.
+        let eventCallback: ((event: any) => void) | undefined;
+        const wallet = makeWallet({
+            getContractManager: vi.fn().mockResolvedValue({
+                onContractEvent: vi.fn((cb: any) => {
+                    eventCallback = cb;
+                    return vi.fn();
+                }),
+                getContracts: vi.fn().mockResolvedValue([]),
+            }),
+        });
+        attach(wallet);
+
+        await (updater as any).onWalletInitialized();
+        await (updater as any).onWalletInitialized();
+
+        eventCallback?.({ type: "test" });
+        expect(emitted("CONTRACT_EVENT")).toBe(true);
+    });
+
+    it("keeps a settle's progress stream alive across a second INIT_WALLET", async () => {
+        // Folding requests into the incoming-funds counter would truncate this,
+        // leaving the page a SETTLE_SUCCESS with no progress behind it.
+        const gate = deferred();
+        const wallet = makeWallet();
+        const signer = {
+            settle: vi.fn(async (_params: any, cb: any) => {
+                cb({ type: "first" });
+                await gate.promise;
+                cb({ type: "second" });
+                return "settle-txid";
+            }),
+        };
+        attach(wallet);
+        (updater as any).wallet = signer;
+
+        const inFlight = (updater as any).handleSettle({
+            ...baseMessage("s1"),
+            type: "SETTLE",
+            payload: { params: {} },
+        });
+        await flush();
+
+        await (updater as any).onWalletInitialized();
+        gate.resolve();
+        await inFlight;
+
+        const events = broadcast.mock.calls
+            .map(([r]) => r)
+            .filter((r) => r?.type === "SETTLE_EVENT");
+        expect(events.map((r) => r.payload.type)).toEqual(["first", "second"]);
+    });
+
+    it("drops the previous incoming-funds callback across a second INIT_WALLET", async () => {
+        const gate = deferred();
+        const callbacks: ((funds: any) => Promise<void>)[] = [];
+        const wallet = makeWallet({
+            getContractManager: vi.fn().mockResolvedValue({
+                onContractEvent: vi.fn(() => vi.fn()),
+                getContracts: vi.fn(async () => {
+                    await gate.promise;
+                    return [];
+                }),
+            }),
+            notifyIncomingFunds: vi.fn(async (cb: any) => {
+                callbacks.push(cb);
+                return vi.fn();
+            }),
+        });
+        attach(wallet);
+        await (updater as any).onWalletInitialized();
+
+        const inFlight = callbacks[0](vtxoFunds());
+        await flush();
+
+        await (updater as any).onWalletInitialized();
+        gate.resolve();
+        await inFlight;
+
+        expect(callbacks).toHaveLength(2);
+        expect(emitted("VTXO_UPDATE")).toBe(false);
+        expect(await repository.getVtxosForScript(TEST_DEFAULT_SCRIPT)).toEqual([]);
+    });
+
+    it("keeps CONTRACT_EVENT delivery alive when a stale setup lands after stop()", async () => {
+        // The damage is the field assignment, not the emit: a stale run that
+        // assigns contractEventsSubscription makes every later call no-op at the
+        // early return, and delivery dies silently.
+        const gate = deferred();
+        const staleManager = { onContractEvent: vi.fn(() => vi.fn()) };
+        attach(
+            makeWallet({
+                getContractManager: vi.fn(async () => {
+                    await gate.promise;
+                    return staleManager;
+                }),
+            }),
+        );
+
+        const pending = (updater as any).ensureContractEventBroadcasting();
+        await flush();
+        await updater.stop();
+        gate.resolve();
+        await pending;
+
+        expect(staleManager.onContractEvent).not.toHaveBeenCalled();
+        expect((updater as any).contractEventsSubscription).toBeUndefined();
+
+        let eventCallback: ((event: any) => void) | undefined;
+        const fresh = makeWallet({
+            getContractManager: vi.fn().mockResolvedValue({
+                onContractEvent: vi.fn((cb: any) => {
+                    eventCallback = cb;
+                    return vi.fn();
+                }),
+            }),
+        });
+        await updater.start(
+            { readonlyWallet: fresh, arkProvider: {} } as any,
+            { walletRepository: repository },
+            { broadcast },
+        );
+        await (updater as any).ensureContractEventBroadcasting();
+
+        eventCallback?.({ type: "test" });
+        expect(emitted("CONTRACT_EVENT")).toBe(true);
+    });
+
+    it("unsubscribes an incoming-funds registration that lands after stop()", async () => {
+        // The subscription is already live when the check runs, so a bare return
+        // would leave a callback with no handle to cancel it.
+        const gate = deferred();
+        const unsubscribe = vi.fn();
+        attach(
+            makeWallet({
+                notifyIncomingFunds: vi.fn(async () => {
+                    await gate.promise;
+                    return unsubscribe;
+                }),
+            }),
+        );
+
+        const pending = (updater as any).onWalletInitialized();
+        await flush();
+        await updater.stop();
+        gate.resolve();
+        await pending;
+
+        expect(unsubscribe).toHaveBeenCalled();
+        expect((updater as any).incomingFundsSubscription).toBeUndefined();
+    });
+
+    it("lets the later of two overlapping INIT_WALLETs own the subscription", async () => {
+        // incomingFundsEpoch doing double duty as the initializer's mutual
+        // exclusion: the loser cannot unsubscribe the winner.
+        const gate = deferred();
+        const unsubFirst = vi.fn();
+        const unsubSecond = vi.fn();
+        let calls = 0;
+        attach(
+            makeWallet({
+                notifyIncomingFunds: vi.fn(async () => {
+                    if (++calls === 1) {
+                        await gate.promise;
+                        return unsubFirst;
+                    }
+                    return unsubSecond;
+                }),
+            }),
+        );
+
+        const first = (updater as any).onWalletInitialized();
+        await flush();
+        const second = (updater as any).onWalletInitialized();
+        await flush();
+        gate.resolve();
+        await Promise.all([first, second]);
+
+        expect(unsubFirst).toHaveBeenCalled();
+        expect(unsubSecond).not.toHaveBeenCalled();
+        expect((updater as any).incomingFundsSubscription).toBe(unsubSecond);
     });
 });

--- a/packages/ts-sdk/test/worker/messageBus.test.ts
+++ b/packages/ts-sdk/test/worker/messageBus.test.ts
@@ -65,13 +65,25 @@ class TestHandler implements MessageHandler {
     readonly messageTag: string;
     handleMessage = vi.fn<(message: RequestEnvelope) => Promise<ResponseEnvelope | null>>();
     tick = vi.fn<(now: number) => Promise<ResponseEnvelope[]>>().mockResolvedValue([]);
-    start = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    start = vi.fn<MessageHandler["start"]>().mockResolvedValue(undefined);
     stop = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 
     constructor(tag = "TEST_HANDLER") {
         this.messageTag = tag;
     }
+
+    /** The push channel the bus handed this handler on its last start(). */
+    get channel() {
+        const calls = this.start.mock.calls;
+        return calls[calls.length - 1]?.[2];
+    }
 }
+
+/**
+ * Broadcast delivery sits behind `matchAll`, one task deeper than the call that
+ * queued it — never rely on incidental microtask ordering to observe it.
+ */
+const flushDelivery = () => new Promise((resolve) => globalThis.setTimeout(resolve, 0));
 
 async function createAndInitBus(options: {
     handlers: MessageHandler[];
@@ -88,21 +100,24 @@ async function createAndInitBus(options: {
         buildServices: async () => ({}) as never,
     });
     await bus.start();
-    const initSource = { postMessage: vi.fn() };
+    await sendInit();
+    return bus;
+}
+
+async function sendInit(id = "init-1") {
     await messageHandler({
         data: {
             type: "INITIALIZE_MESSAGE_BUS",
-            id: "init-1",
+            id,
             tag: "INITIALIZE_MESSAGE_BUS",
             config: {
                 wallet: { publicKey: "00".repeat(33) },
                 arkServer: { url: "http://localhost" },
             },
         } as never,
-        source: initSource as never,
+        source: { postMessage: vi.fn() } as never,
         waitUntil: (p: Promise<unknown>) => p,
     });
-    return bus;
 }
 
 describe("MessageBus PING/PONG", () => {
@@ -1213,5 +1228,203 @@ describe("MessageBus default buildServices", () => {
 
     it("leaves it unset when none is configured", async () => {
         expect(await buildServices()).not.toHaveProperty("intentRepository");
+    });
+});
+
+describe("MessageBus broadcast fan-out", () => {
+    let selfMock: StubbedSelf;
+    let clientA: { postMessage: ReturnType<typeof vi.fn> };
+    let clientB: { postMessage: ReturnType<typeof vi.fn> };
+
+    const posted = (client: { postMessage: ReturnType<typeof vi.fn> }) =>
+        client.postMessage.mock.calls.map(([m]) => (m as ResponseEnvelope).id);
+
+    const event = (id: string): ResponseEnvelope => ({ tag: "wallet", id, broadcast: true });
+
+    beforeEach(() => {
+        selfMock = installSelfStub();
+        clientA = { postMessage: vi.fn() };
+        clientB = { postMessage: vi.fn() };
+        selfMock.clients.matchAll.mockResolvedValue([clientA, clientB]);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("posts tick responses to every window client, in order, behind one matchAll", async () => {
+        // One handler only: once runTick posts through the drain loop, a second
+        // handler's batch joins the first pass or opens a new one depending on
+        // when its tick() resolved, so the call count is stable only here.
+        const handler = new TestHandler("wallet");
+        handler.tick.mockResolvedValue([event("e1"), event("e2"), event("e3")]);
+
+        const bus = await createAndInitBus({ handlers: [handler] });
+        selfMock.clients.matchAll.mockClear();
+
+        await (bus as any).runTick();
+        await flushDelivery();
+
+        // The count is the load-bearing assertion: a FIFO stub keeps an
+        // order-only check passing even with one matchAll per message.
+        expect(selfMock.clients.matchAll).toHaveBeenCalledExactlyOnceWith({
+            includeUncontrolled: true,
+            type: "window",
+        });
+        expect(posted(clientA)).toEqual(["e1", "e2", "e3"]);
+        expect(posted(clientB)).toEqual(["e1", "e2", "e3"]);
+
+        await bus.stop();
+    });
+
+    it("delivers pushed events without a tick, in emission order", async () => {
+        // The whole bug in one assertion.
+        const handler = new TestHandler("wallet");
+        const bus = await createAndInitBus({ handlers: [handler] });
+
+        const channel = handler.channel;
+        expect(channel).toBeDefined();
+        channel!.broadcast(event("e1"));
+        channel!.broadcast(event("e2"));
+        channel!.broadcast(event("e3"));
+        await flushDelivery();
+
+        expect(handler.tick).not.toHaveBeenCalled();
+        expect(posted(clientA)).toEqual(["e1", "e2", "e3"]);
+        expect(posted(clientB)).toEqual(["e1", "e2", "e3"]);
+
+        await bus.stop();
+    });
+
+    it("coalesces events queued while a batch is in flight", async () => {
+        const handler = new TestHandler("wallet");
+        const bus = await createAndInitBus({ handlers: [handler] });
+        selfMock.clients.matchAll.mockClear();
+
+        let release: ((clients: unknown[]) => void) | undefined;
+        selfMock.clients.matchAll.mockReturnValueOnce(
+            new Promise((resolve) => {
+                release = resolve as (clients: unknown[]) => void;
+            }),
+        );
+
+        handler.channel!.broadcast(event("first"));
+        await Promise.resolve(); // let drain() reach the matchAll await
+        handler.channel!.broadcast(event("second"));
+        release!([clientA, clientB]);
+        await flushDelivery();
+
+        expect(posted(clientA)).toEqual(["first", "second"]);
+        expect(selfMock.clients.matchAll).toHaveBeenCalledTimes(2);
+
+        await bus.stop();
+    });
+
+    it("restarts the drain when a failed pass leaves work queued", async () => {
+        // Events no longer ride the tick, so there is no periodic recovery: an
+        // early return or an unexpected throw must not strand the queue.
+        const handler = new TestHandler("wallet");
+        const bus = await createAndInitBus({ handlers: [handler] });
+
+        let release: ((clients: unknown) => void) | undefined;
+        selfMock.clients.matchAll.mockReturnValueOnce(
+            new Promise((resolve) => {
+                release = resolve as (clients: unknown) => void;
+            }),
+        );
+
+        handler.channel!.broadcast(event("first"));
+        await Promise.resolve();
+        handler.channel!.broadcast(event("second"));
+        // Non-iterable: throws inside the fan-out loop, past the per-client and
+        // per-matchAll catches, so only the `finally` restart can recover.
+        release!(null);
+        await flushDelivery();
+
+        expect(posted(clientA)).toEqual(["second"]);
+
+        await bus.stop();
+    });
+
+    it("posts nothing through the channel after stop()", async () => {
+        const handler = new TestHandler("wallet");
+        const bus = await createAndInitBus({ handlers: [handler] });
+        const channel = handler.channel!;
+
+        await bus.stop();
+        channel.broadcast(event("late"));
+        await flushDelivery();
+
+        expect(clientA.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("makes a channel retained across a re-init inert", async () => {
+        // Written against a stub handler on purpose: the guarantee is the bus's,
+        // and must hold for an implementor that drops nothing in stop().
+        const handler = new TestHandler("wallet");
+        const bus = await createAndInitBus({ handlers: [handler] });
+        const stale = handler.channel!;
+
+        await sendInit("init-2");
+        expect(handler.channel).not.toBe(stale);
+
+        stale.broadcast(event("stale"));
+        await flushDelivery();
+        expect(clientA.postMessage).not.toHaveBeenCalled();
+
+        handler.channel!.broadcast(event("live"));
+        await flushDelivery();
+        expect(posted(clientA)).toEqual(["live"]);
+
+        await bus.stop();
+    });
+
+    it("drops a batch already in flight when a re-init lands", async () => {
+        // `running` never goes false in doInit, so only the epoch can catch this.
+        const handler = new TestHandler("wallet");
+        const bus = await createAndInitBus({ handlers: [handler] });
+
+        let release: ((clients: unknown[]) => void) | undefined;
+        selfMock.clients.matchAll.mockReturnValueOnce(
+            new Promise((resolve) => {
+                release = resolve as (clients: unknown[]) => void;
+            }),
+        );
+
+        handler.channel!.broadcast(event("doomed"));
+        await Promise.resolve();
+        await sendInit("init-2");
+        release!([clientA, clientB]);
+        await flushDelivery();
+
+        expect(clientA.postMessage).not.toHaveBeenCalled();
+
+        await bus.stop();
+    });
+
+    it("keeps draining under the new generation after an invalidation", async () => {
+        // An epoch mismatch drops the dead batch without stranding what the
+        // restarted generation queued behind it — no further broadcast needed
+        // to kick the loop.
+        const handler = new TestHandler("wallet");
+        const bus = await createAndInitBus({ handlers: [handler] });
+
+        let release: ((clients: unknown[]) => void) | undefined;
+        selfMock.clients.matchAll.mockReturnValueOnce(
+            new Promise((resolve) => {
+                release = resolve as (clients: unknown[]) => void;
+            }),
+        );
+
+        handler.channel!.broadcast(event("old"));
+        await Promise.resolve();
+        await sendInit("init-2");
+        handler.channel!.broadcast(event("new"));
+        release!([clientA, clientB]);
+        await flushDelivery();
+
+        expect(posted(clientA)).toEqual(["new"]);
+
+        await bus.stop();
     });
 });

--- a/packages/ts-sdk/test/worker/messageBus.test.ts
+++ b/packages/ts-sdk/test/worker/messageBus.test.ts
@@ -1310,11 +1310,14 @@ describe("MessageBus broadcast fan-out", () => {
 
         handler.channel!.broadcast(event("first"));
         await Promise.resolve(); // let drain() reach the matchAll await
+        // Two, not one: with a single straggler the expected count matches what
+        // one matchAll per message would also produce, and the test says nothing.
         handler.channel!.broadcast(event("second"));
+        handler.channel!.broadcast(event("third"));
         release!([clientA, clientB]);
         await flushDelivery();
 
-        expect(posted(clientA)).toEqual(["first", "second"]);
+        expect(posted(clientA)).toEqual(["first", "second", "third"]);
         expect(selfMock.clients.matchAll).toHaveBeenCalledTimes(2);
 
         await bus.stop();


### PR DESCRIPTION
## Reason

On consumer's side, when using the Service Worker the events have to wait the ticker before they are notified. This explains the perception of slow swaps in receive.

## Description

Every event the worker pushes to the page — `CONTRACT_EVENT`, `VTXO_UPDATE`, `UTXO_UPDATE` and the settle/renew/recover/migrate progress events — was queued and released only when the tick timer fired, adding up to `tickIntervalMs` of latency (10s default, 5s in arkade) to a push the worker already had.

**Bus.** A single FIFO drain loop behind one `matchAll`, exposed to handlers as an optional third `start()` argument. The channel is generation-scoped, so one retained across a re-init or `stop()` goes inert on its own rather than relying on the implementor. `runTick` posts through the same queue, so ordering is preserved across both paths.

**Wallet handler.** Three generation counters — one per subscription field, one for requests — replace `scheduleForNextTick`. They cannot be merged: the incoming-funds re-subscribe would otherwise leave the live contract-event emitter permanently stale, and folding requests in would truncate an in-flight settle. They also guard the repository writes and the subscription-field assignments a stale initializer would otherwise perform.

`tick()` and `onNextTick` stay as the fallback when no channel is supplied.

No consumer change required — `tickIntervalMs` simply stops governing event latency.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet and worker events can now be delivered immediately through a push channel, without waiting for the next update cycle.
  * Broadcasts are delivered to connected clients in order, with continued delivery after temporary failures.
  * Wallet restoration now preserves aggregate error details across worker communication.

* **Bug Fixes**
  * Prevented stale callbacks and events from being delivered after stopping or reinitializing the wallet.
  * Improved lifecycle handling for queued updates and contract events.

* **Documentation**
  * Updated worker messaging documentation to explain immediate broadcasts and scheduled responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->