### PR TITLE
fix: the exited-vtxo gaps the unrolled branch left open

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -759,6 +759,23 @@ through their stored `preimageHex` or their HD descriptor, and `DB_VERSION` is u
 
 Notes from before 0.0.1, kept for consumers who tracked the branch.
 
+- **`refundIfUnresolved` reports an exited lockup, and its input gained `paymentHash`.**
+  `RefundOutcome` has a new `{ outcome: "exited"; outpoints; status }` variant: a lockup whose
+  outputs were unilaterally exited lives onchain under the VHTLC script, where no offchain refund
+  reaches it. It used to come back as `nothing_to_refund`, which reads as "already resolved" over
+  money still sitting at the script — the swept case gets `needs_recovery` for the same reason, and
+  this is deliberately **not** that variant: recovery into a fresh batch is a spend no batch can
+  make for an onchain output. Complete the unroll and spend the outputs onchain instead.
+
+  Two required changes for direct callers. The input gains **`paymentHash`** (`sha256(P)` hex — the
+  quote's `payment_hash`, which callers already hold): the exit is read through `readLockupFate`,
+  and the VHTLC script cannot supply it, since its `preimageHash` is a `hash160` of the same secret.
+  And the `indexer` parameter widened from `RefundIndexer` to **`LockupSpendIndexer`**, so it must
+  now carry `getVirtualTxs` as well as `getVtxos` — a real `RestIndexerProvider` already does.
+
+  A lockup funded in two sends of which only one exited reports `exited` for the whole thing and
+  leaves the live half unrefunded. That matches `RfqSwapManager`, which reports the same lockup
+  `exited` on the same any-output rule; the two must not disagree.
 - **`RfqSwapManager` can own its own persistence.** New optional
   `RfqSwapManagerDeps.repository`, new `restoreFromRepository()` and `pruneRetiredSwaps()`, and
   `addSwap(swap, origin?)` gains an optional second argument. Nothing narrows and nothing is

--- a/packages/swap/src/refund.ts
+++ b/packages/swap/src/refund.ts
@@ -259,9 +259,11 @@ export class LockupNeedsRecoveryError extends Error {
  * defensively rather than assumed. It costs the two waiting callers nothing
  * they wanted: `awaitLockupFunding` keeps waiting for a claimable lockup
  * instead of publishing `P` into a spend that cannot land, and
- * `refundIfUnresolved` reports `nothing_to_refund` instead of grinding a doomed
- * push to its deadline. The manager reads the exit through
- * {@link readLockupFate}, which queries unfiltered and reports it as `exited`.
+ * `refundIfUnresolved` reports rather than grinding a doomed push to its
+ * deadline. Both that function and `RfqSwapManager` name the exit through
+ * {@link readLockupFate}, which queries unfiltered and reports it as `exited`;
+ * this drop is the second line, and what still refuses the push on a pass where
+ * the fate read learned nothing.
  *
  * This read — not the RFQ's reported state — is the authority on whether
  * there is anything left at the lockup.
@@ -671,7 +673,18 @@ export type RefundOutcome =
           outpoints: string[];
           vtxos: LockupVtxo[];
           status: RfqStatus | null;
-      };
+      }
+    /**
+     * The lockup was unilaterally exited: its outputs sit onchain under the VHTLC
+     * script, where no offchain refund can reach them. Returned rather than
+     * retried: no amount of waiting changes where the money lives. Complete the
+     * unroll and spend the outputs onchain — then there is nothing left to refund.
+     *
+     * Distinct from {@link RefundOutcome} `needs_recovery` on purpose: that
+     * variant's remedy is recovery into a fresh batch, which is a spend no batch
+     * can make for an output that is already onchain.
+     */
+    | { outcome: "exited"; outpoints: string[]; status: RfqStatus | null };
 
 /**
  * Ask first, then fall back: watch the swap for the solver to resolve it, and
@@ -700,6 +713,20 @@ export type RefundOutcome =
  *   is gone the CLTV refund is not "not yet" but "not this way", so it returns
  *   `needs_recovery` naming the outpoints rather than retrying until the
  *   deadline. Recover them and call again.
+ * - **An exited lockup ends it the same way, and is checked first.** Each pass
+ *   past the deadline asks {@link readLockupFate} before reading what is
+ *   refundable, so an output that has been unilaterally exited returns `exited`
+ *   instead of feeding a push that cannot land. It costs one extra `getVtxos`
+ *   per such pass (three where there were two), plus a `getVirtualTxs` on a
+ *   fully-spent lockup; only the pass that returns `exited` saves the other two.
+ *   Paid to prevent a push that would otherwise be retried to the deadline and
+ *   then rethrown. A failing fate read is swallowed, not raised: it is a
+ *   shortcut, and losing it must not end a wait the ordinary path could answer.
+ *
+ *   A lockup funded in two sends of which only one exited reports `exited` for
+ *   the whole thing and leaves the live half unrefunded. That is deliberate:
+ *   `RfqSwapManager` reports the same lockup `exited` on the same any-output
+ *   rule, and the two must not disagree.
  *
  * Safe to call late, and safe to call again: a caller recovering from a crash
  * well past the deadline skips straight to the push, and a lockup that is
@@ -708,12 +735,18 @@ export type RefundOutcome =
 export async function refundIfUnresolved(
     transport: RfqTransport,
     ark: RefundArkProvider,
-    indexer: RefundIndexer,
+    indexer: LockupSpendIndexer,
     input: {
         rfqId: string;
         script: InstanceType<typeof VHTLC.ScriptV2>;
         /** @see pushRefundWithoutReceiver */
         sender: Identity;
+        /**
+         * `sha256(P)`, hex — the quote's `payment_hash`, as {@link readLockupFate}
+         * takes it. Not derivable from `script`, whose `preimageHash` is a
+         * `hash160` of the same secret.
+         */
+        paymentHash: string;
         /** `refund_locktime` from the quote, unix seconds. */
         refundLocktime: number;
         /** Defaults to the contract's own committed refund destination. */
@@ -735,6 +768,31 @@ export async function refundIfUnresolved(
         if (status && isResolved(status.state)) return { outcome: "resolved", status };
 
         if (now() >= input.refundLocktime) {
+            // Before the refundable read, not after it: the point is to prevent
+            // the doomed push, not to interpret its refusal a pass too late.
+            //
+            // Guarded because it is an addition to this path, not a replacement:
+            // the fate read reaches `getVirtualTxs`, which nothing here called
+            // before, and a transient failure there must not end a refund wait
+            // the ordinary path below would have answered. `RfqSwapManager`
+            // guards the same call for the same reason.
+            let fate: LockupFate = { fate: "unknown" };
+            try {
+                fate = await readLockupFate(indexer, {
+                    swapPkScript: input.script.pkScript,
+                    paymentHash: input.paymentHash,
+                });
+            } catch {
+                // `findLockupVtxos`'s own drop still refuses the doomed push.
+            }
+            if (fate.fate === "exited") {
+                return {
+                    outcome: "exited",
+                    outpoints: fate.outpoints.map((o) => `${o.txid}:${o.vout}`),
+                    status,
+                };
+            }
+
             const vtxos = await findLockupVtxos(indexer, input.script.pkScript);
             if (vtxos.length === 0) return { outcome: "nothing_to_refund", status };
             try {

--- a/packages/swap/test/refund.test.ts
+++ b/packages/swap/test/refund.test.ts
@@ -109,7 +109,7 @@ const fakeOperator = (
     } as unknown as FakeOperator;
 };
 
-const fakeIndexer = (vtxos: LockupVtxo[]): RefundIndexer & { scripts: string[][] } => {
+const fakeIndexer = (vtxos: LockupVtxo[]): LockupSpendIndexer & { scripts: string[][] } => {
     const scripts: string[][] = [];
     return {
         scripts,
@@ -118,7 +118,7 @@ const fakeIndexer = (vtxos: LockupVtxo[]): RefundIndexer & { scripts: string[][]
             return { vtxos };
         },
         getVirtualTxs: async () => ({ txs: [] }),
-    } as unknown as RefundIndexer & { scripts: string[][] };
+    } as unknown as LockupSpendIndexer & { scripts: string[][] };
 };
 
 const statusOf = (state: string): RfqStatus => ({

--- a/packages/swap/test/refund.test.ts
+++ b/packages/swap/test/refund.test.ts
@@ -38,13 +38,15 @@ const SENDER_PRIVATE_KEY = priv(13);
 /** The sender key as the signer the refund path now takes. */
 const SENDER = SingleKey.fromPrivateKey(SENDER_PRIVATE_KEY);
 const REFUND_PK_SCRIPT = p2tr(key(5));
+/** `sha256(P)` for the golden participant set — what `refundIfUnresolved` now takes. */
+const SWAP_PAYMENT_HASH = hex.encode(sha256(new Uint8Array(32).fill(7)));
 
 /** The same golden participant set rfq.test.ts pins the script bytes against. */
 const swapScript = () =>
     lightningSendVtxoScript({
         solverPubkey: key(1),
         serverPubkey: key(3),
-        paymentHash: hex.encode(sha256(new Uint8Array(32).fill(7))),
+        paymentHash: SWAP_PAYMENT_HASH,
         refundLocktime: REFUND_LOCKTIME,
         claimDelay: 4096,
         emulatorPubkey: key(9),
@@ -115,6 +117,7 @@ const fakeIndexer = (vtxos: LockupVtxo[]): RefundIndexer & { scripts: string[][]
             scripts.push(opts?.scripts ?? []);
             return { vtxos };
         },
+        getVirtualTxs: async () => ({ txs: [] }),
     } as unknown as RefundIndexer & { scripts: string[][] };
 };
 
@@ -467,6 +470,7 @@ describe("refundIfUnresolved", () => {
         rfqId: RFQ_ID,
         script: swapScript(),
         sender: SENDER,
+        paymentHash: SWAP_PAYMENT_HASH,
         refundLocktime: REFUND_LOCKTIME,
         pollMs: 1,
     });
@@ -515,7 +519,8 @@ describe("refundIfUnresolved", () => {
             getVtxos: async (opts?: { spendableOnly?: boolean; recoverableOnly?: boolean }) => ({
                 vtxos: opts?.recoverableOnly ? [swept] : [],
             }),
-        } as unknown as RefundIndexer;
+            getVirtualTxs: async () => ({ txs: [] }),
+        } as unknown as LockupSpendIndexer;
 
         const result = await refundIfUnresolved(fakeTransport(["quoted"]), operator, indexer, {
             ...baseInput(),
@@ -570,35 +575,85 @@ describe("refundIfUnresolved", () => {
         ).rejects.toThrow(/FORFEIT_CLOSURE_LOCKED/);
     });
 
-    it("reports nothing to refund when the lockup's only output was unrolled", async () => {
-        // The output is unspent, but onchain behind its CSV: no offchain leaf
-        // reaches it. Pushing anyway would fail every retry until
-        // `attemptDeadline` and then rethrow — burning the window on a spend
-        // that was never going to land.
+    /** An operator that counts how many times a push started building. */
+    const watchedOperator = () => {
         const operator = fakeOperator();
         let pushes = 0;
-        const watched = {
+        const provider = {
             ...operator,
             getInfo: async () => {
                 pushes += 1;
                 return operator.getInfo();
             },
         } as unknown as RefundArkProvider;
-        const exited = { txid: "66".repeat(32), vout: 0, value: 8_000, isUnrolled: true };
-        const indexer = {
-            getVtxos: async (opts?: { spendableOnly?: boolean }) => ({
-                vtxos: opts?.spendableOnly ? [exited] : [],
-            }),
-        } as unknown as RefundIndexer;
+        return { operator, provider, pushes: () => pushes };
+    };
 
-        const result = await refundIfUnresolved(fakeTransport(["quoted"]), watched, indexer, {
+    const EXITED = { txid: "66".repeat(32), vout: 0, value: 8_000, isUnrolled: true };
+
+    it("reports an exited lockup instead of pushing a refund that cannot land", async () => {
+        // The output is unspent, but onchain behind its CSV: no offchain leaf
+        // reaches it. `nothing_to_refund` would read as "already resolved" over
+        // money still sitting at the script.
+        const { operator, provider, pushes } = watchedOperator();
+        const indexer = {
+            getVtxos: async () => ({ vtxos: [EXITED] }),
+            getVirtualTxs: async () => ({ txs: [] }),
+        } as unknown as LockupSpendIndexer;
+
+        const result = await refundIfUnresolved(fakeTransport(["quoted"]), provider, indexer, {
+            ...baseInput(),
+            now: () => REFUND_LOCKTIME + 1,
+        });
+
+        expect(result.outcome).toBe("exited");
+        if (result.outcome === "exited") {
+            expect(result.outpoints).toEqual([`${"66".repeat(32)}:0`]);
+        }
+        // The outcome alone would pass while the doomed push still went out.
+        expect(pushes()).toBe(0);
+        expect(operator.submitted).toEqual([]);
+    });
+
+    it("does not report `exited` for an exit output that was already spent", async () => {
+        // The exit happened AND the onchain output was swept: that is history,
+        // not a remedy the caller can still act on, so the fate's terminal-spend
+        // guard drops it and the ordinary path answers.
+        const { operator, provider, pushes } = watchedOperator();
+        const indexer = {
+            getVtxos: async () => ({ vtxos: [{ ...EXITED, isSpent: true, spentBy: "" }] }),
+            getVirtualTxs: async () => ({ txs: [] }),
+        } as unknown as LockupSpendIndexer;
+
+        const result = await refundIfUnresolved(fakeTransport(["quoted"]), provider, indexer, {
             ...baseInput(),
             now: () => REFUND_LOCKTIME + 1,
         });
 
         expect(result.outcome).toBe("nothing_to_refund");
-        // The outcome alone would pass while the doomed push still went out.
-        expect(pushes).toBe(0);
+        expect(pushes()).toBe(0);
+        expect(operator.submitted).toEqual([]);
+    });
+
+    it("still refuses the push when the fate read learns nothing about an exited output", async () => {
+        // Defense in depth: the fate query comes back empty (indexer lag), so
+        // nothing says `exited` — and `findLockupVtxos`'s own drop is what keeps
+        // the doomed push from going out and burning the whole window.
+        const { operator, provider, pushes } = watchedOperator();
+        const indexer = {
+            getVtxos: async (opts?: { spendableOnly?: boolean }) => ({
+                vtxos: opts?.spendableOnly ? [EXITED] : [],
+            }),
+            getVirtualTxs: async () => ({ txs: [] }),
+        } as unknown as LockupSpendIndexer;
+
+        const result = await refundIfUnresolved(fakeTransport(["quoted"]), provider, indexer, {
+            ...baseInput(),
+            now: () => REFUND_LOCKTIME + 1,
+        });
+
+        expect(result.outcome).toBe("nothing_to_refund");
+        expect(pushes()).toBe(0);
         expect(operator.submitted).toEqual([]);
     });
 

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -574,6 +574,11 @@ const expiringVtxos = await manager.getExpiringVtxos()
 const urgentlyExpiring = await manager.getExpiringVtxos(60_000)
 ```
 
+A virtual output whose unilateral exit already happened is never offered for renewal, and the
+exported `isVtxoExpiringSoon` answers `false` for one whatever its batch expiry says: "expiring
+soon" is a renewal signal, and no batch can take an output that already lives onchain. Its remedy
+is `Unroll.completeUnroll`, and its value shows up in `balance.unrolled`.
+
 #### Boarding Input Sweep
 
 When a boarding input's CSV timelock expires, it can no longer be onboarded into Arkade cooperatively. The sweep feature detects these expired UTXOs and builds a raw onchain transaction that spends them via the unilateral exit path back to a fresh boarding address, restarting the timelock.

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -575,7 +575,7 @@ const urgentlyExpiring = await manager.getExpiringVtxos(60_000)
 ```
 
 A virtual output whose unilateral exit already happened is never offered for renewal, and the
-exported `isVtxoExpiringSoon` answers `false` for one whatever its batch expiry says: "expiring
+exported `isVtxoExpiringSoon` answers `false` for it regardless of its batch expiry: "expiring
 soon" is a renewal signal, and no batch can take an output that already lives onchain. Its remedy
 is `Unroll.completeUnroll`, and its value shows up in `balance.unrolled`.
 

--- a/packages/ts-sdk/src/arkade/contract.ts
+++ b/packages/ts-sdk/src/arkade/contract.ts
@@ -530,6 +530,10 @@ export class ArkadeContract<P extends Program = Program> {
      * When a `contractManager` is configured and this contract is registered,
      * reads the repository-backed state (offline-first, kept fresh by the
      * contract watcher). Otherwise falls back to a direct indexer query.
+     *
+     * Both branches refuse a spent or unilaterally exited output. They are not
+     * otherwise interchangeable: the fallback asks `spendableOnly`, which also
+     * drops swept coins — the manager branch keeps those.
      */
     async getUtxos(): Promise<VirtualCoin[]> {
         const manager = this.client.contractManager;
@@ -553,7 +557,10 @@ export class ArkadeContract<P extends Program = Program> {
             scripts: [scriptHex],
             spendableOnly: true,
         });
-        return vtxos;
+        // Same guard as the manager branch above, kept alongside the server-side
+        // ask rather than instead of it: what the server calls spendable is its
+        // answer, not a fact this accessor may lean on.
+        return vtxos.filter((v) => !hasTerminalSpend(v) && !v.isUnrolled);
     }
 
     /** Total spendable balance (requires an indexer). */

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -455,6 +455,12 @@ export interface WalletBalance {
     /**
      * Total balance across offchain, recoverable, pending-recovery, unrolled,
      * and boarding funds.
+     *
+     * One known main-thread-only wedge: while a `settle` or `sendBitcoin` is in
+     * flight its inputs are withheld from every bucket, including this one. That
+     * state lives on the `Wallet` instance driving the spend, so a service-worker
+     * client reading the same repository still counts them until the spend
+     * settles. Both sides converge when it does.
      */
     total: number;
 

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -456,11 +456,12 @@ export interface WalletBalance {
      * Total balance across offchain, recoverable, pending-recovery, unrolled,
      * and boarding funds.
      *
-     * One known main-thread-only wedge: while a `settle` or `sendBitcoin` is in
-     * flight its inputs are withheld from every bucket, including this one. That
-     * state lives on the `Wallet` instance driving the spend, so a service-worker
-     * client reading the same repository still counts them until the spend
-     * settles. Both sides converge when it does.
+     * One known main-thread-only wedge: while a spend is in flight — `send`,
+     * `sendBitcoin` or `settle` — its VTXO inputs are withheld from every bucket,
+     * including this one. Boarding inputs are not: only virtual coins enter the
+     * set. That state lives on the `Wallet` instance driving the spend, so a
+     * service-worker client reading the same repository still counts them until
+     * the spend settles. Both sides converge when it does.
      */
     total: number;
 

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -655,6 +655,9 @@ function getRecoverableWithSubdust(
 /**
  * Check if a virtual output is expiring soon based on threshold
  *
+ * Always `false` for an unilaterally exited output: "expiring soon" is a renewal
+ * signal, and no batch can renew an output that already lives onchain.
+ *
  * @param vtxo - The virtual output to check
  * @param thresholdMs - Threshold in milliseconds from now
  * @returns true if virtual output expires within threshold, false otherwise
@@ -663,6 +666,9 @@ export function isVtxoExpiringSoon(
     vtxo: ExtendedVirtualCoin,
     thresholdMs: number, // in milliseconds
 ): boolean {
+    // Bare, not off the normalized coin: `normalizeVtxo` never defaults this flag.
+    if (vtxo.isUnrolled) return false;
+
     const realThresholdMs = thresholdMs <= 100 ? DEFAULT_THRESHOLD_MS : thresholdMs;
 
     // Being synchronous, this has no chain tip to compare a height-encoded expiry against, so
@@ -679,7 +685,9 @@ export function isVtxoExpiringSoon(
 }
 
 /**
- * Filter virtual outputs that are expiring soon or are recoverable/subdust
+ * Filter virtual outputs that are expiring soon or are recoverable/subdust.
+ * Unilaterally exited outputs are never included — none of the three arms
+ * describes a coin a batch can take.
  *
  * @param vtxos - Array of virtual outputs to check
  * @param thresholdMs - Threshold in milliseconds from now
@@ -693,10 +701,13 @@ export function getExpiringAndRecoverableVtxos(
     now: TimeHeight,
 ): NormalizedExtendedVirtualCoin[] {
     return vtxos.filter(
+        // The leading exclusion covers the `isSubdust` arm too, which is a value
+        // property and would otherwise re-admit an exited coin on its own.
         (vtxo) =>
-            isVtxoExpiringSoon(vtxo, thresholdMs) ||
-            canRecoverOnchain(vtxo, now) ||
-            isSubdust(vtxo, dustAmount),
+            !vtxo.isUnrolled &&
+            (isVtxoExpiringSoon(vtxo, thresholdMs) ||
+                canRecoverOnchain(vtxo, now) ||
+                isSubdust(vtxo, dustAmount)),
     );
 }
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -441,6 +441,15 @@ const PENDING_RECOVERY_REASON =
     "is past its operator signer's rotation cutoff — the operator will not co-sign it until it recovers";
 
 /**
+ * The fourth reason generic selection drops a coin. Reported from the raw
+ * snapshot rather than through the other exclusions: {@link filterSnapshotVtxos}
+ * removes unrolled coins before they reach that call, so an exclusion there
+ * could never match.
+ */
+const UNROLLED_REASON =
+    "was unilaterally exited and lives onchain — `Unroll.completeUnroll` is the only spend that reaches it";
+
+/**
  * What signer classification needs of a snapshot: contract params and the coins
  * under them. Structural rather than {@link ContractWithVtxos} so a repository-
  * built snapshot — the worker's, whose VTXOs carry no `contractScript` — can be
@@ -1285,6 +1294,20 @@ export class ReadonlyWallet implements IReadonlyWallet {
                 "is locked by an in-flight settlement intent",
             ),
         ]);
+        // Its own call over its own array: the set above cannot contain these,
+        // and widening it to the raw snapshot would report every terminally-spent
+        // coin under a gated contract as gated. Skipped when the caller asked for
+        // unrolled coins — those were not excluded. A completed unroll stays out:
+        // `completeUnroll` no longer reaches it either.
+        if (!filter?.withUnrolled) {
+            logExcludedVtxos(
+                "getSpendableVtxos",
+                snapshot
+                    .flatMap((contract) => contract.vtxos)
+                    .filter((vtxo) => vtxo.isUnrolled && !hasTerminalSpend(vtxo)),
+                [() => UNROLLED_REASON],
+            );
+        }
         return unlocked;
     }
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -5138,8 +5138,12 @@ export class Wallet
         // regardless: the proof describes every input by the contract's P2TR
         // pkScript, which is a lie for an OP_RETURN outpoint and would have the
         // server reject the whole proof. It is excluded by value, since the
-        // indexer reports subdust under that same P2TR script.
-        const drainable = vtxos.filter((vtxo) => !isSubdust(vtxo, this.dustAmount));
+        // indexer reports subdust under that same P2TR script. An exited output
+        // is excluded by state instead: it lives onchain, so no pending sweep
+        // naming it can ever be finalized.
+        const drainable = vtxos.filter(
+            (vtxo) => !isSubdust(vtxo, this.dustAmount) && !vtxo.isUnrolled,
+        );
         if (drainable.length > 0) {
             let drained = { count: 0, swept: 0, claimed: new Set<string>() };
             try {

--- a/packages/ts-sdk/test/arkade-contract.test.ts
+++ b/packages/ts-sdk/test/arkade-contract.test.ts
@@ -72,7 +72,7 @@ function _typecheckStrongInputs(ark: arkade.Arkade) {
     c.functions.nope();
 }
 
-function stubProviders(server: Uint8Array, emulatorKey: Uint8Array) {
+function stubProviders(server: Uint8Array, emulatorKey: Uint8Array, indexerVtxos?: unknown[]) {
     const checkpointTapscript = hex.encode(
         CSVMultisigTapscript.encode({
             timelock: { type: "blocks", value: 10n },
@@ -90,7 +90,7 @@ function stubProviders(server: Uint8Array, emulatorKey: Uint8Array) {
     };
     const indexer = {
         async getVtxos() {
-            return { vtxos: [{ ...COIN } as any] };
+            return { vtxos: (indexerVtxos ?? [{ ...COIN }]) as any[] };
         },
         getVirtualTxs,
     };
@@ -138,8 +138,12 @@ describe("arkade.Arkade / ArkadeContract", () => {
     const receiver = xOnly(); // 32-byte witness program
     const args = { hash: HASH, receiver, amount: AMOUNT };
 
-    async function connect(contractManager?: IContractManager) {
-        const { arkProvider, indexer, emulator, captured } = stubProviders(server, emulatorKey);
+    async function connect(contractManager?: IContractManager, indexerVtxos?: unknown[]) {
+        const { arkProvider, indexer, emulator, captured } = stubProviders(
+            server,
+            emulatorKey,
+            indexerVtxos,
+        );
         const ark = await arkade.Arkade.connect({
             arkade: arkProvider,
             emulator,
@@ -193,6 +197,22 @@ describe("arkade.Arkade / ArkadeContract", () => {
 
         // The value also proves the manager branch ran: the fallback indexer
         // would have answered with COIN (10_000) instead.
+        expect((await contract.getUtxos()).map((u) => u.txid)).toEqual([healthy.txid]);
+        expect(await contract.getBalance()).toBe(7_000n);
+    });
+
+    // Paired with the manager-branch test above: the two branches must answer
+    // the same about an exited coin, so neither may be narrowed alone.
+    it("drops them in the no-manager fallback too, whatever spendableOnly returns", async () => {
+        // A spent coin too: `spendableOnly` is the server's answer, and a stale
+        // or proxying indexer that returns one must not reach the caller either.
+        const healthy = { ...mintCoin(7_000), isSpent: false };
+        const exited = { ...mintCoin(3_000), isSpent: false, isUnrolled: true };
+        const spent = { ...mintCoin(1_000), isSpent: true };
+
+        const { ark } = await connect(undefined, [healthy, exited, spent]);
+        const contract = ark.contract(htlcProgram(), args);
+
         expect((await contract.getUtxos()).map((u) => u.txid)).toEqual([healthy.txid]);
         expect(await contract.getBalance()).toBe(7_000n);
     });

--- a/packages/ts-sdk/test/arkadeCashClaim.test.ts
+++ b/packages/ts-sdk/test/arkadeCashClaim.test.ts
@@ -364,6 +364,33 @@ describe("claimCash drain-pending accounting", () => {
         ]);
     });
 
+    // Excluded by state, not by value: the drain finalizes pending sweeps, and
+    // no sweep naming an output that already lives onchain can ever close.
+    it("keeps an exited VTXO out of the drain proof", async () => {
+        const cash = makeCash();
+        const cashPkScript = hex.encode(cash.vtxoScript.pkScript);
+        const finalizeTx = vi.fn(async () => {});
+        const getPendingTxs = vi.fn(async () => []);
+
+        const healthy = spentCashVtxoAt(cashPkScript, 1);
+        const exited = { ...spentCashVtxoAt(cashPkScript, 2), isSpent: false, isUnrolled: true };
+        const wallet = await makeWallet(cashIndexer(cashPkScript, [healthy, exited]), {
+            getPendingTxs,
+            finalizeTx,
+        });
+
+        await wallet.claimCash(cash.toString());
+
+        expect(getPendingTxs).toHaveBeenCalledOnce();
+        const { proof } = (getPendingTxs.mock.calls as unknown as [{ proof: string }][])[0][0];
+        const tx = Transaction.fromPSBT(base64.decode(proof), { allowUnknown: true });
+        const inputs = Array.from({ length: tx.inputsLength }, (_, i) =>
+            hex.encode(tx.getInput(i).txid!),
+        );
+        expect(inputs).toContain(healthy.txid);
+        expect(inputs).not.toContain(exited.txid);
+    });
+
     it("surfaces the recoverable token when the funding send fails", async () => {
         const wallet = await makeWallet(cashIndexer("x", []), {});
 

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -920,9 +920,10 @@ describe("main-thread / worker balance parity", () => {
      * silently drops them and reports `unrolled: 0` forever.
      *
      * Scoped to `unrolled` and `total` on purpose. `_pendingSpendOutpoints` is
-     * main-thread-only state — written around `settle`/`sendBitcoin` by the
-     * instance driving the spend — so mid-send the two sides legitimately
-     * disagree, and an all-buckets assertion would trip on it. Not a bug to
+     * main-thread-only state — the VTXO inputs of an in-flight `send`,
+     * `sendBitcoin` or `settle`, written by the instance driving it — so
+     * mid-send the two sides legitimately disagree, and an all-buckets assertion
+     * would trip on it. Not a bug to
      * repair by widening the worker's balance read: the fix for a consumer that
      * ever needs agreement mid-send is a `SPEND_STARTED`/`SPEND_SETTLED` event on
      * the existing bus, not a balance-read change.

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -170,6 +170,17 @@ async function seededWallet(opts?: {
 const scriptsOf = (vtxos: { script: string }[]) => vtxos.map((v) => v.script).sort();
 const txidsOf = (vtxos: { txid: string }[]) => vtxos.map((v) => v.txid).sort();
 
+/** Every `[spendability]` debug line the call emitted, in order. */
+const captureDebug = async (run: () => Promise<void>): Promise<string[]> => {
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, "debug").mockImplementation((...args: unknown[]) => {
+        lines.push(args.join(" "));
+    });
+    await run();
+    spy.mockRestore();
+    return lines.filter((l) => l.startsWith("[spendability]"));
+};
+
 describe("ContractHandler.isGenericallySpendable", () => {
     it("answers true for every built-in wallet-owned type", () => {
         const row = contract("s", "default");
@@ -686,17 +697,6 @@ describe("logUngatedInputs", () => {
     const DEPRECATED_KEY = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
     const EXPIRED_SCRIPT = "51200000000000000000000000000000000000000000000000000000000000000004";
 
-    /** Every debug line the call emitted, in order. */
-    const captureDebug = async (run: () => Promise<void>): Promise<string[]> => {
-        const lines: string[] = [];
-        const spy = vi.spyOn(console, "debug").mockImplementation((...args: unknown[]) => {
-            lines.push(args.join(" "));
-        });
-        await run();
-        spy.mockRestore();
-        return lines.filter((l) => l.startsWith("[spendability]"));
-    };
-
     it("reports all three exclusions, not just the contract gate", async () => {
         const intents = new InMemoryIntentRepository();
         const { wallet, contractRepository, defaultScript } = await seededWallet({ intents });
@@ -750,6 +750,99 @@ describe("logUngatedInputs", () => {
             wallet.logUngatedInputs("buildAndSubmitOffchainTx", [vtxo(defaultScript, 10_000)]),
         );
         expect(lines).toEqual([]);
+    });
+});
+
+describe("getSpendableVtxos reports the exited coins it dropped", () => {
+    const UNROLLED_TXID = "e7".repeat(32);
+
+    /** The seeded wallet plus one exited coin of its own. */
+    const withExitedCoin = async (over?: { isSpent?: boolean }) => {
+        const seeded = await seededWallet();
+        await seeded.walletRepository.saveVtxos(await seeded.wallet.getAddress(), [
+            createMockExtendedVtxo({
+                txid: UNROLLED_TXID,
+                vout: 0,
+                value: 12_000,
+                script: seeded.defaultScript,
+                virtualStatus: { state: "settled" },
+                isSpent: over?.isSpent ?? false,
+                isUnrolled: true,
+            }),
+        ]);
+        return seeded;
+    };
+
+    const linesFor = async (filter?: GetVtxosFilter) => {
+        const { wallet } = await withExitedCoin();
+        return captureDebug(async () => {
+            await wallet.getSpendableVtxos(filter);
+        });
+    };
+
+    it("names the outpoint and the remedy that reaches it", async () => {
+        const lines = await linesFor();
+        const line = lines.find((l) => l.includes(UNROLLED_TXID));
+        expect(line).toContain(`${UNROLLED_TXID}:0`);
+        expect(line).toContain("unilaterally exited");
+        expect(line).toContain("Unroll.completeUnroll");
+    });
+
+    it("stays quiet when the caller asked for unrolled coins", async () => {
+        // Nothing was excluded, so describing it as excluded would be wrong.
+        const lines = await linesFor({ withRecoverable: true, withUnrolled: true });
+        expect(lines.join("\n")).not.toContain(UNROLLED_TXID);
+    });
+
+    it("stays quiet about a completed unroll", async () => {
+        // The exit output is already spent: `completeUnroll` does not reach it
+        // either, so the line would name a remedy that throws.
+        const { wallet } = await withExitedCoin({ isSpent: true });
+        const lines = await captureDebug(async () => {
+            await wallet.getSpendableVtxos();
+        });
+        expect(lines.join("\n")).not.toContain(UNROLLED_TXID);
+    });
+
+    it("says nothing on the reads that are not spending", async () => {
+        // The other placement the design rejects: logging inside
+        // `filterSnapshotVtxos` would make `getVtxos` — a raw reporting read
+        // where an exited coin is out of scope, not excluded — and `getBalance`,
+        // which asks for them on purpose, both report one as excluded.
+        const { wallet } = await withExitedCoin();
+        const lines = await captureDebug(async () => {
+            await wallet.getVtxos();
+            await wallet.getVtxos({ withUnrolled: true });
+            await wallet.getBalance();
+        });
+        expect(lines.join("\n")).not.toContain(UNROLLED_TXID);
+    });
+
+    it("does not report a terminally-spent coin under a gated contract as gated", async () => {
+        // The regression the separate call exists to prevent: reporting the raw
+        // snapshot through the gate exclusion would emit a `gated` line for every
+        // spent coin under an escrow contract, none of which was ever a candidate.
+        const spentEscrowTxid = "e8".repeat(32);
+        const { wallet, walletRepository } = await seededWallet();
+        await walletRepository.saveVtxos(contract(ESCROW_SCRIPT, "arkade").address, [
+            createMockExtendedVtxo({
+                txid: spentEscrowTxid,
+                vout: 0,
+                value: 9_000,
+                script: ESCROW_SCRIPT,
+                virtualStatus: { state: "settled" },
+                isSpent: true,
+            }),
+        ]);
+
+        const lines = await captureDebug(async () => {
+            await wallet.getSpendableVtxos();
+        });
+
+        // The live escrow coin is still reported — the gate line is not gone,
+        // just not extended to coins that are already spent.
+        expect(lines.join("\n")).toContain("is not generically spendable");
+        expect(lines.join("\n")).not.toContain(spentEscrowTxid);
     });
 });
 
@@ -825,6 +918,20 @@ describe("main-thread / worker balance parity", () => {
      * unrolled coins explicitly. Comparing the two is the only assertion that
      * catches `Wallet.getBalance` going back to the default filter, which
      * silently drops them and reports `unrolled: 0` forever.
+     *
+     * Scoped to `unrolled` and `total` on purpose. `_pendingSpendOutpoints` is
+     * main-thread-only state — written around `settle`/`sendBitcoin` by the
+     * instance driving the spend — so mid-send the two sides legitimately
+     * disagree, and an all-buckets assertion would trip on it. Not a bug to
+     * repair by widening the worker's balance read: the fix for a consumer that
+     * ever needs agreement mid-send is a `SPEND_STARTED`/`SPEND_SETTLED` event on
+     * the existing bus, not a balance-read change.
+     *
+     * `unrolled` is not exempt from that wedge either, only out of its reach in
+     * practice: generic selection refuses exited coins, but the explicit-input
+     * paths are ungated, so a caller *naming* one puts it in the set. Accepted
+     * because it is bounded and self-inflicted — such a spend is doomed at the
+     * server, and the wedge lasts until it rejects.
      */
     const workerBalance = async (seeded: Awaited<ReturnType<typeof seededWallet>>) => {
         // Same wallet, same repository as the main-thread read — two stubs

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -825,6 +825,25 @@ describe("VtxoManager - Renewal utilities", () => {
             const thresholdMs = 10_000; // 10 seconds threshold
             expect(isVtxoExpiringSoon(vtxo, thresholdMs)).toBe(false);
         });
+
+        it("should return false for an unrolled VTXO expiring within threshold", () => {
+            // The arm the past-expiry test below cannot reach: there the early
+            // "already expired" return answers first, so the exclusion under
+            // test never runs.
+            const now = Date.now();
+            const expiring = (isUnrolled: boolean) =>
+                ({
+                    txid: isUnrolled ? "exited" : "healthy",
+                    vout: 0,
+                    value: 1000,
+                    createdAt: new Date(now - 90_000),
+                    virtualStatus: { state: "settled", batchExpiry: now + 10_000 },
+                    isUnrolled,
+                }) as ExtendedVirtualCoin;
+
+            expect(isVtxoExpiringSoon(expiring(false), 20_000)).toBe(true);
+            expect(isVtxoExpiringSoon(expiring(true), 20_000)).toBe(false);
+        });
     });
 
     describe("getExpiringVtxos", () => {
@@ -940,6 +959,35 @@ describe("VtxoManager - Renewal utilities", () => {
 
             const expiring = getExpiringAndRecoverableVtxos(
                 [expired("healthy", 3000, false), expired("exited", 4000, true)],
+                10_000,
+                330n,
+                { timestamp: new Date() },
+            );
+
+            expect(expiring.map((v) => v.txid)).toEqual(["healthy"]);
+        });
+
+        it("should not offer an unrolled subdust VTXO for renewal", () => {
+            // Subdust is a value property, orthogonal to expiry, so this coin
+            // never reaches `isVtxoExpiringSoon`'s guard — only the filter's own
+            // leading exclusion keeps it out.
+            const subdust = (txid: string, isUnrolled: boolean) =>
+                ({
+                    txid,
+                    vout: 0,
+                    value: 100, // below the 330 dust threshold
+                    createdAt: new Date(Date.now() - 100_000),
+                    virtualStatus: { state: "settled" }, // no expiry
+                    isSpent: false,
+                    isSwept: false,
+                    isPreconfirmed: false,
+                    isUnrolled,
+                    spentBy: "",
+                    commitmentTxIds: [],
+                }) as ExtendedVirtualCoin;
+
+            const expiring = getExpiringAndRecoverableVtxos(
+                [subdust("healthy", false), subdust("exited", true)],
                 10_000,
                 330n,
                 { timestamp: new Date() },


### PR DESCRIPTION
Implements the six items the unrolled-VTXO branch (#816) deliberately left open. A unilaterally exited output lives onchain behindits CSV timelock; `Unroll.completeUnroll` is the only spend that reaches it. Each item below is a
place that still handed one to something offchain.

### §1 — the public expiry helpers carry no liveness check

`isVtxoExpiringSoon` returned `true` for an exited coin expiring within the threshold, and
`getExpiringAndRecoverableVtxos` admitted an exited *subdust* coin through an arm the first guard
never sees. Two clauses, one per admitting arm. The existing past-expiry test kept as the
`canRecoverOnchain`-arm pin.

### §2 — exited coins were dropped with no diagnostic

`getSpendableVtxos` reported gated, pending-recovery and intent-locked exclusions but removed exited
coins silently, inside `filterSnapshotVtxos`, before that reporting ran. Now a separate
`logExcludedVtxos` call over the unrolled coins in the raw snapshot, skipped when the caller passed
`{ withUnrolled: true }` and silent about a completed unroll. Its own call rather than widening the
existing one: `gateExclusion` matches on script, so handing it the raw snapshot would report every
terminally-spent coin under an escrow contract as `gated`. `logUngatedInputs` is deliberately left
alone — its inputs carry no `isUnrolled`, and reading it would force the repository read that method
exists to avoid.

### §3 — `refundIfUnresolved` reported an exited lockup as `nothing_to_refund`

Indistinguishable from "already resolved" over money still sitting at the script. New `exited`
variant on `RefundOutcome`, read through `readLockupFate` before `findLockupVtxos` so the doomed push
never goes out. **Breaking for direct callers**, see below.

The fate read is wrapped in try/catch. It is an *addition* to this path, not a replacement: it
reaches `getVirtualTxs`, which nothing here called before, and a transient failure there must not end
a refund wait the ordinary path would have answered — `RfqSwapManager` guards the same call for the
same reason. On failure `findLockupVtxos`' own drop still refuses the push, which the third new test
pins.

### §4 / §5 — two more reads that admitted an exited coin

`ArkadeContract.getUtxos`' no-manager fallback trusted server-side `spendableOnly` and applied no
local guard, so the accessor's answer depended on how the client was constructed. `claimCash`'s drain
candidate set passed an exited coin into `finalizePendingCashTxs` as a proof input for a sweep that
can never be finalized. Both now apply the predicate the manager branch and the classification
already use.

### §6 — main/worker balance parity

No code change. `_pendingSpendOutpoints` is main-thread-only state, and a message invented to keep a
debug-time balance figure consistent is the wrong weight. The parity test's scoping is made
load-bearing with a comment naming the accepted divergence and the correct fix if a consumer ever
needs it (`SPEND_STARTED`/`SPEND_SETTLED` on the existing bus), plus a `WalletBalance.total` docstring
line.

## Compatibility

- `isVtxoExpiringSoon` narrows on a public export — behaviour change, semver **minor**.
  `getExpiringAndRecoverableVtxos` is not exported from the barrel, so its narrowing is internal.
- `RefundOutcome` gains an `exited` variant — additive, semver **minor** for `@arkade-os/swap`.
- **`refundIfUnresolved` is breaking for direct callers**: its input gains a required `paymentHash`
  (`sha256(P)`, the quote's `payment_hash` — not derivable from the VHTLC script, whose `preimageHash`
  is a `hash160` of the same secret), and its `indexer` parameter widened from `RefundIndexer` to
  `LockupSpendIndexer`, so it must now carry `getVirtualTxs`. A real `RestIndexerProvider` already
  satisfies both. No in-repo caller: `RfqSwapManager` reads the exit through `readLockupFate` and
  `arkadeRefunder` composes the atomic push.
- `getUtxos()` fallback and the `claimCash` drain set narrow — correctness fixes, no API change.
- No repository schema change, no `readonly version` bump.

## Out of scope (recorded in the plan)

The explorer-confirmed → indexer-read seam residual, `boltz-swap` (deprecated, unmaintained), and the
`onchain-exit-rebatch.md` capability work.

## Testing

`pnpm run build`, `pnpm run test:unit` (2855 + 602 + 616 passing), `pnpm run lint`, `tsc --noEmit` on
both packages. Every src change was mutation-checked: reverting its clause fails the test that pins
it, including all three rejected designs §2 guards against — unconditional logging, widening the
existing `logExcludedVtxos` call to the raw snapshot, and moving the log inside `filterSnapshotVtxos`
(which would make `getVtxos`/`getBalance` report a coin they are not excluding). Integration tests
left to CI.

An adversarial review of the diff ran before this was committed; five of its findings were real and
are fixed here rather than deferred:

- the `getUtxos` docstring claimed a branch parity that swept coins break (the manager branch keeps
  them; `spendableOnly` cannot return one) — reworded to the narrower true claim;
- the fallback test fixture had no spent coin, leaving the `!hasTerminalSpend` half of the new guard
  unpinned — added, and it now fails against `filter(v => !v.isUnrolled)`;
- the `filterSnapshotVtxos` placement was unpinned — new test;
- the unguarded fate read turned a `nothing_to_refund` into a rethrow — guarded;
- two stale doc claims in `refund.ts` (`findLockupVtxos`' outcome sentence, and a cost paragraph that
  credited a saving to a pass that returns before either read) — corrected, including the honest
  per-pass cost.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Refund handling now reports when a lockup has already exited on-chain, including affected outputs and status.
  - Wallet balance and spendability handling now consistently excludes exited or terminally spent virtual outputs from active spending and renewal.
  - Fallback coin selection now filters unavailable outputs consistently.

- **Bug Fixes**
  - Prevented refund attempts for lockups that have already exited.
  - Exited outputs are excluded from cash-claim drain proofs and expiry detection.

- **Documentation**
  - Added migration guidance for the updated refund inputs and indexer requirements.
  - Clarified balance and renewal behavior for exited outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->