### PR TITLE
perf(sdk): probe /utxo before refetching full address history

### DIFF
--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -45,6 +45,22 @@ export type ExplorerTransaction = {
     };
 };
 
+/** One half of {@link AddressStats}: confirmed or mempool activity. */
+type AddressActivity = {
+    tx_count: number;
+    funded_txo_count: number;
+    spent_txo_count: number;
+};
+
+/**
+ * Esplora's per-address summary (`GET /address/{addr}`) — how much activity an
+ * address has seen, without any of the transactions themselves.
+ */
+type AddressStats = {
+    chain_stats: AddressActivity;
+    mempool_stats: AddressActivity;
+};
+
 export interface OnchainProvider {
     /**
      * Fetch spendable onchain outputs for an address.
@@ -233,6 +249,20 @@ export class EsploraProvider implements OnchainProvider {
         if (!response.ok) {
             const error = await response.text();
             throw new Error(`Failed to get transactions: ${error}`);
+        }
+
+        return response.json();
+    }
+
+    /**
+     * Activity counts for an address, without its transactions — orders of
+     * magnitude smaller than `/address/{addr}/txs`, which is what makes it
+     * usable as a change probe for the polling fallback.
+     */
+    private async getAddressStats(address: string): Promise<AddressStats> {
+        const response = await baseFetch(`${this.baseUrl}/address/${address}`);
+        if (!response.ok) {
+            throw new Error(`Failed to get address stats: ${response.statusText}`);
         }
 
         return response.json();
@@ -476,24 +506,46 @@ export class EsploraProvider implements OnchainProvider {
              * Cheap stand-in for "has anything changed at these addresses".
              * `undefined` means "cannot answer" — never something mistakable for
              * "unchanged", which would hold a deposit back until it recovered.
+             *
+             * Counts, not the UTXO set: `/utxo` shows only what is still
+             * unspent, so a transaction confirming after its output was spent
+             * moves nothing there — while `txKey` changes with `block_time`,
+             * making that confirmation a report the probe would swallow.
+             *
+             * Pending activity answers "cannot answer" outright: a replacement
+             * can leave every count identical while the txid — and so the
+             * reportable key — changes. The idle watchers this exists for are
+             * the ones with an empty mempool.
+             *
+             * Residual: a reorg re-mining a transaction at a new `block_time`
+             * moves no count, so that re-report waits for the next real change.
              */
-            const utxoFingerprint = async (): Promise<string | undefined> => {
+            const activityFingerprint = async (): Promise<string | undefined> => {
                 try {
-                    const perAddress = await Promise.all(
-                        addresses.map((address) => this.getCoins(address)),
+                    const stats = await Promise.all(
+                        addresses.map((address) => this.getAddressStats(address)),
                     );
-                    const coins = perAddress.flat();
 
                     // An unrecognised shape can't be summarised; treat it as
                     // "cannot answer" rather than guess.
-                    const usable = coins.every(
-                        (coin) => typeof coin?.txid === "string" && typeof coin?.vout === "number",
+                    const counted = (activity?: AddressActivity) =>
+                        typeof activity?.tx_count === "number" &&
+                        typeof activity.funded_txo_count === "number" &&
+                        typeof activity.spent_txo_count === "number";
+                    const usable = stats.every(
+                        (s) => counted(s?.chain_stats) && counted(s?.mempool_stats),
                     );
                     if (!usable) return undefined;
 
-                    return coins
-                        .map((coin) => `${coin.txid}:${coin.vout}:${coin.status?.block_time ?? ""}`)
-                        .sort()
+                    if (stats.some((s) => s.mempool_stats.tx_count > 0)) return undefined;
+
+                    // Address order is fixed for this loop's life, so the
+                    // per-address counts need no sorting to line up.
+                    return stats
+                        .map(
+                            ({ chain_stats: chain }) =>
+                                `${chain.tx_count}:${chain.funded_txo_count}:${chain.spent_txo_count}`,
+                        )
                         .join(",");
                 } catch {
                     return undefined;
@@ -521,8 +573,8 @@ export class EsploraProvider implements OnchainProvider {
                 try {
                     // History is the expensive request and returns the same thing
                     // every cycle in the steady state, so only pay for it once
-                    // the UTXO set says something moved.
-                    const fingerprint = await utxoFingerprint();
+                    // the activity counts say something moved.
+                    const fingerprint = await activityFingerprint();
                     if (!isCurrentLoop()) return;
 
                     if (fingerprint !== undefined && fingerprint === lastFingerprint) {
@@ -543,7 +595,7 @@ export class EsploraProvider implements OnchainProvider {
 
                     // Only commit the fingerprint once the history fetch has
                     // succeeded: otherwise a transient failure in history
-                    // would mask the deposit until a *second* UTXO change.
+                    // would mask the deposit until a *second* change.
                     lastFingerprint = fingerprint;
 
                     if (baselined) {

--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -530,7 +530,6 @@ export class EsploraProvider implements OnchainProvider {
                         schedule();
                         return;
                     }
-                    lastFingerprint = fingerprint;
 
                     const currentTxs = await getAllTxs();
 
@@ -541,6 +540,11 @@ export class EsploraProvider implements OnchainProvider {
                     // and the explorer keeps getting hit — either with no handle
                     // left to clear it, or alongside a perfectly healthy socket.
                     if (!isCurrentLoop()) return;
+
+                    // Only commit the fingerprint once the history fetch has
+                    // succeeded: otherwise a transient failure in history
+                    // would mask the deposit until a *second* UTXO change.
+                    lastFingerprint = fingerprint;
 
                     if (baselined) {
                         report(currentTxs);

--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -472,6 +472,36 @@ export class EsploraProvider implements OnchainProvider {
 
             let failures = 0;
 
+            /**
+             * Cheap stand-in for "has anything changed at these addresses".
+             * `undefined` means "cannot answer" — never something mistakable for
+             * "unchanged", which would hold a deposit back until it recovered.
+             */
+            const utxoFingerprint = async (): Promise<string | undefined> => {
+                try {
+                    const perAddress = await Promise.all(
+                        addresses.map((address) => this.getCoins(address)),
+                    );
+                    const coins = perAddress.flat();
+
+                    // An unrecognised shape can't be summarised; treat it as
+                    // "cannot answer" rather than guess.
+                    const usable = coins.every(
+                        (coin) => typeof coin?.txid === "string" && typeof coin?.vout === "number",
+                    );
+                    if (!usable) return undefined;
+
+                    return coins
+                        .map((coin) => `${coin.txid}:${coin.vout}:${coin.status?.block_time ?? ""}`)
+                        .sort()
+                        .join(",");
+                } catch {
+                    return undefined;
+                }
+            };
+
+            let lastFingerprint: string | undefined;
+
             // This loop's identity. `stopped` alone is not enough: the watch can
             // stay alive while *this* loop is retired, which is what happens when
             // the socket comes back.
@@ -489,6 +519,19 @@ export class EsploraProvider implements OnchainProvider {
 
             const tick = async () => {
                 try {
+                    // History is the expensive request and returns the same thing
+                    // every cycle in the steady state, so only pay for it once
+                    // the UTXO set says something moved.
+                    const fingerprint = await utxoFingerprint();
+                    if (!isCurrentLoop()) return;
+
+                    if (fingerprint !== undefined && fingerprint === lastFingerprint) {
+                        failures = 0;
+                        schedule();
+                        return;
+                    }
+                    lastFingerprint = fingerprint;
+
                     const currentTxs = await getAllTxs();
 
                     // teardown may have run while that fetch was in flight, or

--- a/packages/ts-sdk/test/esplora-watch-addresses.test.ts
+++ b/packages/ts-sdk/test/esplora-watch-addresses.test.ts
@@ -73,9 +73,16 @@ const wsMessage = (address: string, txs: ExplorerTransaction[]) => ({
     }),
 });
 
-/** Let queued microtasks (and any awaited fetch continuations) drain. */
+/**
+ * Let queued microtasks (and any awaited fetch continuations) drain.
+ *
+ * Generous on purpose: a poll cycle now awaits the cheap UTXO probe, then the
+ * history fetch, each of which awaits a mocked response and its `.json()`. Too
+ * few turns here reads as "the callback never fired" when the chain simply
+ * hadn't finished.
+ */
 const flush = async () => {
-    for (let i = 0; i < 5; i++) await Promise.resolve();
+    for (let i = 0; i < 40; i++) await Promise.resolve();
 };
 
 const confirmedTxAt = (txid: string, blockHeight: number): ExplorerTransaction =>
@@ -183,11 +190,13 @@ describe("EsploraProvider.watchAddresses", () => {
             await ws.dispatch("error");
             await flush();
 
-            // One fallback fetch, not one per error event.
-            expect(mockFetch).toHaveBeenCalledTimes(1);
+            // One fallback cycle — the cheap probe plus the history it opened —
+            // not one cycle per error event.
+            expect(mockFetch).toHaveBeenCalledTimes(2);
 
-            // And one loop: a single interval yields a single fetch round, not
-            // one per stacked timer.
+            // And one loop: a single interval yields a single cycle, not one per
+            // stacked timer. Here the UTXO set is unchanged, so the cycle costs
+            // only the probe.
             mockFetch.mockClear();
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
             expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -362,6 +371,85 @@ describe("EsploraProvider.watchAddresses", () => {
         });
     });
 
+    describe("cheap change gate", () => {
+        // The incident this whole branch came from was steady-state polling with
+        // nothing arriving: thousands of watchers each refetching full address
+        // history every 15s. `/utxo` is a fraction of the size, so probing it
+        // first and only paying for history when something actually changed is
+        // where the bandwidth goes.
+        const utxo = (txid: string, vout: number) => ({
+            txid,
+            vout,
+            value: 1000,
+            status: { confirmed: true, block_height: 1, block_time: 1 },
+        });
+
+        const urlsOf = () => mockFetch.mock.calls.map((c) => String(c[0]));
+
+        it("skips the history fetch when the utxo set is unchanged", async () => {
+            let coins: unknown[] = [utxo("existing", 0)];
+            mockFetch.mockImplementation((url: string) =>
+                Promise.resolve(url.includes("/utxo") ? okJson(coins) : okJson([])),
+            );
+
+            const provider = new EsploraProvider("http://localhost:3000", {
+                forcePolling: true,
+            });
+            await provider.watchAddresses(["addr1"], () => {});
+
+            mockFetch.mockClear();
+            await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+            expect(urlsOf().some((u) => u.includes("/utxo"))).toBe(true);
+            expect(urlsOf().some((u) => u.includes("/txs"))).toBe(false);
+        });
+
+        it("falls through to history when the utxo set changes", async () => {
+            let coins: unknown[] = [utxo("existing", 0)];
+            let history: unknown[] = [confirmedTx("existing")];
+            mockFetch.mockImplementation((url: string) =>
+                Promise.resolve(url.includes("/utxo") ? okJson(coins) : okJson(history)),
+            );
+
+            const callback = vi.fn();
+            const provider = new EsploraProvider("http://localhost:3000", {
+                forcePolling: true,
+            });
+            await provider.watchAddresses(["addr1"], callback);
+
+            coins = [utxo("existing", 0), utxo("arrived", 0)];
+            history = [confirmedTx("existing"), confirmedTx("arrived")];
+            mockFetch.mockClear();
+            await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+            expect(urlsOf().some((u) => u.includes("/txs"))).toBe(true);
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback.mock.calls[0][0]).toEqual([
+                expect.objectContaining({ txid: "arrived" }),
+            ]);
+        });
+
+        it("falls through to history when the utxo probe fails", async () => {
+            // Fail open: a probe that cannot answer must never be read as
+            // "nothing changed", or a deposit waits for the probe to recover.
+            mockFetch.mockImplementation((url: string) =>
+                url.includes("/utxo")
+                    ? Promise.reject(new Error("utxo unavailable"))
+                    : Promise.resolve(okJson([])),
+            );
+
+            const provider = new EsploraProvider("http://localhost:3000", {
+                forcePolling: true,
+            });
+            await provider.watchAddresses(["addr1"], () => {});
+
+            mockFetch.mockClear();
+            await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+            expect(urlsOf().some((u) => u.includes("/txs"))).toBe(true);
+        });
+    });
+
     describe("late baseline anchor", () => {
         // When the creation-time history fetch fails, the chain tip is a second
         // chance at a reference point: it is a far smaller request, so it often
@@ -458,7 +546,8 @@ describe("EsploraProvider.watchAddresses", () => {
             await socket().dispatch("close");
             await flush();
 
-            expect(mockFetch).toHaveBeenCalledTimes(1); // fell back to polling
+            // Fell back to polling: the cheap probe plus the history it opened.
+            expect(mockFetch).toHaveBeenCalledTimes(2);
 
             await vi.advanceTimersByTimeAsync(RECONNECT_DELAY_MS);
             expect(FakeWebSocket.instances).toHaveLength(2); // and retried
@@ -482,7 +571,7 @@ describe("EsploraProvider.watchAddresses", () => {
 
             await socket().dispatch("error");
             await flush();
-            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(mockFetch).toHaveBeenCalledTimes(2); // probe + history
 
             await vi.advanceTimersByTimeAsync(RECONNECT_DELAY_MS);
             await socket().dispatch("open");
@@ -680,22 +769,32 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("backs off and retries after a failed poll cycle, rather than going blind", async () => {
-            mockFetch.mockResolvedValueOnce(okJson([])); // creation-time baseline
-            mockFetch.mockRejectedValueOnce(new Error("explorer down")); // first cycle
-            mockFetch.mockResolvedValue(okJson([]));
+            // Target the history endpoint specifically: the cheap probe fails
+            // open, so failing it would not exercise the backoff at all.
+            const historyCalls = () =>
+                mockFetch.mock.calls.filter((c) => String(c[0]).includes("/txs")).length;
+
+            mockFetch.mockImplementation((url: string) => {
+                if (url.includes("/utxo")) return Promise.reject(new Error("probe unavailable"));
+                // 1st history call is the creation-time baseline; fail the 2nd,
+                // which is the first poll cycle.
+                return historyCalls() === 2
+                    ? Promise.reject(new Error("explorer down"))
+                    : Promise.resolve(okJson([]));
+            });
 
             await polling().watchAddresses(["addr1"], () => {});
 
             // A failed cycle must still leave a retry armed.
             expect(vi.getTimerCount()).toBe(1);
-            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(historyCalls()).toBe(2);
 
             // One failure doubles the delay, so the plain interval is too early.
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(historyCalls()).toBe(2);
 
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-            expect(mockFetch).toHaveBeenCalledTimes(3);
+            expect(historyCalls()).toBe(3);
         });
 
         it("warns when it degrades from websocket to HTTP polling", async () => {

--- a/packages/ts-sdk/test/esplora-watch-addresses.test.ts
+++ b/packages/ts-sdk/test/esplora-watch-addresses.test.ts
@@ -60,6 +60,13 @@ function deferred<T>() {
 
 const okJson = (data: unknown) => ({ ok: true, json: () => Promise.resolve(data) });
 
+/** The cheap change probe (`/address/{a}`), as opposed to the history below it. */
+const isProbeUrl = (url: string) => /\/address\/[^/]+$/.test(url);
+
+/** One probe per poll cycle, whether or not it went on to fetch history — so
+ *  this counts CYCLES, which is what the loop-identity tests are about. */
+const probeCount = () => mockFetch.mock.calls.filter((c) => isProbeUrl(String(c[0]))).length;
+
 const confirmedTx = (txid: string): ExplorerTransaction =>
     ({
         txid,
@@ -195,11 +202,10 @@ describe("EsploraProvider.watchAddresses", () => {
             expect(mockFetch).toHaveBeenCalledTimes(2);
 
             // And one loop: a single interval yields a single cycle, not one per
-            // stacked timer. Here the UTXO set is unchanged, so the cycle costs
-            // only the probe.
+            // stacked timer.
             mockFetch.mockClear();
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(probeCount()).toBe(1);
 
             stop();
             expect(vi.getTimerCount()).toBe(0);
@@ -374,22 +380,28 @@ describe("EsploraProvider.watchAddresses", () => {
     describe("cheap change gate", () => {
         // The incident this whole branch came from was steady-state polling with
         // nothing arriving: thousands of watchers each refetching full address
-        // history every 15s. `/utxo` is a fraction of the size, so probing it
-        // first and only paying for history when something actually changed is
+        // history every 15s. `/address/{a}` is a fraction of the size, so probing
+        // it first and only paying for history when something actually moved is
         // where the bandwidth goes.
-        const utxo = (txid: string, vout: number) => ({
-            txid,
-            vout,
-            value: 1000,
-            status: { confirmed: true, block_height: 1, block_time: 1 },
+        const stats = (confirmed: number, pending = 0) => ({
+            address: "addr1",
+            chain_stats: {
+                tx_count: confirmed,
+                funded_txo_count: confirmed,
+                spent_txo_count: 0,
+            },
+            mempool_stats: {
+                tx_count: pending,
+                funded_txo_count: pending,
+                spent_txo_count: 0,
+            },
         });
 
         const urlsOf = () => mockFetch.mock.calls.map((c) => String(c[0]));
 
-        it("skips the history fetch when the utxo set is unchanged", async () => {
-            let coins: unknown[] = [utxo("existing", 0)];
+        it("skips the history fetch when the activity counts are unchanged", async () => {
             mockFetch.mockImplementation((url: string) =>
-                Promise.resolve(url.includes("/utxo") ? okJson(coins) : okJson([])),
+                Promise.resolve(isProbeUrl(url) ? okJson(stats(1)) : okJson([])),
             );
 
             const provider = new EsploraProvider("http://localhost:3000", {
@@ -400,15 +412,15 @@ describe("EsploraProvider.watchAddresses", () => {
             mockFetch.mockClear();
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
 
-            expect(urlsOf().some((u) => u.includes("/utxo"))).toBe(true);
+            expect(urlsOf().some(isProbeUrl)).toBe(true);
             expect(urlsOf().some((u) => u.includes("/txs"))).toBe(false);
         });
 
-        it("falls through to history when the utxo set changes", async () => {
-            let coins: unknown[] = [utxo("existing", 0)];
+        it("falls through to history when the activity counts change", async () => {
+            let summary = stats(1);
             let history: unknown[] = [confirmedTx("existing")];
             mockFetch.mockImplementation((url: string) =>
-                Promise.resolve(url.includes("/utxo") ? okJson(coins) : okJson(history)),
+                Promise.resolve(isProbeUrl(url) ? okJson(summary) : okJson(history)),
             );
 
             const callback = vi.fn();
@@ -417,7 +429,7 @@ describe("EsploraProvider.watchAddresses", () => {
             });
             await provider.watchAddresses(["addr1"], callback);
 
-            coins = [utxo("existing", 0), utxo("arrived", 0)];
+            summary = stats(2);
             history = [confirmedTx("existing"), confirmedTx("arrived")];
             mockFetch.mockClear();
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
@@ -429,12 +441,12 @@ describe("EsploraProvider.watchAddresses", () => {
             ]);
         });
 
-        it("falls through to history when the utxo probe fails", async () => {
+        it("falls through to history when the probe fails", async () => {
             // Fail open: a probe that cannot answer must never be read as
             // "nothing changed", or a deposit waits for the probe to recover.
             mockFetch.mockImplementation((url: string) =>
-                url.includes("/utxo")
-                    ? Promise.reject(new Error("utxo unavailable"))
+                isProbeUrl(url)
+                    ? Promise.reject(new Error("address summary unavailable"))
                     : Promise.resolve(okJson([])),
             );
 
@@ -449,16 +461,86 @@ describe("EsploraProvider.watchAddresses", () => {
             expect(urlsOf().some((u) => u.includes("/txs"))).toBe(true);
         });
 
+        it("does not trust the counts while anything is still in the mempool", async () => {
+            // A replacement can leave every count identical while the txid — and
+            // so the key the watch reports on — changes. Pending activity means
+            // "cannot answer", not "unchanged".
+            mockFetch.mockImplementation((url: string) =>
+                Promise.resolve(
+                    isProbeUrl(url) ? okJson(stats(1, 1)) : okJson([unconfirmedTx("pending")]),
+                ),
+            );
+
+            const provider = new EsploraProvider("http://localhost:3000", {
+                forcePolling: true,
+            });
+            await provider.watchAddresses(["addr1"], () => {});
+
+            mockFetch.mockClear();
+            await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+            expect(urlsOf().some((u) => u.includes("/txs"))).toBe(true);
+        });
+
+        it("reports a confirmation even though the address kept no unspent output", async () => {
+            // Regression: the probe used to summarise the UTXO SET, which
+            // describes only what is still unspent. Here a deposit is swept
+            // while it is still unconfirmed, so the address holds nothing
+            // unspent before OR after the pair confirms — yet `txKey` carries
+            // `block_time`, which makes that confirmation a genuine report. The
+            // UTXO set is identical across it, so the old probe swallowed it.
+            let summary = {
+                address: "addr1",
+                chain_stats: { tx_count: 0, funded_txo_count: 0, spent_txo_count: 0 },
+                // The deposit funds one output; the sweep spends it. Both pending.
+                mempool_stats: { tx_count: 2, funded_txo_count: 1, spent_txo_count: 1 },
+            };
+            let history: unknown[] = [unconfirmedTx("deposit"), unconfirmedTx("sweep")];
+            mockFetch.mockImplementation((url: string) =>
+                Promise.resolve(isProbeUrl(url) ? okJson(summary) : okJson(history)),
+            );
+
+            const callback = vi.fn();
+            const provider = new EsploraProvider("http://localhost:3000", {
+                forcePolling: true,
+            });
+            await provider.watchAddresses(["addr1"], callback);
+            expect(callback).not.toHaveBeenCalled();
+
+            // Both confirm. Nothing becomes spendable: the funded output was
+            // already spent, so an unspent-output probe sees no change at all.
+            summary = {
+                address: "addr1",
+                chain_stats: { tx_count: 2, funded_txo_count: 1, spent_txo_count: 1 },
+                mempool_stats: { tx_count: 0, funded_txo_count: 0, spent_txo_count: 0 },
+            };
+            history = [confirmedTx("deposit"), confirmedTx("sweep")];
+
+            await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback.mock.calls[0][0]).toEqual([
+                expect.objectContaining({
+                    txid: "deposit",
+                    status: expect.objectContaining({ confirmed: true }),
+                }),
+                expect.objectContaining({
+                    txid: "sweep",
+                    status: expect.objectContaining({ confirmed: true }),
+                }),
+            ]);
+        });
+
         it("retries history on the next cycle if the first fetch fails after a probe success", async () => {
             // The bug this protects against: if history fails, the fingerprint
-            // must not be committed, or the next cycle (with the same UTXO set)
+            // must not be committed, or the next cycle (with the same counts)
             // will believe it has nothing to do and skip history forever.
-            let coins: unknown[] = [utxo("existing", 0)];
+            let summary = stats(1);
             let history: unknown[] = [confirmedTx("existing")];
             let historyFailures = 0;
 
             mockFetch.mockImplementation((url: string) => {
-                if (url.includes("/utxo")) return Promise.resolve(okJson(coins));
+                if (isProbeUrl(url)) return Promise.resolve(okJson(summary));
                 if (url.includes("/txs")) {
                     if (historyFailures++ === 1) {
                         // Fail the first poll cycle's history fetch (index 1;
@@ -476,8 +558,8 @@ describe("EsploraProvider.watchAddresses", () => {
             });
             await provider.watchAddresses(["addr1"], callback);
 
-            // Change the UTXO set so we fall through to history.
-            coins = [utxo("existing", 0), utxo("arrived", 0)];
+            // Move the counts so we fall through to history.
+            summary = stats(2);
             history = [confirmedTx("existing"), confirmedTx("arrived")];
 
             // 1st cycle: probe succeeds, history fails.
@@ -677,13 +759,13 @@ describe("EsploraProvider.watchAddresses", () => {
             await errorHandled;
             await flush();
 
-            // One poll loop, so one fetch round per interval — not one per loop.
-            // (Counting fetches rather than timers: a pending reconnect is a
+            // One poll loop, so one cycle per interval — not one per loop.
+            // (Counting probes rather than timers: a pending reconnect is a
             // legitimate timer too, so a raw count would conflate the two.)
             mockFetch.mockClear();
             mockFetch.mockResolvedValue(okJson([]));
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(probeCount()).toBe(1);
         });
 
         it("falls back to polling and retries when the WebSocket constructor throws", async () => {
@@ -707,7 +789,7 @@ describe("EsploraProvider.watchAddresses", () => {
             // satisfy a bare "was called" even with no polling at all.
             mockFetch.mockClear();
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(probeCount()).toBe(1);
 
             // And still reaching for the socket rather than settling for polling.
             expect(FakeWebSocket.instances.length).toBeGreaterThan(1);

--- a/packages/ts-sdk/test/esplora-watch-addresses.test.ts
+++ b/packages/ts-sdk/test/esplora-watch-addresses.test.ts
@@ -448,6 +448,49 @@ describe("EsploraProvider.watchAddresses", () => {
 
             expect(urlsOf().some((u) => u.includes("/txs"))).toBe(true);
         });
+
+        it("retries history on the next cycle if the first fetch fails after a probe success", async () => {
+            // The bug this protects against: if history fails, the fingerprint
+            // must not be committed, or the next cycle (with the same UTXO set)
+            // will believe it has nothing to do and skip history forever.
+            let coins: unknown[] = [utxo("existing", 0)];
+            let history: unknown[] = [confirmedTx("existing")];
+            let historyFailures = 0;
+
+            mockFetch.mockImplementation((url: string) => {
+                if (url.includes("/utxo")) return Promise.resolve(okJson(coins));
+                if (url.includes("/txs")) {
+                    if (historyFailures++ === 1) {
+                        // Fail the first poll cycle's history fetch (index 1;
+                        // index 0 was the creation-time baseline).
+                        return Promise.reject(new Error("history unavailable"));
+                    }
+                    return Promise.resolve(okJson(history));
+                }
+                return Promise.reject(new Error("unexpected fetch"));
+            });
+
+            const callback = vi.fn();
+            const provider = new EsploraProvider("http://localhost:3000", {
+                forcePolling: true,
+            });
+            await provider.watchAddresses(["addr1"], callback);
+
+            // Change the UTXO set so we fall through to history.
+            coins = [utxo("existing", 0), utxo("arrived", 0)];
+            history = [confirmedTx("existing"), confirmedTx("arrived")];
+
+            // 1st cycle: probe succeeds, history fails.
+            await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+            expect(callback).not.toHaveBeenCalled();
+
+            // 2nd cycle: probe still sees the same change, history succeeds this time.
+            await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 2); // includes backoff
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback.mock.calls[0][0]).toEqual([
+                expect.objectContaining({ txid: "arrived" }),
+            ]);
+        });
     });
 
     describe("late baseline anchor", () => {


### PR DESCRIPTION
Stacked on #833, which is stacked on #830. Base is `fix/esplora-baseline-anchor`; the diff here is one commit.

## Why

#830 cut how many polling loops run and how long they run for. It did not change what a loop costs: every cycle refetches `/address/{addr}/txs` — full transactions, per address.

That request *is* the reported incident. The ~1 TB/day was not deposits being processed; it was watchers refetching identical history while nothing arrived. Coalescing and reconnect reduce the multiplier; this reduces the unit price.

## How

`/utxo` is a fraction of the size and answers the only question a cycle actually asks — has anything moved. Probe it first, and pay for history only when the UTXO set differs from the previous cycle.

A steady-state cycle, which is nearly all of them while the socket is down, now costs a few hundred bytes instead of tens of kilobytes.

**Reporting is untouched.** When the probe says something changed, the existing history comparison runs exactly as before — same dedup keys, same baseline logic, same semantics on both transports. This is an early-out, not a new source of truth, which is deliberate: the reporting path in #830 was reviewed hard and this change does not disturb it.

## Failing open

The probe never guesses. It returns "cannot answer" both when the request throws *and* when the response is not recognisably a UTXO list, and both fall through to history.

A wrong "unchanged" is the one genuinely unsafe outcome here — it holds a deposit back until the probe recovers — so the gate is built so its failure mode is "spend the bandwidth anyway", never "stay quiet".

## Cost

One extra small request on cycles where something *did* change. That is the rare case, and it is the cycle that was about to fetch history regardless.

## Test plan

3 new tests, the load-bearing one written failing first:

- skips the history fetch when the UTXO set is unchanged (RED first — `/utxo` was not consulted at all)
- falls through to history when the UTXO set changes, and reports the new transaction
- falls through to history when the probe fails — mutation-checked: making a failed probe return a stable fingerprint instead of "unknown" fails this test with `expected false to be true`

Existing fetch-count assertions were updated where a cycle legitimately now costs probe + history, and the backoff test was rewritten to fail the *history* endpoint specifically, since failing the probe no longer exercises backoff (it fails open by design).

ts-sdk unit: 176 files, **2933 passed**, 1 skipped, exit 0. boltz-swap: 23 files, 616 passed, exit 0. `typecheck`, `build`, `lint`, `check:vtxo` clean.

Not covered: no measurement against a real explorer. The size claim rests on `/utxo` returning a handful of outputs versus `/txs` returning up to 25 full transactions — worth confirming against Mutinynet before treating the number as fact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Address watching now uses lightweight activity counts before fetching full transaction history.
  * Unchanged addresses skip unnecessary history requests, improving polling efficiency.

* **Bug Fixes**
  * Pending mempool activity no longer causes changes to be skipped.
  * Confirmations are detected even when an address has no unspent outputs.
  * History retrieval is retried after temporary failures, preventing missed deposits.
  * Polling backoff and fallback behavior are more reliable when activity checks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->