### PR TITLE
fix(sdk): anchor a late address-watch baseline on chain height

### DIFF
--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -40,6 +40,8 @@ export type ExplorerTransaction = {
     status: {
         confirmed: boolean;
         block_time: number;
+        /** Set by Esplora; the electrum provider omits it. */
+        block_height?: number;
     };
 };
 
@@ -396,6 +398,9 @@ export class EsploraProvider implements OnchainProvider {
         const seen = new Set<string>();
         let baselined = false;
 
+        /** Chain height at watch start, captured only if the history baseline failed. */
+        let anchorHeight: number | undefined;
+
         /**
          * Establish what predates the watch, so the first poll pass has
          * something to compare against other than "everything is new".
@@ -417,6 +422,14 @@ export class EsploraProvider implements OnchainProvider {
                     "Could not baseline watched addresses; the first poll pass will establish it instead:",
                     error,
                 );
+
+                // `/blocks` is small enough to survive a timeout that killed the
+                // history fetch, and a height is reference enough.
+                try {
+                    anchorHeight = (await this.getChainTip()).height;
+                } catch {
+                    // No reference of any kind; the late baseline adopts wholesale.
+                }
             }
         })();
 
@@ -488,18 +501,24 @@ export class EsploraProvider implements OnchainProvider {
 
                     if (baselined) {
                         report(currentTxs);
+                    } else if (anchorHeight !== undefined) {
+                        // Anything confirmed above the anchor arrived after we
+                        // started. Unconfirmed counts as new too: a duplicate
+                        // notification is cheaper than a missed deposit.
+                        const arrivedAfterStart = (tx: ExplorerTransaction) =>
+                            !tx.status.confirmed ||
+                            tx.status.block_height === undefined ||
+                            tx.status.block_height > anchorHeight!;
+
+                        for (const tx of currentTxs) {
+                            if (!arrivedAfterStart(tx)) seen.add(txKey(tx));
+                        }
+                        baselined = true;
+                        report(currentTxs);
                     } else {
-                        // The creation-time baseline failed, so this fetch is
-                        // the first reference point we have. Anything that
-                        // arrived between the watch starting and now is
-                        // indistinguishable from history that predates it, and
-                        // is adopted as known rather than reported — the
-                        // alternative is announcing an entire address history as
-                        // incoming, which is the worse of the two.
-                        //
-                        // Say so. A deposit going unreported is precisely what
-                        // an operator needs told, and staying quiet about it is
-                        // how a missing payment becomes unexplainable.
+                        // No reference at all: anything arriving before now is
+                        // indistinguishable from history, so adopt rather than
+                        // announce one. Warn — a silent miss is unexplainable later.
                         console.warn(
                             `Esplora address watch established its baseline late for ${addresses.length} address(es); deposits arriving before now may not have been reported`,
                         );

--- a/packages/ts-sdk/test/esplora-watch-addresses.test.ts
+++ b/packages/ts-sdk/test/esplora-watch-addresses.test.ts
@@ -78,6 +78,39 @@ const flush = async () => {
     for (let i = 0; i < 5; i++) await Promise.resolve();
 };
 
+const confirmedTxAt = (txid: string, blockHeight: number): ExplorerTransaction =>
+    ({
+        txid,
+        vout: [],
+        status: { confirmed: true, block_height: blockHeight, block_hash: "h", block_time: 1 },
+    }) as unknown as ExplorerTransaction;
+
+const unconfirmedTx = (txid: string): ExplorerTransaction =>
+    ({ txid, vout: [], status: { confirmed: false } }) as unknown as ExplorerTransaction;
+
+const blocksTip = (height: number) => okJson([{ id: "tip", height, mediantime: 1 }]);
+
+/**
+ * Route the mocked fetch by endpoint, so a test can fail address history while
+ * leaving the (much smaller) chain-tip request working — which is the whole
+ * situation the anchor exists for.
+ */
+const routeFetch = (routes: { txs?: () => unknown; blocks?: () => unknown }) => {
+    mockFetch.mockImplementation((url: string) => {
+        if (url.includes("/blocks")) {
+            return routes.blocks
+                ? Promise.resolve(routes.blocks())
+                : Promise.reject(new Error("tip unavailable"));
+        }
+        if (url.includes("/txs")) {
+            return routes.txs
+                ? Promise.resolve(routes.txs())
+                : Promise.reject(new Error("history unavailable"));
+        }
+        return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+};
+
 /** `EsploraProvider`'s default HTTP poll interval. */
 const POLL_INTERVAL_MS = 15_000;
 /** First websocket reconnect delay; doubles per consecutive failure. */
@@ -316,7 +349,9 @@ describe("EsploraProvider.watchAddresses", () => {
 
             await provider.watchAddresses(["addr1"], callback);
 
-            expect(mockFetch).toHaveBeenCalledTimes(1); // it was attempted
+            // The history baseline was attempted, and its failure was followed
+            // by the chain-tip fallback that anchors a late baseline.
+            expect(mockFetch).toHaveBeenCalledTimes(2);
 
             // A failed baseline must degrade, not throw and not go deaf.
             await FakeWebSocket.instances[0].dispatch(
@@ -324,6 +359,84 @@ describe("EsploraProvider.watchAddresses", () => {
                 wsMessage("addr1", [confirmedTx("aa")]),
             );
             expect(callback).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("late baseline anchor", () => {
+        // When the creation-time history fetch fails, the chain tip is a second
+        // chance at a reference point: it is a far smaller request, so it often
+        // survives a timeout that a large address history does not.
+
+        it("reports a transaction confirmed after the watch started", async () => {
+            let history: unknown[] = [];
+            routeFetch({
+                blocks: () => blocksTip(100),
+                txs: () => okJson(history),
+            });
+            // Fail only the creation-time history fetch.
+            mockFetch.mockImplementationOnce((url: string) =>
+                url.includes("/txs")
+                    ? Promise.reject(new Error("history unavailable"))
+                    : Promise.resolve(blocksTip(100)),
+            );
+
+            const callback = vi.fn();
+            const provider = new EsploraProvider("http://localhost:3000");
+            await provider.watchAddresses(["addr1"], callback);
+
+            history = [confirmedTxAt("older", 90), confirmedTxAt("newer", 105)];
+            await FakeWebSocket.instances[0].dispatch("error");
+            await flush();
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback.mock.calls[0][0]).toEqual([expect.objectContaining({ txid: "newer" })]);
+        });
+
+        it("treats an unconfirmed transaction at late baseline as new", async () => {
+            // A deposit landing during a short outage is typically still in the
+            // mempool. Re-announcing a genuinely pre-existing mempool tx is a
+            // duplicate notification for real funds; missing a deposit is not
+            // recoverable the same way, so bias towards reporting.
+            let history: unknown[] = [];
+            routeFetch({ blocks: () => blocksTip(100), txs: () => okJson(history) });
+            mockFetch.mockImplementationOnce((url: string) =>
+                url.includes("/txs")
+                    ? Promise.reject(new Error("history unavailable"))
+                    : Promise.resolve(blocksTip(100)),
+            );
+
+            const callback = vi.fn();
+            const provider = new EsploraProvider("http://localhost:3000");
+            await provider.watchAddresses(["addr1"], callback);
+
+            history = [unconfirmedTx("in-mempool")];
+            await FakeWebSocket.instances[0].dispatch("error");
+            await flush();
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback.mock.calls[0][0]).toEqual([
+                expect.objectContaining({ txid: "in-mempool" }),
+            ]);
+        });
+
+        it("adopts everything and warns when the chain tip is unavailable too", async () => {
+            // Explorer fully down at creation: no history, no tip, no reference
+            // point. Unchanged behaviour — adopt silently rather than announce a
+            // whole address history, but say so.
+            routeFetch({ txs: undefined, blocks: undefined });
+
+            const callback = vi.fn();
+            const provider = new EsploraProvider("http://localhost:3000");
+            await provider.watchAddresses(["addr1"], callback);
+
+            routeFetch({ txs: () => okJson([confirmedTxAt("unknowable", 105)]) });
+            await FakeWebSocket.instances[0].dispatch("error");
+            await flush();
+
+            expect(callback).not.toHaveBeenCalled();
+            expect(
+                warn.mock.calls.some((c) => /may not have been reported/i.test(String(c[0]))),
+            ).toBe(true);
         });
     });
 


### PR DESCRIPTION
Stacked on #830 — base is `fix/esplora-watcher-leak`, so review that first. The diff here is one commit.

## What this closes

#830 narrowed a gap and warned about the remainder. This closes most of the remainder.

When the creation-time history fetch fails, the first successful poll has to adopt current address history as its reference point — so a deposit arriving between the watch starting and that fetch is indistinguishable from history predating it, and is silently dropped. #830 made that loud (`deposits arriving before now may not have been reported`) but not rare.

## How

The chain tip is a second chance at a reference point. `/blocks` is a far smaller request than a full address history, so it frequently survives the timeout or rate limit that just killed `/address/{addr}/txs`. When the history baseline fails, record the height; a late baseline can then tell what genuinely arrived afterwards.

```
history baseline OK        → compare against it (unchanged)
history fails, tip OK      → report anything confirmed above the recorded height
history fails, tip fails   → adopt wholesale + warn (unchanged from #830)
```

**Unconfirmed counts as new.** A deposit landing during a short outage is usually still in the mempool, and the two failure directions are not symmetric: re-announcing a genuinely pre-existing mempool transaction is a duplicate notification for funds that do exist, whereas missing a deposit is silence about money that arrived.

`ExplorerTransaction.status` now declares `block_height`, which Esplora already returns and the type simply hadn't described. Optional, because `ElectrumProvider` does not populate it — absence reads as "height unknown", which biases towards reporting rather than swallowing.

## What it does not do

This narrows the window rather than closing it absolutely. If the explorer is unreachable for **both** history and tip, there is no reference of any kind and the behaviour is exactly #830's: adopt wholesale, and say so. That case is unclosable without state captured before the outage.

## Test plan

3 new tests, written failing first:

- reports a transaction confirmed after the watch started, while adopting one from before it
- treats an unconfirmed transaction at late baseline as new
- adopts everything and warns when the chain tip is unavailable too (the unchanged path)

ts-sdk unit: 176 files, **2930 passed**, 1 skipped, exit 0. boltz-swap: 23 files, 616 passed, exit 0. `typecheck`, `build`, `lint`, `check:vtxo` clean.

Not covered: no e2e against a real explorer — the partial-outage shape this depends on (history times out, tip succeeds) is exercised with a routed fetch mock, not observed in the wild.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address watching when the initial transaction history cannot be retrieved.
  * Correctly identifies transactions confirmed after monitoring begins, along with unconfirmed transactions, when recovering from a failed baseline.
  * Preserves existing behavior when no chain-height reference is available.
  * Added clearer warnings when both transaction history and chain-tip requests fail.

* **Enhancements**
  * Transaction status information can now include the confirmed block height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->