### PR TITLE
feat(sdk): treat isUnrolled as a location axis, not a spend fact

### DIFF
--- a/packages/swap/src/refund.ts
+++ b/packages/swap/src/refund.ts
@@ -52,6 +52,7 @@ import {
     assertSubmittedArkTxid,
     buildOffchainTx,
     getArkPsbtFields,
+    hasTerminalSpend,
     matchServerCheckpoints,
 } from "@arkade-os/sdk";
 
@@ -140,12 +141,15 @@ export interface LockupVtxo {
      * It is still the trader's money and it is still visible, which is why
      * {@link findLockupVtxos} returns it. What it is not is refundable by
      * {@link pushRefundWithoutReceiver}: that builds an offchain Ark
-     * transaction, and the SDK's own predicates make the two states mutually
-     * exclusive — `canSpendOffchain` is false exactly when `canRecoverOnchain`
-     * is true (`wallet/vtxo.ts`), and the latter is documented as "must be
-     * recovered into a fresh batch rather than spent offchain". Holding the
-     * trader's `sender` key does not change that; a sweep removes the leaf from
-     * the live tree, not the signature from the trader.
+     * transaction, and the SDK's own predicates put the two states on opposite
+     * sides — `canSpendOffchain` is false whenever `canRecoverOnchain` is true
+     * (`wallet/vtxo.ts`), and the latter is documented as "must be recovered
+     * into a fresh batch rather than spent offchain". Holding the trader's
+     * `sender` key does not change that; a sweep removes the leaf from the live
+     * tree, not the signature from the trader.
+     *
+     * Opposite, but not exhaustive: an unrolled output satisfies neither, and
+     * {@link findLockupVtxos} drops those before they reach this type at all.
      *
      * `packages/boltz-swap` splits on exactly this fact rather than working
      * around it: `settleRefundWithoutReceiver` sends a live VTXO through an
@@ -247,6 +251,18 @@ export class LockupNeedsRecoveryError extends Error {
  * That function refuses the recoverable ones by name rather than submitting a
  * spend the server must reject.
  *
+ * **Unrolled outputs are the one exception, and are dropped.** A unilaterally
+ * exited output lives onchain behind its CSV; no offchain spend of any leaf can
+ * reach it, and `LockupVtxo` carries no field to say so, so a caller could not
+ * tell it apart from a live one. Whether arkd returns such an output under
+ * `spendableOnly` is not determinable from here, so the exclusion is made
+ * defensively rather than assumed. It costs the two waiting callers nothing
+ * they wanted: `awaitLockupFunding` keeps waiting for a claimable lockup
+ * instead of publishing `P` into a spend that cannot land, and
+ * `refundIfUnresolved` reports `nothing_to_refund` instead of grinding a doomed
+ * push to its deadline. The manager reads the exit through
+ * {@link readLockupFate}, which queries unfiltered and reports it as `exited`.
+ *
  * This read — not the RFQ's reported state — is the authority on whether
  * there is anything left at the lockup.
  *
@@ -277,6 +293,10 @@ export async function findLockupVtxos(
         [recoverable.vtxos ?? [], true],
     ] as const) {
         for (const vtxo of vtxos) {
+            // Dropped here, before the map: `LockupVtxo` discards the flag, so
+            // this is the last point at which an exited output can be told
+            // apart from a live one.
+            if (vtxo.isUnrolled) continue;
             // Deduped by outpoint: the two filters are disjoint today, but an
             // output counted twice would be added twice to the refund's
             // aggregate output and make a transaction that cannot be built.
@@ -327,6 +347,23 @@ export type LockupFate =
     /** Fully spent, and nothing that spent it revealed a matching preimage —
      * so the money went back to the trader. See {@link readLockupFate}. */
     | { fate: "returned"; spends: readonly LockupSpend[] }
+    /**
+     * At least one output was unilaterally exited: it sits onchain under the
+     * VHTLC script, where no offchain claim or refund can reach it.
+     *
+     * Not terminal, and not a loss. The money is still under the same script
+     * with the same leaves, so `completeUnroll` plus an onchain spend can still
+     * end the swap either way — which is why this outranks `open`: an output
+     * that is "still unspent" but unreachable is not a swap that is merely
+     * running.
+     *
+     * It outranks a verdict too, on a lockup where a sibling output was claimed
+     * or returned. That is the rule `open` already sets, not a new one: the
+     * unspent test short-circuits before any witness is read, so a partially
+     * resolved lockup has never reported `claimed`/`returned`. What changes is
+     * only that such a lockup now says why it is unresolved.
+     */
+    | { fate: "exited"; outpoints: readonly { txid: string; vout: number }[] }
     /** Nothing was learned: no outputs visible, an output spent by nothing the
      * indexer names, a spend it could not produce, or a blob that would not
      * decode. Never an answer. */
@@ -386,6 +423,11 @@ const candidateWitnessItems = (tx: Transaction, inputIndex: number): Uint8Array[
  * response to `unknown` is the same as to `open`: keep watching, and let the
  * refund timelock — which no outage can move — be what ends the wait.
  *
+ * **An exit is read before anything else, and over the whole set.** It is the
+ * one fact that makes an unspent output unreachable, so it outranks `open`; and
+ * it is scanned across every output rather than in outpoint order, so which
+ * output happens to come first cannot change the answer.
+ *
  * Ask-the-indexer, don't-trust-local-state: read fresh on every poll, never
  * cached, the same posture {@link findLockupVtxos} already establishes.
  */
@@ -401,15 +443,23 @@ export async function readLockupFate(
     const all = vtxos ?? [];
     if (all.length === 0) return { fate: "unknown" };
 
+    const exited = all.filter((vtxo) => vtxo.isUnrolled && !hasTerminalSpend(vtxo));
+    if (exited.length > 0) {
+        return {
+            fate: "exited",
+            outpoints: exited.map((vtxo) => ({ txid: vtxo.txid, vout: vtxo.vout })),
+        };
+    }
+
     const spentBy = new Map<string, LockupSpend>();
     let everySpendNamed = true;
     for (const vtxo of all) {
-        // Unions all three spend facts rather than trusting `spentBy` alone:
-        // the wire contract permits `isSpent: true` with an EMPTY `spentBy`,
-        // so a `spentBy`-only test would read an output that is gone as one
-        // still sitting there. Same union — and the same reason — as the SDK's
-        // own `hasTerminalSpend`.
-        if (!vtxo.isSpent && !vtxo.spentBy && !vtxo.settledBy) return { fate: "open" };
+        // The SDK's own predicate, not a fourth copy of it: it unions all three
+        // spend facts rather than trusting `spentBy` alone, because the wire
+        // contract permits `isSpent: true` with an EMPTY `spentBy` and a
+        // `spentBy`-only test would read an output that is gone as one still
+        // sitting there.
+        if (!hasTerminalSpend(vtxo)) return { fate: "open" };
         // `spentBy` is the EMPTY STRING, not absent, when there is nothing to
         // name, so this is a truthiness test and never a presence one. When it
         // IS set it names the CHECKPOINT transaction, which is exactly the one
@@ -493,9 +543,9 @@ export async function readLockupFate(
  * {@link refundIfUnresolved}, which retries.
  *
  * **Swept outputs are refused, not attempted.** This is an OFFCHAIN spend, and
- * a swept output is no longer a live leaf: `canSpendOffchain` and
- * `canRecoverOnchain` are mutually exclusive by construction, so a recoverable
- * input cannot be spent this way whatever key signs it (see
+ * a swept output is no longer a live leaf: `canSpendOffchain` is false wherever
+ * `canRecoverOnchain` is true, so a recoverable input cannot be spent this way
+ * whatever key signs it (see
  * {@link LockupVtxo.recoverable}). Because every input lands in ONE aggregate
  * transaction, a single swept output would take the live ones down with it —
  * so the whole push is refused with {@link LockupNeedsRecoveryError} naming the

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -694,7 +694,9 @@ const notify = <T extends (...args: never[]) => void>(
  *    `settled`; a lockup fully spent by anything else ends it `refunded`.
  *    Anything the indexer could not answer is `unknown`, which is NOT an
  *    answer: the pass carries on to the steps below, whose deadlines an indexer
- *    outage has no bearing on.
+ *    outage has no bearing on. `exited` — an output unilaterally taken onchain
+ *    — ends neither the swap nor the pass: it blocks the Arkade half below,
+ *    with the L1 half left running.
  * 2. **Drive the trader's claim.** On an onchain send that is the L1 fill — see
  *    {@link nextOnchainAction}. On a receive it is the lockup itself, and it
  *    ends the pass: that leg has no step 3.
@@ -1459,7 +1461,11 @@ export class RfqSwapManager {
         //    to the solver, so the best case is a wasted callback every pass
         //    and the worst is a caller who wired it generically watching that
         //    push fail forever against a key this wallet does not hold.
-        if (swap.kind === "lightning_receive") return this.driveReceiveClaim(swap);
+        if (swap.kind === "lightning_receive") {
+            return fate.fate === "exited"
+                ? this.blockExitedLockup(swap, fate)
+                : this.driveReceiveClaim(swap);
+        }
 
         //    The L1 half. Skipped once claimed — there is nothing further to
         //    learn from chain, and the record already carries the txid.
@@ -1467,8 +1473,39 @@ export class RfqSwapManager {
             if ((await this.driveOnchain(swap)) === "handled") return;
         }
 
-        // 3. The Arkade lockup.
+        // 3. The Arkade lockup. An exit is checked per-half rather than up at
+        //    step 1 on purpose: it says nothing about the L1 fill above, which
+        //    is a different output under a different key and keeps being driven
+        //    and claimed — the same split `setOnchainState` maintains.
+        if (fate.fate === "exited") {
+            // And deferred the same way `driveArkadeRefund` defers a probe
+            // refusal: before the window an onchain-send swap's live claim keeps
+            // the label, because that is the half the trader can still act on.
+            // Relabelling it here would un-say a claim the record can prove.
+            const claiming = swap.state === "claimable" || swap.state === "claimed";
+            if (this.config.now() < swap.refundLocktime && claiming) return;
+            return this.blockExitedLockup(swap, fate);
+        }
         await this.driveArkadeRefund(swap);
+    }
+
+    /**
+     * The lockup was unilaterally exited: its outputs sit onchain under the
+     * VHTLC script, where no offchain claim or refund can reach them.
+     *
+     * `needs_counterparty` rather than a terminal state, because the money still
+     * needs action and the swap can still end either way — an onchain claim can
+     * reveal the preimage, an onchain refund can return it — and that state is
+     * documented as re-checked every pass. It must be set from HERE and not from
+     * inside `driveArkadeRefund`, whose two `unblock` calls would lift it again
+     * on the very next pass.
+     */
+    private blockExitedLockup(swap: RfqSwap, fate: Extract<LockupFate, { fate: "exited" }>): void {
+        this.block(
+            swap,
+            `the lockup was unilaterally exited (${fate.outpoints.length} output(s) onchain), ` +
+                "so no offchain spend can move it — complete the unroll and spend it onchain",
+        );
     }
 
     /**

--- a/packages/swap/test/refund.test.ts
+++ b/packages/swap/test/refund.test.ts
@@ -356,8 +356,11 @@ describe("findLockupVtxos", () => {
     });
 
     /** Filter-aware, unlike `fakeIndexer`: the two sets are disjoint here, which
-     * is what makes a swept output visible or not. */
-    const byFilterIndexer = (spendable: LockupVtxo[], recoverable: LockupVtxo[]): RefundIndexer =>
+     * is what makes a swept output visible or not. `isUnrolled` is the wire's,
+     * not `LockupVtxo`'s — the point is that it never survives the mapping. */
+    type IndexedVtxo = LockupVtxo & { isUnrolled?: boolean };
+
+    const byFilterIndexer = (spendable: IndexedVtxo[], recoverable: IndexedVtxo[]): RefundIndexer =>
         ({
             getVtxos: async (opts?: { spendableOnly?: boolean; recoverableOnly?: boolean }) => ({
                 vtxos: opts?.recoverableOnly ? recoverable : opts?.spendableOnly ? spendable : [],
@@ -387,6 +390,42 @@ describe("findLockupVtxos", () => {
             { ...live, recoverable: false },
             { ...swept, recoverable: true },
         ]);
+    });
+
+    it("drops an unrolled output the indexer still lists as spendable", async () => {
+        // arkd is not depended on to exclude a unilateral exit from
+        // `spendableOnly`, and `LockupVtxo` carries no flag to pass one along —
+        // so anything that reached the mapping would be indistinguishable from
+        // the live output beside it and would be signed into a refund that no
+        // offchain leaf can land. The live sibling proves the drop is the
+        // output's own, not the whole response being discarded.
+        const script = swapScript();
+        const live = { txid: "ee".repeat(32), vout: 0, value: 3_000, recoverable: false };
+        const exited = {
+            txid: "ef".repeat(32),
+            vout: 1,
+            value: 6_000,
+            recoverable: false,
+            isUnrolled: true,
+        };
+        const found = await findLockupVtxos(byFilterIndexer([live, exited], []), script.pkScript);
+        expect(found).toEqual([live]);
+    });
+
+    it("drops an unrolled output from the recoverable half too", async () => {
+        // Both queries feed one loop, so the exclusion has to hold on the side
+        // whose outputs are already un-spendable for a different reason.
+        const script = swapScript();
+        const swept = { txid: "f0".repeat(32), vout: 0, value: 2_500, recoverable: false };
+        const exited = {
+            txid: "f1".repeat(32),
+            vout: 3,
+            value: 9_000,
+            recoverable: false,
+            isUnrolled: true,
+        };
+        const found = await findLockupVtxos(byFilterIndexer([], [swept, exited]), script.pkScript);
+        expect(found).toEqual([{ ...swept, recoverable: true }]);
     });
 
     it("counts an output appearing in both sets exactly once", async () => {
@@ -531,6 +570,38 @@ describe("refundIfUnresolved", () => {
         ).rejects.toThrow(/FORFEIT_CLOSURE_LOCKED/);
     });
 
+    it("reports nothing to refund when the lockup's only output was unrolled", async () => {
+        // The output is unspent, but onchain behind its CSV: no offchain leaf
+        // reaches it. Pushing anyway would fail every retry until
+        // `attemptDeadline` and then rethrow — burning the window on a spend
+        // that was never going to land.
+        const operator = fakeOperator();
+        let pushes = 0;
+        const watched = {
+            ...operator,
+            getInfo: async () => {
+                pushes += 1;
+                return operator.getInfo();
+            },
+        } as unknown as RefundArkProvider;
+        const exited = { txid: "66".repeat(32), vout: 0, value: 8_000, isUnrolled: true };
+        const indexer = {
+            getVtxos: async (opts?: { spendableOnly?: boolean }) => ({
+                vtxos: opts?.spendableOnly ? [exited] : [],
+            }),
+        } as unknown as RefundIndexer;
+
+        const result = await refundIfUnresolved(fakeTransport(["quoted"]), watched, indexer, {
+            ...baseInput(),
+            now: () => REFUND_LOCKTIME + 1,
+        });
+
+        expect(result.outcome).toBe("nothing_to_refund");
+        // The outcome alone would pass while the doomed push still went out.
+        expect(pushes).toBe(0);
+        expect(operator.submitted).toEqual([]);
+    });
+
     it("reports an empty lockup instead of failing", async () => {
         const operator = fakeOperator();
         const result = await refundIfUnresolved(
@@ -571,6 +642,8 @@ describe("readLockupFate", () => {
         vout: number;
         spentBy: string;
         isSpent?: boolean;
+        settledBy?: string;
+        isUnrolled?: boolean;
         arkTxId?: string;
     }
 
@@ -658,6 +731,52 @@ describe("readLockupFate", () => {
 
     it("claims no spend when the lockup is still open", async () => {
         expect(await read(fateIndexer([{ ...OUT_A, spentBy: "" }]))).toEqual({ fate: "open" });
+    });
+
+    it("reports an unrolled output as exited rather than open", async () => {
+        // Unspent, but sitting onchain under the VHTLC script: neither the
+        // claim nor any refund leaf can be spent offchain against it. Reading
+        // it as a swap that is merely still running would leave a caller
+        // waiting on a resolution nobody is able to produce.
+        const fate = await read(fateIndexer([{ ...OUT_A, spentBy: "", isUnrolled: true }]));
+        expect(fate).toEqual({ fate: "exited", outpoints: [OUT_A] });
+    });
+
+    it("finds the exit wherever the indexer happens to list it", async () => {
+        // Scanned over the whole set, not in outpoint order: an in-loop test
+        // would hit the plain unspent output first and answer `open`, making
+        // the fate depend on the order the indexer returned rows in.
+        const fate = await read(
+            fateIndexer([
+                { ...OUT_A, spentBy: "" },
+                { ...OUT_B, spentBy: "", isUnrolled: true },
+            ]),
+        );
+        expect(fate).toEqual({ fate: "exited", outpoints: [OUT_B] });
+    });
+
+    it("leaves an exited output that was then spent on the ordinary spent path", async () => {
+        // `completeUnroll` already moved it, so the exit is history and the
+        // witness is what says how the swap ended. Reporting `exited` here
+        // would throw away hash-verified proof of a claim.
+        const spend = spendOf(OUT_A, [PREIMAGE]);
+        const fate = await read(
+            fateIndexer([{ ...OUT_A, spentBy: spend.txid, isUnrolled: true }], [spend]),
+        );
+        expect(fate).toEqual({
+            fate: "claimed",
+            preimage: PREIMAGE,
+            spends: [{ checkpointTxid: spend.txid, arkTxid: undefined }],
+        });
+    });
+
+    it("reads a settled-only output as spent, not as money still sitting there", async () => {
+        // The third spend fact, carried by the SDK's `hasTerminalSpend` and by
+        // nothing else here: `settledBy` with no `spentBy` and no `isSpent`
+        // means the output was renewed away, and a `spentBy`-only test would
+        // call the empty lockup `open`.
+        const settled = { ...OUT_A, spentBy: "", settledBy: "e1".repeat(32) };
+        expect(await read(fateIndexer([settled]))).toEqual({ fate: "unknown" });
     });
 
     it("claims no spend when a spend was not named, or could not be produced", async () => {

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -206,11 +206,25 @@ interface FakeVtxo {
     arkTxId?: string;
     isSpent?: boolean;
     settledBy?: string;
+    /** Broadcast onchain by a unilateral exit. A LOCATION, not a spend: the
+     * wire pairs it with `isSpent: false`, so the money is still at the lockup
+     * — it is just money no offchain spend can reach. */
+    isUnrolled?: boolean;
 }
 
 /** An unspent lockup output, exactly as the indexer shapes one. */
 const unspent = (): FakeVtxo[] => [{ ...LOCKUP_OUTPOINT, spentBy: "" }];
 const spentBy = (txid: string): FakeVtxo[] => [{ ...LOCKUP_OUTPOINT, spentBy: txid }];
+/** Unilaterally exited, and still unspent — the shape `readLockupFate` reads
+ * as `exited` ahead of everything else. */
+const exited = (count = 1): FakeVtxo[] =>
+    Array.from({ length: count }, (_, vout) => ({
+        ...LOCKUP_OUTPOINT,
+        vout,
+        spentBy: "",
+        isSpent: false,
+        isUnrolled: true,
+    }));
 /** Spent, but by nothing the indexer names — the shape `hasTerminalSpend`
  * exists to catch. There is no witness to go and verify. */
 const spentUnnamed = (over: Partial<FakeVtxo> = {}): FakeVtxo => ({
@@ -1901,6 +1915,186 @@ describe("RfqSwapManager — a refund this wallet cannot make", () => {
         expect(states).toEqual(["needs_counterparty", "pending", "refunded"]);
         expect(swap.blockedReason).toBeUndefined();
         expect(s.refunds).toEqual([RFQ_ID]);
+    });
+});
+
+describe("RfqSwapManager — a lockup that was unilaterally exited", () => {
+    /** The lockup, exited and still unspent — for however many passes run. */
+    const exitedIndexer = (count = 1) => fakeIndexer({ vtxos: exited(count) });
+
+    it("does not push the refund the exit has put out of reach", async () => {
+        // THE assertion, and it is on the DRIVE rather than the label: a state
+        // check alone passes while the doomed push still goes out. `refundArkade`
+        // builds an offchain spend of a leaf that is no longer in the live tree,
+        // so a pass that reached it would hand the caller a transaction the
+        // server must reject.
+        const s = spies();
+        const swap = lightningSwap();
+        const m = manager({ indexer: exitedIndexer(2), now: REFUND_LOCKTIME + 1, spies: s });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(s.refunds).toEqual([]);
+        expect(s.actions).toEqual([]);
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/unilaterally exited \(2 output\(s\) onchain\)/);
+    });
+
+    it("is not terminal, and the swap stays monitored past the refund deadline", async () => {
+        // The money is still there and the onchain spend has no window, so this
+        // has no deadline of its own — unlike the push, which ends `failed` once
+        // median-time-past can no longer be the excuse.
+        let now = REFUND_LOCKTIME + 1;
+        const s = spies();
+        const failures: string[] = [];
+        const swap = lightningSwap();
+        const m = manager({ indexer: exitedIndexer(), now: () => now, spies: s });
+        m.onSwapFailed((_swap, error) => failures.push(error.message));
+        await m.addSwap(swap);
+        await m.poll();
+        now = REFUND_LOCKTIME + REFUND_MTP_LAG_SECONDS + 1;
+        await m.poll();
+        await m.poll();
+
+        expect(s.refunds).toEqual([]);
+        expect(isRfqSwapTerminal(swap.state)).toBe(false);
+        expect(swap.failure).toBeUndefined();
+        expect(failures).toEqual([]);
+        expect(await m.hasSwap(RFQ_ID)).toBe(true);
+    });
+
+    it("still ends `settled` when the counterparty resolves the lockup", async () => {
+        // What the non-terminal state is FOR: the swap is still watched, so the
+        // pass that reads a resolution still ends it — and the refusal's reason
+        // goes with the state, since a settled swap carrying one reads as blocked.
+        const s = spies();
+        const swap = lightningSwap();
+        let claimed = false;
+        const m = manager({
+            indexer: {
+                getVtxos: async () =>
+                    claimed
+                        ? fakeIndexer({ vtxos: spentBy(CLAIM_SPEND.txid) }).getVtxos()
+                        : fakeIndexer({ vtxos: exited() }).getVtxos(),
+                getVirtualTxs: fakeIndexer({ txs: [CLAIM_SPEND] }).getVirtualTxs,
+            } as unknown as LockupSpendIndexer,
+            now: REFUND_LOCKTIME + 1,
+            spies: s,
+        });
+        await m.addSwap(swap);
+        await m.poll();
+        expect(swap.state).toBe("needs_counterparty");
+
+        claimed = true;
+        await m.poll();
+
+        expect(swap.state).toBe("settled");
+        expect(swap.blockedReason).toBeUndefined();
+        expect(await m.hasSwap(RFQ_ID)).toBe(false);
+    });
+
+    it("reads an exit the counterparty has since spent as the spend", async () => {
+        // `isUnrolled` is a LOCATION, not a spend fact, and a terminal spend
+        // outranks it: once the output really is gone the swap ends on that
+        // spend rather than sitting blocked behind a flag describing where the
+        // money used to be.
+        const s = spies();
+        const swap = lightningSwap();
+        const m = manager({
+            indexer: fakeIndexer({
+                vtxos: [{ ...LOCKUP_OUTPOINT, spentBy: CLAIM_SPEND.txid, isUnrolled: true }],
+                txs: [CLAIM_SPEND],
+            }),
+            now: REFUND_LOCKTIME + 1,
+            spies: s,
+        });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("settled");
+        expect(s.refunds).toEqual([]);
+    });
+
+    it("does not publish the preimage into a receive claim that cannot land", async () => {
+        // The receive leg's version of the same hazard, and the worse one:
+        // `claimLockup` spends the claim leaf offchain, so a spend that cannot
+        // land still makes `P` public — and `P` is what lets the solver settle
+        // the payer's held HTLC. The funded read is deliberately left claimable,
+        // because the branch under test is the manager's and not
+        // `findLockupVtxos`' own drop of exited outputs.
+        const s = spies();
+        const swap = receiveSwap();
+        const m = manager({
+            indexer: fakeIndexer({
+                vtxos: exited(),
+                funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }],
+            }),
+            now: REFUND_LOCKTIME - 3600,
+            spies: s,
+        });
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(s.lockupClaims).toEqual([]);
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/unilaterally exited/);
+    });
+
+    it("claims the L1 fill anyway: the exit is one half's fact, not the swap's", async () => {
+        // Why the check sits per-half instead of at step 1. The fill is a
+        // different output, under a different key, on a different chain; a swap
+        // blocked before step 2 would let its claim window pass in silence and
+        // give up money the Arkade exit says nothing about.
+        const s = spies();
+        const swap = onchainSwap();
+        const m = manager({
+            indexer: exitedIndexer(),
+            chain: fakeChain({ utxos: [FILL], mtp: SAFE_NOW }),
+            now: SAFE_NOW,
+            spies: s,
+        });
+        await m.addSwap(swap);
+        await m.poll();
+        expect(s.claims).toHaveLength(1);
+        expect(swap.claimTxid).toBe("dd".repeat(32));
+
+        // The Arkade half is reached on the next pass — step 2 no longer ends
+        // the pass once the claim is made — but before the refund window the
+        // proven claim keeps the label: relabelling it would un-say something
+        // the record can prove, and the exit is the other half's fact.
+        await m.poll();
+
+        expect(s.claims).toHaveLength(1);
+        expect(swap.claimTxid).toBe("dd".repeat(32));
+        expect(swap.state).toBe("claimed");
+        expect(swap.blockedReason).toBeUndefined();
+    });
+
+    it("reports the exit once the refund window opens, without re-claiming", async () => {
+        // The other side of the deferral above: past `refundLocktime` the Arkade
+        // half is the live one, so the refusal wins the label — the same
+        // hand-over `driveArkadeRefund` makes for a probe refusal.
+        let now = SAFE_NOW;
+        const s = spies();
+        const swap = onchainSwap();
+        const m = manager({
+            indexer: exitedIndexer(),
+            chain: fakeChain({ utxos: [FILL], mtp: SAFE_NOW }),
+            now: () => now,
+            spies: s,
+        });
+        await m.addSwap(swap);
+        await m.poll();
+        expect(swap.state).toBe("claimed");
+
+        now = REFUND_LOCKTIME + 1;
+        await m.poll();
+
+        expect(s.claims).toHaveLength(1);
+        expect(s.refunds).toEqual([]);
+        expect(swap.claimTxid).toBe("dd".repeat(32));
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/unilaterally exited/);
     });
 });
 

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -370,21 +370,27 @@ console.log('Gated by a contract:', balance.gated) // swap escrow, chiefly
 console.log('Locked by an in-flight intent:', balance.intentLocked)
 console.log('Recoverable:', balance.recoverable)
 console.log('Awaiting recovery:', balance.pendingRecovery)
+console.log('Unilaterally exited:', balance.unrolled)
 ```
 
 `settled` and `preconfirmed` are the owned offchain buckets this relationship is
-about — `recoverable` and `pendingRecovery` are the wallet's funds too, just held
-under a different predicate. `available` is what generic spending will actually
-pick, and the difference between the two is accounted for exactly:
+about — `recoverable`, `pendingRecovery` and `unrolled` are the wallet's funds
+too, just held under a different predicate. `available` is what generic spending
+will actually pick, and the difference between the two is accounted for exactly:
 
 ```text
 settled + preconfirmed === available + gated + intentLocked
 ```
 
+`unrolled` holds virtual outputs whose unilateral exit already happened: they sit
+onchain behind their CSV timelock, so nothing offchain can move them and
+`Unroll.completeUnroll` is the only thing that will. They are never `available` and
+never `recoverable` — but they are still your money, so they still count in `total`.
+
 To show "your money, minus what is tied up", subtract from `settled + preconfirmed`
-— **not from `total`**, which also contains `boarding.total`, `recoverable` and
-`pendingRecovery`. Those are still your funds, so subtracting a bucket from `total`
-silently drops them from the figure.
+— **not from `total`**, which also contains `boarding.total`, `recoverable`,
+`pendingRecovery` and `unrolled`. Those are still your funds, so subtracting a bucket
+from `total` silently drops them from the figure.
 
 ```typescript
 
@@ -772,12 +778,7 @@ const onchainWallet = await OnchainWallet.create(onchainIdentity, 'regtest');
 
 // Unroll a specific virtual output
 const vtxo = { txid: 'your_vtxo_txid', vout: 0 };
-const session = await Unroll.Session.create(
-  vtxo,
-  onchainWallet,
-  onchainWallet.provider,
-  wallet.indexerProvider
-);
+const session = await Unroll.sessionFor(wallet, vtxo, onchainWallet);
 
 // Iterate through the unrolling steps
 for await (const step of session) {
@@ -794,6 +795,16 @@ for await (const step of session) {
   }
 }
 ```
+
+`Unroll.sessionFor` is `Session.create` with the wallet's explorer, indexer and
+virtual-tx cache filled in, plus the exit observer wired: at `StepType.DONE` the
+wallet's own repository learns the virtual output is now unrolled, and its value moves
+into the `unrolled` balance bucket. Nothing else would tell it — delta sync filters on
+creation time, so it never sees a status change on an older virtual output.
+
+If you hold no `Wallet` — driving an exit from providers alone — build the session with
+the lower-level `Unroll.Session.create(vtxo, bumper, explorer, indexer,
+virtualTxRepository?, onExitObserved?)`, whose last two parameters are optional.
 
 The unrolling process works by:
 
@@ -844,9 +855,10 @@ await Unroll.completeUnroll(
 
 ### Unilateral Exit Packages (pre-signed)
 
-`Unroll.Session` requires the wallet (keys + indexer access) to stay online for the whole
-multi-day exit. `UnilateralExit` removes that requirement: it pre-signs **every** transaction
-needed to unroll a VTXO's offchain transaction chain onchain **and** sweep each matured output
+`Unroll.sessionFor` (and the `Unroll.Session` it builds) requires the wallet — keys plus
+indexer access — to stay online for the whole multi-day exit. `UnilateralExit` removes that
+requirement: it pre-signs **every** transaction needed to unroll a VTXO's offchain
+transaction chain onchain **and** sweep each matured output
 to an address you solely control, then emits a versioned JSON package that anything with an
 Esplora-compatible endpoint can execute — no keys, no Arkade infrastructure.
 
@@ -882,6 +894,10 @@ for await (const event of executor) {
   console.log(event.stepIndex, event.kind, event.status)
 }
 ```
+
+Where the executing machine does hold the `Wallet`, `UnilateralExit.execute(wallet, pkg, opts?)`
+returns the same executor with the exit observer already wired, so the repository learns each
+branch is unrolled as it confirms.
 
 Every exit terminates in a **sweep**. Unrolling only lands a VTXO back onchain still encumbered
 by its Arkade script; the funds become yours unilaterally only once a sweep spends that output

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -797,10 +797,18 @@ for await (const step of session) {
 ```
 
 `Unroll.sessionFor` is `Session.create` with the wallet's explorer, indexer and
-virtual-tx cache filled in, plus the exit observer wired: at `StepType.DONE` the
-wallet's own repository learns the virtual output is now unrolled, and its value moves
-into the `unrolled` balance bucket. Nothing else would tell it — delta sync filters on
-creation time, so it never sees a status change on an older virtual output.
+virtual-tx cache filled in, plus the exit observer wired: at `StepType.DONE` it re-reads
+the outpoint from the indexer, so the value moves into the `unrolled` balance bucket
+without waiting for a sync that would never bring it. Nothing else would tell the wallet
+— delta sync filters on creation time, so it never sees a status change on an older
+virtual output.
+
+That re-read is a prompt rather than a guarantee: `StepType.DONE` means your Esplora
+endpoint saw the exit confirm, and the Arkade indexer may not have marked the output
+`isUnrolled` yet. The session fires once, so a re-read that lands early simply leaves the
+wallet where it would have been anyway, and the next thing to refresh that outpoint picks
+the exit up. `UnilateralExit` fires twice per virtual output — branch-confirmed and
+sweep-confirmed — and by the sweep the exit has been onchain for at least the CSV delay.
 
 If you hold no `Wallet` — driving an exit from providers alone — build the session with
 the lower-level `Unroll.Session.create(vtxo, bumper, explorer, indexer,

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -904,8 +904,10 @@ for await (const event of executor) {
 ```
 
 Where the executing machine does hold the `Wallet`, `UnilateralExit.execute(wallet, pkg, opts?)`
-returns the same executor with the exit observer already wired, so the repository learns each
-branch is unrolled as it confirms.
+returns the same executor with the exit observer already wired, so the repository re-reads each
+branch as it confirms and again as its sweep does — picking the exit up as it lands, indexer lag
+permitting. The same prompt-not-guarantee caveat as `Unroll.sessionFor` above applies, with the
+sweep-confirm re-read as its own retry.
 
 Every exit terminates in a **sweep**. Unrolling only lands a VTXO back onchain still encumbered
 by its Arkade script; the funds become yours unilaterally only once a sweep spends that output

--- a/packages/ts-sdk/src/arkade/contract.ts
+++ b/packages/ts-sdk/src/arkade/contract.ts
@@ -538,7 +538,12 @@ export class ArkadeContract<P extends Program = Program> {
             const [registered] = await manager.getContracts({ script: scriptHex });
             if (registered) {
                 const [withVtxos] = await manager.getContractsWithVtxos({ script: scriptHex });
-                return (withVtxos?.vtxos ?? []).filter((v) => !hasTerminalSpend(v));
+                // Not `canSpendOffchain`: that would also drop swept coins,
+                // which this accessor has always returned. Only the exited ones
+                // are new, and they are spendable by nothing offchain.
+                return (withVtxos?.vtxos ?? []).filter(
+                    (v) => !hasTerminalSpend(v) && !v.isUnrolled,
+                );
             }
         }
         if (!this.client.indexer) {

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -111,6 +111,7 @@ import {
     // VTXO capability predicates
     canRecoverOnchain,
     canSpendOffchain,
+    canSweepOnchain,
     hasTerminalSpend,
     isPastExpiry,
     isVirtualCoin,
@@ -353,6 +354,8 @@ import { PartialSig } from "./musig2/sign";
 import { AnchorBumper, P2A } from "./utils/anchor";
 import { TxWeightEstimator, type VSize } from "./utils/txSizeEstimator";
 import { Unroll } from "./wallet/unroll";
+import { exitObserverFor, notifyExitObserved } from "./wallet/exitObserver";
+import type { OnExitObserved } from "./wallet/exitObserver";
 import {
     UnilateralExit,
     createExitChainResolver,
@@ -369,6 +372,7 @@ import type {
     ExitVtxoInfo,
     ExitOptions,
     ExecutorEvent,
+    ExecutorOptions,
     ExitFeeWallet,
     ExitCaptureMode,
     ExitChainResolver,
@@ -760,6 +764,10 @@ export {
     P2A,
     Unroll,
     UnilateralExit,
+    // Exit-observed seam
+    exitObserverFor,
+    notifyExitObserved,
+    type OnExitObserved,
     createExitChainResolver,
     serializeExitPackage,
     deserializeExitPackage,
@@ -807,6 +815,7 @@ export {
     // VTXO capability predicates
     canRecoverOnchain,
     canSpendOffchain,
+    canSweepOnchain,
     hasTerminalSpend,
     isPastExpiry,
     isVirtualCoin,
@@ -1009,6 +1018,7 @@ export type {
     ExitVtxoInfo,
     ExitOptions,
     ExecutorEvent,
+    ExecutorOptions,
     ExitFeeWallet,
     // Storage
     StorageConfig,

--- a/packages/ts-sdk/src/wallet/balance.ts
+++ b/packages/ts-sdk/src/wallet/balance.ts
@@ -38,7 +38,17 @@ export interface OffchainBalance {
     intentLocked: number;
     recoverable: number;
     pendingRecovery: number;
-    /** `settled + preconfirmed + recoverable + pendingRecovery` — the buckets are disjoint. */
+    /**
+     * Funds whose unilateral exit already happened: the output sits onchain
+     * behind its CSV, so only `completeUnroll` can move it. Never `available`
+     * and never `recoverable` — a batch cannot lift an onchain output — but
+     * still the user's money, so counted in `total`.
+     */
+    unrolled: number;
+    /**
+     * `settled + preconfirmed + recoverable + pendingRecovery + unrolled` — the
+     * buckets are disjoint.
+     */
     total: number;
     assets: Asset[];
     availableAssets: Asset[];
@@ -70,8 +80,10 @@ export interface BalanceCapabilities {
  * spending would actually pick, so nothing reported as available can be refused
  * by `send`.
  *
- * Terminally spent VTXOs are skipped outright: neither capability predicate
- * claims them, and they must not reach the asset rollup.
+ * Terminally spent VTXOs are skipped outright: no capability predicate claims
+ * them, and they must not reach the asset rollup. An unrolled one is not spent,
+ * so it does: the sats stay in `total` and the asset units stay in `assets`,
+ * both out of the `available` half.
  */
 export function computeOffchainBalance(
     vtxos: readonly NormalizedExtendedVirtualCoin[],
@@ -86,6 +98,7 @@ export function computeOffchainBalance(
     let intentLocked = 0;
     let recoverable = 0;
     let pendingRecovery = 0;
+    let unrolled = 0;
     const owned = new Map<string, bigint>();
     const spendable = new Map<string, bigint>();
 
@@ -96,8 +109,23 @@ export function computeOffchainBalance(
     };
 
     for (const vtxo of vtxos) {
+        // Load-bearing, not belt-and-braces: `Wallet.getBalance` passes
+        // `withUnrolled: true`, so the filter hands over unrolled coins WITHOUT
+        // testing terminal spend, and this guard is what drops the ones that
+        // are also spent.
         if (hasTerminalSpend(vtxo)) continue;
         addAssets(owned, vtxo);
+
+        // Exited onchain: still the user's money, but only `completeUnroll` can
+        // move it. Never `available`, never `recoverable` — a batch cannot lift
+        // an onchain output. Tested BEFORE `isPendingRecovery`, and that order
+        // is depended upon: `selectPendingRecoveryOutpoints` also excludes
+        // unrolled coins, so this is the second of two independent guards
+        // keeping an exited coin out of the pending-recovery bucket.
+        if (vtxo.isUnrolled) {
+            unrolled += vtxo.value;
+            continue;
+        }
 
         // Pending recovery is tested first, and before expiry: such funds cannot
         // be renewed until they recover, so once their batch expiry passes
@@ -144,7 +172,8 @@ export function computeOffchainBalance(
         intentLocked,
         recoverable,
         pendingRecovery,
-        total: settled + preconfirmed + recoverable + pendingRecovery,
+        unrolled,
+        total: settled + preconfirmed + recoverable + pendingRecovery + unrolled,
         assets: toAssets(owned),
         availableAssets: toAssets(spendable),
     };

--- a/packages/ts-sdk/src/wallet/exit/execute.ts
+++ b/packages/ts-sdk/src/wallet/exit/execute.ts
@@ -5,9 +5,11 @@ import { Executor, type ExecutorOptions } from "./executor";
 import type { ExitPackage } from "./types";
 
 /**
- * An {@link Executor} with the wallet's exit observer already wired, so the repository learns
- * `isUnrolled` as each branch confirms and the balance moves into the `unrolled` bucket without an
- * indexer round-trip — which could not see the change anyway, delta sync filtering on creation time.
+ * An {@link Executor} with the wallet's exit observer already wired, so the repository re-reads
+ * each outpoint as its branch confirms and again as its sweep does, moving the value into the
+ * `unrolled` balance bucket without waiting for a delta sync — which could not see the change
+ * anyway, filtering as it does on creation time. What the re-read learns depends on the indexer
+ * having caught up; see `exitObserverFor`.
  *
  * The bare `Executor` stays keyless and provider-only; this is the wallet-side convenience that
  * makes the default path correct, because an opt-in parameter only reaches callers who know to pass

--- a/packages/ts-sdk/src/wallet/exit/execute.ts
+++ b/packages/ts-sdk/src/wallet/exit/execute.ts
@@ -1,0 +1,26 @@
+import type { OnchainProvider } from "../../providers/onchain";
+import { exitObserverFor } from "../exitObserver";
+import type { Wallet } from "../wallet";
+import { Executor, type ExecutorOptions } from "./executor";
+import type { ExitPackage } from "./types";
+
+/**
+ * An {@link Executor} with the wallet's exit observer already wired, so the repository learns
+ * `isUnrolled` as each branch confirms and the balance moves into the `unrolled` bucket without an
+ * indexer round-trip — which could not see the change anyway, delta sync filtering on creation time.
+ *
+ * The bare `Executor` stays keyless and provider-only; this is the wallet-side convenience that
+ * makes the default path correct, because an opt-in parameter only reaches callers who know to pass
+ * it. An explicit `opts.onExitObserved` still wins.
+ */
+export async function execute(
+    wallet: Wallet,
+    pkg: ExitPackage,
+    opts?: ExecutorOptions & { provider?: OnchainProvider },
+): Promise<Executor> {
+    const manager = await wallet.getContractManager();
+    return new Executor(pkg, opts?.provider ?? wallet.onchainProvider, {
+        ...opts,
+        onExitObserved: opts?.onExitObserved ?? exitObserverFor(manager),
+    });
+}

--- a/packages/ts-sdk/src/wallet/exit/executor.ts
+++ b/packages/ts-sdk/src/wallet/exit/executor.ts
@@ -1,4 +1,5 @@
 import { OnchainProvider } from "../../providers/onchain";
+import { notifyExitObserved, type OnExitObserved } from "../exitObserver";
 import { ExitPackage, ExitStep, SweepStep } from "./types";
 
 /**
@@ -51,6 +52,29 @@ export interface ExitFeeWallet {
 
 type TxStatus = { confirmed: boolean; blockHeight?: number; blockTime?: number };
 
+export interface ExecutorOptions {
+    pollIntervalMs?: number;
+    feeWallet?: ExitFeeWallet;
+    /** Abort to stop execution.
+     *
+     * Iteration then rejects with `signal.reason`. Calling `abort()`
+     * with no argument yields an error whose `name` is `"AbortError"`;
+     * a custom reason is forwarded as-is, matching `fetch` and
+     * `AbortSignal.prototype.throwIfAborted`.
+     *
+     * Already-broadcast transactions are not recalled; the executor is
+     * idempotent, so a later run resumes from the chain. */
+    signal?: AbortSignal;
+    /**
+     * Fired per VTXO once every step serving its branch is onchain, and again
+     * once its sweep confirms — the two moments an exit becomes observable.
+     * Best-effort: a rejection never reaches the exit, which is the whole point
+     * of a keyless disaster-recovery path. `UnilateralExit.execute` wires it
+     * from a wallet; passing it here keeps the bare executor provider-only.
+     */
+    onExitObserved?: OnExitObserved;
+}
+
 /**
  * Keyless, stateless executor for a pre-signed exit package.
  *
@@ -65,27 +89,36 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
 
     private readonly signal?: AbortSignal;
 
+    private readonly onExitObserved?: OnExitObserved;
+
     constructor(
         readonly pkg: ExitPackage,
         readonly provider: OnchainProvider,
-        opts?: {
-            pollIntervalMs?: number;
-            feeWallet?: ExitFeeWallet;
-            /** Abort to stop execution.
-             *
-             * Iteration then rejects with `signal.reason`. Calling `abort()`
-             * with no argument yields an error whose `name` is `"AbortError"`;
-             * a custom reason is forwarded as-is, matching `fetch` and
-             * `AbortSignal.prototype.throwIfAborted`.
-             *
-             * Already-broadcast transactions are not recalled; the executor is
-             * idempotent, so a later run resumes from the chain. */
-            signal?: AbortSignal;
-        },
+        opts?: ExecutorOptions,
     ) {
         this.pollIntervalMs = opts?.pollIntervalMs ?? 5_000;
         this.feeWallet = opts?.feeWallet;
         this.signal = opts?.signal;
+        this.onExitObserved = opts?.onExitObserved;
+    }
+
+    /**
+     * Per-VTXO branch progress, which the executor otherwise does not track:
+     * `dead` / `done` are per-step, and a VTXO is only onchain once EVERY
+     * `package`/`bump` step naming it has confirmed. (`broadcast` — the funding
+     * splitter — carries no `forVtxos` and serves no single VTXO.)
+     */
+    private branchSteps(): Map<string, Set<number>> {
+        const byVtxo = new Map<string, Set<number>>();
+        this.pkg.steps.forEach((step, i) => {
+            if (step.kind !== "package" && step.kind !== "bump") return;
+            for (const vtxo of step.forVtxos) {
+                let steps = byVtxo.get(vtxo);
+                if (!steps) byVtxo.set(vtxo, (steps = new Set()));
+                steps.add(i);
+            }
+        });
+        return byVtxo;
     }
 
     /**
@@ -137,6 +170,23 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
         throwIfAborted(this.signal); // before anything is broadcast
         const dead = new Set<string>(); // outpoints whose branch failed
 
+        const branchSteps = this.branchSteps();
+        const onchainSteps = new Set<number>();
+        const branchObserved = new Set<string>();
+        // Fired BEFORE the matching yield: a consumer that `break`s out of the
+        // loop leaves the generator suspended forever, and the repository write
+        // must not be the thing that gets stranded.
+        const observeBranch = async (stepIndex: number, forVtxos?: string[]) => {
+            onchainSteps.add(stepIndex);
+            for (const vtxo of forVtxos ?? []) {
+                if (branchObserved.has(vtxo)) continue;
+                const steps = branchSteps.get(vtxo);
+                if (!steps || ![...steps].every((i) => onchainSteps.has(i))) continue;
+                branchObserved.add(vtxo);
+                await this.observe(vtxo);
+            }
+        };
+
         if (this.pkg.validUntil && Date.now() / 1000 > this.pkg.validUntil) {
             yield {
                 stepIndex: -1,
@@ -174,6 +224,7 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
                 step.kind === "package" || step.kind === "bump" ? step.parentTxid : step.txid;
             const existing = await this.status(anchorTxid);
             if (existing?.confirmed) {
+                await observeBranch(i, forVtxos);
                 yield {
                     stepIndex: i,
                     kind: step.kind,
@@ -232,6 +283,7 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
                 }
             }
             await this.waitConfirmed(anchorTxid);
+            await observeBranch(i, forVtxos);
             yield {
                 stepIndex: i,
                 kind: step.kind,
@@ -267,6 +319,10 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
                 const swept = await this.status(step.txid);
                 if (swept?.confirmed) {
                     done.add(index);
+                    // Second observation for this VTXO: its exit output is
+                    // spent now, which is a further state change worth
+                    // persisting. `refreshOutpoints` is idempotent.
+                    await this.observe(step.vtxo);
                     yield {
                         stepIndex: index,
                         kind: "sweep",
@@ -334,5 +390,17 @@ export class Executor implements AsyncIterable<ExecutorEvent> {
             }
             if (done.size < pending.length) await this.sleep();
         }
+    }
+
+    /** `"txid:vout"` -> outpoint, then hand it to the hook. A malformed entry is skipped. */
+    private async observe(outpoint: string): Promise<void> {
+        if (!this.onExitObserved) return;
+        const sep = outpoint.lastIndexOf(":");
+        // `Number("")` is 0, so the empty test is what stops `"txid:"` being
+        // observed as vout 0 — a different outpoint than the package named.
+        const rest = outpoint.slice(sep + 1);
+        const vout = Number(rest);
+        if (sep <= 0 || rest === "" || !Number.isInteger(vout)) return;
+        await notifyExitObserved(this.onExitObserved, { txid: outpoint.slice(0, sep), vout });
     }
 }

--- a/packages/ts-sdk/src/wallet/exit/executor.ts
+++ b/packages/ts-sdk/src/wallet/exit/executor.ts
@@ -68,6 +68,10 @@ export interface ExecutorOptions {
     /**
      * Fired per VTXO once every step serving its branch is onchain, and again
      * once its sweep confirms — the two moments an exit becomes observable.
+     * Two fires rather than one is what makes an observer reading a lagging
+     * indexer recoverable here: by the sweep the exit has been onchain for at
+     * least the CSV delay.
+     *
      * Best-effort: a rejection never reaches the exit, which is the whole point
      * of a keyless disaster-recovery path. `UnilateralExit.execute` wires it
      * from a wallet; passing it here keeps the bare executor provider-only.

--- a/packages/ts-sdk/src/wallet/exit/index.ts
+++ b/packages/ts-sdk/src/wallet/exit/index.ts
@@ -1,12 +1,13 @@
 import { estimate } from "./estimate";
 import type { ExitOptions } from "./estimate";
+import { execute } from "./execute";
 import { Executor } from "./executor";
 import { prepare } from "./prepare";
 
 export * from "./types";
 export { ExitPathError, resolveUnilateralPath } from "./path";
 export type { ResolvedExitPath } from "./path";
-export type { ExecutorEvent, ExitFeeWallet } from "./executor";
+export type { ExecutorEvent, ExecutorOptions, ExitFeeWallet } from "./executor";
 export type { ExitOptions } from "./estimate";
 export type { ExitCaptureMode } from "./capture";
 export type { ExitChainResolver, ExitDataSource } from "./resolver";
@@ -20,10 +21,15 @@ export { createExitChainResolver } from "./resolver";
  * VTXOs onchain and broadcasts the fee-funding splitter; `Executor` drives
  * the resulting package to completion with nothing but an
  * Esplora-compatible endpoint — no keys, no Arkade infrastructure.
+ *
+ * `execute` is the wallet-side shorthand for that last step: the same
+ * executor, with the exit observer wired so the wallet's own repository
+ * learns the exit as it lands.
  */
 export const UnilateralExit = {
     estimate,
     prepare,
+    execute,
     Executor,
 } as const;
 

--- a/packages/ts-sdk/src/wallet/exit/index.ts
+++ b/packages/ts-sdk/src/wallet/exit/index.ts
@@ -24,7 +24,9 @@ export { createExitChainResolver } from "./resolver";
  *
  * `execute` is the wallet-side shorthand for that last step: the same
  * executor, with the exit observer wired so the wallet's own repository
- * learns the exit as it lands.
+ * re-reads each outpoint as its branch confirms and again as its sweep
+ * does — picking the exit up as it lands, indexer lag permitting. See
+ * `exitObserverFor` for why that is a prompt rather than a guarantee.
  */
 export const UnilateralExit = {
     estimate,

--- a/packages/ts-sdk/src/wallet/exitObserver.ts
+++ b/packages/ts-sdk/src/wallet/exitObserver.ts
@@ -20,6 +20,14 @@ export type OnExitObserved = (outpoint: Outpoint) => void | Promise<void>;
 /**
  * Adapt a contract manager into an {@link OnExitObserved}: the wallet-side half of the seam, kept
  * out of `exit/` so the dependency direction stays outward.
+ *
+ * **A prompt, not a guarantee.** The hook fires when the EXPLORER reports the exit confirmed, and
+ * `refreshOutpoints` then asks the INDEXER. If arkd has not yet marked the output `isUnrolled` the
+ * refresh writes the state it does report — or returns silently when it names no vtxo at all — and
+ * nothing here retries. A miss leaves the wallet exactly where it was before this seam existed: it
+ * learns the exit whenever something else next refreshes the outpoint. The executor's second fire
+ * at sweep-confirm is the natural retry, and by then the exit has been onchain for at least the
+ * CSV delay.
  */
 export function exitObserverFor(
     manager: Pick<IContractManager, "refreshOutpoints">,

--- a/packages/ts-sdk/src/wallet/exitObserver.ts
+++ b/packages/ts-sdk/src/wallet/exitObserver.ts
@@ -1,0 +1,44 @@
+import type { Outpoint } from ".";
+import type { IContractManager } from "../contracts/contractManager";
+
+/**
+ * Called when a VTXO's exit becomes observable onchain.
+ *
+ * The seam exists because nothing else can learn the fact: delta sync filters on *creation* time
+ * (`GetVtxosOptions.after` / `before`), so a status change on an older VTXO is invisible to it, and
+ * neither exit path can reach a contract manager on its own — `Unroll.Session` takes no contract
+ * layer by design, and the `UnilateralExit` executor is deliberately keyless and provider-only.
+ *
+ * A plain function type, with no runtime import anywhere in this module, is what lets both keep
+ * that independence: an exit path calls the hook, it does not import the contract layer.
+ *
+ * **Best-effort by contract.** An exit is a disaster-recovery path and must never fail because a
+ * cache write did, so every call site goes through {@link notifyExitObserved}.
+ */
+export type OnExitObserved = (outpoint: Outpoint) => void | Promise<void>;
+
+/**
+ * Adapt a contract manager into an {@link OnExitObserved}: the wallet-side half of the seam, kept
+ * out of `exit/` so the dependency direction stays outward.
+ */
+export function exitObserverFor(
+    manager: Pick<IContractManager, "refreshOutpoints">,
+): OnExitObserved {
+    return (outpoint) => manager.refreshOutpoints([outpoint]);
+}
+
+/** Fire an observation without letting it into the exit's failure path. */
+export async function notifyExitObserved(
+    onExitObserved: OnExitObserved | undefined,
+    outpoint: Outpoint,
+): Promise<void> {
+    if (!onExitObserved) return;
+    try {
+        await onExitObserved(outpoint);
+    } catch (e) {
+        console.error(
+            `exit observer failed for ${outpoint.txid}:${outpoint.vout} — the exit is unaffected`,
+            e,
+        );
+    }
+}

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -411,9 +411,9 @@ export interface WalletBalance {
      * obtainable split under a different predicate and is not counted here.
      *
      * Subtract this from `settled + preconfirmed`, never from `total`. `total`
-     * also carries {@link boarding}, {@link recoverable} and
-     * {@link pendingRecovery}, which are still the user's funds — netting a
-     * bucket out of it drops them from the figure with no signal.
+     * also carries {@link boarding}, {@link recoverable}, {@link pendingRecovery}
+     * and {@link unrolled}, which are still the user's funds — netting a bucket
+     * out of it drops them from the figure with no signal.
      */
     gated: number;
     /**
@@ -443,7 +443,19 @@ export interface WalletBalance {
      */
     pendingRecovery: number;
 
-    /** Total balance across offchain, recoverable, pending-recovery, and boarding funds. */
+    /**
+     * Funds whose unilateral exit already happened — the output is onchain
+     * behind its CSV timelock, so `Unroll.completeUnroll` is the only thing
+     * that moves it. Excluded from `available`/`settled`/`preconfirmed`, from
+     * `recoverable` (no batch can lift an onchain output), and from coin
+     * selection — but still the wallet's funds, so counted in `total`.
+     */
+    unrolled: number;
+
+    /**
+     * Total balance across offchain, recoverable, pending-recovery, unrolled,
+     * and boarding funds.
+     */
     total: number;
 
     /** Asset balance entries (`assetId` & `amount`) the wallet owns. */
@@ -453,7 +465,8 @@ export interface WalletBalance {
      * The subset of {@link assets} generic spending will accept, i.e. the asset
      * analogue of {@link available}. `assets - availableAssets` is what is held
      * but not selectable, for the {@link gated} and {@link intentLocked} causes
-     * plus recovery — assets have no per-cause split of their own.
+     * plus recovery and {@link unrolled} — assets have no per-cause split of
+     * their own.
      */
     availableAssets: Asset[];
 }
@@ -939,6 +952,7 @@ import type { NormalizedExtendedVirtualCoin } from "./vtxo";
 export {
     canRecoverOnchain,
     canSpendOffchain,
+    canSweepOnchain,
     convertVtxo,
     getAllNormalizedVtxos,
     getNormalizedVtxos,

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -993,7 +993,15 @@ export type GetVtxosFilter = {
     /** Include swept but still unspent virtual outputs. */
     withRecoverable?: boolean;
 
-    /** Include virtual outputs that have been unrolled onchain. */
+    /**
+     * Include virtual outputs that have been unrolled onchain.
+     *
+     * Authoritative on the *location* axis and only that: an exited output is
+     * returned whatever else is true of it, spent ones included. So unlike
+     * {@link withRecoverable}, this flag does not narrow to a capability —
+     * test {@link canSweepOnchain} before acting on what comes back.
+     * `Unroll.prepareUnrollTransaction`, the flag's main consumer, does.
+     */
     withUnrolled?: boolean;
 };
 

--- a/packages/ts-sdk/src/wallet/intentReconciliation.ts
+++ b/packages/ts-sdk/src/wallet/intentReconciliation.ts
@@ -7,7 +7,7 @@ import {
     isTerminalIntentState,
 } from "../repositories/intentRepository";
 import type { Outpoint, VirtualCoin } from ".";
-import { getNormalizedVtxos } from "./vtxo";
+import { getNormalizedVtxos, hasTerminalSpend } from "./vtxo";
 
 /**
  * Intent states a persisted intent can be stuck in after a crash: none of
@@ -33,7 +33,7 @@ export interface IntentReconciliationDeps {
 
 /** A VTXO is consumed once the indexer reports it spent (offchain) or settled onchain. */
 function isConsumed(vtxo: VirtualCoin | undefined): boolean {
-    return vtxo !== undefined && (vtxo.isSpent === true || vtxo.settledBy !== undefined);
+    return vtxo !== undefined && hasTerminalSpend(vtxo);
 }
 
 /**
@@ -48,6 +48,8 @@ function isConsumed(vtxo: VirtualCoin | undefined): boolean {
  *
  *   - all inputs consumed by a batch  → `batch_succeeded` (the money moved;
  *     the crash lost only the local record, not the funds);
+ *   - any input unilaterally exited → `cancelled` (an onchain output cannot be
+ *     an input to a batch, so the intent is dead however the server records it);
  *   - never submitted (`waiting_to_submit`), inputs still unspent → `cancelled`
  *     (arkd never saw it, so the inputs are safe to unlock);
  *   - past `validUntil`, inputs still unspent → `cancelled` (expired);
@@ -72,6 +74,19 @@ export async function classifyIntent(
             intent.commitmentTransactionId ??
             consumed.map((v) => v?.settledBy).find((s): s is string => !!s);
         return terminal(intent, "batch_succeeded", now, { commitmentTransactionId });
+    }
+
+    // An exited input can never be batched, so the intent is dead — and unlike
+    // the cases below, waiting does not help. Tested after `batch_succeeded`, so
+    // an input that settled AND unrolled still reports the settlement.
+    //
+    // Bare `isUnrolled`, not `canSweepOnchain`: the question here is whether the
+    // input can still join a batch, and an exited output cannot whether or not
+    // its onchain spend has happened yet.
+    if (consumed.some((vtxo) => vtxo?.isUnrolled)) {
+        return terminal(intent, "cancelled", now, {
+            cancellationReason: "reconciliation: an input was unilaterally exited",
+        });
     }
 
     // From here the inputs are (at least partly) still unspent.

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1592,6 +1592,7 @@ export class WalletMessageHandler
             intentLocked: offchain.intentLocked,
             recoverable: offchain.recoverable,
             pendingRecovery: offchain.pendingRecovery,
+            unrolled: offchain.unrolled,
             total: totalBoarding + offchain.total,
             assets: offchain.assets,
             availableAssets: offchain.availableAssets,
@@ -1888,31 +1889,35 @@ export class WalletMessageHandler
             throw new WalletNotInitializedError();
         }
         const allVtxos = await this.getVtxosFromRepo();
-        const vtxos = allVtxos.filter((v) => !hasTerminalSpend(v));
         const dustAmount = this.readonlyWallet.dustAmount;
+        const withUnrolled = message.payload.filter?.withUnrolled ?? false;
         const includeRecoverable = message.payload.filter?.withRecoverable ?? false;
-        const filteredVtxos = includeRecoverable
-            ? vtxos
-            : vtxos.filter((v) => {
-                  if (dustAmount != null && isSubdust(v, dustAmount)) {
-                      return false;
-                  }
-                  if (isRecoverable(v)) {
-                      return false;
-                  }
-                  if (isExpired(v)) {
-                      return false;
-                  }
-                  return true;
-              });
 
-        // Unrolling terminally spends the virtual output, so unrolled coins never
-        // survive the unspent read above — append them on request, as `Wallet.getVtxos`
-        // does, otherwise `prepareUnrollTransaction` finds nothing behind the worker.
-        if (!message.payload.filter?.withUnrolled) {
-            return filteredVtxos;
-        }
-        return filteredVtxos.concat(allVtxos.filter((v) => hasTerminalSpend(v) && v.isUnrolled));
+        // Same shape as `filterSnapshotVtxos`: location first, so `withUnrolled`
+        // is authoritative for an exited coin and `prepareUnrollTransaction`
+        // finds it behind the worker. (The `withRecoverable` default differs
+        // from the main thread's — pre-existing, not touched here.)
+        return allVtxos.filter((v) => {
+            if (v.isUnrolled) {
+                return withUnrolled;
+            }
+            if (hasTerminalSpend(v)) {
+                return false;
+            }
+            if (includeRecoverable) {
+                return true;
+            }
+            if (dustAmount != null && isSubdust(v, dustAmount)) {
+                return false;
+            }
+            if (isRecoverable(v)) {
+                return false;
+            }
+            if (isExpired(v)) {
+                return false;
+            }
+            return true;
+        });
     }
 
     /** Tear down handler subscriptions, then delegate the full wipe to the wallet. */

--- a/packages/ts-sdk/src/wallet/unroll.ts
+++ b/packages/ts-sdk/src/wallet/unroll.ts
@@ -194,6 +194,14 @@ export namespace Unroll {
 
         /**
          * Get the next step to be executed
+         *
+         * @remarks
+         * `do()` is the step, not a formality: every effect lives there, and at
+         * `StepType.DONE` that includes firing {@link onExitObserved}. A caller
+         * driving `next()` by hand must always await it — the async iterator
+         * below does. Reading `type` and skipping `do()` leaves the exit
+         * unobserved, and on the other step kinds unbroadcast.
+         *
          * @returns The next step to be executed + the function to execute it
          */
         async next(): Promise<Step & { do: () => Promise<void> }> {

--- a/packages/ts-sdk/src/wallet/unroll.ts
+++ b/packages/ts-sdk/src/wallet/unroll.ts
@@ -18,6 +18,8 @@ import { Transaction } from "../utils/transaction";
 import { DUST_AMOUNT } from "./utils";
 import { finalizeVirtualTx } from "./exit/finalizeVirtualTx";
 import { resolveUnilateralPath } from "./exit/path";
+import { exitObserverFor, notifyExitObserved, type OnExitObserved } from "./exitObserver";
+import { canSweepOnchain } from "./vtxo";
 
 /**
  * Local ChainTxType → ChainedTxType map. Duplicated (not imported from
@@ -124,6 +126,14 @@ export namespace Unroll {
              * previous behaviour (indexer only).
              */
             readonly virtualTxRepository?: VirtualTxRepository,
+            /**
+             * Fired once the chain is fully onchain (`StepType.DONE`), so a
+             * wallet repository can learn `isUnrolled` without an indexer
+             * round-trip that could not see the change anyway. Best-effort —
+             * a rejection never reaches the exit. Prefer {@link sessionFor},
+             * which wires it from the wallet.
+             */
+            readonly onExitObserved?: OnExitObserved,
         ) {}
 
         /** Create an unroll session by loading the virtual output chain from the indexer. */
@@ -133,6 +143,7 @@ export namespace Unroll {
             explorer: OnchainProvider,
             indexer: IndexerProvider,
             virtualTxRepository?: VirtualTxRepository,
+            onExitObserved?: OnExitObserved,
         ): Promise<Session> {
             const { chain } = await indexer.getVtxoChain(toUnroll);
             return new Session(
@@ -141,6 +152,7 @@ export namespace Unroll {
                 explorer,
                 indexer,
                 virtualTxRepository,
+                onExitObserved,
             );
         }
 
@@ -223,7 +235,13 @@ export namespace Unroll {
                 return {
                     type: StepType.DONE,
                     vtxoTxid: this.toUnroll.txid,
-                    do: () => Promise.resolve(),
+                    // The observation rides on `do` rather than the iterator so
+                    // a caller driving `next()` by hand fires it too.
+                    do: () =>
+                        notifyExitObserved(this.onExitObserved, {
+                            txid: this.toUnroll.txid,
+                            vout: this.toUnroll.vout,
+                        }),
                 };
             }
 
@@ -268,6 +286,30 @@ export namespace Unroll {
     }
 
     /**
+     * {@link Session.create} with everything the wallet already holds — explorer, indexer,
+     * virtual-tx cache — plus the exit observer, so the repository learns `isUnrolled` at
+     * `StepType.DONE`.
+     *
+     * Prefer this to building a `Session` by hand: an optional parameter only reaches callers who
+     * know to pass it, which is the same failure mode the seam exists to close.
+     */
+    export async function sessionFor(
+        wallet: Wallet,
+        toUnroll: Outpoint,
+        bumper: AnchorBumper,
+    ): Promise<Session> {
+        const manager = await wallet.getContractManager();
+        return Session.create(
+            toUnroll,
+            bumper,
+            wallet.onchainProvider,
+            wallet.indexerProvider,
+            wallet.virtualTxRepository,
+            exitObserverFor(manager),
+        );
+    }
+
+    /**
      * Complete the unroll of a virtual output by broadcasting the transaction that spends the CSV path.
      * @param wallet the wallet owning the virtual output(s)
      * @param vtxoTxids the txids of the virtual output(s) to complete unroll
@@ -282,6 +324,9 @@ export namespace Unroll {
     ): Promise<string> {
         const signedTx = await prepareUnrollTransaction(wallet, vtxoTxids, outputAddress);
         await wallet.onchainProvider.broadcastTransaction(signedTx.hex);
+        // The inputs ARE the exited VTXOs, so no second read is needed to name them. Refreshing
+        // is best-effort: the broadcast already succeeded and a cache write must not undo that.
+        await refreshSpentExitOutputs(wallet, signedTx);
         return signedTx.id;
     }
 }
@@ -316,9 +361,10 @@ export async function prepareUnrollTransaction(
     let totalAmount = 0n;
     const txWeightEstimator = TxWeightEstimator.create();
     for (const vtxo of vtxos) {
-        if (!vtxo.isUnrolled) {
+        if (!canSweepOnchain(vtxo)) {
             throw new Error(
-                `Vtxo ${vtxo.txid}:${vtxo.vout} is not fully unrolled, use unroll first`,
+                `Vtxo ${vtxo.txid}:${vtxo.vout} cannot be swept onchain: it is not fully unrolled ` +
+                    `(use unroll first), or its exit output was already spent`,
             );
         }
 
@@ -396,6 +442,28 @@ export async function prepareUnrollTransaction(
     const signedTx = await wallet.identity.sign(tx);
     signedTx.finalize();
     return signedTx;
+}
+
+/**
+ * Pull the authoritative state of the outpoints a completed unroll just spent, so the wallet stops
+ * reporting them under the `unrolled` balance bucket. Swallows everything: this runs after a
+ * successful broadcast.
+ */
+async function refreshSpentExitOutputs(wallet: Wallet, signedTx: Transaction): Promise<void> {
+    const outpoints: Outpoint[] = [];
+    for (let i = 0; i < signedTx.inputsLength; i++) {
+        const input = signedTx.getInput(i);
+        if (input.txid && input.index !== undefined) {
+            outpoints.push({ txid: hex.encode(input.txid), vout: input.index });
+        }
+    }
+    if (outpoints.length === 0) return;
+    try {
+        const manager = await wallet.getContractManager();
+        await manager.refreshOutpoints(outpoints);
+    } catch (e) {
+        console.error("completeUnroll: failed to refresh the spent exit outputs", e);
+    }
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/ts-sdk/src/wallet/unroll.ts
+++ b/packages/ts-sdk/src/wallet/unroll.ts
@@ -128,9 +128,11 @@ export namespace Unroll {
             readonly virtualTxRepository?: VirtualTxRepository,
             /**
              * Fired once the chain is fully onchain (`StepType.DONE`), so a
-             * wallet repository can learn `isUnrolled` without an indexer
-             * round-trip that could not see the change anyway. Best-effort —
-             * a rejection never reaches the exit. Prefer {@link sessionFor},
+             * wallet repository can be prompted to re-read the outpoint —
+             * delta sync never would, filtering as it does on creation time.
+             * Fired ONCE, so an observer that reads a lagging indexer gets no
+             * second chance; see {@link exitObserverFor}. Best-effort — a
+             * rejection never reaches the exit. Prefer {@link sessionFor},
              * which wires it from the wallet.
              */
             readonly onExitObserved?: OnExitObserved,
@@ -287,8 +289,9 @@ export namespace Unroll {
 
     /**
      * {@link Session.create} with everything the wallet already holds — explorer, indexer,
-     * virtual-tx cache — plus the exit observer, so the repository learns `isUnrolled` at
-     * `StepType.DONE`.
+     * virtual-tx cache — plus the exit observer, which re-reads the outpoint at `StepType.DONE`
+     * rather than waiting for a delta sync that cannot see the change. That single fire is a
+     * prompt and not a guarantee — see {@link exitObserverFor}.
      *
      * Prefer this to building a `Session` by hand: an optional parameter only reaches callers who
      * know to pass it, which is the same failure mode the seam exists to close.

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -74,7 +74,12 @@ export function selectPendingRecoveryOutpoints(
             continue;
         }
         for (const v of vtxos) {
-            if (!hasTerminalSpend(v) && !v.isSwept) out.add(`${v.txid}:${v.vout}`);
+            // Exited coins are excluded: their remedy is `completeUnroll`,
+            // not a signer rotation, and reporting them here would blame the
+            // rotation for a coin the user took onchain themselves.
+            if (!hasTerminalSpend(v) && !v.isSwept && !v.isUnrolled) {
+                out.add(`${v.txid}:${v.vout}`);
+            }
         }
     }
     return out;
@@ -2330,8 +2335,13 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // are exactly the funds already draining into the active signer, so
             // the report still counts them (recoverableCount) alongside the
             // not-yet-swept holdings (awaitingSweepCount) (Section 6 / post-cutoff).
-            const recoverable = vtxos.filter((v) => v.isSwept && !hasTerminalSpend(v));
-            const spendable = vtxos.filter((v) => !hasTerminalSpend(v) && !v.isSwept);
+            // Exited coins are on neither leg — `completeUnroll` is their only
+            // remedy — so they belong in no migration bucket. Without this the
+            // report over-counts migratable value and announces the coin as
+            // recovering through the sweep path, which will never happen.
+            const live = vtxos.filter((v) => !v.isUnrolled);
+            const recoverable = live.filter((v) => v.isSwept && !hasTerminalSpend(v));
+            const spendable = live.filter((v) => !hasTerminalSpend(v) && !v.isSwept);
 
             const value = spendable.reduce((sum, v) => sum + v.value, 0);
 

--- a/packages/ts-sdk/src/wallet/vtxo.ts
+++ b/packages/ts-sdk/src/wallet/vtxo.ts
@@ -332,15 +332,18 @@ export async function fetchVtxoCreatedAtByTxid(
  * Whether a virtual output has been consumed and can never be spent again.
  *
  * @remarks
- * Unions all terminal facts rather than trusting any one of them. The wire contract permits
+ * Unions all three spend facts rather than trusting any one of them. The wire contract permits
  * `isSpent: true` with an empty `spentBy` (settlement inputs needing no forfeit are written that
- * way), and unilateral exits set `isUnrolled` without necessarily setting `isSpent`; omitting
- * either would classify a consumed VTXO as spendable, inflating balance and selecting it for a send
- * that must fail.
+ * way), so a `spentBy || settledBy` definition would classify a spent VTXO as spendable — inflating
+ * balance and selecting it for a send that must fail.
+ *
+ * `isUnrolled` is deliberately **not** part of this union: it says where the output lives, not that
+ * it was consumed. Mirrors NArk's `ArkVtxo.IsSpent()`. The location axis is {@link canSweepOnchain},
+ * which the two capability predicates below subtract instead.
  */
 export function hasTerminalSpend(vtxo: VirtualCoin): boolean {
     const n = normalizeVtxo(vtxo);
-    return !!n.isUnrolled || !!n.isSpent || !!n.spentBy || !!n.settledBy;
+    return !!n.isSpent || !!n.spentBy || !!n.settledBy;
 }
 
 /**
@@ -367,7 +370,7 @@ export function isPastExpiry(vtxo: VirtualCoin, now: TimeHeight): boolean {
 /** Whether a virtual output can be spent in an offchain transaction. The send/coin-selection test. */
 export function canSpendOffchain(vtxo: VirtualCoin, now: TimeHeight): boolean {
     const n = normalizeVtxo(vtxo);
-    return !hasTerminalSpend(n) && !(n.isSwept || isPastExpiry(n, now));
+    return !hasTerminalSpend(n) && !n.isUnrolled && !(n.isSwept || isPastExpiry(n, now));
 }
 
 /**
@@ -376,7 +379,23 @@ export function canSpendOffchain(vtxo: VirtualCoin, now: TimeHeight): boolean {
  */
 export function canRecoverOnchain(vtxo: VirtualCoin, now: TimeHeight): boolean {
     const n = normalizeVtxo(vtxo);
-    return !hasTerminalSpend(n) && (n.isSwept || isPastExpiry(n, now));
+    return !hasTerminalSpend(n) && !n.isUnrolled && (n.isSwept || isPastExpiry(n, now));
+}
+
+/**
+ * Whether a virtual output's exit already happened: the output lives onchain and `completeUnroll`
+ * is the only remedy. The third and last capability, on the location axis rather than the spend
+ * one — together the three partition the live set, since this claims every unrolled coin and the
+ * other two refuse them.
+ *
+ * @remarks
+ * The ts-sdk analogue of NArk's `OnchainSweepService` filter, minus the expiry clause: the relevant
+ * maturity here is the exit tx's CSV timelock, which `prepareUnrollTransaction` checks against the
+ * chain tip, not the batch expiry.
+ */
+export function canSweepOnchain(vtxo: VirtualCoin): boolean {
+    const n = normalizeVtxo(vtxo);
+    return !hasTerminalSpend(n) && !!n.isUnrolled;
 }
 
 // --- fee estimation ----------------------------------------------------------------------------
@@ -434,8 +453,8 @@ export function isVirtualCoin<T>(input: T): input is T & VirtualCoin {
  * @param vtxo - virtual output to inspect
  * @returns `true` when the virtual output has not been consumed
  *
- * @deprecated Ambiguous: `true` for swept or expired virtual outputs, which cannot in fact be spent
- * offchain. Use {@link canSpendOffchain}.
+ * @deprecated Ambiguous: `true` for swept, expired or unrolled virtual outputs, none of which can
+ * in fact be spent offchain. Use {@link canSpendOffchain}.
  */
 export function isSpendable(vtxo: VirtualCoin): boolean {
     return !hasTerminalSpend(vtxo);
@@ -448,7 +467,8 @@ export function isSpendable(vtxo: VirtualCoin): boolean {
  * @returns `true` when the virtual output is swept but not yet consumed
  *
  * @deprecated Swept-only: ignores virtual outputs that are past expiry but not yet swept, which are
- * equally recoverable. Use {@link canRecoverOnchain}.
+ * equally recoverable, and claims unrolled ones, which are not recoverable at all. Use
+ * {@link canRecoverOnchain}.
  */
 export function isRecoverable(vtxo: VirtualCoin): boolean {
     const n = normalizeVtxo(vtxo);

--- a/packages/ts-sdk/src/wallet/vtxo.ts
+++ b/packages/ts-sdk/src/wallet/vtxo.ts
@@ -332,14 +332,15 @@ export async function fetchVtxoCreatedAtByTxid(
  * Whether a virtual output has been consumed and can never be spent again.
  *
  * @remarks
- * Unions all three spend facts rather than trusting any one of them. The wire contract permits
+ * Unions all terminal facts rather than trusting any one of them. The wire contract permits
  * `isSpent: true` with an empty `spentBy` (settlement inputs needing no forfeit are written that
- * way), so a `spentBy || settledBy` definition would classify a spent VTXO as spendable — inflating
- * balance and selecting it for a send that must fail.
+ * way), and unilateral exits set `isUnrolled` without necessarily setting `isSpent`; omitting
+ * either would classify a consumed VTXO as spendable, inflating balance and selecting it for a send
+ * that must fail.
  */
 export function hasTerminalSpend(vtxo: VirtualCoin): boolean {
     const n = normalizeVtxo(vtxo);
-    return !!n.isSpent || !!n.spentBy || !!n.settledBy;
+    return !!n.isUnrolled || !!n.isSpent || !!n.spentBy || !!n.settledBy;
 }
 
 /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -416,13 +416,19 @@ export function filterSnapshotVtxos(
             if (pendingSpendOutpoints.has(`${vtxo.txid}:${vtxo.vout}`)) {
                 return false;
             }
-            if (!hasTerminalSpend(vtxo)) {
-                if (!f.withRecoverable && canRecoverOnchain(vtxo, now)) {
-                    return false;
-                }
-                return true;
+            // Location before spend: `withUnrolled` is authoritative for an
+            // exited coin whatever else is true of it, which is also what
+            // preserves today's behaviour for unrolled-and-spent coins.
+            if (vtxo.isUnrolled) {
+                return !!f.withUnrolled;
             }
-            return !!(f.withUnrolled && vtxo.isUnrolled);
+            if (hasTerminalSpend(vtxo)) {
+                return false;
+            }
+            if (!f.withRecoverable && canRecoverOnchain(vtxo, now)) {
+                return false;
+            }
+            return true;
         });
 }
 
@@ -520,6 +526,8 @@ export interface BoardingUtxoGroup {
  * - `subdust` — below dust, so it sits at an OP_RETURN script with no spendable
  *   leaf. Unspendable as cash; `createCash` prevents minting these.
  * - `already-spent` — someone else claimed it first.
+ * - `exited` — unilaterally exited onchain, so the offchain sweep cannot reach it;
+ *   `Unroll.completeUnroll` is the remedy.
  * - `has-assets` — asset-bearing; the BTC-only sweep would burn the assets.
  * - `sweep-failed` — spendable, but its own sweep was rejected.
  */
@@ -527,6 +535,7 @@ export type ArkadeCashUnclaimedReason =
     | "swept"
     | "subdust"
     | "already-spent"
+    | "exited"
     | "has-assets"
     | "sweep-failed";
 
@@ -1191,7 +1200,13 @@ export class ReadonlyWallet implements IReadonlyWallet {
             this.getBoardingUtxos(),
             this.contractSnapshot(),
         ]);
-        const vtxos = filterSnapshotVtxos(snapshot, undefined, this._pendingSpendOutpoints);
+        // Explicit, not the default filter: the default drops unrolled coins,
+        // and `computeOffchainBalance` cannot report a bucket it never sees.
+        const vtxos = filterSnapshotVtxos(
+            snapshot,
+            { withRecoverable: true, withUnrolled: true },
+            this._pendingSpendOutpoints,
+        );
 
         // boarding
         let confirmed = 0;
@@ -1227,6 +1242,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             intentLocked: offchain.intentLocked,
             recoverable: offchain.recoverable,
             pendingRecovery: offchain.pendingRecovery,
+            unrolled: offchain.unrolled,
             total: totalBoarding + offchain.total,
             assets: offchain.assets,
             availableAssets: offchain.availableAssets,
@@ -5197,6 +5213,12 @@ export class Wallet
         for (const vtxo of vtxos) {
             if (hasTerminalSpend(vtxo)) {
                 unclaimed.push(cashReport(vtxo, "already-spent"));
+            } else if (vtxo.isUnrolled) {
+                // Exited onchain. The thin sweep is an offchain spend, so it
+                // cannot reach the output whatever its dust or sweep state —
+                // hence before both of those checks, and with its own reason:
+                // the remedy is `completeUnroll`, not a settlement.
+                unclaimed.push(cashReport(vtxo, "exited"));
             } else if (isSubdust(vtxo, this.dustAmount)) {
                 // Subdust lives at an OP_RETURN output: no forfeit leaf, nothing
                 // to spend, and no settlement can lift it out on its own. The

--- a/packages/ts-sdk/test/arkade-contract.test.ts
+++ b/packages/ts-sdk/test/arkade-contract.test.ts
@@ -12,6 +12,7 @@ import {
     VtxoScript,
     type EmulatorInfo,
     type EmulatorProvider,
+    type IContractManager,
 } from "../src";
 import { getVirtualTxs, mintCoin } from "./helpers/prevArkTx";
 
@@ -115,18 +116,35 @@ function stubProviders(server: Uint8Array, emulatorKey: Uint8Array) {
     return { arkProvider, indexer, emulator, captured };
 }
 
+/**
+ * Minimal `IContractManager` that reports every script it is asked about as
+ * registered, holding `vtxos`. The test builds exactly one contract, so echoing
+ * the queried script is enough to put `getUtxos` on the manager-backed branch.
+ */
+function stubManager(vtxos: unknown[]): IContractManager {
+    return {
+        async getContracts(filter?: { script?: string }) {
+            return [{ script: filter?.script }];
+        },
+        async getContractsWithVtxos(filter?: { script?: string }) {
+            return [{ contract: { script: filter?.script }, vtxos }];
+        },
+    } as unknown as IContractManager;
+}
+
 describe("arkade.Arkade / ArkadeContract", () => {
     const server = xOnly();
     const emulatorKey = xOnly();
     const receiver = xOnly(); // 32-byte witness program
     const args = { hash: HASH, receiver, amount: AMOUNT };
 
-    async function connect() {
+    async function connect(contractManager?: IContractManager) {
         const { arkProvider, indexer, emulator, captured } = stubProviders(server, emulatorKey);
         const ark = await arkade.Arkade.connect({
             arkade: arkProvider,
             emulator,
             indexer,
+            contractManager,
             network: networks.regtest,
             // connect() takes the co-signer key from the network, not from the
             // emulator's own getInfo, so this fixture key has to come in as the
@@ -160,6 +178,23 @@ describe("arkade.Arkade / ArkadeContract", () => {
         const { ark } = await connect();
         const contract = ark.contract(htlcProgram(), args);
         expect(await contract.getBalance()).toBe(BigInt(COIN.value));
+    });
+
+    it("getUtxos drops exited and spent coins, keeping the healthy sibling", async () => {
+        const { ark: probe } = await connect();
+        const script = hex.encode(probe.contract(htlcProgram(), args).pkScript);
+
+        const healthy = { ...mintCoin(7_000), script, isSpent: false };
+        const exited = { ...mintCoin(3_000), script, isSpent: false, isUnrolled: true };
+        const spent = { ...mintCoin(1_000), script, isSpent: true };
+
+        const { ark } = await connect(stubManager([healthy, exited, spent]));
+        const contract = ark.contract(htlcProgram(), args);
+
+        // The value also proves the manager branch ran: the fallback indexer
+        // would have answered with COIN (10_000) instead.
+        expect((await contract.getUtxos()).map((u) => u.txid)).toEqual([healthy.txid]);
+        expect(await contract.getBalance()).toBe(7_000n);
     });
 
     it("send() resolves the covenant + encodes the witness ([0] → empty push)", async () => {

--- a/packages/ts-sdk/test/arkadeCashClaim.test.ts
+++ b/packages/ts-sdk/test/arkadeCashClaim.test.ts
@@ -105,6 +105,11 @@ function spentCashVtxo(cashPkScript: string): VirtualCoin {
     } as VirtualCoin;
 }
 
+/** The same VTXO after a unilateral exit: onchain now, but nothing spent it. */
+function exitedCashVtxo(cashPkScript: string): VirtualCoin {
+    return { ...spentCashVtxo(cashPkScript), isSpent: false, isUnrolled: true };
+}
+
 /** A distinct spent arkadeCash VTXO, one per index, all at the same pkScript. */
 function spentCashVtxoAt(cashPkScript: string, index: number): VirtualCoin {
     return {
@@ -308,6 +313,55 @@ describe("claimCash drain-pending accounting", () => {
         await wallet.claimCash(cash.toString());
 
         expect(finalizeTx).toHaveBeenCalledOnce();
+    });
+
+    // An exited output lives onchain: the thin sweep is an offchain spend, so
+    // it can only report the coin — and it must say so as `exited`, not as a
+    // spend that never happened.
+    it("reports an exited VTXO as `exited` and never sweeps it", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const submitTx = vi.fn();
+        const finalizeTx = vi.fn(async () => {});
+        const getPendingTxs = vi.fn(async () => []);
+
+        const wallet = await makeWallet(cashIndexer(cashPkScript, [exitedCashVtxo(cashPkScript)]), {
+            getPendingTxs,
+            finalizeTx,
+            submitTx,
+        });
+
+        const result = await wallet.claimCash(cash.toString());
+
+        expect(submitTx).not.toHaveBeenCalled();
+        expect(finalizeTx).not.toHaveBeenCalled();
+        expect(result.swept).toBe(0);
+        expect(result.unclaimed.amount).toBe(CASH_VALUE);
+        expect(result.unclaimed.vtxos).toEqual([
+            { txid: CASH_TXID, vout: 0, value: CASH_VALUE, reason: "exited" },
+        ]);
+    });
+
+    // Exit is a location, spend is a fate: a coin carrying both is reported by
+    // its fate, so the terminal-spend branch deliberately runs first.
+    it("reports an exited VTXO that was also spent as already-spent", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const finalizeTx = vi.fn(async () => {});
+        const getPendingTxs = vi.fn(async () => []);
+
+        const exitedAndSpent = { ...spentCashVtxo(cashPkScript), isUnrolled: true };
+        const wallet = await makeWallet(cashIndexer(cashPkScript, [exitedAndSpent]), {
+            getPendingTxs,
+            finalizeTx,
+        });
+
+        const result = await wallet.claimCash(cash.toString());
+
+        expect(result.swept).toBe(0);
+        expect(result.unclaimed.vtxos).toEqual([
+            { txid: CASH_TXID, vout: 0, value: CASH_VALUE, reason: "already-spent" },
+        ]);
     });
 
     it("surfaces the recoverable token when the funding send fails", async () => {

--- a/packages/ts-sdk/test/deprecatedSignerMigration.test.ts
+++ b/packages/ts-sdk/test/deprecatedSignerMigration.test.ts
@@ -332,6 +332,28 @@ describe("VtxoManager - deprecated-signer migration", () => {
         expect(report.signers.find((s) => s.signerPubKey === DEP_DUE)?.vtxoCount).toBe(2);
     });
 
+    it("excludes an exited VTXO from the migration send and from the per-signer rollup", async () => {
+        // Unlike the no-expiry case above, an exit is not merely unsendable: it
+        // is no longer under the deprecated signer's custody at all, so it must
+        // not be counted as a holding awaiting migration either.
+        const script = "default-" + DEP_DUE;
+        const exited = makeVtxo(script, 4000);
+        (exited as { isUnrolled: boolean }).isUnrolled = true;
+        const { wallet, sendSelectedVtxosToSelf } = createMigrationMockWallet({
+            info: makeInfo(ACTIVE, [{ pubkey: DEP_DUE }]),
+            contractsWithVtxos: [cwv(DEP_DUE, [makeVtxo(script, 5000), exited])],
+        });
+        const manager = newManager(wallet);
+
+        const report = await manager.migrateDeprecatedSignerVtxos();
+
+        const inputs = sendSelectedVtxosToSelf.mock.calls[0][0] as ExtendedContractVtxo[];
+        expect(inputs.map((v) => v.value)).toEqual([5000]);
+        const row = report.signers.find((s) => s.signerPubKey === DEP_DUE)!;
+        expect(row.vtxoCount).toBe(1);
+        expect(row.totalValue).toBe(5000);
+    });
+
     it("applies a mid-session rotation first when the wallet's own signer is deprecated", async () => {
         const { wallet, rotateServerSigner, sendSelectedVtxosToSelf } = createMigrationMockWallet({
             walletSigner: DEP_A, // wallet was built before the rotation
@@ -1114,6 +1136,41 @@ describe("VtxoManager - post-cutoff lifecycle reporting (Section 6)", () => {
         expect(row.recoverableValue).toBe(0);
         expect(row.awaitingSweepCount).toBe(0);
         expect(row.nextSweepEta).toBeUndefined();
+    });
+
+    it("keeps an exited VTXO out of the EXPIRED rollup and out of the sweep ETA", async () => {
+        const script = "default-" + DEP_EXPIRED;
+        const etaSoon = Date.now() + 100_000;
+        const etaFar = Date.now() + 200_000;
+        // Exited on both legs of the split: one not yet swept, one swept.
+        const exitedAwaiting = makeVtxoWithExpiry(script, 4000, "settled", etaSoon);
+        (exitedAwaiting as { isUnrolled: boolean }).isUnrolled = true;
+        const exitedSwept = makeVtxo(script, 7000, "swept");
+        (exitedSwept as { isUnrolled: boolean }).isUnrolled = true;
+        const { wallet } = createMigrationMockWallet({
+            info: makeInfo(ACTIVE, [{ pubkey: DEP_EXPIRED, cutoffDate: BigInt(NOW_S - 100) }]),
+            contractsWithVtxos: [
+                cwv(DEP_EXPIRED, [
+                    makeVtxoWithExpiry(script, 5000, "settled", etaFar),
+                    exitedAwaiting,
+                    exitedSwept,
+                ]),
+            ],
+        });
+
+        const row = (await newManager(wallet).getDeprecatedSignerStatus()).find(
+            (s) => s.signerPubKey === DEP_EXPIRED,
+        )!;
+
+        expect(row.vtxoCount).toBe(1);
+        expect(row.totalValue).toBe(5000);
+        expect(row.awaitingSweepCount).toBe(1);
+        expect(row.awaitingSweepValue).toBe(5000);
+        expect(row.recoverableCount).toBe(0);
+        expect(row.recoverableValue).toBe(0);
+        // The exit's nearer expiry must not be advertised as a recovery ETA: no
+        // sweep will ever make that coin recoverable.
+        expect(row.nextSweepEta).toBe(etaFar);
     });
 
     it("transitions awaitingSweep → recoverableNow on sweep, and recovery drains the swept set", async () => {

--- a/packages/ts-sdk/test/e2e/ark.test.ts
+++ b/packages/ts-sdk/test/e2e/ark.test.ts
@@ -446,11 +446,16 @@ describe("Common", () => {
 
                 await new Promise((resolve) => setTimeout(resolve, 5000));
 
-                const session = await Unroll.Session.create(
+                const balanceBeforeExit = await alice.wallet.getBalance();
+
+                // `sessionFor` over `Session.create`: it wires the exit observer,
+                // so the repository learns the exit at DONE rather than waiting
+                // for a delta sync that filters on creation time and would never
+                // see it.
+                const session = await Unroll.sessionFor(
+                    alice.wallet,
                     { txid: vtxo.txid, vout: vtxo.vout },
                     onchainAlice,
-                    onchainAlice.provider,
-                    new RestIndexerProvider("http://localhost:7070"),
                 );
 
                 for await (const done of session) {
@@ -467,6 +472,15 @@ describe("Common", () => {
                 });
                 expect(virtualCoinsAfterExit).toHaveLength(1);
                 expect(virtualCoinsAfterExit[0].isUnrolled).toBe(true);
+                // Hidden from the default read: the exit is not something a send
+                // or a settlement can build on.
+                expect(await alice.wallet.getVtxos()).toHaveLength(0);
+
+                // The money moved buckets, it did not disappear.
+                const balanceAfterExit = await alice.wallet.getBalance();
+                expect(balanceAfterExit.unrolled).toBe(vtxo.value);
+                expect(balanceAfterExit.available).toBe(balanceBeforeExit.available - vtxo.value);
+                expect(balanceAfterExit.total).toBe(balanceBeforeExit.total);
             });
 
             it("should reject complete-unroll before unilateral exit delay matures", {

--- a/packages/ts-sdk/test/exit-executor.test.ts
+++ b/packages/ts-sdk/test/exit-executor.test.ts
@@ -599,3 +599,244 @@ describe("Executor cancellation", () => {
         ]);
     });
 });
+
+describe("Executor exit observation", () => {
+    type Observed = { txid: string; vout: number };
+
+    // `seenAt` records `<step>:<status>=<observations so far>`: the hook fires BEFORE the
+    // matching yield, so the count read at an event includes that event's own observation.
+
+    it("observes a vtxo when its branch confirms, and again when its sweep confirms", async () => {
+        const script = scriptedProvider();
+        script.register("parent1-hex", P1);
+        script.register("sweep1-hex", SW1);
+        const observed: Observed[] = [];
+        const seenAt: string[] = [];
+        const pkg = pkgOf([
+            {
+                kind: "package",
+                parentTxid: P1,
+                parentHex: "parent1-hex",
+                childTxid: C1,
+                childHex: "child1-hex",
+                forVtxos: [`${P1}:0`],
+            },
+            {
+                kind: "sweep",
+                vtxo: `${P1}:0`,
+                txid: SW1,
+                hex: "sweep1-hex",
+                dependsOnTxid: P1,
+                delay: { type: "blocks", value: 10 },
+            },
+        ]);
+
+        await run(
+            new Executor(pkg, script.provider, {
+                pollIntervalMs: 1,
+                onExitObserved: (o) => void observed.push({ ...o }),
+            }),
+            (e, s) => {
+                seenAt.push(`${e.kind}:${e.status}=${observed.length}`);
+                if (e.status === "broadcast" && e.txid) s.confirm(e.txid);
+                if (e.status === "waiting_csv") s.tip.height = e.maturesAtHeight!;
+            },
+            script,
+        );
+
+        expect(seenAt).toEqual([
+            "package:broadcast=0",
+            "package:confirmed=1",
+            "sweep:waiting_csv=1",
+            "sweep:broadcast=1",
+            "sweep:confirmed=2",
+        ]);
+        // The outpoint is parsed out of `"txid:vout"`, both halves.
+        expect(observed).toEqual([
+            { txid: P1, vout: 0 },
+            { txid: P1, vout: 0 },
+        ]);
+    });
+
+    it("observes a multi-step branch only once, after its last step confirms", async () => {
+        const script = scriptedProvider();
+        script.register("parent1-hex", P1);
+        script.register("parent2-hex", P2);
+        const observed: Observed[] = [];
+        const seenAt: string[] = [];
+        const pkg = pkgOf([
+            {
+                kind: "package",
+                parentTxid: P1,
+                parentHex: "parent1-hex",
+                childTxid: C1,
+                childHex: "child1-hex",
+                forVtxos: ["vtxoA:0"],
+            },
+            {
+                kind: "package",
+                parentTxid: P2,
+                parentHex: "parent2-hex",
+                childTxid: C2,
+                childHex: "child2-hex",
+                forVtxos: ["vtxoA:0"],
+            },
+        ]);
+
+        await run(
+            new Executor(pkg, script.provider, {
+                pollIntervalMs: 1,
+                onExitObserved: (o) => void observed.push({ ...o }),
+            }),
+            (e, s) => {
+                seenAt.push(`${e.stepIndex}:${e.status}=${observed.length}`);
+                if (e.status === "broadcast" && e.txid) s.confirm(e.txid);
+            },
+            script,
+        );
+
+        expect(seenAt).toEqual([
+            "0:broadcast=0",
+            "0:confirmed=0", // one of two steps onchain: the branch is not exited yet
+            "1:broadcast=0",
+            "1:confirmed=1",
+        ]);
+        expect(observed).toEqual([{ txid: "vtxoA", vout: 0 }]);
+    });
+
+    it("counts a step skipped as already-confirmed toward its branch", async () => {
+        const script = scriptedProvider();
+        script.confirm(P1);
+        script.register("parent2-hex", P2);
+        const observed: Observed[] = [];
+        const seenAt: string[] = [];
+        const pkg = pkgOf([
+            {
+                kind: "package",
+                parentTxid: P1,
+                parentHex: "parent1-hex",
+                childTxid: C1,
+                childHex: "child1-hex",
+                forVtxos: ["vtxoA:0"],
+            },
+            {
+                kind: "package",
+                parentTxid: P2,
+                parentHex: "parent2-hex",
+                childTxid: C2,
+                childHex: "child2-hex",
+                forVtxos: ["vtxoA:0"],
+            },
+        ]);
+
+        await run(
+            new Executor(pkg, script.provider, {
+                pollIntervalMs: 1,
+                onExitObserved: (o) => void observed.push({ ...o }),
+            }),
+            (e, s) => {
+                seenAt.push(`${e.stepIndex}:${e.status}=${observed.length}`);
+                if (e.status === "broadcast" && e.txid) s.confirm(e.txid);
+            },
+            script,
+        );
+
+        // Step 0 never broadcasts, yet the branch still completes on step 1.
+        expect(seenAt).toEqual(["0:skipped=0", "1:broadcast=0", "1:confirmed=1"]);
+        expect(observed).toEqual([{ txid: "vtxoA", vout: 0 }]);
+    });
+
+    it("observes nothing for a vtxo whose branch failed", async () => {
+        const script = scriptedProvider({ rejectTxids: new Set([P1]) });
+        script.register("parent1-hex", P1);
+        script.register("parent2-hex", P2);
+        script.register("sweep2-hex", SW2);
+        const observed: Observed[] = [];
+        const pkg = pkgOf([
+            {
+                kind: "package",
+                parentTxid: P1,
+                parentHex: "parent1-hex",
+                childTxid: C1,
+                childHex: "child1-hex",
+                forVtxos: ["vtxoA:0"],
+            },
+            {
+                kind: "package",
+                parentTxid: P2,
+                parentHex: "parent2-hex",
+                childTxid: C2,
+                childHex: "child2-hex",
+                forVtxos: ["vtxoB:0"],
+            },
+            {
+                kind: "sweep",
+                vtxo: "vtxoA:0",
+                txid: SW1,
+                hex: "sweep1-hex",
+                dependsOnTxid: P1,
+                delay: { type: "blocks", value: 0 },
+            },
+            {
+                kind: "sweep",
+                vtxo: "vtxoB:0",
+                txid: SW2,
+                hex: "sweep2-hex",
+                dependsOnTxid: P2,
+                delay: { type: "blocks", value: 0 },
+            },
+        ]);
+
+        await run(
+            new Executor(pkg, script.provider, {
+                pollIntervalMs: 1,
+                onExitObserved: (o) => void observed.push({ ...o }),
+            }),
+            (e, s) => {
+                if (e.status === "broadcast" && e.txid) s.confirm(e.txid);
+            },
+            script,
+        );
+
+        expect(observed).toEqual([
+            { txid: "vtxoB", vout: 0 },
+            { txid: "vtxoB", vout: 0 },
+        ]);
+    });
+
+    it("does not let a rejecting hook break the exit", async () => {
+        const errors: unknown[] = [];
+        const realError = console.error;
+        console.error = (...args: unknown[]) => void errors.push(args);
+        const script = scriptedProvider();
+        script.register("parent1-hex", P1);
+        try {
+            const pkg = pkgOf([
+                {
+                    kind: "package",
+                    parentTxid: P1,
+                    parentHex: "parent1-hex",
+                    childTxid: C1,
+                    childHex: "child1-hex",
+                    forVtxos: [`${P1}:0`],
+                },
+            ]);
+            const events = await run(
+                new Executor(pkg, script.provider, {
+                    pollIntervalMs: 1,
+                    onExitObserved: async () => {
+                        throw new Error("repository is gone");
+                    },
+                }),
+                (e, s) => {
+                    if (e.status === "broadcast" && e.txid) s.confirm(e.txid);
+                },
+                script,
+            );
+            expect(events.map((e) => e.status)).toEqual(["broadcast", "confirmed"]);
+        } finally {
+            console.error = realError;
+        }
+        expect(errors).toHaveLength(1);
+    });
+});

--- a/packages/ts-sdk/test/exit-executor.test.ts
+++ b/packages/ts-sdk/test/exit-executor.test.ts
@@ -804,6 +804,41 @@ describe("Executor exit observation", () => {
         ]);
     });
 
+    it("skips a malformed forVtxos entry rather than inventing an outpoint for it", async () => {
+        // `Number("")` is 0, so a trailing-colon entry would otherwise be
+        // observed as vout 0 — a real outpoint, and a different one than the
+        // package named. Reporting the wrong outpoint is worse than reporting
+        // none: the repository would refresh a coin nobody exited.
+        const script = scriptedProvider();
+        script.register("parent1-hex", P1);
+        const observed: { txid: string; vout: number }[] = [];
+        const pkg = pkgOf([
+            {
+                kind: "package",
+                parentTxid: P1,
+                parentHex: "parent1-hex",
+                childTxid: C1,
+                childHex: "child1-hex",
+                forVtxos: ["deadbeef:", ":0", "nocolon", "deadbeef:abc", `${P1}:1`],
+            },
+        ]);
+
+        const events = await run(
+            new Executor(pkg, script.provider, {
+                pollIntervalMs: 1,
+                onExitObserved: (o) => void observed.push({ ...o }),
+            }),
+            (e, s) => {
+                if (e.status === "broadcast" && e.txid) s.confirm(e.txid);
+            },
+            script,
+        );
+
+        // Only the well-formed entry is observed; the step itself still runs.
+        expect(observed).toEqual([{ txid: P1, vout: 1 }]);
+        expect(events.map((e) => e.status)).toEqual(["broadcast", "confirmed"]);
+    });
+
     it("does not let a rejecting hook break the exit", async () => {
         const errors: unknown[] = [];
         const realError = console.error;

--- a/packages/ts-sdk/test/exit-observer.test.ts
+++ b/packages/ts-sdk/test/exit-observer.test.ts
@@ -11,6 +11,7 @@ import {
     notifyExitObserved,
     type OnExitObserved,
 } from "../src/wallet/exitObserver";
+import { UnilateralExit } from "../src/wallet/exit";
 import { prepareUnrollTransaction, Unroll } from "../src/wallet/unroll";
 import type { Wallet } from "../src/wallet/wallet";
 
@@ -125,9 +126,14 @@ function walletStub(vtxos: ExtendedVirtualCoin[], refresh?: () => Promise<void>)
     const refreshOutpoints = vi.fn(refresh ?? (async () => {}));
     const broadcastTransaction = vi.fn(async (..._hexes: string[]) => "broadcast-txid");
     const getVtxos = vi.fn(async (_opts?: unknown) => vtxos);
+    const getVtxoChain = vi.fn(async (_o: unknown) => ({ chain: [] }));
+    const indexerProvider = { getVtxoChain };
+    const virtualTxRepository = { marker: "repo" };
     const wallet = {
         network,
         identity,
+        indexerProvider,
+        virtualTxRepository,
         onchainProvider: {
             getChainTip: async () => ({ height: 1_000, time: 2_000_000 }),
             getTxStatus: async () => ({
@@ -146,8 +152,39 @@ function walletStub(vtxos: ExtendedVirtualCoin[], refresh?: () => Promise<void>)
         refreshOutpoints,
         broadcastTransaction,
         getVtxos,
+        indexerProvider,
+        virtualTxRepository,
+        onchainProvider: wallet.onchainProvider,
     };
 }
+
+/** One already-confirmed package step, so the executor completes on the first pass. */
+const onePackageFor = (vtxo: string) =>
+    ({
+        version: 1,
+        network: "regtest",
+        createdAt: 1,
+        feeRate: 2,
+        sweepAddress: "bcrt1unused",
+        totals: { txCount: 0, totalFeeSats: 0, fundingRequiredSats: 0, recoveredSats: 0 },
+        vtxos: [],
+        steps: [
+            {
+                kind: "package",
+                parentTxid: "aa".repeat(32),
+                parentHex: "parent-hex",
+                childTxid: "bb".repeat(32),
+                childHex: "child-hex",
+                forVtxos: [vtxo],
+            },
+        ],
+    }) as never;
+
+const drain = async (iterable: AsyncIterable<unknown>) => {
+    for await (const _ of iterable) {
+        // drive to completion; the events themselves are the executor's own tests
+    }
+};
 
 describe("Unroll.completeUnroll", () => {
     it("refreshes the outpoints the sweep just spent", async () => {
@@ -180,6 +217,68 @@ describe("Unroll.completeUnroll", () => {
         expect(broadcastTransaction).toHaveBeenCalledTimes(1);
         expect(refreshOutpoints).toHaveBeenCalledTimes(1);
         errors.mockRestore();
+    });
+});
+
+describe("Unroll.sessionFor", () => {
+    // Thin by design, but it is the recommended entry point: everything the
+    // wallet already holds, plus the one parameter a caller would forget.
+    it("wires the wallet's providers and its exit observer", async () => {
+        const stub = walletStub([]);
+        const session = await Unroll.sessionFor(
+            stub.wallet,
+            { txid: EXITED, vout: 5 },
+            {} as never,
+        );
+
+        expect(session.explorer).toBe(stub.onchainProvider);
+        expect(session.indexer).toBe(stub.indexerProvider);
+        expect(session.virtualTxRepository).toBe(stub.virtualTxRepository);
+
+        // The assertion that matters: a hook that is present but unwired would
+        // pass every check above and still leave the repository stale.
+        await drain(session);
+        expect(stub.refreshOutpoints).toHaveBeenCalledWith([{ txid: EXITED, vout: 5 }]);
+    });
+});
+
+describe("UnilateralExit.execute", () => {
+    it("wires the wallet's exit observer into the executor", async () => {
+        const stub = walletStub([]);
+        const executor = await UnilateralExit.execute(stub.wallet, onePackageFor(`${EXITED}:7`));
+
+        expect(executor.provider).toBe(stub.onchainProvider);
+        await drain(executor);
+        expect(stub.refreshOutpoints).toHaveBeenCalledWith([{ txid: EXITED, vout: 7 }]);
+    });
+
+    it("lets an explicit observer win over the wallet's", async () => {
+        const stub = walletStub([]);
+        const mine = vi.fn();
+        const executor = await UnilateralExit.execute(stub.wallet, onePackageFor(`${EXITED}:7`), {
+            onExitObserved: mine,
+        });
+
+        await drain(executor);
+        expect(mine).toHaveBeenCalledWith({ txid: EXITED, vout: 7 });
+        expect(stub.refreshOutpoints).not.toHaveBeenCalled();
+    });
+
+    it("forwards the rest of the options, provider override included", async () => {
+        const stub = walletStub([]);
+        const provider = { ...stub.onchainProvider } as never;
+        const signal = new AbortController().signal;
+        const executor = await UnilateralExit.execute(stub.wallet, onePackageFor(`${EXITED}:7`), {
+            provider,
+            signal,
+            pollIntervalMs: 1,
+        });
+
+        expect(executor.provider).toBe(provider);
+        // `signal` reaches the executor: an already-aborted one would throw, so
+        // assert on the live path instead — it drives to completion.
+        await drain(executor);
+        expect(stub.refreshOutpoints).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/packages/ts-sdk/test/exit-observer.test.ts
+++ b/packages/ts-sdk/test/exit-observer.test.ts
@@ -1,0 +1,200 @@
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { hex } from "@scure/base";
+import { p2tr } from "@scure/btc-signer";
+import { describe, expect, it, vi } from "vitest";
+import { SingleKey } from "../src/identity/singleKey";
+import { getNetwork } from "../src/networks";
+import { DefaultVtxo } from "../src/script/default";
+import type { ExtendedVirtualCoin } from "../src/wallet";
+import {
+    exitObserverFor,
+    notifyExitObserved,
+    type OnExitObserved,
+} from "../src/wallet/exitObserver";
+import { prepareUnrollTransaction, Unroll } from "../src/wallet/unroll";
+import type { Wallet } from "../src/wallet/wallet";
+
+const network = getNetwork("regtest");
+const identity = SingleKey.fromHex("aa".repeat(32));
+const server = schnorr.getPublicKey(new Uint8Array(32).fill(0xbb));
+const timelock = { type: "blocks", value: 144n } as const;
+const destAddress = p2tr(schnorr.getPublicKey(new Uint8Array(32).fill(4)), undefined, network)
+    .address!;
+
+// Deliberately not byte-reversal-symmetric, so a wrong txid encoding cannot pass unnoticed.
+const EXITED = "0123456789abcdef".repeat(4);
+
+/** An empty chain makes `next()` return DONE on the first call, so nothing else is touched. */
+function doneSession(vout: number, onExitObserved?: OnExitObserved) {
+    return new Unroll.Session(
+        { txid: EXITED, vout, chain: [] },
+        {} as never,
+        {} as never,
+        {} as never,
+        undefined,
+        onExitObserved,
+    );
+}
+
+describe("Unroll.Session exit observation", () => {
+    it("fires the hook once with the full outpoint at DONE", async () => {
+        const hook = vi.fn();
+        const steps: Unroll.Step[] = [];
+        for await (const step of doneSession(3, hook)) steps.push(step);
+
+        expect(steps.map((s) => s.type)).toEqual([Unroll.StepType.DONE]);
+        expect(hook).toHaveBeenCalledTimes(1);
+        expect(hook).toHaveBeenCalledWith({ txid: EXITED, vout: 3 });
+    });
+
+    it("runs to DONE with no hook attached", async () => {
+        const steps: Unroll.Step[] = [];
+        for await (const step of doneSession(0)) steps.push(step);
+        expect(steps.map((s) => s.type)).toEqual([Unroll.StepType.DONE]);
+    });
+
+    it("completes the exit even when the hook rejects", async () => {
+        const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+        const hook = vi.fn(async () => {
+            throw new Error("repository is gone");
+        });
+
+        const steps: Unroll.Step[] = [];
+        for await (const step of doneSession(1, hook)) steps.push(step);
+
+        expect(steps.map((s) => s.type)).toEqual([Unroll.StepType.DONE]);
+        expect(hook).toHaveBeenCalledTimes(1);
+        expect(errors).toHaveBeenCalled();
+        errors.mockRestore();
+    });
+});
+
+describe("exitObserverFor", () => {
+    it("forwards the outpoint to refreshOutpoints as a one-element array", async () => {
+        const refreshOutpoints = vi.fn(async () => {});
+        await exitObserverFor({ refreshOutpoints })({ txid: EXITED, vout: 2 });
+        expect(refreshOutpoints).toHaveBeenCalledWith([{ txid: EXITED, vout: 2 }]);
+    });
+
+    it("swallows a rejecting refreshOutpoints when fired through notifyExitObserved", async () => {
+        const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+        const refreshOutpoints = vi.fn(async () => {
+            throw new Error("indexer down");
+        });
+
+        await expect(
+            notifyExitObserved(exitObserverFor({ refreshOutpoints }), { txid: EXITED, vout: 0 }),
+        ).resolves.toBeUndefined();
+        expect(refreshOutpoints).toHaveBeenCalledTimes(1);
+        errors.mockRestore();
+    });
+
+    it("is a no-op without a hook", async () => {
+        await expect(
+            notifyExitObserved(undefined, { txid: EXITED, vout: 0 }),
+        ).resolves.toBeUndefined();
+    });
+});
+
+function exitedVtxo(overrides?: Partial<ExtendedVirtualCoin>): ExtendedVirtualCoin {
+    const script = new DefaultVtxo.Script({
+        pubKey: schnorr.getPublicKey(hex.decode("aa".repeat(32))),
+        serverPubKey: server,
+        csvTimelock: timelock,
+    });
+    return {
+        txid: EXITED,
+        vout: 1,
+        value: 50_000,
+        status: { confirmed: true },
+        createdAt: new Date(0),
+        script: hex.encode(script.pkScript),
+        tapTree: script.encode(),
+        forfeitTapLeafScript: script.forfeit(),
+        intentTapLeafScript: script.exit(),
+        isUnrolled: true,
+        isSpent: false,
+        isSwept: false,
+        isPreconfirmed: false,
+        virtualStatus: { state: "settled" },
+        ...overrides,
+    };
+}
+
+function walletStub(vtxos: ExtendedVirtualCoin[], refresh?: () => Promise<void>) {
+    const refreshOutpoints = vi.fn(refresh ?? (async () => {}));
+    const broadcastTransaction = vi.fn(async (..._hexes: string[]) => "broadcast-txid");
+    const getVtxos = vi.fn(async (_opts?: unknown) => vtxos);
+    const wallet = {
+        network,
+        identity,
+        onchainProvider: {
+            getChainTip: async () => ({ height: 1_000, time: 2_000_000 }),
+            getTxStatus: async () => ({
+                confirmed: true,
+                blockHeight: 100,
+                blockTime: 1_000_000,
+            }),
+            getFeeRate: async () => 2,
+            broadcastTransaction,
+        },
+        getVtxos,
+        getContractManager: async () => ({ refreshOutpoints }),
+    };
+    return {
+        wallet: wallet as never as Wallet,
+        refreshOutpoints,
+        broadcastTransaction,
+        getVtxos,
+    };
+}
+
+describe("Unroll.completeUnroll", () => {
+    it("refreshes the outpoints the sweep just spent", async () => {
+        const { wallet, refreshOutpoints, broadcastTransaction, getVtxos } = walletStub([
+            exitedVtxo(),
+        ]);
+
+        const txid = await Unroll.completeUnroll(wallet, [EXITED], destAddress);
+
+        expect(txid).toMatch(/^[0-9a-f]{64}$/);
+        expect(broadcastTransaction).toHaveBeenCalledTimes(1);
+        // The unrolled coin is only visible to a read that asks for it.
+        expect(getVtxos).toHaveBeenCalledWith({ withUnrolled: true });
+        expect(refreshOutpoints).toHaveBeenCalledTimes(1);
+        expect(refreshOutpoints).toHaveBeenCalledWith([{ txid: EXITED, vout: 1 }]);
+    });
+
+    it("still returns the broadcast txid when the refresh fails", async () => {
+        const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+        const { wallet, refreshOutpoints, broadcastTransaction } = walletStub(
+            [exitedVtxo()],
+            async () => {
+                throw new Error("repository is gone");
+            },
+        );
+
+        await expect(Unroll.completeUnroll(wallet, [EXITED], destAddress)).resolves.toMatch(
+            /^[0-9a-f]{64}$/,
+        );
+        expect(broadcastTransaction).toHaveBeenCalledTimes(1);
+        expect(refreshOutpoints).toHaveBeenCalledTimes(1);
+        errors.mockRestore();
+    });
+});
+
+describe("prepareUnrollTransaction exit gate", () => {
+    it("refuses an unrolled coin whose exit output was already spent", async () => {
+        const { wallet } = walletStub([exitedVtxo({ spentBy: "ff".repeat(32) })]);
+        await expect(prepareUnrollTransaction(wallet, [EXITED], destAddress)).rejects.toThrow(
+            /cannot be swept onchain/,
+        );
+    });
+
+    it("accepts an unrolled coin that is past its batch expiry", async () => {
+        // Expiry is the batch clock, not the exit's CSV — an exited coin is still sweepable.
+        const { wallet } = walletStub([exitedVtxo({ expiresAtHeight: 1 })]);
+        const tx = await prepareUnrollTransaction(wallet, [EXITED], destAddress);
+        expect(tx.getInput(0).finalScriptWitness).toBeDefined();
+    });
+});

--- a/packages/ts-sdk/test/exports-unrolled.test.ts
+++ b/packages/ts-sdk/test/exports-unrolled.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import * as sdk from "../src";
+import type { ExecutorOptions, OnExitObserved, WalletBalance } from "../src";
+
+// The barrel is the only surface a consumer sees, and `src/index.ts` re-exports
+// through two hand-maintained lists — so a predicate can exist, be correct, and
+// still be unreachable.
+describe("unrolled-VTXO public surface", () => {
+    it("exports the location-axis predicate and the exit-observed seam", () => {
+        expect(typeof sdk.canSweepOnchain).toBe("function");
+        expect(typeof sdk.exitObserverFor).toBe("function");
+        expect(typeof sdk.notifyExitObserved).toBe("function");
+        expect(typeof sdk.Unroll.sessionFor).toBe("function");
+        expect(typeof sdk.UnilateralExit.execute).toBe("function");
+    });
+
+    it("types the new balance bucket and executor option", () => {
+        const hook: OnExitObserved = () => {};
+        const opts: ExecutorOptions = { onExitObserved: hook };
+        const unrolled: WalletBalance["unrolled"] = 0;
+        expect(opts.onExitObserved).toBe(hook);
+        expect(unrolled).toBe(0);
+    });
+});

--- a/packages/ts-sdk/test/intent-reconciliation.test.ts
+++ b/packages/ts-sdk/test/intent-reconciliation.test.ts
@@ -192,4 +192,78 @@ describe("reconcileIntents", () => {
         expect(await stateOf(repo, "stale")).toBe("cancelled");
         expect(await stateOf(repo, "live")).toBe("waiting_for_batch");
     });
+
+    it("cancels a submitted, unexpired intent whose input was unilaterally exited", async () => {
+        const repo = await seed(
+            new InMemoryIntentRepository(),
+            intent({ state: "waiting_for_batch" }),
+        );
+        // The wire shape of an exit: onchain now, but never consumed offchain.
+        const indexerProvider = indexerReturning([coin("v", 0, { isUnrolled: true })]);
+
+        await reconcileIntents({ intentRepository: repo, indexerProvider });
+
+        const done = (await repo.getIntents({ intentTxIds: ["i1"] }))[0];
+        expect(done.state).toBe("cancelled");
+        expect(done.cancellationReason).toMatch(/unilaterally exited/i);
+        // The whole point: without the exit branch these stay locked forever.
+        expect(await repo.getLockedVtxoOutpoints()).toEqual([]);
+    });
+
+    it("reports batch_succeeded when an input both settled and unrolled", async () => {
+        const repo = await seed(
+            new InMemoryIntentRepository(),
+            intent({ state: "waiting_for_batch" }),
+        );
+        const indexerProvider = indexerReturning([
+            coin("v", 0, { settledBy: "commitment-tx", isUnrolled: true }),
+        ]);
+
+        await reconcileIntents({ intentRepository: repo, indexerProvider });
+
+        const done = (await repo.getIntents({ intentTxIds: ["i1"] }))[0];
+        expect(done.state).toBe("batch_succeeded");
+        expect(done.commitmentTransactionId).toBe("commitment-tx");
+    });
+
+    it("treats a spentBy-only input as consumed", async () => {
+        const repo = await seed(
+            new InMemoryIntentRepository(),
+            intent({
+                state: "waiting_for_batch",
+                intentVtxos: [
+                    { txid: "v", vout: 0 },
+                    { txid: "v", vout: 1 },
+                ],
+            }),
+        );
+        // No isSpent, no settledBy: the wire writes forfeited inputs this way.
+        const indexerProvider = indexerReturning([
+            coin("v", 0, { spentBy: "ark-tx" }),
+            coin("v", 1, { spentBy: "ark-tx" }),
+        ]);
+
+        await reconcileIntents({ intentRepository: repo, indexerProvider });
+
+        const done = (await repo.getIntents({ intentTxIds: ["i1"] }))[0];
+        expect(done.state).toBe("batch_succeeded");
+        expect(done.commitmentTransactionId).toBeUndefined();
+        expect(await repo.getLockedVtxoOutpoints()).toEqual([]);
+    });
+
+    it("does not treat an empty settledBy as consumed", async () => {
+        const repo = await seed(
+            new InMemoryIntentRepository(),
+            intent({ state: "waiting_for_batch" }),
+        );
+        // "" is the wire convention for "unset", not a commitment txid.
+        const indexerProvider = indexerReturning([coin("v", 0, { settledBy: "" })]);
+
+        await reconcileIntents({ intentRepository: repo, indexerProvider });
+
+        const done = (await repo.getIntents({ intentTxIds: ["i1"] }))[0];
+        expect(done.state).toBe("waiting_for_batch");
+        expect(done.commitmentTransactionId).toBeUndefined();
+        expect(await repo.getLockedVtxoOutpoints()).toEqual([{ txid: "v", vout: 0 }]);
+    });
 });

--- a/packages/ts-sdk/test/pending-recovery-outpoints.test.ts
+++ b/packages/ts-sdk/test/pending-recovery-outpoints.test.ts
@@ -20,7 +20,7 @@ const signerSet: SignerSet = {
 
 // Minimal VirtualCoin-shaped stub: selectPendingRecoveryOutpoints only reads
 // txid/vout (outpoint) and the spend/swept facts.
-const vtxo = (txid: string, vout: number, state: string, isSpent = false) =>
+const vtxo = (txid: string, vout: number, state: string, isSpent = false, isUnrolled = false) =>
     ({
         txid,
         vout,
@@ -28,6 +28,7 @@ const vtxo = (txid: string, vout: number, state: string, isSpent = false) =>
         isSpent,
         isSwept: state === "swept",
         isPreconfirmed: state === "preconfirmed",
+        isUnrolled,
         spentBy: "",
         commitmentTxIds: [],
     }) as never;
@@ -51,6 +52,22 @@ describe("selectPendingRecoveryOutpoints", () => {
             NOW,
         );
         expect([...out]).toEqual(["exp-settled:0"]);
+    });
+
+    it("excludes an exited VTXO while keeping its sibling on the same contract", () => {
+        // The exit is the user's own doing and `completeUnroll` is its remedy;
+        // reporting it as pendingRecovery would blame the signer rotation.
+        const out = selectPendingRecoveryOutpoints(
+            [
+                row(EXPIRED_SIGNER, [
+                    vtxo("exp-live", 0, "settled"),
+                    vtxo("exp-exited", 1, "settled", false, true),
+                ]),
+            ],
+            signerSet,
+            NOW,
+        );
+        expect([...out]).toEqual(["exp-live:0"]);
     });
 
     it("is empty when there are no deprecated signers", () => {

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -240,7 +240,7 @@ describe("getSpendableVtxos", () => {
                 vout: 0,
                 value: 10_000,
                 script: defaultScript,
-                isSpent: true,
+                isSpent: false,
                 isUnrolled: true,
             }),
         ]);
@@ -371,6 +371,31 @@ describe("getBalance", () => {
         expect(balance.available).toBe(50_000);
         expect(balance.gated).toBe(20_000);
         expect(balance.intentLocked).toBe(0);
+        expectSplit(balance);
+    });
+
+    it("does not count unrolled VTXOs in offchain balance", async () => {
+        const { wallet, walletRepository, defaultScript } = await seededWallet();
+        const unrolledTxid = "f1".repeat(32);
+        await walletRepository.saveVtxos(await wallet.getAddress(), [
+            createMockExtendedVtxo({
+                txid: unrolledTxid,
+                vout: 0,
+                value: 25_000,
+                script: defaultScript,
+                virtualStatus: { state: "settled" },
+                isSpent: false,
+                isUnrolled: true,
+            }),
+        ]);
+
+        expect(txidsOf(await wallet.getVtxos())).not.toContain(unrolledTxid);
+        expect(txidsOf(await wallet.getVtxos({ withUnrolled: true }))).toContain(unrolledTxid);
+
+        const balance = await wallet.getBalance();
+        expect(balance.settled).toBe(70_000);
+        expect(balance.total).toBe(70_000);
+        expect(balance.available).toBe(50_000);
         expectSplit(balance);
     });
 

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -22,6 +22,10 @@ import {
 } from "../src";
 import type { ArkInfo } from "../src/providers/ark";
 import { InMemoryIntentRepository } from "../src/repositories/inMemory/intentRepository";
+import {
+    DEFAULT_MESSAGE_TAG,
+    WalletMessageHandler,
+} from "../src/wallet/serviceWorker/wallet-message-handler";
 import { ReadonlySingleKey, SingleKey } from "../src/identity/singleKey";
 import { Ramps } from "../src/wallet/ramps";
 import { VtxoManager } from "../src/wallet/vtxo-manager";
@@ -334,17 +338,35 @@ describe("getSpendableVtxos", () => {
 });
 
 describe("getBalance", () => {
-    /** `settled + preconfirmed === available + gated + intentLocked`. */
+    /**
+     * `settled + preconfirmed === available + gated + intentLocked`, and the
+     * five owned buckets sum to `total` — which is what catches a bucket added
+     * without being counted, or counted twice.
+     */
     const expectSplit = (balance: {
         settled: number;
         preconfirmed: number;
         available: number;
         gated: number;
         intentLocked: number;
-    }) =>
+        recoverable: number;
+        pendingRecovery: number;
+        unrolled: number;
+        total: number;
+        boarding: { total: number };
+    }) => {
         expect(balance.settled + balance.preconfirmed).toBe(
             balance.available + balance.gated + balance.intentLocked,
         );
+        expect(balance.total).toBe(
+            balance.boarding.total +
+                balance.settled +
+                balance.preconfirmed +
+                balance.recoverable +
+                balance.pendingRecovery +
+                balance.unrolled,
+        );
+    };
 
     const lockOutpoint = async (intents: InMemoryIntentRepository, txid: string) =>
         intents.saveIntent({
@@ -374,7 +396,7 @@ describe("getBalance", () => {
         expectSplit(balance);
     });
 
-    it("does not count unrolled VTXOs in offchain balance", async () => {
+    it("buckets an unrolled VTXO as unrolled — visible in total, in no spendable bucket", async () => {
         const { wallet, walletRepository, defaultScript } = await seededWallet();
         const unrolledTxid = "f1".repeat(32);
         await walletRepository.saveVtxos(await wallet.getAddress(), [
@@ -386,6 +408,7 @@ describe("getBalance", () => {
                 virtualStatus: { state: "settled" },
                 isSpent: false,
                 isUnrolled: true,
+                assets: [{ assetId: ASSET_ID, amount: 3n }],
             }),
         ]);
 
@@ -393,10 +416,81 @@ describe("getBalance", () => {
         expect(txidsOf(await wallet.getVtxos({ withUnrolled: true }))).toContain(unrolledTxid);
 
         const balance = await wallet.getBalance();
+        // The 70k baseline is untouched; the exited 25k shows up only under
+        // `unrolled`, and `total` still accounts for every sat.
+        expect(balance.unrolled).toBe(25_000);
+        expect(balance.total).toBe(95_000);
         expect(balance.settled).toBe(70_000);
-        expect(balance.total).toBe(70_000);
+        expect(balance.preconfirmed).toBe(0);
         expect(balance.available).toBe(50_000);
+        expect(balance.recoverable).toBe(0);
+        expect(balance.pendingRecovery).toBe(0);
         expectSplit(balance);
+
+        // Assets follow the value: owned, never offered to generic spending.
+        expect(balance.assets).toContainEqual({ assetId: ASSET_ID, amount: 25n });
+        expect(balance.availableAssets).toContainEqual({ assetId: ASSET_ID, amount: 12n });
+    });
+
+    it("keeps an unrolled-AND-swept VTXO out of recoverable", async () => {
+        const { wallet, walletRepository, defaultScript } = await seededWallet();
+        await walletRepository.saveVtxos(await wallet.getAddress(), [
+            createMockExtendedVtxo({
+                txid: "f2".repeat(32),
+                vout: 0,
+                value: 25_000,
+                script: defaultScript,
+                isSwept: true,
+                isUnrolled: true,
+            }),
+        ]);
+
+        const balance = await wallet.getBalance();
+        expect(balance.recoverable).toBe(0);
+        expect(balance.unrolled).toBe(25_000);
+        expectSplit(balance);
+    });
+
+    it("drops an unrolled-AND-spent VTXO from every bucket", async () => {
+        // The `hasTerminalSpend` guard in the bucketer is what does this: the
+        // filter now hands unrolled coins over WITHOUT testing spend first.
+        const { wallet, walletRepository, defaultScript } = await seededWallet();
+        await walletRepository.saveVtxos(await wallet.getAddress(), [
+            createMockExtendedVtxo({
+                txid: "f3".repeat(32),
+                vout: 0,
+                value: 25_000,
+                script: defaultScript,
+                isSpent: true,
+                spentBy: "ab".repeat(32),
+                isUnrolled: true,
+            }),
+        ]);
+
+        const balance = await wallet.getBalance();
+        expect(balance.unrolled).toBe(0);
+        expect(balance.total).toBe(70_000);
+        expectSplit(balance);
+    });
+
+    it("never selects an unrolled VTXO for a send or a settlement", async () => {
+        const { wallet, walletRepository, defaultScript } = await seededWallet();
+        const unrolledTxid = "f4".repeat(32);
+        await walletRepository.saveVtxos(await wallet.getAddress(), [
+            createMockExtendedVtxo({
+                txid: unrolledTxid,
+                vout: 0,
+                value: 500_000,
+                script: defaultScript,
+                isUnrolled: true,
+            }),
+        ]);
+
+        // Big enough to be picked first by any value-ordered selector, so its
+        // absence is the selector refusing it rather than not needing it.
+        for (const filter of [undefined, { withRecoverable: true }, { withRecoverable: false }]) {
+            expect(txidsOf(await wallet.getSpendableVtxos(filter))).not.toContain(unrolledTxid);
+        }
     });
 
     it("counts a gated-and-locked VTXO once, as gated", async () => {
@@ -721,5 +815,68 @@ describe("a contract whose handler rejects its stored params", () => {
                 { txid: "ab".repeat(32), vout: 0, script: "5120" + "cd".repeat(32) },
             ]),
         ).rejects.toThrow(/no contract registered/);
+    });
+});
+
+describe("main-thread / worker balance parity", () => {
+    /**
+     * The worker hands `computeOffchainBalance` an unfiltered repository read,
+     * so its `unrolled` bucket fills itself; the main thread has to ask for
+     * unrolled coins explicitly. Comparing the two is the only assertion that
+     * catches `Wallet.getBalance` going back to the default filter, which
+     * silently drops them and reports `unrolled: 0` forever.
+     */
+    const workerBalance = async (seeded: Awaited<ReturnType<typeof seededWallet>>) => {
+        // Same wallet, same repository as the main-thread read — two stubs
+        // would agree with each other and prove nothing.
+        const handler = new WalletMessageHandler();
+        (handler as any).readonlyWallet = seeded.wallet;
+        (handler as any).walletRepository = seeded.walletRepository;
+        (handler as any).indexerProvider = offlineIndexer();
+        (handler as any).arkProvider = {};
+
+        const response = await handler.handleMessage({
+            id: "1",
+            tag: DEFAULT_MESSAGE_TAG,
+            type: "GET_BALANCE",
+        } as any);
+        expect(response.error).toBeUndefined();
+        return (response as any).payload as Awaited<ReturnType<Wallet["getBalance"]>>;
+    };
+
+    it("reports the same unrolled bucket on both sides of the bus", async () => {
+        const seeded = await seededWallet();
+        await seeded.walletRepository.saveVtxos(await seeded.wallet.getAddress(), [
+            createMockExtendedVtxo({
+                txid: "f5".repeat(32),
+                vout: 0,
+                value: 25_000,
+                script: seeded.defaultScript,
+                virtualStatus: { state: "settled" },
+                isSpent: false,
+                isUnrolled: true,
+            }),
+        ]);
+
+        const main = await seeded.wallet.getBalance();
+        const worker = await workerBalance(seeded);
+
+        // Non-zero first: two paths both reporting 0 must not pass as parity.
+        expect(worker.unrolled).toBe(25_000);
+        expect(main.unrolled).toBe(worker.unrolled);
+        expect(main.total).toBe(worker.total);
+        expect(main.total).toBe(95_000);
+    });
+
+    it("agrees when there is no unrolled coin at all", async () => {
+        const seeded = await seededWallet();
+
+        const main = await seeded.wallet.getBalance();
+        const worker = await workerBalance(seeded);
+
+        expect(worker.unrolled).toBe(0);
+        expect(main.unrolled).toBe(0);
+        expect(main.total).toBe(worker.total);
+        expect(main.total).toBe(70_000);
     });
 });

--- a/packages/ts-sdk/test/vtxo-canonical.test.ts
+++ b/packages/ts-sdk/test/vtxo-canonical.test.ts
@@ -217,6 +217,13 @@ describe("truth table", () => {
         expect(canSpendOffchain(v, now)).toBe(false);
         expect(canRecoverOnchain(v, now)).toBe(false);
     });
+
+    it("row 9: unrolled without isSpent → terminal", () => {
+        const v = coin({ isUnrolled: true, isSpent: false, spentBy: "" });
+        expect(hasTerminalSpend(v)).toBe(true);
+        expect(canSpendOffchain(v, now)).toBe(false);
+        expect(canRecoverOnchain(v, now)).toBe(false);
+    });
 });
 
 describe("normalization", () => {
@@ -334,9 +341,10 @@ describe("deprecated compatibility wrappers", () => {
         expect(isExpired(coin({ expiresAt: FUTURE }))).toBe(false);
     });
 
-    it("rows 6 and 8 narrow isSpendable/isRecoverable — only ever toward 'spent'", () => {
+    it("rows 6, 8, and 9 narrow isSpendable/isRecoverable — only ever toward 'spent'", () => {
         expect(isSpendable(coin({ isSpent: true, spentBy: "" }))).toBe(false);
         expect(isSpendable(coin({ isSpent: false, settledBy: "44".repeat(32) }))).toBe(false);
+        expect(isSpendable(coin({ isUnrolled: true, isSpent: false }))).toBe(false);
         expect(isRecoverable(coin({ isSwept: true, settledBy: "44".repeat(32) }))).toBe(false);
     });
 });

--- a/packages/ts-sdk/test/vtxo-canonical.test.ts
+++ b/packages/ts-sdk/test/vtxo-canonical.test.ts
@@ -3,6 +3,7 @@ import {
     EXPIRY_MIN_PLAUSIBLE_MS,
     canRecoverOnchain,
     canSpendOffchain,
+    canSweepOnchain,
     convertVtxo,
     getNormalizedVtxos,
     hasTerminalSpend,
@@ -218,11 +219,58 @@ describe("truth table", () => {
         expect(canRecoverOnchain(v, now)).toBe(false);
     });
 
-    it("row 9: unrolled without isSpent → terminal", () => {
+    it("row 9: unrolled without isSpent → onchain, not terminal", () => {
+        // The location axis. `hasTerminalSpend` mirrors NArk's `IsSpent()` and
+        // says nothing about where the output lives, so it stays false — but no
+        // batch and no offchain spend can reach the coin, so both capability
+        // predicates refuse it and `canSweepOnchain` claims it instead.
         const v = coin({ isUnrolled: true, isSpent: false, spentBy: "" });
-        expect(hasTerminalSpend(v)).toBe(true);
+        expect(hasTerminalSpend(v)).toBe(false);
         expect(canSpendOffchain(v, now)).toBe(false);
         expect(canRecoverOnchain(v, now)).toBe(false);
+        expect(canSweepOnchain(v)).toBe(true);
+    });
+
+    it("row 10: unrolled AND swept → still only sweepable, never recoverable", () => {
+        // Without the `!isUnrolled` clause in `canRecoverOnchain` this coin
+        // would be offered to a recovery batch, which cannot lift an output
+        // that already lives onchain.
+        const v = coin({ isUnrolled: true, isSwept: true });
+        expect(canRecoverOnchain(v, now)).toBe(false);
+        expect(canSpendOffchain(v, now)).toBe(false);
+        expect(canSweepOnchain(v)).toBe(true);
+    });
+
+    it("row 11: unrolled and then spent → no capability at all", () => {
+        // The exit output was swept away by `completeUnroll`; nothing is left.
+        for (const over of [
+            { isSpent: true, spentBy: "" },
+            { spentBy: "33".repeat(32) },
+            { settledBy: "44".repeat(32) },
+        ]) {
+            const v = coin({ isUnrolled: true, ...over });
+            expect(hasTerminalSpend(v)).toBe(true);
+            expect(canSweepOnchain(v)).toBe(false);
+            expect(canSpendOffchain(v, now)).toBe(false);
+            expect(canRecoverOnchain(v, now)).toBe(false);
+        }
+    });
+
+    it("the three capabilities partition the unspent set", () => {
+        for (const v of [
+            coin(),
+            coin({ isSwept: true }),
+            coin({ expiresAt: PAST }),
+            coin({ isUnrolled: true }),
+            coin({ isUnrolled: true, isSwept: true }),
+        ]) {
+            const claims = [
+                canSpendOffchain(v, now),
+                canRecoverOnchain(v, now),
+                canSweepOnchain(v),
+            ].filter(Boolean);
+            expect(claims).toHaveLength(1);
+        }
     });
 });
 
@@ -341,11 +389,23 @@ describe("deprecated compatibility wrappers", () => {
         expect(isExpired(coin({ expiresAt: FUTURE }))).toBe(false);
     });
 
-    it("rows 6, 8, and 9 narrow isSpendable/isRecoverable — only ever toward 'spent'", () => {
+    it("rows 6 and 8 narrow isSpendable/isRecoverable — only ever toward 'spent'", () => {
         expect(isSpendable(coin({ isSpent: true, spentBy: "" }))).toBe(false);
         expect(isSpendable(coin({ isSpent: false, settledBy: "44".repeat(32) }))).toBe(false);
-        expect(isSpendable(coin({ isUnrolled: true, isSpent: false }))).toBe(false);
         expect(isRecoverable(coin({ isSwept: true, settledBy: "44".repeat(32) }))).toBe(false);
+    });
+
+    it("row 9 is where the wrappers are WIDE: an exited coin reads spendable", () => {
+        // True to their documented contract — "has not been consumed" — and
+        // exactly why exit safety may not be built on them. `canSpendOffchain`
+        // is the predicate that knows.
+        const exited = coin({ isUnrolled: true, isSpent: false });
+        expect(isSpendable(exited)).toBe(true);
+        expect(canSpendOffchain(exited, { timestamp: NOW })).toBe(false);
+        expect(isRecoverable(coin({ isUnrolled: true, isSwept: true }))).toBe(true);
+        expect(
+            canRecoverOnchain(coin({ isUnrolled: true, isSwept: true }), { timestamp: NOW }),
+        ).toBe(false);
     });
 });
 

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../src/wallet/vtxo-manager";
 import { IWallet, ExtendedCoin, ExtendedVirtualCoin } from "../src/wallet";
 import type { IntentFeeConfig } from "../src/arkfee";
-import { Wallet } from "../src/wallet/wallet";
+import { filterSnapshotVtxos, Wallet } from "../src/wallet/wallet";
 import { CSVMultisigTapscript } from "../src/script/tapscript";
 import { hex } from "@scure/base";
 
@@ -258,6 +258,19 @@ describe("VtxoManager - Recovery", () => {
             expect(balance.vtxoCount).toBe(1);
         });
 
+        it("should not count an unrolled VTXO, even when swept", async () => {
+            // The exit already moved it on-chain: no batch can reclaim it, so
+            // recovery must neither promise nor price it.
+            const exited = { ...createMockVtxo(4000, "swept"), isUnrolled: true } as any;
+            const wallet = createMockWallet([createMockVtxo(5000, "swept"), exited]);
+            const manager = new VtxoManager(wallet);
+
+            const balance = await manager.getRecoverableBalance();
+
+            expect(balance.recoverable).toBe(5000n);
+            expect(balance.vtxoCount).toBe(1);
+        });
+
         it("should include preconfirmed subdust in recoverable balance", async () => {
             const wallet = createMockWallet([
                 createMockVtxo(5000, "swept", false), // Recoverable
@@ -322,6 +335,27 @@ describe("VtxoManager - Recovery", () => {
                             amount: 8000n,
                         },
                     ],
+                },
+                undefined,
+            );
+        });
+
+        it("should not settle an unrolled VTXO, and should ask the wallet not to hand one back", async () => {
+            const healthy = createMockVtxo(5000, "swept");
+            const exited = { ...createMockVtxo(4000, "swept"), isUnrolled: true } as any;
+            const wallet = createMockWallet([healthy, exited], "arkade1myaddress");
+            const manager = new VtxoManager(wallet);
+
+            await manager.recoverVtxos();
+
+            expect(wallet.getVtxos).toHaveBeenCalledWith({
+                withRecoverable: true,
+                withUnrolled: false,
+            });
+            expect(wallet.settle).toHaveBeenCalledWith(
+                {
+                    inputs: [healthy],
+                    outputs: [{ address: "arkade1myaddress", amount: 5000n }],
                 },
                 undefined,
             );
@@ -883,6 +917,37 @@ describe("VtxoManager - Renewal utilities", () => {
             expect(expiring).toHaveLength(0);
         });
 
+        it("should not offer an unrolled VTXO for renewal once it is past expiry", () => {
+            // NArk renews `Unrolled` eagerly; ts-sdk cannot re-batch an exit
+            // output at all, so here the same fact excludes instead.
+            const now = Date.now();
+            const createdAt = new Date(now - 100_000);
+            const expired = (txid: string, value: number, isUnrolled: boolean) =>
+                ({
+                    txid,
+                    vout: 0,
+                    value,
+                    createdAt,
+                    virtualStatus: { state: "settled", batchExpiry: now - 5_000 },
+                    isSpent: false,
+                    isSwept: false,
+                    isPreconfirmed: false,
+                    isUnrolled,
+                    spentBy: "",
+                    commitmentTxIds: [],
+                    expiresAt: new Date(now - 5_000),
+                }) as ExtendedVirtualCoin;
+
+            const expiring = getExpiringAndRecoverableVtxos(
+                [expired("healthy", 3000, false), expired("exited", 4000, true)],
+                10_000,
+                330n,
+                { timestamp: new Date() },
+            );
+
+            expect(expiring.map((v) => v.txid)).toEqual(["healthy"]);
+        });
+
         it("should return recoverable and subdust VTXOs", () => {
             const now = Date.now();
             const createdAt = new Date(now - 100_000);
@@ -1017,6 +1082,42 @@ describe("VtxoManager - Renewal", () => {
             expect(expiring).toHaveLength(2);
             expect(expiring[0].txid).toBe("vtxo1");
             expect(expiring[1].txid).toBe("vtxo2");
+        });
+
+        it("should exclude an unrolled VTXO expiring within the threshold", async () => {
+            const now = Date.now();
+            const soon = (txid: string, value: number, isUnrolled: boolean) =>
+                ({
+                    txid,
+                    vout: 0,
+                    value,
+                    createdAt: new Date(now - 100_000),
+                    virtualStatus: { state: "settled", batchExpiry: now + 40_000 },
+                    isSpent: false,
+                    isSwept: false,
+                    isPreconfirmed: false,
+                    isUnrolled,
+                    spentBy: "",
+                    commitmentTxIds: [],
+                    expiresAt: new Date(now + 40_000),
+                }) as ExtendedVirtualCoin;
+            const vtxos = [soon("healthy", 5000, false), soon("exited", 3000, true)];
+            const wallet = createMockWallet(vtxos);
+            // The bare mock hands back the snapshot verbatim; the real wallet
+            // reads it through `filterSnapshotVtxos`, which is where the exit is
+            // dropped — so the renewal selection only holds if the manager asks
+            // for a filter that leaves `withUnrolled` off.
+            (wallet.getSpendableVtxos as any).mockImplementation(async (filter: any) =>
+                filterSnapshotVtxos([{ vtxos } as any], filter, new Set()),
+            );
+            const manager = new VtxoManager(wallet, {
+                enabled: true,
+                thresholdMs: 100_000,
+            });
+
+            const expiring = await manager.getExpiringVtxos();
+
+            expect(expiring.map((v) => v.txid)).toEqual(["healthy"]);
         });
 
         it("should return empty array when no VTXOs have expiry set", async () => {

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -1588,7 +1588,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
             txid: "bb".repeat(32),
             value: 50000,
             virtualStatus: { state: "settled" },
-            isSpent: true,
+            isSpent: false,
             isUnrolled: true,
         });
         await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [settled, unrolled]);
@@ -1635,6 +1635,38 @@ describe("WalletMessageHandler repo-backed reads", () => {
                 settled: 100000,
                 preconfirmed: 50000,
                 available: 150000,
+            },
+        });
+    });
+
+    it("GET_BALANCE excludes unrolled VTXOs that are not marked isSpent", async () => {
+        setupHandler();
+        const settled = createMockExtendedVtxo({
+            txid: "aa".repeat(32),
+            value: 100000,
+            virtualStatus: { state: "settled" },
+        });
+        const unrolled = createMockExtendedVtxo({
+            txid: "bb".repeat(32),
+            value: 50000,
+            virtualStatus: { state: "settled" },
+            isSpent: false,
+            isUnrolled: true,
+        });
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [settled, unrolled]);
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "GET_BALANCE",
+        } as any);
+
+        expect(response).toMatchObject({
+            type: "BALANCE",
+            payload: {
+                settled: 100000,
+                preconfirmed: 0,
+                available: 100000,
+                total: 100000,
             },
         });
     });

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -1583,7 +1583,8 @@ describe("WalletMessageHandler repo-backed reads", () => {
             value: 50000,
             virtualStatus: { state: "settled" },
         });
-        // Unrolling spends the virtual output, so nothing but the filter can surface it.
+        // `isUnrolled` says where the output lives, not that it was consumed: this coin is
+        // unspent, and only the filter decides whether an exited output is in scope.
         const unrolled = createMockExtendedVtxo({
             txid: "bb".repeat(32),
             value: 50000,
@@ -1607,6 +1608,54 @@ describe("WalletMessageHandler repo-backed reads", () => {
             "aa".repeat(32),
             "bb".repeat(32),
         ]);
+    });
+
+    it("GET_VTXOS surfaces unrolled VTXOs the spend-axis tests would have dropped", async () => {
+        setupHandler();
+        const exitedSwept = createMockExtendedVtxo({
+            txid: "aa".repeat(32),
+            value: 50000,
+            virtualStatus: { state: "swept" },
+            isUnrolled: true,
+        });
+        const exitedExpired = createMockExtendedVtxo({
+            txid: "bb".repeat(32),
+            value: 50000,
+            virtualStatus: { state: "settled" },
+            expiresAt: new Date(Date.now() - 60000),
+            isUnrolled: true,
+        });
+        const exitedSpent = createMockExtendedVtxo({
+            txid: "cc".repeat(32),
+            value: 50000,
+            virtualStatus: { state: "spent" },
+            isSpent: true,
+            isUnrolled: true,
+        });
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [
+            exitedSwept,
+            exitedExpired,
+            exitedSpent,
+        ]);
+
+        const get = async (filter: Record<string, boolean>) =>
+            (
+                (await updater.handleMessage({
+                    ...baseMessage(),
+                    type: "GET_VTXOS",
+                    payload: { filter },
+                } as any)) as any
+            ).payload.vtxos.map((v: any) => v.txid);
+
+        // Location is decided first, so `withUnrolled` alone answers for all three and the
+        // swept/expiry/spend tests below it never run — `prepareUnrollTransaction` behind the
+        // worker needs every exited output, whatever its spend state.
+        expect(await get({ withUnrolled: true })).toEqual([
+            "aa".repeat(32),
+            "bb".repeat(32),
+            "cc".repeat(32),
+        ]);
+        expect(await get({ withRecoverable: true })).toEqual([]);
     });
 
     it("GET_BALANCE reads from repository, not indexer", async () => {
@@ -1639,7 +1688,7 @@ describe("WalletMessageHandler repo-backed reads", () => {
         });
     });
 
-    it("GET_BALANCE excludes unrolled VTXOs that are not marked isSpent", async () => {
+    it("GET_BALANCE buckets an unrolled VTXO as unrolled instead of dropping it", async () => {
         setupHandler();
         const settled = createMockExtendedVtxo({
             txid: "aa".repeat(32),
@@ -1660,12 +1709,88 @@ describe("WalletMessageHandler repo-backed reads", () => {
             type: "GET_BALANCE",
         } as any);
 
+        // Exited but unspent: out of every spendable bucket, still the user's money in `total`.
         expect(response).toMatchObject({
             type: "BALANCE",
             payload: {
                 settled: 100000,
                 preconfirmed: 0,
                 available: 100000,
+                recoverable: 0,
+                pendingRecovery: 0,
+                unrolled: 50000,
+                total: 150000,
+            },
+        });
+    });
+
+    it("GET_BALANCE reports an unrolled swept VTXO as unrolled, not recoverable", async () => {
+        setupHandler();
+        const settled = createMockExtendedVtxo({
+            txid: "aa".repeat(32),
+            value: 100000,
+            virtualStatus: { state: "settled" },
+        });
+        // Swept AND exited: a batch cannot lift an output that already sits onchain, so the
+        // location wins over the recovery test.
+        const exitedSwept = createMockExtendedVtxo({
+            txid: "bb".repeat(32),
+            value: 50000,
+            virtualStatus: { state: "swept" },
+            isUnrolled: true,
+        });
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [settled, exitedSwept]);
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "GET_BALANCE",
+        } as any);
+
+        expect(response).toMatchObject({
+            type: "BALANCE",
+            payload: {
+                settled: 100000,
+                available: 100000,
+                recoverable: 0,
+                pendingRecovery: 0,
+                unrolled: 50000,
+                total: 150000,
+            },
+        });
+    });
+
+    it("GET_BALANCE drops an unrolled VTXO that was also spent", async () => {
+        setupHandler();
+        const settled = createMockExtendedVtxo({
+            txid: "aa".repeat(32),
+            value: 100000,
+            virtualStatus: { state: "settled" },
+        });
+        // The completed unroll: exited, then swept onchain. The repository read is unfiltered,
+        // so only the terminal-spend guard keeps this out of `unrolled` and out of `total`.
+        const exitedSpent = createMockExtendedVtxo({
+            txid: "bb".repeat(32),
+            value: 50000,
+            virtualStatus: { state: "spent" },
+            isSpent: true,
+            isUnrolled: true,
+        });
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [settled, exitedSpent]);
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "GET_BALANCE",
+        } as any);
+
+        expect(response).toMatchObject({
+            type: "BALANCE",
+            payload: {
+                settled: 100000,
+                preconfirmed: 0,
+                available: 100000,
+                recoverable: 0,
+                pendingRecovery: 0,
+                unrolled: 0,
                 total: 100000,
             },
         });


### PR DESCRIPTION
A unilateral exit is written `isUnrolled: true, isSpent: false`, and the terminal-spend predicate never read it — so an exited VTXO still counted as Arkade-spendable and stayed selectable for a send, a renewal batch or a recovery batch, all of which fail at the server.

Supersedes edd95df9 on `fix/unrolled-vtxo-balance`, which folded `isUnrolled` into `hasTerminalSpend`. NArk doesn't: `Unrolled` there means "this output lives onchain now" and is never part of the spend predicate. Same outcome for the bug, but it keeps `hasTerminalSpend` == `ArkVtxo.IsSpent()` and the copies of it around the codebase honest.

**Predicates.** `canSpendOffchain` / `canRecoverOnchain` both refuse an unrolled coin; new `canSweepOnchain` claims it. The three now partition the unspent set. `filterSnapshotVtxos` and the worker's `handleGetVtxos` branch on location first, so `withUnrolled` is authoritative.

**Balance.** New `unrolled` bucket, disjoint from the other four and inside `total` — the money is still the user's, onchain behind a CSV, with `completeUnroll` as the remedy. `WalletBalance` gains a field (semver minor). Note `Wallet.getBalance` has to ask for unrolled coins explicitly or the bucket reads zero on the main thread while the worker reports the truth; there's a parity test over one real wallet and one real repository.

**Gap A.** Neither exit path could reach a `ContractManager`, and delta sync can't see the change (`GetVtxosOptions.after` filters on creation time). `OnExitObserved` is a plain function type with no runtime imports, so `Unroll.Session` and the keyless `Executor` keep their independence; `Unroll.sessionFor` / `UnilateralExit.execute` wire it from a wallet so the default path is right without callers opting in. It's a prompt, not a guarantee — the hook fires on the explorer, the refresh reads the indexer, and a miss just leaves things where they already were. Documented at each surface.

**Also fixed, because reverting `hasTerminalSpend` would otherwise regress them:** `ArkadeContract.getUtxos`, the deprecated-signer migration rollup, `selectPendingRecoveryOutpoints`, `classifyCashVtxos` (new `exited` reason), `prepareUnrollTransaction`, and `intentReconciliation.isConsumed` — which also missed `spentBy` and read `settledBy: ""` as set.

**swap** (separate commit): `readLockupFate` stops keeping its own copy of the union and gains an `exited` fate; `runPass` reports it as `needs_counterparty` per half, so the independent L1 claim keeps running and a proven claim keeps its label until the refund window opens. `findLockupVtxos` drops exited outputs so no caller can push a doomed refund.

### Worth a reviewer's eye
- `boltz-swap` regresses deliberately (`arkade-swaps.ts:676,2501` now count an unrolled coin as unspent). Deprecated + unmaintained, stated rather than silently exempted.
- `ArkadeContract.getUtxos`'s no-manager fallback still trusts server-side `spendableOnly` — pre-existing, the two branches can disagree.
- `refundIfUnresolved` reports an exited lockup as `nothing_to_refund`, where the analogous swept case gets `needs_recovery` with outpoints.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking funds that have been unilaterally exited onchain.
  * Added an `unrolled` balance category; these funds remain included in totals but are excluded from spending and recovery.
  * Added wallet helpers for executing exits and automatically refreshing exit status.
  * Added APIs to identify funds eligible for onchain sweeping.

* **Bug Fixes**
  * Prevented exited outputs from being treated as spendable, recoverable, or refundable.
  * Swap flows now correctly block or report exited lockups while preserving valid claims.

* **Documentation**
  * Updated unilateral-exit and balance guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->