### PR TITLE
feat(swap): a client-side ceiling on what a quote may charge

### DIFF
--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -440,51 +440,21 @@ export const assertFundable = (input: {
         direction: "send" | "receive";
     };
     /**
-     * The most this client will pay, as the GREATER of a proportion of
-     * `from_amount` and an absolute number of sats. Absent means no ceiling —
-     * which is what every caller written before this got, and keeps.
-     *
-     * BOTH bounds, because a solver's fee is partly flat. With dynamic pricing
-     * that flat component tracks the chain fee market, and a flat charge is a
-     * large proportion of a small swap: 420 sats is 8.4% of 5_000 and 0.084% of
-     * 500_000. A bare percentage therefore refuses every small swap the moment
-     * fees rise, while an absolute alone stops protecting a large one. `max()`
-     * lets the absolute cover the flat component without loosening the
-     * proportional bound where that is the one doing the work.
-     *
-     * This is the ONLY ceiling a client has. The quote carries no fee field,
-     * and the registry card cannot stand in for one: it publishes the
-     * corridor's CONFIGURED flat fee, not the cap live pricing may reach, so a
-     * solver with a low fallback and a high cap advertises cheaper than it can
-     * charge. `from_amount - to_amount` off the quote is the real number.
-     *
-     * OMIT a bound rather than zeroing it. `{ bps: 0, sats: 500 }` is the right
-     * way to write an absolute-only ceiling and behaves as intended — but a lone
-     * `{ bps: 0 }` is a ceiling of ZERO, which refuses every quote carrying any
-     * fee at all. That cannot be rejected as a mistake, because it is also how a
-     * caller says "free or nothing"; the two are told apart only by what else is
-     * set. `{}`, which names no bound whatsoever, IS refused.
+     * The most this client will pay: the GREATER of the two bounds, because a
+     * flat fee is a large proportion of a small swap (420 sats is 8.4% of
+     * 5_000, 0.084% of 500_000). Absent means no ceiling. OMIT a bound rather
+     * than zeroing it: `{ bps: 0 }` alone is a ceiling of zero, indistinguishable
+     * from "free or nothing". `{}` IS refused.
      */
     maxFee?: {
+        /** Integer, 0..10_000 (10_000 = 100%). Out of range throws `max_fee_out_of_range`. */
         bps?: number;
+        /** Non-negative integer. Out of range throws `max_fee_out_of_range`. */
         sats?: number;
         /**
-         * To-units per from-unit, for a CROSS-ASSET pair. Without it such a pair
-         * is refused rather than waved through — the fee there is the spread
-         * against a rate, and this function is given no rate of its own.
-         *
-         * Must come from a source of YOUR OWN. Reading it off the solver's
-         * published market feed checks the solver against its own number and
-         * passes anything; the feed URL being right there on the card is what
-         * makes that the easy mistake.
-         *
-         * Ignored on a same-asset pair, where the exact fee is already known —
-         * so one ceiling can be set for every pair a wallet handles.
-         *
-         * Expect to need a LOOSER tolerance than same-asset: the spread you
-         * measure necessarily includes rate movement between your feed read and
-         * the solver's quote, so a tight bound refuses honest quotes on
-         * volatility alone.
+         * To-units per from-unit, required for a CROSS-ASSET pair. Must come
+         * from a source of YOUR OWN — the solver's own feed would check it
+         * against its own number. Needs a looser tolerance than same-asset.
          */
         referenceRate?: number;
     };
@@ -506,9 +476,7 @@ export const assertFundable = (input: {
     if (input.maxFee) {
         const { bps, sats, referenceRate } = input.maxFee;
         if (bps === undefined && sats === undefined) {
-            // Read literally `{}` is "tolerate no fee at all", which no caller
-            // means and every caller would then be refused by. A ceiling that
-            // names nothing is a mistake at the call site, not a bad quote.
+            // A ceiling naming nothing is a call-site mistake, not a bad quote.
             fail("max_fee_unbounded", "maxFee names neither bps nor sats");
         }
         if (bps !== undefined && (!Number.isInteger(bps) || bps < 0 || bps > 10_000)) {
@@ -517,17 +485,10 @@ export const assertFundable = (input: {
         if (sats !== undefined && (!Number.isInteger(sats) || sats < 0)) {
             fail("max_fee_out_of_range", `maxFee.sats must be a non-negative integer, got ${sats}`);
         }
-        // `from_amount - to_amount` is a fee only while both legs name the same
-        // asset. Across assets it subtracts tokens from sats — but the fee is
-        // not unknowable there, it is the spread against a reference rate, and
-        // the caller is the only party who can supply one honestly.
         const legs = input.quote.pair.split("->");
         const assetOf = (leg: string): string => leg.slice(leg.indexOf(":") + 1);
         const sameAsset = legs.length === 2 && assetOf(legs[0]!) === assetOf(legs[1]!);
         if (!sameAsset && referenceRate === undefined) {
-            // LOUD, never silent: a caller who set a ceiling and got no gate
-            // would believe one applied. Better to refuse the swap than to fund
-            // it under a protection that was never there.
             fail(
                 "fee_gate_unavailable",
                 `maxFee cannot gate ${input.quote.pair}: its legs name different assets, so ` +
@@ -542,9 +503,7 @@ export const assertFundable = (input: {
                 `maxFee.referenceRate must be a positive finite number, got ${referenceRate}`,
             );
         }
-        // Both branches yield a fee in FROM units, so one ceiling covers both.
-        // Cross-asset rounds the fee UP: a borderline quote should be refused
-        // rather than funded on a rounding artefact.
+        // Rounds UP: refuse a borderline quote, do not fund a rounding artefact.
         const fee = sameAsset
             ? input.quote.from_amount - input.quote.to_amount
             : Math.ceil(

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -457,6 +457,13 @@ export const assertFundable = (input: {
      * corridor's CONFIGURED flat fee, not the cap live pricing may reach, so a
      * solver with a low fallback and a high cap advertises cheaper than it can
      * charge. `from_amount - to_amount` off the quote is the real number.
+     *
+     * OMIT a bound rather than zeroing it. `{ bps: 0, sats: 500 }` is the right
+     * way to write an absolute-only ceiling and behaves as intended — but a lone
+     * `{ bps: 0 }` is a ceiling of ZERO, which refuses every quote carrying any
+     * fee at all. That cannot be rejected as a mistake, because it is also how a
+     * caller says "free or nothing"; the two are told apart only by what else is
+     * set. `{}`, which names no bound whatsoever, IS refused.
      */
     maxFee?: {
         bps?: number;

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -439,6 +439,26 @@ export const assertFundable = (input: {
         /** "send" = arkade->onchain (the L1 timelock-order gate applies). */
         direction: "send" | "receive";
     };
+    /**
+     * The most this client will pay, as the GREATER of a proportion of
+     * `from_amount` and an absolute number of sats. Absent means no ceiling —
+     * which is what every caller written before this got, and keeps.
+     *
+     * BOTH bounds, because a solver's fee is partly flat. With dynamic pricing
+     * that flat component tracks the chain fee market, and a flat charge is a
+     * large proportion of a small swap: 420 sats is 8.4% of 5_000 and 0.084% of
+     * 500_000. A bare percentage therefore refuses every small swap the moment
+     * fees rise, while an absolute alone stops protecting a large one. `max()`
+     * lets the absolute cover the flat component without loosening the
+     * proportional bound where that is the one doing the work.
+     *
+     * This is the ONLY ceiling a client has. The quote carries no fee field,
+     * and the registry card cannot stand in for one: it publishes the
+     * corridor's CONFIGURED flat fee, not the cap live pricing may reach, so a
+     * solver with a low fallback and a high cap advertises cheaper than it can
+     * charge. `from_amount - to_amount` off the quote is the real number.
+     */
+    maxFee?: { bps?: number; sats?: number };
 }): void => {
     const fail = (reason: string, message: string): never => {
         throw gateError(reason, message);
@@ -453,6 +473,45 @@ export const assertFundable = (input: {
         input.quote.refund_locktime - input.now < MIN_HEADROOM_SECONDS
     ) {
         fail("insufficient_headroom", "refund deadline headroom below 90 minutes");
+    }
+    if (input.maxFee) {
+        const { bps, sats } = input.maxFee;
+        if (bps === undefined && sats === undefined) {
+            // Read literally `{}` is "tolerate no fee at all", which no caller
+            // means and every caller would then be refused by. A ceiling that
+            // names nothing is a mistake at the call site, not a bad quote.
+            fail("max_fee_unbounded", "maxFee names neither bps nor sats");
+        }
+        if (bps !== undefined && (!Number.isInteger(bps) || bps < 0 || bps > 10_000)) {
+            fail("max_fee_out_of_range", `maxFee.bps must be an integer in 0..10000, got ${bps}`);
+        }
+        if (sats !== undefined && (!Number.isInteger(sats) || sats < 0)) {
+            fail("max_fee_out_of_range", `maxFee.sats must be a non-negative integer, got ${sats}`);
+        }
+        // LOUD on a cross-asset pair, never silent. `from_amount - to_amount` is
+        // a fee only while both legs name the same asset; on
+        // `arkade:BTC->ethereum:<token>` it subtracts tokens from sats and means
+        // nothing. Skipping quietly would leave a caller believing a ceiling
+        // applied when none did, which is worse than having no gate at all —
+        // the fee there is inside the rate, and judging it needs a price this
+        // function is not given.
+        const legs = input.quote.pair.split("->");
+        const assetOf = (leg: string): string => leg.slice(leg.indexOf(":") + 1);
+        if (legs.length !== 2 || assetOf(legs[0]!) !== assetOf(legs[1]!)) {
+            fail(
+                "fee_gate_unavailable",
+                `maxFee cannot gate ${input.quote.pair}: its legs name different assets, so ` +
+                    `from_amount - to_amount is not a fee`,
+            );
+        }
+        const fee = input.quote.from_amount - input.quote.to_amount;
+        const allowed = Math.max(
+            sats ?? 0,
+            Math.floor((input.quote.from_amount * (bps ?? 0)) / 10_000),
+        );
+        if (fee > allowed) {
+            fail("fee_too_high", `fee ${fee} exceeds the ${allowed} this client allows`);
+        }
     }
     if (input.onchain) {
         const { htlcLocktime, minConfirmations, direction } = input.onchain;

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -458,7 +458,29 @@ export const assertFundable = (input: {
      * solver with a low fallback and a high cap advertises cheaper than it can
      * charge. `from_amount - to_amount` off the quote is the real number.
      */
-    maxFee?: { bps?: number; sats?: number };
+    maxFee?: {
+        bps?: number;
+        sats?: number;
+        /**
+         * To-units per from-unit, for a CROSS-ASSET pair. Without it such a pair
+         * is refused rather than waved through — the fee there is the spread
+         * against a rate, and this function is given no rate of its own.
+         *
+         * Must come from a source of YOUR OWN. Reading it off the solver's
+         * published market feed checks the solver against its own number and
+         * passes anything; the feed URL being right there on the card is what
+         * makes that the easy mistake.
+         *
+         * Ignored on a same-asset pair, where the exact fee is already known —
+         * so one ceiling can be set for every pair a wallet handles.
+         *
+         * Expect to need a LOOSER tolerance than same-asset: the spread you
+         * measure necessarily includes rate movement between your feed read and
+         * the solver's quote, so a tight bound refuses honest quotes on
+         * volatility alone.
+         */
+        referenceRate?: number;
+    };
 }): void => {
     const fail = (reason: string, message: string): never => {
         throw gateError(reason, message);
@@ -475,7 +497,7 @@ export const assertFundable = (input: {
         fail("insufficient_headroom", "refund deadline headroom below 90 minutes");
     }
     if (input.maxFee) {
-        const { bps, sats } = input.maxFee;
+        const { bps, sats, referenceRate } = input.maxFee;
         if (bps === undefined && sats === undefined) {
             // Read literally `{}` is "tolerate no fee at all", which no caller
             // means and every caller would then be refused by. A ceiling that
@@ -488,23 +510,40 @@ export const assertFundable = (input: {
         if (sats !== undefined && (!Number.isInteger(sats) || sats < 0)) {
             fail("max_fee_out_of_range", `maxFee.sats must be a non-negative integer, got ${sats}`);
         }
-        // LOUD on a cross-asset pair, never silent. `from_amount - to_amount` is
-        // a fee only while both legs name the same asset; on
-        // `arkade:BTC->ethereum:<token>` it subtracts tokens from sats and means
-        // nothing. Skipping quietly would leave a caller believing a ceiling
-        // applied when none did, which is worse than having no gate at all —
-        // the fee there is inside the rate, and judging it needs a price this
-        // function is not given.
+        // `from_amount - to_amount` is a fee only while both legs name the same
+        // asset. Across assets it subtracts tokens from sats — but the fee is
+        // not unknowable there, it is the spread against a reference rate, and
+        // the caller is the only party who can supply one honestly.
         const legs = input.quote.pair.split("->");
         const assetOf = (leg: string): string => leg.slice(leg.indexOf(":") + 1);
-        if (legs.length !== 2 || assetOf(legs[0]!) !== assetOf(legs[1]!)) {
+        const sameAsset = legs.length === 2 && assetOf(legs[0]!) === assetOf(legs[1]!);
+        if (!sameAsset && referenceRate === undefined) {
+            // LOUD, never silent: a caller who set a ceiling and got no gate
+            // would believe one applied. Better to refuse the swap than to fund
+            // it under a protection that was never there.
             fail(
                 "fee_gate_unavailable",
                 `maxFee cannot gate ${input.quote.pair}: its legs name different assets, so ` +
-                    `from_amount - to_amount is not a fee`,
+                    `from_amount - to_amount is not a fee. Supply maxFee.referenceRate ` +
+                    `(to-units per from-unit) from a source of your OWN — reading it off the ` +
+                    `solver's published feed would check the solver against its own number`,
             );
         }
-        const fee = input.quote.from_amount - input.quote.to_amount;
+        if (!sameAsset && (!Number.isFinite(referenceRate) || (referenceRate as number) <= 0)) {
+            fail(
+                "max_fee_out_of_range",
+                `maxFee.referenceRate must be a positive finite number, got ${referenceRate}`,
+            );
+        }
+        // Both branches yield a fee in FROM units, so one ceiling covers both.
+        // Cross-asset rounds the fee UP: a borderline quote should be refused
+        // rather than funded on a rounding artefact.
+        const fee = sameAsset
+            ? input.quote.from_amount - input.quote.to_amount
+            : Math.ceil(
+                  (input.quote.from_amount * (referenceRate as number) - input.quote.to_amount) /
+                      (referenceRate as number),
+              );
         const allowed = Math.max(
             sats ?? 0,
             Math.floor((input.quote.from_amount * (bps ?? 0)) / 10_000),

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -737,3 +737,82 @@ describe("assertFundable — the max-fee gate", () => {
         );
     });
 });
+
+/**
+ * The cross-asset half of the same ceiling.
+ *
+ * `from_amount - to_amount` is not a fee when the legs name different assets,
+ * but the fee is not unknowable — it is the spread against a reference rate,
+ * and the caller is the only party that can supply one honestly. Given `R` in
+ * to-units per from-unit, the fee in FROM units is
+ * `(from_amount * R - to_amount) / R`, and the same max(proportional, absolute)
+ * rule applies unchanged.
+ */
+describe("assertFundable — the max-fee gate, cross-asset", () => {
+    const now = 1_800_000_000;
+    const CROSS = "arkade:BTC->ethereum:0xa0b86991";
+    const gate = (
+        over: Partial<RfqQuote>,
+        maxFee?: { bps?: number; sats?: number; referenceRate?: number },
+    ) =>
+        assertFundable({
+            quote: quoteFixture({
+                pair: CROSS,
+                from_amount: 100_000,
+                valid_until: now + 900,
+                refund_locktime: now + 7200,
+                ...over,
+            }),
+            invoiceExpiresAt: now + 3600,
+            now,
+            maxFee,
+        });
+
+    // R = 0.5 token-units per sat, so 100_000 sats is fairly worth 50_000.
+    it("gates on the spread against the caller's own rate", () => {
+        // 49_500 received = 500 short = 1_000 sats of fee = exactly 1% of 100_000.
+        expect(() => gate({ to_amount: 49_500 }, { bps: 100, referenceRate: 0.5 })).not.toThrow();
+        expect(() => gate({ to_amount: 49_499 }, { bps: 100, referenceRate: 0.5 })).toThrow(/fee/i);
+    });
+
+    it("still refuses when no rate is supplied — unchanged from before", () => {
+        expect(() => gate({ to_amount: 42 }, { bps: 100 })).toThrow(/different assets|rate/i);
+    });
+
+    it("refuses a rate that cannot price anything", () => {
+        for (const referenceRate of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+            expect(() => gate({ to_amount: 49_500 }, { bps: 100, referenceRate })).toThrow(
+                /referenceRate/i,
+            );
+        }
+    });
+
+    /**
+     * Rounds the fee UP, and this is the only case that can tell. R = 3 with
+     * 2_999 to-units short is 999.67 sats of fee: ceil refuses it against a
+     * 999-sat ceiling, floor funds it. Erring toward refusing is the client's
+     * side to err on, and without this the choice was untested — a floor
+     * mutation passed every other case here.
+     */
+    it("rounds a fractional cross-asset fee up, not down", () => {
+        expect(() => gate({ to_amount: 297_001 }, { sats: 999, referenceRate: 3 })).toThrow(/fee/i);
+    });
+
+    it("ignores a rate on a same-asset pair, where the exact fee is already known", () => {
+        // A wallet setting one ceiling for every pair must not be punished for
+        // carrying a rate the same-asset branch has no use for.
+        expect(() =>
+            assertFundable({
+                quote: quoteFixture({
+                    from_amount: 100_000,
+                    to_amount: 99_500,
+                    valid_until: now + 900,
+                    refund_locktime: now + 7200,
+                }),
+                invoiceExpiresAt: now + 3600,
+                now,
+                maxFee: { bps: 100, referenceRate: 0.5 },
+            }),
+        ).not.toThrow();
+    });
+});

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -654,3 +654,86 @@ describe("offerTermsFromQuote", () => {
         expect(() => offerTermsFromQuote(quoteFixture(), {})).toThrow(/exactly one/);
     });
 });
+
+/**
+ * The max-fee gate: the client's own ceiling on what a quote may charge.
+ *
+ * A solver's fee is `from_amount - to_amount` and nothing in the quote breaks it
+ * down. With dynamic pricing the flat component tracks the chain fee market, so
+ * the registry card cannot bound it either — the card publishes the configured
+ * fallback, not the live ceiling. This is the only place a client can hold a
+ * line, and it needs nothing from the solver.
+ */
+describe("assertFundable — the max-fee gate", () => {
+    const now = 1_800_000_000;
+    const fundable = (over: Partial<RfqQuote>, maxFee?: { bps?: number; sats?: number }) =>
+        assertFundable({
+            quote: quoteFixture({ valid_until: now + 900, refund_locktime: now + 7200, ...over }),
+            invoiceExpiresAt: now + 3600,
+            now,
+            maxFee,
+        });
+
+    it("does not gate at all when no ceiling is given", () => {
+        // Backward compatibility is the point: every existing caller passes no
+        // `maxFee` and must keep funding exactly what it funded before.
+        expect(() => fundable({ from_amount: 10_000, to_amount: 1 })).not.toThrow();
+    });
+
+    it("refuses a fee above the proportional ceiling", () => {
+        expect(() =>
+            fundable({ from_amount: 100_000, to_amount: 99_000 }, { bps: 100 }),
+        ).not.toThrow();
+        expect(() => fundable({ from_amount: 100_000, to_amount: 98_999 }, { bps: 100 })).toThrow(
+            /fee/i,
+        );
+    });
+
+    /**
+     * THE CASE THIS EXISTS FOR. A flat network component is a large percentage
+     * of a small swap: 420 sats on 5_000 is 8.4%, and on 500_000 it is 0.084%.
+     * A bare percentage therefore refuses every small swap the moment fees rise.
+     * The ceiling is the GREATER of the two allowances, so an absolute floor
+     * covers the flat component without weakening the proportional bound.
+     */
+    it("allows a flat network fee on a small swap that a bare percentage would refuse", () => {
+        expect(() => fundable({ from_amount: 5_420, to_amount: 5_000 }, { bps: 100 })).toThrow(
+            /fee/i,
+        );
+        expect(() =>
+            fundable({ from_amount: 5_420, to_amount: 5_000 }, { bps: 100, sats: 1_000 }),
+        ).not.toThrow();
+    });
+
+    it("keeps the proportional bound on a large swap, where the absolute one is slack", () => {
+        // allowed = max(1_000, 1% of 500_000) = 5_000.
+        expect(() =>
+            fundable({ from_amount: 500_000, to_amount: 495_000 }, { bps: 100, sats: 1_000 }),
+        ).not.toThrow();
+        expect(() =>
+            fundable({ from_amount: 500_000, to_amount: 494_999 }, { bps: 100, sats: 1_000 }),
+        ).toThrow(/fee/i);
+    });
+
+    /**
+     * LOUD, not silent. `from_amount - to_amount` is a fee only when both sides
+     * name the same asset; on `arkade:BTC->ethereum:<token>` it subtracts tokens
+     * from sats and means nothing. Skipping quietly would leave a wallet
+     * believing a ceiling applied when it did not, which is worse than no gate.
+     */
+    it("refuses to pretend it can gate a cross-asset pair", () => {
+        expect(() =>
+            fundable(
+                { pair: "arkade:BTC->ethereum:0xa0b86991", from_amount: 100_000, to_amount: 42 },
+                { bps: 100 },
+            ),
+        ).toThrow(/cross-asset|different assets/i);
+    });
+
+    it("refuses a ceiling that names neither bound, rather than tolerating no fee", () => {
+        // `{}` reads as "no fee at all" if taken literally, which no caller means.
+        expect(() => fundable({ from_amount: 100_000, to_amount: 99_999 }, {})).toThrow(
+            /bps|sats/i,
+        );
+    });
+});

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -680,6 +680,52 @@ describe("assertFundable — the max-fee gate", () => {
         expect(() => fundable({ from_amount: 10_000, to_amount: 1 })).not.toThrow();
     });
 
+    /**
+     * The guards on the CEILING itself, as opposed to on the quote.
+     *
+     * A ceiling only protects while it is a bound the comparison can hold, and
+     * each of these is a way to write one that is not: `bps: 10_001` is looser
+     * than any real quote and therefore no bound at all, a fractional `bps`
+     * silently truncates through `Math.floor` into a different ceiling than the
+     * caller wrote, and a negative bound refuses everything. All are mistakes at
+     * the CALL SITE, so they fail there by name rather than being clamped into
+     * something plausible — a clamped ceiling is a wallet believing it is
+     * protected at a level it never asked for.
+     *
+     * Asserted on `reason` rather than on the message: the reason code is the
+     * closed contract a caller branches on, and the sentence beside it is not.
+     */
+    const reasonOf = (run: () => unknown): string => {
+        try {
+            run();
+        } catch (error) {
+            return (error as { reason?: string }).reason ?? "<threw without a reason>";
+        }
+        return "<did not throw>";
+    };
+
+    it.each([
+        ["bps past 100%", { bps: 10_001 }],
+        ["negative bps", { bps: -1 }],
+        ["fractional bps", { bps: 12.5 }],
+        ["negative sats", { sats: -1 }],
+        ["fractional sats", { sats: 0.5 }],
+    ])("refuses a ceiling that is not a usable bound: %s", (_label, maxFee) => {
+        expect(reasonOf(() => fundable({ from_amount: 100_000, to_amount: 99_999 }, maxFee))).toBe(
+            "max_fee_out_of_range",
+        );
+    });
+
+    it("allows the boundary values, so the guard does not become the bug", () => {
+        // 10_000 bps is exactly 100% and 0 is a real choice — an absolute-only
+        // ceiling is written `{ bps: 0, sats: n }`. Refusing either would make
+        // this guard reject ceilings a caller is entitled to set.
+        const quote = { from_amount: 100_000, to_amount: 99_999 };
+        expect(() => fundable(quote, { bps: 10_000 })).not.toThrow();
+        expect(() => fundable(quote, { bps: 0, sats: 1 })).not.toThrow();
+        expect(() => fundable(quote, { sats: 0, bps: 1 })).not.toThrow();
+    });
+
     it("refuses a fee above the proportional ceiling", () => {
         expect(() =>
             fundable({ from_amount: 100_000, to_amount: 99_000 }, { bps: 100 }),

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -655,15 +655,7 @@ describe("offerTermsFromQuote", () => {
     });
 });
 
-/**
- * The max-fee gate: the client's own ceiling on what a quote may charge.
- *
- * A solver's fee is `from_amount - to_amount` and nothing in the quote breaks it
- * down. With dynamic pricing the flat component tracks the chain fee market, so
- * the registry card cannot bound it either — the card publishes the configured
- * fallback, not the live ceiling. This is the only place a client can hold a
- * line, and it needs nothing from the solver.
- */
+/** The max-fee gate: the client's own ceiling on what a quote may charge. */
 describe("assertFundable — the max-fee gate", () => {
     const now = 1_800_000_000;
     const fundable = (over: Partial<RfqQuote>, maxFee?: { bps?: number; sats?: number }) =>
@@ -675,26 +667,9 @@ describe("assertFundable — the max-fee gate", () => {
         });
 
     it("does not gate at all when no ceiling is given", () => {
-        // Backward compatibility is the point: every existing caller passes no
-        // `maxFee` and must keep funding exactly what it funded before.
         expect(() => fundable({ from_amount: 10_000, to_amount: 1 })).not.toThrow();
     });
 
-    /**
-     * The guards on the CEILING itself, as opposed to on the quote.
-     *
-     * A ceiling only protects while it is a bound the comparison can hold, and
-     * each of these is a way to write one that is not: `bps: 10_001` is looser
-     * than any real quote and therefore no bound at all, a fractional `bps`
-     * silently truncates through `Math.floor` into a different ceiling than the
-     * caller wrote, and a negative bound refuses everything. All are mistakes at
-     * the CALL SITE, so they fail there by name rather than being clamped into
-     * something plausible — a clamped ceiling is a wallet believing it is
-     * protected at a level it never asked for.
-     *
-     * Asserted on `reason` rather than on the message: the reason code is the
-     * closed contract a caller branches on, and the sentence beside it is not.
-     */
     const reasonOf = (run: () => unknown): string => {
         try {
             run();
@@ -717,9 +692,6 @@ describe("assertFundable — the max-fee gate", () => {
     });
 
     it("allows the boundary values, so the guard does not become the bug", () => {
-        // 10_000 bps is exactly 100% and 0 is a real choice — an absolute-only
-        // ceiling is written `{ bps: 0, sats: n }`. Refusing either would make
-        // this guard reject ceilings a caller is entitled to set.
         const quote = { from_amount: 100_000, to_amount: 99_999 };
         expect(() => fundable(quote, { bps: 10_000 })).not.toThrow();
         expect(() => fundable(quote, { bps: 0, sats: 1 })).not.toThrow();
@@ -735,13 +707,6 @@ describe("assertFundable — the max-fee gate", () => {
         );
     });
 
-    /**
-     * THE CASE THIS EXISTS FOR. A flat network component is a large percentage
-     * of a small swap: 420 sats on 5_000 is 8.4%, and on 500_000 it is 0.084%.
-     * A bare percentage therefore refuses every small swap the moment fees rise.
-     * The ceiling is the GREATER of the two allowances, so an absolute floor
-     * covers the flat component without weakening the proportional bound.
-     */
     it("allows a flat network fee on a small swap that a bare percentage would refuse", () => {
         expect(() => fundable({ from_amount: 5_420, to_amount: 5_000 }, { bps: 100 })).toThrow(
             /fee/i,
@@ -761,12 +726,6 @@ describe("assertFundable — the max-fee gate", () => {
         ).toThrow(/fee/i);
     });
 
-    /**
-     * LOUD, not silent. `from_amount - to_amount` is a fee only when both sides
-     * name the same asset; on `arkade:BTC->ethereum:<token>` it subtracts tokens
-     * from sats and means nothing. Skipping quietly would leave a wallet
-     * believing a ceiling applied when it did not, which is worse than no gate.
-     */
     it("refuses to pretend it can gate a cross-asset pair", () => {
         expect(() =>
             fundable(
@@ -777,7 +736,6 @@ describe("assertFundable — the max-fee gate", () => {
     });
 
     it("refuses a ceiling that names neither bound, rather than tolerating no fee", () => {
-        // `{}` reads as "no fee at all" if taken literally, which no caller means.
         expect(() => fundable({ from_amount: 100_000, to_amount: 99_999 }, {})).toThrow(
             /bps|sats/i,
         );
@@ -785,14 +743,8 @@ describe("assertFundable — the max-fee gate", () => {
 });
 
 /**
- * The cross-asset half of the same ceiling.
- *
- * `from_amount - to_amount` is not a fee when the legs name different assets,
- * but the fee is not unknowable — it is the spread against a reference rate,
- * and the caller is the only party that can supply one honestly. Given `R` in
- * to-units per from-unit, the fee in FROM units is
- * `(from_amount * R - to_amount) / R`, and the same max(proportional, absolute)
- * rule applies unchanged.
+ * Cross-asset: with `R` in to-units per from-unit the fee in FROM units is
+ * `(from_amount * R - to_amount) / R`, and the same max() rule applies.
  */
 describe("assertFundable — the max-fee gate, cross-asset", () => {
     const now = 1_800_000_000;
@@ -814,9 +766,8 @@ describe("assertFundable — the max-fee gate, cross-asset", () => {
             maxFee,
         });
 
-    // R = 0.5 token-units per sat, so 100_000 sats is fairly worth 50_000.
     it("gates on the spread against the caller's own rate", () => {
-        // 49_500 received = 500 short = 1_000 sats of fee = exactly 1% of 100_000.
+        // R = 0.5: 100_000 sats is worth 50_000; 49_500 received = 1_000 sats fee = 1%.
         expect(() => gate({ to_amount: 49_500 }, { bps: 100, referenceRate: 0.5 })).not.toThrow();
         expect(() => gate({ to_amount: 49_499 }, { bps: 100, referenceRate: 0.5 })).toThrow(/fee/i);
     });
@@ -833,20 +784,13 @@ describe("assertFundable — the max-fee gate, cross-asset", () => {
         }
     });
 
-    /**
-     * Rounds the fee UP, and this is the only case that can tell. R = 3 with
-     * 2_999 to-units short is 999.67 sats of fee: ceil refuses it against a
-     * 999-sat ceiling, floor funds it. Erring toward refusing is the client's
-     * side to err on, and without this the choice was untested — a floor
-     * mutation passed every other case here.
-     */
+    // The only case that distinguishes ceil from floor: R = 3, 2_999 short =
+    // 999.67 sats, which ceil refuses against a 999-sat ceiling and floor funds.
     it("rounds a fractional cross-asset fee up, not down", () => {
         expect(() => gate({ to_amount: 297_001 }, { sats: 999, referenceRate: 3 })).toThrow(/fee/i);
     });
 
     it("ignores a rate on a same-asset pair, where the exact fee is already known", () => {
-        // A wallet setting one ceiling for every pair must not be punished for
-        // carrying a rate the same-asset branch has no use for.
         expect(() =>
             assertFundable({
                 quote: quoteFixture({


### PR DESCRIPTION
## Why

A solver's fee is `from_amount - to_amount` and the quote breaks it down no further. Nothing on the client could refuse a quote for being expensive.

That mattered less when a fee was a fixed spread. It matters now that solvers can price dynamically: the flat component tracks the chain fee market, so the same corridor quotes a different fee minute to minute. And the registry card cannot stand in for a ceiling — it publishes the corridor's *configured* flat fee, not the cap live pricing may reach, so a solver with a low fallback and a high cap advertises cheaper than it can charge.

The quote is the only honest number, and until now the only thing a client could do with it was pay.

## What

`assertFundable` takes an optional `maxFee`:

```ts
maxFee?: { bps?: number; sats?: number; referenceRate?: number }
```

**The ceiling is the GREATER of the proportional and absolute bounds.** That is the whole design, because a flat charge is a large proportion of a small swap — 420 sats is 8.4% of 5,420 and 0.084% of 500,000. A bare percentage refuses every small swap the moment fees rise; an absolute alone stops protecting a large one. `max()` lets the absolute cover the flat component without loosening the proportional bound where it does the work.

**Cross-asset is gated too, given a rate.** `from_amount - to_amount` is a fee only while both legs name the same asset; across assets it is the spread against a reference rate, and only the caller can supply one. With `referenceRate` (to-units per from-unit) the fee in FROM units is `(from * R - to) / R` and the same ceiling applies. Without it, a cross-asset pair is refused **loudly** rather than waved through — a caller who set a ceiling and silently got no gate would fund believing they were protected.

The rate must be the caller's **own**. Reading it off the solver's published market feed checks the solver against its own number and passes anything; the feed URL sitting on the card is what makes that the easy mistake rather than an unlikely one. The doc comment says so.

## Compatibility

Absent `maxFee` gates nothing, so every existing caller funds exactly what it funded before. Additive only.

## Testing

17 cases. Mutation-verified in both files:

| mutation | tests killed |
|---|---|
| `max` → `min` | 3 |
| `>` → `>=` | 2 |
| drop the cross-asset refusal | 1 |
| drop the no-rate guard | 1 |
| drop rate validation | 1 |
| `ceil` → `floor` | 1 |
| drop the `bps` range guard | 1 |
| drop the `sats` range guard | 1 |
| drop the `bps` integer check | 1 |
| drop the `sats` integer check | 1 |
| drop the `bps` upper bound | 1 |
| move the `bps` bound off by one | 1 |

The `ceil` → `floor` row is why the rounding is a pinned claim rather than a comment: it passed all ten earlier cases because every one of them divided evenly. The added case is the only one that can tell them apart — R = 3 with 2,999 to-units short is 999.67 sats, which `ceil` refuses against a 999-sat ceiling and `floor` funds. Erring toward refusing is the client's side to err on.

The last six rows come from [arkana's review](https://github.com/arkade-os/ts-sdk/pull/832#pullrequestreview-0): the guards on the *ceiling itself* were unexercised, so a mutation removing either went undetected. They are now pinned by reason code (`max_fee_out_of_range`), asserted on `reason` rather than the message — that code is the closed contract a caller branches on. The boundary values the guards must keep allowing (`bps: 10_000`, and a zeroed bound beside a set one) are pinned alongside, so the guard cannot become the bug it exists to prevent.

Unit suites green: ts-sdk 2886, swap 648, boltz-swap 616.

## Note

The reference client in `arkade-os/intent-solver` (`examples/lib/rfq-core.mjs`) already carries the same gate with identical reason codes, mirrored deliberately so the shipped client and the reference cannot disagree about a money gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional fee ceilings when validating swap quotes.
  * Supports proportional, absolute, and reference-rate-based limits for cross-asset swaps.
  * Same-asset fees are assessed from the amount difference; cross-asset fees use the supplied reference rate with rounded-up calculations.
  * Quotes without configured limits continue to be accepted under existing behavior.

* **Bug Fixes**
  * Rejects quotes with unavailable, invalid, out-of-range, or excessive fee limits.
  * Added clearer refusal reasons for fee-limit validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
