### PR TITLE
feat(swap): publish the v2 client from a ./client subpath

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -17,6 +17,10 @@ the package-level developer UX note for the new client surface as it lands; the
 current README still documents the existing package exports and protocol
 building blocks.
 
+The v2 client (`createSwapClient`, `pay`/`receive`/`exchange`, the `SwapError`
+taxonomy) is published from `@arkade-os/swap/client`; the root's
+`createSwapClient` is still the v1 facade until M8 moves the v2 client to the root.
+
 **The covenant-deriving entry points need a wallet and nothing else.** `createOffer`,
 `requestLightningSend`, `requestLightningReceive`, `requestOnchainSend` and
 `requestOnchainReceive` take their server facts from `wallet.getArkadeInfo()`: the network and

--- a/packages/swap/V2_API.md
+++ b/packages/swap/V2_API.md
@@ -9,27 +9,26 @@ introduces the API they describe, or be marked as future shape.
 
 ## Status
 
-The current branch has the v2 type foundation and corridor modules. The v2
-client surface is still internal under `src/client`; it is not exported from the
-package root yet. The root export continues to expose the existing offer, RFQ,
-restore, watch and manager building blocks until the deprecation milestone moves
-the protocol helpers behind their final boundary.
+The v2 client surface has landed through M7 and is published from the
+`@arkade-os/swap/client` subpath. The root export continues to expose the
+existing offer, RFQ, restore, watch and manager building blocks — including the
+v1 `createSwapClient` facade — until the deprecation milestone moves the v2
+client onto the root name and the protocol helpers behind their final boundary.
 
-Current contributor imports look like this:
+Current imports look like this:
 
 ```ts
-import { Amount, canonicalAssetId } from "./src/client";
-import { corridorSet, resolveCorridorBase } from "./src/client/corridors";
+import { createSwapClient } from "@arkade-os/swap/client";
+import { Amount, canonicalAssetId } from "@arkade-os/swap/client";
 ```
-
-Future application imports should come from `@arkade-os/swap` once the client
-surface is published.
 
 ## The Shape
 
 A v2 swap starts with a route request:
 
 ```ts
+const client = createSwapClient({ wallet, repository });
+
 const quote = await client.quote({
     give: "arkade:bitcoin/slip44:0",
     take: "bolt11:bitcoin/slip44:0",
@@ -39,8 +38,16 @@ const quote = await client.quote({
 const outcome = await client.accept(quote);
 ```
 
-That is the target shape. The current branch provides the pieces that make the
-route safe before quote and accept are wired:
+`quote` is network-free terms and persists nothing; `accept` writes the record
+before funding. Most applications skip both and use a verb — `pay`, `receive`
+or `exchange` — which run `quote` → fee ceiling → `accept` as one call:
+
+```ts
+const result = await client.pay(destination, { amount: 50_000n });
+```
+
+That is the target shape, and it is wired. The pieces below are what make the
+route safe before and inside it:
 
 - asset ids are parsed and checked before they reach discovery or RFQ;
 - display amounts become `bigint` atomic units before records or wire payloads;
@@ -150,7 +157,10 @@ const claim = corridors.claim(to);
 true })` read and derives the network and signer set from it. A stale snapshot
 is not used for covenant derivation.
 
-`corridors.claim(to)` returns:
+`corridors.claim(to)` returns `ClaimedDestination | undefined`: `undefined`
+when core classifies the string but no corridor serves it — an LNURL today —
+which becomes `UnsupportedRoute` at route resolution rather than a parse
+failure here. Otherwise it returns:
 
 ```ts
 type ClaimedDestination = {
@@ -181,8 +191,8 @@ disabled" and is refused only when that corridor is actually used.
 
 ## Persistence and Outcomes
 
-Quote, accept and outcome driving are later milestones. The rules this document
-will keep carrying forward are:
+Quote, accept and outcome driving have landed. The rules this document keeps
+carrying forward are:
 
 - persist before funding;
 - funding is acceptance;
@@ -190,3 +200,10 @@ will keep carrying forward are:
 - everything after funding is an outcome, not a thrown setup error;
 - the wallet is the source of Arkade server identity, network and signing
   policy.
+
+Past funding, the client owns the lifecycle: `cancel` takes back an unfilled
+offer's deposit (a fill winning the race reconciles to `filled`, never throws),
+`swaps` reads the client's history in the drive's outcome vocabulary, and
+`onUpdate` streams every transition — including `needs_recovery`, which
+`recover` drives. Construction stays inert; the first `await client.ready`
+runs the restore read and arms the drive where there is live work.

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -31,6 +31,16 @@
                 "default": "./dist/nostr.cjs"
             }
         },
+        "./client": {
+            "import": {
+                "types": "./dist/client/index.d.ts",
+                "default": "./dist/client/index.js"
+            },
+            "require": {
+                "types": "./dist/client/index.d.ts",
+                "default": "./dist/client/index.cjs"
+            }
+        },
         "./node": {
             "import": {
                 "types": "./dist/node/index.d.ts",
@@ -67,7 +77,7 @@
     ],
     "scripts": {
         "build": "pnpm run build:web && pnpm run build:node",
-        "build:web": "tsup src/index.ts src/nostr.ts src/repositories/sqlite/index.ts src/repositories/realm/index.ts --format esm,cjs --dts --clean",
+        "build:web": "tsup src/index.ts src/nostr.ts src/client/index.ts src/repositories/sqlite/index.ts src/repositories/realm/index.ts --format esm,cjs --dts --clean",
         "build:node": "tsup --config tsup.node.config.ts",
         "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
         "format": "biome format --write src test",

--- a/packages/swap/scripts/smoke-dist.mjs
+++ b/packages/swap/scripts/smoke-dist.mjs
@@ -65,6 +65,27 @@ for (const specifier of specifiers) {
     }
 }
 
+// Named-symbol coverage: the walk above only proves each subpath resolves
+// non-empty. A barrel that drops a name resolves fine and breaks the consumer's
+// first import instead of the release, so pin the names this package exists to
+// publish: the v2 factory and one verb off `./client`, the v1 facade off the root.
+const clientEsm = await import("@arkade-os/swap/client");
+const clientCjs = require("@arkade-os/swap/client");
+for (const [condition, mod] of [
+    ["import", clientEsm],
+    ["require", clientCjs],
+]) {
+    for (const name of ["createSwapClient", "pay"]) {
+        if (typeof mod[name] !== "function") {
+            throw new Error(`@arkade-os/swap/client (${condition}) is missing ${name}`);
+        }
+    }
+}
+const root = await import("@arkade-os/swap");
+if (typeof root.createSwapClient !== "function") {
+    throw new Error("@arkade-os/swap is missing createSwapClient");
+}
+
 // Constructing is the check: neither handle is touched.
 const stubExecutor = { run: async () => {}, get: async () => undefined, all: async () => [] };
 new SQLiteAssetSwapRepository(stubExecutor);

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -245,6 +245,10 @@ export {
     type RfqSwapActivityDeps,
     type SwapActivityInput,
 } from "./activity";
+// The v2 `createSwapClient`/`SwapClient` live at `@arkade-os/swap/client` until
+// M8 swaps them onto these root names; this block stays the v1 (#793) facade
+// meanwhile. Do not "fix" the duplication by merging the two — same names,
+// different declarations.
 export {
     createSwapClient,
     type LightningReceiveQuote,

--- a/packages/swap/test/e2e/rfqVerbs.test.ts
+++ b/packages/swap/test/e2e/rfqVerbs.test.ts
@@ -12,9 +12,16 @@
  * quote anyway. Nothing here fills a swap — a fill needs a solver that pays the
  * invoice — so what is real is everything the maker side does.
  *
+ * The `rfq` prefix is routing, not decoration: `test:integration:rfq` selects
+ * `test/e2e/rfq*` onto the seconds-typed arkd stack (`.env.regtest.rfq`), while
+ * `test:integration` runs everything else on the block-typed one. This file
+ * derives its claim delay from the server's own exit delay, and
+ * `unilateralClaimDelay` refuses the block stack's 20 outright — so a name
+ * without the prefix puts the suite on a server it cannot quote against.
+ *
  * `exchange` is not here. Its route is `arkade <-> arkade`, which needs an
  * issued asset and a live price feed rather than a stubbed RFQ answer, and the
- * offer primitive it funds already has `offerCancel.test.ts` against this stack.
+ * offer primitive it funds already has `offerCancel.test.ts` on the block stack.
  */
 import { beforeAll, describe, expect, it } from "vitest";
 import { execSync } from "child_process";

--- a/scripts/regtest.sh
+++ b/scripts/regtest.sh
@@ -11,6 +11,12 @@
 # types — see that file's header. The profiles share ports, so only one stack
 # can be up at a time.
 #
+# The FILENAME picks the profile: `test/e2e/rfq*.test.ts` runs on the
+# seconds-typed stack, everything else on the block-typed one (see the swap
+# package's `test:integration` / `test:integration:rfq` scripts). The default is
+# the block stack, so a new seconds-typed suite that forgets the prefix fails on
+# a server it cannot quote against — name it `rfq*`.
+#
 # Usage: scripts/regtest.sh <ts-sdk|swap|swap-rfq> <up|down|reset|setup|test|cycle|groups> [test file...]
 #   up     – clean + start with the package's .env.regtest
 #   down   – stop the stack (preserves data)


### PR DESCRIPTION
Publishes the v2 client from a ./client subpath, docs included. Stacked on swap-verbs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The v2 swap client is now available through the `@arkade-os/swap/client` package entry point for both modern and CommonJS applications.
  - The client supports quoting, accepting, and completing swaps through `pay`, `receive`, and `exchange`.
  - Added lifecycle tools including cancellation, swap tracking, update notifications, and recovery.

- **Documentation**
  - Clarified v1 and v2 client availability, supported routes, readiness behavior, and swap workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->