### PR TITLE
test: e2e for the activity resolver and the payment rails, and the market bounds they depend on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
               test/e2e/arkade-script.test.ts
               test/e2e/contractWatchState.test.ts
               test/e2e/lookAhead.test.ts
+              test/e2e/activity.test.ts
           - package: ts-sdk
             group: exit-providers-rotation
             test_files: >-

--- a/packages/swap/src/client/market.ts
+++ b/packages/swap/src/client/market.ts
@@ -115,9 +115,14 @@ export const usableMarkets = (
  * is what makes a card's own `min/max` bounds mean something: without it a
  * snapshot serving the pair answers "eligible" for any size, and the swap rails'
  * documented self-healing — an out-of-range amount drops the rail at
- * `available()` and the collaborative exit wins — never fires. Only a take-side
- * pin is passed, because that is the side `wantSide` names; converting a
- * give-side pin would need the price this read deliberately does not have.
+ * `available()` and the collaborative exit wins — never fires.
+ *
+ * @param takeAmount The pin on the TAKE leg only, which is the side `wantSide`
+ *   names. Omitting it skips the bounds entirely — an unpinned read is not a
+ *   zero-sized trade. A GIVE-side pin is deliberately not converted and passed:
+ *   that would need a price this read does not have, so a give-side amount past
+ *   a card's ceiling still answers `eligible: 1` here and is refused by the
+ *   solver instead. That asymmetry is the known sharp edge of this parameter.
  */
 export const eligibleMarkets = (
     snapshot: DiscoverySnapshot,

--- a/packages/swap/src/client/market.ts
+++ b/packages/swap/src/client/market.ts
@@ -110,11 +110,20 @@ export const usableMarkets = (
  * `source` and not `discovery_pubkey` because the latter is the field a cached
  * card carries unvalidated: filtering trust on untrusted content would give the
  * allowlist the shape of a check and none of the effect.
+ *
+ * `takeAmount` is the pinned trade size on the leg the trader receives, and it
+ * is what makes a card's own `min/max` bounds mean something: without it a
+ * snapshot serving the pair answers "eligible" for any size, and the swap rails'
+ * documented self-healing — an out-of-range amount drops the rail at
+ * `available()` and the collaborative exit wins — never fires. Only a take-side
+ * pin is passed, because that is the side `wantSide` names; converting a
+ * give-side pin would need the price this read deliberately does not have.
  */
 export const eligibleMarkets = (
     snapshot: DiscoverySnapshot,
     legs: { give: DiscoveryLeg; take: DiscoveryLeg },
     policy?: SwapPolicy,
+    takeAmount?: bigint,
 ): MarketCandidate[] => {
     const markets = usableMarkets(snapshot, policy);
 
@@ -135,6 +144,7 @@ export const eligibleMarkets = (
             // The trader receives the take leg, so that side must be one the
             // solver can pay out; a direction nobody solves yields no market.
             wantSide: side === "base" ? "quote" : "base",
+            ...(takeAmount === undefined ? {} : { wantAmount: takeAmount }),
         }).map((card) => ({
             card,
             give: side,

--- a/packages/swap/src/client/resolve.ts
+++ b/packages/swap/src/client/resolve.ts
@@ -227,7 +227,15 @@ export const resolveRoute = async (
     const amount = pinAmount(input, take.instrument);
 
     // 7. The market, after the policy filters that must run before disclosure.
-    const candidates = eligibleMarkets(snapshot, { give: giveLeg, take: takeLeg }, deps.policy);
+    //    A take-side pin also bounds-checks the card, so a size no solver on
+    //    this snapshot serves is `eligible: 0` here rather than an RFQ round
+    //    trip that discloses the amount only to be refused.
+    const candidates = eligibleMarkets(
+        snapshot,
+        { give: giveLeg, take: takeLeg },
+        deps.policy,
+        amount?.on === "take" ? amount.value : undefined,
+    );
     const market = chooseMarket(candidates, deps.policy);
 
     const resolution: RouteResolution = {

--- a/packages/swap/test/client/errors.test.ts
+++ b/packages/swap/test/client/errors.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { AddressMismatch, SwapRefusal } from "../../src/rfq";
 import { SwapDriveRefusedError } from "../../src/client/drive";
@@ -167,7 +168,8 @@ const COVERAGE = {
 /** Every `.ts` under `src/`, concatenated — what "has a throwing site" is read
  * from, so the map cannot claim coverage the code does not have. */
 const SOURCES = ((): string => {
-    const root = new URL("../../src", import.meta.url).pathname;
+    // `fileURLToPath`, not `.pathname`: the latter yields `/C:/…` on Windows.
+    const root = fileURLToPath(new URL("../../src", import.meta.url));
     const walk = (dir: string): string[] =>
         readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
             const path = join(dir, entry.name);

--- a/packages/swap/test/client/market.test.ts
+++ b/packages/swap/test/client/market.test.ts
@@ -102,6 +102,17 @@ describe("the eligible set", () => {
         );
     });
 
+    it("bounds the take leg against the card, and only when a pin names it", () => {
+        const snapshot = snapshotOf([lightningCard]);
+        const legs = { give: ARKADE_BTC, take: LIGHTNING_BTC } as const;
+        // The card serves 1000..50_000_000 on either side.
+        expect(eligibleMarkets(snapshot, legs, undefined, 100_000n)).toHaveLength(1);
+        expect(eligibleMarkets(snapshot, legs, undefined, 50_000_001n)).toEqual([]);
+        expect(eligibleMarkets(snapshot, legs, undefined, 999n)).toEqual([]);
+        // An unpinned read is not a zero-sized trade; it still serves.
+        expect(eligibleMarkets(snapshot, legs, undefined, undefined)).toHaveLength(1);
+    });
+
     it("filters on the registry URL, exactly", () => {
         const snapshot = snapshotOf([lightningCard, rivalLightningCard]);
         const both = eligibleMarkets(snapshot, { give: ARKADE_BTC, take: LIGHTNING_BTC });

--- a/packages/swap/test/client/resolve.test.ts
+++ b/packages/swap/test/client/resolve.test.ts
@@ -288,6 +288,25 @@ describe("what the snapshot serves", () => {
         expect((await client.resolve({ to: invoiceFor(PAYMENT_HASH, CLOCK) })).eligible).toBe(0);
     });
 
+    it("lands a size the cards do not serve there as well, without disclosing it", async () => {
+        const { client, transport } = await withCards();
+        const overCeiling = { to: BCRT1, amount: 50_000_001n, amountOn: "take" } as const;
+        expect((await client.resolve(overCeiling)).eligible).toBe(0);
+        expect((await client.resolve({ ...overCeiling, amount: 100_000n })).eligible).toBe(1);
+        await expect(client.quote(overCeiling)).rejects.toThrow(UnsupportedRoute);
+        expect(transport.sent).toHaveLength(0);
+    });
+
+    it("leaves a give-side pin unbounded, having no price to convert it with", async () => {
+        const { client } = await withCards();
+        const resolution = await client.resolve({
+            to: BCRT1,
+            amount: 50_000_001n,
+            amountOn: "give",
+        });
+        expect(resolution.eligible).toBe(1);
+    });
+
     it("resolves an asset swap's tickers against the cards", async () => {
         const { client } = await withCards();
         const resolution = await client.resolve({

--- a/packages/swap/test/e2e/rfqRails.test.ts
+++ b/packages/swap/test/e2e/rfqRails.test.ts
@@ -49,10 +49,17 @@ const FAUCET_SATS = 30_000;
 const LOCKUP_SATS = 1_000;
 const INVOICE_SATS = 990;
 
-/** The card's ceiling, and the two sizes either side of it. */
-const MAX_BASE_SATS = 50_000;
-const OVER_CEILING_SATS = MAX_BASE_SATS * 10;
+/**
+ * The onchain card's window, and the three sizes around it. Its floor is well
+ * clear of `ONCHAIN_DUST_SATS` plus the claim fee the rail grosses up by, so
+ * `UNDER_FLOOR_SATS` is refused by the CARD rather than by the rail's own dust
+ * check — otherwise that case would pass for the wrong reason.
+ */
+const MIN_ONCHAIN_SATS = 5_000;
+const MAX_ONCHAIN_SATS = 50_000;
+const OVER_CEILING_SATS = MAX_ONCHAIN_SATS * 10;
 const IN_RANGE_SATS = 20_000;
+const UNDER_FLOOR_SATS = 1_000;
 
 /** Somewhere for the exit to pay; the regtest node's own is not needed. */
 const BCRT1 = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
@@ -96,7 +103,11 @@ const PREIMAGE = new Uint8Array(32).fill(11);
 const PAYMENT_HASH = hex.encode(sha256(PREIMAGE));
 const DISCOVERY_KEY = hex.encode(schnorr.getPublicKey(new Uint8Array(32).fill(4)));
 
-const cardOn = (quoteCorridor: "lightning" | "onchain"): DiscoveredMarket =>
+const cardOn = (
+    quoteCorridor: "lightning" | "onchain",
+    min: number,
+    max: number,
+): DiscoveredMarket =>
     ({
         pair: `BTC/${quoteCorridor}:BTC`,
         base_asset: { id: "btc", name: "Bitcoin", ticker: "BTC", decimals: 8 },
@@ -104,10 +115,10 @@ const cardOn = (quoteCorridor: "lightning" | "onchain"): DiscoveredMarket =>
         base_corridor: "arkade",
         quote_corridor: quoteCorridor,
         fee_bps: 0,
-        min_base_amount: "100",
-        max_base_amount: String(MAX_BASE_SATS),
-        min_quote_amount: "100",
-        max_quote_amount: String(MAX_BASE_SATS),
+        min_base_amount: String(min),
+        max_base_amount: String(max),
+        min_quote_amount: String(min),
+        max_quote_amount: String(max),
         solver: "stub",
         source: "https://registry.example/regtest.json",
         sourceType: "registry",
@@ -115,7 +126,11 @@ const cardOn = (quoteCorridor: "lightning" | "onchain"): DiscoveredMarket =>
         transports: { nostr: { relays: ["wss://relay.invalid"] } },
     }) as unknown as DiscoveredMarket;
 
-const CARDS = [cardOn("lightning"), cardOn("onchain")];
+// The lightning card keeps a low floor: the expiry case quotes a 990 sat invoice.
+const CARDS = [
+    cardOn("lightning", 100, MAX_ONCHAIN_SATS),
+    cardOn("onchain", MIN_ONCHAIN_SATS, MAX_ONCHAIN_SATS),
+];
 
 const invoice = (): string =>
     encodeInvoice({
@@ -242,9 +257,16 @@ describe("a rail that refuses (regtest)", () => {
         const client = clientOn();
         const router = createSwapPaymentRouter(wallet, client, { claimFeeRateSatVb: 2 });
 
-        // Over the claim's dust floor, so it is the CARD refusing, not the rail.
-        const options = await router.options({ raw: BCRT1, amount: 400 });
+        // Clear of the rail's own dust check even after the claim-fee gross-up,
+        // so it is the CARD refusing this size and not the rail.
+        const resolution = await client.resolve({
+            to: BCRT1,
+            amount: BigInt(UNDER_FLOOR_SATS),
+            amountOn: "take",
+        });
+        expect(resolution.eligible).toBe(0);
 
+        const options = await router.options({ raw: BCRT1, amount: UNDER_FLOOR_SATS });
         expect(options.map((o) => o.railId)).toEqual(["onchain"]);
         await client[Symbol.asyncDispose]();
     }, 120_000);

--- a/packages/swap/test/e2e/rfqRails.test.ts
+++ b/packages/swap/test/e2e/rfqRails.test.ts
@@ -1,0 +1,279 @@
+/**
+ * The two ways a payment rail declines, against the real stack. The unit suite
+ * asserts both against a `SwapRailClient` stubbed to answer `eligible: 0` — a
+ * value the real client did not produce for an in-pair route until this
+ * branch's bounds fix, so the stub was pinning a number rather than a
+ * behaviour. Here the refusal comes from the real `resolve()`, and the exit
+ * that takes over is priced by arkd's own fee schedule.
+ *
+ * The `rfq` prefix is the routing, not the subject — see `rfqVerbs.test.ts`.
+ * `lightningSendContract` needs the seconds-typed `swap-rfq` profile.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { execSync } from "child_process";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+    ArkAddress,
+    EsploraProvider,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    REGTEST_EMULATOR_PUBKEY,
+    SingleKey,
+    Wallet,
+} from "@arkade-os/sdk";
+import type { DiscoveredMarket } from "@arkade-os/solver-discovery";
+import {
+    LIGHTNING_SEND_PAIR,
+    lightningSendContract,
+    unilateralClaimDelay,
+    type RfqQuote,
+} from "../../src/protocol";
+import {
+    type AttestingRfqTransport,
+    createSwapClient,
+    createSwapPaymentRouter,
+    InMemoryAssetSwapRepository,
+    LIGHTNING_RAIL,
+    ONCHAIN_SWAP_RAIL,
+    type SwapClient,
+} from "../../src";
+import { encodeInvoice } from "../helpers/bolt11";
+
+const OPERATOR_URL = "http://localhost:7070";
+const ESPLORA_API_URL = "http://localhost:3000/api";
+const arkdExec = "docker exec -t arkd";
+
+const FAUCET_SATS = 30_000;
+const LOCKUP_SATS = 1_000;
+const INVOICE_SATS = 990;
+
+/** The card's ceiling, and the two sizes either side of it. */
+const MAX_BASE_SATS = 50_000;
+const OVER_CEILING_SATS = MAX_BASE_SATS * 10;
+const IN_RANGE_SATS = 20_000;
+
+/** Somewhere for the exit to pay; the regtest node's own is not needed. */
+const BCRT1 = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+
+const xOnly = (key: Uint8Array): Uint8Array => (key.length === 32 ? key : key.slice(1));
+
+const execCommand = (command: string): string => {
+    const result = execSync(command, { encoding: "utf8" })
+        .replace(/\r/g, "")
+        .split("\n")
+        .filter((line) => !line.includes("WARN"))
+        .join("\n")
+        .trim();
+    if (result.startsWith("error:")) throw new Error(result);
+    return result;
+};
+
+const waitFor = async (
+    fn: () => Promise<boolean>,
+    { timeout = 60_000, interval = 500 } = {},
+): Promise<void> => {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+        if (await fn()) return;
+        await new Promise((r) => setTimeout(r, interval));
+    }
+    throw new Error("timeout in waitFor");
+};
+
+let wallet: Wallet;
+let emulatorPubkey: Uint8Array;
+let operatorPubkey: Uint8Array;
+let claimDelay: number;
+let hrp: string;
+
+const NOW = () => Math.floor(Date.now() / 1000);
+
+const SOLVER = schnorr.getPublicKey(new Uint8Array(32).fill(7));
+const SOLVER_PK_SCRIPT = Uint8Array.from([0x51, 0x20, ...SOLVER]);
+const PREIMAGE = new Uint8Array(32).fill(11);
+const PAYMENT_HASH = hex.encode(sha256(PREIMAGE));
+const DISCOVERY_KEY = hex.encode(schnorr.getPublicKey(new Uint8Array(32).fill(4)));
+
+const cardOn = (quoteCorridor: "lightning" | "onchain"): DiscoveredMarket =>
+    ({
+        pair: `BTC/${quoteCorridor}:BTC`,
+        base_asset: { id: "btc", name: "Bitcoin", ticker: "BTC", decimals: 8 },
+        quote_asset: { id: "btc", name: "Bitcoin", ticker: "BTC", decimals: 8 },
+        base_corridor: "arkade",
+        quote_corridor: quoteCorridor,
+        fee_bps: 0,
+        min_base_amount: "100",
+        max_base_amount: String(MAX_BASE_SATS),
+        min_quote_amount: "100",
+        max_quote_amount: String(MAX_BASE_SATS),
+        solver: "stub",
+        source: "https://registry.example/regtest.json",
+        sourceType: "registry",
+        discovery_pubkey: DISCOVERY_KEY,
+        transports: { nostr: { relays: ["wss://relay.invalid"] } },
+    }) as unknown as DiscoveredMarket;
+
+const CARDS = [cardOn("lightning"), cardOn("onchain")];
+
+const invoice = (): string =>
+    encodeInvoice({
+        prefix: "lnbcrt",
+        amount: `${INVOICE_SATS * 10}n`,
+        timestamp: NOW() - 60,
+        expiry: 7_200,
+        paymentHash: PAYMENT_HASH,
+    });
+
+/** The `rfqVerbs` stub's send leg, with the quote's lifetime opened up. */
+const stubTransport = (validForSeconds: number): AttestingRfqTransport => ({
+    attestedResponder: DISCOVERY_KEY,
+    async requestQuote(payload) {
+        const profile = (payload as { profile: Record<string, unknown> }).profile;
+        const refundLocktime = NOW() + 200 * 3600;
+        const contract = lightningSendContract({
+            solverPubkey: SOLVER,
+            refundLocktime,
+            operatorPubkey,
+            paymentHash: PAYMENT_HASH,
+            claimDelay,
+            emulatorPubkey,
+            senderPubkey: hex.decode(profile.client_refund_pubkey as string),
+            receiverPkScript: SOLVER_PK_SCRIPT,
+            refundPkScript: ArkAddress.decode(profile.refund_address as string).pkScript,
+        });
+        return {
+            v: 1,
+            type: "rfq_quote",
+            rfq_id: payload.rfq_id as string,
+            solver_pubkey: hex.encode(SOLVER),
+            valid_until: NOW() + validForSeconds,
+            refund_locktime: refundLocktime,
+            pair: LIGHTNING_SEND_PAIR,
+            from_amount: LOCKUP_SATS,
+            to_amount: INVOICE_SATS,
+            profile: {
+                receiver_pk_script: hex.encode(SOLVER_PK_SCRIPT),
+                lockup_address: contract.address(hrp, operatorPubkey).encode(),
+            },
+        } satisfies RfqQuote;
+    },
+    async status() {
+        return null;
+    },
+    async close() {},
+});
+
+const repository = new InMemoryAssetSwapRepository();
+
+const clientOn = (validForSeconds = 3_600): SwapClient =>
+    createSwapClient({
+        wallet,
+        repository,
+        discovery: { snapshot: CARDS },
+        transportFor: () => stubTransport(validForSeconds),
+    });
+
+beforeAll(async () => {
+    wallet = await Wallet.create({
+        identity: SingleKey.fromRandomBytes(),
+        arkServerUrl: OPERATOR_URL,
+        onchainProvider: new EsploraProvider(ESPLORA_API_URL, {
+            forcePolling: true,
+            pollingInterval: 2000,
+        }),
+        storage: {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        },
+        settlementConfig: false,
+    });
+
+    const note = execCommand(`${arkdExec} arkd note --amount 200000`);
+    execCommand(`${arkdExec} ark redeem-notes -n ${note} --password secret`);
+    const address = await wallet.getAddress();
+    execCommand(`${arkdExec} ark send --to ${address} --amount ${FAUCET_SATS} --password secret`);
+    await waitFor(async () => (await wallet.getVtxos()).length > 0);
+
+    const info = await wallet.getArkadeInfo();
+    operatorPubkey = xOnly(hex.decode(info.signerPubkey));
+    claimDelay = unilateralClaimDelay(Number(info.unilateralExitDelay));
+    hrp = ArkAddress.decode(address).hrp;
+    emulatorPubkey = xOnly(hex.decode(REGTEST_EMULATOR_PUBKEY));
+}, 180_000);
+
+describe("a rail that refuses (regtest)", () => {
+    it("keeps the swap rail for a size the card serves, ranked ahead of the exit", async () => {
+        const client = clientOn();
+        const router = createSwapPaymentRouter(wallet, client, { claimFeeRateSatVb: 2 });
+
+        const options = await router.options({ raw: BCRT1, amount: IN_RANGE_SATS });
+
+        expect(options.map((o) => o.railId)).toEqual([ONCHAIN_SWAP_RAIL, "onchain"]);
+        await client[Symbol.asyncDispose]();
+    }, 120_000);
+
+    it("drops it past the card's ceiling and lets the real exit win, with no error", async () => {
+        const client = clientOn();
+        const router = createSwapPaymentRouter(wallet, client, { claimFeeRateSatVb: 2 });
+
+        // The refusal is network-free: no solver hears this amount.
+        const resolution = await client.resolve({
+            to: BCRT1,
+            amount: BigInt(OVER_CEILING_SATS),
+            amountOn: "take",
+        });
+        expect(resolution.eligible).toBe(0);
+
+        const options = await router.options({ raw: BCRT1, amount: OVER_CEILING_SATS });
+        expect(options.map((o) => o.railId)).toEqual(["onchain"]);
+
+        // And the fallback is a real quote: arkd's own fee schedule priced it.
+        const quote = await router.route({ raw: BCRT1, amount: OVER_CEILING_SATS });
+        expect(quote.railId).toBe("onchain");
+        expect(quote.amount).toBe(OVER_CEILING_SATS);
+        expect(quote.total).toBe(quote.amount + quote.fee);
+
+        await client[Symbol.asyncDispose]();
+    }, 120_000);
+
+    it("refuses a size under the card's floor the same way", async () => {
+        const client = clientOn();
+        const router = createSwapPaymentRouter(wallet, client, { claimFeeRateSatVb: 2 });
+
+        // Over the claim's dust floor, so it is the CARD refusing, not the rail.
+        const options = await router.options({ raw: BCRT1, amount: 400 });
+
+        expect(options.map((o) => o.railId)).toEqual(["onchain"]);
+        await client[Symbol.asyncDispose]();
+    }, 120_000);
+});
+
+describe("a quote that expires (regtest)", () => {
+    it("fails the send with QuoteExpired, having funded nothing", async () => {
+        const client = clientOn(2);
+        const router = createSwapPaymentRouter(wallet, client, { claimFeeRateSatVb: 2 });
+        const before = (await repository.getAllSwapRecords()).length;
+
+        const quote = await router.route({ raw: invoice() });
+        expect(quote.railId).toBe(LIGHTNING_RAIL);
+        const expiresAt = quote.meta?.expiresAt as number;
+        expect(expiresAt).toBeGreaterThan(0);
+
+        // Against the quote's own deadline, so this cannot race it.
+        await waitFor(async () => NOW() > expiresAt, { timeout: 30_000, interval: 250 });
+
+        const handle = await quote.send();
+        const seen: { status: string; error?: unknown }[] = [];
+        handle.subscribe((u) => seen.push({ status: u.status, error: u.error }));
+
+        await expect(handle.settled()).rejects.toMatchObject({ name: "QuoteExpired" });
+        expect(seen.at(-1)).toMatchObject({ status: "failed" });
+        expect((seen.at(-1)?.error as Error).name).toBe("QuoteExpired");
+        // The refusal came before persistence, which is the whole point of it.
+        expect(await repository.getAllSwapRecords()).toHaveLength(before);
+
+        await client[Symbol.asyncDispose]();
+    }, 180_000);
+});

--- a/packages/swap/test/e2e/rfqRails.test.ts
+++ b/packages/swap/test/e2e/rfqRails.test.ts
@@ -290,7 +290,11 @@ describe("a quote that expires (regtest)", () => {
         const seen: { status: string; error?: unknown }[] = [];
         handle.subscribe((u) => seen.push({ status: u.status, error: u.error }));
 
-        await expect(handle.settled()).rejects.toMatchObject({ name: "QuoteExpired" });
+        // Bounded: a refusal is immediate, so a client that funds instead fails
+        // here by name rather than by running the whole case out of time.
+        await expect(handle.settled({ timeoutMs: 30_000 })).rejects.toMatchObject({
+            name: "QuoteExpired",
+        });
         expect(seen.at(-1)).toMatchObject({ status: "failed" });
         expect((seen.at(-1)?.error as Error).name).toBe("QuoteExpired");
         // The refusal came before persistence, which is the whole point of it.

--- a/packages/swap/test/exports.test.ts
+++ b/packages/swap/test/exports.test.ts
@@ -32,7 +32,9 @@ const { S, P, I, D, R } = dispositions;
 
 const namesOf = (entry: string) => new Set(inventory(entry).map((e) => e.name));
 const moduleOf = (entry: string) =>
-    new Map(inventory(entry).map((e) => [e.name, e.module] as const));
+    // Posix separators: the module path is asserted against a `src/...` pattern,
+    // which a Windows checkout would otherwise spell with backslashes.
+    new Map(inventory(entry).map((e) => [e.name, e.module.replaceAll("\\", "/")] as const));
 
 const root = namesOf(ROOT_ENTRY);
 const client = namesOf(CLIENT_ENTRY);

--- a/packages/ts-sdk/test/e2e/activity.test.ts
+++ b/packages/ts-sdk/test/e2e/activity.test.ts
@@ -118,14 +118,20 @@ describe("a custom resolver over real transactions (regtest)", () => {
 
     it("prepares before it resolves, and can correlate on what prepare loaded", async () => {
         const seen: string[] = [];
+        // The correlation data lands only AFTER an await, so a builder that
+        // called `prepare()` without awaiting it would resolve against an empty
+        // table and fail here rather than pass on the synchronous first line.
+        let loaded: string | undefined;
         const activities = await activitiesWith({
             id: "test:prepared",
             prepare: async () => {
                 seen.push("prepare");
+                await Promise.resolve();
+                loaded = sendTxid;
             },
             resolve: (tx) => {
                 seen.push("resolve");
-                return tx.key.arkTxid === sendTxid
+                return loaded !== undefined && tx.key.arkTxid === loaded
                     ? [{ groupId: "test:prepared-group", label: "Prepared" }]
                     : undefined;
             },

--- a/packages/ts-sdk/test/e2e/activity.test.ts
+++ b/packages/ts-sdk/test/e2e/activity.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The activity resolver against a real wallet history.
+ *
+ * Every transaction in `buildActivities`' unit suite is hand-built, which is
+ * what it cannot check: a hand-built `ArkTransaction` agrees with the resolver
+ * by construction, whether or not the real `getTransactionHistory()` populates
+ * `key.boardingTxid`, `type` and `tag` the same way. These rows come from a real
+ * boarding, settle and offchain send.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { boardingResolver, TxType, type ActivityResolver, type ArkTransaction } from "../../src";
+import {
+    beforeEachFaucet,
+    createTestArkWallet,
+    execCommand,
+    waitFor,
+    type TestArkWallet,
+} from "./utils";
+
+const BOARDING_SATS = 10_000;
+const SEND_SATS = 2_000;
+
+let alice: TestArkWallet;
+let bob: TestArkWallet;
+let boardingTxid: string;
+let sendTxid: string;
+
+/** Every resolver the wallet ships, plus whatever this case registers. */
+const activitiesWith = async (...extra: ActivityResolver[]) => {
+    for (const resolver of extra) alice.wallet.activity.use(resolver);
+    try {
+        return await alice.wallet.getActivityHistory();
+    } finally {
+        for (const resolver of extra) alice.wallet.activity.remove(resolver.id);
+    }
+};
+
+beforeAll(async () => {
+    await beforeEachFaucet();
+    alice = await createTestArkWallet();
+    bob = await createTestArkWallet();
+
+    const boardingAddress = await alice.wallet.getBoardingAddress();
+    execCommand(
+        `node regtest/regtest.mjs faucet ${boardingAddress} ${(BOARDING_SATS * 1e-8).toFixed(8)} --confirm`,
+    );
+    await waitFor(async () => (await alice.wallet.getBoardingUtxos()).length > 0);
+
+    const inputs = await alice.wallet.getBoardingUtxos();
+    boardingTxid = inputs[0].txid;
+    await alice.wallet.settle({
+        inputs,
+        outputs: [{ address: await alice.wallet.getAddress(), amount: BigInt(BOARDING_SATS) }],
+    });
+    execCommand("node regtest/regtest.mjs mine 1");
+    await waitFor(async () => (await alice.wallet.getVtxos()).length > 0);
+
+    sendTxid = await alice.wallet.send({
+        address: await bob.wallet.getAddress(),
+        amount: SEND_SATS,
+    });
+    await waitFor(async () => (await alice.wallet.getTransactionHistory()).length >= 2);
+}, 180_000);
+
+describe("the built-in resolvers, against a real history (regtest)", () => {
+    it("groups the real boarding transaction under the boarding resolver", async () => {
+        const activities = await alice.wallet.getActivityHistory();
+
+        const boarding = activities.find((a) => a.id === `boarding:${boardingTxid}`);
+        expect(boarding).toBeDefined();
+        expect(boarding?.intent).toMatchObject({ label: "Deposit", kind: "boarding" });
+        expect(boarding?.amount).toBe(BOARDING_SATS);
+        expect(boarding?.txs.every((tx) => tx.key.boardingTxid === boardingTxid)).toBe(true);
+    }, 120_000);
+
+    it("leaves the send ungrouped, bucketed by its own transaction key", async () => {
+        const activities = await alice.wallet.getActivityHistory();
+
+        const send = activities.find((a) => a.id === sendTxid);
+        expect(send).toBeDefined();
+        expect(send?.intent).toBeUndefined();
+        expect(send?.amount).toBe(-SEND_SATS);
+        expect(send?.txs[0].type).toBe(TxType.TxSent);
+    }, 120_000);
+
+    it("falls back to a plain row once the boarding resolver is removed", async () => {
+        alice.wallet.activity.remove("boarding");
+        try {
+            const activities = await alice.wallet.getActivityHistory();
+            expect(activities.some((a) => a.id === `boarding:${boardingTxid}`)).toBe(false);
+            const plain = activities.find((a) => a.id === boardingTxid);
+            expect(plain).toBeDefined();
+            expect(plain?.intent).toBeUndefined();
+        } finally {
+            // Restore for the cases that follow; the registry is wallet-wide.
+            alice.wallet.activity.use(boardingResolver());
+        }
+    }, 120_000);
+});
+
+describe("a custom resolver over real transactions (regtest)", () => {
+    it("collapses the boarding and the send into one activity that nets", async () => {
+        const activities = await activitiesWith({
+            id: "test:both",
+            resolve: (tx: ArkTransaction) =>
+                tx.key.boardingTxid === boardingTxid || tx.key.arkTxid === sendTxid
+                    ? [{ groupId: "test:group", label: "Both", kind: "test" }]
+                    : undefined,
+        });
+
+        const grouped = activities.find((a) => a.id === "test:group");
+        expect(grouped).toBeDefined();
+        expect(grouped?.intent).toMatchObject({ label: "Both", kind: "test" });
+        expect(grouped?.txs).toHaveLength(2);
+        // Signed by direction: the deposit came in, the send went out.
+        expect(grouped?.amount).toBe(BOARDING_SATS - SEND_SATS);
+    }, 120_000);
+
+    it("prepares before it resolves, and can correlate on what prepare loaded", async () => {
+        const seen: string[] = [];
+        const activities = await activitiesWith({
+            id: "test:prepared",
+            prepare: async () => {
+                seen.push("prepare");
+            },
+            resolve: (tx) => {
+                seen.push("resolve");
+                return tx.key.arkTxid === sendTxid
+                    ? [{ groupId: "test:prepared-group", label: "Prepared" }]
+                    : undefined;
+            },
+        });
+
+        expect(seen[0]).toBe("prepare");
+        expect(activities.find((a) => a.id === "test:prepared-group")?.intent?.label).toBe(
+            "Prepared",
+        );
+    }, 120_000);
+});
+
+describe("a resolver the builder has to survive (regtest)", () => {
+    it("isolates one that throws on every real row", async () => {
+        const activities = await activitiesWith({
+            id: "test:thrower",
+            resolve: () => {
+                throw new Error("resolver is broken");
+            },
+        });
+
+        // The built-ins still did their job, which is what isolation means.
+        expect(activities.some((a) => a.id === `boarding:${boardingTxid}`)).toBe(true);
+        expect(activities.some((a) => a.id === sendTxid)).toBe(true);
+    }, 120_000);
+
+    it("isolates one whose prepare rejects, keeping its resolve out entirely", async () => {
+        let resolved = 0;
+        const activities = await activitiesWith({
+            id: "test:bad-prepare",
+            prepare: async () => {
+                throw new Error("could not load");
+            },
+            resolve: () => {
+                resolved += 1;
+                return [{ groupId: "test:never", label: "Never" }];
+            },
+        });
+
+        expect(resolved).toBe(0);
+        expect(activities.some((a) => a.id === "test:never")).toBe(false);
+        expect(activities.some((a) => a.id === `boarding:${boardingTxid}`)).toBe(true);
+    }, 120_000);
+
+    it("drops memberships it cannot use, and keeps the row it would have taken", async () => {
+        const activities = await activitiesWith({
+            id: "test:bad-shapes",
+            resolve: (tx) =>
+                tx.key.arkTxid === sendTxid
+                    ? [
+                          { groupId: "", label: "Empty id" },
+                          { groupId: "test:nan", amount: Number.NaN },
+                      ]
+                    : undefined,
+        });
+
+        expect(activities.some((a) => a.id === "")).toBe(false);
+        expect(activities.some((a) => a.id === "test:nan")).toBe(false);
+        // Every membership was dropped, so the row is plain again rather than lost.
+        expect(activities.find((a) => a.id === sendTxid)?.amount).toBe(-SEND_SATS);
+    }, 120_000);
+
+    it("keeps the first writer's intent when two resolvers claim one group", async () => {
+        const claim = (id: string, label: string): ActivityResolver => ({
+            id,
+            resolve: (tx) =>
+                tx.key.arkTxid === sendTxid
+                    ? [{ groupId: "test:shared", label, metadata: { [id]: true } }]
+                    : undefined,
+        });
+        const activities = await activitiesWith(
+            claim("test:first", "First"),
+            claim("test:second", "Second"),
+        );
+
+        const shared = activities.find((a) => a.id === "test:shared");
+        expect(shared?.intent?.label).toBe("First");
+        expect(shared?.intent?.metadata).toMatchObject({ "test:first": true, "test:second": true });
+    }, 120_000);
+});
+
+describe("the registry itself (regtest)", () => {
+    it("ships the three built-ins and overwrites by id", async () => {
+        expect(alice.wallet.activity.list()).toEqual(
+            expect.arrayContaining(["boarding", "collab-exit", "asset-mint"]),
+        );
+
+        const before = alice.wallet.activity.list().length;
+        alice.wallet.activity.use({ id: "boarding", resolve: () => undefined });
+        try {
+            expect(alice.wallet.activity.list().length).toBe(before);
+            const activities = await alice.wallet.getActivityHistory();
+            // The override answers nothing, so the real boarding row is plain.
+            expect(activities.some((a) => a.id === `boarding:${boardingTxid}`)).toBe(false);
+        } finally {
+            alice.wallet.activity.use(boardingResolver());
+        }
+    }, 120_000);
+});

--- a/packages/ts-sdk/test/e2e/activity.test.ts
+++ b/packages/ts-sdk/test/e2e/activity.test.ts
@@ -88,7 +88,14 @@ describe("the built-in resolvers, against a real history (regtest)", () => {
         try {
             const activities = await alice.wallet.getActivityHistory();
             expect(activities.some((a) => a.id === `boarding:${boardingTxid}`)).toBe(false);
-            const plain = activities.find((a) => a.id === boardingTxid);
+            // Found by its member rather than by a predicted id: the natural key
+            // is `arkTxid || commitmentTxid || boardingTxid`, so once the settle's
+            // commitment lands on the row the bucket is no longer the boarding
+            // txid. The claim here is that the row survives ungrouped, not which
+            // of the three it buckets under.
+            const plain = activities.find((a) =>
+                a.txs.some((tx) => tx.key.boardingTxid === boardingTxid),
+            );
             expect(plain).toBeDefined();
             expect(plain?.intent).toBeUndefined();
         } finally {

--- a/packages/ts-sdk/test/e2e/activity.test.ts
+++ b/packages/ts-sdk/test/e2e/activity.test.ts
@@ -118,15 +118,16 @@ describe("a custom resolver over real transactions (regtest)", () => {
 
     it("prepares before it resolves, and can correlate on what prepare loaded", async () => {
         const seen: string[] = [];
-        // The correlation data lands only AFTER an await, so a builder that
-        // called `prepare()` without awaiting it would resolve against an empty
-        // table and fail here rather than pass on the synchronous first line.
+        // The correlation data lands a macrotask later, so a builder that
+        // CALLED `prepare()` without awaiting it resolves against an empty
+        // table and fails here. A microtask boundary is not enough: the
+        // surrounding `await Promise.all` flushes those anyway.
         let loaded: string | undefined;
         const activities = await activitiesWith({
             id: "test:prepared",
             prepare: async () => {
                 seen.push("prepare");
-                await Promise.resolve();
+                await new Promise((r) => setTimeout(r, 0));
                 loaded = sendTxid;
             },
             resolve: (tx) => {


### PR DESCRIPTION
## What this is

A coverage pass on three subsystems, which started by measuring what was
actually covered rather than assuming. One of the three turned out to be well
covered, one had a happy path only, and one had nothing. Measuring also turned
up a production defect, which is the one non-test change here.

## The inventory I found

Every swap e2e file that exists **does** run: the `swap` and `swap-rfq` CI jobs
pass an empty `test_files` and the package scripts glob
(`vitest run test/e2e --exclude 'test/e2e/rfq*.test.ts'` and
`vitest run test/e2e/rfq`). Read off the run logs for #845, not the job
conclusions: `swap/all` ran `swap`, `offerCancel`, `chainSource` (3 files, 13
tests) and `swap-rfq/all` ran `rfqVerbs`, `rfqDrive`, `rfqRegister` (3 files, 12
tests). The ts-sdk matrix enumerates instead of globbing, and it was complete —
25 files listed, 25 on disk, no orphans either way.

| Subsystem | Unit | e2e that runs | Verdict |
|---|---|---|---|
| Activity resolver | `ts-sdk/test/wallet/activity.test.ts`, `swap/test/activity.test.ts` | **none** — no e2e in either package referenced `buildActivities`, `getActivityHistory` or `ActivityRegistry` | gap |
| Payment rails | `swap/test/payment/*` (5 files) | one case: `rfqVerbs.test.ts` "the lightning rail through a real router", happy path | partial |
| Swap v2 | `swap/test/client/*` (~26 files) | `rfqVerbs`, `rfqDrive`, `offerCancel`, `chainSource` — including unhappy paths (fee ceiling, repeat cancel, refused ids, rebuild mismatch) | **already covered; nothing added** |

## The defect

`selectMarkets` takes a `wantAmount` ("trade size, checked against that side's
bounds") and `eligibleMarkets` never passed it, so every card's
`min_base_amount` / `max_base_amount` / `min_quote_amount` / `max_quote_amount`
was dead data — none of the four is read anywhere under `packages/swap/src`.
`resolve()` answered `eligible: 1` for a size 100x a card's ceiling.

That is what breaks the swap rails' documented self-healing. `payment/router.ts`
and `payment/onchainSwap.ts` both promise an out-of-range amount drops
`onchain-swap` at `available()` and the collaborative exit wins with no error,
and `available()` decides on `resolve().eligible > 0`. The existing unit test
asserts the fallback against a client hand-stubbed to `eligible: 0` — a value
the real client could not produce for an in-pair route — so it pinned a number
rather than the behaviour. In practice an out-of-range payment reached `quote()`
and failed at the solver instead of falling back to a working exit.

Only a take-side pin is forwarded; a give-side pin would need a price this read
deliberately does not have, so it stays unbounded. That asymmetry is documented
on the parameter.

**This is the one change here that is not a test.** It is separable: revert
`be29c318` and the three unit cases in `market.test.ts` / `resolve.test.ts` go
red, everything else stands.

## What was added

- `packages/ts-sdk/test/e2e/activity.test.ts` — real boarding, settle and
  offchain send, then the built-in resolvers against the shapes the wallet
  actually emits, plus the unhappy half: a resolver that throws, one whose
  `prepare()` rejects, one returning an empty `groupId` and a NaN amount, two
  claiming one group, and registry removal/override. **Added to the
  `settlement-delegation` group in `ci.yml`** — without that entry it would run
  nowhere while every job stayed green.
- `packages/swap/test/e2e/rfqRails.test.ts` — the two ways a rail declines: an
  out-of-range amount dropping `onchain-swap` so the real exit wins (priced by
  arkd's own fee schedule), a size under the card's floor doing the same, and a
  held `RouteQuote` outliving its `Quote` so `send()` fails `QuoteExpired`
  having funded nothing and written no record. The expiry wait polls the quote's
  own `expiresAt` rather than sleeping, so it does not race the clock it asserts
  on.
- Three unit cases pinning the bounds fix.
- Two Windows-only test-harness fixes, which took 2 of the swap package's 60
  suites out of any local run.

## Baseline vs post

Captured on `f6804f04` before any edit.

| | baseline | post |
|---|---|---|
| ts-sdk unit | 177 files, 3000 tests (2999 pass, 1 skip) | 177 files, 3000 tests (2999 pass, 1 skip) |
| swap unit | 60 files, **2 failing**, 1301 tests | 60 files, **0 failing**, 1318 tests |
| swap-rfq e2e | 3 files, 12 tests | 4 files, 16 tests |
| settlement-delegation e2e | 9 files, 25 tests | 10 files, 35 tests |

The two baseline unit failures were Windows-only and green on Linux CI:
`test/client/errors.test.ts` (the suite would not collect — `ENOENT scandir`
on a `/C:/…` path) and `test/exports.test.ts > the M8 disposition record >
binds each R name to the v2 declaration…` (a backslashed module path asserted
against a posix pattern).

+17 unit tests reconciles exactly: +14 from `errors.test.ts` now collecting at
all, +3 new.

## Mutations run

Each applied, pushed to a scratch branch, run in CI, then reverted. The e2e ones
needed the unit gate dropped on the scratch branch so the integration jobs would
run at all — the unit suite catches several of these first.

| Mutation | Test that caught it | Failure |
|---|---|---|
| Drop the `wantAmount` pass-through in `eligibleMarkets` | `market.test.ts > bounds the take leg against the card…` | `expected [ { card: {…(15)}, …(3) } ] to deeply equal []` |
| (same) | `resolve.test.ts > lands a size the cards do not serve there…` | `expected 1 to be +0` |
| Forward `amount?.value` regardless of side | `resolve.test.ts > leaves a give-side pin unbounded…` | `expected +0 to be 1` |
| `boardingResolver` match inverted | `activity.test.ts` — 5 cases | `expected undefined to be defined`, `expected false to be true`, `expected undefined to be -2000` |
| `railAvailable` returns true unconditionally | `rfqRails.test.ts` — 2 cases | `expected [ 'onchain-swap', 'onchain' ] to deeply equal [ 'onchain' ]` |
| `prepare()` rejection no longer isolated | `activity.test.ts > isolates one whose prepare rejects…` | `Error: could not load` propagated out of `getActivityHistory()` |
| Membership merge becomes last-writer-wins | `activity.test.ts > keeps the first writer's intent…` | `expected 'Second' to be 'First'` |
| `accept()` stops refusing an expired quote | `rfqRails.test.ts > fails the send with QuoteExpired…` | `expected Error: settle timeout to match object { name: 'QuoteExpired' }` |
| `prepare()` called but not awaited | `activity.test.ts > prepares before it resolves…` | `expected undefined to be 'Prepared'` |

Two of these changed the tests rather than confirming them, which is the point
of running them:

- The expiry case originally called `handle.settled()` unbounded. With
  `accept()`'s expiry check removed the swap funds, the handle never goes
  terminal, and the case burned its full 180s budget instead of reporting.
  It now waits with `settled({ timeoutMs: 30_000 })`.
- The prepare-ordering case originally pushed its marker on the synchronous
  first line of `prepare()`, so it passed even when `buildActivities` called
  `prepare()` without awaiting it (CodeRabbit spotted this). The first fix used
  a microtask boundary, which the mutation also survived — `await Promise.all`
  flushes those anyway. It now uses `setTimeout`.

## What I could not verify locally

The regtest stack on this machine belongs to another project and has been up for
36 hours; `container_name: arkd` is hardcoded in the compose file, so a second
stack cannot coexist, and its arkd has intent fees enabled (min 2000) while the
swap profile zeroes them — the existing e2e suites fail on it in `beforeAll`.
I did not tear it down. **The two new e2e files have therefore only ever run in
CI, not on my machine**; the unit, lint and typecheck results above are what I
verified locally.

One flake surfaced and was fixed rather than retried: the boarding-fallback case
predicted the ungrouped bucket would be keyed by the boarding txid, but the
natural key is `arkTxid || commitmentTxid || boardingTxid`, so once the settle's
commitment reached the row the lookup found nothing. It passed three runs before
failing one. It now finds the activity by its member transaction.

A separate, unrelated flake was observed once and cleared on re-run:
`offerCancel.test.ts > names the rebuild mismatch…` returned `needs_recovery`
instead of `cancelled` in a job whose log also showed `arkd not ready` and a DNS
lookup failure during bring-up. That file is untouched by this PR.
