### PR TITLE
feat(swap): v2 type foundation

### DIFF
--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -57,7 +57,7 @@
     ],
     "scripts": {
         "build": "tsup src/index.ts src/nostr.ts src/repositories/sqlite/index.ts src/repositories/realm/index.ts --format esm,cjs --dts --clean",
-        "typecheck": "tsc --noEmit",
+        "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
         "format": "biome format --write src test",
         "lint": "biome format src test",
         "prepack": "pnpm run build",

--- a/packages/swap/src/client/aliases.ts
+++ b/packages/swap/src/client/aliases.ts
@@ -121,10 +121,7 @@ const networkOfRow = (row: RegisteredAsset): string => parseAssetId(row.id).refe
  * sends the money to the wrong one.
  */
 export const canonicalAssetId = (input: string, table: AssetAliasTable): AssetId => {
-    if (isAssetId(input)) {
-        parseAssetId(input);
-        return input;
-    }
+    if (isAssetId(input)) return input;
     const wanted = input.trim().toLowerCase();
     const matches = table.assets.filter(
         (row) => row.ticker.toLowerCase() === wanted && networkOfRow(row) === table.network,

--- a/packages/swap/src/client/aliases.ts
+++ b/packages/swap/src/client/aliases.ts
@@ -1,0 +1,150 @@
+/**
+ * The alias layer: public ids down to the vocabulary discovery and RFQ speak.
+ *
+ * One way only. A public id is CAIP-19 and carries its rail; discovery keeps
+ * chain-relative leg keys (a `Corridor` plus an `AssetInfo.id` of `"btc"` or
+ * the 68-hex identity), and the two are not in bijection — several public ids
+ * can share one discovery asset. Promising a round trip through it was the
+ * mistake the earlier Q5 shape made; what does round-trip byte-for-byte is the
+ * covenant identity itself, which this layer carries verbatim.
+ *
+ * Registry ratification of the CAIP form (Q11) does not block any of this: if
+ * solver-registry adopts it, the table below shortens.
+ *
+ * The RFQ wire's `pair` string is not built here. It is `<from-leg>-><to-leg>`,
+ * byte-compared by the solver and length-capped, and the quote path's request
+ * builder owns it — a CAIP-19 id would both break the comparison and overrun
+ * the cap.
+ */
+import { NETWORKS, isNetwork, type Network as IndexedNetwork } from "@arkade-os/solver-discovery";
+import { BTC_ASSET_ID } from "../store";
+import {
+    ARKADE_ASSET_NAMESPACE,
+    AssetIdError,
+    BTC_ASSET_PART,
+    type AssetId,
+    isAssetId,
+    parseAssetId,
+} from "./assetId";
+import type { NetworkRef } from "./assetId";
+import type { Corridor } from "./corridor";
+import { UnsupportedRoute } from "./errors";
+
+/** What discovery names a leg by: its corridor, and the asset id on it. */
+export interface DiscoveryLeg {
+    corridor: Corridor;
+    /** `"btc"`, or the 68-hex Arkade asset identity. */
+    assetId: string;
+}
+
+/**
+ * A public id down to its discovery leg.
+ *
+ * Total over the ids v2 can route and refusing everything else: an `eip155:` id
+ * is grammar-valid and unserved (§9 is deferred), and a non-BTC asset on
+ * lightning or L1 names a corridor that carries only BTC.
+ */
+export const toDiscoveryLeg = (id: AssetId): DiscoveryLeg => {
+    const { rail, assetNamespace, assetReference } = parseAssetId(id);
+    const asset = `${assetNamespace}:${assetReference}`;
+    if (rail === "arkade") {
+        if (asset === BTC_ASSET_PART) return { corridor: "arkade", assetId: BTC_ASSET_ID };
+        if (assetNamespace === ARKADE_ASSET_NAMESPACE) {
+            return { corridor: "arkade", assetId: assetReference };
+        }
+        throw new UnsupportedRoute(`the arkade corridor has no ${asset}`);
+    }
+    // Lightning and L1 carry BTC and nothing else — there is no leg name for
+    // an asset on them, so this is a refusal rather than a lookup miss.
+    if (rail === "bolt11") {
+        if (asset === BTC_ASSET_PART) return { corridor: "lightning", assetId: BTC_ASSET_ID };
+        throw new UnsupportedRoute(`the lightning corridor carries BTC only, not ${asset}`);
+    }
+    if (rail === "bitcoin") {
+        if (asset === BTC_ASSET_PART) return { corridor: "onchain", assetId: BTC_ASSET_ID };
+        throw new UnsupportedRoute(`the onchain corridor carries BTC only, not ${asset}`);
+    }
+    throw new UnsupportedRoute(`no corridor serves ${id}`);
+};
+
+/** One registry row: what a ticker canonicalizes to. */
+export interface RegisteredAsset {
+    id: AssetId;
+    /** The display ticker. Matched case-insensitively; never an identity. */
+    ticker: string;
+}
+
+/**
+ * The table caller input is canonicalized against.
+ *
+ * Injected rather than fetched: M1 owns no network layer, and the quote path
+ * fills this from discovery when it has one.
+ */
+export interface AssetAliasTable {
+    /** The wallet's network. An id on any other network is not a candidate. */
+    network: NetworkRef;
+    assets: readonly RegisteredAsset[];
+}
+
+/**
+ * The networks discovery publishes a market index for, restated as network
+ * references.
+ *
+ * The two vocabularies are spelled identically and differ only in that core
+ * carries `testnet` and discovery does not, so the narrowing is set membership
+ * and nothing more. The `satisfies` is the pin: a rename on either side fails
+ * to compile here instead of degrading into a silent "no index for this
+ * network".
+ */
+export const INDEXED_NETWORKS = NETWORKS satisfies readonly NetworkRef[];
+
+/**
+ * Whether a market index can be fetched for `network`.
+ *
+ * Partial by construction, and `testnet` is the member outside it: an asset on
+ * testnet is nameable — `arkade:testnet/slip44:0` is a valid id — there is
+ * simply no published index to price it against. Which error that becomes is
+ * the quote path's call, not this layer's.
+ */
+export const isIndexedNetwork = (network: NetworkRef): network is IndexedNetwork =>
+    isNetwork(network);
+
+const networkOfRow = (row: RegisteredAsset): string => parseAssetId(row.id).reference;
+
+/**
+ * Caller input to a public id: an id passes through validated, a ticker is
+ * resolved against the table.
+ *
+ * Ticker matching is case-insensitive and scoped to the wallet's network, and a
+ * ticker that matches more than one asset on that network is refused rather
+ * than guessed — two assets called `USDT` are exactly the case where guessing
+ * sends the money to the wrong one.
+ */
+export const canonicalAssetId = (input: string, table: AssetAliasTable): AssetId => {
+    if (isAssetId(input)) {
+        parseAssetId(input);
+        return input;
+    }
+    const wanted = input.trim().toLowerCase();
+    const matches = table.assets.filter(
+        (row) => row.ticker.toLowerCase() === wanted && networkOfRow(row) === table.network,
+    );
+    if (matches.length === 0) {
+        throw new AssetIdError(
+            "unknown_alias",
+            input,
+            `no asset with that ticker on ${table.network}`,
+        );
+    }
+    // Distinct rows may still name one asset — a registry listing the same id
+    // twice is duplication, not ambiguity.
+    const distinct = new Set(matches.map((row) => row.id));
+    if (distinct.size > 1) {
+        throw new AssetIdError(
+            "ambiguous_alias",
+            input,
+            `${distinct.size} assets on ${table.network} answer to that ticker: ${[...distinct].join(", ")}`,
+        );
+    }
+    return matches[0].id;
+};

--- a/packages/swap/src/client/amount.ts
+++ b/packages/swap/src/client/amount.ts
@@ -1,0 +1,195 @@
+/**
+ * The amount law: `bigint` atomic units in memory, decimal strings at the
+ * edges, and exactly two conversion sites — this module and the RFQ adapter
+ * beside it.
+ *
+ * Two different decimal strings live at those edges and conflating them is how
+ * the v1 units footgun comes back. The *scaled* decimal is human-facing and only
+ * {@link Amount.parse} and {@link Amount.format} produce or consume it: `"0.01"`
+ * BTC, read against the asset's `decimals`. The *atomic-unit* decimal is what
+ * records and the wire hold — the same integer the `bigint` carries, written
+ * out, never scaled. Records and the RFQ wire take the second form and never the
+ * first, which is why there is no display-amount code path to deprecate later.
+ *
+ * {@link AtomicDecimal} is branded, so the confusion that actually loses money —
+ * `Amount.parse(record.fromAmount, btc)`, reading `"10000"` sats as 10,000 BTC —
+ * is a compile error rather than a comment. The display side is not branded: it
+ * arrives from a text input as a plain `string`, and requiring a constructor
+ * there would tax every UI caller for nothing.
+ *
+ * The exact arithmetic is discovery's `toAtomic` / `fromAtomic`, not a second
+ * implementation. What this module adds is the narrower door: discovery's codec
+ * accepts a JS `number`, scientific notation, a leading `+` and surrounding
+ * whitespace, and a display amount arriving as `100000` meaning sats is exactly
+ * the v1 defect where it quoted 100,000 BTC. Validate here, delegate there —
+ * after this module's checks the delegated call cannot throw.
+ */
+import {
+    AMOUNT_PATTERN,
+    MAX_ASSET_DECIMALS,
+    fromAtomic,
+    isAmount,
+    toAtomic,
+} from "@arkade-os/solver-discovery";
+
+/**
+ * What the codec needs from an asset, and nothing else. Structural, so
+ * discovery's `AssetInfo` satisfies it directly and this module reaches for no
+ * network layer. There is no id-to-decimals lookup at M1: that needs the
+ * registry M3 builds, and M3 adds an id-taking convenience on top of this rather
+ * than replacing it.
+ */
+export interface AssetScale {
+    decimals: number;
+}
+
+declare const ATOMIC_DECIMAL: unique symbol;
+
+/** Atomic units written out: the form records and the wire hold. */
+export type AtomicDecimal = string & { readonly [ATOMIC_DECIMAL]: true };
+
+/** A string that is provably not an {@link AtomicDecimal}; plain strings qualify. */
+export type DisplayDecimal = string & { readonly [ATOMIC_DECIMAL]?: never };
+
+/** Why an amount was refused. */
+export type AmountRefusal =
+    | "not_decimal"
+    | "negative"
+    | "too_precise"
+    | "too_large"
+    | "invalid_decimals"
+    | "not_canonical";
+
+/**
+ * An amount that cannot be represented in the form asked for.
+ *
+ * Not a member of the §7 `SwapError` taxonomy: that taxonomy is the client
+ * surface's, thrown by a verb before value moves, and this is a codec refusing
+ * its input before a swap exists. The wire's compatibility failure is different
+ * and does have a member — `AmountEncodingUnsupported`, in `rfqAmount.ts`.
+ */
+export class AmountFormatError extends Error {
+    override readonly name = "AmountFormatError";
+    constructor(
+        readonly reason: AmountRefusal,
+        message: string,
+    ) {
+        super(message);
+    }
+}
+
+/** Unsigned, digits on both sides of any point. No sign, no exponent, no space. */
+const SCALED_DECIMAL = /^([0-9]+)(?:\.([0-9]+))?$/;
+
+/** One past the largest amount `AMOUNT_PATTERN`'s 30 digits can hold. */
+const ATOMIC_CEILING = 10n ** 30n;
+
+/** Discovery's own significant-digit bound, checked here so its codec is total. */
+const MAX_SIGNIFICANT_DIGITS = 64;
+
+const assertDecimals = (decimals: number): void => {
+    if (!Number.isInteger(decimals) || decimals < 0 || decimals > MAX_ASSET_DECIMALS) {
+        throw new AmountFormatError(
+            "invalid_decimals",
+            `decimals must be an integer in [0, ${MAX_ASSET_DECIMALS}], got ${decimals}`,
+        );
+    }
+};
+
+const assertRepresentable = (value: bigint, what: string): void => {
+    if (value >= ATOMIC_CEILING) {
+        throw new AmountFormatError(
+            "too_large",
+            `${what} does not fit the canonical 30-digit encoding`,
+        );
+    }
+};
+
+export const Amount = {
+    /**
+     * A human decimal into atomic units.
+     *
+     * `string` only, and no exponent. Accepting a `number` is the whole v1
+     * footgun: it makes `100000` ambiguous between sats and whole BTC, and by
+     * the time the ambiguity resolves the offer is funded. Exponent form goes
+     * for the same reason — a UI never produces `1e-4`, so accepting it only
+     * widens what a mistake can look like.
+     *
+     * Refuses rather than rounds when the input is finer than the asset: a
+     * silently truncated amount is a swap for the wrong size, and nothing
+     * downstream can tell it was ever a different number. Refuses too when the
+     * result would not survive the record boundary, so one law holds in both
+     * directions.
+     */
+    parse(display: DisplayDecimal, asset: AssetScale): bigint {
+        assertDecimals(asset.decimals);
+        const parts = SCALED_DECIMAL.exec(display);
+        if (!parts) {
+            throw new AmountFormatError(
+                "not_decimal",
+                `not an unsigned decimal amount: ${JSON.stringify(display)}` +
+                    " (write 0.5, not .5; no sign, exponent, separator or space)",
+            );
+        }
+        const [, whole, fraction = ""] = parts;
+        if (fraction.length > asset.decimals) {
+            throw new AmountFormatError(
+                "too_precise",
+                `${display} has more precision than ${asset.decimals} decimals allow`,
+            );
+        }
+        if (whole.length + fraction.length > MAX_SIGNIFICANT_DIGITS) {
+            throw new AmountFormatError("too_large", `${display} has too many digits`);
+        }
+        const value = toAtomic(display, asset.decimals);
+        assertRepresentable(value, `${display} at ${asset.decimals} decimals`);
+        return value;
+    },
+
+    /**
+     * Atomic units into a human decimal, trailing zeros trimmed.
+     *
+     * Refuses a negative: every amount on this surface is an obligation, and a
+     * negative one is a defect upstream rather than a number to render.
+     */
+    format(value: bigint, asset: AssetScale): string {
+        assertDecimals(asset.decimals);
+        if (value < 0n) {
+            throw new AmountFormatError("negative", `amount must be non-negative, got ${value}`);
+        }
+        assertRepresentable(value, `${value}`);
+        return fromAtomic(value, asset.decimals);
+    },
+};
+
+/**
+ * Atomic units into the canonical decimal string records and the wire hold:
+ * discovery's `AMOUNT_PATTERN` — unsigned, no leading zeros, at most 30 digits.
+ */
+export const toAtomicDecimal = (value: bigint): AtomicDecimal => {
+    if (value < 0n) {
+        throw new AmountFormatError("negative", `amount must be non-negative, got ${value}`);
+    }
+    assertRepresentable(value, `${value}`);
+    return value.toString() as AtomicDecimal;
+};
+
+/**
+ * The canonical decimal string back into atomic units.
+ *
+ * Takes a plain `string` on purpose: it is what a record read and a `JSON.parse`
+ * hand back, and demanding a cast would put one on the safe direction.
+ */
+export const fromAtomicDecimal = (text: string): bigint => {
+    if (!isAmount(text)) {
+        throw new AmountFormatError(
+            "not_canonical",
+            `not a canonical atomic amount: ${JSON.stringify(text)}`,
+        );
+    }
+    return BigInt(text);
+};
+
+/** Whether `value` is already in the canonical atomic form. */
+export const isAtomicDecimal = (value: unknown): value is AtomicDecimal =>
+    typeof value === "string" && AMOUNT_PATTERN.test(value);

--- a/packages/swap/src/client/assetId.ts
+++ b/packages/swap/src/client/assetId.ts
@@ -1,0 +1,345 @@
+/**
+ * Asset identity for the v2 client: CAIP-19 with the rail as the CAIP-2
+ * namespace — `<rail>:<network>/<asset-ns>:<reference>`.
+ *
+ * The rail is the namespace rather than the settlement chain because sameness
+ * across rails is then a comparison on the asset part instead of a shared
+ * string: `arkade:bitcoin/slip44:0` and `bitcoin:bitcoin/slip44:0` are one BTC
+ * on two rails, and nothing has to agree on a single id for them. Arkade has no
+ * CAIP-2 namespace and no bitcoin-chain identity to nest under, so
+ * `bip122:…/arkade:…` would assert a relationship it does not have.
+ *
+ * These ids parse under CAIP-19 and resolve under no published namespace spec:
+ * `arkade`, `bitcoin` and `bolt11` are registered in no CASA registry. That is
+ * the price of naming rails instead of chains, and it costs nothing here — this
+ * module is the grammar, and what an id *means* is the alias layer's job.
+ */
+import { asset, networks, type NetworkName } from "@arkade-os/sdk";
+
+/**
+ * A CAIP-2 namespace this client can spell. Closed rather than open to the
+ * CAIP-2 character class, so a rail nobody implements is a parse failure here
+ * rather than a lookup miss three layers down.
+ *
+ * `bolt11` is lightning: CAIP-2 caps a namespace at eight characters, which
+ * `lightning` overruns, and floors it at three, which `ln` misses. It names the
+ * instrument the rail carries today; BOLT12 is a separate corridor when it
+ * ships.
+ *
+ * `eip155` is grammar and nothing else. §9's EVM corridor is deferred, and §9
+ * exists to prove the seams hold, so its own examples have to parse; the
+ * refusal belongs where a route is chosen, not where a string is read, and the
+ * alias layer is where it happens.
+ */
+export const RAILS = ["arkade", "bitcoin", "bolt11", "eip155"] as const;
+export type Rail = (typeof RAILS)[number];
+
+/** The rails whose CAIP-2 reference is a bitcoin network rather than a chain id. */
+export const BITCOIN_RAILS = ["arkade", "bitcoin", "bolt11"] as const;
+export type BitcoinRail = (typeof BITCOIN_RAILS)[number];
+
+/**
+ * The network half of a bitcoin-family chain part: core's own
+ * {@link NetworkName}, because the wallet is the only source of the network —
+ * v2 accepts no server URL anywhere — and this is the vocabulary a wallet
+ * resolves to.
+ *
+ * It is one wider than discovery's `NETWORKS`, which omits `testnet`. That
+ * difference belongs to the alias layer and not to the grammar: an asset on
+ * testnet exists whether or not anyone publishes a market index for it, so
+ * amputating the identity to match the index would make a network the SDK fully
+ * supports unnameable.
+ */
+export type NetworkRef = NetworkName;
+
+type BitcoinAssetId<R extends BitcoinRail> = `${R}:${NetworkRef}/${string}:${string}`;
+
+/**
+ * A public asset id.
+ *
+ * A template literal type and not `string`, which is what makes the other three
+ * asset spellings in this package — core's 68-hex `asset.AssetId#toString()`,
+ * discovery's `AssetInfo.id`, the RFQ leg's `arkade:BTC` — a compile error in a
+ * slot that wants a public id, rather than a wrong pair string three layers
+ * down. The rail parameter carries that further: `AssetId<"arkade">` accepts no
+ * `bitcoin:` string, which is what makes an endpoint whose corridor and asset
+ * disagree a compile error (see `route.ts`).
+ *
+ * Deliberately not branded — `client.quote({ give: "arkade:bitcoin/slip44:0" })`
+ * must stay writable, and the spec's own examples are written that way — so the
+ * shape is what the type checks and {@link parseAssetId} is the gate for
+ * everything else. A value out of a record or off the wire is a `string`: parse
+ * it, never cast it.
+ */
+export type AssetId<R extends Rail = Rail> = R extends BitcoinRail
+    ? BitcoinAssetId<R>
+    : `eip155:${number}/${string}:${string}`;
+
+/** The `<asset-ns>:<reference>` half of an id — what sameness compares. */
+export type AssetPart = `${string}:${string}`;
+
+/** BTC's asset part on every rail that carries it (SLIP-44 coin type 0). */
+export const BTC_ASSET_PART = "slip44:0" satisfies AssetPart;
+
+/** The asset namespace an Arkade-issued asset takes. */
+export const ARKADE_ASSET_NAMESPACE = "asset";
+
+export interface ParsedAssetId {
+    /** CAIP-2 namespace. */
+    readonly rail: Rail;
+    /**
+     * CAIP-2 reference: the bitcoin network on a bitcoin-family rail, the
+     * decimal chain id on `eip155`.
+     */
+    readonly reference: string;
+    /** CAIP-19 asset namespace — `slip44`, `asset`, `erc20`. */
+    readonly assetNamespace: AssetNamespace;
+    /** CAIP-19 asset reference. */
+    readonly assetReference: string;
+}
+
+/** Why an id was refused. Stable strings; callers switch on them. */
+export type AssetIdRefusal =
+    | "malformed"
+    | "uppercase"
+    | "unknown_rail"
+    | "unknown_network"
+    | "invalid_chain_id"
+    | "unknown_asset_namespace"
+    | "invalid_asset_reference"
+    | "token_id_unsupported"
+    | "unknown_alias"
+    | "ambiguous_alias";
+
+/**
+ * A string that is not a public asset id.
+ *
+ * Not a member of the §7 `SwapError` taxonomy, and deliberately so: that
+ * taxonomy is the client surface's, thrown by a verb before value moves, and
+ * this is a codec refusing its input before a swap exists at all. Core's own
+ * `AssetId.fromBytes` sets the same precedent.
+ */
+export class AssetIdError extends Error {
+    readonly reason: AssetIdRefusal;
+    readonly value: string;
+    constructor(reason: AssetIdRefusal, value: string, detail: string, options?: ErrorOptions) {
+        super(`invalid asset id ${JSON.stringify(value)}: ${detail}`, options);
+        this.name = "AssetIdError";
+        this.reason = reason;
+        this.value = value;
+    }
+}
+
+/**
+ * The asset namespaces this client spells, and the reference form each takes.
+ *
+ * Closed for the same reason the rail set is: the parser *is* the vocabulary,
+ * and an id nothing downstream can map is a lookup miss dressed as an id. The
+ * per-namespace form is what makes `arkade:bitcoin/asset:notahex` a parse
+ * failure rather than an unserved RFQ pair.
+ */
+const REFERENCE_RULE = {
+    slip44: /^(0|[1-9][0-9]{0,9})$/,
+    /** The 68-lowercase-hex identity form; `asset.AssetId` then re-validates it. */
+    asset: /^[0-9a-f]{68}$/,
+    /**
+     * Reserved for §9. Lowercase, never EIP-55: a checksum belongs on an
+     * address a human types, and an id here comes out of the alias table or a
+     * market card. Mixed case would be two spellings of one asset comparing
+     * unequal in a pair string, a record and a cache key.
+     */
+    erc20: /^0x[0-9a-f]{40}$/,
+} as const satisfies Record<string, RegExp>;
+
+export type AssetNamespace = keyof typeof REFERENCE_RULE;
+
+/** A CAIP-2 reference, and so the outer bound on any network or chain id. */
+const CHAIN_REFERENCE = /^[-_a-z0-9]{1,32}$/;
+/** No leading zeros: `eip155:01` and `eip155:1` would otherwise be two ids for one chain. */
+const CHAIN_ID = /^(0|[1-9][0-9]*)$/;
+/** CAIP-19's own class, minus the uppercase this layer refuses. */
+const ASSET_REFERENCE = /^[-.%a-z0-9]{1,128}$/;
+
+const isRail = (value: string): value is Rail => (RAILS as readonly string[]).includes(value);
+
+/** Whether `value` is a network core can resolve. Read off core's own table, so
+ * a network added there needs no edit here. */
+export const isNetworkRef = (value: string): value is NetworkRef => Object.hasOwn(networks, value);
+
+/**
+ * Parse an id, or refuse it.
+ *
+ * Total over strings and throwing rather than returning a result, because every
+ * caller in the client either has an id or has nothing to do: an unparsed id
+ * has no route, no market and no leg.
+ */
+export const parseAssetId = (value: string): ParsedAssetId => {
+    // Every identity in this system is compared byte for byte and nothing folds
+    // at the comparison — the RFQ pair, the markets cache key, the store's
+    // asset fields. Refusing rather than lowercasing keeps a caller's checksum
+    // intact and stays the loosenable direction: accepting-and-folding can be
+    // added later without breaking anyone, the reverse cannot.
+    if (/[A-Z]/.test(value)) {
+        throw new AssetIdError(
+            "uppercase",
+            value,
+            "ids are lowercase throughout — lowercase an EIP-55 reference before it becomes one",
+        );
+    }
+    const slash = value.indexOf("/");
+    if (slash < 0) {
+        throw new AssetIdError("malformed", value, "expected <rail>:<network>/<asset-ns>:<ref>");
+    }
+    if (value.indexOf("/", slash + 1) >= 0) {
+        // CAIP-19 allows a trailing `/<token_id>` for non-fungibles. Nothing in
+        // v2 has one, and accepting a segment no layer reads would let two ids
+        // for one asset both parse.
+        throw new AssetIdError(
+            "token_id_unsupported",
+            value,
+            "a CAIP-19 token id has no meaning here",
+        );
+    }
+    const chain = value.slice(0, slash);
+    const assetPart = value.slice(slash + 1);
+
+    const chainColon = chain.indexOf(":");
+    const assetColon = assetPart.indexOf(":");
+    if (chainColon < 0 || assetColon < 0) {
+        throw new AssetIdError("malformed", value, "expected <rail>:<network>/<asset-ns>:<ref>");
+    }
+
+    const rail = chain.slice(0, chainColon);
+    const reference = chain.slice(chainColon + 1);
+    const assetNamespace = assetPart.slice(0, assetColon);
+    const assetReference = assetPart.slice(assetColon + 1);
+
+    if (!isRail(rail)) {
+        throw new AssetIdError("unknown_rail", value, `no rail named ${JSON.stringify(rail)}`);
+    }
+    if (!CHAIN_REFERENCE.test(reference)) {
+        throw new AssetIdError("malformed", value, "the chain reference is not CAIP-2 shaped");
+    }
+    if (rail === "eip155") {
+        if (!CHAIN_ID.test(reference)) {
+            throw new AssetIdError("invalid_chain_id", value, "eip155 takes a decimal chain id");
+        }
+    } else if (!isNetworkRef(reference)) {
+        throw new AssetIdError(
+            "unknown_network",
+            value,
+            `no bitcoin network named ${JSON.stringify(reference)}`,
+        );
+    }
+    if (!Object.hasOwn(REFERENCE_RULE, assetNamespace)) {
+        throw new AssetIdError(
+            "unknown_asset_namespace",
+            value,
+            `no asset namespace named ${JSON.stringify(assetNamespace)}`,
+        );
+    }
+    const namespace = assetNamespace as AssetNamespace;
+    if (!ASSET_REFERENCE.test(assetReference) || !REFERENCE_RULE[namespace].test(assetReference)) {
+        throw new AssetIdError(
+            "invalid_asset_reference",
+            value,
+            `${namespace} takes no reference ${JSON.stringify(assetReference)}`,
+        );
+    }
+    if (namespace === ARKADE_ASSET_NAMESPACE) {
+        // The shape rule cannot see an all-zero txid or an out-of-range group
+        // index. Core's validator can, and it is the one that has to agree.
+        try {
+            asset.AssetId.fromString(assetReference);
+        } catch (cause) {
+            throw new AssetIdError(
+                "invalid_asset_reference",
+                value,
+                "core refuses that issuance identity",
+                { cause },
+            );
+        }
+    }
+    return { rail, reference, assetNamespace: namespace, assetReference };
+};
+
+/** Whether `value` parses as a public asset id. */
+export const isAssetId = (value: string): value is AssetId => {
+    try {
+        parseAssetId(value);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+/** Build an id from its parts, validating the result. */
+export const formatAssetId = <R extends Rail>(parts: ParsedAssetId & { rail: R }): AssetId<R> => {
+    const id = `${parts.rail}:${parts.reference}/${parts.assetNamespace}:${parts.assetReference}`;
+    parseAssetId(id);
+    return id as AssetId<R>;
+};
+
+/** The rail an id names. */
+export const railOf = (id: AssetId): Rail => parseAssetId(id).rail;
+
+/**
+ * The bitcoin network an id settles on, or `undefined` on a rail whose CAIP-2
+ * reference is a chain id rather than a network.
+ */
+export const bitcoinNetworkOf = (id: AssetId): NetworkRef | undefined => {
+    const { rail, reference } = parseAssetId(id);
+    return rail === "eip155" ? undefined : (reference as NetworkRef);
+};
+
+/** The `<asset-ns>:<reference>` half. */
+export const assetPartOf = (id: AssetId): AssetPart => {
+    const { assetNamespace, assetReference } = parseAssetId(id);
+    return `${assetNamespace}:${assetReference}`;
+};
+
+/**
+ * Whether two ids name the same asset on (possibly) different rails.
+ *
+ * This is the whole reason the rail is the namespace: BTC's sameness is the
+ * shared `slip44:0`, a comparison, where a single cross-rail id would have made
+ * it a string both sides had to already agree on.
+ */
+export const sameAsset = (a: AssetId, b: AssetId): boolean => assetPartOf(a) === assetPartOf(b);
+
+/** BTC on a bitcoin-family rail: the same coin, named once per rail. */
+export const btcOn = <R extends BitcoinRail>(rail: R, network: NetworkRef): AssetId<R> =>
+    // The checker will not resolve the conditional against an unbound `R`; the
+    // assertion is confined to this expression and never reaches a call site.
+    `${rail}:${network}/${BTC_ASSET_PART}` as AssetId<R>;
+
+/**
+ * An Arkade-issued asset.
+ *
+ * Takes `asset.AssetId` rather than a hex string for the reason `arkadeAssetLeg`
+ * does (`rfq.ts:111`): `hex.decode` accepts uppercase where `hex.encode` emits
+ * only lowercase, so the parameter type is what enforces the case rule, and a
+ * value that reached us as `A1B2…` leaves here as `a1b2…`.
+ *
+ * The reference is that identity verbatim — 68 lowercase hex, `toString()`'s
+ * own output. The spec's prose spells it `<genesis_txid>.<idx>`, which is what
+ * those bytes mean, not a second encoding: the identity is implemented in seven
+ * places across three repos and pinned by `asset.ASSET_ID_VECTORS` precisely
+ * because every disagreement between sites fails silently, so this layer adds
+ * no eighth spelling.
+ */
+export const arkadeAsset = (network: NetworkRef, id: asset.AssetId): AssetId<"arkade"> =>
+    `arkade:${network}/${ARKADE_ASSET_NAMESPACE}:${id.toString()}`;
+
+/**
+ * The issuance identity nested inside an arkade id; `undefined` for BTC.
+ *
+ * The inverse of {@link arkadeAsset}, and the round trip the shared vectors
+ * pin: the 34 bytes in equal the 34 bytes out.
+ */
+export const issuanceOf = (id: AssetId<"arkade">): asset.AssetId | undefined => {
+    const { assetNamespace, assetReference } = parseAssetId(id);
+    return assetNamespace === ARKADE_ASSET_NAMESPACE
+        ? asset.AssetId.fromString(assetReference)
+        : undefined;
+};

--- a/packages/swap/src/client/assetId.ts
+++ b/packages/swap/src/client/assetId.ts
@@ -304,8 +304,24 @@ export const assetPartOf = (id: AssetId): AssetPart => {
  * This is the whole reason the rail is the namespace: BTC's sameness is the
  * shared `slip44:0`, a comparison, where a single cross-rail id would have made
  * it a string both sides had to already agree on.
+ *
+ * The rail is the *only* half sameness drops. The CAIP-2 reference still has to
+ * agree: `arkade:regtest/slip44:0` and `bitcoin:bitcoin/slip44:0` share a coin
+ * type and nothing else — regtest BTC settles nothing on mainnet — and an ERC-20
+ * contract address repeats verbatim across every chain that copied the token, so
+ * the asset part alone would make USDT-on-mainnet the same asset as its address
+ * twin on another chain. Comparing references across rail families is safe on a
+ * plain string: a bitcoin network name is never a decimal chain id.
  */
-export const sameAsset = (a: AssetId, b: AssetId): boolean => assetPartOf(a) === assetPartOf(b);
+export const sameAsset = (a: AssetId, b: AssetId): boolean => {
+    const left = parseAssetId(a);
+    const right = parseAssetId(b);
+    return (
+        left.reference === right.reference &&
+        left.assetNamespace === right.assetNamespace &&
+        left.assetReference === right.assetReference
+    );
+};
 
 /** BTC on a bitcoin-family rail: the same coin, named once per rail. */
 export const btcOn = <R extends BitcoinRail>(rail: R, network: NetworkRef): AssetId<R> =>

--- a/packages/swap/src/client/corridor.ts
+++ b/packages/swap/src/client/corridor.ts
@@ -1,0 +1,69 @@
+/**
+ * The corridor axis, and its bijection with the rail namespaces.
+ *
+ * One axis, two vocabularies: discovery speaks `arkade | lightning | onchain`
+ * and an asset id's CAIP-2 namespace is `arkade | bolt11 | bitcoin`. They agree
+ * on one member of three. Collapsing them was the alternative and it loses
+ * either way — take the rail names and every market lookup translates on the
+ * way out to discovery; take the corridor names and `lightning:` overruns
+ * CAIP-2's eight-character namespace cap.
+ *
+ * So both stay, and the disagreement is spent once, here: `Corridor` is
+ * discovery's type verbatim, {@link railOfCorridor} is total, and `route.ts`
+ * ties an endpoint's corridor to its asset's rail in the type system so the two
+ * cannot disagree in a value.
+ */
+import type { Corridor as DiscoveryCorridor } from "@arkade-os/solver-discovery";
+import type { BitcoinRail, Rail } from "./assetId";
+
+/**
+ * The corridor a leg settles on.
+ *
+ * Aliased from discovery rather than re-declared: it is discovery's vocabulary,
+ * the alias layer has to speak it, and a re-declaration would drift silently
+ * the day discovery adds a corridor.
+ */
+export type Corridor = DiscoveryCorridor;
+
+/** Every corridor, in the order the route union uses them. */
+export const CORRIDORS = ["arkade", "lightning", "onchain"] as const satisfies readonly Corridor[];
+
+/**
+ * A corridor id: the three implemented corridors plus §9's EVM chains.
+ *
+ * The template arm stays open against the registry's closed enum on purpose —
+ * which chains a registry lists is a listing decision, not an id-grammar one.
+ */
+export type CorridorId = Corridor | `eip155:${number}`;
+
+/** The rail namespace a corridor's assets are spelled on. */
+export type RailOf<C extends CorridorId> = C extends "arkade"
+    ? "arkade"
+    : C extends "lightning"
+      ? "bolt11"
+      : C extends "onchain"
+        ? "bitcoin"
+        : "eip155";
+
+const RAIL_BY_CORRIDOR = {
+    arkade: "arkade",
+    lightning: "bolt11",
+    onchain: "bitcoin",
+} as const satisfies Record<Corridor, BitcoinRail>;
+
+const CORRIDOR_BY_RAIL = {
+    arkade: "arkade",
+    bolt11: "lightning",
+    bitcoin: "onchain",
+} as const satisfies Record<BitcoinRail, Corridor>;
+
+/** The rail a corridor's assets are spelled on. Total, and the type agrees. */
+export const railOfCorridor = <C extends CorridorId>(corridor: C): RailOf<C> =>
+    (corridor in RAIL_BY_CORRIDOR ? RAIL_BY_CORRIDOR[corridor as Corridor] : "eip155") as RailOf<C>;
+
+/**
+ * The corridor a rail belongs to, or `undefined` for `eip155` — whose corridor
+ * id carries a chain reference this side has no way to invent.
+ */
+export const corridorOfRail = (rail: Rail): Corridor | undefined =>
+    rail === "eip155" ? undefined : CORRIDOR_BY_RAIL[rail];

--- a/packages/swap/src/client/errors.ts
+++ b/packages/swap/src/client/errors.ts
@@ -1,0 +1,373 @@
+/**
+ * The §7 taxonomy, as typed errors.
+ *
+ * The contract every member shares: it is thrown before value moves, or not at
+ * all. Anything that can go wrong after funding is an outcome, not an exception,
+ * and belongs to the drive loop instead. Each class names the boundary it fires
+ * at, because that is the part a caller cannot infer from the name.
+ *
+ * Naming rule, and it cuts both ways. A member of this taxonomy is a bare
+ * condition noun — `QuoteExpired`, `NotCancellable` — because `SwapRefusal` is
+ * one and §8 keeps it unchanged, so a module holding all sixteen is bare or it
+ * is the first mixed-convention module in the package. An error class that is
+ * *not* a member keeps the `Error` suffix: `AssetIdError` and
+ * `AmountFormatError` are codec faults on caller input, and the suffix is what
+ * says so at the catch site.
+ *
+ * v1's `AddressMismatch` (`rfq.ts:163`) is deliberately not a seventeenth
+ * member: M3 folds it into {@link QuoteVerificationFailed}'s `lockup_address`
+ * check, and M8 gives it the `/protocol` re-export and the `@deprecated`
+ * pointer. Tagging it here would deprecate a live behaviour against a
+ * replacement that does not exist yet.
+ */
+import type { NetworkName } from "@arkade-os/sdk";
+import { SwapRefusal } from "../rfq";
+import type { AssetId } from "./assetId";
+import type { CorridorId } from "./corridor";
+
+/**
+ * A solver declined, with its closed-set reason. The protocol's own class,
+ * reused rather than shadowed or wrapped: §8 keeps it on the v2 surface
+ * unchanged, and a second class would give two `SwapRefusal`s that fail
+ * `instanceof` against each other across the v1/v2 seam.
+ *
+ * Boundary: the RFQ response, before anything is funded.
+ */
+export { SwapRefusal };
+
+/** The four checks §3.1 runs on every quote. Closed, so M3 fits into it. */
+export type QuoteCheck = "pair" | "lockup_address" | "invoice" | "refund_window";
+
+/**
+ * `to` is underdetermined — it parses as nothing, or as more than one thing.
+ *
+ * Boundary: `resolve()`/`quote()`, the single place `to` is parsed.
+ */
+export class AmbiguousDestination extends Error {
+    override readonly name = "AmbiguousDestination";
+    constructor(
+        readonly destination: string,
+        detail: string,
+    ) {
+        super(`cannot route ${JSON.stringify(destination)}: ${detail}`);
+    }
+}
+
+/**
+ * The corridor pair is not in the implemented route union — `onchain -> arkade`
+ * included, until the manager owns the trader's L1 refund path end to end.
+ *
+ * Boundary: route resolution, before RFQ disclosure, artifact creation,
+ * persistence or funding. Also the alias layer, for a rail no corridor serves.
+ */
+export class UnsupportedRoute extends Error {
+    override readonly name = "UnsupportedRoute";
+    readonly give: CorridorId | undefined;
+    readonly take: CorridorId | undefined;
+    constructor(detail: string, corridors: { give?: CorridorId; take?: CorridorId } = {}) {
+        super(`unsupported route: ${detail}`);
+        this.give = corridors.give;
+        this.take = corridors.take;
+    }
+}
+
+/**
+ * `resolve()` needs market data and has neither an injected nor a cached
+ * snapshot. Deliberately not a third, half-resolved route state: the type system
+ * excludes one, and a caller that needs offline resolution warms or injects a
+ * snapshot.
+ *
+ * Boundary: `resolve()` only — `quote()` may fetch discovery itself.
+ */
+export class DiscoverySnapshotUnavailable extends Error {
+    override readonly name = "DiscoverySnapshotUnavailable";
+    constructor(
+        readonly network: NetworkName,
+        detail: string,
+    ) {
+        super(`cannot resolve on ${network} offline: ${detail}`);
+    }
+}
+
+/**
+ * Two amounts are pinned. Exactly one may be: the caller's `amount` +
+ * `amountOn`, or the invoice's.
+ *
+ * Boundary: `quote()`, before any network round trip.
+ */
+export class AmountMismatch extends Error {
+    override readonly name = "AmountMismatch";
+    constructor(readonly sources: readonly [string, string]) {
+        super(`exactly one amount may be pinned; got ${sources[0]} and ${sources[1]}`);
+    }
+}
+
+/**
+ * The amount cannot cross this encoding without an unsafe narrowing — a quote
+ * field arriving as a JSON number past 2^53, a non-canonical decimal string, or
+ * a `bigint` too large for a foreign `number` amount.
+ *
+ * Boundary: the RFQ adapter, both directions; from M7, core's payment rails.
+ */
+export class AmountEncodingUnsupported extends Error {
+    override readonly name = "AmountEncodingUnsupported";
+    constructor(
+        readonly field: string,
+        readonly value: string,
+        detail: string,
+        options?: ErrorOptions,
+    ) {
+        super(`${field}: ${detail}`, options);
+    }
+}
+
+/**
+ * A solver response failed a local check. v1 documented the pair check as the
+ * caller's job, in bold; here it is an invariant. v1's `AddressMismatch` is the
+ * `lockup_address` case of this and folds into it at M3.
+ *
+ * Boundary: `quote()`, before the quote is returned and so before funding.
+ */
+export class QuoteVerificationFailed extends Error {
+    override readonly name = "QuoteVerificationFailed";
+    readonly expected: string | undefined;
+    readonly actual: string | undefined;
+    constructor(
+        readonly check: QuoteCheck,
+        expected?: string,
+        actual?: string,
+    ) {
+        super(`quote failed the ${check} check — refusing to fund`);
+        this.expected = expected;
+        this.actual = actual;
+    }
+}
+
+/**
+ * `accept()` past the quote's TTL. The client never silently re-quotes: the
+ * price the caller saw is not the price they would get.
+ *
+ * Boundary: `accept()`, before persistence.
+ */
+export class QuoteExpired extends Error {
+    override readonly name = "QuoteExpired";
+    constructor(
+        readonly quoteId: string,
+        readonly expiresAt: number,
+        readonly now: number,
+    ) {
+        super(`quote ${quoteId} expired at ${expiresAt}, ${now - expiresAt} ago`);
+    }
+}
+
+/**
+ * The quote's fee is over the verb's ceiling.
+ *
+ * Carries the terms rather than the quote: a `Quote` field would make this
+ * module depend on M3, and an app re-presenting the terms calls `quote()` again
+ * anyway.
+ *
+ * Boundary: the verbs layer, between `quote` and `accept` — before funding.
+ */
+export class MaxFeeExceeded extends Error {
+    override readonly name = "MaxFeeExceeded";
+    constructor(
+        readonly quoteId: string,
+        readonly asset: AssetId,
+        readonly fee: bigint,
+        readonly maxFee: bigint,
+    ) {
+        super(`fee ${fee} of ${asset} exceeds the ${maxFee} ceiling`);
+    }
+}
+
+/**
+ * The wallet cannot fund the give leg. v1 left this to `validatePlan` and the
+ * caller, and `validatePlan` returned rather than threw.
+ *
+ * Boundary: `accept()`, before persistence and funding.
+ */
+export class InsufficientFunds extends Error {
+    override readonly name = "InsufficientFunds";
+    readonly available: bigint | undefined;
+    constructor(
+        readonly asset: AssetId,
+        readonly required: bigint,
+        available?: bigint,
+    ) {
+        super(
+            `funding needs ${required} of ${asset}` +
+                (available === undefined ? "" : `, wallet holds ${available}`),
+        );
+        this.available = available;
+    }
+}
+
+/**
+ * A quote id maps to a persisted accept record that contradicts it. Only
+ * incompatible *durable evidence* qualifies — an ordinary duplicate `accept()`
+ * returns or resumes the original swap, and a funding txid appearing where there
+ * was none is a benign resume.
+ *
+ * Boundary: `accept()`, on the persisted record, before any second funding.
+ */
+export class AcceptConflict extends Error {
+    override readonly name = "AcceptConflict";
+    constructor(
+        readonly quoteId: string,
+        readonly swapId: string,
+        readonly fields: readonly string[],
+    ) {
+        super(`accept ${quoteId} conflicts with swap ${swapId} on ${fields.join(", ")}`);
+    }
+}
+
+/**
+ * A method called after async disposal. Disposal is terminal for the instance;
+ * the durable records survive it and a new client resumes them.
+ *
+ * Boundary: every client method, before it does anything.
+ */
+export class ClientDisposed extends Error {
+    override readonly name = "ClientDisposed";
+    constructor(readonly method: string) {
+        super(`${method}() called after the client was disposed`);
+    }
+}
+
+/**
+ * `cancel()` on a corridor swap. The asymmetry is structural: an offer covenant
+ * has no expiry, so cancellation is an unfilled offer's only exit, where an HTLC
+ * has phases and its exits are a claim or a refund.
+ *
+ * Boundary: `cancel()`, for ids that arrive untyped from `swaps()`.
+ */
+export class NotCancellable extends Error {
+    override readonly name = "NotCancellable";
+    constructor(readonly swapId: string) {
+        super(`swap ${swapId} is a corridor swap; only asset swaps cancel`);
+    }
+}
+
+/**
+ * A destination disagrees with its asset's chain.
+ *
+ * Inert by ruling. §9's EVM corridor is the only place two chain identities can
+ * disagree, and it is deferred, so nothing throws this yet. Declared anyway so
+ * the taxonomy has no unowned member, and so M6's coverage pass can assert that
+ * exactly one declared error has no throwing site — this one. Its fields are
+ * pinned now for the same reason: nothing throws it, so this is the moment to
+ * say what the evidence is.
+ */
+export class InconsistentRoute extends Error {
+    override readonly name = "InconsistentRoute";
+    constructor(
+        readonly asset: AssetId,
+        readonly destination: string,
+    ) {
+        super(`destination ${JSON.stringify(destination)} is not on ${asset}'s chain`);
+    }
+}
+
+/**
+ * `getArkadeInfo({ requireLive: true })` failed while deriving a covenant. A
+ * snapshot would bind the covenant to a signer key the operator may no longer
+ * co-sign for, so this fails closed rather than falling back.
+ *
+ * Boundary: `quote()`, at covenant derivation — before funding.
+ */
+export class OperatorUnreachable extends Error {
+    override readonly name = "OperatorUnreachable";
+    constructor(detail: string, options?: ErrorOptions) {
+        super(`cannot derive a covenant: ${detail}`, options);
+    }
+}
+
+/**
+ * A corridor's dependency was explicitly overridden to nothing — the onchain
+ * chain source, the lightning decoder, the arkade repository.
+ *
+ * Boundary: `quote()`, when a route first touches that corridor. Never
+ * construction: a missing dep for a corridor nobody uses is not an error.
+ */
+export class MissingCorridorDep extends Error {
+    override readonly name = "MissingCorridorDep";
+    constructor(
+        readonly corridor: CorridorId,
+        readonly dep: string,
+    ) {
+        super(`the ${corridor} corridor has no ${dep}`);
+    }
+}
+
+/** Every member of the taxonomy. */
+export type SwapError =
+    | AmbiguousDestination
+    | UnsupportedRoute
+    | DiscoverySnapshotUnavailable
+    | AmountMismatch
+    | AmountEncodingUnsupported
+    | QuoteVerificationFailed
+    | SwapRefusal
+    | QuoteExpired
+    | MaxFeeExceeded
+    | InsufficientFunds
+    | AcceptConflict
+    | ClientDisposed
+    | NotCancellable
+    | InconsistentRoute
+    | OperatorUnreachable
+    | MissingCorridorDep;
+
+/** The sixteen names. Derived, so there is no second list to drift. */
+export type SwapErrorName = SwapError["name"];
+
+/**
+ * Name to class.
+ *
+ * The `satisfies` is what makes drift a compile error rather than a review
+ * catch: a member missing here fails the `Record`, an extra key fails the
+ * excess-property check, and a class whose `name` disagrees with its identifier
+ * fails both at once.
+ */
+const SWAP_ERRORS = {
+    AmbiguousDestination,
+    UnsupportedRoute,
+    DiscoverySnapshotUnavailable,
+    AmountMismatch,
+    AmountEncodingUnsupported,
+    QuoteVerificationFailed,
+    SwapRefusal,
+    QuoteExpired,
+    MaxFeeExceeded,
+    InsufficientFunds,
+    AcceptConflict,
+    ClientDisposed,
+    NotCancellable,
+    InconsistentRoute,
+    OperatorUnreachable,
+    MissingCorridorDep,
+} as const satisfies Record<SwapErrorName, new (...args: never[]) => SwapError>;
+
+/** The sixteen, as values — what the coverage pass counts. */
+export const SWAP_ERROR_NAMES = Object.keys(SWAP_ERRORS) as readonly SwapErrorName[];
+
+/**
+ * Whether `e` belongs to the taxonomy, optionally narrowed to one member.
+ *
+ * Catalog-driven rather than a chain of `instanceof`, so it stays total as
+ * members are added, and it rejects an impostor: a foreign error that happens to
+ * be named `QuoteExpired` fails the constructor check.
+ */
+export function isSwapError(e: unknown): e is SwapError;
+export function isSwapError<N extends SwapErrorName>(
+    e: unknown,
+    name: N,
+): e is Extract<SwapError, { name: N }>;
+export function isSwapError(e: unknown, name?: SwapErrorName): boolean {
+    if (!(e instanceof Error)) return false;
+    const table: Record<string, new (...args: never[]) => SwapError> = SWAP_ERRORS;
+    const ctor = table[e.name];
+    if (ctor === undefined || !(e instanceof ctor)) return false;
+    return name === undefined || e.name === name;
+}

--- a/packages/swap/src/client/index.ts
+++ b/packages/swap/src/client/index.ts
@@ -1,0 +1,13 @@
+/**
+ * The v2 client's vocabulary: asset identity, the corridor axis, the closed
+ * route union, the amount law, the alias layer and the error taxonomy.
+ *
+ * Internal to the package for now. M8 is what slims the root export to the v2
+ * surface and moves the v1 building blocks to `/protocol`; exporting any of
+ * this from `src/index.ts` today would publish a surface the milestones after
+ * this one are still deciding.
+ */
+export * from "./assetId";
+export * from "./corridor";
+export * from "./primitives";
+export * from "./route";

--- a/packages/swap/src/client/index.ts
+++ b/packages/swap/src/client/index.ts
@@ -7,8 +7,10 @@
  * this from `src/index.ts` today would publish a surface the milestones after
  * this one are still deciding.
  */
+export * from "./amount";
 export * from "./assetId";
 export * from "./corridor";
 export * from "./errors";
 export * from "./primitives";
+export * from "./rfqAmount";
 export * from "./route";

--- a/packages/swap/src/client/index.ts
+++ b/packages/swap/src/client/index.ts
@@ -9,5 +9,6 @@
  */
 export * from "./assetId";
 export * from "./corridor";
+export * from "./errors";
 export * from "./primitives";
 export * from "./route";

--- a/packages/swap/src/client/index.ts
+++ b/packages/swap/src/client/index.ts
@@ -7,6 +7,7 @@
  * this from `src/index.ts` today would publish a surface the milestones after
  * this one are still deciding.
  */
+export * from "./aliases";
 export * from "./amount";
 export * from "./assetId";
 export * from "./corridor";

--- a/packages/swap/src/client/primitives.ts
+++ b/packages/swap/src/client/primitives.ts
@@ -1,0 +1,14 @@
+/**
+ * The two string aliases the v2 surface is written in.
+ *
+ * Aliases rather than branded types: they document what a field carries at the
+ * places §3.1's `Quote` reads (`lock.hash`, `solver`) without making every
+ * literal go through a constructor. Core exports neither, so nothing here is a
+ * duplicate.
+ */
+
+/** Lowercase hex, no `0x` prefix — the encoding `@scure/base`'s `hex` emits. */
+export type Hex = string;
+
+/** A secp256k1 public key as {@link Hex}: x-only (32 bytes) or compressed (33). */
+export type Pubkey = Hex;

--- a/packages/swap/src/client/rfqAmount.ts
+++ b/packages/swap/src/client/rfqAmount.ts
@@ -1,0 +1,107 @@
+/**
+ * The RFQ wire's amount encoding, and the one place the wire's side vocabulary
+ * is translated.
+ *
+ * The target contract is canonical decimal strings in both directions, and the
+ * solver already landed them; ts-sdk is the lagging side and still emits and
+ * reads JSON numbers (`rfq.ts`'s `amount`, `from_amount`, `to_amount`). So this
+ * adapter emits strings unconditionally — emitting one is never a narrowing —
+ * and accepts either on the way in, a number only while it is a non-negative
+ * safe integer. Past 2^53 a JSON number has already lost the amount and there is
+ * nothing to narrow: {@link AmountEncodingUnsupported}, refused rather than
+ * rounded.
+ */
+import { isAmount } from "@arkade-os/solver-discovery";
+import { type AtomicDecimal, toAtomicDecimal } from "./amount";
+import { AmountEncodingUnsupported } from "./errors";
+
+/** Which side of the trade an amount pins, in v2's vocabulary. */
+export type AmountOn = "give" | "take";
+
+/** The same axis on the wire, where the key is `amount_side`. */
+export type RfqAmountSide = "from" | "to";
+
+/** v2 to the wire. One translation point, so the rename cannot spread. */
+export const toRfqAmountSide = (on: AmountOn): RfqAmountSide => (on === "give" ? "from" : "to");
+
+/** The wire back to v2. */
+export const fromRfqAmountSide = (side: RfqAmountSide): AmountOn =>
+    side === "from" ? "give" : "take";
+
+/**
+ * An amount out to the wire, as the canonical decimal string.
+ *
+ * `field` has no default: every throw on a quote would otherwise say `"amount"`,
+ * and telling `from_amount` from `to_amount` is the only thing it is for.
+ */
+export const encodeRfqAmount = (value: bigint, field: string): AtomicDecimal => {
+    try {
+        return toAtomicDecimal(value);
+    } catch (cause) {
+        throw new AmountEncodingUnsupported(
+            field,
+            `${value}`,
+            "the wire's canonical encoding cannot carry it",
+            { cause },
+        );
+    }
+};
+
+/**
+ * An amount in from the wire.
+ *
+ * Accepts the canonical string, or a JSON number inside the safe-integer window
+ * — the migration's compatibility arm, and the only place a number is tolerated
+ * anywhere in v2. A non-canonical string is this error too, not a verification
+ * failure: verification is the four semantic checks over a well-formed quote,
+ * and this fires before them.
+ */
+export const decodeRfqAmount = (raw: unknown, field: string): bigint => {
+    if (typeof raw === "string") {
+        if (!isAmount(raw)) {
+            throw new AmountEncodingUnsupported(
+                field,
+                raw,
+                "not a canonical decimal amount (unsigned, no leading zeros, 30 digits)",
+            );
+        }
+        return BigInt(raw);
+    }
+    if (typeof raw === "number") {
+        if (!Number.isSafeInteger(raw) || raw < 0) {
+            throw new AmountEncodingUnsupported(
+                field,
+                `${raw}`,
+                // Past 2^53 the number arrived already rounded — there is no
+                // "narrow carefully" branch, only a wrong amount.
+                "a JSON number amount is only readable as a non-negative safe integer",
+            );
+        }
+        return BigInt(raw);
+    }
+    throw new AmountEncodingUnsupported(
+        field,
+        typeof raw === "bigint" || typeof raw === "boolean" ? `${raw}` : String(raw),
+        `expected a decimal string, got ${typeof raw}`,
+    );
+};
+
+/**
+ * A `bigint` amount into a foreign `number` one, checked.
+ *
+ * Core's payment router types its amounts as `number` sats and M7's swap-backed
+ * rail narrows at that boundary rather than changing a published core type. The
+ * narrowing is sound because both sides are sats and a sat count past 2^53 is
+ * not a payment — but it has to be checked, which is why it lives here beside
+ * the error rather than as a bare `Number()` at the call site.
+ */
+export const toSafeNumber = (value: bigint, field: string): number => {
+    if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new AmountEncodingUnsupported(
+            field,
+            `${value}`,
+            "does not fit a non-negative safe integer",
+        );
+    }
+    return Number(value);
+};

--- a/packages/swap/src/client/route.ts
+++ b/packages/swap/src/client/route.ts
@@ -1,0 +1,89 @@
+/**
+ * A route is two endpoints, each an asset on a corridor, plus the instrument
+ * that settles it.
+ *
+ * Two invariants live in the types rather than in a check. An endpoint's
+ * corridor and its asset's rail cannot disagree, because {@link Endpoint} spells
+ * the asset as `AssetId<RailOf<C>>`. And `onchain -> arkade` is not in
+ * {@link Route} at all, so once a route has been resolved the misroute is a
+ * compile error; before resolution it is `UnsupportedRoute`, thrown ahead of
+ * RFQ disclosure, artifact creation, persistence and funding.
+ */
+import type { AssetId } from "./assetId";
+import type { CorridorId, RailOf } from "./corridor";
+import type { Hex } from "./primitives";
+
+/**
+ * A leg's concrete settlement locus. Direction comes from give versus take,
+ * never from the instrument.
+ *
+ * `{ kind: "wallet" }` is the only instrument the SDK holds signing authority
+ * over, which is why it is the only one nobody passes: `accept()` spends the
+ * balance and lands the claim on wallet legs and merely watches the others. The
+ * supply law is that the caller provides non-wallet take instruments (that is
+ * what `to` is), the quote provides non-wallet give instruments (that is
+ * exactly what the artifact is), and every remaining slot resolves to `wallet`.
+ *
+ * `wallet` is an explicit variant rather than an absent field because absence
+ * would mean two unrelated things — wallet-by-default and not-yet-resolved —
+ * and a receive leg lives in the second state until the quote returns.
+ */
+export type Instrument =
+    | { kind: "wallet" }
+    | { kind: "address"; address: string }
+    | {
+          kind: "invoice";
+          bolt11: string;
+          paymentHash: Hex;
+          amount?: bigint;
+          expiresAt: number;
+      };
+
+/**
+ * An asset on a corridor, with the instrument that settles it.
+ *
+ * `corridor` is a cross-check rather than an input: every id already carries
+ * its rail. Typing `asset` against that rail is what makes the cross-check free
+ * — there is no value in which the two disagree.
+ */
+export interface Endpoint<C extends CorridorId = CorridorId> {
+    corridor: C;
+    asset: AssetId<RailOf<C>>;
+    /** Resolved by the client, never constructed by callers. */
+    instrument: Instrument;
+}
+
+/** Shorthand for one corridor's endpoint, as the route union spells it. */
+export type Ep<C extends CorridorId> = Endpoint<C>;
+
+/**
+ * The implemented routes, as a closed union.
+ *
+ * `onchain -> arkade` is deliberately absent until the manager owns the
+ * trader's L1 refund path end to end.
+ */
+export type Route =
+    | { give: Ep<"arkade">; take: Ep<"arkade"> }
+    | { give: Ep<"arkade">; take: Ep<"lightning"> }
+    | { give: Ep<"lightning">; take: Ep<"arkade"> }
+    | { give: Ep<"arkade">; take: Ep<"onchain"> };
+
+/**
+ * The one thing a counterparty must see, when a route has one.
+ *
+ * The deposit variant carries no `chain` field. §3.4 reserved one and Q12 made
+ * it redundant: the chain part lives inside `asset`, and a second, untyped
+ * spelling of it is a fact two fields can disagree about with nothing checking.
+ * `corridor` stays because it is the typed axis `route.ts` already ties to the
+ * asset's rail — a cross-check, where `chain?: string | number` was a copy.
+ */
+export type Artifact =
+    | { kind: "invoice"; bolt11: string }
+    | {
+          kind: "deposit";
+          corridor: CorridorId;
+          address: string;
+          asset: AssetId;
+          amount: bigint;
+          expiresAt?: number;
+      };

--- a/packages/swap/src/client/route.ts
+++ b/packages/swap/src/client/route.ts
@@ -3,14 +3,15 @@
  * that settles it.
  *
  * Two invariants live in the types rather than in a check. An endpoint's
- * corridor and its asset's rail cannot disagree, because {@link Endpoint} spells
- * the asset as `AssetId<RailOf<C>>`. And `onchain -> arkade` is not in
+ * corridor and its asset cannot disagree, because {@link Endpoint} is a union
+ * with one member per corridor and each member types its asset as
+ * {@link AssetOn} of that one corridor. And `onchain -> arkade` is not in
  * {@link Route} at all, so once a route has been resolved the misroute is a
  * compile error; before resolution it is `UnsupportedRoute`, thrown ahead of
  * RFQ disclosure, artifact creation, persistence and funding.
  */
-import type { AssetId } from "./assetId";
-import type { CorridorId, RailOf } from "./corridor";
+import type { AssetId, AssetPart } from "./assetId";
+import type { Corridor, CorridorId, RailOf } from "./corridor";
 import type { Hex } from "./primitives";
 
 /**
@@ -40,18 +41,42 @@ export type Instrument =
       };
 
 /**
+ * The asset ids corridor `C` can carry.
+ *
+ * On the three bitcoin-family corridors the corridor names no network, so the
+ * tie is the rail alone. On an EVM corridor it is more than that: `eip155:8453`
+ * *is* the CAIP-2 chain part its assets are spelled with, so the asset id has to
+ * start with the corridor id verbatim. Enforcing only the rail there would admit
+ * `eip155:1/erc20:…` on a Base corridor — the same near-miss `sameAsset` refuses
+ * one layer up, an address being a chain's fact and not a token's.
+ */
+export type AssetOn<C extends CorridorId> = C extends Corridor
+    ? AssetId<RailOf<C>>
+    : `${C}/${AssetPart}`;
+
+/**
  * An asset on a corridor, with the instrument that settles it.
  *
  * `corridor` is a cross-check rather than an input: every id already carries
  * its rail. Typing `asset` against that rail is what makes the cross-check free
  * — there is no value in which the two disagree.
+ *
+ * Distributed over `C` rather than written as one object whose two fields both
+ * mention it: `{ corridor: C; asset: AssetOn<C> }` at `C = CorridorId` widens
+ * *each field independently* to its own union, and correlates nothing —
+ * `{ corridor: "arkade", asset: "bitcoin:…" }` satisfies it. The conditional
+ * makes `Endpoint` the union of the four single-corridor shapes instead, so the
+ * pairing survives the default type argument, which is the case every unwitnessed
+ * `Endpoint` in a signature lands on.
  */
-export interface Endpoint<C extends CorridorId = CorridorId> {
-    corridor: C;
-    asset: AssetId<RailOf<C>>;
-    /** Resolved by the client, never constructed by callers. */
-    instrument: Instrument;
-}
+export type Endpoint<C extends CorridorId = CorridorId> = C extends CorridorId
+    ? {
+          corridor: C;
+          asset: AssetOn<C>;
+          /** Resolved by the client, never constructed by callers. */
+          instrument: Instrument;
+      }
+    : never;
 
 /** Shorthand for one corridor's endpoint, as the route union spells it. */
 export type Ep<C extends CorridorId> = Endpoint<C>;
@@ -77,13 +102,20 @@ export type Route =
  * `corridor` stays because it is the typed axis `route.ts` already ties to the
  * asset's rail — a cross-check, where `chain?: string | number` was a copy.
  */
-export type Artifact =
-    | { kind: "invoice"; bolt11: string }
-    | {
+export type Artifact = { kind: "invoice"; bolt11: string } | DepositArtifact;
+
+/**
+ * The deposit half of {@link Artifact}, distributed over the corridor for the
+ * reason {@link Endpoint} is: `corridor` is only a cross-check if a value cannot
+ * spell it against an asset from another corridor.
+ */
+export type DepositArtifact<C extends CorridorId = CorridorId> = C extends CorridorId
+    ? {
           kind: "deposit";
-          corridor: CorridorId;
+          corridor: C;
           address: string;
-          asset: AssetId;
+          asset: AssetOn<C>;
           amount: bigint;
           expiresAt?: number;
-      };
+      }
+    : never;

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -149,11 +149,14 @@ export const RFQ_TERMINAL_STATES = ["settled", "refused", "expired", "refunded",
 
 /** A refusal from the solver, carrying its closed-set reason. */
 export class SwapRefusal extends Error {
+    /** Literal-typed so the v2 error taxonomy's union discriminates on `name`
+     * — a `string` here collapses the discriminant for every member. Same value
+     * the constructor has always set, moved to a field initializer. */
+    override readonly name = "SwapRefusal";
     readonly reason: string;
     readonly rfqId: string | undefined;
     constructor(reason: string, rfqId?: string) {
         super(`solver refused: ${reason}`);
-        this.name = "SwapRefusal";
         this.reason = reason;
         this.rfqId = rfqId;
     }

--- a/packages/swap/test/client/aliases.test.ts
+++ b/packages/swap/test/client/aliases.test.ts
@@ -1,0 +1,120 @@
+import { asset } from "@arkade-os/sdk";
+import { describe, expect, it } from "vitest";
+import { BTC_ASSET_ID } from "../../src/store";
+import { arkadeAsset, btcOn } from "../../src/client/assetId";
+import { type AssetAliasTable, canonicalAssetId, toDiscoveryLeg } from "../../src/client/aliases";
+
+const NETWORK = "regtest";
+const issued = (hex: string): asset.AssetId => asset.AssetId.fromString(hex);
+
+const USD = arkadeAsset(NETWORK, issued(`${"11".repeat(32)}0000`));
+const CHF = arkadeAsset(NETWORK, issued(`${"22".repeat(32)}0000`));
+
+const table: AssetAliasTable = {
+    network: NETWORK,
+    assets: [
+        { id: btcOn("arkade", NETWORK), ticker: "BTC" },
+        { id: USD, ticker: "USD" },
+        { id: CHF, ticker: "CHF" },
+        // another network's listing, so the scoping rule has something to drop
+        { id: arkadeAsset("bitcoin", issued(`${"33".repeat(32)}0000`)), ticker: "USD" },
+    ],
+};
+
+describe("public ids down to discovery legs", () => {
+    it("covers every leg of the four implemented routes", () => {
+        expect(toDiscoveryLeg(btcOn("arkade", NETWORK))).toEqual({
+            corridor: "arkade",
+            assetId: BTC_ASSET_ID,
+        });
+        expect(toDiscoveryLeg(btcOn("bolt11", NETWORK))).toEqual({
+            corridor: "lightning",
+            assetId: BTC_ASSET_ID,
+        });
+        expect(toDiscoveryLeg(btcOn("bitcoin", NETWORK))).toEqual({
+            corridor: "onchain",
+            assetId: BTC_ASSET_ID,
+        });
+        expect(toDiscoveryLeg(USD)).toEqual({
+            corridor: "arkade",
+            assetId: `${"11".repeat(32)}0000`,
+        });
+    });
+
+    it("carries the covenant identity through byte for byte", () => {
+        const V = asset.ASSET_ID_VECTORS;
+        for (const v of V.valid) {
+            const leg = toDiscoveryLeg(arkadeAsset(NETWORK, issued(v.asset_id_hex)));
+            expect(leg.assetId, `identity drifted (${v.label})`).toBe(v.asset_id_hex);
+            expect(asset.AssetId.fromString(leg.assetId).toString()).toBe(v.asset_id_hex);
+        }
+    });
+
+    it("is rail-blind about BTC and rail-specific about everything else", () => {
+        // Three public ids, one discovery leg per corridor: the alias layer
+        // runs one way, and the reverse is not a function.
+        const legs = (["arkade", "bolt11", "bitcoin"] as const).map((rail) =>
+            toDiscoveryLeg(btcOn(rail, NETWORK)),
+        );
+        expect(new Set(legs.map((l) => l.assetId))).toEqual(new Set([BTC_ASSET_ID]));
+        expect(legs.map((l) => l.corridor)).toEqual(["arkade", "lightning", "onchain"]);
+    });
+
+    it.each([
+        [
+            "an asset on lightning, which carries BTC only",
+            `bolt11:${NETWORK}/asset:${"aa".repeat(34)}` as const,
+        ],
+        ["an asset on L1", `bitcoin:${NETWORK}/asset:${"aa".repeat(34)}` as const],
+        ["an unknown namespace on arkade", `arkade:${NETWORK}/slip44:60` as const],
+        [
+            "an eip155 id, which is grammar-valid and unserved",
+            "eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7" as const,
+        ],
+    ])("refuses %s", (_label, id) => {
+        expect(() => toDiscoveryLeg(id)).toThrowError(
+            expect.objectContaining({ name: "UnsupportedRoute" }),
+        );
+    });
+});
+
+describe("caller input to a public id", () => {
+    it("passes an id through", () => {
+        expect(canonicalAssetId(btcOn("arkade", NETWORK), table)).toBe(btcOn("arkade", NETWORK));
+    });
+
+    it("canonicalises a ticker case-insensitively", () => {
+        expect(canonicalAssetId("btc", table)).toBe(btcOn("arkade", NETWORK));
+        expect(canonicalAssetId("BTC", table)).toBe(btcOn("arkade", NETWORK));
+        expect(canonicalAssetId("uSd", table)).toBe(USD);
+    });
+
+    it("scopes tickers to the wallet's network", () => {
+        // The mainnet USD row is in the table and must not answer here.
+        expect(canonicalAssetId("USD", table)).toBe(USD);
+    });
+
+    it("rejects a collision rather than guessing", () => {
+        const colliding: AssetAliasTable = {
+            network: NETWORK,
+            assets: [...table.assets, { id: CHF, ticker: "USD" }],
+        };
+        expect(() => canonicalAssetId("USD", colliding)).toThrowError(
+            expect.objectContaining({ name: "AssetIdError", reason: "ambiguous_alias" }),
+        );
+    });
+
+    it("tolerates a registry listing one asset twice", () => {
+        const duplicated: AssetAliasTable = {
+            network: NETWORK,
+            assets: [...table.assets, { id: USD, ticker: "usd" }],
+        };
+        expect(canonicalAssetId("USD", duplicated)).toBe(USD);
+    });
+
+    it("refuses a ticker nothing on this network answers to", () => {
+        expect(() => canonicalAssetId("USDT", table)).toThrowError(
+            expect.objectContaining({ name: "AssetIdError", reason: "unknown_alias" }),
+        );
+    });
+});

--- a/packages/swap/test/client/amount.test.ts
+++ b/packages/swap/test/client/amount.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+    Amount,
+    AmountFormatError,
+    fromAtomicDecimal,
+    toAtomicDecimal,
+} from "../../src/client/amount";
+
+const BTC = { decimals: 8 };
+const ETH = { decimals: 18 };
+const SATS = { decimals: 0 };
+
+describe("the scaled decimal, at the UI edge", () => {
+    it("round-trips at 8 decimals", () => {
+        expect(Amount.parse("0.01", BTC)).toBe(1_000_000n);
+        expect(Amount.format(1_000_000n, BTC)).toBe("0.01");
+        expect(Amount.format(Amount.parse("21000000", BTC), BTC)).toBe("21000000");
+    });
+
+    it("round-trips at 18 decimals, where a float would already be wrong", () => {
+        expect(Amount.parse("1.000000000000000001", ETH)).toBe(1_000_000_000_000_000_001n);
+        expect(Amount.format(1_000_000_000_000_000_001n, ETH)).toBe("1.000000000000000001");
+    });
+
+    it("is the identity at 0 decimals", () => {
+        expect(Amount.parse("100000", SATS)).toBe(100_000n);
+        expect(Amount.format(100_000n, SATS)).toBe("100000");
+    });
+
+    it("refuses a finer amount rather than truncating it", () => {
+        // A truncated amount is a swap for the wrong size, and nothing
+        // downstream can tell it was ever a different number.
+        expect(() => Amount.parse("0.000000001", BTC)).toThrowError(
+            expect.objectContaining({ name: "AmountFormatError", reason: "too_precise" }),
+        );
+    });
+
+    it.each([
+        ["a JS number's spelling of sats", "1e5"],
+        ["a negative", "-1"],
+        ["leading whitespace", " 1"],
+        ["a bare point", "1."],
+        ["a leading point", ".5"],
+        ["nothing at all", ""],
+        ["a word", "abc"],
+        ["a thousands separator", "1,000"],
+    ])("refuses %s", (_label, input) => {
+        expect(() => Amount.parse(input, BTC)).toThrowError(
+            expect.objectContaining({ name: "AmountFormatError", reason: "not_decimal" }),
+        );
+    });
+
+    it("refuses an asset scale no registry can advertise", () => {
+        expect(() => Amount.parse("1", { decimals: 19 })).toThrowError(
+            expect.objectContaining({ reason: "invalid_decimals" }),
+        );
+        expect(() => Amount.format(1n, { decimals: -1 })).toThrowError(
+            expect.objectContaining({ reason: "invalid_decimals" }),
+        );
+    });
+
+    it("refuses a negative obligation", () => {
+        expect(() => Amount.format(-1n, BTC)).toThrowError(
+            expect.objectContaining({ reason: "negative" }),
+        );
+    });
+});
+
+describe("the atomic decimal, at the record and wire edge", () => {
+    it("is the same integer written out, never scaled", () => {
+        // The distinction this pair exists for: 1_000_000n is "0.01" to a user
+        // and "1000000" to a record, and conflating them is the v1 footgun.
+        expect(toAtomicDecimal(1_000_000n)).toBe("1000000");
+        expect(Amount.format(1_000_000n, BTC)).toBe("0.01");
+        expect(fromAtomicDecimal("1000000")).toBe(1_000_000n);
+        expect(toAtomicDecimal(0n)).toBe("0");
+    });
+
+    it("holds an amount no JSON number could", () => {
+        const big = 10n ** 29n;
+        expect(fromAtomicDecimal(toAtomicDecimal(big))).toBe(big);
+        expect(Number.isSafeInteger(Number(big))).toBe(false);
+    });
+
+    it("refuses anything outside the canonical form", () => {
+        expect(() => toAtomicDecimal(-1n)).toThrowError(
+            expect.objectContaining({ reason: "negative" }),
+        );
+        // 31 digits, past the wire's bound.
+        expect(() => toAtomicDecimal(10n ** 30n)).toThrowError(
+            expect.objectContaining({ reason: "too_large" }),
+        );
+        for (const bad of ["01", "1.0", "", "-1", " 1", "1e5"]) {
+            expect(() => fromAtomicDecimal(bad), bad).toThrow(AmountFormatError);
+        }
+    });
+});

--- a/packages/swap/test/client/amount.types.ts
+++ b/packages/swap/test/client/amount.types.ts
@@ -1,0 +1,34 @@
+/**
+ * Type-level assertions for the amount law. Checked by `tsconfig.test.json`,
+ * which the package's `typecheck` script runs, so every `@ts-expect-error` here
+ * is an assertion CI enforces — and one that stops erroring fails the build.
+ */
+import {
+    Amount,
+    type AtomicDecimal,
+    type DisplayDecimal,
+    fromAtomicDecimal,
+    toAtomicDecimal,
+} from "../../src/client/amount";
+
+const BTC = { decimals: 8 };
+
+/** A display decimal comes off a text input as a plain string; no constructor. */
+export const fromInput: DisplayDecimal = "0.01";
+export const parsed: bigint = Amount.parse(fromInput, BTC);
+export const rendered: string = Amount.format(1_000_000n, BTC);
+
+const atomic: AtomicDecimal = toAtomicDecimal(1_000_000n);
+
+// The one defect on this surface a type can catch outright: reading a record's
+// "1000000" sats back as 1,000,000 BTC.
+// @ts-expect-error an atomic decimal is not a display decimal
+export const misread: bigint = Amount.parse(atomic, BTC);
+
+// ...and the safe direction stays cast-free, because a record read and a
+// JSON.parse both hand back a plain string.
+export const fromRecord: bigint = fromAtomicDecimal("1000000");
+
+const claimed = "1000000";
+// @ts-expect-error only the codec mints an atomic decimal
+export const forged: AtomicDecimal = claimed;

--- a/packages/swap/test/client/assetId.test.ts
+++ b/packages/swap/test/client/assetId.test.ts
@@ -1,0 +1,165 @@
+import { asset } from "@arkade-os/sdk";
+import { describe, expect, it } from "vitest";
+import {
+    AssetIdError,
+    arkadeAsset,
+    assetPartOf,
+    bitcoinNetworkOf,
+    btcOn,
+    formatAssetId,
+    isAssetId,
+    issuanceOf,
+    parseAssetId,
+    railOf,
+    sameAsset,
+} from "../../src/client/assetId";
+
+const BTC_ON_ARKADE = "arkade:bitcoin/slip44:0";
+const issued = (hex: string): asset.AssetId => asset.AssetId.fromString(hex);
+
+describe("asset id grammar", () => {
+    it("parses the chain part as rail plus network", () => {
+        expect(parseAssetId(BTC_ON_ARKADE)).toEqual({
+            rail: "arkade",
+            reference: "bitcoin",
+            assetNamespace: "slip44",
+            assetReference: "0",
+        });
+    });
+
+    it("round-trips every id it accepts", () => {
+        const ids = [
+            BTC_ON_ARKADE,
+            "bitcoin:regtest/slip44:0",
+            "bolt11:signet/slip44:0",
+            `arkade:regtest/asset:${"a1".repeat(32)}0000`,
+            "eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7",
+        ];
+        for (const id of ids) {
+            expect(formatAssetId(parseAssetId(id))).toBe(id);
+        }
+    });
+
+    it("names the rail as the CAIP-2 namespace, so lightning is bolt11", () => {
+        expect(railOf("bolt11:bitcoin/slip44:0")).toBe("bolt11");
+        // `lightning` is nine characters, over CAIP-2's eight-character cap:
+        // the reason the rail is not simply the corridor's name.
+        expect(() => parseAssetId("lightning:bitcoin/slip44:0")).toThrow(AssetIdError);
+    });
+
+    it("admits every network core resolves, not only the indexed ones", () => {
+        // `testnet` has no market index. It still has assets, and amputating
+        // the identity to match the index would make them unnameable.
+        expect(bitcoinNetworkOf("arkade:testnet/slip44:0")).toBe("testnet");
+        expect(bitcoinNetworkOf("bitcoin:regtest/slip44:0")).toBe("regtest");
+        expect(bitcoinNetworkOf("eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7")).toBe(
+            undefined,
+        );
+    });
+
+    describe("refusals", () => {
+        const cases: ReadonlyArray<[string, string, string]> = [
+            ["a bare 0x address", "0xdac17f958d2ee523a2206206994597c13d831ec7", "malformed"],
+            ["no asset part", "arkade:bitcoin", "malformed"],
+            ["no asset namespace", "arkade:bitcoin/slip440", "malformed"],
+            ["a nine-character namespace", "lightning:bitcoin/slip44:0", "unknown_rail"],
+            ["a rail nobody implements", "solana:mainnet/slip44:501", "unknown_rail"],
+            ["a network nobody runs", "arkade:liquid/slip44:0", "unknown_network"],
+            ["an eip155 chain id with a leading zero", "eip155:01/erc20:0x00", "invalid_chain_id"],
+            [
+                "a colon in the asset reference",
+                "arkade:bitcoin/slip44:0:1",
+                "invalid_asset_reference",
+            ],
+            ["a CAIP-19 token id", "eip155:1/erc721:0xabc/1", "token_id_unsupported"],
+            [
+                "an asset namespace nothing serves",
+                "arkade:bitcoin/erc721:0",
+                "unknown_asset_namespace",
+            ],
+            [
+                "an EIP-55 checksummed reference",
+                "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                "uppercase",
+            ],
+            [
+                "an arkade reference that is not the identity form",
+                "arkade:bitcoin/asset:notanidentity",
+                "invalid_asset_reference",
+            ],
+            [
+                "an identity core itself refuses",
+                `arkade:bitcoin/asset:${"00".repeat(32)}0000`,
+                "invalid_asset_reference",
+            ],
+        ];
+        for (const [label, value, reason] of cases) {
+            it(`refuses ${label}`, () => {
+                expect(isAssetId(value)).toBe(false);
+                expect(() => parseAssetId(value)).toThrowError(
+                    expect.objectContaining({ name: "AssetIdError", reason }),
+                );
+            });
+        }
+    });
+});
+
+describe("sameness across rails", () => {
+    it("is the shared asset part, not a shared id", () => {
+        // The whole reason the rail is the namespace: one BTC per rail, and
+        // sameness stays a comparison instead of a string both sides must agree on.
+        expect(sameAsset(btcOn("arkade", "bitcoin"), btcOn("bitcoin", "bitcoin"))).toBe(true);
+        expect(sameAsset(btcOn("bolt11", "bitcoin"), btcOn("arkade", "bitcoin"))).toBe(true);
+        expect(btcOn("arkade", "bitcoin")).not.toBe(btcOn("bitcoin", "bitcoin"));
+        expect(assetPartOf(btcOn("arkade", "regtest"))).toBe("slip44:0");
+    });
+
+    it("does not confuse two arkade assets", () => {
+        const one = arkadeAsset("regtest", issued(`${"a1".repeat(32)}0000`));
+        const two = arkadeAsset("regtest", issued(`${"a1".repeat(32)}0100`));
+        expect(sameAsset(one, two)).toBe(false);
+    });
+
+    it("keeps BTC and an issued asset apart on the same rail", () => {
+        const asset0 = arkadeAsset("bitcoin", issued(`${"ff".repeat(32)}0000`));
+        expect(sameAsset(asset0, btcOn("arkade", "bitcoin"))).toBe(false);
+        expect(issuanceOf(btcOn("arkade", "bitcoin"))).toBe(undefined);
+    });
+});
+
+/**
+ * The identity form is implemented in seven places across three repos and every
+ * disagreement between them fails silently, which is what the shared vectors
+ * exist to catch. The public id adds no eighth spelling: its asset reference is
+ * `AssetId.toString()` verbatim.
+ */
+describe("arkade asset ids, against the shared vector", () => {
+    const V = asset.ASSET_ID_VECTORS;
+    const drift = (label: string) => `asset id encoding drifted from ASSET_ID_VECTORS (${label})`;
+
+    V.valid.forEach((v) => {
+        it(`carries the identity form verbatim -- ${v.label}`, () => {
+            const id = arkadeAsset("regtest", asset.AssetId.create(V.txid_hex, v.group_index));
+            expect(id, drift(v.label)).toBe(`arkade:regtest/asset:${v.asset_id_hex}`);
+            expect(parseAssetId(id).assetReference, drift(v.label)).toMatch(/^[0-9a-f]{68}$/);
+            // ...and the same 34 bytes back out.
+            expect(issuanceOf(id)?.serialize(), drift(v.label)).toEqual(
+                asset.AssetId.fromString(v.asset_id_hex).serialize(),
+            );
+        });
+    });
+
+    V.invalid_identity
+        .filter((v) => v.normalizes_to !== undefined)
+        .forEach((v) => {
+            it(`normalises through core rather than propagating -- ${v.label}`, () => {
+                // Taking an `asset.AssetId` rather than a string is what
+                // enforces the case rule: `hex.decode` accepts uppercase and
+                // `hex.encode` emits only lowercase.
+                expect(arkadeAsset("regtest", issued(v.value)), drift(v.label)).toBe(
+                    `arkade:regtest/asset:${v.normalizes_to}`,
+                );
+                expect(() => parseAssetId(`arkade:regtest/asset:${v.value}`)).toThrow(AssetIdError);
+            });
+        });
+});

--- a/packages/swap/test/client/assetId.test.ts
+++ b/packages/swap/test/client/assetId.test.ts
@@ -105,7 +105,7 @@ describe("asset id grammar", () => {
 });
 
 describe("sameness across rails", () => {
-    it("is the shared asset part, not a shared id", () => {
+    it("crosses rails without a shared id", () => {
         // The whole reason the rail is the namespace: one BTC per rail, and
         // sameness stays a comparison instead of a string both sides must agree on.
         expect(sameAsset(btcOn("arkade", "bitcoin"), btcOn("bitcoin", "bitcoin"))).toBe(true);
@@ -124,6 +124,25 @@ describe("sameness across rails", () => {
         const asset0 = arkadeAsset("bitcoin", issued(`${"ff".repeat(32)}0000`));
         expect(sameAsset(asset0, btcOn("arkade", "bitcoin"))).toBe(false);
         expect(issuanceOf(btcOn("arkade", "bitcoin"))).toBe(undefined);
+    });
+
+    it("drops the rail and nothing else: the network still has to agree", () => {
+        // Regtest BTC settles nothing on mainnet, on either rail. The asset
+        // part is identical in all four of these; the reference is what parts
+        // them.
+        expect(sameAsset(btcOn("arkade", "regtest"), btcOn("bitcoin", "bitcoin"))).toBe(false);
+        expect(sameAsset(btcOn("arkade", "regtest"), btcOn("arkade", "bitcoin"))).toBe(false);
+        expect(sameAsset(btcOn("bolt11", "signet"), btcOn("bolt11", "testnet"))).toBe(false);
+        expect(sameAsset(btcOn("arkade", "regtest"), btcOn("bitcoin", "regtest"))).toBe(true);
+    });
+
+    it("does not confuse a token with its address twin on another chain", () => {
+        // A contract address is unique to a chain, not across chains: the same
+        // address is deployed on many EVM chains, and comparing the asset part
+        // alone would make every one of them the same asset.
+        const usdt = "erc20:0xdac17f958d2ee523a2206206994597c13d831ec7";
+        expect(sameAsset(`eip155:1/${usdt}`, `eip155:10/${usdt}`)).toBe(false);
+        expect(sameAsset(`eip155:1/${usdt}`, `eip155:1/${usdt}`)).toBe(true);
     });
 });
 

--- a/packages/swap/test/client/corridor.test.ts
+++ b/packages/swap/test/client/corridor.test.ts
@@ -1,0 +1,40 @@
+import { CORRIDORS as DISCOVERY_CORRIDORS } from "@arkade-os/solver-discovery";
+import { describe, expect, it } from "vitest";
+import { BITCOIN_RAILS, railOf } from "../../src/client/assetId";
+import { CORRIDORS, corridorOfRail, railOfCorridor } from "../../src/client/corridor";
+
+describe("the corridor axis and its rails", () => {
+    it("keeps discovery's corridor set verbatim", () => {
+        // Aliased rather than re-declared: a re-declaration would drift
+        // silently the day discovery adds a corridor.
+        expect([...CORRIDORS].sort()).toEqual([...DISCOVERY_CORRIDORS].sort());
+    });
+
+    it("is a bijection with the bitcoin-family rails", () => {
+        for (const corridor of CORRIDORS) {
+            expect(corridorOfRail(railOfCorridor(corridor))).toBe(corridor);
+        }
+        for (const rail of BITCOIN_RAILS) {
+            expect(railOfCorridor(corridorOfRail(rail) ?? "arkade")).toBe(rail);
+        }
+    });
+
+    it("disagrees with discovery on exactly one member, and names it bolt11", () => {
+        expect(railOfCorridor("arkade")).toBe("arkade");
+        expect(railOfCorridor("onchain")).toBe("bitcoin");
+        expect(railOfCorridor("lightning")).toBe("bolt11");
+    });
+
+    it("puts every EVM chain on the eip155 rail", () => {
+        expect(railOfCorridor("eip155:8453")).toBe("eip155");
+        // ...and cannot invert it: the corridor id carries a chain reference
+        // this side has no way to invent.
+        expect(corridorOfRail("eip155")).toBe(undefined);
+    });
+
+    it("agrees with the rail an asset id spells", () => {
+        expect(railOf("bolt11:bitcoin/slip44:0")).toBe(railOfCorridor("lightning"));
+        expect(railOf("bitcoin:bitcoin/slip44:0")).toBe(railOfCorridor("onchain"));
+        expect(railOf("arkade:bitcoin/slip44:0")).toBe(railOfCorridor("arkade"));
+    });
+});

--- a/packages/swap/test/client/errors.test.ts
+++ b/packages/swap/test/client/errors.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { AddressMismatch, SwapRefusal } from "../../src/rfq";
+import {
+    AcceptConflict,
+    AmbiguousDestination,
+    AmountEncodingUnsupported,
+    AmountMismatch,
+    ClientDisposed,
+    DiscoverySnapshotUnavailable,
+    InconsistentRoute,
+    InsufficientFunds,
+    MaxFeeExceeded,
+    MissingCorridorDep,
+    NotCancellable,
+    OperatorUnreachable,
+    QuoteExpired,
+    QuoteVerificationFailed,
+    SWAP_ERROR_NAMES,
+    type SwapError,
+    type SwapErrorName,
+    UnsupportedRoute,
+    isSwapError,
+} from "../../src/client/errors";
+
+const BTC = "arkade:regtest/slip44:0" as const;
+
+/** One instance per member, so the coverage assertion has something to count. */
+const every: readonly SwapError[] = [
+    new AmbiguousDestination("0xdeadbeef", "no corridor claims it"),
+    new UnsupportedRoute("onchain -> arkade", { give: "onchain", take: "arkade" }),
+    new DiscoverySnapshotUnavailable("regtest", "no cached snapshot"),
+    new AmountMismatch(["amount", "the invoice"]),
+    new AmountEncodingUnsupported("to_amount", "9007199254740992", "past the safe-integer range"),
+    new QuoteVerificationFailed("lockup_address", "tark1derived", "tark1quoted"),
+    new SwapRefusal("amount_out_of_range", "rfq-1"),
+    new QuoteExpired("quote-1", 1_700_000_000, 1_700_000_060),
+    new MaxFeeExceeded("quote-1", BTC, 120n, 100n),
+    new InsufficientFunds(BTC, 50_000n, 10_000n),
+    new AcceptConflict("quote-1", "swap-1", ["take.amount", "refundLocktime"]),
+    new ClientDisposed("quote"),
+    new NotCancellable("swap-1"),
+    new InconsistentRoute(BTC, "bc1qexample"),
+    new OperatorUnreachable("the operator did not answer"),
+    new MissingCorridorDep("onchain", "chain source"),
+];
+
+describe("the swap error taxonomy", () => {
+    it("has exactly the sixteen members §7 declares", () => {
+        expect(SWAP_ERROR_NAMES).toHaveLength(16);
+        expect(new Set(SWAP_ERROR_NAMES).size).toBe(16);
+    });
+
+    it("declares one class per member, and none spare", () => {
+        // What the coverage pass checks against: a member with no class is a
+        // member nothing can throw.
+        const built = every.map((e) => e.name);
+        expect(new Set(built)).toEqual(new Set<SwapErrorName>(SWAP_ERROR_NAMES));
+    });
+
+    it("carries a message that identifies the condition without the fields", () => {
+        // Own properties and a custom `name` do not survive structured clone,
+        // so the message has to stand on its own across a worker boundary.
+        for (const error of every) {
+            expect(error.message.length, error.name).toBeGreaterThan(0);
+        }
+    });
+
+    it("recognises every member, including the protocol's own class", () => {
+        for (const error of every) expect(isSwapError(error), error.name).toBe(true);
+        expect(isSwapError(new SwapRefusal("rate_limited"))).toBe(true);
+    });
+
+    it("narrows to one member on request", () => {
+        const error: unknown = new QuoteExpired("quote-1", 1_700_000_000, 1_700_000_060);
+        expect(isSwapError(error, "QuoteExpired")).toBe(true);
+        expect(isSwapError(error, "AcceptConflict")).toBe(false);
+        if (isSwapError(error, "QuoteExpired")) {
+            expect(error.quoteId).toBe("quote-1");
+        }
+    });
+
+    it("claims nothing it did not throw", () => {
+        expect(isSwapError(new Error("boom"))).toBe(false);
+        expect(isSwapError("boom")).toBe(false);
+        // An impostor wearing a member's name is still not a member — which a
+        // chain of `instanceof` against a shared base could not tell.
+        const impostor = new Error("boom");
+        impostor.name = "QuoteExpired";
+        expect(isSwapError(impostor)).toBe(false);
+    });
+
+    it("does not admit v1's AddressMismatch as a seventeenth member", () => {
+        // M3 folds it into QuoteVerificationFailed's lockup_address check, and
+        // M8 gives it the /protocol re-export and the @deprecated pointer.
+        expect(isSwapError(new AddressMismatch("tark1derived", "tark1quoted"))).toBe(false);
+    });
+
+    it("keeps the evidence a caller acts on", () => {
+        expect(new AcceptConflict("quote-1", "swap-1", ["take.amount"]).fields).toEqual([
+            "take.amount",
+        ]);
+        const refusal = new SwapRefusal("exposure_cap", "rfq-9");
+        expect([refusal.reason, refusal.rfqId]).toEqual(["exposure_cap", "rfq-9"]);
+        expect(new MissingCorridorDep("lightning", "decode").dep).toBe("decode");
+        expect(new MaxFeeExceeded("quote-1", BTC, 120n, 100n).fee).toBe(120n);
+        expect(new UnsupportedRoute("no market", { give: "arkade" }).take).toBe(undefined);
+    });
+});

--- a/packages/swap/test/client/rfqAmount.test.ts
+++ b/packages/swap/test/client/rfqAmount.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+    decodeRfqAmount,
+    encodeRfqAmount,
+    fromRfqAmountSide,
+    toRfqAmountSide,
+    toSafeNumber,
+} from "../../src/client/rfqAmount";
+
+describe("the RFQ amount adapter", () => {
+    it("emits the canonical decimal string, never a number", () => {
+        expect(encodeRfqAmount(100_000n, "amount")).toBe("100000");
+        expect(encodeRfqAmount(0n, "amount")).toBe("0");
+        expect(encodeRfqAmount(10n ** 29n, "amount")).toBe(`1${"0".repeat(29)}`);
+    });
+
+    it("reads the canonical decimal string back exactly", () => {
+        expect(decodeRfqAmount("100000", "amount")).toBe(100_000n);
+        const past2p53 = 12_345_678_901_234_567_890n;
+        expect(decodeRfqAmount(past2p53.toString(), "from_amount")).toBe(past2p53);
+    });
+
+    it("accepts a JSON number only inside the safe-integer window", () => {
+        // The migration's compatibility arm: the solver landed strings, this
+        // side has not, so a number still arrives — but only where it is still
+        // the number that was sent.
+        expect(decodeRfqAmount(0, "amount")).toBe(0n);
+        expect(decodeRfqAmount(Number.MAX_SAFE_INTEGER, "amount")).toBe(
+            BigInt(Number.MAX_SAFE_INTEGER),
+        );
+        expect(() => decodeRfqAmount(Number.MAX_SAFE_INTEGER + 1, "to_amount")).toThrowError(
+            expect.objectContaining({ name: "AmountEncodingUnsupported", field: "to_amount" }),
+        );
+    });
+
+    it.each([
+        ["a non-integer", 1.5],
+        ["a negative", -1],
+        ["a decimal string with a point", "1.0"],
+        ["a leading zero", "01"],
+        ["null", null],
+        ["undefined", undefined],
+        ["a bigint the wire cannot carry", 1n],
+    ])("refuses %s", (_label, raw) => {
+        expect(() => decodeRfqAmount(raw, "amount")).toThrowError(
+            expect.objectContaining({ name: "AmountEncodingUnsupported" }),
+        );
+    });
+
+    it("refuses to emit what the wire cannot hold", () => {
+        expect(() => encodeRfqAmount(-1n, "amount")).toThrowError(
+            expect.objectContaining({ name: "AmountEncodingUnsupported" }),
+        );
+        expect(() => encodeRfqAmount(10n ** 30n, "from_amount")).toThrowError(
+            expect.objectContaining({ field: "from_amount" }),
+        );
+    });
+
+    it("narrows to a foreign number amount only where it is exact", () => {
+        // Core's payment router types its sats as `number`; M7's rail crosses
+        // that boundary here rather than with a bare `Number()`.
+        expect(toSafeNumber(100_000n, "amount")).toBe(100_000);
+        expect(toSafeNumber(BigInt(Number.MAX_SAFE_INTEGER), "amount")).toBe(
+            Number.MAX_SAFE_INTEGER,
+        );
+        for (const bad of [-1n, BigInt(Number.MAX_SAFE_INTEGER) + 1n]) {
+            expect(() => toSafeNumber(bad, "total"), `${bad}`).toThrowError(
+                expect.objectContaining({ name: "AmountEncodingUnsupported", field: "total" }),
+            );
+        }
+    });
+
+    it("owns the side rename, so it cannot spread", () => {
+        expect(toRfqAmountSide("give")).toBe("from");
+        expect(toRfqAmountSide("take")).toBe("to");
+        expect(fromRfqAmountSide("from")).toBe("give");
+        expect(fromRfqAmountSide("to")).toBe("take");
+    });
+});

--- a/packages/swap/test/client/route.types.ts
+++ b/packages/swap/test/client/route.types.ts
@@ -1,0 +1,54 @@
+/**
+ * Type-level assertions for the route union. Not a vitest file: it is checked
+ * by `tsconfig.test.json`, which the package's `typecheck` script runs, so
+ * every `@ts-expect-error` below is an assertion CI enforces. A `@ts-expect-error`
+ * that stops erroring fails the build.
+ */
+import type { AssetId } from "../../src/client/assetId";
+import type { Ep, Instrument, Route } from "../../src/client/route";
+
+const wallet: Instrument = { kind: "wallet" };
+
+export const arkadeBtc: Ep<"arkade"> = {
+    corridor: "arkade",
+    asset: "arkade:regtest/slip44:0",
+    instrument: wallet,
+};
+
+export const lightningBtc: Ep<"lightning"> = {
+    corridor: "lightning",
+    asset: "bolt11:regtest/slip44:0",
+    instrument: wallet,
+};
+
+export const onchainBtc: Ep<"onchain"> = {
+    corridor: "onchain",
+    asset: "bitcoin:regtest/slip44:0",
+    instrument: wallet,
+};
+
+// The four implemented routes are representable.
+export const assetSwap: Route = { give: arkadeBtc, take: arkadeBtc };
+export const lightningSend: Route = { give: arkadeBtc, take: lightningBtc };
+export const lightningReceive: Route = { give: lightningBtc, take: arkadeBtc };
+export const onchainSend: Route = { give: arkadeBtc, take: onchainBtc };
+
+const inbound = { give: onchainBtc, take: arkadeBtc };
+// @ts-expect-error `onchain -> arkade` is outside the union until the manager owns the L1 refund path
+export const inboundOnchain: Route = inbound;
+
+const lightningToOnchain = { give: lightningBtc, take: onchainBtc };
+// @ts-expect-error no route crosses two non-arkade corridors
+export const crossCorridor: Route = lightningToOnchain;
+
+const l1Btc: AssetId = "bitcoin:regtest/slip44:0";
+// @ts-expect-error an endpoint's corridor and its asset's rail cannot disagree
+export const crossedRail: Ep<"arkade">["asset"] = l1Btc;
+
+const corridorNamedRail: AssetId<"arkade"> | string = "lightning:regtest/slip44:0";
+// @ts-expect-error the lightning rail is spelled `bolt11`: `lightning` overruns CAIP-2's namespace cap
+export const wrongLightningRail: Ep<"lightning">["asset"] = corridorNamedRail;
+
+const noRail = "slip44:0";
+// @ts-expect-error an asset part on its own is not an id
+export const bareAssetPart: AssetId = noRail;

--- a/packages/swap/test/client/route.types.ts
+++ b/packages/swap/test/client/route.types.ts
@@ -5,7 +5,7 @@
  * that stops erroring fails the build.
  */
 import type { AssetId } from "../../src/client/assetId";
-import type { Ep, Instrument, Route } from "../../src/client/route";
+import type { Artifact, Endpoint, Ep, Instrument, Route } from "../../src/client/route";
 
 const wallet: Instrument = { kind: "wallet" };
 
@@ -52,3 +52,52 @@ export const wrongLightningRail: Ep<"lightning">["asset"] = corridorNamedRail;
 const noRail = "slip44:0";
 // @ts-expect-error an asset part on its own is not an id
 export const bareAssetPart: AssetId = noRail;
+
+/**
+ * The pairing has to survive the default type argument. `Endpoint` unwitnessed
+ * is what every signature that takes "some endpoint" lands on, and a shape whose
+ * two fields widen independently correlates nothing.
+ */
+export const anyEndpoint: Endpoint = arkadeBtc;
+
+// @ts-expect-error the corridor is arkade and the asset is on the bitcoin rail
+export const bareEndpointCrossed: Endpoint = {
+    corridor: "arkade",
+    asset: "bitcoin:regtest/slip44:0",
+    instrument: wallet,
+};
+
+export const crossedDeposit: Artifact = {
+    kind: "deposit",
+    corridor: "onchain",
+    // @ts-expect-error same crossing, reached through the deposit artifact
+    asset: "arkade:regtest/slip44:0",
+    address: "bcrt1qexample",
+    amount: 1_000n,
+    expiresAt: undefined,
+};
+
+export const deposit: Artifact = {
+    kind: "deposit",
+    corridor: "onchain",
+    asset: "bitcoin:regtest/slip44:0",
+    address: "bcrt1qexample",
+    amount: 1_000n,
+};
+
+/**
+ * §9's EVM corridor carries its chain in the corridor id, so the tie is the
+ * whole chain part and not just the `eip155` rail: a contract address is a
+ * chain's fact, and the same address is deployed on chains that copied the token.
+ */
+const usdcOnBase = "eip155:8453/erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+export const baseUsdc: Ep<"eip155:8453"> = {
+    corridor: "eip155:8453",
+    asset: usdcOnBase,
+    instrument: wallet,
+};
+
+const usdcOnMainnet: AssetId<"eip155"> =
+    "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+// @ts-expect-error chain 1 is not chain 8453, though both are the eip155 rail
+export const wrongChain: Ep<"eip155:8453">["asset"] = usdcOnMainnet;

--- a/packages/swap/tsconfig.test.json
+++ b/packages/swap/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src/**/*.ts", "src/**/*.json", "test/client/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Milestone 1 of the Swap SDK v2 track: the vocabulary every later milestone
imports. Pure types, one amount codec, one mapping table — no client, no
network, no persistence.

## What lands

`packages/swap/src/client/` — a directory rather than `src/v2/`, because the
package ends as two layers the spec already names (the client at the root, the
v1 building blocks demoted to `/protocol`), and a version-numbered directory
becomes a lie the day v2 is the only thing. `src/swapClient.ts` and the
`createSwapClient` name are occupied by the facade #793 landed; the exported
name stays an open question, the file question is settled.

| Module | Contents |
|---|---|
| `assetId.ts` | CAIP-19 grammar, `AssetId<R>`, parse/format, cross-rail sameness |
| `corridor.ts` | `Corridor` (discovery's, aliased), `CorridorId`, the rail bijection |
| `route.ts` | `Instrument`, `Endpoint<C>`, the closed `Route`, `Artifact` |
| `amount.ts` | the amount law and both decimal codecs |
| `rfqAmount.ts` | the wire adapter and the `amount_side` rename |
| `aliases.ts` | public ids down to discovery/RFQ vocabulary |
| `errors.ts` | the sixteen-member taxonomy |
| `primitives.ts` | `Hex`, `Pubkey` |

## Two invariants that are now compile errors

`Endpoint<C>` spells its asset `AssetId<RailOf<C>>`, so no value exists in which
an endpoint's corridor and its asset's rail disagree. And `onchain -> arkade` is
absent from `Route`, so the misroute is a type error once a route has been
resolved — before resolution it stays `UnsupportedRoute`, thrown ahead of RFQ
disclosure, artifact creation, persistence and funding.

Both are asserted in `test/client/route.types.ts`, and the branded
`AtomicDecimal` in `test/client/amount.types.ts`. These are enforced, not
decorative: `tsc --noEmit` reads a tsconfig whose `exclude` names `test`, and
vitest runs without `--typecheck` where `expectTypeOf` is `() => true`. The
first commit adds `tsconfig.test.json` scoped to `test/client/**` and extends
the `typecheck` script, which CI already runs. A `@ts-expect-error` that stops
erroring now fails the build (`TS2578`).

## Rulings the milestone owed

- **`CorridorId` survives** beside the rail namespaces. It is the vocabulary
  §3, §6 and §9 are written in, `bolt11` is a CAIP-2 artifact rather than a
  product word, and the correspondence is not a bijection once §9 is admitted —
  one `eip155` rail, many `eip155:<chain>` corridors. The redundancy objection
  is answered by the type, not a runtime check.
- **The arkade asset reference is the flat 68-hex identity**, not the spec's
  prose `<genesis_txid>.<idx>`. That identity is implemented in seven places
  across three repos and pinned by `ASSET_ID_VECTORS` precisely because every
  disagreement between sites fails silently; this layer adds no eighth spelling.
- **The network reference is core's `NetworkName`**, all five members.
  Discovery omits `testnet`; an asset on testnet exists whether or not anyone
  indexes it, so the partiality belongs at the discovery boundary.
- **Ids are lowercase throughout**, `erc20` included, and an uppercase one is
  refused rather than folded — folding destroys a caller's checksum silently,
  and loosening a validator later is the reversible direction.
- **Taxonomy members are bare condition nouns**, so `QuoteVerificationError`
  becomes `QuoteVerificationFailed`. The inverse is what earns it:
  `AssetIdError` and `AmountFormatError` are codec faults on caller input, not
  swap-boundary errors, and the suffix is what says so at the catch site.
- **The v2 modules stay internal.** `src/index.ts` is not in this diff, so
  nothing here reaches `dist` or npm; M8 slims the root export and creates
  `src/protocol.ts` (one exports key, one tsup entry, a barrel over the same
  declarations). Exporting now would make every M2–M7 refinement a change to a
  published surface.

## Existing code touched

One line, in `rfq.ts`: `SwapRefusal` moves the `name` it already set into a
literal-typed field. A `string` there collapses the discriminant for the whole
union. Same own property, same value, same runtime.

## Verification

`pnpm -C packages/swap run typecheck` (both projects), `test:unit` — 698 passing,
81 new — `lint`, `build`, `smoke:dist` and `npm pack --dry-run`. No regtest:
M1 has no network path, which is the point of the milestone.
