### PR TITLE
feat(swap): the three verbs, and the rails that route them

### DIFF
--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@arkade-os/swap",
-    "version": "0.1.0-rc.0",
+    "version": "0.1.0-rc.1",
     "type": "module",
     "description": "Client-side Arkade Intents asset swaps: discover markets, quote, create/track/cancel offers, restore from chain.",
     "repository": {

--- a/packages/swap/src/client/client.ts
+++ b/packages/swap/src/client/client.ts
@@ -21,6 +21,11 @@
  * thing — it registers the swap it just persisted — and everything else the
  * lifecycle needs lives behind {@link createSwapDrive}.
  *
+ * From M7 the three verbs hang off the same object: `pay`, `receive` and
+ * `exchange` are `quote` -> fee ceiling -> `accept` and nothing else, and they
+ * add no capability — everything they call was already here. What they add is
+ * the ceiling; what they subtract is vocabulary.
+ *
  * From M6 the surface closes: `cancel`, `swaps`, `markets`, and `ClientDisposed`
  * enforced across every member after disposal. Disposal is terminal; what the
  * terminal gate refuses is a NEW act, and an `Unsubscribe` already handed out
@@ -60,6 +65,17 @@ import { feedFetch, quoteFromFeed, type FeedFetch } from "./quoteOffer";
 import { quoteViaRfq } from "./quoteRfq";
 import type { Quote, QuoteId, QuoteInput, RouteResolution } from "./quote";
 import { resolveRoute, type ResolvedRoute } from "./resolve";
+import {
+    exchange,
+    pay,
+    receive,
+    type ExchangeOptions,
+    type PayOptions,
+    type PayResult,
+    type ReceiveOptions,
+    type ReceiveRequest,
+    type VerbDeps,
+} from "./verbs";
 import { cardMarketOf, marketBackendOf, marketKeyOf, usableMarkets, type Market } from "./market";
 import { nostrTransportFactory, type RfqTransportFactory } from "./transport";
 
@@ -278,6 +294,42 @@ export interface SwapClient {
      */
     accept(quote: Quote): Promise<Swap>;
     /**
+     * Pay a destination: a bolt11, a `bc1…`, or a plain Arkade address.
+     *
+     * One call for §5's whole pay box. `quote` → fee ceiling → `accept`, with
+     * the amount taken as what the recipient gets; an amount-bearing invoice
+     * pins it already, so passing one beside it is `AmountMismatch`.
+     *
+     * A plain Arkade address is **not** a swap and does not become one: it
+     * settles through `wallet.send` and answers `{ kind: "payment", txid }`,
+     * which is why the return is a union. Rejecting it would put the same
+     * branch in every product that has one pay box.
+     *
+     * @throws {MaxFeeExceeded} when the quoted fee is over `maxFee` or
+     *   `policy.maxFee`, whichever is tighter — before anything is funded.
+     */
+    pay(destination: string, options?: PayOptions): Promise<PayResult>;
+
+    /**
+     * Ask for an incoming payment, and get back the artifact to show its payer.
+     *
+     * Returns only after `accept()` has persisted, which is the point: an
+     * invoice shown to a payer while its claim secret is still in memory buys a
+     * lockup nobody can claim. The artifact is non-optional on the return type
+     * for the same reason — a receive has one by construction.
+     *
+     * @throws {MaxFeeExceeded} as {@link pay} does.
+     */
+    receive(options: ReceiveOptions): Promise<ReceiveRequest>;
+
+    /**
+     * Swap one Arkade asset for another.
+     *
+     * @throws {MaxFeeExceeded} as {@link pay} does.
+     */
+    exchange(options: ExchangeOptions): Promise<Swap>;
+
+    /**
      * What the quote with this id derived — the covenant, the keys, the wire
      * reply.
      *
@@ -409,7 +461,7 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
         }
     };
 
-    return {
+    const client: SwapClient = {
         resolve: async (input) => {
             ensureLive("resolve");
             return (await route(input, "resolve")).resolution;
@@ -600,6 +652,21 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
             );
         },
 
+        pay: async (destination, options) => {
+            ensureLive("pay");
+            return pay(verbs, destination, options);
+        },
+
+        receive: async (options) => {
+            ensureLive("receive");
+            return receive(verbs, options);
+        },
+
+        exchange: async (options) => {
+            ensureLive("exchange");
+            return exchange(verbs, options);
+        },
+
         preparationOf: (id) => {
             ensureLive("preparationOf");
             return preparations.get(id);
@@ -636,4 +703,18 @@ export const createSwapClient = (config: SwapClientConfig): SwapClient => {
             return driving().recover(quoteIdOfSwapId(id));
         },
     };
+
+    /**
+     * What the verbs call: the client's own gated members, not the raw helpers,
+     * so a verb inherits `quote`'s market re-pin and `accept`'s
+     * restore-before-persist rather than reimplementing either.
+     */
+    const verbs: VerbDeps = {
+        wallet,
+        quote: (input) => client.quote(input),
+        accept: (quote) => client.accept(quote),
+        ...(config.policy?.maxFee === undefined ? {} : { policyMaxFee: config.policy.maxFee }),
+    };
+
+    return client;
 };

--- a/packages/swap/src/client/index.ts
+++ b/packages/swap/src/client/index.ts
@@ -32,5 +32,7 @@ export * from "./resolve";
 export * from "./rfqAmount";
 export * from "./rfqWire";
 export * from "./route";
+export * from "./sats";
 export * from "./transport";
+export * from "./verbs";
 export * from "./verify";

--- a/packages/swap/src/client/policy.ts
+++ b/packages/swap/src/client/policy.ts
@@ -2,10 +2,10 @@
  * Application policy: the vetoes and floors a client applies before it
  * discloses anything, plus the two names §10 reserved.
  *
- * Five members touch the quote path — three active here, two inert — and
- * {@link SwapPolicy.drive} is the lifecycle's. `maxFee` still belongs to the
- * milestone that can enforce it: the verbs' ceiling is added by the layer that
- * applies it rather than declared early and ignored.
+ * Six members touch the quote path — four active here, two inert — and
+ * {@link SwapPolicy.drive} is the lifecycle's. `maxFee` landed with M7, the
+ * milestone that can enforce it: a ceiling declared before a layer applies it
+ * is a field, not a policy.
  *
  * Every active member has the same shape of purpose: it runs BEFORE the RFQ
  * round trip that discloses an invoice or an amount. A policy that could only
@@ -13,6 +13,7 @@
  */
 import type { MarketCandidate } from "./market";
 import type { RankedBid } from "./quote";
+import type { FeeCeiling } from "./verbs";
 
 /**
  * A published-RFQ auction's parameters (§10, Q9).
@@ -64,6 +65,21 @@ export interface SwapPolicy {
      * dependency the client needs to work.
      */
     readonly drive?: DriveMode;
+
+    /**
+     * The most a swap may cost, as a standing instruction.
+     *
+     * The verbs take the **minimum** of this and their own `maxFee`, so a call
+     * can only tighten it: a policy ceiling a call could raise would be
+     * decorative. Enforced between `quote` and `accept` and nowhere else —
+     * before funding, which is the only place a ceiling is worth anything.
+     *
+     * Denominated, like every ceiling on this surface: the fee sits on the give
+     * leg on corridor routes and the take leg on asset swaps, so a bare number
+     * would name no asset. A ceiling whose asset is not the quoted fee's is
+     * refused rather than converted.
+     */
+    readonly maxFee?: FeeCeiling;
 
     /**
      * The last word on which market prices a swap.

--- a/packages/swap/src/client/sats.ts
+++ b/packages/swap/src/client/sats.ts
@@ -1,0 +1,26 @@
+/**
+ * The one narrowing between P3's `bigint` law and core's `number` sats.
+ *
+ * Core's payment surface is `number` throughout — `RouteQuote.amount`, `.fee`,
+ * `.total`, `PaymentRequest.amount`, `Wallet.send` — and converting it is the
+ * router's own work, next to the asset-aware routing ts-sdk #586 already
+ * assigns it. Until then the crossing happens here, checked, at the boundary
+ * where both sides are sats: a sat count past 2^53 is not a payment, so the
+ * narrowing is sound and its failure is a refusal rather than a rounded amount.
+ *
+ * Core already crosses the same boundary itself, unchecked, at
+ * `payment/rails/onchain.ts`'s `BigInt(amt)`. This side refuses instead.
+ */
+import { AmountEncodingUnsupported } from "./errors";
+
+/** A `number` of sats from atomic units, or {@link AmountEncodingUnsupported}. */
+export const satsOf = (value: bigint, field: string): number => {
+    if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new AmountEncodingUnsupported(
+            field,
+            `${value}`,
+            "outside the non-negative safe-integer window core's payment amounts are numbers in",
+        );
+    }
+    return Number(value);
+};

--- a/packages/swap/src/client/verbs.ts
+++ b/packages/swap/src/client/verbs.ts
@@ -1,0 +1,262 @@
+/**
+ * The three product-facing verbs, and the one thing they add.
+ *
+ * `pay`, `receive` and `exchange` compile a {@link QuoteInput}, call `quote`,
+ * check `quote.fee` against a ceiling and call `accept`. Everything they call
+ * was built in M3–M6; what they add is the ceiling — and what they subtract is
+ * vocabulary. A product integrating payments never sees the words route,
+ * corridor, market or quote.
+ *
+ * The verbs are deliberately thin, and one asymmetry is the reason they exist
+ * at all: `receive` is what makes the artifact's exposure order unlosable. It
+ * returns only after `accept()` has persisted, so a caller cannot show a payer
+ * an invoice whose claim secret is still in memory — the ordering M4 bought,
+ * stated in a signature.
+ *
+ * §5's fourth row — `pay` to a plain Arkade address — is not a swap and must
+ * not become one. It delegates: same asset, same rail, rate 1, nothing swapped.
+ * See {@link PayResult}.
+ */
+import type { IWallet } from "@arkade-os/sdk";
+import { arkTarget, resolveSendAmount } from "@arkade-os/sdk";
+import { sameAsset, type AssetId } from "./assetId";
+import type { CorridorId } from "./corridor";
+import { MaxFeeExceeded } from "./errors";
+import type { AmountOn } from "./rfqAmount";
+import type { AssetRef, Quote, QuoteInput } from "./quote";
+import type { Swap } from "./record";
+import type { Artifact } from "./route";
+import { satsOf } from "./sats";
+
+/**
+ * A fee ceiling: an amount, and the asset it is denominated in.
+ *
+ * The asset is not ceremony. M3/D denominates the fee on the give leg on
+ * corridor routes and on the take leg on asset swaps, so a bare `bigint` names
+ * no asset — and on `exchange` the caller cannot know which leg carries it
+ * before quoting. A ceiling whose asset is not the fee's is a refusal rather
+ * than a conversion: the SDK holds no rate, and inventing one to compare two
+ * numbers is how a ceiling silently stops being one.
+ *
+ * The same shape on every verb and on {@link SwapPolicy.maxFee}, so the call
+ * ceiling and the policy ceiling it is taken against are comparable without a
+ * translation.
+ */
+export interface FeeCeiling {
+    readonly amount: bigint;
+    readonly asset: AssetId;
+}
+
+/**
+ * What `pay` takes beside the destination.
+ *
+ * `amount` is what the *recipient* gets, and it is omitted exactly when the
+ * destination pins it — an amount-bearing bolt11 does, and passing one beside
+ * it is `AmountMismatch`. §9.5's EVM destinations grow a required `take` here;
+ * they are deferred, so it is not declared yet.
+ */
+export interface PayOptions {
+    /** Atomic units delivered to the recipient. Omitted when an invoice pins it. */
+    readonly amount?: bigint;
+    readonly maxFee?: FeeCeiling;
+}
+
+/**
+ * What `receive` takes.
+ *
+ * `via` names the corridor because a receive has no instrument to parse — the
+ * instrument *is* the artifact the solver mints, and it does not exist until
+ * the quote comes back. `asset` is reserved for §9.5's EVM form: on the
+ * implemented corridors the corridor carries BTC and nothing else, so naming
+ * one would be a fact with nothing to disagree with.
+ */
+export interface ReceiveOptions {
+    /** Atomic units the trader receives. */
+    readonly amount: bigint;
+    readonly via: CorridorId;
+    /** §9.5, reserved: the asset arriving, where a corridor carries more than one. */
+    readonly asset?: AssetRef;
+    readonly maxFee?: FeeCeiling;
+}
+
+/**
+ * What `exchange` takes: {@link QuoteInput} minus `to` and `via`, plus the
+ * ceiling.
+ *
+ * Thin because `exchange` hides the two-step, not the vocabulary — an asset
+ * swap names both assets by construction, and there is nothing left to infer.
+ */
+export interface ExchangeOptions {
+    readonly give?: AssetRef;
+    readonly take?: AssetRef;
+    readonly amount?: bigint;
+    readonly amountOn?: AmountOn;
+    readonly maxFee?: FeeCeiling;
+}
+
+/**
+ * What `receive` answers with: a {@link Swap} whose artifact is a guarantee
+ * rather than a maybe.
+ *
+ * An intersection rather than a parallel record, because that is where the
+ * guarantee gets *stated*: `Quote.artifact` and `Swap.artifact` are optional —
+ * three of the four routes have nothing a counterparty must see — and a receive
+ * always has one. Narrowing the field on the base type is not open to an
+ * intersection, so this is the shape that says it.
+ */
+export type ReceiveRequest = Swap & { readonly artifact: Artifact };
+
+/**
+ * What `pay` answers with.
+ *
+ * Two arms, because §5's four destination rows are not four swaps. A bolt11 and
+ * a `bc1…` cross a corridor and produce a {@link Swap}; a plain Arkade address
+ * is a plain Arkade payment and produces a txid and no swap id. Manufacturing a
+ * `Swap` for the second would be a swap record for something nothing swapped —
+ * same asset, same rail, rate 1 — and rejecting it instead would put a branch in
+ * every product's one pay box rather than once here.
+ */
+export type PayResult =
+    | { readonly kind: "swap"; readonly swap: Swap }
+    | { readonly kind: "payment"; readonly txid: string };
+
+/** What a verb needs from the client it hangs off. */
+export interface VerbDeps {
+    readonly wallet: IWallet;
+    quote(input: QuoteInput): Promise<Quote>;
+    accept(quote: Quote): Promise<Swap>;
+    /** {@link SwapPolicy.maxFee}, when the client was configured with one. */
+    readonly policyMaxFee?: FeeCeiling;
+}
+
+/**
+ * The effective ceiling, and the refusal when the quote is over it.
+ *
+ * The effective ceiling is the **minimum** of the call's and the policy's: a
+ * policy ceiling a call could raise would be decorative, and a call ceiling a
+ * policy could raise would make the tighter of two explicit instructions lose.
+ * Either may be absent; both absent means no ceiling, which is the documented
+ * default and not a zero.
+ *
+ * A ceiling denominated in another asset is refused as caller input rather than
+ * as a member of §7's taxonomy: the taxonomy's members are conditions of the
+ * swap, and this is a field naming the wrong unit — the same rule that keeps
+ * "amount needs amountOn" a plain `Error`.
+ *
+ * @throws {MaxFeeExceeded} when `quote.fee` is over the effective ceiling —
+ *   between `quote` and `accept`, so nothing was funded.
+ */
+export const enforceFeeCeiling = (
+    quote: Quote,
+    call: FeeCeiling | undefined,
+    policy: FeeCeiling | undefined,
+): void => {
+    let ceiling: bigint | undefined;
+    for (const [source, limit] of [
+        ["maxFee", call],
+        ["policy.maxFee", policy],
+    ] as const) {
+        if (limit === undefined) continue;
+        if (!sameAsset(limit.asset, quote.fee.asset)) {
+            throw new Error(
+                `${source} is denominated in ${limit.asset} and the quote's fee in ` +
+                    `${quote.fee.asset} — no rate converts one ceiling into the other`,
+            );
+        }
+        ceiling = ceiling === undefined || limit.amount < ceiling ? limit.amount : ceiling;
+    }
+    if (ceiling !== undefined && quote.fee.amount > ceiling) {
+        throw new MaxFeeExceeded(quote.id, quote.fee.asset, quote.fee.amount, ceiling);
+    }
+};
+
+/** quote -> ceiling -> accept, which is every verb's whole body. */
+const settle = async (
+    deps: VerbDeps,
+    input: QuoteInput,
+    maxFee: FeeCeiling | undefined,
+): Promise<Swap> => {
+    const quote = await deps.quote(input);
+    enforceFeeCeiling(quote, maxFee, deps.policyMaxFee);
+    return deps.accept(quote);
+};
+
+/**
+ * Pay a destination: a bolt11, a `bc1…`, or a plain Arkade address.
+ *
+ * The Arkade arm is checked first and against core's own parse, so a bare
+ * address and a BIP21 `ark=` param behave identically here and in the `ark`
+ * rail — one classification, not two that can drift. It settles through
+ * `wallet.send`, which is what the `ark` rail settles through: fee 0 and
+ * receiver-exact for free, with nothing to quote and nothing to persist.
+ */
+export const pay = async (
+    deps: VerbDeps,
+    destination: string,
+    options: PayOptions = {},
+): Promise<PayResult> => {
+    const arkade = arkTarget(destination);
+    if (arkade !== undefined) {
+        // Core's own amount law, so an amountless `ark:` URI is refused in the
+        // same words the `ark` rail refuses it in.
+        const amount = resolveSendAmount(
+            "ark",
+            destination,
+            options.amount === undefined ? undefined : satsOf(options.amount, "amount"),
+        );
+        return { kind: "payment", txid: await deps.wallet.send({ address: arkade, amount }) };
+    }
+    const swap = await settle(
+        deps,
+        {
+            to: destination,
+            // `amountOn: "take"` because the number a caller writes beside a
+            // destination is what the recipient gets. An invoice pins the same
+            // leg by existing, which is why passing both is `AmountMismatch`.
+            ...(options.amount === undefined ? {} : { amount: options.amount, amountOn: "take" }),
+        },
+        options.maxFee,
+    );
+    return { kind: "swap", swap };
+};
+
+/**
+ * Ask for an incoming payment over `via`, and get back the artifact to show.
+ *
+ * The artifact is non-optional on the return type and the assertion behind it
+ * is real: a receive route has one by construction, and a client that answered
+ * without one has failed rather than answered.
+ */
+export const receive = async (deps: VerbDeps, options: ReceiveOptions): Promise<ReceiveRequest> => {
+    const swap = await settle(
+        deps,
+        {
+            via: options.via,
+            ...(options.asset === undefined ? {} : { take: options.asset }),
+            amount: options.amount,
+            // The trader's side is the take leg: `receive({ amount })` is
+            // "credit me this much", not "let the payer send this much".
+            amountOn: "take",
+        },
+        options.maxFee,
+    );
+    if (swap.artifact === undefined) {
+        throw new Error(
+            `receive over ${options.via} returned no artifact — there is nothing to show a payer`,
+        );
+    }
+    return swap as ReceiveRequest;
+};
+
+/** Swap one Arkade asset for another. */
+export const exchange = async (deps: VerbDeps, options: ExchangeOptions): Promise<Swap> =>
+    settle(
+        deps,
+        {
+            ...(options.give === undefined ? {} : { give: options.give }),
+            ...(options.take === undefined ? {} : { take: options.take }),
+            ...(options.amount === undefined ? {} : { amount: options.amount }),
+            ...(options.amountOn === undefined ? {} : { amountOn: options.amountOn }),
+        },
+        options.maxFee,
+    );

--- a/packages/swap/src/onchainHtlc.ts
+++ b/packages/swap/src/onchainHtlc.ts
@@ -69,6 +69,22 @@ export const ONCHAIN_SECONDS_PER_BLOCK = 600;
  */
 export const ONCHAIN_DUST_SATS = BigInt(330);
 
+/**
+ * vsize of the trader's claim transaction, for pricing it before it is built.
+ *
+ * The claim is one-in-one-out with a fixed witness — a 64-byte DEFAULT-sighash
+ * signature, the 32-byte preimage, the claim leaf and its control block — so
+ * the only variable is the payout script, and this is the largest standard one
+ * (P2TR, 34 bytes; P2WPKH measures 140 and P2PKH 143). Rounded UP on purpose:
+ * a rail quoting a claim fee must not under-charge, since the shortfall would
+ * come out of the recipient's payout.
+ *
+ * Pinned against a real sizing pass in `onchainHtlc.test.ts` — the number is an
+ * estimate of a transaction this module builds, so a change to the leaf shape
+ * has to move both together.
+ */
+export const ONCHAIN_CLAIM_VSIZE = 152;
+
 // ── Preimage utilities ───────────────────────────────────────────────────────
 
 /** 32 random bytes. The user generates P for BOTH onchain directions. */

--- a/packages/swap/src/payment/index.ts
+++ b/packages/swap/src/payment/index.ts
@@ -16,3 +16,34 @@ export {
     type SolverLightningRailDeps,
     type SolverLightningSend,
 } from "./solverLightning";
+
+/** The v2 swap rails: `SwapClient`-backed, one dep each, and the router that
+ *  registers them beside core's own. The `solver-*` rails above are the v1 RFQ
+ *  path and predate them. */
+export {
+    LIGHTNING_RAIL,
+    lightningRail,
+} from "./lightning";
+export {
+    ONCHAIN_SWAP_RAIL,
+    claimFeeSats,
+    onchainSwapRail,
+    type OnchainSwapRailDeps,
+} from "./onchainSwap";
+export {
+    SWAP_ROUTER_PRIORITY,
+    createSwapPaymentRouter,
+    type SwapPaymentRouterConfig,
+} from "./router";
+export {
+    PAYMENT_STATUS,
+    isTerminalStatus,
+    paymentStatusOf,
+} from "./status";
+export {
+    SwapPaymentFailedError,
+    railAvailable,
+    receiverExact,
+    swapHandle,
+    type SwapRailClient,
+} from "./swapRail";

--- a/packages/swap/src/payment/lightning.ts
+++ b/packages/swap/src/payment/lightning.ts
@@ -1,0 +1,96 @@
+/**
+ * `lightning` — pay a BOLT11 invoice out of an Arkade balance, through the v2
+ * swap client.
+ *
+ * The rail id is a registry key with published history: the factory deleted
+ * with `packages/boltz-swap` registered `"lightning"`, and a key is what an
+ * app's `priority` array and `disabled` list name. It therefore stays
+ * `lightning` even though Q12 renamed the lightning *asset* namespace to
+ * `bolt11` — the divergence between a registry key and an asset vocabulary is
+ * recorded here, not resolved by a rename that would break every consumer's
+ * preferences.
+ *
+ * The whole rail is an adapter. The invoice fixes the amount, the client
+ * verifies and prices the route, `accept()` persists before it funds, and the
+ * drive owns everything after — so there is no `persist`, no `awaitSettlement`
+ * and no solver selection to configure here.
+ */
+import type { PaymentRail, RouteQuote } from "@arkade-os/sdk";
+import { invoiceTarget } from "@arkade-os/sdk";
+import type { QuoteInput } from "../client/quote";
+import { railAvailable, receiverExact, swapHandle, type SwapRailClient } from "./swapRail";
+
+export const LIGHTNING_RAIL = "lightning";
+
+/**
+ * The input for an invoice.
+ *
+ * A request amount is passed through rather than dropped, and the v2 rule then
+ * applies: exactly one amount may be pinned, and an amount-bearing invoice pins
+ * one by existing. Passing both is `AmountMismatch` **even when they agree** —
+ * "they agreed this time" is not a rule anyone can rely on, and the invoice is
+ * what both sides settle against. An amountless invoice is where the request's
+ * own amount is the only pin there is.
+ */
+const inputFor = (invoice: string, amount: number | undefined): QuoteInput => ({
+    to: invoice,
+    ...(amount === undefined ? {} : { amount: BigInt(amount), amountOn: "take" }),
+});
+
+/**
+ * Register alongside core's rails. The deleted factory's ranking was
+ * `["ark", "lightning", "onchain-swap", "onchain"]`; see
+ * {@link createSwapPaymentRouter}.
+ */
+export function lightningRail(client: SwapRailClient): PaymentRail {
+    return {
+        id: LIGHTNING_RAIL,
+        // Amount-blind and non-throwing: classification only, which is what
+        // keeps `match` from being a second gate on top of `available`.
+        match: (req) => invoiceTarget(req.raw) !== undefined,
+
+        available: async (req) => {
+            const invoice = invoiceTarget(req.raw);
+            if (invoice === undefined) return false;
+            // Resolution, never a quote: quoting here would disclose the
+            // invoice to a solver merely to rank a route the caller may not
+            // take.
+            return railAvailable(client, inputFor(invoice, req.amount));
+        },
+
+        quote: async (req): Promise<RouteQuote> => {
+            const invoice = invoiceTarget(req.raw);
+            if (invoice === undefined) {
+                throw new Error(`${LIGHTNING_RAIL}: the request carries no BOLT11 invoice`);
+            }
+            const quote = await client.quote(inputFor(invoice, req.amount));
+            // The payee is paid the invoice, and the spread sits on top: on a
+            // corridor route the fee is denominated on the give leg, so the
+            // give amount IS the receiver-exact total.
+            const amounts = receiverExact(LIGHTNING_RAIL, {
+                amount: quote.take.amount,
+                fee: quote.fee.amount,
+                total: quote.give.amount,
+            });
+            return {
+                railId: LIGHTNING_RAIL,
+                ...amounts,
+                meta: {
+                    quoteId: quote.id,
+                    // A `RouteQuote` carries no expiry of its own, so a held one
+                    // can outlive the terms behind it. This is where a caller
+                    // can see that; `send()` refuses with `QuoteExpired` rather
+                    // than silently re-quoting.
+                    expiresAt: quote.expiresAt,
+                    ...(quote.refundLocktime === undefined
+                        ? {}
+                        : { refundLocktime: quote.refundLocktime }),
+                    ...(quote.solver === undefined ? {} : { solver: quote.solver }),
+                    ...(quote.lock === undefined ? {} : { paymentHash: quote.lock.hash }),
+                    market: quote.market.key,
+                },
+                send: () => swapHandle(LIGHTNING_RAIL, client, quote),
+            };
+        },
+    };
+}

--- a/packages/swap/src/payment/onchainSwap.ts
+++ b/packages/swap/src/payment/onchainSwap.ts
@@ -1,0 +1,130 @@
+/**
+ * `onchain-swap` — pay an L1 address out of an Arkade balance through a solver,
+ * via the v2 swap client.
+ *
+ * Registered alongside core's `onchain` rail (the collaborative exit) and
+ * ranked ahead of it, with both left registered: the default is a *preference*,
+ * not a restriction. The preference self-heals by amount — an out-of-range
+ * request drops this rail at `available()` and `onchain` wins with no error.
+ *
+ * The id is the deleted factory's published registry key, `"onchain-swap"`,
+ * kept for the reason the `lightning` rail keeps its own: a rail id is what an
+ * app's `priority` array names.
+ *
+ * **The claim fee is this rail's whole subtlety.** On `arkade -> onchain` the
+ * trader claims the solver's L1 HTLC itself, and that claim's fee comes out of
+ * the HTLC output — `payout = utxo.amount - fee`. So the sats the recipient
+ * actually receives are less than the sats the solver locks, by an amount the
+ * swap quote knows nothing about. A rail that quoted the solver's spread alone
+ * would be reporting a fee it does not charge, and would win a ranking against
+ * the collaborative exit that it should lose.
+ *
+ * This rail therefore takes a claim fee-rate policy at construction and grosses
+ * the swap up by the estimate: it asks the solver for `amount + claimFee` on the
+ * take leg, so what lands after the claim is the `amount` the caller asked for,
+ * and it reports the estimate inside `fee` where a ranking can see it. A fee
+ * rate is environment-specific and is nobody's to default — the same reason
+ * `CorridorOverrides.onchain.claim` has no default.
+ */
+import type { PaymentRail, RouteQuote } from "@arkade-os/sdk";
+import { btcTarget, resolveSendAmount, tryResolveSendAmount } from "@arkade-os/sdk";
+import { ONCHAIN_CLAIM_VSIZE } from "../onchainHtlc";
+import type { QuoteInput } from "../client/quote";
+import { railAvailable, receiverExact, swapHandle, type SwapRailClient } from "./swapRail";
+
+export const ONCHAIN_SWAP_RAIL = "onchain-swap";
+
+export interface OnchainSwapRailDeps {
+    /**
+     * Sat/vB the trader's L1 claim will be built at — the rate the corridor's
+     * own `claim` dep will use.
+     *
+     * No default, and the rail refuses to exist without it: the fee comes out
+     * of the recipient's payout, so a rail with no rate either quotes a fee it
+     * does not charge or short-pays the recipient. Neither is a default.
+     */
+    readonly claimFeeRateSatVb: number;
+    /** vsize the claim is priced at. Defaults to {@link ONCHAIN_CLAIM_VSIZE}. */
+    readonly claimVsize?: number;
+}
+
+/** What the trader's L1 claim will cost, rounded up as the builder rounds it. */
+export const claimFeeSats = (deps: OnchainSwapRailDeps): bigint =>
+    BigInt(Math.ceil((deps.claimVsize ?? ONCHAIN_CLAIM_VSIZE) * deps.claimFeeRateSatVb));
+
+/**
+ * Register alongside core's rails, ranked ahead of `onchain`:
+ * `["ark", "lightning", "onchain-swap", "onchain"]`. See
+ * {@link createSwapPaymentRouter}.
+ */
+export function onchainSwapRail(client: SwapRailClient, deps: OnchainSwapRailDeps): PaymentRail {
+    if (!Number.isFinite(deps.claimFeeRateSatVb) || deps.claimFeeRateSatVb <= 0) {
+        throw new Error(
+            `${ONCHAIN_SWAP_RAIL}: claimFeeRateSatVb must be positive, got ${deps.claimFeeRateSatVb}`,
+        );
+    }
+    const claimFee = claimFeeSats(deps);
+
+    /** The solver's obligation: what the recipient gets, plus what the claim costs. */
+    const inputFor = (address: string, amount: number): QuoteInput => ({
+        to: address,
+        amount: BigInt(amount) + claimFee,
+        amountOn: "take",
+    });
+
+    return {
+        id: ONCHAIN_SWAP_RAIL,
+        match: (req) => btcTarget(req.raw) !== undefined,
+
+        available: async (req) => {
+            const address = btcTarget(req.raw);
+            if (address === undefined) return false;
+            // An amountless request defers to `quote()`, which is where "an
+            // amount is required" belongs: nothing can be bounds-checked
+            // without one, so the rail cannot claim to fit.
+            const amount = tryResolveSendAmount(req.raw, req.amount);
+            if (amount === undefined) return false;
+            // Resolution, never a quote — and the address is validated against
+            // the wallet's network by the corridor that claims it, so a `tb1…`
+            // on mainnet drops this rail here rather than at settlement.
+            return railAvailable(client, inputFor(address, amount));
+        },
+
+        quote: async (req): Promise<RouteQuote> => {
+            const address = btcTarget(req.raw);
+            if (address === undefined) {
+                throw new Error(`${ONCHAIN_SWAP_RAIL}: the request carries no bitcoin address`);
+            }
+            const amount = resolveSendAmount(ONCHAIN_SWAP_RAIL, req.raw, req.amount);
+            const quote = await client.quote(inputFor(address, amount));
+            const amounts = receiverExact(ONCHAIN_SWAP_RAIL, {
+                // What lands at the address, which is the HTLC the solver locks
+                // minus the claim this wallet will broadcast to take it.
+                amount: quote.take.amount - claimFee,
+                // Both halves of the cost, inside one number: the solver's
+                // spread, and the claim the trader pays for out of the payout.
+                fee: quote.fee.amount + claimFee,
+                total: quote.give.amount,
+            });
+            return {
+                railId: ONCHAIN_SWAP_RAIL,
+                ...amounts,
+                meta: {
+                    quoteId: quote.id,
+                    expiresAt: quote.expiresAt,
+                    ...(quote.refundLocktime === undefined
+                        ? {}
+                        : { refundLocktime: quote.refundLocktime }),
+                    ...(quote.solver === undefined ? {} : { solver: quote.solver }),
+                    ...(quote.lock === undefined ? {} : { paymentHash: quote.lock.hash }),
+                    market: quote.market.key,
+                    /** The estimate folded into `fee`, so a caller can see it. */
+                    claimFeeSats: Number(claimFee),
+                    /** What the solver locks on L1, before the claim's fee. */
+                    htlcAmountSats: Number(quote.take.amount),
+                },
+                send: () => swapHandle(ONCHAIN_SWAP_RAIL, client, quote),
+            };
+        },
+    };
+}

--- a/packages/swap/src/payment/onchainSwap.ts
+++ b/packages/swap/src/payment/onchainSwap.ts
@@ -25,10 +25,15 @@
  * and it reports the estimate inside `fee` where a ranking can see it. A fee
  * rate is environment-specific and is nobody's to default — the same reason
  * `CorridorOverrides.onchain.claim` has no default.
+ *
+ * The same arithmetic gives the rail its floor: a payout under
+ * {@link ONCHAIN_DUST_SATS} is one `buildHtlcClaim` refuses to build, so an
+ * amount that small drops the rail at `available()` and is refused outright at
+ * `quote()` — before a lockup exists, rather than after one is funded.
  */
 import type { PaymentRail, RouteQuote } from "@arkade-os/sdk";
 import { btcTarget, resolveSendAmount, tryResolveSendAmount } from "@arkade-os/sdk";
-import { ONCHAIN_CLAIM_VSIZE } from "../onchainHtlc";
+import { ONCHAIN_CLAIM_VSIZE, ONCHAIN_DUST_SATS } from "../onchainHtlc";
 import type { QuoteInput } from "../client/quote";
 import { railAvailable, receiverExact, swapHandle, type SwapRailClient } from "./swapRail";
 
@@ -84,6 +89,12 @@ export function onchainSwapRail(client: SwapRailClient, deps: OnchainSwapRailDep
             // without one, so the rail cannot claim to fit.
             const amount = tryResolveSendAmount(req.raw, req.amount);
             if (amount === undefined) return false;
+            // The gross-up is exactly the claim's fee, so the payout the
+            // recipient is left with IS the requested amount. A request under
+            // the dust limit is therefore out of this rail's range, and
+            // dropping it here is what lets the collaborative exit win with no
+            // error — the same self-healing the bounds check below performs.
+            if (BigInt(amount) < ONCHAIN_DUST_SATS) return false;
             // Resolution, never a quote — and the address is validated against
             // the wallet's network by the corridor that claims it, so a `tb1…`
             // on mainnet drops this rail here rather than at settlement.
@@ -97,10 +108,25 @@ export function onchainSwapRail(client: SwapRailClient, deps: OnchainSwapRailDep
             }
             const amount = resolveSendAmount(ONCHAIN_SWAP_RAIL, req.raw, req.amount);
             const quote = await client.quote(inputFor(address, amount));
+            // What lands at the address: the HTLC the solver locks, minus the
+            // claim this wallet will broadcast to take it.
+            const payout = quote.take.amount - claimFee;
+            // `buildHtlcClaim` applies this same floor — but it applies it at
+            // claim time, with the lockup funded and the swap committed, where
+            // the only way out is a refund. Applied here it is a refusal before
+            // anything moves. It covers the degenerate end too: a take leg that
+            // does not even cover the claim arrives as a negative payout, named
+            // with its cause, rather than as `satsOf`'s `AmountEncodingUnsupported`
+            // complaining about a window it never explains.
+            if (payout < ONCHAIN_DUST_SATS) {
+                throw new Error(
+                    `${ONCHAIN_SWAP_RAIL}: the solver's take leg of ${quote.take.amount} sat ` +
+                        `leaves ${payout} sat after the ${claimFee} sat claim fee, under the ` +
+                        `${ONCHAIN_DUST_SATS} sat dust limit the claim is built against`,
+                );
+            }
             const amounts = receiverExact(ONCHAIN_SWAP_RAIL, {
-                // What lands at the address, which is the HTLC the solver locks
-                // minus the claim this wallet will broadcast to take it.
-                amount: quote.take.amount - claimFee,
+                amount: payout,
                 // Both halves of the cost, inside one number: the solver's
                 // spread, and the claim the trader pays for out of the payout.
                 fee: quote.fee.amount + claimFee,
@@ -118,9 +144,9 @@ export function onchainSwapRail(client: SwapRailClient, deps: OnchainSwapRailDep
                     ...(quote.solver === undefined ? {} : { solver: quote.solver }),
                     ...(quote.lock === undefined ? {} : { paymentHash: quote.lock.hash }),
                     market: quote.market.key,
-                    /** The estimate folded into `fee`, so a caller can see it. */
+                    // The estimate folded into `fee`, so a caller can see it.
                     claimFeeSats: Number(claimFee),
-                    /** What the solver locks on L1, before the claim's fee. */
+                    // What the solver locks on L1, before the claim's fee.
                     htlcAmountSats: Number(quote.take.amount),
                 },
                 send: () => swapHandle(ONCHAIN_SWAP_RAIL, client, quote),

--- a/packages/swap/src/payment/router.ts
+++ b/packages/swap/src/payment/router.ts
@@ -1,0 +1,71 @@
+/**
+ * The router that puts lightning and `arkade -> onchain` back into a payment
+ * app's reach.
+ *
+ * Core's `createDefaultPaymentRouter(wallet)` registers `ark` and `onchain` and
+ * nothing else. The two swap rails never lived there — they were in
+ * `packages/boltz-swap`, behind a second overload with the priority
+ * `["ark", "lightning", "onchain-swap", "onchain"]`, and ts-sdk #811 removed
+ * them along with the package. This is that overload's shape, rebuilt on the v2
+ * client.
+ *
+ * **The rails close over their own dependencies, and `RouterContext` is not
+ * re-opened.** Widening core's context was the alternative and it is the wrong
+ * half: it edits a published payment type, re-imports the `swaps?: unknown`
+ * smell that was deliberately deleted, and asks core to name things it cannot —
+ * a repository, a transport, a discovery index. A rail factory over an
+ * already-constructed `SwapClient` names none of that in core.
+ *
+ * This factory stays out of core's own, which is pinned at exactly
+ * `["ark", "onchain"]`. Registering the swap rails is the app's decision, and
+ * the ranking it gets is a *preference*: both `onchain-swap` and `onchain` stay
+ * registered, so an amount outside the solver's range drops the swap rail at
+ * `available()` and the collaborative exit wins with no error.
+ */
+import type { PaymentRouter, RouterPreferences, Wallet } from "@arkade-os/sdk";
+import { PaymentRouter as Router, arkRail, onchainRail } from "@arkade-os/sdk";
+import { LIGHTNING_RAIL, lightningRail } from "./lightning";
+import { ONCHAIN_SWAP_RAIL, onchainSwapRail, type OnchainSwapRailDeps } from "./onchainSwap";
+import type { SwapRailClient } from "./swapRail";
+
+/** The deleted factory's ranking, and the one this factory ships. */
+export const SWAP_ROUTER_PRIORITY: readonly string[] = [
+    "ark",
+    LIGHTNING_RAIL,
+    ONCHAIN_SWAP_RAIL,
+    "onchain",
+];
+
+export interface SwapPaymentRouterConfig extends OnchainSwapRailDeps {
+    /** Overrides the shipped ranking; `disabled`, `caps` and `tieBreak` pass through. */
+    readonly prefs?: RouterPreferences;
+}
+
+/**
+ * Core's four rails plus the two this package supplies, ranked as the deleted
+ * factory ranked them.
+ *
+ * Takes the concrete `Wallet` because that is what `RouterContext` holds — core
+ * types it as the class, not `IWallet` — and the already-constructed client,
+ * because building one here would put storage, discovery and corridor policy
+ * behind a payment-router call that has no business deciding any of them.
+ */
+export function createSwapPaymentRouter(
+    wallet: Wallet,
+    client: SwapRailClient,
+    config: SwapPaymentRouterConfig,
+): PaymentRouter {
+    return new Router({
+        wallet,
+        prefs: { priority: [...SWAP_ROUTER_PRIORITY], ...config.prefs },
+    })
+        .use(arkRail())
+        .use(onchainRail())
+        .use(lightningRail(client))
+        .use(
+            onchainSwapRail(client, {
+                claimFeeRateSatVb: config.claimFeeRateSatVb,
+                ...(config.claimVsize === undefined ? {} : { claimVsize: config.claimVsize }),
+            }),
+        );
+}

--- a/packages/swap/src/payment/status.ts
+++ b/packages/swap/src/payment/status.ts
@@ -1,0 +1,79 @@
+/**
+ * Fourteen outcomes onto four payment statuses — the only artefact M7 mints.
+ *
+ * Declared **total** even though a send rail cannot reach every member, because
+ * a partial map is where the collapse hides: an outcome with no row does not
+ * fail loudly, it renders as whatever the lookup happens to return.
+ *
+ * The projection is lossy by construction and the loss is recoverable, which is
+ * the whole design. `refunded` and `lapsed` both land on `failed` — P6 exists so
+ * those two never become one word, and the difference survives on the update's
+ * `error`, which core's `PaymentHandle` docblock already reserves for it. No
+ * fifth `PaymentStatus` is proposed: a status is what a payment UI branches on,
+ * and "the trader's value came back" versus "the incoming payment never arrived"
+ * is a sentence, not a branch.
+ *
+ * **Where the rail goes terminal is a decision, not a rounding.** It goes
+ * terminal at `refunding`, not at `refunded`: `makeHandle` clears its subscriber
+ * set on a terminal update and replays-without-registering afterwards, so the
+ * `refunded` that follows could not reach that handle anyway — and holding
+ * terminality back until the refund resolves would hang every
+ * `settled({ timeoutMs })` caller for a whole refund window. The refund is
+ * observed through `client.onUpdate` and `swaps()`, keyed by the tagged
+ * `RouteResult.swapId`.
+ *
+ * The same rule answers the `unblock` backslide. `needs_recovery -> funded` is
+ * a legal re-entry that crosses the terminality boundary the rail just drew; it
+ * is emitted rather than swallowed, because the drive's idempotence key is the
+ * DERIVED outcome and the second `funded` is a new key — delivered on
+ * `client.onUpdate`, never through the handle, which stays terminal. A handle
+ * observes a payment up to and including its first terminal outcome; every
+ * recovery past that point is observed on the client's update stream.
+ */
+import type { PaymentStatus } from "@arkade-os/sdk";
+import type { Outcome } from "../client/outcome";
+
+/**
+ * The projection, total over {@link Outcome}.
+ *
+ * The `on the rail` column of M7's table is not encoded here: a send rail
+ * cannot reach `open`, `filled`, `cancelling`, `cancelled` or `lapsed`, but a
+ * map that refused them would be a map with holes, and the point of totality is
+ * that there are none.
+ */
+export const PAYMENT_STATUS = {
+    /** Persisted, funding not broadcast. */
+    accepted: "pending",
+    funding: "pending",
+    /** The lockup is funded. Nothing has emitted `"sent"` in core since the
+     *  `onchain-swap` rail left with `packages/boltz-swap`. */
+    funded: "sent",
+    /** Asset swaps only: an unfilled offer. */
+    open: "pending",
+    /** Asset swaps only. */
+    filled: "settled",
+    /** The trader's L1 claim on `arkade -> onchain`. */
+    claimed: "settled",
+    /** Terminal success on `arkade -> lightning`: the solver's hash-verified
+     *  spend IS the invoice being paid. */
+    paid: "settled",
+    cancelling: "pending",
+    /** Value returned, and the router has no non-loss terminal to say so with. */
+    cancelled: "failed",
+    /** Terminal HERE, not at `refunded` — see the module docblock. */
+    refunding: "failed",
+    /** The trader's value came back. Reaches `onUpdate`, not the handle. */
+    refunded: "failed",
+    /** The solver reclaimed a receive-leg lockup: a loss, and not `refunded`. */
+    lapsed: "failed",
+    /** Never retried silently; `client.recover` drives it. */
+    needs_recovery: "failed",
+    failed: "failed",
+} as const satisfies Record<Outcome, PaymentStatus>;
+
+/** Where a payment stands, in core's four-state vocabulary. */
+export const paymentStatusOf = (outcome: Outcome): PaymentStatus => PAYMENT_STATUS[outcome];
+
+/** Whether this status ends the handle's observation. Core's own rule. */
+export const isTerminalStatus = (status: PaymentStatus): boolean =>
+    status === "settled" || status === "failed";

--- a/packages/swap/src/payment/swapRail.ts
+++ b/packages/swap/src/payment/swapRail.ts
@@ -1,0 +1,182 @@
+/**
+ * What the two v2 swap rails share: the client seam, the quote arithmetic, and
+ * the handle that observes a swap through core's four-state stream.
+ *
+ * A rail here is a thin adapter and deliberately nothing more. Persistence,
+ * refunds, recovery and the outcome vocabulary all live behind the v2 client;
+ * the rail's whole job is to turn a `PaymentRequest` into a `QuoteInput`, a
+ * `Quote` into a receiver-exact `RouteQuote`, and a swap's outcome stream into
+ * a `PaymentHandle`.
+ *
+ * Two boundaries are crossed here and both are named. Amounts narrow from P3's
+ * `bigint` to core's `number` (see `client/sats.ts`). And a ranking estimate
+ * meets a binding quote: `RouteQuote.fee` is documented as "a display and
+ * ranking figure, not a guarantee" while a v2 `Quote` is verified before return
+ * and expires. `PaymentOption.quote()` is lazy and `options()` never calls it,
+ * so ranking is free — but a swap rail's `quote()` is an RFQ round trip that
+ * discloses an invoice and an amount, and an app that ranks then quotes several
+ * options would disclose to every solver. `available()` therefore **never
+ * quotes**: it resolves, which is network-free against the cached snapshot.
+ *
+ * A held `RouteQuote` can outlive its `Quote` — core's shape carries no
+ * `expiresAt` — and then `send()` throws `QuoteExpired` inside `makeHandle`'s
+ * run, which core turns into a terminal `failed`. That stays: re-quoting inside
+ * `send()` is the silent re-quote §3.2 forbids.
+ */
+import type { PaymentHandle, PaymentStatus, RouteResult } from "@arkade-os/sdk";
+import { makeHandle } from "@arkade-os/sdk";
+import { isSwapError } from "../client/errors";
+import type { Outcome, SwapUpdate, Unsubscribe } from "../client/outcome";
+import type { Quote, QuoteInput, RouteResolution } from "../client/quote";
+import type { Swap } from "../client/record";
+import { satsOf } from "../client/sats";
+import { isTerminalStatus, paymentStatusOf } from "./status";
+
+/**
+ * The slice of `SwapClient` a rail uses.
+ *
+ * Structural and minimal, so what a rail can reach is visible in one place and
+ * a test can stand in for it without a wallet, a repository or a solver behind
+ * it. A full `SwapClient` satisfies it.
+ */
+export interface SwapRailClient {
+    resolve(input: QuoteInput): Promise<RouteResolution>;
+    quote(input: QuoteInput): Promise<Quote>;
+    accept(quote: Quote): Promise<Swap>;
+    onUpdate(fn: (update: SwapUpdate) => void): Unsubscribe;
+}
+
+/**
+ * A payment that ended in something other than success.
+ *
+ * Not a member of §7's taxonomy and suffixed to say so: that taxonomy is thrown
+ * *before* value moves, and this is an outcome reported after it did. It exists
+ * to carry the {@link Outcome} onto the handle's terminal `error`, which is
+ * where `refunded` and `lapsed` stay distinguishable after the four-state
+ * projection has mapped both to `failed`.
+ */
+export class SwapPaymentFailedError extends Error {
+    override readonly name = "SwapPaymentFailedError";
+    constructor(
+        readonly railId: string,
+        readonly outcome: Outcome,
+        readonly swap: Swap,
+    ) {
+        super(
+            `${railId}: swap ${swap.id} ended ${outcome}` +
+                (swap.failure === undefined ? "" : `: ${swap.failure}`) +
+                (swap.blockedReason === undefined ? "" : ` (${swap.blockedReason})`),
+        );
+    }
+}
+
+/**
+ * Whether a resolution refusal means "not routable" rather than "broken".
+ *
+ * `available()` answers false for the first and lets the second through, where
+ * the router warns and drops the rail — which is the intended fallback and
+ * louder than swallowing it here would be.
+ */
+const unroutable = (error: unknown): boolean =>
+    isSwapError(error, "UnsupportedRoute") || isSwapError(error, "AmbiguousDestination");
+
+/** `eligible > 0` for this input, or false for anything that will not route. */
+export const railAvailable = async (
+    client: SwapRailClient,
+    input: QuoteInput,
+): Promise<boolean> => {
+    try {
+        return (await client.resolve(input)).eligible > 0;
+    } catch (error) {
+        if (unroutable(error)) return false;
+        throw error;
+    }
+};
+
+/**
+ * The three receiver-exact numbers, checked against each other.
+ *
+ * `total === amount + fee` is core's contract and this is where a rail proves
+ * it rather than asserting it in a comment: `amount` is what the recipient
+ * gets, `fee` is what the rail and its counterparty charge on top, and `total`
+ * is what leaves the wallet. A `Quote` whose give leg does not equal the take
+ * leg plus the spread has broken an invariant M3 owns, and surfacing it here
+ * beats quoting a number that would rank this rail against the collaborative
+ * exit on a fee it does not charge.
+ */
+export const receiverExact = (
+    railId: string,
+    parts: { amount: bigint; fee: bigint; total: bigint },
+): { amount: number; fee: number; total: number } => {
+    if (parts.total !== parts.amount + parts.fee) {
+        throw new Error(
+            `${railId}: ${parts.total} leaving the wallet is not ${parts.amount} delivered ` +
+                `plus ${parts.fee} in fees — the quote is not receiver-exact`,
+        );
+    }
+    return {
+        amount: satsOf(parts.amount, `${railId}.amount`),
+        fee: satsOf(parts.fee, `${railId}.fee`),
+        total: satsOf(parts.total, `${railId}.total`),
+    };
+};
+
+/** What a rail reports back: the tagged swap id, and the wallet's own txid. */
+const resultOf = (railId: string, swap: Swap): RouteResult => ({
+    railId,
+    // The tagged public form M6 minted — round-trippable to `client.swaps()`,
+    // which is where the outcomes past this handle's terminal one are read.
+    swapId: swap.id,
+    // The transaction that left THIS wallet, which is what `txid` means on
+    // every other rail. A swap's later legs — the solver's fill, the trader's
+    // L1 claim — are the client's to report, not the handle's.
+    ...(swap.fundingTxid === undefined ? {} : { txid: swap.fundingTxid }),
+});
+
+/**
+ * Accept the quote, then observe it to its first terminal outcome.
+ *
+ * The handle's contract, stated once: it observes the payment up to and
+ * including the first terminal outcome, and every recovery past that point is
+ * observed on `client.onUpdate` — keyed by the tagged `RouteResult.swapId`, so
+ * the two views join. `client.onUpdate` replays synchronously on subscribe, so
+ * a swap that was already terminal by the time we subscribed still resolves.
+ */
+export const swapHandle = async (
+    railId: string,
+    client: SwapRailClient,
+    quote: Quote,
+): Promise<PaymentHandle> =>
+    makeHandle(railId, async (emit) => {
+        const accepted = await client.accept(quote);
+        return await new Promise<RouteResult>((resolve, reject) => {
+            let finished = false;
+            let unsubscribe: Unsubscribe | undefined;
+            const listener = (update: SwapUpdate): void => {
+                if (finished || update.swap.id !== accepted.id) return;
+                const status: PaymentStatus = paymentStatusOf(update.outcome);
+                const result = resultOf(railId, update.swap);
+                if (!isTerminalStatus(status)) {
+                    emit({ status, result });
+                    return;
+                }
+                finished = true;
+                // `unsubscribe` is still undefined when the replay — which runs
+                // INSIDE `onUpdate` — is itself terminal. The flag is what the
+                // line after the subscription reads, and this call is what
+                // covers every later transition.
+                unsubscribe?.();
+                if (status === "settled") {
+                    emit({ status, result });
+                    resolve(result);
+                    return;
+                }
+                // Rejecting rather than emitting: `makeHandle` turns the
+                // rejection into the terminal `failed` update itself, and its
+                // `error` is where the outcome survives the projection.
+                reject(new SwapPaymentFailedError(railId, update.outcome, update.swap));
+            };
+            unsubscribe = client.onUpdate(listener);
+            if (finished) unsubscribe();
+        });
+    });

--- a/packages/swap/test/client/errors.test.ts
+++ b/packages/swap/test/client/errors.test.ts
@@ -157,7 +157,7 @@ const COVERAGE = {
         thrownAt: "cancel(), on a corridor id or an id no record backs",
     },
     ClientDisposed: { owner: "M6", thrownAt: "any client member after async disposal" },
-    MaxFeeExceeded: { owner: "M7", thrownAt: "the verb layer, before accept", pending: "M7" },
+    MaxFeeExceeded: { owner: "M7", thrownAt: "the verb layer, between quote and accept" },
     InconsistentRoute: { owner: "M1", thrownAt: null },
 } as const satisfies Record<
     SwapErrorName,

--- a/packages/swap/test/client/verbs.test.ts
+++ b/packages/swap/test/client/verbs.test.ts
@@ -1,0 +1,292 @@
+/**
+ * The three verbs, through the real client.
+ *
+ * They add no capability, so what is worth pinning is exactly what they decide:
+ * which `QuoteInput` each destination compiles to, that the ceiling is checked
+ * between `quote` and `accept` and therefore before anything is funded, that a
+ * plain Arkade address never becomes a swap, and that `receive` cannot return
+ * before its artifact is durable.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ArkAddress } from "@arkade-os/sdk";
+import { createSwapClient, type SwapClient } from "../../src/client/client";
+import { MaxFeeExceeded } from "../../src/client/errors";
+import { InMemoryAssetSwapRepository, type AssetSwapRepository } from "../../src/repository";
+import type { FeeCeiling } from "../../src/client/verbs";
+import type { SwapPolicy } from "../../src/client/policy";
+import {
+    EMULATOR_PUBKEY_HEX,
+    NETWORK,
+    OPERATOR_PUBKEY,
+    PAYMENT_HASH,
+    USD_ASSET_ID,
+    acceptWallet,
+    clockAt,
+    feedServing,
+    invoiceFor,
+    key,
+    lightningCard,
+    onchainCard,
+    solverFor,
+    solverTransport,
+    spotCard,
+    type AcceptWallet,
+} from "./fixtures";
+
+const NOW = 1_700_000_000;
+const CLOCK = clockAt(NOW);
+const BCRT1 = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+const ARK_ADDRESS = new ArkAddress(OPERATOR_PUBKEY, key(21), NETWORK.hrp).encode();
+const INVOICE = invoiceFor(PAYMENT_HASH, CLOCK);
+
+/** BTC on the leg every corridor quote denominates its fee on. */
+const ARKADE_BTC = "arkade:regtest/slip44:0" as const;
+const USD = `arkade:regtest/asset:${USD_ASSET_ID}` as const;
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW * 1000);
+});
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+interface Harness {
+    readonly client: SwapClient;
+    readonly repository: AssetSwapRepository;
+    readonly wallet: AcceptWallet;
+}
+
+const harness = async (policy?: SwapPolicy): Promise<Harness> => {
+    const wallet = await acceptWallet();
+    const repository = new InMemoryAssetSwapRepository();
+    const client = createSwapClient({
+        wallet: wallet.wallet,
+        repository,
+        discovery: { snapshot: [lightningCard, onchainCard, spotCard] },
+        emulatorPubkey: EMULATOR_PUBKEY_HEX,
+        transportFor: () => solverTransport(solverFor(CLOCK)),
+        fetchImpl: feedServing().fetch,
+        ...(policy === undefined ? {} : { policy }),
+    });
+    return { client, repository, wallet };
+};
+
+const ceiling = (amount: bigint, asset: string = ARKADE_BTC): FeeCeiling =>
+    ({ amount, asset }) as FeeCeiling;
+
+describe("pay", () => {
+    it("compiles a bolt11 to the lightning send, taking the invoice's own amount", async () => {
+        const { client, repository } = await harness();
+        const result = await client.pay(INVOICE);
+
+        expect(result.kind).toBe("swap");
+        if (result.kind !== "swap") return;
+        expect(result.swap.route.give.corridor).toBe("arkade");
+        expect(result.swap.route.take.corridor).toBe("lightning");
+        expect(result.swap.take.amount).toBe(5_000n);
+        expect(result.swap.fee).toEqual({ asset: ARKADE_BTC, amount: 50n });
+        expect(await repository.getSwapRecord(result.swap.id.slice(4))).toBeDefined();
+    });
+
+    it("compiles a bitcoin address to the onchain send, pinning what the recipient gets", async () => {
+        const { client } = await harness();
+        const result = await client.pay(BCRT1, { amount: 99_000n });
+
+        expect(result.kind).toBe("swap");
+        if (result.kind !== "swap") return;
+        expect(result.swap.route.take.corridor).toBe("onchain");
+        // `amountOn: "take"`: the number beside a destination is what lands there.
+        expect(result.swap.take.amount).toBe(99_000n);
+        expect(result.swap.give.amount).toBe(100_000n);
+    });
+
+    it("refuses an amount beside an invoice that already pins one", async () => {
+        const { client } = await harness();
+        await expect(client.pay(INVOICE, { amount: 5_000n })).rejects.toThrow(
+            /exactly one amount may be pinned/,
+        );
+    });
+
+    describe("to a plain Arkade address", () => {
+        it("sends through the wallet and manufactures no swap", async () => {
+            const { client, repository, wallet } = await harness();
+            const result = await client.pay(ARK_ADDRESS, { amount: 1_000n });
+
+            expect(result).toEqual({ kind: "payment", txid: expect.any(String) });
+            expect(wallet.sent).toEqual([{ address: ARK_ADDRESS, amount: 1_000 }]);
+            // Same asset, same rail, rate 1: there is nothing to record.
+            expect(await repository.getAllSwapRecords()).toEqual([]);
+        });
+
+        it("reads the address out of a unified BIP21 URI too", async () => {
+            const { client, wallet } = await harness();
+            const uri = `bitcoin:${BCRT1}?ark=${ARK_ADDRESS}&amount=0.00001`;
+            const result = await client.pay(uri);
+
+            expect(result.kind).toBe("payment");
+            // Core's own amount law: the URI's `amount=` is what it resolves to.
+            expect(wallet.sent).toEqual([{ address: ARK_ADDRESS, amount: 1_000 }]);
+        });
+
+        it("refuses an amountless send in core's own words", async () => {
+            const { client } = await harness();
+            await expect(client.pay(ARK_ADDRESS)).rejects.toThrow(/an amount is required/);
+        });
+    });
+});
+
+describe("receive", () => {
+    it("returns the artifact, durable, with nothing left in memory to lose", async () => {
+        const { client, repository } = await harness();
+        const request = await client.receive({ amount: 4_950n, via: "lightning" });
+
+        expect(request.artifact.kind).toBe("invoice");
+        expect(request.route.give.corridor).toBe("lightning");
+        expect(request.route.take.corridor).toBe("arkade");
+        // `amountOn: "take"`: "credit me this much", the trader's own leg.
+        expect(request.take.amount).toBe(4_950n);
+        expect(request.give.amount).toBe(5_000n);
+
+        // The ordering M4 bought, stated in a signature: the record and its
+        // claim secret are at rest before the invoice can reach a payer.
+        const record = await repository.getSwapRecord(request.id.slice(4));
+        expect(record?.artifact).toMatchObject({ kind: "invoice" });
+    });
+
+    it("funds nothing — the payer paying the invoice is the acceptance", async () => {
+        const { client, wallet } = await harness();
+        await client.receive({ amount: 4_950n, via: "lightning" });
+        expect(wallet.sent).toEqual([]);
+    });
+
+    it("refuses a corridor no receive can arrive over", async () => {
+        const { client } = await harness();
+        await expect(client.receive({ amount: 1_000n, via: "arkade" })).rejects.toThrow(
+            /not a corridor a receive can arrive over/,
+        );
+    });
+});
+
+describe("exchange", () => {
+    it("swaps one Arkade asset for another, denominating the fee on the take leg", async () => {
+        const { client } = await harness();
+        const swap = await client.exchange({
+            give: "BTC",
+            take: "USD",
+            amount: 100_000n,
+            amountOn: "give",
+        });
+
+        expect(swap.family).toBe("offer");
+        expect(swap.give).toEqual({ asset: ARKADE_BTC, amount: 100_000n });
+        expect(swap.take.asset).toBe(USD);
+        expect(swap.fee.asset).toBe(USD);
+    });
+
+    it("names the omission rather than the registry when one side is left out", async () => {
+        const { client } = await harness();
+        await expect(
+            client.exchange({ give: "BTC", amount: 100_000n, amountOn: "give" }),
+        ).rejects.toThrow(/name the other side/);
+    });
+});
+
+describe("the fee ceiling", () => {
+    it("throws MaxFeeExceeded with the terms, having funded nothing", async () => {
+        const { client, repository, wallet } = await harness();
+        const error = await client.pay(INVOICE, { maxFee: ceiling(49n) }).then(
+            () => undefined,
+            (e) => e,
+        );
+
+        expect(error).toBeInstanceOf(MaxFeeExceeded);
+        expect(error).toMatchObject({
+            asset: ARKADE_BTC,
+            fee: 50n,
+            maxFee: 49n,
+            quoteId: expect.any(String),
+        });
+        // Between `quote` and `accept`: nothing persisted, nothing funded.
+        expect(await repository.getAllSwapRecords()).toEqual([]);
+        expect(wallet.sent).toEqual([]);
+    });
+
+    it("lets a quote at exactly the ceiling through", async () => {
+        const { client } = await harness();
+        await expect(client.pay(INVOICE, { maxFee: ceiling(50n) })).resolves.toMatchObject({
+            kind: "swap",
+        });
+    });
+
+    it("clamps to the policy ceiling a call tried to raise", async () => {
+        // A policy ceiling a call can raise is decorative.
+        const { client } = await harness({ maxFee: ceiling(10n) });
+        await expect(client.pay(INVOICE, { maxFee: ceiling(1_000n) })).rejects.toMatchObject({
+            name: "MaxFeeExceeded",
+            maxFee: 10n,
+        });
+    });
+
+    it("lets a call tighten the policy ceiling", async () => {
+        const { client } = await harness({ maxFee: ceiling(1_000n) });
+        await expect(client.pay(INVOICE, { maxFee: ceiling(10n) })).rejects.toMatchObject({
+            name: "MaxFeeExceeded",
+            maxFee: 10n,
+        });
+    });
+
+    it("applies the policy ceiling to a call that names none", async () => {
+        const { client } = await harness({ maxFee: ceiling(10n) });
+        await expect(client.pay(INVOICE)).rejects.toBeInstanceOf(MaxFeeExceeded);
+    });
+
+    it("refuses a ceiling denominated in another asset rather than converting it", async () => {
+        // The SDK holds no rate, and inventing one to compare two numbers is
+        // how a ceiling silently stops being one.
+        const { client, wallet } = await harness();
+        await expect(client.pay(INVOICE, { maxFee: ceiling(10_000n, USD) })).rejects.toThrow(
+            /no rate converts one ceiling into the other/,
+        );
+        expect(wallet.sent).toEqual([]);
+    });
+
+    it("accepts the same asset spelled on another rail, which needs no rate", async () => {
+        // `bolt11:…/slip44:0` and `arkade:…/slip44:0` are one BTC, one sat.
+        const { client } = await harness();
+        await expect(
+            client.pay(INVOICE, { maxFee: ceiling(50n, "bolt11:regtest/slip44:0") }),
+        ).resolves.toMatchObject({ kind: "swap" });
+    });
+
+    it("guards receive and exchange the same way", async () => {
+        const { client } = await harness();
+        await expect(
+            client.receive({ amount: 4_950n, via: "lightning", maxFee: ceiling(1n) }),
+        ).rejects.toBeInstanceOf(MaxFeeExceeded);
+        await expect(
+            client.exchange({
+                give: "BTC",
+                take: "USD",
+                amount: 100_000n,
+                amountOn: "give",
+                maxFee: ceiling(1n, USD),
+            }),
+        ).rejects.toBeInstanceOf(MaxFeeExceeded);
+    });
+});
+
+describe("the disposal gate", () => {
+    it("covers the three verbs like every other new act", async () => {
+        const { client } = await harness();
+        await client[Symbol.asyncDispose]();
+        for (const call of [
+            () => client.pay(INVOICE),
+            () => client.receive({ amount: 4_950n, via: "lightning" }),
+            () => client.exchange({ give: "BTC", take: "USD", amount: 1n, amountOn: "give" }),
+        ]) {
+            await expect(call()).rejects.toMatchObject({ name: "ClientDisposed" });
+        }
+    });
+});

--- a/packages/swap/test/e2e/rfqVerbs.test.ts
+++ b/packages/swap/test/e2e/rfqVerbs.test.ts
@@ -7,10 +7,19 @@
  * rail can carry — that `RouteResult.swapId` round-trips from a payment handle
  * back to `client.swaps()`.
  *
- * Same stub-solver posture as `rfqDrive.test.ts`: the solver quotes back the
- * maker's OWN derivation, which is all the trust model lets a maker use from a
- * quote anyway. Nothing here fills a swap — a fill needs a solver that pays the
- * invoice — so what is real is everything the maker side does.
+ * Same stack and same stub-solver posture as `rfqDrive.test.ts`: the solver
+ * quotes back the maker's OWN derivation, which is all the trust model lets a
+ * maker use from a quote anyway. Nothing here fills a swap — a fill needs a
+ * solver that pays the invoice — so what is real is everything the maker side
+ * does.
+ *
+ * The `rfq` prefix on the filename is the ROUTING, not the subject: it is what
+ * puts the file on the seconds-typed `swap-rfq` profile and keeps it off the
+ * block-typed `swap` one (`packages/swap/package.json`'s two e2e scripts split
+ * on exactly that prefix). `lightningSendContract` emits seconds-typed
+ * timelocks and `unilateralClaimDelay` refuses a server exit delay below 512s,
+ * so on the offer suite's arkd (`ARKD_UNILATERAL_EXIT_DELAY=20`) this suite
+ * throws in `beforeAll` before a single verb runs. See `.env.regtest.rfq`.
  *
  * `exchange` is not here. Its route is `arkade <-> arkade`, which needs an
  * issued asset and a live price feed rather than a stubbed RFQ answer, and the

--- a/packages/swap/test/e2e/verbs.test.ts
+++ b/packages/swap/test/e2e/verbs.test.ts
@@ -1,0 +1,341 @@
+/**
+ * The verbs and the `lightning` rail against the real regtest stack.
+ *
+ * What the unit suite cannot prove, and this can: that the delegating arm of
+ * `pay` moves real value through the real wallet, that `receive`'s artifact is
+ * durable in a real repository before the call returns, and — the clause only a
+ * rail can carry — that `RouteResult.swapId` round-trips from a payment handle
+ * back to `client.swaps()`.
+ *
+ * Same stub-solver posture as `rfqDrive.test.ts`: the solver quotes back the
+ * maker's OWN derivation, which is all the trust model lets a maker use from a
+ * quote anyway. Nothing here fills a swap — a fill needs a solver that pays the
+ * invoice — so what is real is everything the maker side does.
+ *
+ * `exchange` is not here. Its route is `arkade <-> arkade`, which needs an
+ * issued asset and a live price feed rather than a stubbed RFQ answer, and the
+ * offer primitive it funds already has `offerCancel.test.ts` against this stack.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { execSync } from "child_process";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+    ArkAddress,
+    EsploraProvider,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    REGTEST_EMULATOR_PUBKEY,
+    SingleKey,
+    Wallet,
+} from "@arkade-os/sdk";
+import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
+import {
+    LIGHTNING_RECEIVE_PAIR,
+    LIGHTNING_SEND_PAIR,
+    lightningReceiveContract,
+    lightningSendContract,
+    unilateralClaimDelay,
+    type RfqQuote,
+} from "../../src";
+// The v2 client is still internal to the package — `src/index.ts` exports the
+// v1 facade under the same name — so it is imported by path, as the unit suite
+// does. M8 is what slims the root export to the v2 surface.
+import { createSwapClient, type SwapClient } from "../../src/client/client";
+import { quoteIdOfSwapId } from "../../src/client/record";
+import { btcOn } from "../../src/client/assetId";
+import type { AttestingRfqTransport } from "../../src/client/transport";
+import { InMemoryAssetSwapRepository } from "../../src/repository";
+import { LIGHTNING_RAIL } from "../../src/payment/lightning";
+import { createSwapPaymentRouter } from "../../src/payment/router";
+import { encodeInvoice } from "../helpers/bolt11";
+
+const OPERATOR_URL = "http://localhost:7070";
+const ESPLORA_API_URL = "http://localhost:3000/api";
+const arkdExec = "docker exec -t arkd";
+
+const FAUCET_SATS = 30_000;
+const LOCKUP_SATS = 1_000;
+/** What the payee is paid; the stub's spread is the difference. */
+const INVOICE_SATS = 990;
+
+const xOnly = (key: Uint8Array): Uint8Array => (key.length === 32 ? key : key.slice(1));
+
+const execCommand = (command: string): string => {
+    const result = execSync(command, { encoding: "utf8" })
+        .replace(/\r/g, "")
+        .split("\n")
+        .filter((line) => !line.includes("WARN"))
+        .join("\n")
+        .trim();
+    if (result.startsWith("error:")) throw new Error(result);
+    return result;
+};
+
+const waitFor = async (
+    fn: () => Promise<boolean>,
+    { timeout = 60_000, interval = 500 } = {},
+): Promise<void> => {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+        if (await fn()) return;
+        await new Promise((r) => setTimeout(r, interval));
+    }
+    throw new Error("timeout in waitFor");
+};
+
+let wallet: Wallet;
+let emulatorPubkey: Uint8Array;
+let operatorPubkey: Uint8Array;
+let claimDelay: number;
+let hrp: string;
+
+const NOW = () => Math.floor(Date.now() / 1000);
+
+const SOLVER = schnorr.getPublicKey(new Uint8Array(32).fill(7));
+const SOLVER_PK_SCRIPT = Uint8Array.from([0x51, 0x20, ...SOLVER]);
+const PREIMAGE = new Uint8Array(32).fill(11);
+const PAYMENT_HASH = hex.encode(sha256(PREIMAGE));
+const DISCOVERY_KEY = hex.encode(schnorr.getPublicKey(new Uint8Array(32).fill(4)));
+
+/** One card, both directions: `arkade:BTC <-> lightning:BTC`. */
+const CARD: DiscoveredMarket = {
+    pair: "BTC/lightning:BTC",
+    base_asset: { id: "btc", name: "Bitcoin", ticker: "BTC", decimals: 8 },
+    quote_asset: { id: "btc", name: "Bitcoin", ticker: "BTC", decimals: 8 },
+    base_corridor: "arkade",
+    quote_corridor: "lightning",
+    fee_bps: 0,
+    min_base_amount: "100",
+    max_base_amount: "50000000",
+    min_quote_amount: "100",
+    max_quote_amount: "50000000",
+    solver: "stub",
+    source: "https://registry.example/regtest.json",
+    sourceType: "registry",
+    discovery_pubkey: DISCOVERY_KEY,
+    transports: { nostr: { relays: ["wss://relay.invalid"] } },
+} as unknown as DiscoveredMarket;
+
+const invoiceFor = (paymentHash: string, sats: number): string =>
+    encodeInvoice({
+        prefix: "lnbcrt",
+        amount: `${sats * 10}n`,
+        timestamp: NOW() - 60,
+        expiry: 7_200,
+        paymentHash,
+    });
+
+/** The invoice `pay` is quoted against. */
+const invoice = (): string => invoiceFor(PAYMENT_HASH, INVOICE_SATS);
+
+/**
+ * A solver that quotes back the maker's own derivation on both legs, and
+ * attests to the card's own key so the responder check runs for real.
+ */
+const stubTransport = (): AttestingRfqTransport => ({
+    attestedResponder: DISCOVERY_KEY,
+    async requestQuote(payload) {
+        const profile = (payload as { profile: Record<string, unknown> }).profile;
+        // Far enough out to clear both legs' headroom gates.
+        const refundLocktime = NOW() + 200 * 3600;
+        const base = {
+            v: 1 as const,
+            type: "rfq_quote" as const,
+            rfq_id: payload.rfq_id as string,
+            solver_pubkey: hex.encode(SOLVER),
+            valid_until: NOW() + 3600,
+            refund_locktime: refundLocktime,
+        };
+        if (payload.pair === LIGHTNING_RECEIVE_PAIR) {
+            const paymentHash = profile.payment_hash as string;
+            const contract = lightningReceiveContract({
+                solverPubkey: SOLVER,
+                refundLocktime,
+                operatorPubkey,
+                paymentHash,
+                claimDelay,
+                emulatorPubkey,
+                solverRefundPkScript: SOLVER_PK_SCRIPT,
+                payoutPubkey: hex.decode(profile.payout_pubkey as string),
+                payoutPkScript: ArkAddress.decode(profile.payout_address as string).pkScript,
+            });
+            return {
+                ...base,
+                pair: LIGHTNING_RECEIVE_PAIR,
+                from_amount: LOCKUP_SATS,
+                to_amount: INVOICE_SATS,
+                profile: {
+                    payment_hash: paymentHash,
+                    invoice: invoiceFor(paymentHash, LOCKUP_SATS),
+                    lockup_address: contract.address(hrp, operatorPubkey).encode(),
+                    solver_refund_pk_script: hex.encode(SOLVER_PK_SCRIPT),
+                },
+            } satisfies RfqQuote;
+        }
+        const contract = lightningSendContract({
+            solverPubkey: SOLVER,
+            refundLocktime,
+            operatorPubkey,
+            paymentHash: PAYMENT_HASH,
+            claimDelay,
+            emulatorPubkey,
+            senderPubkey: hex.decode(profile.client_refund_pubkey as string),
+            receiverPkScript: SOLVER_PK_SCRIPT,
+            refundPkScript: ArkAddress.decode(profile.refund_address as string).pkScript,
+        });
+        return {
+            ...base,
+            pair: LIGHTNING_SEND_PAIR,
+            from_amount: LOCKUP_SATS,
+            to_amount: INVOICE_SATS,
+            profile: {
+                receiver_pk_script: hex.encode(SOLVER_PK_SCRIPT),
+                lockup_address: contract.address(hrp, operatorPubkey).encode(),
+            },
+        } satisfies RfqQuote;
+    },
+    async status() {
+        return null;
+    },
+    async close() {},
+});
+
+const repository = new InMemoryAssetSwapRepository();
+
+const clientOn = (): SwapClient =>
+    createSwapClient({
+        wallet,
+        repository,
+        discovery: { snapshot: [CARD] },
+        transportFor: () => stubTransport(),
+    });
+
+beforeAll(async () => {
+    wallet = await Wallet.create({
+        identity: SingleKey.fromRandomBytes(),
+        arkServerUrl: OPERATOR_URL,
+        onchainProvider: new EsploraProvider(ESPLORA_API_URL, {
+            forcePolling: true,
+            pollingInterval: 2000,
+        }),
+        storage: {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        },
+        settlementConfig: false,
+    });
+
+    const note = execCommand(`${arkdExec} arkd note --amount 200000`);
+    execCommand(`${arkdExec} ark redeem-notes -n ${note} --password secret`);
+    const address = await wallet.getAddress();
+    execCommand(`${arkdExec} ark send --to ${address} --amount ${FAUCET_SATS} --password secret`);
+    await waitFor(async () => (await wallet.getVtxos()).length > 0);
+
+    const info = await wallet.getArkadeInfo();
+    operatorPubkey = xOnly(hex.decode(info.signerPubkey));
+    claimDelay = unilateralClaimDelay(Number(info.unilateralExitDelay));
+    hrp = ArkAddress.decode(address).hrp;
+    emulatorPubkey = xOnly(hex.decode(REGTEST_EMULATOR_PUBKEY));
+}, 180_000);
+
+describe("the verbs (regtest)", () => {
+    it("pays a bolt11 and answers with the swap it funded", async () => {
+        const client = clientOn();
+        const result = await client.pay(invoice());
+
+        expect(result.kind).toBe("swap");
+        if (result.kind !== "swap") return;
+        expect(result.swap.take.amount).toBe(BigInt(INVOICE_SATS));
+        expect(result.swap.give.amount).toBe(BigInt(LOCKUP_SATS));
+        expect(result.swap.fundingTxid).toEqual(expect.any(String));
+
+        // The record the verb never mentions is there under the bare quote id.
+        expect(await repository.getSwapRecord(quoteIdOfSwapId(result.swap.id))).toBeDefined();
+        // And the tagged id round-trips to the history read.
+        const swaps = await client.swaps();
+        expect(swaps.map((s) => s.id)).toContain(result.swap.id);
+
+        await client[Symbol.asyncDispose]();
+    }, 180_000);
+
+    it("refuses to fund a quote over the ceiling, before anything moves", async () => {
+        const client = clientOn();
+        const before = (await repository.getAllSwapRecords()).length;
+        // The stub's spread is LOCKUP_SATS - INVOICE_SATS, on the give leg.
+        const maxFee = { amount: 1n, asset: btcOn("arkade", "regtest") };
+
+        await expect(client.pay(invoice(), { maxFee })).rejects.toMatchObject({
+            name: "MaxFeeExceeded",
+            fee: BigInt(LOCKUP_SATS - INVOICE_SATS),
+            maxFee: 1n,
+        });
+        expect(await repository.getAllSwapRecords()).toHaveLength(before);
+
+        await client[Symbol.asyncDispose]();
+    }, 120_000);
+
+    it("sends a plain Arkade address through the wallet, with no swap behind it", async () => {
+        const client = clientOn();
+        const before = (await repository.getAllSwapRecords()).length;
+        const destination = await wallet.getAddress();
+
+        const result = await client.pay(destination, { amount: 500n });
+
+        expect(result.kind).toBe("payment");
+        if (result.kind !== "payment") return;
+        expect(result.txid).toMatch(/^[0-9a-f]{64}$/);
+        // Same asset, same rail, rate 1: nothing was recorded.
+        expect(await repository.getAllSwapRecords()).toHaveLength(before);
+
+        await client[Symbol.asyncDispose]();
+    }, 120_000);
+
+    it("returns a receive artifact that is already durable", async () => {
+        const client = clientOn();
+        const request = await client.receive({ amount: BigInt(INVOICE_SATS), via: "lightning" });
+
+        expect(request.artifact).toMatchObject({ kind: "invoice" });
+        expect(request.take.amount).toBe(BigInt(INVOICE_SATS));
+        // The ordering: the record and its claim secret are at rest before the
+        // invoice can reach a payer.
+        const stored = await repository.getSwapRecord(quoteIdOfSwapId(request.id));
+        expect(stored?.artifact).toMatchObject({ kind: "invoice" });
+        // A receive funds nothing — the payer paying the invoice is the accept.
+        expect(stored?.fundingTxid).toBeUndefined();
+
+        await client[Symbol.asyncDispose]();
+    }, 180_000);
+});
+
+describe("the lightning rail through a real router (regtest)", () => {
+    it("routes an invoice, funds it, and hands back a swapId swaps() knows", async () => {
+        const client = clientOn();
+        const router = createSwapPaymentRouter(wallet, client, { claimFeeRateSatVb: 2 });
+
+        const quote = await router.route({ raw: invoice() });
+        expect(quote.railId).toBe(LIGHTNING_RAIL);
+        // Receiver-exact: the payee is paid the invoice and the spread is on top.
+        expect(quote.amount).toBe(INVOICE_SATS);
+        expect(quote.total).toBe(quote.amount + quote.fee);
+
+        const handle = await quote.send();
+        const seen: { status: string; swapId?: string }[] = [];
+        handle.subscribe((u) => seen.push({ status: u.status, ...(u.result ?? {}) }));
+
+        // The lockup is funded and the drive adopts it. Nothing fills it, so
+        // `"sent"` is where this stops — which is exactly what `funded` means.
+        await waitFor(async () => seen.some((u) => u.status === "sent"));
+
+        // The clause only a rail carries: the handle's own result id is the
+        // tagged form, and it names a swap the client's history read holds as
+        // funded — the two views joined on one identity.
+        const swapId = seen.find((u) => u.status === "sent")?.swapId;
+        expect(swapId).toMatch(/^rfq:/);
+        const swaps = await client.swaps();
+        expect(swaps.find((s) => s.id === swapId)?.outcome).toBe("funded");
+
+        await client[Symbol.asyncDispose]();
+    }, 240_000);
+});

--- a/packages/swap/test/onchainHtlc.test.ts
+++ b/packages/swap/test/onchainHtlc.test.ts
@@ -16,6 +16,7 @@ import * as btc from "@scure/btc-signer";
 import {
     LOCKTIME_THRESHOLD,
     ONCHAIN_CLAIM_MARGIN_SECONDS,
+    ONCHAIN_CLAIM_VSIZE,
     awaitOnchainFill,
     buildHtlcClaim,
     buildHtlcRefund,
@@ -185,6 +186,22 @@ describe("buildHtlcClaim", () => {
 
         // The published preimage is recoverable — the receipt.
         expect(hex.encode(extractPreimage(spend.txHex, PAYMENT_HASH)!)).toBe(hex.encode(PREIMAGE));
+    });
+
+    it("costs what ONCHAIN_CLAIM_VSIZE prices it at, on the widest standard payout", async () => {
+        // The rail quotes this fee before the claim exists, so the constant and
+        // the builder have to move together. `PAYOUT` is P2TR — the largest
+        // standard output script, and the one the constant is sized against, so
+        // a rail's estimate never under-charges the recipient's payout.
+        const spend = await buildHtlcClaim({
+            htlc: htlc(),
+            utxo: UTXO,
+            preimage: PREIMAGE,
+            payoutPkScript: PAYOUT,
+            feeRateSatVb: 1,
+            sign: signWith(1),
+        });
+        expect(UTXO.amount - spend.payoutAmount).toBe(BigInt(ONCHAIN_CLAIM_VSIZE));
     });
 
     it("refuses a preimage that does not match the HTLC", async () => {

--- a/packages/swap/test/payment/status.test.ts
+++ b/packages/swap/test/payment/status.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The fourteen-to-four projection, and the two things it must not lose.
+ *
+ * Totality is asserted against the outcome vocabulary itself rather than
+ * against a list retyped here — a member added upstream has to fail something,
+ * and a second hand-written list is a second thing to forget.
+ */
+import { describe, expect, it } from "vitest";
+import { ACTIVITY_TOKEN, type Outcome } from "../../src/client/outcome";
+import { PAYMENT_STATUS, isTerminalStatus, paymentStatusOf } from "../../src/payment/status";
+import { SwapPaymentFailedError } from "../../src/payment/swapRail";
+import type { Swap } from "../../src/client/record";
+
+/** Every `Outcome`, read off the one other total map over the same union. */
+const OUTCOMES = Object.keys(ACTIVITY_TOKEN) as Outcome[];
+
+const swap = (over: Partial<Swap> = {}): Swap => ({ id: "rfq:q1", family: "rfq", ...over }) as Swap;
+
+describe("Outcome -> PaymentStatus", () => {
+    it("maps all fourteen members, and no more", () => {
+        expect(OUTCOMES).toHaveLength(14);
+        expect(Object.keys(PAYMENT_STATUS).sort()).toEqual([...OUTCOMES].sort());
+        for (const outcome of OUTCOMES) {
+            expect(paymentStatusOf(outcome), outcome).toMatch(/^(pending|sent|settled|failed)$/);
+        }
+    });
+
+    it("puts the funded lockup on the status nothing in core has emitted since #811", () => {
+        expect(paymentStatusOf("funded")).toBe("sent");
+        expect(OUTCOMES.filter((o) => PAYMENT_STATUS[o] === "sent")).toEqual(["funded"]);
+    });
+
+    it("settles only on a completed leg", () => {
+        expect(OUTCOMES.filter((o) => PAYMENT_STATUS[o] === "settled").sort()).toEqual([
+            "claimed",
+            "filled",
+            "paid",
+        ]);
+    });
+
+    it("goes terminal at refunding, not at refunded", () => {
+        // Holding terminality back until the refund resolves would hang every
+        // `settled({ timeoutMs })` caller for a whole refund window — and the
+        // handle could not hear the `refunded` anyway, since a terminal update
+        // clears core's subscriber set.
+        expect(isTerminalStatus(paymentStatusOf("refunding"))).toBe(true);
+        expect(paymentStatusOf("refunding")).toBe("failed");
+    });
+
+    it("never silently retries a swap that needs recovery", () => {
+        expect(paymentStatusOf("needs_recovery")).toBe("failed");
+    });
+
+    it("keeps refunded and lapsed distinguishable on the error, having merged them", () => {
+        // P6's whole point: value returned, versus an incoming payment that
+        // never arrived. The projection loses it; the `error` carries it.
+        expect(paymentStatusOf("refunded")).toBe("failed");
+        expect(paymentStatusOf("lapsed")).toBe("failed");
+
+        const refunded = new SwapPaymentFailedError("onchain-swap", "refunded", swap());
+        const lapsed = new SwapPaymentFailedError("onchain-swap", "lapsed", swap());
+        expect(refunded.outcome).not.toBe(lapsed.outcome);
+        expect(refunded.message).toContain("refunded");
+        expect(lapsed.message).toContain("lapsed");
+    });
+
+    it("carries the record's own reason onto the failure, when there is one", () => {
+        const blocked = new SwapPaymentFailedError(
+            "lightning",
+            "needs_recovery",
+            swap({ blockedReason: "no claim callback" }),
+        );
+        expect(blocked.message).toContain("no claim callback");
+        expect(blocked.name.endsWith("Error")).toBe(true);
+    });
+});

--- a/packages/swap/test/payment/swapRails.test.ts
+++ b/packages/swap/test/payment/swapRails.test.ts
@@ -1,0 +1,385 @@
+/**
+ * The two v2 swap rails: conformance, ranking, and the handle's contract.
+ *
+ * The client behind them is a double. What is under test here is the adapter —
+ * what `match` classifies, when `available()` drops the rail, that `quote()` is
+ * the first place an amount is refused, that the three numbers are
+ * receiver-exact, and what a handle observes and stops observing. The swap
+ * machinery those calls stand for is pinned by `test/client/`.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { PaymentRouter, arkRail, onchainRail, type PaymentHandle } from "@arkade-os/sdk";
+import { ArkAddress } from "@arkade-os/sdk";
+import { UnsupportedRoute } from "../../src/client/errors";
+import type { Outcome, SwapUpdate, Unsubscribe } from "../../src/client/outcome";
+import type { Quote, QuoteInput, RouteResolution } from "../../src/client/quote";
+import type { Swap } from "../../src/client/record";
+import { LIGHTNING_RAIL, lightningRail } from "../../src/payment/lightning";
+import { ONCHAIN_SWAP_RAIL, claimFeeSats, onchainSwapRail } from "../../src/payment/onchainSwap";
+import { SWAP_ROUTER_PRIORITY, createSwapPaymentRouter } from "../../src/payment/router";
+import { SwapPaymentFailedError, type SwapRailClient } from "../../src/payment/swapRail";
+import { ONCHAIN_CLAIM_VSIZE } from "../../src/onchainHtlc";
+import {
+    NETWORK,
+    OPERATOR_PUBKEY,
+    PAYMENT_HASH,
+    clockAt,
+    invoiceFor,
+    key,
+} from "../client/fixtures";
+
+const NOW = 1_700_000_000;
+const CLOCK = clockAt(NOW);
+const BCRT1 = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+const INVOICE = invoiceFor(PAYMENT_HASH, CLOCK);
+const ARK_ADDRESS = new ArkAddress(OPERATOR_PUBKEY, key(21), NETWORK.hrp).encode();
+
+/** 1 sat/vB, so the claim estimate is the vsize itself. */
+const CLAIM_RATE = 1;
+const CLAIM_FEE = claimFeeSats({ claimFeeRateSatVb: CLAIM_RATE });
+
+const ARKADE_BTC = "arkade:regtest/slip44:0" as const;
+const BOLT11_BTC = "bolt11:regtest/slip44:0" as const;
+const BITCOIN_BTC = "bitcoin:regtest/slip44:0" as const;
+
+const quoteFor = (give: bigint, take: bigint, takeAsset: string): Quote =>
+    ({
+        id: "q1",
+        route: {} as Quote["route"],
+        give: { asset: ARKADE_BTC, amount: give },
+        take: { asset: takeAsset, amount: take },
+        fee: { asset: ARKADE_BTC, amount: give - take },
+        market: { kind: "card", key: "arkade:BTC/lightning:BTC" },
+        expiresAt: NOW + 600,
+    }) as unknown as Quote;
+
+const swapFor = (over: Partial<Swap> = {}): Swap =>
+    ({ id: "rfq:q1", family: "rfq", outcome: "accepted", ...over }) as Swap;
+
+interface Double extends SwapRailClient {
+    /** Push an outcome onto every subscriber, as the drive's `emit` would. */
+    emit(outcome: Outcome, swap?: Partial<Swap>): void;
+    inputs(): QuoteInput[];
+    listeners(): number;
+}
+
+const double = (
+    over: Partial<SwapRailClient> & { eligible?: number; quoted?: Quote } = {},
+): Double => {
+    const inputs: QuoteInput[] = [];
+    const subscribers = new Set<(u: SwapUpdate) => void>();
+    let replay: SwapUpdate | undefined;
+    const client: Double = {
+        resolve: async (input) => {
+            inputs.push(input);
+            return { eligible: over.eligible ?? 1 } as RouteResolution;
+        },
+        quote: async (input) => {
+            inputs.push(input);
+            return over.quoted ?? quoteFor(5_050n, 5_000n, BOLT11_BTC);
+        },
+        accept: async () => swapFor(),
+        onUpdate: (fn): Unsubscribe => {
+            subscribers.add(fn);
+            if (replay) fn(replay);
+            return () => subscribers.delete(fn);
+        },
+        emit: (outcome, swap = {}) => {
+            const update = {
+                swap: swapFor({ outcome, ...swap }),
+                outcome,
+                detail: { family: "rfq" },
+            } as SwapUpdate;
+            replay = update;
+            for (const fn of [...subscribers]) fn(update);
+        },
+        inputs: () => inputs,
+        listeners: () => subscribers.size,
+        ...over,
+    };
+    return client;
+};
+
+/** A wallet stub: `options()` never quotes, so no rail dereferences it. */
+const ctxWallet = {} as never;
+
+describe("rail conformance", () => {
+    it("classifies amount-blind and without throwing", () => {
+        const ln = lightningRail(double());
+        const l1 = onchainSwapRail(double(), { claimFeeRateSatVb: CLAIM_RATE });
+        const ctx = { wallet: ctxWallet, prefs: {} };
+        for (const [rail, mine, theirs] of [
+            [ln, INVOICE, BCRT1],
+            [l1, BCRT1, INVOICE],
+        ] as const) {
+            expect(rail.match({ raw: mine }, ctx)).toBe(true);
+            expect(rail.match({ raw: mine, amount: 1 }, ctx)).toBe(true);
+            expect(rail.match({ raw: theirs }, ctx)).toBe(false);
+            expect(rail.match({ raw: ARK_ADDRESS }, ctx)).toBe(false);
+            expect(() => rail.match({ raw: "nonsense" }, ctx)).not.toThrow();
+        }
+    });
+
+    it("reads both rails' targets out of a unified BIP21 URI", () => {
+        const ctx = { wallet: ctxWallet, prefs: {} };
+        const uri = `bitcoin:${BCRT1}?lightning=${INVOICE}`;
+        expect(lightningRail(double()).match({ raw: uri }, ctx)).toBe(true);
+        expect(
+            onchainSwapRail(double(), { claimFeeRateSatVb: CLAIM_RATE }).match({ raw: uri }, ctx),
+        ).toBe(true);
+    });
+
+    it("never quotes to answer available()", async () => {
+        const client = double();
+        const quote = vi.spyOn(client, "quote");
+        const ctx = { wallet: ctxWallet, prefs: {} };
+        await lightningRail(client).available?.({ raw: INVOICE }, ctx);
+        await onchainSwapRail(client, { claimFeeRateSatVb: CLAIM_RATE }).available?.(
+            { raw: BCRT1, amount: 10_000 },
+            ctx,
+        );
+        expect(quote).not.toHaveBeenCalled();
+    });
+
+    it("drops itself when no market serves the route, and reports the fault otherwise", async () => {
+        const ctx = { wallet: ctxWallet, prefs: {} };
+        const none = lightningRail(double({ eligible: 0 }));
+        expect(await none.available?.({ raw: INVOICE }, ctx)).toBe(false);
+
+        // An unroutable destination is a classification, not a fault.
+        const refused = lightningRail(
+            double({
+                resolve: async () => {
+                    throw new UnsupportedRoute("nothing serves it");
+                },
+            }),
+        );
+        expect(await refused.available?.({ raw: INVOICE }, ctx)).toBe(false);
+
+        // Anything else propagates: the router warns and drops the rail, which
+        // is louder than swallowing it here.
+        const broken = lightningRail(
+            double({
+                resolve: async () => {
+                    throw new Error("registry unreachable");
+                },
+            }),
+        );
+        await expect(broken.available?.({ raw: INVOICE }, ctx)).rejects.toThrow(/unreachable/);
+    });
+
+    it("defers an amountless onchain request to quote(), where the refusal belongs", async () => {
+        const rail = onchainSwapRail(double(), { claimFeeRateSatVb: CLAIM_RATE });
+        const ctx = { wallet: ctxWallet, prefs: {} };
+        expect(await rail.available?.({ raw: BCRT1 }, ctx)).toBe(false);
+        await expect(rail.quote({ raw: BCRT1 }, ctx)).rejects.toThrow(/amount is required/);
+    });
+
+    it("refuses to build an onchain rail with no claim fee rate", () => {
+        for (const rate of [0, -1, Number.NaN]) {
+            expect(() => onchainSwapRail(double(), { claimFeeRateSatVb: rate })).toThrow(
+                /claimFeeRateSatVb must be positive/,
+            );
+        }
+    });
+});
+
+describe("the quote a rail hands the router", () => {
+    const ctx = { wallet: ctxWallet, prefs: {} };
+
+    it("is receiver-exact on lightning: the payee is paid the invoice", async () => {
+        const client = double();
+        const quote = await lightningRail(client).quote({ raw: INVOICE }, ctx);
+        expect(quote.railId).toBe(LIGHTNING_RAIL);
+        expect(quote.amount).toBe(5_000);
+        expect(quote.fee).toBe(50);
+        expect(quote.total).toBe(quote.amount + quote.fee);
+        // The invoice is the pin; the rail adds none of its own.
+        expect(client.inputs().at(-1)).toEqual({ to: INVOICE });
+    });
+
+    it("grosses the onchain swap up by the claim fee, and reports it inside fee", async () => {
+        // The trader claims the solver's L1 HTLC itself and the claim's fee
+        // comes out of that output, so a rail quoting the spread alone would
+        // beat the collaborative exit on a fee it does not charge.
+        const target = 98_848n;
+        const client = double({ quoted: quoteFor(100_000n, target + CLAIM_FEE, BITCOIN_BTC) });
+        const rail = onchainSwapRail(client, { claimFeeRateSatVb: CLAIM_RATE });
+        const quote = await rail.quote({ raw: BCRT1, amount: Number(target) }, ctx);
+
+        expect(client.inputs().at(-1)).toEqual({
+            to: BCRT1,
+            amount: target + CLAIM_FEE,
+            amountOn: "take",
+        });
+        expect(quote.amount).toBe(Number(target));
+        expect(quote.fee).toBe(Number(1_152n));
+        expect(quote.total).toBe(100_000);
+        expect(quote.total).toBe(quote.amount + quote.fee);
+        expect(quote.meta?.claimFeeSats).toBe(Number(CLAIM_FEE));
+        expect(quote.meta?.htlcAmountSats).toBe(Number(target + CLAIM_FEE));
+    });
+
+    it("prices the claim off the measured vsize", () => {
+        expect(claimFeeSats({ claimFeeRateSatVb: 10 })).toBe(BigInt(ONCHAIN_CLAIM_VSIZE * 10));
+        expect(claimFeeSats({ claimFeeRateSatVb: 1.5, claimVsize: 100 })).toBe(150n);
+    });
+
+    it("refuses a quote whose legs are not receiver-exact rather than shipping the number", async () => {
+        // `total !== amount + fee` means M3's own invariant broke; a rail that
+        // passed it through would rank on a fee nobody charges.
+        const bent = quoteFor(5_050n, 5_000n, BOLT11_BTC);
+        const client = double({ quoted: { ...bent, fee: { asset: ARKADE_BTC, amount: 10n } } });
+        await expect(lightningRail(client).quote({ raw: INVOICE }, ctx)).rejects.toThrow(
+            /not receiver-exact/,
+        );
+    });
+
+    it("surfaces the quote's deadline, which a RouteQuote has nowhere else to carry", async () => {
+        const quote = await lightningRail(double()).quote({ raw: INVOICE }, ctx);
+        expect(quote.meta?.expiresAt).toBe(NOW + 600);
+    });
+});
+
+describe("ranking against core's rails", () => {
+    const router = (client: SwapRailClient): PaymentRouter =>
+        new PaymentRouter({ wallet: ctxWallet, prefs: { priority: [...SWAP_ROUTER_PRIORITY] } })
+            .use(arkRail())
+            .use(onchainRail())
+            .use(lightningRail(client))
+            .use(onchainSwapRail(client, { claimFeeRateSatVb: CLAIM_RATE }));
+
+    it("prefers the swap over the collaborative exit, and still lists the exit", async () => {
+        const options = await router(double()).options({ raw: BCRT1, amount: 100_000 });
+        expect(options.map((o) => o.railId)).toEqual([ONCHAIN_SWAP_RAIL, "onchain"]);
+    });
+
+    it("self-heals by amount: the swap rail drops and onchain wins with no error", async () => {
+        const options = await router(double({ eligible: 0 })).options({
+            raw: BCRT1,
+            amount: 100_000_000_000,
+        });
+        expect(options.map((o) => o.railId)).toEqual(["onchain"]);
+    });
+
+    it("leaves a plain Arkade address to core's ark rail alone", async () => {
+        const options = await router(double()).options({ raw: ARK_ADDRESS, amount: 1_000 });
+        expect(options.map((o) => o.railId)).toEqual(["ark"]);
+    });
+
+    it("registers the four rails the deleted factory registered, in its order", async () => {
+        const built = createSwapPaymentRouter(ctxWallet, double(), {
+            claimFeeRateSatVb: CLAIM_RATE,
+        });
+        const uri = `bitcoin:${BCRT1}?ark=${ARK_ADDRESS}&lightning=${INVOICE}&amount=0.001`;
+        const options = await built.options({ raw: uri });
+        expect(options.map((o) => o.railId)).toEqual([...SWAP_ROUTER_PRIORITY]);
+    });
+});
+
+describe("the handle a send returns", () => {
+    const ctx = { wallet: ctxWallet, prefs: {} };
+    const settled = (handle: PaymentHandle): Promise<unknown> =>
+        handle.settled().then(
+            (r) => ({ ok: r }),
+            (e) => ({ error: e }),
+        );
+
+    const send = async (client: Double): Promise<PaymentHandle> => {
+        const quote = await lightningRail(client).quote({ raw: INVOICE }, ctx);
+        return quote.send();
+    };
+
+    it("streams the projection and resolves on the terminal outcome", async () => {
+        const client = double();
+        const handle = await send(client);
+        const seen: string[] = [];
+        handle.subscribe((u) => seen.push(u.status));
+
+        client.emit("funded", { fundingTxid: "f".repeat(64) });
+        client.emit("paid", { fundingTxid: "f".repeat(64) });
+
+        const result = await handle.settled();
+        expect(seen).toEqual(["pending", "sent", "settled"]);
+        expect(result.railId).toBe(LIGHTNING_RAIL);
+        // The tagged public id M6 minted, so it round-trips to `swaps()`.
+        expect(result.swapId).toBe("rfq:q1");
+        expect(result.txid).toBe("f".repeat(64));
+    });
+
+    it("fails with the outcome on the error, and drops its subscription", async () => {
+        const client = double();
+        const handle = await send(client);
+        client.emit("funded");
+        client.emit("refunding");
+
+        const outcome = (await settled(handle)) as { error: SwapPaymentFailedError };
+        expect(outcome.error).toBeInstanceOf(SwapPaymentFailedError);
+        expect(outcome.error.outcome).toBe("refunding");
+        expect(client.listeners()).toBe(0);
+    });
+
+    it("goes terminal at refunding and never hears the refunded that follows", async () => {
+        const client = double();
+        const handle = await send(client);
+        client.emit("refunding");
+        await settled(handle);
+
+        const after: string[] = [];
+        handle.subscribe((u) => after.push(u.status));
+        // The refund resolving is real and observable — on `client.onUpdate`,
+        // keyed by the tagged swap id, which is where `swaps()` reads it too.
+        const onClient: Outcome[] = [];
+        client.onUpdate((u) => onClient.push(u.outcome));
+        client.emit("refunded");
+
+        // A late subscriber gets the replay of the terminal update and nothing
+        // after it; the client's own stream carries the rest.
+        expect(after).toEqual(["failed"]);
+        expect(onClient).toEqual(["refunding", "refunded"]);
+    });
+
+    it("delivers the unblock backslide on the client, after the handle went terminal", async () => {
+        // `needs_recovery -> funded` crosses the terminality boundary the rail
+        // drew. It is emitted rather than swallowed — the drive's idempotence
+        // key is the derived outcome, so the second `funded` is a new key — and
+        // it reaches `onUpdate`, never the handle.
+        const client = double();
+        const handle = await send(client);
+        client.emit("funded");
+        client.emit("needs_recovery");
+        const failure = (await settled(handle)) as { error: SwapPaymentFailedError };
+        expect(failure.error.outcome).toBe("needs_recovery");
+
+        const seen: Array<[Outcome, string | undefined]> = [];
+        client.onUpdate((u) => seen.push([u.outcome, u.swap.id]));
+        client.emit("funded");
+        client.emit("claimed");
+
+        expect(seen).toEqual([
+            ["needs_recovery", "rfq:q1"],
+            ["funded", "rfq:q1"],
+            ["claimed", "rfq:q1"],
+        ]);
+        expect(handle.status).toBe("failed");
+    });
+
+    it("resolves a swap that was already terminal when the handle subscribed", async () => {
+        // The replay runs inside `onUpdate`, so the terminal listener fires
+        // before there is an unsubscribe to call.
+        const client = double();
+        client.emit("paid");
+        const handle = await send(client);
+        await expect(handle.settled()).resolves.toMatchObject({ railId: LIGHTNING_RAIL });
+        expect(client.listeners()).toBe(0);
+    });
+
+    it("ignores another swap's updates", async () => {
+        const client = double();
+        const handle = await send(client);
+        const seen: string[] = [];
+        handle.subscribe((u) => seen.push(u.status));
+        client.emit("paid", { id: "rfq:other" });
+        expect(seen).toEqual(["pending"]);
+    });
+});

--- a/packages/swap/test/payment/swapRails.test.ts
+++ b/packages/swap/test/payment/swapRails.test.ts
@@ -220,6 +220,31 @@ describe("the quote a rail hands the router", () => {
         expect(quote.meta?.htlcAmountSats).toBe(Number(target + CLAIM_FEE));
     });
 
+    it("refuses a payout the claim could not build, before a lockup exists", async () => {
+        // 200 sat asked for is 200 sat left after the gross-up — under the L1
+        // dust limit, so `buildHtlcClaim` would refuse. It refuses at claim
+        // time, with the lockup funded; the rail refuses here, with nothing
+        // committed.
+        const target = 200n;
+        const client = double({ quoted: quoteFor(1_000n, target + CLAIM_FEE, BITCOIN_BTC) });
+        const rail = onchainSwapRail(client, { claimFeeRateSatVb: CLAIM_RATE });
+        await expect(rail.quote({ raw: BCRT1, amount: Number(target) }, ctx)).rejects.toThrow(
+            /leaves 200 sat after the 152 sat claim fee, under the 330 sat dust limit/,
+        );
+    });
+
+    it("names the cause when a take leg does not even cover the claim", async () => {
+        // The degenerate end of the same check. `receiverExact`'s invariant
+        // holds here — the claim-fee terms cancel — so without the guard this
+        // reaches `satsOf` and surfaces as a complaint about a safe-integer
+        // window, which says nothing about a solver under-delivering.
+        const client = double({ quoted: quoteFor(1_000n, 100n, BITCOIN_BTC) });
+        const rail = onchainSwapRail(client, { claimFeeRateSatVb: CLAIM_RATE });
+        await expect(rail.quote({ raw: BCRT1, amount: 10_000 }, ctx)).rejects.toThrow(
+            /take leg of 100 sat leaves -52 sat after the 152 sat claim fee/,
+        );
+    });
+
     it("prices the claim off the measured vsize", () => {
         expect(claimFeeSats({ claimFeeRateSatVb: 10 })).toBe(BigInt(ONCHAIN_CLAIM_VSIZE * 10));
         expect(claimFeeSats({ claimFeeRateSatVb: 1.5, claimVsize: 100 })).toBe(150n);
@@ -260,6 +285,17 @@ describe("ranking against core's rails", () => {
             amount: 100_000_000_000,
         });
         expect(options.map((o) => o.railId)).toEqual(["onchain"]);
+    });
+
+    it("self-heals by dust too: a payout the claim would eat drops the rail", async () => {
+        // Not a market bound — the solver would quote this happily — but a
+        // payout under the dust limit, which the trader's own claim could not
+        // build. The exit takes it, with no error and no quote round trip.
+        const client = double();
+        const quote = vi.spyOn(client, "quote");
+        const options = await router(client).options({ raw: BCRT1, amount: 300 });
+        expect(options.map((o) => o.railId)).toEqual(["onchain"]);
+        expect(quote).not.toHaveBeenCalled();
     });
 
     it("leaves a plain Arkade address to core's ark rail alone", async () => {

--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@arkade-os/sdk",
-    "version": "0.5.0-rc.0",
+    "version": "0.5.0-rc.1",
     "description": "TypeScript SDK for building Bitcoin wallets using the Arkade protocol",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Implements **M7 — Swap verbs** of the swap-sdk-v2 track. Stacked on #842 (M6); retarget to `feat/v0.5` when that merges.

`pay`, `receive` and `exchange` on the v2 client, plus the two rails that put lightning and `arkade -> onchain` back into a payment app's reach. M7 adds no capability — everything the verbs call was built in M3–M6. What it adds is the fee ceiling; what it subtracts is vocabulary.

## The verbs

Each compiles a `QuoteInput`, calls `quote`, checks `quote.fee` against a ceiling, and calls `accept`.

```ts
await client.pay(bolt11)                                  // -> { kind: "swap", swap }
await client.pay(bc1Address, { amount, maxFee })          // -> { kind: "swap", swap }
await client.pay(arkAddress, { amount })                  // -> { kind: "payment", txid }
const r = await client.receive({ amount, via: "lightning" })   // r.artifact is non-optional
await client.exchange({ give: "BTC", take: "USD", amount, amountOn: "give" })
```

`pay` to a plain Arkade address **delegates** rather than rejecting: it classifies with core's own `arkTarget`, resolves the amount under core's own law, and settles through `wallet.send`. Rejecting it as `UnsupportedRoute` is cheaper here and dearer everywhere else — every product with one pay box would carry the branch. That is what widens the return to a union whose non-swap arm carries a txid and no swap id; manufacturing a `Swap` for same-asset, same-rail, rate-1 would be a swap record for something nothing swapped.

`receive` returns only after `accept()` has persisted, and its `ReceiveRequest = Swap & { artifact: Artifact }` is where that guarantee gets stated: you cannot show a payer an invoice whose claim secret is still in memory.

## The ceiling

`maxFee` is `{ amount: bigint; asset: AssetId }` on every verb and on the new `SwapPolicy.maxFee`, and the effective ceiling is the **minimum** of the two — a policy ceiling a call can raise is decorative. A bare `bigint` is refused as under-specified: the fee sits on the give leg on corridors and the take leg on asset swaps, so one number names no asset. `MaxFeeExceeded` is thrown between `quote` and `accept`, carrying the terms (`quoteId`, `asset`, `fee`, `maxFee`) and nothing funded.

## The rails

`lightningRail(client)` and `onchainSwapRail(client, { claimFeeRateSatVb })`, plus `createSwapPaymentRouter(wallet, client, config)` — the shape #811 deleted with `packages/boltz-swap`, rebuilt on the v2 client. The rails close over their own deps rather than re-opening `RouterContext`, so **nothing under `packages/ts-sdk/src/payment/` is edited**; they write M6's tagged `AssetSwapId` into a field core still declares `string`.

`available()` never quotes — it resolves, which is network-free — because a swap rail's `quote()` is an RFQ round trip that discloses an invoice and an amount, and an app that ranks then quotes several options would disclose to every solver.

`onchainSwapRail` **grosses the take leg up** by the claim fee. On `arkade -> onchain` the trader claims the solver's L1 HTLC itself and that claim's fee comes out of the payout, so a rail quoting the solver's spread alone would beat the collaborative exit on a fee it does not charge — and would under-deliver, which core's receiver-exact contract forbids. It asks the solver for `amount + claimFee` and reports the estimate inside `fee`, keeping `total === amount + fee`.

## The projection

Fourteen `Outcome` members onto four `PaymentStatus` literals, declared total — a partial map is where the collapse hides. It is lossy by design and the loss is recoverable: `refunded` and `lapsed` both land on `failed`, and the difference survives on the update's `error` as `SwapPaymentFailedError.outcome`. The rail goes terminal at `refunding`, not `refunded`, because holding terminality back would hang every `settled({ timeoutMs })` caller for a whole refund window. A handle observes a payment up to its first terminal outcome; every recovery past that — the `needs_recovery -> funded` backslide included — is observed on `client.onUpdate`, keyed by the tagged swap id that round-trips to `swaps()`.

## One stale premise, corrected

The plan claimed a grep for `PaymentRail|PaymentRouter|RouterContext` over `packages/swap` returns nothing. It was pinned at `a16d93b2`, which predates #837 (`fa3a2d1f`): `solver-lightning` and `solver-onchain` already ship from the root barrel — the same two corridors on the **v1 RFQ path**. M7's rails land beside them rather than replacing them. They are one generation apart, not two designs: the v1 rails take `discover`/`connect`/`persist`/`awaitSettlement`/`payoutPubkey`/`l1Network` from the app and own no persistence, drive, recovery or outcome vocabulary, where the v2 rails take one `SwapClient`. Retiring the `solver-*` pair is M8's — removing published root exports inside the milestone that ships no deprecations would be a breaking edit in the wrong place.

## Verification

- 49 new unit tests; swap suite **1280 passing** (from 1231).
- `pnpm --filter @arkade-os/sdk exec vitest run test/payment` green **unedited** — nothing under `packages/ts-sdk/` is touched.
- Full workspace `test:unit` green (ts-sdk 2977, swap 1280); build, lint and both typechecks clean.
- M6's `pending: "M7"` coverage marker is retired, leaving `InconsistentRoute` the one declared-inert member.
- `ONCHAIN_CLAIM_VSIZE` (152) is pinned against a real sizing pass in `onchainHtlc.test.ts`.

**Not run:** `test/e2e/verbs.test.ts` ships unrun. It needs the seconds-typed `swap-rfq` regtest profile; the checked-in `.env.regtest` is block-denominated, so `unilateralClaimDelay` refuses the stack's 20-block exit delay.

https://claude.ai/code/session_01NNWu98iCogpRogwMgrkyS1
