### PR TITLE
feat(swap): a covclaimd Reveal API client, so a client can deliver its own packet

### DIFF
--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -169,6 +169,15 @@ export {
 } from "./rfq";
 export { sealClaimPacket, type ClaimPacketInput, type SealedClaimPacket } from "./claimPacket";
 export {
+    CovclaimdRevealError,
+    covclaimdClient,
+    revealClaimPacket,
+    revealFieldsFromScript,
+    type CovclaimdClient,
+    type CovclaimdInfo,
+    type RevealParams,
+} from "./reveal";
+export {
     LockupAmountMismatchError,
     awaitLockupFunding,
     claimReceiveLockup,

--- a/packages/swap/src/reveal.ts
+++ b/packages/swap/src/reveal.ts
@@ -1,0 +1,183 @@
+/**
+ * covclaimd's Reveal API, client side: deliver your own sealed claim packet,
+ * then go offline — instead of handing it to the solver to courier.
+ *
+ * The courier forwards a ciphertext it cannot read to whichever daemon its own
+ * config names, and nothing checks that is the daemon the client sealed to.
+ * Sealing to the key THIS base URL serves removes the mismatch by construction.
+ */
+import { base64, hex } from "@scure/base";
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { ArkAddress, type VHTLC } from "@arkade-os/sdk";
+
+import { sealClaimPacket } from "./claimPacket";
+
+/**
+ * `retryable` is the point of the type: a 400 says the packet does not bind to
+ * this address at this daemon — wrong key, script or taptree — and retrying
+ * changes none of them. Only a full registry (429) and a transport fault (5xx,
+ * or `status` 0 for a throwing `fetch`) are worth trying again.
+ */
+export class CovclaimdRevealError extends Error {
+    readonly name = "CovclaimdRevealError";
+    readonly status: number;
+    readonly detail: string;
+    readonly retryable: boolean;
+    constructor(what: string, status: number, detail: string) {
+        super(`covclaimd ${what} failed: ${status || "no response"} ${detail}`.trimEnd());
+        this.status = status;
+        this.detail = detail;
+        this.retryable = status === 0 || status === 429 || status >= 500;
+    }
+}
+
+export interface CovclaimdInfo {
+    /** 33-byte compressed — feeds {@link sealClaimPacket} unchanged. */
+    covclaimdPubkey: Uint8Array;
+    /** Compressed hex — feeds `requestLightningReceive`'s `emulatorPubkey`. */
+    emulatorPubkey: string;
+}
+
+/** The four fields `POST /v1/reveal` takes. */
+export interface RevealParams {
+    /** The funded lockup's Arkade address, bech32m. */
+    swapAddress: string;
+    /** `sealClaimPacket(...).ciphertext`, base64. */
+    ciphertext: string;
+    /** The covenant's `enforcePayTo` ArkadeScript, base64. */
+    arkadeScript: string;
+    /** The lockup's serialized taptree, hex. */
+    taptree: string;
+}
+
+export interface CovclaimdClient {
+    info(): Promise<CovclaimdInfo>;
+    reveal(params: RevealParams): Promise<void>;
+}
+
+const decodeKey = (value: unknown, field: string): Uint8Array => {
+    if (typeof value !== "string") throw new Error(`covclaimd info: ${field} is not a string`);
+    let bytes: Uint8Array;
+    try {
+        bytes = hex.decode(value);
+    } catch {
+        throw new Error(`covclaimd info: ${field} is not hex`);
+    }
+    if (bytes.length !== 33) {
+        throw new Error(`covclaimd info: ${field} must be 33-byte compressed, got ${bytes.length}`);
+    }
+    return bytes;
+};
+
+/** `fetchImpl` is injectable, matching `httpTransport` in `rfq.ts`. */
+export const covclaimdClient = (
+    baseUrl: string,
+    options: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): CovclaimdClient => {
+    const url = baseUrl.replace(/\/+$/, "");
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const timeoutMs = options.timeoutMs ?? 30_000;
+
+    const send = async (what: string, path: string, init: RequestInit): Promise<Response> => {
+        let response: Response;
+        try {
+            response = await fetchImpl(`${url}${path}`, {
+                ...init,
+                signal: AbortSignal.timeout(timeoutMs),
+            });
+        } catch (error) {
+            throw new CovclaimdRevealError(what, 0, String(error));
+        }
+        if (!response.ok) {
+            throw new CovclaimdRevealError(what, response.status, await response.text());
+        }
+        return response;
+    };
+
+    return {
+        async info() {
+            const response = await send("info", "/v1/preimage/covclaimd-pubkey", {
+                method: "GET",
+            });
+            const body = (await response.json()) as Record<string, unknown> | null;
+            return {
+                covclaimdPubkey: decodeKey(body?.covclaimd_pub_key, "covclaimd_pub_key"),
+                emulatorPubkey: hex.encode(decodeKey(body?.emulator_pub_key, "emulator_pub_key")),
+            };
+        },
+
+        async reveal(params) {
+            await send("reveal", "/v1/reveal", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                    swap_address: params.swapAddress,
+                    packet: { ciphertext: params.ciphertext, arkade_script: params.arkadeScript },
+                    taptree: params.taptree,
+                }),
+            });
+        },
+    };
+};
+
+/**
+ * The two wire fields that are functions of the covenant alone.
+ *
+ * A client-derived `arkadeScript` can differ from the funder's only if the
+ * covenants differ: the script is tweaked into the non-interactive claim leaf's
+ * co-signer key, so a different one is a different leaf, root, and lockup
+ * address — already covered by the address check made before funding.
+ */
+export function revealFieldsFromScript(script: InstanceType<typeof VHTLC.ScriptV2>): {
+    arkadeScript: string;
+    taptree: string;
+} {
+    if (!script.nonInteractiveClaimArkadeScript) {
+        throw new Error("this covenant has no non-interactive claim leaf to reveal against");
+    }
+    return {
+        arkadeScript: base64.encode(script.nonInteractiveClaimArkadeScript),
+        taptree: hex.encode(script.encode()),
+    };
+}
+
+/**
+ * Seal `P` to the daemon `client` speaks to and register it there, so covclaimd
+ * claims the lockup once the solver funds it and the trader can go offline.
+ *
+ * Registration EXPIRES — covclaimd drops it 15 minutes after the last reveal —
+ * and re-revealing refreshes rather than duplicates it, so a caller waiting on
+ * a slow funding should reveal again, not once. The two gates below name a
+ * cause covclaimd would otherwise report as an opaque 400.
+ */
+export async function revealClaimPacket(
+    client: CovclaimdClient,
+    input: {
+        script: InstanceType<typeof VHTLC.ScriptV2>;
+        address: string;
+        /** `P`, 32 bytes, from the swap's `secrets`. */
+        preimage: Uint8Array;
+    },
+): Promise<{ ciphertext: string }> {
+    const fields = revealFieldsFromScript(input.script);
+
+    if (
+        hex.encode(ArkAddress.decode(input.address).pkScript) !== hex.encode(input.script.pkScript)
+    ) {
+        throw new Error("address does not belong to this covenant");
+    }
+    if (
+        hex.encode(ripemd160(sha256(input.preimage))) !==
+        hex.encode(input.script.options.preimageHash)
+    ) {
+        throw new Error("preimage does not match the covenant's payment hash");
+    }
+
+    const { ciphertext } = await sealClaimPacket({
+        preimage: input.preimage,
+        covclaimdPubkey: (await client.info()).covclaimdPubkey,
+    });
+    await client.reveal({ swapAddress: input.address, ciphertext, ...fields });
+    return { ciphertext };
+}

--- a/packages/swap/src/reveal.ts
+++ b/packages/swap/src/reveal.ts
@@ -70,7 +70,8 @@ const decodeKey = (value: unknown, field: string): Uint8Array => {
     return bytes;
 };
 
-const LOOPBACK = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+// `[::1]` bracketed, because that is the form `URL.hostname` reports.
+const LOOPBACK = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 /** `info()` decides which key `P` is sealed to, so plain HTTP hands the preimage
  * to whoever can rewrite the response. Loopback is exempt — no network to be on,
@@ -118,12 +119,27 @@ export const covclaimdClient = (
         return response;
     };
 
+    /** A 2xx carrying a proxy's HTML is still a failed call, so it leaves here as
+     * a `CovclaimdRevealError` rather than a bare `SyntaxError` from the parser. */
+    const readJson = async (what: string, response: Response): Promise<unknown> => {
+        const body = await response.text();
+        try {
+            return JSON.parse(body) as unknown;
+        } catch {
+            throw new CovclaimdRevealError(
+                what,
+                response.status,
+                `non-JSON body: ${body.slice(0, 200)}`,
+            );
+        }
+    };
+
     return {
         async info() {
             const response = await send("info", "/v1/preimage/covclaimd-pubkey", {
                 method: "GET",
             });
-            const body = (await response.json()) as Record<string, unknown> | null;
+            const body = (await readJson("info", response)) as Record<string, unknown> | null;
             return {
                 covclaimdPubkey: decodeKey(body?.covclaimd_pub_key, "covclaimd_pub_key"),
                 emulatorPubkey: hex.encode(decodeKey(body?.emulator_pub_key, "emulator_pub_key")),

--- a/packages/swap/src/reveal.ts
+++ b/packages/swap/src/reveal.ts
@@ -70,11 +70,32 @@ const decodeKey = (value: unknown, field: string): Uint8Array => {
     return bytes;
 };
 
+const LOOPBACK = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/** `info()` decides which key `P` is sealed to, so plain HTTP hands the preimage
+ * to whoever can rewrite the response. Loopback is exempt — no network to be on,
+ * and covclaimd's own default is `http://localhost:7271`. */
+const assertTransportSecure = (baseUrl: string, allowInsecureHttp: boolean): void => {
+    const { protocol, hostname } = new URL(baseUrl);
+    if (protocol === "https:" || allowInsecureHttp) return;
+    if (protocol === "http:" && LOOPBACK.has(hostname)) return;
+    throw new Error(
+        `covclaimd URL must be https (got ${protocol}//${hostname}): the key it serves ` +
+            "is the one the preimage gets sealed to. Pass allowInsecureHttp to override.",
+    );
+};
+
 /** `fetchImpl` is injectable, matching `httpTransport` in `rfq.ts`. */
 export const covclaimdClient = (
     baseUrl: string,
-    options: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+    options: {
+        fetchImpl?: typeof fetch;
+        timeoutMs?: number;
+        /** Opt out of the TLS requirement — a private network you trust. */
+        allowInsecureHttp?: boolean;
+    } = {},
 ): CovclaimdClient => {
+    assertTransportSecure(baseUrl, options.allowInsecureHttp === true);
     const url = baseUrl.replace(/\/+$/, "");
     const fetchImpl = options.fetchImpl ?? fetch;
     const timeoutMs = options.timeoutMs ?? 30_000;
@@ -84,6 +105,8 @@ export const covclaimdClient = (
         try {
             response = await fetchImpl(`${url}${path}`, {
                 ...init,
+                // a redirect would move the key fetch off the vetted origin
+                redirect: "error",
                 signal: AbortSignal.timeout(timeoutMs),
             });
         } catch (error) {

--- a/packages/swap/test/reveal.test.ts
+++ b/packages/swap/test/reveal.test.ts
@@ -162,6 +162,17 @@ describe("covclaimdClient", () => {
         ).rejects.toThrow(/covclaimd_pub_key is not hex/);
     });
 
+    it("reports a 200 carrying a non-JSON body as CovclaimdRevealError, not SyntaxError", async () => {
+        const { impl } = stubFetch([{ body: "<html>502 Bad Gateway</html>" }]);
+        const error = await covclaimdClient("https://cov.example", { fetchImpl: impl })
+            .info()
+            .catch((e: unknown) => e as CovclaimdRevealError);
+        expect(error).toBeInstanceOf(CovclaimdRevealError);
+        expect(error.status).toBe(200);
+        expect(error.retryable).toBe(false);
+        expect(error.message).toContain("502 Bad Gateway");
+    });
+
     it("POSTs /v1/reveal with the nested packet body covclaimd parses", async () => {
         const { impl, calls } = stubFetch([{ body: "{}" }]);
         await covclaimdClient("https://cov.example", { fetchImpl: impl }).reveal({

--- a/packages/swap/test/reveal.test.ts
+++ b/packages/swap/test/reveal.test.ts
@@ -1,0 +1,284 @@
+/** The wire shape asserted here is covclaimd's own, read off its handler and
+ * proto — not one invented to match the code. */
+import { describe, expect, it } from "vitest";
+import { base64, hex } from "@scure/base";
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
+
+import {
+    CovclaimdRevealError,
+    covclaimdClient,
+    revealClaimPacket,
+    revealFieldsFromScript,
+} from "../src/reveal";
+import { receiveVtxoScript } from "../src/rfq";
+import { openClaimPacket } from "./helpers/claimPacket";
+
+const PREIMAGE = new Uint8Array(32).fill(7);
+const COVCLAIMD_SK = new Uint8Array(32).fill(0x22);
+const COVCLAIMD_PK = secp256k1.getPublicKey(COVCLAIMD_SK, true);
+const EMULATOR_PK = secp256k1.getPublicKey(new Uint8Array(32).fill(0x33), true);
+const xonly = (key: Uint8Array): Uint8Array => key.slice(1);
+const p2tr = (fill: number): Uint8Array =>
+    Uint8Array.from([0x51, 0x20, ...new Uint8Array(32).fill(fill)]);
+
+const covenant = (overrides: { payoutPkScript?: Uint8Array } = {}) =>
+    receiveVtxoScript({
+        solverPubkey: xonly(secp256k1.getPublicKey(new Uint8Array(32).fill(0x44), true)),
+        refundLocktime: 1_800_000,
+        serverPubkey: xonly(secp256k1.getPublicKey(new Uint8Array(32).fill(0x55), true)),
+        paymentHash: hex.encode(sha256(PREIMAGE)),
+        claimDelay: 512,
+        emulatorPubkey: xonly(EMULATOR_PK),
+        solverRefundPkScript: p2tr(0x51),
+        payoutPubkey: xonly(secp256k1.getPublicKey(new Uint8Array(32).fill(0x66), true)),
+        payoutPkScript: overrides.payoutPkScript ?? p2tr(0x52),
+    });
+
+const addressOf = (script: ReturnType<typeof covenant>): string =>
+    script.address("ark", script.options.server).encode();
+
+/** A `fetch` double recording every call, answering from a queue of responses. */
+const stubFetch = (
+    replies: Array<{ status?: number; body?: string }>,
+): { impl: typeof fetch; calls: Array<{ url: string; init?: RequestInit }> } => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const impl = (async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        const reply = replies.shift() ?? { status: 200, body: "{}" };
+        const status = reply.status ?? 200;
+        return {
+            ok: status >= 200 && status < 300,
+            status,
+            json: async () => JSON.parse(reply.body ?? "{}"),
+            text: async () => reply.body ?? "",
+        } as Response;
+    }) as unknown as typeof fetch;
+    return { impl, calls };
+};
+
+const infoBody = JSON.stringify({
+    covclaimd_pub_key: hex.encode(COVCLAIMD_PK),
+    emulator_pub_key: hex.encode(EMULATOR_PK),
+});
+
+describe("revealFieldsFromScript", () => {
+    it("derives arkade_script as base64 of the covenant's own NIC arkade script", () => {
+        const script = covenant();
+        expect(revealFieldsFromScript(script).arkadeScript).toBe(
+            base64.encode(script.nonInteractiveClaimArkadeScript!),
+        );
+    });
+
+    it("derives taptree as hex of the covenant's serialized tree", () => {
+        const script = covenant();
+        expect(revealFieldsFromScript(script).taptree).toBe(hex.encode(script.encode()));
+    });
+
+    it("binds the arkade script to the address: a different payout gives both a new script and a new address", () => {
+        const a = covenant();
+        const b = covenant({ payoutPkScript: p2tr(0x53) });
+        expect(revealFieldsFromScript(b).arkadeScript).not.toBe(
+            revealFieldsFromScript(a).arkadeScript,
+        );
+        expect(addressOf(b)).not.toBe(addressOf(a));
+    });
+
+    it("refuses a covenant with no non-interactive claim leaf", () => {
+        const script = covenant();
+        const bare = Object.create(Object.getPrototypeOf(script), {
+            nonInteractiveClaimArkadeScript: { value: undefined },
+        }) as typeof script;
+        expect(() => revealFieldsFromScript(bare)).toThrow(/no non-interactive claim leaf/);
+    });
+});
+
+describe("covclaimdClient", () => {
+    it("GETs the pubkey endpoint and decodes both keys", async () => {
+        const { impl, calls } = stubFetch([{ body: infoBody }]);
+        const info = await covclaimdClient("https://cov.example", { fetchImpl: impl }).info();
+        expect(calls[0].url).toBe("https://cov.example/v1/preimage/covclaimd-pubkey");
+        expect(hex.encode(info.covclaimdPubkey)).toBe(hex.encode(COVCLAIMD_PK));
+        expect(info.emulatorPubkey).toBe(hex.encode(EMULATOR_PK));
+    });
+
+    it("strips trailing slashes from the base URL", async () => {
+        const { impl, calls } = stubFetch([{ body: infoBody }]);
+        await covclaimdClient("https://cov.example//", { fetchImpl: impl }).info();
+        expect(calls[0].url).toBe("https://cov.example/v1/preimage/covclaimd-pubkey");
+    });
+
+    it("refuses a pubkey that is not 33-byte compressed", async () => {
+        const body = JSON.stringify({
+            covclaimd_pub_key: hex.encode(COVCLAIMD_PK.slice(1)),
+            emulator_pub_key: hex.encode(EMULATOR_PK),
+        });
+        const { impl } = stubFetch([{ body }]);
+        await expect(
+            covclaimdClient("https://cov.example", { fetchImpl: impl }).info(),
+        ).rejects.toThrow(/covclaimd_pub_key must be 33-byte compressed, got 32/);
+    });
+
+    it("refuses a pubkey that is not hex", async () => {
+        const body = JSON.stringify({ covclaimd_pub_key: "zz", emulator_pub_key: "00" });
+        const { impl } = stubFetch([{ body }]);
+        await expect(
+            covclaimdClient("https://cov.example", { fetchImpl: impl }).info(),
+        ).rejects.toThrow(/covclaimd_pub_key is not hex/);
+    });
+
+    it("POSTs /v1/reveal with the nested packet body covclaimd parses", async () => {
+        const { impl, calls } = stubFetch([{ body: "{}" }]);
+        await covclaimdClient("https://cov.example", { fetchImpl: impl }).reveal({
+            swapAddress: "ark1swap",
+            ciphertext: "Y2lwaGVy",
+            arkadeScript: "c2NyaXB0",
+            taptree: "deadbeef",
+        });
+        expect(calls[0].url).toBe("https://cov.example/v1/reveal");
+        expect(calls[0].init?.method).toBe("POST");
+        expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+            swap_address: "ark1swap",
+            packet: { ciphertext: "Y2lwaGVy", arkade_script: "c2NyaXB0" },
+            taptree: "deadbeef",
+        });
+    });
+
+    it("marks a 400 NOT retryable — the packet cannot bind to this address at this daemon", async () => {
+        const { impl } = stubFetch([
+            { status: 400, body: "aead open: message authentication failed" },
+        ]);
+        const error = await covclaimdClient("https://cov.example", { fetchImpl: impl })
+            .reveal({ swapAddress: "a", ciphertext: "b", arkadeScript: "c", taptree: "d" })
+            .catch((e: unknown) => e as CovclaimdRevealError);
+        expect(error).toBeInstanceOf(CovclaimdRevealError);
+        expect(error.retryable).toBe(false);
+        expect(error.status).toBe(400);
+        expect(error.detail).toBe("aead open: message authentication failed");
+    });
+
+    it("marks 429 and 503 retryable", async () => {
+        for (const status of [429, 503]) {
+            const { impl } = stubFetch([{ status, body: "busy" }]);
+            const error = await covclaimdClient("https://cov.example", { fetchImpl: impl })
+                .reveal({ swapAddress: "a", ciphertext: "b", arkadeScript: "c", taptree: "d" })
+                .catch((e: unknown) => e as CovclaimdRevealError);
+            expect(error.retryable, `status ${status}`).toBe(true);
+        }
+    });
+
+    it("wraps a throwing fetch as a retryable error with status 0", async () => {
+        const impl = (async () => {
+            throw new Error("ECONNREFUSED");
+        }) as unknown as typeof fetch;
+        const error = await covclaimdClient("https://cov.example", { fetchImpl: impl })
+            .reveal({ swapAddress: "a", ciphertext: "b", arkadeScript: "c", taptree: "d" })
+            .catch((e: unknown) => e as CovclaimdRevealError);
+        expect(error.status).toBe(0);
+        expect(error.retryable).toBe(true);
+        expect(error.message).toContain("ECONNREFUSED");
+    });
+
+    it("names which call failed", async () => {
+        const { impl } = stubFetch([{ status: 500, body: "boom" }]);
+        await expect(
+            covclaimdClient("https://cov.example", { fetchImpl: impl }).info(),
+        ).rejects.toThrow(/covclaimd info failed: 500 boom/);
+    });
+});
+
+describe("revealClaimPacket", () => {
+    const client = (replies: Array<{ status?: number; body?: string }>) => {
+        const { impl, calls } = stubFetch(replies);
+        return { client: covclaimdClient("https://cov.example", { fetchImpl: impl }), calls };
+    };
+
+    it("seals to the key the SAME daemon serves, then reveals there", async () => {
+        const script = covenant();
+        const { client: c, calls } = client([{ body: infoBody }, { body: "{}" }]);
+        const { ciphertext } = await revealClaimPacket(c, {
+            script,
+            address: addressOf(script),
+            preimage: PREIMAGE,
+        });
+
+        expect(calls.map((call) => call.url)).toEqual([
+            "https://cov.example/v1/preimage/covclaimd-pubkey",
+            "https://cov.example/v1/reveal",
+        ]);
+        expect(hex.encode(await openClaimPacket(ciphertext, COVCLAIMD_SK))).toBe(
+            hex.encode(PREIMAGE),
+        );
+        expect(JSON.parse(String(calls[1].init?.body))).toEqual({
+            swap_address: addressOf(script),
+            packet: {
+                ciphertext,
+                arkade_script: base64.encode(script.nonInteractiveClaimArkadeScript!),
+            },
+            taptree: hex.encode(script.encode()),
+        });
+    });
+
+    it("re-sealing produces a fresh packet: no ephemeral key or nonce is reused", async () => {
+        const script = covenant();
+        const first = await revealClaimPacket(client([{ body: infoBody }, { body: "{}" }]).client, {
+            script,
+            address: addressOf(script),
+            preimage: PREIMAGE,
+        });
+        const second = await revealClaimPacket(
+            client([{ body: infoBody }, { body: "{}" }]).client,
+            {
+                script,
+                address: addressOf(script),
+                preimage: PREIMAGE,
+            },
+        );
+        expect(second.ciphertext).not.toBe(first.ciphertext);
+    });
+
+    it("refuses an address that is not this covenant's, before sealing anything", async () => {
+        const script = covenant();
+        const other = covenant({ payoutPkScript: p2tr(0x53) });
+        const { client: c, calls } = client([{ body: infoBody }, { body: "{}" }]);
+        await expect(
+            revealClaimPacket(c, { script, address: addressOf(other), preimage: PREIMAGE }),
+        ).rejects.toThrow(/address does not belong to this covenant/);
+        expect(calls).toHaveLength(0);
+    });
+
+    it("refuses a preimage that does not open the covenant, before sealing anything", async () => {
+        const script = covenant();
+        const { client: c, calls } = client([{ body: infoBody }, { body: "{}" }]);
+        await expect(
+            revealClaimPacket(c, {
+                script,
+                address: addressOf(script),
+                preimage: new Uint8Array(32).fill(9),
+            }),
+        ).rejects.toThrow(/preimage does not match the covenant's payment hash/);
+        expect(calls).toHaveLength(0);
+    });
+
+    it("the covenant commits to ripemd160(sha256(P)), which is what the gate compares", () => {
+        expect(hex.encode(covenant().options.preimageHash)).toBe(
+            hex.encode(ripemd160(sha256(PREIMAGE))),
+        );
+    });
+
+    it("propagates covclaimd's refusal with its retryability intact", async () => {
+        const script = covenant();
+        const { client: c } = client([
+            { body: infoBody },
+            { status: 400, body: "no such closure" },
+        ]);
+        const error = await revealClaimPacket(c, {
+            script,
+            address: addressOf(script),
+            preimage: PREIMAGE,
+        }).catch((e: unknown) => e as CovclaimdRevealError);
+        expect(error).toBeInstanceOf(CovclaimdRevealError);
+        expect(error.retryable).toBe(false);
+    });
+});

--- a/packages/swap/test/reveal.test.ts
+++ b/packages/swap/test/reveal.test.ts
@@ -109,6 +109,40 @@ describe("covclaimdClient", () => {
         expect(calls[0].url).toBe("https://cov.example/v1/preimage/covclaimd-pubkey");
     });
 
+    it("refuses plain http to a remote host: the key served decides where P is sealed", () => {
+        const { impl } = stubFetch([{ body: infoBody }]);
+        expect(() => covclaimdClient("http://cov.example", { fetchImpl: impl })).toThrow(
+            /must be https/,
+        );
+    });
+
+    it("allows plain http to loopback, which covclaimd itself defaults to", async () => {
+        for (const base of [
+            "http://localhost:7271",
+            "http://127.0.0.1:7271",
+            "http://[::1]:7271",
+        ]) {
+            const { impl, calls } = stubFetch([{ body: infoBody }]);
+            await covclaimdClient(base, { fetchImpl: impl }).info();
+            expect(calls[0].url, base).toBe(`${base}/v1/preimage/covclaimd-pubkey`);
+        }
+    });
+
+    it("allows plain http to a remote host only on an explicit opt-out", async () => {
+        const { impl, calls } = stubFetch([{ body: infoBody }]);
+        await covclaimdClient("http://cov.example", {
+            fetchImpl: impl,
+            allowInsecureHttp: true,
+        }).info();
+        expect(calls[0].url).toBe("http://cov.example/v1/preimage/covclaimd-pubkey");
+    });
+
+    it("refuses redirects, which would move the key fetch off the vetted origin", async () => {
+        const { impl, calls } = stubFetch([{ body: infoBody }]);
+        await covclaimdClient("https://cov.example", { fetchImpl: impl }).info();
+        expect(calls[0].init?.redirect).toBe("error");
+    });
+
     it("refuses a pubkey that is not 33-byte compressed", async () => {
         const body = JSON.stringify({
             covclaimd_pub_key: hex.encode(COVCLAIMD_PK.slice(1)),


### PR DESCRIPTION
## What

Gives the sdk a **covclaimd Reveal API client**, so a client can deliver its own
sealed claim packet instead of relying on the solver to courier it.

The sdk could already *seal* a packet (`sealClaimPacket`) and had no way to
*deliver* one — there was no `/v1/reveal` client anywhere in `packages/swap/src`.
This is the missing third option in the client's own claim menu:

| | how | status |
|---|---|---|
| online | keep `P`, claim yourself | already existed — `claimReceiveLockup` / `pushClaim` |
| **offline, own covclaimd** | **seal, Reveal yourself, go offline** | **this PR** |
| offline, no infrastructure | hand the packet to the solver in the quote | already existed — `rfq.ts` |

## Why

The solver calls Reveal on the client's behalf, forwarding a ciphertext it cannot
read to whichever daemon its own `COVCLAIMD_URL` names. Nothing checks that this
is the daemon the client sealed to. When they differ, covclaimd correctly refuses
a packet it cannot decrypt, the solver reads the refusal as transient and retries
to the refund deadline, and the swap funds, never claims, and refunds — loud in
the operator's log, invisible to the client.

Two things in here address that directly:

- **`revealClaimPacket()` seals to the key the same base URL serves.** The daemon
  that receives the packet is the one it was sealed to by construction, rather
  than because two configuration values happened to agree. One source of truth:
  the URL.
- **`CovclaimdRevealError.retryable` distinguishes the two refusals.** A `400`
  means the packet cannot bind to this address at this daemon — wrong key, wrong
  script, wrong taptree — and retrying changes none of them. Only `429`
  (`ErrRegistryFull`, which covclaimd itself annotates "retry later"), `5xx`, and
  a throwing `fetch` are retryable.

## The `arkade_script` question

The prior objection was that a client cannot supply `arkade_script`, because
deriving it would need `enforcePayTo` exported at *request* time, before any
VHTLC exists. That is true of request time and does not apply to Reveal: Reveal
happens after the quote, when the client has already derived the covenant to
verify the lockup address, and `nonInteractiveClaimArkadeScript` is a public
`readonly` field on the instance (`packages/ts-sdk/src/script/vhtlc.ts:170`,
assigned at `:298`). `revealFieldsFromScript()` reads it and `encode()`.

Nor does a client-derived script introduce a disagreement risk. The arkade script
is tweaked into the non-interactive claim leaf's co-signer key via
`computeArkadeScriptPublicKey`, so a differing script is a differing leaf, a
differing merkle root, and a differing lockup address — already caught by the
address check the client makes before funding. A test asserts exactly this
coupling.

## Wire contract

Matched against covclaimd's own handler and proto, not invented:

- `GET /v1/preimage/covclaimd-pubkey` -> `{ covclaimd_pub_key, emulator_pub_key }`, both hex.
- `POST /v1/reveal` -> `{ swap_address, packet: { ciphertext, arkade_script }, taptree }`,
  with `ciphertext`/`arkade_script` base64 (`bytes` in proto3) and `taptree` hex.
- Idempotent: registration is keyed on the address's pkScript, so re-revealing
  refreshes rather than duplicates.
- **Registration expires 15 minutes after the last reveal** (`registrationTTL`).
  That is documented on `revealClaimPacket`, since it is the one thing that can
  silently defeat the offline use case if funding is slow.

Two local gates (the address belongs to this covenant; the preimage opens it) run
*before* anything is sealed, and name a cause covclaimd would otherwise return as
an opaque 400.

## Transport security (from review)

`info()` decides which key `P` is sealed to, so over plain HTTP an active network
attacker substitutes their own key: they learn `P`, and covclaimd gets a packet it
cannot decrypt, so the offline claim never lands. Scoped rather than absolute,
because an unconditional HTTPS rule would break the documented local default
(covclaimd's own `COVCLAIMD_URL` is `http://localhost:7271`):

- `https:` always allowed;
- `http:` to loopback allowed -- no network for an attacker to sit on;
- anything else needs an explicit `allowInsecureHttp`, so a private-network
  deployment stays possible but the deviation is greppable.

Both requests set `redirect: "error"`, since a redirect would move the key fetch
to an origin the check never vetted.

A second review pass added: `info()` now reports a 2xx carrying a non-JSON body
(a proxy's HTML) as a `CovclaimdRevealError` rather than letting a bare
`SyntaxError` escape past the class that exists to be caught.

## Test plan

- `packages/swap/test/reveal.test.ts`, 24 tests, covering the wire shape, the
  retryability classification, both local gates and their ordering, the transport
  rules, and the seal-to-the-same-daemon round trip (opened with covclaimd's
  secret key).
- Baseline on `master` (45a5369): 232 files, 4365 passed, 1 skipped, **0 failing**.
- After: 233 files, 4389 passed, 1 skipped, **0 failing**. Delta `+1 file, +24 tests`;
  `swap` goes 780 -> 804, so no existing test was displaced.
- `pnpm -r build`, both typechecks and `pnpm run test:unit` all exit 0.
- Every added assertion was mutation-tested: **30 mutations of the source, all 30
  killed, no survivors.** They include pointing the info endpoint at `/v1`,
  flattening the nested `packet`, swapping base64/hex on `arkade_script` and
  `taptree`, making everything retryable, removing each gate, running the gates
  after sealing instead of before, sealing to the emulator key instead of
  covclaimd's, dropping the loopback exemption, ignoring `allowInsecureHttp`, and
  letting redirects follow, restoring the unwrapped JSON parse, and keeping only
  the unbracketed `::1` in the loopback set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for revealing claim packets through a Covclaimd service.
  - Added secure client communication with validation, timeout handling, redirect refusal, and retryable error reporting.
  - Added claim packet preparation, including covenant script field extraction and address/preimage validation.
  - Exported the new reveal client, helpers, error type, and related types for public use.

- **Tests**
  - Added comprehensive coverage for reveal workflows, validation, transport security, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->