### PR TITLE
fix(swap): stop rebuilding terminal swaps on every restore

### DIFF
--- a/packages/swap/src/client/drive.ts
+++ b/packages/swap/src/client/drive.ts
@@ -328,7 +328,20 @@ export const createSwapDrive = (config: SwapDriveConfig): SwapDrive => {
 
     let bridge: CorridorRecordStore | undefined;
     const corridorStore = (): CorridorRecordStore =>
-        (bridge ??= corridorRecordStore(storage(), remember, (r) => !undrivable.has(r.id)));
+        (bridge ??= corridorRecordStore(
+            storage(),
+            remember,
+            // Terminal records are readable but never driven: excluding them
+            // here is what keeps `restoreFromRepository` from rebuilding each
+            // one — a covenant derivation and a contract row lookup per
+            // record — only to file it in the manager's `finished` set. The
+            // exclusion is on the manager's read, not the record: the drive's
+            // own `records` registry keeps every readable record, and the
+            // index still learns an excluded record's `rfqId` (see
+            // `getAllRfqSwaps`), so a consumer handing its swap to the manager
+            // directly keeps resolving.
+            (r) => !undrivable.has(r.id) && !isRfqSwapTerminal(r.state),
+        ));
 
     // ── the outcome ──────────────────────────────────────────────────────────
 
@@ -350,9 +363,20 @@ export const createSwapDrive = (config: SwapDriveConfig): SwapDrive => {
 
     const outcomeOfEntry = (record: SwapRecord, current?: RfqSwap): Outcome => {
         // The offer family has no live object of its own — its watcher is
-        // event-driven over the store — and a corridor record with nothing live
-        // behind it has only itself and the clock to answer with.
-        if (record.family === "offer" || current === undefined) return recordOutcome(record);
+        // event-driven over the store — so past the funding the record IS the
+        // state.
+        if (record.family === "offer") return recordOutcome(record);
+        // A terminal record the restore deliberately did not rebuild has
+        // nothing live behind it, so it answers off its own stored state. This
+        // is the same cell the live path reads (`corridorOutcome` below), not
+        // the record-and-clock projection: `recordOutcome` ignores state and
+        // would report a settled swap as `funding`.
+        if (current === undefined) {
+            if (isRfqSwapTerminal(record.state)) return corridorOutcome(record.kind, record.state);
+            // A live record with nothing behind it has only itself and the
+            // clock to answer with.
+            return recordOutcome(record);
+        }
         const state = effectiveState(current);
         // `pending` before any pass is the accept-time word, not an answer: the
         // record says the funding was broadcast and nothing has looked at the
@@ -776,12 +800,19 @@ export const createSwapDrive = (config: SwapDriveConfig): SwapDrive => {
         const { corridor, offer } = splitRecords(all.filter(readableRecord));
         for (const record of [...corridor, ...offer]) records.set(record.id, record);
 
+        // Terminal records stay readable but are never driven: indexing one,
+        // probing it and rebuilding it buys nothing — the manager would file
+        // it in `finished` and no callback path a never-admitted swap can
+        // produce reaches the `rfqId -> QuoteId` index. Every readable record
+        // is already in `records` above, so `list()` and the `onUpdate` replay
+        // keep seeing settled swaps; only this driving half narrows.
+        const liveCorridor = corridor.filter((record) => !isRfqSwapTerminal(record.state));
         const store = corridorStore();
-        for (const record of corridor) store.index(record);
+        for (const record of liveCorridor) store.index(record);
 
-        if (corridor.length > 0) {
+        if (liveCorridor.length > 0) {
             await contractsOf();
-            for (const record of corridor) {
+            for (const record of liveCorridor) {
                 if (!(await drivable(record))) undrivable.add(record.id);
             }
             managerDeps.repository = store;

--- a/packages/swap/src/client/driveRecords.ts
+++ b/packages/swap/src/client/driveRecords.ts
@@ -138,13 +138,19 @@ export const corridorRecordStore = (
     /**
      * Which stored records the restore may hand to the manager.
      *
-     * The filter exists for one case: an `arkade -> onchain` record on a client
-     * whose chain source was refused. `restoreFromRepository` restores
+     * The filter exists for two cases. An `arkade -> onchain` record on a client
+     * whose chain source was refused: `restoreFromRepository` restores
      * everything it reads, and the manager fails an onchain-send swap
      * TERMINALLY on its first pass without a `ChainSource` — a deliberate
      * refusal to watch that corridor blind. Excluding the record here leaves it
      * durable, undriven and reporting off itself, which is the honest answer to
      * "this client cannot drive this swap".
+     *
+     * And a record in a terminal state, which the drive excludes: the manager
+     * would rebuild it only to file it in `finished`, so handing it over pays
+     * a covenant derivation and a contract row lookup per record for nothing.
+     * The record itself stays readable — it is still in the drive's registry
+     * and still answers off its own stored state.
      */
     admits: (record: CorridorSwapRecord) => boolean = () => true,
 ): CorridorRecordStore => {

--- a/packages/swap/test/client/drive.test.ts
+++ b/packages/swap/test/client/drive.test.ts
@@ -291,6 +291,47 @@ describe("the lifecycle", () => {
         await h.drive.dispose();
     });
 
+    it("reports terminal records off their stored state without rebuilding them", async () => {
+        // The restore deliberately does not hand terminal records to the
+        // manager — rebuilding each one is a covenant derivation and a
+        // contract row lookup for a swap the manager would only file in
+        // `finished`. They stay readable and answer off their own state,
+        // through the same table cell the live path reads.
+        const records = [
+            signable({ id: "q1", rfqId: "rfq-1", state: "settled", fundingTxid: "aa".repeat(32) }),
+            signable({ id: "q2", rfqId: "rfq-2", state: "refunded", fundingTxid: "bb".repeat(32) }),
+            signable({
+                id: "q3",
+                rfqId: "rfq-3",
+                kind: "lightning_receive",
+                state: "refunded",
+                fundingTxid: "cc".repeat(32),
+            }),
+            signable({ id: "q4", rfqId: "rfq-4", state: "failed", fundingTxid: "dd".repeat(32) }),
+            // No contract row, no profile: nothing here could be rebuilt, so
+            // a `paid` below proves the rebuild was never attempted rather
+            // than merely survived.
+            signable({
+                id: "q5",
+                rfqId: "rfq-5",
+                state: "settled",
+                fundingTxid: "ee".repeat(32),
+                lockupAddress: "bogus",
+                profile: {},
+            }),
+        ];
+        const h = await build({ records, vtxos: unspent() });
+
+        expect(h.drive.swap("q1")?.outcome).toBe("paid");
+        expect(h.drive.swap("q2")?.outcome).toBe("refunded");
+        // The inversion: the wire calls both `refunded`, but on the receive
+        // leg the lockup was the solver's, so the payment never arrived.
+        expect(h.drive.swap("q3")?.outcome).toBe("lapsed");
+        expect(h.drive.swap("q4")?.outcome).toBe("failed");
+        expect(h.drive.swap("q5")?.outcome).toBe("paid");
+        await h.drive.dispose();
+    });
+
     it("arms on the first accept, which M4 deliberately did not do", async () => {
         const h = await build({ vtxos: unspent() });
         const record = signable({ fundingTxid: "aa".repeat(32) });

--- a/packages/swap/test/e2e/chainSource.test.ts
+++ b/packages/swap/test/e2e/chainSource.test.ts
@@ -121,14 +121,16 @@ describe("the default chain source (regtest)", () => {
         const txid = await chain.broadcast(hex.encode(tx.extract()));
         expect(txid).toBe(tx.id);
 
-        await waitFor(async () => (await chain.getSpendingTx(fill.txid, fill.vout)) !== null);
-        const spend = await chain.getSpendingTx(fill.txid, fill.vout);
+        await waitFor(
+            async () => (await chain.getSpendingTx(fill.txid, fill.vout, funded.script)) !== null,
+        );
+        const spend = await chain.getSpendingTx(fill.txid, fill.vout, funded.script);
         expect(spend).not.toBe(null);
         expect(btc.Transaction.fromRaw(hex.decode(spend!.txHex)).id).toBe(txid);
     }, 120_000);
 
     it("answers null for an outpoint nothing has spent", async () => {
-        const spend = await chain.getSpendingTx(unspent.txid, unspent.vout);
+        const spend = await chain.getSpendingTx(unspent.txid, unspent.vout, idle.script);
         expect(spend).toBe(null);
     });
 });


### PR DESCRIPTION
Stacked on #839. Implements follow-up §1, option 1: restore skips index/drivable probe/rebuild for terminal records (records stay readable); outcomeOfEntry projects terminal stored state via corridorOutcome. One drive test locks paid/refunded/lapsed/failed plus an unbuildable record proving the rebuild is skipped.