### PR TITLE
fix(swap): issue IndexedDB reads in the transaction's own tick

### DIFF
--- a/packages/swap/src/indexedDbRepository.ts
+++ b/packages/swap/src/indexedDbRepository.ts
@@ -64,8 +64,18 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
         return this.connection.get();
     }
 
-    private async readStore(name: string): Promise<IDBObjectStore> {
-        return (await this.ensureDb()).transaction([name], "readonly").objectStore(name);
+    /** Every read in one place, mirroring `write`: the transaction is created
+     * and its request issued in the same tick. WebKit deactivates a transaction
+     * as soon as the script that created it yields — before the microtask queue
+     * drains, where Chrome and Firefox keep it active to the end of the
+     * checkpoint — so a request issued after `await`ing the store throws
+     * `TransactionInactiveError` in Safari, and every read here used to. */
+    private async read<T>(
+        name: string,
+        request: (store: IDBObjectStore) => IDBRequest<T>,
+    ): Promise<T> {
+        const db = await this.ensureDb();
+        return promisifyRequest(request(db.transaction([name], "readonly").objectStore(name)));
     }
 
     /** Every write in one place, so none of them can forget to await the
@@ -84,8 +94,8 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
         });
     }
 
-    async getAllSwaps(): Promise<AssetSwap[]> {
-        return promisifyRequest((await this.readStore(STORE_SWAPS)).getAll());
+    getAllSwaps(): Promise<AssetSwap[]> {
+        return this.read(STORE_SWAPS, (store) => store.getAll() as IDBRequest<AssetSwap[]>);
     }
 
     async saveRfqSwap(record: RfqSwapRecord): Promise<void> {
@@ -94,12 +104,15 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
         });
     }
 
-    async getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined> {
-        return promisifyRequest((await this.readStore(STORE_RFQ_SWAPS)).get(rfqId));
+    getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined> {
+        return this.read(
+            STORE_RFQ_SWAPS,
+            (store) => store.get(rfqId) as IDBRequest<RfqSwapRecord | undefined>,
+        );
     }
 
-    async getAllRfqSwaps(): Promise<RfqSwapRecord[]> {
-        return promisifyRequest((await this.readStore(STORE_RFQ_SWAPS)).getAll());
+    getAllRfqSwaps(): Promise<RfqSwapRecord[]> {
+        return this.read(STORE_RFQ_SWAPS, (store) => store.getAll() as IDBRequest<RfqSwapRecord[]>);
     }
 
     async removeRfqSwap(rfqId: string): Promise<void> {
@@ -109,8 +122,11 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
     }
 
     async getScannedTxids(): Promise<Set<string>> {
-        const keys = await promisifyRequest((await this.readStore(STORE_SCANNED)).getAllKeys());
-        return new Set(keys as string[]);
+        const keys = await this.read(
+            STORE_SCANNED,
+            (store) => store.getAllKeys() as IDBRequest<string[]>,
+        );
+        return new Set(keys);
     }
 
     async markTxidsScanned(txids: Iterable<string>): Promise<void> {
@@ -119,12 +135,14 @@ export class IndexedDbAssetSwapRepository implements AssetSwapRepository {
         });
     }
 
-    async getCachedMarkets(
-        network: string,
-        registry: string,
-    ): Promise<MarketsCacheEntry | undefined> {
-        const store = await this.readStore(STORE_MARKETS);
-        return promisifyRequest(store.get(marketsCacheKey(network, registry)));
+    getCachedMarkets(network: string, registry: string): Promise<MarketsCacheEntry | undefined> {
+        return this.read(
+            STORE_MARKETS,
+            (store) =>
+                store.get(marketsCacheKey(network, registry)) as IDBRequest<
+                    MarketsCacheEntry | undefined
+                >,
+        );
     }
 
     async saveCachedMarkets(

--- a/packages/swap/test/indexedDbRepository.test.ts
+++ b/packages/swap/test/indexedDbRepository.test.ts
@@ -1,0 +1,140 @@
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AssetSwap } from "../src/store";
+import type { RfqSwapRecord } from "../src/rfqRecord";
+import { IndexedDbAssetSwapRepository } from "../src/indexedDbRepository";
+
+/**
+ * WebKit's transaction lifetime: a transaction goes inactive the moment the
+ * script that created it yields — BEFORE the microtask queue drains — so a
+ * request issued after any `await`, even of an already-settled promise, throws
+ * `TransactionInactiveError`. Chrome and Firefox deactivate at the end of the
+ * microtask checkpoint instead, and so does fake-indexeddb. Emulated here:
+ * every store a transaction hands out refuses requests once a microtask has
+ * passed since the transaction was created.
+ */
+const REQUESTS = new Set([
+    "add",
+    "clear",
+    "count",
+    "delete",
+    "get",
+    "getAll",
+    "getAllKeys",
+    "getKey",
+    "put",
+]);
+const originalTransaction = IDBDatabase.prototype.transaction;
+
+function emulateWebKitTransactionLifetime() {
+    IDBDatabase.prototype.transaction = function (
+        this: IDBDatabase,
+        ...args: Parameters<IDBDatabase["transaction"]>
+    ) {
+        const tx = originalTransaction.apply(this, args);
+        let active = true;
+        queueMicrotask(() => {
+            active = false;
+        });
+        const objectStore = tx.objectStore.bind(tx);
+        tx.objectStore = (name: string) =>
+            new Proxy(objectStore(name), {
+                get(target, prop) {
+                    const value = Reflect.get(target, prop, target);
+                    if (typeof value !== "function") return value;
+                    return (...params: unknown[]) => {
+                        if (!active && typeof prop === "string" && REQUESTS.has(prop)) {
+                            throw new DOMException(
+                                "Failed to execute request: the transaction is not active.",
+                                "TransactionInactiveError",
+                            );
+                        }
+                        return value.apply(target, params);
+                    };
+                },
+            });
+        return tx;
+    };
+}
+
+const swap: AssetSwap = {
+    id: "funding-txid",
+    fromAsset: "btc",
+    toAsset: "f1".repeat(34),
+    fromAmount: "10000",
+    toAmount: "992",
+    swapAddress: "",
+    swapPkScript: "5120" + "ab".repeat(32),
+    offerHex: "0100",
+    fundingTxid: "funding-txid",
+    status: "pending",
+    createdAt: 1,
+};
+
+const rfqSwap = {
+    rfqId: "rfq-1",
+    kind: "lightning_send",
+    state: "pending",
+    lockupAddress: "tark1qlockup",
+    profile: {},
+    createdAt: 1,
+    updatedAt: 1,
+} as RfqSwapRecord;
+
+describe("IndexedDbAssetSwapRepository under WebKit's transaction lifetime", () => {
+    let repository: IndexedDbAssetSwapRepository;
+
+    beforeEach(() => {
+        emulateWebKitTransactionLifetime();
+        // unique db name per test so fake-indexeddb state never leaks between tests
+        repository = new IndexedDbAssetSwapRepository(`webkit-${Math.random()}`);
+    });
+
+    afterEach(async () => {
+        IDBDatabase.prototype.transaction = originalTransaction;
+        await repository[Symbol.asyncDispose]();
+    });
+
+    it("reads back the swaps it wrote", async () => {
+        await repository.saveSwap(swap);
+        expect(await repository.getAllSwaps()).toEqual([swap]);
+    });
+
+    it("reads back rfq swap records by key and in bulk", async () => {
+        await repository.saveRfqSwap(rfqSwap);
+        expect(await repository.getRfqSwap("rfq-1")).toEqual(rfqSwap);
+        expect(await repository.getRfqSwap("rfq-2")).toBeUndefined();
+        expect(await repository.getAllRfqSwaps()).toEqual([rfqSwap]);
+    });
+
+    it("reads back the scanned txids", async () => {
+        await repository.markTxidsScanned(["a", "b"]);
+        expect(await repository.getScannedTxids()).toEqual(new Set(["a", "b"]));
+    });
+
+    it("reads back the markets cache", async () => {
+        const entry = { markets: [], fetchedAt: 42 };
+        await repository.saveCachedMarkets("bitcoin", "https://registry", entry);
+        expect(await repository.getCachedMarkets("bitcoin", "https://registry")).toEqual(entry);
+        expect(await repository.getCachedMarkets("bitcoin", "https://other")).toBeUndefined();
+    });
+
+    it("reads an empty store after clear", async () => {
+        await repository.saveSwap(swap);
+        await repository.clear();
+        expect(await repository.getAllSwaps()).toEqual([]);
+    });
+
+    // Proves the emulation bites: a read that takes the store across an await
+    // fails the way the repository's own reads used to.
+    it("rejects a request issued after the creating tick", async () => {
+        await repository.saveSwap(swap);
+        const db = await (repository as any).ensureDb();
+        const store = await Promise.resolve(
+            db.transaction(["swaps"], "readonly").objectStore("swaps"),
+        );
+        expect(() => store.getAll()).toThrowError(
+            expect.objectContaining({ name: "TransactionInactiveError" }),
+        );
+    });
+});


### PR DESCRIPTION
## Problem

Every read on `IndexedDbAssetSwapRepository` rejects with `TransactionInactiveError` in Safari.

WebKit deactivates an IndexedDB transaction as soon as the script that created it yields, before the microtask queue drains. Chrome and Firefox keep it active to the end of the microtask checkpoint, which is what the spec asks for. The repository read through an async `readStore()` and issued the request only after `await`ing it, so `getAllSwaps`, `getRfqSwap`, `getAllRfqSwaps`, `getScannedTxids` and `getCachedMarkets` all threw. Writes were unaffected: `write()` already issued its requests synchronously.

Downstream, in the wallet: `getAssetSwaps` swallowed the error into an empty list, `addAssetSwap` (read, then write) rejected after the funding tx had already been sent, and `RfqSwapManager.saveRecord` lost Lightning records the same way. Wallet-side workaround: arkade-os/wallet#954.

## Change

Two commits.

1. `fix(swap)`: replace `readStore()` with `read()`, which creates the transaction and issues its request in the same tick, mirroring `write()`. No behaviour change on spec-lifetime engines.
2. `test(swap)`: emulate the WebKit lifetime on `fake-indexeddb` (a store refuses requests once a microtask has passed since its transaction was created), round-trip every read against the repository's own write under it, and prove the emulation bites by taking a store across an `await`.

## Validation

`pnpm run lint`, both package typechecks, `pnpm run build`, and `pnpm run test:unit` all pass. Not run in a real Safari; the lifetime is emulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EugrC3vqmX7aGYEGpyYr6i

---
_Generated by [Claude Code](https://claude.ai/code/session_01EugrC3vqmX7aGYEGpyYr6i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IndexedDB data retrieval reliability in Safari and other WebKit-based browsers.
  * Fixed potential transaction inactivity errors when reading saved swaps, RFQ records, scanned transaction IDs, and cached market data.

* **Tests**
  * Added coverage for IndexedDB reads, store clearing, and browser transaction-lifetime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->