### PR TITLE
fix(sdk): capture the address-watch anchor at watch start

### DIFF
--- a/packages/ts-sdk/src/providers/onchain.ts
+++ b/packages/ts-sdk/src/providers/onchain.ts
@@ -398,7 +398,7 @@ export class EsploraProvider implements OnchainProvider {
         const seen = new Set<string>();
         let baselined = false;
 
-        /** Chain height at watch start, captured only if the history baseline failed. */
+        /** Chain height at watch start, used if the history baseline fails. */
         let anchorHeight: number | undefined;
 
         /**
@@ -408,29 +408,25 @@ export class EsploraProvider implements OnchainProvider {
          * Seeded additively rather than by replacing the set: the socket may
          * report a transaction while this fetch is still in flight, and that
          * report must not be undone (nor duplicated) when the fetch lands.
+         *
+         * The tip is fetched alongside the history so an anchor — if needed —
+         * is the height at watch start, not at the moment the history fetch
+         * later gives up. A deposit confirmed while that fetch is still
+         * failing must still read as new.
          */
         const baseline = (async () => {
-            try {
-                for (const tx of await getAllTxs()) seen.add(txKey(tx));
+            const [history, tip] = await Promise.allSettled([getAllTxs(), this.getChainTip()]);
+            if (history.status === "fulfilled") {
+                for (const tx of history.value) seen.add(txKey(tx));
                 baselined = true;
-            } catch (error) {
-                // Degrade rather than fail the watch. The first poll pass adopts
-                // current history as the baseline instead, which can still
-                // swallow a deposit that lands before it — but never invents one
-                // by reporting the whole address history as incoming.
-                console.warn(
-                    "Could not baseline watched addresses; the first poll pass will establish it instead:",
-                    error,
-                );
-
-                // `/blocks` is small enough to survive a timeout that killed the
-                // history fetch, and a height is reference enough.
-                try {
-                    anchorHeight = (await this.getChainTip()).height;
-                } catch {
-                    // No reference of any kind; the late baseline adopts wholesale.
-                }
+                return;
             }
+
+            console.warn(
+                "Could not baseline watched addresses; the first poll pass will establish it instead:",
+                history.reason,
+            );
+            if (tip.status === "fulfilled") anchorHeight = tip.value.height;
         })();
 
         /**

--- a/packages/ts-sdk/test/esplora-watch-addresses.test.ts
+++ b/packages/ts-sdk/test/esplora-watch-addresses.test.ts
@@ -52,10 +52,12 @@ class FakeWebSocket {
 
 function deferred<T>() {
     let resolve!: (value: T) => void;
-    const promise = new Promise<T>((res) => {
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
         resolve = res;
+        reject = rej;
     });
-    return { promise, resolve };
+    return { promise, resolve, reject };
 }
 
 const okJson = (data: unknown) => ({ ok: true, json: () => Promise.resolve(data) });
@@ -349,8 +351,8 @@ describe("EsploraProvider.watchAddresses", () => {
 
             await provider.watchAddresses(["addr1"], callback);
 
-            // The history baseline was attempted, and its failure was followed
-            // by the chain-tip fallback that anchors a late baseline.
+            // The baseline history request was attempted, and the chain-tip
+            // request that can anchor a late baseline went out alongside it.
             expect(mockFetch).toHaveBeenCalledTimes(2);
 
             // A failed baseline must degrade, not throw and not go deaf.
@@ -437,6 +439,46 @@ describe("EsploraProvider.watchAddresses", () => {
             expect(
                 warn.mock.calls.some((c) => /may not have been reported/i.test(String(c[0]))),
             ).toBe(true);
+        });
+
+        it("takes the chain-tip snapshot at watch start, not when history fails", async () => {
+            // A deposit that confirms while the baseline history fetch is still
+            // failing must read as new. That only holds if the anchor is the tip
+            // at watch start, so the tip request goes out alongside the history
+            // fetch rather than waiting for it to give up.
+            const baselineTxs = deferred<ReturnType<typeof okJson>>();
+            let history: unknown[] = [];
+            let txsCalls = 0;
+            mockFetch.mockImplementation((url: string) => {
+                if (url.includes("/blocks")) return Promise.resolve(blocksTip(100));
+                if (url.includes("/txs")) {
+                    txsCalls++;
+                    return txsCalls === 1 ? baselineTxs.promise : Promise.resolve(okJson(history));
+                }
+                return Promise.reject(new Error(`unexpected fetch: ${url}`));
+            });
+
+            const callback = vi.fn();
+            const provider = new EsploraProvider("http://localhost:3000", { forcePolling: true });
+            const watching = provider.watchAddresses(["addr1"], callback);
+
+            // The tip was already requested while the history baseline is still
+            // in flight — the anchor is a watch-start reference.
+            expect(mockFetch.mock.calls.some(([url]) => String(url).includes("/blocks"))).toBe(
+                true,
+            );
+
+            // The deposit confirmed at 101 during the outage: above a watch-start
+            // tip of 100, below the tip the failure path would capture later.
+            history = [confirmedTxAt("gap", 101), confirmedTxAt("old", 90)];
+            baselineTxs.reject(new Error("history unavailable"));
+            const stop = await watching;
+            await flush();
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback.mock.calls[0][0]).toEqual([expect.objectContaining({ txid: "gap" })]);
+
+            stop();
         });
     });
 
@@ -680,22 +722,23 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("backs off and retries after a failed poll cycle, rather than going blind", async () => {
-            mockFetch.mockResolvedValueOnce(okJson([])); // creation-time baseline
-            mockFetch.mockRejectedValueOnce(new Error("explorer down")); // first cycle
+            mockFetch.mockResolvedValueOnce(okJson([])); // baseline history
+            mockFetch.mockImplementationOnce(() => Promise.resolve(blocksTip(1))); // baseline tip
+            mockFetch.mockRejectedValueOnce(new Error("explorer down")); // first poll cycle
             mockFetch.mockResolvedValue(okJson([]));
 
             await polling().watchAddresses(["addr1"], () => {});
 
             // A failed cycle must still leave a retry armed.
             expect(vi.getTimerCount()).toBe(1);
-            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(mockFetch).toHaveBeenCalledTimes(3);
 
             // One failure doubles the delay, so the plain interval is too early.
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(mockFetch).toHaveBeenCalledTimes(3);
 
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-            expect(mockFetch).toHaveBeenCalledTimes(3);
+            expect(mockFetch).toHaveBeenCalledTimes(4);
         });
 
         it("warns when it degrades from websocket to HTTP polling", async () => {


### PR DESCRIPTION
Follow-up to #833. The chain-tip anchor was captured only after the history baseline failed, leaving a silent-miss window equal to the failed fetch's duration. Snapshot the tip at watch start (fetched alongside the history baseline) so a deposit confirming during a slow history fetch reads as new.