### PR TITLE
fix(sdk): harden boarding settlement lifecycle

### DIFF
--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -749,6 +749,7 @@ export class RestArkProvider implements ArkProvider {
                 while (!signal?.aborted) {
                     const currentIterator = eventSourceIterator(
                         resolveEventSource(self.eventSource)(url + queryParams),
+                        { preserveNativeReconnect: true },
                     );
                     iterator = currentIterator;
 

--- a/packages/ts-sdk/src/providers/eventSource.ts
+++ b/packages/ts-sdk/src/providers/eventSource.ts
@@ -28,6 +28,8 @@
  * it waves through this one.
  */
 export interface EventSourceLike {
+    /** Native EventSource state when exposed (0 connecting, 1 open, 2 closed). */
+    readonly readyState?: number;
     addEventListener(type: "message" | "error", listener: (event: MessageEvent) => void): void;
     removeEventListener(type: "message" | "error", listener: (event: MessageEvent) => void): void;
     close(): void;

--- a/packages/ts-sdk/src/providers/utils.ts
+++ b/packages/ts-sdk/src/providers/utils.ts
@@ -17,7 +17,10 @@ function createAbortError(): Error {
  * close() closes the EventSource, removes listeners, and wakes any pending
  * next() even when the browser does not emit an error from EventSource.close().
  */
-export function eventSourceIterator(eventSource: EventSourceLike): ManagedEventSourceIterator {
+export function eventSourceIterator(
+    eventSource: EventSourceLike,
+    options: { preserveNativeReconnect?: boolean } = {},
+): ManagedEventSourceIterator {
     const messageQueue: MessageEvent[] = [];
     const errorQueue: Error[] = [];
     let messageResolve: ((value: MessageEvent) => void) | null = null;
@@ -65,7 +68,7 @@ export function eventSourceIterator(eventSource: EventSourceLike): ManagedEventS
         // Native EventSource reports transient transport loss with CONNECTING
         // and performs its own retry on this same instance. Keep it alive so
         // its retry state (including Last-Event-ID where available) is not lost.
-        if (eventSource.readyState === 0) return;
+        if (options.preserveNativeReconnect && eventSource.readyState === 0) return;
         const error = new Error("EventSource error");
         error.name = "EventSourceError";
         if (errorResolve) {

--- a/packages/ts-sdk/src/providers/utils.ts
+++ b/packages/ts-sdk/src/providers/utils.ts
@@ -62,6 +62,10 @@ export function eventSourceIterator(eventSource: EventSourceLike): ManagedEventS
 
     const errorHandler = () => {
         if (closed) return;
+        // Native EventSource reports transient transport loss with CONNECTING
+        // and performs its own retry on this same instance. Keep it alive so
+        // its retry state (including Last-Event-ID where available) is not lost.
+        if (eventSource.readyState === 0) return;
         const error = new Error("EventSource error");
         error.name = "EventSourceError";
         if (errorResolve) {

--- a/packages/ts-sdk/src/wallet/batch.ts
+++ b/packages/ts-sdk/src/wallet/batch.ts
@@ -141,6 +141,7 @@ export namespace Batch {
         const { abortController, skipVtxoTreeSigning = false, eventCallback } = options;
 
         let step = Step.Start;
+        let selectedBatchId: string | undefined;
 
         // keep track of tree transactions as they arrive
         const flatVtxoTree: TxTreeNode[] = [];
@@ -161,10 +162,12 @@ export namespace Batch {
 
             switch (event.type) {
                 case SettlementEventType.BatchStarted: {
+                    if (selectedBatchId !== undefined) continue;
                     const e = event as BatchStartedEvent;
                     const { skip } = await handler.onBatchStarted(e);
 
                     if (!skip) {
+                        selectedBatchId = e.id;
                         step = Step.BatchStarted;
 
                         if (skipVtxoTreeSigning) {
@@ -176,7 +179,7 @@ export namespace Batch {
                 }
 
                 case SettlementEventType.BatchFinalized: {
-                    if (step !== Step.BatchFinalization) {
+                    if (event.id !== selectedBatchId || step !== Step.BatchFinalization) {
                         continue;
                     }
 
@@ -187,6 +190,7 @@ export namespace Batch {
                 }
 
                 case SettlementEventType.BatchFailed: {
+                    if (event.id !== selectedBatchId) continue;
                     if (handler.onBatchFailed) {
                         await handler.onBatchFailed(event);
                         continue;
@@ -196,6 +200,7 @@ export namespace Batch {
                 }
 
                 case SettlementEventType.TreeTx: {
+                    if (event.id !== selectedBatchId) continue;
                     if (step !== Step.BatchStarted && step !== Step.TreeNoncesAggregated) {
                         continue;
                     }
@@ -214,6 +219,7 @@ export namespace Batch {
                 }
 
                 case SettlementEventType.TreeSignature: {
+                    if (event.id !== selectedBatchId) continue;
                     if (step !== Step.TreeNoncesAggregated) {
                         continue;
                     }
@@ -237,9 +243,16 @@ export namespace Batch {
                 }
 
                 case SettlementEventType.TreeSigningStarted: {
+                    if (event.id !== selectedBatchId) continue;
                     if (step !== Step.BatchStarted) {
                         continue;
                     }
+
+                    // A reconnect can observe the broadcast signing marker
+                    // after missing the topic-filtered tree chunks. Never
+                    // construct or sign an empty tree; wait for usable state or
+                    // the selected batch's terminal failure instead.
+                    if (flatVtxoTree.length === 0) continue;
 
                     // create virtual output tree from collected chunks
                     vtxoTree = TxTree.create(flatVtxoTree);
@@ -253,6 +266,7 @@ export namespace Batch {
                 }
 
                 case SettlementEventType.TreeNonces: {
+                    if (event.id !== selectedBatchId) continue;
                     if (step !== Step.TreeSigningStarted) {
                         continue;
                     }
@@ -265,6 +279,7 @@ export namespace Batch {
                 }
 
                 case SettlementEventType.BatchFinalization: {
+                    if (event.id !== selectedBatchId) continue;
                     if (step !== Step.TreeNoncesAggregated) {
                         continue;
                     }

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -3640,7 +3640,7 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
      * gate. Pass {@link getSpendableVtxos} instead when the intent is "settle
      * whatever is spendable".
      *
-     * @param params - Optional settlement inputs and outputs. When omitted, the wallet settles all eligible funds.
+     * @param params - Optional settlement inputs and outputs. When omitted, the wallet settles eligible funds. If eligible boarding inputs exist, configured boarding destination, input-cap, and automatic-renewal policy are applied.
      * @param eventCallback - Optional callback invoked for settlement stream events.
      * @returns The finalized Arkade transaction id
      */
@@ -3676,9 +3676,9 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         // `findDestinationOutputIndex` against the other, which fails with a
         // spurious "no output matches". A single read pins the no-params output
         // below and the asset-routing destination script later to one address.
-        const offchainAddress = await this.getAddress();
-        const offchainPkScript = ArkAddress.decode(offchainAddress).pkScript;
-        const offchainOutputScript = hex.encode(offchainPkScript);
+        let offchainAddress = await this.getAddress();
+        let offchainPkScript = ArkAddress.decode(offchainAddress).pkScript;
+        let offchainOutputScript = hex.encode(offchainPkScript);
 
         // if no params are provided, use all non-expired boarding inputs and offchain virtual outputs as inputs
         // and send all to the offchain address
@@ -3701,11 +3701,25 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                 chainTipHeight = tip.height;
             }
 
-            const boardingUtxos = (await this.getBoardingUtxos()).filter(
+            let boardingUtxos = (await this.getBoardingUtxos()).filter(
                 (utxo) =>
                     utxo.status.confirmed &&
                     !hasBoardingTxExpired(utxo, boardingTimelock, chainTipHeight),
             );
+
+            if (this.settlementConfig) {
+                const maxBoardingInputs = this.settlementConfig.maxBoardingInputsPerSettle;
+                if (maxBoardingInputs !== undefined) {
+                    boardingUtxos = boardingUtxos
+                        .sort((a, b) => a.txid.localeCompare(b.txid) || a.vout - b.vout)
+                        .slice(0, maxBoardingInputs);
+                }
+                if (boardingUtxos.length > 0 && this.settlementConfig.boardingSettleAddress) {
+                    offchainAddress = this.settlementConfig.boardingSettleAddress;
+                    offchainPkScript = ArkAddress.decode(offchainAddress).pkScript;
+                    offchainOutputScript = hex.encode(offchainPkScript);
+                }
+            }
 
             const filteredBoardingUtxos = [];
             for (const utxo of boardingUtxos) {
@@ -3721,7 +3735,12 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
                 amount += utxo.value - inputFee.satoshis;
             }
 
-            const vtxos = await this.getSpendableVtxos({ withRecoverable: true });
+            const vtxos =
+                boardingUtxos.length > 0 &&
+                this.settlementConfig &&
+                this.settlementConfig.autoRenewVtxos === false
+                    ? []
+                    : await this.getSpendableVtxos({ withRecoverable: true });
 
             // Cap the VTXOs per settlement to stay under the server's
             // intent-size limit (MAX_VTXOS_PER_SETTLEMENT inputs) and its
@@ -3980,17 +3999,16 @@ export class Wallet extends ReadonlyWallet implements IWallet, HDWalletCapable {
         try {
             stream = this.arkProvider.getEventStream(abortController.signal, topics);
 
-            // Prime the iterator so the provider opens the SSE subscription
-            // before safeRegisterIntent can trigger server-side batch events.
-            const firstNext = stream.next();
-            // If settle exits before Batch.join consumes the primed result,
-            // keep the orphaned promise from surfacing as an unhandled rejection.
-            void firstNext.catch(() => {});
+            // Wait for the first stream event before registering. Merely calling
+            // next() starts the EventSource but does not prove that the Operator
+            // has installed the subscription; registration could otherwise race
+            // a BatchStarted event and leave an accepted intent unacknowledged.
+            const first = await stream.next();
+            if (first.done) {
+                throw new Error("event stream closed before intent registration");
+            }
             const primedStream = (async function* () {
-                const first = await firstNext;
-                if (!first.done) {
-                    yield first.value;
-                }
+                yield first.value;
                 yield* stream;
             })();
 

--- a/packages/ts-sdk/test/ark-provider.test.ts
+++ b/packages/ts-sdk/test/ark-provider.test.ts
@@ -73,6 +73,32 @@ describe("RestArkProvider.getEventStream", () => {
         await stream.return?.();
         await pending.catch(() => {});
     });
+
+    it("leaves native EventSource reconnecting on the same settlement stream", async () => {
+        const provider = new RestArkProvider("http://localhost:7070");
+        const ac = new AbortController();
+        const stream = provider.getEventStream(ac.signal, ["topic-1"]);
+
+        const pending = stream.next();
+        await vi.waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+        MockEventSource.instances[0].emitError(0);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(MockEventSource.instances).toHaveLength(1);
+        expect(MockEventSource.instances[0].closed).toBe(false);
+        MockEventSource.instances[0].emitMessage(
+            JSON.stringify({ streamStarted: { id: "stream-2" } }),
+        );
+
+        await expect(pending).resolves.toEqual({
+            done: false,
+            value: { type: "stream_started", id: "stream-2" },
+        });
+
+        ac.abort();
+        await stream.return?.();
+        expect(MockEventSource.instances[0].closed).toBe(true);
+    });
 });
 
 describe("RestArkProvider.getTransactionsStream", () => {

--- a/packages/ts-sdk/test/batch-join-selection.test.ts
+++ b/packages/ts-sdk/test/batch-join-selection.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { Batch } from "../src/wallet/batch";
+import { SettlementEventType, type SettlementEvent } from "../src/providers/ark";
+
+async function* streamOf(...events: SettlementEvent[]): AsyncIterableIterator<SettlementEvent> {
+    yield* events;
+}
+
+const handler = () => ({
+    onBatchStarted: vi.fn().mockResolvedValue({ skip: false }),
+    onTreeSigningStarted: vi.fn().mockResolvedValue({ skip: false }),
+    onTreeNonces: vi.fn().mockResolvedValue({ fullySigned: true }),
+    onBatchFinalization: vi.fn().mockResolvedValue(undefined),
+    onBatchFinalized: vi.fn().mockResolvedValue(undefined),
+    onBatchFailed: vi.fn().mockRejectedValue(new Error("selected batch failed")),
+});
+
+describe("Batch.join selected-batch isolation", () => {
+    it("ignores interleaved lifecycle events from every other batch", async () => {
+        const selected = "selected-batch";
+        const foreign = "foreign-batch";
+        const hooks = handler();
+
+        await expect(
+            Batch.join(
+                streamOf(
+                    {
+                        type: SettlementEventType.BatchStarted,
+                        id: selected,
+                        intentIdHashes: ["ours"],
+                        batchExpiry: 604_672n,
+                    },
+                    {
+                        type: SettlementEventType.BatchStarted,
+                        id: foreign,
+                        intentIdHashes: ["ours"],
+                        batchExpiry: 604_672n,
+                    },
+                    { type: SettlementEventType.BatchFailed, id: foreign, reason: "not ours" },
+                    {
+                        type: SettlementEventType.BatchFinalization,
+                        id: foreign,
+                        commitmentTx: "foreign-psbt",
+                    },
+                    {
+                        type: SettlementEventType.BatchFinalization,
+                        id: selected,
+                        commitmentTx: "selected-psbt",
+                    },
+                    {
+                        type: SettlementEventType.BatchFinalized,
+                        id: foreign,
+                        commitmentTxid: "11".repeat(32),
+                    },
+                    {
+                        type: SettlementEventType.BatchFinalized,
+                        id: selected,
+                        commitmentTxid: "22".repeat(32),
+                    },
+                ),
+                hooks,
+                { skipVtxoTreeSigning: true },
+            ),
+        ).resolves.toBe("22".repeat(32));
+
+        expect(hooks.onBatchStarted).toHaveBeenCalledTimes(1);
+        expect(hooks.onBatchFailed).not.toHaveBeenCalled();
+        expect(hooks.onBatchFinalization).toHaveBeenCalledOnce();
+        expect(hooks.onBatchFinalization).toHaveBeenCalledWith(
+            expect.objectContaining({ id: selected }),
+            undefined,
+            undefined,
+        );
+        expect(hooks.onBatchFinalized).toHaveBeenCalledOnce();
+    });
+
+    it("does not construct a tree for a foreign signing event", async () => {
+        const hooks = handler();
+
+        await expect(
+            Batch.join(
+                streamOf(
+                    {
+                        type: SettlementEventType.BatchStarted,
+                        id: "selected-batch",
+                        intentIdHashes: ["ours"],
+                        batchExpiry: 604_672n,
+                    },
+                    {
+                        type: SettlementEventType.TreeSigningStarted,
+                        id: "foreign-batch",
+                        cosignersPublicKeys: [],
+                        unsignedCommitmentTx: "",
+                    },
+                ),
+                hooks,
+            ),
+        ).rejects.toThrow("event stream closed");
+
+        expect(hooks.onTreeSigningStarted).not.toHaveBeenCalled();
+    });
+
+    it("does not construct an empty tree when a reconnect misses selected tree chunks", async () => {
+        const hooks = handler();
+
+        await expect(
+            Batch.join(
+                streamOf(
+                    {
+                        type: SettlementEventType.BatchStarted,
+                        id: "selected-batch",
+                        intentIdHashes: ["ours"],
+                        batchExpiry: 604_672n,
+                    },
+                    {
+                        type: SettlementEventType.TreeSigningStarted,
+                        id: "selected-batch",
+                        cosignersPublicKeys: [],
+                        unsignedCommitmentTx: "",
+                    },
+                    {
+                        type: SettlementEventType.BatchFailed,
+                        id: "selected-batch",
+                        reason: "expired",
+                    },
+                ),
+                hooks,
+            ),
+        ).rejects.toThrow("selected batch failed");
+
+        expect(hooks.onTreeSigningStarted).not.toHaveBeenCalled();
+        expect(hooks.onBatchFailed).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/ts-sdk/test/providers-utils.test.ts
+++ b/packages/ts-sdk/test/providers-utils.test.ts
@@ -3,21 +3,22 @@ import { eventSourceIterator, isEventSourceError } from "../src/providers/utils"
 import { MockEventSource } from "./mocks/eventSource";
 
 describe("eventSourceIterator", () => {
-    it("surfaces reconnecting EventSource errors as EventSourceError", async () => {
+    it("keeps a reconnecting EventSource alive until it delivers the next message", async () => {
         const eventSource = new MockEventSource();
         const iterator = eventSourceIterator(eventSource as unknown as EventSource);
         const next = iterator.next();
 
         eventSource.emitError(0);
+        await Promise.resolve();
+        expect(eventSource.closed).toBe(false);
 
-        await expect(next).rejects.toMatchObject({
-            name: "EventSourceError",
-            message: "EventSource error",
+        eventSource.emitMessage("reconnected");
+        await expect(next).resolves.toMatchObject({
+            done: false,
+            value: { data: "reconnected" },
         });
 
-        await next.catch((error) => {
-            expect(isEventSourceError(error)).toBe(true);
-        });
+        await iterator.return();
     });
 
     it("surfaces closed EventSource errors as EventSourceError", async () => {

--- a/packages/ts-sdk/test/providers-utils.test.ts
+++ b/packages/ts-sdk/test/providers-utils.test.ts
@@ -3,9 +3,23 @@ import { eventSourceIterator, isEventSourceError } from "../src/providers/utils"
 import { MockEventSource } from "./mocks/eventSource";
 
 describe("eventSourceIterator", () => {
-    it("keeps a reconnecting EventSource alive until it delivers the next message", async () => {
+    it("surfaces reconnecting EventSource errors by default", async () => {
         const eventSource = new MockEventSource();
         const iterator = eventSourceIterator(eventSource as unknown as EventSource);
+        const next = iterator.next();
+
+        eventSource.emitError(0);
+        await expect(next).rejects.toMatchObject({
+            name: "EventSourceError",
+            message: "EventSource error",
+        });
+    });
+
+    it("keeps an opted-in reconnecting EventSource alive until its next message", async () => {
+        const eventSource = new MockEventSource();
+        const iterator = eventSourceIterator(eventSource as unknown as EventSource, {
+            preserveNativeReconnect: true,
+        });
         const next = iterator.next();
 
         eventSource.emitError(0);
@@ -13,10 +27,7 @@ describe("eventSourceIterator", () => {
         expect(eventSource.closed).toBe(false);
 
         eventSource.emitMessage("reconnected");
-        await expect(next).resolves.toMatchObject({
-            done: false,
-            value: { data: "reconnected" },
-        });
+        await expect(next).resolves.toMatchObject({ done: false, value: { data: "reconnected" } });
 
         await iterator.return();
     });

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -2758,7 +2758,10 @@ describe("VtxoManager - Combined periodic settle (boarding + VTXOs)", () => {
                         vtxoMaxAmount: -1n,
                     }),
                     getEventStream: vi.fn().mockImplementation(() => ({
-                        next: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+                        next: vi.fn().mockResolvedValue({
+                            done: false,
+                            value: { type: "stream_started", id: "stream-1" },
+                        }),
                         return: vi.fn().mockResolvedValue({ done: true, value: undefined }),
                         [Symbol.asyncIterator]() {
                             return this;

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -1801,12 +1801,17 @@ describe("Wallet._settleImpl", () => {
         const stream = {
             next: vi
                 .fn()
+                .mockImplementationOnce(
+                    () =>
+                        new Promise((resolve) => {
+                            queueMicrotask(() => {
+                                callOrder.push("stream.ready");
+                                resolve({ done: false, value: primedEvent });
+                            });
+                        }),
+                )
                 .mockImplementationOnce(async () => {
                     callOrder.push("stream.next#1");
-                    return { done: false, value: primedEvent };
-                })
-                .mockImplementationOnce(async () => {
-                    callOrder.push("stream.next#2");
                     return { done: false, value: secondEvent };
                 }),
             return: vi.fn(async () => {
@@ -1873,10 +1878,10 @@ describe("Wallet._settleImpl", () => {
 
         expect(result).toBe("commitment-txid");
         expect(callOrder).toEqual([
-            "stream.next#1",
+            "stream.ready",
             "safeRegisterIntent",
             "Batch.join",
-            "stream.next#2",
+            "stream.next#1",
             "stream.return",
         ]);
         expect(stream.next).toHaveBeenCalledTimes(2);
@@ -1891,18 +1896,13 @@ describe("Wallet._settleImpl", () => {
 
     it("closes the primed stream when safeRegisterIntent fails before Batch.join starts", async () => {
         const callOrder: string[] = [];
-        let resolveFirstNext: ((value: IteratorResult<any>) => void) | undefined = undefined;
-        const firstNext = new Promise<IteratorResult<any>>((resolve) => {
-            resolveFirstNext = resolve;
-        });
         const stream = {
-            next: vi.fn(() => {
+            next: vi.fn(async () => {
                 callOrder.push("stream.next");
-                return firstNext;
+                return { done: false, value: { type: "stream_started", id: "stream-1" } };
             }),
             return: vi.fn(async () => {
                 callOrder.push("stream.return");
-                resolveFirstNext?.({ done: true, value: undefined });
                 return { done: true, value: undefined };
             }),
             [Symbol.asyncIterator]() {
@@ -2067,6 +2067,7 @@ describe("Wallet._settleImpl", () => {
             boardingUtxos: ExtendedCoin[] = [],
         ) => {
             let capturedInputs: ExtendedCoin[] | undefined;
+            let capturedOutputs: Array<{ amount: bigint; script: Uint8Array }> | undefined;
             const sentinel = new Error("stop-after-selection");
             const thisArg: any = {
                 network: "mutinynet",
@@ -2097,17 +2098,28 @@ describe("Wallet._settleImpl", () => {
                         getPublicKey: async () => new Uint8Array(32),
                     }),
                 },
-                makeRegisterIntentSignature: vi.fn(async (coins: ExtendedCoin[]) => {
-                    capturedInputs = coins;
-                    throw sentinel;
-                }),
+                makeRegisterIntentSignature: vi.fn(
+                    async (
+                        coins: ExtendedCoin[],
+                        outputs: Array<{ amount: bigint; script: Uint8Array }>,
+                    ) => {
+                        capturedInputs = coins;
+                        capturedOutputs = outputs;
+                        throw sentinel;
+                    },
+                ),
                 makeDeleteIntentSignature: vi.fn().mockResolvedValue({
                     proof: "delete-proof",
                     message: { type: "delete", expire_at: 0 },
                 }),
                 _addPendingSpends: vi.fn(),
             };
-            return { thisArg, sentinel, getCaptured: () => capturedInputs };
+            return {
+                thisArg,
+                sentinel,
+                getCaptured: () => capturedInputs,
+                getCapturedOutputs: () => capturedOutputs,
+            };
         };
 
         it("auto-selects from the gated read", async () => {
@@ -2152,6 +2164,37 @@ describe("Wallet._settleImpl", () => {
             expect(captured).toHaveLength(boarding.length + MAX_VTXOS_PER_SETTLEMENT);
             expect(captured.slice(0, boarding.length)).toEqual(boarding);
             expect(captured.slice(boarding.length)).toHaveLength(MAX_VTXOS_PER_SETTLEMENT);
+        });
+
+        it("applies the configured named-boarding destination and selection policy", async () => {
+            const boarding = [makeBoardingUtxo(12_000, 1), makeBoardingUtxo(10_000, 0)];
+            const vtxos = [makeVtxo(5_000, 0)];
+            const { thisArg, sentinel, getCaptured, getCapturedOutputs } = buildThisArg(
+                vtxos,
+                {},
+                boarding,
+            );
+            const decodedDefault = ArkAddress.decode(walletAddress);
+            const pinnedAddress = new ArkAddress(
+                decodedDefault.serverPubKey,
+                new Uint8Array(32).fill(2),
+                decodedDefault.hrp,
+            ).encode();
+            thisArg.settlementConfig = {
+                boardingSettleAddress: pinnedAddress,
+                maxBoardingInputsPerSettle: 1,
+                autoRenewVtxos: false,
+            };
+
+            await expect(
+                (Wallet.prototype as any)._settleImpl.call(thisArg, undefined),
+            ).rejects.toBe(sentinel);
+
+            expect(getCaptured()).toEqual([boarding[1]]);
+            expect(thisArg.getSpendableVtxos).not.toHaveBeenCalled();
+            expect(getCapturedOutputs()).toEqual([
+                expect.objectContaining({ script: ArkAddress.decode(pinnedAddress).pkScript }),
+            ]);
         });
 
         it("settles the highest-value VTXOs first when capping", async () => {


### PR DESCRIPTION
## Summary
- wait for the Operator event stream to be ready before registering a settlement intent
- bind Batch.join to the selected batch and ignore foreign broadcast lifecycle events
- preserve native EventSource reconnect behavior and fail closed when tree chunks were missed
- apply configured named-boarding destination/input/renewal policy to no-argument settle

## Verification
- 2,743 SDK unit tests passed, 1 skipped
- targeted boarding/provider regression tests passed
- typecheck and lint passed
- package build and smoke:dist passed

Stacked on #802 because Vault named boarding uses that SDK seam.