### PR TITLE
feat(swap): cancel, the history read, and the disposal gate

### DIFF
--- a/packages/swap/src/client/cancel.ts
+++ b/packages/swap/src/client/cancel.ts
@@ -269,18 +269,25 @@ const persistBestEffort = async (
 };
 
 /** Retire this record's offer script once nothing at it still needs coverage —
- * the same liveness check the watcher applies, over the whole v2 record set. */
+ * the same liveness check the watcher applies, over the whole v2 record set.
+ * Best-effort: the cancel is broadcast and recorded by the time this runs, so
+ * a store read failure or a retire failure must not fail the caller — a script
+ * left watched is recovered by the next restore scan. */
 const retireOfferScripts = async (
     wallet: IWallet,
     repository: AssetSwapRepository,
     record: OfferSwapRecord,
 ): Promise<void> => {
-    const { offer } = splitRecords(await repository.getAllSwapRecords());
-    await retireOfferContract(
-        await wallet.getContractManager(),
-        offer.map(offerFactsOf),
-        record.swapPkScript,
-    );
+    try {
+        const { offer } = splitRecords(await repository.getAllSwapRecords());
+        await retireOfferContract(
+            await wallet.getContractManager(),
+            offer.map(offerFactsOf),
+            record.swapPkScript,
+        );
+    } catch (error) {
+        console.warn(`[swap] could not retire offer script for ${record.id}`, error);
+    }
 };
 
 const isMissingVtxo = (error: unknown): boolean => error instanceof NoSpendableDepositError;

--- a/packages/swap/src/client/cancel.ts
+++ b/packages/swap/src/client/cancel.ts
@@ -37,7 +37,12 @@
 import { base64, hex } from "@scure/base";
 import { ArkAddress, Transaction, type IWallet } from "@arkade-os/sdk";
 import { retireOfferContract } from "../coverage";
-import { NoSpendableDepositError, decodeOffer, prepareOfferCancel } from "../offer";
+import {
+    NoSpendableDepositError,
+    OfferCovenantMismatchError,
+    decodeOffer,
+    prepareOfferCancel,
+} from "../offer";
 import { classifyDepositSpend, spendTxidsOf } from "../restore";
 import { offerOutcome } from "./outcome";
 import type { AssetSwapRepository } from "../repository";
@@ -97,7 +102,9 @@ export const cancelSwap = async (input: CancelInput): Promise<{ outcome: CancelO
     // `cancelling` with no recorded spend is a cancel that never broadcast —
     // the gate's write landed and the call died before `send()`. Resuming is
     // the same idempotence-absorbing retry `accept()` gives; the `cancelling`
-    // write below is a rewrite of an identical marker.
+    // write below is a rewrite of an identical marker. The one exception is a
+    // pre-broadcast rebuild refusal (`OfferCovenantMismatchError`): retrying
+    // cannot help, so the catch rolls the gate back instead of leaving it.
 
     // The gate, written BEFORE the broadcast: it is what keeps a crash between
     // submit and record from leaving a swap that still looks pending. It
@@ -113,6 +120,26 @@ export const cancelSwap = async (input: CancelInput): Promise<{ outcome: CancelO
             ...(record.fundingTxid === undefined ? {} : { fundingTxid: record.fundingTxid }),
         });
     } catch (error) {
+        if (error instanceof OfferCovenantMismatchError) {
+            // Pre-broadcast and non-retryable: the rebuild disagrees with the
+            // funded covenant (rotated operator key, wrong swapAddress, corrupt
+            // record), so a second cancel would fail the same way. Roll the
+            // gate back to the pre-gate status rather than leaving a
+            // `cancelling` no retry can move past — `recover()` is for funds
+            // that moved, and nothing moved here. Best-effort: a lost rollback
+            // write must not mask the mismatch the caller has to act on.
+            const rolledBack = withStatus(record, record.status, now());
+            try {
+                await repository.saveSwapRecord(rolledBack);
+            } catch (rollbackError) {
+                console.warn(
+                    `[swap] could not roll back cancel gate for ${record.id}`,
+                    rollbackError,
+                );
+            }
+            drive.ingest(rolledBack);
+            throw error;
+        }
         if (isMissingVtxo(error)) {
             // The fill won the race: the deposit is already spent. Reconcile
             // the spend rather than throwing — v1's documented throw here meant
@@ -218,7 +245,16 @@ const withStatus = (
     updatedAt: now,
 });
 
-/** A write the caller must not be failed by: the money has already moved. */
+/** A write the caller must not be failed by: the money has already moved.
+ *
+ * The drive ingests the settlement even when this write is lost, so a lost
+ * write diverges the two: the drive reads settled while the store still reads
+ * `cancelling`. In `auto`/`manual` mode the watcher classifies the landed
+ * spend from chain and writes the terminal record, rectifying the gap in the
+ * background; in `readonly` mode nothing re-reads the chain, so the gap lasts
+ * until a new client instance restores. No fund loss either way — the
+ * broadcast already happened — but a `readonly` UI restarts on the stale
+ * status. */
 const persistBestEffort = async (
     repository: AssetSwapRepository,
     record: OfferSwapRecord,

--- a/packages/swap/src/client/cancel.ts
+++ b/packages/swap/src/client/cancel.ts
@@ -170,9 +170,13 @@ const reconcileDepositSpend = async (
 ): Promise<{ kind: "cancelled" | "fulfilled"; spentTxid: string } | undefined> => {
     const offer = decodeOffer(hex.decode(record.offerHex));
     const { vtxos } = await indexer.getVtxos({ scripts: [record.swapPkScript] });
-    const deposit = (vtxos ?? []).find(
-        (vtxo) => record.fundingTxid === undefined || vtxo.txid === record.fundingTxid,
-    );
+    const all = vtxos ?? [];
+    const deposit =
+        record.fundingTxid === undefined
+            ? all.length === 1
+                ? all[0]
+                : undefined
+            : all.find((vtxo) => vtxo.txid === record.fundingTxid);
     if (deposit === undefined) return undefined;
     const candidates = spendTxidsOf(deposit);
     if (candidates.length === 0) return undefined;

--- a/packages/swap/src/client/cancel.ts
+++ b/packages/swap/src/client/cancel.ts
@@ -1,0 +1,246 @@
+/**
+ * `cancel()`: the one value-moving call the client makes inside an awaited
+ * method, not through the drive loop.
+ *
+ * The asymmetry is structural (§3.3): cancel is a 2-of-2 of user and server
+ * against a `fulfill` constrained to pay the maker at least `wantAmount`, so
+ * an unfilled offer's only exit needs no solver. Corridor swaps have phases
+ * instead — they answer {@link NotCancellable} on the tag parse, no repository
+ * read.
+ *
+ * **The fill race resolves by reading the spend.** v1's trap is that
+ * `cancelOffer` throws "no spendable VTXO at the swap address" when the fill
+ * won, and its own doc says in as many words that this means the swap
+ * completed. Here the race is reconciled the way the watcher already does —
+ * `spendTxidsOf(vtxo)`, checkpoint first, `getVirtualTxs`, then
+ * `classifyDepositSpend` against the covenant's leaves — and the widened
+ * answer is the record of it: `cancelled` | `filled` | `needs_recovery`.
+ * `indeterminate` is the third answer: everything the classifier cannot name
+ * is a failure to rebuild the covenant rather than a wrong spend, and throwing
+ * contradicts §7 — value has already moved. `needs_recovery` is surfaced and
+ * never silently retried; `client.recover` is what drives it.
+ *
+ * **The ordering is `cancelOffer`'s, but the record it writes is v2's.** v1
+ * keys its local-record half on the v1 store by funding txid, so passed the v2
+ * repository it finds nothing and submits with nothing written. This runs the
+ * same ordering over the {@link OfferSwapRecord}: strict read, the `cancelling`
+ * write gating the broadcast, the broadcast, best-effort `cancelled` plus
+ * `spentTxid` and `completedAt`, and the retire only when the record persisted
+ * — emitting through `onUpdate` at both edges, because between the gate and the
+ * settlement the record has no `spentTxid` and a crash mid-call would otherwise
+ * leave a permanent `cancelling` nobody hears about. Neither edge is permanent:
+ * the drive keeps `cancelling` in its live set, so a landed spend is still
+ * classified by the watcher, and a `cancelling` record with no spend and an
+ * intact deposit is a cancel that never broadcast — a second `cancel()` resumes
+ * it, the same idempotence-absorbing retry `accept()` already gives.
+ */
+import { base64, hex } from "@scure/base";
+import { ArkAddress, Transaction, type IWallet } from "@arkade-os/sdk";
+import { retireOfferContract } from "../coverage";
+import { NoSpendableDepositError, decodeOffer, prepareOfferCancel } from "../offer";
+import { classifyDepositSpend, spendTxidsOf } from "../restore";
+import { offerOutcome } from "./outcome";
+import type { AssetSwapRepository } from "../repository";
+import type { LockupSpendIndexer } from "../refund";
+import type { SwapDrive } from "./drive";
+import { offerFactsOf, splitRecords } from "./driveRecords";
+import type { OfferSwapRecord } from "./record";
+
+/** What `cancel()` did to the deposit. §3.3's widened return: the
+ * `indeterminate` spend is `needs_recovery`, because value moved and the local
+ * rebuild cannot name how. */
+export type CancelOutcome = "cancelled" | "filled" | "needs_recovery";
+
+/** Offer statuses a spend cannot move — the swap is already resolved, and a
+ * cancel answers from the record rather than re-broadcasting. */
+const OFFER_TERMINAL = (record: OfferSwapRecord): boolean =>
+    record.status === "cancelled" || record.status === "fulfilled";
+
+export interface CancelInput {
+    readonly wallet: IWallet;
+    readonly repository: AssetSwapRepository;
+    /** The record to cancel, read by the caller after `drive.ready` — the one
+     * read the call makes, and what the gate is written from. */
+    readonly record: OfferSwapRecord;
+    /** The delivery channel both edges emit through, armed or not. */
+    readonly drive: SwapDrive;
+    /** The Arkade observation seam — the wallet's own reader, as everywhere. */
+    readonly indexer: LockupSpendIndexer;
+    /** Unix seconds. Injected for tests. */
+    readonly now?: () => number;
+}
+
+/**
+ * Cancel one offer swap, reconciling the fill race and writing the v2 record.
+ *
+ * The caller has already made the strict read — a repository this call cannot
+ * read must not read as "no record here" and send a cancel past its gate — and
+ * refused the corridor tag and the missing record as `NotCancellable`.
+ */
+export const cancelSwap = async (input: CancelInput): Promise<{ outcome: CancelOutcome }> => {
+    const { wallet, repository, record, drive, indexer } = input;
+    const now = input.now ?? (() => Math.floor(Date.now() / 1000));
+
+    // A swap whose outcome is already terminal answers from the record rather
+    // than re-broadcasting — whichever call noticed it, the answer is one
+    // condition, not two.
+    if (OFFER_TERMINAL(record)) {
+        return { outcome: record.status === "cancelled" ? "cancelled" : "filled" };
+    }
+    if (offerOutcome(record.status) === "needs_recovery") {
+        // A swept deposit, or one of the onchain-corridor phases: the value
+        // left the covenant by a route no offchain spend can reach, so
+        // `client.recover` is what drives it. Nothing here to cancel.
+        return { outcome: "needs_recovery" };
+    }
+
+    // `cancelling` with no recorded spend is a cancel that never broadcast —
+    // the gate's write landed and the call died before `send()`. Resuming is
+    // the same idempotence-absorbing retry `accept()` gives; the `cancelling`
+    // write below is a rewrite of an identical marker.
+
+    // The gate, written BEFORE the broadcast: it is what keeps a crash between
+    // submit and record from leaving a swap that still looks pending. It
+    // throws, deliberately — a failed write must not be broadcast past.
+    const gated = withStatus(record, "cancelling", now());
+    await repository.saveSwapRecord(gated);
+    drive.ingest(gated);
+
+    let prepared;
+    try {
+        prepared = await prepareOfferCancel(wallet, record.offerHex, {
+            swapAddress: record.swapAddress,
+            ...(record.fundingTxid === undefined ? {} : { fundingTxid: record.fundingTxid }),
+        });
+    } catch (error) {
+        if (isMissingVtxo(error)) {
+            // The fill won the race: the deposit is already spent. Reconcile
+            // the spend rather than throwing — v1's documented throw here meant
+            // the swap completed.
+            const reconciled = await reconcileDepositSpend(record, indexer);
+            if (reconciled === undefined) {
+                // No terminal write on a guess: the record stays `cancelling`
+                // and the deposit's fate is what `client.recover` drives.
+                return { outcome: "needs_recovery" };
+            }
+            const { kind, spentTxid } = reconciled;
+            const settled = withStatus(gated, kind, now(), {
+                spentTxid,
+                // Mirrors the watcher: a completion time is a fill's, not a
+                // cancel's.
+                ...(kind === "fulfilled" ? { completedAt: now() } : {}),
+            });
+            const { persisted } = await persistBestEffort(repository, settled);
+            drive.ingest(settled);
+            if (persisted) await retireOfferScripts(wallet, repository, settled);
+            return { outcome: kind === "cancelled" ? "cancelled" : "filled" };
+        }
+        throw error;
+    }
+
+    // The broadcast. The gate landed above, so a crash between the two leaves
+    // the `cancelling` marker rather than a pending-looking swap.
+    const txid = await prepared.send();
+
+    // Past the point of no return: the cancel is broadcast, so a lost write
+    // must not fail the caller. The watcher classifies by covenant leaf and the
+    // restore scan re-derives the outcome.
+    const settled = withStatus(gated, "cancelled", now(), { spentTxid: txid });
+    const { persisted } = await persistBestEffort(repository, settled);
+    drive.ingest(settled);
+    if (persisted) {
+        // Retiring belongs beside the settlement write for the same reason the
+        // status does: recording its own outcome is what leaves the watcher
+        // nothing to do. Only on a persisted write — a record that still reads
+        // `cancelling` to the next restore must stay watched.
+        await retireOfferScripts(wallet, repository, settled);
+    }
+    return { outcome: "cancelled" };
+};
+
+/** The deposit's spend, classified the way the watcher classifies it —
+ * checkpoint first, then the ark tx, against the covenant's own leaves.
+ * `undefined` is the indeterminate answer, and it covers a deposit this reader
+ * cannot see at all as well as one whose spend took neither leaf: both are a
+ * failure to name what happened rather than evidence of what did, and neither
+ * may be written down as terminal. */
+const reconcileDepositSpend = async (
+    record: OfferSwapRecord,
+    indexer: LockupSpendIndexer,
+): Promise<{ kind: "cancelled" | "fulfilled"; spentTxid: string } | undefined> => {
+    const offer = decodeOffer(hex.decode(record.offerHex));
+    const { vtxos } = await indexer.getVtxos({ scripts: [record.swapPkScript] });
+    const deposit = (vtxos ?? []).find(
+        (vtxo) => record.fundingTxid === undefined || vtxo.txid === record.fundingTxid,
+    );
+    if (deposit === undefined) return undefined;
+    const candidates = spendTxidsOf(deposit);
+    if (candidates.length === 0) return undefined;
+    // The id the record and history name, chosen as the watcher chooses it: the
+    // ark tx when the indexer gave one, else the checkpoint.
+    const spentTxid = deposit.arkTxId || deposit.spentBy;
+    if (!spentTxid) return undefined;
+    const { txs } = await indexer.getVirtualTxs(candidates);
+    const parsed = txs
+        .map((psbt) => {
+            try {
+                return Transaction.fromPSBT(base64.decode(psbt));
+            } catch {
+                return undefined;
+            }
+        })
+        .filter((tx): tx is Transaction => tx !== undefined);
+    // The operator key the covenant was built with, pinned off the record's
+    // funded address — never the client's current one.
+    const operatorPubkey = ArkAddress.decode(record.swapAddress).serverPubKey;
+    const kind = classifyDepositSpend(offer, operatorPubkey, parsed, {
+        txid: deposit.txid,
+        vout: deposit.vout,
+    });
+    if (kind === "indeterminate") return undefined;
+    return { kind, spentTxid };
+};
+
+const withStatus = (
+    record: OfferSwapRecord,
+    status: OfferSwapRecord["status"],
+    now: number,
+    extra: { spentTxid?: string; completedAt?: number } = {},
+): OfferSwapRecord => ({
+    ...record,
+    status,
+    ...(extra.spentTxid === undefined ? {} : { spentTxid: extra.spentTxid }),
+    ...(extra.completedAt === undefined ? {} : { completedAt: extra.completedAt }),
+    updatedAt: now,
+});
+
+/** A write the caller must not be failed by: the money has already moved. */
+const persistBestEffort = async (
+    repository: AssetSwapRepository,
+    record: OfferSwapRecord,
+): Promise<{ persisted: boolean }> => {
+    try {
+        await repository.saveSwapRecord(record);
+        return { persisted: true };
+    } catch (error) {
+        console.warn(`[swap] could not persist cancel for ${record.id}`, error);
+        return { persisted: false };
+    }
+};
+
+/** Retire this record's offer script once nothing at it still needs coverage —
+ * the same liveness check the watcher applies, over the whole v2 record set. */
+const retireOfferScripts = async (
+    wallet: IWallet,
+    repository: AssetSwapRepository,
+    record: OfferSwapRecord,
+): Promise<void> => {
+    const { offer } = splitRecords(await repository.getAllSwapRecords());
+    await retireOfferContract(
+        await wallet.getContractManager(),
+        offer.map(offerFactsOf),
+        record.swapPkScript,
+    );
+};
+
+const isMissingVtxo = (error: unknown): boolean => error instanceof NoSpendableDepositError;

--- a/packages/swap/src/client/client.ts
+++ b/packages/swap/src/client/client.ts
@@ -20,6 +20,13 @@
  * `quote()` are unchanged and still touch nothing durable; `accept()` gained one
  * thing — it registers the swap it just persisted — and everything else the
  * lifecycle needs lives behind {@link createSwapDrive}.
+ *
+ * From M6 the surface closes: `cancel`, `swaps`, `markets`, and `ClientDisposed`
+ * enforced across every member after disposal. Disposal is terminal; what the
+ * terminal gate refuses is a NEW act, and an `Unsubscribe` already handed out
+ * stays callable as a no-op — disposal drops every listener, so the closure has
+ * nothing left to do, and refusing it would turn correct React-effect teardown
+ * into a throw.
  */
 import { hex } from "@scure/base";
 import type { IWallet } from "@arkade-os/sdk";
@@ -34,17 +41,26 @@ import {
     type CorridorOverrides,
 } from "./corridors/deps";
 import { discoveryIndex, type DiscoveryConfig, type DiscoveryIndex } from "./discovery";
-import { UnsupportedRoute } from "./errors";
+import { ClientDisposed, MissingCorridorDep, NotCancellable, UnsupportedRoute } from "./errors";
 import { acceptQuote, type QuotePreparation } from "./accept";
-import { createSwapDrive, type RecoveryResult, type SwapDrive } from "./drive";
+import { cancelSwap, type CancelOutcome } from "./cancel";
+import { createSwapDrive, readableRecord, type RecoveryResult, type SwapDrive } from "./drive";
 import { walletLockupIndexer } from "./driveRecords";
-import type { SwapUpdate, Unsubscribe } from "./outcome";
-import type { Swap } from "./record";
+import type { Outcome, SwapUpdate, Unsubscribe } from "./outcome";
+import {
+    familyOfSwapId,
+    quoteIdOfSwapId,
+    swapOf,
+    type AssetSwapId,
+    type Swap,
+    type SwapFamily,
+} from "./record";
 import type { SwapPolicy } from "./policy";
 import { feedFetch, quoteFromFeed, type FeedFetch } from "./quoteOffer";
 import { quoteViaRfq } from "./quoteRfq";
 import type { Quote, QuoteId, QuoteInput, RouteResolution } from "./quote";
 import { resolveRoute, type ResolvedRoute } from "./resolve";
+import { cardMarketOf, marketBackendOf, marketKeyOf, usableMarkets, type Market } from "./market";
 import { nostrTransportFactory, type RfqTransportFactory } from "./transport";
 
 export interface SwapClientConfig {
@@ -137,7 +153,13 @@ export interface SwapClient {
      * nothing in this package takes an `AbortSignal`, so the alternative is
      * calling an instance terminal while it is still moving money. Durable swap
      * records, contract registrations and recovery metadata all survive it: a
-     * new client restores and resumes from them.
+     * new client restores and resumes from them, and an injected repository is
+     * never closed — the client closes only a connection it opened itself.
+     *
+     * From M6 every other member refuses with {@link ClientDisposed} afterwards.
+     * The two exceptions are teardown, and for one reason: refusing a cleanup
+     * call turns correct teardown into a throw. A second dispose is a no-op, and
+     * so is an {@link Unsubscribe} this client already handed out.
      */
     [Symbol.asyncDispose](): Promise<void>;
 
@@ -166,7 +188,62 @@ export interface SwapClient {
      *   whole batch; and for a swap with nothing swept — which is what a
      *   `needs_recovery` that came from `needs_counterparty` is.
      */
-    recover(swapId: QuoteId): Promise<RecoveryResult>;
+    recover(swapId: AssetSwapId): Promise<RecoveryResult>;
+
+    /**
+     * Cancel an asset swap: take back an unfilled offer's deposit.
+     *
+     * Defined only for asset swaps and typed that way — an HTLC corridor swap
+     * has phases instead, and its exits are a claim or a refund. The id arrives
+     * tagged (`offer:<quoteId>` / `rfq:<quoteId>`), so a corridor id refuses on
+     * the parse with no repository read, and an offer id no record backs refuses
+     * after the one read this call needed anyway.
+     *
+     * Cancel races a fill. When the deposit is already spent, the spending
+     * transaction is reconciled against the covenant's leaves and the outcome
+     * is `filled` rather than a throw — v1's documented throw-means-completed
+     * behaviour was a trap. A spend the local rebuild cannot classify is
+     * `needs_recovery`: value moved and the client cannot name how, which is
+     * what {@link recover} drives.
+     *
+     * @throws {NotCancellable} for a corridor-tagged id, or an id no record backs.
+     * @throws {MissingCorridorDep} when the client was given no repository.
+     * @throws {ClientDisposed} after disposal.
+     */
+    cancel(swapId: AssetSwapId): Promise<{ outcome: CancelOutcome }>;
+
+    /**
+     * Every swap this client wrote — both families, live and ended.
+     *
+     * One read over the uniform v2 keyspace, projected through the same
+     * derivation the drive publishes: the drive's live answer where it holds the
+     * record, the no-live-state projection otherwise. Membership is therefore
+     * independent of `start()` and of drive mode. A record that will not decode
+     * is skipped rather than fatal. **The v2 keyspace is never pruned** — the
+     * store grows for the life of the wallet, which this method documents
+     * rather than hides.
+     *
+     * The filter is in-memory; the scope is the v2 client's own history. v1-era
+     * rows in the `swaps` and `rfqSwaps` keyspaces are not part of the answer —
+     * they belong to `/protocol`'s re-exported readers.
+     */
+    swaps(filter?: SwapFilter): Promise<Swap[]>;
+
+    /**
+     * The markets a `quote()` could be priced against, as {@link Market} — one
+     * shape with what `Quote.market` references. The escape hatch for a caller
+     * picking a market for a custom `quote()`: it reads the same card the quote
+     * will cite, and the same filters the routing read applies, so it cannot
+     * offer one `quote()` would then refuse. Never required.
+     *
+     * Reads the snapshot the way `quote()` does and not the way `resolve()`
+     * does — fetching when there is none in hand — because this is what a
+     * caller reaches for BEFORE quoting.
+     *
+     * @throws {DiscoverySnapshotUnavailable} when the fetch leaves it with
+     *   nothing either.
+     */
+    markets(): Promise<Market[]>;
 
     /**
      * The route, the market that would price it, and what the active snapshot
@@ -212,6 +289,12 @@ export interface SwapClient {
     preparationOf(id: QuoteId): QuotePreparation | undefined;
 }
 
+/** The in-memory filter {@link SwapClient.swaps} applies. */
+export interface SwapFilter {
+    readonly family?: SwapFamily;
+    readonly outcome?: Outcome;
+}
+
 /**
  * How many quotes' derivations are kept.
  *
@@ -228,6 +311,32 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
     const operator = config.operator ?? walletOperator(wallet);
     const feed: FeedFetch = feedFetch(config.fetchImpl ?? fetch);
     const preparations = new Map<QuoteId, QuotePreparation>();
+    // The wallet's own reader, built once: the drive's observation seam and the
+    // cancel path's fill-race read share it, so both see the same chain.
+    const indexer = walletLockupIndexer(wallet);
+
+    /**
+     * Disposal is terminal, and M6 closes the gate over the whole method set —
+     * which is possible only now that the set is closed.
+     *
+     * The drive already refuses the four members it owns (`start`, `onUpdate`,
+     * `recover`, `adopt`); this covers the ones it never sees — the quote path,
+     * `stop`, the record reads and cancel — so no member is left answering after
+     * disposal. What the gate refuses is a NEW act: a second dispose and an
+     * {@link Unsubscribe} already handed out are teardown, and both are no-ops,
+     * because disposal has already dropped every listener and refusing a
+     * cleanup call would turn correct React-effect teardown into a throw.
+     *
+     * The promise-returning members reject rather than throwing synchronously —
+     * they are declared `Promise<...>` and a caller is entitled to `.catch()`
+     * them — while `ready`, `onUpdate` and `preparationOf` throw where they
+     * stand. A getter handing back a rejected promise nobody awaited would be
+     * an unhandled rejection.
+     */
+    let disposed = false;
+    const ensureLive = (method: string): void => {
+        if (disposed) throw new ClientDisposed(method);
+    };
 
     // Built eagerly and inert: the drive touches nothing until its own `ready`
     // is awaited, and it takes the corridor set as a thunk precisely so
@@ -241,7 +350,7 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
             ...(config.repository === undefined ? {} : { repository: config.repository }),
             corridors: async () => (await resolved()).corridors,
             ...(config.policy?.drive === undefined ? {} : { mode: config.policy.drive }),
-            indexer: walletLockupIndexer(wallet),
+            indexer,
         }));
 
     let context:
@@ -301,9 +410,13 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
     };
 
     return {
-        resolve: async (input) => (await route(input, "resolve")).resolution,
+        resolve: async (input) => {
+            ensureLive("resolve");
+            return (await route(input, "resolve")).resolution;
+        },
 
         quote: async (input) => {
+            ensureLive("quote");
             const { corridors, discovery } = await resolved();
             let resolvedRoute = await route(input, "quote");
 
@@ -406,6 +519,7 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
         },
 
         accept: async (quote) => {
+            ensureLive("accept");
             const { corridors } = await resolved();
             const drive = driving();
             // Before the persist, not after: the restore is what indexes the
@@ -424,15 +538,102 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
             });
         },
 
-        preparationOf: (id) => preparations.get(id),
+        cancel: async (swapId) => {
+            ensureLive("cancel");
+            // The tag parse is the refusal: a corridor id answers `NotCancellable`
+            // with no repository read, which is the point of the prefix. An id
+            // that arrives untagged takes the one read the tagged form takes.
+            if (familyOfSwapId(swapId) === "rfq") throw new NotCancellable(swapId);
+            const repository = config.repository;
+            if (repository === undefined) {
+                throw new MissingCorridorDep("arkade", "repository");
+            }
+            const drive = driving();
+            // Before the read, for `accept()`'s reason: the restore is what
+            // indexes the stored records, and a gate written onto a record the
+            // drive had never read would emit into an empty registry.
+            await drive.ready;
+            // The one read, and the only one: what comes back is what the gate
+            // is written from, so nothing re-reads it downstream.
+            const record = await repository.getSwapRecord(quoteIdOfSwapId(swapId));
+            if (record === undefined || record.family !== "offer") {
+                throw new NotCancellable(swapId);
+            }
+            return cancelSwap({ wallet, repository, record, drive, indexer });
+        },
+
+        swaps: async (filter) => {
+            ensureLive("swaps");
+            const repository = config.repository;
+            if (repository === undefined) return [];
+            const drive = driving();
+            await drive.ready;
+            const records = await repository.getAllSwapRecords();
+            const swaps: Swap[] = [];
+            for (const record of records) {
+                if (!readableRecord(record)) continue;
+                const live = drive.swap(record.id);
+                swaps.push(live ?? swapOf(record, drive.outcomeOf(record)));
+            }
+            if (filter === undefined) return swaps;
+            return swaps.filter(
+                (swap) =>
+                    (filter.family === undefined || swap.family === filter.family) &&
+                    (filter.outcome === undefined || swap.outcome === filter.outcome),
+            );
+        },
+
+        markets: async () => {
+            ensureLive("markets");
+            const { discovery } = await resolved();
+            // `load`, as `quote()` reads it and not as `resolve()` does: the
+            // escape hatch is what a caller reaches for BEFORE quoting, so a
+            // client that has never routed anything must not answer with a
+            // refusal it would not have given the quote.
+            const snapshot = await discovery.load();
+            // One shape with `Quote.market`: the same card a quote will cite,
+            // key for key and snapshot for snapshot. The filter is the routing
+            // read's own, so the hatch cannot offer a card `quote()` would then
+            // refuse — a disallowed registry, or an unaddressable corridor card.
+            return usableMarkets(snapshot, config.policy).map((card) =>
+                cardMarketOf(card, snapshot.ref, marketKeyOf(card), marketBackendOf(card)),
+            );
+        },
+
+        preparationOf: (id) => {
+            ensureLive("preparationOf");
+            return preparations.get(id);
+        },
 
         get ready() {
+            ensureLive("ready");
             return driving().ready;
         },
-        start: () => driving().start(),
-        stop: () => driving().stop(),
-        [Symbol.asyncDispose]: () => driving().dispose(),
-        onUpdate: (fn) => driving().onUpdate(fn),
-        recover: (id) => driving().recover(id),
+        // `async`, so the refusal is a rejection rather than a synchronous
+        // throw: these are declared `Promise<void>` and a caller is entitled to
+        // `.catch()` them.
+        start: async () => {
+            ensureLive("start");
+            return driving().start();
+        },
+        stop: async () => {
+            ensureLive("stop");
+            return driving().stop();
+        },
+        [Symbol.asyncDispose]: async () => {
+            if (disposed) return;
+            disposed = true;
+            // Only a drive that exists: construction is inert, and building one
+            // to dispose it would be the one thing a never-driven client pays.
+            await drive?.dispose();
+        },
+        onUpdate: (fn) => {
+            ensureLive("onUpdate");
+            return driving().onUpdate(fn);
+        },
+        recover: async (id) => {
+            ensureLive("recover");
+            return driving().recover(quoteIdOfSwapId(id));
+        },
     };
 };

--- a/packages/swap/src/client/drive.ts
+++ b/packages/swap/src/client/drive.ts
@@ -108,8 +108,11 @@ export type DriveRefusal =
  * Not a member of §7's sixteen, and it keeps the `Error` suffix to say so —
  * `errors.ts`'s own naming rule. What it replaces is `recoverVtxos`'s bare
  * `Error("No recoverable VTXOs found")`, which is outside the taxonomy and
- * carries nothing a caller can branch on. Which §7 member should carry these
- * refusals, if any, is M6's error-coverage pass.
+ * carries nothing a caller can branch on.
+ *
+ * M6's error-coverage pass ruled it a documented NON-member: no §7 member names
+ * a drive-refusal condition, so none absorbs these four, and the suffix rule is
+ * working as intended rather than marking a loose end.
  */
 export class SwapDriveRefusedError extends Error {
     override readonly name = "SwapDriveRefusedError";
@@ -197,6 +200,16 @@ export interface SwapDrive {
     swap(id: QuoteId): Swap | undefined;
     /** The outcome a record would report with no live state behind it. */
     outcomeOf(record: SwapRecord): Outcome;
+    /**
+     * Take a record written OUTSIDE the drive's own loops — today, the
+     * awaited cancel call — into the registry, and emit through `onUpdate`.
+     *
+     * Cancel writes at two edges, the gate and the settlement, and the
+     * delivery channel for both is this registry: replay plus the
+     * `(swapId, outcome)` key absorb a later pass over the same record, whether
+     * or not the drive armed.
+     */
+    ingest(record: SwapRecord): void;
     recover(id: QuoteId): Promise<RecoveryResult>;
     /** Everything this drive has in flight — registrations and money pushes.
      * Exposed so a test can be deterministic and so dispose can drain. */
@@ -219,7 +232,7 @@ const traderClaimTxid = (swap: RfqSwap): string | undefined =>
  * driving every other swap it holds. Everything checked here is something the
  * drive dereferences unconditionally.
  */
-const readableRecord = (record: SwapRecord): boolean => {
+export const readableRecord = (record: SwapRecord): boolean => {
     if (typeof record?.id !== "string" || record.route?.give === undefined) return false;
     if (record.family === "rfq") {
         return typeof record.rfqId === "string" && typeof record.lockupAddress === "string";
@@ -1068,6 +1081,8 @@ export const createSwapDrive = (config: SwapDriveConfig): SwapDrive => {
         swap: (id) => updateFor(id)?.swap,
 
         outcomeOf: (record) => outcomeOfEntry(record, live.get(record.id)),
+
+        ingest: (record) => remember(record),
 
         recover,
 

--- a/packages/swap/src/client/errors.ts
+++ b/packages/swap/src/client/errors.ts
@@ -276,16 +276,23 @@ export class ClientDisposed extends Error {
 }
 
 /**
- * `cancel()` on a corridor swap. The asymmetry is structural: an offer covenant
- * has no expiry, so cancellation is an unfilled offer's only exit, where an HTLC
- * has phases and its exits are a claim or a refund.
+ * `cancel()` on a swap this client cannot cancel. The asymmetry is structural:
+ * an offer covenant has no expiry, so cancellation is an unfilled offer's only
+ * exit, where an HTLC has phases and its exits are a claim or a refund.
  *
- * Boundary: `cancel()`, for ids that arrive untyped from `swaps()`.
+ * Three ways of refusing, one condition. A corridor-tagged id is refused on the
+ * parse of its prefix, with no repository read; an `offer:` id no record backs
+ * is refused after the one read cancel needed anyway; and an untagged id from
+ * `/protocol`'s readers takes that same read. The taxonomy stays at sixteen —
+ * a "no such swap" member would split one condition across two classes by
+ * which call noticed it.
+ *
+ * Boundary: `cancel()`.
  */
 export class NotCancellable extends Error {
     override readonly name = "NotCancellable";
     constructor(readonly swapId: string) {
-        super(`swap ${swapId} is a corridor swap; only asset swaps cancel`);
+        super(`swap ${swapId} is not a cancellable asset swap`);
     }
 }
 

--- a/packages/swap/src/client/market.ts
+++ b/packages/swap/src/client/market.ts
@@ -79,7 +79,28 @@ export const isAddressable = (card: DiscoveredMarket): boolean =>
     (typeof card.discovery_pubkey === "string" &&
         (card.transports?.nostr?.relays?.length ?? 0) > 0);
 
-const backendOf = (card: DiscoveredMarket): MarketBackend => (isRfqMarket(card) ? "rfq" : "feed");
+/** Which backend a card selects — the card decides it, never the client. */
+export const marketBackendOf = (card: DiscoveredMarket): MarketBackend =>
+    isRfqMarket(card) ? "rfq" : "feed";
+
+/**
+ * The cards on a snapshot this client may act on at all, before any pair is
+ * named: the policy's registry allowlist, then addressability.
+ *
+ * Shared by the routing read and `markets()`, so the escape hatch cannot offer
+ * a card the quote path would then refuse.
+ */
+export const usableMarkets = (
+    snapshot: DiscoverySnapshot,
+    policy?: SwapPolicy,
+): DiscoveredMarket[] => {
+    const allowed = policy?.allowedRegistries;
+    return (
+        allowed
+            ? snapshot.markets.filter((card) => allowed.includes(card.source))
+            : snapshot.markets
+    ).filter(isAddressable);
+};
 
 /**
  * Every card on the snapshot that serves this leg pair, best-ranked first,
@@ -95,12 +116,7 @@ export const eligibleMarkets = (
     legs: { give: DiscoveryLeg; take: DiscoveryLeg },
     policy?: SwapPolicy,
 ): MarketCandidate[] => {
-    const allowed = policy?.allowedRegistries;
-    const markets = (
-        allowed
-            ? snapshot.markets.filter((card) => allowed.includes(card.source))
-            : snapshot.markets
-    ).filter(isAddressable);
+    const markets = usableMarkets(snapshot, policy);
 
     const { give, take } = legs;
     // Same leg on both sides is not a swap — and it is the LEG that has to
@@ -119,7 +135,12 @@ export const eligibleMarkets = (
             // The trader receives the take leg, so that side must be one the
             // solver can pay out; a direction nobody solves yields no market.
             wantSide: side === "base" ? "quote" : "base",
-        }).map((card) => ({ card, give: side, backend: backendOf(card), key: marketKeyOf(card) }));
+        }).map((card) => ({
+            card,
+            give: side,
+            backend: marketBackendOf(card),
+            key: marketKeyOf(card),
+        }));
     };
 
     // Give-as-base first, matching `findMarket`'s own preference order.
@@ -153,19 +174,42 @@ export const chooseMarket = (
 };
 
 /** The provenance a candidate leaves on every quote it prices. */
-export const marketRefOf = (candidate: MarketCandidate, snapshot: SnapshotRef): CardMarketRef => ({
+export const marketRefOf = (candidate: MarketCandidate, snapshot: SnapshotRef): CardMarketRef =>
+    cardMarketOf(candidate.card, snapshot, candidate.key, candidate.backend);
+
+/** A card's own provenance — the same fields {@link marketRefOf} writes, read
+ * off the card rather than off a routed candidate. */
+export const cardMarketOf = (
+    card: DiscoveredMarket,
+    snapshot: SnapshotRef,
+    key: string,
+    backend: MarketBackend,
+): CardMarketRef => ({
     kind: "card",
-    key: candidate.key,
-    backend: candidate.backend,
-    source: candidate.card.source,
-    sourceType: candidate.card.sourceType,
-    solver: candidate.card.solver,
-    ...(candidate.card.discovery_pubkey === undefined
-        ? {}
-        : { discoveryPubkey: candidate.card.discovery_pubkey }),
-    pair: candidate.card.pair,
+    key,
+    backend,
+    source: card.source,
+    sourceType: card.sourceType,
+    solver: card.solver,
+    ...(card.discovery_pubkey === undefined ? {} : { discoveryPubkey: card.discovery_pubkey }),
+    pair: card.pair,
     snapshot,
 });
 
 /** Narrow a `MarketRef` to the card arm — the only one minted today. */
 export const isCardMarket = (market: MarketRef): market is CardMarketRef => market.kind === "card";
+
+/**
+ * A market as the v2 client publishes it — one shape with {@link CardMarketRef},
+ * the type `Quote.market` already points at.
+ *
+ * `markets()` is the escape hatch, and its return is deliberately the same card
+ * a quote cites: a caller picking a market for a custom `quote()` reads the same
+ * provenance the quote will carry, key for key and snapshot for snapshot.
+ * Discovery's own `DiscoveredMarket` never crosses the v2 root — its asset ids
+ * (`"btc"` or a 68-hex string) and its display `pair` are exactly the vocabulary
+ * the alias layer exists to keep off it. The honest limit of the escape hatch
+ * is that it carries no discovery asset id; an integrator needing the native
+ * cards keeps the package's own discovery reader below the public surface.
+ */
+export type Market = CardMarketRef;

--- a/packages/swap/src/client/record.ts
+++ b/packages/swap/src/client/record.ts
@@ -42,10 +42,57 @@ import type { MarketRef, QuoteId, QuoteLeg } from "./quote";
  * Not a cosmetic tag. v1's two families occupied one `string` id space by
  * accident — an offer record's id a funding txid, a corridor record's an
  * `rfqId` — and keying both on `QuoteId` closes that collision (§B). The tag is
- * what lets M6 build `offer:<quoteId>` / `rfq:<quoteId>` without a repository
- * read, and what lets M5 branch its outcome table without one either.
+ * what M6's public id carries, and what lets M5 branch its outcome table
+ * without a repository read.
  */
 export type SwapFamily = "offer" | "rfq";
+
+/**
+ * The public swap id: the family tag over the client-minted quote id,
+ * `offer:<QuoteId>` / `rfq:<QuoteId>`, as {@link Swap.id} carries it.
+ *
+ * The tag is presentation, not a second identity — storage, the drive and
+ * `accept()`'s idempotency stay keyed on the bare quote id. But a branded
+ * string erases at runtime, so the tag is not cosmetic either: it makes
+ * `NotCancellable` a parse of the prefix — a corridor id refused with no
+ * repository read, an offer id distinguished from a corridor id the way the v1
+ * read could not be — and it retypes the id a caller hands around, so
+ * `cancel(swap.id)` and `recover(swap.id)` stop being two spellings of one
+ * thing. An id arriving untagged from `/protocol`'s re-exported readers takes
+ * the same one read the tagged form takes.
+ */
+export type AssetSwapId = `${SwapFamily}:${QuoteId}`;
+
+/** The public id a record answers with — the tag, minted off its family. */
+export const assetSwapIdOf = (family: SwapFamily, quoteId: QuoteId): AssetSwapId =>
+    `${family}:${quoteId}`;
+
+export const OFFER_SWAP_ID_PREFIX = "offer:" as const;
+export const RFQ_SWAP_ID_PREFIX = "rfq:" as const;
+
+/**
+ * The family an id names, or `undefined` for an id no prefix tags — the form
+ * `/protocol`'s re-exported readers still hand back, which takes the
+ * repository read rather than the parse.
+ */
+export const familyOfSwapId = (swapId: string): SwapFamily | undefined =>
+    swapId.startsWith(OFFER_SWAP_ID_PREFIX)
+        ? "offer"
+        : swapId.startsWith(RFQ_SWAP_ID_PREFIX)
+          ? "rfq"
+          : undefined;
+
+/**
+ * The bare quote id under the tag — what storage, the drive and `accept()`'s
+ * idempotency key on. Strips a family prefix when one is present and passes an
+ * untagged id through unchanged, so a reader-era id still reaches its record.
+ */
+export const quoteIdOfSwapId = (swapId: string): QuoteId =>
+    swapId.startsWith(OFFER_SWAP_ID_PREFIX)
+        ? swapId.slice(OFFER_SWAP_ID_PREFIX.length)
+        : swapId.startsWith(RFQ_SWAP_ID_PREFIX)
+          ? swapId.slice(RFQ_SWAP_ID_PREFIX.length)
+          : swapId;
 
 /** One leg's obligation, in the form a record holds it. */
 export interface RecordedLeg {
@@ -268,8 +315,9 @@ export type SwapRecord = OfferSwapRecord | CorridorSwapRecord;
  *
  * `artifact` stays optional: M7's `ReceiveRequest` is `Swap & { artifact:
  * Artifact }`, and an intersection cannot narrow a field that is already
- * required. `id` is the bare {@link QuoteId} — M6 owns the tagged public form
- * and takes this key as given.
+ * required. `id` is the tagged public form {@link AssetSwapId} — minted from
+ * `record.family` by {@link swapOf} — while storage, the drive and `accept()`'s
+ * idempotency stay keyed on the bare quote id.
  *
  * {@link outcome} and the two reason strings are M5's, and they are here rather
  * than on `SwapUpdate.detail` because `detail` is typed `RawState` — the raw
@@ -278,7 +326,7 @@ export type SwapRecord = OfferSwapRecord | CorridorSwapRecord;
  * nowhere to read WHY.
  */
 export interface Swap {
-    readonly id: QuoteId;
+    readonly id: AssetSwapId;
     readonly family: SwapFamily;
     /** Where this swap stands, in the one vocabulary both families share. */
     readonly outcome: Outcome;
@@ -431,7 +479,7 @@ export const legOf = (leg: RecordedLeg): QuoteLeg => ({
  * that union.
  */
 export const swapOf = (record: SwapRecord, outcome: Outcome): Swap => ({
-    id: record.id,
+    id: assetSwapIdOf(record.family, record.id),
     family: record.family,
     outcome,
     route: {

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -5,6 +5,8 @@ export {
     decodeOffer,
     offerContract,
     swapPrograms,
+    NoSpendableDepositError,
+    OfferCovenantMismatchError,
     OFFER_PACKET_TYPE,
     type Offer,
 } from "./offer";

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -720,6 +720,127 @@ export async function cancelOffer(
     },
 ): Promise<string> {
     const { repository, fundingTxid, swapAddress } = opts;
+    const prepared = await prepareOfferCancel(wallet, offerHex, {
+        ...(fundingTxid === undefined ? {} : { fundingTxid }),
+        ...(swapAddress === undefined ? {} : { swapAddress }),
+    });
+    // v1 keys its local-record half on the v1 store by `fundingTxid ?? vtxo.txid`
+    // — the deposit IS the identity there. The v2 client keys on the client-minted
+    // quote id, so it never passes through this half: it runs the same ordering
+    // over its own record (see `client/cancel.ts`).
+    const swapId = fundingTxid ?? prepared.vtxo.txid;
+    // Strict read: a failed one must not read as "no local record here" and
+    // send us past the marker into the broadcast.
+    const hasLocalRecord = (await getAssetSwapsOrThrow(repository)).some((s) => s.id === swapId);
+    // The in-flight marker is useful only when there is a local record to
+    // update; a different or empty repository intentionally leaves the cancel
+    // for event/restore classification. It gates the broadcast, so it throws:
+    // the marker is what keeps a crash here from leaving a swap that still
+    // looks pending.
+    if (hasLocalRecord) await updateAssetSwap(repository, swapId, { status: "cancelling" });
+    const txid = await prepared.send();
+    if (hasLocalRecord) {
+        // Past the point of no return: the cancel is broadcast, so a lost write
+        // must not fail the caller. The watcher classifies by covenant leaf and
+        // the restore scan re-derives the outcome.
+        const { persisted, swaps } = await updateAssetSwapBestEffort(repository, swapId, {
+            status: "cancelled",
+            spentTxid: txid,
+        });
+        // Retiring belongs here for the same reason the status does: recording
+        // its own outcome is what leaves the watcher nothing to do, and a
+        // watcher that sees a terminal record returns before it would retire
+        // (`spendUpdate`). Nothing else would ever drop this script.
+        //
+        // Only on a persisted write, as the watcher does: a record that still
+        // reads `pending` to the next restore scan must stay watched.
+        if (persisted) {
+            const contractManager = await wallet.getContractManager();
+            await retireOfferContract(
+                contractManager,
+                swaps,
+                hex.encode(prepared.offer.swapPkScript),
+            );
+        }
+    }
+    return txid;
+}
+
+const OFFER_COVENANT_MISMATCH = "rebuilt covenant does not match the offer's swapPkScript";
+
+/**
+ * No deposit left to cancel at the swap address.
+ *
+ * Almost always the fill winning the race — v1's documented
+ * throw-means-completed trap, which the v2 client's `cancel()` reconciles
+ * against the covenant's leaves instead of surfacing (see `client/cancel.ts`).
+ * Typed so that reconciliation is an `instanceof`, not a message match; the
+ * message is v1's, unchanged.
+ */
+export class NoSpendableDepositError extends Error {
+    override readonly name = "NoSpendableDepositError";
+    constructor(options?: ErrorOptions) {
+        super("no spendable VTXO at the swap address", options);
+    }
+}
+
+/**
+ * The rebuilt covenant disagrees with the offer's own `swapPkScript`: the
+ * operator key the rebuild pinned is not the one the covenant was funded with.
+ *
+ * v1's fallback read this as a missing VTXO; with a pinned `swapAddress` the
+ * only remaining causes are a record corrupted or a `swapAddress` that is not
+ * the one funded — so the condition is typed rather than left to surface raw.
+ * Fires before any broadcast, where §7's law still governs.
+ */
+export class OfferCovenantMismatchError extends Error {
+    override readonly name = "OfferCovenantMismatchError";
+    constructor(
+        readonly swapPkScript: string,
+        options?: ErrorOptions,
+    ) {
+        super(
+            `${OFFER_COVENANT_MISMATCH} — the operator signing key pinned by the ` +
+                "rebuild does not reproduce the funded covenant; the signing key has " +
+                "likely rotated since funding (pass swapAddress, the funded address, to " +
+                "pin the original key), or the record is corrupt",
+            options,
+        );
+    }
+}
+
+/** A cancel ready to broadcast: the deposit it spends, and the send. */
+export interface PreparedOfferCancel {
+    /** The decoded offer — the covenant's script is the watcher's matching key. */
+    readonly offer: Offer;
+    /** The deposit selected for the cancel. */
+    readonly vtxo: { txid: string; vout: number; value: number };
+    /** Broadcast the cancel and return its txid. */
+    send(): Promise<string>;
+}
+
+/**
+ * Rebuild an offer's covenant, pin the funding-time operator key, select the
+ * deposit and build the `cancel` spend — everything {@link cancelOffer} does
+ * before the broadcast, extracted so the caller owns the record ordering that
+ * gates it.
+ *
+ * The protocol-level half of {@link cancelOffer}. The v2 client's `cancel()`
+ * runs the same mechanics over its own record ordering — the `cancelling`
+ * write, the broadcast, the terminal write — without re-deriving any of this.
+ * Prepares and sends nothing durable: it touches no record.
+ */
+export async function prepareOfferCancel(
+    wallet: IWallet,
+    offerHex: string,
+    opts: {
+        fundingTxid?: string;
+        /** The funded address — pins the operator key the covenant was built
+         * with, so cancel keeps working across a signer rotation. */
+        swapAddress?: string;
+    },
+): Promise<PreparedOfferCancel> {
+    const { fundingTxid, swapAddress } = opts;
     const offer = decodeOffer(hex.decode(offerHex));
 
     const [contractManager, info, reader, broadcaster] = await Promise.all([
@@ -755,11 +876,7 @@ export async function cancelOffer(
     // return nothing, so fail with the diagnosis instead
     const rebuilt = new arkade.ArkadeProgramScript(program, args, keys);
     if (hex.encode(rebuilt.pkScript) !== hex.encode(offer.swapPkScript)) {
-        throw new Error(
-            "rebuilt covenant does not match the offer's swapPkScript — the operator " +
-                "signing key has likely rotated since funding; pass swapAddress (the " +
-                "funded address) to pin the original key",
-        );
+        throw new OfferCovenantMismatchError(hex.encode(offer.swapPkScript));
     }
     const contract = new arkade.ArkadeContract(client, program, args, keys);
 
@@ -772,7 +889,7 @@ export async function cancelOffer(
         );
     }
     const vtxo = fundingTxid ? vtxos.find((v) => v.txid === fundingTxid) : vtxos[0];
-    if (!vtxo) throw new Error("no spendable VTXO at the swap address");
+    if (!vtxo) throw new NoSpendableDepositError();
 
     const makerPkScript = ArkAddress.decode(makerAddress).pkScript;
     const cancel = contract.functions
@@ -787,35 +904,9 @@ export async function cancelOffer(
             outputs: [{ vout: 0, amount: BigInt(a.amount) }],
         });
     }
-    const swapId = fundingTxid ?? vtxo.txid;
-    // Strict read: a failed one must not read as "no local record here" and
-    // send us past the marker into the broadcast.
-    const hasLocalRecord = (await getAssetSwapsOrThrow(repository)).some((s) => s.id === swapId);
-    // The in-flight marker is useful only when there is a local record to
-    // update; a different or empty repository intentionally leaves the cancel
-    // for event/restore classification. It gates the broadcast, so it throws:
-    // the marker is what keeps a crash here from leaving a swap that still
-    // looks pending.
-    if (hasLocalRecord) await updateAssetSwap(repository, swapId, { status: "cancelling" });
-    const { txid } = await cancel.send();
-    if (hasLocalRecord) {
-        // Past the point of no return: the cancel is broadcast, so a lost write
-        // must not fail the caller. The watcher classifies by covenant leaf and
-        // the restore scan re-derives the outcome.
-        const { persisted, swaps } = await updateAssetSwapBestEffort(repository, swapId, {
-            status: "cancelled",
-            spentTxid: txid,
-        });
-        // Retiring belongs here for the same reason the status does: recording
-        // its own outcome is what leaves the watcher nothing to do, and a
-        // watcher that sees a terminal record returns before it would retire
-        // (`spendUpdate`). Nothing else would ever drop this script.
-        //
-        // Only on a persisted write, as the watcher does: a record that still
-        // reads `pending` to the next restore scan must stay watched.
-        if (persisted) {
-            await retireOfferContract(contractManager, swaps, hex.encode(offer.swapPkScript));
-        }
-    }
-    return txid;
+    return {
+        offer,
+        vtxo: { txid: vtxo.txid, vout: vtxo.vout, value: vtxo.value },
+        send: async () => (await cancel.send()).txid,
+    };
 }

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -874,7 +874,16 @@ export async function prepareOfferCancel(
     // disagrees, this operator key is not the one the covenant was built with
     // (rotated since funding, or a wrong swapAddress) — getUtxos would just
     // return nothing, so fail with the diagnosis instead
-    const rebuilt = new arkade.ArkadeProgramScript(program, args, keys);
+    let rebuilt: InstanceType<typeof arkade.ArkadeProgramScript>;
+    try {
+        rebuilt = new arkade.ArkadeProgramScript(program, args, keys);
+    } catch (cause) {
+        // A pinned key that is not even a curve point derives no covenant at
+        // all: the taproot encoder throws before there is a script to compare.
+        // Same diagnosis as a script that differs — the pin is not the funded
+        // key — so it must not surface as a raw encoder error.
+        throw new OfferCovenantMismatchError(hex.encode(offer.swapPkScript), { cause });
+    }
     if (hex.encode(rebuilt.pkScript) !== hex.encode(offer.swapPkScript)) {
         throw new OfferCovenantMismatchError(hex.encode(offer.swapPkScript));
     }

--- a/packages/swap/test/client/accept.test.ts
+++ b/packages/swap/test/client/accept.test.ts
@@ -25,7 +25,11 @@ import { OFFER_PACKET_TYPE, decodeOffer } from "../../src/offer";
 import { SWAP_LOCKUP_CONTRACT_TYPE } from "../../src/lockupContract";
 import { conflictingFields } from "../../src/client/accept";
 import type { Quote, QuoteInput } from "../../src/client/quote";
-import type { CorridorSwapRecord, OfferSwapRecord } from "../../src/client/record";
+import {
+    assetSwapIdOf,
+    type CorridorSwapRecord,
+    type OfferSwapRecord,
+} from "../../src/client/record";
 import {
     EMULATOR_PUBKEY_HEX,
     FUNDING_TXID,
@@ -129,7 +133,8 @@ describe("accept() — the ordering", () => {
         const quote = await quoteFor(h, route);
         const swap = await h.client.accept(quote);
 
-        expect(swap.id).toBe(quote.id);
+        // The public id carries the family tag; the storage key stays bare.
+        expect(swap.id).toBe(assetSwapIdOf(swap.family, quote.id));
         const stored = await h.repository.getSwapRecord(quote.id);
         expect(stored?.id).toBe(quote.id);
         // The txid is a field, never the identity — which is what let the
@@ -321,7 +326,9 @@ describe("accept() — idempotency by quote id", () => {
         // names this a resume rather than a conflict, by name.
         expect(stored?.fundingTxid).toBeDefined();
         vi.setSystemTime((quote.expiresAt + 1) * 1000);
-        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+        await expect(h.client.accept(quote)).resolves.toMatchObject({
+            id: assetSwapIdOf("rfq", quote.id),
+        });
     });
 });
 
@@ -476,7 +483,9 @@ describe("accept() — AcceptConflict, one case per compared field", () => {
         expect(conflictingFields(reordered, quote)).not.toContain("take.instrument");
 
         await h.repository.saveSwapRecord(reordered);
-        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+        await expect(h.client.accept(quote)).resolves.toMatchObject({
+            id: assetSwapIdOf("rfq", quote.id),
+        });
     });
 
     it("does not conflict on a field absent from both sides", async () => {
@@ -486,7 +495,9 @@ describe("accept() — AcceptConflict, one case per compared field", () => {
         const h = await setup();
         const quote = await quoteFor(h, "spot");
         await h.client.accept(quote);
-        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+        await expect(h.client.accept(quote)).resolves.toMatchObject({
+            id: assetSwapIdOf("offer", quote.id),
+        });
     });
 });
 
@@ -509,7 +520,9 @@ describe("accept() — the pre-flight and the clock", () => {
         // instrument and not the asset, both give legs here being BTC.
         const h = await setup({ balance: { available: 0, availableAssets: [] } });
         const quote = await quoteFor(h, "lightningReceive");
-        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+        await expect(h.client.accept(quote)).resolves.toMatchObject({
+            id: assetSwapIdOf("rfq", quote.id),
+        });
     });
 
     it("refuses an accept past the quote's own expiry", async () => {
@@ -527,7 +540,9 @@ describe("accept() — the pre-flight and the clock", () => {
         const h = await setup();
         const quote = await quoteFor(h, "lightningSend");
         vi.setSystemTime(quote.expiresAt * 1000);
-        await expect(h.client.accept(quote)).resolves.toMatchObject({ id: quote.id });
+        await expect(h.client.accept(quote)).resolves.toMatchObject({
+            id: assetSwapIdOf("rfq", quote.id),
+        });
     });
 
     it("names the repository when the client was given none", async () => {

--- a/packages/swap/test/client/cancel.test.ts
+++ b/packages/swap/test/client/cancel.test.ts
@@ -1,0 +1,382 @@
+/**
+ * `cancel()`: the record ordering, the fill race, and the refusals that answer
+ * from the record.
+ *
+ * These run `cancelSwap` against a REAL drive rather than a stub, because the
+ * delivery half is the thing M6 adds: both edges — the `cancelling` gate and
+ * the settlement — reach a listener through the drive's own registry, whether
+ * or not the drive ever armed. A stub with an `ingest` spy would prove the call
+ * was made and nothing about what a consumer sees.
+ *
+ * The covenant underneath is real too. Only the network seam is mocked
+ * (`Arkade.connect` for the current server key, `ArkadeContract` for the vtxo
+ * lookup and the send), so the rebuild that pins the funding-time operator key
+ * and the leaf-based spend classification both run for real — which is the only
+ * way the rotated-key diagnosis and the fill race prove anything.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { base64, hex } from "@scure/base";
+import { ArkAddress, Transaction, type IWallet } from "@arkade-os/sdk";
+import { cancelSwap } from "../../src/client/cancel";
+import { createSwapDrive, type SwapDrive } from "../../src/client/drive";
+import type { SwapUpdate } from "../../src/client/outcome";
+import type { OfferSwapRecord } from "../../src/client/record";
+import { OfferCovenantMismatchError, encodeOffer, offerContract } from "../../src/offer";
+import { InMemoryAssetSwapRepository } from "../../src/repository";
+import {
+    HRP,
+    OFFER,
+    OFFER_SCRIPT,
+    OPERATOR,
+    PAYOUT,
+    WALLET_ADDRESS,
+    fakeContracts,
+    fakeCorridors,
+    fakeIndexer,
+    fakeOperator,
+    fakeWallet,
+    key,
+    offerRecord,
+    type FakeContracts,
+    type FakeVtxo,
+} from "./driveFixtures";
+
+const FUNDING_TXID = "ab".repeat(32);
+const CANCEL_TXID = "cc".repeat(32);
+const NOW = 1_700_000_000;
+
+// Only the network seam. The covenant derivation, the leaf lookup and the spend
+// classification underneath are the production ones.
+const state = vi.hoisted(() => ({
+    serverKey: new Uint8Array(0) as Uint8Array,
+    utxos: [] as { txid: string; vout: number; value: number }[],
+    sends: 0,
+    sendError: undefined as Error | undefined,
+}));
+
+vi.mock("@arkade-os/sdk", async (importOriginal) => {
+    const mod = await importOriginal<typeof import("@arkade-os/sdk")>();
+    return {
+        ...mod,
+        arkade: {
+            ...mod.arkade,
+            Arkade: { connect: async () => ({ serverKey: state.serverKey }) },
+            ArkadeContract: class {
+                getUtxos = async () => state.utxos;
+                functions = {
+                    cancel: () => {
+                        const chain = {
+                            from: () => chain,
+                            to: () => chain,
+                            withAsset: () => chain,
+                            send: async () => {
+                                state.sends += 1;
+                                if (state.sendError) throw state.sendError;
+                                return { txid: CANCEL_TXID };
+                            },
+                        };
+                        return chain;
+                    },
+                };
+            },
+        },
+    };
+});
+
+const OFFER_HEX = hex.encode(encodeOffer(OFFER));
+
+/** A spend of the deposit through one of the covenant's own leaves — what the
+ * classifier reads, and the only thing that tells a fill from a cancel. */
+const spendPsbt = (via: "cancel" | "fulfill"): { psbt: string; txid: string } => {
+    const leaf = offerContract(OFFER, OPERATOR).functionByName(via)?.tapLeafScript;
+    const tx = new Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true });
+    tx.addInput({ txid: hex.decode(FUNDING_TXID), index: 0, tapLeafScript: [leaf!] });
+    tx.addOutput({ script: PAYOUT, amount: 9_000n });
+    return { psbt: base64.encode(tx.toPSBT()), txid: tx.id };
+};
+
+/** The deposit as the indexer shows it once a spend has landed. */
+const spentDeposit = (spentTxid: string): FakeVtxo => ({
+    txid: FUNDING_TXID,
+    vout: 0,
+    spentBy: spentTxid,
+    arkTxId: spentTxid,
+    script: OFFER_SCRIPT,
+    value: 100_000,
+});
+
+const record = (over: Partial<OfferSwapRecord> = {}): OfferSwapRecord =>
+    offerRecord({ offerHex: OFFER_HEX, fundingTxid: FUNDING_TXID, ...over });
+
+interface Harness {
+    readonly drive: SwapDrive;
+    readonly repository: InMemoryAssetSwapRepository;
+    readonly wallet: IWallet;
+    readonly contracts: FakeContracts;
+    readonly seen: SwapUpdate[];
+    outcomes(): string[];
+    stored(): Promise<OfferSwapRecord>;
+    cancel(over?: Partial<OfferSwapRecord>): Promise<{ outcome: string }>;
+}
+
+const build = async (
+    over: {
+        record?: OfferSwapRecord;
+        vtxos?: FakeVtxo[];
+        txs?: { txid: string; psbt: string }[];
+    } = {},
+): Promise<Harness> => {
+    state.serverKey = OPERATOR;
+    state.utxos = [{ txid: FUNDING_TXID, vout: 0, value: 100_000 }];
+    state.sends = 0;
+    state.sendError = undefined;
+
+    const stored = over.record ?? record();
+    const repository = new InMemoryAssetSwapRepository();
+    await repository.saveSwapRecord(stored);
+
+    const contracts = fakeContracts([]);
+    const base = fakeWallet({ contracts, identity: {} });
+    const wallet = {
+        ...(base.wallet as unknown as Record<string, unknown>),
+        getArkadeInfo: async () => ({}),
+        getArkadeBroadcaster: async () => ({
+            submitTx: async () => ({}),
+            finalizeTx: async () => {},
+        }),
+    } as unknown as IWallet;
+
+    const indexer = fakeIndexer({
+        ...(over.vtxos === undefined ? {} : { vtxos: over.vtxos }),
+        ...(over.txs === undefined ? {} : { txs: over.txs }),
+    });
+    // `readonly`: the cancel path is an awaited call, not the loop, and this
+    // keeps every emission these tests see one cancel produced.
+    const drive = createSwapDrive({
+        wallet,
+        repository,
+        contracts,
+        corridors: fakeCorridors(),
+        operator: fakeOperator(),
+        indexer,
+        mode: "readonly",
+        now: () => NOW,
+    });
+    const seen: SwapUpdate[] = [];
+    drive.onUpdate((update) => seen.push(update));
+    await drive.ready;
+
+    return {
+        drive,
+        repository,
+        wallet,
+        contracts,
+        seen,
+        outcomes: () => seen.map((u) => u.outcome),
+        stored: async () => (await repository.getSwapRecord(stored.id)) as OfferSwapRecord,
+        cancel: async (patch = {}) =>
+            cancelSwap({
+                wallet,
+                repository,
+                record: { ...stored, ...patch } as OfferSwapRecord,
+                drive,
+                indexer,
+                now: () => NOW,
+            }),
+    };
+};
+
+describe("cancel() — the ordering", () => {
+    it("gates on the cancelling write, then records the spend it broadcast", async () => {
+        const h = await build();
+
+        await expect(h.cancel()).resolves.toEqual({ outcome: "cancelled" });
+
+        const stored = await h.stored();
+        expect(stored.status).toBe("cancelled");
+        expect(stored.spentTxid).toBe(CANCEL_TXID);
+        // A completion time is a fill's, not a cancel's — the watcher's rule.
+        expect(stored.completedAt).toBeUndefined();
+        expect(state.sends).toBe(1);
+        await h.drive.dispose();
+    });
+
+    it("emits at both edges, on a drive that never armed", async () => {
+        // Between the gate and the settlement the record has no `spentTxid`, so
+        // a crash mid-call leaves a `cancelling` a consumer was told about. The
+        // delivery channel is the drive's registry whether or not it armed.
+        const h = await build();
+        await h.cancel();
+
+        expect(h.outcomes()).toEqual(["open", "cancelling", "cancelled"]);
+        await h.drive.dispose();
+    });
+
+    it("does not broadcast when the gate cannot be written", async () => {
+        // The marker is what keeps a crash between submit and record from
+        // leaving a swap that still looks pending. A lost write must stop the
+        // broadcast, not warn past it.
+        const h = await build();
+        vi.spyOn(h.repository, "saveSwapRecord").mockRejectedValueOnce(new Error("quota exceeded"));
+
+        await expect(h.cancel()).rejects.toThrow(/quota exceeded/);
+        expect(state.sends).toBe(0);
+        await h.drive.dispose();
+    });
+
+    it("retires the offer script only on a settlement the store took", async () => {
+        const h = await build();
+        await h.cancel();
+        expect(h.contracts.watchStates).toEqual([[OFFER_SCRIPT, "retained"]]);
+
+        // And the same cancel with a refused settlement write: the record still
+        // reads `cancelling` to the next restore, so the script stays watched.
+        const g = await build();
+        const save = vi.spyOn(g.repository, "saveSwapRecord");
+        save.mockImplementationOnce(save.getMockImplementation()!).mockRejectedValueOnce(
+            new Error("quota exceeded"),
+        );
+        await expect(g.cancel()).resolves.toEqual({ outcome: "cancelled" });
+        expect(g.contracts.watchStates).toEqual([]);
+        await h.drive.dispose();
+        await g.drive.dispose();
+    });
+
+    it("resumes a cancelling record that never broadcast", async () => {
+        // The gate landed and the call died before `send()`. The deposit is
+        // intact, so a second cancel rewrites an identical marker and goes on —
+        // the same idempotence-absorbing retry `accept()` gives.
+        const h = await build({ record: record({ status: "cancelling", updatedAt: NOW - 60 }) });
+
+        await expect(h.cancel({ status: "cancelling" })).resolves.toEqual({ outcome: "cancelled" });
+        expect((await h.stored()).spentTxid).toBe(CANCEL_TXID);
+        expect(state.sends).toBe(1);
+        await h.drive.dispose();
+    });
+});
+
+describe("cancel() — the fill race", () => {
+    // The deposit is gone from the spendable set: `prepareOfferCancel` throws
+    // the v1 missing-VTXO error, which is where v1's trap was.
+    const raced = () => {
+        state.utxos = [];
+    };
+
+    it("reads a fill off the covenant's own leaf rather than throwing", async () => {
+        const spend = spendPsbt("fulfill");
+        const h = await build({ vtxos: [spentDeposit(spend.txid)], txs: [spend] });
+        raced();
+
+        await expect(h.cancel()).resolves.toEqual({ outcome: "filled" });
+
+        const stored = await h.stored();
+        expect(stored.status).toBe("fulfilled");
+        expect(stored.spentTxid).toBe(spend.txid);
+        // A completion time is a fill's.
+        expect(stored.completedAt).toBe(NOW);
+        expect(h.outcomes()).toEqual(["open", "cancelling", "filled"]);
+        expect(state.sends).toBe(0);
+        await h.drive.dispose();
+    });
+
+    it("reads a cancel that already landed as cancelled", async () => {
+        const spend = spendPsbt("cancel");
+        const h = await build({ vtxos: [spentDeposit(spend.txid)], txs: [spend] });
+        raced();
+
+        await expect(h.cancel()).resolves.toEqual({ outcome: "cancelled" });
+        const stored = await h.stored();
+        expect(stored.status).toBe("cancelled");
+        expect(stored.completedAt).toBeUndefined();
+        await h.drive.dispose();
+    });
+
+    it("answers needs_recovery for a spend it cannot name, and writes nothing terminal", async () => {
+        // Neither leaf, so the classifier is `indeterminate`: value moved and
+        // the local rebuild cannot say how. No terminal write on a guess — the
+        // record stays `cancelling`, which is what `recover` drives.
+        const foreign = new Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true });
+        foreign.addInput({ txid: hex.decode(FUNDING_TXID), index: 0 });
+        foreign.addOutput({ script: PAYOUT, amount: 9_000n });
+        const spend = { psbt: base64.encode(foreign.toPSBT()), txid: foreign.id };
+        const h = await build({ vtxos: [spentDeposit(spend.txid)], txs: [spend] });
+        raced();
+
+        await expect(h.cancel()).resolves.toEqual({ outcome: "needs_recovery" });
+        expect((await h.stored()).status).toBe("cancelling");
+        expect(h.contracts.watchStates).toEqual([]);
+        await h.drive.dispose();
+    });
+
+    it("answers needs_recovery for a deposit the reader cannot see at all", async () => {
+        // Indexer lag reads exactly like a spend nobody can classify, and must:
+        // writing `cancelled` on a deposit that may still be live would retire
+        // the script under it.
+        const h = await build({ vtxos: [] });
+        raced();
+
+        await expect(h.cancel()).resolves.toEqual({ outcome: "needs_recovery" });
+        expect((await h.stored()).status).toBe("cancelling");
+        await h.drive.dispose();
+    });
+});
+
+describe("cancel() — answering from the record", () => {
+    it.each([
+        ["cancelled", "cancelled"],
+        ["fulfilled", "filled"],
+    ] as const)("answers a %s record without re-broadcasting", async (status, outcome) => {
+        const h = await build({ record: record({ status, spentTxid: CANCEL_TXID }) });
+        await expect(h.cancel({ status, spentTxid: CANCEL_TXID })).resolves.toEqual({ outcome });
+        expect(state.sends).toBe(0);
+        await h.drive.dispose();
+    });
+
+    it("answers needs_recovery for a swept deposit rather than trying to spend it", async () => {
+        // `recoverable` is the one status a cancel can never move: the value
+        // left the covenant by a route no offchain spend reaches.
+        const h = await build({ record: record({ status: "recoverable" }) });
+        await expect(h.cancel({ status: "recoverable" })).resolves.toEqual({
+            outcome: "needs_recovery",
+        });
+        expect(state.sends).toBe(0);
+        await h.drive.dispose();
+    });
+});
+
+describe("cancel() — the pinned operator key", () => {
+    it("cancels across a rotation, because the record pins the funded address", async () => {
+        // The client's CURRENT key is the rotated one. The v2 record carries
+        // `swapAddress` as a required field pinned at accept, so #680's
+        // fall-back-to-the-current-key case cannot arise here.
+        const h = await build();
+        state.serverKey = key(4);
+
+        await expect(h.cancel()).resolves.toEqual({ outcome: "cancelled" });
+        await h.drive.dispose();
+    });
+
+    it("names the rebuild mismatch rather than reporting a missing deposit", async () => {
+        // The pinned address is not the one funded: a corrupt record, or a
+        // wrong `swapAddress`. Typed, and before any broadcast.
+        const wrong = new ArkAddress(key(4), key(21), HRP).encode();
+        const h = await build({ record: record({ swapAddress: wrong }) });
+
+        await expect(h.cancel({ swapAddress: wrong })).rejects.toBeInstanceOf(
+            OfferCovenantMismatchError,
+        );
+        expect(state.sends).toBe(0);
+        // The gate landed first, deliberately: the ordering does not depend on
+        // what the rebuild will say.
+        expect((await h.stored()).status).toBe("cancelling");
+        await h.drive.dispose();
+    });
+});
+
+describe("the swap address is what pins the key", () => {
+    it("decodes the funded address to the covenant's own operator key", () => {
+        expect(hex.encode(ArkAddress.decode(WALLET_ADDRESS).serverPubKey)).toBe(
+            hex.encode(OPERATOR),
+        );
+    });
+});

--- a/packages/swap/test/client/cancel.test.ts
+++ b/packages/swap/test/client/cancel.test.ts
@@ -366,9 +366,12 @@ describe("cancel() — the pinned operator key", () => {
             OfferCovenantMismatchError,
         );
         expect(state.sends).toBe(0);
-        // The gate landed first, deliberately: the ordering does not depend on
-        // what the rebuild will say.
-        expect((await h.stored()).status).toBe("cancelling");
+        // Pre-broadcast and non-retryable, so the gate rolls back to the
+        // pre-gate status instead of stranding the record at `cancelling`:
+        // nothing moved, so there is nothing `recover()` could drive, and a
+        // second cancel re-reads a pending record rather than a stuck one.
+        expect((await h.stored()).status).toBe("pending");
+        expect(h.outcomes()).toEqual(["open", "cancelling", "open"]);
         await h.drive.dispose();
     });
 });

--- a/packages/swap/test/client/cancel.test.ts
+++ b/packages/swap/test/client/cancel.test.ts
@@ -374,6 +374,21 @@ describe("cancel() — the pinned operator key", () => {
         expect(h.outcomes()).toEqual(["open", "cancelling", "open"]);
         await h.drive.dispose();
     });
+
+    it("names the mismatch when the pinned key derives no covenant at all", async () => {
+        // A corrupt record can pin bytes that are not a curve point: the
+        // taproot encoder throws before there is a script to compare. Same
+        // diagnosis, same rollback — never a raw "OutScript/tr_ns" error.
+        const corrupt = new ArkAddress(new Uint8Array(32).fill(0x11), key(21), HRP).encode();
+        const h = await build({ record: record({ swapAddress: corrupt }) });
+
+        await expect(h.cancel({ swapAddress: corrupt })).rejects.toBeInstanceOf(
+            OfferCovenantMismatchError,
+        );
+        expect(state.sends).toBe(0);
+        expect((await h.stored()).status).toBe("pending");
+        await h.drive.dispose();
+    });
 });
 
 describe("the swap address is what pins the key", () => {

--- a/packages/swap/test/client/clientDrive.test.ts
+++ b/packages/swap/test/client/clientDrive.test.ts
@@ -16,7 +16,7 @@ import { MissingCorridorDep } from "../../src/client/errors";
 import { SwapDriveRefusedError } from "../../src/client/drive";
 import type { SwapUpdate } from "../../src/client/outcome";
 import type { QuoteInput } from "../../src/client/quote";
-import type { CorridorSwapRecord } from "../../src/client/record";
+import { quoteIdOfSwapId, type CorridorSwapRecord } from "../../src/client/record";
 import {
     EMULATOR_PUBKEY_HEX,
     PAYMENT_HASH,
@@ -143,7 +143,7 @@ describe("arming", () => {
         const quote = await h.client.quote(RECEIVE);
         const swap = await h.client.accept(quote);
         expect(swap.outcome).toBe("accepted");
-        expect(await h.repository.getSwapRecord(swap.id)).toBeDefined();
+        expect(await h.repository.getSwapRecord(quoteIdOfSwapId(swap.id))).toBeDefined();
         // And nothing was driven: the swap keeps the outcome the record gave it.
         expect(h.seen.map((u) => u.outcome)).toEqual(["accepted"]);
         await h.client[Symbol.asyncDispose]();
@@ -180,7 +180,9 @@ describe("dispose", () => {
         // Records and contract registrations survive: a new client restores and
         // resumes from them, and dropping a registration would unwatch a funded
         // lockup.
-        const stored = (await h.repository.getSwapRecord(swap.id)) as CorridorSwapRecord;
+        const stored = (await h.repository.getSwapRecord(
+            quoteIdOfSwapId(swap.id),
+        )) as CorridorSwapRecord;
         expect(stored.lockupAddress).toEqual(expect.any(String));
         expect(h.wallet.contracts).toHaveLength(registered);
         expect(h.wallet.watched.filter(([, state]) => state === "retained")).toEqual([]);
@@ -198,7 +200,9 @@ describe("dispose", () => {
 describe("recover()", () => {
     it("refuses an id the client holds no record for", async () => {
         const h = await harness();
-        await expect(h.client.recover("nope")).rejects.toMatchObject({ reason: "unknown-swap" });
+        await expect(h.client.recover("rfq:nope")).rejects.toMatchObject({
+            reason: "unknown-swap",
+        });
         await h.client[Symbol.asyncDispose]();
     });
 });

--- a/packages/swap/test/client/clientSurface.test.ts
+++ b/packages/swap/test/client/clientSurface.test.ts
@@ -1,0 +1,283 @@
+/**
+ * The rest of the v2 client surface: `swaps()`, `markets()`, cancel's refusals
+ * and the disposal gate.
+ *
+ * These run through `createSwapClient` because the composition is what M6
+ * closes — cancel's mechanics are pinned in `cancel.test.ts`, and what matters
+ * here is the surface a caller meets: which ids are refused before a repository
+ * is touched, what the history read returns independently of the drive, and
+ * which of the thirteen members a disposed instance still answers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSwapClient, type SwapClient } from "../../src/client/client";
+import { ClientDisposed, MissingCorridorDep, NotCancellable } from "../../src/client/errors";
+import { InMemoryAssetSwapRepository, type AssetSwapRepository } from "../../src/repository";
+import type { SwapRecord } from "../../src/client/record";
+import type { QuoteInput } from "../../src/client/quote";
+import {
+    EMULATOR_PUBKEY_HEX,
+    acceptWallet,
+    clockAt,
+    feedServing,
+    lightningCard,
+    onchainCard,
+    rivalLightningCard,
+    solverFor,
+    solverTransport,
+    spotCard,
+    type AcceptWallet,
+} from "./fixtures";
+
+const NOW = 1_700_000_000;
+const CLOCK = clockAt(NOW);
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW * 1000);
+});
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+interface Harness {
+    readonly client: SwapClient;
+    readonly repository: AssetSwapRepository;
+    readonly wallet: AcceptWallet;
+}
+
+const harness = async (
+    over: {
+        omitRepository?: boolean;
+        drive?: "auto" | "manual" | "readonly";
+        repository?: AssetSwapRepository;
+        allowedRegistries?: readonly string[];
+        snapshot?: (typeof lightningCard)[];
+    } = {},
+): Promise<Harness> => {
+    const wallet = await acceptWallet();
+    const repository = over.repository ?? new InMemoryAssetSwapRepository();
+    const client = createSwapClient({
+        wallet: wallet.wallet,
+        ...(over.omitRepository ? {} : { repository }),
+        discovery: { snapshot: over.snapshot ?? [lightningCard, onchainCard, spotCard] },
+        emulatorPubkey: EMULATOR_PUBKEY_HEX,
+        transportFor: () => solverTransport(solverFor(CLOCK)),
+        fetchImpl: feedServing().fetch,
+        ...(over.drive === undefined && over.allowedRegistries === undefined
+            ? {}
+            : {
+                  policy: {
+                      ...(over.drive === undefined ? {} : { drive: over.drive }),
+                      ...(over.allowedRegistries === undefined
+                          ? {}
+                          : { allowedRegistries: over.allowedRegistries }),
+                  },
+              }),
+    });
+    return { client, repository, wallet };
+};
+
+/** `arkade -> arkade`: the offer family, and the only one that cancels. */
+const SPOT: QuoteInput = { give: "BTC", take: "USD", amount: 100_000n, amountOn: "give" };
+/** `lightning -> arkade`: the corridor family, whose exits are a claim or a refund. */
+const RECEIVE: QuoteInput = { via: "lightning", amount: 5_000n, amountOn: "give" };
+
+/** Accept one of each family, and answer with their tagged public ids. */
+const bothFamilies = async (h: Harness): Promise<{ offer: string; rfq: string }> => {
+    const offer = await h.client.accept(await h.client.quote(SPOT));
+    const rfq = await h.client.accept(await h.client.quote(RECEIVE));
+    return { offer: offer.id, rfq: rfq.id };
+};
+
+describe("swaps()", () => {
+    it("returns both families, under the tagged public id", async () => {
+        const h = await harness();
+        const { offer, rfq } = await bothFamilies(h);
+
+        const swaps = await h.client.swaps();
+        expect(swaps.map((s) => s.id).sort()).toEqual([offer, rfq].sort());
+        expect(offer.startsWith("offer:")).toBe(true);
+        expect(rfq.startsWith("rfq:")).toBe(true);
+        await h.client[Symbol.asyncDispose]();
+    });
+
+    it("answers the same set before start(), under readonly, and after a pass", async () => {
+        // Membership is a property of the keyspace, not of the drive: the same
+        // records come back whether or not anything is being driven.
+        const repository = new InMemoryAssetSwapRepository();
+        const h = await harness({ repository });
+        const { offer, rfq } = await bothFamilies(h);
+        const before = (await h.client.swaps()).map((s) => s.id).sort();
+        await h.client.start();
+        await h.client.stop();
+        const after = (await h.client.swaps()).map((s) => s.id).sort();
+        await h.client[Symbol.asyncDispose]();
+
+        // A second client over the same store, told to actuate nothing.
+        const ro = await harness({ repository, drive: "readonly" });
+        const readonly = (await ro.client.swaps()).map((s) => s.id).sort();
+        await ro.client[Symbol.asyncDispose]();
+
+        expect(before).toEqual([offer, rfq].sort());
+        expect(after).toEqual(before);
+        expect(readonly).toEqual(before);
+    });
+
+    it("filters family and outcome in memory", async () => {
+        const h = await harness();
+        const { offer, rfq } = await bothFamilies(h);
+
+        expect((await h.client.swaps({ family: "offer" })).map((s) => s.id)).toEqual([offer]);
+        expect((await h.client.swaps({ family: "rfq" })).map((s) => s.id)).toEqual([rfq]);
+        // The offer is funded and unfilled, the receive leg is a durable invoice
+        // nothing has looked at yet.
+        expect((await h.client.swaps({ outcome: "open" })).map((s) => s.id)).toEqual([offer]);
+        expect(await h.client.swaps({ family: "offer", outcome: "cancelled" })).toEqual([]);
+        await h.client[Symbol.asyncDispose]();
+    });
+
+    it("skips a record that will not decode rather than failing the read", async () => {
+        // The v1 store's rule, applied to the v2 keyspace: one unreadable row
+        // must not cost a caller its whole history.
+        const h = await harness();
+        const { offer } = await bothFamilies(h);
+        await h.repository.saveSwapRecord({ id: "corrupt", family: "offer" } as SwapRecord);
+
+        const swaps = await h.client.swaps();
+        expect(swaps.map((s) => s.id)).toContain(offer);
+        expect(swaps.map((s) => s.id)).not.toContain("offer:corrupt");
+        await h.client[Symbol.asyncDispose]();
+    });
+
+    it("keeps an aged terminal corridor record the v1 retention window would prune", async () => {
+        // M5/A2, read from the `swaps()` side: the bridge's `removeRfqSwap` is
+        // inert for v2 records, so the manager's prune deletes nothing and the
+        // v2 keyspace is never pruned at all.
+        const h = await harness();
+        const { rfq } = await bothFamilies(h);
+        const id = rfq.slice("rfq:".length);
+        const stored = await h.repository.getSwapRecord(id);
+        await h.repository.saveSwapRecord({
+            ...stored,
+            state: "settled",
+            // Far outside any retention window.
+            updatedAt: NOW - 400 * 24 * 3600,
+        } as SwapRecord);
+        await h.client[Symbol.asyncDispose]();
+
+        // A fresh client's construction restore is what runs the prune.
+        const next = await harness({ repository: h.repository });
+        await next.client.ready;
+        expect((await next.client.swaps()).map((s) => s.id)).toContain(rfq);
+        expect(await next.repository.getSwapRecord(id)).toBeDefined();
+        await next.client[Symbol.asyncDispose]();
+    });
+
+    it("answers with nothing for a client that was given no storage", async () => {
+        const h = await harness({ omitRepository: true });
+        expect(await h.client.swaps()).toEqual([]);
+        await h.client[Symbol.asyncDispose]();
+    });
+});
+
+describe("markets()", () => {
+    it("publishes the same card a quote cites", async () => {
+        const h = await harness();
+        const quote = await h.client.quote(SPOT);
+        const markets = await h.client.markets();
+
+        const cited = markets.find((m) => m.key === quote.market.key);
+        expect(cited).toEqual(quote.market);
+        // The escape hatch's own vocabulary: discovery's asset ids and display
+        // labels never cross the v2 root.
+        expect(markets.every((m) => m.kind === "card")).toBe(true);
+        await h.client[Symbol.asyncDispose]();
+    });
+
+    it("offers no card the quote path would then refuse", async () => {
+        // The registry allowlist is the routing read's filter, and the hatch
+        // applies the same one — a caller cannot pick a market `quote()` would
+        // not price.
+        const h = await harness({
+            snapshot: [lightningCard, rivalLightningCard],
+            allowedRegistries: [lightningCard.source],
+        });
+        const markets = await h.client.markets();
+        expect(markets.map((m) => m.source)).toEqual([lightningCard.source]);
+        await h.client[Symbol.asyncDispose]();
+    });
+});
+
+describe("cancel() — what it refuses, and when", () => {
+    it("refuses a corridor id on the parse, with no repository read", async () => {
+        // The point of the tag: the id round-tripped through `swaps()` names its
+        // family, so the refusal costs nothing.
+        const h = await harness();
+        const { rfq } = await bothFamilies(h);
+        const read = vi.spyOn(h.repository, "getSwapRecord");
+
+        await expect(h.client.cancel(rfq as `rfq:${string}`)).rejects.toBeInstanceOf(
+            NotCancellable,
+        );
+        expect(read).not.toHaveBeenCalled();
+        await h.client[Symbol.asyncDispose]();
+    });
+
+    it("refuses an offer id no record backs, after the one read", async () => {
+        const h = await harness();
+        await expect(h.client.cancel("offer:nothing-here")).rejects.toBeInstanceOf(NotCancellable);
+        await h.client[Symbol.asyncDispose]();
+    });
+
+    it("names the repository when the client was given none", async () => {
+        const h = await harness({ omitRepository: true });
+        await expect(h.client.cancel("offer:anything")).rejects.toBeInstanceOf(MissingCorridorDep);
+        await h.client[Symbol.asyncDispose]();
+    });
+});
+
+describe("ClientDisposed", () => {
+    it("refuses every new act after disposal", async () => {
+        const h = await harness();
+        const quote = await h.client.quote(SPOT);
+        await h.client[Symbol.asyncDispose]();
+
+        // Synchronous members, `ready` included: a property that handed back a
+        // rejected promise nobody awaited would be an unhandled rejection.
+        expect(() => h.client.ready).toThrow(ClientDisposed);
+        expect(() => h.client.onUpdate(() => {})).toThrow(ClientDisposed);
+        expect(() => h.client.preparationOf(quote.id)).toThrow(ClientDisposed);
+
+        await expect(h.client.start()).rejects.toBeInstanceOf(ClientDisposed);
+        await expect(h.client.stop()).rejects.toBeInstanceOf(ClientDisposed);
+        await expect(h.client.resolve(SPOT)).rejects.toBeInstanceOf(ClientDisposed);
+        await expect(h.client.quote(SPOT)).rejects.toBeInstanceOf(ClientDisposed);
+        await expect(h.client.accept(quote)).rejects.toBeInstanceOf(ClientDisposed);
+        await expect(h.client.cancel("offer:anything")).rejects.toBeInstanceOf(ClientDisposed);
+        await expect(h.client.swaps()).rejects.toBeInstanceOf(ClientDisposed);
+        await expect(h.client.markets()).rejects.toBeInstanceOf(ClientDisposed);
+        await expect(h.client.recover("offer:anything")).rejects.toBeInstanceOf(ClientDisposed);
+    });
+
+    it("leaves a handed-out Unsubscribe callable, as a no-op", async () => {
+        // Disposal has already dropped every listener, so the closure has
+        // nothing left to do — and refusing it would turn correct React-effect
+        // teardown into a throw.
+        const h = await harness();
+        const unsubscribe = h.client.onUpdate(() => {});
+        await h.client[Symbol.asyncDispose]();
+
+        expect(() => unsubscribe()).not.toThrow();
+    });
+
+    it("closes nothing the caller injected, and disposes idempotently", async () => {
+        const h = await harness();
+        await h.client.accept(await h.client.quote(SPOT));
+        await h.client[Symbol.asyncDispose]();
+        await expect(h.client[Symbol.asyncDispose]()).resolves.toBeUndefined();
+
+        // The repository is the caller's, and it outlives the client.
+        expect(await h.repository.getAllSwapRecords()).toHaveLength(1);
+    });
+});

--- a/packages/swap/test/client/drive.test.ts
+++ b/packages/swap/test/client/drive.test.ts
@@ -12,7 +12,12 @@ import { hex } from "@scure/base";
 import { SingleKey } from "@arkade-os/sdk";
 import { createSwapDrive, SwapDriveRefusedError, type SwapDrive } from "../../src/client/drive";
 import type { SwapUpdate } from "../../src/client/outcome";
-import type { CorridorSwapRecord, OfferSwapRecord, SwapRecord } from "../../src/client/record";
+import {
+    quoteIdOfSwapId,
+    type CorridorSwapRecord,
+    type OfferSwapRecord,
+    type SwapRecord,
+} from "../../src/client/record";
 import { RFQ_CONFIGURATION_REFUSAL, RFQ_CONFIGURATION_REFUSALS } from "../../src/swapManager";
 import { REFUND_MTP_LAG_SECONDS } from "../../src/refund";
 import { RefundNotLocallyPossibleError } from "../../src/refundBlocked";
@@ -143,7 +148,10 @@ const build = async (
         resolved: corridors.resolved,
         seen,
         recoveries,
-        outcomes: (id) => seen.filter((u) => u.swap.id === id).map((u) => u.outcome),
+        // `swap.id` is the tagged public form; these fixtures name the bare
+        // quote id, which is what storage and the drive key on.
+        outcomes: (id) =>
+            seen.filter((u) => quoteIdOfSwapId(u.swap.id) === id).map((u) => u.outcome),
         settle: () => drive.idle(),
     };
 };

--- a/packages/swap/test/client/errors.test.ts
+++ b/packages/swap/test/client/errors.test.ts
@@ -177,6 +177,10 @@ const SOURCES = ((): string => {
     return walk(root).join("\n");
 })();
 
+/** Substring search, deliberately: it only sees a throw spelled exactly
+ * `throw new Name(`. A throw behind a local (`const e = new X(); throw e;`)
+ * or a factory helper defeats the check silently — keep new throwing sites in
+ * the direct form so the coverage map keeps proving what it claims. */
 const throws = (name: SwapErrorName): boolean => SOURCES.includes(`throw new ${name}(`);
 
 describe("the error-coverage map", () => {

--- a/packages/swap/test/client/errors.test.ts
+++ b/packages/swap/test/client/errors.test.ts
@@ -1,5 +1,9 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { AddressMismatch, SwapRefusal } from "../../src/rfq";
+import { SwapDriveRefusedError } from "../../src/client/drive";
+import { NoSpendableDepositError, OfferCovenantMismatchError } from "../../src/offer";
 import {
     AcceptConflict,
     AmbiguousDestination,
@@ -104,5 +108,132 @@ describe("the swap error taxonomy", () => {
         expect(new MissingCorridorDep("lightning", "decode").dep).toBe("decode");
         expect(new MaxFeeExceeded("quote-1", BTC, 120n, 100n).fee).toBe(120n);
         expect(new UnsupportedRoute("no market", { give: "arkade" }).take).toBe(undefined);
+    });
+});
+
+/**
+ * The track's error-coverage registry (M6/F), as a compile-time exhaustive map.
+ *
+ * The `satisfies` is what keeps it honest: a member missing here fails the
+ * `Record`, an extra key fails the excess-property check. Non-members are
+ * outside the map by construction — they are not in `SwapErrorName`.
+ *
+ * `thrownAt` is where the condition fires. `null` means **declared inert**: the
+ * member exists so the taxonomy is complete and its only thrower ships with a
+ * corridor that does not exist yet. `pending` names a milestone whose throwing
+ * site has not landed — an assertion below fails when it does, which is how the
+ * map is forced to keep up rather than rot.
+ */
+const COVERAGE = {
+    AmbiguousDestination: {
+        owner: "M2",
+        thrownAt: "destination parse, once, in resolve()/quote()",
+    },
+    UnsupportedRoute: {
+        owner: "M3",
+        thrownAt: "route resolution, quote-time empty market set, the alias layer",
+    },
+    DiscoverySnapshotUnavailable: {
+        owner: "M3",
+        thrownAt: "resolve()/quote() with no snapshot after any allowed fetch",
+    },
+    AmountMismatch: { owner: "M3", thrownAt: "amount pinning, before any round trip" },
+    AmountEncodingUnsupported: { owner: "M3", thrownAt: "the RFQ amount adapter" },
+    QuoteVerificationFailed: { owner: "M3", thrownAt: "quote verification, all five checks" },
+    SwapRefusal: { owner: "M3", thrownAt: "transport, on a solver decline" },
+    QuoteExpired: { owner: "M3/M4", thrownAt: "quote() TTL floor and accept() past expiresAt" },
+    InsufficientFunds: { owner: "M4", thrownAt: "accept(), before the persist, on funding routes" },
+    AcceptConflict: { owner: "M4", thrownAt: "accept() vs incompatible durable evidence" },
+    OperatorUnreachable: {
+        owner: "M2/M3",
+        thrownAt: "covenant derivation, getArkadeInfo({ requireLive: true })",
+    },
+    MissingCorridorDep: {
+        owner: "M2/M4",
+        thrownAt: "dep resolution on a corridor route; accept()/cancel() without a repository",
+    },
+    NotCancellable: {
+        owner: "M6",
+        thrownAt: "cancel(), on a corridor id or an id no record backs",
+    },
+    ClientDisposed: { owner: "M6", thrownAt: "any client member after async disposal" },
+    MaxFeeExceeded: { owner: "M7", thrownAt: "the verb layer, before accept", pending: "M7" },
+    InconsistentRoute: { owner: "M1", thrownAt: null },
+} as const satisfies Record<
+    SwapErrorName,
+    { owner: string; thrownAt: string | null; pending?: string }
+>;
+
+/** Every `.ts` under `src/`, concatenated — what "has a throwing site" is read
+ * from, so the map cannot claim coverage the code does not have. */
+const SOURCES = ((): string => {
+    const root = new URL("../../src", import.meta.url).pathname;
+    const walk = (dir: string): string[] =>
+        readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+            const path = join(dir, entry.name);
+            if (entry.isDirectory()) return walk(path);
+            return entry.name.endsWith(".ts") ? [readFileSync(path, "utf8")] : [];
+        });
+    return walk(root).join("\n");
+})();
+
+const throws = (name: SwapErrorName): boolean => SOURCES.includes(`throw new ${name}(`);
+
+describe("the error-coverage map", () => {
+    it("names an owner for every member, and no member twice", () => {
+        expect(Object.keys(COVERAGE).sort()).toEqual([...SWAP_ERROR_NAMES].sort());
+        for (const [name, entry] of Object.entries(COVERAGE)) {
+            expect(entry.owner.length, name).toBeGreaterThan(0);
+        }
+    });
+
+    it("leaves exactly one member permanently throwerless, and it is InconsistentRoute", () => {
+        // §9 is deferred, so its only thrower ships with the EVM corridor.
+        // Dropping the member to match a schedule, or leaving it unowned, would
+        // make "fires before value moves or not at all" unverifiable.
+        const inert = Object.entries(COVERAGE)
+            .filter(([, entry]) => entry.thrownAt === null)
+            .map(([name]) => name);
+        expect(inert).toEqual(["InconsistentRoute"]);
+        expect(throws("InconsistentRoute")).toBe(false);
+    });
+
+    it("finds the throwing site every shipped member claims", () => {
+        for (const [name, entry] of Object.entries(COVERAGE)) {
+            if (entry.thrownAt === null || "pending" in entry) continue;
+            expect(throws(name as SwapErrorName), `${name} @ ${entry.thrownAt}`).toBe(true);
+        }
+    });
+
+    it("keeps the pending markers honest", () => {
+        // When the owning milestone lands its throw, this fails and the marker
+        // has to come off — which is the only thing keeping the map current.
+        for (const [name, entry] of Object.entries(COVERAGE)) {
+            if (!("pending" in entry)) continue;
+            expect(throws(name as SwapErrorName), `${name} is owned by ${entry.pending}`).toBe(
+                false,
+            );
+        }
+    });
+
+    it("counts the drive's refusals as documented non-members", () => {
+        // M1/G's rule: a class that is not a member keeps the `Error` suffix.
+        // No §7 member names a drive-refusal condition, so none absorbs these.
+        const refusal = new SwapDriveRefusedError("readonly", "actuates nothing");
+        expect(isSwapError(refusal)).toBe(false);
+        expect(SWAP_ERROR_NAMES).not.toContain(refusal.name as SwapErrorName);
+        expect(refusal.name.endsWith("Error")).toBe(true);
+    });
+
+    it("keeps cancel's protocol-level diagnoses outside the taxonomy too", () => {
+        // The rebuild mismatch and the missing deposit are conditions of the
+        // offer primitive, not of the client's surface: same suffix rule.
+        for (const error of [
+            new OfferCovenantMismatchError("5120aa"),
+            new NoSpendableDepositError(),
+        ]) {
+            expect(isSwapError(error), error.name).toBe(false);
+            expect(error.name.endsWith("Error"), error.name).toBe(true);
+        }
     });
 });

--- a/packages/swap/test/e2e/offerCancel.test.ts
+++ b/packages/swap/test/e2e/offerCancel.test.ts
@@ -1,0 +1,219 @@
+/**
+ * The v2 client's `cancel()` against the real regtest stack.
+ *
+ * What the unit suite cannot prove, and this can: the covenant `accept()` funded
+ * is the one `cancel()` rebuilds from the record's pinned `swapAddress`, the
+ * 2-of-2 maker+server spend is accepted by the real operator, and the record the
+ * cancel writes is the one a second client reads back.
+ *
+ * **The fill half of the race is not here, and cannot be.** A fill needs a taker
+ * holding the want-asset, and no solver runs in this stack — the same limit
+ * `swap.test.ts` records for the v1 loop. The race is pinned in
+ * `test/client/cancel.test.ts` instead, against a real leaf-classified spend;
+ * what regtest adds is everything around it, plus the C diagnosis a rebuild that
+ * disagrees with the funded script produces.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { execSync } from "child_process";
+import { hex } from "@scure/base";
+import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
+import {
+    ArkAddress,
+    EsploraProvider,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    SingleKey,
+    Wallet,
+} from "@arkade-os/sdk";
+// The v2 client is still internal to the package — `src/index.ts` exports the
+// v1 facade under the same name — so it is imported by path, as the unit suite
+// does. M8 is what slims the root export to the v2 surface.
+import { createSwapClient, type SwapClient } from "../../src/client/client";
+import { NotCancellable } from "../../src/client/errors";
+import { quoteIdOfSwapId, type OfferSwapRecord } from "../../src/client/record";
+import { OfferCovenantMismatchError } from "../../src/offer";
+import { InMemoryAssetSwapRepository } from "../../src/repository";
+
+const OPERATOR_URL = "http://localhost:7070";
+const ESPLORA_API_URL = "http://localhost:3000/api";
+const arkdExec = "docker exec -t arkd";
+
+const FAUCET_SATS = 30_000;
+const DEPOSIT_SATS = 10_000;
+
+/** The want-asset never has to exist for accept/cancel: the covenant binds its
+ * id, and only the fill path would ever spend it. */
+const USD_ASSET_ID = "f121ac9b7656797cc68d1e8fecacfbaa2069ec1461edf0bf2f3c37404cb9791a0000";
+
+const execCommand = (command: string): string => {
+    const result = execSync(command, { encoding: "utf8" })
+        .replace(/\r/g, "")
+        .split("\n")
+        .filter((line) => !line.includes("WARN"))
+        .join("\n")
+        .trim();
+    if (result.startsWith("error:")) throw new Error(result);
+    return result;
+};
+
+const waitFor = async (
+    fn: () => Promise<boolean>,
+    { timeout = 60_000, interval = 500 } = {},
+): Promise<void> => {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+        if (await fn()) return;
+        await new Promise((r) => setTimeout(r, interval));
+    }
+    throw new Error("timeout in waitFor");
+};
+
+/** An arkade-to-arkade card: feed-priced, no rendezvous, no corridor. The
+ * registry is not part of what this exercises, so it is injected. */
+const CARD: DiscoveredMarket = {
+    pair: "BTC/USD",
+    base_asset: { id: "btc", name: "Bitcoin", ticker: "BTC", decimals: 8 },
+    quote_asset: { id: USD_ASSET_ID, name: "US Dollar", ticker: "USD", decimals: 2 },
+    price_feed: "https://feed.example/btc-usd",
+    price_feed_schema: { type: "json", price_path: "/price" },
+    price_decimals: 6,
+    fee_bps: 30,
+    min_base_amount: "1000",
+    max_base_amount: "5000000",
+    min_quote_amount: "50",
+    max_quote_amount: "500000",
+    solver: "stub",
+    source: "https://registry.example/regtest.json",
+    sourceType: "registry",
+} as unknown as DiscoveredMarket;
+
+/** The price feed, answering a fixed price. Nothing about pricing is under
+ * test; what is real is the covenant, the funding and the cancel. */
+const feed = (async () =>
+    new Response(JSON.stringify({ price: 100_000 }))) as unknown as typeof fetch;
+
+let wallet: Wallet;
+const repository = new InMemoryAssetSwapRepository();
+
+const clientOn = (over: { repository?: InMemoryAssetSwapRepository } = {}): SwapClient =>
+    createSwapClient({
+        wallet,
+        repository: over.repository ?? repository,
+        discovery: { snapshot: [CARD] },
+        fetchImpl: feed,
+    });
+
+beforeAll(async () => {
+    wallet = await Wallet.create({
+        identity: SingleKey.fromRandomBytes(),
+        arkServerUrl: OPERATOR_URL,
+        onchainProvider: new EsploraProvider(ESPLORA_API_URL, {
+            forcePolling: true,
+            pollingInterval: 2000,
+        }),
+        storage: {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        },
+        settlementConfig: false,
+    });
+
+    const note = execCommand(`${arkdExec} arkd note --amount 200000`);
+    execCommand(`${arkdExec} ark redeem-notes -n ${note} --password secret`);
+    const address = await wallet.getAddress();
+    execCommand(`${arkdExec} ark send --to ${address} --amount ${FAUCET_SATS} --password secret`);
+    await waitFor(async () => (await wallet.getVtxos()).length > 0);
+}, 180_000);
+
+describe("the v2 cancel (regtest)", () => {
+    it("funds an offer covenant and takes the deposit back", async () => {
+        const client = clientOn();
+        const quote = await client.quote({
+            give: "BTC",
+            take: "USD",
+            amount: BigInt(DEPOSIT_SATS),
+            amountOn: "give",
+        });
+        const swap = await client.accept(quote);
+        const quoteId = quoteIdOfSwapId(swap.id);
+
+        expect(swap.family).toBe("offer");
+        expect(swap.id).toBe(`offer:${quoteId}`);
+        expect(swap.fundingTxid).toEqual(expect.any(String));
+
+        // The deposit has to be visible to the operator before the 2-of-2 can
+        // spend it.
+        const funded = (await repository.getSwapRecord(quoteId)) as OfferSwapRecord;
+        await waitFor(async () => {
+            const reader = await wallet.getArkadeReader();
+            const { vtxos } = await reader.getVtxos({ scripts: [funded.swapPkScript] });
+            return vtxos.some((v) => v.txid === funded.fundingTxid);
+        });
+
+        await expect(client.cancel(swap.id)).resolves.toEqual({ outcome: "cancelled" });
+
+        const cancelled = (await repository.getSwapRecord(quoteId)) as OfferSwapRecord;
+        expect(cancelled.status).toBe("cancelled");
+        expect(cancelled.spentTxid).toEqual(expect.any(String));
+        // A completion time is a fill's, not a cancel's.
+        expect(cancelled.completedAt).toBeUndefined();
+        await client[Symbol.asyncDispose]();
+    }, 180_000);
+
+    it("answers a second cancel from the record rather than re-broadcasting", async () => {
+        // A terminal record is one condition however the call reached it, and a
+        // fresh client reads the same answer off the same store.
+        const client = clientOn();
+        const [swap] = await client.swaps({ family: "offer" });
+        await expect(client.cancel(swap.id)).resolves.toEqual({ outcome: "cancelled" });
+        expect(swap.outcome).toBe("cancelled");
+        await client[Symbol.asyncDispose]();
+    }, 120_000);
+
+    it("refuses a corridor id and an id no record backs", async () => {
+        const client = clientOn();
+        const [swap] = await client.swaps({ family: "offer" });
+        const quoteId = quoteIdOfSwapId(swap.id);
+
+        // The tag parse, with no repository read: the same quote id under the
+        // other family's prefix is refused outright.
+        await expect(client.cancel(`rfq:${quoteId}`)).rejects.toBeInstanceOf(NotCancellable);
+        await expect(client.cancel("offer:nothing-here")).rejects.toBeInstanceOf(NotCancellable);
+        await client[Symbol.asyncDispose]();
+    }, 120_000);
+
+    it("names the rebuild mismatch when the pinned address is not the funded one", async () => {
+        // C, against the real operator: the v2 record pins `swapAddress` at
+        // accept, so the only way to reach the diagnosis is to corrupt it — and
+        // it must be the typed error, never "no spendable VTXO".
+        const store = new InMemoryAssetSwapRepository();
+        const client = clientOn({ repository: store });
+        const quote = await client.quote({
+            give: "BTC",
+            take: "USD",
+            amount: BigInt(DEPOSIT_SATS),
+            amountOn: "give",
+        });
+        const swap = await client.accept(quote);
+        const quoteId = quoteIdOfSwapId(swap.id);
+
+        const record = (await store.getSwapRecord(quoteId)) as OfferSwapRecord;
+        const decoded = ArkAddress.decode(record.swapAddress);
+        // Same wallet key, a different operator key: the rebuild derives a
+        // script the offer's own `swapPkScript` does not match.
+        const rotated = new ArkAddress(
+            hex.decode("11".repeat(32)),
+            decoded.tweakedPublicKey,
+            decoded.hrp,
+        ).encode();
+        await store.saveSwapRecord({ ...record, swapAddress: rotated });
+
+        await expect(client.cancel(swap.id)).rejects.toBeInstanceOf(OfferCovenantMismatchError);
+
+        // Restore the pin and the same call goes through — the record was the
+        // only thing wrong.
+        await store.saveSwapRecord({ ...record, status: "pending" });
+        await expect(client.cancel(swap.id)).resolves.toEqual({ outcome: "cancelled" });
+        await client[Symbol.asyncDispose]();
+    }, 180_000);
+});

--- a/packages/swap/test/e2e/offerCancel.test.ts
+++ b/packages/swap/test/e2e/offerCancel.test.ts
@@ -203,7 +203,7 @@ describe("the v2 cancel (regtest)", () => {
         // script the offer's own `swapPkScript` does not match.
         const rotated = new ArkAddress(
             hex.decode("11".repeat(32)),
-            decoded.tweakedPublicKey,
+            decoded.vtxoTaprootKey,
             decoded.hrp,
         ).encode();
         await store.saveSwapRecord({ ...record, swapAddress: rotated });

--- a/packages/swap/test/e2e/rfqDrive.test.ts
+++ b/packages/swap/test/e2e/rfqDrive.test.ts
@@ -44,7 +44,7 @@ import { createSwapClient, type SwapClient } from "../../src/client/client";
 import type { SwapUpdate } from "../../src/client/outcome";
 import { InMemoryAssetSwapRepository } from "../../src/repository";
 import type { AttestingRfqTransport } from "../../src/client/transport";
-import type { CorridorSwapRecord } from "../../src/client/record";
+import { quoteIdOfSwapId, type CorridorSwapRecord } from "../../src/client/record";
 import { encodeInvoice } from "../helpers/bolt11";
 
 const OPERATOR_URL = "http://localhost:7070";
@@ -215,7 +215,10 @@ beforeAll(async () => {
 }, 180_000);
 
 describe("the v2 drive (regtest)", () => {
+    /** The tagged public id, as `onUpdate` carries it. */
     let swapId: string;
+    /** The bare quote id underneath — what the repository keys on. */
+    let quoteId: string;
     let lockupScript: string;
 
     it("persists, funds and adopts an accepted swap", async () => {
@@ -226,6 +229,7 @@ describe("the v2 drive (regtest)", () => {
         const quote = await client.quote({ to: invoice() });
         const swap = await client.accept(quote);
         swapId = swap.id;
+        quoteId = quoteIdOfSwapId(swap.id);
 
         // The record is durable and the funding is broadcast, and NOTHING has
         // read the lockup yet: `accept()` returns once the record is at rest and
@@ -233,7 +237,7 @@ describe("the v2 drive (regtest)", () => {
         expect(swap.fundingTxid).toEqual(expect.any(String));
         expect(swap.outcome).toBe("funding");
 
-        const stored = (await repository.getSwapRecord(swapId)) as CorridorSwapRecord;
+        const stored = (await repository.getSwapRecord(quoteId)) as CorridorSwapRecord;
         expect(stored.family).toBe("rfq");
         lockupScript = stored.lockupPkScript;
 
@@ -291,8 +295,8 @@ describe("the v2 drive (regtest)", () => {
         // One record, and it is still the one `accept()` wrote: the manager's
         // mutable half is merged onto the v2 record rather than replacing it.
         const records = await repository.getAllSwapRecords();
-        expect(records.filter((r) => r.id === swapId)).toHaveLength(1);
-        const stored = (await repository.getSwapRecord(swapId)) as CorridorSwapRecord;
+        expect(records.filter((r) => r.id === quoteId)).toHaveLength(1);
+        const stored = (await repository.getSwapRecord(quoteId)) as CorridorSwapRecord;
         expect(stored.lockupPkScript).toBe(lockupScript);
         expect(stored.state).toBe("pending");
 
@@ -304,7 +308,7 @@ describe("the v2 drive (regtest)", () => {
         // Dispose is terminal for the instance and for nothing else: a new
         // client restores and resumes, and dropping the registration would
         // unwatch a funded lockup.
-        const stored = await repository.getSwapRecord(swapId);
+        const stored = await repository.getSwapRecord(quoteId);
         expect(stored).toBeDefined();
 
         const contracts = await wallet.getContractManager();


### PR DESCRIPTION
M6 of the swap SDK v2 track. Stacked on #839 — review that first.

Closes the v2 client surface: `cancel`, `swaps`, `markets`, and `ClientDisposed`
enforced over the whole method set.

- `Swap.id` becomes the tagged `offer:<QuoteId>` / `rfq:<QuoteId>`. Storage, the
  drive and `accept()`'s idempotency stay on the bare quote id, so the tag is
  presentation — but it makes `NotCancellable` a parse of the prefix rather than
  a repository read.
- `cancel()` reconciles the fill race against the covenant's own leaves instead
  of throwing v1's "no spendable VTXO", and returns `cancelled` / `filled` /
  `needs_recovery`. Nothing terminal is written on a spend it cannot name.
  `prepareOfferCancel` splits the protocol half out of `cancelOffer` so the
  caller owns the record ordering; both of its failures are now typed.
- `swaps()` is one read over the v2 keyspace, independent of `start()` and drive
  mode. The keyspace is never pruned and the method documents it.
- `markets()` publishes the same card a quote cites, through the same filters
  the routing read applies.
- `errors.test.ts` gains the error-coverage map: exhaustive over `SwapErrorName`,
  finds each member's throwing site in the source, and leaves exactly
  `InconsistentRoute` permanently throwerless.

The fill-vs-cancel race is pinned in the unit suite against real leaf-classified
spends. `test/e2e/offerCancel.test.ts` covers everything around it but has not
been run — no regtest stack here, and no solver in that stack to produce a fill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added swap cancellation with status outcomes for cancelled, filled, or recovery-required swaps.
  - Added APIs to cancel swaps, list swaps with filters, and list available markets.
  - Swap IDs now identify their swap family.
  - Added clearer cancellation errors and public offer-cancellation diagnostics.
  - Added idempotent client disposal and consistent safeguards after disposal.

- **Bug Fixes**
  - Improved handling of cancellation and fill races, uncertain deposits, retries, and terminal records.
  - Cancellation now preserves settlement details and update notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->