### PR TITLE
fix(sdk): keep gated contract outputs out of transaction history

### DIFF
--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -1,5 +1,31 @@
+import { gatedContracts } from "../contracts/spendability";
+import type { Contract } from "../contracts/types";
 import { ArkTransaction, Asset, BuiltinTxTag, TxKey, TxType, VirtualCoin } from "../wallet";
 import { normalizeVtxo, type NormalizedVirtualCoin } from "../wallet/vtxo";
+
+/**
+ * The VTXOs history may treat as the wallet's own: everything outside a
+ * contract the spendability gate closes.
+ *
+ * A gated contract — an escrow, a swap offer covenant, a swap lockup, a VHTLC —
+ * is money committed to a covenant, not the wallet's balance, and history has
+ * to read it the same way the balance does. Counting its outputs as the
+ * wallet's made funding one net to zero (the covenant output looked like
+ * change, so no row at all), and made its later spend read as a send of the
+ * escrowed amount. Outside the wallet's set, the same movements read like they
+ * do against any other counterparty: funding is SENT, a claim or refund back
+ * into the wallet is RECEIVED, and a spend by the counterparty is not ours.
+ *
+ * The gate is keyed on script, like {@link gatedContracts}; a VTXO with no
+ * script belongs to no contract row and stays.
+ */
+export function historyVtxos<V extends { script?: string }>(
+    contracts: readonly Contract[],
+    vtxos: readonly V[],
+): V[] {
+    const gated = gatedContracts(contracts);
+    return vtxos.filter((vtxo) => vtxo.script === undefined || !gated.has(vtxo.script));
+}
 
 type ExtendedArkTransaction = ArkTransaction & {
     tag: BuiltinTxTag;

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -63,7 +63,7 @@ import type {
 import type { SignerStatus } from "../signerRotation";
 import { MessageHandler, RequestEnvelope, ResponseEnvelope } from "../../worker/messageBus";
 import { Transaction } from "../../utils/transaction";
-import { buildTransactionHistory } from "../../utils/transactionHistory";
+import { buildTransactionHistory, historyVtxos } from "../../utils/transactionHistory";
 import {
     getVtxosForContract,
     saveVtxosForContract,
@@ -1166,7 +1166,7 @@ export class WalletMessageHandler
                     });
                 }
                 case "GET_TRANSACTION_HISTORY": {
-                    const allVtxos = await this.getVtxosFromRepo();
+                    const allVtxos = await this.getHistoryVtxosFromRepo();
                     const transactions =
                         (await this.buildTransactionHistoryFromCache(allVtxos)) ?? [];
                     return this.tagged({
@@ -1866,7 +1866,7 @@ export class WalletMessageHandler
         }
 
         // Read virtual outputs from repository (now populated by contract manager)
-        const vtxos = await this.getVtxosFromRepo();
+        const vtxos = await this.getHistoryVtxosFromRepo();
 
         // Fetch boarding inputs across the full boarding-address set (current +
         // historical rotated; plan §6-IV.2). Fetch FIRST: getBoardingUtxos
@@ -2069,6 +2069,18 @@ export class WalletMessageHandler
      */
     private async getVtxosFromRepo(): Promise<NormalizedExtendedVirtualCoin[]> {
         return (await this.repoSnapshot()).vtxos;
+    }
+
+    /**
+     * The repository VTXOs history may treat as the wallet's own — the plain
+     * Wallet path's read, off the same snapshot the gate uses. @see historyVtxos
+     */
+    private async getHistoryVtxosFromRepo(): Promise<NormalizedExtendedVirtualCoin[]> {
+        const { snapshot, vtxos } = await this.repoSnapshot();
+        return historyVtxos(
+            snapshot.map((_) => _.contract),
+            vtxos,
+        );
     }
 
     /**

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -138,7 +138,7 @@ import {
 import { Batch } from "./batch";
 import { Estimator } from "../arkfee";
 import { DelegateProvider } from "../providers/delegate";
-import { buildTransactionHistory } from "../utils/transactionHistory";
+import { buildTransactionHistory, historyVtxos } from "../utils/transactionHistory";
 import { createDefaultActivityRegistry, buildActivities, type Activity } from "./activity";
 import { AssetManager, ReadonlyAssetManager } from "./asset-manager";
 import { Extension, type ExtensionPacket } from "../extension";
@@ -1481,7 +1481,12 @@ export class ReadonlyWallet implements IReadonlyWallet {
     async getTransactionHistory(): Promise<ArkTransaction[]> {
         const contractManager = await this.getContractManager();
         const response = await contractManager.getContractsWithVtxos();
-        const allVtxos = response.flatMap((_) => _.vtxos);
+        // Gated contracts stay out, as they do for the balance: their outputs are
+        // destinations, not change. @see historyVtxos
+        const allVtxos = historyVtxos(
+            response.map((_) => _.contract),
+            response.flatMap((_) => _.vtxos),
+        );
 
         const { boardingTxs, commitmentsToIgnore } = await this.getBoardingTxs();
 

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -551,14 +551,29 @@ describe("getBalance", () => {
 });
 
 describe("gated reads stay ungated (D1b/D1d)", () => {
-    it("keeps escrowed funds in the recovery and history reads", async () => {
+    it("keeps escrowed funds in the recovery read", async () => {
         const { wallet } = await seededWallet();
 
         expect(scriptsOf(await wallet.getVtxos({ withRecoverable: true }))).toContain(
             ESCROW_SCRIPT,
         );
+    });
+
+    // History is not a gated read: it answers "what moved in and out of the
+    // wallet", and an escrowed coin is committed to a covenant, not the
+    // wallet's own — the same line the balance draws. Funding the escrow is
+    // the row; the coin sitting in it is not. @see historyVtxos
+    it("reads escrowed coins as outside the wallet in history", async () => {
+        const { wallet, defaultScript } = await seededWallet();
+        const txidOf = (script: string) => script.slice(-2).repeat(32);
+
         const history = await wallet.getTransactionHistory();
-        expect(history.length).toBeGreaterThan(0);
+        const arkTxids = history.map((tx) => tx.key.arkTxid);
+
+        expect(arkTxids).toContain(txidOf(defaultScript));
+        expect(arkTxids).toContain(txidOf(MARKED_SCRIPT));
+        expect(arkTxids).not.toContain(txidOf(ESCROW_SCRIPT));
+        expect(arkTxids).not.toContain(txidOf(UNKNOWN_SCRIPT));
     });
 
     it("settles a gated VTXO when it is named explicitly (D1d)", async () => {

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import transactionHistory from "./fixtures/transaction_history.json";
 import { VirtualCoin, TxType, ArkTransaction } from "../src/wallet";
-import { buildTransactionHistory } from "../src/utils/transactionHistory";
+import type { Contract } from "../src/contracts/types";
+import { buildTransactionHistory, historyVtxos } from "../src/utils/transactionHistory";
+import { createDefaultContractParams } from "./contracts/helpers";
 
 describe("buildTransactionHistory", () => {
     // TODO FIX THIS!
@@ -1141,5 +1143,129 @@ describe("buildTransactionHistory", () => {
                 });
             },
         );
+    });
+});
+
+/**
+ * A swap offer: the wallet funds a covenant it registered (gated: an unmarked
+ * `arkade` row), the solver fills it or the wallet cancels it. With the
+ * covenant's coin counted as the wallet's, the funding netted to zero and
+ * produced no row, the cancel netted to zero too, and the fill read as a send
+ * of the escrowed amount. Read through `historyVtxos` the three movements are
+ * what they are: sent, received, received.
+ */
+describe("history of a gated contract", () => {
+    const WALLET_SCRIPT = "5120" + "aa".repeat(32);
+    const OFFER_SCRIPT = "5120" + "bb".repeat(32);
+    const ASSET_ID = "cc".repeat(32);
+    const FUNDING = "f0".repeat(32);
+    const FILL = "f1".repeat(32);
+    const CANCEL = "f2".repeat(32);
+
+    const contract = (script: string, type: string, metadata?: Record<string, unknown>) =>
+        ({
+            type,
+            params: type === "default" ? createDefaultContractParams() : {},
+            script,
+            address: `addr-${script.slice(-2)}`,
+            state: "active",
+            createdAt: 1,
+            ...(metadata ? { metadata } : {}),
+        }) as Contract;
+    const contracts = [contract(WALLET_SCRIPT, "default"), contract(OFFER_SCRIPT, "arkade")];
+
+    const at = (minute: number) => new Date(1_700_000_000_000 + minute * 60_000);
+    const coin = (
+        over: Partial<VirtualCoin> & Pick<VirtualCoin, "txid" | "value">,
+    ): VirtualCoin => ({
+        vout: 0,
+        script: WALLET_SCRIPT,
+        status: { confirmed: false },
+        virtualStatus: { state: "preconfirmed" },
+        createdAt: at(0),
+        isUnrolled: false,
+        isSpent: false,
+        ...over,
+    });
+
+    // 10 000 sats the wallet held, spent into the covenant by the funding tx.
+    const deposit = coin({
+        txid: "a0".repeat(32),
+        value: 10_000,
+        isSpent: true,
+        arkTxId: FUNDING,
+        spentBy: FUNDING,
+    });
+    const covenant = coin({ txid: FUNDING, value: 10_000, script: OFFER_SCRIPT, createdAt: at(1) });
+
+    const history = (vtxos: VirtualCoin[]) =>
+        buildTransactionHistory(historyVtxos(contracts, vtxos), [], new Set());
+    const sentRows = (txs: ArkTransaction[]) => txs.filter((tx) => tx.type === TxType.TxSent);
+    const receivedByTxid = (txs: ArkTransaction[], arkTxid: string) =>
+        txs.find((tx) => tx.type === TxType.TxReceived && tx.key.arkTxid === arkTxid);
+
+    it("keeps every coin outside a gated contract, script or no script", () => {
+        const marked = contract("5120" + "dd".repeat(32), "arkade", { genericallySpendable: true });
+        const scriptless = {
+            ...coin({ txid: "e0".repeat(32), value: 1 }),
+            script: undefined,
+        } as VirtualCoin;
+        const kept = historyVtxos(
+            [...contracts, marked],
+            [
+                deposit,
+                covenant,
+                coin({ txid: "e1".repeat(32), value: 1, script: marked.script }),
+                scriptless,
+            ],
+        );
+
+        expect(kept.map((v) => v.txid)).toEqual([deposit.txid, "e1".repeat(32), "e0".repeat(32)]);
+    });
+
+    it("reads the funding as a send of the full deposit while the offer is open", async () => {
+        const txs = await history([deposit, covenant]);
+
+        expect(sentRows(txs)).toEqual([
+            expect.objectContaining({
+                amount: 10_000,
+                key: expect.objectContaining({ arkTxid: FUNDING }),
+            }),
+        ]);
+        expect(receivedByTxid(txs, FUNDING)).toBeUndefined();
+    });
+
+    it("reads the fill as a receive of the asset, not a send of the covenant", async () => {
+        const filled = { ...covenant, isSpent: true, arkTxId: FILL, spentBy: FILL };
+        const payout = coin({
+            txid: FILL,
+            value: 330,
+            createdAt: at(2),
+            assets: [{ assetId: ASSET_ID, amount: 500n }],
+        });
+        const txs = await history([deposit, filled, payout]);
+
+        expect(sentRows(txs).map((tx) => tx.key.arkTxid)).toEqual([FUNDING]);
+        expect(receivedByTxid(txs, FILL)).toMatchObject({
+            amount: 330,
+            assets: [{ assetId: ASSET_ID, amount: 500n }],
+        });
+    });
+
+    it("reads the cancel as the deposit coming back", async () => {
+        const cancelled = { ...covenant, isSpent: true, arkTxId: CANCEL, spentBy: CANCEL };
+        const refund = coin({ txid: CANCEL, value: 10_000, createdAt: at(2) });
+        const txs = await history([deposit, cancelled, refund]);
+
+        expect(sentRows(txs).map((tx) => tx.key.arkTxid)).toEqual([FUNDING]);
+        expect(receivedByTxid(txs, CANCEL)).toMatchObject({ amount: 10_000 });
+    });
+
+    // The defect this guards against, kept as a control: with the covenant's coin
+    // in the wallet's set the funding output is change, and nothing is sent.
+    it("nets the funding to nothing when the covenant's coin counts as the wallet's", async () => {
+        const txs = await buildTransactionHistory([deposit, covenant], [], new Set());
+
+        expect(sentRows(txs)).toEqual([]);
     });
 });

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -1969,6 +1969,45 @@ describe("WalletMessageHandler repo-backed reads", () => {
         });
     });
 
+    it("GET_TRANSACTION_HISTORY reads a gated contract's output as sent, not as change", async () => {
+        // An unmarked `arkade` row is closed by the gate: an escrow, a swap offer covenant.
+        setupHandler([{ address: "escrow", script: "s-escrow", type: "arkade" }]);
+        const fundingTxid = "ff".repeat(32);
+        const funded = createMockExtendedVtxo({
+            txid: "aa".repeat(32),
+            value: 50000,
+            virtualStatus: { state: "settled" },
+            createdAt: new Date(1_700_000_000_000),
+            isSpent: true,
+            spentBy: fundingTxid,
+            arkTxId: fundingTxid,
+        });
+        const escrowed = createMockExtendedVtxo({
+            txid: fundingTxid,
+            value: 50000,
+            script: "s-escrow",
+            virtualStatus: { state: "preconfirmed" },
+            createdAt: new Date(1_700_000_060_000),
+        });
+        await walletRepo.saveVtxos(TEST_DEFAULT_ARK_ADDRESS, [funded]);
+        await walletRepo.saveVtxos("escrow", [escrowed]);
+
+        const response = await updater.handleMessage({
+            ...baseMessage(),
+            type: "GET_TRANSACTION_HISTORY",
+        } as any);
+
+        const sent = (response as any).payload.transactions.filter((tx: any) => tx.type === "SENT");
+        // Without the gate the escrow output counted as change and the funding
+        // netted to zero: no sent row at all.
+        expect(sent).toEqual([
+            expect.objectContaining({
+                amount: 50000,
+                key: expect.objectContaining({ arkTxid: fundingTxid }),
+            }),
+        ]);
+    });
+
     it("GET_VTXOS aggregates across contract addresses", async () => {
         const contracts = [
             { address: "contract-1", script: "s1", type: "default" },


### PR DESCRIPTION
## Problem

`getTransactionHistory` folds every contract's vtxos into the wallet's set, including contracts the spendability gate closes: escrows, swap offer covenants, swap lockups, VHTLCs. `buildTransactionHistory` then counts a covenant output as change.

For a swap offer, run against `buildTransactionHistory` with synthetic vtxos:

| Movement | Today | Should read |
|---|---|---|
| Funding the offer | no row (nets to zero) | `SENT` deposit |
| Solver fills | `SENT` covenant value minus dust, negative asset | `RECEIVED` asset |
| Wallet cancels | no row (nets to zero) | `RECEIVED` deposit |

So a pending or cancelled swap has no row at all. The same shape hits Lightning lockups. The wallet has been synthesizing rows from its own records to compensate (`ungroupedLnSendTx`, and now the asset swap row in arkade-os/wallet#954).

## Change

Two commits.

1. `fix(sdk)`: add `historyVtxos()` in `utils/transactionHistory.ts`. The vtxos history may treat as the wallet's own are everything outside a gated contract, keyed on script like `gatedContracts()`. Applied on both history paths: `Wallet.getTransactionHistory` and the worker's `GET_TRANSACTION_HISTORY` / `refreshCachedData`, off the same snapshot the gate uses. `getVtxos` stays ungated; recovery still sees every coin.
2. `test(sdk)`: the three movements above as pure cases, a control that keeps the old netting visible, the worker funding case through `GET_TRANSACTION_HISTORY`, and a sharper D1b/D1d assertion.

## Design call to confirm

History draws the line where the balance does: a coin in a gated contract is committed to a covenant, not the wallet's own. The existing D1b/D1d test was titled "gated reads stay ungated" and covered history with `history.length > 0`. This PR reads that as recovery must stay ungated, and history must report what moved in and out of the wallet. If history is meant to list escrowed coins as the wallet's, this is the wrong fix and the netting needs a different treatment.

Not checked against `NArk`; no checkout available here.

## Validation

`pnpm run lint`, both package typechecks, `pnpm run build`, and `pnpm run test:unit` all pass (ts-sdk 177 files, swap 33, boltz-swap 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EugrC3vqmX7aGYEGpyYr6i

---
_Generated by [Claude Code](https://claude.ai/code/session_01EugrC3vqmX7aGYEGpyYr6i)_