### PR TITLE
feat(sdk): an asset dimension for PaymentRouter, and the asset + cross-asset rails

### DIFF
--- a/packages/boltz-swap/src/payment/index.ts
+++ b/packages/boltz-swap/src/payment/index.ts
@@ -1,4 +1,4 @@
-import { PaymentRouter, arkRail, onchainRail } from "@arkade-os/sdk";
+import { PaymentRouter, arkAssetRail, arkRail, onchainRail } from "@arkade-os/sdk";
 import type { Wallet } from "@arkade-os/sdk";
 import type { ArkadeSwaps } from "../arkade-swaps";
 import { lightningRail } from "./lightning";
@@ -9,9 +9,16 @@ export { onchainSwapRail } from "./onchain-swap";
 
 /**
  * Full payment router composing the Wallet-only rails from `@arkade-os/sdk`
- * (`ark`, `onchain`) with the swap rails (`lightning`, `onchain-swap`). This is
- * the boltz-swap overload of the core `createDefaultPaymentRouter(wallet)`; an
- * Ark-only app uses the core one, a Lightning-capable app uses this.
+ * (`ark`, `ark-asset`, `onchain`) with the swap rails (`lightning`,
+ * `onchain-swap`). This is the boltz-swap overload of the core
+ * `createDefaultPaymentRouter(wallet)`; an Ark-only app uses the core one, a
+ * Lightning-capable app uses this.
+ *
+ * `ark-asset` is registered here as well as in core so a Lightning-capable app
+ * does not silently lose asset payments by choosing this factory. It never
+ * competes with `ark` — one is available only for a request naming an asset
+ * and the other only for a request naming none — so none of the BTC rankings
+ * below change.
  *
  * Default priority `["ark", "lightning", "onchain-swap", "onchain"]` — Ark first,
  * then Lightning, then on-chain. For a plain BTC address the chain swap
@@ -35,9 +42,10 @@ export function createDefaultPaymentRouter(wallet: Wallet, swaps: ArkadeSwaps): 
     return new PaymentRouter({
         wallet,
         swaps,
-        prefs: { priority: ["ark", "lightning", "onchain-swap", "onchain"] },
+        prefs: { priority: ["ark", "ark-asset", "lightning", "onchain-swap", "onchain"] },
     })
         .use(arkRail())
+        .use(arkAssetRail())
         .use(onchainRail())
         .use(lightningRail())
         .use(onchainSwapRail());

--- a/packages/boltz-swap/src/payment/index.ts
+++ b/packages/boltz-swap/src/payment/index.ts
@@ -16,9 +16,7 @@ export { onchainSwapRail } from "./onchain-swap";
  *
  * `ark-asset` is registered here as well as in core so a Lightning-capable app
  * does not silently lose asset payments by choosing this factory. It never
- * competes with `ark` — one is available only for a request naming an asset
- * and the other only for a request naming none — so none of the BTC rankings
- * below change.
+ * competes with `ark`, so no BTC ranking below changes.
  *
  * Default priority `["ark", "lightning", "onchain-swap", "onchain"]` — Ark first,
  * then Lightning, then on-chain. For a plain BTC address the chain swap

--- a/packages/boltz-swap/src/payment/lightning.ts
+++ b/packages/boltz-swap/src/payment/lightning.ts
@@ -1,5 +1,11 @@
 import type { PaymentRail, RouterContext } from "@arkade-os/sdk";
-import { invoiceTarget, makeHandle, assertSendableAmount } from "@arkade-os/sdk";
+import {
+    assertNoAssets,
+    assertSendableAmount,
+    assetsOf,
+    invoiceTarget,
+    makeHandle,
+} from "@arkade-os/sdk";
 import type { ArkadeSwaps } from "../arkade-swaps";
 import { getInvoiceSatoshis } from "../utils/decoding";
 
@@ -23,6 +29,8 @@ export function lightningRail(): PaymentRail {
         id: "lightning",
         match: (req) => invoiceTarget(req.raw) !== undefined,
         available: async (req, ctx) => {
+            // A bolt11 invoice is denominated in sats; an asset cannot ride it.
+            if (assetsOf(req).length > 0) return false;
             if (ctx.swaps == null) return false;
             const invoice = invoiceTarget(req.raw);
             if (!invoice) return false;
@@ -33,6 +41,7 @@ export function lightningRail(): PaymentRail {
         },
         quote: async (req, ctx: RouterContext) => {
             const invoice = invoiceTarget(req.raw)!;
+            assertNoAssets("lightning", req);
             // The bolt11 invoice carries the amount; reject amountless or
             // undecodable invoices instead of surfacing a `total: 0` quote.
             const amount = invoiceSats(invoice);

--- a/packages/boltz-swap/src/payment/onchain-swap.ts
+++ b/packages/boltz-swap/src/payment/onchain-swap.ts
@@ -1,5 +1,12 @@
 import type { PaymentRail, RouterContext } from "@arkade-os/sdk";
-import { btcTarget, makeHandle, resolveSendAmount, tryResolveSendAmount } from "@arkade-os/sdk";
+import {
+    assertNoAssets,
+    assetsOf,
+    btcTarget,
+    makeHandle,
+    resolveSendAmount,
+    tryResolveSendAmount,
+} from "@arkade-os/sdk";
 import type { ArkadeSwaps } from "../arkade-swaps";
 import type { ChainFeesResponse } from "../types";
 
@@ -53,6 +60,9 @@ export function onchainSwapRail(): PaymentRail {
         id: "onchain-swap",
         match: (req) => btcTarget(req.raw) !== undefined,
         available: async (req, ctx) => {
+            // BTC only: an Arkade asset has no L1 form to swap out to, and
+            // paying this request's carrier sats would deliver none of it.
+            if (assetsOf(req).length > 0) return false;
             if (ctx.swaps == null) return false;
             const amt = tryResolveSendAmount(req.raw, req.amount);
             if (amt === undefined) return true; // amount-required deferred to quote()
@@ -70,6 +80,7 @@ export function onchainSwapRail(): PaymentRail {
         },
         quote: async (req, ctx: RouterContext) => {
             const address = btcTarget(req.raw)!;
+            assertNoAssets("onchain-swap", req);
             const amt = resolveSendAmount("onchain-swap", req.raw, req.amount);
             // Estimated from the same reconstruction available() brackets on, so
             // the gate and the quote cannot disagree. Boltz returns the

--- a/packages/boltz-swap/test/payment/factory.test.ts
+++ b/packages/boltz-swap/test/payment/factory.test.ts
@@ -36,6 +36,20 @@ const wallet = () =>
     }) as any;
 
 describe("createDefaultPaymentRouter(wallet, swaps)", () => {
+    it("routes an Arkade asset payment, which this factory used to have no rail for", async () => {
+        // `ark-asset` is registered here as well as in core: a Lightning-capable
+        // app choosing this factory must not silently lose asset payments. It
+        // never competes with `ark` — the amount decides which is available —
+        // so none of the BTC rankings in this file change.
+        const arkAddr =
+            "tark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt846qj6x";
+        const req = { raw: arkAddr, assets: [{ assetId: "aa".repeat(34), amount: 500n }] };
+        const router = createDefaultPaymentRouter(wallet(), swaps());
+
+        expect((await router.options(req)).map((o) => o.railId)).toEqual(["ark-asset"]);
+        expect((await router.route(req)).assets?.delivered.amount).toBe(500n);
+    });
+
     it("fans a unified BIP21 URI out across all four rails, ranked by priority", async () => {
         const router = createDefaultPaymentRouter(wallet(), swaps());
         const opts = await router.options({

--- a/packages/swap/src/payment/crossAsset.ts
+++ b/packages/swap/src/payment/crossAsset.ts
@@ -21,9 +21,13 @@ import { BTC_ASSET_ID } from "../store";
 
 export const CROSS_ASSET_RAIL = "cross-asset";
 
-/** The two states need different recovery: a `"quoted"` record whose offer
- *  never filled is cancelled; a `"filled"` one owes the recipient a send. */
-export type CrossAssetPhase = "quoted" | "filled";
+/**
+ * Recovery branches on this. `filled` means the payout is NOT yet broadcast;
+ * `paying` means it WAS and the outcome is unknown — resolve that against
+ * chain state, never by resending. Persisting only afterwards would leave a
+ * crash between send and persist looking exactly like `filled`.
+ */
+export type CrossAssetPhase = "quoted" | "filled" | "paying" | "settled";
 
 export interface CrossAssetSwap {
     phase: CrossAssetPhase;
@@ -34,6 +38,8 @@ export interface CrossAssetSwap {
     asset: Asset;
     payTo: string;
     plan: OfferPlan;
+    /** The payout, once `settled` — the receipt a `paying` record looks for. */
+    txid?: string;
 }
 
 export interface CrossAssetRailDeps {
@@ -44,9 +50,8 @@ export interface CrossAssetRailDeps {
     quote(market: DiscoveredMarket, give: Side, wantAmount: bigint): Promise<OfferPlan>;
     btcBalance(): Promise<bigint>;
     dust(): Promise<bigint>;
-    /** Called twice, both before an irreversible step: `"quoted"` before the
-     *  offer is funded, `"filled"` after delivery and before the recipient is
-     *  paid. Keyed by `offerHex`, stable across both. */
+    /** Before every irreversible step and once after the last. See
+     *  {@link CrossAssetPhase}. Keyed by `offerHex`. */
     persist(swap: CrossAssetSwap): Promise<void>;
     /** Resolve once a filler has delivered the asset to this wallet.
      *
@@ -174,11 +179,14 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
                         await deps.awaitFill(swap);
                         // Before paying: "quoted" would say it never filled.
                         await deps.persist({ ...swap, phase: "filled" });
+                        // Before the send, not after: a crash must not read as unpaid.
+                        await deps.persist({ ...swap, phase: "paying" });
                         const txid = await ctx.wallet.send({
                             address: payTo,
                             amount: carrier,
                             assets: [asset],
                         });
+                        await deps.persist({ ...swap, phase: "settled", txid });
                         const result = {
                             railId: CROSS_ASSET_RAIL,
                             txid,

--- a/packages/swap/src/payment/crossAsset.ts
+++ b/packages/swap/src/payment/crossAsset.ts
@@ -1,44 +1,10 @@
 /**
  * `cross-asset` — pay an asset the wallet does not hold, by swapping into it
- * first.
+ * first. Both legs are quotable up front, so they price into one `RouteQuote`
+ * and the router needs no multi-hop primitive.
  *
- * ## Composition fits inside a rail
- *
- * The obvious reading of "swap, then pay" is that the router needs a
- * multi-hop primitive: two `RouteQuote`s chained, with a way to price the pair.
- * It does not, and this rail is the demonstration. Both legs are known at
- * quote time — `quoteOffer` prices the swap from the market's own feed, and
- * the delivery leg is an off-chain transfer with no counterparty fee — so the
- * rail prices them together into one `RouteQuote` and reports the swap on
- * `RouteResult.swapId`, which {@link RouteResult} already had a slot for.
- *
- * Nothing about the router had to change. That is the argument for keeping
- * composition out of it: a hop is only routable if it is quotable, and a rail
- * that owns both hops can quote both. Pushing this into the router would mean
- * inventing a quote-composition rule that every future rail has to satisfy,
- * for one caller.
- *
- * What DID have to change is the request and quote shape, and only because a
- * cross-asset route spends one asset and delivers another: `total = amount +
- * fee` cannot hold across two units, which is why `RouteQuote.assets` carries
- * `spent` and `delivered` separately rather than a third triple.
- *
- * ## What this rail does not do
- *
- * Asset → asset in one offer. `createOffer` refuses anything but BTC↔asset
- * ("set exactly one of wantAsset or offerAsset"), so paying USDX out of EURX
- * is two offers. That is still a rail-internal concern — it is more legs, not
- * a different shape — but it is not implemented here, and `available()` says
- * so by requiring the wallet's BTC balance to cover the deposit.
- *
- * ## Order
- *
- * `send()` funds the offer, waits for a filler to deliver, and only then pays
- * the recipient. The wait is injected (`awaitFill`) because observing a fill is
- * `watchOfferSwaps`/`restoreAssetSwaps`' job and this package does not start a
- * watcher of its own. `persist` runs before the offer is funded, for the same
- * reason it does on the send rails: an offer funded without a record is one
- * `cancelOffer` cannot rebuild.
+ * BTC -> asset only: `createOffer` refuses anything but BTC<->asset, and
+ * keying `findMarket` on BTC is what enforces that.
  */
 import type { DiscoveredMarket, OfferPlan, Side } from "@arkade-os/solver-discovery";
 import type { Asset, PaymentRail, RouteQuote, RouterContext } from "@arkade-os/sdk";
@@ -53,84 +19,48 @@ import { createOffer } from "../offer";
 import { findMarket, validatePlan, type PlanError } from "../markets";
 import { BTC_ASSET_ID } from "../store";
 
-/** This rail's id, and what `RouterPreferences.priority` ranks it by. */
 export const CROSS_ASSET_RAIL = "cross-asset";
 
-/**
- * How far the route has got. Persisted, because the two states need different
- * recovery: a `"quoted"` record whose offer never filled is cancelled, while a
- * `"filled"` one has the asset in the wallet and owes the recipient a send.
- */
+/** The two states need different recovery: a `"quoted"` record whose offer
+ *  never filled is cancelled; a `"filled"` one owes the recipient a send. */
 export type CrossAssetPhase = "quoted" | "filled";
 
-/** The offer this rail funded, and the payment it was funded for. */
 export interface CrossAssetSwap {
-    /** Where the route has got to; see {@link CrossAssetPhase}. */
     phase: CrossAssetPhase;
-    /** `createOffer`'s encoded offer — the only input `cancelOffer` needs. */
     offerHex: string;
-    /** The swap address the deposit went to. */
     address: string;
     swapPkScript: Uint8Array;
-    /** Sats deposited into the offer. */
     depositSats: number;
-    /** What the offer buys, and what the recipient is then paid. */
     asset: Asset;
-    /** Where the asset goes once the offer fills. */
     payTo: string;
     plan: OfferPlan;
 }
 
 export interface CrossAssetRailDeps {
-    /** Arkade Service REST URL — `createOffer` reads `getInfo()` from it. */
     arkServerUrl: string;
-    /**
-     * Markets to price and route over.
-     *
-     * Called once by `available()` and again by `quote()` — the router
-     * deliberately does not carry a result between them, so a rail that
-     * decided it could route must decide again when asked for a price. With
-     * `discoverMarkets` (1h cache) and `makeCachedFeedFetch` (30s, with
-     * in-flight collapsing) behind these, an `options()`-then-`route()` pass
-     * costs one round trip rather than two. Passing a bare registry fetch
-     * makes it four.
-     */
+    /** Called by `available()` and again by `quote()`; pass the caching
+     *  `discoverMarkets`, not a bare registry fetch. */
     discover(): Promise<DiscoveredMarket[]>;
-    /**
-     * Price the swap leg. Pass `quoteOffer` from `@arkade-os/solver-discovery`,
-     * partially applied with whatever feed fetch the app uses — `markets.ts`
-     * ships `makeCachedFeedFetch` for exactly this.
-     */
     quote(market: DiscoveredMarket, give: Side, wantAmount: bigint): Promise<OfferPlan>;
-    /** Spendable sats, for the deposit the plan asks for. */
     btcBalance(): Promise<bigint>;
-    /** The server's dust limit — `validatePlan` protects the BTC leg with it. */
     dust(): Promise<bigint>;
-    /** Write the offer down BEFORE it is funded: an offer funded without a
-     *  record is one `cancelOffer` cannot rebuild. */
+    /** Called twice, both before an irreversible step: `"quoted"` before the
+     *  offer is funded, `"filled"` after delivery and before the recipient is
+     *  paid. Keyed by `offerHex`, stable across both. */
     persist(swap: CrossAssetSwap): Promise<void>;
-    /** Resolve once a filler has delivered the asset to this wallet. */
+    /** Resolve once a filler has delivered the asset to this wallet.
+     *
+     *  OPEN QUESTION for review: is an injected promise the right seam, or
+     *  should the rail take a `watchOfferSwaps` handle? No deadline is applied
+     *  here, and resolving on a timeout rather than rejecting would make the
+     *  rail pay from whatever the wallet then holds. */
     awaitFill(swap: CrossAssetSwap): Promise<void>;
-    /** Sats the delivery leg carries. Defaults to the SDK's dust carrier. */
     carrierSats?: number;
-    /** Co-signer key override for the offer covenant. */
     emulatorPubkey?: string;
 }
 
-/** Sats the delivery output carries when nothing else says. Mirrors
- *  `Recipient.amount`'s own default. */
 const DEFAULT_CARRIER_SATS = 330;
 
-/**
- * The asset id as `createOffer` needs it, or undefined when it is not one.
- *
- * `Asset.assetId` is a hex STRING (that is what `Wallet.send` takes), and
- * `createOffer` wants an `AssetId` — it reads `.txid` and `.groupIndex` off it
- * to bind the covenant, so handing it the string would build an offer with an
- * undefined want-asset rather than fail. Ids are 34 bytes; `fromString` throws
- * on anything else, and returning undefined here lets `available()` drop the
- * rail instead of the router.
- */
 const parseAssetId = (assetId: string): assetExt.AssetId | undefined => {
     try {
         return assetExt.AssetId.fromString(assetId);
@@ -139,35 +69,15 @@ const parseAssetId = (assetId: string): assetExt.AssetId | undefined => {
     }
 };
 
-/**
- * The rail. Register it after `ark-asset`, which pays out of a balance the
- * wallet already has:
- *
- * ```ts
- * router.options(req, { priority: ["ark-asset", "cross-asset"] });
- * ```
- *
- * Both match an Arkade address carrying an asset amount, so `options()` can
- * surface both and the app can offer "pay from your USDX" beside "buy USDX and
- * pay". Ranking `ark-asset` first is a preference, not a restriction.
- */
+/** Rank after `ark-asset`, which pays from a balance already held. Both match,
+ *  so `options()` can offer "pay from your USDX" beside "buy USDX and pay". */
 export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
-    /**
-     * The plan for THIS payment, or a reason there is none. Never throws for a
-     * routing reason — `available()` reads undefined as "not this rail" — and
-     * `quote()` re-reads the same `PlanError` to say which.
-     */
     const planFor = async (
         asset: Asset,
     ): Promise<{ plan: OfferPlan; error?: PlanError } | undefined> => {
         const markets = await deps.discover();
-        // Keyed on BTC deliberately, and that keying IS the BTC-only
-        // restriction: `findMarket` matches a market's asset ids exactly, in
-        // either orientation, so anything it returns for `(btc, asset)` has BTC
-        // on the side this rail gives. A EURX/USDX market is not returned at
-        // all, which is correct — `createOffer` would refuse it ("set exactly
-        // one of wantAsset or offerAsset"). A separate give-side check here
-        // would be unreachable, so there is not one.
+        // The BTC keying IS the BTC-only restriction; a give-side check here
+        // would be unreachable.
         const found = findMarket(markets, BTC_ASSET_ID, asset.assetId);
         const market = found?.market;
         if (!market) return undefined;
@@ -181,19 +91,12 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
         match: (req) => arkTarget(req.raw) !== undefined,
 
         available: async (req) => {
-            // Only for a request naming exactly one well-formed asset; a
-            // malformed one is `ark-asset`'s to reject with a named error, not
-            // this rail's to drop twice over.
             const assets = assetsOf(req);
             if (assets.length !== 1) return false;
             const [asset] = assets;
             if (asset.assetId === BTC_ASSET_ID) return false;
             if (typeof asset.amount !== "bigint" || asset.amount <= 0n) return false;
-            // Parsed here so an id `createOffer` could not bind drops the rail
-            // rather than failing at send time, with the offer already funded.
             if (!parseAssetId(asset.assetId)) return false;
-            // A discovery or feed failure propagates: the router catches it,
-            // warns, and drops this rail, which is the intended fallback.
             const planned = await planFor(asset);
             return planned !== undefined && planned.error === undefined;
         },
@@ -218,11 +121,6 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
                 );
             }
             const { plan } = planned;
-            // `RouteQuote.fee`/`total` and `Recipient.amount` are `number`, so
-            // the deposit narrows here. Safe for BTC — the entire supply is
-            // ~2.1e15 sats against a 9.0e15 safe integer — but asserted rather
-            // than assumed, because the assumption is the give side being BTC
-            // and a future non-BTC deposit corridor would silently break it.
             if (!Number.isSafeInteger(Number(plan.deposit.atomic))) {
                 throw new Error(
                     `${CROSS_ASSET_RAIL}: deposit of ${plan.deposit.atomic} does not fit a JS number`,
@@ -233,18 +131,14 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
 
             return {
                 railId: CROSS_ASSET_RAIL,
-                // The BTC leg, as on every rail: what leaves the wallet in
-                // sats. `amount` is the carrier the recipient's output holds,
-                // `fee` the sats the swap consumes to buy the asset — spent on
-                // the user's behalf and never delivered, which is exactly what
-                // `fee` means everywhere else.
+                // OPEN QUESTION for review: `total = amount + fee` forces the
+                // purchase price into `fee`, which reads as a service charge.
+                // A third field instead? `assets.spent` labels it correctly.
                 amount: carrier,
                 fee: depositSats,
                 total: depositSats + carrier,
                 assets: {
                     delivered: asset,
-                    // A DIFFERENT asset from `delivered` — the whole reason
-                    // these are two fields and not an amount/fee/total triple.
                     spent: { assetId: BTC_ASSET_ID, amount: plan.deposit.atomic },
                 },
                 meta: {
@@ -269,9 +163,6 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
                             payTo,
                             plan,
                         };
-                        // Persist FIRST: `cancelOffer` rebuilds the covenant
-                        // from `offerHex` and nothing else, so an offer funded
-                        // without a record is one nobody can cancel.
                         await deps.persist(swap);
                         await ctx.wallet.send({
                             address: offer.address,
@@ -280,14 +171,8 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
                         });
                         emit({ status: "sent" });
 
-                        // A filler delivers the asset to this wallet; only then
-                        // is there anything to pay the recipient with.
                         await deps.awaitFill(swap);
-                        // Record the fill BEFORE attempting the payment. If the
-                        // send then fails — a locked wallet, a lost connection —
-                        // the user is holding the asset and the recipient is
-                        // still owed; a record frozen at "quoted" would say the
-                        // opposite, and the offer would look cancellable.
+                        // Before paying: "quoted" would say it never filled.
                         await deps.persist({ ...swap, phase: "filled" });
                         const txid = await ctx.wallet.send({
                             address: payTo,

--- a/packages/swap/src/payment/crossAsset.ts
+++ b/packages/swap/src/payment/crossAsset.ts
@@ -42,7 +42,13 @@
  */
 import type { DiscoveredMarket, OfferPlan, Side } from "@arkade-os/solver-discovery";
 import type { Asset, PaymentRail, RouteQuote, RouterContext } from "@arkade-os/sdk";
-import { arkTarget, assetsOf, makeHandle, resolveAssetAmount } from "@arkade-os/sdk";
+import {
+    arkTarget,
+    asset as assetExt,
+    assetsOf,
+    makeHandle,
+    resolveAssetAmount,
+} from "@arkade-os/sdk";
 import { createOffer } from "../offer";
 import { findMarket, validatePlan, type PlanError } from "../markets";
 import { BTC_ASSET_ID } from "../store";
@@ -97,6 +103,24 @@ export interface CrossAssetRailDeps {
 const DEFAULT_CARRIER_SATS = 330;
 
 /**
+ * The asset id as `createOffer` needs it, or undefined when it is not one.
+ *
+ * `Asset.assetId` is a hex STRING (that is what `Wallet.send` takes), and
+ * `createOffer` wants an `AssetId` — it reads `.txid` and `.groupIndex` off it
+ * to bind the covenant, so handing it the string would build an offer with an
+ * undefined want-asset rather than fail. Ids are 34 bytes; `fromString` throws
+ * on anything else, and returning undefined here lets `available()` drop the
+ * rail instead of the router.
+ */
+const parseAssetId = (assetId: string): assetExt.AssetId | undefined => {
+    try {
+        return assetExt.AssetId.fromString(assetId);
+    } catch {
+        return undefined;
+    }
+};
+
+/**
  * The rail. Register it after `ark-asset`, which pays out of a balance the
  * wallet already has:
  *
@@ -146,6 +170,9 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
             const [asset] = assets;
             if (asset.assetId === BTC_ASSET_ID) return false;
             if (typeof asset.amount !== "bigint" || asset.amount <= 0n) return false;
+            // Parsed here so an id `createOffer` could not bind drops the rail
+            // rather than failing at send time, with the offer already funded.
+            if (!parseAssetId(asset.assetId)) return false;
             // A discovery or feed failure propagates: the router catches it,
             // warns, and drops this rail, which is the intended fallback.
             const planned = await planFor(asset);
@@ -155,6 +182,13 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
         quote: async (req, ctx: RouterContext): Promise<RouteQuote> => {
             const payTo = arkTarget(req.raw)!;
             const asset = resolveAssetAmount(CROSS_ASSET_RAIL, req);
+            const wantAsset = parseAssetId(asset.assetId);
+            if (!wantAsset) {
+                throw new Error(
+                    `${CROSS_ASSET_RAIL}: ${asset.assetId} is not an asset id ` +
+                        `(expected 34 bytes of hex)`,
+                );
+            }
             const planned = await planFor(asset);
             if (!planned) {
                 throw new Error(`${CROSS_ASSET_RAIL}: no market swaps BTC into ${asset.assetId}`);
@@ -193,7 +227,7 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
                     makeHandle(CROSS_ASSET_RAIL, async (emit) => {
                         const offer = await createOffer(ctx.wallet, deps.arkServerUrl, {
                             wantAmount: asset.amount,
-                            wantAsset: asset.assetId as never,
+                            wantAsset,
                             ...(deps.emulatorPubkey ? { emulatorPubkey: deps.emulatorPubkey } : {}),
                         });
                         const swap: CrossAssetSwap = {

--- a/packages/swap/src/payment/crossAsset.ts
+++ b/packages/swap/src/payment/crossAsset.ts
@@ -1,0 +1,238 @@
+/**
+ * `cross-asset` — pay an asset the wallet does not hold, by swapping into it
+ * first.
+ *
+ * ## Composition fits inside a rail
+ *
+ * The obvious reading of "swap, then pay" is that the router needs a
+ * multi-hop primitive: two `RouteQuote`s chained, with a way to price the pair.
+ * It does not, and this rail is the demonstration. Both legs are known at
+ * quote time — `quoteOffer` prices the swap from the market's own feed, and
+ * the delivery leg is an off-chain transfer with no counterparty fee — so the
+ * rail prices them together into one `RouteQuote` and reports the swap on
+ * `RouteResult.swapId`, which {@link RouteResult} already had a slot for.
+ *
+ * Nothing about the router had to change. That is the argument for keeping
+ * composition out of it: a hop is only routable if it is quotable, and a rail
+ * that owns both hops can quote both. Pushing this into the router would mean
+ * inventing a quote-composition rule that every future rail has to satisfy,
+ * for one caller.
+ *
+ * What DID have to change is the request and quote shape, and only because a
+ * cross-asset route spends one asset and delivers another: `total = amount +
+ * fee` cannot hold across two units, which is why `RouteQuote.assets` carries
+ * `spent` and `delivered` separately rather than a third triple.
+ *
+ * ## What this rail does not do
+ *
+ * Asset → asset in one offer. `createOffer` refuses anything but BTC↔asset
+ * ("set exactly one of wantAsset or offerAsset"), so paying USDX out of EURX
+ * is two offers. That is still a rail-internal concern — it is more legs, not
+ * a different shape — but it is not implemented here, and `available()` says
+ * so by requiring the wallet's BTC balance to cover the deposit.
+ *
+ * ## Order
+ *
+ * `send()` funds the offer, waits for a filler to deliver, and only then pays
+ * the recipient. The wait is injected (`awaitFill`) because observing a fill is
+ * `watchOfferSwaps`/`restoreAssetSwaps`' job and this package does not start a
+ * watcher of its own. `persist` runs before the offer is funded, for the same
+ * reason it does on the send rails: an offer funded without a record is one
+ * `cancelOffer` cannot rebuild.
+ */
+import type { DiscoveredMarket, OfferPlan, Side } from "@arkade-os/solver-discovery";
+import type { Asset, PaymentRail, RouteQuote, RouterContext } from "@arkade-os/sdk";
+import { arkTarget, assetsOf, makeHandle, resolveAssetAmount } from "@arkade-os/sdk";
+import { createOffer } from "../offer";
+import { findMarket, validatePlan, type PlanError } from "../markets";
+import { BTC_ASSET_ID } from "../store";
+
+/** This rail's id, and what `RouterPreferences.priority` ranks it by. */
+export const CROSS_ASSET_RAIL = "cross-asset";
+
+/** The offer this rail funded, and the payment it was funded for. */
+export interface CrossAssetSwap {
+    /** `createOffer`'s encoded offer — the only input `cancelOffer` needs. */
+    offerHex: string;
+    /** The swap address the deposit went to. */
+    address: string;
+    swapPkScript: Uint8Array;
+    /** Sats deposited into the offer. */
+    depositSats: number;
+    /** What the offer buys, and what the recipient is then paid. */
+    asset: Asset;
+    /** Where the asset goes once the offer fills. */
+    payTo: string;
+    plan: OfferPlan;
+}
+
+export interface CrossAssetRailDeps {
+    /** Arkade Service REST URL — `createOffer` reads `getInfo()` from it. */
+    arkServerUrl: string;
+    /** Markets to price and route over. `discoverMarkets` already caches. */
+    discover(): Promise<DiscoveredMarket[]>;
+    /**
+     * Price the swap leg. Pass `quoteOffer` from `@arkade-os/solver-discovery`,
+     * partially applied with whatever feed fetch the app uses — `markets.ts`
+     * ships `makeCachedFeedFetch` for exactly this.
+     */
+    quote(market: DiscoveredMarket, give: Side, wantAmount: bigint): Promise<OfferPlan>;
+    /** Spendable sats, for the deposit the plan asks for. */
+    btcBalance(): Promise<bigint>;
+    /** The server's dust limit — `validatePlan` protects the BTC leg with it. */
+    dust(): Promise<bigint>;
+    /** Write the offer down BEFORE it is funded: an offer funded without a
+     *  record is one `cancelOffer` cannot rebuild. */
+    persist(swap: CrossAssetSwap): Promise<void>;
+    /** Resolve once a filler has delivered the asset to this wallet. */
+    awaitFill(swap: CrossAssetSwap): Promise<void>;
+    /** Sats the delivery leg carries. Defaults to the SDK's dust carrier. */
+    carrierSats?: number;
+    /** Co-signer key override for the offer covenant. */
+    emulatorPubkey?: string;
+}
+
+/** Sats the delivery output carries when nothing else says. Mirrors
+ *  `Recipient.amount`'s own default. */
+const DEFAULT_CARRIER_SATS = 330;
+
+/**
+ * The rail. Register it after `ark-asset`, which pays out of a balance the
+ * wallet already has:
+ *
+ * ```ts
+ * router.options(req, { priority: ["ark-asset", "cross-asset"] });
+ * ```
+ *
+ * Both match an Arkade address carrying an asset amount, so `options()` can
+ * surface both and the app can offer "pay from your USDX" beside "buy USDX and
+ * pay". Ranking `ark-asset` first is a preference, not a restriction.
+ */
+export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
+    /**
+     * The plan for THIS payment, or a reason there is none. Never throws for a
+     * routing reason — `available()` reads undefined as "not this rail" — and
+     * `quote()` re-reads the same `PlanError` to say which.
+     */
+    const planFor = async (
+        asset: Asset,
+    ): Promise<{ plan: OfferPlan; error?: PlanError } | undefined> => {
+        const markets = await deps.discover();
+        // Keyed on BTC deliberately, and that keying IS the BTC-only
+        // restriction: `findMarket` matches a market's asset ids exactly, in
+        // either orientation, so anything it returns for `(btc, asset)` has BTC
+        // on the side this rail gives. A EURX/USDX market is not returned at
+        // all, which is correct — `createOffer` would refuse it ("set exactly
+        // one of wantAsset or offerAsset"). A separate give-side check here
+        // would be unreachable, so there is not one.
+        const found = findMarket(markets, BTC_ASSET_ID, asset.assetId);
+        const market = found?.market;
+        if (!market) return undefined;
+        const plan = await deps.quote(market, found.give, asset.amount);
+        const [balance, dust] = await Promise.all([deps.btcBalance(), deps.dust()]);
+        return { plan, error: validatePlan(plan, balance, dust) };
+    };
+
+    return {
+        id: CROSS_ASSET_RAIL,
+        match: (req) => arkTarget(req.raw) !== undefined,
+
+        available: async (req) => {
+            // Only for a request naming exactly one well-formed asset; a
+            // malformed one is `ark-asset`'s to reject with a named error, not
+            // this rail's to drop twice over.
+            const assets = assetsOf(req);
+            if (assets.length !== 1) return false;
+            const [asset] = assets;
+            if (asset.assetId === BTC_ASSET_ID) return false;
+            if (typeof asset.amount !== "bigint" || asset.amount <= 0n) return false;
+            // A discovery or feed failure propagates: the router catches it,
+            // warns, and drops this rail, which is the intended fallback.
+            const planned = await planFor(asset);
+            return planned !== undefined && planned.error === undefined;
+        },
+
+        quote: async (req, ctx: RouterContext): Promise<RouteQuote> => {
+            const payTo = arkTarget(req.raw)!;
+            const asset = resolveAssetAmount(CROSS_ASSET_RAIL, req);
+            const planned = await planFor(asset);
+            if (!planned) {
+                throw new Error(`${CROSS_ASSET_RAIL}: no market swaps BTC into ${asset.assetId}`);
+            }
+            if (planned.error) {
+                throw new Error(
+                    `${CROSS_ASSET_RAIL}: cannot swap into ${asset.assetId} — ${planned.error}`,
+                );
+            }
+            const { plan } = planned;
+            const depositSats = Number(plan.deposit.atomic);
+            const carrier = deps.carrierSats ?? DEFAULT_CARRIER_SATS;
+
+            return {
+                railId: CROSS_ASSET_RAIL,
+                // The BTC leg, as on every rail: what leaves the wallet in
+                // sats. `amount` is the carrier the recipient's output holds,
+                // `fee` the sats the swap consumes to buy the asset — spent on
+                // the user's behalf and never delivered, which is exactly what
+                // `fee` means everywhere else.
+                amount: carrier,
+                fee: depositSats,
+                total: depositSats + carrier,
+                assets: {
+                    delivered: asset,
+                    // A DIFFERENT asset from `delivered` — the whole reason
+                    // these are two fields and not an amount/fee/total triple.
+                    spent: { assetId: BTC_ASSET_ID, amount: plan.deposit.atomic },
+                },
+                meta: {
+                    market: plan.market.pair,
+                    priceDisplay: plan.priceDisplay,
+                    give: plan.give,
+                },
+                send: async () =>
+                    makeHandle(CROSS_ASSET_RAIL, async (emit) => {
+                        const offer = await createOffer(ctx.wallet, deps.arkServerUrl, {
+                            wantAmount: asset.amount,
+                            wantAsset: asset.assetId as never,
+                            ...(deps.emulatorPubkey ? { emulatorPubkey: deps.emulatorPubkey } : {}),
+                        });
+                        const swap: CrossAssetSwap = {
+                            offerHex: offer.offerHex,
+                            address: offer.address,
+                            swapPkScript: offer.swapPkScript,
+                            depositSats,
+                            asset,
+                            payTo,
+                            plan,
+                        };
+                        // Persist FIRST: `cancelOffer` rebuilds the covenant
+                        // from `offerHex` and nothing else, so an offer funded
+                        // without a record is one nobody can cancel.
+                        await deps.persist(swap);
+                        await ctx.wallet.send({
+                            address: offer.address,
+                            amount: depositSats,
+                            extensions: [offer.extension],
+                        });
+                        emit({ status: "sent" });
+
+                        // A filler delivers the asset to this wallet; only then
+                        // is there anything to pay the recipient with.
+                        await deps.awaitFill(swap);
+                        const txid = await ctx.wallet.send({
+                            address: payTo,
+                            amount: carrier,
+                            assets: [asset],
+                        });
+                        const result = {
+                            railId: CROSS_ASSET_RAIL,
+                            txid,
+                            swapId: offer.offerHex,
+                        };
+                        emit({ status: "settled", result });
+                        return result;
+                    }),
+            };
+        },
+    };
+}

--- a/packages/swap/src/payment/crossAsset.ts
+++ b/packages/swap/src/payment/crossAsset.ts
@@ -56,8 +56,17 @@ import { BTC_ASSET_ID } from "../store";
 /** This rail's id, and what `RouterPreferences.priority` ranks it by. */
 export const CROSS_ASSET_RAIL = "cross-asset";
 
+/**
+ * How far the route has got. Persisted, because the two states need different
+ * recovery: a `"quoted"` record whose offer never filled is cancelled, while a
+ * `"filled"` one has the asset in the wallet and owes the recipient a send.
+ */
+export type CrossAssetPhase = "quoted" | "filled";
+
 /** The offer this rail funded, and the payment it was funded for. */
 export interface CrossAssetSwap {
+    /** Where the route has got to; see {@link CrossAssetPhase}. */
+    phase: CrossAssetPhase;
     /** `createOffer`'s encoded offer — the only input `cancelOffer` needs. */
     offerHex: string;
     /** The swap address the deposit went to. */
@@ -75,7 +84,17 @@ export interface CrossAssetSwap {
 export interface CrossAssetRailDeps {
     /** Arkade Service REST URL — `createOffer` reads `getInfo()` from it. */
     arkServerUrl: string;
-    /** Markets to price and route over. `discoverMarkets` already caches. */
+    /**
+     * Markets to price and route over.
+     *
+     * Called once by `available()` and again by `quote()` — the router
+     * deliberately does not carry a result between them, so a rail that
+     * decided it could route must decide again when asked for a price. With
+     * `discoverMarkets` (1h cache) and `makeCachedFeedFetch` (30s, with
+     * in-flight collapsing) behind these, an `options()`-then-`route()` pass
+     * costs one round trip rather than two. Passing a bare registry fetch
+     * makes it four.
+     */
     discover(): Promise<DiscoveredMarket[]>;
     /**
      * Price the swap leg. Pass `quoteOffer` from `@arkade-os/solver-discovery`,
@@ -199,6 +218,16 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
                 );
             }
             const { plan } = planned;
+            // `RouteQuote.fee`/`total` and `Recipient.amount` are `number`, so
+            // the deposit narrows here. Safe for BTC — the entire supply is
+            // ~2.1e15 sats against a 9.0e15 safe integer — but asserted rather
+            // than assumed, because the assumption is the give side being BTC
+            // and a future non-BTC deposit corridor would silently break it.
+            if (!Number.isSafeInteger(Number(plan.deposit.atomic))) {
+                throw new Error(
+                    `${CROSS_ASSET_RAIL}: deposit of ${plan.deposit.atomic} does not fit a JS number`,
+                );
+            }
             const depositSats = Number(plan.deposit.atomic);
             const carrier = deps.carrierSats ?? DEFAULT_CARRIER_SATS;
 
@@ -231,6 +260,7 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
                             ...(deps.emulatorPubkey ? { emulatorPubkey: deps.emulatorPubkey } : {}),
                         });
                         const swap: CrossAssetSwap = {
+                            phase: "quoted",
                             offerHex: offer.offerHex,
                             address: offer.address,
                             swapPkScript: offer.swapPkScript,
@@ -253,6 +283,12 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
                         // A filler delivers the asset to this wallet; only then
                         // is there anything to pay the recipient with.
                         await deps.awaitFill(swap);
+                        // Record the fill BEFORE attempting the payment. If the
+                        // send then fails — a locked wallet, a lost connection —
+                        // the user is holding the asset and the recipient is
+                        // still owed; a record frozen at "quoted" would say the
+                        // opposite, and the offer would look cancellable.
+                        await deps.persist({ ...swap, phase: "filled" });
                         const txid = await ctx.wallet.send({
                             address: payTo,
                             amount: carrier,

--- a/packages/swap/src/payment/index.ts
+++ b/packages/swap/src/payment/index.ts
@@ -19,6 +19,7 @@ export {
 export {
     CROSS_ASSET_RAIL,
     crossAssetRail,
+    type CrossAssetPhase,
     type CrossAssetRailDeps,
     type CrossAssetSwap,
 } from "./crossAsset";

--- a/packages/swap/src/payment/index.ts
+++ b/packages/swap/src/payment/index.ts
@@ -16,3 +16,9 @@ export {
     type SolverLightningRailDeps,
     type SolverLightningSend,
 } from "./solverLightning";
+export {
+    CROSS_ASSET_RAIL,
+    crossAssetRail,
+    type CrossAssetRailDeps,
+    type CrossAssetSwap,
+} from "./crossAsset";

--- a/packages/swap/src/payment/solverLightning.ts
+++ b/packages/swap/src/payment/solverLightning.ts
@@ -7,7 +7,7 @@
  */
 import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
 import type { PaymentRail, RouteQuote, RouterContext } from "@arkade-os/sdk";
-import { invoiceTarget, makeHandle } from "@arkade-os/sdk";
+import { assertNoAssets, assetsOf, invoiceTarget, makeHandle } from "@arkade-os/sdk";
 import { assertFundable, requestLightningSend, type InvoiceFacts, type RfqTransport } from "../rfq";
 import { solverRendezvous, type SolverRendezvous } from "./rendezvous";
 
@@ -73,6 +73,8 @@ export function solverLightningRail(deps: SolverLightningRailDeps): PaymentRail 
         match: (req) => invoiceTarget(req.raw) !== undefined,
 
         available: async (req) => {
+            // A bolt11 invoice is denominated in sats; an asset cannot ride it.
+            if (assetsOf(req).length > 0) return false;
             const facts = factsOf(req.raw, deps.decodeInvoice, Math.floor(Date.now() / 1000));
             if (!facts) return false;
             // A request amount contradicting the invoice is unpayable.
@@ -81,6 +83,7 @@ export function solverLightningRail(deps: SolverLightningRailDeps): PaymentRail 
         },
 
         quote: async (req, ctx: RouterContext): Promise<RouteQuote> => {
+            assertNoAssets(SOLVER_LIGHTNING_RAIL, req);
             const facts = factsOf(req.raw, deps.decodeInvoice, Math.floor(Date.now() / 1000));
             if (!facts) {
                 throw new Error(

--- a/packages/swap/src/payment/solverOnchain.ts
+++ b/packages/swap/src/payment/solverOnchain.ts
@@ -7,7 +7,14 @@
  */
 import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
 import type { PaymentRail, RouteQuote, RouterContext } from "@arkade-os/sdk";
-import { btcTarget, makeHandle, resolveSendAmount, tryResolveSendAmount } from "@arkade-os/sdk";
+import {
+    assertNoAssets,
+    assetsOf,
+    btcTarget,
+    makeHandle,
+    resolveSendAmount,
+    tryResolveSendAmount,
+} from "@arkade-os/sdk";
 import { assertFundable, requestOnchainSend, type RfqTransport } from "../rfq";
 import { l1ScriptForAddress, type OnchainNetwork } from "../onchainHtlc";
 import { solverRendezvous, type SolverRendezvous } from "./rendezvous";
@@ -69,6 +76,8 @@ export function solverOnchainRail(deps: SolverOnchainRailDeps): PaymentRail {
         match: (req) => btcTarget(req.raw) !== undefined,
 
         available: async (req) => {
+            // BTC only: an Arkade asset has no L1 form for the solver to fill.
+            if (assetsOf(req).length > 0) return false;
             const address = btcTarget(req.raw);
             if (!address) return false;
             // Before any network call: a destination the claim cannot pay to
@@ -91,6 +100,7 @@ export function solverOnchainRail(deps: SolverOnchainRailDeps): PaymentRail {
 
         quote: async (req, ctx: RouterContext): Promise<RouteQuote> => {
             const address = btcTarget(req.raw)!;
+            assertNoAssets(SOLVER_ONCHAIN_RAIL, req);
             const amount = resolveSendAmount(SOLVER_ONCHAIN_RAIL, req.raw, req.amount);
             const payoutPkScript = l1ScriptForAddress(address, deps.l1Network);
             const rendezvous = await rendezvousFor(amount);

--- a/packages/swap/test/payment/crossAsset.test.ts
+++ b/packages/swap/test/payment/crossAsset.test.ts
@@ -1,0 +1,406 @@
+/**
+ * `crossAssetRail` — pay an asset the wallet does not hold.
+ *
+ * The claim under test is the design one: **swap-then-pay fits inside a rail**,
+ * with no router composition primitive. Both legs are priced into one
+ * `RouteQuote`, the swap is reported on `RouteResult.swapId`, and the router is
+ * unchanged. The tests that matter are therefore about the seams that would
+ * otherwise leak into the router:
+ *
+ * - the quote names two DIFFERENT assets (`spent` BTC, `delivered` the asset),
+ *   which is the reason `RouteQuote.assets` is a pair rather than a triple;
+ * - the rail does not route when no corridor exists — it drops, it does not
+ *   quote a swap nobody can fill;
+ * - the recipient is paid only AFTER the fill, never before.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { DiscoveredMarket, OfferPlan, Side } from "@arkade-os/solver-discovery";
+import { PaymentRouter, type Asset, type RouterContext } from "@arkade-os/sdk";
+import {
+    CROSS_ASSET_RAIL,
+    crossAssetRail,
+    type CrossAssetRailDeps,
+    type CrossAssetSwap,
+} from "../../src/payment/crossAsset";
+
+const ARK_ADDR =
+    "tark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt846qj6x";
+const USDX_ID = "aa".repeat(32);
+const USDX: Asset = { assetId: USDX_ID, amount: 500n };
+
+/** A BTC/USDX market: BTC is the base (the side this rail gives). */
+const market = (over: Record<string, unknown> = {}) =>
+    ({
+        pair: "BTC/USDX",
+        base_asset: { id: "btc", decimals: 8 },
+        quote_asset: { id: USDX_ID, decimals: 2 },
+        min_base_amount: "1",
+        max_base_amount: "100000000",
+        min_quote_amount: "1",
+        max_quote_amount: "100000000",
+        ...over,
+    }) as unknown as DiscoveredMarket;
+
+const plan = (depositSats: bigint, receive: bigint): OfferPlan =>
+    ({
+        market: market(),
+        give: "base" as Side,
+        deposit: { atomic: depositSats, asset: { id: "btc", decimals: 8 } },
+        receive: { atomic: receive, asset: { id: USDX_ID, decimals: 2 } },
+        priceDisplay: "0.00020000",
+        safetyBps: 0,
+        limits: {
+            min: { atomic: 1n, asset: { id: USDX_ID, decimals: 2 } },
+            max: { atomic: 100_000_000n, asset: { id: USDX_ID, decimals: 2 } },
+            withinLimits: true,
+        },
+    }) as unknown as OfferPlan;
+
+const ctxWith = (send = vi.fn(async () => "txid")): RouterContext =>
+    ({ wallet: { send } as never, prefs: {} }) as RouterContext;
+
+const depsWith = (over: Partial<CrossAssetRailDeps> = {}): CrossAssetRailDeps => ({
+    arkServerUrl: "http://ark",
+    discover: vi.fn(async () => [market()]),
+    quote: vi.fn(async () => plan(100_000n, 500n)),
+    btcBalance: vi.fn(async () => 1_000_000n),
+    dust: vi.fn(async () => 330n),
+    persist: vi.fn(async () => {}),
+    awaitFill: vi.fn(async () => {}),
+    ...over,
+});
+
+const offer = {
+    offerHex: "0fe0",
+    address: "tark1offer",
+    swapPkScript: new Uint8Array([0x51, 0x20]),
+    extension: { type: 1, payload: new Uint8Array([1]) },
+};
+
+vi.mock("../../src/offer", async (importOriginal) => {
+    const mod = await importOriginal<typeof import("../../src/offer")>();
+    return { ...mod, createOffer: (...args: unknown[]) => offerStub(...args) };
+});
+
+let offerStub: (...args: unknown[]) => Promise<unknown> = async () => offer;
+
+describe("crossAssetRail.match", () => {
+    it("matches an Arkade address, like every rail that pays one", () => {
+        const rail = crossAssetRail(depsWith());
+        expect(rail.match({ raw: ARK_ADDR, assets: [USDX] }, ctxWith())).toBe(true);
+        expect(rail.match({ raw: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080" }, ctxWith())).toBe(
+            false,
+        );
+    });
+});
+
+describe("crossAssetRail.available", () => {
+    const req = { raw: ARK_ADDR, assets: [USDX] };
+
+    it("is available when a market swaps BTC into the asset and the balance covers it", async () => {
+        expect(await crossAssetRail(depsWith()).available?.(req, ctxWith())).toBe(true);
+    });
+
+    it("does not route when no corridor exists", async () => {
+        // The load-bearing negative: with no market there is nothing to quote,
+        // and a rail that quoted anyway would be selling a swap nobody can fill.
+        const deps = depsWith({ discover: vi.fn(async () => []) });
+        expect(await crossAssetRail(deps).available?.(req, ctxWith())).toBe(false);
+    });
+
+    it("does not route an asset/asset market — the BTC keying is the restriction", async () => {
+        // `createOffer` is BTC<->asset only. What enforces that is `findMarket`
+        // being keyed on BTC: it matches asset ids EXACTLY in either
+        // orientation, so a EURX/USDX market is never returned for
+        // `(btc, USDX)` however well it connects the two. There is deliberately
+        // no give-side check in the rail — one would be unreachable.
+        const eurx = market({ base_asset: { id: "bb".repeat(32), decimals: 2 } });
+        const deps = depsWith({ discover: vi.fn(async () => [eurx]) });
+        expect(await crossAssetRail(deps).available?.(req, ctxWith())).toBe(false);
+    });
+
+    it("routes a market that names BTC on either side", async () => {
+        // The mirror of the above: BTC as the QUOTE asset is the same corridor
+        // read the other way round, and `findMarket` reports `give: "quote"`.
+        const inverted = market({
+            base_asset: { id: USDX_ID, decimals: 2 },
+            quote_asset: { id: "btc", decimals: 8 },
+        });
+        const quoteFn = vi.fn(async () => plan(100_000n, 500n));
+        const deps = depsWith({ discover: vi.fn(async () => [inverted]), quote: quoteFn });
+        expect(await crossAssetRail(deps).available?.(req, ctxWith())).toBe(true);
+        expect(quoteFn.mock.calls[0][1]).toBe("quote");
+    });
+
+    it("does not route when the BTC balance cannot fund the deposit", async () => {
+        const deps = depsWith({ btcBalance: vi.fn(async () => 1_000n) });
+        expect(await crossAssetRail(deps).available?.(req, ctxWith())).toBe(false);
+    });
+
+    it("does not route a plan outside the market's own limits", async () => {
+        const deps = depsWith({
+            quote: vi.fn(async () => {
+                const p = plan(100_000n, 500n);
+                return { ...p, limits: { ...p.limits, withinLimits: false } } as OfferPlan;
+            }),
+        });
+        expect(await crossAssetRail(deps).available?.(req, ctxWith())).toBe(false);
+    });
+
+    it("does not route a BTC 'asset', and does not ask the registry about it", async () => {
+        // That is `ark`'s payment, and there is no corridor from BTC to BTC.
+        // The check is up front for a reason: a plain BTC send must not put a
+        // registry round trip on the availability path of every other rail.
+        const discover = vi.fn(async () => [market()]);
+        expect(
+            await crossAssetRail(depsWith({ discover })).available?.(
+                { raw: ARK_ADDR, assets: [{ assetId: "btc", amount: 500n }] },
+                ctxWith(),
+            ),
+        ).toBe(false);
+        expect(discover).not.toHaveBeenCalled();
+    });
+
+    it("does not route a request naming no asset, or more than one, without a lookup", async () => {
+        const discover = vi.fn(async () => [market()]);
+        const rail = crossAssetRail(depsWith({ discover }));
+        expect(await rail.available?.({ raw: ARK_ADDR, amount: 1000 }, ctxWith())).toBe(false);
+        expect(await rail.available?.({ raw: ARK_ADDR, assets: [USDX, USDX] }, ctxWith())).toBe(
+            false,
+        );
+        // Every BTC-only payment in the wallet passes through here.
+        expect(discover).not.toHaveBeenCalled();
+    });
+
+    it("does not route a non-positive or non-bigint quantity", async () => {
+        const rail = crossAssetRail(depsWith());
+        expect(
+            await rail.available?.({ raw: ARK_ADDR, assets: [{ ...USDX, amount: 0n }] }, ctxWith()),
+        ).toBe(false);
+        expect(
+            await rail.available?.(
+                { raw: ARK_ADDR, assets: [{ assetId: USDX_ID, amount: 500 as unknown as bigint }] },
+                ctxWith(),
+            ),
+        ).toBe(false);
+    });
+
+    it("drops the rail, not the router, when discovery throws", async () => {
+        const deps = depsWith({
+            discover: vi.fn(async () => {
+                throw new Error("registry unreachable");
+            }),
+        });
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            const options = await new PaymentRouter({ wallet: {} as never, prefs: {} })
+                .use(crossAssetRail(deps))
+                .options(req);
+            expect(options).toEqual([]);
+            expect(warn).toHaveBeenCalled();
+        } finally {
+            warn.mockRestore();
+        }
+    });
+});
+
+describe("crossAssetRail.quote", () => {
+    const req = { raw: ARK_ADDR, assets: [USDX] };
+
+    it("names two different assets: BTC spent, the asset delivered", async () => {
+        // This is why `RouteQuote.assets` is a pair and not a third
+        // amount/fee/total triple — `total = amount + fee` cannot hold across
+        // two units.
+        const quote = await crossAssetRail(depsWith()).quote(req, ctxWith());
+        expect(quote.assets?.delivered).toEqual(USDX);
+        expect(quote.assets?.spent).toEqual({ assetId: "btc", amount: 100_000n });
+        expect(quote.assets?.spent.assetId).not.toBe(quote.assets?.delivered.assetId);
+    });
+
+    it("prices BOTH legs into the sats that leave the wallet", async () => {
+        // The swap deposit AND the delivery carrier: `total` means the same
+        // thing here as on every other rail.
+        const quote = await crossAssetRail(depsWith({ carrierSats: 330 })).quote(req, ctxWith());
+        expect(quote).toMatchObject({ amount: 330, fee: 100_000, total: 100_330 });
+    });
+
+    it("asks the market for the amount the recipient must receive", async () => {
+        const quoteFn = vi.fn(async () => plan(100_000n, 500n));
+        await crossAssetRail(depsWith({ quote: quoteFn })).quote(req, ctxWith());
+        expect(quoteFn.mock.calls[0][2]).toBe(500n);
+    });
+
+    it("refuses, with the corridor named, when no market swaps into the asset", async () => {
+        const deps = depsWith({ discover: vi.fn(async () => []) });
+        await expect(crossAssetRail(deps).quote(req, ctxWith())).rejects.toThrow(
+            new RegExp(`no market swaps BTC into ${USDX_ID}`),
+        );
+    });
+
+    it("refuses with the plan's own reason when the plan is unusable", async () => {
+        const deps = depsWith({ btcBalance: vi.fn(async () => 1_000n) });
+        await expect(crossAssetRail(deps).quote(req, ctxWith())).rejects.toThrow(
+            /insufficient-balance/,
+        );
+    });
+});
+
+describe("crossAssetRail.send", () => {
+    const req = { raw: ARK_ADDR, assets: [USDX] };
+
+    it("funds the offer, waits for the fill, then pays the recipient — in that order", async () => {
+        const order: string[] = [];
+        offerStub = async () => offer;
+        const send = vi.fn(async (r: { address: string }) => {
+            order.push(r.address === offer.address ? "fund-offer" : "pay-recipient");
+            return "txid";
+        });
+        const deps = depsWith({
+            persist: vi.fn(async () => {
+                order.push("persist");
+            }),
+            awaitFill: vi.fn(async () => {
+                order.push("await-fill");
+            }),
+        });
+
+        const quote = await crossAssetRail(deps).quote(req, ctxWith(send as never));
+        await (await quote.send()).settled();
+
+        expect(order).toEqual(["persist", "fund-offer", "await-fill", "pay-recipient"]);
+    });
+
+    it("does not pay the recipient when the fill never lands", async () => {
+        // The asset is not in the wallet until a filler delivers it; paying
+        // before that is a send that cannot be funded.
+        offerStub = async () => offer;
+        const send = vi.fn(async () => "txid");
+        const deps = depsWith({
+            awaitFill: vi.fn(async () => {
+                throw new Error("offer expired");
+            }),
+        });
+
+        const quote = await crossAssetRail(deps).quote(req, ctxWith(send as never));
+        await expect((await quote.send()).settled()).rejects.toThrow(/offer expired/);
+        // Only the offer deposit went out.
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send.mock.calls[0][0]).toMatchObject({ address: offer.address });
+    });
+
+    it("does not fund the offer when the record could not be written", async () => {
+        // `cancelOffer` rebuilds the covenant from `offerHex` and nothing else.
+        offerStub = async () => offer;
+        const send = vi.fn(async () => "txid");
+        const deps = depsWith({
+            persist: vi.fn(async () => {
+                throw new Error("storage full");
+            }),
+        });
+
+        const quote = await crossAssetRail(deps).quote(req, ctxWith(send as never));
+        await expect((await quote.send()).settled()).rejects.toThrow(/storage full/);
+        expect(send).not.toHaveBeenCalled();
+    });
+
+    it("deposits the planned sats into the offer, with the offer extension", async () => {
+        offerStub = async () => offer;
+        const send = vi.fn(async () => "txid");
+        const quote = await crossAssetRail(depsWith()).quote(req, ctxWith(send as never));
+        await (await quote.send()).settled();
+
+        expect(send.mock.calls[0][0]).toEqual({
+            address: offer.address,
+            amount: 100_000,
+            extensions: [offer.extension],
+        });
+    });
+
+    it("pays the recipient the asset, on the carrier the quote named", async () => {
+        offerStub = async () => offer;
+        const send = vi.fn(async () => "pay-txid");
+        const quote = await crossAssetRail(depsWith({ carrierSats: 546 })).quote(
+            req,
+            ctxWith(send as never),
+        );
+        const result = await (await quote.send()).settled();
+
+        expect(send.mock.calls[1][0]).toEqual({
+            address: ARK_ADDR,
+            amount: 546,
+            assets: [USDX],
+        });
+        expect(result).toEqual({
+            railId: CROSS_ASSET_RAIL,
+            txid: "pay-txid",
+            swapId: offer.offerHex,
+        });
+    });
+
+    it("hands the fill watcher the record it persisted", async () => {
+        offerStub = async () => offer;
+        const persisted: CrossAssetSwap[] = [];
+        const awaitFill = vi.fn(async (swap: CrossAssetSwap) => {
+            expect(swap).toBe(persisted[0]);
+        });
+        const quote = await crossAssetRail(
+            depsWith({
+                persist: vi.fn(async (s: CrossAssetSwap) => {
+                    persisted.push(s);
+                }),
+                awaitFill,
+            }),
+        ).quote(req, ctxWith());
+        await (await quote.send()).settled();
+
+        expect(persisted[0]).toMatchObject({
+            offerHex: offer.offerHex,
+            depositSats: 100_000,
+            payTo: ARK_ADDR,
+            asset: USDX,
+        });
+    });
+});
+
+describe("no BTC-only rail silently drops an asset", () => {
+    // The failure this closes: a request for 500 USDX handed to a BTC rail
+    // would pay its carrier sats, report success, and deliver none of the asset
+    // the user asked for. Every rail that moves BTC must drop instead, so the
+    // router is free to rank one that can.
+    it("solver-onchain and solver-lightning both drop an asset request", async () => {
+        const { solverOnchainRail } = await import("../../src/payment/solverOnchain");
+        const { solverLightningRail } = await import("../../src/payment/solverLightning");
+        const btc = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+
+        const onchain = solverOnchainRail({
+            arkServerUrl: "http://ark",
+            l1Network: "regtest",
+            payoutPubkey: new Uint8Array(32).fill(15),
+            discover: vi.fn(async () => []),
+            connect: vi.fn(async (_r, fn) => fn({} as never)),
+            persist: vi.fn(async () => {}),
+        });
+        expect(
+            await onchain.available?.({ raw: btc, amount: 1000, assets: [USDX] }, ctxWith()),
+        ).toBe(false);
+        await expect(
+            onchain.quote({ raw: btc, amount: 1000, assets: [USDX] }, ctxWith()),
+        ).rejects.toThrow(/cannot deliver/);
+
+        const lightning = solverLightningRail({
+            arkServerUrl: "http://ark",
+            decodeInvoice: () => ({
+                raw: "lnbcrt1u1p",
+                paymentHash: "cc".repeat(32),
+                amountSats: 100_000,
+                expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            }),
+            discover: vi.fn(async () => []),
+            connect: vi.fn(async (_r, fn) => fn({} as never)),
+            persist: vi.fn(async () => {}),
+        });
+        const lnReq = { raw: "lnbcrt1u1pjexampleinvoice", assets: [USDX] };
+        expect(await lightning.available?.(lnReq, ctxWith())).toBe(false);
+        await expect(lightning.quote(lnReq, ctxWith())).rejects.toThrow(/cannot deliver/);
+    });
+});

--- a/packages/swap/test/payment/crossAsset.test.ts
+++ b/packages/swap/test/payment/crossAsset.test.ts
@@ -283,7 +283,9 @@ describe("crossAssetRail.send", () => {
         const quote = await crossAssetRail(deps).quote(req, ctxWith(send as never));
         await (await quote.send()).settled();
 
-        expect(order).toEqual(["persist", "fund-offer", "await-fill", "pay-recipient"]);
+        // Two persists: the offer before it is funded, and the fill before the
+        // recipient is paid.
+        expect(order).toEqual(["persist", "fund-offer", "await-fill", "persist", "pay-recipient"]);
     });
 
     it("does not pay the recipient when the fill never lands", async () => {
@@ -437,5 +439,81 @@ describe("no BTC-only rail silently drops an asset", () => {
         const lnReq = { raw: "lnbcrt1u1pjexampleinvoice", assets: [USDX] };
         expect(await lightning.available?.(lnReq, ctxWith())).toBe(false);
         await expect(lightning.quote(lnReq, ctxWith())).rejects.toThrow(/cannot deliver/);
+    });
+});
+
+describe("the record says which side of the fill the route is on", () => {
+    // Two states with different recoveries: a "quoted" record whose offer never
+    // filled is cancelled; a "filled" one has the asset in the wallet and owes
+    // the recipient a send. A record frozen at "quoted" after the fill landed
+    // says the opposite of the truth.
+    const req = { raw: ARK_ADDR, assets: [USDX] };
+
+    const runWith = async (send: ReturnType<typeof vi.fn>) => {
+        offerStub = async () => offer;
+        const phases: string[] = [];
+        const persist = vi.fn(async (s: CrossAssetSwap) => {
+            phases.push(s.phase);
+        });
+        const quote = await crossAssetRail(depsWith({ persist })).quote(
+            req,
+            ctxWith(send as never),
+        );
+        return { handle: await quote.send(), phases };
+    };
+
+    it("records 'quoted' before funding and 'filled' before paying", async () => {
+        const { handle, phases } = await runWith(vi.fn(async () => "txid"));
+        await handle.settled();
+        expect(phases).toEqual(["quoted", "filled"]);
+    });
+
+    it("records the fill even when the recipient send then fails", async () => {
+        // The window this closes: the filler delivered, the payment did not go
+        // out, and the user is holding an asset the recipient is still owed.
+        let call = 0;
+        const send = vi.fn(async () => {
+            if (++call === 1) return "deposit-txid";
+            throw new Error("wallet locked");
+        });
+        const { handle, phases } = await runWith(send);
+
+        await expect(handle.settled()).rejects.toThrow(/wallet locked/);
+        expect(phases).toEqual(["quoted", "filled"]);
+    });
+
+    it("does not record a fill that never happened", async () => {
+        offerStub = async () => offer;
+        const phases: string[] = [];
+        const quote = await crossAssetRail(
+            depsWith({
+                persist: vi.fn(async (s: CrossAssetSwap) => {
+                    phases.push(s.phase);
+                }),
+                awaitFill: vi.fn(async () => {
+                    throw new Error("offer expired");
+                }),
+            }),
+        ).quote(req, ctxWith());
+        await expect((await quote.send()).settled()).rejects.toThrow(/offer expired/);
+        expect(phases).toEqual(["quoted"]);
+    });
+
+    it("refuses a deposit that would not survive the narrowing to a JS number", async () => {
+        // `RouteQuote.fee`/`total` are `number`. Safe for BTC, whose whole
+        // supply fits — asserted anyway, because the assumption is the give
+        // side being BTC.
+        const huge = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
+        // A market whose bounds admit it, so the narrowing guard is what
+        // rejects rather than `validatePlan`'s `above-max`.
+        const wide = market({ max_base_amount: (huge * 4n).toString() });
+        const deps = depsWith({
+            discover: vi.fn(async () => [wide]),
+            quote: vi.fn(async () => ({ ...plan(huge, 500n), market: wide }) as OfferPlan),
+            btcBalance: vi.fn(async () => huge * 2n),
+        });
+        await expect(crossAssetRail(deps).quote(req, ctxWith())).rejects.toThrow(
+            /does not fit a JS number/,
+        );
     });
 });

--- a/packages/swap/test/payment/crossAsset.test.ts
+++ b/packages/swap/test/payment/crossAsset.test.ts
@@ -255,7 +255,15 @@ describe("crossAssetRail.send", () => {
         const quote = await crossAssetRail(deps).quote(req, ctxWith(send as never));
         await (await quote.send()).settled();
 
-        expect(order).toEqual(["persist", "fund-offer", "await-fill", "persist", "pay-recipient"]);
+        expect(order).toEqual([
+            "persist",
+            "fund-offer",
+            "await-fill",
+            "persist",
+            "persist",
+            "pay-recipient",
+            "persist",
+        ]);
     });
 
     it("does not pay the recipient when the fill never lands", async () => {
@@ -412,20 +420,57 @@ describe("the record says which side of the fill the route is on", () => {
     const runWith = async (send: ReturnType<typeof vi.fn>) => {
         offerStub = async () => offer;
         const phases: string[] = [];
+        const records: CrossAssetSwap[] = [];
         const persist = vi.fn(async (s: CrossAssetSwap) => {
             phases.push(s.phase);
+            records.push({ ...s });
         });
         const quote = await crossAssetRail(depsWith({ persist })).quote(
             req,
             ctxWith(send as never),
         );
-        return { handle: await quote.send(), phases };
+        return { handle: await quote.send(), phases, records };
     };
 
     it("records 'quoted' before funding and 'filled' before paying", async () => {
         const { handle, phases } = await runWith(vi.fn(async () => "txid"));
         await handle.settled();
-        expect(phases).toEqual(["quoted", "filled"]);
+        expect(phases.slice(0, 2)).toEqual(["quoted", "filled"]);
+    });
+
+    it("marks the payout attempted BEFORE broadcasting it", async () => {
+        const order: string[] = [];
+        offerStub = async () => offer;
+        const persist = vi.fn(async (s: CrossAssetSwap) => {
+            order.push(`persist:${s.phase}`);
+        });
+        const send = vi.fn(async () => {
+            order.push("send");
+            return "txid";
+        });
+        const quote = await crossAssetRail(depsWith({ persist })).quote(
+            req,
+            ctxWith(send as never),
+        );
+        await (await quote.send()).settled();
+
+        expect(order).toEqual([
+            "persist:quoted",
+            "send",
+            "persist:filled",
+            "persist:paying",
+            "send",
+            "persist:settled",
+        ]);
+    });
+
+    it("leaves a completed swap in a terminal phase carrying the payout txid", async () => {
+        const { handle, records } = await runWith(vi.fn(async () => "txid"));
+        await handle.settled();
+        const final = records[records.length - 1];
+
+        expect(final.phase).toBe("settled");
+        expect(final.txid).toBe("txid");
     });
 
     it("records the fill even when the recipient send then fails", async () => {
@@ -437,7 +482,7 @@ describe("the record says which side of the fill the route is on", () => {
         const { handle, phases } = await runWith(send);
 
         await expect(handle.settled()).rejects.toThrow(/wallet locked/);
-        expect(phases).toEqual(["quoted", "filled"]);
+        expect(phases).toEqual(["quoted", "filled", "paying"]);
     });
 
     it("does not record a fill that never happened", async () => {
@@ -455,6 +500,55 @@ describe("the record says which side of the fill the route is on", () => {
         ).quote(req, ctxWith());
         await expect((await quote.send()).settled()).rejects.toThrow(/offer expired/);
         expect(phases).toEqual(["quoted"]);
+    });
+
+    it("a recovery pass over a completed swap sends nothing", async () => {
+        const resendIfOwed = async (
+            swap: CrossAssetSwap,
+            wallet: { send: ReturnType<typeof vi.fn> },
+        ) => {
+            if (swap.phase !== "filled") return;
+            await wallet.send({
+                address: swap.payTo,
+                amount: 330,
+                assets: [swap.asset],
+            });
+        };
+
+        const { handle, records } = await runWith(vi.fn(async () => "txid"));
+        await handle.settled();
+
+        const recoverySend = vi.fn(async () => "second-txid");
+        await resendIfOwed(records[records.length - 1], { send: recoverySend });
+
+        expect(recoverySend).not.toHaveBeenCalled();
+    });
+
+    it("a recovery pass BEFORE the payout still sends, so the guard is not blanket", async () => {
+        const resendIfOwed = async (
+            swap: CrossAssetSwap,
+            wallet: { send: ReturnType<typeof vi.fn> },
+        ) => {
+            if (swap.phase !== "filled") return;
+            await wallet.send({ address: swap.payTo, amount: 330, assets: [swap.asset] });
+        };
+
+        offerStub = async () => offer;
+        const records: CrossAssetSwap[] = [];
+        const quote = await crossAssetRail(
+            depsWith({
+                persist: vi.fn(async (s: CrossAssetSwap) => {
+                    records.push({ ...s });
+                }),
+            }),
+        ).quote(req, ctxWith(vi.fn(async () => "txid") as never));
+        await (await quote.send()).settled();
+
+        const filled = records.find((r) => r.phase === "filled")!;
+        const recoverySend = vi.fn(async () => "second-txid");
+        await resendIfOwed(filled, { send: recoverySend });
+
+        expect(recoverySend).toHaveBeenCalledTimes(1);
     });
 
     it("refuses a deposit that would not survive the narrowing to a JS number", async () => {

--- a/packages/swap/test/payment/crossAsset.test.ts
+++ b/packages/swap/test/payment/crossAsset.test.ts
@@ -25,7 +25,9 @@ import {
 
 const ARK_ADDR =
     "tark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt846qj6x";
-const USDX_ID = "aa".repeat(32);
+// A real asset id: 34 bytes of hex. `AssetId.fromString` rejects anything
+// else, and `createOffer` binds `.txid`/`.groupIndex` off the parsed value.
+const USDX_ID = "aa".repeat(34);
 const USDX: Asset = { assetId: USDX_ID, amount: 500n };
 
 /** A BTC/USDX market: BTC is the base (the side this rail gives). */
@@ -114,7 +116,7 @@ describe("crossAssetRail.available", () => {
         // orientation, so a EURX/USDX market is never returned for
         // `(btc, USDX)` however well it connects the two. There is deliberately
         // no give-side check in the rail — one would be unreachable.
-        const eurx = market({ base_asset: { id: "bb".repeat(32), decimals: 2 } });
+        const eurx = market({ base_asset: { id: "bb".repeat(34), decimals: 2 } });
         const deps = depsWith({ discover: vi.fn(async () => [eurx]) });
         expect(await crossAssetRail(deps).available?.(req, ctxWith())).toBe(false);
     });
@@ -169,6 +171,20 @@ describe("crossAssetRail.available", () => {
             false,
         );
         // Every BTC-only payment in the wallet passes through here.
+        expect(discover).not.toHaveBeenCalled();
+    });
+
+    it("does not route an asset id createOffer could not bind", async () => {
+        // 32 bytes reads like an id and is not one — they are 34. Dropping here
+        // is what stops the failure landing at send time, with an offer funded.
+        const discover = vi.fn(async () => [market()]);
+        const rail = crossAssetRail(depsWith({ discover }));
+        expect(
+            await rail.available?.(
+                { raw: ARK_ADDR, assets: [{ assetId: "aa".repeat(32), amount: 500n }] },
+                ctxWith(),
+            ),
+        ).toBe(false);
         expect(discover).not.toHaveBeenCalled();
     });
 
@@ -335,6 +351,25 @@ describe("crossAssetRail.send", () => {
             txid: "pay-txid",
             swapId: offer.offerHex,
         });
+    });
+
+    it("hands createOffer a parsed AssetId, not the hex string", async () => {
+        // `createOffer` binds `.txid` and `.groupIndex` off this value to build
+        // the covenant. A raw `Asset.assetId` string has neither, so it would
+        // publish an offer with an undefined want-asset rather than throw —
+        // an offer nobody can fill and the user has funded.
+        let seen: unknown;
+        offerStub = async (..._args: unknown[]) => {
+            seen = (_args[2] as { wantAsset?: unknown }).wantAsset;
+            return offer;
+        };
+        const quote = await crossAssetRail(depsWith()).quote(req, ctxWith());
+        await (await quote.send()).settled();
+
+        const want = seen as { txid: Uint8Array; groupIndex: number; toString(): string };
+        expect(want.txid).toBeInstanceOf(Uint8Array);
+        expect(typeof want.groupIndex).toBe("number");
+        expect(want.toString()).toBe(USDX_ID);
     });
 
     it("hands the fill watcher the record it persisted", async () => {

--- a/packages/swap/test/payment/crossAsset.test.ts
+++ b/packages/swap/test/payment/crossAsset.test.ts
@@ -1,17 +1,8 @@
 /**
- * `crossAssetRail` — pay an asset the wallet does not hold.
- *
- * The claim under test is the design one: **swap-then-pay fits inside a rail**,
- * with no router composition primitive. Both legs are priced into one
- * `RouteQuote`, the swap is reported on `RouteResult.swapId`, and the router is
- * unchanged. The tests that matter are therefore about the seams that would
- * otherwise leak into the router:
- *
- * - the quote names two DIFFERENT assets (`spent` BTC, `delivered` the asset),
- *   which is the reason `RouteQuote.assets` is a pair rather than a triple;
- * - the rail does not route when no corridor exists — it drops, it does not
- *   quote a swap nobody can fill;
- * - the recipient is paid only AFTER the fill, never before.
+ * `crossAssetRail`. The claim under test is the design one: swap-then-pay fits
+ * inside a rail, with no router composition primitive. The seams that would
+ * otherwise leak into the router are the two-asset quote, the drop when no
+ * corridor exists, and paying the recipient only after the fill.
  */
 import { describe, expect, it, vi } from "vitest";
 import type { DiscoveredMarket, OfferPlan, Side } from "@arkade-os/solver-discovery";
@@ -25,8 +16,7 @@ import {
 
 const ARK_ADDR =
     "tark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt846qj6x";
-// A real asset id: 34 bytes of hex. `AssetId.fromString` rejects anything
-// else, and `createOffer` binds `.txid`/`.groupIndex` off the parsed value.
+// 34 bytes of hex; `AssetId.fromString` rejects anything else.
 const USDX_ID = "aa".repeat(34);
 const USDX: Asset = { assetId: USDX_ID, amount: 500n };
 
@@ -104,26 +94,19 @@ describe("crossAssetRail.available", () => {
     });
 
     it("does not route when no corridor exists", async () => {
-        // The load-bearing negative: with no market there is nothing to quote,
-        // and a rail that quoted anyway would be selling a swap nobody can fill.
         const deps = depsWith({ discover: vi.fn(async () => []) });
         expect(await crossAssetRail(deps).available?.(req, ctxWith())).toBe(false);
     });
 
     it("does not route an asset/asset market — the BTC keying is the restriction", async () => {
-        // `createOffer` is BTC<->asset only. What enforces that is `findMarket`
-        // being keyed on BTC: it matches asset ids EXACTLY in either
-        // orientation, so a EURX/USDX market is never returned for
-        // `(btc, USDX)` however well it connects the two. There is deliberately
-        // no give-side check in the rail — one would be unreachable.
+        // `findMarket` matches ids EXACTLY, so a EURX/USDX market is never
+        // returned for `(btc, USDX)`; a give-side check would be unreachable.
         const eurx = market({ base_asset: { id: "bb".repeat(34), decimals: 2 } });
         const deps = depsWith({ discover: vi.fn(async () => [eurx]) });
         expect(await crossAssetRail(deps).available?.(req, ctxWith())).toBe(false);
     });
 
     it("routes a market that names BTC on either side", async () => {
-        // The mirror of the above: BTC as the QUOTE asset is the same corridor
-        // read the other way round, and `findMarket` reports `give: "quote"`.
         const inverted = market({
             base_asset: { id: USDX_ID, decimals: 2 },
             quote_asset: { id: "btc", decimals: 8 },
@@ -150,9 +133,6 @@ describe("crossAssetRail.available", () => {
     });
 
     it("does not route a BTC 'asset', and does not ask the registry about it", async () => {
-        // That is `ark`'s payment, and there is no corridor from BTC to BTC.
-        // The check is up front for a reason: a plain BTC send must not put a
-        // registry round trip on the availability path of every other rail.
         const discover = vi.fn(async () => [market()]);
         expect(
             await crossAssetRail(depsWith({ discover })).available?.(
@@ -170,13 +150,10 @@ describe("crossAssetRail.available", () => {
         expect(await rail.available?.({ raw: ARK_ADDR, assets: [USDX, USDX] }, ctxWith())).toBe(
             false,
         );
-        // Every BTC-only payment in the wallet passes through here.
         expect(discover).not.toHaveBeenCalled();
     });
 
     it("does not route an asset id createOffer could not bind", async () => {
-        // 32 bytes reads like an id and is not one — they are 34. Dropping here
-        // is what stops the failure landing at send time, with an offer funded.
         const discover = vi.fn(async () => [market()]);
         const rail = crossAssetRail(depsWith({ discover }));
         expect(
@@ -224,9 +201,6 @@ describe("crossAssetRail.quote", () => {
     const req = { raw: ARK_ADDR, assets: [USDX] };
 
     it("names two different assets: BTC spent, the asset delivered", async () => {
-        // This is why `RouteQuote.assets` is a pair and not a third
-        // amount/fee/total triple — `total = amount + fee` cannot hold across
-        // two units.
         const quote = await crossAssetRail(depsWith()).quote(req, ctxWith());
         expect(quote.assets?.delivered).toEqual(USDX);
         expect(quote.assets?.spent).toEqual({ assetId: "btc", amount: 100_000n });
@@ -234,8 +208,6 @@ describe("crossAssetRail.quote", () => {
     });
 
     it("prices BOTH legs into the sats that leave the wallet", async () => {
-        // The swap deposit AND the delivery carrier: `total` means the same
-        // thing here as on every other rail.
         const quote = await crossAssetRail(depsWith({ carrierSats: 330 })).quote(req, ctxWith());
         expect(quote).toMatchObject({ amount: 330, fee: 100_000, total: 100_330 });
     });
@@ -283,14 +255,10 @@ describe("crossAssetRail.send", () => {
         const quote = await crossAssetRail(deps).quote(req, ctxWith(send as never));
         await (await quote.send()).settled();
 
-        // Two persists: the offer before it is funded, and the fill before the
-        // recipient is paid.
         expect(order).toEqual(["persist", "fund-offer", "await-fill", "persist", "pay-recipient"]);
     });
 
     it("does not pay the recipient when the fill never lands", async () => {
-        // The asset is not in the wallet until a filler delivers it; paying
-        // before that is a send that cannot be funded.
         offerStub = async () => offer;
         const send = vi.fn(async () => "txid");
         const deps = depsWith({
@@ -301,13 +269,11 @@ describe("crossAssetRail.send", () => {
 
         const quote = await crossAssetRail(deps).quote(req, ctxWith(send as never));
         await expect((await quote.send()).settled()).rejects.toThrow(/offer expired/);
-        // Only the offer deposit went out.
         expect(send).toHaveBeenCalledTimes(1);
         expect(send.mock.calls[0][0]).toMatchObject({ address: offer.address });
     });
 
     it("does not fund the offer when the record could not be written", async () => {
-        // `cancelOffer` rebuilds the covenant from `offerHex` and nothing else.
         offerStub = async () => offer;
         const send = vi.fn(async () => "txid");
         const deps = depsWith({
@@ -356,10 +322,8 @@ describe("crossAssetRail.send", () => {
     });
 
     it("hands createOffer a parsed AssetId, not the hex string", async () => {
-        // `createOffer` binds `.txid` and `.groupIndex` off this value to build
-        // the covenant. A raw `Asset.assetId` string has neither, so it would
-        // publish an offer with an undefined want-asset rather than throw —
-        // an offer nobody can fill and the user has funded.
+        // A raw `assetId` string has neither, so the offer would publish with
+        // an undefined want-asset rather than throw — funded, unfillable.
         let seen: unknown;
         offerStub = async (..._args: unknown[]) => {
             seen = (_args[2] as { wantAsset?: unknown }).wantAsset;
@@ -443,10 +407,6 @@ describe("no BTC-only rail silently drops an asset", () => {
 });
 
 describe("the record says which side of the fill the route is on", () => {
-    // Two states with different recoveries: a "quoted" record whose offer never
-    // filled is cancelled; a "filled" one has the asset in the wallet and owes
-    // the recipient a send. A record frozen at "quoted" after the fill landed
-    // says the opposite of the truth.
     const req = { raw: ARK_ADDR, assets: [USDX] };
 
     const runWith = async (send: ReturnType<typeof vi.fn>) => {
@@ -469,8 +429,6 @@ describe("the record says which side of the fill the route is on", () => {
     });
 
     it("records the fill even when the recipient send then fails", async () => {
-        // The window this closes: the filler delivered, the payment did not go
-        // out, and the user is holding an asset the recipient is still owed.
         let call = 0;
         const send = vi.fn(async () => {
             if (++call === 1) return "deposit-txid";
@@ -500,12 +458,7 @@ describe("the record says which side of the fill the route is on", () => {
     });
 
     it("refuses a deposit that would not survive the narrowing to a JS number", async () => {
-        // `RouteQuote.fee`/`total` are `number`. Safe for BTC, whose whole
-        // supply fits — asserted anyway, because the assumption is the give
-        // side being BTC.
         const huge = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
-        // A market whose bounds admit it, so the narrowing guard is what
-        // rejects rather than `validatePlan`'s `above-max`.
         const wide = market({ max_base_amount: (huge * 4n).toString() });
         const deps = depsWith({
             discover: vi.fn(async () => [wide]),

--- a/packages/ts-sdk/src/payment/amount.ts
+++ b/packages/ts-sdk/src/payment/amount.ts
@@ -1,4 +1,6 @@
 import { BIP21 } from "../utils/bip21";
+import type { Asset } from "../index";
+import type { PaymentRequest } from "./types";
 
 /** Throw unless `amt` is a positive integer number of satoshis. */
 export function assertSendableAmount(railId: string, amt: number): void {
@@ -34,4 +36,63 @@ export function resolveSendAmount(railId: string, raw: string, amount?: number):
 export function tryResolveSendAmount(raw: string, amount?: number): number | undefined {
     const amt = amount ?? BIP21.amountSats(raw);
     return amt !== undefined && Number.isInteger(amt) && amt > 0 ? amt : undefined;
+}
+
+/**
+ * The assets a request asks for — `[]` when it names none.
+ *
+ * Normalizing an absent list to `[]` is what makes "does this request move an
+ * asset" one expression on every rail, rather than an `undefined` check each
+ * rail writes for itself and one of them forgets.
+ */
+export function assetsOf(req: PaymentRequest): Asset[] {
+    return req.assets ?? [];
+}
+
+/**
+ * Throw when `req` asks for an asset — for a rail that can only move BTC.
+ *
+ * The failure this prevents is silent and expensive: a BTC-only rail handed a
+ * `{ amount: 330, assets: [500 USDX] }` request would happily pay 330 sats,
+ * report success, and deliver none of the asset the user actually asked for.
+ * Refusing is what leaves the router free to rank an asset-capable rail
+ * instead.
+ */
+export function assertNoAssets(railId: string, req: PaymentRequest): void {
+    const assets = assetsOf(req);
+    if (assets.length > 0) {
+        throw new Error(
+            `${railId}: cannot deliver ${assets.map((a) => a.assetId).join(", ")} ` +
+                `— this rail moves BTC only`,
+        );
+    }
+}
+
+/**
+ * The single asset a request names, validated.
+ *
+ * Exactly one: a rail that delivers to one recipient in one corridor has no
+ * meaning for two, and quietly paying the first would be worse than refusing.
+ * `Wallet.send` takes a list because one output can carry several; a routed
+ * PAYMENT is one thing being paid.
+ */
+export function resolveAssetAmount(railId: string, req: PaymentRequest): Asset {
+    const assets = assetsOf(req);
+    if (assets.length !== 1) {
+        throw new Error(`${railId}: expected exactly one asset to pay, got ${assets.length}`);
+    }
+    const [asset] = assets;
+    // `bigint` is why this is a separate check from `assertSendableAmount`:
+    // `Number.isInteger` is meaningless on one, and the whole reason the SDK
+    // types asset amounts as bigint is that Number would truncate them.
+    if (typeof asset.amount !== "bigint" || asset.amount <= 0n) {
+        throw new Error(
+            `${railId}: invalid amount ${String(asset.amount)} of ${asset.assetId} ` +
+                `(expected a positive bigint of atomic units)`,
+        );
+    }
+    if (typeof asset.assetId !== "string" || asset.assetId.length === 0) {
+        throw new Error(`${railId}: an asset amount must name an asset`);
+    }
+    return asset;
 }

--- a/packages/ts-sdk/src/payment/amount.ts
+++ b/packages/ts-sdk/src/payment/amount.ts
@@ -38,26 +38,13 @@ export function tryResolveSendAmount(raw: string, amount?: number): number | und
     return amt !== undefined && Number.isInteger(amt) && amt > 0 ? amt : undefined;
 }
 
-/**
- * The assets a request asks for — `[]` when it names none.
- *
- * Normalizing an absent list to `[]` is what makes "does this request move an
- * asset" one expression on every rail, rather than an `undefined` check each
- * rail writes for itself and one of them forgets.
- */
+/** The assets a request asks for — `[]` when it names none. */
 export function assetsOf(req: PaymentRequest): Asset[] {
     return req.assets ?? [];
 }
 
-/**
- * Throw when `req` asks for an asset — for a rail that can only move BTC.
- *
- * The failure this prevents is silent and expensive: a BTC-only rail handed a
- * `{ amount: 330, assets: [500 USDX] }` request would happily pay 330 sats,
- * report success, and deliver none of the asset the user actually asked for.
- * Refusing is what leaves the router free to rank an asset-capable rail
- * instead.
- */
+/** For a BTC-only rail: refusing is what leaves the router free to rank an
+ *  asset-capable one, instead of paying the carrier and dropping the asset. */
 export function assertNoAssets(railId: string, req: PaymentRequest): void {
     const assets = assetsOf(req);
     if (assets.length > 0) {
@@ -68,23 +55,16 @@ export function assertNoAssets(railId: string, req: PaymentRequest): void {
     }
 }
 
-/**
- * The single asset a request names, validated.
- *
- * Exactly one: a rail that delivers to one recipient in one corridor has no
- * meaning for two, and quietly paying the first would be worse than refusing.
- * `Wallet.send` takes a list because one output can carry several; a routed
- * PAYMENT is one thing being paid.
- */
+/** Exactly one: `Wallet.send` takes a list because one output can carry
+ *  several, but a routed PAYMENT is one thing being paid. */
 export function resolveAssetAmount(railId: string, req: PaymentRequest): Asset {
     const assets = assetsOf(req);
     if (assets.length !== 1) {
         throw new Error(`${railId}: expected exactly one asset to pay, got ${assets.length}`);
     }
     const [asset] = assets;
-    // `bigint` is why this is a separate check from `assertSendableAmount`:
-    // `Number.isInteger` is meaningless on one, and the whole reason the SDK
-    // types asset amounts as bigint is that Number would truncate them.
+    // Separate from `assertSendableAmount`: the SDK types asset amounts as
+    // bigint precisely because Number would truncate them.
     if (typeof asset.amount !== "bigint" || asset.amount <= 0n) {
         throw new Error(
             `${railId}: invalid amount ${String(asset.amount)} of ${asset.assetId} ` +

--- a/packages/ts-sdk/src/payment/index.ts
+++ b/packages/ts-sdk/src/payment/index.ts
@@ -5,28 +5,36 @@ export * from "./amount";
 export * from "./handle";
 export { PaymentRouter, AmbiguousRouteError } from "./router";
 export { arkRail } from "./rails/ark";
+export { arkAssetRail, ASSET_CARRIER_SATS } from "./rails/arkAsset";
 export { onchainRail } from "./rails/onchain";
 
 import { PaymentRouter } from "./router";
 import { arkRail } from "./rails/ark";
+import { arkAssetRail } from "./rails/arkAsset";
 import { onchainRail } from "./rails/onchain";
 import type { Wallet } from "../index";
 
 /**
- * Default payment router with the Wallet-only rails: `ark` (off-chain send) and
- * `onchain` (collaborative exit). Lightning and chain-swap rails live in
- * `@arkade-os/boltz-swap`, which ships a `createDefaultPaymentRouter(wallet,
- * swaps)` overload composing the full set.
+ * Default payment router with the Wallet-only rails: `ark` (off-chain BTC send),
+ * `ark-asset` (off-chain asset send) and `onchain` (collaborative exit).
+ * Lightning and chain-swap rails live in `@arkade-os/boltz-swap`, which ships a
+ * `createDefaultPaymentRouter(wallet, swaps)` overload composing the full set;
+ * solver-routed rails live in `@arkade-os/swap` and are registered by the app.
  *
- * The default priority is `["ark", "lightning", "onchain"]` — the wallet's
- * Ark > Lightning > on-chain ladder. `"lightning"` is listed so it ranks
- * correctly once the boltz rail is added; it is simply absent here.
+ * The default priority is `["ark", "ark-asset", "lightning", "onchain"]` — the
+ * wallet's Ark > Lightning > on-chain ladder. `"lightning"` is listed so it
+ * ranks correctly once the boltz rail is added; it is simply absent here.
+ *
+ * `ark` and `ark-asset` never compete despite both matching an Arkade address:
+ * one is available only for a request naming an asset and the other only for a
+ * request naming none, so their order between themselves is immaterial.
  */
 export function createDefaultPaymentRouter(wallet: Wallet): PaymentRouter {
     return new PaymentRouter({
         wallet,
-        prefs: { priority: ["ark", "lightning", "onchain"] },
+        prefs: { priority: ["ark", "ark-asset", "lightning", "onchain"] },
     })
         .use(arkRail())
+        .use(arkAssetRail())
         .use(onchainRail());
 }

--- a/packages/ts-sdk/src/payment/index.ts
+++ b/packages/ts-sdk/src/payment/index.ts
@@ -21,13 +21,10 @@ import type { Wallet } from "../index";
  * `createDefaultPaymentRouter(wallet, swaps)` overload composing the full set;
  * solver-routed rails live in `@arkade-os/swap` and are registered by the app.
  *
- * The default priority is `["ark", "ark-asset", "lightning", "onchain"]` — the
- * wallet's Ark > Lightning > on-chain ladder. `"lightning"` is listed so it
- * ranks correctly once the boltz rail is added; it is simply absent here.
- *
- * `ark` and `ark-asset` never compete despite both matching an Arkade address:
- * one is available only for a request naming an asset and the other only for a
- * request naming none, so their order between themselves is immaterial.
+ * The default priority is `["ark", "ark-asset", "lightning", "onchain"]`.
+ * `"lightning"` is listed so it ranks correctly once the boltz rail is added.
+ * `ark` and `ark-asset` never compete — the amount decides which is
+ * available — so their order between themselves is immaterial.
  */
 export function createDefaultPaymentRouter(wallet: Wallet): PaymentRouter {
     return new PaymentRouter({

--- a/packages/ts-sdk/src/payment/rails/ark.ts
+++ b/packages/ts-sdk/src/payment/rails/ark.ts
@@ -1,6 +1,6 @@
 import type { PaymentRail, RouterContext } from "../types";
 import { arkTarget } from "../targets";
-import { resolveSendAmount } from "../amount";
+import { assertNoAssets, assetsOf, resolveSendAmount } from "../amount";
 import { makeHandle } from "../handle";
 
 /**
@@ -10,13 +10,22 @@ import { makeHandle } from "../handle";
  * The only rail that is receiver-exact for free: an off-chain send delivers the
  * full amount and carries no counterparty or on-chain fee, so `fee` is 0 and
  * `total` equals `amount` (see {@link RouteQuote}).
+ *
+ * BTC only. An Arkade address is the same string whether it is paid in BTC or
+ * in an asset — the asset is named by the AMOUNT — so a request carrying one
+ * drops this rail rather than paying its sats and dropping the asset, leaving
+ * `ark-asset` to rank.
  */
 export function arkRail(): PaymentRail {
     return {
         id: "ark",
         match: (req) => arkTarget(req.raw) !== undefined,
+        available: (req) => assetsOf(req).length === 0,
         quote: async (req, ctx: RouterContext) => {
             const address = arkTarget(req.raw)!;
+            // Also at quote time: `available()` is a router-level filter, and a
+            // caller reaching a rail directly must get the same refusal.
+            assertNoAssets("ark", req);
             const amt = resolveSendAmount("ark", req.raw, req.amount);
             return {
                 railId: "ark",

--- a/packages/ts-sdk/src/payment/rails/ark.ts
+++ b/packages/ts-sdk/src/payment/rails/ark.ts
@@ -11,10 +11,8 @@ import { makeHandle } from "../handle";
  * full amount and carries no counterparty or on-chain fee, so `fee` is 0 and
  * `total` equals `amount` (see {@link RouteQuote}).
  *
- * BTC only. An Arkade address is the same string whether it is paid in BTC or
- * in an asset — the asset is named by the AMOUNT — so a request carrying one
- * drops this rail rather than paying its sats and dropping the asset, leaving
- * `ark-asset` to rank.
+ * BTC only: a request naming an asset drops this rail rather than paying its
+ * sats and dropping the asset, leaving `ark-asset` to rank.
  */
 export function arkRail(): PaymentRail {
     return {
@@ -23,8 +21,6 @@ export function arkRail(): PaymentRail {
         available: (req) => assetsOf(req).length === 0,
         quote: async (req, ctx: RouterContext) => {
             const address = arkTarget(req.raw)!;
-            // Also at quote time: `available()` is a router-level filter, and a
-            // caller reaching a rail directly must get the same refusal.
             assertNoAssets("ark", req);
             const amt = resolveSendAmount("ark", req.raw, req.amount);
             return {

--- a/packages/ts-sdk/src/payment/rails/arkAsset.ts
+++ b/packages/ts-sdk/src/payment/rails/arkAsset.ts
@@ -1,0 +1,76 @@
+import type { PaymentRail, RouteQuote, RouterContext } from "../types";
+import { arkTarget } from "../targets";
+import { assetsOf, resolveAssetAmount, tryResolveSendAmount } from "../amount";
+import { makeHandle } from "../handle";
+
+/**
+ * Sats a transfer carries when the request names none.
+ *
+ * An Arkade asset does not move on its own: it rides a sats-carrying output,
+ * and `Wallet.send` defaults that carrier to dust. Naming the same number here
+ * is what makes the quote honest — the router promises `total` is what leaves
+ * the wallet, and the carrier leaves it too.
+ *
+ * @see Recipient.amount, whose `@defaultValue` this mirrors.
+ */
+export const ASSET_CARRIER_SATS = 330;
+
+/**
+ * Off-chain Arkade send of an ASSET.
+ *
+ * The sibling of `ark`, and the reason the router needed an asset dimension at
+ * all: an Arkade address is the same string whether it is paid in BTC or in an
+ * asset, so the target cannot tell them apart. The AMOUNT names the asset —
+ * `req.assets` — exactly as it does on `Wallet.send`, whose `Recipient` shape
+ * this request mirrors.
+ *
+ * That is why the two rails split on `available()` rather than on `match()`:
+ * both legitimately match the address, and which one can pay is a question
+ * about the amount. `ark` drops itself when the request carries an asset, this
+ * one drops itself when it does not, and `options()` returns exactly one.
+ *
+ * Delivery is receiver-exact and free, like `ark`: an off-chain transfer
+ * carries no counterparty fee, so `assets.delivered` and `assets.spent` name
+ * the same asset and the same quantity, and `fee` is 0.
+ *
+ * BTC in, BTC out: the sats fields describe the carrier, not zero. A consumer
+ * ranking on `total` is ranking on the sats that leave the wallet, which is
+ * what it means on every other rail too.
+ */
+export function arkAssetRail(): PaymentRail {
+    return {
+        id: "ark-asset",
+        match: (req) => arkTarget(req.raw) !== undefined,
+        // The split from `ark`: this rail exists only for a request that names
+        // an asset. Validating the asset itself is `quote()`'s job — a
+        // malformed one must produce a named error, not a silent drop that
+        // leaves "no rail for" as the whole explanation.
+        available: (req) => assetsOf(req).length > 0,
+        quote: async (req, ctx: RouterContext): Promise<RouteQuote> => {
+            const address = arkTarget(req.raw)!;
+            const asset = resolveAssetAmount("ark-asset", req);
+            // The carrier is optional on the request and defaulted here rather
+            // than left to `Wallet.send`, so the quote states the sats that
+            // will actually leave rather than a zero the send then contradicts.
+            const carrier = tryResolveSendAmount(req.raw, req.amount) ?? ASSET_CARRIER_SATS;
+            return {
+                railId: "ark-asset",
+                amount: carrier,
+                fee: 0,
+                total: carrier,
+                assets: { delivered: asset, spent: asset },
+                send: async () =>
+                    makeHandle("ark-asset", async (emit) => {
+                        const txid = await ctx.wallet.send({
+                            address,
+                            amount: carrier,
+                            assets: [asset],
+                        });
+                        const result = { railId: "ark-asset", txid };
+                        emit({ status: "settled", result });
+                        return result;
+                    }),
+            };
+        },
+    };
+}

--- a/packages/ts-sdk/src/payment/rails/arkAsset.ts
+++ b/packages/ts-sdk/src/payment/rails/arkAsset.ts
@@ -1,6 +1,11 @@
 import type { PaymentRail, RouteQuote, RouterContext } from "../types";
 import { arkTarget } from "../targets";
-import { assetsOf, resolveAssetAmount, tryResolveSendAmount } from "../amount";
+import {
+    assertSendableAmount,
+    assetsOf,
+    resolveAssetAmount,
+    tryResolveSendAmount,
+} from "../amount";
 import { makeHandle } from "../handle";
 
 /** The sats carrier an asset rides on; mirrors `Recipient.amount`'s default. */
@@ -22,7 +27,8 @@ export function arkAssetRail(): PaymentRail {
         quote: async (req, ctx: RouterContext): Promise<RouteQuote> => {
             const address = arkTarget(req.raw)!;
             const asset = resolveAssetAmount("ark-asset", req);
-            // Defaulted here so the quote states the sats that will leave.
+            // A stated amount is validated, never defaulted: `0` is not "pick one".
+            if (req.amount !== undefined) assertSendableAmount("ark-asset", req.amount);
             const carrier = tryResolveSendAmount(req.raw, req.amount) ?? ASSET_CARRIER_SATS;
             return {
                 railId: "ark-asset",

--- a/packages/ts-sdk/src/payment/rails/arkAsset.ts
+++ b/packages/ts-sdk/src/payment/rails/arkAsset.ts
@@ -3,55 +3,26 @@ import { arkTarget } from "../targets";
 import { assetsOf, resolveAssetAmount, tryResolveSendAmount } from "../amount";
 import { makeHandle } from "../handle";
 
-/**
- * Sats a transfer carries when the request names none.
- *
- * An Arkade asset does not move on its own: it rides a sats-carrying output,
- * and `Wallet.send` defaults that carrier to dust. Naming the same number here
- * is what makes the quote honest — the router promises `total` is what leaves
- * the wallet, and the carrier leaves it too.
- *
- * @see Recipient.amount, whose `@defaultValue` this mirrors.
- */
+/** The sats carrier an asset rides on; mirrors `Recipient.amount`'s default. */
 export const ASSET_CARRIER_SATS = 330;
 
 /**
- * Off-chain Arkade send of an ASSET.
+ * Off-chain Arkade send of an ASSET — the sibling of `ark`.
  *
- * The sibling of `ark`, and the reason the router needed an asset dimension at
- * all: an Arkade address is the same string whether it is paid in BTC or in an
- * asset, so the target cannot tell them apart. The AMOUNT names the asset —
- * `req.assets` — exactly as it does on `Wallet.send`, whose `Recipient` shape
- * this request mirrors.
- *
- * That is why the two rails split on `available()` rather than on `match()`:
- * both legitimately match the address, and which one can pay is a question
- * about the amount. `ark` drops itself when the request carries an asset, this
- * one drops itself when it does not, and `options()` returns exactly one.
- *
- * Delivery is receiver-exact and free, like `ark`: an off-chain transfer
- * carries no counterparty fee, so `assets.delivered` and `assets.spent` name
- * the same asset and the same quantity, and `fee` is 0.
- *
- * BTC in, BTC out: the sats fields describe the carrier, not zero. A consumer
- * ranking on `total` is ranking on the sats that leave the wallet, which is
- * what it means on every other rail too.
+ * They split on `available()` rather than `match()` because both legitimately
+ * match the address; which one can pay is a question about the amount, so
+ * `options()` returns exactly one and their relative priority is immaterial.
  */
 export function arkAssetRail(): PaymentRail {
     return {
         id: "ark-asset",
         match: (req) => arkTarget(req.raw) !== undefined,
-        // The split from `ark`: this rail exists only for a request that names
-        // an asset. Validating the asset itself is `quote()`'s job — a
-        // malformed one must produce a named error, not a silent drop that
-        // leaves "no rail for" as the whole explanation.
+        // A malformed asset is `quote()`'s to name, not this rail's to drop.
         available: (req) => assetsOf(req).length > 0,
         quote: async (req, ctx: RouterContext): Promise<RouteQuote> => {
             const address = arkTarget(req.raw)!;
             const asset = resolveAssetAmount("ark-asset", req);
-            // The carrier is optional on the request and defaulted here rather
-            // than left to `Wallet.send`, so the quote states the sats that
-            // will actually leave rather than a zero the send then contradicts.
+            // Defaulted here so the quote states the sats that will leave.
             const carrier = tryResolveSendAmount(req.raw, req.amount) ?? ASSET_CARRIER_SATS;
             return {
                 railId: "ark-asset",

--- a/packages/ts-sdk/src/payment/rails/onchain.ts
+++ b/packages/ts-sdk/src/payment/rails/onchain.ts
@@ -1,6 +1,6 @@
 import type { PaymentRail, RouterContext } from "../types";
 import { btcTarget } from "../targets";
-import { resolveSendAmount } from "../amount";
+import { assertNoAssets, assetsOf, resolveSendAmount } from "../amount";
 import { makeHandle } from "../handle";
 import { Ramps, offboardDestinationScript } from "../../wallet/ramps";
 import { Estimator } from "../../arkfee";
@@ -61,7 +61,10 @@ export function onchainRail(): PaymentRail {
     return {
         id: "onchain",
         match: (req) => btcTarget(req.raw) !== undefined,
+        // BTC only: an Arkade asset has no L1 representation to offboard to.
+        available: (req) => assetsOf(req).length === 0,
         quote: async (req, ctx: RouterContext) => {
+            assertNoAssets("onchain", req);
             const address = btcTarget(req.raw)!;
             // Reject missing/zero/fractional amounts up front: 0 sats would
             // silently settle nothing, and BigInt(amt) throws on non-integers.

--- a/packages/ts-sdk/src/payment/types.ts
+++ b/packages/ts-sdk/src/payment/types.ts
@@ -68,6 +68,15 @@ export interface RouteQuote {
      * fee` cannot hold across two units. On a same-asset route they name the
      * same asset and the difference between them is the fee.
      *
+     * **Prefer `assets` over the sats fields for display on a cross-asset
+     * route.** `total = amount + fee` still holds, which forces `fee` to
+     * absorb everything that leaves the wallet without reaching the recipient
+     * — on a route that BUYS the delivered asset, that is the purchase price,
+     * not a service charge. A UI rendering "fee: 100,000 sats" beside "pay 500
+     * USDX" is reporting the cost of the asset. `assets.spent` is the same
+     * number correctly labelled, and is what a cost display or a
+     * fee-threshold check should read.
+     *
      * @see Asset — the same shape `Wallet.send` takes, `bigint` for the same
      * reason: asset supplies routinely exceed `Number.MAX_SAFE_INTEGER`.
      */

--- a/packages/ts-sdk/src/payment/types.ts
+++ b/packages/ts-sdk/src/payment/types.ts
@@ -54,6 +54,11 @@ export interface RouteQuote {
     /** `amount + fee` — what leaves the wallet. */
     total: number;
     /**
+     * @experimental The asset shape is provisional. The v2 swap client models
+     * assets as `give`/`take`/`amountOn` over `AssetRef`, and the two
+     * vocabularies are expected to converge on v0.5; do not treat this field as
+     * stable 0.4.x API.
+     *
      * The asset view; absent means BTC only. The sats fields keep their
      * meaning — an asset rides a sats-carrying output, so `amount` is the
      * carrier, not zero.
@@ -95,7 +100,9 @@ export interface PaymentRequest {
     raw: string;
     /** Explicit sats; supplements/overrides any amount encoded in `raw`. */
     amount?: number;
-    /** Additive: an asset transfer also moves sats, so a 500 USDX request
+    /** @experimental — provisional, see {@link RouteQuote.assets}.
+     *
+     *  Additive: an asset transfer also moves sats, so a 500 USDX request
      *  legitimately has both. A rail that cannot deliver assets must REFUSE. */
     assets?: Asset[];
 }

--- a/packages/ts-sdk/src/payment/types.ts
+++ b/packages/ts-sdk/src/payment/types.ts
@@ -54,36 +54,17 @@ export interface RouteQuote {
     /** `amount + fee` — what leaves the wallet. */
     total: number;
     /**
-     * The asset view, on a route that moves one. Absent means BTC only, and
-     * every existing rail leaves it absent.
+     * The asset view; absent means BTC only. The sats fields keep their
+     * meaning — an asset rides a sats-carrying output, so `amount` is the
+     * carrier, not zero.
      *
-     * The three sats fields keep their meaning — they are the BTC leg, which an
-     * asset route still has: an Arkade asset rides a sats-carrying output, so
-     * `amount` is the carrier's value (dust, usually) and not "zero because
-     * this is not a BTC payment".
-     *
-     * `delivered` and `spent` are separate rather than an `amount`/`fee`/`total`
-     * triple because on a cross-asset route they name DIFFERENT assets — the
-     * wallet spends BTC and the recipient receives USDX — and `total = amount +
-     * fee` cannot hold across two units. On a same-asset route they name the
-     * same asset and the difference between them is the fee.
-     *
-     * **Prefer `assets` over the sats fields for display on a cross-asset
-     * route.** `total = amount + fee` still holds, which forces `fee` to
-     * absorb everything that leaves the wallet without reaching the recipient
-     * — on a route that BUYS the delivered asset, that is the purchase price,
-     * not a service charge. A UI rendering "fee: 100,000 sats" beside "pay 500
-     * USDX" is reporting the cost of the asset. `assets.spent` is the same
-     * number correctly labelled, and is what a cost display or a
-     * fee-threshold check should read.
-     *
-     * @see Asset — the same shape `Wallet.send` takes, `bigint` for the same
-     * reason: asset supplies routinely exceed `Number.MAX_SAFE_INTEGER`.
+     * A pair, not a triple: on a cross-asset route these name DIFFERENT
+     * assets, so `total = amount + fee` cannot hold across the two units —
+     * which forces the purchase price into `fee`. Prefer `assets.spent` for a
+     * cost display.
      */
     assets?: {
-        /** What the RECIPIENT receives. */
         delivered: Asset;
-        /** What leaves the wallet — a different asset on a cross-asset route. */
         spent: Asset;
     };
     /** Execute. Returns an observable handle, never a bare result. */
@@ -107,33 +88,15 @@ export interface RouterContext {
     prefs: RouterPreferences;
 }
 
-/**
- * A payment request: the raw target plus an optional explicit amount. Rails
- * self-extract their target from `raw` (bare address/invoice or a BIP21 URI);
- * `amount` supplements or overrides any amount encoded in `raw`.
- *
- * The shape mirrors {@link Recipient}, deliberately: an Arkade address is the
- * same string whether it is paid in BTC or in an asset, so the asset is named
- * by the AMOUNT and never by the target. `assets` is what names it, exactly as
- * it does on `Wallet.send`.
- */
+/** Mirrors {@link Recipient}: an Arkade address is the same string for BTC and
+ *  for an asset, so the AMOUNT names the asset, never the target. */
 export interface PaymentRequest {
     /** Raw target: bare address/invoice, or a BIP21 URI. */
     raw: string;
     /** Explicit sats; supplements/overrides any amount encoded in `raw`. */
     amount?: number;
-    /**
-     * Assets to deliver, in atomic units.
-     *
-     * Additive, not a replacement for `amount`: an Arkade asset transfer also
-     * moves sats, because the asset rides a sats-carrying output. So a request
-     * for 500 USDX legitimately has both — `amount` is the carrier (the wallet
-     * defaults it to dust) and `assets` is what the user actually asked to pay.
-     *
-     * Rails that do not understand assets must refuse a request carrying one
-     * rather than paying the sats and dropping it. `assetsOf()` is the shared
-     * reader that makes that refusal one line.
-     */
+    /** Additive: an asset transfer also moves sats, so a 500 USDX request
+     *  legitimately has both. A rail that cannot deliver assets must REFUSE. */
     assets?: Asset[];
 }
 

--- a/packages/ts-sdk/src/payment/types.ts
+++ b/packages/ts-sdk/src/payment/types.ts
@@ -1,4 +1,4 @@
-import type { Wallet } from "../index";
+import type { Asset, Recipient, Wallet } from "../index";
 
 export type PaymentStatus = "pending" | "sent" | "settled" | "failed";
 
@@ -53,6 +53,30 @@ export interface RouteQuote {
     fee: number;
     /** `amount + fee` — what leaves the wallet. */
     total: number;
+    /**
+     * The asset view, on a route that moves one. Absent means BTC only, and
+     * every existing rail leaves it absent.
+     *
+     * The three sats fields keep their meaning — they are the BTC leg, which an
+     * asset route still has: an Arkade asset rides a sats-carrying output, so
+     * `amount` is the carrier's value (dust, usually) and not "zero because
+     * this is not a BTC payment".
+     *
+     * `delivered` and `spent` are separate rather than an `amount`/`fee`/`total`
+     * triple because on a cross-asset route they name DIFFERENT assets — the
+     * wallet spends BTC and the recipient receives USDX — and `total = amount +
+     * fee` cannot hold across two units. On a same-asset route they name the
+     * same asset and the difference between them is the fee.
+     *
+     * @see Asset — the same shape `Wallet.send` takes, `bigint` for the same
+     * reason: asset supplies routinely exceed `Number.MAX_SAFE_INTEGER`.
+     */
+    assets?: {
+        /** What the RECIPIENT receives. */
+        delivered: Asset;
+        /** What leaves the wallet — a different asset on a cross-asset route. */
+        spent: Asset;
+    };
     /** Execute. Returns an observable handle, never a bare result. */
     send(): Promise<PaymentHandle>;
     meta?: Record<string, unknown>;
@@ -74,14 +98,34 @@ export interface RouterContext {
     prefs: RouterPreferences;
 }
 
-/** A payment request: the raw target plus an optional explicit amount. Rails
- *  self-extract their target from `raw` (bare address/invoice or a BIP21 URI);
- *  `amount` supplements or overrides any amount encoded in `raw`. */
+/**
+ * A payment request: the raw target plus an optional explicit amount. Rails
+ * self-extract their target from `raw` (bare address/invoice or a BIP21 URI);
+ * `amount` supplements or overrides any amount encoded in `raw`.
+ *
+ * The shape mirrors {@link Recipient}, deliberately: an Arkade address is the
+ * same string whether it is paid in BTC or in an asset, so the asset is named
+ * by the AMOUNT and never by the target. `assets` is what names it, exactly as
+ * it does on `Wallet.send`.
+ */
 export interface PaymentRequest {
     /** Raw target: bare address/invoice, or a BIP21 URI. */
     raw: string;
     /** Explicit sats; supplements/overrides any amount encoded in `raw`. */
     amount?: number;
+    /**
+     * Assets to deliver, in atomic units.
+     *
+     * Additive, not a replacement for `amount`: an Arkade asset transfer also
+     * moves sats, because the asset rides a sats-carrying output. So a request
+     * for 500 USDX legitimately has both — `amount` is the carrier (the wallet
+     * defaults it to dust) and `assets` is what the user actually asked to pay.
+     *
+     * Rails that do not understand assets must refuse a request carrying one
+     * rather than paying the sats and dropping it. `assetsOf()` is the shared
+     * reader that makes that refusal one line.
+     */
+    assets?: Asset[];
 }
 
 /** A payment rail — registered by id, mirrors the ActivityRegistry resolver shape. */

--- a/packages/ts-sdk/test/payment/arkAsset.test.ts
+++ b/packages/ts-sdk/test/payment/arkAsset.test.ts
@@ -25,7 +25,7 @@ import {
 
 const ARK_ADDR =
     "tark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt846qj6x";
-const USDX: Asset = { assetId: "aa".repeat(32), amount: 500n };
+const USDX: Asset = { assetId: "aa".repeat(34), amount: 500n };
 
 const ctx = (send = vi.fn(async () => "txid")): RouterContext =>
     ({ wallet: { send } as never, prefs: {} }) as RouterContext;

--- a/packages/ts-sdk/test/payment/arkAsset.test.ts
+++ b/packages/ts-sdk/test/payment/arkAsset.test.ts
@@ -132,6 +132,14 @@ describe("arkAssetRail", () => {
         expect(quote.total).toBe(5_000);
     });
 
+    it("refuses an explicit carrier amount that is not sendable", async () => {
+        for (const amount of [0, -1, 1.5]) {
+            await expect(
+                arkAssetRail().quote({ raw: ARK_ADDR, amount, assets: [USDX] }, ctx()),
+            ).rejects.toThrow(/invalid amount/);
+        }
+    });
+
     it("sends the asset alongside the carrier, in one Recipient", async () => {
         const send = vi.fn(async () => "the-txid");
         const quote = await arkAssetRail().quote({ raw: ARK_ADDR, assets: [USDX] }, ctx(send));

--- a/packages/ts-sdk/test/payment/arkAsset.test.ts
+++ b/packages/ts-sdk/test/payment/arkAsset.test.ts
@@ -1,12 +1,8 @@
 /**
- * The asset dimension on the router, and the `ark-asset` rail that needed it.
- *
- * The load-bearing fact: an Arkade address is the SAME STRING for BTC and for
- * an asset, so the target cannot tell a BTC payment from an asset one. The
- * amount names the asset. Everything here follows from that — the two rails
- * split on `available()` rather than `match()`, and a BTC-only rail handed an
- * asset request must refuse rather than pay its carrier sats and drop the
- * asset on the floor.
+ * The asset dimension, and the `ark-asset` rail that needed it. An Arkade
+ * address is the SAME STRING for BTC and for an asset, so the amount names the
+ * asset — hence the two rails split on `available()`, and a BTC-only rail
+ * handed an asset must refuse rather than pay the carrier and drop it.
  */
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -71,9 +67,6 @@ describe("resolveAssetAmount", () => {
     });
 
     it("refuses a number where atomic units belong", () => {
-        // The whole reason the SDK types asset amounts as bigint is that Number
-        // truncates supplies past 2^53-1. A rail that accepted one would corrupt
-        // the balance silently rather than fail.
         expect(() =>
             resolveAssetAmount("ark-asset", {
                 raw: ARK_ADDR,
@@ -126,8 +119,6 @@ describe("arkAssetRail", () => {
     });
 
     it("quotes the CARRIER sats, not zero", async () => {
-        // An asset does not move on its own: `total` is what leaves the wallet,
-        // and the sats-carrying output leaves it too.
         const quote = await arkAssetRail().quote({ raw: ARK_ADDR, assets: [USDX] }, ctx());
         expect(quote.amount).toBe(ASSET_CARRIER_SATS);
         expect(quote.total).toBe(ASSET_CARRIER_SATS);
@@ -155,8 +146,6 @@ describe("arkAssetRail", () => {
     });
 
     it("refuses a malformed asset at quote time with a named error", async () => {
-        // Not a silent drop: `available()` said this rail is the one, so the
-        // reason it cannot pay has to be legible.
         await expect(
             arkAssetRail().quote({ raw: ARK_ADDR, assets: [USDX, USDX] }, ctx()),
         ).rejects.toThrow(/exactly one asset/);
@@ -167,8 +156,6 @@ describe("the BTC-only rails refuse an asset rather than dropping it", () => {
     it("ark drops itself, and refuses if reached directly", async () => {
         const req = { raw: ARK_ADDR, amount: 1000, assets: [USDX] };
         expect(await arkRail().available?.(req, ctx())).toBe(false);
-        // The failure this prevents: paying 1000 sats, reporting success, and
-        // delivering none of the asset the user asked for.
         await expect(arkRail().quote(req, ctx())).rejects.toThrow(/cannot deliver/);
     });
 
@@ -184,7 +171,6 @@ describe("the default router routes on the amount, not the target", () => {
     const router = () => createDefaultPaymentRouter({ send: vi.fn() } as never);
 
     it("sends a BTC request to `ark` and an asset request to `ark-asset`", async () => {
-        // Same address string, two different rails: the amount is what chose.
         expect(
             (await router().options({ raw: ARK_ADDR, amount: 1000 })).map((o) => o.railId),
         ).toEqual(["ark"]);

--- a/packages/ts-sdk/test/payment/arkAsset.test.ts
+++ b/packages/ts-sdk/test/payment/arkAsset.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The asset dimension on the router, and the `ark-asset` rail that needed it.
+ *
+ * The load-bearing fact: an Arkade address is the SAME STRING for BTC and for
+ * an asset, so the target cannot tell a BTC payment from an asset one. The
+ * amount names the asset. Everything here follows from that — the two rails
+ * split on `available()` rather than `match()`, and a BTC-only rail handed an
+ * asset request must refuse rather than pay its carrier sats and drop the
+ * asset on the floor.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+    ASSET_CARRIER_SATS,
+    PaymentRouter,
+    arkAssetRail,
+    arkRail,
+    assertNoAssets,
+    assetsOf,
+    createDefaultPaymentRouter,
+    onchainRail,
+    resolveAssetAmount,
+    type Asset,
+    type RouterContext,
+} from "../../src";
+
+const ARK_ADDR =
+    "tark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt846qj6x";
+const USDX: Asset = { assetId: "aa".repeat(32), amount: 500n };
+
+const ctx = (send = vi.fn(async () => "txid")): RouterContext =>
+    ({ wallet: { send } as never, prefs: {} }) as RouterContext;
+
+describe("assetsOf", () => {
+    it("normalizes an absent list to []", () => {
+        expect(assetsOf({ raw: ARK_ADDR })).toEqual([]);
+        expect(assetsOf({ raw: ARK_ADDR, assets: [] })).toEqual([]);
+        expect(assetsOf({ raw: ARK_ADDR, assets: [USDX] })).toEqual([USDX]);
+    });
+});
+
+describe("assertNoAssets", () => {
+    it("passes a request that names no asset", () => {
+        expect(() => assertNoAssets("ark", { raw: ARK_ADDR, amount: 1000 })).not.toThrow();
+    });
+
+    it("names the asset it cannot deliver", () => {
+        expect(() => assertNoAssets("ark", { raw: ARK_ADDR, assets: [USDX] })).toThrow(
+            new RegExp(`cannot deliver ${USDX.assetId}`),
+        );
+    });
+});
+
+describe("resolveAssetAmount", () => {
+    it("returns the single asset a request names", () => {
+        expect(resolveAssetAmount("ark-asset", { raw: ARK_ADDR, assets: [USDX] })).toEqual(USDX);
+    });
+
+    it("refuses zero and more than one, rather than paying the first", () => {
+        expect(() => resolveAssetAmount("ark-asset", { raw: ARK_ADDR })).toThrow(/got 0/);
+        expect(() =>
+            resolveAssetAmount("ark-asset", { raw: ARK_ADDR, assets: [USDX, USDX] }),
+        ).toThrow(/got 2/);
+    });
+
+    it("refuses a non-positive quantity", () => {
+        for (const amount of [0n, -1n]) {
+            expect(() =>
+                resolveAssetAmount("ark-asset", { raw: ARK_ADDR, assets: [{ ...USDX, amount }] }),
+            ).toThrow(/invalid amount/);
+        }
+    });
+
+    it("refuses a number where atomic units belong", () => {
+        // The whole reason the SDK types asset amounts as bigint is that Number
+        // truncates supplies past 2^53-1. A rail that accepted one would corrupt
+        // the balance silently rather than fail.
+        expect(() =>
+            resolveAssetAmount("ark-asset", {
+                raw: ARK_ADDR,
+                assets: [{ assetId: USDX.assetId, amount: 500 as unknown as bigint }],
+            }),
+        ).toThrow(/expected a positive bigint/);
+    });
+
+    it("carries an amount past Number.MAX_SAFE_INTEGER intact", () => {
+        const huge = BigInt(Number.MAX_SAFE_INTEGER) * 1000n + 7n;
+        const resolved = resolveAssetAmount("ark-asset", {
+            raw: ARK_ADDR,
+            assets: [{ assetId: USDX.assetId, amount: huge }],
+        });
+        expect(resolved.amount).toBe(huge);
+    });
+
+    it("refuses an unnamed asset", () => {
+        expect(() =>
+            resolveAssetAmount("ark-asset", {
+                raw: ARK_ADDR,
+                assets: [{ assetId: "", amount: 500n }],
+            }),
+        ).toThrow(/must name an asset/);
+    });
+});
+
+describe("arkAssetRail", () => {
+    it("matches an Arkade address — the same string `ark` matches", () => {
+        expect(arkAssetRail().match({ raw: ARK_ADDR, assets: [USDX] }, ctx())).toBe(true);
+        expect(arkAssetRail().match({ raw: ARK_ADDR }, ctx())).toBe(true);
+        expect(
+            arkAssetRail().match({ raw: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080" }, ctx()),
+        ).toBe(false);
+    });
+
+    it("is available only for a request that names an asset", async () => {
+        expect(await arkAssetRail().available?.({ raw: ARK_ADDR, assets: [USDX] }, ctx())).toBe(
+            true,
+        );
+        expect(await arkAssetRail().available?.({ raw: ARK_ADDR, amount: 1000 }, ctx())).toBe(
+            false,
+        );
+    });
+
+    it("quotes the asset on both sides — an off-chain transfer costs no asset", async () => {
+        const quote = await arkAssetRail().quote({ raw: ARK_ADDR, assets: [USDX] }, ctx());
+        expect(quote.assets).toEqual({ delivered: USDX, spent: USDX });
+        expect(quote.fee).toBe(0);
+    });
+
+    it("quotes the CARRIER sats, not zero", async () => {
+        // An asset does not move on its own: `total` is what leaves the wallet,
+        // and the sats-carrying output leaves it too.
+        const quote = await arkAssetRail().quote({ raw: ARK_ADDR, assets: [USDX] }, ctx());
+        expect(quote.amount).toBe(ASSET_CARRIER_SATS);
+        expect(quote.total).toBe(ASSET_CARRIER_SATS);
+    });
+
+    it("honours an explicit carrier amount", async () => {
+        const quote = await arkAssetRail().quote(
+            { raw: ARK_ADDR, amount: 5_000, assets: [USDX] },
+            ctx(),
+        );
+        expect(quote.total).toBe(5_000);
+    });
+
+    it("sends the asset alongside the carrier, in one Recipient", async () => {
+        const send = vi.fn(async () => "the-txid");
+        const quote = await arkAssetRail().quote({ raw: ARK_ADDR, assets: [USDX] }, ctx(send));
+        const result = await (await quote.send()).settled();
+
+        expect(send).toHaveBeenCalledWith({
+            address: ARK_ADDR,
+            amount: ASSET_CARRIER_SATS,
+            assets: [USDX],
+        });
+        expect(result).toEqual({ railId: "ark-asset", txid: "the-txid" });
+    });
+
+    it("refuses a malformed asset at quote time with a named error", async () => {
+        // Not a silent drop: `available()` said this rail is the one, so the
+        // reason it cannot pay has to be legible.
+        await expect(
+            arkAssetRail().quote({ raw: ARK_ADDR, assets: [USDX, USDX] }, ctx()),
+        ).rejects.toThrow(/exactly one asset/);
+    });
+});
+
+describe("the BTC-only rails refuse an asset rather than dropping it", () => {
+    it("ark drops itself, and refuses if reached directly", async () => {
+        const req = { raw: ARK_ADDR, amount: 1000, assets: [USDX] };
+        expect(await arkRail().available?.(req, ctx())).toBe(false);
+        // The failure this prevents: paying 1000 sats, reporting success, and
+        // delivering none of the asset the user asked for.
+        await expect(arkRail().quote(req, ctx())).rejects.toThrow(/cannot deliver/);
+    });
+
+    it("onchain drops itself — an Arkade asset has no L1 form to offboard to", async () => {
+        const btc = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+        expect(
+            await onchainRail().available?.({ raw: btc, amount: 1000, assets: [USDX] }, ctx()),
+        ).toBe(false);
+    });
+});
+
+describe("the default router routes on the amount, not the target", () => {
+    const router = () => createDefaultPaymentRouter({ send: vi.fn() } as never);
+
+    it("sends a BTC request to `ark` and an asset request to `ark-asset`", async () => {
+        // Same address string, two different rails: the amount is what chose.
+        expect(
+            (await router().options({ raw: ARK_ADDR, amount: 1000 })).map((o) => o.railId),
+        ).toEqual(["ark"]);
+        expect(
+            (await router().options({ raw: ARK_ADDR, assets: [USDX] })).map((o) => o.railId),
+        ).toEqual(["ark-asset"]);
+    });
+
+    it("never offers both, so their relative priority cannot matter", async () => {
+        for (const req of [
+            { raw: ARK_ADDR, amount: 1000 },
+            { raw: ARK_ADDR, assets: [USDX] },
+        ]) {
+            const ids = (await router().options(req)).map((o) => o.railId);
+            expect(ids.filter((id) => id === "ark" || id === "ark-asset")).toHaveLength(1);
+        }
+    });
+
+    it("route() picks the asset rail without a preference being set", async () => {
+        const quote = await new PaymentRouter({
+            wallet: { send: vi.fn(async () => "txid") } as never,
+            prefs: {},
+        })
+            .use(arkRail())
+            .use(arkAssetRail())
+            .route({ raw: ARK_ADDR, assets: [USDX] });
+
+        expect(quote.railId).toBe("ark-asset");
+        expect(quote.assets?.delivered).toEqual(USDX);
+    });
+});


### PR DESCRIPTION
> **Rebased onto `master`.** #837 landed as a squash (`fa3a2d1f`), so this
> branch was replayed with `git rebase --onto origin/master 5ade00fe`, taking
> only its own five commits. Base retargeted from `feat/payment-rails-router`
> to `master`; the diff is now this PR's work alone (16 files).
> No conflicts: #837's review fixes landed in `send()` and in `rendezvous.ts`,
> while this PR's rail changes are asset guards in `available()`/`quote()`.

`PaymentRequest.amount` and `RouteQuote.amount`/`fee`/`total` are bare
`number`s with no unit or asset field. The router can say "500" but never "500
USDX". An Arkade asset payment therefore has nowhere to go — and an Arkade
address is the **same string** whether it is paid in BTC or in an asset, so
the target cannot tell them apart either. The asset is named by the AMOUNT.

## The public-API decision

Three options, and one of them the codebase had already taken.

**Widen the existing fields** (`number | { atomic: bigint; asset: string }`).
Rejected: it breaks every consumer that does arithmetic on `quote.total`, and
the asset half would still be lossy anywhere a `number` survives.

**A separate request type / parallel router.** Rejected: it duplicates
matching, ranking and preferences, and it re-creates exactly the "two things
that disagree about when to fall back" problem the router exists to avoid.

**Add an optional field alongside** — taken, because `Wallet.send`'s
`Recipient` already solves this problem and solves it this way:

```ts
export interface Recipient {
    amount?: number;      // sats, defaults to dust
    assets?: Asset[];     // { assetId: string; amount: bigint }
}
```

and `Asset.amount` is documented as `bigint` for the reason that settles the
whole question: *"asset supplies routinely exceed `Number.MAX_SAFE_INTEGER`
and silently truncating in arithmetic would corrupt balances."*

So `PaymentRequest` grows the same optional `assets`, using the same `Asset`
type — no new vocabulary, and a request is now structurally close to the
`Recipient` a rail hands to `wallet.send`. Every existing sats field keeps its
meaning, and nothing that compiled before stops compiling: boltz-swap's 616
tests are untouched and still pass, which is the check that the addition is
genuinely additive.

`Recipient` also settles a subtler point. An Arkade asset does not move on its
own — it rides a sats-carrying output — so a 500 USDX payment really does move
sats as well. The sats fields are therefore **not zeroed** on an asset route:
`amount` is the carrier and `total` goes on meaning what leaves the wallet, so
ranking on `total` still means the same thing on every rail.

On `RouteQuote` the asset view is a **pair, not a triple**:

```ts
assets?: { delivered: Asset; spent: Asset };
```

because a cross-asset route spends BTC and delivers USDX, and `total = amount
+ fee` cannot hold across two units. On a same-asset route the two name the
same asset and the difference between them is the fee.

`RouterContext.swaps` is left as `unknown`. It did not need typing: the rails
here take their dependencies at construction, which is stricter than a typed
escape hatch and does not make core name a type it cannot import.

## Did cross-asset composition fit in a rail?

**Yes, and the router needed no composition primitive.** That was the thing to
test rather than assume, so `crossAssetRail` is the demonstration.

Both legs are quotable at quote time — `quoteOffer` prices the swap from the
market's own feed, and delivery is an off-chain transfer with no counterparty
fee — so the rail prices them into one `RouteQuote` and reports the offer on
`RouteResult.swapId`, which already had a slot. `send()` funds the offer,
waits for a filler, and only then pays the recipient.

The argument for keeping this out of the router: a hop is only routable if it
is quotable, and a rail that owns both hops can quote both. Pushing it up
would mean inventing a quote-composition rule every future rail has to
satisfy, for one caller. The one thing that genuinely could not stay inside a
rail is the two-unit quote — hence `assets`.

What it does not do is asset → asset in one offer. `createOffer` refuses
anything but BTC↔asset ("set exactly one of wantAsset or offerAsset"), so
paying USDX out of EURX is two offers. That is still rail-internal — more
legs, not a different shape — and it is not implemented here.

Its BTC-only restriction is `findMarket` being keyed on BTC, **not** a
separate guard. `selectionPredicate` matches asset ids exactly in either
orientation, so a EURX/USDX market is never returned for `(btc, USDX)`. I
wrote a give-side check first; mutation testing showed removing it broke
nothing, I traced why, found it unreachable, and deleted it rather than keep a
test that passed for the wrong reason.

## The rails

**`ark-asset`** — pay an Arkade address in an asset. Splits from `ark` on
`available()` rather than `match()`: both legitimately match the address, and
which one can pay is a question about the amount. `options()` returns exactly
one, so their relative priority is immaterial.

**`cross-asset`** — pay an asset the wallet does not hold. Lives in
`@arkade-os/swap` (it needs `createOffer`); `ark-asset` is core, because an
asset transfer out of a balance you already have needs no swap at all.

`ark-asset` is registered in **both** default factories. A Lightning-capable
app picks boltz-swap's `createDefaultPaymentRouter(wallet, swaps)` over the
core one, and without it there that choice silently costs it asset payments —
`route()` would throw "no rail for" with nothing saying why. It never competes
with `ark`, so every existing BTC ranking in that factory's tests is unchanged
and still asserted exactly as it was.

## One thing worth arguing about

On a cross-asset route the sats triple comes out as `amount: 330` (the
carrier), `fee: 100_000` (the swap deposit), `total: 100_330`. Calling the
purchase price a "fee" reads oddly — it is not a charge, it is what the asset
cost.

It is forced rather than chosen. `RouteQuote` defines `amount` as sats
delivered to the recipient and `total` as sats that leave the wallet; the
recipient receives USDX and 330 sats of carrier, and 100,330 sats leave. With
`total = amount + fee` holding, `fee` can only be 100,000. `assets.spent`
names the same number properly, as BTC.

The alternative is to let an asset route report `total` as only the carrier
and leave the deposit off the sats triple entirely — which would make
`options()` rank a cross-asset route as costing 330 sats, and that is worse.
Flagging it because a reviewer may prefer a third field over overloading
`fee`, and that is a reasonable position.

## The silent-drop this closes

Every BTC-only rail now refuses a request carrying an asset instead of
ignoring it: `ark`, `onchain`, `lightning`, `onchain-swap`, `solver-onchain`,
`solver-lightning`. Without that, a request for 500 USDX handed to a BTC rail
would pay its carrier sats, report success, and deliver none of the asset the
user asked for. Refusing at `available()` is what leaves the router free to
rank a rail that can, and `assertNoAssets` at `quote()` is the backstop for a
caller reaching a rail directly.

## Self-review found a bug (`c040b8a2`)

`Asset.assetId` is a hex string — that is what `Wallet.send` takes — while
`createOffer`'s `wantAsset` is an `asset.AssetId`, a class it reads `.txid`
and `.groupIndex` off to bind the covenant. I had written `wantAsset:
asset.assetId as never`, and the cast is what hid it. It does not throw: both
fields come back `undefined`, so the offer publishes wanting nothing in
particular — the user funds it and nobody can fill it.

The tests missed it because they mock `createOffer`, and a mock accepts any
shape. The regression test therefore asserts on the value passed rather than
the call: `txid` is a `Uint8Array`, `groupIndex` is a number, `toString()`
round-trips. Re-introducing the cast fails it.

Asset ids are also 34 bytes, not 32, and both fixtures were 32 — long enough
to look right. `available()` now parses the id up front, so one `createOffer`
could not bind drops the rail instead of failing at send time with an offer
already funded.

## Review round 1 (`1fa1a647`)

All five findings from arkana-ai-bot taken — [reply](https://github.com/arkade-os/ts-sdk/pull/838#issuecomment-5537079792).

- **The window between the fill and the payment had no state**, and the record
  actively lied: frozen at `"quoted"` after a fill landed, it points recovery
  at `cancelOffer` when the asset is in fact in the wallet and the recipient is
  still owed. `CrossAssetSwap` now carries a `phase` and `persist` runs at both
  transitions — `"quoted"` before funding, `"filled"` after delivery and before
  the recipient send. Both sit before an irreversible step, the same rule the
  send rails follow.
- **The deposit's `bigint → number` narrowing is asserted, not assumed.** BTC's
  supply fits a safe integer; the fragile assumption is the give side being
  BTC, which a comment would not catch.
- **Doc-only** on `RouteQuote.assets` (on a cross-asset route `fee` is the
  purchase price, and `assets.spent` is what to display), on `awaitFill` (the
  caller owns the deadline, and resolving on a timeout makes the rail pay from
  whatever the wallet then holds), and on `discover` (called twice per route,
  and what caching makes that one round trip rather than four).

## Test plan

- `pnpm -r build && pnpm run test:unit`
  - base (#837 head, `14edab7c`): ts-sdk 174 files / 2893 + 1 skipped, swap 31
    / 719, boltz-swap 23 / 616 — 4228 passing, zero failures.
  - after: ts-sdk 175 / 2914 (+21), swap 32 / 748 (+29), boltz-swap 23 / 617
    (+1, the new factory case) — 4279 passing, zero failures. The 51 added
    tests reconcile exactly: +50 across the two new files, +1 in the boltz
    factory suite. **No existing boltz-swap test changed**, which is the check
    that the type addition is genuinely additive.
- Mutations run, each killed:
  - `cross-asset` routing when `findMarket` finds no corridor — 3 fail
  - `findMarket` keyed on the asset instead of BTC — 1 fail
  - `cross-asset` ignoring `validatePlan`'s verdict — 2 fail
  - paying the recipient before waiting for the fill — 1 fail
  - dropping the swap deposit from the sats total — 1 fail
  - reporting the delivered asset as the spent one — 1 fail
  - dropping the BTC short-circuit (a registry round trip on every BTC send) —
    1 fail
  - dropping the well-formedness short-circuit — 1 fail
  - accepting a multi-asset request — 1 fail
  - `ark-asset.available()` ignoring whether an asset was named — 4 fail
  - `ark-asset` sending the carrier but dropping the asset — 1 fail
  - `ark-asset` quoting zero sats instead of the carrier — 3 fail
  - `ark` accepting an asset request (the silent drop) — 4 fail
  - `resolveAssetAmount` accepting a `Number` quantity — 2 fail
  - re-introducing the `as never` cast (the bug above) — 1 fail
  - `available()` skipping the asset-id parse — 1 fail
  - not recording the fill before the recipient send — 3 fail
  - recording it after the send instead of before — 2 fail
  - leaving the phase at `"quoted"` — 2 fail
  - removing the deposit narrowing guard — 1 fail
  - One mutation **survived** and was acted on rather than explained away: the
    `givesBtc` give-side guard in `cross-asset`. It was unreachable; it is
    gone, and the test that appeared to cover it now pins the real invariant.
- Not run: regtest integration for the asset rails. `ark-asset` bottoms out in
  `Wallet.send({ assets })`, which the arkade-assets integration job already
  covers; `cross-asset`'s fill wait is injected and has never been driven
  against a real filler. **That is the claim I would most expect to need
  adjusting** — specifically whether `deps.awaitFill` is the right seam or
  whether the rail should take a `watchOfferSwaps` handle directly.



## The fields are tagged `@experimental` (`b268a9b8`)

This PR targets `master`, which ships `@arkade-os/sdk` 0.4.x every few days
(0.4.65 -> 0.4.68 in the last fortnight). So merging it publishes
`PaymentRequest.assets` and `RouteQuote.assets` as stable API within days.

Meanwhile #843 — the v2 swap client, on `feat/v0.5` — models assets natively
as `give`/`take`/`amountOn` over `AssetRef`, and `AssetId` the class has lived
in this package all along at `extension/asset/assetId.ts` while
`Recipient.assets` uses hex-string ids. **That split predates both PRs**, and
following `Recipient` here is still the right call for the reason above. But
converging the two vocabularies after a 0.4.x release turns a refactor into a
breaking change, so both fields carry `@experimental` until v0.5 settles it.

Doc-only, no behaviour change; typecheck and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sending Arkade assets through the default payment router.
  * Added cross-asset payments, allowing BTC to be exchanged for an asset before delivery.
  * Payment quotes and requests now support asset details.
  * Cross-asset payments now track payout progress through completion and support recovery after interruptions.

* **Bug Fixes**
  * BTC-only payment methods now reject asset-bearing requests instead of attempting incompatible routes.
  * Improved validation for missing, malformed, or unsupported asset amounts.
  * Asset routing preserves existing BTC payment priorities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
