### PR TITLE
feat(swap): v2 corridor modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ style and have not been backfilled.
 
 ### Features
 
+- **`assertRecipientArkAddress` and `RecipientAddressContext` are
+  root-exported.** The rotation-aware recipient check — hrp, then
+  `classifyAgainstSignerSet`, refusing `UNKNOWN_SIGNER` and `EXPIRED`
+  distinctly — was reachable only from inside core, while every
+  ingredient it needs already was. A plugin classifying a destination
+  address had to hand-roll a `serverPubKey ===` comparison, which
+  rejects valid addresses mid-rotation. Nothing about the function
+  changed.
 - **`IReadonlyWallet.getArkadeInfo()`.** The wallet is the single place
   that knows which Arkade server it speaks to, so a plugin needs only
   the wallet, never a server URL of its own. It answers with the live
@@ -136,6 +144,23 @@ style and have not been backfilled.
   listed under Breaking Changes above. The shape is exported as
   `ArkadeServerProvider`, so a caller building a derivation-only client
   has a name to import. (#734)
+
+### Bug Fixes
+
+- **`BIP21.parse` no longer lowercases the address in a URI, and
+  `BIP21.create` no longer lowercases the one it writes.** Base58 is
+  case-sensitive, so `bitcoin:mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn` parsed
+  as a *different* address — and silently, because `isBtcAddress` admits
+  a lowercase base58 string, so the corrupted address passed
+  classification and whatever it decoded to is what a rail would have
+  funded. Bech32 is unaffected either way: BIP173 forbids a case *mix*,
+  not upper case, and every decoder here takes an all-upper address.
+- **The `ark=` BIP21 parameter is matched case-insensitively.** Bech32m
+  permits an all-upper address and `ArkAddress.decode` accepts one, so a
+  case-sensitive prefix test dropped — with a `console.warn` — an
+  address that `arkTarget` claims happily when it arrives bare. Same fix
+  in `BIP21.create`. One destination classifying differently bare than
+  as a parameter was the defect; both forms now agree.
 
 ## [0.4.23] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ style and have not been backfilled.
 
 ### Features
 
-- **`assertRecipientArkAddress` and `RecipientAddressContext` are
+- **`assertRecipientArkadeAddress` and `RecipientArkadeAddressContext` are
   root-exported.** The rotation-aware recipient check — hrp, then
   `classifyAgainstSignerSet`, refusing `UNKNOWN_SIGNER` and `EXPIRED`
   distinctly — was reachable only from inside core, while every

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -12,6 +12,11 @@ React Native does not, so install `react-native-get-random-values` (or `expo-cry
 it before this package. `crypto.subtle` is not used. `EventSource` and `WebSocket` are needed only
 by the watch and relay transports, both of which take an injected implementation.
 
+The v2 swap client API is tracked in [V2_API.md](./V2_API.md). That document is
+the package-level developer UX note for the new client surface as it lands; the
+current README still documents the existing package exports and protocol
+building blocks.
+
 **The covenant-deriving entry points need a wallet and nothing else.** `createOffer`,
 `requestLightningSend`, `requestLightningReceive`, `requestOnchainSend` and
 `requestOnchainReceive` take their server facts from `wallet.getArkadeInfo()`: the network and

--- a/packages/swap/V2_API.md
+++ b/packages/swap/V2_API.md
@@ -1,0 +1,192 @@
+# Swap SDK v2 API
+
+This document is the package-level developer UX note for the v2 swap client. It
+tracks what the package API is meant to feel like as the v2 milestones land.
+
+The planning track remains broader than this file. This file should stay close
+to the code in `packages/swap`: examples should compile on the branch that
+introduces the API they describe, or be marked as future shape.
+
+## Status
+
+The current branch has the v2 type foundation and corridor modules. The v2
+client surface is still internal under `src/client`; it is not exported from the
+package root yet. The root export continues to expose the existing offer, RFQ,
+restore, watch and manager building blocks until the deprecation milestone moves
+the protocol helpers behind their final boundary.
+
+Current contributor imports look like this:
+
+```ts
+import { Amount, canonicalAssetId } from "./src/client";
+import { corridorSet, resolveCorridorBase } from "./src/client/corridors";
+```
+
+Future application imports should come from `@arkade-os/swap` once the client
+surface is published.
+
+## The Shape
+
+A v2 swap starts with a route request:
+
+```ts
+const quote = await client.quote({
+    give: "arkade:bitcoin/slip44:0",
+    take: "bolt11:bitcoin/slip44:0",
+    to: invoice,
+});
+
+const outcome = await client.accept(quote);
+```
+
+That is the target shape. The current branch provides the pieces that make the
+route safe before quote and accept are wired:
+
+- asset ids are parsed and checked before they reach discovery or RFQ;
+- display amounts become `bigint` atomic units before records or wire payloads;
+- destination strings are claimed by exactly one corridor before any solver sees
+  them;
+- corridor dependencies are resolved lazily, so disabling an unused corridor
+  does not break an unrelated route.
+
+## Asset IDs
+
+Asset ids are CAIP-19 shaped, with the rail as the CAIP-2 namespace:
+
+```text
+<rail>:<network>/<asset-namespace>:<asset-reference>
+```
+
+Examples:
+
+```text
+arkade:bitcoin/slip44:0
+bolt11:bitcoin/slip44:0
+bitcoin:bitcoin/slip44:0
+arkade:regtest/asset:<68 lowercase hex chars>
+eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7
+```
+
+`arkade`, `bolt11` and `bitcoin` are the implemented bitcoin-family rails.
+`eip155` parses as reserved vocabulary for the later EVM corridor; it is not a
+routeable corridor today.
+
+Use the alias layer when accepting human input:
+
+```ts
+const asset = canonicalAssetId("BTC", {
+    network: "regtest",
+    assets: [{ ticker: "BTC", id: "arkade:regtest/slip44:0" }],
+});
+```
+
+Ticker matching is case-insensitive, scoped to the wallet network, and refuses a
+collision instead of guessing.
+
+## Amounts
+
+Amounts inside the v2 client are `bigint` atomic units. Decimal strings split
+into two forms:
+
+- display decimals, such as `"0.001"`, are only for UI input and output;
+- atomic decimals, such as `"100000"`, are only for records and RFQ payloads.
+
+Use `Amount` at the UI boundary:
+
+```ts
+const sats = Amount.parse("0.001", { decimals: 8 });
+const display = Amount.format(sats, { decimals: 8 });
+```
+
+Use the RFQ amount helpers at the record or wire boundary; do not parse a stored
+atomic amount as a display amount.
+
+## Corridors
+
+Corridors are the settlement paths. Their names are discovery vocabulary, not
+always the same string as the asset id rail:
+
+| Corridor | Asset rail | Destination forms |
+| --- | --- | --- |
+| `arkade` | `arkade` | Arkade address, or `bitcoin:?ark=<address>` |
+| `lightning` | `bolt11` | BOLT11 invoice, `lightning:<invoice>`, or `bitcoin:?lightning=<invoice>` |
+| `onchain` | `bitcoin` | Bitcoin address, or the body of a BIP21 URI |
+
+The implemented route union is:
+
+- `arkade -> arkade`;
+- `arkade -> lightning`;
+- `lightning -> arkade`;
+- `arkade -> onchain`.
+
+`onchain -> arkade` is deliberately absent until the client owns the trader's L1
+refund path end to end.
+
+## Destination Claiming
+
+The corridor registry is the current source-level API for parsing a destination
+string:
+
+```ts
+const broadcaster = await wallet.getArkadeBroadcaster();
+const operator = {
+    getInfo: () => wallet.getArkadeInfo({ requireLive: true }),
+    submitTx: (signedArkTx: string, checkpointTxs: string[]) =>
+        broadcaster.submitTx(signedArkTx, checkpointTxs),
+    finalizeTx: (arkTxid: string, finalCheckpointTxs: string[]) =>
+        broadcaster.finalizeTx(arkTxid, finalCheckpointTxs),
+};
+
+const base = await resolveCorridorBase({ wallet, operator });
+const corridors = corridorSet(base, {
+    lightning: { decode: myBolt11Decoder },
+    onchain: { chain: { esploraUrl: "http://localhost:3000" } },
+});
+
+const claim = corridors.claim(to);
+```
+
+`resolveCorridorBase` performs one live `wallet.getArkadeInfo({ requireLive:
+true })` read and derives the network and signer set from it. A stale snapshot
+is not used for covenant derivation.
+
+`corridors.claim(to)` returns:
+
+```ts
+type ClaimedDestination = {
+    corridor: "arkade" | "lightning" | "onchain";
+    instrument:
+        | { kind: "address"; address: string }
+        | {
+              kind: "invoice";
+              bolt11: string;
+              paymentHash: string;
+              amount?: bigint;
+              expiresAt: number;
+          };
+};
+```
+
+It throws before value moves:
+
+- `AmbiguousDestination` when the string names no corridor, more than one
+  corridor, or a corridor-owned destination that fails validation;
+- `MissingCorridorDep` when the destination belongs to a corridor whose required
+  dependency was explicitly set to `null`;
+- later route resolution turns a known-but-unserved destination, such as LNURL
+  today, into `UnsupportedRoute`.
+
+`undefined` in an override means "use the default". `null` means "this dep is
+disabled" and is refused only when that corridor is actually used.
+
+## Persistence and Outcomes
+
+Quote, accept and outcome driving are later milestones. The rules this document
+will keep carrying forward are:
+
+- persist before funding;
+- funding is acceptance;
+- exceptions stop before value moves;
+- everything after funding is an outcome, not a thrown setup error;
+- the wallet is the source of Arkade server identity, network and signing
+  policy.

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -82,7 +82,8 @@
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
-        "@scure/btc-signer": "2.0.1"
+        "@scure/btc-signer": "2.0.1",
+        "light-bolt11-decoder": "3.2.0"
     },
     "peerDependencies": {
         "nostr-tools": "^2.12.0"

--- a/packages/swap/src/client/corridors/arkade.ts
+++ b/packages/swap/src/client/corridors/arkade.ts
@@ -1,0 +1,63 @@
+/**
+ * The arkade corridor: an Arkade address, checked against this operator.
+ *
+ * The check core omits is the one that matters here. `isValidArkAddress` — and
+ * so `arkTarget`, which is built on it — proves bech32m and a 65-byte payload
+ * and nothing about *whose* server key is embedded, so a well-formed address
+ * belonging to another operator classifies as ours. Core already ships the
+ * check, rotation-aware: {@link assertRecipientArkAddress} compares the hrp and
+ * runs `classifyAgainstSignerSet`, refusing an unknown signer and a past-cutoff
+ * one distinctly. It is promoted to core's root export rather than hand-rolled
+ * as a `serverPubKey ===` comparison, which would reject valid addresses
+ * mid-rotation.
+ *
+ * It throws rather than returning, so the module catches and maps its message
+ * into the `refused` arm — which is what makes the difference between *not
+ * mine* and *mine, and wrong* legible one layer up.
+ */
+import { ArkAddress, arkTarget, assertRecipientArkAddress } from "@arkade-os/sdk";
+import type { CorridorDrive, CorridorFactory, CorridorModule } from "./contract";
+import type { ArkadeCorridorDeps } from "./deps";
+
+/**
+ * Nothing, and each absence is a decision.
+ *
+ * `arkade -> arkade` is an offer covenant: no VHTLC lockup, no `refundLocktime`,
+ * no manager action, and its watcher is `watchOfferSwaps`, which reads the
+ * wallet's OWN contract events and drops everything that is not an offer — a
+ * different seam from the two an RFQ drive pass reads, and no corridor's to
+ * declare. On every corridor route the arkade leg's lockup IS the route's
+ * lockup, declared once by the counter-corridor's entry, so declaring it again
+ * here would be the same fact written twice with nothing keeping the two in
+ * step.
+ */
+const ARKADE_DRIVE: CorridorDrive = {};
+
+const messageOf = (error: unknown): string =>
+    error instanceof Error ? error.message : String(error);
+
+export const arkadeCorridor: CorridorFactory<ArkadeCorridorDeps> = Object.assign(
+    (deps: ArkadeCorridorDeps): CorridorModule<ArkadeCorridorDeps> => ({
+        corridor: "arkade",
+        deps,
+        drive: ARKADE_DRIVE,
+        matches(raw: string) {
+            const target = arkTarget(raw);
+            if (target === undefined) return undefined;
+            try {
+                // `arkTarget` already decoded this to classify it, so the
+                // decode cannot fail here — but `matches` must not throw, and
+                // the second decode is what hands the signer key over.
+                const address = ArkAddress.decode(target);
+                assertRecipientArkAddress(target, address, {
+                    hrp: deps.network.hrp,
+                    signerSet: deps.signerSet,
+                });
+            } catch (error) {
+                return { refused: messageOf(error) };
+            }
+            return { claimed: { kind: "address", address: target } };
+        },
+    }),
+    { target: arkTarget },
+);

--- a/packages/swap/src/client/corridors/arkade.ts
+++ b/packages/swap/src/client/corridors/arkade.ts
@@ -5,7 +5,7 @@
  * so `arkTarget`, which is built on it — proves bech32m and a 65-byte payload
  * and nothing about *whose* server key is embedded, so a well-formed address
  * belonging to another operator classifies as ours. Core already ships the
- * check, rotation-aware: {@link assertRecipientArkAddress} compares the hrp and
+ * check, rotation-aware: {@link assertRecipientArkadeAddress} compares the hrp and
  * runs `classifyAgainstSignerSet`, refusing an unknown signer and a past-cutoff
  * one distinctly. It is promoted to core's root export rather than hand-rolled
  * as a `serverPubKey ===` comparison, which would reject valid addresses
@@ -15,7 +15,7 @@
  * into the `refused` arm — which is what makes the difference between *not
  * mine* and *mine, and wrong* legible one layer up.
  */
-import { ArkAddress, arkTarget, assertRecipientArkAddress } from "@arkade-os/sdk";
+import { ArkAddress, arkTarget, assertRecipientArkadeAddress } from "@arkade-os/sdk";
 import type { CorridorDrive, CorridorFactory, CorridorModule } from "./contract";
 import type { ArkadeCorridorDeps } from "./deps";
 
@@ -49,7 +49,7 @@ export const arkadeCorridor: CorridorFactory<ArkadeCorridorDeps> = Object.assign
                 // decode cannot fail here — but `matches` must not throw, and
                 // the second decode is what hands the signer key over.
                 const address = ArkAddress.decode(target);
-                assertRecipientArkAddress(target, address, {
+                assertRecipientArkadeAddress(target, address, {
                     hrp: deps.network.hrp,
                     signerSet: deps.signerSet,
                 });

--- a/packages/swap/src/client/corridors/bolt11.ts
+++ b/packages/swap/src/client/corridors/bolt11.ts
@@ -1,0 +1,86 @@
+/**
+ * The built-in BOLT11 decoder.
+ *
+ * Shipped rather than injected, with the override kept: §4 promises the caller
+ * passes a bolt11 string and the corridor decodes it, which is false for every
+ * integrator under a `decodeInvoice` callback, and NArk decides it the same way
+ * — `BOLT11PaymentRequest.Parse(invoice, network)` is a library decode. Core
+ * still carries no bolt11 dependency; this one belongs to the swap package.
+ *
+ * What it produces is v1's {@link InvoiceFacts}, unchanged, because that is the
+ * shape `CorridorOverrides.lightning.decode` is declared in and the shape
+ * `verifyReceiveInvoice` already reads. Two conversions the deleted
+ * `boltz-swap` decoder made are corrected here, and a third is left to the
+ * module boundary:
+ *
+ * - **Expiry is absolute.** The library's `expiry` getter is the `x` tag's
+ *   RELATIVE seconds (its own absolute getter is overwritten by the tag loop
+ *   right after it is defined), so the timestamp is added here and BOLT11's
+ *   3600-second default applies when the tag is absent.
+ * - **Millisats convert through `bigint`.** `Number(millisats) / 1000` loses
+ *   precision past 2^53; the division happens in `bigint` and narrows after.
+ * - **An amountless invoice reports `0`**, which is how v1 spells it
+ *   (`verifyReceiveInvoice` gates on `amountSats <= 0`). Turning that into
+ *   `amount: undefined` on the instrument, and refusing it on a send route, is
+ *   the lightning module's job.
+ *
+ * A missing payment hash is a throw and not a `?? ""`: the `p` tag is required
+ * by BOLT11, `Hex` is a bare alias, and an empty hash would typecheck onto the
+ * invoice instrument and then be compared byte-for-byte downstream.
+ */
+import bolt11 from "light-bolt11-decoder";
+import type { InvoiceFacts } from "../../rfq";
+
+/** BOLT11's default expiry when an invoice carries no `x` tag. */
+export const DEFAULT_INVOICE_EXPIRY_SECONDS = 3600;
+
+/**
+ * One section lookup, over a widened view of the decoder's output.
+ *
+ * `light-bolt11-decoder` types `sections` as a union whose arms disagree about
+ * `value`, and it emits tags the union does not name at all (`description_hash`
+ * is the known one). One widening at the boundary beats a cast per lookup.
+ */
+const valueOf = (decoded: { sections: readonly unknown[] }, name: string): unknown =>
+    (decoded.sections as readonly { name: string; value?: unknown }[]).find(
+        (section) => section.name === name,
+    )?.value;
+
+/** `sha256(P)` as {@link InvoiceFacts} declares it: 64 lowercase hex chars. */
+const PAYMENT_HASH = /^[0-9a-f]{64}$/;
+
+/**
+ * Decode a BOLT11 invoice into the facts the corridor needs.
+ *
+ * Signature-blind, like the library: nothing here proves the invoice was issued
+ * by whoever offered it. What it does prove is that the payment hash the
+ * corridor will compare against is the one the payer would pay to.
+ *
+ * @throws when the string is not a decodable BOLT11 invoice, or decodes without
+ *   the timestamp or payment hash BOLT11 requires.
+ */
+export const decodeBolt11 = (invoice: string): InvoiceFacts => {
+    const decoded = bolt11.decode(invoice);
+
+    const timestamp = valueOf(decoded, "timestamp");
+    if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+        throw new Error("bolt11 invoice carries no timestamp");
+    }
+    const expiry = valueOf(decoded, "expiry");
+    const expiresAt =
+        timestamp + (typeof expiry === "number" ? expiry : DEFAULT_INVOICE_EXPIRY_SECONDS);
+
+    const paymentHash = valueOf(decoded, "payment_hash");
+    if (typeof paymentHash !== "string" || !PAYMENT_HASH.test(paymentHash)) {
+        throw new Error("bolt11 invoice carries no payment hash");
+    }
+
+    // Absent for an amountless invoice, which BOLT11 permits and which lets a
+    // payer pay anything. `0` is how v1 spells that, and every gate above this
+    // one reads `<= 0` rather than a nullish check.
+    const millisats = valueOf(decoded, "amount");
+    const amountSats =
+        typeof millisats === "string" ? Number(BigInt(millisats) / 1000n) : /* amountless */ 0;
+
+    return { raw: invoice, paymentHash, amountSats, expiresAt };
+};

--- a/packages/swap/src/client/corridors/chainSource.ts
+++ b/packages/swap/src/client/corridors/chainSource.ts
@@ -1,0 +1,188 @@
+/**
+ * The onchain corridor's default {@link ChainSource}.
+ *
+ * `ChainSource` has shipped since the onchain corridor did and nothing has ever
+ * implemented it: its own doc assigns the esplora-backed one to the caller, and
+ * the only implementations in the tree are scripted test fakes. §6's
+ * "Arkade-provided chain source" is that gap, and this closes it.
+ *
+ * Built from an esplora base URL rather than from the wallet's provider,
+ * because there is no such thing to reach: `onchainProvider` is a field of
+ * `BaseWalletConfig` and of the concrete `Wallet`, never of `IWallet` /
+ * `IReadonlyWallet` — core states the rule at `vtxo-manager.ts` — and every
+ * swap entry point takes the interface. So the URL is what the override
+ * replaces, and its default is `ESPLORA_URL[network]` off the same live info
+ * read every corridor makes.
+ *
+ * Three of the four methods adapt core's `OnchainProvider`. The fourth does
+ * not, and the difference is a *contract* gap rather than a missing endpoint:
+ * `getMtp` must answer median-time-past, `OnchainProvider.getChainTip` promises
+ * no more than "block time", and the two shipped implementations disagree —
+ * Esplora answers `tip[0].mediantime`, Electrum answers the header's nTime. A
+ * source that forwarded `getChainTip().time` would therefore be right on one
+ * backend and wrong on the other, and being wrong here is not a rounding error:
+ * `classifyOnchainHtlc` returns `refundable` once MTP reaches the HTLC's
+ * locktime, `nextOnchainAction` turns that into `claim_window_closed`, and an
+ * MTP that runs high abandons a still-live L1 claim. So the tip is read off
+ * `/blocks` here, where `mediantime` is named explicitly.
+ */
+import { hex } from "@scure/base";
+import * as btc from "@scure/btc-signer";
+import { EsploraProvider, type OnchainProvider } from "@arkade-os/sdk";
+import type { ChainSource, ChainUtxo } from "../../onchainHtlc";
+
+/** The chain tip, as the two reads that need it want it. */
+export interface L1Tip {
+    height: number;
+    /** Median-time-past, unix seconds. */
+    mtp: number;
+}
+
+/** What the adapter reads L1 through: core's provider, plus the one fact its
+ * interface does not promise. */
+export interface ChainSourceBackend {
+    provider: OnchainProvider;
+    tip(): Promise<L1Tip>;
+}
+
+/** The address parameters an output script is encoded under. Structural, so
+ * core's `Network` and `L1_NETWORKS`' entries both satisfy it directly. */
+export type AddressParams = typeof btc.NETWORK;
+
+const addressOfScript = (script: Uint8Array, network: AddressParams): string =>
+    btc.Address(network).encode(btc.OutScript.decode(script));
+
+/**
+ * A {@link ChainSource} over an arbitrary L1 backend.
+ *
+ * Separate from {@link esploraChainSource} so the adapter's logic — the
+ * confirmations arithmetic, the script-to-address encode, the missing-spender
+ * fallback — is exercisable without a server, and so a caller with its own
+ * `OnchainProvider` can reuse it.
+ */
+export const chainSourceOver = (
+    backend: ChainSourceBackend,
+    network: AddressParams,
+): ChainSource => {
+    /**
+     * The spender of an outpoint when `/outspends` did not name it.
+     *
+     * Some deployments answer `{spent: true}` with no `txid` —
+     * `mempool.arkade.sh`, which is `ESPLORA_URL.bitcoin` — so the spend is
+     * recovered the way core recovers a boarding output's: scan the spent
+     * output's own address history for the transaction whose vin names this
+     * outpoint. The address is derived from the funding transaction rather than
+     * passed in, because `getSpendingTx` is handed an outpoint and nothing else.
+     */
+    const spenderFromVins = async (txid: string, vout: number): Promise<string | undefined> => {
+        let address: string;
+        try {
+            const funding = btc.RawTx.decode(await backend.provider.getRawTransaction(txid));
+            const output = funding.outputs[vout];
+            if (!output?.script) return undefined;
+            address = addressOfScript(output.script, network);
+        } catch {
+            return undefined;
+        }
+        for (const tx of await backend.provider.getTransactions(address)) {
+            // `vin` is optional on the interface: the electrum provider omits
+            // inputs entirely, in which case this fallback simply finds nothing.
+            if ((tx.vin ?? []).some((input) => input.txid === txid && input.vout === vout)) {
+                return tx.txid;
+            }
+        }
+        return undefined;
+    };
+
+    return {
+        async getScriptUtxos(pkScript: Uint8Array): Promise<ChainUtxo[]> {
+            // `getCoins` is address-keyed where this is script-keyed, and the
+            // encode is why the adapter needs a network at all.
+            const address = addressOfScript(pkScript, network);
+            const [coins, tip] = await Promise.all([
+                backend.provider.getCoins(address),
+                backend.tip(),
+            ]);
+            return coins.map((coin) => ({
+                txid: coin.txid,
+                vout: coin.vout,
+                // `Coin.value` is `number` sats; the HTLC's is `bigint`.
+                amount: BigInt(coin.value),
+                // `Coin` carries a height, never a depth, so the tip is the
+                // second half of the answer. A confirmed coin is one deep, not
+                // zero — the block it landed in counts.
+                confirmations:
+                    coin.status.confirmed && coin.status.block_height !== undefined
+                        ? Math.max(0, tip.height - coin.status.block_height + 1)
+                        : 0,
+            }));
+        },
+
+        async getSpendingTx(txid: string, vout: number): Promise<{ txHex: string } | null> {
+            const outspends = await backend.provider.getTxOutspends(txid);
+            const outspend = outspends[vout];
+            if (!outspend?.spent) return null;
+            // `||`, not `??`: the electrum provider uses `txid: ""` as its
+            // unspent sentinel, and an empty string is not a spender either.
+            const spender = outspend.txid || (await spenderFromVins(txid, vout));
+            if (!spender) return null;
+            return { txHex: hex.encode(await backend.provider.getRawTransaction(spender)) };
+        },
+
+        broadcast(txHex: string): Promise<string> {
+            return backend.provider.broadcastTransaction(txHex);
+        },
+
+        async getMtp(): Promise<number> {
+            return (await backend.tip()).mtp;
+        },
+    };
+};
+
+/**
+ * Tip height and median-time-past off Esplora's `/blocks`.
+ *
+ * `/blocks` rather than `/blocks/tip`, for the reason core already records:
+ * the latter is not part of the Esplora spec — electrs serves it as an alias,
+ * a strict backend like mempool answers an empty array.
+ */
+export const esploraTip = async (esploraUrl: string, fetchImpl?: typeof fetch): Promise<L1Tip> => {
+    const response = await (fetchImpl ?? fetch)(`${esploraUrl}/blocks`);
+    if (!response.ok) {
+        throw new Error(`failed to read the chain tip: ${response.status} ${response.statusText}`);
+    }
+    const blocks: unknown = await response.json();
+    const tip = Array.isArray(blocks)
+        ? (blocks[0] as Record<string, unknown> | undefined)
+        : undefined;
+    if (
+        !tip ||
+        typeof tip.height !== "number" ||
+        typeof tip.mediantime !== "number" ||
+        !(tip.mediantime > 0)
+    ) {
+        // Fail rather than substitute: a tip time standing in for MTP is the
+        // exact substitution this function exists to prevent.
+        throw new Error(`esplora returned no usable chain tip for ${esploraUrl}`);
+    }
+    return { height: tip.height, mtp: tip.mediantime };
+};
+
+/** The default: core's Esplora provider at `esploraUrl`, with the tip read off
+ * `/blocks` beside it. */
+export const esploraChainSource = (input: {
+    /** Esplora REST base — the corridor's override, or `ESPLORA_URL[network]`. */
+    esploraUrl: string;
+    /** Address parameters for the script-to-address encode. */
+    network: AddressParams;
+    /** For hosts without a global `fetch`, and for tests. Only the `/blocks`
+     * read takes it: core's provider carries its own fetch wrapper. */
+    fetchImpl?: typeof fetch;
+}): ChainSource =>
+    chainSourceOver(
+        {
+            provider: new EsploraProvider(input.esploraUrl),
+            tip: () => esploraTip(input.esploraUrl, input.fetchImpl),
+        },
+        input.network,
+    );

--- a/packages/swap/src/client/corridors/contract.ts
+++ b/packages/swap/src/client/corridors/contract.ts
@@ -1,0 +1,154 @@
+/**
+ * One contract, three implementations.
+ *
+ * A corridor module owns four things: its parse claim over destination strings
+ * and the {@link Instrument} that claim produces, the deps it closes over, the
+ * observation seams a drive pass reads, and the lockup-owner axis the outcome
+ * table keys on. Not the table itself — the module declares the axis, and the
+ * drive layer writes the table against it.
+ *
+ * The key is the **corridor**, not v1's `RfqSwap["kind"]`. That union —
+ * `lightning_send | onchain_send | lightning_receive` — is a route pair, and two
+ * of its three members are the lightning corridor seen from opposite ends. The
+ * kind-keyed `RfqCorridorHandler` in `../../rfqCorridor.ts` is untouched and
+ * stays: `project`/`hydrate` are per-route facts about a *stored record*, and
+ * folding them in here would make this module own a persistence schema it does
+ * not decide.
+ *
+ * Registration is internal, exactly as `rfqCorridor.ts` argues for its own
+ * registry: a corridor registered from outside would parse and quote and then
+ * sit undriven, which is worse than not being registrable at all.
+ */
+import type { RfqSwapActionName } from "../../swapManager";
+import type { Corridor } from "../corridor";
+import type { Instrument } from "../route";
+
+/**
+ * A module's answer about one destination string. Three outcomes, not two.
+ *
+ * "An {@link Instrument} or nothing" cannot say *mine, and wrong* — a `tb1…` on
+ * a mainnet wallet, another operator's Arkade address, a bolt11 the shape-only
+ * classifier admits and the decoder then refuses. Collapsing those into *not
+ * mine* hands a well-formed destination to `UnsupportedRoute`, which names the
+ * wrong fault, so the refusal is its own arm and the registry turns it into
+ * `AmbiguousDestination` with the reason attached.
+ *
+ * The two object arms are mutually exclusive by construction (`refused?: never`
+ * / `claimed?: never`), so the registry's count over them is total.
+ */
+export type CorridorClaim =
+    | { claimed: Instrument; refused?: never }
+    | { refused: string; claimed?: never }
+    | undefined;
+
+/** What a drive pass reads. Two, and a solver status read is not one of them. */
+export type ObservationSeam =
+    /** Arkade access — `RfqSwapManagerDeps.indexer`. */
+    | "indexer"
+    /** L1 access — `RfqSwapManagerDeps.chain`. */
+    | "chain";
+
+/** A covenant a pass reads. */
+export type CorridorCovenant =
+    /** The Arkade-side VHTLC every corridor route has exactly one of. */
+    | "arkade_lockup"
+    /** The L1 HTLC, which only `arkade -> onchain` adds. */
+    | "onchain_htlc";
+
+/**
+ * Whose covenant it is — the axis the outcome table keys on.
+ *
+ * *Which* lockup a pass reads does not discriminate: every route reads the same
+ * Arkade lockup and only `arkade -> onchain` reads a second. What inverts is
+ * ownership, and with it what to do about the deadline: on a give-side leg the
+ * lockup is the TRADER's and the deadline is a moment to act after, on a
+ * take-side leg it is the SOLVER's and the deadline is a moment to have acted
+ * before.
+ */
+export type LockupOwner = "trader" | "solver";
+
+/** The deadlines the code already fixes. Margins belong to the drive layer. */
+export type CorridorDeadline =
+    /** `RfqSwapCommon.refundLocktime`, on every kind. */
+    | "refund_locktime"
+    /** `OnchainSendSwap.htlc.refundLocktime`, on `arkade -> onchain` alone. */
+    | "htlc_refund_locktime";
+
+/** One covenant a pass reads, with its owner and the deadline it runs against. */
+export interface CorridorLockup {
+    readonly covenant: CorridorCovenant;
+    readonly owner: LockupOwner;
+    readonly deadline: CorridorDeadline;
+}
+
+/**
+ * Which side of a route this corridor is on: the trader gives on it, or takes
+ * on it. The direction is what inverts every ownership answer below.
+ */
+export type RouteSide = "give" | "take";
+
+/** What a drive pass does about a route whose non-arkade leg is this corridor. */
+export interface CorridorPass {
+    /** Every covenant the pass reads, in the order it reads them. */
+    readonly lockups: readonly CorridorLockup[];
+    /** The actions the manager may execute; a subset of v1's own union. */
+    readonly actions: readonly RfqSwapActionName[];
+    /** The seams the pass reads. */
+    readonly seams: readonly ObservationSeam[];
+}
+
+/**
+ * A corridor's drive facts, per side of the route it serves.
+ *
+ * Partial on purpose, and each absence is a decision: `onchain` has no `give`
+ * entry because `onchain -> arkade` is outside the `Route` union — covering its
+ * Arkade half alone would produce a manager that silently lets the trader's L1
+ * refund window pass — and `arkade` has neither, because `arkade -> arkade` is
+ * an offer covenant with no lockup, no RFQ deadline and no manager action. On
+ * every corridor route the arkade leg's lockup IS the route's lockup, and it is
+ * declared once, by the counter-corridor's entry.
+ */
+export type CorridorDrive = Partial<Record<RouteSide, CorridorPass>>;
+
+/**
+ * One corridor.
+ *
+ * `deps` are closed over at construction rather than passed per call: the
+ * network, the operator's signer set and the decoder are all needed at the
+ * parse, and none of them is in the destination string.
+ */
+export interface CorridorModule<D = unknown> {
+    readonly corridor: Corridor;
+
+    /**
+     * This corridor's claim over `raw` — a bare destination or a BIP21 URI.
+     *
+     * **Sync, non-throwing and amount-blind**, and none of the three is this
+     * module's to reopen: core's rail contract is `match(req, ctx): boolean`,
+     * "classification only — amount-blind", and core's router calls it bare
+     * inside `options()`. A plain Arkade destination stays core's own `ark` rail
+     * and is wrapped by nothing, but one shape across all three beats a second
+     * one for the corridor that happens not to be wrapped.
+     */
+    matches(raw: string): CorridorClaim;
+
+    readonly deps: D;
+    readonly drive: CorridorDrive;
+}
+
+/**
+ * A module's factory, plus the one question that can be asked without deps.
+ *
+ * `target` is core's classifier for this corridor's destination class — the
+ * same one `matches` extracts with, named once so there is no second spelling
+ * to drift. The registry asks it FIRST, and that is what keeps
+ * `MissingCorridorDep`'s contract: a bolt11 arriving while the onchain chain
+ * source is overridden to `null` must not resolve the onchain corridor's deps,
+ * because a missing dep for a corridor nobody uses is not an error.
+ */
+export interface CorridorFactory<D> {
+    (deps: D): CorridorModule<D>;
+    /** The destination class this corridor speaks for. Dep-free by
+     * construction: core's classifiers read the string and nothing else. */
+    readonly target: (raw: string) => string | undefined;
+}

--- a/packages/swap/src/client/corridors/deps.ts
+++ b/packages/swap/src/client/corridors/deps.ts
@@ -1,0 +1,297 @@
+/**
+ * What a corridor is given, what a caller may replace, and where "overridden to
+ * nothing" is refused.
+ *
+ * §6's rules stand as written; what is added here is a shape, because
+ * `chain?: ChainSource` cannot tell "absent, use the default" from "disabled,
+ * deliberately". Every override field is `T | null`: `undefined` takes the
+ * default, `null` is the refusal, and {@link resolveCorridorDeps} throws
+ * {@link MissingCorridorDep} naming the dep. It cannot reuse the facade's
+ * `need()` guard, which tests `value === undefined` and passes a deliberate
+ * `null` straight through.
+ *
+ * Resolution runs when a route first touches a corridor and never at
+ * construction — a missing dep for a corridor nobody uses is not an error, which
+ * is `MissingCorridorDep`'s own boundary note and what §6 means by "at quote
+ * time". The registry beside this file is what memoizes that.
+ *
+ * Four keys, not three: §6 gives lightning two overridable deps and the
+ * covclaimd deployment key is the second. The operator seam and the co-signer
+ * key are deliberately NOT among them — an override there is a trust anchor §6
+ * never granted — so the co-signer arrives on {@link CorridorBase} instead, the
+ * way the facade already threads it.
+ */
+import {
+    ESPLORA_URL,
+    defaultEmulatorPubkey,
+    getNetwork,
+    resolveEmulatorPubkey,
+    signerSetFromInfo,
+    type IWallet,
+    type Network,
+    type NetworkName,
+    type SignerSet,
+} from "@arkade-os/sdk";
+import type { ChainSource } from "../../onchainHtlc";
+import { L1_NETWORKS } from "../../onchainHtlc";
+import { l1NetworkFromArk, type InvoiceFacts } from "../../rfq";
+import type { SwapOperator } from "../../refund";
+import type { AssetSwapRepository } from "../../repository";
+import type { Corridor } from "../corridor";
+import { MissingCorridorDep, OperatorUnreachable } from "../errors";
+import type { Pubkey } from "../primitives";
+import { decodeBolt11 } from "./bolt11";
+import { esploraChainSource } from "./chainSource";
+
+/**
+ * The facts every module reads and no caller replaces.
+ *
+ * Both wallet and operator seam, and the split is what each is for: the wallet
+ * answers *who and where* — it is the only thing that can make the live,
+ * fail-closed info read, since `SwapOperator.getInfo()` takes no options — and
+ * the operator seam answers *submit and finalize*. Collapsing either into the
+ * other would delete a seam the unit tests already double.
+ */
+export interface CorridorBase {
+    readonly wallet: IWallet;
+    readonly operator: SwapOperator;
+    /** The network the live operator info named. */
+    readonly networkName: NetworkName;
+    /** Address parameters for {@link networkName}. */
+    readonly network: Network;
+    /** The operator's signer set, for the rotation-aware recipient check. */
+    readonly signerSet: SignerSet;
+    /**
+     * Covenant co-signer override, 33-byte compressed hex.
+     *
+     * A dep of the arkade module and not a `CorridorOverrides` key, by the same
+     * rule that keeps the operator seam out of them. Required on `testnet` and
+     * `signet`, which `EMULATOR_PUBKEYS` does not pin.
+     */
+    readonly emulatorPubkey?: string;
+    /** For hosts without a global `fetch`, and for tests. */
+    readonly fetchImpl?: typeof fetch;
+}
+
+/**
+ * §6's override matrix, with each field widened to admit the refusal.
+ *
+ * An override replaces a dependency inside an implemented corridor. It never
+ * enables a route, never selects a solver or transport, and never alters
+ * settlement behaviour — and each one is a named trust anchor: the chain source
+ * is whose L1 view evidence is reconciled against, the decoder is who validates
+ * an invoice before display, the covclaimd key is who may open the sealed claim
+ * packet, the repository is where persist-first lands.
+ */
+export interface CorridorOverrides {
+    arkade?: {
+        /** Where persist-first lands. No default until the accept path owns
+         * one, so `undefined` leaves it absent rather than building one. */
+        repository?: AssetSwapRepository | null;
+    };
+    lightning?: {
+        /** Default: the package's own {@link decodeBolt11}. */
+        decode?: ((bolt11: string) => InvoiceFacts) | null;
+        /** Default: an internal ephemeral self-claim seal, which is what
+         * `undefined` here means — a deployment key is optional config. */
+        covclaimd?: { pubkey: Pubkey } | null;
+    };
+    onchain?: {
+        /** Default: `ESPLORA_URL[network]`. The override is the URL, not a
+         * `ChainSource`: there is no wallet-held provider to substitute. */
+        chain?: { esploraUrl: string } | null;
+    };
+}
+
+/** The arkade corridor's deps. Only the repository is overridable. */
+export interface ArkadeCorridorDeps {
+    readonly wallet: IWallet;
+    readonly operator: SwapOperator;
+    readonly networkName: NetworkName;
+    readonly network: Network;
+    readonly signerSet: SignerSet;
+    /**
+     * The pinned per-network co-signer, or the caller's override.
+     *
+     * Resolved from the network NAME the wallet reports, never from a key the
+     * operator reports about itself — `defaultEmulatorPubkey` refuses that
+     * self-report by name, because the value ends up in a covenant leaf that
+     * decides who can move the funds.
+     */
+    readonly emulatorPubkey: string;
+    readonly repository: AssetSwapRepository | undefined;
+}
+
+/** The lightning corridor's deps. */
+export interface LightningCorridorDeps {
+    readonly networkName: NetworkName;
+    readonly decode: (bolt11: string) => InvoiceFacts;
+    /** `undefined` is the default seal — an internal ephemeral self-claim key —
+     * and not a missing dep. */
+    readonly covclaimd: { pubkey: Pubkey } | undefined;
+}
+
+/** The onchain corridor's deps. */
+export interface OnchainCorridorDeps {
+    readonly networkName: NetworkName;
+    readonly chain: ChainSource;
+}
+
+/** Which corridor gets which dep record. */
+export interface CorridorDepsByCorridor {
+    arkade: ArkadeCorridorDeps;
+    lightning: LightningCorridorDeps;
+    onchain: OnchainCorridorDeps;
+}
+
+/** Any corridor's deps. */
+export type CorridorDeps = CorridorDepsByCorridor[Corridor];
+
+/**
+ * The `T | null` rule, in one place: `null` is the refusal, `undefined` is
+ * "take the default" and is handed back for the caller to default.
+ *
+ * A caller saying "not this one" should fail loudly at the corridor rather than
+ * quietly at the first thing that needed the dep, and it is the only shape that
+ * can say so — `chain?: ChainSource` cannot tell absence from refusal.
+ */
+const refusedIfNull = <T>(
+    value: T | null | undefined,
+    corridor: Corridor,
+    dep: string,
+): T | undefined => {
+    if (value === null) throw new MissingCorridorDep(corridor, dep);
+    return value;
+};
+
+/**
+ * The co-signer key for `base`'s network.
+ *
+ * A malformed override is core's refusal and stays one — it would otherwise be
+ * passed into a covenant leaf and surface as an unspendable contract long after
+ * the fact. An *absent* key on an unpinned network is this corridor's, though:
+ * `EMULATOR_PUBKEYS` pins `bitcoin`, `mutinynet` and `regtest` only, so on
+ * `testnet` and `signet` — both of which the v2 id vocabulary admits — the
+ * override is required, and its absence is a missing dep rather than a bare
+ * `Error` escaping the module.
+ */
+const emulatorPubkeyFor = (base: CorridorBase): string => {
+    if (base.emulatorPubkey !== undefined) {
+        return resolveEmulatorPubkey(base.network, base.emulatorPubkey);
+    }
+    try {
+        return defaultEmulatorPubkey(base.network);
+    } catch {
+        throw new MissingCorridorDep(
+            "arkade",
+            `covenant co-signer key (none is pinned for ${base.networkName}; ` +
+                "pass emulatorPubkey)",
+        );
+    }
+};
+
+/**
+ * A corridor's deps, with `undefined` taking the default and `null` refused.
+ *
+ * Per corridor, and never for all three at once: resolving a corridor a route
+ * does not touch is what would turn a deliberate `null` on an unused corridor
+ * into an error.
+ */
+export function resolveCorridorDeps<C extends Corridor>(
+    corridor: C,
+    overrides: CorridorOverrides | undefined,
+    base: CorridorBase,
+): CorridorDepsByCorridor[C];
+export function resolveCorridorDeps(
+    corridor: Corridor,
+    overrides: CorridorOverrides | undefined,
+    base: CorridorBase,
+): CorridorDeps {
+    switch (corridor) {
+        case "arkade": {
+            // The one dep with no default to fall back to: the repository
+            // default belongs to the milestone that owns persistence, so an
+            // absent one stays absent and only a deliberate `null` is refused.
+            const repository = refusedIfNull(overrides?.arkade?.repository, "arkade", "repository");
+            return {
+                wallet: base.wallet,
+                operator: base.operator,
+                networkName: base.networkName,
+                network: base.network,
+                signerSet: base.signerSet,
+                emulatorPubkey: emulatorPubkeyFor(base),
+                repository,
+            };
+        }
+        case "lightning": {
+            return {
+                networkName: base.networkName,
+                decode:
+                    refusedIfNull(overrides?.lightning?.decode, "lightning", "bolt11 decoder") ??
+                    decodeBolt11,
+                covclaimd: refusedIfNull(
+                    overrides?.lightning?.covclaimd,
+                    "lightning",
+                    "covclaimd deployment key",
+                ),
+            };
+        }
+        case "onchain": {
+            const chain = refusedIfNull(overrides?.onchain?.chain, "onchain", "chain source");
+            return {
+                networkName: base.networkName,
+                chain: esploraChainSource({
+                    esploraUrl: chain?.esploraUrl ?? ESPLORA_URL[base.networkName],
+                    network: L1_NETWORKS[l1NetworkFromArk(base.networkName)],
+                    fetchImpl: base.fetchImpl,
+                }),
+            };
+        }
+    }
+}
+
+/**
+ * The one live operator read, made once for all three corridors.
+ *
+ * `requireLive: true` because a snapshot binds a covenant to a signer key the
+ * operator may no longer co-sign for. The whole read is wrapped rather than a
+ * matched subset of its failures: `requireLive` re-throws the provider's raw
+ * error unwrapped, which is a `FetchError`, a `ProviderUnavailableError`, an
+ * `ArkError`, a bare `Error` or a `TimeoutError` depending on how the read
+ * failed — and across a service-worker boundary it is a fresh `Error` whose only
+ * branchable identity is `cause.name`. A `catch` on a matched set would let
+ * exactly those through untyped.
+ *
+ * The network narrowing after it is core's own fail-closed one and stays that
+ * way: an operator that answers with a network name this SDK does not know is
+ * not unreachable, and resolving it to mainnet parameters is the failure mode
+ * `getNetwork` exists to prevent.
+ */
+export const resolveCorridorBase = async (input: {
+    wallet: IWallet;
+    operator: SwapOperator;
+    emulatorPubkey?: string;
+    fetchImpl?: typeof fetch;
+}): Promise<CorridorBase> => {
+    let info;
+    try {
+        info = await input.wallet.getArkadeInfo({ requireLive: true });
+    } catch (cause) {
+        throw new OperatorUnreachable(
+            `the Arkade server info could not be read live: ${
+                cause instanceof Error ? cause.message : String(cause)
+            }`,
+            { cause },
+        );
+    }
+    const networkName = info.network as NetworkName;
+    return {
+        wallet: input.wallet,
+        operator: input.operator,
+        networkName,
+        network: getNetwork(networkName),
+        signerSet: signerSetFromInfo(info),
+        emulatorPubkey: input.emulatorPubkey,
+        fetchImpl: input.fetchImpl,
+    };
+};

--- a/packages/swap/src/client/corridors/index.ts
+++ b/packages/swap/src/client/corridors/index.ts
@@ -1,0 +1,16 @@
+/**
+ * The corridor modules: one contract, three implementations, and the registry
+ * that turns a destination string into a corridor plus an instrument.
+ *
+ * Under `client/` rather than beside `rfqCorridor.ts`, because the flat layout
+ * is v1's and the v2 layer is deliberately kept off the package's root barrel
+ * until the deprecation milestone decides what the published surface is.
+ */
+export * from "./bolt11";
+export * from "./chainSource";
+export * from "./contract";
+export * from "./deps";
+export * from "./registry";
+export { arkadeCorridor } from "./arkade";
+export { lightningCorridor, networksOfInvoiceHrp, INVOICE_HRPS } from "./lightning";
+export { onchainCorridor } from "./onchain";

--- a/packages/swap/src/client/corridors/lightning.ts
+++ b/packages/swap/src/client/corridors/lightning.ts
@@ -1,0 +1,151 @@
+/**
+ * The lightning corridor: a BOLT11 invoice, on this wallet's network.
+ *
+ * Core settles the shape and stops there — `isLightningInvoice` matches the HRP
+ * and a bech32 tail, strips a `lightning:` prefix, and by its own comment
+ * carries no bolt11 dependency and so no checksum and no decode. The two gaps
+ * are this module's, and §6 puts both at the parse boundary.
+ *
+ * The HRP-to-network table exists in neither package, so it is authored here.
+ * Two of its facts are worth stating because a test could otherwise claim more
+ * than the vocabulary can express: `lntbs` is signet AND mutinynet, which share
+ * an HRP exactly as they share `tark`, so a signet-versus-mutinynet rejection is
+ * not expressible; and `lnsb` (simnet) is admitted by core's regex — five
+ * prefixes, where §6 names four — and named by no `NetworkName`, so it is
+ * refused rather than mapped to a neighbour.
+ *
+ * Of §6's parse-boundary gates, this module owns three: the HRP check, the
+ * invoice expiry, and the amountless refusal. The rest read the quote — the
+ * headroom check needs `quote.refund_locktime` and no parse has a quote — and
+ * belong to the quote path.
+ */
+import { invoiceTarget, type NetworkName } from "@arkade-os/sdk";
+import type { InvoiceFacts } from "../../rfq";
+import type { CorridorClaim, CorridorDrive, CorridorFactory, CorridorModule } from "./contract";
+import type { LightningCorridorDeps } from "./deps";
+
+/**
+ * Which networks an invoice HRP can belong to.
+ *
+ * An ordered list rather than a record, because the order is load-bearing:
+ * `lnbcrt` has to be tested before `lnbc` and `lntbs` before `lntb`, and a
+ * record would leave that to key-iteration order.
+ */
+export const INVOICE_HRPS = [
+    ["lnbcrt", ["regtest"]],
+    ["lntbs", ["signet", "mutinynet"]],
+    ["lnbc", ["bitcoin"]],
+    ["lntb", ["testnet"]],
+] as const satisfies readonly (readonly [string, readonly NetworkName[]])[];
+
+/** The networks `raw`'s HRP names, or `undefined` for one no network claims. */
+export const networksOfInvoiceHrp = (raw: string): readonly NetworkName[] | undefined => {
+    const lower = raw.toLowerCase();
+    return INVOICE_HRPS.find(([hrp]) => lower.startsWith(hrp))?.[1];
+};
+
+/** `sha256(P)` as the invoice instrument carries it: 64 lowercase hex chars. */
+const PAYMENT_HASH = /^[0-9a-f]{64}$/;
+
+/**
+ * Both directions, and the ownership inverts between them.
+ *
+ * On `arkade -> lightning` the trader funds the lockup, so `refundLocktime` is
+ * the trader's and is a moment to act AFTER — the only action is the Arkade
+ * refund, since the solver claims the lockup with the preimage it learns by
+ * paying. On `lightning -> arkade` the solver funds it: every non-claim leaf is
+ * the solver's, the trader has no refund at all, and the deadline is a moment to
+ * have claimed BEFORE.
+ */
+const LIGHTNING_DRIVE: CorridorDrive = {
+    give: {
+        lockups: [{ covenant: "arkade_lockup", owner: "solver", deadline: "refund_locktime" }],
+        actions: ["claimLockup"],
+        seams: ["indexer"],
+    },
+    take: {
+        lockups: [{ covenant: "arkade_lockup", owner: "trader", deadline: "refund_locktime" }],
+        actions: ["refundArkade"],
+        seams: ["indexer"],
+    },
+};
+
+export const lightningCorridor: CorridorFactory<LightningCorridorDeps> = Object.assign(
+    (deps: LightningCorridorDeps): CorridorModule<LightningCorridorDeps> => ({
+        corridor: "lightning",
+        deps,
+        drive: LIGHTNING_DRIVE,
+        matches(raw: string): CorridorClaim {
+            const invoice = invoiceTarget(raw);
+            if (invoice === undefined) return undefined;
+
+            const networks = networksOfInvoiceHrp(invoice);
+            if (networks === undefined) {
+                return { refused: "this invoice's network prefix names no network this SDK knows" };
+            }
+            if (!networks.includes(deps.networkName)) {
+                return {
+                    refused:
+                        `this is a ${networks.join(" or ")} invoice and the wallet is on ` +
+                        `${deps.networkName}`,
+                };
+            }
+
+            let facts: InvoiceFacts;
+            try {
+                facts = deps.decode(invoice);
+                // Read under the same guard as the call. The decoder is a
+                // replaceable seam, so nothing its answer contains is
+                // guaranteed by the type, and `matches` must not throw — one
+                // dereference inside the `try` settles that the object is
+                // readable at all, and the checks after it are total.
+                //
+                // An empty or malformed hash is the case that matters: `Hex` is
+                // a bare alias, so it would typecheck onto the instrument and
+                // then be compared byte-for-byte against a real one.
+                if (!PAYMENT_HASH.test(facts.paymentHash)) {
+                    return { refused: "the decoded invoice carries no usable payment hash" };
+                }
+            } catch (error) {
+                return {
+                    refused: `the invoice did not decode: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                };
+            }
+
+            if (!Number.isFinite(facts.expiresAt)) {
+                return { refused: "the decoded invoice carries no usable expiry" };
+            }
+            const now = Math.floor(Date.now() / 1000);
+            if (facts.expiresAt <= now) {
+                return { refused: `the invoice expired ${now - facts.expiresAt}s ago` };
+            }
+
+            if (!Number.isSafeInteger(facts.amountSats) || facts.amountSats < 0) {
+                return { refused: "the decoded invoice carries no usable amount" };
+            }
+            // Amountless is refused rather than carried, and `0` is how it
+            // arrives. A destination string is by construction the TAKE leg of a
+            // send, which is exactly where §6 puts this refusal: the invoice is
+            // the amount pin there, and `amountOn` does not rescue it. The
+            // instrument keeps `amount` optional for the reusable-instrument
+            // corridors (BOLT12) that will arrive by another door with amount
+            // rules of their own.
+            if (facts.amountSats === 0) {
+                return { refused: "the invoice names no amount, and a send route needs one" };
+            }
+
+            return {
+                claimed: {
+                    kind: "invoice",
+                    bolt11: invoice,
+                    paymentHash: facts.paymentHash,
+                    amount: BigInt(facts.amountSats),
+                    expiresAt: facts.expiresAt,
+                },
+            };
+        },
+    }),
+    { target: invoiceTarget },
+);

--- a/packages/swap/src/client/corridors/lightning.ts
+++ b/packages/swap/src/client/corridors/lightning.ts
@@ -114,7 +114,7 @@ export const lightningCorridor: CorridorFactory<LightningCorridorDeps> = Object.
                 };
             }
 
-            if (!Number.isFinite(facts.expiresAt)) {
+            if (!Number.isSafeInteger(facts.expiresAt)) {
                 return { refused: "the decoded invoice carries no usable expiry" };
             }
             const now = Math.floor(Date.now() / 1000);

--- a/packages/swap/src/client/corridors/onchain.ts
+++ b/packages/swap/src/client/corridors/onchain.ts
@@ -1,0 +1,71 @@
+/**
+ * The onchain corridor: a Bitcoin L1 address, on this wallet's network.
+ *
+ * Core's `isBtcAddress` classifies bech32 and base58 for "any network", by its
+ * own doc comment, so the network match is this module's. It is made by
+ * decoding against the wallet's parameters rather than by comparing prefixes:
+ * a prefix table would have to restate what `L1_NETWORKS` already holds, and a
+ * base58 address carries its network in a version byte and not in a prefix
+ * anyone can read off the front.
+ *
+ * The mapping is promoted rather than re-authored — `l1NetworkFromArk` and
+ * `L1_NETWORKS` were module-private, and the alternative was writing them a
+ * third time. Their shape is also why no caller can claim a signet-versus-
+ * testnet rejection: `OnchainNetwork` has three members and signet, mutinynet
+ * and testnet all fold into `testnet`.
+ */
+import { btcTarget } from "@arkade-os/sdk";
+import * as btc from "@scure/btc-signer";
+import { L1_NETWORKS } from "../../onchainHtlc";
+import { l1NetworkFromArk } from "../../rfq";
+import type { CorridorDrive, CorridorFactory, CorridorModule } from "./contract";
+import type { OnchainCorridorDeps } from "./deps";
+
+/**
+ * One direction only, and the absence is the decision.
+ *
+ * `onchain -> arkade` gets no entry because it is outside the `Route` union:
+ * its Arkade half is the same solver-funded lockup a lightning receive has, but
+ * it adds an L1 half the trader funds and must take back itself — a second
+ * deadline, a second observation seam AND a second action callback. Declaring
+ * the lockup half alone is what would produce a manager that silently lets the
+ * trader's L1 refund window pass.
+ *
+ * On `arkade -> onchain` the pass reads two covenants and they have different
+ * owners. The Arkade lockup is the trader's, and `refundLocktime` is the moment
+ * the money comes back. The L1 HTLC is the solver's on its refund leaf — the
+ * trader holds only the claim key — so reaching `htlc.refundLocktime` does not
+ * mean "refund the HTLC", it means the claim was missed.
+ */
+const ONCHAIN_DRIVE: CorridorDrive = {
+    take: {
+        lockups: [
+            { covenant: "arkade_lockup", owner: "trader", deadline: "refund_locktime" },
+            { covenant: "onchain_htlc", owner: "solver", deadline: "htlc_refund_locktime" },
+        ],
+        actions: ["claimOnchain", "refundArkade"],
+        seams: ["indexer", "chain"],
+    },
+};
+
+export const onchainCorridor: CorridorFactory<OnchainCorridorDeps> = Object.assign(
+    (deps: OnchainCorridorDeps): CorridorModule<OnchainCorridorDeps> => {
+        const l1 = l1NetworkFromArk(deps.networkName);
+        return {
+            corridor: "onchain",
+            deps,
+            drive: ONCHAIN_DRIVE,
+            matches(raw: string) {
+                const target = btcTarget(raw);
+                if (target === undefined) return undefined;
+                try {
+                    btc.Address(L1_NETWORKS[l1]).decode(target);
+                } catch {
+                    return { refused: `this is not a ${l1} address` };
+                }
+                return { claimed: { kind: "address", address: target } };
+            },
+        };
+    },
+    { target: btcTarget },
+);

--- a/packages/swap/src/client/corridors/registry.ts
+++ b/packages/swap/src/client/corridors/registry.ts
@@ -1,0 +1,139 @@
+/**
+ * The registry: three modules, keyed on the corridor, and the one place a
+ * destination string becomes a corridor plus an instrument.
+ *
+ * Keyed on `Corridor` and not `CorridorId`, deliberately.
+ * `noUncheckedIndexedAccess` is off in this workspace, so a `CorridorId`-keyed
+ * record types an `eip155:` lookup as present and hands back `undefined` at
+ * runtime — the EVM corridor is deferred and its absence should be a type
+ * error, not a null deref three layers down.
+ *
+ * Internal, exactly as v1's kind-keyed registry argues: a corridor registered
+ * from outside would parse, quote, persist and restore correctly and then sit
+ * undriven, which is worse than not being registrable at all.
+ */
+import { isLnurl } from "@arkade-os/sdk";
+import { CORRIDORS, type Corridor } from "../corridor";
+import { AmbiguousDestination } from "../errors";
+import type { Instrument } from "../route";
+import { arkadeCorridor } from "./arkade";
+import type { CorridorFactory, CorridorModule } from "./contract";
+import {
+    resolveCorridorDeps,
+    type CorridorBase,
+    type CorridorDeps,
+    type CorridorDepsByCorridor,
+    type CorridorOverrides,
+} from "./deps";
+import { lightningCorridor } from "./lightning";
+import { onchainCorridor } from "./onchain";
+
+/** The shipped corridors. Total over `Corridor`, checked at compile time. */
+export const CORRIDOR_FACTORIES = {
+    arkade: arkadeCorridor,
+    lightning: lightningCorridor,
+    onchain: onchainCorridor,
+} as const satisfies { [C in Corridor]: CorridorFactory<CorridorDepsByCorridor[C]> };
+
+/** What a destination resolves to: the corridor that claimed it, and how it
+ * settles. No asset — no destination class carries one, since every Arkade
+ * asset shares a single address form. */
+export interface ClaimedDestination {
+    corridor: Corridor;
+    instrument: Instrument;
+}
+
+/**
+ * The corridors of one client, with deps resolved on first use.
+ *
+ * The laziness is the contract: `resolveCorridorDeps` throws
+ * `MissingCorridorDep` for a dep overridden to `null`, and a missing dep for a
+ * corridor nobody uses is not an error.
+ */
+export interface CorridorSet {
+    /** The module for `corridor`, resolving and memoizing its deps on the first
+     * call. Throws `MissingCorridorDep` when a dep of THIS corridor was
+     * overridden to nothing. */
+    get<C extends Corridor>(corridor: C): CorridorModule<CorridorDepsByCorridor[C]>;
+
+    /**
+     * Which corridor claims `raw`, if any.
+     *
+     * @throws {AmbiguousDestination} when more than one corridor claims it,
+     *   when the corridor that owns its class refuses it, or when nothing
+     *   classifies it at all.
+     * @returns `undefined` when core classifies the string but no corridor
+     *   serves it — an LNURL today — which becomes `UnsupportedRoute` at route
+     *   resolution rather than a parse failure here.
+     */
+    claim(raw: string): ClaimedDestination | undefined;
+}
+
+export const corridorSet = (base: CorridorBase, overrides?: CorridorOverrides): CorridorSet => {
+    const built = new Map<Corridor, CorridorModule<CorridorDeps>>();
+    const get = <C extends Corridor>(corridor: C): CorridorModule<CorridorDepsByCorridor[C]> => {
+        const memoized = built.get(corridor);
+        if (memoized) return memoized as CorridorModule<CorridorDepsByCorridor[C]>;
+        // The `satisfies` above pins every factory to its own dep record and
+        // `resolveCorridorDeps` returns exactly that record for the same `C`.
+        // TypeScript will not correlate two indexed accesses through one type
+        // parameter, so the pairing is asserted here — at the single place it
+        // is needed, and against a `satisfies` that fails to compile if a
+        // factory and its deps ever stop agreeing.
+        const factory = CORRIDOR_FACTORIES[corridor] as unknown as CorridorFactory<
+            CorridorDepsByCorridor[C]
+        >;
+        const module = factory(resolveCorridorDeps(corridor, overrides, base));
+        built.set(corridor, module as CorridorModule<CorridorDeps>);
+        return module;
+    };
+
+    return {
+        get,
+        claim(raw: string): ClaimedDestination | undefined {
+            // Which corridors this string is even the business of, decided with
+            // no deps at all: `CorridorFactory.target` is core's own classifier,
+            // the same one the module extracts with. Asking first is what keeps
+            // a `null` override on an unused corridor from throwing.
+            const owners = CORRIDORS.filter(
+                (corridor) => CORRIDOR_FACTORIES[corridor].target(raw) !== undefined,
+            );
+
+            if (owners.length === 0) {
+                // Core classifies it and no corridor serves it: leave it
+                // unclaimed, and let route resolution name it `UnsupportedRoute`
+                // — which is the fault, where "ambiguous" would not be.
+                if (isLnurl(raw)) return undefined;
+                // Nothing classifies it at all — `0x…` is the realizable case.
+                throw new AmbiguousDestination(raw, "no corridor recognises this destination");
+            }
+
+            const claims: ClaimedDestination[] = [];
+            const refusals: string[] = [];
+            for (const corridor of owners) {
+                const answer = get(corridor).matches(raw);
+                if (answer?.claimed) claims.push({ corridor, instrument: answer.claimed });
+                else if (answer?.refused) refusals.push(`${corridor}: ${answer.refused}`);
+            }
+
+            if (claims.length > 1) {
+                // Core resolves a multi-target URI by rail priority and chooses
+                // in silence, which is safe for core: its rails are
+                // interchangeable and `RouteQuote`'s amounts are receiver-exact,
+                // so a swapped rail changes nothing the recipient gets. A route
+                // choice here changes which asset moves and against which
+                // counterparty, so it is refused instead.
+                throw new AmbiguousDestination(
+                    raw,
+                    `it names ${claims.map((claim) => claim.corridor).join(" and ")}, ` +
+                        "with nothing to choose between them",
+                );
+            }
+            if (claims.length === 1) return claims[0];
+            if (refusals.length > 0) throw new AmbiguousDestination(raw, refusals.join("; "));
+            // The classifier took it and the module answered neither — which
+            // only happens if a module's `target` and its `matches` disagree.
+            return undefined;
+        },
+    };
+};

--- a/packages/swap/src/client/corridors/registry.ts
+++ b/packages/swap/src/client/corridors/registry.ts
@@ -62,6 +62,8 @@ export interface CorridorSet {
      * @throws {AmbiguousDestination} when more than one corridor claims it,
      *   when the corridor that owns its class refuses it, or when nothing
      *   classifies it at all.
+     * @throws {MissingCorridorDep} when the corridor that owns this destination
+     *   has a dep disabled via overrides.
      * @returns `undefined` when core classifies the string but no corridor
      *   serves it — an LNURL today — which becomes `UnsupportedRoute` at route
      *   resolution rather than a parse failure here.

--- a/packages/swap/src/client/errors.ts
+++ b/packages/swap/src/client/errors.ts
@@ -39,7 +39,19 @@ export { SwapRefusal };
 export type QuoteCheck = "pair" | "lockup_address" | "invoice" | "refund_window";
 
 /**
- * `to` is underdetermined — it parses as nothing, or as more than one thing.
+ * `to` is underdetermined — it parses as nothing, as more than one thing, or as
+ * one thing the corridor that owns it refuses.
+ *
+ * The third arm is the one a name reading only "ambiguous" would hide. A
+ * corridor module answers *mine, and wrong* for a `tb1…` on a mainnet wallet,
+ * another operator's Arkade address, or a bolt11 the shape-only classifier
+ * admits and the decoder then rejects; collapsing that into *not mine* would
+ * hand a well-formed destination to {@link UnsupportedRoute}, which names the
+ * wrong fault. The refusal rides on `detail`, so the taxonomy stays at sixteen.
+ *
+ * A destination core classifies but no module claims — an LNURL today — is NOT
+ * this: it is left unclaimed at the parse and becomes {@link UnsupportedRoute}
+ * at route resolution.
  *
  * Boundary: `resolve()`/`quote()`, the single place `to` is parsed.
  */
@@ -284,10 +296,18 @@ export class OperatorUnreachable extends Error {
 }
 
 /**
- * A corridor's dependency was explicitly overridden to nothing — the onchain
- * chain source, the lightning decoder, the arkade repository.
+ * A corridor's dependency was explicitly overridden to nothing, or is required
+ * on this network and absent.
  *
- * Boundary: `quote()`, when a route first touches that corridor. Never
+ * Four overridable deps, not three: the arkade repository, the lightning
+ * decoder, the lightning covclaimd deployment key, and the onchain chain
+ * source. `undefined` takes the default; `null` is the refusal this names. The
+ * arkade module's co-signer key reaches it by the second door — it is not a
+ * `CorridorOverrides` key, but `EMULATOR_PUBKEYS` pins three of the five
+ * networks, so on `testnet` and `signet` the override is required and its
+ * absence is this rather than a bare `Error`.
+ *
+ * Boundary: dep resolution, when a route first touches that corridor. Never
  * construction: a missing dep for a corridor nobody uses is not an error.
  */
 export class MissingCorridorDep extends Error {

--- a/packages/swap/src/client/index.ts
+++ b/packages/swap/src/client/index.ts
@@ -1,6 +1,7 @@
 /**
  * The v2 client's vocabulary: asset identity, the corridor axis, the closed
- * route union, the amount law, the alias layer and the error taxonomy.
+ * route union, the amount law, the alias layer, the error taxonomy and the
+ * corridor modules.
  *
  * Internal to the package for now. M8 is what slims the root export to the v2
  * surface and moves the v1 building blocks to `/protocol`; exporting any of
@@ -11,6 +12,7 @@ export * from "./aliases";
 export * from "./amount";
 export * from "./assetId";
 export * from "./corridor";
+export * from "./corridors";
 export * from "./errors";
 export * from "./primitives";
 export * from "./rfqAmount";

--- a/packages/swap/src/onchainHtlc.ts
+++ b/packages/swap/src/onchainHtlc.ts
@@ -84,7 +84,18 @@ const h160FromPaymentHash = (paymentHash: string): Uint8Array => ripemd160(hex.d
 
 export type OnchainNetwork = "bitcoin" | "testnet" | "regtest";
 
-const L1_NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
+/**
+ * The `@scure/btc-signer` parameters each L1 network is addressed under.
+ *
+ * Exported because it is the only table in the workspace that maps an
+ * {@link OnchainNetwork} to address parameters, and the onchain corridor's
+ * network check needs exactly it — the alternative was a third hand-written
+ * copy. Three members, not five: `signet` and `mutinynet` are indistinguishable
+ * from `testnet` at the address level, which is why {@link l1NetworkFromArk}
+ * folds them together and why no caller can claim a signet-versus-testnet
+ * rejection.
+ */
+export const L1_NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
     bitcoin: btc.NETWORK,
     testnet: btc.TEST_NETWORK,
     regtest: { ...btc.TEST_NETWORK, bech32: "bcrt" },

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -979,7 +979,16 @@ export const offerTermsFromQuote = (
  * payment hash differs (user-generated P instead of a BOLT11). One function,
  * one golden test. */
 
-const l1NetworkFromArk = (network: string): OnchainNetwork =>
+/**
+ * The L1 network an Arkade network settles on.
+ *
+ * Three-valued where {@link NetworkName} is five: `signet` and `mutinynet` both
+ * carry testnet address parameters, so they fold into `testnet` and nothing
+ * downstream can tell them apart from an address alone. Exported for the
+ * onchain corridor module, which would otherwise write this mapping a third
+ * time.
+ */
+export const l1NetworkFromArk = (network: string): OnchainNetwork =>
     network === "bitcoin" ? "bitcoin" : network === "regtest" ? "regtest" : "testnet";
 
 /** The rfq_request for `arkade:BTC->onchain:BTC`. Exact-out means "this much

--- a/packages/swap/test/client/corridors/bolt11.test.ts
+++ b/packages/swap/test/client/corridors/bolt11.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_INVOICE_EXPIRY_SECONDS, decodeBolt11 } from "../../../src/client/corridors/bolt11";
+import { encodeInvoice } from "../../helpers/bolt11";
+
+/**
+ * A real, published mainnet invoice — `light-bolt11-decoder`'s own fixture.
+ * It is what pins the encoder in `test/helpers/bolt11.ts` against reality: the
+ * per-HRP vectors below are built, because published invoices exist for
+ * mainnet only.
+ */
+const REAL_MAINNET =
+    "lnbc20u1p3y0x3hpp5743k2g0fsqqxj7n8qzuhns5gmkk4djeejk3wkp64ppevgekvc0jsdqcve5kzar2v9nr5gpq" +
+    "d4hkuetesp5ez2g297jduwc20t6lmqlsg3man0vf2jfd8ar9fh8fhn2g8yttfkqxqy9gcqcqzys9qrsgqrzjqtx3k" +
+    "77yrrav9hye7zar2rtqlfkytl094dsp0ms5majzth6gt7ca6uhdkxl983uywgqqqqlgqqqvx5qqjqrzjqd98kxkpy" +
+    "w0l9tyy8r8q57k7zpy9zjmh6sez752wj6gcumqnj3yxzhdsmg6qq56utgqqqqqqqqqqqeqqjq7jd56882gtxhrjm0" +
+    "3c93aacyfy306m4fq0tskf83c0nmet8zc2lxyyg3saz8x6vwcp26xnrlagf9semau3qm2glysp7sv95693fphvsp5" +
+    "4l567";
+
+const HASH = "f5636521e98000697a6700b979c288ddad56cb3995a2eb07550872c466ccc3e5";
+const TIMESTAMP = 1_700_000_000;
+
+describe("the built-in bolt11 decoder", () => {
+    it("decodes a real invoice", () => {
+        expect(decodeBolt11(REAL_MAINNET)).toEqual({
+            raw: REAL_MAINNET,
+            paymentHash: HASH,
+            amountSats: 2_000,
+            // timestamp 1648859703 plus the `x` tag's 48 hours
+            expiresAt: 1_648_859_703 + 172_800,
+        });
+    });
+
+    it("reports an absolute expiry, where the library's tag is relative", () => {
+        const invoice = encodeInvoice({
+            prefix: "lnbc",
+            amount: "20u",
+            timestamp: TIMESTAMP,
+            expiry: 600,
+            paymentHash: HASH,
+        });
+        expect(decodeBolt11(invoice).expiresAt).toBe(TIMESTAMP + 600);
+    });
+
+    it("applies BOLT11's default expiry when the invoice carries no `x` tag", () => {
+        const invoice = encodeInvoice({
+            prefix: "lnbc",
+            amount: "20u",
+            timestamp: TIMESTAMP,
+            paymentHash: HASH,
+        });
+        expect(decodeBolt11(invoice).expiresAt).toBe(TIMESTAMP + DEFAULT_INVOICE_EXPIRY_SECONDS);
+        expect(DEFAULT_INVOICE_EXPIRY_SECONDS).toBe(3_600);
+    });
+
+    it("converts millisats through bigint, so precision survives past 2^53", () => {
+        // 90071992547419990p is 9_007_199_254_741_999 msat — over `Number`'s
+        // integer range, where `Number(msat) / 1000` would round before it
+        // divided.
+        const invoice = encodeInvoice({
+            prefix: "lnbc",
+            amount: "90071992547419990p",
+            timestamp: TIMESTAMP,
+            paymentHash: HASH,
+        });
+        expect(decodeBolt11(invoice).amountSats).toBe(9_007_199_254_741);
+    });
+
+    it("reports an amountless invoice as 0, which is how the gates spell it", () => {
+        const invoice = encodeInvoice({ prefix: "lnbc", timestamp: TIMESTAMP, paymentHash: HASH });
+        expect(decodeBolt11(invoice).amountSats).toBe(0);
+    });
+
+    it("carries the payment hash verbatim, lowercase", () => {
+        const invoice = encodeInvoice({
+            prefix: "lnbcrt",
+            amount: "20u",
+            timestamp: TIMESTAMP,
+            paymentHash: HASH,
+        });
+        expect(decodeBolt11(invoice).paymentHash).toBe(HASH);
+    });
+
+    it("decodes every HRP the network table names", () => {
+        for (const prefix of ["lnbc", "lntb", "lntbs", "lnbcrt", "lnsb"]) {
+            const invoice = encodeInvoice({
+                prefix,
+                amount: "20u",
+                timestamp: TIMESTAMP,
+                paymentHash: HASH,
+            });
+            // The decoder is network-blind on purpose: the HRP check is the
+            // corridor's, so an `lnsb` invoice decodes here and is refused there.
+            expect(decodeBolt11(invoice).amountSats).toBe(2_000);
+        }
+    });
+
+    describe("refusals", () => {
+        it("refuses a string that is not an invoice", () => {
+            expect(() => decodeBolt11("not-an-invoice")).toThrow();
+        });
+
+        it("refuses an invoice whose checksum does not hold", () => {
+            const invoice = encodeInvoice({
+                prefix: "lnbc",
+                amount: "20u",
+                timestamp: TIMESTAMP,
+                paymentHash: HASH,
+            });
+            expect(() =>
+                decodeBolt11(`${invoice.slice(0, -1)}${invoice.endsWith("q") ? "p" : "q"}`),
+            ).toThrow();
+        });
+
+        it("refuses an invoice with no payment hash rather than defaulting to an empty one", () => {
+            // `?? ""` was the deleted decoder's answer. An empty hash typechecks
+            // onto the invoice instrument and is then compared byte-for-byte
+            // against a real one.
+            const withoutHash = encodeInvoice({
+                prefix: "lnbc",
+                amount: "20u",
+                timestamp: TIMESTAMP,
+            });
+            expect(() => decodeBolt11(withoutHash)).toThrow(/payment hash/);
+        });
+    });
+});

--- a/packages/swap/test/client/corridors/chainSource.test.ts
+++ b/packages/swap/test/client/corridors/chainSource.test.ts
@@ -1,0 +1,206 @@
+/**
+ * The default chain source, over a scripted backend.
+ *
+ * The regtest suite exercises the real esplora one; what is proved here is the
+ * adapter: the script-to-address encode `getScriptUtxos` needs and
+ * `ChainSource`'s signature does not carry, the confirmations arithmetic
+ * `Coin` cannot answer alone, the missing-spender fallback core already carries
+ * for boarding outputs, and the one read that must never come from
+ * `getChainTip().time`.
+ */
+import { hex } from "@scure/base";
+import * as btc from "@scure/btc-signer";
+import type { ExplorerTransaction, OnchainProvider } from "@arkade-os/sdk";
+import { describe, expect, it, vi } from "vitest";
+import {
+    chainSourceOver,
+    esploraTip,
+    type ChainSourceBackend,
+} from "../../../src/client/corridors/chainSource";
+import { L1_NETWORKS } from "../../../src/onchainHtlc";
+
+const NETWORK = L1_NETWORKS.regtest;
+const PK_SCRIPT = btc.OutScript.encode({
+    type: "wpkh",
+    hash: hex.decode("751e76e8199196d454941c45d1b3a323f1433bd6"),
+});
+const ADDRESS = btc.Address(NETWORK).encode(btc.OutScript.decode(PK_SCRIPT));
+
+/** A raw transaction paying `PK_SCRIPT`, so the fallback can derive its
+ * address from the outpoint alone. */
+const funding = (() => {
+    const tx = new btc.Transaction({ allowUnknownInputs: true, allowUnknownOutputs: true });
+    tx.addInput({ txid: new Uint8Array(32), index: 0 });
+    tx.addOutput({ script: PK_SCRIPT, amount: 10_000n });
+    return tx;
+})();
+const FUNDING_TXID = funding.id;
+const FUNDING_HEX = hex.encode(funding.toBytes(true, false));
+const SPEND_HEX = "0200000000";
+
+const backendOver = (provider: Partial<OnchainProvider>, height = 100, mtp = 1_700_000_000) =>
+    ({
+        provider: provider as OnchainProvider,
+        tip: async () => ({ height, mtp }),
+    }) as ChainSourceBackend;
+
+describe("the default chain source's adapter", () => {
+    describe("getScriptUtxos", () => {
+        it("encodes the script to an address and converts sats to bigint", async () => {
+            const getCoins = vi.fn(async () => [
+                { txid: "a".repeat(64), vout: 0, value: 10_000, status: { confirmed: false } },
+            ]);
+            const chain = chainSourceOver(backendOver({ getCoins }), NETWORK);
+            expect(await chain.getScriptUtxos(PK_SCRIPT)).toEqual([
+                { txid: "a".repeat(64), vout: 0, amount: 10_000n, confirmations: 0 },
+            ]);
+            expect(getCoins).toHaveBeenCalledWith(ADDRESS);
+        });
+
+        it("derives confirmations against the tip, counting the block it landed in", async () => {
+            // `Coin` carries a height, never a depth, so the tip is the second
+            // half of the answer — which is why the utxo read and the tip read
+            // happen together.
+            const chain = chainSourceOver(
+                backendOver({
+                    getCoins: async () => [
+                        {
+                            txid: "a".repeat(64),
+                            vout: 0,
+                            value: 1,
+                            status: { confirmed: true, block_height: 100 },
+                        },
+                        {
+                            txid: "b".repeat(64),
+                            vout: 1,
+                            value: 2,
+                            status: { confirmed: true, block_height: 95 },
+                        },
+                    ],
+                }),
+                NETWORK,
+            );
+            expect((await chain.getScriptUtxos(PK_SCRIPT)).map((u) => u.confirmations)).toEqual([
+                1, 6,
+            ]);
+        });
+    });
+
+    describe("getSpendingTx", () => {
+        it("follows the spender `/outspends` names", async () => {
+            const getRawTransaction = vi.fn(async () => hex.decode(SPEND_HEX));
+            const chain = chainSourceOver(
+                backendOver({
+                    getTxOutspends: async () => [{ spent: true, txid: "c".repeat(64) }],
+                    getRawTransaction,
+                }),
+                NETWORK,
+            );
+            expect(await chain.getSpendingTx(FUNDING_TXID, 0)).toEqual({ txHex: SPEND_HEX });
+            expect(getRawTransaction).toHaveBeenCalledWith("c".repeat(64));
+        });
+
+        it("scans the spent output's address history when `/outspends` omits the txid", async () => {
+            // Some deployments answer `{spent: true}` with no `txid` —
+            // `mempool.arkade.sh`, which is `ESPLORA_URL.bitcoin`. The address
+            // is derived from the funding transaction, because `getSpendingTx`
+            // is handed an outpoint and nothing else.
+            const history: ExplorerTransaction[] = [
+                {
+                    txid: "d".repeat(64),
+                    vin: [{ txid: "e".repeat(64), vout: 3 }],
+                    vout: [],
+                    status: { confirmed: true, block_time: 1 },
+                },
+                {
+                    txid: "f".repeat(64),
+                    vin: [{ txid: FUNDING_TXID, vout: 0 }],
+                    vout: [],
+                    status: { confirmed: true, block_time: 2 },
+                },
+            ];
+            const getTransactions = vi.fn(async () => history);
+            const chain = chainSourceOver(
+                backendOver({
+                    getTxOutspends: async () => [{ spent: true }],
+                    getTransactions,
+                    getRawTransaction: async (txid: string) =>
+                        hex.decode(txid === FUNDING_TXID ? FUNDING_HEX : SPEND_HEX),
+                }),
+                NETWORK,
+            );
+            expect(await chain.getSpendingTx(FUNDING_TXID, 0)).toEqual({ txHex: SPEND_HEX });
+            expect(getTransactions).toHaveBeenCalledWith(ADDRESS);
+        });
+
+        it("treats the electrum provider's empty-string txid as no spender", async () => {
+            // `""` is its unspent sentinel, and `??` would have taken it.
+            const chain = chainSourceOver(
+                backendOver({
+                    getTxOutspends: async () => [{ spent: true, txid: "" }],
+                    getTransactions: async () => [],
+                    getRawTransaction: async () => hex.decode(FUNDING_HEX),
+                }),
+                NETWORK,
+            );
+            expect(await chain.getSpendingTx(FUNDING_TXID, 0)).toBe(null);
+        });
+
+        it("answers null for an unspent outpoint", async () => {
+            const chain = chainSourceOver(
+                backendOver({ getTxOutspends: async () => [{ spent: false }] }),
+                NETWORK,
+            );
+            expect(await chain.getSpendingTx(FUNDING_TXID, 0)).toBe(null);
+        });
+    });
+
+    it("broadcasts through the provider", async () => {
+        const broadcastTransaction = vi.fn(async () => "txid");
+        const chain = chainSourceOver(backendOver({ broadcastTransaction }), NETWORK);
+        expect(await chain.broadcast(SPEND_HEX)).toBe("txid");
+        expect(broadcastTransaction).toHaveBeenCalledWith(SPEND_HEX);
+    });
+
+    it("answers median-time-past, not a block time", async () => {
+        const chain = chainSourceOver(backendOver({}, 100, 1_699_999_000), NETWORK);
+        expect(await chain.getMtp()).toBe(1_699_999_000);
+    });
+});
+
+describe("esploraTip", () => {
+    const respondWith = (body: unknown, ok = true) =>
+        vi.fn(async () =>
+            ok
+                ? Response.json(body)
+                : new Response("nope", { status: 502, statusText: "Bad Gateway" }),
+        ) as unknown as typeof fetch;
+
+    it("reads `mediantime` off `/blocks`", async () => {
+        // `/blocks` rather than `/blocks/tip`: the latter is not part of the
+        // Esplora spec and a strict backend answers an empty array.
+        const fetchImpl = respondWith([
+            { id: "h", height: 812, mediantime: 1_700_000_000 },
+            { id: "g", height: 811, mediantime: 1_699_999_000 },
+        ]);
+        expect(await esploraTip("http://esplora/api", fetchImpl)).toEqual({
+            height: 812,
+            mtp: 1_700_000_000,
+        });
+        expect(fetchImpl).toHaveBeenCalledWith("http://esplora/api/blocks");
+    });
+
+    it("fails rather than substituting a tip time for MTP", async () => {
+        // The one substitution this read exists to prevent: an MTP that runs
+        // high abandons a still-live L1 claim.
+        await expect(
+            esploraTip("http://esplora/api", respondWith([{ id: "h", height: 812, time: 1 }])),
+        ).rejects.toThrow(/no usable chain tip/);
+        await expect(esploraTip("http://esplora/api", respondWith([]))).rejects.toThrow(
+            /no usable chain tip/,
+        );
+        await expect(
+            esploraTip("http://esplora/api", respondWith(undefined, false)),
+        ).rejects.toThrow(/failed to read the chain tip/);
+    });
+});

--- a/packages/swap/test/client/corridors/contract.test.ts
+++ b/packages/swap/test/client/corridors/contract.test.ts
@@ -1,0 +1,105 @@
+/**
+ * What each module declares, checked against the manager that will run it.
+ *
+ * These are declarations and not behaviour, so what is worth asserting is that
+ * they agree with the code they describe: the action names are the manager's
+ * own union, the seams are the two `RfqSwapManagerDeps` takes, and the deadline
+ * set is the one the swap types already fix.
+ */
+import { describe, expect, it } from "vitest";
+import { arkadeCorridor } from "../../../src/client/corridors/arkade";
+import type { CorridorPass, RouteSide } from "../../../src/client/corridors/contract";
+import { lightningCorridor } from "../../../src/client/corridors/lightning";
+import { onchainCorridor } from "../../../src/client/corridors/onchain";
+import type { RfqSwapActionName } from "../../../src/swapManager";
+import { corridorBaseFor } from "./fixtures";
+import { resolveCorridorDeps } from "../../../src/client/corridors/deps";
+
+const base = corridorBaseFor("regtest");
+const arkade = arkadeCorridor(resolveCorridorDeps("arkade", undefined, base));
+const lightning = lightningCorridor(resolveCorridorDeps("lightning", undefined, base));
+const onchain = onchainCorridor(resolveCorridorDeps("onchain", undefined, base));
+
+const ALL_ACTIONS: readonly RfqSwapActionName[] = ["claimOnchain", "claimLockup", "refundArkade"];
+const passes = (drive: Partial<Record<RouteSide, CorridorPass>>): CorridorPass[] =>
+    Object.values(drive);
+
+describe("what a corridor module declares", () => {
+    it("keys on the corridor, not on a route pair", () => {
+        // v1's registry keys on `RfqSwap["kind"]`, two of whose three members
+        // are this same corridor from opposite ends.
+        expect(lightning.corridor).toBe("lightning");
+        expect(Object.keys(lightning.drive).sort()).toEqual(["give", "take"]);
+    });
+
+    it("names only actions the manager can execute", () => {
+        for (const module of [arkade, lightning, onchain]) {
+            for (const pass of passes(module.drive)) {
+                for (const action of pass.actions) expect(ALL_ACTIONS).toContain(action);
+            }
+        }
+    });
+
+    it("names only the two seams a pass reads", () => {
+        // `RfqSwapManagerDeps` excludes `RfqTransport` by name: nothing the
+        // manager decides depends on the solver answering.
+        for (const module of [arkade, lightning, onchain]) {
+            for (const pass of passes(module.drive)) {
+                for (const seam of pass.seams) expect(["indexer", "chain"]).toContain(seam);
+            }
+        }
+    });
+
+    describe("the lightning corridor", () => {
+        it("inverts the lockup's owner with the direction", () => {
+            // The trader funds the lockup on a send; the solver funds it on a
+            // receive, where every non-claim leaf is the solver's.
+            expect(lightning.drive.take?.lockups).toEqual([
+                { covenant: "arkade_lockup", owner: "trader", deadline: "refund_locktime" },
+            ]);
+            expect(lightning.drive.give?.lockups).toEqual([
+                { covenant: "arkade_lockup", owner: "solver", deadline: "refund_locktime" },
+            ]);
+        });
+
+        it("refunds on the send and claims on the receive, never both", () => {
+            expect(lightning.drive.take?.actions).toEqual(["refundArkade"]);
+            expect(lightning.drive.give?.actions).toEqual(["claimLockup"]);
+        });
+
+        it("reads one seam, on both directions", () => {
+            expect(lightning.drive.take?.seams).toEqual(["indexer"]);
+            expect(lightning.drive.give?.seams).toEqual(["indexer"]);
+        });
+    });
+
+    describe("the onchain corridor", () => {
+        it("is the only corridor that reads a second covenant", () => {
+            expect(onchain.drive.take?.lockups).toEqual([
+                { covenant: "arkade_lockup", owner: "trader", deadline: "refund_locktime" },
+                { covenant: "onchain_htlc", owner: "solver", deadline: "htlc_refund_locktime" },
+            ]);
+            expect(onchain.drive.take?.seams).toEqual(["indexer", "chain"]);
+        });
+
+        it("declares nothing for `onchain -> arkade`", () => {
+            // Outside the `Route` union: it adds a deadline, a seam AND an
+            // action the manager does not drive, and declaring the lockup half
+            // alone is what would let the trader's L1 refund window pass.
+            expect(onchain.drive.give).toBe(undefined);
+        });
+    });
+
+    it("declares no pass for the arkade corridor at all", () => {
+        // `arkade -> arkade` is an offer covenant: no lockup, no
+        // `refundLocktime`, no manager action, and a watcher of its own that
+        // reads the wallet's own contract events.
+        expect(arkade.drive).toEqual({});
+    });
+
+    it("closes its deps over at construction", () => {
+        expect(onchain.deps.networkName).toBe("regtest");
+        expect(lightning.deps.networkName).toBe("regtest");
+        expect(arkade.deps.network.hrp).toBe("tark");
+    });
+});

--- a/packages/swap/test/client/corridors/deps.test.ts
+++ b/packages/swap/test/client/corridors/deps.test.ts
@@ -1,0 +1,322 @@
+/**
+ * The override matrix: default, replaced and `null` for every
+ * `CorridorOverrides` key, plus the two deps that reach `MissingCorridorDep` by
+ * another door — the arkade repository, which has no default to fall back to,
+ * and the co-signer key, which is required on the networks nobody pinned.
+ *
+ * Called through `resolveCorridorDeps` rather than through a quote: "at quote
+ * time" names an entry point a later milestone owns, and this milestone's
+ * promise is that the refusal lands at dep resolution, before funding.
+ */
+import {
+    BITCOIN_EMULATOR_PUBKEY,
+    ESPLORA_URL,
+    ProviderUnavailableError,
+    REGTEST_EMULATOR_PUBKEY,
+    type ArkadeInfo,
+    type IWallet,
+} from "@arkade-os/sdk";
+import { describe, expect, it, vi } from "vitest";
+import { decodeBolt11 } from "../../../src/client/corridors/bolt11";
+import {
+    resolveCorridorBase,
+    resolveCorridorDeps,
+    type CorridorOverrides,
+} from "../../../src/client/corridors/deps";
+import { MissingCorridorDep, OperatorUnreachable } from "../../../src/client/errors";
+import type { AssetSwapRepository } from "../../../src/repository";
+import type { SwapOperator } from "../../../src/refund";
+import { OPERATOR_SIGNER, corridorBaseFor } from "./fixtures";
+
+const repository = {} as AssetSwapRepository;
+
+describe("resolveCorridorDeps", () => {
+    describe("the lightning decoder", () => {
+        it("defaults to the built-in", () => {
+            expect(
+                resolveCorridorDeps("lightning", undefined, corridorBaseFor("regtest")).decode,
+            ).toBe(decodeBolt11);
+        });
+
+        it("takes a replacement", () => {
+            const decode = vi.fn();
+            const overrides: CorridorOverrides = { lightning: { decode } };
+            expect(
+                resolveCorridorDeps("lightning", overrides, corridorBaseFor("regtest")).decode,
+            ).toBe(decode);
+        });
+
+        it("refuses `null` — the shape `need()` cannot see", () => {
+            // `undefined` takes the default; `null` is a caller saying "not
+            // this one", and a guard that tests `value === undefined` passes it
+            // straight through to whatever needed it.
+            expect(() =>
+                resolveCorridorDeps(
+                    "lightning",
+                    { lightning: { decode: null } },
+                    corridorBaseFor("regtest"),
+                ),
+            ).toThrow(MissingCorridorDep);
+            expect(() =>
+                resolveCorridorDeps(
+                    "lightning",
+                    { lightning: { decode: null } },
+                    corridorBaseFor("regtest"),
+                ),
+            ).toThrow(/the lightning corridor has no bolt11 decoder/);
+        });
+    });
+
+    describe("the covclaimd deployment key", () => {
+        it("defaults to absent, which is the internal ephemeral seal", () => {
+            expect(
+                resolveCorridorDeps("lightning", undefined, corridorBaseFor("regtest")).covclaimd,
+            ).toBe(undefined);
+        });
+
+        it("takes a deployment key", () => {
+            const covclaimd = { pubkey: `02${"11".repeat(32)}` };
+            expect(
+                resolveCorridorDeps(
+                    "lightning",
+                    { lightning: { covclaimd } },
+                    corridorBaseFor("regtest"),
+                ).covclaimd,
+            ).toEqual(covclaimd);
+        });
+
+        it("refuses `null`", () => {
+            expect(() =>
+                resolveCorridorDeps(
+                    "lightning",
+                    { lightning: { covclaimd: null } },
+                    corridorBaseFor("regtest"),
+                ),
+            ).toThrow(/the lightning corridor has no covclaimd deployment key/);
+        });
+    });
+
+    describe("the onchain chain source", () => {
+        it("defaults to one built on `ESPLORA_URL[network]`", () => {
+            const fetchImpl = vi.fn(async () =>
+                Response.json([{ id: "b", height: 101, mediantime: 1_700_000_000 }]),
+            );
+            const base = corridorBaseFor("regtest", { fetchImpl: fetchImpl as never });
+            const { chain } = resolveCorridorDeps("onchain", undefined, base);
+            return chain.getMtp().then((mtp) => {
+                expect(mtp).toBe(1_700_000_000);
+                expect(fetchImpl).toHaveBeenCalledWith(`${ESPLORA_URL.regtest}/blocks`);
+            });
+        });
+
+        it("takes an esplora URL — the override is the URL, not a ChainSource", () => {
+            // There is no wallet-held provider to substitute: `onchainProvider`
+            // is a field of the concrete wallet and never of `IWallet`.
+            const fetchImpl = vi.fn(async () =>
+                Response.json([{ id: "b", height: 7, mediantime: 42 }]),
+            );
+            const base = corridorBaseFor("regtest", { fetchImpl: fetchImpl as never });
+            const { chain } = resolveCorridorDeps(
+                "onchain",
+                { onchain: { chain: { esploraUrl: "http://elsewhere/api" } } },
+                base,
+            );
+            return chain.getMtp().then(() => {
+                expect(fetchImpl).toHaveBeenCalledWith("http://elsewhere/api/blocks");
+            });
+        });
+
+        it("refuses `null`", () => {
+            expect(() =>
+                resolveCorridorDeps(
+                    "onchain",
+                    { onchain: { chain: null } },
+                    corridorBaseFor("regtest"),
+                ),
+            ).toThrow(/the onchain corridor has no chain source/);
+        });
+    });
+
+    describe("the arkade repository", () => {
+        it("has no default yet, so an absent one stays absent", () => {
+            expect(
+                resolveCorridorDeps("arkade", undefined, corridorBaseFor("regtest")).repository,
+            ).toBe(undefined);
+        });
+
+        it("takes a replacement", () => {
+            expect(
+                resolveCorridorDeps(
+                    "arkade",
+                    { arkade: { repository } },
+                    corridorBaseFor("regtest"),
+                ).repository,
+            ).toBe(repository);
+        });
+
+        it("refuses `null`", () => {
+            expect(() =>
+                resolveCorridorDeps(
+                    "arkade",
+                    { arkade: { repository: null } },
+                    corridorBaseFor("regtest"),
+                ),
+            ).toThrow(/the arkade corridor has no repository/);
+        });
+    });
+
+    describe("the covenant co-signer", () => {
+        it("resolves from the network name, never from the operator's self-report", () => {
+            expect(
+                resolveCorridorDeps("arkade", undefined, corridorBaseFor("regtest")).emulatorPubkey,
+            ).toBe(REGTEST_EMULATOR_PUBKEY);
+            expect(
+                resolveCorridorDeps("arkade", undefined, corridorBaseFor("bitcoin")).emulatorPubkey,
+            ).toBe(BITCOIN_EMULATOR_PUBKEY);
+        });
+
+        it("is required on the networks nobody pinned, and its absence is typed", () => {
+            // `EMULATOR_PUBKEYS` pins bitcoin, mutinynet and regtest only. The
+            // v2 id vocabulary admits testnet and signet, where the override is
+            // the only source — and a bare `Error` escaping the module is what
+            // this converts.
+            for (const network of ["testnet", "signet"] as const) {
+                expect(() =>
+                    resolveCorridorDeps("arkade", undefined, corridorBaseFor(network)),
+                ).toThrow(MissingCorridorDep);
+                expect(() =>
+                    resolveCorridorDeps("arkade", undefined, corridorBaseFor(network)),
+                ).toThrow(new RegExp(`covenant co-signer key \\(none is pinned for ${network}`));
+            }
+        });
+
+        it("takes the override on an unpinned network", () => {
+            const emulatorPubkey = `03${"ab".repeat(32)}`;
+            expect(
+                resolveCorridorDeps(
+                    "arkade",
+                    undefined,
+                    corridorBaseFor("signet", { emulatorPubkey }),
+                ).emulatorPubkey,
+            ).toBe(emulatorPubkey);
+        });
+
+        it("leaves a malformed override to core's own refusal", () => {
+            // Core refuses rather than passing it into a leaf, and a typo here
+            // would otherwise surface as an unspendable contract much later.
+            expect(() =>
+                resolveCorridorDeps(
+                    "arkade",
+                    undefined,
+                    corridorBaseFor("regtest", { emulatorPubkey: "nope" }),
+                ),
+            ).toThrow(/33-byte compressed secp256k1 hex/);
+        });
+    });
+
+    it("carries both seams onto the arkade module, and neither replaces the other", () => {
+        // The wallet answers *who and where* — only it can make the live,
+        // fail-closed info read, since `SwapOperator.getInfo()` takes no
+        // options — and the operator seam answers *submit and finalize*.
+        const wallet = {} as IWallet;
+        const operator = {} as SwapOperator;
+        const deps = resolveCorridorDeps(
+            "arkade",
+            undefined,
+            corridorBaseFor("regtest", { wallet, operator }),
+        );
+        expect(deps.wallet).toBe(wallet);
+        expect(deps.operator).toBe(operator);
+    });
+
+    it("resolves one corridor without touching another's deps", () => {
+        // `MissingCorridorDep`'s own boundary note: a missing dep for a
+        // corridor nobody uses is not an error.
+        const overrides: CorridorOverrides = {
+            onchain: { chain: null },
+            arkade: { repository: null },
+        };
+        expect(resolveCorridorDeps("lightning", overrides, corridorBaseFor("regtest")).decode).toBe(
+            decodeBolt11,
+        );
+    });
+});
+
+describe("resolveCorridorBase", () => {
+    const info = { network: "regtest", signerPubkey: OPERATOR_SIGNER, deprecatedSigners: [] };
+    const walletAnswering = (getArkadeInfo: IWallet["getArkadeInfo"]): IWallet =>
+        ({ getArkadeInfo }) as IWallet;
+
+    it("reads live, and derives the network and signer set from that one read", async () => {
+        const getArkadeInfo = vi.fn(async () => info as unknown as ArkadeInfo);
+        const base = await resolveCorridorBase({
+            wallet: walletAnswering(getArkadeInfo),
+            operator: {} as SwapOperator,
+        });
+        // A snapshot would bind a covenant to a signer key the operator may no
+        // longer co-sign for.
+        expect(getArkadeInfo).toHaveBeenCalledWith({ requireLive: true });
+        expect(base.networkName).toBe("regtest");
+        expect(base.network.hrp).toBe("tark");
+        expect(base.signerSet.active).toBe(OPERATOR_SIGNER);
+    });
+
+    it("wraps every shape the live read can throw", async () => {
+        // `requireLive` re-throws the provider's raw error unwrapped, so the
+        // shape depends on how the read failed. A `catch` on a matched subset
+        // would let exactly these through untyped.
+        const shapes: unknown[] = [
+            new ProviderUnavailableError("offline"),
+            new TypeError("fetch failed"),
+            new Error("boom"),
+            Object.assign(new Error("aborted"), { name: "TimeoutError" }),
+            // Across the service-worker boundary the error is a fresh `Error`
+            // whose only branchable identity is `cause.name`.
+            new Error("Failed to get arkade info: Error", {
+                cause: Object.assign(new Error("offline"), { name: "ProviderUnavailableError" }),
+            }),
+            "a thrown string",
+        ];
+        for (const shape of shapes) {
+            const thrown = await resolveCorridorBase({
+                wallet: walletAnswering(async () => {
+                    throw shape;
+                }),
+                operator: {} as SwapOperator,
+            }).catch((error: unknown) => error);
+            expect(thrown).toBeInstanceOf(OperatorUnreachable);
+            expect((thrown as OperatorUnreachable).cause).toBe(shape);
+        }
+    });
+
+    it("fails closed even when the snapshot would have answered", async () => {
+        // `requireLive` is the whole point: a snapshot binds a covenant to a
+        // signer key the operator may no longer co-sign for, so a wallet that
+        // could answer from cache still refuses here.
+        const getArkadeInfo = vi.fn(async (opts?: { requireLive?: boolean }) => {
+            if (opts?.requireLive) throw new ProviderUnavailableError("offline");
+            return info as unknown as ArkadeInfo;
+        });
+        await expect(
+            resolveCorridorBase({
+                wallet: walletAnswering(getArkadeInfo as IWallet["getArkadeInfo"]),
+                operator: {} as SwapOperator,
+            }),
+        ).rejects.toBeInstanceOf(OperatorUnreachable);
+        await expect(
+            (walletAnswering(getArkadeInfo as IWallet["getArkadeInfo"]) as IWallet).getArkadeInfo(),
+        ).resolves.toMatchObject({ network: "regtest" });
+    });
+
+    it("leaves core's fail-closed network narrowing alone", async () => {
+        // An operator answering with a network this SDK does not know is not
+        // unreachable, and resolving it to mainnet parameters is the failure
+        // `getNetwork` exists to prevent.
+        const thrown = await resolveCorridorBase({
+            wallet: walletAnswering(async () => ({ ...info, network: "elsewhere" }) as never),
+            operator: {} as SwapOperator,
+        }).catch((error: unknown) => error);
+        expect(thrown).not.toBeInstanceOf(OperatorUnreachable);
+        expect((thrown as Error).message).toMatch(/Unsupported network/);
+    });
+});

--- a/packages/swap/test/client/corridors/fixtures.ts
+++ b/packages/swap/test/client/corridors/fixtures.ts
@@ -1,0 +1,39 @@
+/**
+ * A {@link CorridorBase} without a wallet behind it.
+ *
+ * `matches` reads three things off the base — the network name, its address
+ * parameters and the operator's signer set — and every one of them is a value
+ * the live info read produced. Building them directly keeps the parsing matrix
+ * about parsing.
+ */
+import { ArkAddress, getNetwork, type IWallet, type NetworkName } from "@arkade-os/sdk";
+import type { CorridorBase } from "../../../src/client/corridors/deps";
+import type { SwapOperator } from "../../../src/refund";
+
+/** The operator this wallet talks to, x-only hex. */
+export const OPERATOR_SIGNER = "aa".repeat(32);
+/** Somebody else's. Well-formed, and not ours. */
+export const FOREIGN_SIGNER = "bb".repeat(32);
+
+const VTXO_KEY = "cc".repeat(32);
+
+const bytes = (hexString: string): Uint8Array =>
+    Uint8Array.from(hexString.match(/../g)?.map((byte) => parseInt(byte, 16)) ?? []);
+
+/** An Arkade address under `signer`, on `network`'s hrp. */
+export const arkAddressFor = (network: NetworkName, signer = OPERATOR_SIGNER): string =>
+    new ArkAddress(bytes(signer), bytes(VTXO_KEY), getNetwork(network).hrp).encode();
+
+export const corridorBaseFor = (
+    networkName: NetworkName,
+    over: Partial<CorridorBase> = {},
+): CorridorBase => ({
+    // Neither seam is reached by a parse: `matches` is sync and non-throwing,
+    // so anything needing a round trip has already happened by the time it runs.
+    wallet: {} as IWallet,
+    operator: {} as SwapOperator,
+    networkName,
+    network: getNetwork(networkName),
+    signerSet: { active: OPERATOR_SIGNER, deprecated: new Map() },
+    ...over,
+});

--- a/packages/swap/test/client/corridors/parsing.test.ts
+++ b/packages/swap/test/client/corridors/parsing.test.ts
@@ -1,0 +1,253 @@
+/**
+ * The parsing matrix: every destination class, bare and as a BIP21 param,
+ * against each module's `matches` and the registry's three-way count.
+ *
+ * The "bare and as a param" axis is not decoration. It is the axis two core
+ * defects sat on — a base58 address lowercased into a different address on the
+ * way through `BIP21.parse`, and an upper-case Arkade address dropped from the
+ * params by a case-sensitive filter — and both made one destination classify
+ * differently depending on which form it arrived in.
+ */
+import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
+import { AmbiguousDestination, MissingCorridorDep } from "../../../src/client/errors";
+import { corridorSet } from "../../../src/client/corridors/registry";
+import { encodeInvoice } from "../../helpers/bolt11";
+import { FOREIGN_SIGNER, arkAddressFor, corridorBaseFor } from "./fixtures";
+
+const HASH = "f5636521e98000697a6700b979c288ddad56cb3995a2eb07550872c466ccc3e5";
+const NOW = 1_700_000_000;
+
+const invoiceOn = (prefix: string, amount = "20u"): string =>
+    encodeInvoice({ prefix, amount, timestamp: NOW - 60, expiry: 3_600, paymentHash: HASH });
+
+/** BOLT11 permits an invoice with no amount, which lets a payer pay anything. */
+const amountlessOn = (prefix: string): string =>
+    encodeInvoice({ prefix, timestamp: NOW - 60, expiry: 3_600, paymentHash: HASH });
+
+const ARK_REGTEST = arkAddressFor("regtest");
+const ARK_MAINNET = arkAddressFor("bitcoin");
+const ARK_FOREIGN = arkAddressFor("regtest", FOREIGN_SIGNER);
+
+/** Bech32 on each network. */
+const BCRT1 = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+const TB1 = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx";
+const BC1 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+/** Base58 P2PKH, mixed case on purpose: it is what a lowercasing parse ate. */
+const TESTNET_P2PKH = "mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn";
+
+const claimOn = (network: Parameters<typeof corridorBaseFor>[0], raw: string) =>
+    corridorSet(corridorBaseFor(network)).claim(raw);
+
+describe("the parsing matrix", () => {
+    beforeAll(() => {
+        // The invoice expiry gate is one of §6's parse-boundary checks, so
+        // `matches` reads the clock. Pin it rather than build invoices whose
+        // validity outlives the suite.
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW * 1000);
+    });
+    afterAll(() => vi.useRealTimers());
+
+    describe("bare destinations", () => {
+        it("claims an Arkade address for the arkade corridor", () => {
+            expect(claimOn("regtest", ARK_REGTEST)).toEqual({
+                corridor: "arkade",
+                instrument: { kind: "address", address: ARK_REGTEST },
+            });
+        });
+
+        it("claims an on-chain address for the onchain corridor", () => {
+            expect(claimOn("regtest", BCRT1)).toEqual({
+                corridor: "onchain",
+                instrument: { kind: "address", address: BCRT1 },
+            });
+        });
+
+        it("claims a bolt11 invoice for the lightning corridor, with its facts", () => {
+            const invoice = invoiceOn("lnbcrt");
+            expect(claimOn("regtest", invoice)).toEqual({
+                corridor: "lightning",
+                instrument: {
+                    kind: "invoice",
+                    bolt11: invoice,
+                    paymentHash: HASH,
+                    amount: 2_000n,
+                    expiresAt: NOW - 60 + 3_600,
+                },
+            });
+        });
+
+        it("strips a `lightning:` prefix, as core's classifier does", () => {
+            const invoice = invoiceOn("lnbcrt");
+            const claim = claimOn("regtest", `lightning:${invoice}`);
+            expect(claim?.corridor).toBe("lightning");
+            expect(claim?.instrument).toMatchObject({ bolt11: invoice });
+        });
+    });
+
+    describe("as a BIP21 param", () => {
+        it("claims the `ark=` param", () => {
+            expect(claimOn("regtest", `bitcoin:?ark=${ARK_REGTEST}`)).toEqual({
+                corridor: "arkade",
+                instrument: { kind: "address", address: ARK_REGTEST },
+            });
+        });
+
+        it("claims an upper-case `ark=` param, exactly as it claims it bare", () => {
+            // The filter was case-sensitive and dropped this with a
+            // `console.warn`, while `arkTarget` claimed the same string bare.
+            const upper = ARK_REGTEST.toUpperCase();
+            expect(claimOn("regtest", upper)?.corridor).toBe("arkade");
+            expect(claimOn("regtest", `bitcoin:?ark=${upper}`)).toEqual({
+                corridor: "arkade",
+                instrument: { kind: "address", address: upper },
+            });
+        });
+
+        it("claims the URI body for the onchain corridor", () => {
+            expect(claimOn("regtest", `bitcoin:${BCRT1}?amount=0.001`)).toEqual({
+                corridor: "onchain",
+                instrument: { kind: "address", address: BCRT1 },
+            });
+        });
+
+        it("carries a base58 address through verbatim", () => {
+            // The parse lowercased the URI body unconditionally, which is a
+            // DIFFERENT base58 address — and `isBtcAddress` admits a lowercase
+            // one, so the corruption classified fine and the corridor would
+            // have claimed an address nobody typed.
+            expect(claimOn("testnet", `bitcoin:${TESTNET_P2PKH}`)).toEqual({
+                corridor: "onchain",
+                instrument: { kind: "address", address: TESTNET_P2PKH },
+            });
+            expect(claimOn("testnet", TESTNET_P2PKH)?.instrument).toEqual({
+                kind: "address",
+                address: TESTNET_P2PKH,
+            });
+        });
+
+        it("claims the `lightning=` param", () => {
+            const invoice = invoiceOn("lnbcrt");
+            const claim = claimOn("regtest", `bitcoin:?lightning=${invoice}`);
+            expect(claim?.corridor).toBe("lightning");
+            expect(claim?.instrument).toMatchObject({ bolt11: invoice, amount: 2_000n });
+        });
+    });
+
+    describe("the network checks core does not make", () => {
+        it("refuses another operator's Arkade address", () => {
+            // `isValidArkAddress` proves bech32m and a 65-byte payload and
+            // nothing about whose server key is embedded.
+            expect(() => claimOn("regtest", ARK_FOREIGN)).toThrow(AmbiguousDestination);
+            expect(() => claimOn("regtest", ARK_FOREIGN)).toThrow(/unknown operator signer key/);
+        });
+
+        it("refuses an Arkade address from another network", () => {
+            expect(() => claimOn("regtest", ARK_MAINNET)).toThrow(/expected prefix "tark"/);
+        });
+
+        it("refuses a mainnet on-chain address on a regtest wallet", () => {
+            expect(() => claimOn("regtest", BC1)).toThrow(AmbiguousDestination);
+            expect(() => claimOn("regtest", BC1)).toThrow(/not a regtest address/);
+        });
+
+        it("refuses a testnet invoice on a mainnet wallet", () => {
+            expect(() => claimOn("bitcoin", invoiceOn("lntb"))).toThrow(AmbiguousDestination);
+            expect(() => claimOn("bitcoin", invoiceOn("lntb"))).toThrow(
+                /testnet invoice and the wallet is on bitcoin/,
+            );
+        });
+
+        it("refuses an `lnsb` invoice, which core admits and no network names", () => {
+            // Core's regex carries five prefixes where §6 names four. `simnet`
+            // is not a `NetworkName`, so it is refused rather than folded into
+            // a neighbour.
+            expect(() => claimOn("regtest", invoiceOn("lnsb"))).toThrow(
+                /names no network this SDK knows/,
+            );
+        });
+
+        it("refuses an expired invoice", () => {
+            const expired = encodeInvoice({
+                prefix: "lnbcrt",
+                amount: "20u",
+                timestamp: NOW - 7_200,
+                expiry: 3_600,
+                paymentHash: HASH,
+            });
+            expect(() => claimOn("regtest", expired)).toThrow(/expired 3600s ago/);
+        });
+
+        it("refuses an amountless invoice, because a destination is a send route", () => {
+            expect(() => claimOn("regtest", amountlessOn("lnbcrt"))).toThrow(/names no amount/);
+        });
+    });
+
+    describe("what the vocabulary cannot express", () => {
+        it("claims an `lntbs` invoice on signet AND on mutinynet", () => {
+            // They share the HRP exactly as they share `tark`, so a
+            // signet-versus-mutinynet rejection is not expressible and must not
+            // be claimed.
+            const invoice = invoiceOn("lntbs");
+            expect(claimOn("signet", invoice)?.corridor).toBe("lightning");
+            expect(claimOn("mutinynet", invoice)?.corridor).toBe("lightning");
+        });
+
+        it("claims a testnet on-chain address on signet, mutinynet and testnet", () => {
+            // `OnchainNetwork` has three members and all three of these fold
+            // into `testnet`, so the address alone cannot tell them apart.
+            for (const network of ["testnet", "signet", "mutinynet"] as const) {
+                expect(claimOn(network, TB1)?.corridor).toBe("onchain");
+                expect(claimOn(network, TESTNET_P2PKH)?.corridor).toBe("onchain");
+            }
+        });
+    });
+
+    describe("what the registry decides", () => {
+        it("refuses a URI naming two corridors with nothing to choose between", () => {
+            // Core resolves this by rail priority and chooses in silence, which
+            // is safe for core — its rails are interchangeable and its quotes
+            // are receiver-exact. Here the choice decides which asset moves and
+            // against which counterparty.
+            const uri = `bitcoin:${BCRT1}?ark=${ARK_REGTEST}`;
+            expect(() => claimOn("regtest", uri)).toThrow(AmbiguousDestination);
+            expect(() => claimOn("regtest", uri)).toThrow(/arkade and onchain/);
+        });
+
+        it("refuses a string nothing classifies", () => {
+            expect(() => claimOn("regtest", "0xdac17f958d2ee523a2206206994597c13d831ec7")).toThrow(
+                AmbiguousDestination,
+            );
+        });
+
+        it("leaves an LNURL unclaimed rather than refusing it", () => {
+            // Core classifies it; no corridor serves it. That is
+            // `UnsupportedRoute` at route resolution, not a parse failure.
+            expect(claimOn("regtest", "lnurl1dp68gurn8ghj7ct5d")).toBe(undefined);
+            expect(claimOn("regtest", "payme@example.com")).toBe(undefined);
+        });
+
+        it("does not resolve the deps of a corridor the destination is not for", () => {
+            // `MissingCorridorDep`'s own boundary note. The classifier that
+            // decides whose business a string is reads the string and nothing
+            // else, so a deliberately disabled corridor stays silent until
+            // something actually addresses it.
+            const disabled = corridorSet(corridorBaseFor("regtest"), {
+                onchain: { chain: null },
+                arkade: { repository: null },
+            });
+            expect(disabled.claim(invoiceOn("lnbcrt"))?.corridor).toBe("lightning");
+            expect(() => disabled.claim(BCRT1)).toThrow(MissingCorridorDep);
+            expect(() => disabled.claim(ARK_REGTEST)).toThrow(MissingCorridorDep);
+        });
+
+        it("asks a module only about its own destination class", () => {
+            // Each module answers `undefined` for a string that is not its
+            // business — the arm the registry counts as "not mine".
+            const set = corridorSet(corridorBaseFor("regtest"));
+            expect(set.get("onchain").matches(ARK_REGTEST)).toBe(undefined);
+            expect(set.get("lightning").matches(BCRT1)).toBe(undefined);
+            expect(set.get("arkade").matches(invoiceOn("lnbcrt"))).toBe(undefined);
+        });
+    });
+});

--- a/packages/swap/test/e2e/chainSource.test.ts
+++ b/packages/swap/test/e2e/chainSource.test.ts
@@ -60,16 +60,20 @@ const keyPair = () => {
 describe("the default chain source (regtest)", () => {
     let chain: ChainSource;
     let funded: ReturnType<typeof keyPair>;
+    let idle: ReturnType<typeof keyPair>;
     let payout: ReturnType<typeof keyPair>;
     let fill: ChainUtxo;
+    let unspent: ChainUtxo;
 
     beforeAll(async () => {
         // Built exactly the way `resolveCorridorDeps` builds it with no
         // override: `ESPLORA_URL[network]` off the wallet's network.
         chain = esploraChainSource({ esploraUrl: ESPLORA_URL.regtest, network: NETWORK });
         funded = keyPair();
+        idle = keyPair();
         payout = keyPair();
         regtest(`faucet ${funded.address} ${(Number(FUND_SATS) / 1e8).toFixed(8)} --confirm`);
+        regtest(`faucet ${idle.address} ${(Number(FUND_SATS) / 1e8).toFixed(8)} --confirm`);
         // The indexer trails Core by up to a block, so every read below waits
         // for it rather than assuming the faucet's own confirmation is visible.
         await waitFor(async () => {
@@ -77,6 +81,13 @@ describe("the default chain source (regtest)", () => {
                 (candidate) => candidate.amount === FUND_SATS && candidate.confirmations > 0,
             );
             if (utxo) fill = utxo;
+            return utxo !== undefined;
+        });
+        await waitFor(async () => {
+            const utxo = (await chain.getScriptUtxos(idle.script)).find(
+                (candidate) => candidate.amount === FUND_SATS && candidate.confirmations > 0,
+            );
+            if (utxo) unspent = utxo;
             return utxo !== undefined;
         });
     }, 180_000);
@@ -117,7 +128,7 @@ describe("the default chain source (regtest)", () => {
     }, 120_000);
 
     it("answers null for an outpoint nothing has spent", async () => {
-        const spend = await chain.getSpendingTx("00".repeat(32), 0).catch(() => null);
+        const spend = await chain.getSpendingTx(unspent.txid, unspent.vout);
         expect(spend).toBe(null);
     });
 });

--- a/packages/swap/test/e2e/chainSource.test.ts
+++ b/packages/swap/test/e2e/chainSource.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The default chain source against the regtest stack's real esplora.
+ *
+ * The unit suite proves the adapter over a scripted backend; what needs a
+ * server is the half that is a claim about esplora itself — that `/blocks`
+ * answers `mediantime`, that `/address/:a/utxo` carries the height the
+ * confirmations arithmetic needs, and that `/tx/:t/outspends` plus
+ * `/tx/:t/hex` recover a spend. `getMtp` most of all: it is the read
+ * `classifyOnchainHtlc` gates an L1 claim window on, and a tip time standing in
+ * for median-time-past abandons a still-live claim.
+ *
+ * Only the `base` profile is needed — bitcoind plus mempool's esplora API on
+ * port 3000, which is `ESPLORA_URL.regtest`.
+ */
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { hex } from "@scure/base";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
+import * as btc from "@scure/btc-signer";
+import { ESPLORA_URL } from "@arkade-os/sdk";
+import { beforeAll, describe, expect, it } from "vitest";
+import { esploraChainSource } from "../../src/client/corridors/chainSource";
+import { L1_NETWORKS } from "../../src/onchainHtlc";
+import type { ChainSource, ChainUtxo } from "../../src/onchainHtlc";
+
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+const NETWORK = L1_NETWORKS.regtest;
+const FUND_SATS = 100_000n;
+const FEE_SATS = 1_000n;
+
+const regtest = (args: string): string =>
+    execSync(`node regtest/regtest.mjs ${args}`, {
+        encoding: "utf8",
+        cwd: REPO_ROOT,
+        timeout: 120_000,
+    }).trim();
+
+/** `bitcoin-cli getblockchaininfo`, for the node's own median-time-past. */
+const chainInfo = (): { blocks: number; mediantime: number } =>
+    JSON.parse(regtest("rpc getblockchaininfo"));
+
+const waitFor = async (
+    fn: () => Promise<boolean>,
+    { timeout = 60_000, interval = 500 } = {},
+): Promise<void> => {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+        if (await fn()) return;
+        await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+    throw new Error("timeout in waitFor");
+};
+
+const keyPair = () => {
+    const priv = secp256k1.utils.randomSecretKey();
+    const payment = btc.p2wpkh(secp256k1.getPublicKey(priv, true), NETWORK);
+    return { priv, ...payment };
+};
+
+describe("the default chain source (regtest)", () => {
+    let chain: ChainSource;
+    let funded: ReturnType<typeof keyPair>;
+    let payout: ReturnType<typeof keyPair>;
+    let fill: ChainUtxo;
+
+    beforeAll(async () => {
+        // Built exactly the way `resolveCorridorDeps` builds it with no
+        // override: `ESPLORA_URL[network]` off the wallet's network.
+        chain = esploraChainSource({ esploraUrl: ESPLORA_URL.regtest, network: NETWORK });
+        funded = keyPair();
+        payout = keyPair();
+        regtest(`faucet ${funded.address} ${(Number(FUND_SATS) / 1e8).toFixed(8)} --confirm`);
+        // The indexer trails Core by up to a block, so every read below waits
+        // for it rather than assuming the faucet's own confirmation is visible.
+        await waitFor(async () => {
+            const utxo = (await chain.getScriptUtxos(funded.script)).find(
+                (candidate) => candidate.amount === FUND_SATS && candidate.confirmations > 0,
+            );
+            if (utxo) fill = utxo;
+            return utxo !== undefined;
+        });
+    }, 180_000);
+
+    it("finds the funded output, in bigint sats and with a real depth", () => {
+        expect(fill.amount).toBe(FUND_SATS);
+        // `--confirm` mined it, so the block it landed in counts as one.
+        expect(fill.confirmations).toBeGreaterThanOrEqual(1);
+    });
+
+    it("answers the node's own median-time-past", async () => {
+        // A poll, not a single comparison: the indexer's tip trails Core's, and
+        // MTP moves with it. What matters is that the value converges on the
+        // node's `mediantime` and never on a block time — the substitution
+        // `OnchainProvider.getChainTip` would invite, since it promises no more
+        // than "block time" and its two implementations disagree about which.
+        await waitFor(async () => (await chain.getMtp()) === chainInfo().mediantime);
+    });
+
+    it("broadcasts a spend and then finds it from the outpoint", async () => {
+        const tx = new btc.Transaction();
+        tx.addInput({
+            txid: fill.txid,
+            index: fill.vout,
+            witnessUtxo: { script: funded.script, amount: FUND_SATS },
+        });
+        tx.addOutputAddress(payout.address!, FUND_SATS - FEE_SATS, NETWORK);
+        tx.sign(funded.priv);
+        tx.finalize();
+
+        const txid = await chain.broadcast(hex.encode(tx.extract()));
+        expect(txid).toBe(tx.id);
+
+        await waitFor(async () => (await chain.getSpendingTx(fill.txid, fill.vout)) !== null);
+        const spend = await chain.getSpendingTx(fill.txid, fill.vout);
+        expect(spend).not.toBe(null);
+        expect(btc.Transaction.fromRaw(hex.decode(spend!.txHex)).id).toBe(txid);
+    }, 120_000);
+
+    it("answers null for an outpoint nothing has spent", async () => {
+        const spend = await chain.getSpendingTx("00".repeat(32), 0).catch(() => null);
+        expect(spend).toBe(null);
+    });
+});

--- a/packages/swap/test/helpers/bolt11.ts
+++ b/packages/swap/test/helpers/bolt11.ts
@@ -1,0 +1,85 @@
+/**
+ * A BOLT11 encoder, for the decoder's test vectors.
+ *
+ * The corridor's decoder is signature-blind — `light-bolt11-decoder` does not
+ * check signatures and says so — so an invoice is "real" here in every sense
+ * the decoder can observe: a valid bech32 checksum, a well-formed HRP with its
+ * amount inside it, a 35-bit timestamp and correctly length-prefixed tagged
+ * fields. Only the 65-byte signature is filler.
+ *
+ * Written rather than collected because the vectors have to span the HRP table,
+ * and published invoices exist only for mainnet. The one mainnet invoice the
+ * suite uses is a real one, which is what pins this encoder against reality.
+ */
+import { bech32 } from "@scure/base";
+import { hex } from "@scure/base";
+
+/** The tag codes the vectors need. Values are BOLT11's. */
+const TAGCODES = {
+    payment_hash: 1,
+    expiry: 6,
+    description: 13,
+} as const;
+
+/** Big-endian 5-bit words, `count` of them. */
+const intToWords = (value: number, count: number): number[] => {
+    const words: number[] = [];
+    let rest = value;
+    for (let i = 0; i < count; i++) {
+        words.unshift(rest % 32);
+        rest = Math.floor(rest / 32);
+    }
+    return words;
+};
+
+/** The same, in as few words as the value needs. */
+const minimalWords = (value: number): number[] => {
+    let count = 1;
+    while (value >= 32 ** count) count += 1;
+    return intToWords(value, count);
+};
+
+const taggedField = (tag: number, dataWords: number[]): number[] => [
+    tag,
+    ...intToWords(dataWords.length, 2),
+    ...dataWords,
+];
+
+export interface InvoiceParts {
+    /** The network prefix: `lnbc`, `lntb`, `lntbs`, `lnbcrt` or `lnsb`. */
+    prefix: string;
+    /** The amount as it rides inside the HRP (`"20u"`). Omit for an amountless
+     * invoice, which BOLT11 permits and which lets a payer pay anything. */
+    amount?: string;
+    /** Invoice creation time, unix seconds. */
+    timestamp: number;
+    /** The `x` tag, in seconds RELATIVE to the timestamp. Omit to leave BOLT11's
+     * 3600-second default in force. */
+    expiry?: number;
+    /** `sha256(P)`, 64 lowercase hex chars. Omit to build the malformed
+     * invoice BOLT11 forbids — no `p` tag at all. */
+    paymentHash?: string;
+    description?: string;
+}
+
+export const encodeInvoice = (parts: InvoiceParts): string => {
+    const fields = [
+        ...(parts.paymentHash === undefined
+            ? []
+            : taggedField(TAGCODES.payment_hash, bech32.toWords(hex.decode(parts.paymentHash)))),
+        ...taggedField(
+            TAGCODES.description,
+            bech32.toWords(new TextEncoder().encode(parts.description ?? "test")),
+        ),
+        ...(parts.expiry === undefined
+            ? []
+            : taggedField(TAGCODES.expiry, minimalWords(parts.expiry))),
+    ];
+    const words = [
+        ...intToWords(parts.timestamp, 7),
+        ...fields,
+        // 65 bytes of signature, which nothing on this path verifies.
+        ...new Array<number>(104).fill(0),
+    ];
+    return bech32.encode(`${parts.prefix}${parts.amount ?? ""}`, words, Number.MAX_SAFE_INTEGER);
+};

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -280,8 +280,8 @@ import {
     combineTapscriptSigs,
     isValidArkAddress,
 } from "./utils/arkTransaction";
-import { getRandomId, assertRecipientArkAddress } from "./wallet/utils";
-import type { RecipientAddressContext } from "./wallet/utils";
+import { getRandomId, assertRecipientArkadeAddress } from "./wallet/utils";
+import type { RecipientArkadeAddressContext } from "./wallet/utils";
 import {
     VtxoTaprootTree,
     ConditionWitness,
@@ -722,7 +722,7 @@ export {
     // its ingredients already are and a plugin deriving against another
     // operator's address would otherwise hand-roll a `serverPubKey ===` that
     // rejects valid addresses mid-rotation.
-    assertRecipientArkAddress,
+    assertRecipientArkadeAddress,
     getRandomId,
     buildVersion,
     sdkVersion,
@@ -873,7 +873,7 @@ export {
 
 export type {
     // Types and Interfaces
-    RecipientAddressContext,
+    RecipientArkadeAddressContext,
     Identity,
     ReadonlyIdentity,
     BatchSignableIdentity,

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -280,7 +280,8 @@ import {
     combineTapscriptSigs,
     isValidArkAddress,
 } from "./utils/arkTransaction";
-import { getRandomId } from "./wallet/utils";
+import { getRandomId, assertRecipientArkAddress } from "./wallet/utils";
+import type { RecipientAddressContext } from "./wallet/utils";
 import {
     VtxoTaprootTree,
     ConditionWitness,
@@ -716,6 +717,12 @@ export {
     combineTapscriptSigs,
     isVtxoExpiringSoon,
     isValidArkAddress,
+    // The rotation-aware recipient check: hrp plus `classifyAgainstSignerSet`,
+    // refusing an unknown or past-cutoff operator signer. Root-exported because
+    // its ingredients already are and a plugin deriving against another
+    // operator's address would otherwise hand-roll a `serverPubKey ===` that
+    // rejects valid addresses mid-rotation.
+    assertRecipientArkAddress,
     getRandomId,
     buildVersion,
     sdkVersion,
@@ -866,6 +873,7 @@ export {
 
 export type {
     // Types and Interfaces
+    RecipientAddressContext,
     Identity,
     ReadonlyIdentity,
     BatchSignableIdentity,

--- a/packages/ts-sdk/src/utils/bip21.ts
+++ b/packages/ts-sdk/src/utils/bip21.ts
@@ -34,7 +34,7 @@ export enum BIP21Error {
  * One destination classifying differently bare than as an `ark=` param is the
  * defect; this is the only place the two forms are told apart.
  */
-const ARK_HRP = /^t?ark/i;
+const ARK_HRP = /^(?:t?ark|T?ARK)/;
 
 export class BIP21 {
     /**

--- a/packages/ts-sdk/src/utils/bip21.ts
+++ b/packages/ts-sdk/src/utils/bip21.ts
@@ -25,6 +25,17 @@ export enum BIP21Error {
     INVALID_ADDRESS = "Invalid address",
 }
 
+/**
+ * The Arkade address prefixes, matched case-INSENSITIVELY.
+ *
+ * Bech32m forbids a case *mix*, not upper case, and `ArkAddress.decode`
+ * accepts an all-upper address — so a case-sensitive filter dropped, with a
+ * `console.warn`, an address the bare classifier (`arkTarget`) claims happily.
+ * One destination classifying differently bare than as an `ark=` param is the
+ * defect; this is the only place the two forms are told apart.
+ */
+const ARK_HRP = /^t?ark/i;
+
 export class BIP21 {
     /**
      * Create a BIP21 URI from the provided parameters.
@@ -52,10 +63,7 @@ export class BIP21 {
                 queryParams[key] = value;
             } else if (key === "ark") {
                 // Validate Arkade address format
-                if (
-                    typeof value === "string" &&
-                    (value.startsWith("ark") || value.startsWith("tark"))
-                ) {
+                if (typeof value === "string" && ARK_HRP.test(value)) {
                     queryParams[key] = value;
                 } else {
                     console.warn("Invalid ARK address format");
@@ -82,7 +90,7 @@ export class BIP21 {
                   ).toString()
                 : "";
 
-        return `bitcoin:${address ? address.toLowerCase() : ""}${query}`;
+        return `bitcoin:${address ?? ""}${query}`;
     }
 
     /**
@@ -121,7 +129,14 @@ export class BIP21 {
 
         const params: BIP21Params = {};
         if (address) {
-            params.address = address.toLowerCase();
+            // Verbatim. Base58 is case-SENSITIVE, so lowercasing here produced a
+            // DIFFERENT address and did it silently: `isBtcAddress` admits a
+            // lowercase base58 string, so the corruption passed classification
+            // and the rail funded whatever the mangled string decoded to.
+            // Bech32 is unharmed either way — BIP173 forbids a case MIX, not
+            // upper case, and every decoder in this SDK takes an all-upper
+            // address.
+            params.address = address;
         }
 
         if (query) {
@@ -142,7 +157,7 @@ export class BIP21 {
                     params[key] = amount;
                 } else if (key === "ark") {
                     // Validate Arkade address format
-                    if (value.startsWith("ark") || value.startsWith("tark")) {
+                    if (ARK_HRP.test(value)) {
                         params[key] = value;
                     } else {
                         console.warn("Invalid ARK address format");

--- a/packages/ts-sdk/src/wallet/utils.ts
+++ b/packages/ts-sdk/src/wallet/utils.ts
@@ -224,7 +224,7 @@ type ValidatedRecipient = Required<Omit<Recipient, "extensions" | "tapTree">> & 
  * belongs to another network or operator, so this wallet's operator cannot
  * create the VTXO where the recipient's wallet expects it.
  */
-export type RecipientAddressContext = {
+export type RecipientArkadeAddressContext = {
     hrp: string;
     signerSet: SignerSet;
 };
@@ -233,10 +233,10 @@ export type RecipientAddressContext = {
  * The embedded server key may be the current signer or a deprecated signer
  * whose rotation cutoff has not passed.
  */
-export function assertRecipientArkAddress(
+export function assertRecipientArkadeAddress(
     encoded: string,
     address: ArkAddress,
-    context: RecipientAddressContext,
+    context: RecipientArkadeAddressContext,
 ): void {
     if (address.hrp !== context.hrp) {
         throw new Error(
@@ -286,7 +286,7 @@ function assertTapTreeDerivesAddress(encoded: string, tapTree: Bytes, address: A
 export function validateRecipients(
     recipients: Recipient[],
     dustAmount: number,
-    context: RecipientAddressContext,
+    context: RecipientArkadeAddressContext,
 ): ValidatedRecipient[] {
     const validatedRecipients: ValidatedRecipient[] = [];
 
@@ -298,7 +298,7 @@ export function validateRecipients(
             throw new Error(`Invalid Arkade address: ${recipient.address}`);
         }
 
-        assertRecipientArkAddress(recipient.address, address, context);
+        assertRecipientArkadeAddress(recipient.address, address, context);
 
         const amount = recipient.amount || dustAmount;
         if (amount <= 0) {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -123,10 +123,10 @@ import { isTerminalIntentState } from "../repositories/intentRepository";
 import type { VirtualTxRepository } from "../repositories/virtualTxRepository";
 import { wrapHandlerWithIntentPersistence } from "./intentPersistenceHandler";
 import {
-    assertRecipientArkAddress,
+    assertRecipientArkadeAddress,
     extendCoinWithTapscript,
     validateRecipients,
-    type RecipientAddressContext,
+    type RecipientArkadeAddressContext,
 } from "./utils";
 import {
     captureExitBranch,
@@ -884,7 +884,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
      */
     protected recipientAddressContext(
         serverPubKey: Bytes = this._arkServerPublicKey,
-    ): RecipientAddressContext {
+    ): RecipientArkadeAddressContext {
         return {
             hrp: this.network.hrp,
             signerSet: {
@@ -3915,7 +3915,7 @@ export class Wallet
                 };
 
                 const outputAddress = ArkAddress.decode(params.address);
-                assertRecipientArkAddress(
+                assertRecipientArkadeAddress(
                     params.address,
                     outputAddress,
                     this.recipientAddressContext(serverPubKey),
@@ -4130,7 +4130,7 @@ export class Wallet
         const outputs: TransactionOutput[] = [];
         let hasOffchainOutputs = false;
 
-        let recipientContext: RecipientAddressContext | undefined;
+        let recipientContext: RecipientArkadeAddressContext | undefined;
         for (const [index, output] of params.outputs.entries()) {
             let script: Bytes | undefined;
 
@@ -4145,7 +4145,7 @@ export class Wallet
 
             if (arkAddress) {
                 recipientContext ??= this.recipientAddressContext();
-                assertRecipientArkAddress(output.address, arkAddress, recipientContext);
+                assertRecipientArkadeAddress(output.address, arkAddress, recipientContext);
                 script = arkAddress.pkScript;
                 hasOffchainOutputs = true;
             } else {

--- a/packages/ts-sdk/test/bip21.test.ts
+++ b/packages/ts-sdk/test/bip21.test.ts
@@ -64,5 +64,11 @@ describe("BIP21", () => {
         it("still drops a param that is no Arkade address at all", () => {
             expect(BIP21.parse("bitcoin:?ark=nope").params.ark).toBeUndefined();
         });
+
+        it("drops a mixed-case `ark=` param, which Bech32m forbids", () => {
+            // Bech32m (BIP350) forbids a case mix.
+            expect(BIP21.parse("bitcoin:?ark=ArK1QZ4EXAMPLE").params.ark).toBeUndefined();
+            expect(BIP21.create({ ark: "ArK1QZ4EXAMPLE" })).toBe("bitcoin:");
+        });
     });
 });

--- a/packages/ts-sdk/test/bip21.test.ts
+++ b/packages/ts-sdk/test/bip21.test.ts
@@ -31,4 +31,38 @@ describe("BIP21", () => {
 
         expect(uri).toBe("bitcoin:bc1qexample");
     });
+
+    describe("case", () => {
+        // Base58 is case-SENSITIVE. Lowercasing produced a DIFFERENT address,
+        // and silently: `isBtcAddress` admits a lowercase base58 string, so the
+        // corrupted one classified fine and whatever it decoded to got funded.
+        const BASE58 = "mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn";
+
+        it("parses a base58 address verbatim", () => {
+            expect(BIP21.parse(`bitcoin:${BASE58}`).params.address).toBe(BASE58);
+        });
+
+        it("creates a URI with a base58 address verbatim", () => {
+            expect(BIP21.create({ address: BASE58 })).toBe(`bitcoin:${BASE58}`);
+        });
+
+        it("keeps an all-upper bech32 address, which BIP173 permits", () => {
+            const upper = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+            expect(BIP21.parse(`bitcoin:${upper}`).params.address).toBe(upper);
+        });
+
+        it("keeps an upper-case `ark=` param, which `arkTarget` claims bare", () => {
+            // Bech32m forbids a case MIX, not upper case, and
+            // `ArkAddress.decode` accepts an all-upper address — so a
+            // case-sensitive filter dropped, with a `console.warn`, an address
+            // the bare classifier claims happily.
+            const upper = "TARK1QZ4EXAMPLE";
+            expect(BIP21.parse(`bitcoin:?ark=${upper}`).params.ark).toBe(upper);
+            expect(BIP21.create({ ark: upper })).toBe(`bitcoin:?ark=${encodeURIComponent(upper)}`);
+        });
+
+        it("still drops a param that is no Arkade address at all", () => {
+            expect(BIP21.parse("bitcoin:?ark=nope").params.ark).toBeUndefined();
+        });
+    });
 });

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -5,9 +5,9 @@ import { Wallet, SingleKey, type Recipient } from "../src";
 import { VtxoScript } from "../src/script/base";
 import { ArkAddress } from "../src/script/address";
 import {
-    assertRecipientArkAddress,
+    assertRecipientArkadeAddress,
     validateRecipients,
-    type RecipientAddressContext,
+    type RecipientArkadeAddressContext,
 } from "../src/wallet/utils";
 
 // Mock fetch
@@ -31,7 +31,7 @@ const encodeAddr = (serverPubKey: Uint8Array, hrp: string) =>
 
 const NOW_SECONDS = Math.floor(Date.now() / 1000);
 
-function makeContext(deprecated?: Map<string, bigint>): RecipientAddressContext {
+function makeContext(deprecated?: Map<string, bigint>): RecipientArkadeAddressContext {
     return {
         hrp: "tark",
         signerSet: {
@@ -41,25 +41,25 @@ function makeContext(deprecated?: Map<string, bigint>): RecipientAddressContext 
     };
 }
 
-describe("assertRecipientArkAddress", () => {
+describe("assertRecipientArkadeAddress", () => {
     it("rejects an address with another network's prefix", () => {
         const encoded = encodeAddr(SERVER_XONLY, "ark");
         expect(() =>
-            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext()),
+            assertRecipientArkadeAddress(encoded, ArkAddress.decode(encoded), makeContext()),
         ).toThrow(/expected prefix "tark", got "ark"/);
     });
 
     it("rejects an address embedding an unknown operator signer key", () => {
         const encoded = encodeAddr(FOREIGN_XONLY, "tark");
         expect(() =>
-            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext()),
+            assertRecipientArkadeAddress(encoded, ArkAddress.decode(encoded), makeContext()),
         ).toThrow(/unknown operator signer key/);
     });
 
     it("accepts an address embedding the current signer key", () => {
         const encoded = encodeAddr(SERVER_XONLY, "tark");
         expect(() =>
-            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext()),
+            assertRecipientArkadeAddress(encoded, ArkAddress.decode(encoded), makeContext()),
         ).not.toThrow();
     });
 
@@ -67,7 +67,11 @@ describe("assertRecipientArkAddress", () => {
         const encoded = encodeAddr(DEPRECATED_XONLY, "tark");
         const deprecated = new Map([[hex.encode(DEPRECATED_XONLY), BigInt(NOW_SECONDS + 100_000)]]);
         expect(() =>
-            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext(deprecated)),
+            assertRecipientArkadeAddress(
+                encoded,
+                ArkAddress.decode(encoded),
+                makeContext(deprecated),
+            ),
         ).not.toThrow();
     });
 
@@ -75,7 +79,11 @@ describe("assertRecipientArkAddress", () => {
         const encoded = encodeAddr(DEPRECATED_XONLY, "tark");
         const deprecated = new Map([[hex.encode(DEPRECATED_XONLY), 0n]]);
         expect(() =>
-            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext(deprecated)),
+            assertRecipientArkadeAddress(
+                encoded,
+                ArkAddress.decode(encoded),
+                makeContext(deprecated),
+            ),
         ).not.toThrow();
     });
 
@@ -83,7 +91,11 @@ describe("assertRecipientArkAddress", () => {
         const encoded = encodeAddr(DEPRECATED_XONLY, "tark");
         const deprecated = new Map([[hex.encode(DEPRECATED_XONLY), 1n]]);
         expect(() =>
-            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), makeContext(deprecated)),
+            assertRecipientArkadeAddress(
+                encoded,
+                ArkAddress.decode(encoded),
+                makeContext(deprecated),
+            ),
         ).toThrow(/past its rotation cutoff/);
     });
 });
@@ -278,13 +290,13 @@ describe("Wallet recipient address binding", () => {
         });
 
         const context = (
-            wallet as unknown as { recipientAddressContext(): RecipientAddressContext }
+            wallet as unknown as { recipientAddressContext(): RecipientArkadeAddressContext }
         ).recipientAddressContext();
         expect(context.signerSet.deprecated.get(hex.encode(DEPRECATED_XONLY))).toBe(cutoff);
 
         const encoded = encodeAddr(DEPRECATED_XONLY, "tark");
         expect(() =>
-            assertRecipientArkAddress(encoded, ArkAddress.decode(encoded), context),
+            assertRecipientArkadeAddress(encoded, ArkAddress.decode(encoded), context),
         ).not.toThrow();
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@scure/btc-signer':
         specifier: 2.0.1
         version: 2.0.1
+      light-bolt11-decoder:
+        specifier: 3.2.0
+        version: 3.2.0
     devDependencies:
       fake-indexeddb:
         specifier: 6.2.5
@@ -1478,6 +1481,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@scure/base@1.1.1':
+    resolution: {integrity: sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==}
+
   '@scure/base@2.0.0':
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
 
@@ -2559,6 +2565,9 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  light-bolt11-decoder@3.2.0:
+    resolution: {integrity: sha512-3QEofgiBOP4Ehs9BI+RkZdXZNtSys0nsJ6fyGeSiAGCBsMwHGUDS/JQlY/sTnWs91A2Nh0S9XXfA8Sy9g6QpuQ==}
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -5414,6 +5423,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@scure/base@1.1.1': {}
+
   '@scure/base@2.0.0': {}
 
   '@scure/bip32@2.0.1':
@@ -6598,6 +6609,10 @@ snapshots:
   lan-network@0.2.0: {}
 
   leven@3.1.0: {}
+
+  light-bolt11-decoder@3.2.0:
+    dependencies:
+      '@scure/base': 1.1.1
 
   lighthouse-logger@1.4.2:
     dependencies:


### PR DESCRIPTION
Swap SDK v2, M2 — corridor modules. Plan: `meta/tracks/swap-sdk-v2/02-corridor-modules.md`. Stacked on M1 (#821).

One contract, three implementations under `packages/swap/src/client/corridors/`. Internal — nothing is added to either root barrel and `createSwapClient` is untouched.

- **Contract + registry.** Keyed on the corridor, not v1's `RfqSwap["kind"]`. `matches(raw)` answers `{claimed}` / `{refused}` / `undefined` — sync, non-throwing, amount-blind, since M7 wraps two of these in core's `PaymentRail.match`. The registry turns the counts into `AmbiguousDestination`; an LNURL is left unclaimed for M3.
- **Parsing.** Core's `arkTarget`/`btcTarget`/`invoiceTarget`; no second classifier. The network checks core omits are the modules': `assertRecipientArkAddress` (arkade), `L1_NETWORKS[l1NetworkFromArk]` (onchain), an authored HRP table (lightning).
- **Decoder.** `light-bolt11-decoder` becomes a dependency of `@arkade-os/swap`, behind the overridable `decode` seam. Absolute expiry, `bigint` millisats, a missing payment hash refused rather than defaulted to `""`.
- **Chain source.** First implementation of `ChainSource`, over an esplora URL. `getMtp` reads `mediantime` off `/blocks` and never forwards `getChainTip().time`.
- **Overrides.** `T | null`; `resolveCorridorDeps` throws `MissingCorridorDep` per corridor on first use.

Two core changes ride along: `BIP21.parse`/`create` stop lowercasing the address (base58 is case-sensitive) and the `ark=` filter becomes case-insensitive — both made a destination classify differently bare than as a param. Plus one root export, `assertRecipientArkAddress`.

Verified: build, both typechecks, lint, `test:unit`, `smoke:dist`, and the new `test/e2e/chainSource.test.ts` against a regtest stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added swap destination support for Arkade addresses, Bitcoin on-chain addresses, and BOLT11 Lightning invoices.
  * Added corridor-based destination classification with network validation and clear handling for unsupported or ambiguous destinations.
  * Exposed address validation utilities and recipient address types through the SDK’s root API.
  * Added default chain and invoice processing for swap flows.

* **Bug Fixes**
  * Preserved case-sensitive addresses when creating and parsing BIP21 URIs.
  * Made `ark=` parameter matching case-insensitive while retaining valid address formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->