### PR TITLE
feat(swap): accept(), the durable record, and the storage defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ style and have not been backfilled.
 
 ### Breaking Changes
 
+- **`@arkade-os/swap`: `AssetSwapRepository.version` is `5`, adding a v2
+  swap-record store.** Four methods land beside the existing ones —
+  `saveSwapRecord`, `getSwapRecord`, `getAllSwapRecords`,
+  `removeSwapRecord` — keyed by the client-minted quote id rather than a
+  funding txid, which is what lets a swap record exist *before* its
+  money does. An out-of-tree implementor of the interface fails to
+  compile until it adds them, which is what the version literal is for.
+  The four in-tree backends are updated; the IndexedDB one bumps
+  `DB_VERSION` to 3 and the migration is additive, so existing rows come
+  through untouched. Realm consumers gain a fifth schema,
+  `ArkadeSwapRecord` — spread `AssetSwapRealmSchemas` into your config
+  and bump your `schemaVersion`. The v1 readers are unchanged and keep
+  reading v1 rows; the two record families are deliberately invisible to
+  each other, while the restore-scan cursor and the markets cache stay
+  shared.
+
 - **`@arkade-os/swap`: the `arkServerUrl` positional is gone from the
   five covenant-deriving entrypoints.** `createOffer(wallet, params)`,
   and `requestLightningSend` / `requestLightningReceive` /
@@ -47,6 +63,17 @@ style and have not been backfilled.
   untouched, so there is no runtime or on-disk effect. (#734)
 
 ### Features
+
+- **`@arkade-os/swap/node`: the Node storage default.**
+  `nodeSwapRepository({ network })` opens a file-backed SQLite database
+  under the platform config directory (XDG /
+  `~/Library/Application Support` / `%APPDATA%`) at
+  `arkade/swaps/swaps-<network>.sqlite`, and is the one backend whose
+  `[Symbol.asyncDispose]` closes the connection — because it is the one
+  that opened it. `createNodeSqlExecutor(path)` and
+  `swapDatabasePath(network)` are exported beside it. A separate subpath
+  rather than a conditional import, so the browser bundle never sees
+  `node:sqlite`.
 
 - **`assertRecipientArkAddress` and `RecipientAddressContext` are
   root-exported.** The rotation-aware recipient check — hrp, then

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -139,9 +139,25 @@ uncached discovery.
 | `IndexedDbAssetSwapRepository` | `@arkade-os/swap`                     | the browser (or a polyfilled IndexedDB)         |
 | `SQLiteAssetSwapRepository`    | `@arkade-os/swap/repositories/sqlite` | React Native, over your SQLite driver           |
 | `RealmAssetSwapRepository`     | `@arkade-os/swap/repositories/realm`  | React Native, over your Realm instance          |
+| `nodeSwapRepository()`         | `@arkade-os/swap/node`                | Node — file-backed SQLite, opened for you       |
 
-Neither subpath adds a dependency: they take the SDK's structural `SQLExecutor` / `RealmLike`
-handles, so you pass the database you already opened.
+Neither React Native subpath adds a dependency: they take the SDK's structural `SQLExecutor` /
+`RealmLike` handles, so you pass the database you already opened.
+
+`@arkade-os/swap/node` is the exception, and the only entry point that imports `node:` builtins —
+which is why it is a separate subpath rather than something the main entry falls back to. It opens
+the database itself, under the platform config directory (XDG / `~/Library/Application Support` /
+`%APPDATA%`) at `arkade/swaps/swaps-<network>.sqlite`, and it is the one backend whose disposal
+closes a connection:
+
+```ts
+import { nodeSwapRepository } from "@arkade-os/swap/node";
+
+await using swaps = nodeSwapRepository({ network: "mainnet" }); // or { path } to choose the file
+```
+
+Every other backend's `[Symbol.asyncDispose]` is a no-op, because you opened the handle and it is
+yours to close. This one opened it, so it closes it.
 
 All four carry both record types: asset swaps and the monitored RFQ swaps
 (`saveRfqSwap` / `getRfqSwap` / `getAllRfqSwaps` / `removeRfqSwap`). Each keeps them in a store of their own — a
@@ -205,15 +221,17 @@ const realm = await Realm.open({
 const swaps = new RealmAssetSwapRepository(realm);
 ```
 
-Four classes land in your Realm namespace: `ArkadeAssetSwap`, `ArkadeRfqSwap`,
+Five classes land in your Realm namespace: `ArkadeAssetSwap`, `ArkadeRfqSwap`, `ArkadeSwapRecord`,
 `ArkadeAssetSwapScannedTxid`, `ArkadeAssetSwapMarketsCache`. Unlike SQLite there is no prefix option
 — a Realm schema name is baked into the schema objects you register — so reconcile against your own
 models by name.
 
-`ArkadeRfqSwap` arrived after the other three. **If you already shipped them, add it and bump
-`schemaVersion` again**: Realm creates schemas at open, so a config still listing three fails on the
-first RFQ read rather than at open. SQLite needs nothing — its DDL runs `CREATE TABLE IF NOT EXISTS`
-on every init, so the table appears on the next operation.
+`ArkadeRfqSwap` and `ArkadeSwapRecord` arrived after the first three. **If you already shipped an
+earlier set, add the new ones and bump `schemaVersion` again**: Realm creates schemas at open, so a
+config listing fewer fails on the first read of the missing one rather than at open. Spreading
+`AssetSwapRealmSchemas` rather than listing names by hand is what keeps that from happening again.
+SQLite needs nothing — its DDL runs `CREATE TABLE IF NOT EXISTS` on every init, so a new table
+appears on the next operation.
 
 ## Creating an offer
 

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -31,6 +31,16 @@
                 "default": "./dist/nostr.cjs"
             }
         },
+        "./node": {
+            "import": {
+                "types": "./dist/node/index.d.ts",
+                "default": "./dist/node/index.js"
+            },
+            "require": {
+                "types": "./dist/node/index.d.ts",
+                "default": "./dist/node/index.cjs"
+            }
+        },
         "./repositories/sqlite": {
             "import": {
                 "types": "./dist/repositories/sqlite/index.d.ts",
@@ -56,7 +66,9 @@
         "dist"
     ],
     "scripts": {
-        "build": "tsup src/index.ts src/nostr.ts src/repositories/sqlite/index.ts src/repositories/realm/index.ts --format esm,cjs --dts --clean",
+        "build": "pnpm run build:web && pnpm run build:node",
+        "build:web": "tsup src/index.ts src/nostr.ts src/repositories/sqlite/index.ts src/repositories/realm/index.ts --format esm,cjs --dts --clean",
+        "build:node": "tsup --config tsup.node.config.ts",
         "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
         "format": "biome format --write src test",
         "lint": "biome format src test",
@@ -66,6 +78,9 @@
         "test:integration": "vitest run test/e2e/** --exclude test/e2e/rfq*.test.ts",
         "test:integration:rfq": "vitest run test/e2e/rfq*.test.ts",
         "smoke:dist": "node scripts/smoke-dist.mjs"
+    },
+    "engines": {
+        "node": ">=22.12.0"
     },
     "keywords": [
         "arkade",

--- a/packages/swap/scripts/smoke-dist.mjs
+++ b/packages/swap/scripts/smoke-dist.mjs
@@ -69,8 +69,25 @@ for (const specifier of specifiers) {
 const stubExecutor = { run: async () => {}, get: async () => undefined, all: async () => [] };
 new SQLiteAssetSwapRepository(stubExecutor);
 new RealmAssetSwapRepository({});
-if (AssetSwapRealmSchemas.length !== 4) {
-    throw new Error(`expected 4 Realm schemas, got ${AssetSwapRealmSchemas.length}`);
+// Name-based, not a magic count: the count is what makes adding a schema a
+// build failure in a file that has no other reason to change, and what it
+// actually needs to catch is a schema that never made it into the exported
+// list — the one mistake that fails at a consumer's first `realm.objects(…)`
+// rather than at open.
+const schemaNames = AssetSwapRealmSchemas.map((s) => s.name);
+for (const required of [
+    "ArkadeAssetSwap",
+    "ArkadeRfqSwap",
+    "ArkadeSwapRecord",
+    "ArkadeAssetSwapScannedTxid",
+    "ArkadeAssetSwapMarketsCache",
+]) {
+    if (!schemaNames.includes(required)) {
+        throw new Error(`AssetSwapRealmSchemas is missing ${required}: [${schemaNames}]`);
+    }
+}
+if (new Set(schemaNames).size !== schemaNames.length) {
+    throw new Error(`AssetSwapRealmSchemas has duplicate names: [${schemaNames}]`);
 }
 
 const operatorPubkey = hex.decode("4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa");

--- a/packages/swap/src/client/accept.ts
+++ b/packages/swap/src/client/accept.ts
@@ -50,6 +50,7 @@ import { rfqSecretsProfile } from "../rfqProfileParts";
 import { BTC_ASSET_ID } from "../store";
 import type { AssetSwapRepository } from "../repository";
 import { assetPartOf, BTC_ASSET_PART } from "./assetId";
+import { toDiscoveryLeg } from "./aliases";
 import type { CorridorSet } from "./corridors/registry";
 import { AcceptConflict, InsufficientFunds, MissingCorridorDep, QuoteExpired } from "./errors";
 import { fromAtomicDecimal } from "./amount";
@@ -65,6 +66,7 @@ import {
     swapOf,
     type CorridorSwapRecord,
     type OfferSwapRecord,
+    type RecordedInstrument,
     type Swap,
     type SwapRecord,
 } from "./record";
@@ -74,7 +76,7 @@ export type QuotePreparation = RfqPreparation | OfferPreparation;
 
 export interface AcceptInput {
     readonly quote: Quote;
-    readonly preparation: QuotePreparation;
+    readonly preparation?: QuotePreparation;
     readonly wallet: IWallet;
     readonly repository: AssetSwapRepository | undefined;
     readonly corridors: CorridorSet;
@@ -117,24 +119,59 @@ const storageOf = (repository: AssetSwapRepository | undefined): AssetSwapReposi
  * both sides encode to. That is one comparison of one representation, instead
  * of a `bigint` round trip that could differ only by how it was parsed.
  */
+type RecordedFacts = {
+    readonly "route.pair": string;
+    readonly "give.asset": string;
+    readonly "take.asset": string;
+    readonly "give.amount": string;
+    readonly "take.amount": string;
+    readonly "give.instrument": RecordedInstrument;
+    readonly "take.instrument": RecordedInstrument;
+    readonly "lock.hash": string | undefined;
+    readonly refundLocktime: string | undefined;
+    readonly solver: string | undefined;
+    readonly "market.source": string | undefined;
+};
+
+const sameRecordedInstrument = (a: RecordedInstrument, b: RecordedInstrument): boolean => {
+    switch (a.kind) {
+        case "wallet":
+            return b.kind === "wallet";
+        case "address":
+            return b.kind === "address" && a.address === b.address;
+        case "invoice":
+            return (
+                b.kind === "invoice" &&
+                a.bolt11 === b.bolt11 &&
+                a.paymentHash === b.paymentHash &&
+                a.amount === b.amount &&
+                a.expiresAt === b.expiresAt
+            );
+    }
+};
+
 export const conflictingFields = (record: SwapRecord, quote: Quote): string[] => {
     const incoming = recordedFacts(quote);
-    const stored = {
+    const stored: RecordedFacts = {
         "route.pair": `${record.route.give.corridor}->${record.route.take.corridor}`,
         "give.asset": record.route.give.asset,
         "take.asset": record.route.take.asset,
         "give.amount": record.give.amount,
         "take.amount": record.take.amount,
-        "give.instrument": JSON.stringify(record.route.give.instrument),
-        "take.instrument": JSON.stringify(record.route.take.instrument),
+        "give.instrument": record.route.give.instrument,
+        "take.instrument": record.route.take.instrument,
         "lock.hash": record.family === "rfq" ? record.lock.hash : undefined,
         refundLocktime: record.family === "rfq" ? String(record.refundLocktime) : undefined,
         solver: record.solver,
         "market.source": marketSourceOf(record.market),
     };
-    return Object.keys(incoming).filter((field) => {
-        const a = stored[field as keyof typeof stored];
-        const b = incoming[field as keyof typeof incoming];
+    return (Object.keys(incoming) as (keyof RecordedFacts)[]).filter((field) => {
+        if (field === "give.instrument" || field === "take.instrument") {
+            return !sameRecordedInstrument(stored[field], incoming[field]);
+        }
+
+        const a = stored[field];
+        const b = incoming[field];
         // Absent on both sides is agreement, not a difference: it is how a
         // feed-priced quote's missing solver and lock hash read.
         if (a === undefined && b === undefined) return false;
@@ -143,14 +180,14 @@ export const conflictingFields = (record: SwapRecord, quote: Quote): string[] =>
 };
 
 /** The same facts off a `Quote`, in the record's own encoding. */
-const recordedFacts = (quote: Quote) => ({
+const recordedFacts = (quote: Quote): RecordedFacts => ({
     "route.pair": `${quote.route.give.corridor}->${quote.route.take.corridor}`,
     "give.asset": quote.route.give.asset as string,
     "take.asset": quote.route.take.asset as string,
     "give.amount": recordLeg(quote.give).amount as string,
     "take.amount": recordLeg(quote.take).amount as string,
-    "give.instrument": JSON.stringify(recordEndpoint(quote.route.give).instrument),
-    "take.instrument": JSON.stringify(recordEndpoint(quote.route.take).instrument),
+    "give.instrument": recordEndpoint(quote.route.give).instrument,
+    "take.instrument": recordEndpoint(quote.route.take).instrument,
     "lock.hash": quote.lock?.hash,
     refundLocktime: quote.refundLocktime === undefined ? undefined : String(quote.refundLocktime),
     solver: quote.solver,
@@ -304,16 +341,10 @@ const profileOf = (preparation: RfqPreparation, paymentHash: string): Record<str
  * durable evidence contradicts the quote on a material field.
  */
 export const acceptQuote = async (input: AcceptInput): Promise<Swap> => {
-    const { quote, preparation, wallet, now } = input;
+    const { quote, wallet, now } = input;
     const repository = storageOf(input.repository);
 
-    // Strictly past its own deadline, and not against `policy.quoteTtlFloor`:
-    // the floor is the quote path's question — "is there enough life left in
-    // these terms to be worth showing" — and inheriting it here would refuse a
-    // quote §3.2 still considers acceptable.
-    if (now > quote.expiresAt) {
-        throw new QuoteExpired(quote.id, quote.expiresAt, now);
-    }
+    const expired = now > quote.expiresAt;
 
     const stored = await repository.getSwapRecord(quote.id);
     if (stored !== undefined) {
@@ -329,12 +360,34 @@ export const acceptQuote = async (input: AcceptInput): Promise<Swap> => {
         if (stored.fundingTxid !== undefined) return swapOf(stored);
         if (!fundsFromWallet(stored.route)) return swapOf(stored);
         // Persisted but unfunded. Before a second `wallet.send`, look for the
-        // deposit a crashed first attempt may already have made.
-        const found = await reconcileFunding(input, stored);
+        // deposit a crashed first attempt may already have made. This path uses
+        // the stored record only, so it survives a restart or preparation-cache
+        // eviction.
+        const found = await reconcileFunding({ wallet }, stored);
         if (found !== undefined) {
             return swapOf(await stampFunding(repository, stored, found, now));
         }
-        return swapOf(await fundAndStamp(input, stored, repository));
+        // No funding evidence exists yet, so retrying would move new value and
+        // still has to respect the quote's deadline.
+        if (expired) throw new QuoteExpired(quote.id, quote.expiresAt, now);
+        return swapOf(await fundAndStamp({ wallet, now }, stored, repository));
+    }
+
+    // Strictly past its own deadline, and not against `policy.quoteTtlFloor`:
+    // the floor is the quote path's question — "is there enough life left in
+    // these terms to be worth showing" — and inheriting it here would refuse a
+    // quote §3.2 still considers acceptable.
+    if (expired) throw new QuoteExpired(quote.id, quote.expiresAt, now);
+
+    const preparation = input.preparation;
+    if (preparation === undefined) {
+        // The derivation this quote was verified against is gone, and no record
+        // exists yet to resume from. Re-deriving would be a second derivation of
+        // the same tree — two sources for one covenant, which is the failure the
+        // preparation hand-off exists to prevent.
+        throw new Error(
+            `quote ${quote.id} was not derived by this client instance; re-quote before accepting`,
+        );
     }
 
     const funds = fundsFromWallet(quote.route);
@@ -352,7 +405,7 @@ export const acceptQuote = async (input: AcceptInput): Promise<Swap> => {
     await repository.saveSwapRecord(record);
 
     if (!funds) return swapOf(record);
-    return swapOf(await fundAndStamp(input, record, repository));
+    return swapOf(await fundAndStamp({ wallet, now }, record, repository));
 };
 
 /**
@@ -406,8 +459,10 @@ const registeredCorridorRecord = async (
  * What recovers a lost stamp is the reconcile above, which finds the deposit
  * from chain evidence on the next accept.
  */
+type FundingInput = Pick<AcceptInput, "wallet" | "now">;
+
 const fundAndStamp = async (
-    input: AcceptInput,
+    input: FundingInput,
     record: SwapRecord,
     repository: AssetSwapRepository,
 ): Promise<SwapRecord> => {
@@ -440,45 +495,33 @@ const stampFunding = async (
  * nowhere and merely lands the deposit at a covenant no solver can see. That
  * silent loss is the failure this route's packet handling exists to delete.
  */
-const fund = async (input: AcceptInput, record: SwapRecord): Promise<string> => {
-    const { wallet, preparation } = input;
+const fund = async (input: FundingInput, record: SwapRecord): Promise<string> => {
+    const { wallet } = input;
     if (record.family === "offer") {
-        if (preparation.backend !== "feed") {
-            throw new Error(
-                `offer record ${record.id} accepted with an ${preparation.backend} quote`,
-            );
-        }
-        const { plan } = preparation;
-        const depositIsBtc = plan.deposit.asset.id === BTC_ASSET_ID;
-        // The amount comes off the RECORD, not the plan: v1 made a caller read
-        // a `fundAmount` field beside the amount they quoted, and v2 has no
-        // such field because the quote's own give amount is what accept funds.
-        // The plan is still what spells the asset id, which only it carries.
         const amount = fromAtomicDecimal(record.give.amount);
+        const depositIsBtc = assetPartOf(record.route.give.asset) === BTC_ASSET_PART;
         return wallet.send({
             address: record.swapAddress,
             // An asset deposit rides the SDK's dust-sat carrier, so the sats
             // amount is left to the default rather than set here.
             ...(depositIsBtc
                 ? { amount: toSafeNumber(amount, "give.amount") }
-                : { assets: [{ assetId: plan.deposit.asset.id, amount }] }),
+                : {
+                      assets: [
+                          { assetId: toDiscoveryLeg(record.route.give.asset).assetId, amount },
+                      ],
+                  }),
             extensions: [offerExtensionOf(record)],
         });
     }
-    if (preparation.backend !== "rfq") {
-        throw new Error(
-            `corridor record ${record.id} accepted with an ${preparation.backend} quote`,
-        );
-    }
-    if (preparation.route === "lightning->arkade") {
+    if (record.kind === "lightning_receive") {
         // Unreachable: the caller gates on `fundsFromWallet`, and a receive's
         // give instrument is the invoice. Stated so the union is exhaustive
         // rather than narrowed by an assumption.
         throw new Error(`receive swap ${record.id} funds nothing from this wallet`);
     }
-    // Again the record's own give amount, which `verifyQuotedAmount` already
-    // proved equal to the preparation's `fundAmount` at quote time. One source
-    // means the resume path funds the same number the first attempt would have.
+    // The record's own give amount is the only source on resume: quote-time
+    // verification already proved it equal to the negotiated funding amount.
     return wallet.send({
         address: record.lockupAddress,
         amount: toSafeNumber(fromAtomicDecimal(record.give.amount), "give.amount"),
@@ -516,7 +559,7 @@ const offerExtensionOf = (record: OfferSwapRecord): { type: number; payload: Uin
  * swap, and the swap it really belongs to would then be funded twice.
  */
 const reconcileFunding = async (
-    input: AcceptInput,
+    input: Pick<AcceptInput, "wallet">,
     record: SwapRecord,
 ): Promise<string | undefined> => {
     const script = record.family === "offer" ? record.swapPkScript : record.lockupPkScript;

--- a/packages/swap/src/client/accept.ts
+++ b/packages/swap/src/client/accept.ts
@@ -1,0 +1,559 @@
+/**
+ * `accept()`: where value moves, and the one ordering it moves in.
+ *
+ * ```
+ * QuoteExpired
+ *   -> the record by quote id: return | resume | AcceptConflict
+ *   -> InsufficientFunds                     [funding routes]
+ *   -> derive the covenant and REGISTER its row
+ *   -> persist the record and its secrets    <- throwing; nothing past here
+ *                                               happens without it
+ *   -> fund                                  [funding routes]
+ *   -> write the funding txid                [funding routes, best effort]
+ * ```
+ *
+ * **Persist-first is a mechanism here, not an instruction.** v1 wrote the rule
+ * down in a README and could not keep it: `AssetSwap.id` *is* the funding txid,
+ * so on the spot route the record could not exist before the money did, and the
+ * e2e ran the opposite order because it had to. Keying on the client-minted
+ * quote id is what makes the record precede the funding on every route, with
+ * `fundingTxid` a later best-effort write.
+ *
+ * **Registration is part of the ordering, before the persist.** The quote path
+ * deliberately registers nothing — it derives a covenant and discloses nothing
+ * durable — but a lockup's contract row is the only place its tree parameters
+ * live, and a rebuild reads them from there. So a record persisted without one
+ * is unrebuildable. Registering first buys the invariant that *a persisted
+ * record always has its covenant row*; the row is local, idempotent
+ * (first-writer-wins) and inert until funded, so a crash between the two leaves
+ * nothing at stake — which is the same argument `createOffer` already makes for
+ * registering before funding rather than after.
+ *
+ * **A funding route is one whose give instrument is the wallet's.** On
+ * `lightning -> arkade` the give leg is the hold invoice a third party pays, so
+ * the pipeline ends at the persist: nothing is pre-flighted and nothing is sent.
+ * The discriminant is the instrument and never the asset — a receive gives BTC
+ * too, and branching on the asset would refuse the canonical empty-wallet
+ * receive for want of a balance it never spends.
+ *
+ * What does NOT happen here: arming. The drive loop, the watcher and the
+ * outcome vocabulary are the next milestone's, and this one stops once the
+ * record is durable. A receive route therefore hands back a durable invoice
+ * that nothing is yet watching.
+ */
+import { hex } from "@scure/base";
+import { asset, getAllNormalizedVtxos, type IWallet } from "@arkade-os/sdk";
+import { createOffer, OFFER_PACKET_TYPE } from "../offer";
+import { registerLockupContract } from "../lockupContract";
+import { onchainSendProfile } from "../rfqCorridors";
+import { rfqSecretsProfile } from "../rfqProfileParts";
+import { BTC_ASSET_ID } from "../store";
+import type { AssetSwapRepository } from "../repository";
+import { assetPartOf, BTC_ASSET_PART } from "./assetId";
+import type { CorridorSet } from "./corridors/registry";
+import { AcceptConflict, InsufficientFunds, MissingCorridorDep, QuoteExpired } from "./errors";
+import { fromAtomicDecimal } from "./amount";
+import { toSafeNumber } from "./rfqAmount";
+import type { Quote, QuoteId } from "./quote";
+import type { OfferPreparation } from "./quoteOffer";
+import type { RfqPreparation } from "./quoteRfq";
+import {
+    fundsFromWallet,
+    recordArtifact,
+    recordEndpoint,
+    recordLeg,
+    swapOf,
+    type CorridorSwapRecord,
+    type OfferSwapRecord,
+    type Swap,
+    type SwapRecord,
+} from "./record";
+
+/** What a quote derived, kept in memory for the accept that may follow. */
+export type QuotePreparation = RfqPreparation | OfferPreparation;
+
+export interface AcceptInput {
+    readonly quote: Quote;
+    readonly preparation: QuotePreparation;
+    readonly wallet: IWallet;
+    readonly repository: AssetSwapRepository | undefined;
+    readonly corridors: CorridorSet;
+    /** Unix seconds. */
+    readonly now: number;
+}
+
+/**
+ * The repository, or the refusal that names it.
+ *
+ * `MissingCorridorDep("arkade", "repository")` rather than a bare `Error`: the
+ * arkade corridor declares the repository as its one overridable dep, described
+ * in the override matrix as "where persist-first lands", and this is the call
+ * that lands it. Refused here rather than at dep resolution because the arkade
+ * module is a leg of every route, so a required dep would mean a client with no
+ * storage could not even `quote()` — and quoting persists nothing.
+ */
+const storageOf = (repository: AssetSwapRepository | undefined): AssetSwapRepository => {
+    if (repository === undefined) {
+        throw new MissingCorridorDep("arkade", "repository");
+    }
+    return repository;
+};
+
+/**
+ * The fields on which a stored record and an incoming quote disagree.
+ *
+ * §3.2's list, spelled as dotted paths so the message names a field rather than
+ * a concept: route pair, both assets and amounts, both instruments, the lock
+ * hash, `refundLocktime`, the solver and the registry.
+ *
+ * Two rules from the spec, both load-bearing. Only **material** differences
+ * count, so a field absent on both sides never conflicts — which is what keeps
+ * a feed-priced quote, whose `solver` and `lock` are absent by construction,
+ * from conflicting with its own record. And `fundingTxid` is not compared at
+ * all: it appearing where there was none is the benign resume, named as such.
+ *
+ * The comparison runs over the record's *stored* form rather than over a
+ * rehydrated `Swap`, so an amount is compared as the canonical decimal string
+ * both sides encode to. That is one comparison of one representation, instead
+ * of a `bigint` round trip that could differ only by how it was parsed.
+ */
+export const conflictingFields = (record: SwapRecord, quote: Quote): string[] => {
+    const incoming = recordedFacts(quote);
+    const stored = {
+        "route.pair": `${record.route.give.corridor}->${record.route.take.corridor}`,
+        "give.asset": record.route.give.asset,
+        "take.asset": record.route.take.asset,
+        "give.amount": record.give.amount,
+        "take.amount": record.take.amount,
+        "give.instrument": JSON.stringify(record.route.give.instrument),
+        "take.instrument": JSON.stringify(record.route.take.instrument),
+        "lock.hash": record.family === "rfq" ? record.lock.hash : undefined,
+        refundLocktime: record.family === "rfq" ? String(record.refundLocktime) : undefined,
+        solver: record.solver,
+        "market.source": marketSourceOf(record.market),
+    };
+    return Object.keys(incoming).filter((field) => {
+        const a = stored[field as keyof typeof stored];
+        const b = incoming[field as keyof typeof incoming];
+        // Absent on both sides is agreement, not a difference: it is how a
+        // feed-priced quote's missing solver and lock hash read.
+        if (a === undefined && b === undefined) return false;
+        return a !== b;
+    });
+};
+
+/** The same facts off a `Quote`, in the record's own encoding. */
+const recordedFacts = (quote: Quote) => ({
+    "route.pair": `${quote.route.give.corridor}->${quote.route.take.corridor}`,
+    "give.asset": quote.route.give.asset as string,
+    "take.asset": quote.route.take.asset as string,
+    "give.amount": recordLeg(quote.give).amount as string,
+    "take.amount": recordLeg(quote.take).amount as string,
+    "give.instrument": JSON.stringify(recordEndpoint(quote.route.give).instrument),
+    "take.instrument": JSON.stringify(recordEndpoint(quote.route.take).instrument),
+    "lock.hash": quote.lock?.hash,
+    refundLocktime: quote.refundLocktime === undefined ? undefined : String(quote.refundLocktime),
+    solver: quote.solver,
+    "market.source": marketSourceOf(quote.market),
+});
+
+/**
+ * The registry a market came from.
+ *
+ * `CardMarketRef.source` and not `snapshot.registry`: `source` is the field the
+ * policy allowlist already matches on and the one a locally pinned card carries
+ * a label in, while `snapshot.registry` is absent on an injected snapshot. The
+ * auction arm has no source at all, which reads as "absent on both sides" and
+ * therefore never conflicts.
+ */
+const marketSourceOf = (market: Quote["market"]): string | undefined =>
+    market.kind === "card" ? market.source : undefined;
+
+/**
+ * The wallet can fund the give leg, or it cannot and nothing is written.
+ *
+ * Runs only on a funding route, and deliberately coarse: `balance.available` is
+ * documented as what generic selection would pick, "so nothing counted here can
+ * be refused by `send`", which makes a shortfall it reports real. What it does
+ * NOT model is the other direction — `send`'s dust carrier, and the sats it
+ * credits back off selected asset coins — because a false refusal is the one
+ * failure that matters here. A shortfall this misses surfaces as `send`'s own
+ * throw, after the persist, and the record survives that.
+ */
+const assertFundable = async (wallet: IWallet, quote: Quote): Promise<void> => {
+    const give = quote.give;
+    const balance = await wallet.getBalance();
+    // On the asset part, not the whole id: the rail differs per corridor —
+    // `arkade:…/slip44:0` and `bitcoin:…/slip44:0` are one coin — and it is the
+    // part that says *which asset* rather than *on which rail*.
+    if (assetPartOf(give.asset) === BTC_ASSET_PART) {
+        const available = BigInt(balance.available);
+        if (available < give.amount) {
+            throw new InsufficientFunds(give.asset, give.amount, available);
+        }
+        return;
+    }
+    const held = balance.availableAssets.find((a) => give.asset.endsWith(a.assetId));
+    const available = held?.amount ?? 0n;
+    if (available < give.amount) {
+        throw new InsufficientFunds(give.asset, give.amount, available);
+    }
+};
+
+/**
+ * The v2 record for an accepted quote, before anything is funded.
+ *
+ * One builder for both families so the common half cannot drift between them —
+ * every field §3.2 compares is written in one place, which is what makes "the
+ * compared field is durable" a property of the type rather than a review note.
+ */
+const commonOf = (quote: Quote, now: number) => ({
+    id: quote.id,
+    route: {
+        give: recordEndpoint(quote.route.give),
+        take: recordEndpoint(quote.route.take),
+    },
+    give: recordLeg(quote.give),
+    take: recordLeg(quote.take),
+    fee: recordLeg(quote.fee),
+    market: quote.market,
+    ...(quote.solver === undefined ? {} : { solver: quote.solver }),
+    expiresAt: quote.expiresAt,
+    ...(quote.artifact === undefined ? {} : { artifact: recordArtifact(quote.artifact) }),
+    createdAt: now,
+    updatedAt: now,
+});
+
+/** The corridor record: the lockup, its clocks, its secrets and its profile. */
+const corridorRecord = (
+    quote: Quote,
+    preparation: RfqPreparation,
+    now: number,
+): CorridorSwapRecord => {
+    if (quote.lock === undefined || quote.refundLocktime === undefined) {
+        // Unreachable from `quote()`: every corridor route refuses a reply
+        // without both, in verification. Stated so the record's non-optional
+        // fields are not an unchecked cast.
+        throw new Error(`corridor quote ${quote.id} carries no lock hash or refund locktime`);
+    }
+    return {
+        ...commonOf(quote, now),
+        family: "rfq",
+        state: "pending",
+        kind: kindOf(preparation),
+        rfqId: preparation.rfqId,
+        lockupAddress: preparation.lockup.address,
+        lockupPkScript: hex.encode(preparation.lockup.pkScript),
+        lock: { hash: quote.lock.hash },
+        refundLocktime: quote.refundLocktime,
+        profile: profileOf(preparation, quote.lock.hash),
+    };
+};
+
+/** The manager's own vocabulary for this route — a route pair, not a corridor. */
+const kindOf = (preparation: RfqPreparation): CorridorSwapRecord["kind"] => {
+    switch (preparation.route) {
+        case "arkade->lightning":
+            return "lightning_send";
+        case "lightning->arkade":
+            return "lightning_receive";
+        case "arkade->onchain":
+            return "onchain_send";
+    }
+};
+
+/**
+ * The corridor's opaque half, written through the corridor-owned builders.
+ *
+ * `rfqSecretsProfile` rather than hand-listed fields: it splits the provisioned
+ * secret so `preimageSaltHex` rides into `hashlock` with the rest of the
+ * preimage material, and hand-listing is exactly how that field was lost
+ * before. The at-most-one-of `preimageHex`/`preimageSaltHex` rule comes with
+ * it, since the provisioning result is what decides which arm exists.
+ */
+const profileOf = (preparation: RfqPreparation, paymentHash: string): Record<string, unknown> => {
+    const secrets = rfqSecretsProfile(preparation.secrets, paymentHash);
+    switch (preparation.route) {
+        case "arkade->lightning":
+            return { ...secrets };
+        case "lightning->arkade":
+            return {
+                ...secrets,
+                expectedAmount: toSafeNumber(preparation.expectedAmount, "expectedAmount"),
+                payoutAddress: preparation.payoutAddress,
+            };
+        case "arkade->onchain":
+            return {
+                ...secrets,
+                ...onchainSendProfile({
+                    htlc: preparation.htlc,
+                    htlcParams: preparation.htlcParams,
+                    l1Network: preparation.l1Network,
+                    minConfirmations: preparation.minConfirmations,
+                }),
+            };
+    }
+};
+
+/**
+ * Accept a quote: make it durable, then move the value.
+ *
+ * Idempotent by quote id and only by quote id. A second call with the same
+ * quote returns the stored swap when the funding txid is already known, resumes
+ * the record when it is not, and refuses as `AcceptConflict` only when the
+ * durable evidence contradicts the quote on a material field.
+ */
+export const acceptQuote = async (input: AcceptInput): Promise<Swap> => {
+    const { quote, preparation, wallet, now } = input;
+    const repository = storageOf(input.repository);
+
+    // Strictly past its own deadline, and not against `policy.quoteTtlFloor`:
+    // the floor is the quote path's question — "is there enough life left in
+    // these terms to be worth showing" — and inheriting it here would refuse a
+    // quote §3.2 still considers acceptable.
+    if (now > quote.expiresAt) {
+        throw new QuoteExpired(quote.id, quote.expiresAt, now);
+    }
+
+    const stored = await repository.getSwapRecord(quote.id);
+    if (stored !== undefined) {
+        const fields = conflictingFields(stored, quote);
+        if (fields.length > 0) {
+            throw new AcceptConflict(quote.id, stored.id, fields);
+        }
+        // The record is this quote's, and its funding already happened: the
+        // whole call is a no-op and the answer comes off the record, artifact
+        // included. A duplicate receive accept therefore returns the invoice
+        // that was stored rather than the one on whatever quote object the
+        // caller still holds.
+        if (stored.fundingTxid !== undefined) return swapOf(stored);
+        if (!fundsFromWallet(stored.route)) return swapOf(stored);
+        // Persisted but unfunded. Before a second `wallet.send`, look for the
+        // deposit a crashed first attempt may already have made.
+        const found = await reconcileFunding(input, stored);
+        if (found !== undefined) {
+            return swapOf(await stampFunding(repository, stored, found, now));
+        }
+        return swapOf(await fundAndStamp(input, stored, repository));
+    }
+
+    const funds = fundsFromWallet(quote.route);
+    if (funds) await assertFundable(wallet, quote);
+
+    // Derive-and-register, then persist. Both families register before the
+    // record exists, which is what makes a stored record always rebuildable.
+    const record =
+        preparation.backend === "feed"
+            ? await registeredOfferRecord(input, preparation)
+            : await registeredCorridorRecord(input, preparation);
+
+    // Throwing, deliberately: nothing past this line may happen if the record
+    // is not durable, and that is the whole invariant.
+    await repository.saveSwapRecord(record);
+
+    if (!funds) return swapOf(record);
+    return swapOf(await fundAndStamp(input, record, repository));
+};
+
+/**
+ * The offer covenant, registered, and the record that describes it.
+ *
+ * `createOffer` derives and registers in one call — the contract row and the
+ * process-local issuance mark are both written inside it — so on this route
+ * "derive and register" is one step and the offer TLV is what the record keeps.
+ */
+const registeredOfferRecord = async (
+    input: AcceptInput,
+    preparation: OfferPreparation,
+): Promise<OfferSwapRecord> => {
+    const { quote, wallet, corridors, now } = input;
+    const { plan } = preparation;
+    const arkade = corridors.get("arkade").deps;
+    const receiveIsBtc = plan.receive.asset.id === BTC_ASSET_ID;
+    const offer = await createOffer(wallet, {
+        // Keyed on the receive side: the covenant binds what the fill delivers.
+        wantAmount: plan.receive.atomic,
+        ...(receiveIsBtc
+            ? { offerAsset: asset.AssetId.fromString(plan.deposit.asset.id) }
+            : { wantAsset: asset.AssetId.fromString(plan.receive.asset.id) }),
+        emulatorPubkey: arkade.emulatorPubkey,
+    });
+    return {
+        ...commonOf(quote, now),
+        family: "offer",
+        status: "pending",
+        offerHex: offer.offerHex,
+        swapAddress: offer.address,
+        swapPkScript: hex.encode(offer.swapPkScript),
+    };
+};
+
+/** The lockup's contract row, then the record that names it. */
+const registeredCorridorRecord = async (
+    input: AcceptInput,
+    preparation: RfqPreparation,
+): Promise<CorridorSwapRecord> => {
+    const contracts = await input.wallet.getContractManager();
+    await registerLockupContract(contracts, preparation.lockup.script, preparation.lockup.address);
+    return corridorRecord(input.quote, preparation, input.now);
+};
+
+/**
+ * Fund the give leg, then stamp the txid.
+ *
+ * The stamp is best effort by design: the money has moved, and failing the
+ * caller here would report as failed a swap whose funding is already broadcast.
+ * What recovers a lost stamp is the reconcile above, which finds the deposit
+ * from chain evidence on the next accept.
+ */
+const fundAndStamp = async (
+    input: AcceptInput,
+    record: SwapRecord,
+    repository: AssetSwapRepository,
+): Promise<SwapRecord> => {
+    const txid = await fund(input, record);
+    return stampFunding(repository, record, txid, input.now);
+};
+
+const stampFunding = async (
+    repository: AssetSwapRepository,
+    record: SwapRecord,
+    fundingTxid: string,
+    now: number,
+): Promise<SwapRecord> => {
+    const stamped = { ...record, fundingTxid, updatedAt: now } as SwapRecord;
+    try {
+        await repository.saveSwapRecord(stamped);
+    } catch (error) {
+        console.warn(`[swap] funded ${record.id} but could not store its txid`, error);
+    }
+    return stamped;
+};
+
+/**
+ * The `wallet.send` each funding route makes.
+ *
+ * The recipient object is passed **straight** to `send`, never rebuilt or
+ * normalised on the way: `send` re-reads `extensions` off its own raw arguments
+ * rather than off the validated recipients, so a helper that reassembled the
+ * list would drop the offer packet — silently, since omitting it throws
+ * nowhere and merely lands the deposit at a covenant no solver can see. That
+ * silent loss is the failure this route's packet handling exists to delete.
+ */
+const fund = async (input: AcceptInput, record: SwapRecord): Promise<string> => {
+    const { wallet, preparation } = input;
+    if (record.family === "offer") {
+        if (preparation.backend !== "feed") {
+            throw new Error(
+                `offer record ${record.id} accepted with an ${preparation.backend} quote`,
+            );
+        }
+        const { plan } = preparation;
+        const depositIsBtc = plan.deposit.asset.id === BTC_ASSET_ID;
+        // The amount comes off the RECORD, not the plan: v1 made a caller read
+        // a `fundAmount` field beside the amount they quoted, and v2 has no
+        // such field because the quote's own give amount is what accept funds.
+        // The plan is still what spells the asset id, which only it carries.
+        const amount = fromAtomicDecimal(record.give.amount);
+        return wallet.send({
+            address: record.swapAddress,
+            // An asset deposit rides the SDK's dust-sat carrier, so the sats
+            // amount is left to the default rather than set here.
+            ...(depositIsBtc
+                ? { amount: toSafeNumber(amount, "give.amount") }
+                : { assets: [{ assetId: plan.deposit.asset.id, amount }] }),
+            extensions: [offerExtensionOf(record)],
+        });
+    }
+    if (preparation.backend !== "rfq") {
+        throw new Error(
+            `corridor record ${record.id} accepted with an ${preparation.backend} quote`,
+        );
+    }
+    if (preparation.route === "lightning->arkade") {
+        // Unreachable: the caller gates on `fundsFromWallet`, and a receive's
+        // give instrument is the invoice. Stated so the union is exhaustive
+        // rather than narrowed by an assumption.
+        throw new Error(`receive swap ${record.id} funds nothing from this wallet`);
+    }
+    // Again the record's own give amount, which `verifyQuotedAmount` already
+    // proved equal to the preparation's `fundAmount` at quote time. One source
+    // means the resume path funds the same number the first attempt would have.
+    return wallet.send({
+        address: record.lockupAddress,
+        amount: toSafeNumber(fromAtomicDecimal(record.give.amount), "give.amount"),
+    });
+};
+
+/**
+ * The offer packet, rebuilt from the record's own TLV.
+ *
+ * Rebuilt from the record rather than carried through from `createOffer`'s
+ * return, so the packet a resumed funding attaches is the one the *stored*
+ * covenant commits to rather than a second value that could drift from it. The
+ * TLV is the covenant, so re-encoding it is not a second derivation.
+ */
+const offerExtensionOf = (record: OfferSwapRecord): { type: number; payload: Uint8Array } => ({
+    type: OFFER_PACKET_TYPE,
+    payload: hex.decode(record.offerHex),
+});
+
+/**
+ * The deposit a crashed accept may already have made, found from evidence.
+ *
+ * The window this closes: the record is durable, `wallet.send` was called, and
+ * the process died before the txid was written. A blind retry would fund the
+ * same covenant twice.
+ *
+ * Matching is by script, then by amount, because the script alone is not unique
+ * — identical offers derive one address, and `createContract` is
+ * first-writer-wins precisely so nothing per-swap is written against it. What
+ * disambiguates is the deposited amount, which only the record carries: the
+ * covenant binds what the fill must *deliver*, never what was deposited.
+ *
+ * A VTXO at the script that matches no record's amount is left alone rather
+ * than adopted into a guess: adopting it would attach a deposit to the wrong
+ * swap, and the swap it really belongs to would then be funded twice.
+ */
+const reconcileFunding = async (
+    input: AcceptInput,
+    record: SwapRecord,
+): Promise<string | undefined> => {
+    const script = record.family === "offer" ? record.swapPkScript : record.lockupPkScript;
+    const expected = BigInt(record.give.amount);
+    const reader = await input.wallet.getArkadeReader();
+    // `getAllNormalizedVtxos` rather than the reader's own `getVtxos`: that one
+    // is a single logical query whose paging is the caller's to follow, and a
+    // missed page here would read as "no deposit" and fund the covenant twice.
+    const vtxos = await getAllNormalizedVtxos(reader, [script]);
+    const deposit = vtxos.find((vtxo) => depositMatches(vtxo, record, expected));
+    return deposit?.txid;
+};
+
+/**
+ * Whether this VTXO is the deposit the record describes.
+ *
+ * The give leg decides which figure to compare: a BTC give leg is the VTXO's
+ * own value, while an asset give leg rides the dust-sat carrier and the amount
+ * lives on the asset entry, so comparing `value` there would test the carrier
+ * rather than the deposit.
+ */
+const depositMatches = (
+    vtxo: { value: number; assets?: readonly { assetId: string; amount: bigint }[] },
+    record: SwapRecord,
+    expected: bigint,
+): boolean => {
+    const giveAsset = record.route.give.asset;
+    if (assetPartOf(giveAsset) === BTC_ASSET_PART) {
+        return BigInt(vtxo.value) === expected;
+    }
+    return (vtxo.assets ?? []).some(
+        (entry) => giveAsset.endsWith(entry.assetId) && entry.amount === expected,
+    );
+};
+
+/** The stored record for a quote id, for a caller that holds only the id. */
+export const swapRecordOf = async (
+    repository: AssetSwapRepository | undefined,
+    id: QuoteId,
+): Promise<SwapRecord | undefined> => storageOf(repository).getSwapRecord(id);

--- a/packages/swap/src/client/client.ts
+++ b/packages/swap/src/client/client.ts
@@ -296,22 +296,9 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
         accept: async (quote) => {
             const { corridors } = await resolved();
             const preparation = preparations.get(quote.id);
-            if (preparation === undefined) {
-                // The derivation this quote was verified against is gone, and
-                // re-deriving it would be a second derivation of the same tree
-                // — two sources for one covenant, which is the failure the
-                // preparation hand-off exists to prevent. The cache is bounded
-                // and process-local, so this is what a caller sees after a
-                // restart or after 64 intervening quotes: re-quote and accept
-                // that. A record already persisted under this id is still
-                // resumable, and `accept()` finds it either way.
-                throw new Error(
-                    `quote ${quote.id} was not derived by this client instance; re-quote before accepting`,
-                );
-            }
             return acceptQuote({
                 quote,
-                preparation,
+                ...(preparation === undefined ? {} : { preparation }),
                 wallet,
                 repository: config.repository,
                 corridors,

--- a/packages/swap/src/client/client.ts
+++ b/packages/swap/src/client/client.ts
@@ -28,15 +28,14 @@ import {
 } from "./corridors/deps";
 import { discoveryIndex, type DiscoveryConfig, type DiscoveryIndex } from "./discovery";
 import { UnsupportedRoute } from "./errors";
+import { acceptQuote, type QuotePreparation } from "./accept";
+import type { Swap } from "./record";
 import type { SwapPolicy } from "./policy";
-import { feedFetch, quoteFromFeed, type FeedFetch, type OfferPreparation } from "./quoteOffer";
-import { quoteViaRfq, type RfqPreparation } from "./quoteRfq";
+import { feedFetch, quoteFromFeed, type FeedFetch } from "./quoteOffer";
+import { quoteViaRfq } from "./quoteRfq";
 import type { Quote, QuoteId, QuoteInput, RouteResolution } from "./quote";
 import { resolveRoute, type ResolvedRoute } from "./resolve";
 import { nostrTransportFactory, type RfqTransportFactory } from "./transport";
-
-/** What a quote derived, kept in memory for the accept that may follow. */
-export type QuotePreparation = RfqPreparation | OfferPreparation;
 
 export interface SwapClientConfig {
     /**
@@ -45,8 +44,20 @@ export interface SwapClientConfig {
      */
     readonly wallet: IWallet;
     /**
-     * Storage. At this milestone it backs the markets cache and nothing else —
-     * the persist-first record is M4's, and so is the platform default.
+     * Storage: the accept records, the markets cache, the restore-scan cursor.
+     *
+     * One seam for all three — the arkade corridor's `repository` override
+     * defaults to this object, so a client cannot write records to one store
+     * and read its cache from another.
+     *
+     * No implicit default, and never an in-memory fallback: silently losing
+     * active swaps is the thing a storage default exists to prevent. A browser
+     * consumer passes `IndexedDbAssetSwapRepository`, a Node consumer imports
+     * `@arkade-os/swap/node` for the file-backed SQLite default, and a test
+     * passes `InMemoryAssetSwapRepository` — explicitly, which is the only way
+     * ephemeral storage is available. `accept()` without one is
+     * `MissingCorridorDep("arkade", "repository")`; `quote()` and `resolve()`
+     * work without one, since neither persists anything.
      */
     readonly repository?: AssetSwapRepository;
     readonly discovery?: DiscoveryConfig;
@@ -79,6 +90,27 @@ export interface SwapClient {
     resolve(input: QuoteInput): Promise<RouteResolution>;
     /** Verified, binding terms. Nothing is persisted, funded or watched. */
     quote(input: QuoteInput): Promise<Quote>;
+    /**
+     * Make the quote durable, then move the value.
+     *
+     * One ordering, on every route: the record and its secrets are at rest
+     * before anything irreversible, and the funding txid is a later best-effort
+     * write. Idempotent by quote id and only by quote id — a second call with
+     * the same quote returns or resumes the stored swap and never mints a
+     * second invoice or funds a second time.
+     *
+     * Does not arm a drive loop or a watcher: this returns once the record is
+     * durable. On `lightning -> arkade` that means a durable invoice the payer
+     * can be shown — which is the point of the ordering, since showing one
+     * whose claim secret is still in memory is what buys a lockup nobody can
+     * claim.
+     *
+     * @throws {QuoteExpired} past `quote.expiresAt`; the client never re-quotes.
+     * @throws {InsufficientFunds} before the persist, on funding routes only.
+     * @throws {AcceptConflict} when a record for this quote id contradicts it.
+     * @throws {MissingCorridorDep} when the client was given no repository.
+     */
+    accept(quote: Quote): Promise<Swap>;
     /**
      * What the quote with this id derived — the covenant, the keys, the wire
      * reply.
@@ -259,6 +291,32 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
                 // resource this call owns and nothing else will close.
                 await transport.close().catch(() => {});
             }
+        },
+
+        accept: async (quote) => {
+            const { corridors } = await resolved();
+            const preparation = preparations.get(quote.id);
+            if (preparation === undefined) {
+                // The derivation this quote was verified against is gone, and
+                // re-deriving it would be a second derivation of the same tree
+                // — two sources for one covenant, which is the failure the
+                // preparation hand-off exists to prevent. The cache is bounded
+                // and process-local, so this is what a caller sees after a
+                // restart or after 64 intervening quotes: re-quote and accept
+                // that. A record already persisted under this id is still
+                // resumable, and `accept()` finds it either way.
+                throw new Error(
+                    `quote ${quote.id} was not derived by this client instance; re-quote before accepting`,
+                );
+            }
+            return acceptQuote({
+                quote,
+                preparation,
+                wallet,
+                repository: config.repository,
+                corridors,
+                now: Math.floor(Date.now() / 1000),
+            });
         },
 
         preparationOf: (id) => preparations.get(id),

--- a/packages/swap/src/client/corridors/deps.ts
+++ b/packages/swap/src/client/corridors/deps.ts
@@ -72,6 +72,16 @@ export interface CorridorBase {
     readonly emulatorPubkey?: string;
     /** For hosts without a global `fetch`, and for tests. */
     readonly fetchImpl?: typeof fetch;
+    /**
+     * The client's storage, if it was given one.
+     *
+     * Here rather than only in the override matrix so the two seams cannot be
+     * two different objects: a client that takes a repository and an arkade
+     * override that names one would otherwise write records to one and read the
+     * markets cache from the other. The override still wins where it is set,
+     * and a deliberate `null` there still refuses.
+     */
+    readonly repository?: AssetSwapRepository;
 }
 
 /**
@@ -86,8 +96,8 @@ export interface CorridorBase {
  */
 export interface CorridorOverrides {
     arkade?: {
-        /** Where persist-first lands. No default until the accept path owns
-         * one, so `undefined` leaves it absent rather than building one. */
+        /** Where persist-first lands. Defaults to the client's own
+         * `repository`, so the two seams are one object; `null` refuses. */
         repository?: AssetSwapRepository | null;
     };
     lightning?: {
@@ -210,10 +220,16 @@ export function resolveCorridorDeps(
 ): CorridorDeps {
     switch (corridor) {
         case "arkade": {
-            // The one dep with no default to fall back to: the repository
-            // default belongs to the milestone that owns persistence, so an
-            // absent one stays absent and only a deliberate `null` is refused.
-            const repository = refusedIfNull(overrides?.arkade?.repository, "arkade", "repository");
+            // The accept path owns the default now, and it is the client's own
+            // repository — so the override and `SwapClientConfig.repository`
+            // resolve to one object rather than two. Still `undefined` when
+            // neither is set: the arkade module is a leg of every route, so
+            // demanding one here would mean a client with no storage could not
+            // `quote()`, and quoting persists nothing. `accept()` is what
+            // refuses, with this same `MissingCorridorDep`.
+            const repository =
+                refusedIfNull(overrides?.arkade?.repository, "arkade", "repository") ??
+                base.repository;
             return {
                 wallet: base.wallet,
                 operator: base.operator,
@@ -300,6 +316,8 @@ export const resolveCorridorBase = async (input: {
     operator: SwapOperator;
     emulatorPubkey?: string;
     fetchImpl?: typeof fetch;
+    /** The client's storage, threaded so the arkade dep can default to it. */
+    repository?: AssetSwapRepository;
     /** Defaults to `true` — see {@link liveArkadeInfo}. */
     requireLive?: boolean;
 }): Promise<CorridorBase> => {
@@ -313,5 +331,6 @@ export const resolveCorridorBase = async (input: {
         signerSet: signerSetFromInfo(info),
         emulatorPubkey: input.emulatorPubkey,
         fetchImpl: input.fetchImpl,
+        repository: input.repository,
     };
 };

--- a/packages/swap/src/client/index.ts
+++ b/packages/swap/src/client/index.ts
@@ -1,13 +1,14 @@
 /**
  * The v2 client's vocabulary: asset identity, the corridor axis, the closed
- * route union, the amount law, the alias layer, the error taxonomy and the
- * corridor modules.
+ * route union, the amount law, the alias layer, the error taxonomy, the
+ * corridor modules, and the durable record `accept()` writes.
  *
  * Internal to the package for now. M8 is what slims the root export to the v2
  * surface and moves the v1 building blocks to `/protocol`; exporting any of
  * this from `src/index.ts` today would publish a surface the milestones after
  * this one are still deciding.
  */
+export * from "./accept";
 export * from "./aliases";
 export * from "./aliasTable";
 export * from "./amount";
@@ -23,6 +24,7 @@ export * from "./primitives";
 export * from "./quote";
 export * from "./quoteOffer";
 export * from "./quoteRfq";
+export * from "./record";
 export * from "./resolve";
 export * from "./rfqAmount";
 export * from "./rfqWire";

--- a/packages/swap/src/client/record.ts
+++ b/packages/swap/src/client/record.ts
@@ -159,11 +159,15 @@ export interface SwapRecordCommon {
      * `AcceptConflict` — §3.2 says so by name.
      */
     readonly fundingTxid?: string;
-    /** M5's ask: the durable claim-error strings its outcome table reads, so a
-     * restarted client ends a broken claim `failed` with a reason instead of
-     * `lapsed` with none. v1 persists both; dropping them in the rewrite is the
-     * regression §B's "floor, not ceiling" wording exists to catch. */
+    /**
+     * Last local receive-claim error while the swap is still retryable. If the
+     * claim window later closes without a submitted claim, this becomes the
+     * terminal failure reason after restore.
+     */
+    readonly claimFailure?: string;
+    /** Terminal failure reason. */
     readonly failure?: string;
+    /** Refusal reason while `state` is `needs_counterparty`. */
     readonly blockedReason?: string;
     /** Unix **seconds**, both — the unit `RfqSwapRecord` carries and
      * `shouldRetainRfqSwap` compares against, not `AssetSwap`'s milliseconds. */

--- a/packages/swap/src/client/record.ts
+++ b/packages/swap/src/client/record.ts
@@ -1,0 +1,441 @@
+/**
+ * What survives a crash, and the public shape `accept()` hands back.
+ *
+ * Two types, one key. {@link SwapRecord} is the storage form — JSON-safe by
+ * declaration, every amount a canonical decimal string — and {@link Swap} is the
+ * answer a caller reads, with `bigint` amounts and the resolved `Route`. The
+ * conversion between them is §D's record-boundary codec, and it is not a third
+ * law: `toAtomicDecimal`/`fromAtomicDecimal` already ship in `./amount`, minted
+ * by M1 and used by M3's wire adapter, so both sites emit the same canonical
+ * form — atomic units, unsigned, no leading zeros, never a scaled display
+ * decimal.
+ *
+ * **The key is the quote id, on every route.** That is what makes persist-first
+ * representable at all: v1's `AssetSwap.id` *is* the funding txid
+ * (`store.ts:70-71`), so a record could not exist before the money did, and
+ * `coverage.ts` carries a process-local issuance mark precisely to paper over
+ * the gap. Here the record precedes the funding and `fundingTxid` is a later,
+ * best-effort write.
+ *
+ * **JSON-safe means no `bigint` anywhere, at any depth.** The SQLite and Realm
+ * backends `JSON.stringify` the record whole, so a `bigint` throws on two
+ * backends and round-trips on the third — the asymmetry
+ * `test/repository.test.ts` refuses to paper over. Every amount here is an
+ * {@link AtomicDecimal}; `test/client/record.types.ts` proves the absence
+ * structurally rather than by review.
+ */
+import type { AssetSwapStatus } from "../store";
+import type { RfqSwapState } from "../rfqSwapState";
+import type { PersistableRfqSwap } from "../rfqRecord";
+import { fromAtomicDecimal, toAtomicDecimal, type AtomicDecimal } from "./amount";
+import type { AssetId } from "./assetId";
+import type { Corridor, CorridorId } from "./corridor";
+import type { Hex, Pubkey } from "./primitives";
+import type { Artifact, Instrument, Route } from "./route";
+import type { MarketRef, QuoteId, QuoteLeg } from "./quote";
+
+/**
+ * Which family a record belongs to, and the discriminant M5's `RawState` keys
+ * on.
+ *
+ * Not a cosmetic tag. v1's two families occupied one `string` id space by
+ * accident — an offer record's id a funding txid, a corridor record's an
+ * `rfqId` — and keying both on `QuoteId` closes that collision (§B). The tag is
+ * what lets M6 build `offer:<quoteId>` / `rfq:<quoteId>` without a repository
+ * read, and what lets M5 branch its outcome table without one either.
+ */
+export type SwapFamily = "offer" | "rfq";
+
+/** One leg's obligation, in the form a record holds it. */
+export interface RecordedLeg {
+    readonly asset: AssetId;
+    /** Atomic units as a canonical decimal string — never a `bigint`. */
+    readonly amount: AtomicDecimal;
+}
+
+/**
+ * An endpoint as the record holds it: the corridor, the asset, the instrument.
+ *
+ * `Instrument`'s invoice arm carries a `bigint` amount, so it cannot be stored
+ * as declared — {@link RecordedInstrument} is the same union with that one field
+ * in decimal form. The rest is field for field identical, which is what keeps the
+ * comparison in `acceptConflict` honest.
+ */
+export interface RecordedEndpoint {
+    readonly corridor: CorridorId;
+    readonly asset: AssetId;
+    readonly instrument: RecordedInstrument;
+}
+
+/** {@link Instrument}, with the invoice arm's amount in decimal form. */
+export type RecordedInstrument =
+    | { readonly kind: "wallet" }
+    | { readonly kind: "address"; readonly address: string }
+    | {
+          readonly kind: "invoice";
+          readonly bolt11: string;
+          readonly paymentHash: Hex;
+          readonly amount?: AtomicDecimal;
+          readonly expiresAt: number;
+      };
+
+/** {@link Artifact}, with the deposit arm's amount in decimal form. */
+export type RecordedArtifact =
+    | { readonly kind: "invoice"; readonly bolt11: string }
+    | {
+          readonly kind: "deposit";
+          readonly corridor: CorridorId;
+          readonly address: string;
+          readonly asset: AssetId;
+          readonly amount: AtomicDecimal;
+          readonly expiresAt?: number;
+      };
+
+/**
+ * The half both families carry.
+ *
+ * Every field is either something `AcceptConflict` compares (§3.2's list), or
+ * something M5 named as a cross-milestone ask, or the two timestamps. Nothing
+ * is here for display: a record carries what no covenant and no chain read can
+ * give back, which is the same rule `RfqSwapRecord` is arranged by.
+ */
+export interface SwapRecordCommon {
+    /** The client-minted quote id — the primary key, per C1 and §B. */
+    readonly id: QuoteId;
+    readonly family: SwapFamily;
+    /**
+     * Both endpoints, instruments included — `AcceptConflict` items 1 and 3.
+     *
+     * Nested under `route` so the record's field names are `Quote`'s field
+     * names: the conflict check walks the two shapes together, and a record
+     * that spelled the same fact differently would make every comparison a
+     * translation.
+     */
+    readonly route: { readonly give: RecordedEndpoint; readonly take: RecordedEndpoint };
+    /** The two obligations — `AcceptConflict` item 2. */
+    readonly give: RecordedLeg;
+    readonly take: RecordedLeg;
+    /** The spread, as the quote precomputed it. */
+    readonly fee: RecordedLeg;
+    /**
+     * Which card priced this, from which registry, how fresh — stored WHOLE.
+     *
+     * A trimmed projection could not rebuild the type {@link Swap.market}
+     * promises: `CardMarketRef` requires `kind`, `pair` and `snapshot` beside
+     * the fields a summary would keep. Every member is a string, number or
+     * boolean, so the union round-trips through JSON untouched, and `snapshot`
+     * is restated as read at accept rather than restamped — a past `fetchedAt`
+     * beside the recorded `live` is the honest answer about how fresh the card
+     * was when this swap was accepted.
+     */
+    readonly market: MarketRef;
+    /**
+     * The committed counterparty, from the quote's covenant role.
+     *
+     * NOT `CardMarketRef.solver`, which is the card's display name. Two
+     * different facts that v1 spelled with one word: this one is a key that
+     * ends up in a covenant leaf, the other is a label. `AcceptConflict`
+     * compares this one.
+     */
+    readonly solver?: Pubkey;
+    /** The quote's own deadline, unix seconds — what makes a stalled accept a
+     * benign abandon rather than a live obligation. */
+    readonly expiresAt: number;
+    /**
+     * The one thing a counterparty must see, when this route has one.
+     *
+     * Durable because a duplicate accept must return the SAME invoice, and the
+     * invoice lives on the quote object — nowhere in the corridor profile. A
+     * caller that re-accepts after a restart has no quote object left, so
+     * without this field the only honest answer would be a second invoice,
+     * which §3.2 forbids by name.
+     */
+    readonly artifact?: RecordedArtifact;
+    /**
+     * The transaction that funded this swap, once known.
+     *
+     * A later, best-effort write, and the field that separates M5's `accepted`
+     * from `funding`. Set-where-absent is a benign resume and never an
+     * `AcceptConflict` — §3.2 says so by name.
+     */
+    readonly fundingTxid?: string;
+    /** M5's ask: the durable claim-error strings its outcome table reads, so a
+     * restarted client ends a broken claim `failed` with a reason instead of
+     * `lapsed` with none. v1 persists both; dropping them in the rewrite is the
+     * regression §B's "floor, not ceiling" wording exists to catch. */
+    readonly failure?: string;
+    readonly blockedReason?: string;
+    /** Unix **seconds**, both — the unit `RfqSwapRecord` carries and
+     * `shouldRetainRfqSwap` compares against, not `AssetSwap`'s milliseconds. */
+    readonly createdAt: number;
+    readonly updatedAt: number;
+}
+
+/**
+ * `arkade <-> arkade`: the offer covenant, and what cancels it.
+ *
+ * `offerHex` is the whole covenant — `cancelOffer` needs nothing else to
+ * rebuild it — so this arm stores no tree parameters of its own.
+ */
+export interface OfferSwapRecord extends SwapRecordCommon {
+    readonly family: "offer";
+    /** v1's raw status vocabulary, which M5's `RawState` reads verbatim. */
+    readonly status: AssetSwapStatus;
+    /** The TLV offer, hex. The only input `cancelOffer` needs. */
+    readonly offerHex: string;
+    readonly swapAddress: string;
+    /** The covenant's scriptPubKey, hex — the indexer's monitoring key, and
+     * what §F's reconcile matches a discovered deposit against. */
+    readonly swapPkScript: string;
+    readonly spentTxid?: string;
+    readonly completedAt?: number;
+}
+
+/**
+ * The three corridor routes: a VHTLC lockup, its clocks and its secrets.
+ *
+ * **No covenant tree here.** Every lockup registers a contract row before its
+ * address can be funded, and that row already holds the parameters, keyed by
+ * the script they derive — a key `createContract` refuses to write unless the
+ * params reproduce it. Storing the tree a second time would be two sources for
+ * one covenant. `accept()` is what writes that row (see `./accept.ts`), which
+ * is why a persisted record always has one.
+ */
+export interface CorridorSwapRecord extends SwapRecordCommon {
+    readonly family: "rfq";
+    /** v1's raw state vocabulary, read verbatim by M5's `RawState`. */
+    readonly state: RfqSwapState;
+    /**
+     * Which corridor, in the manager's own vocabulary.
+     *
+     * `PersistableRfqSwap["kind"]` rather than a `Corridor`: it is a route pair
+     * — `lightning_send` and `lightning_receive` are one corridor from opposite
+     * ends — and it is what resolves the handler that owns {@link profile}.
+     */
+    readonly kind: PersistableRfqSwap["kind"];
+    /** The solver's own id for the negotiation, echoed back on the wire. */
+    readonly rfqId: string;
+    /** The Arkade address that was funded, and the swap's handle on its
+     * covenant row. */
+    readonly lockupAddress: string;
+    /** Its pkScript, hex — the row's key, and §F's matching key. */
+    readonly lockupPkScript: string;
+    /** The hash both covenants commit to. `sha256(P)`, hex. */
+    readonly lock: { readonly hash: Hex };
+    /** When the trader's value comes back if the swap does not complete. */
+    readonly refundLocktime: number;
+    /**
+     * The corridor's own half, as plain JSON.
+     *
+     * v1's opaque bag (`rfqRecord.ts:108-123`), written with `rfqSecretsProfile`
+     * and read by `rfqCorridorHandlers.hydrate` — reused rather than
+     * reinvented, so M5 rebuilds through machinery that already exists and a new
+     * corridor still ships without touching this file. It is also what carries
+     * `expectedAmount`, the claim value gate's request-time input.
+     *
+     * Amounts inside it follow v1's shapes (`expectedAmount` is a `number`),
+     * which is JSON-safe and therefore fine: the decimal-string law governs
+     * this record's OWN amount fields, not the bag it carries forward.
+     *
+     * **This is also where the swap's secrets live** — `profile.signer` and,
+     * on a leg locked to a preimage, `profile.hashlock`. Deliberately not a
+     * second copy at the record's top level: `rfqClaimSecretOf` and
+     * `preimageForSwapRecord` already read them from here, and two homes for
+     * one claim secret is two things to keep in step with one of them always
+     * empty. At most one of `preimageHex`/`preimageSaltHex` is ever written,
+     * and which arm exists is decided by the wallet's provisioning result, not
+     * here.
+     */
+    readonly profile: Record<string, unknown>;
+    readonly refundTxid?: string;
+    readonly lockupSpendTxids?: readonly string[];
+}
+
+/** Everything `accept()` persists, both families in one key space. */
+export type SwapRecord = OfferSwapRecord | CorridorSwapRecord;
+
+/**
+ * A swap, as a caller reads it.
+ *
+ * The quote's terms plus what has happened to them. `bigint` amounts and the
+ * resolved `Route`, because this is the public answer and the record is the
+ * storage form — §D's codec is the boundary between the two.
+ *
+ * `artifact` stays optional: M7's `ReceiveRequest` is `Swap & { artifact:
+ * Artifact }`, and an intersection cannot narrow a field that is already
+ * required. `id` is the bare {@link QuoteId} — M6 owns the tagged public form
+ * and takes this key as given. No `outcome`: that is M5's, and declaring an
+ * inert one here would occupy the name.
+ */
+export interface Swap {
+    readonly id: QuoteId;
+    readonly family: SwapFamily;
+    /** Both endpoints resolved, instruments included. */
+    readonly route: Route;
+    /** What the trader gives, fee included. */
+    readonly give: QuoteLeg;
+    /** What the trader takes. */
+    readonly take: QuoteLeg;
+    /** The spread, denominated on the leg where it is exact. */
+    readonly fee: QuoteLeg;
+    readonly market: MarketRef;
+    readonly solver?: Pubkey;
+    /** Corridor routes: the hash both covenants commit to. */
+    readonly lock?: { readonly hash: Hex };
+    /** Corridor routes: when the trader's value comes back. */
+    readonly refundLocktime?: number;
+    readonly artifact?: Artifact;
+    readonly expiresAt: number;
+    /** Absent until the funding is broadcast and its txid written. */
+    readonly fundingTxid?: string;
+    readonly createdAt: number;
+    readonly updatedAt: number;
+}
+
+// ── §D's codec, at the record boundary and nowhere else ──
+
+/** An endpoint into its stored form. */
+export const recordEndpoint = (endpoint: {
+    corridor: CorridorId;
+    asset: string;
+    instrument: Instrument;
+}): RecordedEndpoint => ({
+    corridor: endpoint.corridor,
+    asset: endpoint.asset as AssetId,
+    instrument: recordInstrument(endpoint.instrument),
+});
+
+/** An instrument into its stored form: only the invoice arm's amount moves. */
+export const recordInstrument = (instrument: Instrument): RecordedInstrument => {
+    switch (instrument.kind) {
+        case "wallet":
+            return { kind: "wallet" };
+        case "address":
+            return { kind: "address", address: instrument.address };
+        case "invoice":
+            return {
+                kind: "invoice",
+                bolt11: instrument.bolt11,
+                paymentHash: instrument.paymentHash,
+                ...(instrument.amount === undefined
+                    ? {}
+                    : { amount: toAtomicDecimal(instrument.amount) }),
+                expiresAt: instrument.expiresAt,
+            };
+    }
+};
+
+/** A stored instrument back into the live union. */
+export const instrumentOf = (instrument: RecordedInstrument): Instrument => {
+    switch (instrument.kind) {
+        case "wallet":
+            return { kind: "wallet" };
+        case "address":
+            return { kind: "address", address: instrument.address };
+        case "invoice":
+            return {
+                kind: "invoice",
+                bolt11: instrument.bolt11,
+                paymentHash: instrument.paymentHash,
+                ...(instrument.amount === undefined
+                    ? {}
+                    : { amount: fromAtomicDecimal(instrument.amount) }),
+                expiresAt: instrument.expiresAt,
+            };
+    }
+};
+
+/** An artifact into its stored form. */
+export const recordArtifact = (artifact: Artifact): RecordedArtifact =>
+    artifact.kind === "invoice"
+        ? { kind: "invoice", bolt11: artifact.bolt11 }
+        : {
+              kind: "deposit",
+              corridor: artifact.corridor,
+              address: artifact.address,
+              asset: artifact.asset as AssetId,
+              amount: toAtomicDecimal(artifact.amount),
+              ...(artifact.expiresAt === undefined ? {} : { expiresAt: artifact.expiresAt }),
+          };
+
+/** A stored artifact back into the live union. */
+export const artifactOf = (artifact: RecordedArtifact): Artifact =>
+    artifact.kind === "invoice"
+        ? { kind: "invoice", bolt11: artifact.bolt11 }
+        : ({
+              kind: "deposit",
+              corridor: artifact.corridor as Corridor,
+              address: artifact.address,
+              asset: artifact.asset,
+              amount: fromAtomicDecimal(artifact.amount),
+              ...(artifact.expiresAt === undefined ? {} : { expiresAt: artifact.expiresAt }),
+          } as Artifact);
+
+/** A leg into its stored form. */
+export const recordLeg = (leg: QuoteLeg): RecordedLeg => ({
+    asset: leg.asset,
+    amount: toAtomicDecimal(leg.amount),
+});
+
+/** A stored leg back into `bigint` units. */
+export const legOf = (leg: RecordedLeg): QuoteLeg => ({
+    asset: leg.asset,
+    amount: fromAtomicDecimal(leg.amount),
+});
+
+/**
+ * The public {@link Swap} a stored record answers with.
+ *
+ * The one read path, so a duplicate `accept()` answers from the record rather
+ * than from the in-memory preparation cache — which is bounded, evicted in
+ * insertion order, and therefore not a durable answer to anything.
+ *
+ * The `Route` is reassembled from the two stored endpoints. The cast is the
+ * seam: `Route` is a closed union of four corridor pairs and a record read off
+ * disk carries two independently-typed endpoints, so nothing in the type system
+ * can re-correlate them. What guarantees the pairing is that `accept()` only
+ * ever writes a record from a `Quote` whose route was already resolved through
+ * that union.
+ */
+export const swapOf = (record: SwapRecord): Swap => ({
+    id: record.id,
+    family: record.family,
+    route: {
+        give: {
+            corridor: record.route.give.corridor,
+            asset: record.route.give.asset,
+            instrument: instrumentOf(record.route.give.instrument),
+        },
+        take: {
+            corridor: record.route.take.corridor,
+            asset: record.route.take.asset,
+            instrument: instrumentOf(record.route.take.instrument),
+        },
+    } as Route,
+    give: legOf(record.give),
+    take: legOf(record.take),
+    fee: legOf(record.fee),
+    market: record.market,
+    ...(record.solver === undefined ? {} : { solver: record.solver }),
+    ...(record.family === "rfq" ? { lock: record.lock } : {}),
+    ...(record.family === "rfq" ? { refundLocktime: record.refundLocktime } : {}),
+    ...(record.artifact === undefined ? {} : { artifact: artifactOf(record.artifact) }),
+    expiresAt: record.expiresAt,
+    ...(record.fundingTxid === undefined ? {} : { fundingTxid: record.fundingTxid }),
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+});
+
+/**
+ * Whether this swap's give leg is funded from the wallet.
+ *
+ * The discriminant for every funding-route decision in `accept()` — the balance
+ * pre-flight, the `wallet.send`, the funding-txid write. It is the
+ * **instrument** and not the asset: a `lightning -> arkade` receive gives BTC
+ * too, but the give instrument is the hold invoice a third party pays, so an
+ * asset-branched test would send every receive down the wallet-balance path and
+ * refuse the canonical empty-wallet receive.
+ */
+export const fundsFromWallet = (route: {
+    give: { instrument: Instrument | RecordedInstrument };
+}): boolean => route.give.instrument.kind === "wallet";

--- a/packages/swap/src/indexedDbRepository.ts
+++ b/packages/swap/src/indexedDbRepository.ts
@@ -7,15 +7,17 @@ import {
 import { marketsCacheKey, type AssetSwapRepository, type MarketsCacheEntry } from "./repository";
 import type { AssetSwap } from "./store";
 import type { RfqSwapRecord } from "./rfqRecord";
+import type { SwapRecord } from "./client/record";
 
 const DEFAULT_DB_NAME = "arkade-intents";
 /** Bump when adding an object store or index. `initDatabase` only runs inside
  * `onupgradeneeded`, which fires on a version *increase* — its contains-guard
  * cannot backfill a store into a database already open at this version, so a
  * new store added without a bump is simply missing for existing users. */
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const STORE_SWAPS = "swaps";
 const STORE_RFQ_SWAPS = "rfqSwaps";
+const STORE_SWAP_RECORDS = "swapRecords";
 const STORE_SCANNED = "scannedTxids";
 const STORE_MARKETS = "markets";
 
@@ -28,6 +30,11 @@ const STORES: readonly [name: string, options?: IDBObjectStoreParameters][] = [
     // v2. Separate from `swaps` rather than sharing it: the two record types
     // have different keys and no consumer wants them interleaved.
     [STORE_RFQ_SWAPS, { keyPath: "rfqId" }],
+    // v3. The v2 client's accept records, keyed by quote id. Its own store for
+    // the same reason, plus one more: the v1 read path drops a row carrying
+    // neither `offerHex` nor `paymentHash`, so sharing `swaps` would pin the
+    // v2 shape to a v1 predicate.
+    [STORE_SWAP_RECORDS, { keyPath: "id" }],
     [STORE_SCANNED],
     [STORE_MARKETS],
 ];
@@ -38,9 +45,12 @@ const STORES: readonly [name: string, options?: IDBObjectStoreParameters][] = [
  * existing rows during a migration.
  *
  * Both unused today: every version so far has only added an object store, and
- * `createObjectStore` needs neither. Named rather than dropped because the next
- * migration will not be additive, and a signature that takes them is what makes
- * "cursor over v2 rows and rewrite them" a local change here.
+ * `createObjectStore` needs neither — version 3's v2-record store included,
+ * which is why the v1 and v2 histories being disjoint matters. It is what keeps
+ * this migration from being the one that rewrites rows. Named rather than
+ * dropped because the next migration may not be additive, and a signature that
+ * takes them is what makes "cursor over the rows and rewrite them" a local
+ * change here.
  */
 function initDatabase(db: IDBDatabase, oldVersion: number, transaction: IDBTransaction | null) {
     void oldVersion;
@@ -52,7 +62,7 @@ function initDatabase(db: IDBDatabase, oldVersion: number, transaction: IDBTrans
 
 /** Browser backend over the SDK's shared IndexedDB manager. */
 export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 4 as const;
+    readonly version = 5 as const;
     private readonly connection: ManagedConnection;
 
     constructor(dbName: string = DEFAULT_DB_NAME) {
@@ -104,6 +114,26 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
     async removeRfqSwap(rfqId: string): Promise<void> {
         await this.write(STORE_RFQ_SWAPS, (store) => {
             store.delete(rfqId);
+        });
+    }
+
+    async saveSwapRecord(record: SwapRecord): Promise<void> {
+        await this.write(STORE_SWAP_RECORDS, (store) => {
+            store.put(record);
+        });
+    }
+
+    async getSwapRecord(id: string): Promise<SwapRecord | undefined> {
+        return promisifyRequest((await this.readStore(STORE_SWAP_RECORDS)).get(id));
+    }
+
+    async getAllSwapRecords(): Promise<SwapRecord[]> {
+        return promisifyRequest((await this.readStore(STORE_SWAP_RECORDS)).getAll());
+    }
+
+    async removeSwapRecord(id: string): Promise<void> {
+        await this.write(STORE_SWAP_RECORDS, (store) => {
+            store.delete(id);
         });
     }
 

--- a/packages/swap/src/node/executor.ts
+++ b/packages/swap/src/node/executor.ts
@@ -1,0 +1,153 @@
+/**
+ * A file-backed `SQLExecutor` over Node's built-in SQLite, and the repository
+ * that owns one.
+ *
+ * §3's Node default. The only in-tree executors were a test helper hard-coded
+ * to `":memory:"` and an example built on a `better-sqlite3` devDependency that
+ * no package ships — so a Node consumer following the documented default had
+ * nothing to import. This is that import.
+ *
+ * It lives behind the `./node` subpath rather than inside the main entry so the
+ * browser bundle never sees `node:sqlite`. The alternative — a guarded dynamic
+ * `import("node:sqlite")` in the main entry — keeps one import site and hands
+ * every bundler a conditional it has to be told to drop.
+ */
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import type { SQLExecutor } from "@arkade-os/sdk/repositories/sqlite";
+import { SQLiteAssetSwapRepository } from "../repositories/sqlite";
+import type { AssetSwapRepository } from "../repository";
+import { swapDatabasePath } from "./paths";
+
+/**
+ * An executor that owns its connection.
+ *
+ * `SQLExecutor` declares no lifecycle — the interface is three query methods,
+ * because every other implementation wraps a connection the consumer already
+ * opened. This one opens the file itself, so it is the one that has something
+ * to close.
+ */
+export interface NodeSqlExecutor extends SQLExecutor {
+    /** Close the underlying database handle. Idempotent. */
+    close(): Promise<void>;
+}
+
+/**
+ * `node:sqlite` rejects a bound `undefined`; `null` is what it means.
+ *
+ * The cast is the seam between two vocabularies: `SQLExecutor` types its
+ * parameters as `unknown[]`, because it is implemented over drivers that each
+ * accept their own scalar set, while `node:sqlite` names its set exactly. Every
+ * value this package binds is a string, a number or `null` — the repositories
+ * store records as JSON text and map out only `id`-like strings and integer
+ * timestamps — so a value outside that set is a caller's bug, and the driver
+ * throws on it either way.
+ */
+const bindable = (params?: unknown[]): SQLInputValue[] =>
+    (params ?? []).map((p) => (p === undefined ? null : (p as SQLInputValue)));
+
+/**
+ * Open (creating if absent) a SQLite database at `path`.
+ *
+ * **One instance per file, held for the process's life.** `runInTransaction`
+ * keys its write chain on the executor *object* through a `WeakMap`, so a
+ * second executor over the same file forks the chain and two "transactions" can
+ * interleave on one connection. Every repository on a database must be handed
+ * the same instance — which is what {@link nodeSwapRepository} does for the
+ * common case.
+ *
+ * The parent directory is created on open: the config dir exists on any real
+ * machine but `arkade/swaps` under it does not, and failing on a first run for
+ * a directory the caller never chose would be a poor default.
+ */
+export const createNodeSqlExecutor = (path: string): NodeSqlExecutor => {
+    mkdirSync(dirname(path), { recursive: true });
+    const db = new DatabaseSync(path);
+    let open = true;
+    return {
+        async run(sql: string, params?: unknown[]): Promise<void> {
+            db.prepare(sql).run(...bindable(params));
+        },
+        async get<T = Record<string, unknown>>(
+            sql: string,
+            params?: unknown[],
+        ): Promise<T | undefined> {
+            return (db.prepare(sql).get(...bindable(params)) as T | undefined) ?? undefined;
+        },
+        async all<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> {
+            return db.prepare(sql).all(...bindable(params)) as T[];
+        },
+        async close(): Promise<void> {
+            // Idempotent: `await using` disposal and an explicit `close()` in a
+            // shutdown handler both happen in practice, and the second
+            // `db.close()` would throw.
+            if (!open) return;
+            open = false;
+            db.close();
+        },
+    };
+};
+
+export interface NodeSwapRepositoryOptions {
+    /**
+     * Which network's database. Used to build the default path — pass the same
+     * name the wallet reports.
+     */
+    readonly network: string;
+    /** An explicit path, overriding the platform default. */
+    readonly path?: string;
+    /** Table-name prefix, passed through to the SQLite backend. */
+    readonly prefix?: string;
+}
+
+/**
+ * The Node storage default, connection included.
+ *
+ * This is where D1/D2's ownership rule lands: the returned repository's
+ * `[Symbol.asyncDispose]` closes the connection **it** opened, and an injected
+ * repository is disposed by whoever built it — which is already true of every
+ * other backend, whose disposal is a no-op precisely because the consumer owns
+ * the handle.
+ *
+ * Hanging ownership on the repository rather than on a client lifecycle method
+ * is deliberate: the v2 client has no `stop()` or `dispose()` yet — the
+ * lifecycle is the next milestone's — and a connection that could only be
+ * closed through a method that does not exist would leak until the process
+ * ended.
+ *
+ * ```ts
+ * await using repository = nodeSwapRepository({ network: "mainnet" });
+ * const client = createSwapClient({ wallet, repository });
+ * ```
+ */
+export const nodeSwapRepository = (options: NodeSwapRepositoryOptions): AssetSwapRepository => {
+    const executor = createNodeSqlExecutor(options.path ?? swapDatabasePath(options.network));
+    return new NodeSwapRepository(
+        executor,
+        options.prefix === undefined ? undefined : { prefix: options.prefix },
+    );
+};
+
+/**
+ * The SQLite backend, plus the one thing it cannot do: close a connection it
+ * did not open.
+ *
+ * A subclass overriding exactly one method, rather than a delegating wrapper:
+ * the base's `[Symbol.asyncDispose]` is a documented no-op *because* the
+ * consumer owns the handle, and here the consumer is this class. Every other
+ * method must keep working unchanged, which a hand-written delegate would have
+ * to restate one by one and would silently miss on the next interface bump.
+ */
+class NodeSwapRepository extends SQLiteAssetSwapRepository {
+    constructor(
+        private readonly executor: NodeSqlExecutor,
+        options?: { prefix?: string },
+    ) {
+        super(executor, options);
+    }
+
+    override async [Symbol.asyncDispose](): Promise<void> {
+        await this.executor.close();
+    }
+}

--- a/packages/swap/src/node/index.ts
+++ b/packages/swap/src/node/index.ts
@@ -1,0 +1,27 @@
+/**
+ * The Node platform default: file-backed SQLite storage for swap records.
+ *
+ * A separate entry point because it imports `node:sqlite`, `node:fs`,
+ * `node:os` and `node:path` — none of which belong in a browser bundle, and
+ * none of which the main entry touches. Importing this path is how a Node
+ * consumer asks for the storage default §3 describes:
+ *
+ * ```ts
+ * import { createSwapClient } from "@arkade-os/swap";
+ * import { nodeSwapRepository } from "@arkade-os/swap/node";
+ *
+ * await using repository = nodeSwapRepository({ network: "mainnet" });
+ * const client = createSwapClient({ wallet, repository });
+ * ```
+ *
+ * There is no implicit fallback for a Node client that passes no repository:
+ * accepting a swap without durable storage is the silent-loss default the
+ * storage rule exists to forbid, so `accept()` refuses instead.
+ */
+export { swapDatabasePath, configDir } from "./paths";
+export {
+    createNodeSqlExecutor,
+    nodeSwapRepository,
+    type NodeSqlExecutor,
+    type NodeSwapRepositoryOptions,
+} from "./executor";

--- a/packages/swap/src/node/paths.ts
+++ b/packages/swap/src/node/paths.ts
@@ -13,6 +13,16 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+const NETWORK_PATH_SEGMENT = /^[a-z][a-z0-9-]{0,32}$/;
+
+const assertSafeNetworkPathSegment = (network: string): void => {
+    if (NETWORK_PATH_SEGMENT.test(network)) return;
+    throw new Error(
+        `Invalid network name for swap database path: ${JSON.stringify(network)}. ` +
+            "Use lowercase letters, digits, and hyphens, starting with a letter.",
+    );
+};
+
 /**
  * The platform's per-user configuration directory.
  *
@@ -46,5 +56,7 @@ export const configDir = (env: NodeJS.ProcessEnv = process.env): string => {
  * caller that only wants to know where the file would be — to report it, to
  * back it up, to delete it — should not have to make one as a side effect.
  */
-export const swapDatabasePath = (network: string, env: NodeJS.ProcessEnv = process.env): string =>
-    join(configDir(env), "arkade", "swaps", `swaps-${network}.sqlite`);
+export const swapDatabasePath = (network: string, env: NodeJS.ProcessEnv = process.env): string => {
+    assertSafeNetworkPathSegment(network);
+    return join(configDir(env), "arkade", "swaps", `swaps-${network}.sqlite`);
+};

--- a/packages/swap/src/node/paths.ts
+++ b/packages/swap/src/node/paths.ts
@@ -1,0 +1,50 @@
+/**
+ * Where a Node consumer's swap database lives.
+ *
+ * `arkade/swaps/swaps-<network>.sqlite` under the platform config directory,
+ * which is the default §3 names and which nothing in this repo could resolve
+ * before — there is no XDG, `Application Support` or `%APPDATA%` helper
+ * anywhere in the SDK, so this is it.
+ *
+ * Per network, deliberately: a record's covenant, its solver and its market are
+ * all network-scoped, and one file holding two networks' swaps would let a
+ * mainnet restore read a regtest record as its own.
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The platform's per-user configuration directory.
+ *
+ * The three conventions, in the order each platform expects:
+ *
+ * - Linux and the BSDs follow the XDG Base Directory spec — `$XDG_CONFIG_HOME`
+ *   when set to an absolute path, else `~/.config`. A relative value is
+ *   ignored, which the spec requires rather than suggests.
+ * - macOS uses `~/Library/Application Support`.
+ * - Windows uses `%APPDATA%`, falling back to the roaming path under the home
+ *   directory when the variable is missing — as it is in some service contexts.
+ */
+export const configDir = (env: NodeJS.ProcessEnv = process.env): string => {
+    if (process.platform === "win32") {
+        return env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+    }
+    if (process.platform === "darwin") {
+        return join(homedir(), "Library", "Application Support");
+    }
+    const xdg = env.XDG_CONFIG_HOME;
+    // The spec: a relative path "should be ignored" rather than resolved
+    // against the cwd, which would put the database wherever the process
+    // happened to start.
+    return xdg && xdg.startsWith("/") ? xdg : join(homedir(), ".config");
+};
+
+/**
+ * The default database path for one network.
+ *
+ * Returned rather than created: opening it is what creates the directory, and a
+ * caller that only wants to know where the file would be — to report it, to
+ * back it up, to delete it — should not have to make one as a side effect.
+ */
+export const swapDatabasePath = (network: string, env: NodeJS.ProcessEnv = process.env): string =>
+    join(configDir(env), "arkade", "swaps", `swaps-${network}.sqlite`);

--- a/packages/swap/src/refund.ts
+++ b/packages/swap/src/refund.ts
@@ -695,7 +695,18 @@ export type RefundOutcome =
      * The lockup was unilaterally exited: its outputs sit onchain under the VHTLC
      * script, where no offchain refund can reach them. Returned rather than
      * retried: no amount of waiting changes where the money lives. Complete the
-     * unroll and spend the outputs onchain — then there is nothing left to refund.
+     * unroll and spend the named outputs onchain.
+     *
+     * **`outpoints` is not necessarily the whole lockup, and `exited` does not
+     * mean "nothing left to refund".** A lockup funded by more than one UTXO
+     * reports `exited` as soon as ANY of them has been exited, and `outpoints`
+     * names only those; a still-live sibling is left unrefunded, and this call
+     * will not come back for it — the outcome is terminal, so the caller's retry
+     * loop ends here. That is deliberate rather than an oversight: `RfqSwapManager`
+     * reports the same lockup `exited` on the same any-output rule, and the two
+     * must not disagree. It does make the surviving outputs the caller's to
+     * pursue, through an independent onchain or offchain recovery path that this
+     * function will not reach.
      *
      * Distinct from {@link RefundOutcome} `needs_recovery` on purpose: that
      * variant's remedy is recovery into a fresh batch, which is a spend no batch

--- a/packages/swap/src/repositories/realm/index.ts
+++ b/packages/swap/src/repositories/realm/index.ts
@@ -4,4 +4,8 @@ export {
     ArkadeAssetSwapSchema,
     ArkadeAssetSwapScannedTxidSchema,
     ArkadeAssetSwapMarketsCacheSchema,
+    // Both were reachable only through `AssetSwapRealmSchemas` before: a
+    // consumer registering schemas individually could not name them.
+    ArkadeRfqSwapSchema,
+    ArkadeSwapRecordSchema,
 } from "./schemas";

--- a/packages/swap/src/repositories/realm/repository.ts
+++ b/packages/swap/src/repositories/realm/repository.ts
@@ -6,9 +6,11 @@ import {
 } from "../../repository";
 import type { AssetSwap } from "../../store";
 import type { RfqSwapRecord } from "../../rfqRecord";
+import type { SwapRecord } from "../../client/record";
 
 const SWAPS = "ArkadeAssetSwap";
 const RFQ_SWAPS = "ArkadeRfqSwap";
+const SWAP_RECORDS = "ArkadeSwapRecord";
 const SCANNED = "ArkadeAssetSwapScannedTxid";
 const MARKETS = "ArkadeAssetSwapMarketsCache";
 
@@ -33,7 +35,7 @@ const MARKETS = "ArkadeAssetSwapMarketsCache";
  * consumer owns the Realm lifecycle — `[Symbol.asyncDispose]` is a no-op.
  */
 export class RealmAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 4 as const;
+    readonly version = 5 as const;
 
     constructor(private readonly realm: RealmLike) {}
 
@@ -94,6 +96,42 @@ export class RealmAssetSwapRepository implements AssetSwapRepository {
         });
     }
 
+    async saveSwapRecord(record: SwapRecord): Promise<void> {
+        this.realm.write(() => {
+            this.realm.create(
+                SWAP_RECORDS,
+                {
+                    id: record.id,
+                    family: record.family,
+                    updatedAt: record.updatedAt,
+                    data: JSON.stringify(record),
+                },
+                "modified",
+            );
+        });
+    }
+
+    async getSwapRecord(id: string): Promise<SwapRecord | undefined> {
+        const [found] = [
+            ...this.realm.objects<{ data: string }>(SWAP_RECORDS).filtered("id == $0", id),
+        ];
+        return found ? (JSON.parse(found.data) as SwapRecord) : undefined;
+    }
+
+    async getAllSwapRecords(): Promise<SwapRecord[]> {
+        return [...this.realm.objects<{ data: string }>(SWAP_RECORDS)].map(
+            (o) => JSON.parse(o.data) as SwapRecord,
+        );
+    }
+
+    async removeSwapRecord(id: string): Promise<void> {
+        this.realm.write(() => {
+            this.realm.delete(
+                this.realm.objects<{ id: string }>(SWAP_RECORDS).filtered("id == $0", id),
+            );
+        });
+    }
+
     async getScannedTxids(): Promise<Set<string>> {
         return new Set([...this.realm.objects<{ txid: string }>(SCANNED)].map((o) => o.txid));
     }
@@ -135,7 +173,7 @@ export class RealmAssetSwapRepository implements AssetSwapRepository {
      * partial clear must not be observable. */
     async clear(): Promise<void> {
         this.realm.write(() => {
-            for (const name of [SWAPS, RFQ_SWAPS, SCANNED, MARKETS]) {
+            for (const name of [SWAPS, RFQ_SWAPS, SWAP_RECORDS, SCANNED, MARKETS]) {
                 this.realm.delete(this.realm.objects(name));
             }
         });

--- a/packages/swap/src/repositories/realm/schemas.ts
+++ b/packages/swap/src/repositories/realm/schemas.ts
@@ -12,10 +12,12 @@
  * adds them to its Realm config and bumps its own `schemaVersion`; no migration
  * helper ships here.
  *
- * `ArkadeRfqSwap` arrived after the first three. A consumer already shipping
- * those has to add it and bump `schemaVersion` again — Realm creates schemas on
- * open, so a config that lists three while the code reads four fails on the
- * fourth `realm.objects(…)` rather than at open.
+ * `ArkadeRfqSwap` arrived after the first three, and `ArkadeSwapRecord` after
+ * that. A consumer already shipping the earlier set has to add the new one and
+ * bump `schemaVersion` again — Realm creates schemas on open, so a config that
+ * lists four while the code reads five fails on the fifth `realm.objects(…)`
+ * rather than at open. Export {@link AssetSwapRealmSchemas} into the config
+ * rather than listing names by hand and the mismatch cannot happen.
  */
 
 export const ArkadeAssetSwapSchema = {
@@ -60,8 +62,27 @@ export const ArkadeRfqSwapSchema = {
     },
 };
 
+/**
+ * The v2 client's accept records, keyed by the client-minted quote id.
+ *
+ * `family` and `updatedAt` are mapped out for querying; the record itself goes
+ * in whole, which is what keeps a nested corridor `profile` from being lost the
+ * way a field-mapped schema could lose it.
+ */
+export const ArkadeSwapRecordSchema = {
+    name: "ArkadeSwapRecord",
+    primaryKey: "id",
+    properties: {
+        id: "string",
+        family: "string",
+        updatedAt: "int",
+        data: "string",
+    },
+};
+
 export const AssetSwapRealmSchemas = [
     ArkadeRfqSwapSchema,
+    ArkadeSwapRecordSchema,
     ArkadeAssetSwapSchema,
     ArkadeAssetSwapScannedTxidSchema,
     ArkadeAssetSwapMarketsCacheSchema,

--- a/packages/swap/src/repositories/sqlite/repository.ts
+++ b/packages/swap/src/repositories/sqlite/repository.ts
@@ -10,6 +10,7 @@ import {
 } from "../../repository";
 import type { AssetSwap } from "../../store";
 import type { RfqSwapRecord } from "../../rfqRecord";
+import type { SwapRecord } from "../../client/record";
 
 const DEFAULT_PREFIX = "arkade_";
 // SQLite's default parameter ceiling is 999; stay well under it per statement.
@@ -38,11 +39,12 @@ const INSERT_CHUNK = 500;
  * write chain is keyed by that object, and a per-repository literal splits it.
  */
 export class SQLiteAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 4 as const;
+    readonly version = 5 as const;
     private initPromise: Promise<void> | null = null;
     private readonly prefix: string;
     private readonly swaps: string;
     private readonly rfqSwaps: string;
+    private readonly swapRecords: string;
     private readonly scanned: string;
     private readonly markets: string;
 
@@ -53,6 +55,7 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
         this.prefix = sanitizeTablePrefix(options?.prefix ?? DEFAULT_PREFIX);
         this.swaps = `${this.prefix}asset_swaps`;
         this.rfqSwaps = `${this.prefix}rfq_swaps`;
+        this.swapRecords = `${this.prefix}swap_records`;
         this.scanned = `${this.prefix}asset_swap_scanned_txids`;
         this.markets = `${this.prefix}asset_swap_markets`;
     }
@@ -99,6 +102,21 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
             )`);
             await this.db.run(
                 `CREATE INDEX IF NOT EXISTS idx_${this.prefix}rfq_swaps_state ON ${this.rfqSwaps} (state)`,
+            );
+            // The v2 client's accept records. Its own table for the reason
+            // the one above has one, plus the v1 read predicate: a row with
+            // neither `offerHex` nor `paymentHash` is dropped as corrupt by
+            // `getAssetSwapsOrThrow`, so sharing `asset_swaps` would pin the v2
+            // shape to a v1 filter. `family` and `updated_at` are mapped out
+            // for querying; the record goes in whole.
+            await this.db.run(`CREATE TABLE IF NOT EXISTS ${this.swapRecords} (
+                id TEXT PRIMARY KEY,
+                family TEXT NOT NULL,
+                updated_at INTEGER NOT NULL,
+                data TEXT NOT NULL
+            )`);
+            await this.db.run(
+                `CREATE INDEX IF NOT EXISTS idx_${this.prefix}swap_records_family ON ${this.swapRecords} (family)`,
             );
             await this.db.run(`CREATE TABLE IF NOT EXISTS ${this.scanned} (txid TEXT PRIMARY KEY)`);
             await this.db.run(
@@ -167,6 +185,39 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
         });
     }
 
+    async saveSwapRecord(record: SwapRecord): Promise<void> {
+        await this.ensureInit();
+        await this.withTx(async () => {
+            await this.db.run(
+                `INSERT OR REPLACE INTO ${this.swapRecords} (id, family, updated_at, data)
+                 VALUES (?, ?, ?, ?)`,
+                [record.id, record.family, record.updatedAt, JSON.stringify(record)],
+            );
+        });
+    }
+
+    async getSwapRecord(id: string): Promise<SwapRecord | undefined> {
+        await this.ensureInit();
+        const row = await this.db.get<{ data: string }>(
+            `SELECT data FROM ${this.swapRecords} WHERE id = ?`,
+            [id],
+        );
+        return row ? (JSON.parse(row.data) as SwapRecord) : undefined;
+    }
+
+    async getAllSwapRecords(): Promise<SwapRecord[]> {
+        await this.ensureInit();
+        const rows = await this.db.all<{ data: string }>(`SELECT data FROM ${this.swapRecords}`);
+        return rows.map((r) => JSON.parse(r.data) as SwapRecord);
+    }
+
+    async removeSwapRecord(id: string): Promise<void> {
+        await this.ensureInit();
+        await this.withTx(async () => {
+            await this.db.run(`DELETE FROM ${this.swapRecords} WHERE id = ?`, [id]);
+        });
+    }
+
     async getScannedTxids(): Promise<Set<string>> {
         await this.ensureInit();
         const rows = await this.db.all<{ txid: string }>(`SELECT txid FROM ${this.scanned}`);
@@ -224,6 +275,7 @@ export class SQLiteAssetSwapRepository implements AssetSwapRepository {
         await this.withTx(async () => {
             await this.db.run(`DELETE FROM ${this.swaps}`);
             await this.db.run(`DELETE FROM ${this.rfqSwaps}`);
+            await this.db.run(`DELETE FROM ${this.swapRecords}`);
             await this.db.run(`DELETE FROM ${this.scanned}`);
             await this.db.run(`DELETE FROM ${this.markets}`);
         });

--- a/packages/swap/src/repository.ts
+++ b/packages/swap/src/repository.ts
@@ -1,6 +1,7 @@
 import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
 import type { AssetSwap } from "./store";
 import type { RfqSwapRecord } from "./rfqRecord";
+import type { SwapRecord } from "./client/record";
 
 /** A registry discovery result held for reuse. Refetchable — unlike a swap
  * record, losing it costs one network round trip — but it must survive a cold
@@ -29,11 +30,12 @@ export const marketsCacheKey = (network: string, registry: string) =>
  * in memory; add a filter type when a consumer needs subset queries.
  */
 export interface AssetSwapRepository extends AsyncDisposable {
-    /** 4 adds `getRfqSwap`. 3 added the other RFQ methods below; 2 was the
-     * released shape — swaps, scan cursor, markets, with `preimageSaltHex` on
-     * the swap record — so an implementor built against either cannot satisfy
-     * this one silently. */
-    readonly version: 4;
+    /** 5 adds the v2 swap-record store — one row per accepted swap, keyed by
+     * the client-minted quote id. 4 added `getRfqSwap`; 3 added the other RFQ
+     * methods below; 2 was the released shape — swaps, scan cursor, markets,
+     * with `preimageSaltHex` on the swap record — so an implementor built
+     * against any of them cannot satisfy this one silently. */
+    readonly version: 5;
 
     /** Insert or replace a swap by id. Store the record whole: `preimageHex`
      * and `preimageSaltHex` both leave the swap unclaimable if a field-mapped
@@ -68,11 +70,49 @@ export interface AssetSwapRepository extends AsyncDisposable {
     /** Drop one, once it is past retention — see `shouldRetainRfqSwap`. */
     removeRfqSwap(rfqId: string): Promise<void>;
 
-    /** Sent txids already checked for offer packets (see restore.ts). */
+    /**
+     * Insert or replace a v2 swap record by its quote id.
+     *
+     * The store the v2 client's `accept()` writes, and the reason this
+     * interface is at 5. Separate from `swaps` rather than sharing it: the v1
+     * read path drops any row carrying neither `offerHex` nor `paymentHash`
+     * (`getAssetSwapsOrThrow`), silently and as corrupt, so a v2 record in that
+     * store would be pinned by a v1 predicate — and the two histories are meant
+     * to be disjoint for the deprecation window anyway. A v1 reader not seeing
+     * v2 rows is the design, asserted in the conformance suite rather than
+     * tolerated.
+     *
+     * Store the record WHOLE, and note that it is **JSON-safe by declaration**:
+     * every amount on it is a canonical decimal string, precisely so the SQLite
+     * and Realm backends' `JSON.stringify` and IndexedDB's structured clone
+     * agree. A `bigint` reaching here would throw on two backends and
+     * round-trip on the third.
+     */
+    saveSwapRecord(record: SwapRecord): Promise<void>;
+    /** One record by quote id. `undefined` on a miss — which is the ordinary
+     * answer for a first `accept()`, and what makes it idempotent. */
+    getSwapRecord(id: string): Promise<SwapRecord | undefined>;
+    /** Every stored v2 record, in no particular order. */
+    getAllSwapRecords(): Promise<SwapRecord[]>;
+    /** Drop one, once it is past retention. */
+    removeSwapRecord(id: string): Promise<void>;
+
+    /**
+     * Sent txids already checked for offer packets (see restore.ts).
+     *
+     * **Shared across both record families, deliberately.** This is not
+     * record-family data — it marks txids of transactions a scan has answered,
+     * whatever family a later record belongs to — and both families walk the
+     * same sent-txid set during the deprecation window. Two cursors would have
+     * each side re-walking deposits the other already answered.
+     */
     getScannedTxids(): Promise<Set<string>>;
     markTxidsScanned(txids: Iterable<string>): Promise<void>;
 
-    /** Cached registry markets, or undefined on a miss. */
+    /** Cached registry markets, or undefined on a miss. Shared across both
+     * record families for the reason the cursor is: the key is network-and-
+     * registry, not a store, and two caches would serve two staleness clocks
+     * for one registry. */
     getCachedMarkets(network: string, registry: string): Promise<MarketsCacheEntry | undefined>;
     saveCachedMarkets(network: string, registry: string, entry: MarketsCacheEntry): Promise<void>;
 
@@ -80,8 +120,9 @@ export interface AssetSwapRepository extends AsyncDisposable {
 }
 
 export class InMemoryAssetSwapRepository implements AssetSwapRepository {
-    readonly version = 4 as const;
+    readonly version = 5 as const;
     private readonly swaps = new Map<string, AssetSwap>();
+    private readonly records = new Map<string, SwapRecord>();
     private readonly rfqSwaps = new Map<string, RfqSwapRecord>();
     private readonly scanned = new Set<string>();
     private readonly markets = new Map<string, MarketsCacheEntry>();
@@ -110,6 +151,22 @@ export class InMemoryAssetSwapRepository implements AssetSwapRepository {
         this.rfqSwaps.delete(rfqId);
     }
 
+    async saveSwapRecord(record: SwapRecord): Promise<void> {
+        this.records.set(record.id, record);
+    }
+
+    async getSwapRecord(id: string): Promise<SwapRecord | undefined> {
+        return this.records.get(id);
+    }
+
+    async getAllSwapRecords(): Promise<SwapRecord[]> {
+        return [...this.records.values()];
+    }
+
+    async removeSwapRecord(id: string): Promise<void> {
+        this.records.delete(id);
+    }
+
     async getScannedTxids(): Promise<Set<string>> {
         return new Set(this.scanned);
     }
@@ -136,6 +193,7 @@ export class InMemoryAssetSwapRepository implements AssetSwapRepository {
     async clear(): Promise<void> {
         this.swaps.clear();
         this.rfqSwaps.clear();
+        this.records.clear();
         this.scanned.clear();
         this.markets.clear();
     }

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -149,6 +149,8 @@ export interface RfqSwapRecord extends RfqSwapOrigin {
      * `RfqSwapCommon.lockupSpendTxids`. */
     lockupSpendTxids?: string[];
     failure?: string;
+    /** Last local receive-claim error while the swap is still retryable. */
+    claimFailure?: string;
     blockedReason?: string;
 }
 
@@ -232,6 +234,7 @@ const managerState = (swap: PersistableRfqSwap) => ({
     ...(swap.refundTxid ? { refundTxid: swap.refundTxid } : {}),
     ...(swap.lockupSpendTxids?.length ? { lockupSpendTxids: [...swap.lockupSpendTxids] } : {}),
     ...(swap.failure ? { failure: swap.failure } : {}),
+    ...(swap.claimFailure ? { claimFailure: swap.claimFailure } : {}),
     ...(swap.blockedReason ? { blockedReason: swap.blockedReason } : {}),
 });
 
@@ -293,8 +296,9 @@ export function createRfqSwapRecord(
  * The mutable half is REPLACED, not merged. `managerState` omits a key the live
  * swap no longer carries, so spreading it over the old record could only ever
  * set these fields, never clear them. The manager clears them on purpose: it
- * deletes `blockedReason` when a swap leaves `needs_counterparty`, precisely
- * because a stale `blockedReason` reads as a live refusal.
+ * deletes `blockedReason` when a swap leaves `needs_counterparty` and
+ * `claimFailure` when a swap becomes terminal, precisely because stale mutable
+ * reasons read as live refusal or retry state.
  */
 export function updateRfqSwapRecord(
     record: RfqSwapRecord,
@@ -310,6 +314,7 @@ export function updateRfqSwapRecord(
         refundTxid: _refundTxid,
         lockupSpendTxids: _lockupSpendTxids,
         failure: _failure,
+        claimFailure: _claimFailure,
         blockedReason: _blockedReason,
         ...origin
     } = stored;
@@ -330,9 +335,9 @@ export function updateRfqSwapRecord(
  * A record IS an origin plus manager state, so `record` where an
  * {@link RfqSwapOrigin} is wanted type-checks — and is a bug. Spread into
  * {@link createRfqSwapRecord} it carries the OLD state's `failure`,
- * `blockedReason` and `refundTxid` past `managerState`, which omits a field
- * the live swap no longer has and therefore cannot clear one. That is the same
- * trap {@link updateRfqSwapRecord} strips those three fields to avoid; this is
+ * `blockedReason`, `claimFailure` and `refundTxid` past `managerState`, which omits
+ * fields the live swap no longer has and therefore cannot clear them. That is the same
+ * trap {@link updateRfqSwapRecord} strips those mutable fields to avoid; this is
  * how a caller holding only a record gets an origin that is safe to keep.
  *
  * What `RfqSwapManager.restoreFromRepository` remembers for each record it
@@ -403,6 +408,7 @@ export function rebuildRfqSwap(record: RfqSwapRecord, params: LockupParams): Per
             ? { lockupSpendTxids: [...stored.lockupSpendTxids] }
             : {}),
         ...(stored.failure ? { failure: stored.failure } : {}),
+        ...(stored.claimFailure ? { claimFailure: stored.claimFailure } : {}),
         ...(stored.blockedReason ? { blockedReason: stored.blockedReason } : {}),
     };
 

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -210,6 +210,14 @@ interface RfqSwapCommon {
     lockupSpendTxids?: string[];
     /** Why `state` is `failed`. */
     failure?: string;
+    /**
+     * Last local claim error while the receive swap is still retryable.
+     *
+     * Distinct from terminal `failure`: this records a claim attempt that failed
+     * before the window closed. If the window later closes without a submitted
+     * claim, it becomes the terminal failure reason.
+     */
+    claimFailure?: string;
     /** Why `state` is `needs_counterparty`. Distinct from {@link failure},
      * which means an action was attempted and did not work. */
     blockedReason?: string;
@@ -770,20 +778,6 @@ export class RfqSwapManager {
      */
     private readonly refundRefused = new Set<string>();
     /**
-     * The last error a receive swap's claim callback threw, by rfqId.
-     *
-     * Kept only to tell two terminal outcomes apart once the claim window
-     * shuts: a swap whose claim was attempted and kept failing ends `failed`
-     * with that reason, while one that simply never became claimable ends
-     * `refunded`. Without it a broken claim callback would resolve a caller's
-     * {@link waitForSwapCompletion} as an ordinary unwind.
-     *
-     * Process-local, like {@link refundRefused}: after a restart the same swap
-     * ends `refunded` instead, which costs the caller a reason and nothing else
-     * — every throw was already reported through `onSwapFailed` as it happened.
-     */
-    private readonly lastClaimError = new Map<string, string>();
-    /**
      * The lockup outpoints a receive swap's claim callback has already been
      * handed, by rfqId.
      *
@@ -1265,7 +1259,6 @@ export class RfqSwapManager {
         if (swap) this.byLockupScript.delete(hex.encode(swap.lockupPkScript));
         this.monitored.delete(rfqId);
         this.refundRefused.delete(rfqId);
-        this.lastClaimError.delete(rfqId);
         this.claimedOutpoints.delete(rfqId);
     }
 
@@ -1590,7 +1583,7 @@ export class RfqSwapManager {
         // long since reclaimed, one it never funded will never be, and either
         // way there is nothing further to observe and no move left to make.
         // Ending the wait at all costs the distinction between them.
-        const failure = this.lastClaimError.get(swap.rfqId);
+        const failure = swap.claimFailure;
         if (failure && !swap.claimTxid) {
             // The one shape that is not an ordinary unwind: this wallet had a
             // claimable lockup and could not take it. `failed` rather than
@@ -1678,7 +1671,7 @@ export class RfqSwapManager {
 
         try {
             const { txid } = await this.callbacks.claimLockup(swap, vtxos, { partiallyClaimed });
-            this.lastClaimError.delete(swap.rfqId);
+            delete swap.claimFailure;
             // Recorded only on success: a claim that threw must be retried, and
             // these outputs are still there to retry with.
             this.rememberClaimed(swap.rfqId, vtxos);
@@ -1698,7 +1691,8 @@ export class RfqSwapManager {
             // while it is — so the next pass retries. Recorded so that, if the
             // window shuts having never succeeded, the swap can end `failed`
             // with a reason rather than looking like a quiet expiry.
-            this.lastClaimError.set(swap.rfqId, errorMessage(error));
+            swap.claimFailure = errorMessage(error);
+            this.touch(swap);
             this.emitFailed(swap, error);
         }
     }
@@ -1993,6 +1987,7 @@ export class RfqSwapManager {
         // a swap the counterparty finally claimed leaves through `settled`, and
         // a stale `blockedReason` there reads as a live refusal.
         if (previous === "needs_counterparty") delete swap.blockedReason;
+        if (isRfqSwapTerminal(state)) delete swap.claimFailure;
         swap.state = state;
         this.touch(swap);
         notify(this.swapUpdateListeners, (listener) => listener(swap, previous));

--- a/packages/swap/test/client/accept.test.ts
+++ b/packages/swap/test/client/accept.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../../src/client/errors";
 import { OFFER_PACKET_TYPE, decodeOffer } from "../../src/offer";
 import { SWAP_LOCKUP_CONTRACT_TYPE } from "../../src/lockupContract";
+import { conflictingFields } from "../../src/client/accept";
 import type { Quote, QuoteInput } from "../../src/client/quote";
 import type { CorridorSwapRecord, OfferSwapRecord } from "../../src/client/record";
 import {
@@ -85,6 +86,13 @@ const FUNDING_ROUTES: RouteName[] = ["spot", "lightningSend", "onchainSend"];
 const ALL_ROUTES: RouteName[] = [...FUNDING_ROUTES, "lightningReceive"];
 
 const quoteFor = (h: Harness, route: RouteName): Promise<Quote> => h.client.quote(ROUTES[route]());
+
+const evictPreparationFor = async (h: Harness, id: string): Promise<void> => {
+    for (let i = 0; i < 64; i++) {
+        await quoteFor(h, "spot");
+    }
+    expect(h.client.preparationOf(id)).toBeUndefined();
+};
 
 beforeEach(() => {
     vi.useFakeTimers();
@@ -293,6 +301,16 @@ describe("accept() — idempotency by quote id", () => {
         expect(await h.repository.getAllSwapRecords()).toHaveLength(1);
     });
 
+    it("still refuses a quote whose preparation was evicted before it was persisted", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+
+        await evictPreparationFor(h, quote.id);
+
+        await expect(h.client.accept(quote)).rejects.toThrow(/re-quote before accepting/);
+        expect(await h.repository.getSwapRecord(quote.id)).toBeUndefined();
+    });
+
     it("treats a funding txid appearing where there was none as a benign resume", async () => {
         const h = await setup();
         const quote = await quoteFor(h, "lightningSend");
@@ -302,6 +320,7 @@ describe("accept() — idempotency by quote id", () => {
         // The record now carries a txid the quote knows nothing about. §3.2
         // names this a resume rather than a conflict, by name.
         expect(stored?.fundingTxid).toBeDefined();
+        vi.setSystemTime((quote.expiresAt + 1) * 1000);
         await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
     });
 });
@@ -425,6 +444,41 @@ describe("accept() — AcceptConflict, one case per compared field", () => {
         await expect(h.client.accept({ ...onchain, id: send.id })).rejects.toThrow(AcceptConflict);
     });
 
+    it("does not conflict on a reordered but equal stored instrument", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+        await h.client.accept(quote);
+
+        const stored = (await h.repository.getSwapRecord(quote.id)) as CorridorSwapRecord;
+        const instrument = stored.route.take.instrument;
+        if (instrument.kind !== "invoice") throw new Error("expected invoice instrument");
+
+        const reordered: CorridorSwapRecord = {
+            ...stored,
+            route: {
+                ...stored.route,
+                take: {
+                    ...stored.route.take,
+                    instrument: {
+                        expiresAt: instrument.expiresAt,
+                        ...(instrument.amount === undefined ? {} : { amount: instrument.amount }),
+                        paymentHash: instrument.paymentHash,
+                        bolt11: instrument.bolt11,
+                        kind: "invoice",
+                    },
+                },
+            },
+        };
+
+        expect(JSON.stringify(reordered.route.take.instrument)).not.toBe(
+            JSON.stringify(stored.route.take.instrument),
+        );
+        expect(conflictingFields(reordered, quote)).not.toContain("take.instrument");
+
+        await h.repository.saveSwapRecord(reordered);
+        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+    });
+
     it("does not conflict on a field absent from both sides", async () => {
         // A feed-priced quote carries no solver and no lock hash by
         // construction, so "absent" must read as agreement rather than as a
@@ -507,6 +561,63 @@ describe("accept() — reconcile from evidence before a second funding", () => {
         const swap = await h.client.accept(quote);
 
         expect(swap.fundingTxid).toBe("a".repeat(64));
+        expect(h.wallet.sent).toHaveLength(0);
+    });
+
+    it("does not fund a persisted record after expiry when no deposit is found", async () => {
+        let fail = true;
+        const h = await setup({
+            failSend: () => (fail ? new Error("send exploded") : undefined!),
+        });
+        const quote = await quoteFor(h, "lightningSend");
+        await expect(h.client.accept(quote)).rejects.toThrow(/send exploded/);
+
+        await evictPreparationFor(h, quote.id);
+        fail = false;
+        vi.setSystemTime((quote.expiresAt + 1) * 1000);
+
+        await expect(h.client.accept(quote)).rejects.toThrow(QuoteExpired);
+        expect((await h.repository.getSwapRecord(quote.id))?.fundingTxid).toBeUndefined();
+        expect(h.wallet.sent).toHaveLength(0);
+    });
+
+    it("funds a persisted record after preparation eviction when no deposit is found", async () => {
+        let fail = true;
+        const h = await setup({
+            failSend: () => (fail ? new Error("send exploded") : undefined!),
+        });
+        const quote = await quoteFor(h, "lightningSend");
+        await expect(h.client.accept(quote)).rejects.toThrow(/send exploded/);
+
+        await evictPreparationFor(h, quote.id);
+
+        fail = false;
+        const swap = await h.client.accept(quote);
+
+        expect(swap.fundingTxid).toBe(FUNDING_TXID);
+        expect(h.wallet.sent).toHaveLength(1);
+    });
+
+    it("reconciles a persisted funding record after preparation eviction", async () => {
+        let fail = true;
+        const h = await setup({
+            failSend: () => (fail ? new Error("crashed mid-send") : undefined!),
+        });
+        const quote = await quoteFor(h, "lightningSend");
+        await expect(h.client.accept(quote)).rejects.toThrow(/crashed mid-send/);
+
+        const stored = (await h.repository.getSwapRecord(quote.id)) as CorridorSwapRecord;
+        h.wallet.deposits.set(stored.lockupPkScript, [
+            { txid: "e".repeat(64), value: Number(quote.give.amount) },
+        ]);
+        await evictPreparationFor(h, quote.id);
+        vi.setSystemTime((quote.expiresAt + 1) * 1000);
+
+        fail = false;
+        const swap = await h.client.accept(quote);
+
+        expect(swap.fundingTxid).toBe("e".repeat(64));
+        expect((await h.repository.getSwapRecord(quote.id))?.fundingTxid).toBe("e".repeat(64));
         expect(h.wallet.sent).toHaveLength(0);
     });
 

--- a/packages/swap/test/client/accept.test.ts
+++ b/packages/swap/test/client/accept.test.ts
@@ -1,0 +1,654 @@
+/**
+ * `accept()`: the ordering, the crash windows, and what a duplicate does.
+ *
+ * The centrepiece is the crash-window matrix. A process kill is not
+ * reproducible in a unit test, so each window is reached by making the *next*
+ * step fail and then asserting what is durable — which tests the same thing a
+ * kill would, since what a kill leaves behind is exactly what the steps before
+ * it wrote. The windows, in order: before register, before persist, after
+ * persist and before funding, after funding and before the txid, after the txid.
+ *
+ * Every route is run through them: spot, lightning send and onchain send fund,
+ * and lightning receive funds nothing and so runs the first rows only.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { hex } from "@scure/base";
+import { createSwapClient, type SwapClient } from "../../src/client/client";
+import { InMemoryAssetSwapRepository, type AssetSwapRepository } from "../../src/repository";
+import {
+    AcceptConflict,
+    InsufficientFunds,
+    MissingCorridorDep,
+    QuoteExpired,
+} from "../../src/client/errors";
+import { OFFER_PACKET_TYPE, decodeOffer } from "../../src/offer";
+import { SWAP_LOCKUP_CONTRACT_TYPE } from "../../src/lockupContract";
+import type { Quote, QuoteInput } from "../../src/client/quote";
+import type { CorridorSwapRecord, OfferSwapRecord } from "../../src/client/record";
+import {
+    EMULATOR_PUBKEY_HEX,
+    FUNDING_TXID,
+    PAYMENT_HASH,
+    USD_ASSET_ID,
+    acceptWallet,
+    clockAt,
+    feedServing,
+    invoiceFor,
+    lightningCard,
+    onchainCard,
+    solverFor,
+    solverTransport,
+    spotCard,
+    type AcceptWallet,
+} from "./fixtures";
+
+const NOW = 1_700_000_000;
+const CLOCK = clockAt(NOW);
+const BCRT1 = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+
+interface Harness {
+    client: SwapClient;
+    repository: AssetSwapRepository;
+    wallet: AcceptWallet;
+}
+
+const setup = async (
+    over: Parameters<typeof acceptWallet>[0] & {
+        repository?: AssetSwapRepository | undefined;
+        omitRepository?: boolean;
+    } = {},
+): Promise<Harness> => {
+    const wallet = await acceptWallet(over);
+    const repository = over.repository ?? new InMemoryAssetSwapRepository();
+    const client = createSwapClient({
+        wallet: wallet.wallet,
+        ...(over.omitRepository ? {} : { repository }),
+        discovery: { snapshot: [lightningCard, onchainCard, spotCard] },
+        emulatorPubkey: EMULATOR_PUBKEY_HEX,
+        transportFor: () => solverTransport(solverFor(CLOCK)),
+        fetchImpl: feedServing().fetch,
+    });
+    return { client, repository, wallet };
+};
+
+/** The four routes, each as the input that resolves to it. */
+const ROUTES = {
+    spot: (): QuoteInput => ({ give: "BTC", take: "USD", amount: 100_000n, amountOn: "give" }),
+    lightningSend: (): QuoteInput => ({ to: invoiceFor(PAYMENT_HASH, CLOCK) }),
+    lightningReceive: (): QuoteInput => ({ via: "lightning", amount: 5_000n, amountOn: "give" }),
+    onchainSend: (): QuoteInput => ({ to: BCRT1, amount: 100_000n, amountOn: "give" }),
+} as const;
+
+type RouteName = keyof typeof ROUTES;
+/** The three that spend from this wallet. */
+const FUNDING_ROUTES: RouteName[] = ["spot", "lightningSend", "onchainSend"];
+const ALL_ROUTES: RouteName[] = [...FUNDING_ROUTES, "lightningReceive"];
+
+const quoteFor = (h: Harness, route: RouteName): Promise<Quote> => h.client.quote(ROUTES[route]());
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW * 1000);
+});
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+describe("accept() — the ordering", () => {
+    it.each(ALL_ROUTES)("registers the covenant before persisting, on %s", async (route) => {
+        const h = await setup();
+        const quote = await quoteFor(h, route);
+        // Nothing is registered by quoting: the derivation happened, the row
+        // did not.
+        expect(h.wallet.contracts).toHaveLength(0);
+
+        await h.client.accept(quote);
+
+        expect(h.wallet.contracts).toHaveLength(1);
+        const stored = await h.repository.getSwapRecord(quote.id);
+        expect(stored).toBeDefined();
+        // The row a rebuild will read is keyed by the script the record names.
+        const script =
+            stored?.family === "offer"
+                ? stored.swapPkScript
+                : (stored as CorridorSwapRecord).lockupPkScript;
+        expect(h.wallet.contracts[0]?.script).toBe(script);
+    });
+
+    it.each(ALL_ROUTES)("keys the record on the quote id, not a txid, on %s", async (route) => {
+        const h = await setup();
+        const quote = await quoteFor(h, route);
+        const swap = await h.client.accept(quote);
+
+        expect(swap.id).toBe(quote.id);
+        const stored = await h.repository.getSwapRecord(quote.id);
+        expect(stored?.id).toBe(quote.id);
+        // The txid is a field, never the identity — which is what let the
+        // record exist before the money did.
+        expect(stored?.fundingTxid).not.toBe(stored?.id);
+    });
+
+    it.each(FUNDING_ROUTES)("persists before it funds, on %s", async (route) => {
+        const h = await setup({ failSend: () => new Error("send exploded") });
+        const quote = await quoteFor(h, route);
+
+        await expect(h.client.accept(quote)).rejects.toThrow(/send exploded/);
+
+        // The window the invariant exists for: the record is at rest and no
+        // value moved. A retry resumes this record rather than starting over.
+        const stored = await h.repository.getSwapRecord(quote.id);
+        expect(stored).toBeDefined();
+        expect(stored?.fundingTxid).toBeUndefined();
+        expect(h.wallet.sent).toHaveLength(0);
+    });
+
+    it("funds nothing on a receive, and still persists the invoice", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningReceive");
+        const swap = await h.client.accept(quote);
+
+        expect(h.wallet.sent).toHaveLength(0);
+        expect(swap.artifact).toEqual({ kind: "invoice", bolt11: expect.any(String) });
+        const stored = await h.repository.getSwapRecord(quote.id);
+        // Durable before the payer can be shown it: an invoice whose claim
+        // secret is only in memory buys a lockup nobody can claim.
+        expect(stored?.artifact).toEqual(swap.artifact);
+        // And so is what claims it: the descriptor the wallet re-derives P
+        // from, in the corridor profile where the claim path already reads it.
+        const profile = (stored as CorridorSwapRecord).profile;
+        expect(profile.signer).toMatchObject({ signingDescriptor: expect.any(String) });
+        expect(profile.hashlock).toMatchObject({ paymentHash: expect.any(String) });
+    });
+
+    it("writes the funding txid after the money moves", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+        const swap = await h.client.accept(quote);
+
+        expect(h.wallet.sent).toHaveLength(1);
+        expect(swap.fundingTxid).toBe(FUNDING_TXID);
+        expect((await h.repository.getSwapRecord(quote.id))?.fundingTxid).toBe(FUNDING_TXID);
+    });
+
+    it("keeps a swap whose funding landed but whose txid could not be stored", async () => {
+        const repository = new InMemoryAssetSwapRepository();
+        const h = await setup({ repository });
+        const quote = await quoteFor(h, "lightningSend");
+        // The stamp is best effort: the money has moved, and failing the caller
+        // here would report as failed a swap that is already funded.
+        const saved = vi.spyOn(repository, "saveSwapRecord");
+        saved.mockImplementationOnce(async (r) => {
+            await InMemoryAssetSwapRepository.prototype.saveSwapRecord.call(repository, r);
+        });
+        saved.mockImplementationOnce(async () => {
+            throw new Error("quota exceeded");
+        });
+
+        const swap = await h.client.accept(quote);
+        expect(swap.fundingTxid).toBe(FUNDING_TXID);
+        expect(h.wallet.sent).toHaveLength(1);
+    });
+
+    it("leaves nothing durable when registration fails", async () => {
+        const h = await setup({ failRegistration: () => new Error("contract store gone") });
+        const quote = await quoteFor(h, "lightningSend");
+
+        await expect(h.client.accept(quote)).rejects.toThrow();
+        // The safe point: no record, no funding, and the quote is inert.
+        expect(await h.repository.getSwapRecord(quote.id)).toBeUndefined();
+        expect(h.wallet.sent).toHaveLength(0);
+    });
+
+    it("leaves nothing durable when the record cannot be written", async () => {
+        const repository = new InMemoryAssetSwapRepository();
+        vi.spyOn(repository, "saveSwapRecord").mockRejectedValue(new Error("quota exceeded"));
+        const h = await setup({ repository });
+        const quote = await quoteFor(h, "lightningSend");
+
+        await expect(h.client.accept(quote)).rejects.toThrow(/quota exceeded/);
+        // The whole point of the throwing write: funding must not follow a lost
+        // record.
+        expect(h.wallet.sent).toHaveLength(0);
+    });
+});
+
+describe("accept() — the offer extension packet", () => {
+    it("attaches the packet the covenant commits to", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "spot");
+        await h.client.accept(quote);
+
+        const [payment] = h.wallet.sent;
+        expect(payment?.extensions).toHaveLength(1);
+        expect(payment?.extensions?.[0]?.type).toBe(OFFER_PACKET_TYPE);
+
+        // The packet is the record's own TLV, so the deposit is visible to the
+        // solver that priced it. Omitting it throws nowhere and lands the money
+        // at a covenant nobody can see, which is the silent loss this asserts
+        // against.
+        const stored = (await h.repository.getSwapRecord(quote.id)) as OfferSwapRecord;
+        expect(hex.encode(payment?.extensions?.[0]?.payload as Uint8Array)).toBe(stored.offerHex);
+        expect(decodeOffer(hex.decode(stored.offerHex)).wantAmount).toBe(quote.take.amount);
+    });
+
+    it("sends the asset leg as an asset, not as sats", async () => {
+        const h = await setup();
+        // USD -> BTC: the give leg is the asset, and it rides the dust-sat
+        // carrier rather than being spelled as an amount.
+        const quote = await h.client.quote({
+            give: "USD",
+            take: "BTC",
+            amount: 10_000n,
+            amountOn: "give",
+        });
+        await h.client.accept(quote);
+
+        const [payment] = h.wallet.sent;
+        expect(payment?.assets).toEqual([{ assetId: USD_ASSET_ID, amount: 10_000n }]);
+        expect(payment?.amount).toBeUndefined();
+    });
+});
+
+describe("accept() — idempotency by quote id", () => {
+    it.each(ALL_ROUTES)("returns the same swap and funds once, on %s", async (route) => {
+        const h = await setup();
+        const quote = await quoteFor(h, route);
+
+        const first = await h.client.accept(quote);
+        const second = await h.client.accept(quote);
+
+        expect(second).toEqual(first);
+        expect(h.wallet.sent).toHaveLength(route === "lightningReceive" ? 0 : 1);
+        expect(await h.repository.getAllSwapRecords()).toHaveLength(1);
+        // One covenant row, because `createContract` is first-writer-wins and
+        // the second accept never reaches a second derivation.
+        expect(h.wallet.contracts).toHaveLength(1);
+    });
+
+    it("returns the stored invoice, not a second one", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningReceive");
+        const first = await h.client.accept(quote);
+
+        // Asserted against the record rather than the quote object: after a
+        // restart the quote is gone and the record is the only answer.
+        const stored = await h.repository.getSwapRecord(quote.id);
+        const second = await h.client.accept(quote);
+        expect(second.artifact).toEqual(stored?.artifact);
+        expect(second.artifact).toEqual(first.artifact);
+    });
+
+    it("resumes a persisted-but-unfunded record rather than starting over", async () => {
+        let fail = true;
+        const h = await setup({ failSend: () => (fail ? new Error("send exploded") : undefined!) });
+        const quote = await quoteFor(h, "lightningSend");
+        await expect(h.client.accept(quote)).rejects.toThrow(/send exploded/);
+
+        fail = false;
+        const swap = await h.client.accept(quote);
+
+        expect(swap.fundingTxid).toBe(FUNDING_TXID);
+        expect(h.wallet.sent).toHaveLength(1);
+        expect(await h.repository.getAllSwapRecords()).toHaveLength(1);
+    });
+
+    it("treats a funding txid appearing where there was none as a benign resume", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+        await h.client.accept(quote);
+        const stored = await h.repository.getSwapRecord(quote.id);
+
+        // The record now carries a txid the quote knows nothing about. §3.2
+        // names this a resume rather than a conflict, by name.
+        expect(stored?.fundingTxid).toBeDefined();
+        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+    });
+});
+
+describe("accept() — AcceptConflict, one case per compared field", () => {
+    /** Accept `quote`, then re-accept a tampered copy of it. */
+    const conflictOn = async (
+        route: RouteName,
+        tamper: (quote: Quote) => Quote,
+    ): Promise<readonly string[]> => {
+        const h = await setup();
+        const quote = await quoteFor(h, route);
+        await h.client.accept(quote);
+        try {
+            await h.client.accept(tamper(quote));
+            throw new Error("expected AcceptConflict");
+        } catch (error) {
+            expect(error).toBeInstanceOf(AcceptConflict);
+            return (error as AcceptConflict).fields;
+        }
+    };
+
+    it("refuses a changed give amount", async () => {
+        expect(
+            await conflictOn("lightningSend", (q) => ({
+                ...q,
+                give: { ...q.give, amount: q.give.amount + 1n },
+            })),
+        ).toContain("give.amount");
+    });
+
+    it("refuses a changed take amount", async () => {
+        expect(
+            await conflictOn("lightningSend", (q) => ({
+                ...q,
+                take: { ...q.take, amount: q.take.amount + 1n },
+            })),
+        ).toContain("take.amount");
+    });
+
+    it("refuses a changed give asset", async () => {
+        const fields = await conflictOn(
+            "spot",
+            (q) =>
+                ({
+                    ...q,
+                    route: { ...q.route, give: { ...q.route.give, asset: q.route.take.asset } },
+                }) as Quote,
+        );
+        expect(fields).toContain("give.asset");
+    });
+
+    it("refuses a changed take asset", async () => {
+        const fields = await conflictOn(
+            "spot",
+            (q) =>
+                ({
+                    ...q,
+                    route: { ...q.route, take: { ...q.route.take, asset: q.route.give.asset } },
+                }) as Quote,
+        );
+        expect(fields).toContain("take.asset");
+    });
+
+    it("refuses a changed take instrument", async () => {
+        const fields = await conflictOn(
+            "onchainSend",
+            (q) =>
+                ({
+                    ...q,
+                    route: {
+                        ...q.route,
+                        take: {
+                            ...q.route.take,
+                            instrument: { kind: "address", address: "bcrt1qelsewhere" },
+                        },
+                    },
+                }) as Quote,
+        );
+        expect(fields).toContain("take.instrument");
+    });
+
+    it("refuses a changed lock hash", async () => {
+        expect(
+            await conflictOn("lightningSend", (q) => ({ ...q, lock: { hash: "f".repeat(64) } })),
+        ).toContain("lock.hash");
+    });
+
+    it("refuses a changed refund locktime", async () => {
+        expect(
+            await conflictOn("lightningSend", (q) => ({ ...q, refundLocktime: NOW + 999 })),
+        ).toContain("refundLocktime");
+    });
+
+    it("refuses a changed solver", async () => {
+        expect(
+            await conflictOn("lightningSend", (q) => ({ ...q, solver: "0".repeat(64) })),
+        ).toContain("solver");
+    });
+
+    it("refuses a changed registry", async () => {
+        const fields = await conflictOn(
+            "lightningSend",
+            (q) =>
+                ({
+                    ...q,
+                    market: { ...q.market, source: "https://elsewhere.example/regtest.json" },
+                }) as Quote,
+        );
+        expect(fields).toContain("market.source");
+    });
+
+    it("refuses a changed route pair", async () => {
+        // Repricing the same id against another corridor: the pair is the first
+        // thing §3.2 compares, and the one a caller could plausibly reuse an id
+        // across.
+        const h = await setup();
+        const send = await quoteFor(h, "lightningSend");
+        await h.client.accept(send);
+        const onchain = await quoteFor(h, "onchainSend");
+        await expect(h.client.accept({ ...onchain, id: send.id })).rejects.toThrow(AcceptConflict);
+    });
+
+    it("does not conflict on a field absent from both sides", async () => {
+        // A feed-priced quote carries no solver and no lock hash by
+        // construction, so "absent" must read as agreement rather than as a
+        // difference — otherwise every spot re-accept would conflict.
+        const h = await setup();
+        const quote = await quoteFor(h, "spot");
+        await h.client.accept(quote);
+        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+    });
+});
+
+describe("accept() — the pre-flight and the clock", () => {
+    it.each(FUNDING_ROUTES)("refuses an unfundable %s before persisting", async (route) => {
+        const h = await setup({ balance: { available: 1, availableAssets: [] } });
+        const quote = await quoteFor(h, route);
+
+        await expect(h.client.accept(quote)).rejects.toThrow(InsufficientFunds);
+        // Nothing durable, nothing registered, nothing sent: a caller who
+        // cannot fund leaves no record behind.
+        expect(await h.repository.getSwapRecord(quote.id)).toBeUndefined();
+        expect(h.wallet.contracts).toHaveLength(0);
+        expect(h.wallet.sent).toHaveLength(0);
+    });
+
+    it("runs no balance check on a receive", async () => {
+        // The give leg is the payer's invoice, so an empty wallet is the
+        // canonical case rather than a refusal — which is why the gate is the
+        // instrument and not the asset, both give legs here being BTC.
+        const h = await setup({ balance: { available: 0, availableAssets: [] } });
+        const quote = await quoteFor(h, "lightningReceive");
+        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+    });
+
+    it("refuses an accept past the quote's own expiry", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+        vi.setSystemTime((quote.expiresAt + 1) * 1000);
+
+        await expect(h.client.accept(quote)).rejects.toThrow(QuoteExpired);
+        expect(await h.repository.getSwapRecord(quote.id)).toBeUndefined();
+    });
+
+    it("accepts at the last second rather than inheriting the quote-time floor", async () => {
+        // `policy.quoteTtlFloorSeconds` is the quote path's question. Applying
+        // it here would refuse terms §3.2 still considers acceptable.
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+        vi.setSystemTime(quote.expiresAt * 1000);
+        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+    });
+
+    it("names the repository when the client was given none", async () => {
+        const h = await setup({ omitRepository: true });
+        // Quoting works without storage, since it persists nothing.
+        const quote = await quoteFor(h, "lightningSend");
+        await expect(h.client.accept(quote)).rejects.toThrow(MissingCorridorDep);
+        // And it never silently fell back to memory, which is the loss the
+        // storage rule forbids.
+        expect(h.wallet.sent).toHaveLength(0);
+    });
+});
+
+describe("accept() — reconcile from evidence before a second funding", () => {
+    it("adopts the deposit a crashed accept already made", async () => {
+        let fail = true;
+        const h = await setup({
+            failSend: () => (fail ? new Error("crashed mid-send") : undefined!),
+        });
+        const quote = await quoteFor(h, "lightningSend");
+        await expect(h.client.accept(quote)).rejects.toThrow(/crashed mid-send/);
+
+        // The window: the record is durable, the funding actually landed, and
+        // the txid was never written. A blind retry would fund twice.
+        const stored = (await h.repository.getSwapRecord(quote.id)) as CorridorSwapRecord;
+        h.wallet.deposits.set(stored.lockupPkScript, [
+            { txid: "a".repeat(64), value: Number(quote.give.amount) },
+        ]);
+
+        fail = false;
+        const swap = await h.client.accept(quote);
+
+        expect(swap.fundingTxid).toBe("a".repeat(64));
+        expect(h.wallet.sent).toHaveLength(0);
+    });
+
+    it("does not adopt a deposit for the wrong amount", async () => {
+        let fail = true;
+        const h = await setup({
+            failSend: () => (fail ? new Error("crashed mid-send") : undefined!),
+        });
+        const quote = await quoteFor(h, "lightningSend");
+        await expect(h.client.accept(quote)).rejects.toThrow(/crashed mid-send/);
+
+        const stored = (await h.repository.getSwapRecord(quote.id)) as CorridorSwapRecord;
+        // Identical offers derive one address, so a VTXO at the script is not
+        // proof it is THIS swap's deposit. Adopting it would attach the money
+        // to the wrong record and leave the right one funded twice.
+        h.wallet.deposits.set(stored.lockupPkScript, [{ txid: "c".repeat(64), value: 1 }]);
+
+        fail = false;
+        const swap = await h.client.accept(quote);
+        expect(swap.fundingTxid).toBe(FUNDING_TXID);
+        expect(h.wallet.sent).toHaveLength(1);
+    });
+
+    it("matches an asset deposit on the asset entry, not the sat carrier", async () => {
+        let fail = true;
+        const h = await setup({
+            failSend: () => (fail ? new Error("crashed mid-send") : undefined!),
+        });
+        const quote = await h.client.quote({
+            give: "USD",
+            take: "BTC",
+            amount: 10_000n,
+            amountOn: "give",
+        });
+        await expect(h.client.accept(quote)).rejects.toThrow(/crashed mid-send/);
+
+        const stored = (await h.repository.getSwapRecord(quote.id)) as OfferSwapRecord;
+        h.wallet.deposits.set(stored.swapPkScript, [
+            // The sats are the carrier; the deposit is the asset entry.
+            {
+                txid: "d".repeat(64),
+                value: 330,
+                assets: [{ assetId: USD_ASSET_ID, amount: 10_000n }],
+            },
+        ]);
+
+        fail = false;
+        const swap = await h.client.accept(quote);
+        expect(swap.fundingTxid).toBe("d".repeat(64));
+        expect(h.wallet.sent).toHaveLength(0);
+    });
+});
+
+describe("accept() — what the record carries", () => {
+    it("registers the lockup under the type a rebuild reads", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+        await h.client.accept(quote);
+
+        const [row] = h.wallet.contracts;
+        expect(row?.type).toBe(SWAP_LOCKUP_CONTRACT_TYPE);
+        // The row is the only place the covenant tree lives — the record
+        // deliberately stores none — so a rebuild reads its params from here.
+        expect(Object.keys(row?.params ?? {}).length).toBeGreaterThan(0);
+    });
+
+    it("carries the corridor profile the drive pass will hydrate", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningReceive");
+        await h.client.accept(quote);
+
+        const stored = (await h.repository.getSwapRecord(quote.id)) as CorridorSwapRecord;
+        expect(stored.kind).toBe("lightning_receive");
+        expect(stored.profile.signer).toMatchObject({ signingDescriptor: expect.any(String) });
+        expect(stored.profile.hashlock).toMatchObject({ paymentHash: stored.lock.hash });
+        // The claim value gate's request-time input. Read at claim time it
+        // would be whatever the solver funded, which is the attack rather than
+        // a check on it.
+        expect(stored.profile.expectedAmount).toBe(Number(quote.take.amount));
+        expect(stored.profile.payoutAddress).toEqual(expect.any(String));
+    });
+
+    it("carries the L1 half of an onchain send, which no covenant row holds", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "onchainSend");
+        await h.client.accept(quote);
+
+        const stored = (await h.repository.getSwapRecord(quote.id)) as CorridorSwapRecord;
+        expect(stored.kind).toBe("onchain_send");
+        expect(stored.profile).toMatchObject({
+            claimKey: expect.any(String),
+            refundKey: expect.any(String),
+            htlcLocktime: expect.any(Number),
+            htlcAddress: expect.any(String),
+            minConfirmations: expect.any(Number),
+        });
+    });
+
+    it("writes at most one of the preimage and its salt", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningReceive");
+        await h.client.accept(quote);
+
+        const stored = (await h.repository.getSwapRecord(quote.id)) as CorridorSwapRecord;
+        const hashlock = stored.profile.hashlock as Record<string, unknown>;
+        const both = hashlock.preimageHex !== undefined && hashlock.preimageSaltHex !== undefined;
+        expect(both).toBe(false);
+    });
+
+    it("carries the market whole, so the swap it answers with needs no fabrication", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+        const swap = await h.client.accept(quote);
+
+        // Round-tripped through the record, not copied off the quote object:
+        // the second accept reads it back off disk.
+        const again = await h.client.accept(quote);
+        expect(again.market).toEqual(quote.market);
+        expect(swap.market).toEqual(quote.market);
+    });
+
+    it("stores every amount as a decimal string and reads it back as a bigint", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+        const swap = await h.client.accept(quote);
+
+        const stored = await h.repository.getSwapRecord(quote.id);
+        expect(stored?.give.amount).toBe(quote.give.amount.toString());
+        expect(stored?.take.amount).toBe(quote.take.amount.toString());
+        // The record survives the two backends that JSON-serialize it.
+        expect(() => JSON.stringify(stored)).not.toThrow();
+        expect(swap.give.amount).toBe(quote.give.amount);
+    });
+
+    it("stamps both timestamps in seconds, the unit the record layer compares", async () => {
+        const h = await setup();
+        const quote = await quoteFor(h, "lightningSend");
+        await h.client.accept(quote);
+
+        const stored = await h.repository.getSwapRecord(quote.id);
+        // Milliseconds here would retire a terminal record after ~43 minutes.
+        expect(stored?.createdAt).toBe(NOW);
+        expect(stored?.updatedAt).toBe(NOW);
+    });
+});

--- a/packages/swap/test/client/fixtures.ts
+++ b/packages/swap/test/client/fixtures.ts
@@ -12,6 +12,7 @@ import { schnorr, secp256k1 } from "@noble/curves/secp256k1.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import {
     ArkAddress,
+    CSVMultisigTapscript,
     DescriptorIdentity,
     HDDescriptorProvider,
     InMemoryWalletRepository,
@@ -51,12 +52,28 @@ export const HTLC_REFUND_PUBKEY = key(7);
 export const NETWORK = getNetwork("regtest");
 export const CLAIM_DELAY = unilateralClaimDelay(4096);
 
+/**
+ * The checkpoint closure, derived from the signer key rather than pinned — the
+ * way arkd advertises it, so a checkpoint committing to another key would
+ * describe a different server.
+ *
+ * Needed by the offer route's registration, which builds an `Arkade` client to
+ * derive the contract row; the quote path never reads it.
+ */
+export const CHECKPOINT_TAPSCRIPT = hex.encode(
+    CSVMultisigTapscript.encode({
+        timelock: { type: "blocks", value: 10n },
+        pubkeys: [OPERATOR_PUBKEY],
+    }).script,
+);
+
 /** What the wallet answers `getArkadeInfo()` with. */
 export const ARK_INFO = {
     signerPubkey: hex.encode(OPERATOR_PUBKEY),
     unilateralExitDelay: 4096,
     network: "regtest",
     deprecatedSigners: [],
+    checkpointTapscript: CHECKPOINT_TAPSCRIPT,
 };
 
 export const WALLET_ADDRESS = new ArkAddress(OPERATOR_PUBKEY, key(21), NETWORK.hrp).encode();
@@ -368,3 +385,122 @@ export const solverFor = (clock: SolverClock): SolverAnswer => {
 
 export const compressed = (fill: number): string =>
     hex.encode(secp256k1.getPublicKey(new Uint8Array(32).fill(fill), true));
+
+// ── What `accept()` needs behind it, and nothing the quote path had ─────────
+
+/** One `wallet.send` call, exactly as the accept path issued it. */
+export interface SentPayment {
+    address: string;
+    amount?: number;
+    assets?: { assetId: string; amount: bigint }[];
+    extensions?: { type: number; payload: Uint8Array }[];
+}
+
+/** A contract row, as `createContract` was asked to write it. */
+export interface WrittenContract {
+    type: string;
+    script: string;
+    address: string;
+    params: Record<string, string>;
+}
+
+/** One `setContractWatchState` call: the script, and the state asked for. */
+export type WatchStateCall = [script: string, state: string];
+
+export interface AcceptWallet {
+    readonly wallet: IWallet;
+    /** Every funding call, in order. */
+    readonly sent: SentPayment[];
+    /** Every contract row written, in order — first-writer-wins is modelled. */
+    readonly contracts: WrittenContract[];
+    /** Every watch-state change, in order. The offer route promotes its row. */
+    readonly watched: WatchStateCall[];
+    /** VTXOs the reader will answer with, keyed by script hex. */
+    readonly deposits: Map<
+        string,
+        { txid: string; value: number; assets?: { assetId: string; amount: bigint }[] }[]
+    >;
+}
+
+/**
+ * The quote path's wallet, plus the four seams `accept()` reaches.
+ *
+ * `getContractManager` no longer throws — it records instead — because
+ * registration is part of the accept ordering. The quote path's assertion that
+ * *it* never reaches the manager is unaffected: that test builds its wallet
+ * with {@link hdWallet}, whose thrower is untouched.
+ *
+ * `send` records and returns a txid rather than deriving one, and `failSend`
+ * makes it throw, which is how the after-persist-before-funding window is
+ * reached without killing a process.
+ */
+export const acceptWallet = async (
+    over: {
+        balance?: { available?: number; availableAssets?: { assetId: string; amount: bigint }[] };
+        txid?: string;
+        failSend?: () => Error;
+        failRegistration?: () => Error;
+    } = {},
+): Promise<AcceptWallet> => {
+    const base = await hdWallet();
+    const sent: SentPayment[] = [];
+    const contracts: WrittenContract[] = [];
+    const watched: WatchStateCall[] = [];
+    const deposits = new Map<
+        string,
+        { txid: string; value: number; assets?: { assetId: string; amount: bigint }[] }[]
+    >();
+    const wallet = {
+        ...base,
+        getBalance: async () => ({
+            available: over.balance?.available ?? 100_000_000,
+            availableAssets: over.balance?.availableAssets ?? [
+                { assetId: USD_ASSET_ID, amount: 1_000_000n },
+            ],
+            assets: [],
+        }),
+        // The whole seam the accept path reaches, not just `createContract`:
+        // the offer route registers through `Arkade.connect` and then promotes
+        // the row, so `setContractWatchState` and `getContracts` are part of
+        // registration rather than extras.
+        getContractManager: async () => ({
+            createContract: async (row: WrittenContract) => {
+                const failure = over.failRegistration?.();
+                if (failure) throw failure;
+                // First-writer-wins, as the real one is: identical offers derive
+                // one address, so a second write for a script already present is
+                // a no-op rather than a conflict.
+                if (!contracts.some((c) => c.script === row.script)) contracts.push(row);
+                return { ...row, state: "active", createdAt: 0 };
+            },
+            getContracts: async (filter?: { script?: string }) =>
+                contracts.filter((c) => filter?.script === undefined || c.script === filter.script),
+            setContractWatchState: async (script: string, state: string) => {
+                watched.push([script, state]);
+            },
+            onContractEvent: () => () => {},
+        }),
+        getArkadeReader: async () => ({
+            getVtxos: async ({ scripts }: { scripts?: string[] }) => ({
+                vtxos: (scripts ?? []).flatMap((s) =>
+                    (deposits.get(s) ?? []).map((d) => ({
+                        txid: d.txid,
+                        vout: 0,
+                        value: d.value,
+                        ...(d.assets ? { assets: d.assets } : {}),
+                    })),
+                ),
+            }),
+        }),
+        send: async (recipient: SentPayment) => {
+            const failure = over.failSend?.();
+            if (failure) throw failure;
+            sent.push(recipient);
+            return over.txid ?? FUNDING_TXID;
+        },
+    } as unknown as IWallet;
+    return { wallet, sent, contracts, watched, deposits };
+};
+
+/** The txid `acceptWallet`'s `send` returns unless told otherwise. */
+export const FUNDING_TXID = "b".repeat(64);

--- a/packages/swap/test/client/fixtures.ts
+++ b/packages/swap/test/client/fixtures.ts
@@ -70,7 +70,7 @@ export const CHECKPOINT_TAPSCRIPT = hex.encode(
 /** What the wallet answers `getArkadeInfo()` with. */
 export const ARK_INFO = {
     signerPubkey: hex.encode(OPERATOR_PUBKEY),
-    unilateralExitDelay: 4096,
+    unilateralExitDelay: 4096n,
     network: "regtest",
     deprecatedSigners: [],
     checkpointTapscript: CHECKPOINT_TAPSCRIPT,

--- a/packages/swap/test/client/record.types.ts
+++ b/packages/swap/test/client/record.types.ts
@@ -1,0 +1,140 @@
+/**
+ * Type-level assertions for the durable record. Checked by `tsconfig.test.json`,
+ * which the package's `typecheck` script runs, so every `@ts-expect-error` here
+ * is an assertion CI enforces — and one that stops erroring fails the build.
+ *
+ * The load-bearing one is {@link NoBigint}: the SQLite and Realm backends
+ * `JSON.stringify` the record whole, so a `bigint` anywhere in it throws on two
+ * of the four backends and round-trips on the third. That asymmetry is not
+ * something a review catches reliably, and the conformance suite cannot catch a
+ * field no fixture happens to populate — so it is proved structurally instead.
+ */
+import type { Artifact, Instrument } from "../../src/client/route";
+import type { Quote, QuoteLeg } from "../../src/client/quote";
+import type {
+    CorridorSwapRecord,
+    OfferSwapRecord,
+    RecordedArtifact,
+    RecordedInstrument,
+    Swap,
+    SwapRecord,
+} from "../../src/client/record";
+
+/**
+ * Every `bigint` reachable from `T`, as the paths that reach one.
+ *
+ * Recursive on purpose: a `keyof` check over the top level passes happily on a
+ * `bigint` nested inside an artifact, an instrument or a corridor profile,
+ * which is exactly where the ones that got away would hide. `never` when the
+ * type is clean, so the assertion below is an equality against `never` rather
+ * than a boolean nobody can read the failure of.
+ *
+ * `Record<string, unknown>` — the corridor profile's declared type — stops the
+ * recursion at `unknown`, which is honest: the bag is opaque by contract and
+ * what goes in it is checked by the writer, not by this type.
+ */
+type NoBigint<T, Path extends string = ""> = T extends bigint
+    ? Path
+    : T extends string | number | boolean | null | undefined
+      ? never
+      : T extends readonly (infer E)[]
+        ? NoBigint<E, `${Path}[]`>
+        : T extends object
+          ? { [K in keyof T & string]-?: NoBigint<T[K], `${Path}.${K}`> }[keyof T & string]
+          : never;
+
+/** `true` only when `T` is `never`. */
+type IsNever<T> = [T] extends [never] ? true : false;
+
+/**
+ * The record carries no `bigint`, at any depth.
+ *
+ * Asserted as `IsNever<...> = true` rather than against a list of field paths:
+ * a failure then reads as "expected true, got false" beside the type whose
+ * paths TypeScript prints in full, and adding a clean field to the record does
+ * not require editing an expectation.
+ */
+export const recordIsJsonSafe: IsNever<NoBigint<SwapRecord>> = true;
+export const offerRecordIsJsonSafe: IsNever<NoBigint<OfferSwapRecord>> = true;
+export const corridorRecordIsJsonSafe: IsNever<NoBigint<CorridorSwapRecord>> = true;
+export const recordedArtifactIsJsonSafe: IsNever<NoBigint<RecordedArtifact>> = true;
+export const recordedInstrumentIsJsonSafe: IsNever<NoBigint<RecordedInstrument>> = true;
+
+/**
+ * The helper actually finds one — otherwise every assertion above would pass
+ * against a type that returned `never` unconditionally, which is the way a
+ * structural proof like this fails silently.
+ *
+ * `Quote` is the natural control: the same information in public form, carrying
+ * `bigint` amounts deliberately.
+ */
+// @ts-expect-error Quote carries bigint amounts, so it is NOT json-safe
+export const quoteIsNotJsonSafe: IsNever<NoBigint<Quote>> = true;
+
+/** And it finds a nested one, not just a top-level field. */
+type Nested = { outer: { inner: bigint } };
+// @ts-expect-error the bigint is two levels down, and must still be found
+export const nestedIsFound: IsNever<NoBigint<Nested>> = true;
+
+/** ...and it reports *where*, which is what makes a failure actionable. */
+export const nestedPath: ".outer.inner" = ".outer.inner" satisfies NoBigint<Nested>;
+
+// ── What `Swap` promises the milestones after this one ─────────────────────
+
+/**
+ * `artifact` stays optional, so M7's `ReceiveRequest` can narrow it.
+ *
+ * An intersection cannot make a required field required — if `Swap.artifact`
+ * were already non-optional the intersection would be a no-op and the guarantee
+ * it exists to state would be unstated.
+ */
+export type ReceiveRequest = Swap & { artifact: Artifact };
+export const narrowed = (r: ReceiveRequest): Artifact => r.artifact;
+
+// @ts-expect-error a plain Swap's artifact may be absent
+export const notNarrowed = (s: Swap): Artifact => s.artifact;
+
+/** The public shape keeps `bigint` amounts: it is the answer, not the storage. */
+export const swapAmountsAreBigint = (s: Swap): [bigint, bigint, bigint] => [
+    s.give.amount,
+    s.take.amount,
+    s.fee.amount,
+];
+
+/** And its legs are the quote's own leg type, not a second spelling of it. */
+export const legsAgree = (s: Swap): QuoteLeg => s.give;
+
+// ── The two records are told apart by their tag, never by a probe ──────────
+
+export const familyDiscriminates = (record: SwapRecord): string =>
+    record.family === "offer" ? record.offerHex : record.lockupAddress;
+
+// @ts-expect-error the offer arm has no lockup
+export const noLockupOnOffer = (record: OfferSwapRecord): string => record.lockupAddress;
+
+// @ts-expect-error the corridor arm has no offer TLV
+export const noOfferOnCorridor = (record: CorridorSwapRecord): string => record.offerHex;
+
+/**
+ * A corridor record's lock hash and refund locktime are non-optional.
+ *
+ * They are optional on `Quote`, because an asset swap has neither — and a
+ * corridor record that inherited that optionality would make every read of the
+ * refund deadline a `?? throw` at the call site.
+ */
+export const corridorClocksAreCertain = (record: CorridorSwapRecord): [string, number] => [
+    record.lock.hash,
+    record.refundLocktime,
+];
+
+// ── The instrument round trip covers every arm ────────────────────────────
+
+/** Each union stays total: a new arm on one must be added to the other. */
+export const instrumentArms: Instrument["kind"][] = ["wallet", "address", "invoice"];
+export const recordedInstrumentArms: RecordedInstrument["kind"][] = [
+    "wallet",
+    "address",
+    "invoice",
+];
+export const artifactArms: Artifact["kind"][] = ["invoice", "deposit"];
+export const recordedArtifactArms: RecordedArtifact["kind"][] = ["invoice", "deposit"];

--- a/packages/swap/test/node/storage.test.ts
+++ b/packages/swap/test/node/storage.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The Node storage default: where the database goes, and who closes it.
+ *
+ * Node-only by construction — it opens a real `node:sqlite` handle on a real
+ * file — which is why it lives under `test/node/` rather than beside the client
+ * tests.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    configDir,
+    createNodeSqlExecutor,
+    nodeSwapRepository,
+    swapDatabasePath,
+} from "../../src/node";
+import type { AtomicDecimal } from "../../src/client/amount";
+import type { OfferSwapRecord } from "../../src/client/record";
+
+let scratch: string;
+
+beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), "swap-node-"));
+});
+afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("the default database path", () => {
+    it("puts one file per network under arkade/swaps", () => {
+        // Per network on purpose: a record's covenant, solver and market are
+        // all network-scoped, and one file holding two networks would let a
+        // mainnet restore read a regtest record as its own.
+        const mainnet = swapDatabasePath("mainnet");
+        const regtest = swapDatabasePath("regtest");
+        expect(mainnet).not.toBe(regtest);
+        expect(mainnet.endsWith(join("arkade", "swaps", "swaps-mainnet.sqlite"))).toBe(true);
+        expect(regtest.endsWith(join("arkade", "swaps", "swaps-regtest.sqlite"))).toBe(true);
+    });
+
+    it("follows XDG when it names an absolute path", () => {
+        if (process.platform !== "linux") return;
+        expect(configDir({ XDG_CONFIG_HOME: "/custom/config" })).toBe("/custom/config");
+    });
+
+    it("ignores a relative XDG value rather than resolving it against the cwd", () => {
+        if (process.platform !== "linux") return;
+        // The spec says a relative value "should be ignored". Resolving it
+        // would put the database wherever the process happened to start.
+        expect(configDir({ XDG_CONFIG_HOME: "relative/path" })).not.toContain("relative/path");
+        expect(configDir({ XDG_CONFIG_HOME: "relative/path" }).endsWith(".config")).toBe(true);
+    });
+});
+
+describe("the file-backed executor", () => {
+    it("creates the parent directory and the file", async () => {
+        const path = join(scratch, "nested", "deeper", "swaps.sqlite");
+        const executor = createNodeSqlExecutor(path);
+        // The config dir exists on a real machine but `arkade/swaps` under it
+        // does not, and failing a first run for a directory the caller never
+        // chose would be a poor default.
+        await executor.run("CREATE TABLE t (x TEXT)");
+        expect(existsSync(path)).toBe(true);
+        await executor.close();
+    });
+
+    it("round-trips through real SQL", async () => {
+        const executor = createNodeSqlExecutor(join(scratch, "swaps.sqlite"));
+        await executor.run("CREATE TABLE t (k TEXT PRIMARY KEY, v TEXT)");
+        await executor.run("INSERT INTO t (k, v) VALUES (?, ?)", ["a", "1"]);
+        expect(await executor.get<{ v: string }>("SELECT v FROM t WHERE k = ?", ["a"])).toEqual({
+            v: "1",
+        });
+        expect(await executor.all("SELECT k FROM t")).toEqual([{ k: "a" }]);
+        await executor.close();
+    });
+
+    it("binds undefined as null rather than throwing", async () => {
+        const executor = createNodeSqlExecutor(join(scratch, "swaps.sqlite"));
+        await executor.run("CREATE TABLE t (k TEXT, v TEXT)");
+        // `node:sqlite` rejects a bound `undefined`; `null` is what it means.
+        await executor.run("INSERT INTO t (k, v) VALUES (?, ?)", ["a", undefined]);
+        expect(await executor.get("SELECT v FROM t")).toEqual({ v: null });
+        await executor.close();
+    });
+
+    it("closes idempotently", async () => {
+        const executor = createNodeSqlExecutor(join(scratch, "swaps.sqlite"));
+        await executor.close();
+        // Disposal and an explicit shutdown-handler close both happen; the
+        // second `db.close()` would throw.
+        await expect(executor.close()).resolves.toBeUndefined();
+    });
+});
+
+describe("the Node repository default", () => {
+    it("persists a record to the file and reads it back from a new handle", async () => {
+        const path = join(scratch, "swaps.sqlite");
+        const record: OfferSwapRecord = {
+            id: "q1",
+            family: "offer",
+            route: {
+                give: {
+                    corridor: "arkade",
+                    asset: "arkade:regtest/slip44:0",
+                    instrument: { kind: "wallet" },
+                },
+                take: {
+                    corridor: "arkade",
+                    asset: "arkade:regtest/slip44:0",
+                    instrument: { kind: "wallet" },
+                },
+            },
+            give: { asset: "arkade:regtest/slip44:0", amount: "1000" as AtomicDecimal },
+            take: { asset: "arkade:regtest/slip44:0", amount: "990" as AtomicDecimal },
+            fee: { asset: "arkade:regtest/slip44:0", amount: "10" as AtomicDecimal },
+            market: {
+                kind: "card",
+                key: "k",
+                backend: "feed",
+                source: "https://r.example",
+                sourceType: "registry",
+                solver: "s",
+                pair: "BTC/USD",
+                snapshot: { fetchedAt: 1, live: true, source: "live" },
+            },
+            expiresAt: 2,
+            status: "pending",
+            offerHex: "0100",
+            swapAddress: "tark1q",
+            swapPkScript: "5120",
+            createdAt: 1,
+            updatedAt: 1,
+        };
+
+        {
+            await using repository = nodeSwapRepository({ network: "regtest", path });
+            await repository.saveSwapRecord(record);
+        }
+        // A second handle over the same file: durability is the whole point of
+        // the Node default, so it has to survive the connection that wrote it.
+        await using reopened = nodeSwapRepository({ network: "regtest", path });
+        expect(await reopened.getSwapRecord("q1")).toEqual(record);
+    });
+
+    it("closes the connection it opened, unlike every injected backend", async () => {
+        const path = join(scratch, "swaps.sqlite");
+        const repository = nodeSwapRepository({ network: "regtest", path });
+        await repository.getAllSwapRecords();
+        await repository[Symbol.asyncDispose]();
+
+        // Disposal closed the handle this repository opened — an injected one
+        // is the caller's to close, which is why every other backend's
+        // disposal is a no-op.
+        await expect(repository.getAllSwapRecords()).rejects.toThrow();
+    });
+});

--- a/packages/swap/test/node/storage.test.ts
+++ b/packages/swap/test/node/storage.test.ts
@@ -39,6 +39,24 @@ describe("the default database path", () => {
         expect(regtest.endsWith(join("arkade", "swaps", "swaps-regtest.sqlite"))).toBe(true);
     });
 
+    it("rejects network names that are not single safe path segments", () => {
+        for (const network of [
+            "",
+            "1regtest",
+            "reg/test",
+            "reg\\test",
+            "x/../../../outside",
+            "regtest.sqlite",
+            "reg_test",
+            "Regtest",
+        ]) {
+            expect(() => swapDatabasePath(network)).toThrow(/invalid network name/i);
+        }
+
+        expect(() => swapDatabasePath("regtest")).not.toThrow();
+        expect(() => swapDatabasePath("mutiny-net")).not.toThrow();
+    });
+
     it("follows XDG when it names an absolute path", () => {
         if (process.platform !== "linux") return;
         expect(configDir({ XDG_CONFIG_HOME: "/custom/config" })).toBe("/custom/config");

--- a/packages/swap/test/repository.test.ts
+++ b/packages/swap/test/repository.test.ts
@@ -2,6 +2,8 @@ import "fake-indexeddb/auto";
 import { describe, expect, it } from "vitest";
 import type { AssetSwap } from "../src/store";
 import type { RfqSwapRecord } from "../src/rfqRecord";
+import type { AtomicDecimal } from "../src/client/amount";
+import type { CorridorSwapRecord } from "../src/client/record";
 import { AssetSwapRepository, InMemoryAssetSwapRepository } from "../src/repository";
 import { IndexedDbAssetSwapRepository } from "../src/indexedDbRepository";
 import { runInTransaction, type SQLExecutor } from "@arkade-os/sdk/repositories/sqlite";
@@ -18,6 +20,67 @@ const rfqRecord = (rfqId: string): RfqSwapRecord => ({
     lockupAddress: "tark1qlockup",
     // The corridor's own keys, nested — which is what a field-mapped backend is
     // likeliest to flatten or drop.
+    profile: {
+        signer: { signingDescriptor: `tr(${"a7".repeat(32)})` },
+        hashlock: { paymentHash: "d4".repeat(32) },
+    },
+    createdAt: 1,
+    updatedAt: 1,
+});
+
+/**
+ * A v2 accept record, in the shape `accept()` writes.
+ *
+ * JSON-safe on purpose, like the `AssetSwap` fixture below: every amount is a
+ * decimal string and the nested `profile` and `market` are plain objects, so
+ * the two backends that `JSON.stringify` the record and the one that
+ * structured-clones it must agree field for field. A `bigint` here would throw
+ * on two of the four and round-trip on the third.
+ */
+const swapRecord = (id: string): CorridorSwapRecord => ({
+    id,
+    family: "rfq",
+    route: {
+        give: {
+            corridor: "arkade",
+            asset: "arkade:regtest/slip44:0",
+            instrument: { kind: "wallet" },
+        },
+        take: {
+            corridor: "lightning",
+            asset: "bolt11:regtest/slip44:0",
+            instrument: {
+                kind: "invoice",
+                bolt11: "lnbcrt50u1p",
+                paymentHash: "d4".repeat(32),
+                amount: "5000" as AtomicDecimal,
+                expiresAt: 1_700_003_600,
+            },
+        },
+    },
+    give: { asset: "arkade:regtest/slip44:0", amount: "5050" as AtomicDecimal },
+    take: { asset: "bolt11:regtest/slip44:0", amount: "5000" as AtomicDecimal },
+    fee: { asset: "arkade:regtest/slip44:0", amount: "50" as AtomicDecimal },
+    market: {
+        kind: "card",
+        key: "arkade:BTC/lightning:BTC",
+        backend: "rfq",
+        source: REGISTRY,
+        sourceType: "registry",
+        solver: "frenchman",
+        pair: "BTC/lightning:BTC",
+        snapshot: { fetchedAt: 1_000, live: true, source: "live", registry: REGISTRY },
+    },
+    solver: "aa".repeat(32),
+    expiresAt: 1_700_003_600,
+    state: "pending",
+    kind: "lightning_send",
+    rfqId: `rfq-${id}`,
+    lockupAddress: "tark1qlockup",
+    lockupPkScript: "5120" + "cd".repeat(32),
+    lock: { hash: "d4".repeat(32) },
+    refundLocktime: 1_900_000_000,
+    // Nested, which is what a field-mapped backend is likeliest to flatten.
     profile: {
         signer: { signingDescriptor: `tr(${"a7".repeat(32)})` },
         hashlock: { paymentHash: "d4".repeat(32) },
@@ -57,6 +120,7 @@ const backends: [string, () => AssetSwapRepository][] = [
                     ArkadeRfqSwap: "rfqId",
                     ArkadeAssetSwapScannedTxid: "txid",
                     ArkadeAssetSwapMarketsCache: "key",
+                    ArkadeSwapRecord: "id",
                 }),
             ),
     ],
@@ -357,14 +421,134 @@ describe.each(backends)("RFQ swap records (%s)", (_, create) => {
 });
 
 /**
+ * The v2 accept record store, on every backend.
+ *
+ * The store `accept()` writes, keyed by the client-minted quote id rather than
+ * a funding txid — which is what lets a record exist before the money does. Its
+ * own store, so the v1 read path's `offerHex || paymentHash` predicate never
+ * sees it: v2 rows being invisible to v1 readers is the design, and the last
+ * case here asserts that rather than tolerating it.
+ */
+describe.each(backends)("v2 swap records (%s)", (_, create) => {
+    it("upserts by quote id and reads one back", async () => {
+        await using repository = create();
+        await repository.saveSwapRecord(swapRecord("q1"));
+        await repository.saveSwapRecord(swapRecord("q2"));
+
+        expect(await repository.getSwapRecord("q1")).toEqual(swapRecord("q1"));
+        expect((await repository.getAllSwapRecords()).map((r) => r.id).sort()).toEqual([
+            "q1",
+            "q2",
+        ]);
+    });
+
+    it("round-trips the record whole, nested profile and market included", async () => {
+        await using repository = create();
+        await repository.saveSwapRecord(swapRecord("q1"));
+
+        const read = await repository.getSwapRecord("q1");
+        // Field for field: a backend that dropped `profile.hashlock` would
+        // round-trip a swap whose preimage cannot be re-derived, which surfaces
+        // as an unclaimable lockup long after the write.
+        expect(read).toEqual(swapRecord("q1"));
+        expect((read as CorridorSwapRecord).profile.hashlock).toEqual({
+            paymentHash: "d4".repeat(32),
+        });
+        expect(read?.market).toEqual(swapRecord("q1").market);
+    });
+
+    it("answers a miss with undefined rather than throwing", async () => {
+        await using repository = create();
+        // The ordinary answer for a first `accept()`, and what makes it
+        // idempotent without a separate existence check.
+        expect(await repository.getSwapRecord("never-stored")).toBeUndefined();
+    });
+
+    it("replaces a record on a second save rather than duplicating it", async () => {
+        await using repository = create();
+        await repository.saveSwapRecord(swapRecord("q1"));
+        await repository.saveSwapRecord({ ...swapRecord("q1"), fundingTxid: "ab".repeat(32) });
+
+        const all = await repository.getAllSwapRecords();
+        expect(all).toHaveLength(1);
+        expect(all[0]?.fundingTxid).toBe("ab".repeat(32));
+    });
+
+    it("removes one", async () => {
+        await using repository = create();
+        await repository.saveSwapRecord(swapRecord("q1"));
+        await repository.removeSwapRecord("q1");
+        expect(await repository.getAllSwapRecords()).toEqual([]);
+    });
+
+    it("keeps the two families in separate key spaces", async () => {
+        await using repository = create();
+        // The same string as an id in both families: v1 keyed an offer record
+        // on a funding txid and a corridor record on an rfqId, so one `string`
+        // space held both by accident. Keying v2 on the quote id closes that,
+        // and this is the assertion that they cannot collide.
+        await repository.saveSwapRecord(swapRecord("shared-id"));
+        await repository.saveSwap(swap("shared-id"));
+        await repository.saveRfqSwap(rfqRecord("shared-id"));
+
+        expect(await repository.getSwapRecord("shared-id")).toMatchObject({ family: "rfq" });
+        expect((await repository.getAllSwaps()).map((s) => s.id)).toEqual(["shared-id"]);
+        expect(await repository.getAllSwapRecords()).toHaveLength(1);
+    });
+
+    it("hides v2 rows from the v1 readers, and v1 rows from the v2 reader", async () => {
+        await using repository = create();
+        await repository.saveSwapRecord(swapRecord("q1"));
+        await repository.saveSwap(swap("v1-swap"));
+
+        // Asserted, not tolerated: the two histories are disjoint for the
+        // deprecation window, which is what keeps the v2 shape from being
+        // pinned by v1's drop-anything-without-offerHex predicate.
+        expect((await repository.getAllSwaps()).map((s) => s.id)).toEqual(["v1-swap"]);
+        expect((await repository.getAllSwapRecords()).map((r) => r.id)).toEqual(["q1"]);
+    });
+
+    it("shares one scan cursor and one markets cache across both families", async () => {
+        await using repository = create();
+        // Neither is record-family data — the cursor marks txids of
+        // transactions, the cache is keyed network-and-registry — and both have
+        // a second consumer while v1 and v2 coexist. Two cursors would have
+        // each side re-walking deposits the other already answered.
+        await repository.markTxidsScanned(["t1"]);
+        await repository.saveSwapRecord(swapRecord("q1"));
+        await repository.saveSwap(swap("v1-swap"));
+
+        expect(await repository.getScannedTxids()).toEqual(new Set(["t1"]));
+        const entry = { markets: [], fetchedAt: 7 };
+        await repository.saveCachedMarkets("regtest", REGISTRY, entry);
+        expect(await repository.getCachedMarkets("regtest", REGISTRY)).toEqual(entry);
+    });
+
+    it("wipes the v2 store with everything else, never partially", async () => {
+        await using repository = create();
+        await repository.saveSwapRecord(swapRecord("q1"));
+        await repository.saveSwap(swap("v1-swap"));
+        await repository.markTxidsScanned(["t1"]);
+
+        await repository.clear();
+
+        // A partial wipe must not be observable: leaving the cursor behind
+        // would have the restore scan permanently skip those funding txs.
+        expect(await repository.getAllSwapRecords()).toEqual([]);
+        expect(await repository.getAllSwaps()).toEqual([]);
+        expect(await repository.getScannedTxids()).toEqual(new Set());
+    });
+});
+
+/**
  * The riskiest claim in this change: the version bump runs against databases
  * that already hold real swaps. `initDatabase`'s contains-guard makes adding a
  * store idempotent, but only `onupgradeneeded` runs it, and that fires on a
  * version *increase* — so the bump is what makes the new store exist at all for
  * an existing user, and the existing stores must come through untouched.
  */
-describe("IndexedDB v1 -> v2 migration", () => {
-    it("adds the rfqSwaps store while keeping swaps, scan state and markets", async () => {
+describe("IndexedDB migrations", () => {
+    it("adds every later store to a v1 database, keeping swaps, scan state and markets", async () => {
         const dbName = `migrate-${Math.random()}`;
         const markets = { markets: [], fetchedAt: 42 };
 
@@ -403,6 +587,58 @@ describe("IndexedDB v1 -> v2 migration", () => {
         // and the new store is usable immediately, not only after a reopen
         await repository.saveRfqSwap(rfqRecord("r1"));
         expect(await repository.getAllRfqSwaps()).toHaveLength(1);
+    });
+
+    it("adds the v2 record store to a v2 database and rewrites no row", async () => {
+        const dbName = `migrate-v2-${Math.random()}`;
+        const markets = { markets: [], fetchedAt: 42 };
+
+        // Seed the shape a shipped consumer actually has: DB_VERSION 2, all
+        // four stores, with rows in each. The case above starts at 1 and so
+        // never exercises the step this bump adds.
+        await new Promise<void>((resolve, reject) => {
+            const open = indexedDB.open(dbName, 2);
+            open.onupgradeneeded = () => {
+                const db = open.result;
+                db.createObjectStore("swaps", { keyPath: "id" });
+                db.createObjectStore("rfqSwaps", { keyPath: "rfqId" });
+                db.createObjectStore("scannedTxids");
+                db.createObjectStore("markets");
+            };
+            open.onsuccess = () => {
+                const db = open.result;
+                const tx = db.transaction(
+                    ["swaps", "rfqSwaps", "scannedTxids", "markets"],
+                    "readwrite",
+                );
+                tx.objectStore("swaps").put(swap("legacy"));
+                tx.objectStore("rfqSwaps").put(rfqRecord("legacy-rfq"));
+                tx.objectStore("scannedTxids").put("t1", "t1");
+                tx.objectStore("markets").put(markets, "arkade-intents-markets-regtest-http://r");
+                tx.oncomplete = () => {
+                    db.close();
+                    resolve();
+                };
+                tx.onerror = () => reject(tx.error);
+            };
+            open.onerror = () => reject(open.error);
+        });
+
+        await using repository = new IndexedDbAssetSwapRepository(dbName);
+
+        // Additive: every existing row comes through byte for byte, which is
+        // what keeps `initDatabase`'s `oldVersion`/`transaction` parameters
+        // unused. Disjoint v1 and v2 histories are exactly the choice that
+        // stops this being the migration that rewrites rows.
+        expect(await repository.getAllSwaps()).toEqual([swap("legacy")]);
+        expect(await repository.getAllRfqSwaps()).toEqual([rfqRecord("legacy-rfq")]);
+        expect(await repository.getScannedTxids()).toEqual(new Set(["t1"]));
+        expect(await repository.getCachedMarkets("regtest", "http://r")).toEqual(markets);
+
+        // and the new store exists, which is the whole reason for the bump
+        expect(await repository.getAllSwapRecords()).toEqual([]);
+        await repository.saveSwapRecord(swapRecord("q1"));
+        expect(await repository.getAllSwapRecords()).toHaveLength(1);
     });
 });
 

--- a/packages/swap/test/store.test.ts
+++ b/packages/swap/test/store.test.ts
@@ -73,7 +73,7 @@ describe("asset swap store", () => {
 
     it("reports failed add writes and keeps update writes best-effort", async () => {
         const broken = (existing: AssetSwap[] = []): AssetSwapRepository => ({
-            version: 4,
+            version: 5,
             saveSwap: async () => {
                 throw new Error("quota exceeded");
             },
@@ -82,6 +82,10 @@ describe("asset swap store", () => {
             getRfqSwap: async () => undefined,
             getAllRfqSwaps: async () => [],
             removeRfqSwap: async () => {},
+            saveSwapRecord: async () => {},
+            getSwapRecord: async () => undefined,
+            getAllSwapRecords: async () => [],
+            removeSwapRecord: async () => {},
             getScannedTxids: async () => new Set(),
             markTxidsScanned: async () => {},
             getCachedMarkets: async () => undefined,
@@ -111,7 +115,7 @@ describe("asset swap store", () => {
 
     it("reads a failed read as empty history, but never writes on one", async () => {
         const broken: AssetSwapRepository = {
-            version: 4,
+            version: 5,
             saveSwap: async () => {},
             getAllSwaps: async () => {
                 throw new Error("backend gone");
@@ -120,6 +124,10 @@ describe("asset swap store", () => {
             getRfqSwap: async () => undefined,
             getAllRfqSwaps: async () => [],
             removeRfqSwap: async () => {},
+            saveSwapRecord: async () => {},
+            getSwapRecord: async () => undefined,
+            getAllSwapRecords: async () => [],
+            removeSwapRecord: async () => {},
             getScannedTxids: async () => new Set(),
             markTxidsScanned: async () => {},
             getCachedMarkets: async () => undefined,

--- a/packages/swap/test/swapClient.test.ts
+++ b/packages/swap/test/swapClient.test.ts
@@ -207,7 +207,7 @@ describe("createSwapClient — cancel", () => {
     it("reports a dead backend as one, not as a swap it could not find", async () => {
         const broken: AssetSwapRepository = {
             ...new InMemoryAssetSwapRepository(),
-            version: 4,
+            version: 5,
             getAllSwaps: async () => {
                 throw new Error("backend gone");
             },

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -3068,6 +3068,61 @@ describe("RfqSwapManager — manager-owned persistence", () => {
             expect(store.records.get(RFQ_ID)?.state).toBe("settled");
         });
 
+        it("restores the last receive-claim failure before closing the window", async () => {
+            let now = REFUND_LOCKTIME - 3600;
+            const store = fakeStore();
+            const failures: string[] = [];
+            const firstSpies = spies({
+                claimLockup: async () => {
+                    throw new Error("ark server unreachable");
+                },
+            });
+            const first = manager({
+                indexer: fakeIndexer({
+                    vtxos: unspent(),
+                    funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }],
+                }),
+                repository: store,
+                now: () => now,
+                spies: firstSpies,
+            });
+            first.onSwapFailed((_swap, error) => failures.push(error.message));
+
+            await first.addSwap(receiveSwap(), receiveOrigin());
+            await first.poll();
+
+            expect(store.records.get(RFQ_ID)?.state).toBe("claimable");
+            expect(store.records.get(RFQ_ID)?.claimFailure).toBe("ark server unreachable");
+            expect(store.records.get(RFQ_ID)?.failure).toBeUndefined();
+            expect(failures).toEqual(["ark server unreachable"]);
+
+            now = REFUND_LOCKTIME + REFUND_MTP_LAG_SECONDS;
+            const resumedSpies = spies();
+            const resumed = manager({
+                indexer: fakeIndexer({ vtxos: [] }),
+                contracts: contractsFor(rowFor(RECEIVE_LOCKUP, RECEIVE_ADDRESS)),
+                repository: store,
+                now: () => now,
+                spies: resumedSpies,
+            });
+
+            const result = await resumed.restoreFromRepository();
+            expect(result.failed).toHaveLength(0);
+            expect(result.restored).toHaveLength(1);
+            const [swap] = result.restored;
+            expect(swap?.claimFailure).toBe("ark server unreachable");
+
+            await resumed.poll();
+
+            expect(swap?.state).toBe("failed");
+            expect(swap?.failure).toBe("ark server unreachable");
+            expect(store.records.get(RFQ_ID)?.failure).toBe("ark server unreachable");
+            expect(store.records.get(RFQ_ID)?.claimFailure).toBeUndefined();
+            await expect(resumed.waitForSwapCompletion(RFQ_ID)).rejects.toThrow(
+                /ark server unreachable/,
+            );
+        });
+
         it("carries a restored swap's origin, so its record can be rewritten", async () => {
             // The store losing a record mid-life is the case the in-memory
             // origin map exists for: without it the next write would have

--- a/packages/swap/tsconfig.test.json
+++ b/packages/swap/tsconfig.test.json
@@ -1,5 +1,11 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/**/*.ts", "src/**/*.json", "test/client/**/*.ts"],
+    "//": "The v2 layer's tests. `test/repository.test.ts` is deliberately still out: it imports the repo-root `config/test-helpers/*`, which do not typecheck under this project today, so pulling it in would absorb a shared, pre-existing failure. The v2 record shape it fixtures is pinned instead by `test/client/record.types.ts`, which proves it structurally, and exercised by `test/client/accept.test.ts`.",
+    "include": [
+        "src/**/*.ts",
+        "src/**/*.json",
+        "test/client/**/*.ts",
+        "test/node/**/*.ts"
+    ],
     "exclude": ["node_modules", "dist"]
 }

--- a/packages/swap/tsup.node.config.ts
+++ b/packages/swap/tsup.node.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from "tsup";
+
+/**
+ * The `./node` subpath's build. Its own config and its own `tsup` invocation.
+ *
+ * **Why the config file exists.** tsup rewrites `node:`-prefixed builtins to
+ * their bare names by default (`removeNodeProtocol`, a legacy default kept for
+ * older Node), and turning that off is config-file-only — there is no CLI flag.
+ * `node:os`, `node:path` and `node:fs` still resolve after the rewrite, so it
+ * is invisible until a specifier has no bare alias: `node:sqlite` has none, so
+ * the rewritten bundle fails at load with `Cannot find package 'sqlite'`.
+ * esbuild on its own preserves the prefix under `platform: "node"`, so this is
+ * tsup's rewrite and not the bundler's.
+ *
+ * **And no `target`.** Passing one re-enables the rewrite regardless of
+ * `removeNodeProtocol`. The default is right here anyway — this entry is only
+ * ever loaded by the Node version in `engines`, so there is nothing to
+ * downlevel for.
+ *
+ * **Why a separate invocation from the web build.** `platform` also decides
+ * which `exports` condition a dependency resolves under, so building the main
+ * entry as Node would quietly pick a dependency's Node build for a bundle
+ * headed to a browser. A separate file also leaves `clean` nothing to race:
+ * `build:web` cleans `dist` and this one only adds to it.
+ *
+ * The dist smoke test is what catches a regression here: it imports every
+ * declared subpath under both `import` and `require`, so a rewritten specifier
+ * fails the build rather than a consumer's first run.
+ */
+export default defineConfig({
+    entry: ["src/node/index.ts"],
+    outDir: "dist/node",
+    format: ["esm", "cjs"],
+    platform: "node",
+    removeNodeProtocol: false,
+    dts: true,
+    clean: false,
+});

--- a/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
+++ b/packages/ts-sdk/src/contracts/handlers/vhtlcV2.ts
@@ -281,16 +281,25 @@ export const VHTLCV2ContractHandler: ContractHandler<VHTLCV2ContractParams, VHTL
                 "asset params are incomplete: assetTxid and assetGroupIndex must both be present or both absent",
             );
         }
-        // A row written by a strict-capable release (0.4.67 and earlier) carries
-        // a quoted bound compiled into its claim leaf. The option is gone, so
-        // that bound cannot be re-derived here — and reading the row as "not
-        // strict" would rebuild the DEFAULT covenant, a different pkScript, and
-        // die at `upsertContractRow` with an opaque `Script mismatch`. Name it.
+        // A row written by a strict-capable release (0.4.65 through 0.4.67)
+        // carries a quoted bound compiled into its claim leaf. The option is
+        // gone, so that bound cannot be re-derived here — and reading the row as
+        // "not strict" would rebuild the DEFAULT covenant, a different pkScript,
+        // and die at `upsertContractRow` with an opaque `Script mismatch`.
+        //
+        // This throw is permanent for such a row: it fires on every read, and no
+        // upgrade repairs it, so the message has to carry the way out rather
+        // than point back at a release the reader has already left. The order
+        // matters — 0.4.67 is the only build that can still rebuild the script,
+        // so the row is deleted after it is settled, never before.
         if (params.strictClaimAmount !== undefined || params.strictClaimAssetAmount !== undefined) {
             throw new Error(
-                "strict claim params on a stored row: the strict claim bound was removed " +
-                    "and this row's lockup cannot be re-derived without it — restore it with " +
-                    "the SDK version that wrote it",
+                "strict claim params on a stored row: the strict claim bound was removed in " +
+                    "0.4.68, so this row — written by 0.4.65-0.4.67 — locks to a script this " +
+                    "build cannot re-derive. To clear it: claim or refund the swap on 0.4.67, " +
+                    "then drop the settled row here with " +
+                    "`contractManager.deleteContract(script)`. Do not delete it first — any " +
+                    "balance it still holds is only reachable from 0.4.67.",
             );
         }
         // Same silent-drop shape as the two checks above, one flag further in:


### PR DESCRIPTION
Swap SDK v2, M4. Stacked on #821's successor — base is `feat/swap-v2-quote-path`, so the diff is M4 only.

`accept()` gets value committed and durable, then stops. One ordering on every route:

```
expiry guard -> idempotency read -> InsufficientFunds -> register covenant -> persist -> fund -> txid
```

Persist-first becomes a mechanism rather than a README instruction: v1 keyed a record on its funding txid, so the record could not exist before the money did. The key is now the client-minted `Quote.id`.

Three things the plan did not name, all settled in the track's Decisions table:

- **Covenant registration was unowned in v2.** The quote path reaches no contract manager by design, and a lockup's contract row is the only place its tree lives — so without registering inside `accept()`, every persisted record is unrebuildable. It is now a step in the ordering, before the persist.
- **The funding gate is the give _instrument_, not its asset.** A `lightning->arkade` receive gives BTC too, so an asset-branched pre-flight would refuse the canonical empty-wallet receive.
- **`version: 5` is a bump, not a fork.** The shared scan-cursor ruling makes a second interface impossible — it would force two repository objects over one database.

Also: `@arkade-os/swap/node` ships the Node storage default (file-backed SQLite, config-dir resolver, disposal that closes the connection it opened).

### Breaking

`AssetSwapRepository.version` is `5`, adding four record-store methods. Realm consumers gain a fifth schema. The IndexedDB migration is additive; v1 readers and rows are untouched.

### Verification

969 unit tests in the package (up from 870); four-backend conformance for the new store, an IndexedDB 2→3 migration case, a structural no-`bigint` type test, and `smoke:dist` over the new subpath under both `import` and `require`.

Not done: the regtest pass. The crash windows are covered at unit level by failing the next step and asserting what is durable, but the matrix wants two e2e profiles that cannot both be up at once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `SwapClient.accept()` to durably accept quotes, move funds, recover from interruptions, and safely retry by quote ID.
  * Added durable swap-record support across repository backends.
  * Added a Node.js file-backed SQLite storage option with per-network database paths and automatic cleanup.
  * Added public types and conversion utilities for persisted swap records.
  * Added direct access to Realm schema exports.

* **Breaking Changes**
  * Repository version increased to 5; custom repository implementations must support swap-record operations.
  * Realm and IndexedDB schemas require migration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->