### PR TITLE
fix(swap): decode the offer TLV fields solverd emits

### DIFF
--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -232,9 +232,14 @@ const readU64 = (value: Uint8Array): bigint =>
 
 /** `0` is how the reference spells an unset ratio — it emits the record only
  * above zero — so a zero is omitted rather than written as a record no reader
- * honours. */
-const setRatio = (value: bigint | undefined): bigint | undefined =>
-    value !== undefined && value > BigInt(0) ? value : undefined;
+ * honours. A negative is not "unset" but a value the u64 field cannot carry,
+ * and normalizing it away here would slip it past {@link u64} and publish an
+ * offer without the ratio the caller asked for. */
+const setRatio = (name: string, value: bigint | undefined): bigint | undefined => {
+    if (value === undefined || value === BigInt(0)) return undefined;
+    if (value < BigInt(0)) throw new Error(`${name} does not fit the offer wire format (u64)`);
+    return value;
+};
 
 function tlv(type: number, value: Uint8Array): Uint8Array {
     // the length prefix is u16 — reject rather than emit a truncated length
@@ -261,8 +266,8 @@ export function encodeOffer(offer: Offer): Uint8Array {
             throw new Error(`${name} must be ${FIELDS[name].width} bytes`);
         }
     }
-    const ratioNum = setRatio(offer.ratioNum);
-    const ratioDen = setRatio(offer.ratioDen);
+    const ratioNum = setRatio("ratioNum", offer.ratioNum);
+    const ratioDen = setRatio("ratioDen", offer.ratioDen);
     // a numerator without its denominator prices nothing
     if ((ratioNum === undefined) !== (ratioDen === undefined)) {
         throw new Error("offer must carry both ratioNum and ratioDen, or neither");
@@ -457,6 +462,29 @@ async function registerOfferContract(
 // ── User operations ─────────────────────────────────────────────────────────
 
 /**
+ * The exit closure's delay from the server's scalar `unilateralExitDelay`,
+ * under the same threshold arkd's own closures use (`wallet.ts`, and solverd's
+ * `fetchServerConfig`): below 512 the number is blocks, at or above it seconds.
+ *
+ * A missing value arrives here as `0` (`RestArkProvider` defaults it), which
+ * would compile to a CSV of zero — an exit in name only. That is refused rather
+ * than published, because an offer that says it has a unilateral exit and does
+ * not is worse than one that never claimed it.
+ */
+function serverExitDelay(delay: bigint): RelativeTimelock {
+    // `typeof` as well as the range: a provider predating the field returns an
+    // info object without it, and comparing that to a bigint throws a TypeError
+    // naming neither the field nor the way out
+    if (typeof delay !== "bigint" || delay <= BigInt(0)) {
+        throw new Error(
+            "the server reports no usable unilateralExitDelay; pass `exitDelay` to set the offer's " +
+                "exit closure explicitly, or `noExit: true` to publish without one",
+        );
+    }
+    return { value: delay, type: delay < BigInt(512) ? "blocks" : "seconds" };
+}
+
+/**
  * Build a new offer for `wallet` (the user). Fund `address` with the side
  * you deposit, embedding the returned extension, and the solver does the rest:
  *
@@ -477,6 +505,14 @@ async function registerOfferContract(
  * funding rather than after: nothing is at stake yet, so a failure can throw
  * and be retried, where the same failure after `wallet.send` would leave a
  * funded deposit unwatched with no way to notice.
+ *
+ * **The maker's unilateral exit closure is built by default**, at the server's
+ * own `unilateralExitDelay` — the same thing solverd does. Without it `cancel`
+ * is the only way back out, and `cancel` needs the server's signature: a server
+ * that will not co-sign leaves the deposit stuck at the swap address until the
+ * VTXO expires and the operator sweeps it. An offer has no expiry of its own,
+ * so that exposure has no end. `noExit` opts out for a caller who wants the
+ * smaller tree and accepts the dependency.
  */
 export async function createOffer(
     wallet: IWallet,
@@ -488,10 +524,12 @@ export async function createOffer(
         /** Co-signer key override (33-byte compressed hex); see
          * {@link resolveEmulatorPubkey}. */
         emulatorPubkey?: string;
-        /** Add the maker's unilateral exit closure, spendable by this wallet
-         * alone once the VTXO is unrolled and the delay elapses. Opt-in: it is
-         * part of the covenant, so it changes the swap address. */
+        /** Override the exit closure's delay. Defaults to the server's own
+         * `unilateralExitDelay`, which is the delay solverd uses too. */
         exitDelay?: RelativeTimelock;
+        /** Publish without the exit closure, leaving `cancel` — which needs the
+         * server — as the only way back out. See the note on this function. */
+        noExit?: boolean;
     },
 ): Promise<{
     /** The encoded offer, hex. **Persist this** — it is the only input
@@ -533,7 +571,9 @@ export async function createOffer(
         makerPkScript: ArkAddress.decode(makerAddress).pkScript,
         makerPublicKey,
         emulatorPubkey: emuKey,
-        exitDelay: params.exitDelay,
+        exitDelay: params.noExit
+            ? undefined
+            : (params.exitDelay ?? serverExitDelay(info.unilateralExitDelay)),
     };
     const script = offerVtxoScript(binding, serverPubKey);
     const offer: Offer = { ...binding, swapPkScript: script.pkScript };
@@ -561,19 +601,23 @@ export async function createOffer(
 /**
  * Cancel an offer: spend the swap VTXO back to the user. Returns the ark txid.
  *
- * This is the refund path — how a user takes back a deposit no solver filled.
- * **Neither program carries a timelock**, so an unfilled deposit keeps its
- * place at the swap address rather than expiring: no deadline to miss and no
- * "expired" state to unwind, at the cost of the refund being something the
+ * This is the cooperative refund path — how a user takes back a deposit no
+ * solver filled. **No path here is on a deadline**, so an unfilled deposit
+ * keeps its place at the swap address rather than expiring: nothing to miss and
+ * no "expired" state to unwind, at the cost of the refund being something the
  * user asks for rather than something a clock delivers.
  *
- * Both paths out of the covenant are deliberately asymmetric:
+ * The routes out of the covenant are deliberately asymmetric:
  *   - `fulfill` is signed by the **server alone**, but the covenant constrains
  *     it to pay output 0 to `makerWP` for at least `wantAmount` — a solver
  *     cannot take the deposit without delivering.
  *   - `cancel` is a **2-of-2 of the user and the server**, so cancelling is
  *     cooperative: the server co-signs. No solver signature is involved, so the
  *     refund never depends on the counterparty being reachable.
+ *   - `exit` is the user **alone** after a relative timelock, present unless the
+ *     offer was created with `noExit`. It is the route that survives a server
+ *     that will not co-sign this one, and it is reached by unrolling the VTXO
+ *     onchain rather than through this function.
  *
  * Cancel therefore races a fill rather than pre-empting it. An offer the solver
  * is filling in the same moment may be spent by `fulfill` first, in which case

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -293,12 +293,28 @@ export function encodeOffer(offer: Offer): Uint8Array {
 
 /** `[type: 1B][value: u64 BE]`, per § 2.2. */
 function encodeExitDelay(exit: RelativeTimelock): Uint8Array {
-    const kind = EXIT_TYPES.indexOf(exit.type);
-    if (kind < 0) throw new Error(`unknown exitDelay locktime type: ${exit.type}`);
+    return concatBytes(
+        Uint8Array.of(EXIT_TYPES.indexOf(assertExitDelay(exit).type)),
+        u64("exitDelay", exit.value),
+    );
+}
+
+/**
+ * The exit delay checks, returning the value so callers can bind it inline.
+ *
+ * Shared with {@link createOffer} rather than left in the encoder, because
+ * `createOffer` derives the covenant and REGISTERS it before it encodes
+ * anything: a delay only the encoder refused would throw after the contract row
+ * exists, leaving a watched script for an offer that never formed — and
+ * `promoteOfferContract` has already marked its address outstanding, so
+ * {@link retireOfferContract} will not take it back.
+ */
+function assertExitDelay(exit: RelativeTimelock): RelativeTimelock {
+    if (EXIT_TYPES.indexOf(exit.type) < 0) {
+        throw new Error(`unknown exitDelay locktime type: ${exit.type}`);
+    }
     // a zero delay is an exit in name only: the leaf exists, so the offer reads
-    // as having a unilateral route out, but the CSV imposes no wait at all.
-    // `serverExitDelay` refuses the same value on the default path — this is
-    // what closes it for a caller passing `exitDelay` explicitly.
+    // as having a unilateral route out, but the CSV imposes no wait at all
     if (exit.value <= BigInt(0)) {
         throw new Error("exitDelay must be a positive relative locktime");
     }
@@ -307,7 +323,7 @@ function encodeExitDelay(exit: RelativeTimelock): Uint8Array {
     if (exit.value >> BigInt(32) > BigInt(0)) {
         throw new Error("exitDelay does not fit the locktime field (u32)");
     }
-    return concatBytes(Uint8Array.of(kind), u64("exitDelay", exit.value));
+    return exit;
 }
 
 /** Parse TLV bytes into an offer. Throws on malformed or unknown records. */
@@ -488,7 +504,9 @@ function serverExitDelay(delay: bigint): RelativeTimelock {
                 "exit closure explicitly, or `noExit: true` to publish without one",
         );
     }
-    return { value: delay, type: delay < BigInt(512) ? "blocks" : "seconds" };
+    // through the same validator as an explicit delay: a server advertising one
+    // the wire cannot carry must fail before the covenant is registered too
+    return assertExitDelay({ value: delay, type: delay < BigInt(512) ? "blocks" : "seconds" });
 }
 
 /**
@@ -578,9 +596,14 @@ export async function createOffer(
         makerPkScript: ArkAddress.decode(makerAddress).pkScript,
         makerPublicKey,
         emulatorPubkey: emuKey,
+        // checked HERE, before the covenant is derived and registered below:
+        // deferring it to `encodeOffer` leaves a registered contract behind for
+        // an offer that then fails to encode. @see assertExitDelay
         exitDelay: params.noExit
             ? undefined
-            : (params.exitDelay ?? serverExitDelay(info.unilateralExitDelay)),
+            : params.exitDelay
+              ? assertExitDelay(params.exitDelay)
+              : serverExitDelay(info.unilateralExitDelay),
     };
     const script = offerVtxoScript(binding, serverPubKey);
     const offer: Offer = { ...binding, swapPkScript: script.pkScript };

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -47,7 +47,18 @@ import { getAssetSwapsOrThrow, updateAssetSwap, updateAssetSwapBestEffort } from
 // json imports widen "type": "pubkey" to string; parseArtifact validates at runtime
 type Artifact = Parameters<typeof arkade.parseArtifact>[0];
 
-/** The contracts — pure data, shared verbatim with any other implementation. */
+/**
+ * The contracts, one per WANT side — pure data, shared verbatim with any other
+ * implementation.
+ *
+ * **These are the base: an offer carrying an exit delay compiles to a third
+ * closure that is not in either file.** The tree is not fixed-shape — the
+ * protocol defines the exit as `iff ExitDelay`, and solverd appends it the same
+ * way (`pkg/swap/contract/offer.go`, `VtxoScript`) — so it cannot be a function
+ * in a static artifact without splitting these into one file per exit variant.
+ * {@link withExitClosure} owns that step, and the golden in `offer.test.ts`
+ * pins the artifact it produces so the whole contract is still readable as data.
+ */
 export const swapPrograms: Record<
     "wantAsset" | "wantBtc",
     ReturnType<typeof arkade.parseArtifact>
@@ -109,12 +120,23 @@ type SwapProgramBinding = {
  * Order is load-bearing. The tree is assembled from the leaf list by btcd's
  * algorithm, so `exit` must remain the third path, after `fulfill` and
  * `cancel` — moving it changes the swap address.
+ *
+ * **Why this is code and not a function in the program JSON.** Two reasons, and
+ * either alone would force it: the closure is conditional, so a static artifact
+ * carrying it would give every offer three leaves; and `csv.type` is a literal
+ * in the artifact format — only `csv.value` resolves a `$param` — so the
+ * blocks/seconds split cannot be bound per offer. Expressing this declaratively
+ * therefore means one file per (want side × none | blocks | seconds), six in
+ * all, with the `fulfill` asm duplicated three times per side and free to drift.
  */
 function withExitClosure(
     program: ReturnType<typeof arkade.parseArtifact>,
     exit: RelativeTimelock | undefined,
 ): ReturnType<typeof arkade.parseArtifact> {
     if (!exit) return program;
+    // Spread, never mutate: `swapPrograms` is module state shared by every
+    // offer, so appending in place would leave later exit-less offers compiling
+    // a third leaf — and an `$exitDelay` they never bind.
     return {
         ...program,
         // typed params are authoritative: an undeclared `$exitDelay` fails

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -35,6 +35,7 @@ import {
     toXOnlySignerHex,
     type IWallet,
     type NetworkName,
+    type RelativeTimelock,
 } from "@arkade-os/sdk";
 
 import wantAssetProgram from "./swap-want-asset.program.json";
@@ -76,6 +77,14 @@ export interface Offer {
     makerPublicKey: Uint8Array;
     /** Covenant co-signer (emulator) x-only key (32 bytes). */
     emulatorPubkey: Uint8Array;
+    /** Partial-fill numerator. Reserved wire space in V1: carried through the
+     * codec so an offer that sets it decodes, never interpreted here. */
+    ratioNum?: bigint;
+    /** Partial-fill denominator. Set with {@link Offer.ratioNum} or not at all. */
+    ratioDen?: bigint;
+    /** The maker's unilateral exit path. Present adds a third closure to the
+     * taproot tree, so it changes `swapPkScript` — see {@link offerVtxoScript}. */
+    exitDelay?: RelativeTimelock;
 }
 
 /** The program + argument/key binding of an offer's contract. Single source for
@@ -89,6 +98,36 @@ type SwapProgramBinding = {
     args: ConstructorParameters<typeof arkade.ArkadeProgramScript>[1];
     keys: ConstructorParameters<typeof arkade.ArkadeProgramScript>[2];
 };
+
+/**
+ * Append the maker's unilateral exit closure to a program.
+ *
+ * A CSV closure of the maker alone: the signer key is deliberately absent, so
+ * once the VTXO is unrolled onchain and the delay elapses the maker spends it
+ * without anyone's cooperation. `cancel` stays the cooperative route.
+ *
+ * Order is load-bearing. The tree is assembled from the leaf list by btcd's
+ * algorithm, so `exit` must remain the third path, after `fulfill` and
+ * `cancel` — moving it changes the swap address.
+ */
+function withExitClosure(
+    program: ReturnType<typeof arkade.parseArtifact>,
+    exit: RelativeTimelock | undefined,
+): ReturnType<typeof arkade.parseArtifact> {
+    if (!exit) return program;
+    return {
+        ...program,
+        // typed params are authoritative: an undeclared `$exitDelay` fails
+        // validateProgram instead of compiling against an unbound value
+        params: [...(program.params ?? []), { name: "exitDelay", type: "int" }],
+        functions: {
+            ...program.functions,
+            exit: {
+                tapscript: { signers: ["$user"], csv: { type: exit.type, value: "$exitDelay" } },
+            },
+        },
+    };
+}
 
 /** Exported for the asset-id vector tests: the covenant is committed behind an
  * emulator-derived key, so the pushed asset bytes never appear in a leaf script
@@ -104,7 +143,10 @@ export function swapProgramBinding(
         throw new Error("makerPkScript is not a 34-byte taproot scriptPubKey");
     }
     return {
-        program: offer.wantAsset ? swapPrograms.wantAsset : swapPrograms.wantBtc,
+        program: withExitClosure(
+            offer.wantAsset ? swapPrograms.wantAsset : swapPrograms.wantBtc,
+            offer.exitDelay,
+        ),
         args: {
             makerWP: offer.makerPkScript.subarray(2),
             wantAmount: offer.wantAmount,
@@ -115,6 +157,7 @@ export function swapProgramBinding(
                 wantAssetTxid: offer.wantAsset.txid.slice().reverse(),
                 wantAssetGroupIndex: offer.wantAsset.groupIndex,
             }),
+            ...(offer.exitDelay && { exitDelay: offer.exitDelay.value }),
         },
         keys: {
             serverKey: serverPubkey,
@@ -155,8 +198,14 @@ const FIELDS = {
     makerPkScript: { tag: 0x05, width: 34 },
     makerPublicKey: { tag: 0x07, width: 32 },
     emulatorPubkey: { tag: 0x08, width: 32 },
+    ratioNum: { tag: 0x09, width: 8 },
+    ratioDen: { tag: 0x0a, width: 8 },
     offerAsset: { tag: 0x0b, width: undefined },
+    exitTimelock: { tag: 0x0c, width: 9 },
 } as const;
+
+/** The `ExitTimelock` locktime types, indexed by their wire byte. */
+const EXIT_TYPES = ["blocks", "seconds"] as const;
 
 type FieldName = keyof typeof FIELDS;
 
@@ -164,6 +213,28 @@ const NAMES = Object.fromEntries(Object.entries(FIELDS).map(([k, f]) => [f.tag, 
     number,
     FieldName
 >;
+
+/** A u64 BE wire field. Rejects an out-of-range value rather than letting
+ * setBigUint64 wrap it silently — reachable at ~18.45 tokens of an 18-decimal
+ * asset — while the covenant binds the full amount. */
+function u64(name: string, value: bigint): Uint8Array {
+    if (value < BigInt(0) || value >> BigInt(64) > BigInt(0)) {
+        throw new Error(`${name} does not fit the offer wire format (u64)`);
+    }
+    const out = new Uint8Array(FIELDS.wantAmount.width);
+    new DataView(out.buffer).setBigUint64(0, value, false);
+    return out;
+}
+
+/** Read a u64 BE wire field. The width was checked when the record was parsed. */
+const readU64 = (value: Uint8Array): bigint =>
+    new DataView(value.buffer, value.byteOffset).getBigUint64(0, false);
+
+/** `0` is how the reference spells an unset ratio — it emits the record only
+ * above zero — so a zero is omitted rather than written as a record no reader
+ * honours. */
+const setRatio = (value: bigint | undefined): bigint | undefined =>
+    value !== undefined && value > BigInt(0) ? value : undefined;
 
 function tlv(type: number, value: Uint8Array): Uint8Array {
     // the length prefix is u16 — reject rather than emit a truncated length
@@ -190,26 +261,41 @@ export function encodeOffer(offer: Offer): Uint8Array {
             throw new Error(`${name} must be ${FIELDS[name].width} bytes`);
         }
     }
-    // the wire field is a fixed u64; setBigUint64 would wrap silently past 2^64
-    // (reachable at ~18.45 tokens of an 18-decimal asset) while the covenant
-    // binds the full amount — reject instead of advertising a wrapped amount
-    if (offer.wantAmount < BigInt(0) || offer.wantAmount >> BigInt(64) > BigInt(0)) {
-        throw new Error("wantAmount does not fit the offer wire format (u64)");
+    const ratioNum = setRatio(offer.ratioNum);
+    const ratioDen = setRatio(offer.ratioDen);
+    // a numerator without its denominator prices nothing
+    if ((ratioNum === undefined) !== (ratioDen === undefined)) {
+        throw new Error("offer must carry both ratioNum and ratioDen, or neither");
     }
-    const amount = new Uint8Array(FIELDS.wantAmount.width);
-    new DataView(amount.buffer).setBigUint64(0, offer.wantAmount, false);
+    // the records are emitted in the order § 2.1 of the swap protocol requires;
+    // parsers key off the type, but a canonical order keeps offer hashes stable
     const recs = [
         tlv(FIELDS.swapPkScript.tag, offer.swapPkScript),
-        tlv(FIELDS.wantAmount.tag, amount),
+        tlv(FIELDS.wantAmount.tag, u64("wantAmount", offer.wantAmount)),
     ];
     if (offer.wantAsset) recs.push(tlv(FIELDS.wantAsset.tag, offer.wantAsset.serialize()));
+    if (ratioNum !== undefined) recs.push(tlv(FIELDS.ratioNum.tag, u64("ratioNum", ratioNum)));
+    if (ratioDen !== undefined) recs.push(tlv(FIELDS.ratioDen.tag, u64("ratioDen", ratioDen)));
     if (offer.offerAsset) recs.push(tlv(FIELDS.offerAsset.tag, offer.offerAsset.serialize()));
     recs.push(
         tlv(FIELDS.makerPkScript.tag, offer.makerPkScript),
         tlv(FIELDS.makerPublicKey.tag, offer.makerPublicKey),
         tlv(FIELDS.emulatorPubkey.tag, offer.emulatorPubkey),
     );
+    if (offer.exitDelay) recs.push(tlv(FIELDS.exitTimelock.tag, encodeExitDelay(offer.exitDelay)));
     return concatBytes(...recs);
+}
+
+/** `[type: 1B][value: u64 BE]`, per § 2.2. */
+function encodeExitDelay(exit: RelativeTimelock): Uint8Array {
+    const kind = EXIT_TYPES.indexOf(exit.type);
+    if (kind < 0) throw new Error(`unknown exitDelay locktime type: ${exit.type}`);
+    // the reference narrows the wire u64 to a uint32 locktime, so a wider value
+    // derives one swap address here and another there — refuse to emit it
+    if (exit.value >> BigInt(32) > BigInt(0)) {
+        throw new Error("exitDelay does not fit the locktime field (u32)");
+    }
+    return concatBytes(Uint8Array.of(kind), u64("exitDelay", exit.value));
 }
 
 /** Parse TLV bytes into an offer. Throws on malformed or unknown records. */
@@ -242,6 +328,14 @@ export function decodeOffer(data: Uint8Array): Offer {
     for (const name of ["wantAsset", "offerAsset"] as const) {
         if (fields[name]?.length === 0) throw new Error(`missing/invalid ${name}`);
     }
+    // width is checked wherever a fixed-width record appears, not only where
+    // `need` reads it back: the optional ones have no other gate
+    for (const [name, value] of Object.entries(fields) as [FieldName, Uint8Array][]) {
+        const width: number | undefined = FIELDS[name].width;
+        if (width !== undefined && value.length !== width) {
+            throw new Error(`missing/invalid ${name}`);
+        }
+    }
     const need = (name: FieldName) => {
         const v = fields[name];
         const len: number | undefined = FIELDS[name].width;
@@ -253,15 +347,43 @@ export function decodeOffer(data: Uint8Array): Offer {
     if (Boolean(fields.wantAsset) === Boolean(fields.offerAsset)) {
         throw new Error("offer must carry exactly one of wantAsset or offerAsset");
     }
+    // a present record valued `0` contradicts itself: that is the reference's
+    // own spelling of "unset", and it emits the record only above zero
+    const readRatio = (name: "ratioNum" | "ratioDen"): bigint | undefined => {
+        const raw = fields[name];
+        if (!raw) return undefined;
+        const value = readU64(raw);
+        if (value === BigInt(0)) throw new Error(`missing/invalid ${name}`);
+        return value;
+    };
+    const ratioNum = readRatio("ratioNum");
+    const ratioDen = readRatio("ratioDen");
+    // enforced on the way in as well as out: another implementation may emit
+    // half a ratio, and half a ratio prices nothing
+    if ((ratioNum === undefined) !== (ratioDen === undefined)) {
+        throw new Error("offer must carry both ratioNum and ratioDen, or neither");
+    }
     return {
         swapPkScript: need("swapPkScript"),
-        wantAmount: new DataView(amount.buffer, amount.byteOffset).getBigUint64(0, false),
+        wantAmount: readU64(amount),
         ...(fields.wantAsset && { wantAsset: asset.AssetId.fromBytes(fields.wantAsset) }),
         ...(fields.offerAsset && { offerAsset: asset.AssetId.fromBytes(fields.offerAsset) }),
         makerPkScript: need("makerPkScript"),
         makerPublicKey: need("makerPublicKey"),
         emulatorPubkey: need("emulatorPubkey"),
+        ...(ratioNum !== undefined && { ratioNum }),
+        ...(ratioDen !== undefined && { ratioDen }),
+        ...(fields.exitTimelock && { exitDelay: decodeExitDelay(fields.exitTimelock) }),
     };
+}
+
+/** The inverse of {@link encodeExitDelay}; the 9-byte width is already checked. */
+function decodeExitDelay(value: Uint8Array): RelativeTimelock {
+    const type = EXIT_TYPES[value[0]];
+    // an unassigned locktime type is a record we cannot interpret, and reading
+    // it as blocks would derive a swap address its emitter never meant
+    if (!type) throw new Error(`unknown exitDelay locktime type: 0x${value[0].toString(16)}`);
+    return { type, value: readU64(value.subarray(1)) };
 }
 
 // ── Contract registration ────────────────────────────────────────────────────
@@ -366,6 +488,10 @@ export async function createOffer(
         /** Co-signer key override (33-byte compressed hex); see
          * {@link resolveEmulatorPubkey}. */
         emulatorPubkey?: string;
+        /** Add the maker's unilateral exit closure, spendable by this wallet
+         * alone once the VTXO is unrolled and the delay elapses. Opt-in: it is
+         * part of the covenant, so it changes the swap address. */
+        exitDelay?: RelativeTimelock;
     },
 ): Promise<{
     /** The encoded offer, hex. **Persist this** — it is the only input
@@ -407,6 +533,7 @@ export async function createOffer(
         makerPkScript: ArkAddress.decode(makerAddress).pkScript,
         makerPublicKey,
         emulatorPubkey: emuKey,
+        exitDelay: params.exitDelay,
     };
     const script = offerVtxoScript(binding, serverPubKey);
     const offer: Offer = { ...binding, swapPkScript: script.pkScript };

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -295,6 +295,13 @@ export function encodeOffer(offer: Offer): Uint8Array {
 function encodeExitDelay(exit: RelativeTimelock): Uint8Array {
     const kind = EXIT_TYPES.indexOf(exit.type);
     if (kind < 0) throw new Error(`unknown exitDelay locktime type: ${exit.type}`);
+    // a zero delay is an exit in name only: the leaf exists, so the offer reads
+    // as having a unilateral route out, but the CSV imposes no wait at all.
+    // `serverExitDelay` refuses the same value on the default path — this is
+    // what closes it for a caller passing `exitDelay` explicitly.
+    if (exit.value <= BigInt(0)) {
+        throw new Error("exitDelay must be a positive relative locktime");
+    }
     // the reference narrows the wire u64 to a uint32 locktime, so a wider value
     // derives one swap address here and another there — refuse to emit it
     if (exit.value >> BigInt(32) > BigInt(0)) {

--- a/packages/swap/src/restore.ts
+++ b/packages/swap/src/restore.ts
@@ -111,10 +111,19 @@ export type SpendKind = "cancelled" | "fulfilled" | "indeterminate";
 /**
  * Classify a spend by the covenant leaf it took.
  *
- * The covenant's whole vocabulary is two leaves: `cancel` returns the deposit
- * to the user, `fulfill` is the solver paying for it. A submitted ark tx keeps
- * each input's `tapLeafScript`, so the spend *states* which one it used — this
- * reads an answer rather than inferring one.
+ * The vocabulary is what became of the deposit, not which key moved it:
+ * `fulfill` is the solver paying for it, and everything else returns it to the
+ * user. A submitted ark tx keeps each input's `tapLeafScript`, so the spend
+ * *states* which one it used — this reads an answer rather than inferring one.
+ *
+ * **`exit` reports `cancelled`, like `cancel` does.** The two differ in who had
+ * to agree — `cancel` is cooperative with the signer, `exit` is the maker alone
+ * after a delay — but not in outcome: the deposit went back unfilled either
+ * way, which is the question this answers. Reporting the exit leaf as
+ * `indeterminate` instead would be worse than imprecise: no status is written,
+ * so the swap stays `pending`, `restoreAssetSwaps` re-queues it on every scan,
+ * and `retireOfferContract` never runs — leaving a dead script in the
+ * subscription and the failsafe poll for the life of the wallet.
  *
  * **Hand it the transaction that actually spends the deposit outpoint, which is
  * the checkpoint, not the ark tx.** A spend is two linked transactions: the
@@ -145,12 +154,16 @@ export function classifySpend(
     spendTx: Transaction,
     deposit: { txid: string; vout: number },
 ): SpendKind {
-    let leaves: { cancel?: Uint8Array; fulfill?: Uint8Array };
+    let leaves: { returned: Uint8Array[]; fulfill?: Uint8Array };
     try {
         const script = offerVtxoScript(offer, serverPubkey);
         if (hex.encode(script.pkScript) !== hex.encode(offer.swapPkScript)) return "indeterminate";
         leaves = {
-            cancel: script.functionByName("cancel")?.leafScript,
+            // both routes that hand the deposit back; `exit` is absent on an
+            // offer that carries no exit closure, and drops out here
+            returned: ["cancel", "exit"]
+                .map((name) => script.functionByName(name)?.leafScript)
+                .filter((leaf): leaf is Uint8Array => leaf !== undefined),
             fulfill: script.functionByName("fulfill")?.leafScript,
         };
     } catch {
@@ -165,12 +178,12 @@ export function classifySpend(
         if (hex.encode(input.txid) !== deposit.txid) continue;
         for (const leaf of input.tapLeafScript ?? []) {
             const spent = hex.encode(scriptFromTapLeafScript(leaf));
-            if (leaves.cancel && spent === hex.encode(leaves.cancel)) return "cancelled";
+            if (leaves.returned.some((back) => spent === hex.encode(back))) return "cancelled";
             if (leaves.fulfill && spent === hex.encode(leaves.fulfill)) return "fulfilled";
         }
     }
-    // the deposit left the covenant by neither leaf (a batch forfeit, say), the
-    // spend carries no tapleaf, or this is the wrong half of the spend
+    // the deposit left the covenant by none of its leaves (a batch forfeit,
+    // say), the spend carries no tapleaf, or this is the wrong half of the spend
     return "indeterminate";
 }
 
@@ -350,15 +363,10 @@ export async function restoreAssetSwaps(
                 vout: vtxo.vout,
             });
             if (kind === "indeterminate") {
-                // the spender is not fetchable yet, or took neither the cancel
-                // nor the fulfill leaf: retry rather than persist a label that
-                // later scans skip.
-                //
-                // The second case is no longer only a foreign spend — an offer
-                // carrying an exit closure has a third leaf, and a maker who
-                // unrolled and took it lands here and re-queues on every scan.
-                // Reporting that outcome needs a SpendKind and a status this
-                // vocabulary does not have yet.
+                // the spender is not fetchable yet, or took none of the
+                // covenant's leaves: retry rather than persist a label that
+                // later scans skip. Both are transient or foreign — every leaf
+                // the covenant itself offers, exit included, classifies.
                 unresolved.add(fundingTx.redeemTxid);
                 continue;
             }

--- a/packages/swap/src/restore.ts
+++ b/packages/swap/src/restore.ts
@@ -350,8 +350,15 @@ export async function restoreAssetSwaps(
                 vout: vtxo.vout,
             });
             if (kind === "indeterminate") {
-                // the spender is not fetchable yet, or took neither covenant
-                // leaf: retry rather than persist a label that later scans skip
+                // the spender is not fetchable yet, or took neither the cancel
+                // nor the fulfill leaf: retry rather than persist a label that
+                // later scans skip.
+                //
+                // The second case is no longer only a foreign spend — an offer
+                // carrying an exit closure has a third leaf, and a maker who
+                // unrolled and took it lands here and re-queues on every scan.
+                // Reporting that outcome needs a SpendKind and a status this
+                // vocabulary does not have yet.
                 unresolved.add(fundingTx.redeemTxid);
                 continue;
             }

--- a/packages/swap/test/emulatorTrustBoundary.test.ts
+++ b/packages/swap/test/emulatorTrustBoundary.test.ts
@@ -20,7 +20,9 @@ import { ArkAddress, SingleKey, asset, type IWallet } from "@arkade-os/sdk";
 // network seam these functions must never touch (RestEmulatorProvider) plus
 // the one they legitimately still call (RestArkProvider), stubbed.
 const state = vi.hoisted(() => ({
-    arkInfo: { signerPubkey: "", unilateralExitDelay: 4096, network: "regtest" },
+    // bigint, as ArkInfo declares it: createOffer builds the offer's exit
+    // closure from this value
+    arkInfo: { signerPubkey: "", unilateralExitDelay: BigInt(4096), network: "regtest" },
 }));
 
 vi.mock("@arkade-os/sdk", async (importOriginal) => {

--- a/packages/swap/test/offer.test.ts
+++ b/packages/swap/test/offer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { hex } from "@scure/base";
-import { ArkAddress, arkade, asset } from "@arkade-os/sdk";
+import { ArkAddress, arkade, asset, type RelativeTimelock } from "@arkade-os/sdk";
 import { decodeOffer, encodeOffer, offerVtxoScript, swapProgramBinding, Offer } from "../src/offer";
 
 // deterministic keys -> the derived swap addresses must never drift (any
@@ -155,6 +155,136 @@ describe("swap offer", () => {
         });
     });
 
+    // Emitted by solverd's own encoder (`pkg/swap/contract`) against the keys
+    // above, so these pin the wire format and the taproot tree to the reference
+    // rather than to ourselves. The two exit-less vectors reproduce the goldens
+    // at the top of this file — which is what says they share the same inputs.
+    describe("solverd reference vectors", () => {
+        const vectors: {
+            label: string;
+            offerHex: string;
+            address: string;
+            exit?: RelativeTimelock;
+            ratio?: [bigint, bigint];
+        }[] = [
+            {
+                label: "wantBtc, no exit",
+                offerHex:
+                    "0100225120004739eb4ad3eab769b0c2278cd70cce628e20477e8b8c508bcf8519a5f451c9020008000000000000c3500b0022aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05002251203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b10700203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1080020466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
+                address:
+                    "tark1qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc65qz8884545l2ka5mps383ntsennz3csywl5t33gghnu9rxjlg5wfv467cj",
+            },
+            {
+                label: "wantBtc, exit blocks 144",
+                offerHex:
+                    "0100225120a928b3f0209a939822b5a73a5d507c9bcc7f68b7875b28b50b5b8412cda16f4d020008000000000000c3500b0022aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05002251203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b10700203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1080020466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f270c0009000000000000000090",
+                address:
+                    "tark1qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc642fgk0czpx5nnq3ttfe6t4g8ex7v0a5t0p6m9z6skkuyztx6zm6d9ccar9",
+                exit: { type: "blocks", value: BigInt(144) },
+            },
+            {
+                label: "wantAsset, no exit",
+                offerHex:
+                    "0100225120b2a1cd158c7a7e2e6346b6d2d0c323eae90d9d6b8c6e2245de4170d953e2bca6020008000000000000c350030022aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05002251203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b10700203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1080020466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
+                address:
+                    "tark1qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc64v4pe52cc7n79e35ddkj6rpj86hfpkwkhrrwyfzaustsm9f7909xukfu7j",
+            },
+            {
+                label: "wantAsset, exit seconds 51200",
+                offerHex:
+                    "0100225120a454544d8df3377853e1ac907f9e67c8284780232ecd9ca76fb04af7f87df6bd020008000000000000c350030022aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05002251203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b10700203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1080020466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f270c000901000000000000c800",
+                address:
+                    "tark1qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc64fz523xcmueh0pf7rtys070x0jpgg7qzxtkdnjnklvz27lu8ma4a2sqp7d",
+                exit: { type: "seconds", value: BigInt(51_200) },
+            },
+            {
+                label: "wantAsset, exit seconds 604672",
+                offerHex:
+                    "0100225120350b08d2374dedf0346be509962c39899ea3b09e9b1b4df572ba3ecb5ae5f6e5020008000000000000c350030022aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05002251203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b10700203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1080020466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f270c0009010000000000093a00",
+                address:
+                    "tark1qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc65dgtprfrwn0d7q6xhegfjckrnzv75wcfaxcmfh6h9w37eddwtah9v56pnn",
+                exit: { type: "seconds", value: BigInt(604_672) },
+            },
+            {
+                label: "wantAsset, ratio 1/4",
+                offerHex:
+                    "0100225120b2a1cd158c7a7e2e6346b6d2d0c323eae90d9d6b8c6e2245de4170d953e2bca6020008000000000000c350030022aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa09000800000000000000010a0008000000000000000405002251203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b10700203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1080020466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
+                address:
+                    "tark1qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc64v4pe52cc7n79e35ddkj6rpj86hfpkwkhrrwyfzaustsm9f7909xukfu7j",
+                ratio: [BigInt(1), BigInt(4)],
+            },
+            {
+                // every optional record at once: the only vector that pins the
+                // canonical order *between* the ratios and offerAsset
+                label: "wantBtc, ratio 3/8, exit blocks 4032",
+                offerHex:
+                    "01002251204a0bd091ba08d9724dcbe74ae91812e8cb3f1a82ff068b8be55c0538842a7fa8020008000000000000c35009000800000000000000030a000800000000000000080b0022aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05002251203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b10700203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1080020466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f270c0009000000000000000fc0",
+                address:
+                    "tark1qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc65jst6zgm5zxewfxuhe62ayvp96xt8udg9lcx3w972hq98zzz5lagzyxac8",
+                exit: { type: "blocks", value: BigInt(4_032) },
+                ratio: [BigInt(3), BigInt(8)],
+            },
+        ];
+
+        vectors.forEach((v) => {
+            it(`decodes and re-derives -- ${v.label}`, () => {
+                const offer = decodeOffer(hex.decode(v.offerHex));
+                expect(offer.exitDelay).toEqual(v.exit);
+                expect(offer.ratioNum).toBe(v.ratio?.[0]);
+                expect(offer.ratioDen).toBe(v.ratio?.[1]);
+
+                // the reconstructed tree must be the one the payload names, or
+                // the § 5.1 consistency check rejects every offer solverd emits
+                const script = offerVtxoScript(offer, server);
+                expect(hex.encode(script.pkScript)).toBe(hex.encode(offer.swapPkScript));
+                expect(new ArkAddress(server, script.tweakedPublicKey, "tark").encode()).toBe(
+                    v.address,
+                );
+                expect(script.scripts).toHaveLength(v.exit ? 3 : 2);
+
+                // and re-emitting must reproduce the reference bytes exactly --
+                // that is what pins our record order to § 2.1
+                expect(hex.encode(encodeOffer(offer))).toBe(v.offerHex);
+            });
+        });
+
+        it("re-derives an exit offer from its persisted contract params", () => {
+            // registerOfferContract stores the program as artifact JSON, and the
+            // exit's timelock is a `$param` reference rather than a literal -- a
+            // round trip that dropped it would leave a registered row whose
+            // script no longer matches the address the maker funded
+            const offer = decodeOffer(hex.decode(vectors[1].offerHex));
+            const { program, args, keys: bound } = swapProgramBinding(offer, server);
+            const stored = arkade.serializeArkadeContractParams({
+                program,
+                args,
+                serverKey: bound.serverKey,
+                userKey: bound.userKey,
+                emulatorKey: bound.emulatorKey,
+            });
+            const back = arkade.deserializeArkadeContractParams(stored);
+            const rebuilt = new arkade.ArkadeProgramScript(back.program, back.args, {
+                serverKey: back.serverKey,
+                userKey: back.userKey,
+                emulatorKey: back.emulatorKey,
+            });
+            expect(hex.encode(rebuilt.pkScript)).toBe(hex.encode(offer.swapPkScript));
+        });
+
+        it("appends the exit closure, leaving the other two leaves in place", () => {
+            // leaf order is part of the address (the tree is assembled from the
+            // list), so an exit inserted anywhere else derives a different swap
+            const withExit = decodeOffer(hex.decode(vectors[1].offerHex));
+            const { exitDelay: _unused, ...withoutExit } = withExit;
+            const before = offerVtxoScript(withoutExit, server);
+            const after = offerVtxoScript(withExit, server);
+            expect(after.scripts.slice(0, 2).map((s) => hex.encode(s))).toEqual(
+                before.scripts.map((s) => hex.encode(s)),
+            );
+            expect(after.scripts).toHaveLength(3);
+        });
+    });
+
     it("rejects offers without exactly one direction at encode time", () => {
         const base = { wantAmount: BigInt(50_000), ...keys, swapPkScript: new Uint8Array(34) };
         expect(() => encodeOffer({ ...base, wantAsset: testAsset, offerAsset: testAsset })).toThrow(
@@ -257,6 +387,81 @@ describe("swap offer", () => {
         // must name the offending TLV field, not an AssetId internal
         const empty = cat(directionlessPayload(), rec(0x03, new Uint8Array(0)));
         expect(() => decodeOffer(empty)).toThrow("missing/invalid wantAsset");
+    });
+
+    describe("the optional records", () => {
+        const base = { wantAmount: BigInt(50_000), wantAsset: testAsset, ...keys };
+        const full = (over: Partial<Offer> = {}): Offer => ({
+            ...base,
+            swapPkScript: new Uint8Array(34),
+            ...over,
+        });
+        /** A valid payload plus one hand-built record — decode-side coverage
+         * for shapes encodeOffer refuses to emit. */
+        const spliced = (...extra: Uint8Array[]) => cat(encodeOffer(full()), ...extra);
+        const u64be = (n: number) => {
+            const out = new Uint8Array(8);
+            new DataView(out.buffer).setBigUint64(0, BigInt(n), false);
+            return out;
+        };
+
+        it("rejects an unassigned exit locktime type", () => {
+            // reading a third type as `blocks` would derive a swap address the
+            // emitter never meant, and the deposit would land somewhere else
+            const exotic = spliced(rec(0x0c, cat(Uint8Array.of(0x02), u64be(144))));
+            expect(() => decodeOffer(exotic)).toThrow("unknown exitDelay locktime type: 0x2");
+            expect(() =>
+                encodeOffer(full({ exitDelay: { type: "months" as never, value: BigInt(1) } })),
+            ).toThrow("unknown exitDelay locktime type");
+        });
+
+        it("rejects an exit record that is not the 9-byte wire width", () => {
+            expect(() => decodeOffer(spliced(rec(0x0c, u64be(144))))).toThrow(
+                "missing/invalid exitTimelock",
+            );
+        });
+
+        it("rejects an exit delay wider than the reference's u32 locktime", () => {
+            // the reference decoder narrows the wire u64 to uint32, so a wider
+            // value derives one swap address there and another here
+            expect(() =>
+                encodeOffer(
+                    full({ exitDelay: { type: "blocks", value: BigInt(1) << BigInt(32) } }),
+                ),
+            ).toThrow("exitDelay does not fit");
+        });
+
+        it("rejects half a ratio on both sides of the codec", () => {
+            expect(() => decodeOffer(spliced(rec(0x09, u64be(3))))).toThrow(
+                "both ratioNum and ratioDen",
+            );
+            expect(() => encodeOffer(full({ ratioNum: BigInt(3) }))).toThrow(
+                "both ratioNum and ratioDen",
+            );
+        });
+
+        it("rejects a zero ratio record, which contradicts its own presence", () => {
+            // the reference spells "unset" as 0 and emits nothing for it
+            const zeroed = spliced(rec(0x09, u64be(0)), rec(0x0a, u64be(4)));
+            expect(() => decodeOffer(zeroed)).toThrow("missing/invalid ratioNum");
+        });
+
+        it("treats a zero ratio as unset when encoding, as the reference does", () => {
+            const encoded = encodeOffer(full({ ratioNum: BigInt(0), ratioDen: BigInt(0) }));
+            expect(hex.encode(encoded)).toBe(hex.encode(encodeOffer(full())));
+        });
+
+        it("roundtrips an offer carrying every optional record", () => {
+            const offer = full({
+                ratioNum: BigInt(3),
+                ratioDen: BigInt(8),
+                exitDelay: { type: "seconds", value: BigInt(51_200) },
+            });
+            const back = decodeOffer(encodeOffer(offer));
+            expect(back.ratioNum).toBe(BigInt(3));
+            expect(back.ratioDen).toBe(BigInt(8));
+            expect(back.exitDelay).toEqual({ type: "seconds", value: BigInt(51_200) });
+        });
     });
 
     it("rejects a wantAmount that is not exactly the u64 wire width", () => {

--- a/packages/swap/test/offer.test.ts
+++ b/packages/swap/test/offer.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { hex } from "@scure/base";
 import { ArkAddress, arkade, asset, type RelativeTimelock } from "@arkade-os/sdk";
-import { decodeOffer, encodeOffer, offerVtxoScript, swapProgramBinding, Offer } from "../src/offer";
+import {
+    decodeOffer,
+    encodeOffer,
+    offerVtxoScript,
+    swapProgramBinding,
+    swapPrograms,
+    Offer,
+} from "../src/offer";
 
 // deterministic keys -> the derived swap addresses must never drift (any
 // change to the program JSONs or the arg binding changes them); goldens from
@@ -15,6 +22,7 @@ const keys = {
     emulatorPubkey: hex.decode("466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27"),
 };
 const testAsset = asset.AssetId.fromString("aa".repeat(32) + "0000");
+const EXIT_BLOCKS: RelativeTimelock = { type: "blocks", value: BigInt(144) };
 
 // hand-built TLV records: encodeOffer now rejects malformed offers, so the
 // decode-side coverage below assembles its foreign payloads from raw records
@@ -69,6 +77,43 @@ describe("swap offer", () => {
             expect(back.wantAsset?.toString()).toBe(offer.wantAsset?.toString());
             expect(back.offerAsset?.toString()).toBe(offer.offerAsset?.toString());
         }
+    });
+
+    it("emits the whole exit-carrying contract as artifact JSON", () => {
+        // The two program files are the base; an offer with an exit delay
+        // compiles to a third closure that is in neither. Pinning the artifact
+        // the binding produces keeps the FULL contract readable as data — the
+        // property `swapPrograms` claims — so another implementation has
+        // something to compare against rather than having to read TypeScript.
+        // It also fails loudly if the exit function's shape or the appended
+        // `exitDelay` param ever drifts, both of which move the swap address.
+        const { program } = swapProgramBinding(
+            { wantAmount: BigInt(50_000), offerAsset: testAsset, ...keys, exitDelay: EXIT_BLOCKS },
+            server,
+        );
+        expect(arkade.stringifyArtifact(program)).toBe(
+            '{"version":0,"name":"banco-asset-to-btc","params":[{"name":"makerWP","type":"pubkey"},' +
+                '{"name":"wantAmount","type":"int"},{"name":"server","type":"pubkey"},' +
+                '{"name":"user","type":"pubkey"},{"name":"exitDelay","type":"int"}],' +
+                '"functions":{"fulfill":{"tapscript":{"signers":["$server"]},"arkadeScript":' +
+                '{"asm":[0,"INSPECTOUTPUTVALUE","$wantAmount","GREATERTHANOREQUAL","VERIFY",0,' +
+                '"INSPECTOUTPUTSCRIPTPUBKEY",1,"EQUALVERIFY","$makerWP","EQUAL"]}},' +
+                '"cancel":{"tapscript":{"signers":["$user","$server"]}},' +
+                '"exit":{"tapscript":{"signers":["$user"],"csv":{"type":"blocks","value":"$exitDelay"}}}}}',
+        );
+    });
+
+    it("leaves the base programs untouched when it appends the exit", () => {
+        // withExitClosure spreads rather than mutates; a mutating version would
+        // leave every later exit-less offer compiling three leaves, silently
+        // moving its address
+        const before = arkade.stringifyArtifact(swapPrograms.wantBtc);
+        swapProgramBinding(
+            { wantAmount: BigInt(50_000), offerAsset: testAsset, ...keys, exitDelay: EXIT_BLOCKS },
+            server,
+        );
+        expect(arkade.stringifyArtifact(swapPrograms.wantBtc)).toBe(before);
+        expect(Object.keys(swapPrograms.wantBtc.functions)).toEqual(["fulfill", "cancel"]);
     });
 
     it("binds the asset group index into the covenant", () => {

--- a/packages/swap/test/offer.test.ts
+++ b/packages/swap/test/offer.test.ts
@@ -446,6 +446,18 @@ describe("swap offer", () => {
             expect(() => decodeOffer(zeroed)).toThrow("missing/invalid ratioNum");
         });
 
+        it("rejects a negative ratio rather than dropping it as unset", () => {
+            // 0 is the reference's "unset"; a negative is a value the u64 field
+            // cannot carry, and treating it as unset would publish an offer
+            // without the ratio the caller asked for
+            expect(() => encodeOffer(full({ ratioNum: BigInt(-1), ratioDen: BigInt(4) }))).toThrow(
+                "ratioNum does not fit",
+            );
+            expect(() => encodeOffer(full({ ratioNum: BigInt(3), ratioDen: BigInt(-4) }))).toThrow(
+                "ratioDen does not fit",
+            );
+        });
+
         it("treats a zero ratio as unset when encoding, as the reference does", () => {
             const encoded = encodeOffer(full({ ratioNum: BigInt(0), ratioDen: BigInt(0) }));
             expect(hex.encode(encoded)).toBe(hex.encode(encodeOffer(full())));

--- a/packages/swap/test/offer.test.ts
+++ b/packages/swap/test/offer.test.ts
@@ -421,6 +421,18 @@ describe("swap offer", () => {
             );
         });
 
+        it("rejects a zero exit delay, which is an exit in name only", () => {
+            // it builds a third leaf, so the offer reads as having a unilateral
+            // route out, while the CSV imposes no wait — weaker than `noExit`
+            // and harder to notice, since the leaf count says otherwise
+            expect(() =>
+                encodeOffer(full({ exitDelay: { type: "blocks", value: BigInt(0) } })),
+            ).toThrow("exitDelay must be a positive relative locktime");
+            expect(() =>
+                encodeOffer(full({ exitDelay: { type: "seconds", value: BigInt(-512) } })),
+            ).toThrow("exitDelay must be a positive relative locktime");
+        });
+
         it("rejects an exit delay wider than the reference's u32 locktime", () => {
             // the reference decoder narrows the wire u64 to uint32, so a wider
             // value derives one swap address there and another here

--- a/packages/swap/test/offer.test.ts
+++ b/packages/swap/test/offer.test.ts
@@ -433,6 +433,16 @@ describe("swap offer", () => {
             ).toThrow("exitDelay must be a positive relative locktime");
         });
 
+        it("DECODES a zero exit delay it would refuse to emit", () => {
+            // deliberately asymmetric. The reference emits any ExitDelay it is
+            // given, so refusing one on the way in would make us unable to read
+            // an offer solverd can publish — and a useless exit closure is the
+            // maker's own protection to waive, not ours to reject on their
+            // behalf. Encode stays strict so WE never publish one.
+            const zeroed = spliced(rec(0x0c, cat(Uint8Array.of(0x00), u64be(0))));
+            expect(decodeOffer(zeroed).exitDelay).toEqual({ type: "blocks", value: BigInt(0) });
+        });
+
         it("rejects an exit delay wider than the reference's u32 locktime", () => {
             // the reference decoder narrows the wire u64 to uint32, so a wider
             // value derives one swap address there and another here

--- a/packages/swap/test/register.test.ts
+++ b/packages/swap/test/register.test.ts
@@ -13,7 +13,7 @@ import {
     type IWallet,
     type OnchainProvider,
 } from "@arkade-os/sdk";
-import { createOffer, OFFER_CONTRACT_KIND, OFFER_CONTRACT_LABEL } from "../src/offer";
+import { createOffer, decodeOffer, OFFER_CONTRACT_KIND, OFFER_CONTRACT_LABEL } from "../src/offer";
 
 // the covenant derivation, Arkade.connect, ArkadeContract and register() are
 // all real here — only the network seam (the three Rest* providers) and the
@@ -27,6 +27,9 @@ const state = vi.hoisted(() => ({
     created: [] as Record<string, unknown>[],
     watched: [] as [string, string][],
     createContract: undefined as ((params: Record<string, unknown>) => unknown) | undefined,
+    // what the server advertises as its unilateral exit delay; createOffer
+    // builds the offer's exit closure from it unless the caller opts out
+    unilateralExitDelay: BigInt(4096),
 }));
 
 vi.mock("@arkade-os/sdk", async (importOriginal) => {
@@ -50,6 +53,7 @@ vi.mock("@arkade-os/sdk", async (importOriginal) => {
                         "02" + "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
                     checkpointTapscript,
                     network: "regtest",
+                    unilateralExitDelay: state.unilateralExitDelay,
                 };
             }
         },
@@ -96,13 +100,16 @@ const create = (maker: IWallet = wallet) =>
         emulatorPubkey,
     });
 
-describe("offer contract registration", () => {
-    beforeEach(() => {
-        state.created = [];
-        state.watched = [];
-        state.createContract = undefined;
-    });
+// file-level, not per-describe: the mocked provider is module state, so a
+// describe that forgot to reset it would inherit the previous one's server
+beforeEach(() => {
+    state.created = [];
+    state.watched = [];
+    state.createContract = undefined;
+    state.unilateralExitDelay = BigInt(4096);
+});
 
+describe("offer contract registration", () => {
     it("registers the funded covenant as an escrowed arkade contract", async () => {
         const offer = await create();
 
@@ -148,6 +155,75 @@ describe("offer contract registration", () => {
     it("states that the address it hands back is watched", async () => {
         const offer = await create();
         expect(state.watched).toEqual([[hex.encode(offer.swapPkScript), "watched"]]);
+    });
+});
+
+// ── The exit closure createOffer builds by default ───────────────────────────
+
+describe("a new offer's unilateral exit", () => {
+    it("is built by default, at the server's own delay", async () => {
+        // without it `cancel` is the only route out, and cancel needs the
+        // server: a server that will not co-sign strands the deposit until the
+        // VTXO expires and the operator sweeps it
+        const offer = decodeOffer(hex.decode((await create()).offerHex));
+        expect(offer.exitDelay).toEqual({ type: "seconds", value: BigInt(4096) });
+    });
+
+    it("reads a sub-512 delay as blocks, the threshold arkd's own closures use", async () => {
+        state.unilateralExitDelay = BigInt(144);
+        const offer = decodeOffer(hex.decode((await create()).offerHex));
+        expect(offer.exitDelay).toEqual({ type: "blocks", value: BigInt(144) });
+    });
+
+    it("puts the 512 boundary on the seconds side, as arkd and solverd do", async () => {
+        // 511 is blocks, 512 is seconds; reading the boundary the other way
+        // derives a different swap address from the same server
+        state.unilateralExitDelay = BigInt(512);
+        expect(decodeOffer(hex.decode((await create()).offerHex)).exitDelay).toEqual({
+            type: "seconds",
+            value: BigInt(512),
+        });
+        state.unilateralExitDelay = BigInt(511);
+        expect(decodeOffer(hex.decode((await create()).offerHex)).exitDelay).toEqual({
+            type: "blocks",
+            value: BigInt(511),
+        });
+    });
+
+    it("takes an explicit delay over the server's", async () => {
+        const created = await createOffer(wallet, "http://ark", {
+            wantAmount: BigInt(50_000),
+            wantAsset: testAsset,
+            emulatorPubkey,
+            exitDelay: { type: "blocks", value: BigInt(10) },
+        });
+        expect(decodeOffer(hex.decode(created.offerHex)).exitDelay).toEqual({
+            type: "blocks",
+            value: BigInt(10),
+        });
+    });
+
+    it("is omitted on noExit, which also moves the swap address", async () => {
+        const withExit = await create();
+        const without = await createOffer(wallet, "http://ark", {
+            wantAmount: BigInt(50_000),
+            wantAsset: testAsset,
+            emulatorPubkey,
+            noExit: true,
+        });
+        expect(decodeOffer(hex.decode(without.offerHex)).exitDelay).toBeUndefined();
+        // the closure is part of the covenant, so the two are different contracts
+        expect(without.swapPkScript).not.toEqual(withExit.swapPkScript);
+    });
+
+    it("refuses to publish an exit in name only when the server reports none", async () => {
+        // RestArkProvider defaults a missing field to 0, which would compile to
+        // a CSV of zero — an offer that claims an exit it does not have
+        state.unilateralExitDelay = BigInt(0);
+        await expect(create()).rejects.toThrow("no usable unilateralExitDelay");
+        expect(state.created, "nothing may be registered for an offer that never formed").toEqual(
+            [],
+        );
     });
 });
 

--- a/packages/swap/test/register.test.ts
+++ b/packages/swap/test/register.test.ts
@@ -11,6 +11,7 @@ import {
     type ArkProvider,
     type IndexerProvider,
     type IWallet,
+    type RelativeTimelock,
     type OnchainProvider,
 } from "@arkade-os/sdk";
 import { createOffer, decodeOffer, OFFER_CONTRACT_KIND, OFFER_CONTRACT_LABEL } from "../src/offer";
@@ -214,6 +215,39 @@ describe("a new offer's unilateral exit", () => {
         expect(decodeOffer(hex.decode(without.offerHex)).exitDelay).toBeUndefined();
         // the closure is part of the covenant, so the two are different contracts
         expect(without.swapPkScript).not.toEqual(withExit.swapPkScript);
+    });
+
+    const withExitDelay = (exitDelay: RelativeTimelock) =>
+        createOffer(wallet, "http://ark", {
+            wantAmount: BigInt(50_000),
+            wantAsset: testAsset,
+            emulatorPubkey,
+            exitDelay,
+        });
+
+    it("registers nothing for an explicit delay it will refuse to encode", async () => {
+        // A CSV of zero compiles happily, so the covenant is derived and
+        // REGISTERED before the encoder ever sees the delay. Refusing only at
+        // encode time leaves a watched contract behind for an offer that never
+        // formed — and promoteOfferContract has already marked its address
+        // outstanding, so retireOfferContract will not take that row back.
+        await expect(withExitDelay({ type: "blocks", value: BigInt(0) })).rejects.toThrow(
+            "exitDelay must be a positive relative locktime",
+        );
+        expect(state.created, "nothing may be registered for an offer that never formed").toEqual(
+            [],
+        );
+        expect(state.watched).toEqual([]);
+    });
+
+    it("names an oversized delay itself, rather than letting bip68 do it", async () => {
+        // deriving first reports `Expected Number seconds <= 33553920` from
+        // inside the timelock encoder, which names neither the field nor the way
+        // out; the check has to run before the covenant is built
+        await expect(
+            withExitDelay({ type: "seconds", value: BigInt(1) << BigInt(32) }),
+        ).rejects.toThrow("exitDelay does not fit the locktime field (u32)");
+        expect(state.created).toEqual([]);
     });
 
     it("refuses to publish an exit in name only when the server reports none", async () => {

--- a/packages/swap/test/restore.test.ts
+++ b/packages/swap/test/restore.test.ts
@@ -25,7 +25,12 @@ const EMULATOR_KEY = key("33");
 // a script whose key is not a point
 const MAKER_PK_SCRIPT = new Uint8Array([0x51, 0x20, ...key("55")]);
 
-const makeOffer = (side: "want-asset" | "want-btc", wantAmount: bigint): Offer => {
+const makeOffer = (
+    side: "want-asset" | "want-btc",
+    wantAmount: bigint,
+    /** Present adds the exit closure, so the offer compiles to three leaves. */
+    exitDelay?: { type: "blocks" | "seconds"; value: bigint },
+): Offer => {
     const binding: Omit<Offer, "swapPkScript"> = {
         wantAmount,
         ...(side === "want-asset"
@@ -34,6 +39,7 @@ const makeOffer = (side: "want-asset" | "want-btc", wantAmount: bigint): Offer =
         makerPkScript: MAKER_PK_SCRIPT,
         makerPublicKey: MAKER_KEY,
         emulatorPubkey: EMULATOR_KEY,
+        ...(exitDelay ? { exitDelay } : {}),
     };
     return { ...binding, swapPkScript: offerVtxoScript(binding, SERVER_KEY).pkScript };
 };
@@ -53,11 +59,15 @@ const fundingPsbt = (offer: Offer): { psbt: string; txid: string } => {
 
 /**
  * A spend of one or more deposits, each input carrying the covenant leaf it
- * took. This is what the classifier reads: `cancel` returns the deposit,
- * `fulfill` is the solver paying for it.
+ * took. This is what the classifier reads: `cancel` and `exit` return the
+ * deposit, `fulfill` is the solver paying for it.
  */
 const spendPsbt = (
-    spends: { offer: Offer; deposit: { txid: string; vout: number }; via: "cancel" | "fulfill" }[],
+    spends: {
+        offer: Offer;
+        deposit: { txid: string; vout: number };
+        via: "cancel" | "fulfill" | "exit";
+    }[],
 ): { psbt: string; txid: string } => {
     const tx = new Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true });
     for (const { offer, deposit, via } of spends) {
@@ -131,6 +141,41 @@ describe("classifySpend", () => {
         const parse = (psbt: string) => Transaction.fromPSBT(base64.decode(psbt));
         expect(classifySpend(offer, SERVER_KEY, parse(cancel.psbt), deposit)).toBe("cancelled");
         expect(classifySpend(offer, SERVER_KEY, parse(fill.psbt), deposit)).toBe("fulfilled");
+    });
+
+    it("reports a unilateral exit as cancelled — the deposit came back either way", async () => {
+        // An unclassified exit would be worse than imprecise: no status is
+        // written, so the swap stays `pending`, the restore scan re-queues it
+        // forever, and retireOfferContract never runs — leaving a dead script
+        // in the subscription and the failsafe poll for the wallet's lifetime.
+        const offer = makeOffer("want-btc", BigInt(21_000), { type: "blocks", value: BigInt(144) });
+        const deposit = { txid: "ab".repeat(32), vout: 0 };
+        const parse = (psbt: string) => Transaction.fromPSBT(base64.decode(psbt));
+
+        const exit = spendPsbt([{ offer, deposit, via: "exit" }]);
+        expect(classifySpend(offer, SERVER_KEY, parse(exit.psbt), deposit)).toBe("cancelled");
+
+        // the other two leaves still answer for themselves on a 3-leaf offer
+        const cancel = spendPsbt([{ offer, deposit, via: "cancel" }]);
+        const fill = spendPsbt([{ offer, deposit, via: "fulfill" }]);
+        expect(classifySpend(offer, SERVER_KEY, parse(cancel.psbt), deposit)).toBe("cancelled");
+        expect(classifySpend(offer, SERVER_KEY, parse(fill.psbt), deposit)).toBe("fulfilled");
+    });
+
+    it("leaves an exit-less offer with nothing to match the exit leaf against", async () => {
+        // functionByName("exit") is undefined there, and a filter that let an
+        // undefined leaf through would match any spend carrying no tapleaf
+        const withExit = makeOffer("want-btc", BigInt(21_000), {
+            type: "blocks",
+            value: BigInt(144),
+        });
+        const withoutExit = makeOffer("want-btc", BigInt(21_000));
+        const deposit = { txid: "ab".repeat(32), vout: 0 };
+        const exitSpend = Transaction.fromPSBT(
+            base64.decode(spendPsbt([{ offer: withExit, deposit, via: "exit" }]).psbt),
+        );
+        // the exit leaf of a DIFFERENT covenant is not this offer's route back
+        expect(classifySpend(withoutExit, SERVER_KEY, exitSpend, deposit)).toBe("indeterminate");
     });
 
     it("classifies each deposit by its own input when one tx spends several", async () => {


### PR DESCRIPTION
`decodeOffer` throws `unknown TLV type: 0xc` on any offer `solverd` publishes.

## The gap

solverd's maker helper builds the maker's unilateral exit closure **by default** —
it is opt-*out* (`pkg/swap/contract/maker.go:97`, `if !params.NoExit`), using the
server's `UnilateralExitDelay` — and emits it as TLV tag `0x0c`. Our `FIELDS`
table knows tags `0x01`, `0x02`, `0x03`, `0x05`, `0x07`, `0x08` and `0x0b` only,
and the decoder is strict by design, so the entire payload is refused.

Tags `0x09`/`0x0a` (the partial-fill ratio) are reserved wire space today —
solverd round-trips them but never sets them — and fail the same way the moment
anything does.

The effect is that a solverd-made offer is undecodable by this SDK. It never
reaches `offerVtxoScript`, `classifySpend`, `fillOffer` (#785, which calls
`decodeOffer` directly), or any acceptance gate a taker puts in front of them.

## The fix

- **Decode and encode `0x09` ratioNum, `0x0a` ratioDen and `0x0c` exitTimelock**,
  in the canonical record order § 2.1 of the swap protocol requires.
- **Build the exit closure into the taproot tree** when `exitDelay` is present: a
  `CSVMultisigClosure` of the maker alone, appended as the third leaf. This has
  to land with the decoding rather than after it — reading the tag without
  building the leaf derives a different address, and every such offer would then
  fail the § 5.1 consistency check instead of decoding.
- **`createOffer` now builds the exit closure by default**, at the server's own
  `unilateralExitDelay`, matching solverd. Without it `cancel` is the only route
  out of an offer, and `cancel` is a 2-of-2 with the server: a server that will
  not co-sign leaves the deposit stuck at the swap address until the VTXO expires
  and the operator sweeps it — and an offer has no expiry of its own, so that
  exposure has no end. `noExit: true` opts out; an explicit `exitDelay`
  overrides.

The delay is derived under the same sub-512-is-blocks threshold arkd's own
closures (`wallet.ts`'s `delayToTimelock`) and solverd's `fetchServerConfig` use.
A server reporting no usable delay is refused rather than published as a CSV of
zero, which would be an offer claiming an exit it does not have.

Ratios are carried, never interpreted — they do not touch the script, which the
`ratio 1/4` vector below pins by deriving the same address as its ratio-less twin.

## What this changes for existing callers

Only **new** offers from `createOffer` get the extra leaf, and their swap address
moves accordingly. A stored `offerHex` carries its own exit field, so it
re-derives to exactly the address it was funded at either way, and `cancelOffer`
and `classifySpend` keep working on offers made before this change.

The exit adds no new race: `cancel` is already **untimelocked**, so the maker can
already spend out from under a fill at any moment. `exit` is strictly more
constrained than a path that already exists.

### Checked against `arkade-os/wallet` (`master`, 179e0b3)

It is the real consumer of this API, so I read it rather than assuming:

- It **imports** `createOffer`/`cancelOffer`/`decodeOffer` from this package and
  holds no copy of the offer construction, the TLV codec or the program JSONs —
  so there is no second implementation to keep in step.
- `createSwap` (`src/providers/assetSwaps.tsx:202`) passes neither `exitDelay`
  nor `noExit`, so it picks up the exit closure with no wallet change. New offers
  derive a different swap address; it persists `offerHex` and passes it back to
  `cancelOffer`, so offers made before the bump still re-derive to the address
  they were funded at.
- Nothing there reads leaves, `tapLeafScript` or `functionByName`, so no code
  assumes a two-leaf tree.
- Its one piece of local swap logic, `isCancelSpend` (`src/lib/swapSpend.ts`),
  is inferential — it asks what the spend moved, not which leaf it took — and
  reports an exit spend as a cancel. That is the same answer `classifySpend` now
  gives, so the wallet's heuristic and this package agree rather than diverging
  on the new leaf.

## Verification

The `solverd reference vectors` block is generated by **solverd's own encoder**,
not by this SDK, so it pins the wire format and the taproot tree against the
reference rather than against ourselves. Each vector asserts that we decode the
payload, re-derive its `swapPkScript` and address, get the right leaf count, and
re-emit byte-identical bytes.

Two of the vectors carry no exit and reproduce the goldens already at the top of
`offer.test.ts` — that is what says the generator ran against the same inputs.

<details>
<summary>Generator (drop in <code>arkade-os/solver</code> at <code>cmd/offervectors/main.go</code>, <code>go run ./cmd/offervectors</code>)</summary>

```go
package main

import (
	"encoding/hex"
	"encoding/json"
	"os"
	"strings"

	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
	"github.com/arkade-os/solver/pkg/swap/contract"
	"github.com/btcsuite/btcd/btcec/v2"
	"github.com/btcsuite/btcd/btcec/v2/schnorr"
)

func xonly(h string) *btcec.PublicKey {
	b, _ := hex.DecodeString(h)
	k, err := schnorr.ParsePubKey(b)
	if err != nil {
		panic(err)
	}
	return k
}

func assetId(h string) *asset.AssetId {
	b, _ := hex.DecodeString(h)
	id, err := asset.NewAssetIdFromBytes(b)
	if err != nil {
		panic(err)
	}
	return id
}

func main() {
	server := xonly("4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa")
	maker := xonly("3c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1")
	emulator := xonly("466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27")
	makerPkScript, _ := hex.DecodeString(
		"51203c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1",
	)
	// the same 34-byte id offer.test.ts builds with AssetId.fromString("aa".repeat(32) + "0000")
	testAsset := assetId(strings.Repeat("aa", 33) + "0000")

	blocks := arklib.RelativeLocktime{Type: arklib.LocktimeTypeBlock, Value: 144}
	seconds := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 51200}
	long := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 604672}
	short := arklib.RelativeLocktime{Type: arklib.LocktimeTypeBlock, Value: 4032}

	cases := []struct {
		label string
		want  *asset.AssetId
		offer *asset.AssetId
		exit  *arklib.RelativeLocktime
		ratio [2]uint64
	}{
		{label: "wantBtc, no exit", offer: testAsset},
		{label: "wantBtc, exit blocks 144", offer: testAsset, exit: &blocks},
		{label: "wantAsset, no exit", want: testAsset},
		{label: "wantAsset, exit seconds 51200", want: testAsset, exit: &seconds},
		{label: "wantAsset, exit seconds 604672", want: testAsset, exit: &long},
		{label: "wantAsset, ratio 1/4", want: testAsset, ratio: [2]uint64{1, 4}},
		{label: "wantBtc, ratio 3/8, exit blocks 4032", offer: testAsset,
			ratio: [2]uint64{3, 8}, exit: &short},
	}

	type vector struct {
		Label     string `json:"label"`
		OfferHex  string `json:"offerHex"`
		Address   string `json:"address"`
		LeafCount int    `json:"leafCount"`
	}
	out := make([]vector, 0, len(cases))
	for _, c := range cases {
		o := &contract.Offer{
			WantAmount: 50_000, WantAsset: c.want, OfferAsset: c.offer,
			RatioNum: c.ratio[0], RatioDen: c.ratio[1],
			MakerPkScript: makerPkScript, MakerPublicKey: maker,
			EmulatorPubkey: emulator, ExitDelay: c.exit,
		}
		vtxoScript, err := o.VtxoScript(server)
		if err != nil {
			panic(err)
		}
		taprootKey, _, err := vtxoScript.TapTree()
		if err != nil {
			panic(err)
		}
		addr := &arklib.Address{HRP: "tark", Signer: server, VtxoTapKey: taprootKey}
		encoded, _ := addr.EncodeV0()
		pkScript, _ := addr.GetPkScript()
		o.SwapPkScript = pkScript
		payload, err := o.Serialize()
		if err != nil {
			panic(err)
		}
		out = append(out, vector{c.label, hex.EncodeToString(payload), encoded,
			len(vtxoScript.Closures)})
	}
	enc := json.NewEncoder(os.Stdout)
	enc.SetIndent("", "  ")
	_ = enc.Encode(out)
}
```

</details>

The tests were checked to be load-bearing by mutation, not just by passing:

| Mutation | Result |
|---|---|
| `exit` moved ahead of `cancel` in the leaf list | 4 vector tests fail |
| ratio records swapped with `offerAsset` in the emitted order | all-optionals vector fails |
| `delay < 512` relaxed to `delay <= 512` | the boundary test fails |
| `exit` dropped from the leaves that mean "returned" | the exit-classification test fails |

The record-order mutation **survived** the first time — no vector carried both an
`offerAsset` and a ratio, so that ordering was untested. The all-optionals vector
exists because of it.

## Test plan

- `pnpm -C packages/swap test` — 600 → 631 passing, no change to the pre-existing
  600.
- `pnpm -C packages/swap run typecheck` — clean.
- `pnpm run build`, `pnpm -C packages/swap run smoke:dist`, `pnpm run test:unit` —
  clean.
- Both golden swap addresses at the top of `offer.test.ts` are unchanged, which is
  the check that no already-published offer's address moved.

## Deliberately not in this PR

- **Partial fills.** The ratio is decoded and carried; nothing interprets it. The
  `fulfill` closure still requires the full `wantAmount`.
- **A distinct `exited` status.** An exit reports as `cancelled` (see below), so
  the record does not say whether the deposit came back cooperatively or
  unilaterally. Adding that distinction means a new `SpendKind` and a new
  persisted status across `TERMINAL`, `RETIRABLE` and every consumer that
  switches on it — worth its own PR, and not needed to keep the swap correct.

## The exit spend had to be classified, not deferred

Adding a third leaf without teaching `classifySpend` about it would have stranded
the swap it belongs to. `classifySpend` matched only `cancel` and `fulfill`, so an
exit spend matched neither and returned `indeterminate` — **deterministically**,
not transiently, unlike the existing `indeterminate` cases which a later poll
clears. From there:

- `spendUpdate` writes nothing for `indeterminate` (`watch.ts:171`), so the swap
  stays `pending` forever;
- `restoreAssetSwaps` adds it to `unresolved` and persists nothing
  (`restore.ts:352`), so every later scan re-queues it;
- and `retireOfferContract` is gated on a `RETIRABLE` status (`watch.ts:187`), so
  the contract is **never retired** — the dead script stays in the subscription,
  the failsafe poll and every sync for the life of the wallet.

So `cancel` and `exit` both report `cancelled`. The vocabulary is what became of
the deposit, not which key moved it: the two differ in who had to agree, not in
outcome. It is also what the wallet's own `isCancelSpend` already infers for an
exit spend, so the two implementations agree rather than diverging.

## Note for solverd

`fetchServerConfig` builds the exit delay as
`RelativeLocktime{Type: LocktimeTypeSecond, Value: uint32(info.UnilateralExitDelay)}`
with no rounding, and both implementations reject seconds that are not a multiple
of 512 (Go: `seconds must be a multiple of 512`; here, bip68's encoder). So an
arkd whose `UnilateralExitDelay` is not 512-granular makes solverd's own
`CreateOffer` fail. Nothing to fix on this side — arkd's own delays are
512-granular (mainnet's is 605184 = 512 × 1182) — but worth knowing.
