### PR TITLE
feat(swap): v2 quote path

### DIFF
--- a/packages/swap/src/client/aliasTable.ts
+++ b/packages/swap/src/client/aliasTable.ts
@@ -1,0 +1,79 @@
+/**
+ * The alias table, filled from discovery.
+ *
+ * M1 declared {@link AssetAliasTable} and left it injected: the alias layer owns
+ * no network, and the table's only real source is the market index, which is
+ * this milestone's. So this is the inverse of `toDiscoveryLeg` -- a card's
+ * corridor and `AssetInfo` back up to the public id a caller may write, plus the
+ * ticker that id answers to.
+ *
+ * Tickers are display metadata on a card and identity nowhere, which is why the
+ * table carries both and `canonicalAssetId` refuses a ticker that names two
+ * assets rather than picking one. Rows are deduplicated by id and ticker, so a
+ * ticker listed by nine solvers for the same asset is one row and not an
+ * ambiguity.
+ */
+import { marketCorridor, type DiscoveredMarket, type Side } from "@arkade-os/solver-discovery";
+import { BTC_ASSET_ID } from "../store";
+import type { AssetAliasTable, RegisteredAsset } from "./aliases";
+import { ARKADE_ASSET_NAMESPACE, type AssetId, type NetworkRef, type Rail, btcOn } from "./assetId";
+import { railOfCorridor, type Corridor } from "./corridor";
+
+/** The 68-lowercase-hex Arkade issuance identity, as a card spells it. */
+const ARKADE_ASSET_IDENTITY = /^[0-9a-f]{68}$/;
+
+/**
+ * The public id for one side of a card.
+ *
+ * `undefined` where the pair is not expressible as a public id: an
+ * arkade-issued asset on lightning or L1, which no corridor carries, and an id
+ * that is neither BTC nor the identity form.
+ */
+export const publicAssetId = (
+    corridor: Corridor,
+    assetId: string,
+    network: NetworkRef,
+): AssetId | undefined => {
+    const rail = railOfCorridor(corridor);
+    if (assetId === BTC_ASSET_ID) return btcOn(rail, network);
+    if (rail !== "arkade") return undefined;
+    if (!ARKADE_ASSET_IDENTITY.test(assetId)) return undefined;
+    return `arkade:${network}/${ARKADE_ASSET_NAMESPACE}:${assetId}`;
+};
+
+/** Every asset the snapshot names, as caller-writable ids and their tickers. */
+export const aliasTableFrom = (
+    markets: readonly DiscoveredMarket[],
+    network: NetworkRef,
+): AssetAliasTable => {
+    const rows = new Map<string, RegisteredAsset>();
+    const add = (card: DiscoveredMarket, side: Side): void => {
+        const info = side === "base" ? card.base_asset : card.quote_asset;
+        const id = publicAssetId(marketCorridor(card, side), info.id, network);
+        if (id === undefined || typeof info.ticker !== "string" || info.ticker === "") return;
+        rows.set(`${id} ${info.ticker.toLowerCase()}`, { id, ticker: info.ticker });
+    };
+    for (const card of markets) {
+        add(card, "base");
+        add(card, "quote");
+    }
+    return { network, assets: [...rows.values()] };
+};
+
+/**
+ * The table narrowed to one rail.
+ *
+ * Q12 gives BTC one id per rail, so `"BTC"` names three assets the moment a
+ * snapshot carries a corridor market — and the alias layer refuses a colliding
+ * ticker rather than guessing, which is the right rule and would make the
+ * spec's own `exchange({ give: "BTC", ... })` unresolvable if the table were
+ * consulted whole. A ticker is therefore resolved on the leg's own rail: the
+ * leg's corridor is already fixed by the destination, by `via`, or by being the
+ * wallet's side, so the scope is a fact rather than a preference. Collisions
+ * WITHIN a rail — two arkade assets both called `USDT` — still refuse, which is
+ * the case the rule exists for.
+ */
+export const scopedToRail = (table: AssetAliasTable, rail: Rail): AssetAliasTable => ({
+    network: table.network,
+    assets: table.assets.filter((row) => row.id.startsWith(`${rail}:`)),
+});

--- a/packages/swap/src/client/client.ts
+++ b/packages/swap/src/client/client.ts
@@ -111,6 +111,11 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
     let context:
         | Promise<{ base: CorridorBase; corridors: CorridorSet; discovery: DiscoveryIndex }>
         | undefined;
+    /** A rejected init is not cached. The read behind it is the reachable-or-not
+     * kind — an operator that cannot be reached and no persisted snapshot to
+     * fall back on — and caching that rejection would strand the client for its
+     * whole lifetime over one unreachable moment. Same rule as the sqlite
+     * repository's `ensureInit`. */
     const resolved = () =>
         (context ??= (async () => {
             // Not `requireLive`: a parse derives no covenant, and `resolve()`
@@ -134,7 +139,10 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
                     ...(config.repository === undefined ? {} : { repository: config.repository }),
                 }),
             };
-        })());
+        })().catch((error) => {
+            context = undefined;
+            throw error;
+        }));
 
     const route = async (input: QuoteInput, mode: "resolve" | "quote"): Promise<ResolvedRoute> => {
         const { base, corridors, discovery } = await resolved();

--- a/packages/swap/src/client/client.ts
+++ b/packages/swap/src/client/client.ts
@@ -1,0 +1,266 @@
+/**
+ * The v2 client, as far as M3 takes it: `resolve()` and `quote()`.
+ *
+ * Everything a caller used to assemble by hand happens behind these two calls —
+ * the destination parse, the corridor pair, the market lookup, the transport to
+ * the card's rendezvous, the amount encoding, the covenant derivation and the
+ * four-and-one checks over the reply. What does NOT happen is anything durable
+ * or irreversible: `quote()` opens no watcher, arms no drive, writes no record
+ * and funds nothing. It returns terms and stops.
+ *
+ * Construction stays synchronous and touches nothing. The operator read, the
+ * corridor deps and the market index are all resolved on first use, which is
+ * what lets a client be built in a component body and only cost something when
+ * somebody asks it a question — and what keeps a missing dep for a corridor
+ * nobody uses from being a construction failure.
+ */
+import { hex } from "@scure/base";
+import type { IWallet } from "@arkade-os/sdk";
+import type { AssetSwapRepository } from "../repository";
+import type { SwapOperator } from "../refund";
+import { walletOperator } from "../refund";
+import { corridorSet, type CorridorSet } from "./corridors/registry";
+import {
+    liveArkadeInfo,
+    resolveCorridorBase,
+    type CorridorBase,
+    type CorridorOverrides,
+} from "./corridors/deps";
+import { discoveryIndex, type DiscoveryConfig, type DiscoveryIndex } from "./discovery";
+import { UnsupportedRoute } from "./errors";
+import type { SwapPolicy } from "./policy";
+import { feedFetch, quoteFromFeed, type FeedFetch, type OfferPreparation } from "./quoteOffer";
+import { quoteViaRfq, type RfqPreparation } from "./quoteRfq";
+import type { Quote, QuoteId, QuoteInput, RouteResolution } from "./quote";
+import { resolveRoute, type ResolvedRoute } from "./resolve";
+import { nostrTransportFactory, type RfqTransportFactory } from "./transport";
+
+/** What a quote derived, kept in memory for the accept that may follow. */
+export type QuotePreparation = RfqPreparation | OfferPreparation;
+
+export interface SwapClientConfig {
+    /**
+     * The wallet, and through it the operator: server info, chain reads and
+     * broadcast all come from it, and no server URL is accepted anywhere.
+     */
+    readonly wallet: IWallet;
+    /**
+     * Storage. At this milestone it backs the markets cache and nothing else —
+     * the persist-first record is M4's, and so is the platform default.
+     */
+    readonly repository?: AssetSwapRepository;
+    readonly discovery?: DiscoveryConfig;
+    /** Dependency overrides only: they never enable a route or pick a solver. */
+    readonly corridors?: CorridorOverrides;
+    readonly policy?: SwapPolicy;
+    /** Covenant co-signer override, 33-byte compressed hex. */
+    readonly emulatorPubkey?: string;
+    /** Overrides the wallet's own connection; for tests and a second operator. */
+    readonly operator?: SwapOperator;
+    readonly fetchImpl?: typeof fetch;
+    /**
+     * How a card's rendezvous is opened. Defaults to the card's Nostr transport,
+     * which is the only shipped one that can attest who answered — an injected
+     * transport that attests nobody fails the responder check rather than
+     * quietly quoting against an unauthenticated wire.
+     */
+    readonly transportFor?: RfqTransportFactory;
+}
+
+export interface SwapClient {
+    /**
+     * The route, the market that would price it, and what the active snapshot
+     * serves — without disclosing anything to anybody.
+     *
+     * Network-free against injected or cached discovery data, which is the point
+     * of having it: application policy gets to veto before an RFQ round trip
+     * discloses an invoice or an amount.
+     */
+    resolve(input: QuoteInput): Promise<RouteResolution>;
+    /** Verified, binding terms. Nothing is persisted, funded or watched. */
+    quote(input: QuoteInput): Promise<Quote>;
+    /**
+     * What the quote with this id derived — the covenant, the keys, the wire
+     * reply.
+     *
+     * Process-local and deliberately not durable: M3 persists nothing, and M4's
+     * `accept()` is what turns this into a record. It exists so the covenant a
+     * quote was verified against is the one that gets funded, rather than a
+     * second derivation of the same tree.
+     */
+    preparationOf(id: QuoteId): QuotePreparation | undefined;
+}
+
+/**
+ * How many quotes' derivations are kept.
+ *
+ * Bounded because a quote UI re-quotes on every keystroke and each one carries a
+ * covenant; the oldest are dropped, and dropping one costs a re-quote rather
+ * than anything durable — there is nothing durable here to lose.
+ */
+const PREPARATIONS_HELD = 64;
+
+const mintQuoteId = (): QuoteId => hex.encode(crypto.getRandomValues(new Uint8Array(16)));
+
+export const createSwapClient = (config: SwapClientConfig): SwapClient => {
+    const { wallet } = config;
+    const operator = config.operator ?? walletOperator(wallet);
+    const feed: FeedFetch = feedFetch(config.fetchImpl ?? fetch);
+    const preparations = new Map<QuoteId, QuotePreparation>();
+
+    let context:
+        | Promise<{ base: CorridorBase; corridors: CorridorSet; discovery: DiscoveryIndex }>
+        | undefined;
+    const resolved = () =>
+        (context ??= (async () => {
+            // Not `requireLive`: a parse derives no covenant, and `resolve()`
+            // answers offline. Every covenant derivation makes its own live read
+            // before it binds anything — see `quote()` below.
+            const base = await resolveCorridorBase({
+                wallet,
+                operator,
+                ...(config.emulatorPubkey === undefined
+                    ? {}
+                    : { emulatorPubkey: config.emulatorPubkey }),
+                ...(config.fetchImpl === undefined ? {} : { fetchImpl: config.fetchImpl }),
+                requireLive: false,
+            });
+            return {
+                base,
+                corridors: corridorSet(base, config.corridors),
+                discovery: discoveryIndex({
+                    network: base.networkName,
+                    ...(config.discovery === undefined ? {} : { config: config.discovery }),
+                    ...(config.repository === undefined ? {} : { repository: config.repository }),
+                }),
+            };
+        })());
+
+    const route = async (input: QuoteInput, mode: "resolve" | "quote"): Promise<ResolvedRoute> => {
+        const { base, corridors, discovery } = await resolved();
+        return resolveRoute(input, {
+            corridors,
+            network: base.networkName,
+            discovery,
+            ...(config.policy === undefined ? {} : { policy: config.policy }),
+            mode,
+        });
+    };
+
+    const remember = (id: QuoteId, preparation: QuotePreparation): void => {
+        preparations.set(id, preparation);
+        while (preparations.size > PREPARATIONS_HELD) {
+            const oldest = preparations.keys().next();
+            if (oldest.done) break;
+            preparations.delete(oldest.value);
+        }
+    };
+
+    return {
+        resolve: async (input) => (await route(input, "resolve")).resolution,
+
+        quote: async (input) => {
+            const { corridors, discovery } = await resolved();
+            let resolvedRoute = await route(input, "quote");
+
+            // The responder check pins against the card's `discovery_pubkey`,
+            // and a card read back out of the cache carries that field
+            // unvalidated. So an addressed quote re-pins the card from the
+            // registry first. If the registry cannot be reached the stale
+            // snapshot still comes back and the check refuses it — which is the
+            // fail-closed half of the same rule, not a second one.
+            if (resolvedRoute.market?.backend === "rfq" && !resolvedRoute.snapshot.ref.live) {
+                await discovery.load({ refresh: true });
+                resolvedRoute = await route(input, "quote");
+            }
+
+            const { market } = resolvedRoute;
+            if (market === undefined) {
+                throw new UnsupportedRoute(
+                    `no market serves ${resolvedRoute.legs.give.corridor}:` +
+                        `${resolvedRoute.legs.give.assetId} -> ` +
+                        `${resolvedRoute.legs.take.corridor}:${resolvedRoute.legs.take.assetId} ` +
+                        "on the active discovery snapshot",
+                    {
+                        give: resolvedRoute.legs.give.corridor,
+                        take: resolvedRoute.legs.take.corridor,
+                    },
+                );
+            }
+            const marketRef = resolvedRoute.resolution.market;
+            if (marketRef === undefined || marketRef.kind !== "card") {
+                throw new Error("a resolved market must carry its card's provenance");
+            }
+
+            // Dep resolution happens when a route first touches a corridor, and
+            // this is that moment: a dep overridden to nothing is
+            // `MissingCorridorDep` here, before anything is disclosed or funded,
+            // and a corridor this route does not touch is never resolved at all.
+            // Both legs, because the arkade one is a leg of every route.
+            corridors.get(resolvedRoute.legs.give.corridor);
+            corridors.get(resolvedRoute.legs.take.corridor);
+
+            const quoteId = mintQuoteId();
+            const now = Math.floor(Date.now() / 1000);
+
+            if (resolvedRoute.pair === "arkade->arkade") {
+                const { quote, preparation } = await quoteFromFeed({
+                    quoteId,
+                    candidate: market,
+                    market: marketRef,
+                    legs: resolvedRoute.legs,
+                    endpoints: { give: resolvedRoute.give, take: resolvedRoute.take },
+                    ...(resolvedRoute.amount === undefined ? {} : { amount: resolvedRoute.amount }),
+                    feed,
+                    ...(config.policy === undefined ? {} : { policy: config.policy }),
+                    now,
+                });
+                remember(quoteId, preparation);
+                return quote;
+            }
+
+            // Every covenant derivation reads live: a snapshot binds the tree to
+            // a signer key the operator may no longer co-sign for, and an
+            // unreachable operator is `OperatorUnreachable` here, before funding.
+            const info = await liveArkadeInfo(wallet, { requireLive: true });
+            const rendezvous = market.card.discovery_pubkey;
+            if (rendezvous === undefined) {
+                // Unreachable: `eligibleMarkets` drops a corridor card with no
+                // rendezvous, precisely so this is never a transport built
+                // against an empty key.
+                throw new Error(`card ${market.card.solver} names no discovery key to address`);
+            }
+            const transport = await (config.transportFor ?? nostrTransportFactory)({
+                card: market.card,
+                solverPubkey: rendezvous,
+                relays: market.card.transports?.nostr?.relays ?? [],
+            });
+            try {
+                const { quote, preparation } = await quoteViaRfq({
+                    quoteId,
+                    route: resolvedRoute.pair,
+                    candidate: market,
+                    market: marketRef,
+                    legs: resolvedRoute.legs,
+                    endpoints: { give: resolvedRoute.give, take: resolvedRoute.take },
+                    ...(resolvedRoute.amount === undefined ? {} : { amount: resolvedRoute.amount }),
+                    wallet,
+                    info,
+                    corridors,
+                    transport,
+                    ...(config.policy === undefined ? {} : { policy: config.policy }),
+                    now,
+                });
+                remember(quoteId, preparation);
+                return quote;
+            } finally {
+                // One negotiation, one transport: the reply has landed or it has
+                // not, and holding a relay subscription open past that is a
+                // resource this call owns and nothing else will close.
+                await transport.close().catch(() => {});
+            }
+        },
+
+        preparationOf: (id) => preparations.get(id),
+    };
+};

--- a/packages/swap/src/client/corridors/deps.ts
+++ b/packages/swap/src/client/corridors/deps.ts
@@ -27,6 +27,7 @@ import {
     getNetwork,
     resolveEmulatorPubkey,
     signerSetFromInfo,
+    type ArkadeInfo,
     type IWallet,
     type Network,
     type NetworkName,
@@ -251,16 +252,43 @@ export function resolveCorridorDeps(
 }
 
 /**
- * The one live operator read, made once for all three corridors.
+ * The operator info read, wrapped so every way it can fail arrives as one
+ * typed error.
  *
- * `requireLive: true` because a snapshot binds a covenant to a signer key the
- * operator may no longer co-sign for. The whole read is wrapped rather than a
- * matched subset of its failures: `requireLive` re-throws the provider's raw
- * error unwrapped, which is a `FetchError`, a `ProviderUnavailableError`, an
- * `ArkError`, a bare `Error` or a `TimeoutError` depending on how the read
- * failed — and across a service-worker boundary it is a fresh `Error` whose only
- * branchable identity is `cause.name`. A `catch` on a matched set would let
- * exactly those through untyped.
+ * The whole read is wrapped rather than a matched subset of its failures:
+ * `requireLive` re-throws the provider's raw error unwrapped, which is a
+ * `FetchError`, a `ProviderUnavailableError`, an `ArkError`, a bare `Error` or a
+ * `TimeoutError` depending on how the read failed — and across a service-worker
+ * boundary it is a fresh `Error` whose only branchable identity is `cause.name`.
+ * A `catch` on a matched set would let exactly those through untyped.
+ *
+ * `requireLive` is the caller's, and the two callers want opposite things.
+ * Every covenant derivation reads live (§6), because a snapshot binds a covenant
+ * to a signer key the operator may no longer co-sign for. A destination *parse*
+ * does not derive anything, and the client's `resolve()` promises to answer
+ * without new disclosure and offline — so it takes the wallet's own fallback
+ * read, which is live when the operator is reachable and the persisted snapshot
+ * when it is not.
+ */
+export const liveArkadeInfo = async (
+    wallet: IWallet,
+    opts: { requireLive?: boolean } = {},
+): Promise<ArkadeInfo> => {
+    const requireLive = opts.requireLive ?? true;
+    try {
+        return await wallet.getArkadeInfo({ requireLive });
+    } catch (cause) {
+        throw new OperatorUnreachable(
+            `the Arkade server info could not be read${requireLive ? " live" : ""}: ${
+                cause instanceof Error ? cause.message : String(cause)
+            }`,
+            { cause },
+        );
+    }
+};
+
+/**
+ * The one operator read, made once for all three corridors.
  *
  * The network narrowing after it is core's own fail-closed one and stays that
  * way: an operator that answers with a network name this SDK does not know is
@@ -272,18 +300,10 @@ export const resolveCorridorBase = async (input: {
     operator: SwapOperator;
     emulatorPubkey?: string;
     fetchImpl?: typeof fetch;
+    /** Defaults to `true` — see {@link liveArkadeInfo}. */
+    requireLive?: boolean;
 }): Promise<CorridorBase> => {
-    let info;
-    try {
-        info = await input.wallet.getArkadeInfo({ requireLive: true });
-    } catch (cause) {
-        throw new OperatorUnreachable(
-            `the Arkade server info could not be read live: ${
-                cause instanceof Error ? cause.message : String(cause)
-            }`,
-            { cause },
-        );
-    }
+    const info = await liveArkadeInfo(input.wallet, { requireLive: input.requireLive });
     const networkName = info.network as NetworkName;
     return {
         wallet: input.wallet,

--- a/packages/swap/src/client/discovery.ts
+++ b/packages/swap/src/client/discovery.ts
@@ -1,0 +1,298 @@
+/**
+ * Discovery, and the three states one `DiscoveredMarket[]` used to collapse.
+ *
+ * `discoverMarkets` answers one array for three different situations: no
+ * registry configured (or a network with no published index), a stale cache
+ * served because every source failed, and a reachable registry that lists
+ * nothing. They are not the same answer and they do not deserve the same
+ * behaviour, so this module separates them and carries the difference on the
+ * snapshot rather than in a comment:
+ *
+ * - **No data at all** — no registry, an unindexed network, or an unreachable
+ *   one with nothing cached — is {@link DiscoverySnapshotUnavailable}. There is
+ *   no route state for "resolved against nothing".
+ * - **A stale cache** resolves and prices, and is marked stale. It is still a
+ *   snapshot; what it cannot do is supply the key an addressed RFQ's responder
+ *   is checked against (see `live` below).
+ * - **Reachable and empty** is a snapshot like any other, with no markets in it.
+ *   The route resolves; `quote()` is where an empty eligible set becomes
+ *   `UnsupportedRoute`.
+ *
+ * It wraps discovery rather than `discoverMarkets`, and the reason is the same
+ * separation: `discover()` reports per-source outcomes and `discoverMarkets`
+ * spends them on the way out. `discoverMarkets` itself is untouched — the
+ * wallet's own wrapper around it keeps working — and the cache is the same
+ * entry under the same key, so a v1 read warms a v2 quote and back.
+ *
+ * The cache is also a trust boundary. `isMarketShaped` revalidates four fields
+ * on read and trusts the rest, `discovery_pubkey` and `transports` included, and
+ * those two are precisely what an addressed RFQ addresses itself to. So a cached
+ * card is revalidated here against every field this client depends on, and a
+ * snapshot that came out of the cache is marked `live: false` — the responder
+ * check refuses to pin against cache content whatever its shape.
+ */
+import {
+    MAX_RELAYS,
+    discover,
+    isRfqMarket,
+    type DiscoveredMarket,
+    type LocalCardInput,
+    type Network as IndexedNetwork,
+} from "@arkade-os/solver-discovery";
+import type { NetworkName } from "@arkade-os/sdk";
+import { MARKETS_CACHE_TTL_MS } from "../markets";
+import type { AssetSwapRepository } from "../repository";
+import { isIndexedNetwork } from "./aliases";
+import { CORRIDORS } from "./corridor";
+import { DiscoverySnapshotUnavailable } from "./errors";
+import type { SnapshotRef } from "./quote";
+
+/** Where the client's market data comes from. Every field is optional: a
+ * client with none of it resolves against nothing and says so. */
+export interface DiscoveryConfig {
+    /**
+     * The network's solver registry index URL.
+     *
+     * Config rather than an inference: nothing in the wallet, the operator info
+     * or this package names a registry, so "inferred from the wallet" reaches
+     * only as far as the network. Absent means no source at all, which is the
+     * unavailable case and not an empty market set.
+     */
+    readonly registryUrl?: string;
+    /** Locally pinned solver cards, merged with the registry's. */
+    readonly localCards?: readonly LocalCardInput[];
+    /**
+     * Markets to resolve against without touching the network.
+     *
+     * Caller-supplied and therefore trusted the way config is: an injected
+     * snapshot can pin an RFQ responder, where a cached one cannot.
+     */
+    readonly snapshot?: readonly DiscoveredMarket[];
+    /** Overrides the network the wallet reports. For tests and multi-network hosts. */
+    readonly network?: IndexedNetwork;
+    readonly fetchImpl?: typeof fetch;
+    /** Receives discovery warnings (stale index, skipped cards, …). */
+    readonly logger?: (...args: unknown[]) => void;
+}
+
+/** A market set, and where it came from. */
+export interface DiscoverySnapshot {
+    readonly markets: readonly DiscoveredMarket[];
+    readonly ref: SnapshotRef;
+}
+
+export interface DiscoveryIndex {
+    /**
+     * The snapshot in hand, without touching the network — an injected one, one
+     * this client already loaded, or the repository's cache.
+     *
+     * @throws {DiscoverySnapshotUnavailable} when there is none.
+     */
+    peek(): Promise<DiscoverySnapshot>;
+    /**
+     * A snapshot, fetching when there is none in hand or when asked to refresh.
+     *
+     * @throws {DiscoverySnapshotUnavailable} when the fetch leaves it with
+     *   nothing either.
+     */
+    load(opts?: { refresh?: boolean }): Promise<DiscoverySnapshot>;
+}
+
+const HEX_64 = /^[0-9a-f]{64}$/;
+
+const isRelayList = (value: unknown): boolean =>
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.length <= MAX_RELAYS &&
+    value.every((relay) => typeof relay === "string" && relay.startsWith("wss://"));
+
+const isCorridorField = (value: unknown): boolean =>
+    value === undefined || (CORRIDORS as readonly string[]).includes(value as string);
+
+/**
+ * Whether a card read back out of the cache is one this client may act on.
+ *
+ * Wider than `isMarketShaped`, and deliberately so: that predicate guards the
+ * v1 pricing path, which reads asset ids and decimals, where this one guards a
+ * path that also addresses a solver over a rendezvous the card names. A stored
+ * entry outlives the schema that wrote it AND the storage it sits in, so every
+ * field the client depends on is re-checked rather than four of them.
+ */
+export const isUsableCard = (value: unknown): value is DiscoveredMarket => {
+    const card = value as Partial<DiscoveredMarket> | null;
+    if (
+        typeof card?.pair !== "string" ||
+        typeof card.solver !== "string" ||
+        typeof card.source !== "string" ||
+        (card.sourceType !== "registry" && card.sourceType !== "local") ||
+        typeof card.base_asset?.id !== "string" ||
+        typeof card.quote_asset?.id !== "string" ||
+        typeof card.base_asset.decimals !== "number" ||
+        typeof card.quote_asset.decimals !== "number" ||
+        !isCorridorField(card.base_corridor) ||
+        !isCorridorField(card.quote_corridor)
+    ) {
+        return false;
+    }
+    // A corridor market is addressed, not just priced: without a key to encrypt
+    // to and a relay to reach, it is a card no quote can be requested from —
+    // and both fields are exactly what the old read trusted.
+    if (isRfqMarket(card)) {
+        if (typeof card.discovery_pubkey !== "string" || !HEX_64.test(card.discovery_pubkey)) {
+            return false;
+        }
+        if (!isRelayList(card.transports?.nostr?.relays)) return false;
+    }
+    return true;
+};
+
+/** The cached entry for this network and registry, revalidated card by card. */
+const readCache = async (
+    repository: AssetSwapRepository,
+    network: IndexedNetwork,
+    registry: string,
+): Promise<{ markets: DiscoveredMarket[]; fetchedAt: number } | undefined> => {
+    try {
+        const entry = await repository.getCachedMarkets(network, registry);
+        if (!Array.isArray(entry?.markets) || typeof entry?.fetchedAt !== "number") return;
+        // Card by card rather than all-or-nothing: one card whose schema moved
+        // should cost that card, not every market on the network.
+        const markets = entry.markets.filter(isUsableCard);
+        return { markets, fetchedAt: entry.fetchedAt };
+    } catch {
+        // A missing, malformed or unreadable cache reads as a miss, exactly as
+        // the v1 read does — the refetch overwrites it.
+        return undefined;
+    }
+};
+
+export interface DiscoveryIndexInput {
+    /** The network the wallet reported. */
+    readonly network: NetworkName;
+    readonly config?: DiscoveryConfig;
+    /** Backs the shared markets cache. Without one, every load hits the registry. */
+    readonly repository?: AssetSwapRepository;
+}
+
+/**
+ * One client's view of the market index.
+ *
+ * Holds at most one snapshot and hands the same one back until it ages out or a
+ * caller asks for a refresh, so a `resolve()` and the `quote()` after it agree
+ * on what the market was — two loads a second apart returning different cards
+ * would make the resolution the caller vetoed a different one from the quote
+ * they got.
+ */
+export const discoveryIndex = (input: DiscoveryIndexInput): DiscoveryIndex => {
+    const config = input.config ?? {};
+    const network = config.network ?? input.network;
+    const registry = config.registryUrl;
+
+    const injected: DiscoverySnapshot | undefined = config.snapshot && {
+        markets: config.snapshot,
+        ref: { fetchedAt: Date.now(), live: true, source: "injected" },
+    };
+
+    let held: DiscoverySnapshot | undefined;
+
+    const unavailable = (detail: string): never => {
+        throw new DiscoverySnapshotUnavailable(input.network, detail);
+    };
+
+    /** Everything a snapshot needs before a registry can be asked at all. */
+    const sources = ():
+        | { network: IndexedNetwork; registry: string }
+        | { network?: undefined; registry?: undefined } => {
+        if (!isIndexedNetwork(network)) return {};
+        if (!registry) return {};
+        return { network, registry };
+    };
+
+    const whyUnavailable = (): string => {
+        if (!isIndexedNetwork(network)) return `no market index is published for ${network}`;
+        if (!registry) return "no registry URL is configured, and no snapshot was injected";
+        return `the registry ${registry} could not be reached and nothing is cached`;
+    };
+
+    const fromCache = async (): Promise<DiscoverySnapshot | undefined> => {
+        const { network: indexed, registry: url } = sources();
+        if (!indexed || !url || !input.repository) return undefined;
+        const cached = await readCache(input.repository, indexed, url);
+        if (!cached) return undefined;
+        return {
+            markets: cached.markets,
+            ref: {
+                fetchedAt: cached.fetchedAt,
+                // The cards were read back out of local storage, whatever their
+                // age: nothing here can attest that a registry ever served them.
+                live: false,
+                source: "cache",
+                registry: url,
+            },
+        };
+    };
+
+    const peek = async (): Promise<DiscoverySnapshot> => {
+        if (injected) return injected;
+        if (held) return held;
+        const cached = await fromCache();
+        if (cached) {
+            held = cached;
+            return cached;
+        }
+        return unavailable(whyUnavailable());
+    };
+
+    const load = async (opts: { refresh?: boolean } = {}): Promise<DiscoverySnapshot> => {
+        if (injected) return injected;
+        const fresh =
+            held?.ref.live === true && Date.now() - held.ref.fetchedAt < MARKETS_CACHE_TTL_MS;
+        if (fresh && !opts.refresh) return held as DiscoverySnapshot;
+
+        const { network: indexed, registry: url } = sources();
+        if (!indexed || !url) {
+            // Nothing to fetch from. The cache is keyed by registry, so there is
+            // nothing to fall back to either.
+            return unavailable(whyUnavailable());
+        }
+
+        const result = await discover({
+            registries: [url],
+            localCards: [...(config.localCards ?? [])],
+            network: indexed,
+            fetchImpl: config.fetchImpl,
+        });
+        if (result.warnings.length) config.logger?.("solver discovery:", ...result.warnings);
+
+        // Reachable is per-source and not per-market: a registry that answers
+        // with an empty index is authoritative about there being no market,
+        // which is a different fact from not having answered.
+        if (result.sources.some((source) => source.ok)) {
+            const fetchedAt = Date.now();
+            held = {
+                markets: result.markets,
+                ref: { fetchedAt, live: true, source: "live", registry: url },
+            };
+            if (input.repository) {
+                try {
+                    await input.repository.saveCachedMarkets(indexed, url, {
+                        markets: result.markets,
+                        fetchedAt,
+                    });
+                } catch {
+                    // Best effort, as in v1: a lost cache write costs one refetch.
+                }
+            }
+            return held;
+        }
+
+        const cached = await fromCache();
+        if (cached) {
+            held = cached;
+            return cached;
+        }
+        return unavailable(whyUnavailable());
+    };
+
+    return { peek, load };
+};

--- a/packages/swap/src/client/errors.ts
+++ b/packages/swap/src/client/errors.ts
@@ -35,8 +35,19 @@ import type { CorridorId } from "./corridor";
  */
 export { SwapRefusal };
 
-/** The four checks §3.1 runs on every quote. Closed, so M3 fits into it. */
-export type QuoteCheck = "pair" | "lockup_address" | "invoice" | "refund_window";
+/**
+ * The checks §3.1 runs on every quote, before it is returned.
+ *
+ * Four of them are the spec's, and the fifth is M3's answer to G2. §3.1 states
+ * that "who answered is a transport property, not one of those four checks",
+ * and the two dev transports authenticate nobody — so leaving attestation at
+ * the transport makes verification skippable by configuration, which is the one
+ * thing verification may not be. `responder` is therefore *delivered* as a
+ * transport property and *run* as a check, and §3.1's sentence narrows to
+ * addressed mode with it: published RFQ (§10) attributes each bid by its own
+ * signature and inherits no transport attestation at all.
+ */
+export type QuoteCheck = "pair" | "lockup_address" | "invoice" | "refund_window" | "responder";
 
 /**
  * `to` is underdetermined — it parses as nothing, as more than one thing, or as
@@ -70,7 +81,11 @@ export class AmbiguousDestination extends Error {
  * included, until the manager owns the trader's L1 refund path end to end.
  *
  * Boundary: route resolution, before RFQ disclosure, artifact creation,
- * persistence or funding. Also the alias layer, for a rail no corridor serves.
+ * persistence or funding. Also the alias layer, for a rail no corridor serves,
+ * and `quote()` for a pair no discovered market serves on the active snapshot —
+ * a resolved route with an empty eligible set, which is an absence of a
+ * market-shaped thing rather than a wrong pairing, and so this member rather
+ * than a seventeenth.
  */
 export class UnsupportedRoute extends Error {
     override readonly name = "UnsupportedRoute";
@@ -89,7 +104,11 @@ export class UnsupportedRoute extends Error {
  * excludes one, and a caller that needs offline resolution warms or injects a
  * snapshot.
  *
- * Boundary: `resolve()` only — `quote()` may fetch discovery itself.
+ * Boundary: `resolve()`, and `quote()` when the fetch it is allowed to make
+ * leaves it with nothing either — no registry configured, an unindexed network,
+ * or an unreachable registry with no cache behind it. Fetching is what `quote()`
+ * may do that `resolve()` may not; having no market data at all is the same
+ * condition on both.
  */
 export class DiscoverySnapshotUnavailable extends Error {
     override readonly name = "DiscoverySnapshotUnavailable";
@@ -148,18 +167,27 @@ export class QuoteVerificationFailed extends Error {
         readonly check: QuoteCheck,
         expected?: string,
         actual?: string,
+        /** The gate or derivation this folds in, kept as the `cause` chain:
+         * `expected`/`actual` say what disagreed, and the cause says which
+         * check said so. */
+        options?: ErrorOptions,
     ) {
-        super(`quote failed the ${check} check — refusing to fund`);
+        super(`quote failed the ${check} check — refusing to fund`, options);
         this.expected = expected;
         this.actual = actual;
     }
 }
 
 /**
- * `accept()` past the quote's TTL. The client never silently re-quotes: the
- * price the caller saw is not the price they would get.
+ * A quote past its TTL, or so close to it that acting on it is the same thing.
  *
- * Boundary: `accept()`, before persistence.
+ * Two boundaries, one condition. At `accept()` it is the spec's: the client
+ * never silently re-quotes, because the price the caller saw is not the price
+ * they would get. At `quote()` it is `policy.quoteTtlFloorSeconds` — a quote arriving
+ * with less validity left than the caller can use is expired on arrival, and
+ * saying so beats handing back terms that die between the return and the accept.
+ *
+ * Boundary: `quote()`, against the policy floor; `accept()`, before persistence.
  */
 export class QuoteExpired extends Error {
     override readonly name = "QuoteExpired";

--- a/packages/swap/src/client/index.ts
+++ b/packages/swap/src/client/index.ts
@@ -9,11 +9,23 @@
  * this one are still deciding.
  */
 export * from "./aliases";
+export * from "./aliasTable";
 export * from "./amount";
 export * from "./assetId";
+export * from "./client";
 export * from "./corridor";
 export * from "./corridors";
+export * from "./discovery";
 export * from "./errors";
+export * from "./market";
+export * from "./policy";
 export * from "./primitives";
+export * from "./quote";
+export * from "./quoteOffer";
+export * from "./quoteRfq";
+export * from "./resolve";
 export * from "./rfqAmount";
+export * from "./rfqWire";
 export * from "./route";
+export * from "./transport";
+export * from "./verify";

--- a/packages/swap/src/client/market.ts
+++ b/packages/swap/src/client/market.ts
@@ -1,0 +1,171 @@
+/**
+ * Market resolution: `(give.asset, take.asset, corridors)` to the card that
+ * prices the swap, and the provenance that card leaves on the quote.
+ *
+ * The lookup itself is discovery's — `selectMarkets` matches a leg pair with
+ * both corridors, arkade defaulted on either side — and this module supplies
+ * the three things around it that the client cannot borrow: the policy filters
+ * that run before disclosure, the canonical market key derived under the
+ * protocol's own leg order rather than the card's, and the addressability check
+ * that keeps an unreachable corridor card out of the candidate set instead of
+ * failing at the transport.
+ *
+ * `findMarket` is not what this calls, and the reason is the candidate set:
+ * that helper answers with the single best market of one orientation, and
+ * `policy.selectMarket` is defined over every eligible card. Both orientations
+ * are tried here for the same reason it tries them — a registry may publish
+ * either leg as base.
+ */
+import {
+    isRfqMarket,
+    marketCorridor,
+    marketLegKey,
+    selectMarkets,
+    type DiscoveredMarket,
+    type Side,
+} from "@arkade-os/solver-discovery";
+import type { DiscoveryLeg } from "./aliases";
+import type { DiscoverySnapshot } from "./discovery";
+import type { SwapPolicy } from "./policy";
+import type { CardMarketRef, MarketBackend, MarketRef, SnapshotRef } from "./quote";
+
+/** One card that can price this route, with what the route needs read off it. */
+export interface MarketCandidate {
+    readonly card: DiscoveredMarket;
+    /** Which side of the card the trader gives; the other side is received. */
+    readonly give: Side;
+    /** Which backend the card selects. The card decides, never the client. */
+    readonly backend: MarketBackend;
+    /** The canonical market key — see {@link marketKeyOf}. */
+    readonly key: string;
+}
+
+/**
+ * The market's canonical key, `<corridor>:<id>/<corridor>:<id>`, under
+ * rfq-protocol.md §2's leg order: when exactly one leg is arkade it comes
+ * first; when both or neither are, the legs sort lexicographically.
+ *
+ * Derived here, from the card in hand, rather than taken from `marketPairKey`,
+ * which emits the card's own base/quote order. The two agree for every card the
+ * registry's reducer validated — it enforces the arkade-as-base half — and
+ * disagree for a card published outside it, which is where the miss would be
+ * silent: both sides of a published negotiation derive this key independently
+ * and subscribe by it, so a key one character apart is not an error either side
+ * can report, it is a request nobody answers.
+ */
+export const marketKeyOf = (card: DiscoveredMarket): string => {
+    const base = marketLegKey(card, "base");
+    const quote = marketLegKey(card, "quote");
+    const baseIsArkade = marketCorridor(card, "base") === "arkade";
+    const quoteIsArkade = marketCorridor(card, "quote") === "arkade";
+    if (baseIsArkade !== quoteIsArkade) {
+        return baseIsArkade ? `${base}/${quote}` : `${quote}/${base}`;
+    }
+    return base <= quote ? `${base}/${quote}` : `${quote}/${base}`;
+};
+
+/**
+ * Whether a corridor card can actually be addressed.
+ *
+ * A corridor market is negotiated per trade over the rendezvous the card names,
+ * so a card missing its key or its relays prices nothing, whatever its feed
+ * says. Dropping it here rather than at the transport is what keeps "no market
+ * serves this pair" one answer instead of two: an unaddressable card in the
+ * candidate set would be selected, disclose nothing, and fail as a transport
+ * error that reads like an outage.
+ */
+export const isAddressable = (card: DiscoveredMarket): boolean =>
+    !isRfqMarket(card) ||
+    (typeof card.discovery_pubkey === "string" &&
+        (card.transports?.nostr?.relays?.length ?? 0) > 0);
+
+const backendOf = (card: DiscoveredMarket): MarketBackend => (isRfqMarket(card) ? "rfq" : "feed");
+
+/**
+ * Every card on the snapshot that serves this leg pair, best-ranked first,
+ * after policy.
+ *
+ * The allowed-registry filter runs first and matches `source` exactly. It is
+ * `source` and not `discovery_pubkey` because the latter is the field a cached
+ * card carries unvalidated: filtering trust on untrusted content would give the
+ * allowlist the shape of a check and none of the effect.
+ */
+export const eligibleMarkets = (
+    snapshot: DiscoverySnapshot,
+    legs: { give: DiscoveryLeg; take: DiscoveryLeg },
+    policy?: SwapPolicy,
+): MarketCandidate[] => {
+    const allowed = policy?.allowedRegistries;
+    const markets = (
+        allowed
+            ? snapshot.markets.filter((card) => allowed.includes(card.source))
+            : snapshot.markets
+    ).filter(isAddressable);
+
+    const { give, take } = legs;
+    // Same leg on both sides is not a swap — and it is the LEG that has to
+    // differ, not the asset: `lightning:btc -> arkade:btc` is the same asset id
+    // on two corridors and is the corridor's whole purpose.
+    if (give.corridor === take.corridor && give.assetId === take.assetId) return [];
+
+    const oriented = (side: Side): MarketCandidate[] => {
+        const base = side === "base" ? give : take;
+        const quote = side === "base" ? take : give;
+        return selectMarkets([...markets], {
+            baseId: base.assetId,
+            quoteId: quote.assetId,
+            baseCorridor: base.corridor,
+            quoteCorridor: quote.corridor,
+            // The trader receives the take leg, so that side must be one the
+            // solver can pay out; a direction nobody solves yields no market.
+            wantSide: side === "base" ? "quote" : "base",
+        }).map((card) => ({ card, give: side, backend: backendOf(card), key: marketKeyOf(card) }));
+    };
+
+    // Give-as-base first, matching `findMarket`'s own preference order.
+    return [...oriented("base"), ...oriented("quote")];
+};
+
+/**
+ * The card that prices this swap: the best-ranked candidate, or the one the
+ * application's policy chose instead.
+ *
+ * A veto — `undefined` from `selectMarket` — is not an error here. It empties
+ * the eligible set, and an empty set is a route no market serves on this
+ * snapshot, which is one condition with one answer whether it was emptied by
+ * the registry, by the allowlist or by the application.
+ */
+export const chooseMarket = (
+    candidates: readonly MarketCandidate[],
+    policy?: SwapPolicy,
+): MarketCandidate | undefined => {
+    if (candidates.length === 0) return undefined;
+    if (!policy?.selectMarket) return candidates[0];
+    const chosen = policy.selectMarket(candidates);
+    if (chosen === undefined) return undefined;
+    if (!candidates.includes(chosen)) {
+        // A card from somewhere else has not been through the pair, corridor and
+        // addressability checks that produced this list, and quoting against it
+        // would skip every one of them.
+        throw new Error("policy.selectMarket returned a market that was not among the candidates");
+    }
+    return chosen;
+};
+
+/** The provenance a candidate leaves on every quote it prices. */
+export const marketRefOf = (candidate: MarketCandidate, snapshot: SnapshotRef): CardMarketRef => ({
+    kind: "card",
+    key: candidate.key,
+    backend: candidate.backend,
+    source: candidate.card.source,
+    sourceType: candidate.card.sourceType,
+    solver: candidate.card.solver,
+    ...(candidate.card.discovery_pubkey === undefined
+        ? {}
+        : { discoveryPubkey: candidate.card.discovery_pubkey }),
+    pair: candidate.card.pair,
+    snapshot,
+});
+
+/** Narrow a `MarketRef` to the card arm — the only one minted today. */
+export const isCardMarket = (market: MarketRef): market is CardMarketRef => market.kind === "card";

--- a/packages/swap/src/client/policy.ts
+++ b/packages/swap/src/client/policy.ts
@@ -1,0 +1,84 @@
+/**
+ * Application policy: the vetoes and floors a client applies before it
+ * discloses anything, plus the two names §10 reserved.
+ *
+ * Five members touch the quote path — three active here, two inert — and the
+ * remaining two belong to milestones that own the behaviour they configure:
+ * `drive` is the lifecycle's and `maxFee` the verbs' ceiling, and each is added
+ * by the milestone that can enforce it rather than declared early and ignored.
+ *
+ * Every active member has the same shape of purpose: it runs BEFORE the RFQ
+ * round trip that discloses an invoice or an amount. A policy that could only
+ * reject a quote after it arrived would be a preference, not a policy.
+ */
+import type { MarketCandidate } from "./market";
+import type { RankedBid } from "./quote";
+
+/**
+ * A published-RFQ auction's parameters (§10, Q9).
+ *
+ * Reserved and inert: nothing reads it, and its shape is sized against ts-sdk
+ * #777's draft so the name cannot be occupied by something narrower in the
+ * meantime — a bid window, the relay set unioned across the pair's cards, and
+ * the fresh per-open transport key rfq-protocol.md §4.6 recommends for
+ * unlinkability.
+ */
+export interface RfqAuctionPolicy {
+    /** How long to hold the bid window open, in ms. */
+    readonly windowMs: number;
+    /** Relays to publish the open request on. Unioned across the pair's cards. */
+    readonly relays?: readonly string[];
+    /** §4.6's SHOULD: a fresh transport key per open, so bids are unlinkable. */
+    readonly freshTransportKey?: boolean;
+}
+
+export interface SwapPolicy {
+    /**
+     * The last word on which market prices a swap.
+     *
+     * Called with every eligible candidate, best-ranked first, and answering
+     * `undefined` vetoes them all — which lands where an empty candidate set
+     * lands, as `UnsupportedRoute`, and not as a seventeenth error member. The
+     * answer must be one of the candidates: a card from somewhere else has not
+     * been through the pair, corridor and addressability checks that produced
+     * this list.
+     */
+    readonly selectMarket?: (candidates: readonly MarketCandidate[]) => MarketCandidate | undefined;
+
+    /**
+     * The registries whose cards may price a swap, matched exactly against
+     * `DiscoveredMarket.source`.
+     *
+     * On `source` and never on `discovery_pubkey`, which is the field the cache
+     * does not revalidate on read: filtering an allowlist on unvalidated cache
+     * content would reintroduce the hole the allowlist exists to close. Exact
+     * URLs, not hostnames or origins — and a locally pinned card follows
+     * whatever label discovery recorded for it, which is a path, not a URL.
+     *
+     * Absent means every source. An allowlist that empties the candidate set is
+     * the empty-eligible-set case, not a refusal of its own.
+     */
+    readonly allowedRegistries?: readonly string[];
+
+    /**
+     * The least validity a quote may arrive with, in seconds.
+     *
+     * One layer above the wire's own refusal of a quote already past
+     * `valid_until`: a quote with four seconds left is not expired and is not
+     * usable either, and the caller is the only one who knows how long their
+     * flow takes between seeing terms and accepting them. Under the floor is
+     * `QuoteExpired`, thrown from `quote()` rather than handed back to fail at
+     * `accept()`.
+     */
+    readonly quoteTtlFloorSeconds?: number;
+
+    /**
+     * §10, reserved and inert: the published-RFQ auction's parameters.
+     */
+    readonly rfq?: RfqAuctionPolicy;
+
+    /**
+     * §10, reserved and inert: which bid to close a published auction with.
+     */
+    readonly selectBid?: (bids: readonly RankedBid[]) => RankedBid | undefined;
+}

--- a/packages/swap/src/client/quote.ts
+++ b/packages/swap/src/client/quote.ts
@@ -1,0 +1,257 @@
+/**
+ * What a quote is: the order, fully resolved, plus the provenance that says who
+ * priced it and where that card came from.
+ *
+ * M1 named these shapes and left them to whichever milestone decided their
+ * semantics; this is that milestone, so `QuoteId`, `QuoteInput`, `Quote`,
+ * `MarketRef` and `AuctionProvenance` are declared here rather than beside the
+ * types they are built out of. Nothing in this module has behaviour — the quote
+ * path assembles these, `accept()` (M4) consumes them.
+ *
+ * The one rule worth restating at the top: a `Quote` is binding terms plus the
+ * evidence for them. Every field is either something the caller must act on
+ * (the two obligations, the artifact, the deadline) or something they must be
+ * able to audit afterwards (the market, the solver, the checks that passed).
+ * Nothing internal rides along — no covenant, no secret, no transport.
+ */
+import type { AssetId } from "./assetId";
+import type { AmountOn } from "./rfqAmount";
+import type { Corridor, CorridorId } from "./corridor";
+import type { Hex, Pubkey } from "./primitives";
+import type { Artifact, Instrument, Route } from "./route";
+
+/**
+ * A quote's identity, minted by the client at quote time.
+ *
+ * Client-minted everywhere, not just where the wire offers no id: a feed-priced
+ * offer quote has no solver-minted id at all, and `accept()` is idempotent by
+ * quote id *and only* by quote id (§3.2), so an identity that exists on one
+ * backend and not the other could not carry that rule. An alias rather than a
+ * brand, matching `Hex` and `Pubkey` beside it.
+ */
+export type QuoteId = string;
+
+/**
+ * A caller's spelling of an asset: a public id, or a ticker the alias layer
+ * canonicalizes against the registry.
+ *
+ * `AssetId | (string & {})` rather than `string`, so an editor still completes
+ * the id form and a mistyped id still shows up as one — `AssetId | string`
+ * collapses to `string` and takes both with it.
+ */
+export type AssetRef = AssetId | (string & {});
+
+/**
+ * Everything a caller supplies. §4's bottom line: two asset ids or one
+ * destination string, one amount, which side it pins, and — on receives, where
+ * no instrument exists yet — a corridor.
+ */
+export interface QuoteInput {
+    /** Omitted when the route determines it: the give leg is the wallet's. */
+    give?: AssetRef;
+    /** Omitted when `to` determines it — a corridor that carries BTC only does. */
+    take?: AssetRef;
+    /** A self-describing instrument: bolt11, an Arkade address, or `bc1…`. */
+    to?: string;
+    /** Receive flows only: names the corridor when no instrument can exist yet. */
+    via?: CorridorId;
+    /** Atomic units. Exactly one amount may be pinned — see `amountOn`. */
+    amount?: bigint;
+    /** Which leg `amount` pins. Required with `amount`, and refused with an
+     * invoice, which pins one already. */
+    amountOn?: AmountOn;
+}
+
+/** Which backend priced a quote. The card decides it; no client switch does. */
+export type MarketBackend = "rfq" | "feed";
+
+/** Where a snapshot came from, and how fresh it is. */
+export interface SnapshotRef {
+    /** Unix ms the markets were read from their sources. */
+    readonly fetchedAt: number;
+    /**
+     * The registry answered in this read, so the cards are registry-served
+     * rather than replayed out of local storage.
+     *
+     * `false` is not an error: a stale snapshot still resolves and still prices
+     * a feed-priced quote — it is marked, not refused. What it cannot do is
+     * supply the key an addressed RFQ's responder is checked against, because
+     * that field is unvalidated cache content (`isMarketShaped` revalidates
+     * four fields and trusts the rest).
+     */
+    readonly live: boolean;
+    /** How the markets were obtained. */
+    readonly source: "live" | "cache" | "injected";
+    /** The registry URL behind it, or `undefined` for an injected snapshot. */
+    readonly registry?: string;
+}
+
+/**
+ * Which card priced a quote, and from which registry.
+ *
+ * A union rather than a bag of optionals, because §10's published RFQ is the
+ * one place the sentence "the market picks the backend" stops: a quote closed
+ * out of an open auction has a market *key* and no card behind it, so every
+ * card-derived field is absent at once rather than one at a time. Sizing that
+ * arm now costs a discriminant and keeps the addressed arm total.
+ */
+export type MarketRef = CardMarketRef | AuctionMarketRef;
+
+export interface CardMarketRef {
+    readonly kind: "card";
+    /**
+     * The canonical market key, `<corridor>:<id>/<corridor>:<id>`, derived under
+     * rfq-protocol.md §2's leg order — arkade first when exactly one leg is
+     * arkade, lexicographic otherwise — and never read off the card's own
+     * base/quote order. The two agree for every card the registry's reducer
+     * validated, and a card published outside it is exactly where the silent
+     * miss lives.
+     */
+    readonly key: string;
+    readonly backend: MarketBackend;
+    /** The registry URL, or the label a locally pinned card was loaded under. */
+    readonly source: string;
+    readonly sourceType: "registry" | "local";
+    /** The solver's name, as the card publishes it. Display, never identity. */
+    readonly solver: string;
+    /** The card's signing key. Absent on spot cards, which need no rendezvous. */
+    readonly discoveryPubkey?: Pubkey;
+    /** The card's display label, e.g. `BTC/lightning:BTC`. Display only. */
+    readonly pair: string;
+    readonly snapshot: SnapshotRef;
+}
+
+/** §10, reserved: a quote closed out of a published auction has no card. */
+export interface AuctionMarketRef {
+    readonly kind: "auction";
+    readonly key: string;
+    readonly backend: "rfq";
+}
+
+/**
+ * One bid seen in a published auction (§10, Q9).
+ *
+ * Typed against ts-sdk #777's shipped draft rather than invented: a bid is a
+ * counter-amount on the leg the client did not fix, attributed to the event key
+ * that signed it — which is NOT the covenant's `solver_pubkey`, a role key the
+ * quote fills from a different field.
+ */
+export interface RankedBid {
+    /** The event key that signed the bid. Attribution, not a covenant role. */
+    readonly bidder: Pubkey;
+    /** The counter-amount, on the leg the client left free. */
+    readonly amount: bigint;
+    readonly amountOn: AmountOn;
+    readonly expiresAt: number;
+}
+
+/**
+ * The auction a published-RFQ quote was closed out of (§10, Q9).
+ *
+ * Reserved and inert: `quote()` never populates it, and Q9 froze the name so
+ * the shape it will take cannot be occupied by something else in the meantime.
+ */
+export interface AuctionProvenance {
+    /** The market key the open request was tagged with. */
+    readonly marketKey: string;
+    /** The bid that was closed with. */
+    readonly winner: RankedBid;
+    /** Every other bid seen before the window closed. */
+    readonly losers: readonly RankedBid[];
+    /** Unix seconds the bid window closed. */
+    readonly closedAt: number;
+}
+
+/** One leg's obligation: an asset, and exactly how much of it. */
+export interface QuoteLeg {
+    readonly asset: AssetId;
+    readonly amount: bigint;
+}
+
+/**
+ * The order, fully resolved.
+ *
+ * Both amounts are exact obligations with the fee already inside them, which is
+ * what `fee` restates rather than adds: it is the spread, precomputed, so a
+ * verb (M7) can compare it to a ceiling without re-deriving it from a price.
+ */
+export interface Quote {
+    readonly id: QuoteId;
+    /** Both endpoints resolved, instruments included. */
+    readonly route: Route;
+    /** What the trader gives, fee included. */
+    readonly give: QuoteLeg;
+    /** What the trader takes. */
+    readonly take: QuoteLeg;
+    /** Corridor routes: the hash both covenants commit to. */
+    readonly lock?: { readonly hash: Hex };
+    /** Which card priced this, from which registry, how fresh. */
+    readonly market: MarketRef;
+    /** RFQ routes: the committed counterparty, from the quote's covenant role. */
+    readonly solver?: Pubkey;
+    /** §10 only, and never populated today. */
+    readonly auction?: AuctionProvenance;
+    /** Unix seconds. Non-optional on both backends — a feed-priced quote has no
+     * wire expiry to inherit, so the client mints one from the feed's freshness. */
+    readonly expiresAt: number;
+    /**
+     * Corridor routes: when the trader's value comes back if the swap does not
+     * complete.
+     *
+     * Optional on the type because an asset swap has no refund clock at all —
+     * an offer covenant never expires — and non-optional in practice on every
+     * corridor route, where the wire's own field is optional and the client
+     * refuses a quote without it.
+     */
+    readonly refundLocktime?: number;
+    /** The one thing a counterparty must see, when this route has one. */
+    readonly artifact?: Artifact;
+    /** The spread, denominated on the leg where it is exact. */
+    readonly fee: { readonly amount: bigint; readonly asset: AssetId };
+}
+
+/**
+ * An endpoint as `resolve()` can answer for it, before any disclosure.
+ *
+ * Not an `Endpoint`: that type's instrument is non-optional, deliberately, and a
+ * receive leg has none until the quote returns — the instrument IS the artifact
+ * the solver mints. Absence here means exactly that one thing, because the
+ * wallet case is spelled `{ kind: "wallet" }` rather than left out.
+ */
+export interface ResolvedEndpoint {
+    readonly corridor: Corridor;
+    readonly asset: AssetId;
+    /** Absent only while the leg's instrument does not exist yet. */
+    readonly instrument?: Instrument;
+}
+
+/** The amount a caller (or an invoice) pinned, and which leg it pins. */
+export interface PinnedAmount {
+    readonly value: bigint;
+    readonly on: AmountOn;
+    /** What pinned it, for the diagnostic an `AmountMismatch` carries. */
+    readonly source: "caller" | "invoice";
+}
+
+/**
+ * What `resolve()` answers: the route's shape, the market that would price it,
+ * and what the active snapshot actually serves.
+ *
+ * `eligible` is reported alongside rather than folded into an error because
+ * zero is not a failure of resolution: the destination parsed, the corridor pair
+ * is implemented, and nothing about the route is wrong — there is simply no
+ * market for it on this snapshot. `quote()` is where that becomes
+ * `UnsupportedRoute`, since a quote cannot proceed past market selection.
+ */
+export interface RouteResolution {
+    readonly give: ResolvedEndpoint;
+    readonly take: ResolvedEndpoint;
+    /** The card that would price it: the first eligible one after policy. */
+    readonly market?: MarketRef;
+    /** How many markets serve this pair on the active snapshot, after policy. */
+    readonly eligible: number;
+    /** Where the market data came from, and how fresh it is. */
+    readonly snapshot: SnapshotRef;
+    /** The amount pinned so far, when the input pinned one. */
+    readonly amount?: PinnedAmount;
+}

--- a/packages/swap/src/client/quoteOffer.ts
+++ b/packages/swap/src/client/quoteOffer.ts
@@ -1,0 +1,194 @@
+/**
+ * The feed-priced backend: an arkade-to-arkade asset swap, priced from the
+ * card's own feed with no round trip to anybody.
+ *
+ * The market picks the backend — a card with both legs on arkade prices from
+ * its feed, and one with a leg off it is negotiated over RFQ — so nothing here
+ * is a client switch. What this module owns are the two things the offer path
+ * has never had an answer for.
+ *
+ * **The margin.** `quoteOffer` defaults `safetyBps` to 50, the package exports
+ * `QUOTE_OPTIONS = { safetyBps: 0 }` and the wallet passes it, and the v1 facade
+ * passes neither — so one card priced two different offers depending on which
+ * path built it. `Quote.fee` is one number with one definition, so this picks:
+ * the package constant, no cushion. A safety margin is a pre-payment against
+ * price drift between quote and fill, and that drift is the solver's risk to
+ * manage rather than the trader's to prepay; charging it would also inflate the
+ * fee a verb's `maxFee` ceiling is compared against, which is a ceiling on what
+ * the trader pays, not on what the client padded.
+ *
+ * **The expiry.** §3.1 makes `expiresAt` non-optional and a feed-priced quote
+ * has no `valid_until` to inherit — `OfferPlan` carries no expiry at all. The
+ * only staleness bound in the whole path is the feed cache's TTL, so that is
+ * what the quote's life is minted from: the moment the feed value was actually
+ * read from upstream, plus the TTL. A quote whose price is thirty seconds old
+ * expires when the price does, which is the honest bound; the policy floor then
+ * applies to a number the client chose rather than one a solver asserted.
+ */
+import {
+    computeWantAmount,
+    quoteOffer,
+    type DiscoveredMarket,
+    type OfferPlan,
+    type Side,
+} from "@arkade-os/solver-discovery";
+import { QUOTE_OPTIONS, makeCachedFeedFetch } from "../markets";
+import type { DiscoveryLeg } from "./aliases";
+import { QuoteVerificationFailed } from "./errors";
+import type { MarketCandidate } from "./market";
+import type { SwapPolicy } from "./policy";
+import type { CardMarketRef, Quote, QuoteId, ResolvedEndpoint } from "./quote";
+import { assembleRoute } from "./resolve";
+import type { PinnedAmount } from "./quote";
+import { verifyQuoteTtl } from "./verify";
+
+/**
+ * How long a feed value is reused, and therefore how long a quote priced from
+ * one lives.
+ *
+ * The same number in both roles on purpose: a quote is only as fresh as the
+ * price behind it, and two TTLs would let a quote outlive the value it quoted.
+ */
+export const FEED_TTL_MS = 30_000;
+
+/** A fetch that caches feed values, and remembers when each was really read. */
+export interface FeedFetch {
+    readonly fetch: typeof fetch;
+    /** Unix ms the value behind `url` was last read from upstream. */
+    fetchedAt(url: string): number | undefined;
+}
+
+/**
+ * The client's feed fetcher.
+ *
+ * The upstream probe sits INSIDE the cache rather than around it, which is what
+ * makes `fetchedAt` mean what it says: the cache calls through only on a miss,
+ * so the recorded time is the age of the value that was served, not the time it
+ * was served. Wrapping the other way would restamp every cache hit as fresh and
+ * hand back a quote whose expiry outlived its price.
+ */
+export const feedFetch = (base: typeof fetch = fetch): FeedFetch => {
+    const at = new Map<string, number>();
+    const probe: typeof fetch = async (input, init) => {
+        at.set(input instanceof Request ? input.url : String(input), Date.now());
+        return base(input, init);
+    };
+    return { fetch: makeCachedFeedFetch(FEED_TTL_MS, probe), fetchedAt: (url) => at.get(url) };
+};
+
+/** What `accept()` (M4) needs back from a feed-priced quote. */
+export interface OfferPreparation {
+    readonly backend: "feed";
+    readonly card: DiscoveredMarket;
+    /** The plan the offer covenant is built from: both amounts and both assets. */
+    readonly plan: OfferPlan;
+    readonly give: Side;
+}
+
+export interface FeedQuoteInput {
+    readonly quoteId: QuoteId;
+    readonly candidate: MarketCandidate;
+    readonly market: CardMarketRef;
+    readonly legs: { readonly give: DiscoveryLeg; readonly take: DiscoveryLeg };
+    readonly endpoints: { readonly give: ResolvedEndpoint; readonly take: ResolvedEndpoint };
+    readonly amount?: PinnedAmount;
+    readonly feed: FeedFetch;
+    readonly policy?: SwapPolicy;
+    /** Unix seconds. */
+    readonly now: number;
+}
+
+export const quoteFromFeed = async (
+    input: FeedQuoteInput,
+): Promise<{ quote: Quote; preparation: OfferPreparation }> => {
+    const { candidate, amount } = input;
+    if (amount === undefined) {
+        // No invoice exists on this route to pin one, so the caller is the only
+        // possible source. Caller input, not a swap-boundary refusal.
+        throw new Error("an asset swap needs an amount and the side it pins");
+    }
+
+    const plan = await quoteOffer(candidate.card, {
+        give: candidate.give,
+        ...(amount.on === "give" ? { giveAmount: amount.value } : { wantAmount: amount.value }),
+        ...QUOTE_OPTIONS,
+        fetchImpl: input.feed.fetch,
+    });
+
+    // The pair check, on the backend that has no wire pair to compare: the plan
+    // that came back must price the two legs that were asked for. It is the same
+    // invariant `expectQuote` enforces over the RFQ string — a quote for another
+    // market is not this market's quote — reached through the only identity a
+    // plan carries, its two asset ids.
+    verifyPlanLegs(plan, input.legs, candidate.give);
+
+    const expiresAt = feedExpiry(candidate.card, input.feed, input.now);
+    verifyQuoteTtl({
+        quoteId: input.quoteId,
+        expiresAt,
+        now: input.now,
+        floorSeconds: input.policy?.quoteTtlFloorSeconds,
+    });
+
+    const route = assembleRoute(
+        { ...input.endpoints.give, instrument: { kind: "wallet" } },
+        { ...input.endpoints.take, instrument: { kind: "wallet" } },
+    );
+
+    return {
+        quote: {
+            id: input.quoteId,
+            route,
+            give: { asset: input.endpoints.give.asset, amount: plan.deposit.atomic },
+            take: { asset: input.endpoints.take.asset, amount: plan.receive.atomic },
+            market: input.market,
+            expiresAt,
+            fee: { amount: spreadOf(plan), asset: input.endpoints.take.asset },
+        },
+        preparation: { backend: "feed", card: candidate.card, plan, give: candidate.give },
+    };
+};
+
+/**
+ * The spread, in the units the trader receives.
+ *
+ * Denominated on the take leg because that is where it is exact: the two legs
+ * of an asset swap carry different assets, so a fee stated in give units would
+ * be this subtraction divided by the price — a rounding introduced for the sake
+ * of a denomination nobody asked for. What it measures is the concession: what
+ * the same deposit would have bought at the feed price with no fee at all,
+ * minus what the plan actually pays out.
+ */
+const spreadOf = (plan: OfferPlan): bigint => {
+    const fair = computeWantAmount({
+        deposit: plan.deposit.atomic,
+        give: plan.give,
+        price: plan.price,
+        feeBps: 0,
+        safetyBps: 0,
+    });
+    const spread = fair - plan.receive.atomic;
+    return spread > 0n ? spread : 0n;
+};
+
+/** When the price behind this card was read, plus the TTL it is good for. */
+const feedExpiry = (card: DiscoveredMarket, feed: FeedFetch, now: number): number => {
+    const readAt = card.price_feed === undefined ? undefined : feed.fetchedAt(card.price_feed);
+    // A same-asset corridor market fetches nothing — its price is identically 1
+    // — so there is no feed age to inherit and the quote's life starts now.
+    const from = readAt === undefined ? now : Math.floor(readAt / 1000);
+    return from + FEED_TTL_MS / 1000;
+};
+
+/** The plan prices the legs that were asked for, in the orientation asked for. */
+const verifyPlanLegs = (
+    plan: OfferPlan,
+    legs: { give: DiscoveryLeg; take: DiscoveryLeg },
+    give: Side,
+): void => {
+    const expected = `${legs.give.assetId}->${legs.take.assetId}`;
+    const priced = `${plan.deposit.asset.id}->${plan.receive.asset.id}`;
+    if (expected !== priced || plan.give !== give) {
+        throw new QuoteVerificationFailed("pair", expected, priced);
+    }
+};

--- a/packages/swap/src/client/quoteRfq.ts
+++ b/packages/swap/src/client/quoteRfq.ts
@@ -1,0 +1,563 @@
+/**
+ * The RFQ backend: one addressed request per corridor route, verified before it
+ * is returned and persisted by nobody.
+ *
+ * Three routes share one shape — provision what the covenant binds, build the
+ * request, send it to the one solver the card names, verify the reply, derive
+ * the covenant locally — and differ only in which fields the profile carries.
+ * What is deliberately NOT here is everything v1's `request*` entrypoints do
+ * after that: no contract registration, no record, no funding. `quote()` returns
+ * terms; `accept()` (M4) is what makes any of it durable, and the covenant this
+ * derived is handed forward on {@link RfqPreparation} so it is derived once
+ * rather than twice.
+ *
+ * The responder check runs BEFORE the request rather than after the reply. An
+ * attestation is a property of the wire, not of the answer, so it is knowable
+ * up front — and the thing the check exists to prevent is disclosing an invoice
+ * and an amount to a transport that cannot say who is listening.
+ */
+import { hex } from "@scure/base";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
+import {
+    networkFromArkadeInfo,
+    provisionClaimSecret,
+    provisionRefundKey,
+    toXOnly,
+    type ArkadeInfo,
+    type IWallet,
+    type ProvisionedClaimSecret,
+    type ProvisionedKey,
+    type VHTLC,
+} from "@arkade-os/sdk";
+import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
+import { sealClaimPacket } from "../claimPacket";
+import type { OnchainHtlc, OnchainHtlcParams, OnchainNetwork } from "../onchainHtlc";
+import {
+    deriveLightningReceive,
+    deriveLightningSend,
+    deriveOnchainSend,
+    l1NetworkFromArk,
+    lightningReceiveRequest,
+    lightningSendRequest,
+    newRfqId,
+    onchainSendRequest,
+    unilateralClaimDelay,
+    type LightningReceiveContractParams,
+    type LightningSendContractParams,
+} from "../rfq";
+import type { DiscoveryLeg } from "./aliases";
+import type { LightningCorridorDeps } from "./corridors/deps";
+import type { CorridorSet } from "./corridors/registry";
+import type { CardMarketRef, PinnedAmount, Quote, QuoteId, ResolvedEndpoint } from "./quote";
+import type { MarketCandidate } from "./market";
+import type { SwapPolicy } from "./policy";
+import { parseRfqQuote, rfqPairFor, withCanonicalAmount, type ParsedRfqQuote } from "./rfqWire";
+import { toRfqAmountSide } from "./rfqAmount";
+import { assembleRoute } from "./resolve";
+import type { AttestingRfqTransport } from "./transport";
+import {
+    verifyPair,
+    verifyQuotedAmount,
+    verifyQuoteTtl,
+    verifyReceiveInvoiceFacts,
+    verifyReceiveWindow,
+    verifyResponder,
+    verifySendInvoice,
+    verifySendWindow,
+    verifyingDerivation,
+} from "./verify";
+
+/** The covenant and the keys behind one quoted corridor swap. */
+interface CommonPreparation {
+    readonly backend: "rfq";
+    readonly card: DiscoveredMarket;
+    readonly rfqId: string;
+    /** The solver's reply, decoded once. */
+    readonly wire: ParsedRfqQuote;
+    /** The trader's OWN derivation of the Arkade lockup. */
+    readonly lockup: {
+        readonly address: string;
+        readonly script: InstanceType<typeof VHTLC.ScriptV2>;
+        readonly pkScript: Uint8Array;
+    };
+}
+
+/**
+ * What `accept()` inherits from a quote.
+ *
+ * Held in memory by the client, keyed by quote id, and written nowhere: M3's
+ * boundary is that `quote()` persists nothing. It exists so the covenant a
+ * quote was verified against is the covenant that gets funded — re-deriving it
+ * at accept from the stored quote would be a second derivation of the same tree,
+ * and two derivations that can disagree is the failure this package guards
+ * against everywhere else.
+ */
+export type RfqPreparation =
+    | (CommonPreparation & {
+          readonly route: "arkade->lightning";
+          readonly contractParams: LightningSendContractParams;
+          /** The refund key, and the address the quote named. */
+          readonly secrets: ProvisionedKey;
+          readonly refundAddress: string;
+          /** What the lockup must carry: the quote's give amount. */
+          readonly fundAmount: bigint;
+      })
+    | (CommonPreparation & {
+          readonly route: "lightning->arkade";
+          readonly contractParams: LightningReceiveContractParams;
+          readonly secrets: ProvisionedClaimSecret;
+          readonly payoutAddress: string;
+          /** What the solver's lockup must carry — the claim refuses less. */
+          readonly expectedAmount: bigint;
+          /** Last moment the hold invoice can be paid, unix seconds. */
+          readonly payDeadline: number;
+      })
+    | (CommonPreparation & {
+          readonly route: "arkade->onchain";
+          readonly secrets: ProvisionedClaimSecret;
+          readonly refundAddress: string;
+          readonly fundAmount: bigint;
+          /** The L1 claim key, provisioned by the wallet like every other key. */
+          readonly payoutKey: ProvisionedKey;
+          readonly htlc: OnchainHtlc;
+          readonly htlcParams: OnchainHtlcParams;
+          readonly l1Network: OnchainNetwork;
+          readonly minConfirmations: number;
+      });
+
+export interface RfqQuoteInput {
+    readonly quoteId: QuoteId;
+    readonly route: "arkade->lightning" | "lightning->arkade" | "arkade->onchain";
+    readonly candidate: MarketCandidate;
+    readonly market: CardMarketRef;
+    readonly legs: { readonly give: DiscoveryLeg; readonly take: DiscoveryLeg };
+    readonly endpoints: { readonly give: ResolvedEndpoint; readonly take: ResolvedEndpoint };
+    readonly amount?: PinnedAmount;
+    readonly wallet: IWallet;
+    /** Live, per section 6: a snapshot binds a covenant to a key that may have rotated. */
+    readonly info: ArkadeInfo;
+    /**
+     * The corridor modules, unresolved.
+     *
+     * The set rather than two dep records, because resolution is what refuses a
+     * dep overridden to nothing — and a route that never touches lightning must
+     * not resolve its decoder to find that out. Each arm below asks for exactly
+     * the corridors it uses.
+     */
+    readonly corridors: CorridorSet;
+    readonly transport: AttestingRfqTransport;
+    readonly policy?: SwapPolicy;
+    /** Unix seconds. */
+    readonly now: number;
+}
+
+/** Everything the covenant derivations read off the trader's own connection. */
+interface CovenantInputs {
+    readonly operatorPubkey: Uint8Array;
+    readonly emulatorPubkey: Uint8Array;
+    readonly claimDelay: number;
+    readonly hrp: string;
+}
+
+const covenantInputs = (input: RfqQuoteInput): CovenantInputs => {
+    const network = networkFromArkadeInfo(input.info);
+    const arkade = input.corridors.get("arkade").deps;
+    return {
+        operatorPubkey: toXOnly(hex.decode(input.info.signerPubkey), "ark signer key"),
+        // The per-network pin the arkade module already resolved, never a key
+        // the operator reports about itself: this one ends up in a covenant leaf
+        // that decides who can move the funds.
+        emulatorPubkey: toXOnly(hex.decode(arkade.emulatorPubkey), "emulator signer key"),
+        claimDelay: unilateralClaimDelay(Number(input.info.unilateralExitDelay)),
+        hrp: network.hrp,
+    };
+};
+
+/**
+ * Who the claim packet is sealed to.
+ *
+ * The default is section 4's "internal ephemeral seal": a fresh key whose secret
+ * is discarded, so the packet is opaque to everyone — the solver carries it
+ * blindly and nobody can open it. That is the honest state of the corridor
+ * today, since covclaimd cannot claim this covenant yet and the trader claims it
+ * itself; the packet exists because the wire requires the field, not because
+ * anything reads it. A deployment key is optional config, and naming one is what
+ * makes the offline path real.
+ *
+ * This is not the key-provisioning rule's business: nothing here signs, and the
+ * secret is destroyed before the function returns.
+ */
+const sealingKey = (deps: LightningCorridorDeps): Uint8Array => {
+    const configured = deps.covclaimd?.pubkey;
+    if (configured === undefined) {
+        return secp256k1.getPublicKey(secp256k1.utils.randomSecretKey(), true);
+    }
+    const key = hex.decode(configured);
+    if (key.length !== 33) {
+        throw new Error(
+            `the covclaimd deployment key must be 33-byte compressed hex, got ${key.length} bytes`,
+        );
+    }
+    return key;
+};
+
+/** The amount a corridor request names, refusing the route that needs one and
+ * was given none. */
+const pinnedFor = (input: RfqQuoteInput): PinnedAmount => {
+    if (input.amount === undefined) {
+        throw new Error(`a ${input.route} quote needs an amount and the side it pins`);
+    }
+    return input.amount;
+};
+
+export const quoteViaRfq = async (
+    input: RfqQuoteInput,
+): Promise<{ quote: Quote; preparation: RfqPreparation }> => {
+    // Before anything is disclosed: the transport must be able to say who
+    // answers on it, and the key it is checked against must come from a card a
+    // registry served rather than from the local cache, which authenticates
+    // nothing it stores.
+    verifyResponder({
+        attested: input.transport.attestedResponder,
+        expected: input.market.discoveryPubkey,
+        pinnable: input.market.snapshot.live,
+    });
+
+    switch (input.route) {
+        case "arkade->lightning":
+            return quoteLightningSend(input);
+        case "lightning->arkade":
+            return quoteLightningReceive(input);
+        case "arkade->onchain":
+            return quoteOnchainSend(input);
+    }
+};
+
+const quoteLightningSend = async (
+    input: RfqQuoteInput,
+): Promise<{ quote: Quote; preparation: RfqPreparation }> => {
+    const invoice = input.endpoints.take.instrument;
+    if (invoice?.kind !== "invoice" || invoice.amount === undefined) {
+        // The corridor's parse refuses an amountless invoice on a send — the
+        // invoice IS the amount pin there — so an instrument without one has
+        // not been through it.
+        throw new Error("a lightning send is quoted against the amountful invoice it pays");
+    }
+    const pair = rfqPairFor(input.legs.give, input.legs.take);
+    const rfqId = newRfqId();
+
+    // This leg is one we fund, so all it needs is the key that refunds it. No
+    // preimage: a lightning send's P belongs to the payee. One address read
+    // inside `provisionRefundKey`, so the quote's refund address and the
+    // covenant's refund script cannot come from two different rotations.
+    const secrets = await provisionRefundKey(input.wallet);
+
+    const wire = await input.transport.requestQuote(
+        lightningSendRequest({
+            rfqId,
+            invoice: invoice.bolt11,
+            refundAddress: secrets.address,
+            senderPubkey: secrets.pubkey,
+        }),
+    );
+    verifyPair(wire.pair, pair);
+    const parsed = parseRfqQuote(wire);
+    // The BOLT11 profile is exact-out, so the invoice IS the pin: `to_amount`
+    // is the invoice verbatim and `from_amount` adds the corridor's fee.
+    verifySendInvoice({ invoiced: invoice.amount, give: parsed.give, take: parsed.take });
+
+    const covenant = covenantInputs(input);
+    const derived = verifyingDerivation(() =>
+        deriveLightningSend({
+            quote: wire,
+            paymentHash: invoice.paymentHash,
+            senderPubkey: secrets.pubkey,
+            refundPkScript: secrets.pkScript,
+            ...covenant,
+        }),
+    );
+    verifySendWindow({
+        quote: wire,
+        quoteId: input.quoteId,
+        now: input.now,
+        invoiceExpiresAt: invoice.expiresAt,
+    });
+    verifyQuoteTtl({
+        quoteId: input.quoteId,
+        expiresAt: parsed.validUntil,
+        now: input.now,
+        floorSeconds: input.policy?.quoteTtlFloorSeconds,
+    });
+
+    return {
+        quote: {
+            id: input.quoteId,
+            route: assembleRoute(
+                { ...input.endpoints.give, instrument: { kind: "wallet" } },
+                { ...input.endpoints.take, instrument: invoice },
+            ),
+            give: { asset: input.endpoints.give.asset, amount: parsed.give },
+            take: { asset: input.endpoints.take.asset, amount: parsed.take },
+            lock: { hash: invoice.paymentHash },
+            market: input.market,
+            solver: parsed.solver,
+            expiresAt: parsed.validUntil,
+            refundLocktime: derived.refundLocktime,
+            fee: { amount: parsed.give - parsed.take, asset: input.endpoints.give.asset },
+        },
+        preparation: {
+            backend: "rfq",
+            route: "arkade->lightning",
+            card: input.candidate.card,
+            rfqId,
+            wire: parsed,
+            lockup: {
+                address: derived.address,
+                script: derived.script,
+                pkScript: derived.swapPkScript,
+            },
+            contractParams: derived.contractParams,
+            secrets,
+            refundAddress: secrets.address,
+            fundAmount: parsed.give,
+        },
+    };
+};
+
+const quoteLightningReceive = async (
+    input: RfqQuoteInput,
+): Promise<{ quote: Quote; preparation: RfqPreparation }> => {
+    const pinned = pinnedFor(input);
+    const pair = rfqPairFor(input.legs.give, input.legs.take);
+    const rfqId = newRfqId();
+
+    // A leg we claim: the key that receives it, and the P that unlocks it.
+    const secrets = await provisionClaimSecret(input.wallet);
+    const paymentHash = hex.encode(secrets.paymentHash);
+    const payoutAddress = await input.wallet.getAddress();
+    const lightning = input.corridors.get("lightning").deps;
+    const claimPacket = await sealClaimPacket({
+        preimage: secrets.preimage,
+        covclaimdPubkey: sealingKey(lightning),
+    });
+
+    const wire = await input.transport.requestQuote(
+        withCanonicalAmount(
+            lightningReceiveRequest({
+                rfqId,
+                paymentHash,
+                payoutAddress,
+                payoutPubkey: secrets.pubkey,
+                claimPacket: claimPacket.ciphertext,
+                // Placeholder: the v1 builders type this field `number`, and the
+                // wire adapter re-encodes it as the canonical decimal string.
+                // Encoding it here as well would put the decision in two places.
+                amount: 0,
+                amountSide: toRfqAmountSide(pinned.on),
+            }),
+            pinned.value,
+        ),
+    );
+    verifyPair(wire.pair, pair);
+    const parsed = parseRfqQuote(wire);
+    verifyQuotedAmount({ pair, pinned, give: parsed.give, take: parsed.take });
+
+    const covenant = covenantInputs(input);
+    const derived = verifyingDerivation(() =>
+        deriveLightningReceive({
+            quote: wire,
+            paymentHash,
+            payoutPubkey: secrets.pubkey,
+            payoutAddress,
+            operatorPubkey: covenant.operatorPubkey,
+            emulatorPubkey: covenant.emulatorPubkey,
+            claimDelay: covenant.claimDelay,
+            hrp: covenant.hrp,
+        }),
+    );
+    // The one field the trader hands to a third party, and the only attack on
+    // this corridor with no on-chain trace.
+    const { payDeadline } = verifyReceiveInvoiceFacts({
+        invoice: derived.invoice,
+        decode: lightning.decode,
+        paymentHash,
+        payAmount: parsed.give,
+        validUntil: parsed.validUntil,
+    });
+    verifyReceiveWindow({
+        quote: wire,
+        quoteId: input.quoteId,
+        payDeadline,
+        now: input.now,
+    });
+    verifyQuoteTtl({
+        quoteId: input.quoteId,
+        // The hold invoice's window is minutes where the quote's is an hour, so
+        // the deadline that binds this leg is the earlier of the two — which is
+        // what `payDeadline` already is.
+        expiresAt: payDeadline,
+        now: input.now,
+        floorSeconds: input.policy?.quoteTtlFloorSeconds,
+    });
+
+    // The give leg's instrument IS the artifact: the supply law says the quote
+    // provides the non-wallet give instrument, and on this route that is the
+    // solver's hold invoice.
+    const artifact = { kind: "invoice", bolt11: derived.invoice } as const;
+    return {
+        quote: {
+            id: input.quoteId,
+            route: assembleRoute(
+                {
+                    ...input.endpoints.give,
+                    instrument: {
+                        kind: "invoice",
+                        bolt11: derived.invoice,
+                        paymentHash,
+                        amount: parsed.give,
+                        expiresAt: payDeadline,
+                    },
+                },
+                { ...input.endpoints.take, instrument: { kind: "wallet" } },
+            ),
+            give: { asset: input.endpoints.give.asset, amount: parsed.give },
+            take: { asset: input.endpoints.take.asset, amount: parsed.take },
+            lock: { hash: paymentHash },
+            market: input.market,
+            solver: parsed.solver,
+            expiresAt: payDeadline,
+            refundLocktime: derived.refundLocktime,
+            artifact,
+            fee: { amount: parsed.give - parsed.take, asset: input.endpoints.give.asset },
+        },
+        preparation: {
+            backend: "rfq",
+            route: "lightning->arkade",
+            card: input.candidate.card,
+            rfqId,
+            wire: parsed,
+            lockup: {
+                address: derived.address,
+                script: derived.script,
+                pkScript: derived.swapPkScript,
+            },
+            contractParams: derived.contractParams,
+            secrets,
+            payoutAddress,
+            expectedAmount: parsed.take,
+            payDeadline,
+        },
+    };
+};
+
+const quoteOnchainSend = async (
+    input: RfqQuoteInput,
+): Promise<{ quote: Quote; preparation: RfqPreparation }> => {
+    const pinned = pinnedFor(input);
+    const destination = input.endpoints.take.instrument;
+    if (destination?.kind !== "address") {
+        throw new Error("an onchain send is quoted against the L1 address it pays");
+    }
+    const pair = rfqPairFor(input.legs.give, input.legs.take);
+    const rfqId = newRfqId();
+
+    // Two keys, both the wallet's: the claim secret carries P and the covenant's
+    // sender role, and the L1 HTLC's claim leaf binds a key the wallet can sign
+    // with later. Asking twice is what keeps them distinct on a wallet that
+    // allocates per artifact — and minting one here instead is exactly what the
+    // key-provisioning rule forbids.
+    const secrets = await provisionClaimSecret(input.wallet);
+    const payoutKey = await provisionRefundKey(input.wallet);
+    const paymentHash = hex.encode(secrets.paymentHash);
+
+    const wire = await input.transport.requestQuote(
+        withCanonicalAmount(
+            onchainSendRequest({
+                rfqId,
+                paymentHash,
+                payoutPubkey: payoutKey.pubkey,
+                refundAddress: payoutKey.address,
+                senderPubkey: secrets.pubkey,
+                amount: 0,
+                amountSide: toRfqAmountSide(pinned.on),
+            }),
+            pinned.value,
+        ),
+    );
+    verifyPair(wire.pair, pair);
+    const parsed = parseRfqQuote(wire);
+    verifyQuotedAmount({ pair, pinned, give: parsed.give, take: parsed.take });
+
+    const covenant = covenantInputs(input);
+    const derived = verifyingDerivation(() =>
+        deriveOnchainSend({
+            quote: wire,
+            paymentHash,
+            payoutPubkey: payoutKey.pubkey,
+            operatorPubkey: covenant.operatorPubkey,
+            emulatorPubkey: covenant.emulatorPubkey,
+            claimDelay: covenant.claimDelay,
+            hrp: covenant.hrp,
+            l1Network: l1NetworkFromArk(input.info.network),
+            refundAddress: payoutKey.address,
+            senderPubkey: secrets.pubkey,
+        }),
+    );
+    verifySendWindow({
+        quote: wire,
+        quoteId: input.quoteId,
+        now: input.now,
+        onchain: {
+            htlcLocktime: derived.htlcLocktime,
+            minConfirmations: derived.minConfirmations,
+            direction: "send",
+        },
+    });
+    verifyQuoteTtl({
+        quoteId: input.quoteId,
+        expiresAt: parsed.validUntil,
+        now: input.now,
+        floorSeconds: input.policy?.quoteTtlFloorSeconds,
+    });
+
+    return {
+        quote: {
+            id: input.quoteId,
+            route: assembleRoute(
+                { ...input.endpoints.give, instrument: { kind: "wallet" } },
+                { ...input.endpoints.take, instrument: destination },
+            ),
+            give: { asset: input.endpoints.give.asset, amount: parsed.give },
+            take: { asset: input.endpoints.take.asset, amount: parsed.take },
+            lock: { hash: paymentHash },
+            market: input.market,
+            solver: parsed.solver,
+            expiresAt: parsed.validUntil,
+            // Read off the derivation and not off the wire: the field is
+            // optional there, a solver may carry it in the profile instead, and
+            // the derivation is what settles which one this covenant used.
+            refundLocktime: derived.refundLocktime,
+            fee: { amount: parsed.give - parsed.take, asset: input.endpoints.give.asset },
+        },
+        preparation: {
+            backend: "rfq",
+            route: "arkade->onchain",
+            card: input.candidate.card,
+            rfqId,
+            wire: parsed,
+            lockup: {
+                address: derived.address,
+                script: derived.script,
+                pkScript: derived.swapPkScript,
+            },
+            secrets,
+            refundAddress: payoutKey.address,
+            fundAmount: parsed.give,
+            payoutKey,
+            htlc: derived.htlc,
+            htlcParams: derived.htlcParams,
+            l1Network: derived.l1Network,
+            minConfirmations: derived.minConfirmations,
+        },
+    };
+};

--- a/packages/swap/src/client/resolve.ts
+++ b/packages/swap/src/client/resolve.ts
@@ -1,0 +1,312 @@
+/**
+ * Route resolution: the single place `to` is parsed, the corridor pair is
+ * decided, the amount is pinned and the market is chosen — everything that has
+ * to happen before a solver is told anything.
+ *
+ * The order is §3.1's and it is load-bearing. `to` is parsed first, because a
+ * destination fault is the caller's most likely mistake and the parse needs no
+ * market data. The corridor pair follows from the parse (or from `via` on a
+ * receive, the one flow where no instrument can exist yet), and it selects the
+ * `Route` variant — a pair outside the union is `UnsupportedRoute` here, before
+ * an RFQ round trip, an artifact or a record. Only then does the market index
+ * come in, and only then can a ticker be canonicalized, since the table a ticker
+ * resolves against is built out of the cards themselves.
+ *
+ * The amount is pinned last and before any network call: exactly one may be
+ * pinned, by the caller or by an invoice, and two is `AmountMismatch` — thrown
+ * with nothing disclosed, which is the whole reason it is thrown here.
+ */
+import type { NetworkName } from "@arkade-os/sdk";
+import {
+    canonicalAssetId,
+    toDiscoveryLeg,
+    type AssetAliasTable,
+    type DiscoveryLeg,
+} from "./aliases";
+import { btcOn, type AssetId } from "./assetId";
+import { railOfCorridor, type Corridor } from "./corridor";
+import type { CorridorSet } from "./corridors/registry";
+import type { DiscoveryIndex, DiscoverySnapshot } from "./discovery";
+import { AmountMismatch, UnsupportedRoute } from "./errors";
+import { aliasTableFrom, scopedToRail } from "./aliasTable";
+import { chooseMarket, eligibleMarkets, marketRefOf, type MarketCandidate } from "./market";
+import type { SwapPolicy } from "./policy";
+import type { PinnedAmount, QuoteInput, ResolvedEndpoint, RouteResolution } from "./quote";
+import type { Instrument, Route } from "./route";
+
+/** The four implemented corridor pairs, spelled as the route union spells them. */
+const SUPPORTED_PAIRS = [
+    "arkade->arkade",
+    "arkade->lightning",
+    "lightning->arkade",
+    "arkade->onchain",
+] as const;
+
+type SupportedPair = (typeof SUPPORTED_PAIRS)[number];
+
+const isSupportedPair = (pair: string): pair is SupportedPair =>
+    (SUPPORTED_PAIRS as readonly string[]).includes(pair);
+
+export interface ResolveDeps {
+    readonly corridors: CorridorSet;
+    /** The network the wallet reported; every defaulted asset id is on it. */
+    readonly network: NetworkName;
+    readonly discovery: DiscoveryIndex;
+    readonly policy?: SwapPolicy;
+    /**
+     * `resolve()` reads what is in hand; `quote()` may fetch.
+     *
+     * The one difference between the two paths, and the reason it is a flag
+     * rather than two functions: everything else about resolution — the parse,
+     * the pair, the pin, the veto — has to be identical, or the resolution a
+     * caller vetoed would not be the one they quoted.
+     */
+    readonly mode: "resolve" | "quote";
+}
+
+/** What the quote path needs from a resolution, over what a caller sees. */
+export interface ResolvedRoute {
+    readonly resolution: RouteResolution;
+    /** Both legs in discovery's vocabulary — what the market lookup matched on. */
+    readonly legs: { readonly give: DiscoveryLeg; readonly take: DiscoveryLeg };
+    readonly give: ResolvedEndpoint;
+    readonly take: ResolvedEndpoint;
+    readonly pair: SupportedPair;
+    readonly candidates: readonly MarketCandidate[];
+    /** The chosen card, absent when nothing eligible survived. */
+    readonly market?: MarketCandidate;
+    readonly snapshot: DiscoverySnapshot;
+    readonly amount?: PinnedAmount;
+    /** The alias table the snapshot produced, so the quote path can reuse it. */
+    readonly aliases: AssetAliasTable;
+}
+
+/**
+ * Assemble the closed `Route` from two fully-instrumented legs.
+ *
+ * The one cast in the quote path, and it is confined to this function. The
+ * checker cannot correlate `corridor` and `asset` across two independently
+ * resolved values, but the pairing is a fact by the time we are here: every
+ * asset went through `toDiscoveryLeg`, which is what decided the corridor. The
+ * runtime re-check is cheap and turns a broken invariant into a throw at the
+ * boundary rather than a covenant built against the wrong rail.
+ */
+export const assembleRoute = (
+    give: ResolvedEndpoint & { instrument: Instrument },
+    take: ResolvedEndpoint & { instrument: Instrument },
+): Route => {
+    for (const leg of [give, take]) {
+        const rail = railOfCorridor(leg.corridor);
+        if (!leg.asset.startsWith(`${rail}:`)) {
+            throw new Error(
+                `route leg ${leg.corridor} carries ${leg.asset}, which is not on the ${rail} rail`,
+            );
+        }
+    }
+    return { give, take } as unknown as Route;
+};
+
+/** A leg's endpoint, with the corridor cross-checked against the asset's rail. */
+const endpoint = (
+    corridor: Corridor,
+    asset: AssetId,
+    instrument: Instrument | undefined,
+): ResolvedEndpoint => ({
+    corridor,
+    asset,
+    ...(instrument === undefined ? {} : { instrument }),
+});
+
+/**
+ * The corridor an id implies, refusing an id no corridor carries.
+ *
+ * The corridor is never an input on a leg whose asset is named: §4 makes it a
+ * cross-check, because every id already carries its rail. Where the destination
+ * or `via` also named one, the two must agree — an id on another rail is a
+ * different route, not a correction.
+ */
+const legFor = (asset: AssetId, expected: Corridor | undefined): DiscoveryLeg => {
+    const leg = toDiscoveryLeg(asset);
+    if (expected !== undefined && leg.corridor !== expected) {
+        throw new UnsupportedRoute(
+            `${asset} settles on ${leg.corridor}, and this leg is ${expected}`,
+            { give: leg.corridor, take: expected },
+        );
+    }
+    return leg;
+};
+
+export const resolveRoute = async (
+    input: QuoteInput,
+    deps: ResolveDeps,
+): Promise<ResolvedRoute> => {
+    // 1. The destination, parsed once. Before the market index, because a
+    //    destination fault needs no market data to be a fault.
+    const claimed = input.to === undefined ? undefined : deps.corridors.claim(input.to);
+    if (input.to !== undefined && claimed === undefined) {
+        // Core classified it and no corridor serves it — an LNURL today. The
+        // fault is the absence of a route, not an ambiguous destination.
+        throw new UnsupportedRoute(`no corridor serves ${JSON.stringify(input.to)}`);
+    }
+    if (claimed?.corridor === "arkade") {
+        // A well-formed Arkade address for this operator, which is a plain
+        // Arkade payment: core's own `ark` rail owns it and the swap client
+        // would only wrap it in a covenant nobody needs (spec section 5).
+        throw new UnsupportedRoute(
+            "an Arkade address is a plain Arkade payment, not a swap — send it with the wallet",
+            { take: "arkade" },
+        );
+    }
+
+    // 2. The market index. `resolve()` reads what is in hand and throws
+    //    `DiscoverySnapshotUnavailable` when there is nothing; `quote()` may
+    //    fetch first.
+    const snapshot =
+        deps.mode === "quote" ? await deps.discovery.load() : await deps.discovery.peek();
+    const aliases = aliasTableFrom(snapshot.markets, deps.network);
+
+    // 3. The two assets. A destination or a `via` names the corridor for the
+    //    leg whose asset the caller left out; everything else comes off the id.
+    if (input.via !== undefined && (input.via === "arkade" || !isCorridor(input.via))) {
+        // `via` exists for the leg with no instrument, which is the give leg of
+        // a receive. Naming arkade there says the value arrives from the wallet
+        // itself, and an `eip155:` corridor names one section 9 defers.
+        throw new UnsupportedRoute(
+            `via names ${input.via}, which is not a corridor a receive can arrive over`,
+        );
+    }
+    const giveCorridor: Corridor | undefined = input.via;
+    const takeCorridor = claimed?.corridor ?? (giveCorridor === undefined ? undefined : "arkade");
+
+    const takeAsset = assetFor(input.take, takeCorridor ?? "arkade", deps.network, aliases);
+    const giveAsset = assetFor(input.give, giveCorridor ?? "arkade", deps.network, aliases);
+
+    const takeLeg = legFor(takeAsset, takeCorridor);
+    const giveLeg = legFor(giveAsset, giveCorridor);
+    if (giveLeg.corridor === takeLeg.corridor && giveLeg.assetId === takeLeg.assetId) {
+        // One leg twice is not a swap, and it is what an `exchange` with no
+        // `take` resolves to — said here rather than left to surface as an
+        // empty market set, which would name the registry for the caller's
+        // omission.
+        throw new UnsupportedRoute(
+            `both legs are ${giveAsset} on ${giveLeg.corridor} — name the other side with take, ` +
+                "a destination, or via",
+            { give: giveLeg.corridor, take: takeLeg.corridor },
+        );
+    }
+
+    // 4. The corridor pair selects the route variant. Outside the union is a
+    //    refusal here, before disclosure, artifact, persistence or funding —
+    //    `onchain -> arkade` included, and named as the deferral it is.
+    const pair = `${giveLeg.corridor}->${takeLeg.corridor}`;
+    if (!isSupportedPair(pair)) {
+        throw new UnsupportedRoute(
+            pair === "onchain->arkade"
+                ? "onchain -> arkade is not served until the client owns the trader's L1 refund path end to end"
+                : `${pair} is not an implemented route`,
+            { give: giveLeg.corridor, take: takeLeg.corridor },
+        );
+    }
+
+    // 5. Instruments, by the supply law: the caller provides non-wallet TAKE
+    //    instruments (that is what `to` is), the quote provides non-wallet GIVE
+    //    instruments (that is exactly what the artifact is), and every
+    //    remaining slot is the wallet.
+    const give = endpoint(
+        giveLeg.corridor,
+        giveAsset,
+        giveLeg.corridor === "arkade" ? { kind: "wallet" } : undefined,
+    );
+    const take = endpoint(
+        takeLeg.corridor,
+        takeAsset,
+        claimed?.instrument ?? (takeLeg.corridor === "arkade" ? { kind: "wallet" } : undefined),
+    );
+
+    // 6. Exactly one amount is pinned, and the check runs before any round trip.
+    const amount = pinAmount(input, take.instrument);
+
+    // 7. The market, after the policy filters that must run before disclosure.
+    const candidates = eligibleMarkets(snapshot, { give: giveLeg, take: takeLeg }, deps.policy);
+    const market = chooseMarket(candidates, deps.policy);
+
+    const resolution: RouteResolution = {
+        give,
+        take,
+        ...(market === undefined ? {} : { market: marketRefOf(market, snapshot.ref) }),
+        eligible: market === undefined ? 0 : candidates.length,
+        snapshot: snapshot.ref,
+        ...(amount === undefined ? {} : { amount }),
+    };
+
+    return {
+        resolution,
+        legs: { give: giveLeg, take: takeLeg },
+        give,
+        take,
+        pair,
+        candidates,
+        ...(market === undefined ? {} : { market }),
+        snapshot,
+        ...(amount === undefined ? {} : { amount }),
+        aliases,
+    };
+};
+
+const isCorridor = (value: string): value is Corridor =>
+    value === "arkade" || value === "lightning" || value === "onchain";
+
+/**
+ * A caller's asset spelling, or the corridor's own BTC when they left it out.
+ *
+ * Defaulting to BTC is what makes `pay(bolt11)` and `receive({via})` need no
+ * asset at all: lightning and L1 carry BTC and nothing else, and the arkade side
+ * of a corridor swap is the BTC that crosses it. On an asset swap both sides are
+ * named, which is the only route where a default would be a guess.
+ */
+const assetFor = (
+    ref: string | undefined,
+    corridor: Corridor,
+    network: NetworkName,
+    aliases: AssetAliasTable,
+): AssetId =>
+    ref === undefined
+        ? btcOn(railOfCorridor(corridor), network)
+        : // Scoped to the leg's rail, because BTC has one id per rail and a
+          // whole-table lookup would refuse `"BTC"` as ambiguous on any snapshot
+          // carrying a corridor market — see `scopedToRail`.
+          canonicalAssetId(ref, scopedToRail(aliases, railOfCorridor(corridor)));
+
+/**
+ * The one pinned amount.
+ *
+ * An invoice pins the take leg by existing, so a caller passing an amount
+ * beside one is pinning a second — refused even when the two agree, because
+ * "they agreed this time" is not a rule anyone can rely on and the invoice is
+ * the one both sides settle against.
+ */
+const pinAmount = (
+    input: QuoteInput,
+    takeInstrument: Instrument | undefined,
+): PinnedAmount | undefined => {
+    const invoiced =
+        takeInstrument?.kind === "invoice" && takeInstrument.amount !== undefined
+            ? takeInstrument.amount
+            : undefined;
+    if (input.amount !== undefined && invoiced !== undefined) {
+        throw new AmountMismatch([`the invoice's ${invoiced}`, `amount ${input.amount}`]);
+    }
+    if (input.amount !== undefined) {
+        if (input.amountOn === undefined) {
+            // Caller input, not a swap-boundary refusal: the taxonomy's members
+            // are conditions of the swap, and this is a field left out.
+            throw new Error("amount needs amountOn ('give' or 'take') to say which leg it pins");
+        }
+        if (input.amount <= 0n) {
+            throw new Error(`amount must be positive, got ${input.amount}`);
+        }
+        return { value: input.amount, on: input.amountOn, source: "caller" };
+    }
+    if (invoiced !== undefined) return { value: invoiced, on: "take", source: "invoice" };
+    return undefined;
+};

--- a/packages/swap/src/client/rfqWire.ts
+++ b/packages/swap/src/client/rfqWire.ts
@@ -1,0 +1,121 @@
+/**
+ * The RFQ wire adapter: the pair string, the amount encoding, and the parse
+ * that turns a solver's reply into values the rest of the client can compare.
+ *
+ * **The pair string is wire, and it is owned here.** Two different fields are
+ * called `pair`. The registry's is a display label (`BTC/lightning:BTC`); the
+ * wire's is `<from-leg>-><to-leg>` over legs of `<corridor>:<asset>`, where the
+ * asset is a registered ticker or, on arkade only, the 68-hex asset id. Solvers
+ * compare it byte for byte and cap it at 158 characters, so a CAIP-19 id cannot
+ * go on it — it would fail the comparison and overrun the cap. The public alias
+ * layer therefore stops one level above this, at a corridor and a discovery
+ * asset id, and the string is built here, one layer below anything public.
+ *
+ * **Amounts go out as canonical decimal strings, unconditionally.** The solver
+ * accepts them on all four corridor request schemas today, and emitting a string
+ * is never a narrowing — where a JSON number past 2^53 has already lost the
+ * amount before anyone can check it. The receipt side takes either form through
+ * M1's adapter, a number only while it is a non-negative safe integer, which is
+ * why `AmountEncodingUnsupported` is a receipt-side error here: it fires on the
+ * way in, before verification, never on the way out.
+ */
+import {
+    ARKADE_BTC,
+    LIGHTNING_BTC,
+    ONCHAIN_BTC,
+    assertPairLength,
+    rfqPair,
+    type RfqQuote,
+} from "../rfq";
+import { BTC_ASSET_ID } from "../store";
+import type { DiscoveryLeg } from "./aliases";
+import type { Corridor } from "./corridor";
+import type { Pubkey } from "./primitives";
+import { decodeRfqAmount, encodeRfqAmount } from "./rfqAmount";
+
+/** The BTC leg constant for each corridor, so the spellings live in one file. */
+const BTC_LEG = {
+    arkade: ARKADE_BTC,
+    lightning: LIGHTNING_BTC,
+    onchain: ONCHAIN_BTC,
+} as const satisfies Record<Corridor, string>;
+
+/**
+ * One leg, as the wire spells it.
+ *
+ * The BTC legs come from `rfq.ts`'s own constants rather than being rebuilt out
+ * of the corridor name and a ticker: the solver compares these byte for byte,
+ * and a second construction of `arkade:BTC` is a second thing that can drift.
+ * An arkade-issued asset is the id verbatim, lowercase — which is what makes the
+ * discovery leg the right input, since the alias layer already lowercased it.
+ */
+export const rfqLeg = (leg: DiscoveryLeg): string =>
+    leg.assetId === BTC_ASSET_ID ? BTC_LEG[leg.corridor] : `${leg.corridor}:${leg.assetId}`;
+
+/**
+ * The directional pair for a route, checked against the wire's length cap.
+ *
+ * Direction is give-to-take and never the card's base/quote order: the card
+ * describes a market, the pair describes this trade.
+ */
+export const rfqPairFor = (give: DiscoveryLeg, take: DiscoveryLeg): string => {
+    const pair = rfqPair(rfqLeg(give), rfqLeg(take));
+    assertPairLength(pair);
+    return pair;
+};
+
+/**
+ * A request payload with its amount in the wire's canonical string encoding.
+ *
+ * The payload itself is built by `rfq.ts`'s own request builders — they are the
+ * schema, and a second copy of the profile field names is a second thing to keep
+ * in step with a `.strict()` remote schema. What this adds is the one field
+ * whose encoding M3 decided: `amount`, out as a decimal string on every corridor
+ * that carries one.
+ */
+export const withCanonicalAmount = (
+    payload: Record<string, unknown>,
+    amount: bigint,
+): Record<string, unknown> => ({
+    ...payload,
+    amount: encodeRfqAmount(amount, "amount"),
+});
+
+/**
+ * A solver's quote, with the fields the client compares against pulled out and
+ * decoded once.
+ *
+ * The amounts are the point: `RfqQuote` declares them `number`, the migration
+ * has them arriving as either, and every check downstream is a comparison. One
+ * decode at the boundary is what keeps a string amount from failing a `!==`
+ * against a bigint three layers down and reading as a solver mismatch.
+ */
+export interface ParsedRfqQuote {
+    /** The reply verbatim, for the record and for anything not decoded here. */
+    readonly raw: RfqQuote;
+    readonly rfqId: string;
+    readonly pair: string;
+    /** `from_amount`: what the trader gives, atomic units of the give leg. */
+    readonly give: bigint;
+    /** `to_amount`: what the trader takes. */
+    readonly take: bigint;
+    /** The covenant role key the quote commits to. */
+    readonly solver: Pubkey;
+    readonly validUntil: number;
+    /** Optional on the wire; every corridor route refuses a quote without it. */
+    readonly refundLocktime?: number;
+    readonly profile: Record<string, unknown>;
+}
+
+/** Read a solver's quote, decoding both amounts. */
+export const parseRfqQuote = (quote: RfqQuote): ParsedRfqQuote => ({
+    raw: quote,
+    rfqId: quote.rfq_id,
+    pair: quote.pair,
+    give: decodeRfqAmount(quote.from_amount, "from_amount"),
+    take: decodeRfqAmount(quote.to_amount, "to_amount"),
+    solver: quote.solver_pubkey,
+    validUntil: quote.valid_until,
+    ...(quote.refund_locktime === undefined ? {} : { refundLocktime: quote.refund_locktime }),
+    profile: quote.profile ?? {},
+});

--- a/packages/swap/src/client/transport.ts
+++ b/packages/swap/src/client/transport.ts
@@ -1,0 +1,85 @@
+/**
+ * The transport seam, and the attestation the responder check runs on.
+ *
+ * §4 makes the transport an inference: the card names the rendezvous — its
+ * relays and its discovery key — and the client opens it, where v1 had the
+ * caller hand-build `nostrRfqTransport({relays, solverPubkey})`. What the card
+ * cannot say is whether the transport that gets built authenticates anybody, and
+ * that is the whole of G2: the production Nostr transport does, through its
+ * `authors` filter and the per-solver conversation key, while `httpTransport`
+ * and `relayTransport` attest nobody and route on `rfq_id` alone.
+ *
+ * So the attestation is a property of the transport and is declared by whoever
+ * built it. A transport that filters replies to one author sets
+ * {@link AttestingRfqTransport.attestedResponder} to that author; anything else
+ * leaves it absent and fails the `responder` check. That is deliberately the
+ * fail-closed default: the two dev transports do not authenticate, and a client
+ * that quoted over them as though they did would be verifying nothing while
+ * reporting that it verified four things.
+ *
+ * The default factory reaches `./nostr` through a dynamic import, which is what
+ * keeps `nostr-tools` an optional peer dependency: a consumer doing HTTP-only
+ * swaps against its own transport never loads the subpath, exactly as importing
+ * it directly never loaded it for them.
+ */
+import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
+import type { RfqTransport } from "../rfq";
+import type { Pubkey } from "./primitives";
+
+/**
+ * An {@link RfqTransport} that can prove who answered.
+ *
+ * Optional rather than required, because the interface has three
+ * implementations today and only one of them can fill it. Absent means "attests
+ * nobody", which the responder check refuses — a transport is never trusted for
+ * a claim it did not make.
+ */
+export interface AttestingRfqTransport extends RfqTransport {
+    /**
+     * The key every reply on this transport is proven to come from.
+     *
+     * x-only hex, and it must be a claim the transport ENFORCES — a filter that
+     * only this author's events satisfy, plus a conversation key only this
+     * author can decrypt to. Setting it without that is worse than leaving it
+     * absent: it turns a check into a decoration.
+     */
+    readonly attestedResponder?: Pubkey;
+}
+
+/** What a factory is told about the card it is opening a rendezvous to. */
+export interface RfqRendezvous {
+    readonly card: DiscoveredMarket;
+    /** The card's `discovery_pubkey` — who the request is addressed to. */
+    readonly solverPubkey: Pubkey;
+    /** The card's relays. */
+    readonly relays: readonly string[];
+}
+
+export type RfqTransportFactory = (
+    rendezvous: RfqRendezvous,
+) => AttestingRfqTransport | Promise<AttestingRfqTransport>;
+
+/** Declare that `transport` proves every reply came from `responder`. */
+export const attesting = <T extends RfqTransport>(
+    transport: T,
+    responder: Pubkey,
+): AttestingRfqTransport => Object.assign(transport, { attestedResponder: responder });
+
+/**
+ * The default: the card's own Nostr rendezvous.
+ *
+ * It attests the card's discovery key because `nostrRfqTransport` subscribes
+ * with `authors: [solverPubkey]` and decrypts with the conversation key derived
+ * against that same key — a reply from anyone else is either filtered out by the
+ * relay or fails to decrypt into anything with an `rfq_id`.
+ */
+export const nostrTransportFactory: RfqTransportFactory = async (rendezvous) => {
+    const { nostrRfqTransport } = await import("../nostr");
+    return attesting(
+        nostrRfqTransport({
+            relays: [...rendezvous.relays],
+            solverPubkey: rendezvous.solverPubkey,
+        }),
+        rendezvous.solverPubkey,
+    );
+};

--- a/packages/swap/src/client/verify.ts
+++ b/packages/swap/src/client/verify.ts
@@ -1,0 +1,382 @@
+/**
+ * Verification, as one invariant instead of four scattered habits.
+ *
+ * v1 spreads these checks across four request entrypoints and reaches the offer
+ * path with none of them: `expectQuote` compares type, id and pair;
+ * `verifyLockupAddress` compares the derived address; `assertFundable`,
+ * `verifyReceiveInvoice` and `assertReceivable` gate expiry, headroom and the
+ * claim window on some legs and not others; and the docs push the rest — plan
+ * validation, the rendezvous choice, the invoice decode — onto the caller. This
+ * module runs the whole set, once, on both backends, before any quote is
+ * returned, and every failure is one error class with the check named on it.
+ *
+ * The gates themselves are still `rfq.ts`'s. They are audited, they carry the
+ * constants (`MIN_HEADROOM_SECONDS`, `MIN_CLAIM_WINDOW_SECONDS`) that mirror the
+ * covenant's own timing, and re-implementing them here would be a second
+ * opinion where the whole point is that there is one. What this adds is the
+ * mapping: a gate's stable `reason` becomes a {@link QuoteCheck}, so a caller
+ * switches on the check rather than on a string the wire's own vocabulary
+ * leaked.
+ *
+ * Two failures deliberately do NOT become verification failures. A solver
+ * declining is `SwapRefusal` — a decision, not a fault. And a quote that has
+ * expired, or is about to, is `QuoteExpired`: the terms were fine, the clock is
+ * the problem, and the remedy is a fresh quote rather than a different solver.
+ */
+import {
+    AddressMismatch,
+    assertFundable,
+    assertReceivable,
+    type InvoiceFacts,
+    type RfqQuote,
+} from "../rfq";
+import { QuoteExpired, QuoteVerificationFailed, type QuoteCheck } from "./errors";
+import type { Pubkey } from "./primitives";
+import type { QuoteId } from "./quote";
+
+/** A gate error, as `rfq.ts` throws it: an `Error` with a stable `reason`. */
+const reasonOf = (error: unknown): string | undefined =>
+    error instanceof Error && typeof (error as { reason?: unknown }).reason === "string"
+        ? (error as unknown as { reason: string }).reason
+        : undefined;
+
+/**
+ * Which check a gate's refusal belongs to.
+ *
+ * `quote_expired` is absent on purpose — it is not a check at all, and is
+ * turned into {@link QuoteExpired} before this table is consulted. So is
+ * `invalid_gate_input`: that fires when the CLIENT hands a gate a `NaN` clock or
+ * ceiling, which is a defect here rather than anything the solver did, and
+ * mapping it to a check would blame the counterparty for our own bug.
+ */
+const CHECK_BY_REASON: Record<string, QuoteCheck> = {
+    invoice_expired: "invoice",
+    invoice_undecodable: "invoice",
+    invoice_hash_mismatch: "invoice",
+    invoice_amount_mismatch: "invoice",
+    insufficient_headroom: "refund_window",
+    missing_refund_locktime: "refund_window",
+    claim_window_too_short: "refund_window",
+    confirmations_out_of_range: "refund_window",
+    timelock_order: "refund_window",
+    quote_malformed: "refund_window",
+    price_too_high: "refund_window",
+};
+
+/** Run a gate, and turn whatever it refuses with into this taxonomy. */
+const gated = (run: () => void, quote: { id: QuoteId; expiresAt: number; now: number }): void => {
+    try {
+        run();
+    } catch (error) {
+        const reason = reasonOf(error);
+        if (reason === "quote_expired") {
+            throw new QuoteExpired(quote.id, quote.expiresAt, quote.now);
+        }
+        const check = reason === undefined ? undefined : CHECK_BY_REASON[reason];
+        if (check === undefined) throw error;
+        throw new QuoteVerificationFailed(
+            check,
+            undefined,
+            error instanceof Error ? error.message : String(error),
+            { cause: error },
+        );
+    }
+};
+
+/**
+ * The fifth check: who answered.
+ *
+ * §3.1 calls this a transport property rather than one of the four, and it is —
+ * but a property only the production transport happens to have is a check the
+ * caller can turn off by handing in a different transport, and verification that
+ * configuration can disable is not an invariant. So the transport delivers the
+ * attestation and this runs it, in addressed mode only: published RFQ has N
+ * unknown responders and attributes each bid by its own signature instead.
+ *
+ * `pinnable` is the trust boundary the cache leaves. The key this compares
+ * against is the card's `discovery_pubkey`, which a cached card carries
+ * unvalidated — so a snapshot read back out of local storage cannot supply it,
+ * and the check fails closed rather than pinning against content anyone with
+ * write access to the browser's storage could have chosen.
+ */
+export const verifyResponder = (input: {
+    /** The key this transport proves every reply came from, if it proves one. */
+    readonly attested?: Pubkey;
+    /** The card's `discovery_pubkey`. */
+    readonly expected?: Pubkey;
+    /** Whether `expected` came from a source that can be trusted to name it. */
+    readonly pinnable: boolean;
+}): void => {
+    if (!input.pinnable || input.expected === undefined) {
+        throw new QuoteVerificationFailed(
+            "responder",
+            "a registry-served card naming the solver's discovery key",
+            input.expected === undefined
+                ? "the card names no discovery key"
+                : "the card came out of the local cache, which does not authenticate it",
+        );
+    }
+    if (input.attested === undefined) {
+        throw new QuoteVerificationFailed(
+            "responder",
+            input.expected,
+            "the transport attests nobody",
+        );
+    }
+    if (input.attested !== input.expected) {
+        throw new QuoteVerificationFailed("responder", input.expected, input.attested);
+    }
+};
+
+/**
+ * The pair check, run here as well as in the transport.
+ *
+ * `expectQuote` already compares it — this is not a gap being filled but the
+ * layer that OWNS the string doing its own comparison, so a transport that
+ * skips the check (or one a caller injected) cannot make the quote path skip it
+ * too. v1 documented this one as the caller's job, in bold.
+ */
+export const verifyPair = (quoted: unknown, requested: string): void => {
+    if (quoted !== requested) {
+        throw new QuoteVerificationFailed("pair", requested, String(quoted));
+    }
+};
+
+/**
+ * Derive the covenant, and fold every way that can fail into one check.
+ *
+ * `AddressMismatch` is the case §8 promised would fold in here: it is the
+ * `lockup_address` check under its v1 name, and keeping it as a seventeenth
+ * error would leave two classes for one condition across the v1/v2 seam. The
+ * other failures — a missing binding field, malformed hex from the solver — are
+ * the same check reached from further back: an address that cannot be derived
+ * cannot be compared, and both mean the same thing to a caller, which is do not
+ * fund this.
+ */
+export const verifyingDerivation = <T>(derive: () => T): T => {
+    try {
+        return derive();
+    } catch (error) {
+        if (error instanceof AddressMismatch) {
+            throw new QuoteVerificationFailed("lockup_address", error.derived, error.quoted, {
+                cause: error,
+            });
+        }
+        if (error instanceof Error) {
+            throw new QuoteVerificationFailed("lockup_address", undefined, error.message, {
+                cause: error,
+            });
+        }
+        throw error;
+    }
+};
+
+/**
+ * The send legs' window gate: the quote's own expiry, the refund headroom, and
+ * — on `arkade -> onchain` — the L1 confirmation window and the timelock order
+ * between the two contracts.
+ */
+export const verifySendWindow = (input: {
+    readonly quote: RfqQuote;
+    readonly quoteId: QuoteId;
+    readonly now: number;
+    readonly invoiceExpiresAt?: number;
+    readonly onchain?: {
+        htlcLocktime: number;
+        minConfirmations: number;
+        direction: "send" | "receive";
+    };
+}): void => {
+    gated(
+        () =>
+            assertFundable({
+                quote: input.quote,
+                now: input.now,
+                ...(input.invoiceExpiresAt === undefined
+                    ? {}
+                    : { invoiceExpiresAt: input.invoiceExpiresAt }),
+                ...(input.onchain === undefined ? {} : { onchain: input.onchain }),
+            }),
+        { id: input.quoteId, expiresAt: input.quote.valid_until, now: input.now },
+    );
+};
+
+/**
+ * The receive legs' window gate, measured from the pay deadline rather than
+ * from now.
+ *
+ * The semantics invert on these legs: `refund_locktime` is the SOLVER's, so
+ * BIP-113's lag extends the trader's claim window instead of shrinking it, and
+ * what can actually run out is the hold invoice. The window that matters is
+ * therefore the one left after a payer pays at the last possible moment.
+ */
+export const verifyReceiveWindow = (input: {
+    readonly quote: RfqQuote;
+    readonly quoteId: QuoteId;
+    readonly payDeadline: number;
+    readonly now: number;
+}): void => {
+    gated(
+        () =>
+            assertReceivable({
+                quote: input.quote,
+                payDeadline: input.payDeadline,
+                now: input.now,
+            }),
+        { id: input.quoteId, expiresAt: input.payDeadline, now: input.now },
+    );
+};
+
+/**
+ * The invoice check on a send: the solver quoted THIS invoice, and quoted it at
+ * a price that is a price.
+ *
+ * Both halves matter. A quote whose `to_amount` is not the invoice's amount is
+ * not a quote for this invoice — the BOLT11 profile is exact-out and the
+ * invoice is the amount pin. A `from_amount` below it is a negative spread,
+ * which is not a quote at all.
+ */
+export const verifySendInvoice = (input: {
+    /** The amount the trader's own decode read off the invoice. */
+    readonly invoiced: bigint;
+    readonly give: bigint;
+    readonly take: bigint;
+}): void => {
+    const invoiced = input.invoiced;
+    if (input.take !== invoiced) {
+        throw new QuoteVerificationFailed("invoice", `${invoiced}`, `${input.take}`);
+    }
+    if (input.give < input.take) {
+        throw new QuoteVerificationFailed(
+            "invoice",
+            `at least the invoice's ${invoiced}`,
+            `${input.give}, a negative spread`,
+        );
+    }
+};
+
+/**
+ * The invoice check on a receive: bind the SOLVER's hold invoice to this swap's
+ * hash and to the quote.
+ *
+ * This is the only field the trader hands to a third party and the only attack
+ * on this corridor with no on-chain trace — an invoice on some other payment
+ * hash is paid to the solver in full and no lockup on `H` is ever funded. It is
+ * re-implemented here rather than delegated to `verifyReceiveInvoice` for one
+ * reason: that gate compares the decoded amount against `quote.from_amount` as a
+ * JS number, and under the amount migration that field arrives as either a
+ * number or a string. A `!==` between a string and a number is always true, and
+ * a check that always fails is not safer than one that compares the decoded
+ * bigint — it just refuses every quote from a solver that already migrated.
+ */
+export const verifyReceiveInvoiceFacts = (input: {
+    readonly invoice: string;
+    readonly decode: (bolt11: string) => InvoiceFacts;
+    /** `sha256(P)`, hex — the trader's OWN. */
+    readonly paymentHash: string;
+    /** The quote's `from_amount`: what the payer is asked for. */
+    readonly payAmount: bigint;
+    readonly validUntil: number;
+}): { payDeadline: number } => {
+    let decoded: InvoiceFacts;
+    try {
+        decoded = input.decode(input.invoice);
+    } catch (cause) {
+        throw new QuoteVerificationFailed(
+            "invoice",
+            "a decodable BOLT11",
+            cause instanceof Error ? cause.message : String(cause),
+            { cause },
+        );
+    }
+    // Both operands of the deadline, before either reaches it: a decoder that
+    // reports a missing expiry tag as NaN, or a `valid_until` that was never
+    // typechecked, would disarm every gate downstream — NaN fails every
+    // comparison, so it does not fail a check, it deletes one.
+    if (!Number.isFinite(decoded.expiresAt)) {
+        throw new QuoteVerificationFailed("invoice", "a finite expiry", `${decoded.expiresAt}`);
+    }
+    if (!Number.isFinite(input.validUntil)) {
+        throw new QuoteVerificationFailed(
+            "refund_window",
+            "a finite valid_until",
+            `${input.validUntil}`,
+        );
+    }
+    if (decoded.paymentHash !== input.paymentHash) {
+        throw new QuoteVerificationFailed("invoice", input.paymentHash, decoded.paymentHash);
+    }
+    // BOLT11 permits an amountless invoice, which lets a payer pay anything;
+    // decoders surface that as 0, so a nullish check would miss it.
+    if (!Number.isSafeInteger(decoded.amountSats) || decoded.amountSats <= 0) {
+        throw new QuoteVerificationFailed(
+            "invoice",
+            `${input.payAmount}`,
+            "the invoice names no amount",
+        );
+    }
+    if (BigInt(decoded.amountSats) !== input.payAmount) {
+        throw new QuoteVerificationFailed("invoice", `${input.payAmount}`, `${decoded.amountSats}`);
+    }
+    return { payDeadline: Math.min(decoded.expiresAt, input.validUntil) };
+};
+
+/**
+ * The policy floor on a quote's remaining life.
+ *
+ * One layer above the wire's own refusal of a quote already past `valid_until`:
+ * that one says the terms are dead, this one says they will be before the caller
+ * can use them. Only the caller knows how long their flow takes between seeing
+ * terms and accepting them, so the floor is theirs to set — and with none set,
+ * only expiry itself refuses.
+ */
+export const verifyQuoteTtl = (input: {
+    readonly quoteId: QuoteId;
+    readonly expiresAt: number;
+    readonly now: number;
+    readonly floorSeconds?: number;
+}): void => {
+    const floor = input.floorSeconds ?? 0;
+    if (input.expiresAt - input.now <= floor) {
+        throw new QuoteExpired(input.quoteId, input.expiresAt, input.now);
+    }
+};
+
+/**
+ * The quote answers the request that was made.
+ *
+ * `expectQuote` compares the pair, which says the quote is for this market;
+ * this says it is for this trade. The request names a side and an amount, and a
+ * quote that reprices the side the caller pinned is a quote for a different
+ * size — v1 checks it on two legs out of four and calls it `assertQuotedAmount`.
+ *
+ * It reports as the `pair` check rather than as a fifth-and-a-half one, because
+ * what it establishes is the same thing: the identity of the trade being
+ * quoted, which on the wire is the pair plus the pinned side. The closed
+ * {@link QuoteCheck} union gains no member for it, and the strings say exactly
+ * what disagreed.
+ */
+export const verifyQuotedAmount = (input: {
+    readonly pair: string;
+    readonly pinned: { on: "give" | "take"; value: bigint };
+    readonly give: bigint;
+    readonly take: bigint;
+}): void => {
+    const quoted = input.pinned.on === "give" ? input.give : input.take;
+    if (quoted !== input.pinned.value) {
+        throw new QuoteVerificationFailed(
+            "pair",
+            `${input.pair} ${input.pinned.on}=${input.pinned.value}`,
+            `${input.pair} ${input.pinned.on}=${quoted}`,
+        );
+    }
+    if (input.take > input.give) {
+        // A quote that pays out more than it takes in is not a quote to fund:
+        // on every corridor these two legs are the same asset.
+        throw new QuoteVerificationFailed(
+            "pair",
+            `${input.pair} give >= take`,
+            `give=${input.give} take=${input.take}`,
+        );
+    }
+};

--- a/packages/swap/src/client/verify.ts
+++ b/packages/swap/src/client/verify.ts
@@ -48,6 +48,12 @@ const reasonOf = (error: unknown): string | undefined =>
  * `invalid_gate_input`: that fires when the CLIENT hands a gate a `NaN` clock or
  * ceiling, which is a defect here rather than anything the solver did, and
  * mapping it to a check would blame the counterparty for our own bug.
+ *
+ * And so is `price_too_high`, on a third ground: a ceiling the caller opted
+ * into is a veto on the price, not a fault in the quote. §3.1's checks have no
+ * member for one — v2's price ceiling is the verbs' `maxFee`, raised as
+ * `MaxFeeExceeded` — so an entry here could only file it under a timing
+ * failure, which is the wrong axis and the wrong remedy.
  */
 const CHECK_BY_REASON: Record<string, QuoteCheck> = {
     invoice_expired: "invoice",
@@ -60,7 +66,6 @@ const CHECK_BY_REASON: Record<string, QuoteCheck> = {
     confirmations_out_of_range: "refund_window",
     timelock_order: "refund_window",
     quote_malformed: "refund_window",
-    price_too_high: "refund_window",
 };
 
 /** Run a gate, and turn whatever it refuses with into this taxonomy. */

--- a/packages/swap/src/markets.ts
+++ b/packages/swap/src/markets.ts
@@ -102,7 +102,11 @@ export const makeCachedFeedFetch = (
     };
 };
 
-const MARKETS_CACHE_TTL_MS = 60 * 60 * 1000;
+/** How long a discovered market set is reused before the registry is asked
+ * again. Exported so the v2 discovery module reuses one number rather than
+ * restating it — registry content changes rarely, and two TTLs that drifted
+ * apart would serve two different answers to the same question. */
+export const MARKETS_CACHE_TTL_MS = 60 * 60 * 1000;
 
 const isMarketShaped = (m: unknown): m is DiscoveredMarket => {
     const market = m as Partial<DiscoveredMarket> | null;

--- a/packages/swap/src/refund.ts
+++ b/packages/swap/src/refund.ts
@@ -54,6 +54,7 @@ import {
     getArkPsbtFields,
     hasTerminalSpend,
     matchServerCheckpoints,
+    type IWallet,
 } from "@arkade-os/sdk";
 
 import { RFQ_TERMINAL_STATES, type RfqStatus, type RfqTransport } from "./rfq";
@@ -133,6 +134,25 @@ export async function awaitRfqResolution(
  * connection of its own (#734). A full `ArkProvider` still fits, structurally.
  */
 export type SwapOperator = Pick<ArkProvider, "getInfo" | "submitTx" | "finalizeTx">;
+
+/**
+ * A wallet's own connection, as a {@link SwapOperator}.
+ *
+ * The broadcaster is resolved on first use and then held, so building one costs
+ * nothing and a client that never pushes never opens a connection. `getInfo` is
+ * deliberately NOT held: it backs the `checkpointTapscript` read on every push,
+ * and a stale one derives a checkpoint the operator will not co-sign. It is also
+ * the live read every covenant derivation needs, which is the same reason.
+ */
+export const walletOperator = (wallet: IWallet): SwapOperator => {
+    let broadcaster: Promise<Awaited<ReturnType<IWallet["getArkadeBroadcaster"]>>> | undefined;
+    const broadcasting = () => (broadcaster ??= wallet.getArkadeBroadcaster());
+    return {
+        getInfo: () => wallet.getArkadeInfo({ requireLive: true }),
+        submitTx: async (...args) => (await broadcasting()).submitTx(...args),
+        finalizeTx: async (...args) => (await broadcasting()).finalizeTx(...args),
+    };
+};
 
 export type RefundIndexer = Pick<RestIndexerProvider, "getVtxos">;
 

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -444,6 +444,13 @@ export const assertFundable = (input: {
     const fail = (reason: string, message: string): never => {
         throw gateError(reason, message);
     };
+    // Ahead of the comparisons, as in assertReceivable: `valid_until` is the
+    // operand of the expiry gate below AND of the TTL floor the v2 client runs
+    // after it, so absent or non-numeric it fails neither — it deletes both.
+    if (input.quote.valid_until === undefined) {
+        fail("quote_malformed", "quote carries no valid_until");
+    }
+    assertFinite(input.quote.valid_until, "quote_malformed", "quote valid_until");
     if (input.invoiceExpiresAt !== undefined && input.now >= input.invoiceExpiresAt) {
         fail("invoice_expired", "invoice expired");
     }

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -788,6 +788,76 @@ export interface InvoiceFacts {
 }
 
 /**
+ * The pure core of {@link requestLightningSend}: derive the Arkade lockup from
+ * the quote's binding fields plus the trader's own data, and refuse on a
+ * mismatch. Binding: `solver_pubkey`, `refund_locktime`,
+ * `profile.receiver_pk_script`; `profile.lockup_address` is compare-only.
+ *
+ * Extracted so the send leg has the same shape its three siblings already have
+ * — {@link deriveOnchainSend}, {@link deriveLightningReceive} and
+ * {@link deriveOnchainReceive} are all pure cores their entrypoints call. A
+ * quote path that derives without registering a contract row (the v2 client's
+ * does: it quotes, and only `accept()` persists) would otherwise have to write
+ * this derivation a second time, and a covenant derived twice from two copies
+ * of the same code is the failure this package spends most of its comments
+ * guarding against.
+ */
+export function deriveLightningSend(input: {
+    quote: RfqQuote;
+    /** BOLT11 payment hash, hex — from the trader's OWN invoice decode. */
+    paymentHash: string;
+    /** The trader's own key for the VHTLC's sender-side leaves. */
+    senderPubkey: Uint8Array;
+    /** Where a refund must pay: the trader's P2TR pkScript. */
+    refundPkScript: Uint8Array;
+    operatorPubkey: Uint8Array;
+    emulatorPubkey: Uint8Array;
+    claimDelay: number;
+    hrp: string;
+}): {
+    /** The trader's OWN derivation — the only address to fund. */
+    address: string;
+    swapPkScript: Uint8Array;
+    script: InstanceType<typeof VHTLC.ScriptV2>;
+    contractParams: LightningSendContractParams;
+    /** The deadline the covenant was built with, non-optional here where the
+     * wire field is optional. */
+    refundLocktime: number;
+} {
+    const { quote } = input;
+    if (quote.refund_locktime === undefined) {
+        throw new Error("lightning-send quote is missing refund_locktime");
+    }
+    const receiverPkScriptHex = quote.profile?.receiver_pk_script as string | undefined;
+    if (receiverPkScriptHex === undefined) {
+        throw new Error("lightning-send quote is missing profile.receiver_pk_script");
+    }
+    // Named rather than inlined so the exact inputs the covenant was built from
+    // can be handed back — see `contractParams` on the return type.
+    const contractParams = {
+        solverPubkey: toXOnly(hex.decode(quote.solver_pubkey), "solver key"),
+        refundLocktime: quote.refund_locktime,
+        operatorPubkey: input.operatorPubkey,
+        paymentHash: input.paymentHash,
+        claimDelay: input.claimDelay,
+        emulatorPubkey: input.emulatorPubkey,
+        senderPubkey: input.senderPubkey,
+        receiverPkScript: solverHex(receiverPkScriptHex, "profile.receiver_pk_script"),
+        refundPkScript: input.refundPkScript,
+    };
+    const script = lightningSendContract(contractParams);
+    const address = script.address(input.hrp, input.operatorPubkey).encode();
+    verifyLockupAddress(quote, address);
+    return {
+        address,
+        swapPkScript: script.pkScript,
+        script,
+        contractParams,
+        refundLocktime: quote.refund_locktime,
+    };
+}
+
+/**
  * The lightning-send user flow, mirroring `createOffer`'s shape: quote →
  * derive locally → verify → gate. Pure of funding on purpose — it returns the
  * address and amount, and the caller funds with its own wallet
@@ -882,13 +952,6 @@ export async function requestLightningSend(
     const quote = await transport.requestQuote(
         lightningSendRequest({ rfqId, invoice: params.invoice.raw, refundAddress, senderPubkey }),
     );
-    if (quote.refund_locktime === undefined) {
-        throw new Error("lightning-send quote is missing refund_locktime");
-    }
-    const receiverPkScriptHex = quote.profile?.receiver_pk_script as string | undefined;
-    if (receiverPkScriptHex === undefined) {
-        throw new Error("lightning-send quote is missing profile.receiver_pk_script");
-    }
     // The BOLT11 profile is exact-out: `to_amount` is the invoice, verbatim,
     // and `from_amount` adds the corridor's fee on top. Funding anything but
     // `from_amount` underfunds by exactly the fee and is refused — and a quote
@@ -906,25 +969,20 @@ export async function requestLightningSend(
 
     const operatorPubkey = toXOnly(hex.decode(info.signerPubkey), "ark signer key");
     const network = networkFromArkadeInfo(info);
-    // Named rather than inlined so the exact inputs the covenant was built from
-    // can be returned to the caller — see `contractParams` on the return type.
-    const contractParams = {
-        solverPubkey: toXOnly(hex.decode(quote.solver_pubkey), "solver key"),
-        refundLocktime: quote.refund_locktime,
-        operatorPubkey,
+    const derived = deriveLightningSend({
+        quote,
         paymentHash: params.invoice.paymentHash,
-        claimDelay: unilateralClaimDelay(Number(info.unilateralExitDelay)),
+        senderPubkey,
+        refundPkScript: secrets.pkScript,
+        operatorPubkey,
         emulatorPubkey: toXOnly(
             hex.decode(resolveEmulatorPubkey(network, params.emulatorPubkey)),
             "emulator signer key",
         ),
-        senderPubkey,
-        receiverPkScript: solverHex(receiverPkScriptHex, "profile.receiver_pk_script"),
-        refundPkScript: secrets.pkScript,
-    };
-    const script = lightningSendContract(contractParams);
-    const address = script.address(network.hrp, operatorPubkey).encode();
-    verifyLockupAddress(quote, address);
+        claimDelay: unilateralClaimDelay(Number(info.unilateralExitDelay)),
+        hrp: network.hrp,
+    });
+    const { address, script, contractParams } = derived;
     assertFundable({
         quote,
         invoiceExpiresAt: params.invoice.expiresAt,
@@ -943,7 +1001,7 @@ export async function requestLightningSend(
         // What the lockup must carry: the quote's `from_amount` — the invoice
         // PLUS the corridor's fee, never the bare invoice amount.
         fundAmount: quote.from_amount,
-        swapPkScript: script.pkScript,
+        swapPkScript: derived.swapPkScript,
         script,
         refundAddress,
         senderPubkey,

--- a/packages/swap/src/swapClient.ts
+++ b/packages/swap/src/swapClient.ts
@@ -37,7 +37,7 @@ import {
     type RfqSwapManagerDeps,
 } from "./swapManager";
 import { createRfqSwapRecord, type RfqSwapOrigin } from "./rfqRecord";
-import type { LockupSpendIndexer, SwapOperator } from "./refund";
+import { walletOperator, type LockupSpendIndexer, type SwapOperator } from "./refund";
 import { rfqClaimSecretOf, rfqSecretsProfile } from "./rfqProfileParts";
 import { onchainSendProfile } from "./rfqCorridors";
 import { arkadeRefunder } from "./arkadeRefunder";
@@ -184,16 +184,8 @@ export function createSwapClient(deps: SwapClientDeps): SwapClient {
 
     // Resolved on first use, not here: `createSwapClient` stays synchronous,
     // and a client that is only ever asked for `markets()` never opens a
-    // connection at all. `getInfo` is not memoized — it backs the
-    // `checkpointTapscript` read on every push, and a stale one derives a
-    // checkpoint the operator will not co-sign.
-    let broadcaster: Promise<Awaited<ReturnType<IWallet["getArkadeBroadcaster"]>>> | undefined;
-    const broadcasting = () => (broadcaster ??= wallet.getArkadeBroadcaster());
-    const ark: SwapOperator = deps.ark ?? {
-        getInfo: () => wallet.getArkadeInfo({ requireLive: true }),
-        submitTx: async (...args) => (await broadcasting()).submitTx(...args),
-        finalizeTx: async (...args) => (await broadcasting()).finalizeTx(...args),
-    };
+    // connection at all.
+    const ark: SwapOperator = deps.ark ?? walletOperator(wallet);
 
     let reader: Promise<Awaited<ReturnType<IWallet["getArkadeReader"]>>> | undefined;
     const reading = () => (reader ??= wallet.getArkadeReader());

--- a/packages/swap/test/client/discovery.test.ts
+++ b/packages/swap/test/client/discovery.test.ts
@@ -7,22 +7,13 @@
  * all, and a caller cannot tell which of the four it got.
  */
 import { describe, expect, it, vi } from "vitest";
-import type { DiscoveredMarket, NetworkIndex } from "@arkade-os/solver-discovery";
+import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
 import { discoveryIndex, isUsableCard } from "../../src/client/discovery";
 import { DiscoverySnapshotUnavailable } from "../../src/client/errors";
 import { InMemoryAssetSwapRepository } from "../../src/repository";
-import { lightningCard, spotCard } from "./fixtures";
+import { indexOf, lightningCard, spotCard } from "./fixtures";
 
 const REGISTRY = "https://registry.example/regtest.json";
-
-/** What the registry publishes: the cards without discovery's own provenance. */
-const indexOf = (markets: DiscoveredMarket[]): NetworkIndex => ({
-    version: 0,
-    network: "regtest",
-    generated_at: Math.floor(Date.now() / 1000),
-    commit: "0".repeat(40),
-    markets: markets.map(({ source, sourceType, ...market }) => market),
-});
 
 const serving = (markets: DiscoveredMarket[]) =>
     vi.fn(async () => new Response(JSON.stringify(indexOf(markets)))) as unknown as typeof fetch &

--- a/packages/swap/test/client/discovery.test.ts
+++ b/packages/swap/test/client/discovery.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The three states one market array used to collapse, separated.
+ *
+ * The distinction that matters most is the last one: a registry that answered
+ * with nothing is authoritative, and a registry that did not answer is not. v1
+ * returns `[]` for both, plus for a network with no index and for no registry at
+ * all, and a caller cannot tell which of the four it got.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { DiscoveredMarket, NetworkIndex } from "@arkade-os/solver-discovery";
+import { discoveryIndex, isUsableCard } from "../../src/client/discovery";
+import { DiscoverySnapshotUnavailable } from "../../src/client/errors";
+import { InMemoryAssetSwapRepository } from "../../src/repository";
+import { lightningCard, spotCard } from "./fixtures";
+
+const REGISTRY = "https://registry.example/regtest.json";
+
+/** What the registry publishes: the cards without discovery's own provenance. */
+const indexOf = (markets: DiscoveredMarket[]): NetworkIndex => ({
+    version: 0,
+    network: "regtest",
+    generated_at: Math.floor(Date.now() / 1000),
+    commit: "0".repeat(40),
+    markets: markets.map(({ source, sourceType, ...market }) => market),
+});
+
+const serving = (markets: DiscoveredMarket[]) =>
+    vi.fn(async () => new Response(JSON.stringify(indexOf(markets)))) as unknown as typeof fetch &
+        ReturnType<typeof vi.fn>;
+
+const failing = () =>
+    vi.fn(async () => {
+        throw new Error("registry unreachable");
+    }) as unknown as typeof fetch & ReturnType<typeof vi.fn>;
+
+describe("with nothing to resolve against", () => {
+    it("refuses to resolve when no registry is configured", async () => {
+        const index = discoveryIndex({ network: "regtest" });
+        await expect(index.peek()).rejects.toThrow(DiscoverySnapshotUnavailable);
+        await expect(index.load()).rejects.toThrow(/no registry URL is configured/);
+    });
+
+    it("names the network when no index is published for it", async () => {
+        const index = discoveryIndex({
+            network: "testnet",
+            config: { registryUrl: REGISTRY, fetchImpl: serving([]) },
+        });
+        await expect(index.load()).rejects.toThrow(/no market index is published for testnet/);
+    });
+
+    it("refuses when the registry is unreachable and nothing is cached", async () => {
+        const fetchImpl = failing();
+        const index = discoveryIndex({
+            network: "regtest",
+            config: { registryUrl: REGISTRY, fetchImpl },
+            repository: new InMemoryAssetSwapRepository(),
+        });
+        await expect(index.load()).rejects.toThrow(/could not be reached and nothing is cached/);
+    });
+});
+
+describe("a reachable registry", () => {
+    it("serves a live snapshot and writes the cache the v1 path reads", async () => {
+        const repository = new InMemoryAssetSwapRepository();
+        const index = discoveryIndex({
+            network: "regtest",
+            config: { registryUrl: REGISTRY, fetchImpl: serving([lightningCard, spotCard]) },
+            repository,
+        });
+        const snapshot = await index.load();
+
+        expect(snapshot.markets).toHaveLength(2);
+        expect(snapshot.ref).toMatchObject({ live: true, source: "live", registry: REGISTRY });
+        expect((await repository.getCachedMarkets("regtest", REGISTRY))?.markets).toHaveLength(2);
+    });
+
+    it("is authoritative when it lists nothing — an empty snapshot, not an error", async () => {
+        const index = discoveryIndex({
+            network: "regtest",
+            config: { registryUrl: REGISTRY, fetchImpl: serving([]) },
+        });
+        const snapshot = await index.load();
+        expect(snapshot.markets).toEqual([]);
+        expect(snapshot.ref.live).toBe(true);
+    });
+
+    it("holds the snapshot, and refetches only when asked", async () => {
+        const fetchImpl = serving([lightningCard]);
+        const index = discoveryIndex({
+            network: "regtest",
+            config: { registryUrl: REGISTRY, fetchImpl },
+        });
+        await index.load();
+        await index.load();
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+        await index.load({ refresh: true });
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe("an unreachable registry with a cache behind it", () => {
+    const cached = async () => {
+        const repository = new InMemoryAssetSwapRepository();
+        await repository.saveCachedMarkets("regtest", REGISTRY, {
+            markets: [lightningCard],
+            fetchedAt: Date.now() - 60_000,
+        });
+        return repository;
+    };
+
+    it("resolves, and says the snapshot is not live", async () => {
+        const index = discoveryIndex({
+            network: "regtest",
+            config: { registryUrl: REGISTRY, fetchImpl: failing() },
+            repository: await cached(),
+        });
+        const snapshot = await index.load();
+        expect(snapshot.markets).toHaveLength(1);
+        expect(snapshot.ref).toMatchObject({ live: false, source: "cache" });
+    });
+
+    it("is what `peek()` reads, without touching the network at all", async () => {
+        const fetchImpl = failing();
+        const index = discoveryIndex({
+            network: "regtest",
+            config: { registryUrl: REGISTRY, fetchImpl },
+            repository: await cached(),
+        });
+        const snapshot = await index.peek();
+        expect(snapshot.ref.source).toBe("cache");
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+});
+
+describe("an injected snapshot", () => {
+    it("resolves offline and counts as a source that can be trusted", async () => {
+        const fetchImpl = failing();
+        const index = discoveryIndex({
+            network: "regtest",
+            config: { snapshot: [lightningCard], fetchImpl },
+        });
+        expect((await index.peek()).ref).toMatchObject({ live: true, source: "injected" });
+        expect((await index.load()).markets).toEqual([lightningCard]);
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+});
+
+describe("the cache as a trust boundary", () => {
+    it("keeps a card whose every depended-on field survived the round trip", () => {
+        expect(isUsableCard(lightningCard)).toBe(true);
+        expect(isUsableCard(spotCard)).toBe(true);
+    });
+
+    it("drops a corridor card with no rendezvous, which the v1 read trusts", () => {
+        const { discovery_pubkey, ...noKey } = lightningCard;
+        expect(isUsableCard(noKey)).toBe(false);
+        expect(isUsableCard({ ...lightningCard, transports: { nostr: { relays: [] } } })).toBe(
+            false,
+        );
+        expect(isUsableCard({ ...lightningCard, discovery_pubkey: "not-a-key" })).toBe(false);
+    });
+
+    it("drops a card whose corridor is not one this client knows", () => {
+        expect(isUsableCard({ ...lightningCard, quote_corridor: "teleport" as never })).toBe(false);
+    });
+
+    it("drops the malformed card, one card at a time", async () => {
+        const repository = new InMemoryAssetSwapRepository();
+        await repository.saveCachedMarkets("regtest", REGISTRY, {
+            markets: [spotCard, { ...lightningCard, transports: undefined }],
+            fetchedAt: Date.now(),
+        });
+        const index = discoveryIndex({
+            network: "regtest",
+            config: { registryUrl: REGISTRY, fetchImpl: failing() },
+            repository,
+        });
+        expect((await index.peek()).markets).toEqual([spotCard]);
+    });
+});

--- a/packages/swap/test/client/fixtures.ts
+++ b/packages/swap/test/client/fixtures.ts
@@ -19,7 +19,7 @@ import {
     getNetwork,
     type IWallet,
 } from "@arkade-os/sdk";
-import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
+import type { DiscoveredMarket, NetworkIndex } from "@arkade-os/solver-discovery";
 import {
     LIGHTNING_RECEIVE_PAIR,
     LIGHTNING_SEND_PAIR,
@@ -63,7 +63,12 @@ export const WALLET_ADDRESS = new ArkAddress(OPERATOR_PUBKEY, key(21), NETWORK.h
 
 /** A wallet backed by the real allocator and the real deterministic signer. */
 export const hdWallet = async (
-    over: { getContractManager?: () => Promise<unknown>; info?: unknown } = {},
+    over: {
+        getContractManager?: () => Promise<unknown>;
+        info?: unknown;
+        /** For the reads that must fail: `info` answers, this one decides. */
+        getArkadeInfo?: () => Promise<unknown>;
+    } = {},
 ): Promise<IWallet> => {
     const identity = MnemonicIdentity.fromMnemonic(
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
@@ -73,7 +78,7 @@ export const hdWallet = async (
     return {
         identity,
         getAddress: async () => WALLET_ADDRESS,
-        getArkadeInfo: async () => over.info ?? ARK_INFO,
+        getArkadeInfo: over.getArkadeInfo ?? (async () => over.info ?? ARK_INFO),
         getContractManager:
             over.getContractManager ??
             (async () => {
@@ -146,6 +151,15 @@ export const spotCard: DiscoveredMarket = {
     source: "https://registry.example/regtest.json",
     sourceType: "registry",
 };
+
+/** What the registry publishes: the cards without discovery's own provenance. */
+export const indexOf = (markets: DiscoveredMarket[]): NetworkIndex => ({
+    version: 0,
+    network: "regtest",
+    generated_at: Math.floor(Date.now() / 1000),
+    commit: "0".repeat(40),
+    markets: markets.map(({ source, sourceType, ...market }) => market),
+});
 
 /** A feed answering a fixed price, and a count of how often it was asked. */
 export const feedServing = (price = 100_000): { fetch: typeof fetch; calls: () => number } => {

--- a/packages/swap/test/client/fixtures.ts
+++ b/packages/swap/test/client/fixtures.ts
@@ -1,0 +1,370 @@
+/**
+ * What a quote path needs standing behind it: a wallet, an operator, cards, and
+ * a solver that answers.
+ *
+ * The solver doubles here derive the same covenants the trader will, from the
+ * request the trader actually sent — which is the only way a verification test
+ * means anything. A double that echoed a fixed address would pass the
+ * `lockup_address` check by accident on a client that derived nothing.
+ */
+import { hex } from "@scure/base";
+import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+    ArkAddress,
+    DescriptorIdentity,
+    HDDescriptorProvider,
+    InMemoryWalletRepository,
+    MnemonicIdentity,
+    getNetwork,
+    type IWallet,
+} from "@arkade-os/sdk";
+import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
+import {
+    LIGHTNING_RECEIVE_PAIR,
+    LIGHTNING_SEND_PAIR,
+    ONCHAIN_SEND_PAIR,
+    lightningReceiveContract,
+    lightningSendContract,
+    unilateralClaimDelay,
+    type RfqQuote,
+    type RfqStatus,
+} from "../../src/rfq";
+import { onchainHtlcScript } from "../../src/onchainHtlc";
+import type { AttestingRfqTransport } from "../../src/client/transport";
+import { encodeInvoice } from "../helpers/bolt11";
+
+export const key = (fill: number): Uint8Array =>
+    schnorr.getPublicKey(new Uint8Array(32).fill(fill));
+const p2tr = (program: Uint8Array): Uint8Array => Uint8Array.from([0x51, 0x20, ...program]);
+
+export const OPERATOR_PUBKEY = key(3);
+export const SOLVER_PUBKEY = key(1);
+export const EMULATOR_PUBKEY = key(9);
+/** The 33-byte compressed form the co-signer override takes. */
+export const EMULATOR_PUBKEY_HEX = `02${hex.encode(EMULATOR_PUBKEY)}`;
+export const SOLVER_DISCOVERY_KEY = hex.encode(key(4));
+export const RECEIVER_PK_SCRIPT = p2tr(key(6));
+export const SOLVER_REFUND_PK_SCRIPT = p2tr(key(8));
+export const HTLC_REFUND_PUBKEY = key(7);
+
+export const NETWORK = getNetwork("regtest");
+export const CLAIM_DELAY = unilateralClaimDelay(4096);
+
+/** What the wallet answers `getArkadeInfo()` with. */
+export const ARK_INFO = {
+    signerPubkey: hex.encode(OPERATOR_PUBKEY),
+    unilateralExitDelay: 4096,
+    network: "regtest",
+    deprecatedSigners: [],
+};
+
+export const WALLET_ADDRESS = new ArkAddress(OPERATOR_PUBKEY, key(21), NETWORK.hrp).encode();
+
+/** A wallet backed by the real allocator and the real deterministic signer. */
+export const hdWallet = async (
+    over: { getContractManager?: () => Promise<unknown>; info?: unknown } = {},
+): Promise<IWallet> => {
+    const identity = MnemonicIdentity.fromMnemonic(
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        { isMainnet: false },
+    );
+    const provider = await HDDescriptorProvider.create(identity, new InMemoryWalletRepository());
+    return {
+        identity,
+        getAddress: async () => WALLET_ADDRESS,
+        getArkadeInfo: async () => over.info ?? ARK_INFO,
+        getContractManager:
+            over.getContractManager ??
+            (async () => {
+                throw new Error("the quote path must not reach the contract manager");
+            }),
+        getCurrentSigningDescriptor: () => provider.getCurrentSigningDescriptor(),
+        getNextSigningDescriptor: () => provider.getNextSigningDescriptor(),
+        getUsedSigningDescriptors: async () => [],
+        advanceSigningDescriptorWatermark: async () => {},
+        signerForDescriptor: async (descriptor: string) =>
+            new DescriptorIdentity({ descriptor, signer: provider, base: identity }),
+    } as unknown as IWallet;
+};
+
+const CORRIDOR_CARD: Omit<DiscoveredMarket, "pair" | "quote_corridor"> = {
+    base_asset: { id: "btc", name: "Bitcoin", ticker: "BTC", decimals: 8 },
+    quote_asset: { id: "btc", name: "Bitcoin", ticker: "BTC", decimals: 8 },
+    base_corridor: "arkade",
+    fee_bps: 30,
+    min_base_amount: "1000",
+    max_base_amount: "50000000",
+    min_quote_amount: "1000",
+    max_quote_amount: "50000000",
+    solver: "frenchman",
+    source: "https://registry.example/regtest.json",
+    sourceType: "registry",
+    discovery_pubkey: SOLVER_DISCOVERY_KEY,
+    transports: { nostr: { relays: ["wss://relay.example"] } },
+};
+
+/** `arkade:BTC <-> lightning:BTC`, both directions off one card. */
+export const lightningCard: DiscoveredMarket = {
+    ...CORRIDOR_CARD,
+    pair: "BTC/lightning:BTC",
+    quote_corridor: "lightning",
+};
+
+/** `arkade:BTC -> onchain:BTC`. */
+export const onchainCard: DiscoveredMarket = {
+    ...CORRIDOR_CARD,
+    pair: "BTC/onchain:BTC",
+    quote_corridor: "onchain",
+};
+
+/** A second lightning card, for the candidate-ranking and allowlist tests. */
+export const rivalLightningCard: DiscoveredMarket = {
+    ...lightningCard,
+    fee_bps: 90,
+    solver: "rival",
+    source: "https://other-registry.example/regtest.json",
+    discovery_pubkey: hex.encode(key(5)),
+};
+
+export const USD_ASSET_ID = "f121ac9b7656797cc68d1e8fecacfbaa2069ec1461edf0bf2f3c37404cb9791a0000";
+
+/** An arkade-to-arkade market: feed-priced, no rendezvous, no corridor. */
+export const spotCard: DiscoveredMarket = {
+    pair: "BTC/USD",
+    base_asset: { id: "btc", name: "Bitcoin", ticker: "BTC", decimals: 8 },
+    quote_asset: { id: USD_ASSET_ID, name: "US Dollar", ticker: "USD", decimals: 2 },
+    price_feed: "https://feed.example/btc-usd",
+    price_feed_schema: { type: "json", price_path: "/price" },
+    price_decimals: 6,
+    fee_bps: 30,
+    min_base_amount: "1000",
+    max_base_amount: "5000000",
+    min_quote_amount: "50",
+    max_quote_amount: "500000",
+    solver: "frenchman",
+    source: "https://registry.example/regtest.json",
+    sourceType: "registry",
+};
+
+/** A feed answering a fixed price, and a count of how often it was asked. */
+export const feedServing = (price = 100_000): { fetch: typeof fetch; calls: () => number } => {
+    let calls = 0;
+    return {
+        fetch: (async () => {
+            calls += 1;
+            return new Response(JSON.stringify({ price }));
+        }) as unknown as typeof fetch,
+        calls: () => calls,
+    };
+};
+
+export interface SolverClock {
+    readonly now: number;
+    readonly validUntil: number;
+    readonly refundLocktime: number;
+    readonly htlcLocktime: number;
+}
+
+export const clockAt = (now: number): SolverClock => ({
+    now,
+    validUntil: now + 3600,
+    // Past MIN_HEADROOM_SECONDS on the send legs, and past the receive leg's
+    // claim window measured from the pay deadline.
+    refundLocktime: now + 200 * 3600,
+    htlcLocktime: now + 24 * 3600,
+});
+
+/** A BOLT11 the built-in decoder reads: 5_000 sats, an hour of validity. */
+export const invoiceFor = (paymentHash: string, clock: SolverClock, amount = "50u"): string =>
+    encodeInvoice({
+        prefix: "lnbcrt",
+        amount,
+        timestamp: clock.now - 60,
+        expiry: 3_600,
+        paymentHash,
+    });
+
+export const PREIMAGE = new Uint8Array(32).fill(7);
+export const PAYMENT_HASH = hex.encode(sha256(PREIMAGE));
+
+type Payload = Record<string, unknown>;
+type Profile = Record<string, unknown>;
+
+const profileOf = (payload: Payload): Profile => payload.profile as Profile;
+
+const baseQuote = (payload: Payload, clock: SolverClock): Omit<RfqQuote, "profile"> => ({
+    v: 1,
+    type: "rfq_quote",
+    rfq_id: payload.rfq_id as string,
+    pair: payload.pair as string,
+    from_amount: 0,
+    to_amount: 0,
+    solver_pubkey: hex.encode(SOLVER_PUBKEY),
+    valid_until: clock.validUntil,
+    refund_locktime: clock.refundLocktime,
+});
+
+/** The solver's answer to `arkade:BTC->lightning:BTC`. */
+export const lightningSendAnswer = (
+    payload: Payload,
+    clock: SolverClock,
+    over: { quote?: Partial<RfqQuote>; profile?: Profile; invoiceAmount?: number } = {},
+): RfqQuote => {
+    const profile = profileOf(payload);
+    const script = lightningSendContract({
+        solverPubkey: SOLVER_PUBKEY,
+        refundLocktime: clock.refundLocktime,
+        operatorPubkey: OPERATOR_PUBKEY,
+        paymentHash: PAYMENT_HASH,
+        claimDelay: CLAIM_DELAY,
+        emulatorPubkey: EMULATOR_PUBKEY,
+        senderPubkey: hex.decode(profile.client_refund_pubkey as string),
+        receiverPkScript: RECEIVER_PK_SCRIPT,
+        refundPkScript: ArkAddress.decode(profile.refund_address as string).pkScript,
+    });
+    const take = over.invoiceAmount ?? 5_000;
+    return {
+        ...baseQuote(payload, clock),
+        from_amount: take + 50,
+        to_amount: take,
+        profile: {
+            lockup_address: script.address(NETWORK.hrp, OPERATOR_PUBKEY).encode(),
+            receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
+            ...over.profile,
+        },
+        ...over.quote,
+    } as RfqQuote;
+};
+
+/** The solver's answer to `lightning:BTC->arkade:BTC`, hold invoice included. */
+export const lightningReceiveAnswer = (
+    payload: Payload,
+    clock: SolverClock,
+    over: { quote?: Partial<RfqQuote>; profile?: Profile; invoice?: string } = {},
+): RfqQuote => {
+    const profile = profileOf(payload);
+    const paymentHash = profile.payment_hash as string;
+    const script = lightningReceiveContract({
+        solverPubkey: SOLVER_PUBKEY,
+        refundLocktime: clock.refundLocktime,
+        operatorPubkey: OPERATOR_PUBKEY,
+        paymentHash,
+        claimDelay: CLAIM_DELAY,
+        emulatorPubkey: EMULATOR_PUBKEY,
+        solverRefundPkScript: SOLVER_REFUND_PK_SCRIPT,
+        payoutPubkey: hex.decode(profile.payout_pubkey as string),
+        payoutPkScript: ArkAddress.decode(profile.payout_address as string).pkScript,
+    });
+    return {
+        ...baseQuote(payload, clock),
+        from_amount: 5_000,
+        to_amount: 4_950,
+        profile: {
+            payment_hash: paymentHash,
+            invoice: over.invoice ?? invoiceFor(paymentHash, clock),
+            lockup_address: script.address(NETWORK.hrp, OPERATOR_PUBKEY).encode(),
+            solver_refund_pk_script: hex.encode(SOLVER_REFUND_PK_SCRIPT),
+            ...over.profile,
+        },
+        ...over.quote,
+    } as RfqQuote;
+};
+
+/** The solver's answer to `arkade:BTC->onchain:BTC`, both contracts included. */
+export const onchainSendAnswer = (
+    payload: Payload,
+    clock: SolverClock,
+    over: { quote?: Partial<RfqQuote>; profile?: Profile } = {},
+): RfqQuote => {
+    const profile = profileOf(payload);
+    const paymentHash = profile.payment_hash as string;
+    const script = lightningSendContract({
+        solverPubkey: SOLVER_PUBKEY,
+        refundLocktime: clock.refundLocktime,
+        operatorPubkey: OPERATOR_PUBKEY,
+        paymentHash,
+        claimDelay: CLAIM_DELAY,
+        emulatorPubkey: EMULATOR_PUBKEY,
+        senderPubkey: hex.decode(profile.client_refund_pubkey as string),
+        receiverPkScript: RECEIVER_PK_SCRIPT,
+        refundPkScript: ArkAddress.decode(profile.refund_address as string).pkScript,
+    });
+    const htlc = onchainHtlcScript(
+        {
+            paymentHash,
+            claimKey: hex.decode(profile.payout_pubkey as string),
+            refundKey: HTLC_REFUND_PUBKEY,
+            refundLocktime: clock.htlcLocktime,
+        },
+        "regtest",
+    );
+    return {
+        ...baseQuote(payload, clock),
+        from_amount: 100_000,
+        to_amount: 99_000,
+        profile: {
+            lockup_address: script.address(NETWORK.hrp, OPERATOR_PUBKEY).encode(),
+            receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
+            htlc_pubkey: hex.encode(HTLC_REFUND_PUBKEY),
+            htlc_locktime: clock.htlcLocktime,
+            htlc_address: htlc.address,
+            min_confirmations: 2,
+            ...over.profile,
+        },
+        ...over.quote,
+    } as RfqQuote;
+};
+
+export type SolverAnswer = (payload: Payload) => RfqQuote | Promise<RfqQuote>;
+
+export interface SolverTransport extends AttestingRfqTransport {
+    /** Every request the client sent, in order. */
+    readonly sent: Payload[];
+    readonly closed: () => boolean;
+}
+
+/** A transport that answers with `answer`, and records what it was asked. */
+export const solverTransport = (
+    answer: SolverAnswer,
+    over: { attestedResponder?: string | undefined } = {},
+): SolverTransport => {
+    const sent: Payload[] = [];
+    let closed = false;
+    return {
+        sent,
+        closed: () => closed,
+        ...("attestedResponder" in over
+            ? { attestedResponder: over.attestedResponder }
+            : { attestedResponder: SOLVER_DISCOVERY_KEY }),
+        async requestQuote(payload) {
+            sent.push(payload);
+            return answer(payload);
+        },
+        async status(): Promise<RfqStatus | null> {
+            return null;
+        },
+        async close() {
+            closed = true;
+        },
+    };
+};
+
+/** The quote a payload asks for, routed to the right solver double. */
+export const solverFor = (clock: SolverClock): SolverAnswer => {
+    return (payload) => {
+        switch (payload.pair) {
+            case LIGHTNING_SEND_PAIR:
+                return lightningSendAnswer(payload, clock);
+            case LIGHTNING_RECEIVE_PAIR:
+                return lightningReceiveAnswer(payload, clock);
+            case ONCHAIN_SEND_PAIR:
+                return onchainSendAnswer(payload, clock);
+            default:
+                throw new Error(`no solver double for ${String(payload.pair)}`);
+        }
+    };
+};
+
+export const compressed = (fill: number): string =>
+    hex.encode(secp256k1.getPublicKey(new Uint8Array(32).fill(fill), true));

--- a/packages/swap/test/client/market.test.ts
+++ b/packages/swap/test/client/market.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Market resolution: the key both sides of a negotiation derive independently,
+ * the candidate set the policy filters run over, and the addressability check
+ * that keeps an unreachable card out of it.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
+import type { DiscoverySnapshot } from "../../src/client/discovery";
+import {
+    chooseMarket,
+    eligibleMarkets,
+    isAddressable,
+    marketKeyOf,
+    marketRefOf,
+    type MarketCandidate,
+} from "../../src/client/market";
+import { lightningCard, onchainCard, rivalLightningCard, spotCard, USD_ASSET_ID } from "./fixtures";
+
+const snapshotOf = (markets: DiscoveredMarket[]): DiscoverySnapshot => ({
+    markets,
+    ref: { fetchedAt: 1_700_000_000_000, live: true, source: "injected" },
+});
+
+const ARKADE_BTC = { corridor: "arkade", assetId: "btc" } as const;
+const LIGHTNING_BTC = { corridor: "lightning", assetId: "btc" } as const;
+const ONCHAIN_BTC = { corridor: "onchain", assetId: "btc" } as const;
+const ARKADE_USD = { corridor: "arkade", assetId: USD_ASSET_ID } as const;
+
+describe("the canonical market key", () => {
+    it("puts the arkade leg first, whichever side the card publishes it on", () => {
+        expect(marketKeyOf(lightningCard)).toBe("arkade:btc/lightning:btc");
+        // The same market with its legs published the other way round derives
+        // the same key — which is the whole point: both sides of a published
+        // negotiation derive it independently and subscribe by it.
+        const inverted: DiscoveredMarket = {
+            ...lightningCard,
+            base_corridor: "lightning",
+            quote_corridor: "arkade",
+        };
+        expect(marketKeyOf(inverted)).toBe("arkade:btc/lightning:btc");
+    });
+
+    it("sorts the legs when both are arkade, or neither is", () => {
+        expect(marketKeyOf(spotCard)).toBe(`arkade:btc/arkade:${USD_ASSET_ID}`);
+        const crossCorridor: DiscoveredMarket = {
+            ...lightningCard,
+            base_corridor: "onchain",
+            quote_corridor: "lightning",
+        };
+        expect(marketKeyOf(crossCorridor)).toBe("lightning:btc/onchain:btc");
+    });
+});
+
+describe("the eligible set", () => {
+    it("finds one card in both directions", () => {
+        const snapshot = snapshotOf([lightningCard, onchainCard, spotCard]);
+        const send = eligibleMarkets(snapshot, { give: ARKADE_BTC, take: LIGHTNING_BTC });
+        const receive = eligibleMarkets(snapshot, { give: LIGHTNING_BTC, take: ARKADE_BTC });
+
+        expect(send.map((c) => c.card)).toEqual([lightningCard]);
+        expect(send[0]).toMatchObject({ give: "base", backend: "rfq" });
+        expect(receive.map((c) => c.card)).toEqual([lightningCard]);
+        // Giving the quote side is the other orientation of the same card.
+        expect(receive[0]).toMatchObject({ give: "quote", backend: "rfq" });
+    });
+
+    it("reads the backend off the card, never off the route", () => {
+        const snapshot = snapshotOf([spotCard]);
+        const [candidate] = eligibleMarkets(snapshot, { give: ARKADE_BTC, take: ARKADE_USD });
+        expect(candidate).toMatchObject({ backend: "feed", give: "base" });
+    });
+
+    it("serves no market for a pair nobody lists", () => {
+        const snapshot = snapshotOf([lightningCard]);
+        expect(eligibleMarkets(snapshot, { give: ARKADE_BTC, take: ONCHAIN_BTC })).toEqual([]);
+    });
+
+    it("is empty for one leg twice, whatever the cards say", () => {
+        const snapshot = snapshotOf([lightningCard, spotCard]);
+        expect(eligibleMarkets(snapshot, { give: ARKADE_BTC, take: ARKADE_BTC })).toEqual([]);
+    });
+
+    it("drops a corridor card nothing can address", () => {
+        const { discovery_pubkey, ...unreachable } = lightningCard;
+        expect(isAddressable(unreachable)).toBe(false);
+        expect(isAddressable(spotCard)).toBe(true);
+        const snapshot = snapshotOf([unreachable]);
+        expect(eligibleMarkets(snapshot, { give: ARKADE_BTC, take: LIGHTNING_BTC })).toEqual([]);
+    });
+
+    it("skips a market whose receive side the solver cannot pay out", () => {
+        const noPayout: DiscoveredMarket = {
+            ...lightningCard,
+            max_quote_amount: "0",
+            min_quote_amount: "0",
+        };
+        const snapshot = snapshotOf([noPayout]);
+        expect(eligibleMarkets(snapshot, { give: ARKADE_BTC, take: LIGHTNING_BTC })).toEqual([]);
+        // The other direction still works: it is that side that is disabled.
+        expect(eligibleMarkets(snapshot, { give: LIGHTNING_BTC, take: ARKADE_BTC })).toHaveLength(
+            1,
+        );
+    });
+
+    it("filters on the registry URL, exactly", () => {
+        const snapshot = snapshotOf([lightningCard, rivalLightningCard]);
+        const both = eligibleMarkets(snapshot, { give: ARKADE_BTC, take: LIGHTNING_BTC });
+        expect(both).toHaveLength(2);
+
+        const allowed = eligibleMarkets(
+            snapshot,
+            { give: ARKADE_BTC, take: LIGHTNING_BTC },
+            { allowedRegistries: [rivalLightningCard.source] },
+        );
+        expect(allowed.map((c) => c.card.solver)).toEqual(["rival"]);
+
+        const none = eligibleMarkets(
+            snapshot,
+            { give: ARKADE_BTC, take: LIGHTNING_BTC },
+            // A hostname is not a source, and the match is exact on purpose.
+            { allowedRegistries: ["registry.example"] },
+        );
+        expect(none).toEqual([]);
+    });
+});
+
+describe("choosing between candidates", () => {
+    const candidates = () =>
+        eligibleMarkets(snapshotOf([lightningCard, rivalLightningCard]), {
+            give: ARKADE_BTC,
+            take: LIGHTNING_BTC,
+        });
+
+    it("takes discovery's ranking when policy says nothing", () => {
+        expect(chooseMarket(candidates())?.card.solver).toBe("frenchman");
+    });
+
+    it("lets policy pick another candidate", () => {
+        const selectMarket = vi.fn((all: readonly MarketCandidate[]) =>
+            all.find((c) => c.card.solver === "rival"),
+        );
+        expect(chooseMarket(candidates(), { selectMarket })?.card.solver).toBe("rival");
+        expect(selectMarket).toHaveBeenCalledWith(expect.arrayContaining([]));
+    });
+
+    it("treats a veto as an empty set rather than an error of its own", () => {
+        expect(chooseMarket(candidates(), { selectMarket: () => undefined })).toBeUndefined();
+    });
+
+    it("refuses a card that was never a candidate", () => {
+        expect(() =>
+            chooseMarket(candidates(), {
+                selectMarket: () => ({
+                    card: spotCard,
+                    give: "base",
+                    backend: "feed",
+                    key: marketKeyOf(spotCard),
+                }),
+            }),
+        ).toThrow(/not among the candidates/);
+    });
+});
+
+describe("the provenance a card leaves on a quote", () => {
+    it("carries the registry, the solver, the key and the snapshot's freshness", () => {
+        const snapshot = snapshotOf([lightningCard]);
+        const [candidate] = eligibleMarkets(snapshot, { give: ARKADE_BTC, take: LIGHTNING_BTC });
+        expect(marketRefOf(candidate, snapshot.ref)).toEqual({
+            kind: "card",
+            key: "arkade:btc/lightning:btc",
+            backend: "rfq",
+            source: lightningCard.source,
+            sourceType: "registry",
+            solver: "frenchman",
+            discoveryPubkey: lightningCard.discovery_pubkey,
+            pair: "BTC/lightning:BTC",
+            snapshot: snapshot.ref,
+        });
+    });
+});

--- a/packages/swap/test/client/quote.test.ts
+++ b/packages/swap/test/client/quote.test.ts
@@ -391,6 +391,18 @@ describe("verification, one failure per check", () => {
         expect(error.check).toBe("refund_window");
     });
 
+    it("refuses a valid_until that would delete the expiry gate rather than fail it", async () => {
+        const { client } = await setup({
+            answer: (payload) => ({
+                ...lightningSendAnswer(payload, CLOCK),
+                valid_until: Number.NaN,
+            }),
+        });
+        const error = await client.quote(sendInput()).catch((e) => e);
+        expect(error).toBeInstanceOf(QuoteVerificationFailed);
+        expect(error.check).toBe("refund_window");
+    });
+
     it("refuses a transport that attests nobody, before disclosing anything", async () => {
         const { client, transport } = await setup({ attestedResponder: undefined });
         const error = await client.quote(sendInput()).catch((e) => e);

--- a/packages/swap/test/client/quote.test.ts
+++ b/packages/swap/test/client/quote.test.ts
@@ -1,0 +1,466 @@
+/**
+ * `quote()` end to end: the four implemented routes, both backends, and one
+ * verification failure per check.
+ *
+ * The solver doubles derive the covenants the client will derive, from the
+ * request the client actually sent, so a passing `lockup_address` check means
+ * the two derivations agreed rather than that neither ran. Every failure case
+ * is a tamper on that agreement.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hex } from "@scure/base";
+import { createSwapClient } from "../../src/client/client";
+import { InMemoryAssetSwapRepository, type AssetSwapRepository } from "../../src/repository";
+import {
+    AmountMismatch,
+    QuoteExpired,
+    QuoteVerificationFailed,
+    UnsupportedRoute,
+} from "../../src/client/errors";
+import { AmountEncodingUnsupported } from "../../src/client/errors";
+import { MIN_HEADROOM_SECONDS, SwapRefusal } from "../../src/rfq";
+import { MissingCorridorDep } from "../../src/client/errors";
+import type { QuoteInput } from "../../src/client/quote";
+import {
+    EMULATOR_PUBKEY_HEX,
+    PAYMENT_HASH,
+    SOLVER_DISCOVERY_KEY,
+    SOLVER_PUBKEY,
+    clockAt,
+    feedServing,
+    hdWallet,
+    invoiceFor,
+    lightningCard,
+    lightningReceiveAnswer,
+    lightningSendAnswer,
+    onchainCard,
+    onchainSendAnswer,
+    solverTransport,
+    solverFor,
+    spotCard,
+    type SolverAnswer,
+    type SolverTransport,
+} from "./fixtures";
+
+const NOW = 1_700_000_000;
+const CLOCK = clockAt(NOW);
+const BCRT1 = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+
+const setup = async (
+    over: {
+        answer?: SolverAnswer;
+        attestedResponder?: string | undefined;
+        snapshot?: (typeof lightningCard)[];
+        policy?: Parameters<typeof createSwapClient>[0]["policy"];
+        price?: number;
+    } = {},
+) => {
+    const wallet = await hdWallet();
+    const transport: SolverTransport = solverTransport(
+        over.answer ?? solverFor(CLOCK),
+        "attestedResponder" in over ? { attestedResponder: over.attestedResponder } : {},
+    );
+    const feed = feedServing(over.price);
+    const client = createSwapClient({
+        wallet,
+        discovery: { snapshot: over.snapshot ?? [lightningCard, onchainCard, spotCard] },
+        emulatorPubkey: EMULATOR_PUBKEY_HEX,
+        transportFor: () => transport,
+        fetchImpl: feed.fetch,
+        ...(over.policy === undefined ? {} : { policy: over.policy }),
+    });
+    return { client, transport, feed, wallet };
+};
+
+const sendInput = (): QuoteInput => ({ to: invoiceFor(PAYMENT_HASH, CLOCK) });
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW * 1000);
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("quote() on arkade -> lightning", () => {
+    it("pins the amount from the invoice and returns the order, fee included", async () => {
+        const { client, transport } = await setup();
+        const quote = await client.quote(sendInput());
+
+        expect(quote.give).toEqual({ asset: "arkade:regtest/slip44:0", amount: 5_050n });
+        expect(quote.take).toEqual({ asset: "bolt11:regtest/slip44:0", amount: 5_000n });
+        expect(quote.fee).toEqual({ amount: 50n, asset: "arkade:regtest/slip44:0" });
+        expect(quote.lock).toEqual({ hash: PAYMENT_HASH });
+        expect(quote.refundLocktime).toBe(CLOCK.refundLocktime);
+        expect(quote.expiresAt).toBe(CLOCK.validUntil);
+        expect(quote.solver).toBe(hex.encode(SOLVER_PUBKEY));
+        // The give leg is the wallet's, the take leg is the invoice the caller
+        // handed in: the supply law, as a value.
+        expect(quote.route.give.instrument).toEqual({ kind: "wallet" });
+        expect(quote.route.take.instrument).toMatchObject({ kind: "invoice" });
+        // Nothing to show a counterparty: the solver already has the invoice.
+        expect(quote.artifact).toBeUndefined();
+        expect(transport.sent).toHaveLength(1);
+    });
+
+    it("carries the card's provenance and closes the rendezvous behind it", async () => {
+        const { client, transport } = await setup();
+        const quote = await client.quote(sendInput());
+
+        expect(quote.market).toMatchObject({
+            kind: "card",
+            backend: "rfq",
+            key: "arkade:btc/lightning:btc",
+            source: lightningCard.source,
+            sourceType: "registry",
+            solver: "frenchman",
+            discoveryPubkey: SOLVER_DISCOVERY_KEY,
+        });
+        expect(quote.market.kind === "card" && quote.market.snapshot.source).toBe("injected");
+        expect(transport.closed()).toBe(true);
+    });
+
+    it("hands the accept path the covenant it verified, and persists nothing", async () => {
+        const { client } = await setup();
+        const quote = await client.quote(sendInput());
+        const preparation = client.preparationOf(quote.id);
+
+        expect(preparation).toMatchObject({ backend: "rfq", route: "arkade->lightning" });
+        // The wallet double throws from `getContractManager`, so reaching here
+        // is the assertion that nothing was registered.
+        expect(preparation && "lockup" in preparation && preparation.lockup.address).toMatch(
+            /^tark1/,
+        );
+    });
+
+    it("populates no auction: published RFQ is reserved and inert", async () => {
+        const { client } = await setup();
+        expect((await client.quote(sendInput())).auction).toBeUndefined();
+    });
+});
+
+describe("quote() on lightning -> arkade", () => {
+    const receive = (): QuoteInput => ({ via: "lightning", amount: 5_000n, amountOn: "give" });
+
+    it("returns the solver's hold invoice as the artifact, verified against this swap", async () => {
+        const { client, transport } = await setup();
+        const quote = await client.quote(receive());
+
+        expect(quote.artifact?.kind).toBe("invoice");
+        // The artifact and the give leg's instrument are one fact, not two.
+        expect(quote.artifact).toEqual({
+            kind: "invoice",
+            bolt11: (quote.route.give.instrument as { bolt11: string }).bolt11,
+        });
+        expect(transport.sent).toHaveLength(1);
+        expect(quote.give.asset).toBe("bolt11:regtest/slip44:0");
+        expect(quote.take).toEqual({ asset: "arkade:regtest/slip44:0", amount: 4_950n });
+        // The give leg's instrument IS the artifact — the quote supplies the
+        // non-wallet give instrument, which is what the artifact is.
+        expect(quote.route.give.instrument).toMatchObject({ kind: "invoice", amount: 5_000n });
+        expect(quote.route.take.instrument).toEqual({ kind: "wallet" });
+    });
+
+    it("sends the amount as a canonical decimal string on the side it pins", async () => {
+        const { client, transport } = await setup();
+        await client.quote(receive());
+        expect(transport.sent[0]).toMatchObject({ amount: "5000", amount_side: "from" });
+    });
+
+    it("expires with the hold invoice rather than with the quote", async () => {
+        const { client } = await setup();
+        const quote = await client.quote(receive());
+        // The invoice's own window is an hour from a minute ago; the quote's is
+        // an hour from now. The earlier of the two binds.
+        expect(quote.expiresAt).toBe(NOW + 3_540);
+        expect(quote.expiresAt).toBeLessThan(CLOCK.validUntil);
+    });
+});
+
+describe("quote() on arkade -> onchain", () => {
+    const send = (): QuoteInput => ({ to: BCRT1, amount: 100_000n, amountOn: "give" });
+
+    it("quotes both contracts and reports the covenant's refund deadline", async () => {
+        const { client } = await setup();
+        const quote = await client.quote(send());
+
+        expect(quote.give).toEqual({ asset: "arkade:regtest/slip44:0", amount: 100_000n });
+        expect(quote.take).toEqual({ asset: "bitcoin:regtest/slip44:0", amount: 99_000n });
+        expect(quote.route.take.instrument).toEqual({ kind: "address", address: BCRT1 });
+        expect(quote.refundLocktime).toBe(CLOCK.refundLocktime);
+        const preparation = client.preparationOf(quote.id);
+        expect(preparation).toMatchObject({
+            route: "arkade->onchain",
+            minConfirmations: 2,
+            l1Network: "regtest",
+        });
+    });
+});
+
+describe("quote() on arkade -> arkade", () => {
+    const exchange = (): QuoteInput => ({
+        give: "BTC",
+        take: "USD",
+        amount: 10_000n,
+        amountOn: "give",
+    });
+
+    it("prices from the card's feed, with no round trip to anybody", async () => {
+        const { client, transport, feed } = await setup();
+        const quote = await client.quote(exchange());
+
+        // 10_000 sats at 0.1 cents/sat, less the card's 30bps and no cushion.
+        expect(quote.give.amount).toBe(10_000n);
+        expect(quote.take).toEqual({
+            asset: `arkade:regtest/asset:${spotCard.quote_asset.id}`,
+            amount: 997n,
+        });
+        expect(quote.fee).toEqual({
+            amount: 3n,
+            asset: `arkade:regtest/asset:${spotCard.quote_asset.id}`,
+        });
+        expect(quote.market.backend).toBe("feed");
+        expect(transport.sent).toHaveLength(0);
+        expect(feed.calls()).toBe(1);
+    });
+
+    it("mints an expiry from the feed's own freshness, since the plan carries none", async () => {
+        const { client } = await setup();
+        const quote = await client.quote(exchange());
+        expect(quote.expiresAt).toBe(NOW + 30);
+        expect(quote.solver).toBeUndefined();
+        expect(quote.lock).toBeUndefined();
+        expect(quote.refundLocktime).toBeUndefined();
+    });
+
+    it("resolves a ticker against the cards themselves", async () => {
+        const { client } = await setup();
+        const resolution = await client.resolve(exchange());
+        expect(resolution.give.asset).toBe("arkade:regtest/slip44:0");
+        expect(resolution.take.asset).toBe(`arkade:regtest/asset:${spotCard.quote_asset.id}`);
+    });
+});
+
+describe("a dependency overridden to nothing", () => {
+    const withoutChainSource = async () => {
+        const wallet = await hdWallet();
+        const transport = solverTransport(solverFor(CLOCK));
+        const feed = feedServing();
+        return {
+            transport,
+            client: createSwapClient({
+                wallet,
+                discovery: { snapshot: [lightningCard, onchainCard, spotCard] },
+                corridors: { onchain: { chain: null } },
+                emulatorPubkey: EMULATOR_PUBKEY_HEX,
+                transportFor: () => transport,
+                fetchImpl: feed.fetch,
+            }),
+        };
+    };
+
+    it("refuses the route that touches it, before anything is disclosed", async () => {
+        const { client, transport } = await withoutChainSource();
+        const error = await client
+            .quote({ to: BCRT1, amount: 100_000n, amountOn: "give" })
+            .catch((e) => e);
+        expect(error).toBeInstanceOf(MissingCorridorDep);
+        expect(error.corridor).toBe("onchain");
+        expect(transport.sent).toHaveLength(0);
+    });
+
+    it("is no error at all for a route that never touches that corridor", async () => {
+        const { client } = await withoutChainSource();
+        await expect(client.quote(sendInput())).resolves.toMatchObject({
+            take: { amount: 5_000n },
+        });
+    });
+});
+
+describe("the boundary quote() stops at", () => {
+    /** Every repository call this quote made, by name. */
+    const recording = (): { repository: AssetSwapRepository; calls: string[] } => {
+        const calls: string[] = [];
+        const backing = new InMemoryAssetSwapRepository();
+        const repository = new Proxy(backing, {
+            get(target, property, receiver) {
+                const value = Reflect.get(target, property, receiver);
+                if (typeof value !== "function") return value;
+                return (...args: unknown[]) => {
+                    calls.push(String(property));
+                    return (value as (...a: unknown[]) => unknown).apply(target, args);
+                };
+            },
+        }) as unknown as AssetSwapRepository;
+        return { repository, calls };
+    };
+
+    it("writes no record on either backend, and reaches no contract manager", async () => {
+        const { repository, calls } = recording();
+        const wallet = await hdWallet();
+        const transport = solverTransport(solverFor(CLOCK));
+        const feed = feedServing();
+        const client = createSwapClient({
+            wallet,
+            repository,
+            discovery: { snapshot: [lightningCard, onchainCard, spotCard] },
+            emulatorPubkey: EMULATOR_PUBKEY_HEX,
+            transportFor: () => transport,
+            fetchImpl: feed.fetch,
+        });
+
+        await client.quote(sendInput());
+        await client.quote({ give: "BTC", take: "USD", amount: 10_000n, amountOn: "give" });
+
+        // The wallet double throws from `getContractManager`, so arriving here
+        // is the proof that no lockup was registered — and the repository saw
+        // no write at all, because the markets came from an injected snapshot.
+        expect(calls.filter((call) => call.startsWith("save"))).toEqual([]);
+        expect(calls.filter((call) => call.includes("Swap"))).toEqual([]);
+    });
+});
+
+describe("the route the union excludes", () => {
+    it("refuses onchain -> arkade before anything is disclosed", async () => {
+        const { client, transport } = await setup();
+        await expect(
+            client.quote({ via: "onchain", amount: 100_000n, amountOn: "give" }),
+        ).rejects.toThrow(UnsupportedRoute);
+        expect(transport.sent).toHaveLength(0);
+    });
+});
+
+describe("verification, one failure per check", () => {
+    it("refuses a quote for another pair", async () => {
+        const { client } = await setup({
+            answer: (payload) =>
+                lightningSendAnswer(payload, CLOCK, { quote: { pair: "arkade:BTC->onchain:BTC" } }),
+        });
+        const error = await client.quote(sendInput()).catch((e) => e);
+        expect(error).toBeInstanceOf(QuoteVerificationFailed);
+        expect(error.check).toBe("pair");
+    });
+
+    it("refuses a lockup address it did not derive", async () => {
+        const { client } = await setup({
+            answer: (payload) =>
+                lightningSendAnswer(payload, CLOCK, {
+                    profile: { lockup_address: "tark1qsomebodyelses" },
+                }),
+        });
+        const error = await client.quote(sendInput()).catch((e) => e);
+        expect(error).toBeInstanceOf(QuoteVerificationFailed);
+        expect(error.check).toBe("lockup_address");
+        // v1's AddressMismatch, folded in rather than admitted as a
+        // seventeenth member.
+        expect(error.cause).toMatchObject({ name: "AddressMismatch" });
+    });
+
+    it("refuses a send quote that reprices the invoice", async () => {
+        const { client } = await setup({
+            answer: (payload) =>
+                lightningSendAnswer(payload, CLOCK, { quote: { to_amount: 4_000 } }),
+        });
+        const error = await client.quote(sendInput()).catch((e) => e);
+        expect(error).toBeInstanceOf(QuoteVerificationFailed);
+        expect(error.check).toBe("invoice");
+    });
+
+    it("refuses a hold invoice on another payment hash", async () => {
+        const { client } = await setup({
+            answer: (payload) =>
+                lightningReceiveAnswer(payload, CLOCK, {
+                    invoice: invoiceFor("ab".repeat(32), CLOCK),
+                }),
+        });
+        const error = await client
+            .quote({ via: "lightning", amount: 5_000n, amountOn: "give" })
+            .catch((e) => e);
+        expect(error).toBeInstanceOf(QuoteVerificationFailed);
+        expect(error.check).toBe("invoice");
+    });
+
+    it("refuses a refund window inside the funding headroom", async () => {
+        const tight = { ...CLOCK, refundLocktime: NOW + MIN_HEADROOM_SECONDS - 60 };
+        const { client } = await setup({
+            answer: (payload) => lightningSendAnswer(payload, tight),
+        });
+        const error = await client.quote(sendInput()).catch((e) => e);
+        expect(error).toBeInstanceOf(QuoteVerificationFailed);
+        expect(error.check).toBe("refund_window");
+    });
+
+    it("refuses a transport that attests nobody, before disclosing anything", async () => {
+        const { client, transport } = await setup({ attestedResponder: undefined });
+        const error = await client.quote(sendInput()).catch((e) => e);
+        expect(error).toBeInstanceOf(QuoteVerificationFailed);
+        expect(error.check).toBe("responder");
+        // The whole point of running it before the request.
+        expect(transport.sent).toHaveLength(0);
+    });
+
+    it("refuses a transport attesting somebody other than the card's key", async () => {
+        const { client } = await setup({ attestedResponder: "cd".repeat(32) });
+        const error = await client.quote(sendInput()).catch((e) => e);
+        expect(error.check).toBe("responder");
+        expect(error.expected).toBe(SOLVER_DISCOVERY_KEY);
+    });
+
+    it("keeps a solver's decline a refusal, not a verification failure", async () => {
+        const { client } = await setup({
+            answer: () => {
+                throw new SwapRefusal("amount_out_of_range");
+            },
+        });
+        const error = await client.quote(sendInput()).catch((e) => e);
+        expect(error).toBeInstanceOf(SwapRefusal);
+        expect(error).not.toBeInstanceOf(QuoteVerificationFailed);
+        expect(error.reason).toBe("amount_out_of_range");
+    });
+
+    it("refuses a quote already inside the policy's TTL floor", async () => {
+        const { client } = await setup({ policy: { quoteTtlFloorSeconds: 7_200 } });
+        const error = await client.quote(sendInput()).catch((e) => e);
+        expect(error).toBeInstanceOf(QuoteExpired);
+    });
+});
+
+describe("the amount encoding, both ways", () => {
+    it("refuses a quote amount a JSON number cannot carry", async () => {
+        const { client } = await setup({
+            answer: (payload) =>
+                onchainSendAnswer(payload, CLOCK, {
+                    quote: { from_amount: Number.MAX_SAFE_INTEGER + 2 },
+                }),
+        });
+        const error = await client
+            .quote({ to: BCRT1, amount: 100_000n, amountOn: "give" })
+            .catch((e) => e);
+        expect(error).toBeInstanceOf(AmountEncodingUnsupported);
+        expect(error.field).toBe("from_amount");
+    });
+
+    it("reads a canonical decimal string quote amount", async () => {
+        const { client } = await setup({
+            answer: (payload) =>
+                onchainSendAnswer(payload, CLOCK, {
+                    quote: {
+                        from_amount: "100000" as unknown as number,
+                        to_amount: "99000" as unknown as number,
+                    },
+                }),
+        });
+        const quote = await client.quote({ to: BCRT1, amount: 100_000n, amountOn: "give" });
+        expect(quote.give.amount).toBe(100_000n);
+        expect(quote.take.amount).toBe(99_000n);
+    });
+
+    it("refuses a second pinned amount before any round trip", async () => {
+        const { client, transport } = await setup();
+        await expect(
+            client.quote({ ...sendInput(), amount: 5_000n, amountOn: "take" }),
+        ).rejects.toThrow(AmountMismatch);
+        expect(transport.sent).toHaveLength(0);
+    });
+});

--- a/packages/swap/test/client/quoteOffer.test.ts
+++ b/packages/swap/test/client/quoteOffer.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The feed-priced backend on its own: the margin, the minted expiry, the spread
+ * definition, and the one check this backend runs.
+ *
+ * `quoteFromFeed` is exercised directly here because two of its guarantees are
+ * not reachable through a well-behaved client — the pair check fires only if the
+ * plan that came back prices legs the resolver did not ask for, which is a
+ * defence against discovery changing under us rather than against a caller.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QuoteExpired, QuoteVerificationFailed } from "../../src/client/errors";
+import { eligibleMarkets, marketRefOf } from "../../src/client/market";
+import { FEED_TTL_MS, feedFetch, quoteFromFeed } from "../../src/client/quoteOffer";
+import type { DiscoverySnapshot } from "../../src/client/discovery";
+import { USD_ASSET_ID, spotCard } from "./fixtures";
+
+const NOW = 1_700_000_000;
+
+const snapshot: DiscoverySnapshot = {
+    markets: [spotCard],
+    ref: { fetchedAt: NOW * 1000, live: true, source: "injected" },
+};
+
+const ARKADE_BTC = { corridor: "arkade", assetId: "btc" } as const;
+const ARKADE_USD = { corridor: "arkade", assetId: USD_ASSET_ID } as const;
+
+const legs = { give: ARKADE_BTC, take: ARKADE_USD };
+const endpoints = {
+    give: { corridor: "arkade" as const, asset: "arkade:regtest/slip44:0" as const },
+    take: {
+        corridor: "arkade" as const,
+        asset: `arkade:regtest/asset:${USD_ASSET_ID}` as const,
+    },
+};
+
+const serving = (price = 100_000) => {
+    const fetchImpl = vi.fn(
+        async () => new Response(JSON.stringify({ price })),
+    ) as unknown as typeof fetch & ReturnType<typeof vi.fn>;
+    return { fetchImpl, feed: feedFetch(fetchImpl) };
+};
+
+const quoteWith = (
+    over: Parameters<typeof quoteFromFeed>[0] extends infer T ? Partial<T> : never,
+) => {
+    const [candidate] = eligibleMarkets(snapshot, legs);
+    const { fetchImpl, feed } = serving();
+    return {
+        fetchImpl,
+        run: () =>
+            quoteFromFeed({
+                quoteId: "q1",
+                candidate,
+                market: marketRefOf(candidate, snapshot.ref),
+                legs,
+                endpoints,
+                amount: { value: 10_000n, on: "give", source: "caller" },
+                feed,
+                now: NOW,
+                ...over,
+            }),
+    };
+};
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW * 1000);
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("the margin", () => {
+    it("concedes the card's fee and no cushion", async () => {
+        const { quote } = await quoteWith({}).run();
+        // 10_000 sats at 0.1 cents/sat is 1000 cents; 30bps is the whole
+        // concession, where `quoteOffer`'s own default would have taken 80.
+        expect(quote.take.amount).toBe(997n);
+        expect(quote.fee.amount).toBe(3n);
+        expect(quote.fee.asset).toBe(endpoints.take.asset);
+    });
+
+    it("denominates the spread on the leg where it is exact", async () => {
+        const { quote } = await quoteWith({}).run();
+        // The two legs carry different assets, so a give-denominated fee would
+        // be this number divided by the price — a rounding nobody asked for.
+        expect(quote.fee.asset).toBe(quote.take.asset);
+        expect(quote.fee.asset).not.toBe(quote.give.asset);
+    });
+});
+
+describe("the minted expiry", () => {
+    it("expires with the feed value it was priced from", async () => {
+        const { quote } = await quoteWith({}).run();
+        expect(quote.expiresAt).toBe(NOW + FEED_TTL_MS / 1000);
+    });
+
+    it("ages with the cached feed value rather than restarting on a cache hit", async () => {
+        const [candidate] = eligibleMarkets(snapshot, legs);
+        const { fetchImpl, feed } = serving();
+        const input = {
+            quoteId: "q1",
+            candidate,
+            market: marketRefOf(candidate, snapshot.ref),
+            legs,
+            endpoints,
+            amount: { value: 10_000n, on: "give" as const, source: "caller" as const },
+            feed,
+        };
+        const first = await quoteFromFeed({ ...input, now: NOW });
+        vi.setSystemTime((NOW + 10) * 1000);
+        const second = await quoteFromFeed({ ...input, now: NOW + 10 });
+
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+        // The second quote is ten seconds younger and expires at the same
+        // moment, because it is the same price.
+        expect(second.quote.expiresAt).toBe(first.quote.expiresAt);
+    });
+
+    it("refuses a quote the policy floor outlives", async () => {
+        await expect(quoteWith({ policy: { quoteTtlFloorSeconds: 60 } }).run()).rejects.toThrow(
+            QuoteExpired,
+        );
+    });
+});
+
+describe("the one check this backend runs", () => {
+    it("refuses a plan that prices legs nobody asked for", async () => {
+        await expect(
+            quoteWith({
+                legs: { give: ARKADE_BTC, take: { corridor: "arkade", assetId: "ff".repeat(34) } },
+            }).run(),
+        ).rejects.toThrow(QuoteVerificationFailed);
+    });
+
+    it("needs an amount, since no invoice can pin one here", async () => {
+        await expect(quoteWith({ amount: undefined }).run()).rejects.toThrow(/needs an amount/);
+    });
+});

--- a/packages/swap/test/client/resolve.test.ts
+++ b/packages/swap/test/client/resolve.test.ts
@@ -1,0 +1,332 @@
+/**
+ * `resolve()`: the parse, the pair, the pin and the veto — everything that
+ * happens before a solver hears anything, and the errors that stop it there.
+ *
+ * The discovery half is the other axis: the same route resolves against an
+ * injected snapshot, a stale cache and a registry that serves nothing, and the
+ * three are told apart on the resolution rather than collapsed into one empty
+ * array.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSwapClient } from "../../src/client/client";
+import {
+    AmbiguousDestination,
+    AmountMismatch,
+    DiscoverySnapshotUnavailable,
+    UnsupportedRoute,
+} from "../../src/client/errors";
+import { InMemoryAssetSwapRepository } from "../../src/repository";
+import type { QuoteInput } from "../../src/client/quote";
+import {
+    EMULATOR_PUBKEY_HEX,
+    PAYMENT_HASH,
+    USD_ASSET_ID,
+    clockAt,
+    feedServing,
+    hdWallet,
+    invoiceFor,
+    lightningCard,
+    onchainCard,
+    solverFor,
+    solverTransport,
+    spotCard,
+} from "./fixtures";
+import { ArkAddress } from "@arkade-os/sdk";
+import { schnorr } from "@noble/curves/secp256k1.js";
+
+const NOW = 1_700_000_000;
+const CLOCK = clockAt(NOW);
+const BCRT1 = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+const OPERATOR = schnorr.getPublicKey(new Uint8Array(32).fill(3));
+const OURS = new ArkAddress(OPERATOR, schnorr.getPublicKey(new Uint8Array(32).fill(21)), "tark");
+const FOREIGN = new ArkAddress(
+    schnorr.getPublicKey(new Uint8Array(32).fill(30)),
+    schnorr.getPublicKey(new Uint8Array(32).fill(21)),
+    "tark",
+);
+
+const clientWith = async (
+    over: {
+        snapshot?: unknown[];
+        registryUrl?: string;
+        fetchImpl?: typeof fetch;
+        repository?: InMemoryAssetSwapRepository;
+        policy?: Parameters<typeof createSwapClient>[0]["policy"];
+    } = {},
+) => {
+    const wallet = await hdWallet();
+    const transport = solverTransport(solverFor(CLOCK));
+    const feed = feedServing();
+    return {
+        transport,
+        client: createSwapClient({
+            wallet,
+            discovery: {
+                ...(over.snapshot === undefined ? {} : { snapshot: over.snapshot as never }),
+                ...(over.registryUrl === undefined ? {} : { registryUrl: over.registryUrl }),
+                ...(over.fetchImpl === undefined ? {} : { fetchImpl: over.fetchImpl }),
+            },
+            ...(over.repository === undefined ? {} : { repository: over.repository }),
+            emulatorPubkey: EMULATOR_PUBKEY_HEX,
+            transportFor: () => transport,
+            fetchImpl: feed.fetch,
+            ...(over.policy === undefined ? {} : { policy: over.policy }),
+        }),
+    };
+};
+
+const withCards = (over: Record<string, unknown> = {}) =>
+    clientWith({ snapshot: [lightningCard, onchainCard, spotCard], ...over });
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW * 1000);
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("the destination, parsed once", () => {
+    it("reads a bolt11 as the lightning corridor, with the invoice as the instrument", async () => {
+        const { client } = await withCards();
+        const resolution = await client.resolve({ to: invoiceFor(PAYMENT_HASH, CLOCK) });
+
+        expect(resolution.give).toMatchObject({
+            corridor: "arkade",
+            asset: "arkade:regtest/slip44:0",
+            instrument: { kind: "wallet" },
+        });
+        expect(resolution.take).toMatchObject({
+            corridor: "lightning",
+            asset: "bolt11:regtest/slip44:0",
+            instrument: { kind: "invoice", amount: 5_000n },
+        });
+        // The invoice pins the take leg by existing.
+        expect(resolution.amount).toEqual({ value: 5_000n, on: "take", source: "invoice" });
+        expect(resolution.eligible).toBe(1);
+        expect(resolution.market?.kind === "card" && resolution.market.backend).toBe("rfq");
+    });
+
+    it("reads an L1 address as the onchain corridor", async () => {
+        const { client } = await withCards();
+        const resolution = await client.resolve({ to: BCRT1, amount: 100_000n, amountOn: "give" });
+        expect(resolution.take).toMatchObject({
+            corridor: "onchain",
+            asset: "bitcoin:regtest/slip44:0",
+            instrument: { kind: "address", address: BCRT1 },
+        });
+        expect(resolution.amount).toEqual({ value: 100_000n, on: "give", source: "caller" });
+    });
+
+    it("sends a plain Arkade address back to the wallet, where it belongs", async () => {
+        const { client } = await withCards();
+        await expect(client.resolve({ to: OURS.encode() })).rejects.toThrow(/plain Arkade payment/);
+    });
+
+    it("refuses another operator's Arkade address as underdetermined, not unrouted", async () => {
+        const { client } = await withCards();
+        await expect(client.resolve({ to: FOREIGN.encode() })).rejects.toThrow(
+            AmbiguousDestination,
+        );
+    });
+
+    it("leaves a destination no corridor serves to the route, not to the parse", async () => {
+        const { client } = await withCards();
+        // Core classifies an LNURL and no corridor claims it.
+        await expect(
+            client.resolve({
+                to: "lnurl1dp68gurn8ghj7ampd3kx2ar0veekzar0wd5xjtnrdakj7tnhv4kxctttdehhwm30d3h82unvwqhkxctnda3h",
+            }),
+        ).rejects.toThrow(UnsupportedRoute);
+    });
+
+    it("refuses a destination nothing classifies at all", async () => {
+        const { client } = await withCards();
+        await expect(client.resolve({ to: "0xdeadbeef" })).rejects.toThrow(AmbiguousDestination);
+    });
+});
+
+describe("the corridor pair", () => {
+    it("takes `via` for the leg with no instrument yet", async () => {
+        const { client } = await withCards();
+        const resolution = await client.resolve({
+            via: "lightning",
+            amount: 5_000n,
+            amountOn: "give",
+        });
+        expect(resolution.give).toMatchObject({ corridor: "lightning" });
+        // No instrument on the give leg: the quote mints it.
+        expect(resolution.give.instrument).toBeUndefined();
+        expect(resolution.take).toMatchObject({
+            corridor: "arkade",
+            instrument: { kind: "wallet" },
+        });
+    });
+
+    it("refuses onchain -> arkade, and says why it is missing", async () => {
+        const { client } = await withCards();
+        await expect(
+            client.resolve({ via: "onchain", amount: 100_000n, amountOn: "give" }),
+        ).rejects.toThrow(/L1 refund path/);
+    });
+
+    it("refuses `via: arkade`, which names the wallet's own side", async () => {
+        const { client } = await withCards();
+        await expect(
+            client.resolve({ via: "arkade", amount: 1_000n, amountOn: "give" }),
+        ).rejects.toThrow(UnsupportedRoute);
+    });
+
+    it("refuses one leg twice", async () => {
+        const { client } = await withCards();
+        await expect(client.resolve({ amount: 1_000n, amountOn: "give" })).rejects.toThrow(
+            /both legs are/,
+        );
+    });
+
+    it("refuses an asset whose rail disagrees with the leg it was named on", async () => {
+        const { client } = await withCards();
+        await expect(
+            client.resolve({
+                to: invoiceFor(PAYMENT_HASH, CLOCK),
+                take: "arkade:regtest/slip44:0",
+            }),
+        ).rejects.toThrow(UnsupportedRoute);
+    });
+});
+
+describe("the pin", () => {
+    const invoice = (): QuoteInput => ({ to: invoiceFor(PAYMENT_HASH, CLOCK) });
+
+    it("refuses a caller amount beside an invoice, even before a market is chosen", async () => {
+        const { client } = await clientWith({ snapshot: [] });
+        await expect(
+            client.resolve({ ...invoice(), amount: 5_000n, amountOn: "take" }),
+        ).rejects.toThrow(AmountMismatch);
+    });
+
+    it("refuses an amount with no side", async () => {
+        const { client } = await withCards();
+        await expect(client.resolve({ via: "lightning", amount: 5_000n })).rejects.toThrow(
+            /amountOn/,
+        );
+    });
+
+    it("refuses a non-positive amount", async () => {
+        const { client } = await withCards();
+        await expect(
+            client.resolve({ via: "lightning", amount: 0n, amountOn: "give" }),
+        ).rejects.toThrow(/must be positive/);
+    });
+});
+
+describe("what the snapshot serves", () => {
+    it("refuses to resolve at all with no market data anywhere", async () => {
+        const { client } = await clientWith({});
+        await expect(client.resolve({ to: invoiceFor(PAYMENT_HASH, CLOCK) })).rejects.toThrow(
+            DiscoverySnapshotUnavailable,
+        );
+    });
+
+    it("resolves against a stale cache, and marks it stale", async () => {
+        const repository = new InMemoryAssetSwapRepository();
+        const registryUrl = "https://registry.example/regtest.json";
+        await repository.saveCachedMarkets("regtest", registryUrl, {
+            markets: [lightningCard],
+            fetchedAt: Date.now() - 3_600_000,
+        });
+        const { client } = await clientWith({
+            registryUrl,
+            repository,
+            fetchImpl: (async () => {
+                throw new Error("registry unreachable");
+            }) as unknown as typeof fetch,
+        });
+        const resolution = await client.resolve({ to: invoiceFor(PAYMENT_HASH, CLOCK) });
+        expect(resolution.snapshot).toMatchObject({ live: false, source: "cache" });
+        expect(resolution.eligible).toBe(1);
+    });
+
+    it("resolves with an empty eligible set when the registry serves no such market", async () => {
+        const { client } = await clientWith({ snapshot: [spotCard] });
+        const resolution = await client.resolve({ to: invoiceFor(PAYMENT_HASH, CLOCK) });
+        expect(resolution.eligible).toBe(0);
+        expect(resolution.market).toBeUndefined();
+        // The route itself resolved: nothing about the destination or the
+        // corridor pair failed.
+        expect(resolution.take.corridor).toBe("lightning");
+    });
+
+    it("turns that empty set into UnsupportedRoute at quote time, naming the snapshot", async () => {
+        const { client, transport } = await clientWith({ snapshot: [spotCard] });
+        const error = await client.quote({ to: invoiceFor(PAYMENT_HASH, CLOCK) }).catch((e) => e);
+        expect(error).toBeInstanceOf(UnsupportedRoute);
+        expect(error.message).toMatch(/active discovery snapshot/);
+        expect(transport.sent).toHaveLength(0);
+    });
+
+    it("lands an allowlist that empties the set in the same place", async () => {
+        const { client } = await withCards({
+            policy: { allowedRegistries: ["https://somewhere.else/regtest.json"] },
+        });
+        const resolution = await client.resolve({ to: invoiceFor(PAYMENT_HASH, CLOCK) });
+        expect(resolution.eligible).toBe(0);
+        await expect(client.quote({ to: invoiceFor(PAYMENT_HASH, CLOCK) })).rejects.toThrow(
+            UnsupportedRoute,
+        );
+    });
+
+    it("lands a policy veto there too", async () => {
+        const { client } = await withCards({ policy: { selectMarket: () => undefined } });
+        expect((await client.resolve({ to: invoiceFor(PAYMENT_HASH, CLOCK) })).eligible).toBe(0);
+    });
+
+    it("resolves an asset swap's tickers against the cards", async () => {
+        const { client } = await withCards();
+        const resolution = await client.resolve({
+            give: "btc",
+            take: "usd",
+            amount: 10_000n,
+            amountOn: "give",
+        });
+        expect(resolution.give.asset).toBe("arkade:regtest/slip44:0");
+        expect(resolution.take.asset).toBe(`arkade:regtest/asset:${USD_ASSET_ID}`);
+        expect(resolution.market?.kind === "card" && resolution.market.backend).toBe("feed");
+    });
+
+    it("does not touch the network to answer", async () => {
+        const fetchImpl = vi.fn(async () => new Response("{}")) as unknown as typeof fetch &
+            ReturnType<typeof vi.fn>;
+        const { client } = await clientWith({
+            snapshot: [lightningCard],
+            registryUrl: "https://registry.example/regtest.json",
+            fetchImpl,
+        });
+        await client.resolve({ to: invoiceFor(PAYMENT_HASH, CLOCK) });
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+});
+
+describe("a quote against a cache-served card", () => {
+    it("re-pins the card from the registry, and refuses when it cannot", async () => {
+        const repository = new InMemoryAssetSwapRepository();
+        const registryUrl = "https://registry.example/regtest.json";
+        await repository.saveCachedMarkets("regtest", registryUrl, {
+            markets: [lightningCard],
+            fetchedAt: Date.now(),
+        });
+        const fetchImpl = vi.fn(async () => {
+            throw new Error("registry unreachable");
+        }) as unknown as typeof fetch & ReturnType<typeof vi.fn>;
+        const { client, transport } = await clientWith({ registryUrl, repository, fetchImpl });
+
+        const error = await client.quote({ to: invoiceFor(PAYMENT_HASH, CLOCK) }).catch((e) => e);
+        // The refetch was attempted, the card stayed cache content, and the
+        // responder check refused to pin against it.
+        expect(fetchImpl).toHaveBeenCalled();
+        expect(error.name).toBe("QuoteVerificationFailed");
+        expect(error.check).toBe("responder");
+        expect(transport.sent).toHaveLength(0);
+    });
+});

--- a/packages/swap/test/client/resolve.test.ts
+++ b/packages/swap/test/client/resolve.test.ts
@@ -5,7 +5,9 @@
  * The discovery half is the other axis: the same route resolves against an
  * injected snapshot, a stale cache and a registry that serves nothing, and the
  * three are told apart on the resolution rather than collapsed into one empty
- * array.
+ * array. The last block follows a cache-served card one step past that line,
+ * into the re-pin `quote()` owes it — both halves of one rule, so they are read
+ * together rather than split across two files by which one reaches a solver.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSwapClient } from "../../src/client/client";
@@ -13,17 +15,20 @@ import {
     AmbiguousDestination,
     AmountMismatch,
     DiscoverySnapshotUnavailable,
+    OperatorUnreachable,
     UnsupportedRoute,
 } from "../../src/client/errors";
 import { InMemoryAssetSwapRepository } from "../../src/repository";
 import type { QuoteInput } from "../../src/client/quote";
 import {
+    ARK_INFO,
     EMULATOR_PUBKEY_HEX,
     PAYMENT_HASH,
     USD_ASSET_ID,
     clockAt,
     feedServing,
     hdWallet,
+    indexOf,
     invoiceFor,
     lightningCard,
     onchainCard,
@@ -52,9 +57,10 @@ const clientWith = async (
         fetchImpl?: typeof fetch;
         repository?: InMemoryAssetSwapRepository;
         policy?: Parameters<typeof createSwapClient>[0]["policy"];
+        wallet?: Awaited<ReturnType<typeof hdWallet>>;
     } = {},
 ) => {
-    const wallet = await hdWallet();
+    const wallet = over.wallet ?? (await hdWallet());
     const transport = solverTransport(solverFor(CLOCK));
     const feed = feedServing();
     return {
@@ -308,6 +314,32 @@ describe("what the snapshot serves", () => {
     });
 });
 
+describe("the deferred init", () => {
+    it("retries the operator read rather than serving its rejection forever", async () => {
+        let reads = 0;
+        let offline = true;
+        const wallet = await hdWallet({
+            getArkadeInfo: async () => {
+                reads += 1;
+                if (offline) throw new Error("operator unreachable");
+                return ARK_INFO;
+            },
+        });
+        const { client } = await clientWith({ wallet, snapshot: [lightningCard] });
+        const invoice = invoiceFor(PAYMENT_HASH, CLOCK);
+
+        const error = await client.resolve({ to: invoice }).catch((e) => e);
+        expect(error).toBeInstanceOf(OperatorUnreachable);
+
+        offline = false;
+        expect((await client.resolve({ to: invoice })).take.corridor).toBe("lightning");
+        // ...and the retry is the ONLY extra read: the resolved context is
+        // still memoized once it succeeds.
+        await client.resolve({ to: invoice });
+        expect(reads).toBe(2);
+    });
+});
+
 describe("a quote against a cache-served card", () => {
     it("re-pins the card from the registry, and refuses when it cannot", async () => {
         const repository = new InMemoryAssetSwapRepository();
@@ -328,5 +360,59 @@ describe("a quote against a cache-served card", () => {
         expect(error.name).toBe("QuoteVerificationFailed");
         expect(error.check).toBe("responder");
         expect(transport.sent).toHaveLength(0);
+    });
+
+    it("quotes against the re-pinned card when the retry reaches the registry", async () => {
+        const repository = new InMemoryAssetSwapRepository();
+        const registryUrl = "https://registry.example/regtest.json";
+        await repository.saveCachedMarkets("regtest", registryUrl, {
+            markets: [lightningCard],
+            fetchedAt: Date.now(),
+        });
+        // Unreachable for the load that resolves the route, reachable for the
+        // re-pin: the one sequence that tells the refresh apart from it.
+        let reached = false;
+        const fetchImpl = vi.fn(async () => {
+            if (!reached) {
+                reached = true;
+                throw new Error("registry unreachable");
+            }
+            return new Response(JSON.stringify(indexOf([lightningCard])));
+        }) as unknown as typeof fetch & ReturnType<typeof vi.fn>;
+        const { client, transport } = await clientWith({ registryUrl, repository, fetchImpl });
+
+        const quote = await client.quote({ to: invoiceFor(PAYMENT_HASH, CLOCK) });
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+        expect(quote.market.kind === "card" && quote.market.snapshot).toMatchObject({
+            live: true,
+            source: "live",
+        });
+        // A live card names the key the responder check pins against, so this
+        // is the one path on which the invoice reaches a solver at all.
+        expect(transport.sent).toHaveLength(1);
+    });
+
+    it("leaves a feed-priced market on the stale snapshot, having nothing to pin", async () => {
+        const repository = new InMemoryAssetSwapRepository();
+        const registryUrl = "https://registry.example/regtest.json";
+        await repository.saveCachedMarkets("regtest", registryUrl, {
+            markets: [spotCard],
+            fetchedAt: Date.now(),
+        });
+        const fetchImpl = vi.fn(async () => {
+            throw new Error("registry unreachable");
+        }) as unknown as typeof fetch & ReturnType<typeof vi.fn>;
+        const { client } = await clientWith({ registryUrl, repository, fetchImpl });
+
+        const quote = await client.quote({
+            give: "BTC",
+            take: "USD",
+            amount: 10_000n,
+            amountOn: "give",
+        });
+        // No re-pin attempted: the refresh is the addressed backend's, and a
+        // feed quote discloses nothing to a responder.
+        expect(quote.market.backend).toBe("feed");
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/swap/test/client/rfqWire.test.ts
+++ b/packages/swap/test/client/rfqWire.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The wire adapter: the pair string M3 owns, and the amount encoding it decided.
+ *
+ * Both halves exist because the wire is byte-compared. A pair one character off
+ * is not an error either side can report — it is a market nobody serves — and an
+ * amount that crossed as a JSON number past 2^53 is not an amount anyone can
+ * check afterwards.
+ */
+import { describe, expect, it } from "vitest";
+import { AmountEncodingUnsupported } from "../../src/client/errors";
+import { parseRfqQuote, rfqLeg, rfqPairFor, withCanonicalAmount } from "../../src/client/rfqWire";
+import {
+    ARKADE_BTC,
+    LIGHTNING_RECEIVE_PAIR,
+    LIGHTNING_SEND_PAIR,
+    ONCHAIN_SEND_PAIR,
+    MAX_PAIR_LENGTH,
+    type RfqQuote,
+} from "../../src/rfq";
+import { USD_ASSET_ID } from "./fixtures";
+
+const arkade = { corridor: "arkade", assetId: "btc" } as const;
+const lightning = { corridor: "lightning", assetId: "btc" } as const;
+const onchain = { corridor: "onchain", assetId: "btc" } as const;
+const usd = { corridor: "arkade", assetId: USD_ASSET_ID } as const;
+
+describe("the pair string", () => {
+    it("spells BTC as the wire's own constants do", () => {
+        expect(rfqLeg(arkade)).toBe(ARKADE_BTC);
+        expect(rfqPairFor(arkade, lightning)).toBe(LIGHTNING_SEND_PAIR);
+        expect(rfqPairFor(lightning, arkade)).toBe(LIGHTNING_RECEIVE_PAIR);
+        expect(rfqPairFor(arkade, onchain)).toBe(ONCHAIN_SEND_PAIR);
+    });
+
+    it("carries an arkade asset as the identity form, verbatim", () => {
+        expect(rfqLeg(usd)).toBe(`arkade:${USD_ASSET_ID}`);
+        expect(rfqPairFor(arkade, usd)).toBe(`arkade:BTC->arkade:${USD_ASSET_ID}`);
+    });
+
+    it("is directional: the trade's direction, never the card's leg order", () => {
+        expect(rfqPairFor(usd, arkade)).toBe(`arkade:${USD_ASSET_ID}->arkade:BTC`);
+    });
+
+    it("stays inside the wire's length cap", () => {
+        expect(rfqPairFor(usd, usd).length).toBeLessThanOrEqual(MAX_PAIR_LENGTH);
+    });
+});
+
+describe("amounts out", () => {
+    it("emits the canonical decimal string on every corridor", () => {
+        expect(withCanonicalAmount({ amount: 0, pair: "x" }, 5_000n)).toEqual({
+            amount: "5000",
+            pair: "x",
+        });
+    });
+
+    it("emits a string a JSON number could not have carried", () => {
+        const big = 2n ** 60n;
+        expect(withCanonicalAmount({}, big)).toEqual({ amount: `${big}` });
+    });
+});
+
+const quote = (over: Partial<RfqQuote>): RfqQuote => ({
+    v: 1,
+    type: "rfq_quote",
+    rfq_id: "ab".repeat(32),
+    pair: LIGHTNING_SEND_PAIR,
+    from_amount: 5_050,
+    to_amount: 5_000,
+    solver_pubkey: "cd".repeat(32),
+    valid_until: 1_700_003_600,
+    refund_locktime: 1_700_007_200,
+    profile: {},
+    ...over,
+});
+
+describe("amounts in", () => {
+    it("reads the number form the migration still emits", () => {
+        const parsed = parseRfqQuote(quote({}));
+        expect(parsed.give).toBe(5_050n);
+        expect(parsed.take).toBe(5_000n);
+        expect(parsed.refundLocktime).toBe(1_700_007_200);
+    });
+
+    it("reads the canonical string form the solver already accepts", () => {
+        const parsed = parseRfqQuote(
+            quote({
+                from_amount: "5050" as unknown as number,
+                to_amount: "5000" as unknown as number,
+            }),
+        );
+        expect(parsed.give).toBe(5_050n);
+        expect(parsed.take).toBe(5_000n);
+    });
+
+    it("refuses a number that has already lost the amount", () => {
+        expect(() => parseRfqQuote(quote({ from_amount: Number.MAX_SAFE_INTEGER + 2 }))).toThrow(
+            AmountEncodingUnsupported,
+        );
+    });
+
+    it("refuses a non-canonical string rather than reading around it", () => {
+        expect(() => parseRfqQuote(quote({ to_amount: "5_000" as unknown as number }))).toThrow(
+            AmountEncodingUnsupported,
+        );
+        expect(() => parseRfqQuote(quote({ to_amount: "0050" as unknown as number }))).toThrow(
+            /canonical/,
+        );
+    });
+
+    it("leaves an absent refund_locktime absent rather than defaulting it", () => {
+        expect(parseRfqQuote(quote({ refund_locktime: undefined })).refundLocktime).toBeUndefined();
+    });
+});

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -547,6 +547,25 @@ describe("guardrails", () => {
             /headroom/,
         );
     });
+
+    it("assertFundable refuses a valid_until it cannot compare against", () => {
+        const now = 1_800_000_000;
+        // The wire is JSON: `valid_until` is typed number here but nothing
+        // typechecks the solver's payload, and `now >= NaN` is false — the
+        // expiry gate would pass rather than fail.
+        for (const valid_until of [Number.NaN, Number.POSITIVE_INFINITY, "soon", undefined]) {
+            const quote = quoteFixture({ valid_until: valid_until as unknown as number });
+            const refusal = ((): unknown => {
+                try {
+                    assertFundable({ quote, invoiceExpiresAt: now + 3600, now });
+                    return undefined;
+                } catch (error) {
+                    return error;
+                }
+            })();
+            expect((refusal as { reason?: string }).reason).toBe("quote_malformed");
+        }
+    });
 });
 
 describe("expectQuote", () => {


### PR DESCRIPTION
M3 on top of #825: `resolve()` and `quote()`, nothing moves.

- discovery snapshots, with the three states one `DiscoveredMarket[]` collapsed told apart
- market resolution, the canonical market key, and the policy filters that run before disclosure
- one quote module per backend — addressed RFQ, feed-priced offer
- verification as an invariant: pair, lockup address, invoice, refund window, and — G2's answer — the responder
- the RFQ wire adapter: the pair string and the amount encoding

Still off the root barrel. Regtest pass pending (needs a live solver).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a v2 swap client for route resolution, market discovery, quote generation, verification, and preparation tracking.
  * Added support for feed-priced and RFQ-based quotes across supported swap routes.
  * Added asset aliases, market selection policies, discovery caching, and configurable RFQ transports.
  * Added comprehensive quote validation for pricing, invoices, responders, lockups, deadlines, and expiration.

* **Bug Fixes**
  * Improved live operator information retrieval and Lightning contract derivation.
  * Added clearer handling for unavailable markets, unsupported routes, stale data, and invalid destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->