### PR TITLE
feat(swap): the EVM corridors' wire layer — pairs, amounts, requests, quotes

### DIFF
--- a/packages/swap/src/evmRfq.ts
+++ b/packages/swap/src/evmRfq.ts
@@ -534,9 +534,24 @@ const assertNonNegativeInteger = (value: unknown, field: string): void => {
     }
 };
 
+/**
+ * Lowercase hex of a whole number of bytes.
+ *
+ * The EVEN-LENGTH half is the part that is easy to leave out, and leaving it
+ * out makes this validator promise something it does not keep. Both fields
+ * checked with it are pkScripts a later step decodes to bytes, and
+ * `hex.decode` refuses an odd-length string — so without this, `"abc"` passes
+ * here and throws during covenant derivation instead, reporting a broken
+ * covenant for what is really a malformed quote field.
+ */
 const assertHex = (value: unknown, field: string): void => {
-    if (typeof value !== "string" || value.length === 0 || !/^[0-9a-f]+$/.test(value)) {
-        throw new Error(`${field} must be lowercase hex, got ${String(value)}`);
+    if (
+        typeof value !== "string" ||
+        value.length === 0 ||
+        value.length % 2 !== 0 ||
+        !/^[0-9a-f]+$/.test(value)
+    ) {
+        throw new Error(`${field} must be lowercase hex of whole bytes, got ${String(value)}`);
     }
 };
 

--- a/packages/swap/src/evmRfq.ts
+++ b/packages/swap/src/evmRfq.ts
@@ -1,0 +1,564 @@
+/**
+ * The EVM corridors' wire layer — `arkade:BTC->ethereum:<token>` and
+ * `ethereum:<token>->arkade:BTC`.
+ *
+ * The negotiation half only: the pair form, the token identity, the amount
+ * encoding, the two `rfq_request` shapes and the two quote shapes a solver
+ * answers with. Deriving the Arkade covenant, checking the two deadlines
+ * against each other and funding are NOT here — see the deadline note on
+ * {@link EvmSendQuoteProfile.evm_timeout_block} for why the ordering check
+ * needs a per-chain block cadence this module deliberately does not invent.
+ *
+ * Its own file rather than more of `rfq.ts` because nothing here is shared
+ * with the four BTC corridors: those dispatch on a pair CONSTANT, and an EVM
+ * pair cannot be one — it names its ERC20, and which tokens are served is a
+ * solver deployment's choice, known only at runtime.
+ *
+ * ## The reference solver, and where the parity is pinned
+ *
+ * Every shape below is the client half of a schema that already exists and is
+ * already strict. The source of truth is `arkade-os/intent-solver` at
+ * `9751a1c`:
+ *
+ * - `packages/solver-corridors-evm/src/wire/evmPayloads.ts` — the two
+ *   `.strict()` request schemas and the two quote payload builders.
+ * - `packages/solver-core/src/core/corridorPolicy.ts` — `evmCorridorFor`,
+ *   `evmDirectionOf`, and the LOWERCASE-only pair regex.
+ * - `docs/rfq-protocol.md` §§ 2.1, 7.1.5 — the amount encoding and the EVM
+ *   profiles.
+ *
+ * Restated here rather than imported, for the reason `rfq.ts` gives for
+ * restating the wire's pair cap: this repo does not own those numbers, and a
+ * copy that drifts is caught by a test that pins it (`test/evmRfq.test.ts`)
+ * rather than by a swap that silently never matches.
+ *
+ * ## Amounts
+ *
+ * **A token quantity is a `bigint` in this API and a canonical decimal string
+ * on the wire.** Not a `number`, at either end.
+ *
+ * An ERC20 amount is 256-bit. A JSON number is an IEEE-754 double, exact only
+ * to 2^53 − 1 — which at 18 decimals is 0.009 tokens, so one whole DAI does
+ * not survive the round trip. The rounding would happen inside `JSON.parse`,
+ * before any validator on either side could see it, and neither party could
+ * detect that it had happened. That is why the solver's schema types
+ * `evm_amount` as a string, why its store declares the column TEXT, and why
+ * § 2.1 of the protocol specifies a canonical decimal string for every amount.
+ *
+ * `bigint` at the API boundary because it is the only exact integer JS has,
+ * and every comparison a client makes against these values — is this the
+ * amount I asked for, is the lock funded for what was quoted — has to be
+ * exact. `String(aBigint)` is already the canonical form for a non-negative
+ * value: digits only, no separator, no exponent, no leading zero. So encoding
+ * needs no formatter, and the only real work is on the way IN — see {@link
+ * evmAmountFromWire}, which refuses a JSON number outright.
+ *
+ * The SATS side of both corridors stays a JSON `number`, matching the four BTC
+ * corridors and the solver's own schemas. § 2.1 makes those strings too; that
+ * is a migration for corridors that already ship, in flight separately, and
+ * bundling it here would change five corridors to add one.
+ */
+import { hex } from "@scure/base";
+
+import { ARKADE_BTC, assertPairLength, rfqPair } from "./rfq";
+
+// ── Pairs and token identity ────────────────────────────────────────────────
+
+/** The EVM leg's chain namespace. One value: the corridor is EVM-shaped, and
+ * WHICH chain it runs on is named by the quote's `evm_chain_id`, not by the
+ * pair. A second namespace here would be a second market key for one corridor. */
+export const EVM_CHAIN = "ethereum";
+
+/** `0x` then 40 hex, either case — what an EIP-55 checksummed address looks
+ * like, and what the solver's profile schema accepts for `evm_claim_address`
+ * and `evm_refund_address`. */
+const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * Atomic units as a canonical decimal string: digits only, no sign, no point,
+ * no exponent, no leading zero. The solver's `TOKEN_AMOUNT`, restated.
+ *
+ * Anchored, so `1e18` is refused rather than partially matched. Three
+ * spellings of exponent notation exist, and quietly reading one wrong
+ * misprices by eighteen orders of magnitude.
+ */
+const TOKEN_AMOUNT = /^(0|[1-9][0-9]*)$/;
+
+/** The two directional pair spellings, LOWERCASE token only — the solver's
+ * `evmDirectionOf`, restated. */
+const SEND_PAIR = /^arkade:BTC->ethereum:0x[0-9a-f]{40}$/;
+const RECEIVE_PAIR = /^ethereum:0x[0-9a-f]{40}->arkade:BTC$/;
+
+/**
+ * The `ethereum:<token>` leg for an ERC20, LOWERCASED.
+ *
+ * Accepts a checksummed address and emits a lowercase one, deliberately. The
+ * solver's pair regex is lowercase-only while its profile address schema is
+ * case-insensitive, so the same address is legal in one field of a request and
+ * refused in another — and a client that normalised in only one place would
+ * build a request whose profile parses and whose pair is `unsupported_pair`.
+ *
+ * The same rule, and the same reason, as `arkadeAssetLeg` for asset ids:
+ * solvers compare pair strings byte for byte, so one spelling normalised in
+ * one layer and not another derives the right market key and is then skipped
+ * as an unserved pair.
+ */
+export const evmTokenLeg = (tokenAddress: string): string =>
+    `${EVM_CHAIN}:${assertEvmAddress(tokenAddress, "token address").toLowerCase()}`;
+
+/** `arkade:BTC->ethereum:<token>` — the client locks sats, the solver pays
+ * tokens. */
+export const evmSendPair = (tokenAddress: string): string => {
+    const pair = rfqPair(ARKADE_BTC, evmTokenLeg(tokenAddress));
+    assertPairLength(pair);
+    return pair;
+};
+
+/** `ethereum:<token>->arkade:BTC` — the client locks tokens, the solver pays
+ * sats. */
+export const evmReceivePair = (tokenAddress: string): string => {
+    const pair = rfqPair(evmTokenLeg(tokenAddress), ARKADE_BTC);
+    assertPairLength(pair);
+    return pair;
+};
+
+/**
+ * Which EVM direction a pair names, or `null` when it names neither.
+ *
+ * Mirrors the solver's `evmDirectionOf`, and exists for the same reason: an
+ * EVM pair is not a constant, so nothing can dispatch on it by equality. A
+ * client holding a stored swap or an inbound status has only the pair string
+ * to decide what it is looking at.
+ */
+export const evmDirectionOf = (pair: string): "send" | "receive" | null => {
+    if (SEND_PAIR.test(pair)) return "send";
+    if (RECEIVE_PAIR.test(pair)) return "receive";
+    return null;
+};
+
+/** The lowercase ERC20 address an EVM pair names, or `null` when the pair is
+ * not an EVM one. */
+export const evmTokenOf = (pair: string): string | null => {
+    const direction = evmDirectionOf(pair);
+    if (direction === null) return null;
+    const leg =
+        direction === "send"
+            ? pair.slice(pair.indexOf("->") + 2)
+            : pair.slice(0, pair.indexOf("->"));
+    return leg.slice(EVM_CHAIN.length + 1);
+};
+
+// ── Amounts ─────────────────────────────────────────────────────────────────
+
+/**
+ * A token quantity in the wire's canonical decimal form.
+ *
+ * Refuses a negative value rather than emitting `-1`: the solver's schema is
+ * anchored, so it would answer `unsupported_payload`, which says nothing about
+ * which field was wrong.
+ */
+export const evmAmountToWire = (units: bigint): string => {
+    if (units < 0n) throw new Error(`token amount may not be negative, got ${units}`);
+    return units.toString();
+};
+
+/**
+ * A token quantity off the wire, as an exact `bigint`.
+ *
+ * **A JSON number is refused, never coerced.** This is the whole point of the
+ * string encoding: by the time a number is sitting in one of these fields,
+ * `JSON.parse` has already rounded it to the nearest double and the original
+ * value is gone. Accepting it — via `BigInt(Math.trunc(v))`, or the implicit
+ * coercion any arithmetic on it would do — turns a detectable protocol
+ * violation into a silently wrong amount, which is exactly the failure the
+ * encoding exists to make impossible.
+ *
+ * Non-canonical strings are refused for the same reason: `"0x10"`, `"1e18"`,
+ * `"01"` and `" 1"` all have a plausible reading and at least one wrong one.
+ */
+export const evmAmountFromWire = (value: unknown, field: string): bigint => {
+    if (typeof value !== "string") {
+        throw new Error(
+            `${field} must be a decimal string of atomic units, not a JSON ${typeof value} — ` +
+                `a number here has already been rounded by the parser`,
+        );
+    }
+    if (!TOKEN_AMOUNT.test(value)) {
+        throw new Error(`${field} is not a canonical decimal amount: ${JSON.stringify(value)}`);
+    }
+    return BigInt(value);
+};
+
+// ── Requests ────────────────────────────────────────────────────────────────
+
+/**
+ * The `rfq_request` for `arkade:BTC->ethereum:<token>`.
+ *
+ * **Exact-in only.** `amount_side` is pinned to `"from"` and `amount` is sats:
+ * the `to` leg is a different asset, so exact-out would mean inverting a
+ * fetched, rounded, directional rate. The solver's schema pins the literal, so
+ * an exact-out request is refused rather than served at a worse price.
+ *
+ * The client funds the Arkade covenant FIRST on this corridor, and funding is
+ * acceptance — so it holds that side's refund role, and `client_refund_pubkey`
+ * is its own x-only key for the covenant's client-side refund leaves. Same
+ * role and same field name as on the Lightning and onchain send legs.
+ *
+ * `evmClaimAddress` is the client's own EVM address, and the only party
+ * `ERC20Swap.claim` will pay. Sent as given: the solver's schema is
+ * case-insensitive here, and flattening an EIP-55 checksum would throw away
+ * the typo protection that spelling exists for.
+ */
+export const evmSendRequest = (input: {
+    rfqId: string;
+    /** The ERC20 being bought. Normalised into the pair — see {@link evmTokenLeg}. */
+    tokenAddress: string;
+    /** `sha256(P)`, hex — client-chosen; see `paymentHashOf`. */
+    paymentHash: string;
+    /** Where the CLIENT takes the tokens. */
+    evmClaimAddress: string;
+    /** The client's Arkade address — where the covenant refund must pay. */
+    refundAddress: string;
+    /** The client's own x-only key for the covenant's refund leaves. */
+    senderPubkey: Uint8Array;
+    /** Sats the client locks. Exact-in. */
+    amountSats: number;
+}): Record<string, unknown> => {
+    assertPositiveInteger(input.amountSats, "amountSats");
+    return {
+        v: 1,
+        type: "rfq_request",
+        rfq_id: input.rfqId,
+        pair: evmSendPair(input.tokenAddress),
+        amount_side: "from",
+        amount: input.amountSats,
+        profile: {
+            payment_hash: input.paymentHash,
+            evm_claim_address: assertEvmAddress(input.evmClaimAddress, "evmClaimAddress"),
+            refund_address: input.refundAddress,
+            client_refund_pubkey: hex.encode(input.senderPubkey),
+        },
+    };
+};
+
+/**
+ * The `rfq_request` for `ethereum:<token>->arkade:BTC`.
+ *
+ * **The envelope carries no `amount` at all**, and its absence is load-bearing
+ * rather than an omission. What the client gives is a token quantity; the
+ * envelope's `amount` is a JSON number, so it cannot hold one. `evm_amount`
+ * carries it in the profile as a decimal string instead. The solver's schema
+ * is `.strict()`, so an `amount` added "for symmetry" is not ignored — it is
+ * an undeclared key, and the whole request is refused as `unsupported_payload`.
+ *
+ * `amount_side` stays `"from"`: the client still names what it gives.
+ *
+ * **`evm_timeout_block` is the CLIENT's own deadline** on this corridor,
+ * because the client locks the ERC20 first. The solver validates it, derives
+ * its own `refund_locktime` underneath it, and refuses outright if the
+ * ordering cannot hold. It is a BLOCK HEIGHT — see {@link
+ * EvmSendQuoteProfile.evm_timeout_block}.
+ *
+ * There is deliberately no `claim_packet` here, unlike the two BTC receive
+ * legs: this profile does not offer the covclaimd non-interactive path, so the
+ * client must be online to claim its own Arkade payout.
+ */
+export const evmReceiveRequest = (input: {
+    rfqId: string;
+    /** The ERC20 being sold. Normalised into the pair — see {@link evmTokenLeg}. */
+    tokenAddress: string;
+    /** `sha256(P)`, hex — client-chosen. */
+    paymentHash: string;
+    /** Atomic units of the token the client locks. */
+    evmAmount: bigint;
+    /** BLOCK HEIGHT after which the client may take its own tokens back. */
+    evmTimeoutBlock: number;
+    /** Where the client's own EVM refund goes. */
+    evmRefundAddress: string;
+    /** The client's Arkade address — where the swapped sats land. */
+    payoutAddress: string;
+    /** The client's x-only Arkade key — the covenant's `receiver` role. */
+    payoutPubkey: Uint8Array;
+}): Record<string, unknown> => {
+    assertPositiveInteger(input.evmTimeoutBlock, "evmTimeoutBlock");
+    return {
+        v: 1,
+        type: "rfq_request",
+        rfq_id: input.rfqId,
+        pair: evmReceivePair(input.tokenAddress),
+        amount_side: "from",
+        profile: {
+            payment_hash: input.paymentHash,
+            evm_amount: evmAmountToWire(input.evmAmount),
+            evm_timeout_block: input.evmTimeoutBlock,
+            evm_refund_address: assertEvmAddress(input.evmRefundAddress, "evmRefundAddress"),
+            payout_address: input.payoutAddress,
+            payout_pubkey: hex.encode(input.payoutPubkey),
+        },
+    };
+};
+
+// ── Quotes ──────────────────────────────────────────────────────────────────
+
+/** What both EVM quote profiles carry. */
+interface EvmQuoteProfileCommon {
+    /** Echo of the client's own `payment_hash`. */
+    payment_hash: string;
+    /** Compare-only: the solver's derivation of the Arkade covenant. NEVER
+     * fund it without re-deriving it locally and matching. */
+    lockup_address: string;
+    /** Which `ERC20Swap` the lock lives in. */
+    evm_contract_address: string;
+    /** Which chain. The same swap key can exist on two of them. */
+    evm_chain_id: number;
+    /** Depth AND age, and the observing side waits for the LATER of the two:
+     * a rollup sequencer can put a lock many confirmations deep in seconds
+     * while the L1 posting it has not finalised. */
+    min_confirmations: number;
+    min_age_seconds: number;
+    [key: string]: unknown;
+}
+
+/** `arkade:BTC->ethereum:<token>`. */
+export interface EvmSendQuoteProfile extends EvmQuoteProfileCommon {
+    /**
+     * Compare-only, and the client cannot re-derive `lockup_address` without
+     * it: the covenant's merkle root spans every leaf, and this one's
+     * destination — the solver's own claim pkScript — is known to nobody else.
+     * It carries none of `lockup_address`'s trust weight itself, since a wrong
+     * value only makes that one leaf unusable for the solver.
+     */
+    receiver_pk_script: string;
+    /**
+     * The deadline the SOLVER's own ERC20 lock carries, as a BLOCK HEIGHT —
+     * `ERC20Swap` denominates its timeout in `block.number`.
+     *
+     * Do NOT diff it against `refund_locktime`, which sits beside it in the
+     * same quote and is unix seconds. The `_block` suffix is the only thing
+     * distinguishing them, and a client reading this one as seconds measures
+     * its recourse window against a ~5-million-block integer, concludes it has
+     * centuries in hand, and skips the check that was protecting it.
+     *
+     * Comparing the two needs a per-chain block cadence, and the safe
+     * direction differs by use — reading someone else's timeout assumes the
+     * FASTEST cadence, sizing your own assumes the SLOWEST. This module does
+     * not invent a constant for that; the ordering gate lands with the
+     * covenant derivation.
+     */
+    evm_timeout_block: number;
+}
+
+/** `ethereum:<token>->arkade:BTC`. */
+export interface EvmReceiveQuoteProfile extends EvmQuoteProfileCommon {
+    /** The mirror of the send leg's `receiver_pk_script`: with the roles
+     * exchanged, the leaf the client cannot supply for itself is the SOLVER's
+     * refund destination. Compare-only, and needed to rebuild the merkle root
+     * behind the client's own payout. */
+    solver_refund_pk_script: string;
+    /** The SOLVER's EVM address — the value the client MUST pass as
+     * `claimAddress` when it locks. */
+    evm_claim_address: string;
+}
+
+/**
+ * A quote for `arkade:BTC->ethereum:<token>`.
+ *
+ * `from_amount` and `to_amount` are in DIFFERENT ASSETS — sats in, token
+ * atomic units out — so they are not comparable as numbers, and the spread
+ * between them is not a fee. What a fee ceiling needs on a cross-asset pair is
+ * a reference rate of the caller's own; `assertFundable`'s `maxFee` takes one,
+ * and `maxFee.referenceRate` is `to`-units per `from`-unit, which on this
+ * direction means **token atomic units per sat**.
+ */
+export interface EvmSendQuote {
+    v: 1;
+    type: "rfq_quote";
+    rfq_id: string;
+    pair: string;
+    /** Sats the client locks in the Arkade covenant. */
+    from_amount: number;
+    /** Token atomic units the solver will lock, canonical decimal string. */
+    to_amount: string;
+    solver_pubkey: string;
+    valid_until: number;
+    /** Unix seconds — the CLIENT's Arkade refund deadline on this corridor. */
+    refund_locktime: number;
+    profile: EvmSendQuoteProfile;
+    [key: string]: unknown;
+}
+
+/** A quote for `ethereum:<token>->arkade:BTC`. `maxFee.referenceRate` on this
+ * direction is **sats per token atomic unit**, the `to`-per-`from` convention
+ * again — the reciprocal of the send leg's, and the easiest thing here to get
+ * wrong by a factor of the token's decimals. */
+export interface EvmReceiveQuote {
+    v: 1;
+    type: "rfq_quote";
+    rfq_id: string;
+    pair: string;
+    /** Token atomic units the client locks, canonical decimal string. */
+    from_amount: string;
+    /** Sats the solver's Arkade lockup will carry. */
+    to_amount: number;
+    solver_pubkey: string;
+    valid_until: number;
+    /** Unix seconds — the SOLVER's Arkade refund deadline on this corridor. */
+    refund_locktime: number;
+    profile: EvmReceiveQuoteProfile;
+    [key: string]: unknown;
+}
+
+/** Either direction. Use where a quote is carried rather than decided upon. */
+export type EvmRfqQuote = EvmSendQuote | EvmReceiveQuote;
+
+/**
+ * Narrow and check a solver's reply to {@link evmSendRequest}.
+ *
+ * Checks SHAPE, not trust. Nothing here makes `lockup_address` safe to fund —
+ * that takes a local re-derivation of the covenant. What it does buy is that
+ * every field the funding path will later read is present and of the right
+ * kind, so a missing `min_age_seconds` fails here, at the quote, rather than
+ * by deleting an acceptance gate hours later.
+ *
+ * **Unknown fields are ignored**, in both the envelope and the profile.
+ * Requests are strict and responses are tolerant (§ 1 of the protocol), so a
+ * solver may extend a quote without a version bump, and a client that refused
+ * the extension would be the one that broke.
+ *
+ * Pass the token you asked for: a quote naming a different one is a different
+ * market, and comparing the pair is the only way to notice.
+ */
+export const readEvmSendQuote = (
+    payload: unknown,
+    expected: { tokenAddress: string },
+): EvmSendQuote => {
+    const { quote, profile } = readEvmQuoteEnvelope(payload, evmSendPair(expected.tokenAddress));
+    readCommonProfile(profile);
+    assertHex(profile.receiver_pk_script, "profile.receiver_pk_script");
+    assertPositiveInteger(profile.evm_timeout_block, "profile.evm_timeout_block");
+    // Refused rather than read as a number: the token side of this quote is
+    // what the client is buying, and a rounded value would be compared against
+    // the ERC20 lock and match nothing.
+    evmAmountFromWire(quote.to_amount, "to_amount");
+    assertPositiveInteger(quote.from_amount, "from_amount");
+    return quote as unknown as EvmSendQuote;
+};
+
+/** Narrow and check a solver's reply to {@link evmReceiveRequest}. See {@link
+ * readEvmSendQuote} for what this does and does not promise. */
+export const readEvmReceiveQuote = (
+    payload: unknown,
+    expected: { tokenAddress: string },
+): EvmReceiveQuote => {
+    const { quote, profile } = readEvmQuoteEnvelope(payload, evmReceivePair(expected.tokenAddress));
+    readCommonProfile(profile);
+    assertHex(profile.solver_refund_pk_script, "profile.solver_refund_pk_script");
+    assertEvmAddress(
+        asString(profile.evm_claim_address, "profile.evm_claim_address"),
+        "profile.evm_claim_address",
+    );
+    evmAmountFromWire(quote.from_amount, "from_amount");
+    assertPositiveInteger(quote.to_amount, "to_amount");
+    return quote as unknown as EvmReceiveQuote;
+};
+
+/**
+ * The token quantity an EVM quote names, exactly.
+ *
+ * Whichever leg is the token's — `to_amount` on a send quote, `from_amount` on
+ * a receive one. The direction is read off the pair rather than taken as an
+ * argument, so a caller cannot ask for the wrong side and get the sats leg
+ * turned into a `bigint` that looks like a token amount.
+ */
+export const evmQuoteTokenAmount = (quote: EvmRfqQuote): bigint => {
+    const direction = evmDirectionOf(quote.pair);
+    if (direction === null) throw new Error(`not an EVM pair: ${JSON.stringify(quote.pair)}`);
+    return direction === "send"
+        ? evmAmountFromWire(quote.to_amount, "to_amount")
+        : evmAmountFromWire(quote.from_amount, "from_amount");
+};
+
+/** The sats leg of an EVM quote — `from_amount` on a send quote, `to_amount`
+ * on a receive one. The counterpart of {@link evmQuoteTokenAmount}, read the
+ * same way off the pair, so the two can never be taken off the same side. */
+export const evmQuoteSats = (quote: EvmRfqQuote): number => {
+    const direction = evmDirectionOf(quote.pair);
+    if (direction === null) throw new Error(`not an EVM pair: ${JSON.stringify(quote.pair)}`);
+    const field = direction === "send" ? "from_amount" : "to_amount";
+    const sats = quote[field];
+    assertPositiveInteger(sats, field);
+    return sats as number;
+};
+
+// ── Shared checks ───────────────────────────────────────────────────────────
+
+const assertEvmAddress = (value: string, field: string): string => {
+    if (!EVM_ADDRESS.test(value)) {
+        throw new Error(`${field} must be 0x then 40 hex, got ${JSON.stringify(value)}`);
+    }
+    return value;
+};
+
+const assertPositiveInteger = (value: unknown, field: string): void => {
+    if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+        throw new Error(`${field} must be a positive integer, got ${String(value)}`);
+    }
+};
+
+const assertNonNegativeInteger = (value: unknown, field: string): void => {
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+        throw new Error(`${field} must be a non-negative integer, got ${String(value)}`);
+    }
+};
+
+const assertHex = (value: unknown, field: string): void => {
+    if (typeof value !== "string" || value.length === 0 || !/^[0-9a-f]+$/.test(value)) {
+        throw new Error(`${field} must be lowercase hex, got ${String(value)}`);
+    }
+};
+
+const asString = (value: unknown, field: string): string => {
+    if (typeof value !== "string") {
+        throw new Error(`${field} must be a string, got ${String(value)}`);
+    }
+    return value;
+};
+
+const readEvmQuoteEnvelope = (
+    payload: unknown,
+    expectedPair: string,
+): { quote: Record<string, unknown>; profile: Record<string, unknown> } => {
+    if (!payload || typeof payload !== "object") throw new Error("EVM quote is not an object");
+    const quote = payload as Record<string, unknown>;
+    if (quote.type !== "rfq_quote") {
+        throw new Error(`expected an rfq_quote, got ${String(quote.type)}`);
+    }
+    if (quote.pair !== expectedPair) {
+        throw new Error(`solver quoted ${JSON.stringify(quote.pair)}, not ${expectedPair}`);
+    }
+    asString(quote.solver_pubkey, "solver_pubkey");
+    assertPositiveInteger(quote.valid_until, "valid_until");
+    // Required on both directions, unlike the arkade-to-arkade class: an EVM
+    // corridor always has an Arkade covenant on one side, and a quote with no
+    // refund deadline for it is one whose recourse window cannot be checked.
+    assertPositiveInteger(quote.refund_locktime, "refund_locktime");
+    if (!quote.profile || typeof quote.profile !== "object") {
+        throw new Error("EVM quote carries no profile");
+    }
+    return { quote, profile: quote.profile as Record<string, unknown> };
+};
+
+const readCommonProfile = (profile: Record<string, unknown>): void => {
+    asString(profile.payment_hash, "profile.payment_hash");
+    asString(profile.lockup_address, "profile.lockup_address");
+    assertEvmAddress(
+        asString(profile.evm_contract_address, "profile.evm_contract_address"),
+        "profile.evm_contract_address",
+    );
+    assertPositiveInteger(profile.evm_chain_id, "profile.evm_chain_id");
+    assertPositiveInteger(profile.min_confirmations, "profile.min_confirmations");
+    // Zero is legal and meaningful: it says the corridor gates on depth alone,
+    // which is a solver's choice on a chain with real block times. Refusing it
+    // would refuse a correct quote.
+    assertNonNegativeInteger(profile.min_age_seconds, "profile.min_age_seconds");
+};

--- a/packages/swap/src/evmRfq.ts
+++ b/packages/swap/src/evmRfq.ts
@@ -340,6 +340,30 @@ export interface EvmSendQuoteProfile extends EvmQuoteProfileCommon {
      */
     receiver_pk_script: string;
     /**
+     * The SOLVER's EVM address — and on this leg the client cannot settle
+     * without it.
+     *
+     * Every EVM address on this wire names a ROLE, not a party.
+     * `evm_refund_address` is whoever the CONTRACT refunds, which here is the
+     * solver, because the solver is the side that locks. It is the mirror of
+     * the receive leg, where the client locks and sends its own
+     * `evm_refund_address` in the request — same name, same meaning, other
+     * party. Read it as "the client's" on both and this leg silently breaks.
+     *
+     * TWO uses, neither optional:
+     *
+     * 1. The sixth field of the swap key. `ERC20Swap` stores no per-swap
+     *    struct — just `mapping(bytes32 => bool)` over
+     *    `keccak256(abi.encode(preimageHash, amount, tokenAddress,
+     *    claimAddress, refundAddress, timelock))`. With five of six a client
+     *    cannot compute the key, so it cannot read `swaps(key)` to prove the
+     *    solver locked before it parts with the preimage.
+     * 2. An explicit argument to `claim(bytes32,uint256,address,address,
+     *    uint256)`. The caller is the claimer, so the contract takes
+     *    `claimAddress` from `msg.sender` and must be told the other side.
+     */
+    evm_refund_address: string;
+    /**
      * The deadline the SOLVER's own ERC20 lock carries, as a BLOCK HEIGHT —
      * `ERC20Swap` denominates its timeout in `block.number`.
      *
@@ -464,6 +488,13 @@ export const readEvmSendQuote = (
     );
     readCommonProfile(profile);
     assertHex(profile.receiver_pk_script, "profile.receiver_pk_script");
+    // Required, not optional. A send quote without it is one this client can
+    // neither verify nor claim — see `EvmSendQuoteProfile.evm_refund_address`.
+    // Refusing at the quote is the only place that failure is cheap.
+    assertEvmAddress(
+        asString(profile.evm_refund_address, "profile.evm_refund_address"),
+        "profile.evm_refund_address",
+    );
     assertPositiveInteger(profile.evm_timeout_block, "profile.evm_timeout_block");
     // Refused rather than read as a number: the token side of this quote is
     // what the client is buying, and a rounded value would be compared against

--- a/packages/swap/src/evmRfq.ts
+++ b/packages/swap/src/evmRfq.ts
@@ -425,8 +425,14 @@ export type EvmRfqQuote = EvmSendQuote | EvmReceiveQuote;
  * solver may extend a quote without a version bump, and a client that refused
  * the extension would be the one that broke.
  *
- * Pass the token you asked for: a quote naming a different one is a different
- * market, and comparing the pair is the only way to notice.
+ * Pass the token AND the negotiation you asked for. A quote naming a different
+ * token is a different market, and comparing the pair is the only way to
+ * notice. `rfqId` is required rather than optional for the reason `expectQuote`
+ * checks it: on a shared relay every one of a solver's events arrives on the
+ * same subscription, so nothing but this id distinguishes the answer to THIS
+ * negotiation from the answer to another one — and an optional check is one a
+ * caller forgets exactly when several are in flight, which is the only time it
+ * matters.
  *
  * **Takes `unknown`, and pass a transport's result straight in.**
  * `RfqTransport.requestQuote` is typed `Promise<RfqQuote>`, which is not
@@ -439,9 +445,13 @@ export type EvmRfqQuote = EvmSendQuote | EvmReceiveQuote;
  */
 export const readEvmSendQuote = (
     payload: unknown,
-    expected: { tokenAddress: string },
+    expected: { tokenAddress: string; rfqId: string },
 ): EvmSendQuote => {
-    const { quote, profile } = readEvmQuoteEnvelope(payload, evmSendPair(expected.tokenAddress));
+    const { quote, profile } = readEvmQuoteEnvelope(
+        payload,
+        evmSendPair(expected.tokenAddress),
+        expected.rfqId,
+    );
     readCommonProfile(profile);
     assertHex(profile.receiver_pk_script, "profile.receiver_pk_script");
     assertPositiveInteger(profile.evm_timeout_block, "profile.evm_timeout_block");
@@ -457,9 +467,13 @@ export const readEvmSendQuote = (
  * readEvmSendQuote} for what this does and does not promise. */
 export const readEvmReceiveQuote = (
     payload: unknown,
-    expected: { tokenAddress: string },
+    expected: { tokenAddress: string; rfqId: string },
 ): EvmReceiveQuote => {
-    const { quote, profile } = readEvmQuoteEnvelope(payload, evmReceivePair(expected.tokenAddress));
+    const { quote, profile } = readEvmQuoteEnvelope(
+        payload,
+        evmReceivePair(expected.tokenAddress),
+        expected.rfqId,
+    );
     readCommonProfile(profile);
     assertHex(profile.solver_refund_pk_script, "profile.solver_refund_pk_script");
     assertEvmAddress(
@@ -536,11 +550,21 @@ const asString = (value: unknown, field: string): string => {
 const readEvmQuoteEnvelope = (
     payload: unknown,
     expectedPair: string,
+    expectedRfqId: string,
 ): { quote: Record<string, unknown>; profile: Record<string, unknown> } => {
     if (!payload || typeof payload !== "object") throw new Error("EVM quote is not an object");
     const quote = payload as Record<string, unknown>;
     if (quote.type !== "rfq_quote") {
         throw new Error(`expected an rfq_quote, got ${String(quote.type)}`);
+    }
+    // Before the pair, deliberately: a reply to another negotiation may well be
+    // for the same market, so the pair check would pass it and the diagnostic
+    // would be about a field that was never wrong.
+    if (quote.rfq_id !== expectedRfqId) {
+        throw new Error(
+            `quote is for rfq_id ${JSON.stringify(quote.rfq_id)}, not this negotiation's ` +
+                `${expectedRfqId}`,
+        );
     }
     if (quote.pair !== expectedPair) {
         throw new Error(`solver quoted ${JSON.stringify(quote.pair)}, not ${expectedPair}`);

--- a/packages/swap/src/evmRfq.ts
+++ b/packages/swap/src/evmRfq.ts
@@ -281,6 +281,16 @@ export const evmReceiveRequest = (input: {
     payoutPubkey: Uint8Array;
 }): Record<string, unknown> => {
     assertPositiveInteger(input.evmTimeoutBlock, "evmTimeoutBlock");
+    // Zero is a legal ENCODING and not a legal amount, which is why the check
+    // belongs here and not in `evmAmountToWire`: `"0"` is canonical per § 2.1
+    // and the codec has to keep emitting and reading it, while a lock of no
+    // tokens is a swap that cannot be filled. The solver refuses it as
+    // `amount_out_of_range`; saying so here names the field instead.
+    if (input.evmAmount <= 0n) {
+        throw new Error(
+            `evmAmount must be a positive number of atomic units, got ${input.evmAmount}`,
+        );
+    }
     return {
         v: 1,
         type: "rfq_request",
@@ -457,7 +467,10 @@ export const readEvmSendQuote = (
     assertPositiveInteger(profile.evm_timeout_block, "profile.evm_timeout_block");
     // Refused rather than read as a number: the token side of this quote is
     // what the client is buying, and a rounded value would be compared against
-    // the ERC20 lock and match nothing.
+    // the ERC20 lock and match nothing. Called for the THROW, not the value —
+    // the amount is retrieved later, from the returned quote, via
+    // `evmQuoteTokenAmount`. Returning it here would hand callers a second,
+    // divergeable copy of a number the quote already carries.
     evmAmountFromWire(quote.to_amount, "to_amount");
     assertPositiveInteger(quote.from_amount, "from_amount");
     return quote as unknown as EvmSendQuote;
@@ -480,6 +493,7 @@ export const readEvmReceiveQuote = (
         asString(profile.evm_claim_address, "profile.evm_claim_address"),
         "profile.evm_claim_address",
     );
+    // Called for the throw, not the value — see the send reader above.
     evmAmountFromWire(quote.from_amount, "from_amount");
     assertPositiveInteger(quote.to_amount, "to_amount");
     return quote as unknown as EvmReceiveQuote;
@@ -555,6 +569,15 @@ const assertHex = (value: unknown, field: string): void => {
     }
 };
 
+/** A 32-byte hash: exactly 64 lowercase hex. The solver's `HEX32`, restated —
+ * fixed-length, unlike {@link assertHex}, because a payment hash of the wrong
+ * SIZE is a different value, not a truncated spelling of the right one. */
+const assertHash32 = (value: unknown, field: string): void => {
+    if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+        throw new Error(`${field} must be 64 lowercase hex characters, got ${String(value)}`);
+    }
+};
+
 const asString = (value: unknown, field: string): string => {
     if (typeof value !== "string") {
         throw new Error(`${field} must be a string, got ${String(value)}`);
@@ -597,7 +620,14 @@ const readEvmQuoteEnvelope = (
 };
 
 const readCommonProfile = (profile: Record<string, unknown>): void => {
-    asString(profile.payment_hash, "profile.payment_hash");
+    // 32 bytes, not merely a string: this is `sha256(P)`, and every other
+    // structured field here enforces its encoding. A solver echoing a
+    // `payment_hash` that is not hex would otherwise reach the caller intact
+    // and fail at the covenant, reported as a broken covenant rather than as
+    // the malformed echo it is. The solver's own schema is `HEX32`, so a
+    // correct one never sends this — the reader should still be the layer that
+    // says so.
+    assertHash32(profile.payment_hash, "profile.payment_hash");
     asString(profile.lockup_address, "profile.lockup_address");
     assertEvmAddress(
         asString(profile.evm_contract_address, "profile.evm_contract_address"),

--- a/packages/swap/src/evmRfq.ts
+++ b/packages/swap/src/evmRfq.ts
@@ -427,6 +427,15 @@ export type EvmRfqQuote = EvmSendQuote | EvmReceiveQuote;
  *
  * Pass the token you asked for: a quote naming a different one is a different
  * market, and comparing the pair is the only way to notice.
+ *
+ * **Takes `unknown`, and pass a transport's result straight in.**
+ * `RfqTransport.requestQuote` is typed `Promise<RfqQuote>`, which is not
+ * accurate for an EVM quote — `RfqQuote` declares both amounts `number`, and
+ * on this corridor one of them is a decimal string. The transport does not
+ * inspect them, so the value is right and only the type is wrong; running it
+ * through here is what makes the two agree again. Do not read `to_amount` off
+ * the transport's return value directly: it types as a `number`, it is a
+ * string, and `+` on it concatenates.
  */
 export const readEvmSendQuote = (
     payload: unknown,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -130,6 +130,30 @@ export {
     type RfqStatus,
     type RfqTransport,
 } from "./rfq";
+// The EVM corridors' wire layer. Negotiation only — pairs, amounts, the two
+// request shapes and the two quote shapes; see `evmRfq.ts` for what is
+// deliberately not here yet.
+export {
+    EVM_CHAIN,
+    evmAmountFromWire,
+    evmAmountToWire,
+    evmDirectionOf,
+    evmQuoteSats,
+    evmQuoteTokenAmount,
+    evmReceivePair,
+    evmReceiveRequest,
+    evmSendPair,
+    evmSendRequest,
+    evmTokenLeg,
+    evmTokenOf,
+    readEvmReceiveQuote,
+    readEvmSendQuote,
+    type EvmReceiveQuote,
+    type EvmReceiveQuoteProfile,
+    type EvmRfqQuote,
+    type EvmSendQuote,
+    type EvmSendQuoteProfile,
+} from "./evmRfq";
 export {
     LOCKTIME_THRESHOLD,
     ONCHAIN_DUST_SATS,

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -85,6 +85,9 @@ import {
 } from "@arkade-os/sdk";
 import { sealClaimPacket } from "./claimPacket";
 import { registerLockupContract } from "./lockupContract";
+// Type-only, and it has to stay that way: `evmRfq.ts` imports the pair
+// helpers from here, so a value import would close the cycle at run time.
+import type { EvmRfqQuote } from "./evmRfq";
 
 /** Decode a solver-supplied hex field, turning a malformed value (odd length,
  * non-hex chars) into a solver-blaming diagnostic instead of a bare
@@ -428,9 +431,22 @@ const matchQuotedLockup = (
  * lightning leg has a second clock that can actually run out (the hold
  * invoice's), which is what the split buys. The onchain-receive leg stays here
  * until its own deadline gets the same treatment; the headroom check is merely
- * over-strict there, never unsafe. */
+ * over-strict there, never unsafe.
+ *
+ * An {@link EvmRfqQuote} is accepted too. The gates it reaches — `valid_until`
+ * and the refund headroom — are the right ones for both EVM corridors, and
+ * both read a plain `number`. What it does NOT yet get is the EVM deadline
+ * ordering: that compares `evm_timeout_block` against `refund_locktime`, which
+ * are a block height and unix seconds, and bridging them needs a per-chain
+ * cadence (see `evmRfq.ts`). It lands with the covenant derivation.
+ *
+ * The widened parameter is also what stops the amounts being read as sats. An
+ * EVM quote's token leg is a canonical decimal string, so `from_amount` and
+ * `to_amount` are `number | string` across the union and no arithmetic
+ * compiles against them unsplit — read them through `evmQuoteSats` and
+ * `evmQuoteTokenAmount`, which pick the side off the pair. */
 export const assertFundable = (input: {
-    quote: RfqQuote;
+    quote: RfqQuote | EvmRfqQuote;
     invoiceExpiresAt?: number;
     now: number;
     onchain?: {

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -444,7 +444,8 @@ const matchQuotedLockup = (
  * EVM quote's token leg is a canonical decimal string, so `from_amount` and
  * `to_amount` are `number | string` across the union and no arithmetic
  * compiles against them unsplit — read them through `evmQuoteSats` and
- * `evmQuoteTokenAmount`, which pick the side off the pair. */
+ * `evmQuoteTokenAmount`, which pick the side off the pair. `maxFee` is
+ * therefore REFUSED on an EVM quote with `fee_gate_unavailable`. */
 export const assertFundable = (input: {
     quote: RfqQuote | EvmRfqQuote;
     invoiceExpiresAt?: number;
@@ -501,6 +502,18 @@ export const assertFundable = (input: {
         if (sats !== undefined && (!Number.isInteger(sats) || sats < 0)) {
             fail("max_fee_out_of_range", `maxFee.sats must be a non-negative integer, got ${sats}`);
         }
+        // NOT NaN: `*` and `-` coerce the token leg's decimal string, so the
+        // gate would compare base units against sats and answer confidently.
+        // Measured without this: a send quote passes even `{ sats: 0 }`.
+        const { from_amount: fromAmount, to_amount: toAmount } = input.quote;
+        if (typeof fromAmount !== "number" || typeof toAmount !== "number") {
+            throw gateError(
+                "fee_gate_unavailable",
+                `maxFee cannot gate ${input.quote.pair}: an EVM token leg is a decimal ` +
+                    `string, not sats, and this gate does its arithmetic in numbers. ` +
+                    `Omit maxFee for an EVM corridor until the token-aware gate lands`,
+            );
+        }
         const legs = input.quote.pair.split("->");
         const assetOf = (leg: string): string => leg.slice(leg.indexOf(":") + 1);
         const sameAsset = legs.length === 2 && assetOf(legs[0]!) === assetOf(legs[1]!);
@@ -521,15 +534,11 @@ export const assertFundable = (input: {
         }
         // Rounds UP: refuse a borderline quote, do not fund a rounding artefact.
         const fee = sameAsset
-            ? input.quote.from_amount - input.quote.to_amount
+            ? fromAmount - toAmount
             : Math.ceil(
-                  (input.quote.from_amount * (referenceRate as number) - input.quote.to_amount) /
-                      (referenceRate as number),
+                  (fromAmount * (referenceRate as number) - toAmount) / (referenceRate as number),
               );
-        const allowed = Math.max(
-            sats ?? 0,
-            Math.floor((input.quote.from_amount * (bps ?? 0)) / 10_000),
-        );
+        const allowed = Math.max(sats ?? 0, Math.floor((fromAmount * (bps ?? 0)) / 10_000));
         if (fee > allowed) {
             fail("fee_too_high", `fee ${fee} exceeds the ${allowed} this client allows`);
         }

--- a/packages/swap/test/evmRfq.test.ts
+++ b/packages/swap/test/evmRfq.test.ts
@@ -351,9 +351,7 @@ describe("solver parity", () => {
             expect(() =>
                 readEvmSendQuote(
                     withoutKey(sendQuote() as unknown as Record<string, unknown>, key),
-                    {
-                        tokenAddress: USDC,
-                    },
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(new RegExp(`profile\\.${key}`));
         }
@@ -361,7 +359,7 @@ describe("solver parity", () => {
             expect(() =>
                 readEvmReceiveQuote(
                     withoutKey(receiveQuote() as unknown as Record<string, unknown>, key),
-                    { tokenAddress: USDC },
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(new RegExp(`profile\\.${key}`));
         }
@@ -600,14 +598,14 @@ describe("request builders", () => {
 
 describe("quote readers", () => {
     it("narrows a well-formed send quote", () => {
-        const quote = readEvmSendQuote(sendQuote(), { tokenAddress: USDC });
+        const quote = readEvmSendQuote(sendQuote(), { tokenAddress: USDC, rfqId: RFQ_ID });
         expect(quote.profile.evm_timeout_block).toBe(21_000_000);
         expect(evmQuoteTokenAmount(quote)).toBe(249_750_000_000_000_000_000n);
         expect(evmQuoteSats(quote)).toBe(250_000);
     });
 
     it("narrows a well-formed receive quote", () => {
-        const quote = readEvmReceiveQuote(receiveQuote(), { tokenAddress: USDC });
+        const quote = readEvmReceiveQuote(receiveQuote(), { tokenAddress: USDC, rfqId: RFQ_ID });
         expect(quote.profile.evm_claim_address).toBe(SOLVER_CLAIM_ADDRESS);
         expect(evmQuoteTokenAmount(quote)).toBe(249_750_000_000_000_000_000n);
         expect(evmQuoteSats(quote)).toBe(250_000);
@@ -616,33 +614,66 @@ describe("quote readers", () => {
     it("takes the token and sats legs off OPPOSITE sides per direction", () => {
         // The one thing that silently swaps: both quotes carry the same two
         // numbers, and reading the wrong side yields a plausible value.
-        const send = readEvmSendQuote(sendQuote(), { tokenAddress: USDC });
-        const receive = readEvmReceiveQuote(receiveQuote(), { tokenAddress: USDC });
+        const send = readEvmSendQuote(sendQuote(), { tokenAddress: USDC, rfqId: RFQ_ID });
+        const receive = readEvmReceiveQuote(receiveQuote(), { tokenAddress: USDC, rfqId: RFQ_ID });
         expect(BigInt(send.to_amount)).toBe(evmQuoteTokenAmount(send));
         expect(send.from_amount).toBe(evmQuoteSats(send));
         expect(BigInt(receive.from_amount)).toBe(evmQuoteTokenAmount(receive));
         expect(receive.to_amount).toBe(evmQuoteSats(receive));
     });
 
+    it("refuses a quote for another negotiation, even on the same market", () => {
+        // The case the pair check cannot catch: a second swap for the same
+        // token, whose quote arrives on the same relay subscription and whose
+        // pair is byte-identical. Only `rfq_id` tells them apart, and taking
+        // the wrong one funds the other swap's terms.
+        const other = "c3".repeat(32);
+        expect(() =>
+            readEvmSendQuote(sendQuote({ rfq_id: other }), {
+                tokenAddress: USDC,
+                rfqId: RFQ_ID,
+            }),
+        ).toThrow(/quote is for rfq_id "c3c3.*not this negotiation's a1a1/);
+        expect(() =>
+            readEvmReceiveQuote(receiveQuote({ rfq_id: other }), {
+                tokenAddress: USDC,
+                rfqId: RFQ_ID,
+            }),
+        ).toThrow(/not this negotiation's/);
+        // …and a quote carrying no id at all, which would otherwise compare
+        // `undefined !== undefined` as false if the caller's were missing too.
+        const anonymous = sendQuote() as unknown as Record<string, unknown>;
+        delete anonymous.rfq_id;
+        expect(() => readEvmSendQuote(anonymous, { tokenAddress: USDC, rfqId: RFQ_ID })).toThrow(
+            /quote is for rfq_id/,
+        );
+    });
+
     it("refuses a quote for another token, or another pair entirely", () => {
-        expect(() => readEvmSendQuote(sendQuote(), { tokenAddress: ERC20_SWAP })).toThrow(
-            /solver quoted .* not arkade:BTC->ethereum/,
-        );
+        expect(() =>
+            readEvmSendQuote(sendQuote(), { tokenAddress: ERC20_SWAP, rfqId: RFQ_ID }),
+        ).toThrow(/solver quoted .* not arkade:BTC->ethereum/);
         // The receive quote's own pair, handed to the send reader.
-        expect(() => readEvmSendQuote(receiveQuote(), { tokenAddress: USDC })).toThrow(
-            /solver quoted/,
-        );
-        expect(() => readEvmReceiveQuote(sendQuote(), { tokenAddress: USDC })).toThrow(
-            /solver quoted/,
-        );
+        expect(() =>
+            readEvmSendQuote(receiveQuote(), { tokenAddress: USDC, rfqId: RFQ_ID }),
+        ).toThrow(/solver quoted/);
+        expect(() =>
+            readEvmReceiveQuote(sendQuote(), { tokenAddress: USDC, rfqId: RFQ_ID }),
+        ).toThrow(/solver quoted/);
     });
 
     it("refuses a token amount that arrived as a JSON number", () => {
         expect(() =>
-            readEvmSendQuote(sendQuote({ to_amount: 249.75e18 }), { tokenAddress: USDC }),
+            readEvmSendQuote(sendQuote({ to_amount: 249.75e18 }), {
+                tokenAddress: USDC,
+                rfqId: RFQ_ID,
+            }),
         ).toThrow(/to_amount must be a decimal string/);
         expect(() =>
-            readEvmReceiveQuote(receiveQuote({ from_amount: 249.75e18 }), { tokenAddress: USDC }),
+            readEvmReceiveQuote(receiveQuote({ from_amount: 249.75e18 }), {
+                tokenAddress: USDC,
+                rfqId: RFQ_ID,
+            }),
         ).toThrow(/from_amount must be a decimal string/);
     });
 
@@ -664,7 +695,7 @@ describe("quote readers", () => {
                     withProfile(sendQuote() as unknown as Record<string, unknown>, {
                         evm_contract_address: bad,
                     }),
-                    { tokenAddress: USDC },
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(/profile\.evm_contract_address must be 0x then 40 hex/);
             expect(() =>
@@ -672,7 +703,7 @@ describe("quote readers", () => {
                     withProfile(receiveQuote() as unknown as Record<string, unknown>, {
                         evm_claim_address: bad,
                     }),
-                    { tokenAddress: USDC },
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(/profile\.evm_claim_address must be 0x then 40 hex/);
         }
@@ -692,7 +723,7 @@ describe("quote readers", () => {
                     withProfile(sendQuote() as unknown as Record<string, unknown>, {
                         receiver_pk_script: bad,
                     }),
-                    { tokenAddress: USDC },
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(/profile\.receiver_pk_script must be lowercase hex/);
             expect(() =>
@@ -700,7 +731,7 @@ describe("quote readers", () => {
                     withProfile(receiveQuote() as unknown as Record<string, unknown>, {
                         solver_refund_pk_script: bad,
                     }),
-                    { tokenAddress: USDC },
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(/profile\.solver_refund_pk_script must be lowercase hex/);
         }
@@ -723,9 +754,9 @@ describe("quote readers", () => {
             "min_confirmations",
             "min_age_seconds",
         ]) {
-            expect(() => readEvmSendQuote(drop(key), { tokenAddress: USDC })).toThrow(
-                new RegExp(`profile\\.${key}`),
-            );
+            expect(() =>
+                readEvmSendQuote(drop(key), { tokenAddress: USDC, rfqId: RFQ_ID }),
+            ).toThrow(new RegExp(`profile\\.${key}`));
         }
     });
 
@@ -748,13 +779,13 @@ describe("quote readers", () => {
             expect(() =>
                 readEvmSendQuote(
                     dropEnvelope(sendQuote() as unknown as Record<string, unknown>, key),
-                    { tokenAddress: USDC },
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(new RegExp(key));
             expect(() =>
                 readEvmReceiveQuote(
                     dropEnvelope(receiveQuote() as unknown as Record<string, unknown>, key),
-                    { tokenAddress: USDC },
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(new RegExp(key));
         }
@@ -762,7 +793,7 @@ describe("quote readers", () => {
         expect(() =>
             readEvmSendQuote(
                 dropEnvelope(sendQuote() as unknown as Record<string, unknown>, "profile"),
-                { tokenAddress: USDC },
+                { tokenAddress: USDC, rfqId: RFQ_ID },
             ),
         ).toThrow(/carries no profile/);
     });
@@ -770,14 +801,19 @@ describe("quote readers", () => {
     it("accepts min_age_seconds of zero — depth-only is a solver's choice", () => {
         const quote = sendQuote() as unknown as Record<string, unknown>;
         const profile = { ...(quote.profile as Record<string, unknown>), min_age_seconds: 0 };
-        expect(() => readEvmSendQuote({ ...quote, profile }, { tokenAddress: USDC })).not.toThrow();
+        expect(() =>
+            readEvmSendQuote({ ...quote, profile }, { tokenAddress: USDC, rfqId: RFQ_ID }),
+        ).not.toThrow();
     });
 
     it("ignores unknown fields — responses are tolerant, requests are not", () => {
         const quote = sendQuote() as unknown as Record<string, unknown>;
         const profile = { ...(quote.profile as Record<string, unknown>), future_field: "x" };
         expect(() =>
-            readEvmSendQuote({ ...quote, profile, another: 1 }, { tokenAddress: USDC }),
+            readEvmSendQuote(
+                { ...quote, profile, another: 1 },
+                { tokenAddress: USDC, rfqId: RFQ_ID },
+            ),
         ).not.toThrow();
     });
 
@@ -785,13 +821,15 @@ describe("quote readers", () => {
         expect(() =>
             readEvmSendQuote(
                 { v: 1, type: "rfq_refusal", reason: "unsupported_pair" },
-                {
-                    tokenAddress: USDC,
-                },
+                { tokenAddress: USDC, rfqId: RFQ_ID },
             ),
         ).toThrow(/expected an rfq_quote, got rfq_refusal/);
-        expect(() => readEvmSendQuote(null, { tokenAddress: USDC })).toThrow(/not an object/);
-        expect(() => readEvmSendQuote("{}", { tokenAddress: USDC })).toThrow(/not an object/);
+        expect(() => readEvmSendQuote(null, { tokenAddress: USDC, rfqId: RFQ_ID })).toThrow(
+            /not an object/,
+        );
+        expect(() => readEvmSendQuote("{}", { tokenAddress: USDC, rfqId: RFQ_ID })).toThrow(
+            /not an object/,
+        );
     });
 });
 

--- a/packages/swap/test/evmRfq.test.ts
+++ b/packages/swap/test/evmRfq.test.ts
@@ -585,9 +585,17 @@ describe("request builders", () => {
         expect(() => evmReceiveRequest({ ...receive, evmTimeoutBlock: 0 })).toThrow(
             /evmTimeoutBlock/,
         );
-        expect(() => evmReceiveRequest({ ...receive, evmAmount: -1n })).toThrow(
-            /may not be negative/,
-        );
+        // Both non-positive amounts are refused by the BUILDER, with one
+        // message, because "not a positive amount" is one rule. The codec's own
+        // negative guard is a separate concern and is tested directly above:
+        // `"0"` is canonical on the wire and `evmAmountToWire` must keep
+        // emitting and accepting it, so the corridor's rule cannot live there.
+        for (const bad of [0n, -1n]) {
+            expect(() => evmReceiveRequest({ ...receive, evmAmount: bad })).toThrow(
+                /evmAmount must be a positive number of atomic units/,
+            );
+        }
+        expect(evmAmountToWire(0n)).toBe("0");
         expect(() => evmReceiveRequest({ ...receive, evmRefundAddress: "nope" })).toThrow(
             /evmRefundAddress/,
         );
@@ -706,6 +714,38 @@ describe("quote readers", () => {
                     { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(/profile\.evm_claim_address must be 0x then 40 hex/);
+        }
+    });
+
+    it("refuses a payment_hash that is not a 32-byte hash", () => {
+        // It is `sha256(P)`, and every other structured field in the profile
+        // enforces its encoding. A bad one reaching the caller intact fails at
+        // the covenant instead, reported as a broken covenant rather than the
+        // malformed echo it is.
+        const withProfile = (
+            quote: Record<string, unknown>,
+            over: Record<string, unknown>,
+        ): Record<string, unknown> => ({
+            ...quote,
+            profile: { ...(quote.profile as Record<string, unknown>), ...over },
+        });
+        for (const bad of ["", "not-hex", "b2".repeat(31), "b2".repeat(33), "B2".repeat(32), 7]) {
+            expect(() =>
+                readEvmSendQuote(
+                    withProfile(sendQuote() as unknown as Record<string, unknown>, {
+                        payment_hash: bad,
+                    }),
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
+                ),
+            ).toThrow(/profile\.payment_hash must be 64 lowercase hex/);
+            expect(() =>
+                readEvmReceiveQuote(
+                    withProfile(receiveQuote() as unknown as Record<string, unknown>, {
+                        payment_hash: bad,
+                    }),
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
+                ),
+            ).toThrow(/profile\.payment_hash must be 64 lowercase hex/);
         }
     });
 

--- a/packages/swap/test/evmRfq.test.ts
+++ b/packages/swap/test/evmRfq.test.ts
@@ -794,9 +794,19 @@ describe("quote readers", () => {
             ).toThrow(new RegExp(key));
         }
         // …and a profile that is missing outright, not merely short a key.
+        // Asserted on BOTH readers even though they share
+        // `readEvmQuoteEnvelope`: which checks are shared is an implementation
+        // fact today, and a test that only covers one direction stops covering
+        // the other the moment they stop sharing it.
         expect(() =>
             readEvmSendQuote(
                 dropEnvelope(sendQuote() as unknown as Record<string, unknown>, "profile"),
+                { tokenAddress: USDC, rfqId: RFQ_ID },
+            ),
+        ).toThrow(/carries no profile/);
+        expect(() =>
+            readEvmReceiveQuote(
+                dropEnvelope(receiveQuote() as unknown as Record<string, unknown>, "profile"),
                 { tokenAddress: USDC, rfqId: RFQ_ID },
             ),
         ).toThrow(/carries no profile/);

--- a/packages/swap/test/evmRfq.test.ts
+++ b/packages/swap/test/evmRfq.test.ts
@@ -717,7 +717,11 @@ describe("quote readers", () => {
             ...quote,
             profile: { ...(quote.profile as Record<string, unknown>), ...over },
         });
-        for (const bad of ["", "zz", "5120AB", 5120]) {
+        // "abc" is the one that matters: it is lowercase hex, so a check that
+        // only looked at the character class would pass it — and `hex.decode`
+        // then throws on the odd length, at covenant derivation, where it reads
+        // as a broken covenant rather than a malformed quote field.
+        for (const bad of ["", "zz", "5120AB", 5120, "abc", "5120" + "aa".repeat(31) + "a"]) {
             expect(() =>
                 readEvmSendQuote(
                     withProfile(sendQuote() as unknown as Record<string, unknown>, {
@@ -725,7 +729,7 @@ describe("quote readers", () => {
                     }),
                     { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
-            ).toThrow(/profile\.receiver_pk_script must be lowercase hex/);
+            ).toThrow(/profile\.receiver_pk_script must be lowercase hex of whole bytes/);
             expect(() =>
                 readEvmReceiveQuote(
                     withProfile(receiveQuote() as unknown as Record<string, unknown>, {
@@ -733,7 +737,7 @@ describe("quote readers", () => {
                     }),
                     { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
-            ).toThrow(/profile\.solver_refund_pk_script must be lowercase hex/);
+            ).toThrow(/profile\.solver_refund_pk_script must be lowercase hex of whole bytes/);
         }
     });
 

--- a/packages/swap/test/evmRfq.test.ts
+++ b/packages/swap/test/evmRfq.test.ts
@@ -164,6 +164,51 @@ const EvmReceiveRfqRequest = strictObject({
 const SOLVER_SEND_PAIR = /^arkade:BTC->ethereum:0x[0-9a-f]{40}$/;
 const SOLVER_RECEIVE_PAIR = /^ethereum:0x[0-9a-f]{40}->arkade:BTC$/;
 
+/**
+ * Exactly what `evmSendRfqQuotePayload` and `evmReceiveRfqQuotePayload` emit.
+ *
+ * The quote direction needs its own pin, and for a different reason than the
+ * request direction. A request is validated by the solver, so getting it wrong
+ * produces a refusal; a QUOTE is validated by nobody but us, so a reader that
+ * looks for `receiver_pkscript` simply never finds it and reports a broken
+ * quote against a solver that sent a correct one. Without this, the only thing
+ * checking those names is the fixture below — which this file also wrote, so
+ * it would agree with any typo.
+ */
+const SOLVER_SEND_QUOTE_KEYS = [
+    "v",
+    "type",
+    "rfq_id",
+    "pair",
+    "from_amount",
+    "to_amount",
+    "solver_pubkey",
+    "valid_until",
+    "refund_locktime",
+    "profile",
+];
+const SOLVER_SEND_QUOTE_PROFILE_KEYS = [
+    "payment_hash",
+    "lockup_address",
+    "receiver_pk_script",
+    "evm_timeout_block",
+    "evm_contract_address",
+    "evm_chain_id",
+    "min_confirmations",
+    "min_age_seconds",
+];
+const SOLVER_RECEIVE_QUOTE_KEYS = SOLVER_SEND_QUOTE_KEYS;
+const SOLVER_RECEIVE_QUOTE_PROFILE_KEYS = [
+    "payment_hash",
+    "lockup_address",
+    "solver_refund_pk_script",
+    "evm_contract_address",
+    "evm_chain_id",
+    "evm_claim_address",
+    "min_confirmations",
+    "min_age_seconds",
+];
+
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
 const sendRequest = (): Record<string, unknown> =>
@@ -271,6 +316,55 @@ describe("solver parity", () => {
         expect(evmSendPair(USDC_CHECKSUMMED)).toMatch(SOLVER_SEND_PAIR);
         expect(evmReceivePair(USDC_CHECKSUMMED)).toMatch(SOLVER_RECEIVE_PAIR);
         expect(USDC_CHECKSUMMED).not.toMatch(/^0x[0-9a-f]{40}$/);
+    });
+
+    it("the quote fixtures carry exactly what the solver's builders emit", () => {
+        // Both directions, and BOTH WAYS round: a key the solver sends and we
+        // do not is a field the reader will never check, and a key we invented
+        // is a field no solver will ever send — the second reads as a broken
+        // solver, which is the harder one to diagnose.
+        const send = sendQuote() as unknown as Record<string, unknown>;
+        expect(Object.keys(send).sort()).toEqual([...SOLVER_SEND_QUOTE_KEYS].sort());
+        expect(Object.keys(send.profile as object).sort()).toEqual(
+            [...SOLVER_SEND_QUOTE_PROFILE_KEYS].sort(),
+        );
+        const receive = receiveQuote() as unknown as Record<string, unknown>;
+        expect(Object.keys(receive).sort()).toEqual([...SOLVER_RECEIVE_QUOTE_KEYS].sort());
+        expect(Object.keys(receive.profile as object).sort()).toEqual(
+            [...SOLVER_RECEIVE_QUOTE_PROFILE_KEYS].sort(),
+        );
+    });
+
+    it("the readers require every profile key the solver actually sends", () => {
+        // The fixture above is what the solver emits; dropping any one of its
+        // profile keys must be noticed. Anything the reader tolerates missing
+        // is a field the funding path would later read as `undefined`.
+        const withoutKey = (
+            quote: Record<string, unknown>,
+            key: string,
+        ): Record<string, unknown> => {
+            const profile = { ...(quote.profile as Record<string, unknown>) };
+            delete profile[key];
+            return { ...quote, profile };
+        };
+        for (const key of SOLVER_SEND_QUOTE_PROFILE_KEYS) {
+            expect(() =>
+                readEvmSendQuote(
+                    withoutKey(sendQuote() as unknown as Record<string, unknown>, key),
+                    {
+                        tokenAddress: USDC,
+                    },
+                ),
+            ).toThrow(new RegExp(`profile\\.${key}`));
+        }
+        for (const key of SOLVER_RECEIVE_QUOTE_PROFILE_KEYS) {
+            expect(() =>
+                readEvmReceiveQuote(
+                    withoutKey(receiveQuote() as unknown as Record<string, unknown>, key),
+                    { tokenAddress: USDC },
+                ),
+            ).toThrow(new RegExp(`profile\\.${key}`));
+        }
     });
 
     it("the strict validator itself refuses what the solver would", () => {
@@ -552,6 +646,66 @@ describe("quote readers", () => {
         ).toThrow(/from_amount must be a decimal string/);
     });
 
+    it("refuses an address field that is PRESENT but not an address", () => {
+        // Distinct from the missing-field case below, and it has to be tested
+        // separately: a check that only fires on absence would pass that one
+        // and let `evm_contract_address: "0x0"` straight through. These are the
+        // two values a client later has to talk to a chain with.
+        const withProfile = (
+            quote: Record<string, unknown>,
+            over: Record<string, unknown>,
+        ): Record<string, unknown> => ({
+            ...quote,
+            profile: { ...(quote.profile as Record<string, unknown>), ...over },
+        });
+        for (const bad of ["0x0", "", "not-an-address", `${ERC20_SWAP}00`, ERC20_SWAP.slice(2)]) {
+            expect(() =>
+                readEvmSendQuote(
+                    withProfile(sendQuote() as unknown as Record<string, unknown>, {
+                        evm_contract_address: bad,
+                    }),
+                    { tokenAddress: USDC },
+                ),
+            ).toThrow(/profile\.evm_contract_address must be 0x then 40 hex/);
+            expect(() =>
+                readEvmReceiveQuote(
+                    withProfile(receiveQuote() as unknown as Record<string, unknown>, {
+                        evm_claim_address: bad,
+                    }),
+                    { tokenAddress: USDC },
+                ),
+            ).toThrow(/profile\.evm_claim_address must be 0x then 40 hex/);
+        }
+    });
+
+    it("refuses a pkScript that is present but not hex", () => {
+        const withProfile = (
+            quote: Record<string, unknown>,
+            over: Record<string, unknown>,
+        ): Record<string, unknown> => ({
+            ...quote,
+            profile: { ...(quote.profile as Record<string, unknown>), ...over },
+        });
+        for (const bad of ["", "zz", "5120AB", 5120]) {
+            expect(() =>
+                readEvmSendQuote(
+                    withProfile(sendQuote() as unknown as Record<string, unknown>, {
+                        receiver_pk_script: bad,
+                    }),
+                    { tokenAddress: USDC },
+                ),
+            ).toThrow(/profile\.receiver_pk_script must be lowercase hex/);
+            expect(() =>
+                readEvmReceiveQuote(
+                    withProfile(receiveQuote() as unknown as Record<string, unknown>, {
+                        solver_refund_pk_script: bad,
+                    }),
+                    { tokenAddress: USDC },
+                ),
+            ).toThrow(/profile\.solver_refund_pk_script must be lowercase hex/);
+        }
+    });
+
     it("refuses a quote missing a field the funding path will read", () => {
         const drop = (key: string): Record<string, unknown> => {
             const quote = sendQuote() as unknown as Record<string, unknown>;
@@ -573,15 +727,44 @@ describe("quote readers", () => {
                 new RegExp(`profile\\.${key}`),
             );
         }
+    });
+
+    it("refuses a quote missing an ENVELOPE field, including the two deadlines", () => {
+        // `valid_until` and `refund_locktime` matter more than the rest, and
+        // they fail in a way that reads as success. `assertFundable` compares
+        // `now >= quote.valid_until` and `refund_locktime - now`; against
+        // `undefined` both are false and NaN, so a missing deadline does not
+        // fail its gate — it deletes it, and the swap funds with no window
+        // check at all.
+        const dropEnvelope = (
+            quote: Record<string, unknown>,
+            key: string,
+        ): Record<string, unknown> => {
+            const copy = { ...quote };
+            delete copy[key];
+            return copy;
+        };
+        for (const key of ["solver_pubkey", "valid_until", "refund_locktime"]) {
+            expect(() =>
+                readEvmSendQuote(
+                    dropEnvelope(sendQuote() as unknown as Record<string, unknown>, key),
+                    { tokenAddress: USDC },
+                ),
+            ).toThrow(new RegExp(key));
+            expect(() =>
+                readEvmReceiveQuote(
+                    dropEnvelope(receiveQuote() as unknown as Record<string, unknown>, key),
+                    { tokenAddress: USDC },
+                ),
+            ).toThrow(new RegExp(key));
+        }
+        // …and a profile that is missing outright, not merely short a key.
         expect(() =>
-            readEvmReceiveQuote(
-                {
-                    ...(receiveQuote() as unknown as Record<string, unknown>),
-                    refund_locktime: undefined,
-                },
+            readEvmSendQuote(
+                dropEnvelope(sendQuote() as unknown as Record<string, unknown>, "profile"),
                 { tokenAddress: USDC },
             ),
-        ).toThrow(/refund_locktime/);
+        ).toThrow(/carries no profile/);
     });
 
     it("accepts min_age_seconds of zero — depth-only is a solver's choice", () => {

--- a/packages/swap/test/evmRfq.test.ts
+++ b/packages/swap/test/evmRfq.test.ts
@@ -1,0 +1,632 @@
+/**
+ * The EVM corridors' wire layer, and its parity with the solver that already
+ * speaks it.
+ *
+ * The `describe("solver parity")` block is the point of this file. Every other
+ * test here checks that our own code does what our own docs say; that one
+ * checks that what we emit is what the OTHER side accepts, which is the only
+ * failure that cannot be found by reading this repo. An EVM offer encoded
+ * differently from the solver is not a bug that surfaces as an error — it is a
+ * swap that quietly never matches.
+ *
+ * The solver's schemas are restated below as data rather than imported: they
+ * live in another repo, behind a `zod` this package does not depend on. Source
+ * of truth, `arkade-os/intent-solver` at `9751a1c`:
+ *
+ *   packages/solver-corridors-evm/src/wire/evmPayloads.ts
+ *   packages/solver-core/src/core/corridorPolicy.ts
+ *
+ * A restatement can drift, which is exactly why it is pinned here: a drift
+ * fails a test, instead of being discovered by a client that quotes and is
+ * never filled.
+ */
+import { describe, expect, it } from "vitest";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+
+import {
+    EVM_CHAIN,
+    evmAmountFromWire,
+    evmAmountToWire,
+    evmDirectionOf,
+    evmQuoteSats,
+    evmQuoteTokenAmount,
+    evmReceivePair,
+    evmReceiveRequest,
+    evmSendPair,
+    evmSendRequest,
+    evmTokenLeg,
+    evmTokenOf,
+    readEvmReceiveQuote,
+    readEvmSendQuote,
+    type EvmReceiveQuote,
+    type EvmSendQuote,
+} from "../src/evmRfq";
+import { MIN_HEADROOM_SECONDS, assertFundable } from "../src/rfq";
+
+const key = (fill: number): Uint8Array => schnorr.getPublicKey(new Uint8Array(32).fill(fill));
+
+const RFQ_ID = "a1".repeat(32);
+const PAYMENT_HASH = "b2".repeat(32);
+/** Lowercase, as a pair must carry it. */
+const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+/** The SAME token, EIP-55 checksummed — legal in a profile, refused in a pair. */
+const USDC_CHECKSUMMED = "0xA0b86991c6218b36c1D19D4a2e9Eb0cE3606eB48";
+const ERC20_SWAP = "0x1111111111111111111111111111111111111111";
+const CLAIM_ADDRESS = "0x2222222222222222222222222222222222222222";
+const SOLVER_CLAIM_ADDRESS = "0x3333333333333333333333333333333333333333";
+
+const NOW = 1_800_000_000;
+
+// ── The solver's schemas, restated ──────────────────────────────────────────
+
+/**
+ * `zod`'s primitives, as much of them as these two schemas use.
+ *
+ * A `rule` answers `null` when the value is acceptable and a reason when it is
+ * not, so a failure names the field AND what was wrong with it — a bare
+ * boolean would make every mutation below report the same thing.
+ */
+type Rule = (value: unknown) => string | null;
+
+const literal =
+    (want: unknown): Rule =>
+    (value) =>
+        value === want
+            ? null
+            : `expected literal ${JSON.stringify(want)}, got ${JSON.stringify(value)}`;
+
+const matching =
+    (pattern: RegExp): Rule =>
+    (value) =>
+        typeof value === "string" && pattern.test(value)
+            ? null
+            : `expected a string matching ${pattern}, got ${JSON.stringify(value)}`;
+
+const boundedString =
+    (min: number, max: number): Rule =>
+    (value) =>
+        typeof value === "string" && value.length >= min && value.length <= max
+            ? null
+            : `expected a string of ${min}..${max} chars, got ${JSON.stringify(value)}`;
+
+const positiveInt: Rule = (value) =>
+    typeof value === "number" && Number.isInteger(value) && value > 0
+        ? null
+        : `expected a positive integer, got ${JSON.stringify(value)}`;
+
+/** `z.object({…}).strict()` — every declared key required, every undeclared
+ * key a refusal. Strictness is the half that catches an extra field, and an
+ * extra field is `unsupported_payload` on this wire, not an ignored key. */
+const strictObject = (fields: Record<string, Rule>): Rule => {
+    return (value) => {
+        if (value === null || typeof value !== "object" || Array.isArray(value)) {
+            return `expected an object, got ${JSON.stringify(value)}`;
+        }
+        const record = value as Record<string, unknown>;
+        const extra = Object.keys(record).filter((name) => !(name in fields));
+        if (extra.length > 0) return `unrecognized key(s): ${extra.join(", ")}`;
+        for (const [name, rule] of Object.entries(fields)) {
+            if (!(name in record)) return `missing key: ${name}`;
+            const failure = rule(record[name]);
+            if (failure) return `${name}: ${failure}`;
+        }
+        return null;
+    };
+};
+
+// `packages/solver-corridors-evm/src/wire/evmPayloads.ts`, verbatim.
+const RFQ_ID_RULE = matching(/^[0-9a-f]{64}$/);
+const HEX32 = matching(/^[0-9a-f]{64}$/);
+const XONLY_HEX = matching(/^[0-9a-f]{64}$/);
+const EVM_ADDRESS = matching(/^0x[0-9a-fA-F]{40}$/);
+const TOKEN_AMOUNT = matching(/^(0|[1-9][0-9]*)$/);
+// `packages/solver-core/src/core/marketKey.ts`: (LONGEST_CORRIDOR + 1 + 68) * 2 + 2,
+// with LONGEST_CORRIDOR = "arkade:BTC->lightning:BTC".length.
+const SOLVER_MAX_PAIR_LENGTH = (25 + 1 + 68) * 2 + 2;
+const PAIR = boundedString(1, SOLVER_MAX_PAIR_LENGTH);
+
+const EvmSendRfqRequest = strictObject({
+    v: literal(1),
+    type: literal("rfq_request"),
+    rfq_id: RFQ_ID_RULE,
+    pair: PAIR,
+    amount_side: literal("from"),
+    amount: positiveInt,
+    profile: strictObject({
+        payment_hash: HEX32,
+        evm_claim_address: EVM_ADDRESS,
+        refund_address: boundedString(1, 200),
+        client_refund_pubkey: XONLY_HEX,
+    }),
+});
+
+const EvmReceiveRfqRequest = strictObject({
+    v: literal(1),
+    type: literal("rfq_request"),
+    rfq_id: RFQ_ID_RULE,
+    pair: PAIR,
+    amount_side: literal("from"),
+    // No `amount`, and `.strict()` is what turns that from an omission into a
+    // rule: the client's amount is a token quantity, so it rides the profile
+    // as a string. An `amount` added for symmetry refuses the whole request.
+    profile: strictObject({
+        payment_hash: HEX32,
+        evm_amount: TOKEN_AMOUNT,
+        evm_timeout_block: positiveInt,
+        evm_refund_address: EVM_ADDRESS,
+        payout_address: boundedString(1, 200),
+        payout_pubkey: XONLY_HEX,
+    }),
+});
+
+// `packages/solver-core/src/core/corridorPolicy.ts` — LOWERCASE token only.
+const SOLVER_SEND_PAIR = /^arkade:BTC->ethereum:0x[0-9a-f]{40}$/;
+const SOLVER_RECEIVE_PAIR = /^ethereum:0x[0-9a-f]{40}->arkade:BTC$/;
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const sendRequest = (): Record<string, unknown> =>
+    evmSendRequest({
+        rfqId: RFQ_ID,
+        tokenAddress: USDC,
+        paymentHash: PAYMENT_HASH,
+        evmClaimAddress: CLAIM_ADDRESS,
+        refundAddress: "ark1qrefund",
+        senderPubkey: key(13),
+        amountSats: 250_000,
+    });
+
+const receiveRequest = (): Record<string, unknown> =>
+    evmReceiveRequest({
+        rfqId: RFQ_ID,
+        tokenAddress: USDC,
+        paymentHash: PAYMENT_HASH,
+        evmAmount: 123_456_789n,
+        evmTimeoutBlock: 21_000_000,
+        evmRefundAddress: CLAIM_ADDRESS,
+        payoutAddress: "ark1qpayout",
+        payoutPubkey: key(9),
+    });
+
+const sendQuote = (over: Record<string, unknown> = {}): EvmSendQuote =>
+    ({
+        v: 1,
+        type: "rfq_quote",
+        rfq_id: RFQ_ID,
+        pair: evmSendPair(USDC),
+        from_amount: 250_000,
+        to_amount: "249750000000000000000",
+        solver_pubkey: "cc".repeat(32),
+        valid_until: NOW + 60,
+        refund_locktime: NOW + 200 * 3600,
+        profile: {
+            payment_hash: PAYMENT_HASH,
+            lockup_address: "ark1qlockup",
+            receiver_pk_script: "51201234",
+            evm_timeout_block: 21_000_000,
+            evm_contract_address: ERC20_SWAP,
+            evm_chain_id: 1,
+            min_confirmations: 12,
+            min_age_seconds: 180,
+        },
+        ...over,
+    }) as unknown as EvmSendQuote;
+
+const receiveQuote = (over: Record<string, unknown> = {}): EvmReceiveQuote =>
+    ({
+        v: 1,
+        type: "rfq_quote",
+        rfq_id: RFQ_ID,
+        pair: evmReceivePair(USDC),
+        from_amount: "249750000000000000000",
+        to_amount: 250_000,
+        solver_pubkey: "cc".repeat(32),
+        valid_until: NOW + 60,
+        refund_locktime: NOW + 200 * 3600,
+        profile: {
+            payment_hash: PAYMENT_HASH,
+            lockup_address: "ark1qlockup",
+            solver_refund_pk_script: "51205678",
+            evm_contract_address: ERC20_SWAP,
+            evm_chain_id: 1,
+            evm_claim_address: SOLVER_CLAIM_ADDRESS,
+            min_confirmations: 12,
+            min_age_seconds: 180,
+        },
+        ...over,
+    }) as unknown as EvmReceiveQuote;
+
+// ── Parity ──────────────────────────────────────────────────────────────────
+
+describe("solver parity", () => {
+    it("the send request satisfies the solver's strict schema", () => {
+        expect(EvmSendRfqRequest(sendRequest())).toBeNull();
+    });
+
+    it("the receive request satisfies the solver's strict schema", () => {
+        expect(EvmReceiveRfqRequest(receiveRequest())).toBeNull();
+    });
+
+    it("the receive request carries NO envelope amount", () => {
+        // Not a style point: the schema is `.strict()`, so an `amount` here is
+        // an unrecognized key and the whole request is `unsupported_payload`.
+        expect(receiveRequest()).not.toHaveProperty("amount");
+        expect(EvmReceiveRfqRequest({ ...receiveRequest(), amount: 1 })).toMatch(
+            /unrecognized key\(s\): amount/,
+        );
+    });
+
+    it("the send request DOES carry one — the schema requires it", () => {
+        const { amount, ...withoutAmount } = sendRequest();
+        expect(amount).toBe(250_000);
+        expect(EvmSendRfqRequest(withoutAmount)).toBe("missing key: amount");
+    });
+
+    it("both pairs match the solver's LOWERCASE-only corridor regexes", () => {
+        expect(evmSendPair(USDC)).toMatch(SOLVER_SEND_PAIR);
+        expect(evmReceivePair(USDC)).toMatch(SOLVER_RECEIVE_PAIR);
+        // The checksummed spelling of the SAME token, which the solver's pair
+        // regex refuses — so normalising is what makes it quotable at all.
+        expect(evmSendPair(USDC_CHECKSUMMED)).toMatch(SOLVER_SEND_PAIR);
+        expect(evmReceivePair(USDC_CHECKSUMMED)).toMatch(SOLVER_RECEIVE_PAIR);
+        expect(USDC_CHECKSUMMED).not.toMatch(/^0x[0-9a-f]{40}$/);
+    });
+
+    it("the strict validator itself refuses what the solver would", () => {
+        // A parity check is only worth what its validator catches, so pin that
+        // the validator is not vacuous.
+        expect(EvmSendRfqRequest({ ...sendRequest(), extra: 1 })).toMatch(/unrecognized key/);
+        expect(EvmSendRfqRequest({ ...sendRequest(), amount_side: "to" })).toMatch(
+            /amount_side: expected literal "from"/,
+        );
+        expect(EvmSendRfqRequest({ ...sendRequest(), v: 2 })).toMatch(/v: expected literal 1/);
+        const request = receiveRequest();
+        const profile = request.profile as Record<string, unknown>;
+        expect(
+            EvmReceiveRfqRequest({ ...request, profile: { ...profile, evm_amount: "1e18" } }),
+        ).toMatch(/evm_amount: expected a string/);
+        expect(
+            EvmReceiveRfqRequest({ ...request, profile: { ...profile, evm_amount: 1e18 } }),
+        ).toMatch(/evm_amount: expected a string/);
+    });
+});
+
+// ── Pairs ───────────────────────────────────────────────────────────────────
+
+describe("pairs and token identity", () => {
+    it("names the EVM legs", () => {
+        expect(EVM_CHAIN).toBe("ethereum");
+        expect(evmTokenLeg(USDC)).toBe(`ethereum:${USDC}`);
+        expect(evmSendPair(USDC)).toBe(`arkade:BTC->ethereum:${USDC}`);
+        expect(evmReceivePair(USDC)).toBe(`ethereum:${USDC}->arkade:BTC`);
+    });
+
+    it("lowercases a checksummed token so the pair still matches byte for byte", () => {
+        expect(evmTokenLeg(USDC_CHECKSUMMED)).toBe(`ethereum:${USDC}`);
+        expect(evmSendPair(USDC_CHECKSUMMED)).toBe(evmSendPair(USDC));
+        expect(evmReceivePair(USDC_CHECKSUMMED)).toBe(evmReceivePair(USDC));
+    });
+
+    it("refuses anything that is not an EVM address", () => {
+        expect(() => evmSendPair("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")).toThrow(
+            /token address must be 0x then 40 hex/,
+        );
+        expect(() => evmSendPair(`${USDC}00`)).toThrow(/token address/);
+        expect(() => evmReceivePair("0xnothex")).toThrow(/token address/);
+    });
+
+    it("reads a direction and a token back off a pair", () => {
+        expect(evmDirectionOf(evmSendPair(USDC))).toBe("send");
+        expect(evmDirectionOf(evmReceivePair(USDC))).toBe("receive");
+        expect(evmTokenOf(evmSendPair(USDC))).toBe(USDC);
+        expect(evmTokenOf(evmReceivePair(USDC))).toBe(USDC);
+    });
+
+    it("answers null for every pair that is not an EVM one", () => {
+        for (const pair of [
+            "arkade:BTC->lightning:BTC",
+            "onchain:BTC->arkade:BTC",
+            // The checksummed token — a spelling no solver serves, and the
+            // exact value a client that skipped normalising would produce.
+            `arkade:BTC->ethereum:${USDC_CHECKSUMMED}`,
+            `ethereum:${USDC}->ethereum:${USDC}`,
+            "",
+        ]) {
+            expect(evmDirectionOf(pair)).toBeNull();
+            expect(evmTokenOf(pair)).toBeNull();
+        }
+    });
+});
+
+// ── Amounts ─────────────────────────────────────────────────────────────────
+
+describe("amounts", () => {
+    it("encodes a bigint as the canonical decimal form", () => {
+        expect(evmAmountToWire(0n)).toBe("0");
+        expect(evmAmountToWire(1n)).toBe("1");
+        // 2^256 - 1 — the widest an ERC20 balance can be, and 60 orders of
+        // magnitude past what a double holds exactly.
+        expect(evmAmountToWire(2n ** 256n - 1n)).toBe(
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        );
+    });
+
+    it("refuses a negative amount rather than emitting a sign the schema anchors out", () => {
+        expect(() => evmAmountToWire(-1n)).toThrow(/may not be negative/);
+    });
+
+    it("round-trips past 2^53 without losing a unit", () => {
+        // One atomic unit above 2^53, and the value a double rounds to. The
+        // point of the string encoding is that these stay distinguishable.
+        const exact = 9_007_199_254_740_993n;
+        expect(evmAmountFromWire(evmAmountToWire(exact), "x")).toBe(exact);
+        expect(Number(exact)).toBe(9_007_199_254_740_992);
+    });
+
+    it("refuses a JSON number outright, at every magnitude", () => {
+        // Including one that IS exactly representable: accepting it would make
+        // the check depend on the value rather than on the encoding, and the
+        // rounding has already happened by the time we look.
+        for (const value of [1, 0, 1e18, Number.MAX_SAFE_INTEGER]) {
+            expect(() => evmAmountFromWire(value, "evm_amount")).toThrow(
+                /evm_amount must be a decimal string of atomic units, not a JSON number/,
+            );
+        }
+    });
+
+    it("refuses every non-canonical spelling", () => {
+        for (const value of ["", "01", "1e18", "0x10", " 1", "1 ", "-1", "1.0", "+1", "١٢٣"]) {
+            expect(() => evmAmountFromWire(value, "evm_amount")).toThrow(/not a canonical decimal/);
+        }
+    });
+
+    it("accepts the two edge spellings that ARE canonical", () => {
+        expect(evmAmountFromWire("0", "x")).toBe(0n);
+        expect(evmAmountFromWire("10", "x")).toBe(10n);
+    });
+});
+
+// ── Requests ────────────────────────────────────────────────────────────────
+
+describe("request builders", () => {
+    it("builds the send request", () => {
+        expect(sendRequest()).toEqual({
+            v: 1,
+            type: "rfq_request",
+            rfq_id: RFQ_ID,
+            pair: `arkade:BTC->ethereum:${USDC}`,
+            amount_side: "from",
+            amount: 250_000,
+            profile: {
+                payment_hash: PAYMENT_HASH,
+                evm_claim_address: CLAIM_ADDRESS,
+                refund_address: "ark1qrefund",
+                client_refund_pubkey: hex.encode(key(13)),
+            },
+        });
+    });
+
+    it("builds the receive request, with the amount in the profile", () => {
+        expect(receiveRequest()).toEqual({
+            v: 1,
+            type: "rfq_request",
+            rfq_id: RFQ_ID,
+            pair: `ethereum:${USDC}->arkade:BTC`,
+            amount_side: "from",
+            profile: {
+                payment_hash: PAYMENT_HASH,
+                evm_amount: "123456789",
+                evm_timeout_block: 21_000_000,
+                evm_refund_address: CLAIM_ADDRESS,
+                payout_address: "ark1qpayout",
+                payout_pubkey: hex.encode(key(9)),
+            },
+        });
+    });
+
+    it("keeps an EIP-55 checksummed profile address as given", () => {
+        // The pair must be lowercased and the profile must not be: the solver
+        // accepts either case here, and flattening it throws away the typo
+        // protection the checksum exists for.
+        const request = evmSendRequest({
+            rfqId: RFQ_ID,
+            tokenAddress: USDC,
+            paymentHash: PAYMENT_HASH,
+            evmClaimAddress: USDC_CHECKSUMMED,
+            refundAddress: "ark1qrefund",
+            senderPubkey: key(13),
+            amountSats: 1,
+        });
+        expect((request.profile as Record<string, unknown>).evm_claim_address).toBe(
+            USDC_CHECKSUMMED,
+        );
+        expect(EvmSendRfqRequest(request)).toBeNull();
+    });
+
+    it("carries a 256-bit amount through to the wire intact", () => {
+        const huge = 2n ** 200n + 7n;
+        const request = evmReceiveRequest({
+            rfqId: RFQ_ID,
+            tokenAddress: USDC,
+            paymentHash: PAYMENT_HASH,
+            evmAmount: huge,
+            evmTimeoutBlock: 1,
+            evmRefundAddress: CLAIM_ADDRESS,
+            payoutAddress: "ark1qpayout",
+            payoutPubkey: key(9),
+        });
+        const encoded = (request.profile as Record<string, unknown>).evm_amount;
+        expect(encoded).toBe(huge.toString());
+        // Survives an actual JSON round trip, which a number would not.
+        const reparsed = JSON.parse(JSON.stringify(request)) as {
+            profile: { evm_amount: unknown };
+        };
+        expect(evmAmountFromWire(reparsed.profile.evm_amount, "evm_amount")).toBe(huge);
+    });
+
+    it("refuses the inputs the solver's schema would refuse anyway", () => {
+        const send = {
+            rfqId: RFQ_ID,
+            tokenAddress: USDC,
+            paymentHash: PAYMENT_HASH,
+            evmClaimAddress: CLAIM_ADDRESS,
+            refundAddress: "ark1qrefund",
+            senderPubkey: key(13),
+            amountSats: 250_000,
+        };
+        expect(() => evmSendRequest({ ...send, amountSats: 0 })).toThrow(/amountSats/);
+        expect(() => evmSendRequest({ ...send, amountSats: 1.5 })).toThrow(/amountSats/);
+        expect(() => evmSendRequest({ ...send, evmClaimAddress: "0x00" })).toThrow(
+            /evmClaimAddress/,
+        );
+        const receive = {
+            rfqId: RFQ_ID,
+            tokenAddress: USDC,
+            paymentHash: PAYMENT_HASH,
+            evmAmount: 1n,
+            evmTimeoutBlock: 21_000_000,
+            evmRefundAddress: CLAIM_ADDRESS,
+            payoutAddress: "ark1qpayout",
+            payoutPubkey: key(9),
+        };
+        expect(() => evmReceiveRequest({ ...receive, evmTimeoutBlock: 0 })).toThrow(
+            /evmTimeoutBlock/,
+        );
+        expect(() => evmReceiveRequest({ ...receive, evmAmount: -1n })).toThrow(
+            /may not be negative/,
+        );
+        expect(() => evmReceiveRequest({ ...receive, evmRefundAddress: "nope" })).toThrow(
+            /evmRefundAddress/,
+        );
+    });
+});
+
+// ── Quotes ──────────────────────────────────────────────────────────────────
+
+describe("quote readers", () => {
+    it("narrows a well-formed send quote", () => {
+        const quote = readEvmSendQuote(sendQuote(), { tokenAddress: USDC });
+        expect(quote.profile.evm_timeout_block).toBe(21_000_000);
+        expect(evmQuoteTokenAmount(quote)).toBe(249_750_000_000_000_000_000n);
+        expect(evmQuoteSats(quote)).toBe(250_000);
+    });
+
+    it("narrows a well-formed receive quote", () => {
+        const quote = readEvmReceiveQuote(receiveQuote(), { tokenAddress: USDC });
+        expect(quote.profile.evm_claim_address).toBe(SOLVER_CLAIM_ADDRESS);
+        expect(evmQuoteTokenAmount(quote)).toBe(249_750_000_000_000_000_000n);
+        expect(evmQuoteSats(quote)).toBe(250_000);
+    });
+
+    it("takes the token and sats legs off OPPOSITE sides per direction", () => {
+        // The one thing that silently swaps: both quotes carry the same two
+        // numbers, and reading the wrong side yields a plausible value.
+        const send = readEvmSendQuote(sendQuote(), { tokenAddress: USDC });
+        const receive = readEvmReceiveQuote(receiveQuote(), { tokenAddress: USDC });
+        expect(BigInt(send.to_amount)).toBe(evmQuoteTokenAmount(send));
+        expect(send.from_amount).toBe(evmQuoteSats(send));
+        expect(BigInt(receive.from_amount)).toBe(evmQuoteTokenAmount(receive));
+        expect(receive.to_amount).toBe(evmQuoteSats(receive));
+    });
+
+    it("refuses a quote for another token, or another pair entirely", () => {
+        expect(() => readEvmSendQuote(sendQuote(), { tokenAddress: ERC20_SWAP })).toThrow(
+            /solver quoted .* not arkade:BTC->ethereum/,
+        );
+        // The receive quote's own pair, handed to the send reader.
+        expect(() => readEvmSendQuote(receiveQuote(), { tokenAddress: USDC })).toThrow(
+            /solver quoted/,
+        );
+        expect(() => readEvmReceiveQuote(sendQuote(), { tokenAddress: USDC })).toThrow(
+            /solver quoted/,
+        );
+    });
+
+    it("refuses a token amount that arrived as a JSON number", () => {
+        expect(() =>
+            readEvmSendQuote(sendQuote({ to_amount: 249.75e18 }), { tokenAddress: USDC }),
+        ).toThrow(/to_amount must be a decimal string/);
+        expect(() =>
+            readEvmReceiveQuote(receiveQuote({ from_amount: 249.75e18 }), { tokenAddress: USDC }),
+        ).toThrow(/from_amount must be a decimal string/);
+    });
+
+    it("refuses a quote missing a field the funding path will read", () => {
+        const drop = (key: string): Record<string, unknown> => {
+            const quote = sendQuote() as unknown as Record<string, unknown>;
+            const profile = { ...(quote.profile as Record<string, unknown>) };
+            delete profile[key];
+            return { ...quote, profile };
+        };
+        for (const key of [
+            "payment_hash",
+            "lockup_address",
+            "receiver_pk_script",
+            "evm_timeout_block",
+            "evm_contract_address",
+            "evm_chain_id",
+            "min_confirmations",
+            "min_age_seconds",
+        ]) {
+            expect(() => readEvmSendQuote(drop(key), { tokenAddress: USDC })).toThrow(
+                new RegExp(`profile\\.${key}`),
+            );
+        }
+        expect(() =>
+            readEvmReceiveQuote(
+                {
+                    ...(receiveQuote() as unknown as Record<string, unknown>),
+                    refund_locktime: undefined,
+                },
+                { tokenAddress: USDC },
+            ),
+        ).toThrow(/refund_locktime/);
+    });
+
+    it("accepts min_age_seconds of zero — depth-only is a solver's choice", () => {
+        const quote = sendQuote() as unknown as Record<string, unknown>;
+        const profile = { ...(quote.profile as Record<string, unknown>), min_age_seconds: 0 };
+        expect(() => readEvmSendQuote({ ...quote, profile }, { tokenAddress: USDC })).not.toThrow();
+    });
+
+    it("ignores unknown fields — responses are tolerant, requests are not", () => {
+        const quote = sendQuote() as unknown as Record<string, unknown>;
+        const profile = { ...(quote.profile as Record<string, unknown>), future_field: "x" };
+        expect(() =>
+            readEvmSendQuote({ ...quote, profile, another: 1 }, { tokenAddress: USDC }),
+        ).not.toThrow();
+    });
+
+    it("refuses a refusal, and anything that is not a quote at all", () => {
+        expect(() =>
+            readEvmSendQuote(
+                { v: 1, type: "rfq_refusal", reason: "unsupported_pair" },
+                {
+                    tokenAddress: USDC,
+                },
+            ),
+        ).toThrow(/expected an rfq_quote, got rfq_refusal/);
+        expect(() => readEvmSendQuote(null, { tokenAddress: USDC })).toThrow(/not an object/);
+        expect(() => readEvmSendQuote("{}", { tokenAddress: USDC })).toThrow(/not an object/);
+    });
+});
+
+// ── The funding gate ────────────────────────────────────────────────────────
+
+describe("assertFundable accepts an EVM quote", () => {
+    it("passes a live quote with headroom", () => {
+        assertFundable({ quote: sendQuote(), now: NOW });
+        assertFundable({ quote: receiveQuote(), now: NOW });
+    });
+
+    it("still gates the quote window and the refund headroom", () => {
+        expect(() => assertFundable({ quote: sendQuote(), now: NOW + 60 })).toThrow(
+            /quote expired/,
+        );
+        const tight = sendQuote({ refund_locktime: NOW + MIN_HEADROOM_SECONDS - 1 });
+        expect(() => assertFundable({ quote: tight, now: NOW })).toThrow(/headroom/);
+        const receiveTight = receiveQuote({ refund_locktime: NOW + MIN_HEADROOM_SECONDS - 1 });
+        expect(() => assertFundable({ quote: receiveTight, now: NOW })).toThrow(/headroom/);
+    });
+});

--- a/packages/swap/test/evmRfq.test.ts
+++ b/packages/swap/test/evmRfq.test.ts
@@ -55,6 +55,8 @@ const USDC_CHECKSUMMED = "0xA0b86991c6218b36c1D19D4a2e9Eb0cE3606eB48";
 const ERC20_SWAP = "0x1111111111111111111111111111111111111111";
 const CLAIM_ADDRESS = "0x2222222222222222222222222222222222222222";
 const SOLVER_CLAIM_ADDRESS = "0x3333333333333333333333333333333333333333";
+/** The solver's own EVM address, as the SEND quote carries it. */
+const SOLVER_EVM_ADDRESS = "0x4444444444444444444444444444444444444444";
 
 const NOW = 1_800_000_000;
 
@@ -191,6 +193,10 @@ const SOLVER_SEND_QUOTE_PROFILE_KEYS = [
     "payment_hash",
     "lockup_address",
     "receiver_pk_script",
+    // The SOLVER's address on this leg. Five of the swap key's six fields were
+    // already reachable from the quote; this is the sixth, and it is also an
+    // explicit argument to `claim`.
+    "evm_refund_address",
     "evm_timeout_block",
     "evm_contract_address",
     "evm_chain_id",
@@ -249,6 +255,7 @@ const sendQuote = (over: Record<string, unknown> = {}): EvmSendQuote =>
             payment_hash: PAYMENT_HASH,
             lockup_address: "ark1qlockup",
             receiver_pk_script: "51201234",
+            evm_refund_address: SOLVER_EVM_ADDRESS,
             evm_timeout_block: 21_000_000,
             evm_contract_address: ERC20_SWAP,
             evm_chain_id: 1,
@@ -714,7 +721,44 @@ describe("quote readers", () => {
                     { tokenAddress: USDC, rfqId: RFQ_ID },
                 ),
             ).toThrow(/profile\.evm_claim_address must be 0x then 40 hex/);
+            // The send leg's third address, and the one a wrong value breaks
+            // most quietly: it is a field of the swap key, so a bad one yields
+            // a key that matches no lock rather than an error.
+            expect(() =>
+                readEvmSendQuote(
+                    withProfile(sendQuote() as unknown as Record<string, unknown>, {
+                        evm_refund_address: bad,
+                    }),
+                    { tokenAddress: USDC, rfqId: RFQ_ID },
+                ),
+            ).toThrow(/profile\.evm_refund_address must be 0x then 40 hex/);
         }
+    });
+
+    it("gives a send client all six fields of the swap key", () => {
+        // The property the field was added for. `ERC20Swap` stores
+        // `mapping(bytes32 => bool)` keyed by
+        // keccak256(abi.encode(preimageHash, amount, tokenAddress,
+        // claimAddress, refundAddress, timelock)) — so a client short of any
+        // one of them cannot address the lock at all: it cannot read
+        // `swaps(key)` to prove the solver locked, and cannot build the claim
+        // call, which takes refundAddress explicitly.
+        const quote = readEvmSendQuote(sendQuote(), { tokenAddress: USDC, rfqId: RFQ_ID });
+        const key = {
+            preimageHash: quote.profile.payment_hash,
+            amount: evmQuoteTokenAmount(quote),
+            tokenAddress: evmTokenOf(quote.pair),
+            // The client's own, from its request — never taken from the quote.
+            claimAddress: CLAIM_ADDRESS,
+            refundAddress: quote.profile.evm_refund_address,
+            timelock: quote.profile.evm_timeout_block,
+        };
+        for (const [field, value] of Object.entries(key)) {
+            expect(value, `${field} is not derivable from the quote`).toBeDefined();
+        }
+        expect(key.refundAddress).toBe(SOLVER_EVM_ADDRESS);
+        expect(key.tokenAddress).toBe(USDC);
+        expect(key.amount).toBe(249_750_000_000_000_000_000n);
     });
 
     it("refuses a payment_hash that is not a 32-byte hash", () => {

--- a/packages/swap/test/evmRfq.test.ts
+++ b/packages/swap/test/evmRfq.test.ts
@@ -948,4 +948,42 @@ describe("assertFundable accepts an EVM quote", () => {
         const receiveTight = receiveQuote({ refund_locktime: NOW + MIN_HEADROOM_SECONDS - 1 });
         expect(() => assertFundable({ quote: receiveTight, now: NOW })).toThrow(/headroom/);
     });
+
+    it.each([
+        ["send", () => sendQuote()],
+        ["receive", () => receiveQuote()],
+    ])("refuses maxFee on an EVM %s quote rather than coercing it", (_direction, quote) => {
+        for (const maxFee of [
+            { sats: 0 },
+            { bps: 100 },
+            { bps: 100, referenceRate: 0.5 },
+            { sats: 1_000_000_000, bps: 10_000 },
+        ]) {
+            let thrown: unknown;
+            try {
+                assertFundable({ quote: quote(), now: NOW, maxFee });
+            } catch (error) {
+                thrown = error;
+            }
+            expect((thrown as { reason?: string } | undefined)?.reason).toBe(
+                "fee_gate_unavailable",
+            );
+            expect(String(thrown)).toMatch(/EVM token leg/);
+        }
+    });
+
+    it("leaves the sats-only gate on a BTC quote working", () => {
+        const btc = {
+            rfq_id: RFQ_ID,
+            pair: "arkade:BTC->lightning:BTC",
+            from_amount: 100_000,
+            to_amount: 99_500,
+            valid_until: NOW + 60,
+            refund_locktime: NOW + MIN_HEADROOM_SECONDS + 60,
+        };
+        expect(() => assertFundable({ quote: btc, now: NOW, maxFee: { sats: 500 } })).not.toThrow();
+        expect(() => assertFundable({ quote: btc, now: NOW, maxFee: { sats: 499 } })).toThrow(
+            /fee 500 exceeds/,
+        );
+    });
 });


### PR DESCRIPTION
`@arkade-os/swap` can quote and fund the Lightning and onchain corridors but not the two EVM ones, which the reference solver has served for some time. This is the **negotiation half** of the client side: the pair form, the token identity, the amount encoding, the two `rfq_request` shapes, and the two quote shapes a solver answers with.

New module `packages/swap/src/evmRfq.ts`, exported from the package index.

## Which parts have production weight

Worth a reviewer's attention up front: the two EVM corridors are independently enabled per token and direction on the solver (`evmEnvStem(token, 'send')` vs `'receive'`), and LVGA — the first real deployment — serves **one** of them. A client receiving LVGA on EVM is, in this codebase's naming, the **`send`** corridor `arkade:BTC->ethereum:<token>`; the names are written from the solver's perspective, so the user-facing "receive" and the code's `send` are the same leg.

On that leg the solver locks, the **client claims**, and the solver refunds on timeout. The client claiming is structural: the solver learns the preimage by watching that claim and uses it to take the Arkade lockup.

So of the surface this PR establishes:

- **Load-bearing today** — the send pair and token identity, the send request builder, `readEvmSendQuote` and everything it validates, the token-amount codec, and `evm_refund_address` (the sixth field of the swap key *and* the explicit `claim` argument).
- **Ahead of demand** — the receive pair, `evmReceiveRequest`, `readEvmReceiveQuote`. Correct and tested, and the generic surface a second deployment or the opposite direction would use, but unexercised by any live corridor today.

Nothing branches on this. There is no direction flag, no LVGA mode, and no deployment-type check — direction is already a solver-config matter, and a client written against the shared surface works either way. The split above is about where to look hardest in review, not about how the code is shaped.

## What is deliberately NOT here

Deriving the Arkade covenant, comparing the two deadlines against each other, and funding.

`evm_timeout_block` is a **block height** and `refund_locktime` is **unix seconds**, and they sit adjacent in the same quote profile. Bridging them needs a per-chain block cadence, and the safe direction of that conversion differs by which side is reading it — reading someone else's timeout assumes the FASTEST cadence, sizing your own assumes the SLOWEST, and a single averaged constant is wrong for one of the two. That is its own decision and its own review, so this PR carries the field, documents the unit trap on it, and gates nothing on it.

## Amounts: bigint in the API, canonical decimal string on the wire

This is the one decision in the PR worth arguing about, so, explicitly: **a token quantity is a `bigint` at this package's API boundary and a canonical decimal string (`^(0|[1-9][0-9]*)$`) on the wire. Never a `number`, at either end.**

An ERC20 amount is 256-bit. A JSON number is an IEEE-754 double, exact only to 2^53 − 1, which at 18 decimals is 0.009 tokens — one whole DAI does not survive the round trip. The rounding happens inside `JSON.parse`, before any validator on either side can see it, and neither party can detect that it happened. This is why the solver's schema types `evm_amount` as a string, why its store declares the column TEXT, and what § 2.1 of the RFQ protocol specifies for every amount.

`bigint` at the boundary because it is the only exact integer JS has, and every comparison a client makes against these values — is this the amount I asked for, is the lock funded for what was quoted — has to be exact. `String(aBigint)` is already the canonical form for a non-negative value, so encoding needs no formatter and the real work is all on the way in: `evmAmountFromWire` **refuses a JSON number outright rather than coercing one**, at every magnitude, including values that happen to be exactly representable. Accepting those would make the check depend on the value rather than on the encoding.

The **sats** side of both corridors stays a JSON `number`, matching the four BTC corridors and the solver's own schemas. § 2.1 makes those strings too; that is a migration for corridors that already ship, in flight separately, and bundling it here would change five corridors to add one.

## Wire parity is pinned, not assumed

A client that encodes an EVM offer differently from the solver is not a bug that surfaces as an error — it is a swap that quietly never matches. So `test/evmRfq.test.ts` opens with a `describe("solver parity")` block that restates the solver's two `.strict()` request schemas **as data**, at a cited commit (`arkade-os/intent-solver@9751a1c`, `packages/solver-corridors-evm/src/wire/evmPayloads.ts` and `packages/solver-core/src/core/corridorPolicy.ts`), and runs both request builders through them. Restated rather than imported because they live in another repo behind a `zod` this package does not depend on — the same discipline `rfq.ts` already uses for the wire's pair cap, and the test is what turns a drift into a failure.

The **quote** direction is pinned separately, because the two fail differently. A wrong request field name produces a refusal from the solver; a wrong quote field name produces a reader that never finds the field and reports a broken quote against a solver that sent a correct one. So the exact key sets both quote builders emit are pinned too, checked both ways round, and every profile key the solver sends is asserted to be one the reader actually requires.

Three traps it pins, each of which silently produces an unmatched swap:

- **The receive envelope carries no `amount` at all.** Its absence is the rule, not an omission: what the client gives is a token quantity, the envelope's `amount` is a JSON number, so it rides the profile as `evm_amount` instead. The schema is `.strict()`, so an `amount` added for symmetry is an undeclared key and the whole request is refused as `unsupported_payload`.
- **The pair token must be LOWERCASE, the profile addresses need not be.** The solver's corridor regex is `[0-9a-f]` only while its profile address schema is `[0-9a-fA-F]` — so the same EIP-55 checksummed address is legal in one field of a request and refused in another. `evmTokenLeg` accepts either and emits lowercase; the profile keeps what it was given, because flattening a checksum throws away the typo protection it exists for.
- **Both corridors are exact-in.** `amount_side` is pinned to `"from"` on both, since the legs are different assets and exact-out would mean inverting a fetched, rounded, directional rate.

## The send quote's `evm_refund_address`

Added in `d65e6fa3`, paired with [arkade-os/intent-solver#3](https://github.com/arkade-os/intent-solver/pull/3), which publishes the field.

The send quote gave a client five of the six fields of the swap key. `ERC20Swap` stores no per-swap struct - only `mapping(bytes32 => bool)` over `keccak256(abi.encode(preimageHash, amount, tokenAddress, claimAddress, refundAddress, timelock))` - so without `refundAddress` a client cannot compute the key, cannot read `swaps(key)` to prove the solver locked before parting with its preimage, and cannot build the claim call, which takes that address explicitly.

`evm_refund_address` names whoever the CONTRACT refunds. On this leg the solver locks, so it is the SOLVER's - the mirror of the receive leg, where the client locks and sends its own in the request. Reading it as "the client's" on both legs is how it came to be missing.

Required rather than optional here: a send quote without it is one this client can neither verify nor claim, so the quote is the only point where that failure is cheap.

## `assertFundable`

Its `quote` parameter widens to `RfqQuote | EvmRfqQuote`. The gates an EVM quote reaches — `valid_until` and the 90-minute refund headroom — are the right ones for both corridors, and both read a plain `number`.

The widening is also what stops the amounts being read as sats. Across the union `from_amount` and `to_amount` are `number | string`, so no arithmetic compiles against them unsplit; read them through `evmQuoteSats` and `evmQuoteTokenAmount`, which pick the side off the pair rather than taking a direction argument.

### `maxFee` is refused on an EVM quote, not run on one

The max-fee gate merged to master (#838) while this branch was open, and the rebase put the two together: the widening turns its `from_amount - to_amount` arithmetic into five compile errors. That is the bug surfacing, not the bug.

The token leg is a canonical decimal string, and **it does not go NaN** — `*` and `-` coerce it, so the gate compares token base units against sats and answers with conviction. Measured, with the guard removed and the rest of the gate intact:

| quote | `maxFee` | what the gate does |
|---|---|---|
| send `arkade:BTC->ethereum:<token>` | `{ bps: 100, referenceRate: 0.5 }` | **passes** |
| send | `{ sats: 0, referenceRate: 0.5 }` | **passes** |
| receive `ethereum:<token>->arkade:BTC` | `{ bps: 100, referenceRate: 0.5 }` | refuses `fee_too_high` |
| receive | `{ sats: 0, referenceRate: 0.5 }` | refuses `fee_too_high` |

A ceiling of **zero sats** passing a live send quote is the one that matters: the caller has asked for the tightest bound expressible and been given no bound at all. The receive direction fails the other way, refusing a quote that is fine.

So `maxFee` on an EVM quote now throws `fee_gate_unavailable` — the reason code the gate already uses for "this ceiling cannot be computed here" — and says to omit it until the sum can be done in bigint against a rate in token base units per sat. Gating for real needs the token's decimals, which are not in the quote, and 256-bit arithmetic, which a double cannot hold; that belongs with the funding work, not here.

The BTC corridors are untouched: `assertFundable` still gates `{ sats: 500 }` against a 500-sat spread and refuses it at `{ sats: 499 }`.

**Note for #832 (`feat/max-fee-gate`), which is open at time of writing.** Its cross-asset branch already handles EVM pairs correctly at the pair level: `assetOf` on `arkade:BTC->ethereum:0x…` yields `BTC` vs `0x…`, so `sameAsset` is false and `referenceRate` is required, which is right. What it will need after this lands is to stop doing raw arithmetic on `from_amount`/`to_amount` — on an EVM quote one of them is a string, and `from_amount * rate - to_amount` coerces it silently and loses precision above 2^53. Measured, not assumed: applying #832's `rfq.ts` diff onto this head compiles with **five `TS2362`/`TS2363` errors at exactly the cross-asset fee lines**, so whichever of the two lands second cannot build until the amounts are read through `evmQuoteSats`/`evmQuoteTokenAmount`. (The coercion it prevents is not uniformly `NaN` — `Number("249750000000000000000")` is finite, so the wrong answer would be plausible below 2^53 and lossy above it, which is quieter and worse.) This PR does not duplicate that gate; the units it expects are documented on the quote types (`maxFee.referenceRate` is to-units per from-unit, so **token atomic units per sat** on the send leg and **sats per token atomic unit** on the receive leg — the easiest thing here to get wrong by a factor of the token's decimals).

## Reading a quote binds it to the negotiation

`readEvmSendQuote` / `readEvmReceiveQuote` take a required `rfqId` alongside the token. The pair check alone leaves the one case it cannot see: a second swap for the SAME token, whose quote arrives on the same relay subscription with a byte-identical pair. Only the id tells those apart, and taking the wrong one funds another swap's terms. `expectQuote` has always made this check for the four BTC corridors; these readers are reached by callers who may not have gone through it.

Required rather than optional, because nothing depends on these readers yet - so making it required costs nothing now and cannot be forgotten later, and an optional binding is one a caller skips exactly when several negotiations are in flight, which is the only time it matters. It is checked *before* the pair, since a reply to another negotiation may well be for the same market and the pair comparison would otherwise pass it and blame a field that was never wrong.

## A known type hole, documented rather than fixed

`RfqTransport.requestQuote` is typed `Promise<RfqQuote>`, and `RfqQuote` declares both amounts `number`. That is not accurate for an EVM quote. The transport never inspects the amounts, so the **value** is right and only the type is wrong — passing the result straight into `readEvmSendQuote` / `readEvmReceiveQuote` (both take `unknown`) is what makes the two agree again. Widening the transport's return type would make every existing caller narrow, which is a bigger change than this PR should carry; the reader's doc comment says so explicitly, including the concrete failure (`to_amount` types as a number, is a string, and `+` concatenates).

## Test plan

Baseline on `c6190783`, via the repo's own `pnpm run test:unit`: **224 files, 4139 passed, 1 skipped, 0 failing.**
After: **225 files, 4180 passed, 1 skipped, 0 failing** — +1 file, +41 tests, which reconciles exactly with the 41 in `test/evmRfq.test.ts`.

`pnpm -r build`, `pnpm -C packages/swap run typecheck`, `smoke:dist` and `npm pack --dry-run` all clean.

Every behaviour asserted here was mutation-tested — the code under test was broken and the suite confirmed to fail. **34 runtime mutations, all killed:**

| # | mutation | killed by |
|---|---|---|
| 1 | pair not lowercased | parity: lowercase-only corridor regexes |
| 2 | receive request carries an envelope `amount` | parity: strict schema / no envelope amount |
| 3 | `evmAmountFromWire` coerces a JSON number | amounts: refuses a JSON number at every magnitude |
| 4 | `TOKEN_AMOUNT` unanchored | amounts: refuses every non-canonical spelling |
| 5 | send profile key renamed | parity: strict schema |
| 6 | token amount read off the wrong leg | readers: opposite sides per direction |
| 7 | sats read off the wrong leg | readers: opposite sides per direction |
| 8 | negative amount encoded, not refused | amounts: refuses a negative |
| 9 | `min_age_seconds` check dropped | readers: refuses a missing profile field |
| 10 | `min_age_seconds` required positive | readers: accepts zero |
| 11 | send pair built in the receive direction | parity + pair tests |
| 12 | quote `pair` not compared | readers: refuses another token/pair |
| 13 | `refund_locktime` not required | readers: refuses a missing envelope field |
| 14 | `receiver_pk_script` unchecked | readers: refuses a missing profile field |
| 15 | `EVM_ADDRESS` accepts a wrong length | pair + request builder refusals |
| 16 | `solver_refund_pk_script` unchecked | readers: refuses a missing profile field |
| 17 | `evm_claim_address` not address-checked | readers: present-but-malformed address |
| 18 | `lockup_address` not required | readers: refuses a missing profile field |
| 19 | `evm_chain_id` not required | readers: refuses a missing profile field |
| 20 | `min_confirmations` not required | readers: refuses a missing profile field |
| 21 | `evm_contract_address` not address-checked | readers: present-but-malformed address |
| 22 | `assertHex` accepts uppercase and empty | readers: present-but-not-hex pkScript |
| 23 | `payment_hash` not required | readers: refuses a missing profile field |
| 24 | `evm_timeout_block` not required | readers: refuses a missing profile field |
| 25 | `valid_until` not required | readers: refuses a missing envelope field |
| 26 | `rfq_id` not bound to the negotiation | readers: refuses a quote for another negotiation |
| 27 | `solver_pubkey` not required | readers: refuses a missing envelope field |
| 28 | a quote with no `profile` at all tolerated | readers: refuses a missing envelope field |
| 29 | `assertHex` accepts an odd-length string | readers: present-but-not-hex pkScript |
| 30 | zero `evmAmount` accepted by the receive builder | request builders: refuses the inputs the solver would |
| 31 | `payment_hash` only string-checked | readers: refuses a non-32-byte hash |
| 32 | `assertHash32` made length-agnostic | readers: 62- and 66-character hashes |
| 33 | `evm_refund_address` not required on a send quote | readers: refuses a missing profile field |
| 34 | `evm_refund_address` present but not address-checked | readers: present-but-malformed address |
| 35 | `maxFee` guard deleted, EVM amounts coerced through | funding gate: refuses `maxFee` on an EVM quote |
| 36 | guard condition inverted | funding gate: the sats-only ceiling on a BTC quote |
| 37 | guard `\|\|` weakened to `&&` (refuse only if BOTH legs are strings) | funding gate: refuses `maxFee` on an EVM quote |
| 38 | refusal reason renamed to `max_fee_out_of_range` | funding gate: `reason` is `fee_gate_unavailable` |

Mutation 29 comes from review: `assertHex` checked the character class but not the length, so `"abc"` passed a validator whose whole job is to guarantee the value decodes - and `hex.decode` refuses an odd-length string, so the failure only moved to covenant derivation, where it reads as a broken covenant rather than a malformed quote field. Fixed in `91711eef`.

Three others (17, 21, 25) **survived the first round** and are why the second commit exists — 17 and 21 because two address checks were exercised only by absence, so the format check could have been deleted outright and nothing would have noticed on the two values a client later has to talk to a chain with; 25 because `valid_until` was required by the reader and by nothing else, and it fails in the shape that reads as success (`now >= undefined` is false, so a missing deadline does not fail `assertFundable`'s gate — it deletes it).

One further mutation is **type-level only**, so vitest cannot see it: reverting `assertFundable`'s parameter to `RfqQuote` alone. Verified with `tsc --noEmit` against a scratch caller — mutated, it fails with `TS2322: Type 'EvmSendQuote' is not assignable to type 'RfqQuote' … 'string' is not assignable to type 'number'`; unmutated, clean. Worth flagging that the package's `tsconfig.json` excludes `test/`, so nothing in CI typechecks the test tree, and this widening is therefore not gated by CI.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EVM RFQ corridors between Arkade BTC and Ethereum tokens.
  * Added creation and validation of send/receive RFQ requests and quotes.
  * Added conversion between token amounts and canonical wire-format values.
  * Added validation for token addresses, quote identifiers, pairs, deadlines, and funding requirements.
  * Exported the EVM RFQ functionality for use across the swap experience.

* **Bug Fixes**
  * Improved funding validation to correctly handle EVM quotes without interpreting token amounts as satoshis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



