### PR TITLE
fix(swap): omit claim_packet when there is no covclaimd to seal to

### DIFF
--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -1165,8 +1165,10 @@ export const lightningReceiveRequest = (input: {
     payoutAddress: string;
     /** Trader's x-only arkade key — the covenant's `receiver` role. */
     payoutPubkey: Uint8Array;
-    /** `P` sealed to covclaimd, base64 — `sealClaimPacket(...).ciphertext`. */
-    claimPacket: string;
+    /** `P` sealed to covclaimd, base64 — `sealClaimPacket(...).ciphertext`.
+     * Omitted when there is no covclaimd to seal to; the field is then left off
+     * the wire entirely, since the solver refuses an empty packet. */
+    claimPacket?: string;
     amount: number;
     amountSide: "from" | "to";
 }): Record<string, unknown> => ({
@@ -1180,7 +1182,7 @@ export const lightningReceiveRequest = (input: {
         payment_hash: input.paymentHash,
         payout_address: input.payoutAddress,
         payout_pubkey: hex.encode(input.payoutPubkey),
-        claim_packet: input.claimPacket,
+        ...(input.claimPacket === undefined ? {} : { claim_packet: input.claimPacket }),
     },
 });
 
@@ -1198,8 +1200,9 @@ export const onchainReceiveRequest = (input: {
     payoutPubkey: Uint8Array;
     /** Trader's x-only L1 key for the HTLC's refund leaf. */
     refundPubkey: Uint8Array;
-    /** `P` sealed to covclaimd, base64 — `sealClaimPacket(...).ciphertext`. */
-    claimPacket: string;
+    /** `P` sealed to covclaimd, base64. Omitted when there is none to seal to —
+     * see {@link lightningReceiveRequest}. */
+    claimPacket?: string;
     amount: number;
     amountSide: "from" | "to";
 }): Record<string, unknown> => ({
@@ -1211,7 +1214,7 @@ export const onchainReceiveRequest = (input: {
     amount: input.amount,
     profile: {
         payment_hash: input.paymentHash,
-        claim_packet: input.claimPacket,
+        ...(input.claimPacket === undefined ? {} : { claim_packet: input.claimPacket }),
         refund_pubkey: hex.encode(input.refundPubkey),
         payout_address: input.payoutAddress,
         payout_pubkey: hex.encode(input.payoutPubkey),
@@ -1805,8 +1808,10 @@ export async function requestLightningReceive(
          * {@link resolveEmulatorPubkey}. */
         emulatorPubkey?: string;
         /** covclaimd's 33-byte compressed pubkey (from its own info endpoint)
-         * — the claim packet seals to it and only it can ever read `P` early. */
-        covclaimdPubkey: Uint8Array;
+         * — the claim packet seals to it and only it can ever read `P` early.
+         * Unset where no covclaimd is deployed: nothing is sealed and no packet
+         * is sent. Never substitute a throwaway key — nobody could open it. */
+        covclaimdPubkey?: Uint8Array;
         /** The caller's own BOLT11 decoder, applied to the SOLVER's invoice.
          * Required: an optional verifier is one integrators skip, and this is
          * the check whose absence loses the whole payment. */
@@ -1861,10 +1866,12 @@ export async function requestLightningReceive(
         new RestArkProvider(arkServerUrl).getInfo(),
         wallet.getAddress(),
     ]);
-    const claimPacket = await sealClaimPacket({
-        preimage,
-        covclaimdPubkey: params.covclaimdPubkey,
-    });
+    const claimPacket = params.covclaimdPubkey
+        ? await sealClaimPacket({
+              preimage,
+              covclaimdPubkey: params.covclaimdPubkey,
+          })
+        : undefined;
 
     const quote = await transport.requestQuote(
         lightningReceiveRequest({
@@ -1872,7 +1879,7 @@ export async function requestLightningReceive(
             paymentHash,
             payoutAddress,
             payoutPubkey,
-            claimPacket: claimPacket.ciphertext,
+            claimPacket: claimPacket?.ciphertext,
             amount: params.amount,
             amountSide: params.amountSide,
         }),
@@ -2036,8 +2043,9 @@ export async function requestOnchainReceive(
         emulatorPubkey?: string;
         /** Trader's x-only L1 key for the HTLC's refund leaf. */
         refundPubkey: Uint8Array;
-        /** covclaimd's 33-byte compressed pubkey — see {@link requestLightningReceive}. */
-        covclaimdPubkey: Uint8Array;
+        /** covclaimd's 33-byte compressed pubkey, unset where none is deployed
+         * — see {@link requestLightningReceive}. */
+        covclaimdPubkey?: Uint8Array;
         rfqId?: string;
     },
 ): Promise<{
@@ -2076,10 +2084,12 @@ export async function requestOnchainReceive(
         new RestArkProvider(arkServerUrl).getInfo(),
         wallet.getAddress(),
     ]);
-    const claimPacket = await sealClaimPacket({
-        preimage,
-        covclaimdPubkey: params.covclaimdPubkey,
-    });
+    const claimPacket = params.covclaimdPubkey
+        ? await sealClaimPacket({
+              preimage,
+              covclaimdPubkey: params.covclaimdPubkey,
+          })
+        : undefined;
 
     const quote = await transport.requestQuote(
         onchainReceiveRequest({
@@ -2088,7 +2098,7 @@ export async function requestOnchainReceive(
             payoutAddress,
             payoutPubkey,
             refundPubkey: params.refundPubkey,
-            claimPacket: claimPacket.ciphertext,
+            claimPacket: claimPacket?.ciphertext,
             amount: params.amount,
             amountSide: params.amountSide,
         }),

--- a/packages/swap/test/rfqReceive.test.ts
+++ b/packages/swap/test/rfqReceive.test.ts
@@ -220,6 +220,44 @@ describe("receive request builders", () => {
             },
         });
     });
+
+    // Absence, not falsiness: the solver keeps `.min(1)`, so `""` is refused and
+    // `null` is no packet either — an omitted key is the only way to say absent.
+    it("omits claim_packet from the lightning profile when there is none", () => {
+        const { profile } = lightningReceiveRequest({
+            rfqId: RFQ_ID,
+            paymentHash: PAYMENT_HASH,
+            payoutAddress: "tark1q...",
+            payoutPubkey: TRADER_PAYOUT_PUBKEY,
+            amount: 5_000,
+            amountSide: "to",
+        }) as { profile: Record<string, unknown> };
+        expect(Object.keys(profile)).not.toContain("claim_packet");
+        expect(profile).toEqual({
+            payment_hash: PAYMENT_HASH,
+            payout_address: "tark1q...",
+            payout_pubkey: hex.encode(TRADER_PAYOUT_PUBKEY),
+        });
+    });
+
+    it("omits claim_packet from the onchain profile when there is none", () => {
+        const { profile } = onchainReceiveRequest({
+            rfqId: RFQ_ID,
+            paymentHash: PAYMENT_HASH,
+            payoutAddress: "tark1q...",
+            payoutPubkey: TRADER_PAYOUT_PUBKEY,
+            refundPubkey: L1_REFUND_PUBKEY,
+            amount: 100_000,
+            amountSide: "from",
+        }) as { profile: Record<string, unknown> };
+        expect(Object.keys(profile)).not.toContain("claim_packet");
+        expect(profile).toEqual({
+            payment_hash: PAYMENT_HASH,
+            refund_pubkey: hex.encode(L1_REFUND_PUBKEY),
+            payout_address: "tark1q...",
+            payout_pubkey: hex.encode(TRADER_PAYOUT_PUBKEY),
+        });
+    });
 });
 
 /** A quote whose covenant fields derive the lockup the maker will derive. */
@@ -1121,5 +1159,87 @@ describe("requestOnchainReceive on an HD wallet", () => {
             stored: result.secrets.preimage,
         });
         expect(seen.paymentHash).toBe(paymentHashOf(preimage));
+    });
+});
+
+/** Captures the profile that actually went out, then aborts the flow. Rejecting
+ * on the sentinel is load-bearing: a seal against an absent key throws first. */
+const capturedProfile = async (
+    send: (transport: RfqTransport) => Promise<unknown>,
+): Promise<Record<string, unknown>> => {
+    const seen: { profile?: Record<string, unknown> } = {};
+    const transport: RfqTransport = {
+        async requestQuote(payload) {
+            seen.profile = (payload as { profile: Record<string, unknown> }).profile;
+            throw new Error("captured");
+        },
+        async status() {
+            return null;
+        },
+        async close() {},
+    };
+    await expect(send(transport)).rejects.toThrow("captured");
+    return seen.profile!;
+};
+
+const decodeStub = (raw: string): InvoiceFacts => ({
+    raw,
+    paymentHash: "",
+    amountSats: 5_000,
+    expiresAt: INVOICE_EXPIRES_AT,
+});
+
+describe("a receive with no covclaimd to seal to", () => {
+    it("sends no claim_packet on the lightning leg", async () => {
+        const wallet = await hdWallet();
+        const profile = await capturedProfile((transport) =>
+            requestLightningReceive(wallet, "http://ark", transport, {
+                emulatorPubkey: EMULATOR_PUBKEY_HEX,
+                amount: 5_000,
+                amountSide: "from",
+                decodeInvoice: decodeStub,
+            }),
+        );
+        expect(Object.keys(profile)).not.toContain("claim_packet");
+    });
+
+    it("sends no claim_packet on the onchain leg", async () => {
+        const wallet = await hdWallet();
+        const profile = await capturedProfile((transport) =>
+            requestOnchainReceive(wallet, "http://ark", transport, {
+                emulatorPubkey: EMULATOR_PUBKEY_HEX,
+                amount: 100_000,
+                amountSide: "from",
+                refundPubkey: L1_REFUND_PUBKEY,
+            }),
+        );
+        expect(Object.keys(profile)).not.toContain("claim_packet");
+    });
+
+    it("still seals on both legs when covclaimd IS configured", async () => {
+        const wallet = await hdWallet();
+        const lightning = await capturedProfile((transport) =>
+            requestLightningReceive(wallet, "http://ark", transport, {
+                emulatorPubkey: EMULATOR_PUBKEY_HEX,
+                amount: 5_000,
+                amountSide: "from",
+                covclaimdPubkey: COVCLAIMD_PK,
+                decodeInvoice: decodeStub,
+            }),
+        );
+        expect(typeof lightning.claim_packet).toBe("string");
+        expect(lightning.claim_packet).not.toBe("");
+
+        const onchain = await capturedProfile((transport) =>
+            requestOnchainReceive(wallet, "http://ark", transport, {
+                emulatorPubkey: EMULATOR_PUBKEY_HEX,
+                amount: 100_000,
+                amountSide: "from",
+                refundPubkey: L1_REFUND_PUBKEY,
+                covclaimdPubkey: COVCLAIMD_PK,
+            }),
+        );
+        expect(typeof onchain.claim_packet).toBe("string");
+        expect(onchain.claim_packet).not.toBe("");
     });
 });


### PR DESCRIPTION
A client with no covclaimd deployed has nothing to seal the preimage to. `covclaimdPubkey` being a required `Uint8Array` left it exactly one option: generate a throwaway key and seal to that, producing a well-formed `claim_packet` that nobody can ever open.

That is not hypothetical. `arkade-os/wallet` does it today on `master` (arkade-os/wallet#952):

```ts
// src/lib/constants.ts:181-186
export const getCovclaimdPubkeyForNetwork = (network: NetworkName): Uint8Array => {
  const pubkey = fromRuntimeEnv(import.meta.env.VITE_COVCLAIMD_PUBKEY) ?? COVCLAIMD_PUBKEY[network]
  return pubkey && COMPRESSED_PUBKEY_HEX.test(pubkey)
    ? hex.decode(pubkey)
    : secp256k1.getPublicKey(secp256k1.utils.randomSecretKey(), true)
}
```

Only `mutinynet` and `regtest` have a real key there. On mainnet, signet and testnet the wallet seals `P` to a key nobody holds, so covclaimd can never claim and the "lock it and go offline" guarantee silently does not hold. **No funds are at risk** — the trader keeps `P` and can claim the lockup itself — but a guarantee the UI implies is simply absent.

Absent should mean absent. This is the SDK half.

## What changed

`covclaimdPubkey` is now optional on `requestLightningReceive` and `requestOnchainReceive`. When it is absent, nothing is sealed and `claim_packet` is left off the wire object **entirely**:

```ts
...(input.claimPacket === undefined ? {} : { claim_packet: input.claimPacket }),
```

Not `""`, not `null`. The solver keeps `.min(1)` on the field precisely so an empty packet is still refused, so omitting the key is the only way to say absent — sending either sentinel would get the quote rejected.

This is **widening only**: every existing caller that passes a key behaves exactly as it did before, byte for byte.

## Both corridors, and how I know there are only two

The specific failure worth avoiding here is fixing one receive leg and leaving the throwaway key alive on the other. There are two of everything, and both are changed:

| | lightning receive | onchain receive |
|---|---|---|
| required param | `requestLightningReceive` | `requestOnchainReceive` |
| unconditional seal | ✅ now conditional | ✅ now conditional |
| wire builder | `lightningReceiveRequest` | `onchainReceiveRequest` |

Established by grepping the whole repo at the branch point for all four spellings — `covclaimdPubkey`, `sealClaimPacket`, `claim_packet`, `claimPacket` — not just `rfq.ts`. Outside these two paths the only hits in `src/` are the sealing primitive itself (`claimPacket.ts`) and its re-export from `index.ts`. There is no third path.

## Tests

Five added, all failing before the change:

- both builders omit `claim_packet` when `claimPacket` is undefined
- both `request*Receive` functions send no `claim_packet` when `covclaimdPubkey` is unset
- both still seal when it IS set (the guard against "fixed" by deleting the feature)

The assertion is `expect(Object.keys(profile)).not.toContain("claim_packet")` — **key absence, not falsiness**. A `toEqual` alone would not catch a key present with value `undefined`, and a falsy check would pass for both `""` and `null`, which are the two wrong answers.

The flow tests use a transport that records the profile and then throws a sentinel. The rejection assertion is load-bearing rather than incidental: a seal attempted against an absent key throws inside `sealClaimPacket` *before* the transport is reached, so "seal anyway" fails with the wrong error rather than passing quietly.

## Mutations

Seven run, each reverted afterwards. **No survivors.**

| Mutation | Result | Message |
|---|---|---|
| M1a lightning builder sends `""` | KILLED | `expected [ 'payment_hash', …(3) ] to not include 'claim_packet'` |
| M1b onchain builder sends `""` | KILLED | `expected [ Array(5) ] to not include 'claim_packet'` |
| M2a lightning builder sends `null` | KILLED | `expected [ 'payment_hash', …(3) ] to not include 'claim_packet'` |
| M2b onchain builder sends `null` | KILLED | `expected [ Array(5) ] to not include 'claim_packet'` |
| M3a lightning seals anyway | KILLED | `expected [Function] to throw error including 'captured' but got 'Cannot read properties of undefined (…'` |
| M3b onchain seals anyway | KILLED | `expected [Function] to throw error including 'captured' but got 'Cannot read properties of undefined (…'` |
| M4 onchain path left entirely unfixed | KILLED | both onchain assertions above |

M1 and M2 produce the same message by design: the assertion is on key presence, so it kills *any* value rather than just falsy ones.

M4 is the one that matters most — it is the "fixed one corridor, shipped the other" failure, and it fails loudly.

## Gate

Baseline at the branch point (`45a53690`): 232 files / 4366 tests, 0 failing. Now 232 files / 4371 tests, 0 failing — **+5, exactly the five new tests**, and the file count is unchanged, so nothing was displaced.

`pnpm run lint`, all three `typecheck`s, `pnpm run build` and `pnpm run test:unit` each exit 0 locally. `smoke:dist` for `boltz-swap` and `swap` pass; `ts-sdk`'s fails locally on `EPERM: operation not permitted, symlink` — a Windows privilege limitation in a temp consumer directory, unrelated to this change and green on Linux CI.

**What the green integration jobs do *not* prove.** Worth saying plainly rather than letting a green tick imply more than it does: `packages/swap/test/e2e` exercises `requestLightningSend` only. Neither `requestLightningReceive` nor `requestOnchainReceive` is called from any e2e test, before or after this change, so the regtest jobs say nothing about either corridor here. The evidence for this change is the unit tests and the mutation run above — not the integration matrix.

## One of three, and this one cannot land first

| order | repo | what |
|---|---|---|
| 1 | `arkade-os/intent-solver` | solver **accepts** an omitted `claim_packet` — arkade-os/intent-solver#60 |
| 2 | **this PR** | stop sealing unconditionally |
| 3 | `arkade-os/wallet` | stop generating the throwaway key |

(1) is backward compatible alone and is already open. **This PR should not be released before (1) is deployed** — a client that omits the field against an old solver gets its quote refused. Nothing in this repo omits it yet, so merging is safe at any time; it is the *release* that needs (1) live.

(3) is blocked on a release of `@arkade-os/swap` from this PR, since the parameter is required until then.

Refs arkade-os/wallet#952
